### PR TITLE
feat: add GPT-4o to GitHub Copilot provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -65,6 +65,7 @@ export const PROVIDER_MODELS = {
     { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
   ],
   gh: [  // GitHub Copilot - OpenAI models
+    { id: "gpt-4o", name: "GPT-4o"},
     { id: "gpt-4.1", name: "GPT-4.1" },
     { id: "gpt-5", name: "GPT-5" },
     { id: "gpt-5-mini", name: "GPT-5 Mini" },


### PR DESCRIPTION
## Summary
Added `GPT-4o` to the list of supported models for the GitHub Copilot (`gh`) provider.

## Changes
- Updated `PROVIDER_MODELS` constant.
- Added `{ id: "gpt-4o", name: "GPT-4o" }` to the `gh` array.

## Motivation
Enables users to select GPT-4o when using the GitHub Copilot provider key.

<img width="1523" height="713" alt="image_2026-02-10_18-16-53" src="https://github.com/user-attachments/assets/cce4f7ca-88ff-465e-9aa7-e2c81513889f" />
