### PR TITLE
feat: add GPT-4o mini to GitHub Copilot provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -65,6 +65,7 @@ export const PROVIDER_MODELS = {
     { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
   ],
   gh: [  // GitHub Copilot - OpenAI models
+    { id: "gpt-4o-mini", name: "GPT-4o mini" },
     { id: "gpt-4.1", name: "GPT-4.1" },
     { id: "gpt-5", name: "GPT-5" },
     { id: "gpt-5-mini", name: "GPT-5 Mini" },


### PR DESCRIPTION
## Summary
Added `GPT-4o-mini` to the list of supported models for the GitHub Copilot (`gh`) provider.

## Changes
- Updated `PROVIDER_MODELS` constant.
- Added `{ id: "gpt-4o-mini", name: "GPT-4o mini" }` to the `gh` array.

## Motivation
Enables users to select GPT-4o mini when using the GitHub Copilot provider key.

<img width="1557" height="712" alt="image_2026-02-10_18-29-40" src="https://github.com/user-attachments/assets/e21b8b2a-c2d1-4761-b685-aeb3292c589a" />