### PR TITLE
feat: Add GitHub username sync feature

### DIFF
--- a/src/app/api/providers/[id]/sync-username/route.js
+++ b/src/app/api/providers/[id]/sync-username/route.js
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { getProviderConnectionById, updateProviderConnection } from "@/lib/localDb";
+
+/**
+ * POST /api/providers/[id]/sync-username
+ * Syncs the GitHub username from the API and updates the account name
+ */
+export async function POST(request, { params }) {
+  try {
+    // In Next.js 15+, params might be a Promise
+    const resolvedParams = await Promise.resolve(params);
+    const { id } = resolvedParams;
+
+    // Get the provider connection
+    const connection = await getProviderConnectionById(id);
+    
+    if (!connection) {
+      return NextResponse.json(
+        { error: "Provider connection not found" },
+        { status: 404 }
+      );
+    }
+
+    // Only support GitHub provider
+    if (connection.provider !== "github") {
+      return NextResponse.json(
+        { error: "Sync username is only supported for GitHub provider" },
+        { status: 400 }
+      );
+    }
+
+    // Check if we have an access token
+    const token = connection.accessToken;
+    if (!token) {
+      return NextResponse.json(
+        { error: "No access token found for this account" },
+        { status: 400 }
+      );
+    }
+
+    // Fetch username from GitHub API
+    try {
+      const response = await fetch("https://api.github.com/user", {
+        headers: {
+          "Authorization": `token ${token}`,
+          "Accept": "application/vnd.github.v3+json",
+          "User-Agent": "9router"
+        }
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          return NextResponse.json(
+            { error: "Invalid or expired token" },
+            { status: 401 }
+          );
+        }
+        throw new Error(`GitHub API returned ${response.status}`);
+      }
+
+      const userData = await response.json();
+      const username = userData.login;
+
+      if (!username) {
+        return NextResponse.json(
+          { error: "Could not retrieve username from GitHub" },
+          { status: 500 }
+        );
+      }
+
+      // Update the connection with the new name
+      const updatedConnection = await updateProviderConnection(id, {
+        name: username,
+        displayName: userData.name || username,
+        email: userData.email || connection.email
+      });
+
+      return NextResponse.json({
+        success: true,
+        username: username,
+        connection: updatedConnection
+      });
+
+    } catch (error) {
+      console.error("Error fetching GitHub user data:", error);
+      return NextResponse.json(
+        { error: "Failed to fetch user data from GitHub" },
+        { status: 500 }
+      );
+    }
+
+  } catch (error) {
+    console.error("Error syncing username:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -524,19 +524,30 @@ const PROVIDERS = {
 
       return { copilotToken, userInfo };
     },
-    mapTokens: (tokens, extra) => ({
-      accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token,
-      expiresIn: tokens.expires_in,
-      providerSpecificData: {
-        copilotToken: extra?.copilotToken?.token,
-        copilotTokenExpiresAt: extra?.copilotToken?.expires_at,
-        githubUserId: extra?.userInfo?.id,
-        githubLogin: extra?.userInfo?.login,
-        githubName: extra?.userInfo?.name,
-        githubEmail: extra?.userInfo?.email,
-      },
-    }),
+    mapTokens: (tokens, extra) => {
+      const username = extra?.userInfo?.login;
+      const email = extra?.userInfo?.email;
+      const displayName = extra?.userInfo?.name;
+      
+      console.log('[GitHub OAuth] Creating connection - username:', username, 'email:', email, 'name:', displayName);
+      
+      return {
+        name: username || email || `Account ${Date.now()}`,
+        email: email,
+        displayName: displayName,
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        expiresIn: tokens.expires_in,
+        providerSpecificData: {
+          copilotToken: extra?.copilotToken?.token,
+          copilotTokenExpiresAt: extra?.copilotToken?.expires_at,
+          githubUserId: extra?.userInfo?.id,
+          githubLogin: extra?.userInfo?.login,
+          githubName: extra?.userInfo?.name,
+          githubEmail: extra?.userInfo?.email,
+        },
+      };
+    },
   },
 
   kiro: {


### PR DESCRIPTION
- Add sync-username API endpoint to fetch GitHub username from token
- Add sync button in GitHub provider detail page UI
- Auto-use GitHub username when adding new GitHub connections
- Update ConnectionRow to show sync button for GitHub provider
- Add console.log for debugging OAuth flow
- Handle success/error states with temporary messages