### PR TITLE
feat: add Claude Opus 4.6 to GitHub Copilot provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -81,6 +81,7 @@ export const PROVIDER_MODELS = {
     { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
     { id: "claude-sonnet-4", name: "Claude Sonnet 4" },
     { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+    { id: "claude-opus-4.6", name: "Claude Opus 4.6" },
     // GitHub Copilot - Google models
     { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },


### PR DESCRIPTION
## Summary
This PR adds the latest `Claude Opus 4.6` to the list of available models for the GitHub Copilot provider.

## Changes
- [x] Modified `PROVIDER_MODELS` object in `models.js` (or filename.ts)
- [x] Added entry: `{ id: "claude-opus-4.6", name: "Claude Opus 4.6" }` under `gh` key

## Motivation
To allow users to select the latest Opus version when using the GitHub Copilot provider.

<img width="1554" height="708" alt="image_2026-02-10_18-07-13" src="https://github.com/user-attachments/assets/5ef8c4d7-1de4-459e-943b-4a8ff998e696" />

