### PR TITLE
test(security): add cloud and docker hardening test scripts

### DIFF
--- a/tester/security/test-cloud-openai-compatible.sh
+++ b/tester/security/test-cloud-openai-compatible.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Defaults requested
+BASE_URL="${BASE_URL:-https://9router.com/v1}"
+MODEL="${MODEL:-kr/claude-sonnet-4.5}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-45}"
+API_KEY="${API_KEY:-${CLOUD_API_KEY:-${OPENAI_API_KEY:-}}}"
+
+ENDPOINT="${BASE_URL%/}/chat/completions"
+
+if [[ -z "${API_KEY}" ]]; then
+  echo "[cloud-test] FAIL: API key not configured."
+  echo "[cloud-test] Set one of: API_KEY, CLOUD_API_KEY, OPENAI_API_KEY"
+  exit 2
+fi
+
+echo "[cloud-test] Endpoint: ${ENDPOINT}"
+echo "[cloud-test] Model: ${MODEL}"
+echo "[cloud-test] API key: ${API_KEY:0:8}...${API_KEY: -6}"
+
+PAYLOAD=$(cat <<JSON
+{
+  "model": "${MODEL}",
+  "stream": false,
+  "messages": [
+    { "role": "user", "content": "Reply with exactly: CLOUD_OK" }
+  ],
+  "max_tokens": 64
+}
+JSON
+)
+
+HTTP_CODE=$(curl -sS -m "${TIMEOUT_SECONDS}" \
+  -o /tmp/9router_cloud_test_response.json \
+  -w "%{http_code}" \
+  -X POST "${ENDPOINT}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  --data "${PAYLOAD}" || true)
+
+echo "[cloud-test] HTTP status: ${HTTP_CODE}"
+echo "[cloud-test] Response body:"
+cat /tmp/9router_cloud_test_response.json || true
+echo
+
+if [[ "${HTTP_CODE}" =~ ^2 ]]; then
+  echo "[cloud-test] PASS"
+  exit 0
+fi
+
+echo "[cloud-test] FAIL"
+exit 1

--- a/tester/security/test-cloud-sync-and-call.sh
+++ b/tester/security/test-cloud-sync-and-call.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCAL_BASE_URL="${LOCAL_BASE_URL:-http://127.0.0.1:20128}"
+CLOUD_BASE_URL="${CLOUD_BASE_URL:-https://9router.com/v1}"
+MODEL="${MODEL:-kr/claude-sonnet-4.5}"
+STREAM_MODE="${STREAM_MODE:-false}"
+MAX_RETRIES="${MAX_RETRIES:-6}"
+RETRY_DELAY_SECONDS="${RETRY_DELAY_SECONDS:-3}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-45}"
+
+LOCAL_KEYS_URL="${LOCAL_BASE_URL%/}/api/keys"
+LOCAL_SYNC_URL="${LOCAL_BASE_URL%/}/api/sync/cloud"
+CLOUD_CHAT_URL="${CLOUD_BASE_URL%/}/chat/completions"
+
+echo "[1/5] Creating local API key"
+KEY_NAME="cloud-e2e-$(date +%s)"
+CREATE_RESP="$(curl -sS -m "${TIMEOUT_SECONDS}" -X POST "${LOCAL_KEYS_URL}" \
+  -H 'Content-Type: application/json' \
+  --data "{\"name\":\"${KEY_NAME}\"}")"
+
+API_KEY="$(echo "${CREATE_RESP}" | jq -r '.key // empty')"
+if [[ -z "${API_KEY}" || "${API_KEY}" == "null" ]]; then
+  echo "FAIL: could not create local API key"
+  echo "Response: ${CREATE_RESP}"
+  exit 1
+fi
+echo "      Key created: ${API_KEY:0:12}...${API_KEY: -6}"
+
+echo "[2/5] Enabling cloud mode"
+ENABLE_CODE="$(curl -sS -m "${TIMEOUT_SECONDS}" -o /tmp/cloud_enable_e2e.json -w '%{http_code}' \
+  -X POST "${LOCAL_SYNC_URL}" \
+  -H 'Content-Type: application/json' \
+  --data '{"action":"enable"}' || true)"
+echo "      enable status: ${ENABLE_CODE}"
+cat /tmp/cloud_enable_e2e.json; echo
+if [[ ! "${ENABLE_CODE}" =~ ^2 ]]; then
+  echo "FAIL: cloud enable failed"
+  exit 1
+fi
+
+echo "[3/5] Running explicit sync"
+SYNC_CODE="$(curl -sS -m "${TIMEOUT_SECONDS}" -o /tmp/cloud_sync_e2e.json -w '%{http_code}' \
+  -X POST "${LOCAL_SYNC_URL}" \
+  -H 'Content-Type: application/json' \
+  --data '{"action":"sync"}' || true)"
+echo "      sync status: ${SYNC_CODE}"
+cat /tmp/cloud_sync_e2e.json; echo
+if [[ ! "${SYNC_CODE}" =~ ^2 ]]; then
+  echo "FAIL: cloud sync failed"
+  exit 1
+fi
+
+build_payload() {
+  local stream_flag="$1"
+  cat <<JSON
+{
+  "model": "${MODEL}",
+  "stream": ${stream_flag},
+  "messages": [
+    {"role":"user","content":"Reply with exactly: CLOUD_OK"}
+  ],
+  "max_tokens": 64
+}
+JSON
+}
+
+PAYLOAD="$(build_payload "${STREAM_MODE}")"
+
+echo "[4/5] Testing cloud OpenAI-compatible endpoint with retry (stream=${STREAM_MODE})"
+SUCCESS=0
+for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
+  CODE="$(curl -sS -m "${TIMEOUT_SECONDS}" -o /tmp/cloud_chat_e2e.json -w '%{http_code}' \
+    -X POST "${CLOUD_CHAT_URL}" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H 'Content-Type: application/json' \
+    --data "${PAYLOAD}" || true)"
+  echo "      attempt ${ATTEMPT}/${MAX_RETRIES}: HTTP ${CODE}"
+  cat /tmp/cloud_chat_e2e.json; echo
+
+  if [[ "${CODE}" =~ ^2 ]]; then
+    SUCCESS=1
+    break
+  fi
+
+  sleep "${RETRY_DELAY_SECONDS}"
+done
+
+echo "[5/5] Result"
+if [[ "${SUCCESS}" -eq 1 ]]; then
+  echo "PASS: cloud endpoint accepted synced key"
+  exit 0
+fi
+
+echo "Primary test failed. Trying fallback with stream=true to distinguish key/auth issues..."
+PAYLOAD_STREAM_TRUE="$(build_payload "true")"
+FALLBACK_CODE="$(curl -sS -m "${TIMEOUT_SECONDS}" -o /tmp/cloud_chat_e2e_fallback.json -w '%{http_code}' \
+  -X POST "${CLOUD_CHAT_URL}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H 'Content-Type: application/json' \
+  --data "${PAYLOAD_STREAM_TRUE}" || true)"
+echo "      fallback stream=true HTTP ${FALLBACK_CODE}"
+cat /tmp/cloud_chat_e2e_fallback.json; echo
+
+if [[ "${FALLBACK_CODE}" =~ ^2 ]]; then
+  echo "PARTIAL PASS: API key is valid and cloud works with stream=true; stream=false path appears broken upstream."
+  exit 2
+fi
+
+echo "FAIL: cloud endpoint still failing after sync/retries (including stream=true fallback)"
+exit 1

