### PR TITLE
fix(auth): prevent auto-login after logout

### DIFF
--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -31,6 +31,9 @@ export default function LoginPage() {
             return;
           }
           setHasPassword(!!data.hasPassword);
+        } else {
+          // Safe fallback on non-OK response to avoid infinite loading state.
+          setHasPassword(true);
         }
       } catch (err) {
         clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
- remove login-page auto-login fallback using `123456`
- use `/api/settings` response field `hasPassword` instead of non-existent `password`

## Root cause
- `src/app/login/page.js` checked `data.password` (not returned by API), which always evaluated as missing and triggered an unintended auto-login attempt after logout.

## Validation
- `npm run build`