### PR TITLE
fix: prevent aborted connections from sticking in Usage Overview

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -412,7 +412,20 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   log?.debug?.("REQUEST", `${provider.toUpperCase()} | ${model} | ${msgCount} msgs`);
 
   // Create stream controller for disconnect detection
-  const streamController = createStreamController({ onDisconnect, log, provider, model });
+  const streamController = createStreamController({ 
+    onDisconnect: (reason) => {
+      // Track request finished (disconnected)
+      trackPendingRequest(model, provider, connectionId, false);
+      if (onDisconnect) onDisconnect(reason);
+    },
+    onError: (error) => {
+      // Track request finished (error/zombie)
+      trackPendingRequest(model, provider, connectionId, false);
+    },
+    log,
+    provider,
+    model
+  });
 
   // Execute request using executor (handles URL building, headers, fallback, transform)
   let providerResponse;

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -13,7 +13,7 @@ function getTimeString() {
  * @param {string} options.provider - Provider name
  * @param {string} options.model - Model name
  */
-export function createStreamController({ onDisconnect, log, provider, model } = {}) {
+export function createStreamController({ onDisconnect, onError, log, provider, model } = {}) {
   const abortController = new AbortController();
   const startTime = Date.now();
   let disconnected = false;
@@ -61,6 +61,9 @@ export function createStreamController({ onDisconnect, log, provider, model } = 
 
     // Call on error
     handleError: (error) => {
+      if (disconnected) return;
+      disconnected = true;
+
       if (abortTimeout) {
         clearTimeout(abortTimeout);
         abortTimeout = null;
@@ -72,6 +75,7 @@ export function createStreamController({ onDisconnect, log, provider, model } = 
       }
 
       logStream(`error: ${error.message}`);
+      onError?.(error);
     },
 
     abort: () => abortController.abort()


### PR DESCRIPTION
## Description
This PR fixes an issue where "Pending" requests would accumulate in the dashboard when a stream failed (e.g., network error) or was aborted.
<img width="1204" height="738" alt="image" src="https://github.com/user-attachments/assets/197d5be0-dc8d-49bd-8719-68be1c8d1e8c" />

## Changes
### [open-sse/utils/streamHandler.js]
- **Updated [createStreamController]**: Added support for an [onError] callback.
- **Updated [handleError]**: Now marks the stream as `disconnected` (to prevent race conditions) and invokes the [onError] callback. This ensuring that write errors (like `EPIPE`) are properly propagated as disconnect events.
### [open-sse/handlers/chatCore.js]
- **Updated [createStreamController] usage**: Passed an [onError] handler that calls [trackPendingRequest(..., false)] , ensuring that ungraceful disconnects (zombies) incorrectly clear their usage tracking.

## Testing

Verified that connections now properly disappear from the Usage Overview page immediately after the request ends or is aborted.