--- a/tester/security/test-docker-hardening.sh
+++ b/tester/security/test-docker-hardening.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="${1:-9router-local-hardened}"
+CONTAINER_NAME="${2:-9router-hardening-test}"
+HOST_PORT="${3:-20129}"
+
+WORKDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${WORKDIR}/.env"
+
+INITIAL_PASSWORD="$(sed -n 's/^INITIAL_PASSWORD=//p' "${ENV_FILE}" | head -n1)"
+if [[ -z "${INITIAL_PASSWORD}" ]]; then
+  INITIAL_PASSWORD="123456"
+fi
+
+cleanup() {
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "[1/6] Building image: ${IMAGE_NAME}"
+docker build -t "${IMAGE_NAME}" "${WORKDIR}" >/tmp/9router_hardening_build.log
+echo "      Build done."
+
+echo "[2/6] Starting test container: ${CONTAINER_NAME} on :${HOST_PORT}"
+docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  -p "${HOST_PORT}:20128" \
+  --env-file "${ENV_FILE}" \
+  -e REQUIRE_API_KEY=true \
+  -e AUTH_COOKIE_SECURE=true \
+  -e DATA_DIR=/app/data \
+  "${IMAGE_NAME}" >/tmp/9router_hardening_container_id.txt
+
+echo "[3/6] Waiting for service..."
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${HOST_PORT}/api/settings" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+BASE_URL="http://127.0.0.1:${HOST_PORT}"
+FAILURES=0
+
+assert_status() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "${actual}" == "${expected}" ]]; then
+    echo "      PASS: ${label} -> ${actual}"
+  else
+    echo "      FAIL: ${label} -> got ${actual}, expected ${expected}"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  local matched=1
+
+  # Prefer rg when available, fallback to grep for portability
+  if command -v rg >/dev/null 2>&1; then
+    echo "${haystack}" | rg -qi "${needle}" && matched=0 || matched=1
+  else
+    echo "${haystack}" | grep -Eiq "${needle}" && matched=0 || matched=1
+  fi
+
+  if [[ "${matched}" -eq 0 ]]; then
+    echo "      PASS: ${label}"
+    return
+  fi
+
+  echo "      FAIL: ${label} (missing '${needle}')"
+  FAILURES=$((FAILURES + 1))
+}
+
+echo "[4/6] Validating cloud auth guardrails"
+S1="$(curl -s -o /tmp/hardening_cloud_noauth.json -w '%{http_code}' -X POST "${BASE_URL}/api/cloud/auth")"
+assert_status "/api/cloud/auth without token" "401" "${S1}"
+
+S2="$(curl -s -o /tmp/hardening_cloud_bad.json -w '%{http_code}' -X POST "${BASE_URL}/api/cloud/auth" -H 'Authorization: Bearer sk-invalid')"
+assert_status "/api/cloud/auth invalid token" "401" "${S2}"
+
+echo "[5/6] Validating strict /v1 API key mode"
+S3="$(curl -s -o /tmp/hardening_v1_noauth.json -w '%{http_code}' -X POST "${BASE_URL}/v1/chat/completions" -H 'Content-Type: application/json' --data '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}')"
+assert_status "/v1/chat/completions without token" "401" "${S3}"
+
+S4="$(curl -s -o /tmp/hardening_v1_bad.json -w '%{http_code}' -X POST "${BASE_URL}/v1/chat/completions" -H 'Authorization: Bearer sk-invalid' -H 'Content-Type: application/json' --data '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}')"
+assert_status "/v1/chat/completions invalid token" "401" "${S4}"
+
+KEY_JSON="$(curl -s -X POST "${BASE_URL}/api/keys" -H 'Content-Type: application/json' --data '{"name":"hardening-test-key"}')"
+API_KEY="$(echo "${KEY_JSON}" | jq -r '.key // empty')"
+if [[ -z "${API_KEY}" || "${API_KEY}" == "null" ]]; then
+  echo "      FAIL: Could not create test API key"
+  FAILURES=$((FAILURES + 1))
+else
+  S5="$(curl -s -o /tmp/hardening_v1_good.json -w '%{http_code}' -X POST "${BASE_URL}/v1/chat/completions" -H "Authorization: Bearer ${API_KEY}" -H 'Content-Type: application/json' --data '{"model":"foo/bar","messages":[{"role":"user","content":"ping"}]}')"
+  if [[ "${S5}" == "401" ]]; then
+    echo "      FAIL: /v1/chat/completions valid token still unauthorized"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "      PASS: /v1/chat/completions valid token accepted auth layer (${S5})"
+  fi
+
+  S6="$(curl -s -o /tmp/hardening_cloud_good.json -w '%{http_code}' -X POST "${BASE_URL}/api/cloud/auth" -H "Authorization: Bearer ${API_KEY}")"
+  assert_status "/api/cloud/auth valid token" "200" "${S6}"
+fi
+
+echo "[6/6] Validating secure cookie behavior"
+LOGIN_HEADERS="$(curl -s -i -X POST "${BASE_URL}/api/auth/login" -H 'x-forwarded-proto: https' -H 'Content-Type: application/json' --data "{\"password\":\"${INITIAL_PASSWORD}\"}" || true)"
+assert_contains "login response sets secure auth cookie" "${LOGIN_HEADERS}" "set-cookie: auth_token=.*secure"
+
+if [[ "${FAILURES}" -gt 0 ]]; then
+  echo
+  echo "Result: FAILED (${FAILURES} checks failed)"
+  exit 1
+fi
+
+echo
+echo "Result: PASSED (all checks)"


### PR DESCRIPTION
## Summary
Add security test scripts for cloud and docker validation. These scripts were part of PR #70 but were separated into their own PR for a clean merge.

### Scripts added:
- **test-cloud-openai-compatible.sh** — Validates cloud endpoint with OpenAI-compatible API format
- **test-cloud-sync-and-call.sh** — End-to-end cloud sync and call testing
- **test-docker-hardening.sh** — Docker container security hardening validation

> Supersedes the test scripts portion of #70 (which was already cherry-picked for the main changes in commit 3d43983).