### PR TITLE
Fix: Correct model ID for Raptor Mini in GitHub provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -87,7 +87,7 @@ export const PROVIDER_MODELS = {
     { id: "gemini-3-pro-preview", name: "Gemini 3 Pro" },
     // GitHub Copilot - Other models
     { id: "grok-code-fast-1", name: "Grok Code Fast 1" },
-    { id: "raptor-mini", name: "Raptor Mini" },
+    { id: "oswe-vscode-prime", name: "Raptor Mini" },
   ],
   kr: [  // Kiro AI
     // { id: "claude-opus-4.5", name: "Claude Opus 4.5" },


### PR DESCRIPTION
### Bug Fix
The model ID for Raptor Mini (`raptor-mini`) in the GitHub Copilot (`gh`) provider was incorrect and did not work. This change updates it to the correct ID, `oswe-vscode-prime`.

### Changes
- Updated the `id` for the "Raptor Mini" model entry from `raptor-mini` to `oswe-vscode-prime`.

### Verification
This was tested locally to confirm that the new ID is functional while the old one was not.

<img width="1541" height="701" alt="image_2026-02-10_17-49-22" src="https://github.com/user-attachments/assets/711e47a6-d861-4303-84f8-834ee3d9196d" />

<img width="1524" height="725" alt="image_2026-02-10_17-50-47" src="https://github.com/user-attachments/assets/663014a5-2357-4759-9a94-f33fd206b7f3" />