### PR TITLE
feat: add database backup import/export

### DIFF
--- a/src/app/api/settings/database/route.js
+++ b/src/app/api/settings/database/route.js
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { exportDb, importDb } from "@/lib/localDb";
+
+export async function GET() {
+  try {
+    const payload = await exportDb();
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.log("Error exporting database:", error);
+    return NextResponse.json({ error: "Failed to export database" }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const payload = await request.json();
+    await importDb(payload);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.log("Error importing database:", error);
+    return NextResponse.json(
+      { error: error?.message || "Failed to import database" },
+      { status: 400 }
+    );
+  }
+}

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -780,6 +780,41 @@ export async function updateSettings(updates) {
 }
 
 /**
+ * Export full database payload
+ */
+export async function exportDb() {
+  const db = await getDb();
+  return db.data || cloneDefaultData();
+}
+
+/**
+ * Import full database payload
+ */
+export async function importDb(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Invalid database payload");
+  }
+
+  const nextData = {
+    ...cloneDefaultData(),
+    ...payload,
+    settings: {
+      ...cloneDefaultData().settings,
+      ...(payload.settings && typeof payload.settings === "object" && !Array.isArray(payload.settings)
+        ? payload.settings
+        : {}),
+    },
+  };
+
+  const { data: normalized } = ensureDbShape(nextData);
+  const db = await getDb();
+  db.data = normalized;
+  await db.write();
+
+  return db.data;
+}
+
+/**
  * Check if cloud is enabled
  */
 export async function isCloudEnabled() {


### PR DESCRIPTION
Hi @decolua,
I’ve completed and submitted a Pull Request for the Database Backup and Restore functionality.
Key changes
- Added a new feature to export/download the database as a `.json` file.
- Added a new feature to upload and restore (import) data from an existing backup file.
- Added JSON format validation and error handling for invalid input to improve stability and prevent data corruption.
I’ve tested these features thoroughly in my local environment, and everything is working as expected.  
Looking forward to your feedback — I hope this can be merged soon.
Thanks!