### PR TITLE
fix(codex): use user-agent detection for Droid CLI compatibility

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -469,10 +469,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Create transform stream with logger for streaming response
   let transformStream;
   // For Codex provider, translate response from openai-responses to openai (Chat Completions) format
-  // UNLESS client originally sent in openai-responses format (like Droid CLI) - they expect same format back
-  const needsCodexTranslation = provider === 'codex' 
-    && targetFormat === 'openai-responses' 
-    && sourceFormat !== 'openai-responses';
+  // UNLESS client is Droid CLI which expects openai-responses format back
+  const isDroidCLI = userAgent?.toLowerCase().includes('droid') || userAgent?.toLowerCase().includes('codex-cli');
+  const needsCodexTranslation = provider === 'codex'
+    && targetFormat === 'openai-responses'
+    && !isDroidCLI;
 
   if (needsCodexTranslation) {
     // Codex returns openai-responses, translate to openai (Chat Completions) that clients expect


### PR DESCRIPTION
Fixes the merge issue from PR #58 where sourceFormat check was used.

Problem
The cherry-pick merge added sourceFormat !== 'openai-responses' condition to preserve Droid CLI compatibility. However, both Cursor and Droid CLI can send openai-responses format, so this broke Cursor - it received raw Responses API format instead of Chat Completions format.

Solution
Use user-agent detection instead of source format:

droid or codex-cli in user-agent → passthrough (Responses API)
Other clients (Cursor, etc.) → translate to Chat Completions format

@decolua 