### PR TITLE
feat: add API key visibility toggle in Endpoint dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Features
+- Added API key visibility toggle (eye icon) to Endpoint dashboard page for improved UX and security.
+
 # v0.2.66 (2026-02-06)
 
 ## Features


### PR DESCRIPTION
- Added eye icon button to show/hide individual API keys
- Keys hidden by default on page load for security

<img width="1912" height="1222" alt="CleanShot 2026-02-28 at 10 55 14@2x" src="https://github.com/user-attachments/assets/fe4fc98b-427f-4cd6-bf87-af8695ac8560" />

<img width="1810" height="1246" alt="CleanShot 2026-02-28 at 10 55 59@2x" src="https://github.com/user-attachments/assets/7001acaa-838c-4dd9-88cc-22cbee914d32" />
