### PR TITLE
feat: add GPT-4 to GitHub Copilot provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -65,6 +65,7 @@ export const PROVIDER_MODELS = {
     { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
   ],
   gh: [  // GitHub Copilot - OpenAI models
+    { id: "gpt-4", name: "GPT-4" },
     { id: "gpt-4.1", name: "GPT-4.1" },
     { id: "gpt-5", name: "GPT-5" },
     { id: "gpt-5-mini", name: "GPT-5 Mini" },


### PR DESCRIPTION
## Summary
Added `GPT-4` to the list of supported models for the GitHub Copilot (`gh`) provider.

## Changes
- Updated `PROVIDER_MODELS` constant.
- Added `{ id: "gpt-4", name: "GPT-4" },` to the `gh` array.

## Motivation
Enables users to select GPT-4 when using the GitHub Copilot provider key.

<img width="1519" height="719" alt="image_2026-02-10_18-37-07" src="https://github.com/user-attachments/assets/a476a63b-b599-4e47-b693-d7f6f320b9e5" />