### PR TITLE
Fix: Correct model ID for Gemini 3 Pro in GitHub provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -84,7 +84,7 @@ export const PROVIDER_MODELS = {
     // GitHub Copilot - Google models
     { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
     { id: "gemini-3-flash", name: "Gemini 3 Flash" },
-    { id: "gemini-3-pro", name: "Gemini 3 Pro" },
+    { id: "gemini-3-pro-preview", name: "Gemini 3 Pro" },
     // GitHub Copilot - Other models
     { id: "grok-code-fast-1", name: "Grok Code Fast 1" },
     { id: "raptor-mini", name: "Raptor Mini" },


### PR DESCRIPTION
### Bug Fix
The model ID for Gemini 3 Pro in the GitHub Copilot (`gh`) provider was missing the `-preview` suffix, which caused requests to this model to fail.

### Changes
- Updated the ID for Gemini 3 Pro from `gemini-3-pro` to `gemini-3-pro-preview`.

### Verification
I confirmed locally that the model does not work with the old ID but functions correctly after this change.
<img width="1534" height="715" alt="image_2026-02-10_17-10-30" src="https://github.com/user-attachments/assets/38d88a79-b98f-4206-9263-111702b880f4" />


<img width="1497" height="693" alt="image_2026-02-10_17-11-18" src="https://github.com/user-attachments/assets/49608281-db21-4750-b74f-eb8a58f664c1" />

