### PR TITLE
fix: resolve GitHub Copilot 400 error for Claude models in Cursor IDE

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -172,16 +172,23 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
         : Array.isArray(msg.content)
           ? msg.content.map(c => {
             if (c.type === "text") return { type: contentType, text: c.text };
-            if (c.type === "image_url") return { type: contentType, text: "[Image content]" };
-            return c;
+            if (c.type === "image_url") return { type: "image_url", image_url: c.image_url };
+            // Serialize any unknown type (tool_use, tool_result, thinking, etc.) as text
+            const text = c.text || c.content || JSON.stringify(c);
+            return { type: contentType, text: typeof text === "string" ? text : JSON.stringify(text) };
           })
           : [];
 
-      result.input.push({
-        type: "message",
-        role: msg.role,
-        content
-      });
+      // Only push a message block if content is non-empty.
+      // Assistant messages with only tool_calls have content: null — skip the
+      // message block in that case; the tool_calls are pushed separately below.
+      if (content.length > 0) {
+        result.input.push({
+          type: "message",
+          role: msg.role,
+          content
+        });
+      }
     }
 
     // Convert tool calls


### PR DESCRIPTION
- github.js: add sanitizeMessages() to convert unsupported content types (tool_use, tool_result, thinking) to plain text before sending to GitHub /chat/completions endpoint
- openai-responses.js: skip pushing message blocks with empty content (e.g. assistant messages that only contain tool_calls)
- providerModels.js: revert targetFormat changes (not needed with sanitize fix)

Fixes: https://github.com/decolua/9router/issues/219