### PR TITLE
feat: add URL-based tab state persistence in usage page

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -1,12 +1,31 @@
 "use client";
 
-import { useState, Suspense } from "react";
+import { useState, Suspense, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { UsageStats, RequestLogger, CardSkeleton, SegmentedControl } from "@/shared/components";
 import ProviderLimits from "./components/ProviderLimits";
 import RequestDetailsTab from "./components/RequestDetailsTab";
 
 export default function UsagePage() {
-  const [activeTab, setActiveTab] = useState("overview");
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState(searchParams.get("tab") || "overview");
+
+  // Sync tab with URL on mount and when URL changes
+  useEffect(() => {
+    const tabFromUrl = searchParams.get("tab");
+    if (tabFromUrl && ["overview", "logs", "limits", "details"].includes(tabFromUrl)) {
+      setActiveTab(tabFromUrl);
+    }
+  }, [searchParams]);
+
+  // Update URL when tab changes
+  const handleTabChange = (value) => {
+    setActiveTab(value);
+    const params = new URLSearchParams(searchParams);
+    params.set("tab", value);
+    router.push(`/dashboard/usage?${params.toString()}`, { scroll: false });
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -18,7 +37,7 @@ export default function UsagePage() {
           { value: "details", label: "Details" },
         ]}
         value={activeTab}
-        onChange={setActiveTab}
+        onChange={handleTabChange}
       />
 
       {/* Content */}


### PR DESCRIPTION
- Add URL search params to track active tab
- Persist tab selection on page refresh
- Enable direct linking to specific tabs (overview, logs, limits, details)
- Implement smooth navigation without page scroll

<img width="2586" height="1494" alt="CleanShot 2026-02-15 at 16 21 29@2x" src="https://github.com/user-attachments/assets/9b9a92a5-7e20-45c0-978b-c17977638700" />

