### PR TITLE
feat: add GPT-3.5 Turbo to GitHub Copilot provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -65,6 +65,7 @@ export const PROVIDER_MODELS = {
     { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
   ],
   gh: [  // GitHub Copilot - OpenAI models
+    { id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo" },
     { id: "gpt-4.1", name: "GPT-4.1" },
     { id: "gpt-5", name: "GPT-5" },
     { id: "gpt-5-mini", name: "GPT-5 Mini" },


### PR DESCRIPTION
## Summary
Added `GPT-3.5 Turbo` to the list of supported models for the GitHub Copilot (`gh`) provider.

## Changes
- Updated `PROVIDER_MODELS` constant.
- Added `{ id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo" }` to the `gh` array.

## Motivation
Enables users to select GPT-3.5 Turbo when using the GitHub Copilot provider key.
<img width="1568" height="701" alt="image_2026-02-10_18-52-28" src="https://github.com/user-attachments/assets/fbedd455-1321-4e23-863a-3695b515b9aa" />
