### PR TITLE
feat: add pause/resume functionality for API keys

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -362,6 +362,7 @@ erDiagram
       string name
       string key
       string machineId
+      boolean isActive
     }
 
     USAGE_ENTRY {

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { Card, Button, Input, Modal, CardSkeleton } from "@/shared/components";
+import { Card, Button, Input, Modal, CardSkeleton, Toggle } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 
 const DEFAULT_CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL || "";
@@ -257,6 +257,21 @@ export default function APIPageClient({ machineId }) {
     }
   };
 
+  const handleToggleKey = async (id, isActive) => {
+    try {
+      const res = await fetch(`/api/keys/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isActive }),
+      });
+      if (res.ok) {
+        setKeys(prev => prev.map(k => k.id === id ? { ...k, isActive } : k));
+      }
+    } catch (error) {
+      console.log("Error toggling key:", error);
+    }
+  };
+
   const [baseUrl, setBaseUrl] = useState("/v1");
   const cloudEndpointNew = cloudUrl ? `${cloudUrl}/v1` : "";
 
@@ -377,7 +392,7 @@ export default function APIPageClient({ machineId }) {
             {keys.map((key) => (
               <div
                 key={key.id}
-                className="group flex items-center justify-between py-3 border-b border-black/[0.03] dark:border-white/[0.03] last:border-b-0"
+                className={`group flex items-center justify-between py-3 border-b border-black/[0.03] dark:border-white/[0.03] last:border-b-0 ${key.isActive === false ? "opacity-60" : ""}`}
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium">{key.name}</p>
@@ -395,13 +410,32 @@ export default function APIPageClient({ machineId }) {
                   <p className="text-xs text-text-muted mt-1">
                     Created {new Date(key.createdAt).toLocaleDateString()}
                   </p>
+                  {key.isActive === false && (
+                    <p className="text-xs text-orange-500 mt-1">Paused</p>
+                  )}
                 </div>
-                <button
-                  onClick={() => handleDeleteKey(key.id)}
-                  className="p-2 hover:bg-red-500/10 rounded text-red-500 opacity-0 group-hover:opacity-100 transition-all"
-                >
-                  <span className="material-symbols-outlined text-[18px]">delete</span>
-                </button>
+                <div className="flex items-center gap-2">
+                  <Toggle
+                    size="sm"
+                    checked={key.isActive ?? true}
+                    onChange={(checked) => {
+                      if (key.isActive && !checked) {
+                        if (confirm(`Pause API key "${key.name}"?\n\nThis key will stop working immediately but can be resumed later.`)) {
+                          handleToggleKey(key.id, checked);
+                        }
+                      } else {
+                        handleToggleKey(key.id, checked);
+                      }
+                    }}
+                    title={key.isActive ? "Pause key" : "Resume key"}
+                  />
+                  <button
+                    onClick={() => handleDeleteKey(key.id)}
+                    className="p-2 hover:bg-red-500/10 rounded text-red-500 opacity-0 group-hover:opacity-100 transition-all"
+                  >
+                    <span className="material-symbols-outlined text-[18px]">delete</span>
+                  </button>
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
Temporarily disable API keys without deletion. Paused keys fail validation (403) and can be resumed later.

## Changes
- **DB**: Added `isActive` field with auto-migration
- **API**: `PUT /api/keys/[id]` endpoint for toggle
- **UI**: Toggle switch with confirmation dialog
- **Validation**: Paused keys rejected immediately

## Testing
✅ 15/15 tests passed

## Usage
```bash
# Pause
curl -X PUT http://localhost:20128/api/keys/{id} \
  -d '{"isActive": false}'

# Resume
curl -X PUT http://localhost:20128/api/keys/{id} \
  -d '{"isActive": true}'
```

**No breaking changes** - existing keys auto-migrated to active.

<img width="2224" height="712" alt="CleanShot 2026-02-20 at 03 07 22@2x" src="https://github.com/user-attachments/assets/441f2f7a-f524-4d6d-870a-0e29b5d50af5" />

<img width="1334" height="1148" alt="CleanShot 2026-02-20 at 03 17 56@2x" src="https://github.com/user-attachments/assets/547ca679-dd7f-4bcf-99bc-f0d2be7b1628" />

