### PR TITLE
feat: implement "force fallback" strategy for unavailable providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ ENABLE_REQUEST_LOGS=false
 OBSERVABILITY_ENABLED=true
 AUTH_COOKIE_SECURE=false
 REQUIRE_API_KEY=false
+FORCE_FALLBACK_ON_ALL_UNAVAILABLE=true
 
 # Cloud sync variables
 # Must point to this running instance so internal sync jobs can call /api/sync/cloud.

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -62,6 +62,21 @@ export default function ProfilePage() {
     }
   };
 
+  const updateForceFallback = async (force) => {
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ forceFallback: force }),
+      });
+      if (res.ok) {
+        setSettings(prev => ({ ...prev, forceFallback: force }));
+      }
+    } catch (err) {
+      console.error("Failed to update force fallback:", err);
+    }
+  };
+
   const updateFallbackStrategy = async (strategy) => {
     try {
       const res = await fetch("/api/settings", {
@@ -257,6 +272,21 @@ export default function ProfilePage() {
             <h3 className="text-lg font-semibold">Routing Strategy</h3>
           </div>
           <div className="flex flex-col gap-4">
+            {/* Force Fallback Toggle */}
+            <div className="flex items-center justify-between pb-4 border-b border-border/50">
+              <div>
+                <p className="font-medium">Force Fallback</p>
+                <p className="text-sm text-text-muted">
+                  If all accounts unavailable, force use of min-cooldown account
+                </p>
+              </div>
+              <Toggle
+                checked={settings.forceFallback === true}
+                onChange={() => updateForceFallback(!settings.forceFallback)}
+                disabled={loading}
+              />
+            </div>
+
             <div className="flex items-center justify-between">
               <div>
                 <p className="font-medium">Round Robin</p>

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -55,7 +55,8 @@ const defaultData = {
     observabilityMaxRecords: 1000,
     observabilityBatchSize: 20,
     observabilityFlushIntervalMs: 5000,
-    observabilityMaxJsonSize: 1024
+    observabilityMaxJsonSize: 1024,
+    forceFallback: false
   },
   pricing: {} // NEW: pricing configuration
 };
@@ -76,7 +77,8 @@ function cloneDefaultData() {
       observabilityMaxRecords: 1000,
       observabilityBatchSize: 20,
       observabilityFlushIntervalMs: 5000,
-      observabilityMaxJsonSize: 1024
+      observabilityMaxJsonSize: 1024,
+      forceFallback: false
     },
     pricing: {},
   };


### PR DESCRIPTION
## Description
  This PR introduces a Force Fallback option to improve system resilience against temporary network glitches or endpoint misconfigurations.
<img width="1451" height="407" alt="image" src="https://github.com/user-attachments/assets/7f2aabfc-9ec8-42c3-ac6e-9a2909480c15" />

## Problem
  Currently, if all endpoints for a specific provider encounter errors (e.g., due to a temporary network flap or client-side setting errors), the system puts them into cooldown. Users must wait for the cooldown to expire before retrying, even if the underlying issue has been resolved.

## Solution
  Added a new routing setting that allows the system to automatically pick the endpoint with the minimum remaining cooldown time when all other options are unavailable. This ensures requests can still be attempted instead of failing immediately.

## Key Changes

-  **Backend** : Updated 
getProviderCredentials
 logic to support forced selection of the least-rate-limited endpoint.
-  **UI** : Added a "Force Fallback" toggle in the Settings > Routing Strategy section.
-  **Storage** : Added a forceFallback persistent setting in the local database.