### PR TITLE
feat: implement comprehensive duplicate provider connection handling

### DIFF
--- a/src/app/api/providers/check-duplicate/route.js
+++ b/src/app/api/providers/check-duplicate/route.js
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { getProviderConnections } from "@/models";
+import { checkDuplicate } from "@/shared/utils/duplicateDetection";
+
+/**
+ * POST /api/providers/check-duplicate
+ * Check if a connection would be a duplicate
+ */
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { provider, authType, email, apiKey, projectId, providerSpecificData } = body;
+
+    if (!provider || !authType) {
+      return NextResponse.json(
+        { error: "Provider and authType are required" },
+        { status: 400 }
+      );
+    }
+
+    // Get existing connections for this provider
+    const existingConnections = await getProviderConnections({ provider });
+
+    // Create a temporary connection object for comparison
+    const tempConnection = {
+      provider,
+      authType,
+      email,
+      apiKey,
+      projectId,
+      providerSpecificData,
+    };
+
+    // Check for duplicates
+    const result = checkDuplicate(tempConnection, existingConnections);
+
+    if (result.isDuplicate) {
+      return NextResponse.json({
+        isDuplicate: true,
+        duplicate: {
+          id: result.duplicate.id,
+          name: result.duplicate.name,
+          email: result.duplicate.email,
+          priority: result.duplicate.priority,
+          isActive: result.duplicate.isActive,
+          createdAt: result.duplicate.createdAt,
+        },
+        reason: result.reason,
+      });
+    }
+
+    return NextResponse.json({ isDuplicate: false });
+  } catch (error) {
+    console.error("Error checking duplicate:", error);
+    return NextResponse.json(
+      { error: "Failed to check duplicate" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/shared/components/DuplicateWarningModal.js
+++ b/src/shared/components/DuplicateWarningModal.js
@@ -1,0 +1,128 @@
+"use client";
+
+import PropTypes from "prop-types";
+import { Modal, Button, Badge } from "@/shared/components";
+
+/**
+ * DuplicateWarningModal - Shows warning when duplicate connection detected
+ * Provides options to replace, keep both, or cancel
+ */
+export default function DuplicateWarningModal({
+  isOpen,
+  duplicate,
+  reason,
+  onReplace,
+  onKeepBoth,
+  onCancel,
+}) {
+  if (!duplicate) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="Duplicate Connection Detected"
+      onClose={onCancel}
+      maxWidth="md"
+    >
+      <div className="flex flex-col gap-4">
+        {/* Warning Icon */}
+        <div className="flex items-center justify-center">
+          <div className="w-16 h-16 rounded-full bg-orange-500/10 flex items-center justify-center">
+            <span className="material-symbols-outlined text-4xl text-orange-500">
+              warning
+            </span>
+          </div>
+        </div>
+
+        {/* Message */}
+        <div className="text-center">
+          <p className="text-text-main font-medium mb-2">
+            A connection with the same credentials already exists
+          </p>
+          <p className="text-sm text-text-muted">{reason}</p>
+        </div>
+
+        {/* Existing Connection Info */}
+        <div className="bg-sidebar/50 rounded-lg p-4 border border-border">
+          <p className="text-xs text-text-muted mb-2">Existing Connection</p>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium text-sm">{duplicate.name}</p>
+              {duplicate.email && (
+                <p className="text-xs text-text-muted mt-1">{duplicate.email}</p>
+              )}
+            </div>
+            <Badge
+              variant={duplicate.isActive ? "success" : "default"}
+              size="sm"
+            >
+              {duplicate.isActive ? "Active" : "Inactive"}
+            </Badge>
+          </div>
+          <div className="mt-2 flex items-center gap-2 text-xs text-text-muted">
+            <span>Priority: {duplicate.priority}</span>
+            <span>•</span>
+            <span>
+              Added: {new Date(duplicate.createdAt).toLocaleDateString()}
+            </span>
+          </div>
+        </div>
+
+        {/* Options */}
+        <div className="flex flex-col gap-2">
+          <Button
+            onClick={onReplace}
+            variant="primary"
+            icon="swap_horiz"
+            fullWidth
+          >
+            Replace Existing Connection
+          </Button>
+          <Button
+            onClick={onKeepBoth}
+            variant="secondary"
+            icon="add"
+            fullWidth
+          >
+            Keep Both (Add as Fallback)
+          </Button>
+          <Button onClick={onCancel} variant="ghost" fullWidth>
+            Cancel
+          </Button>
+        </div>
+
+        {/* Info Box */}
+        <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3">
+          <div className="flex gap-2">
+            <span className="material-symbols-outlined text-blue-500 text-sm">
+              info
+            </span>
+            <p className="text-xs text-text-muted">
+              <strong>Replace:</strong> Updates the existing connection with new
+              credentials while preserving priority.
+              <br />
+              <strong>Keep Both:</strong> Adds as a new connection with lower
+              priority for fallback.
+            </p>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+DuplicateWarningModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  duplicate: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    email: PropTypes.string,
+    priority: PropTypes.number,
+    isActive: PropTypes.bool,
+    createdAt: PropTypes.string,
+  }),
+  reason: PropTypes.string,
+  onReplace: PropTypes.func.isRequired,
+  onKeepBoth: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -22,6 +22,7 @@ export { default as KiroAuthModal } from "./KiroAuthModal";
 export { default as KiroOAuthWrapper } from "./KiroOAuthWrapper";
 export { default as KiroSocialOAuthModal } from "./KiroSocialOAuthModal";
 export { default as CursorAuthModal } from "./CursorAuthModal";
+export { default as DuplicateWarningModal } from "./DuplicateWarningModal";
 export { default as SegmentedControl } from "./SegmentedControl";
 
 // Layouts

--- a/src/shared/utils/duplicateDetection.js
+++ b/src/shared/utils/duplicateDetection.js
@@ -1,0 +1,212 @@
+/**
+ * Duplicate Detection Utilities
+ * 
+ * Handles detection of duplicate provider connections based on:
+ * - OAuth: email, userId, or provider-specific identifiers
+ * - API Key: hashed key comparison
+ */
+
+import crypto from "crypto";
+
+/**
+ * Hash an API key for secure comparison
+ * @param {string} apiKey - The API key to hash
+ * @returns {string} SHA-256 hash of the API key
+ */
+export function hashApiKey(apiKey) {
+  if (!apiKey) return null;
+  return crypto.createHash("sha256").update(apiKey).digest("hex");
+}
+
+/**
+ * Check if two OAuth connections are duplicates
+ * @param {object} connection1 - First connection
+ * @param {object} connection2 - Second connection
+ * @returns {boolean} True if connections are duplicates
+ */
+export function isOAuthDuplicate(connection1, connection2) {
+  // Must be same provider
+  if (connection1.provider !== connection2.provider) {
+    return false;
+  }
+
+  // Check by email (most common OAuth identifier)
+  if (connection1.email && connection2.email) {
+    return connection1.email.toLowerCase() === connection2.email.toLowerCase();
+  }
+
+  // Provider-specific checks
+  switch (connection1.provider) {
+    case "github":
+      // Check GitHub user ID or login
+      if (
+        connection1.providerSpecificData?.githubUserId &&
+        connection2.providerSpecificData?.githubUserId
+      ) {
+        return (
+          connection1.providerSpecificData.githubUserId ===
+          connection2.providerSpecificData.githubUserId
+        );
+      }
+      if (
+        connection1.providerSpecificData?.githubLogin &&
+        connection2.providerSpecificData?.githubLogin
+      ) {
+        return (
+          connection1.providerSpecificData.githubLogin.toLowerCase() ===
+          connection2.providerSpecificData.githubLogin.toLowerCase()
+        );
+      }
+      break;
+
+    case "antigravity":
+    case "gemini-cli":
+      // Check by project ID for Google-based providers
+      if (connection1.projectId && connection2.projectId) {
+        return connection1.projectId === connection2.projectId;
+      }
+      break;
+
+    case "codex":
+      // Codex uses email from idToken
+      if (connection1.email && connection2.email) {
+        return connection1.email.toLowerCase() === connection2.email.toLowerCase();
+      }
+      break;
+
+    case "cursor":
+      // Cursor uses machine ID
+      if (
+        connection1.providerSpecificData?.machineId &&
+        connection2.providerSpecificData?.machineId
+      ) {
+        return (
+          connection1.providerSpecificData.machineId ===
+          connection2.providerSpecificData.machineId
+        );
+      }
+      break;
+  }
+
+  return false;
+}
+
+/**
+ * Check if two API key connections are duplicates
+ * @param {object} connection1 - First connection
+ * @param {object} connection2 - Second connection
+ * @returns {boolean} True if connections are duplicates
+ */
+export function isApiKeyDuplicate(connection1, connection2) {
+  // Must be same provider
+  if (connection1.provider !== connection2.provider) {
+    return false;
+  }
+
+  // Compare hashed API keys
+  if (connection1.apiKey && connection2.apiKey) {
+    const hash1 = hashApiKey(connection1.apiKey);
+    const hash2 = hashApiKey(connection2.apiKey);
+    return hash1 === hash2;
+  }
+
+  return false;
+}
+
+/**
+ * Find duplicate connection in a list
+ * @param {object} newConnection - New connection to check
+ * @param {array} existingConnections - List of existing connections
+ * @returns {object|null} Duplicate connection if found, null otherwise
+ */
+export function findDuplicate(newConnection, existingConnections) {
+  if (!existingConnections || existingConnections.length === 0) {
+    return null;
+  }
+
+  for (const existing of existingConnections) {
+    // Skip if same ID (updating existing connection)
+    if (existing.id === newConnection.id) {
+      continue;
+    }
+
+    // Check based on auth type
+    if (newConnection.authType === "oauth" && existing.authType === "oauth") {
+      if (isOAuthDuplicate(newConnection, existing)) {
+        return existing;
+      }
+    } else if (newConnection.authType === "apikey" && existing.authType === "apikey") {
+      if (isApiKeyDuplicate(newConnection, existing)) {
+        return existing;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get duplicate detection fingerprint for a connection
+ * Used for quick duplicate checking
+ * @param {object} connection - Connection to fingerprint
+ * @returns {string|null} Fingerprint string or null
+ */
+export function getConnectionFingerprint(connection) {
+  if (connection.authType === "oauth") {
+    // Use email or provider-specific identifier
+    if (connection.email) {
+      return `oauth:${connection.provider}:${connection.email.toLowerCase()}`;
+    }
+    if (connection.provider === "github" && connection.providerSpecificData?.githubUserId) {
+      return `oauth:github:user:${connection.providerSpecificData.githubUserId}`;
+    }
+    if (
+      (connection.provider === "antigravity" || connection.provider === "gemini-cli") &&
+      connection.projectId
+    ) {
+      return `oauth:${connection.provider}:project:${connection.projectId}`;
+    }
+  } else if (connection.authType === "apikey" && connection.apiKey) {
+    // Use hashed API key
+    const hash = hashApiKey(connection.apiKey);
+    return `apikey:${connection.provider}:${hash.substring(0, 16)}`;
+  }
+
+  return null;
+}
+
+/**
+ * Check if connection is a duplicate and get duplicate info
+ * @param {object} newConnection - New connection to check
+ * @param {array} existingConnections - List of existing connections
+ * @returns {object} { isDuplicate: boolean, duplicate: object|null, reason: string }
+ */
+export function checkDuplicate(newConnection, existingConnections) {
+  const duplicate = findDuplicate(newConnection, existingConnections);
+
+  if (!duplicate) {
+    return { isDuplicate: false, duplicate: null, reason: null };
+  }
+
+  // Determine reason
+  let reason = "Unknown duplicate";
+  if (newConnection.authType === "oauth") {
+    if (newConnection.email && duplicate.email) {
+      reason = `Same email: ${duplicate.email}`;
+    } else if (newConnection.provider === "github") {
+      reason = `Same GitHub account`;
+    } else if (newConnection.provider === "antigravity" || newConnection.provider === "gemini-cli") {
+      reason = `Same Google project`;
+    } else {
+      reason = `Same OAuth account`;
+    }
+  } else if (newConnection.authType === "apikey") {
+    reason = `Same API key`;
+  }
+
+  return {
+    isDuplicate: true,
+    duplicate,
+    reason,
+  };
+}


### PR DESCRIPTION
- Add duplicate detection utilities with secure API key hashing (SHA-256)
- Implement OAuth duplicate detection by email/user ID/project ID
- Implement API key duplicate detection by hashed key comparison
- Add DuplicateWarningModal component with Replace/Keep Both/Cancel options
- Add visual duplicate badge indicators with warning variant
- Add POST /api/providers/check-duplicate endpoint for pre-check
- Update POST /api/providers to return 409 Conflict on duplicates
- Auto-update OAuth connections when duplicates detected in callback
- Add comprehensive documentation in docs/DUPLICATE_HANDLING.md
- Support provider-specific duplicate detection (GitHub, Antigravity, Cursor, etc.)
- Preserve priority and settings when replacing duplicates
- Allow keeping both connections as fallback with lower priority