### PR TITLE
fix(usage): wrap useSearchParams in Suspense to fix Next 16 build failure

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -7,6 +7,14 @@ import ProviderLimits from "./components/ProviderLimits";
 import RequestDetailsTab from "./components/RequestDetailsTab";
 
 export default function UsagePage() {
+  return (
+    <Suspense fallback={<CardSkeleton />}>
+      <UsagePageContent />
+    </Suspense>
+  );
+}
+
+function UsagePageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [activeTab, setActiveTab] = useState(searchParams.get("tab") || "overview");


### PR DESCRIPTION
  Follow-up to 6caef7f5 *( feat: add URL-based tab state persistence in usage page )*.

  That change introduced useSearchParams in src/app/(dashboard)/dashboard/usage/page.js, but in Next.js 16 this hook must be rendered under a Suspense boundary. Without it, page build can fail in some environments/devices.

  This PR (commit 2505054a) applies a minimal fix:

  - Keep UsagePage as a Suspense wrapper with CardSkeleton fallback
  - Move hook usage into UsagePageContent (inside that boundary)

  No behavior change intended, only build compatibility/stability for Next 16.
