### PR TITLE
Fix: Restore Claude Opus 4.5 entry in provider models

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -78,8 +78,7 @@ export const PROVIDER_MODELS = {
     // GitHub Copilot - Anthropic models
     { id: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
     { id: "claude-opus-4.1", name: "Claude Opus 4.1" },
-    // { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
-    { id: "claude-opus-4-5-20251101", name: "Claude Opus 4.5 (Full ID)" },
+    { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
     { id: "claude-sonnet-4", name: "Claude Sonnet 4" },
     { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
     // GitHub Copilot - Google models


### PR DESCRIPTION
### Bug Fix
The existing model ID for Claude Opus 4.5 in the GitHub Copilot (`gh`) provider was incorrect and caused requests to fail.

### Changes
- Updated the ID for Claude Opus 4.5 to the correct value.

### Verification
I tested this locally. 
- **Before:** The model failed to load/respond with the old ID (see screenshot 1).
- **After:** The model works correctly with the fixed ID (see screenshot 2).

<img width="1562" height="722" alt="image_2026-02-10_16-29-16" src="https://github.com/user-attachments/assets/59c98f93-96a7-4763-94fc-929c05a588db" />

<img width="1555" height="716" alt="image_2026-02-10_16-29-38" src="https://github.com/user-attachments/assets/ec84727d-59af-4ace-9546-17ed2b4ed7b7" />
