### PR TITLE
Fix: Add missing glm-cn provider definition for Web UI discovery

### DIFF
--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -23,6 +23,7 @@ export const OAUTH_PROVIDERS = {
 export const APIKEY_PROVIDERS = {
   openrouter: { id: "openrouter", alias: "openrouter", name: "OpenRouter", icon: "router", color: "#F97316", textIcon: "OR", passthroughModels: true, website: "https://openrouter.ai" },
   glm: { id: "glm", alias: "glm", name: "GLM Coding", icon: "code", color: "#2563EB", textIcon: "GL", website: "https://open.bigmodel.cn" },
+  "glm-cn": { id: "glm-cn", alias: "glm-cn", name: "GLM (China)", icon: "code", color: "#DC2626", textIcon: "GC", website: "https://open.bigmodel.cn" },
   kimi: { id: "kimi", alias: "kimi", name: "Kimi", icon: "psychology", color: "#1E3A8A", textIcon: "KM", website: "https://kimi.moonshot.cn" },
   minimax: { id: "minimax", alias: "minimax", name: "Minimax Coding", icon: "memory", color: "#7C3AED", textIcon: "MM", website: "https://www.minimaxi.com" },
   "minimax-cn": { id: "minimax-cn", alias: "minimax-cn", name: "Minimax (China)", icon: "memory", color: "#DC2626", textIcon: "MC", website: "https://www.minimaxi.com" },


### PR DESCRIPTION
## Problem

The "GLM (China)" option is not visible in Web UI, preventing users from selecting this provider.

## Root Cause

The `APIKEY_PROVIDERS` object in `src/shared/constants/providers.js` was missing the `glm-cn` definition, even though `open-sse/config/providerModels.js` contains glm-cn model definitions.

## Fix

Added `glm-cn` provider definition to `APIKEY_PROVIDERS`:

```javascript
"glm-cn": { id: "glm-cn", alias: "glm-cn", name: "GLM (China)", icon: "code", color: "#DC2626", textIcon: "GC", website: "https://open.bigmodel.cn" }
```

## Impact

- Modified file: `src/shared/constants/providers.js`
- Users can now see and select GLM (China) option in Web UI
- Follows the same pattern as minimax-cn (red color to indicate China region)