### PR TITLE
[URGENT] [SECURITY] fix(auth): wire up dashboard auth guard as Next.js proxy

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,0 +1,5 @@
+export { proxy } from "./dashboardGuard";
+
+export const config = {
+  matcher: ["/", "/dashboard/:path*"],
+};


### PR DESCRIPTION
## Problem

`/dashboard` routes accessible without authentication. The `src/dashboardGuard.js` has proper JWT verification logic but was **never connected** to Next.js middleware pipeline.

## Root Cause

- `dashboardGuard.js` exports `proxy` function + `config` matcher
- No `proxy.js` file existed at `src/` level
- Result: Auth guard completely inactive
                                                                                                                                                         
## Solution
                                                                                                                                                         
Created `src/proxy.js`:

```javascript
export { proxy } from "./dashboardGuard";

export const config = {
  matcher: ["/", "/dashboard/:path*"],
  };
  
  