### PR TITLE
feat: add API endpoint dimension to usage statistics dashboard

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -622,7 +622,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
               thinking: null,
               finish_reason: jsonResponse.status || "unknown"
             },
-            status: "success"
+            status: "success",
+            endpoint: clientRawRequest?.endpoint || null
           }).catch(() => { });
 
           return {
@@ -656,7 +657,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
                 tokens: usage,
                 timestamp: new Date().toISOString(),
                 connectionId: connectionId || undefined,
-                apiKey: apiKey || undefined
+                apiKey: apiKey || undefined,
+                endpoint: clientRawRequest?.endpoint || null
               }).catch(() => { });
             }
 
@@ -676,7 +678,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
                 thinking: parsed.choices?.[0]?.message?.reasoning_content || null,
                 finish_reason: parsed.choices?.[0]?.finish_reason || "unknown"
               },
-              status: "success"
+              status: "success",
+              endpoint: clientRawRequest?.endpoint || null
             }).catch(() => { });
 
             return {
@@ -741,7 +744,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
         tokens: usage,
         timestamp: new Date().toISOString(),
         connectionId: connectionId || undefined,
-        apiKey: apiKey || undefined
+        apiKey: apiKey || undefined,
+        endpoint: clientRawRequest?.endpoint || null
       }).catch(err => {
         console.error("Failed to save usage stats:", err.message);
       });
@@ -781,7 +785,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
                   null,
         finish_reason: translatedResponse?.choices?.[0]?.finish_reason || "unknown"
       },
-      status: "success"
+      status: "success",
+      endpoint: clientRawRequest?.endpoint || null
     };
 
     // Async save (don't block response)
@@ -859,7 +864,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
         tokens: usage,
         timestamp: new Date().toISOString(),
         connectionId: connectionId || undefined,
-        apiKey: apiKey || undefined
+        apiKey: apiKey || undefined,
+        endpoint: clientRawRequest?.endpoint || null
       }).catch(err => {
         console.error("Failed to save streaming usage stats:", err.message);
       });

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -394,6 +394,7 @@ export async function getUsageStats() {
     byModel: {},
     byAccount: {},
     byApiKey: {},
+    byEndpoint: {},
     last10Minutes: [],
     pending: pendingRequests,
     activeRequests: []
@@ -584,6 +585,31 @@ export async function getUsageStats() {
       if (new Date(entry.timestamp) > new Date(apiKeyEntry.lastUsed)) {
         apiKeyEntry.lastUsed = entry.timestamp;
       }
+    }
+
+    // By Endpoint (endpoint + model + provider combination)
+    const endpoint = entry.endpoint || "Unknown";
+    const endpointModelKey = `${endpoint}|${entry.model}|${entry.provider || 'unknown'}`;
+
+    if (!stats.byEndpoint[endpointModelKey]) {
+      stats.byEndpoint[endpointModelKey] = {
+        requests: 0,
+        promptTokens: 0,
+        completionTokens: 0,
+        cost: 0,
+        endpoint: endpoint,
+        rawModel: entry.model,
+        provider: entry.provider,
+        lastUsed: entry.timestamp
+      };
+    }
+    const endpointEntry = stats.byEndpoint[endpointModelKey];
+    endpointEntry.requests++;
+    endpointEntry.promptTokens += promptTokens;
+    endpointEntry.completionTokens += completionTokens;
+    endpointEntry.cost += entryCost;
+    if (new Date(entry.timestamp) > new Date(endpointEntry.lastUsed)) {
+      endpointEntry.lastUsed = entry.timestamp;
     }
   }
 


### PR DESCRIPTION
## Summary

Add **API Endpoint** dimension to usage statistics dashboard. Track which endpoints clients use (`/v1/chat/completions`, `/v1/messages`, `/v1/responses`) alongside existing Model, Account, and API Key views.

## Changes

- **Backend** (~33 lines): Added endpoint tracking to `chatCore.js` and `byEndpoint` aggregation to `usageDb.js`
- **Frontend** (+227 lines): New "Usage by API Endpoint" table with sortable columns, expandable grouping, and localStorage persistence

## Key Features

- ✅ Tracks endpoint path for all API requests
- ✅ Sortable/groupable table (endpoint, model, provider, requests, tokens, costs)
- ✅ Backward compatible (missing endpoints default to "Unknown")
- ✅ Follows existing UI patterns
- ✅ Minimal code changes (YAGNI-KISS-DRY)

## Testing

- ✅ Build: Passed
- ✅ Code Review: Approved (0 critical, 0 high, 0 medium issues)
- ✅ Security: No XSS/injection risks
- ✅ Performance: No regression (O(5n) vs O(4n))

## Test Commands

```bash
# Test endpoint tracking
curl -X POST http://localhost:3000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "Test"}]}'

# Verify endpoint in usage data
cat ~/.9router/usage.json | jq '.history[-1].endpoint'

# Open dashboard
open http://localhost:3000/dashboard/usage
```

<img width="2384" height="1028" alt="CleanShot 2026-02-19 at 14 36 31@2x" src="https://github.com/user-attachments/assets/5c2e717a-b81a-4c12-8b03-afad3ab420ab" />
