### PR TITLE
Fix: incorrect Gemini 3 Flash ID for GitHub provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -83,7 +83,7 @@ export const PROVIDER_MODELS = {
     { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
     // GitHub Copilot - Google models
     { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
-    { id: "gemini-3-flash", name: "Gemini 3 Flash" },
+    { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
     { id: "gemini-3-pro-preview", name: "Gemini 3 Pro" },
     // GitHub Copilot - Other models
     { id: "grok-code-fast-1", name: "Grok Code Fast 1" },


### PR DESCRIPTION
### Bug Fix
The model ID for Gemini 3 Flash in the GitHub Copilot (`gh`) provider was incorrect (`gemini-3-flash`), causing it to fail. The correct ID requires the `-preview` suffix.

### Changes
- Updated the ID from `gemini-3-flash` to `gemini-3-flash-preview` in the `gh` provider list.

### Verification
I tested this locally.
- **Before:** The model failed to load with the old ID.
- **After:** The model works correctly with the updated ID.
<img width="1534" height="697" alt="image_2026-02-10_16-54-19" src="https://github.com/user-attachments/assets/ebb6fa91-a2ce-4fea-8bcc-e9ed7aa32722" />
<img width="1446" height="655" alt="image_2026-02-10_16-55-38" src="https://github.com/user-attachments/assets/2acd5904-0b63-4684-a466-fed80f6664c6" />

