### PR TITLE
Fix: Codex on Cursor - perf_metrics crash and missing SSE event prefix

### DIFF
--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -78,7 +78,20 @@ export function createSSEStream(options = {}) {
 
           if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
-              const parsed = JSON.parse(trimmed.slice(5).trim());
+              let parsed = JSON.parse(trimmed.slice(5).trim());
+
+              // Clean perf_metrics from usage (Cursor crashes: "Cannot read properties of null (reading 'perf_metrics')")
+              let perfMetricsCleaned = false;
+              if (parsed?.usage && typeof parsed.usage === "object" && "perf_metrics" in parsed.usage) {
+                const { perf_metrics, ...usageClean } = parsed.usage;
+                parsed = { ...parsed, usage: usageClean };
+                perfMetricsCleaned = true;
+              }
+              if (parsed?.response?.usage && typeof parsed.response.usage === "object" && "perf_metrics" in parsed.response.usage) {
+                const { perf_metrics, ...usageClean } = parsed.response.usage;
+                parsed = { ...parsed, response: { ...parsed.response, usage: usageClean } };
+                perfMetricsCleaned = true;
+              }
 
               const idFixed = fixInvalidId(parsed);
 
@@ -136,7 +149,7 @@ export function createSSEStream(options = {}) {
                 parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
-              } else if (idFixed || fieldsInjected) {
+              } else if (idFixed || fieldsInjected || perfMetricsCleaned) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               }

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -68,9 +68,13 @@ function cleanUsagePayload(payload) {
     if (cleaned.usage === null) {
       const { usage, ...payloadWithoutUsage } = cleaned;
       cleaned = payloadWithoutUsage;
-    } else if (typeof cleaned.usage === "object" && cleaned.usage.perf_metrics === null) {
-      const { perf_metrics, ...usageWithoutPerf } = cleaned.usage;
-      cleaned = { ...cleaned, usage: usageWithoutPerf };
+    } else if (typeof cleaned.usage === "object") {
+      // Remove perf_metrics regardless of value (null, undefined, or object) —
+      // Cursor crashes with "Cannot read properties of null (reading 'perf_metrics')"
+      if ("perf_metrics" in cleaned.usage) {
+        const { perf_metrics, ...usageWithoutPerf } = cleaned.usage;
+        cleaned = { ...cleaned, usage: usageWithoutPerf };
+      }
     }
   }
 
@@ -89,13 +93,19 @@ export function formatSSE(data, sourceFormat) {
   if (data === null || data === undefined) return "data: null\n\n";
   if (data && data.done) return "data: [DONE]\n\n";
 
-  // OpenAI Responses API format
+  // OpenAI Responses API format (structured { event, data })
   if (data && data.event && data.data) {
     const cleanedEventData = cleanUsagePayload(data.data);
     return `event: ${data.event}\ndata: ${JSON.stringify(cleanedEventData)}\n\n`;
   }
 
   data = cleanUsagePayload(data);
+
+  // OpenAI Responses API format (flat object with .type, e.g. from passthrough translate)
+  // Must emit with event: prefix so Cursor/clients can parse SSE event type
+  if (sourceFormat === FORMATS.OPENAI_RESPONSES && data && data.type && data.type.startsWith("response.")) {
+    return `event: ${data.type}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
 
   // Claude format
   if (sourceFormat === FORMATS.CLAUDE && data && data.type) {


### PR DESCRIPTION
## Summary
- Emit `event:` prefix for openai-responses flat objects in `formatSSE` so Cursor receives proper SSE events instead of raw `data:` lines.
- Remove `perf_metrics` from usage payload regardless of value (not only when null), fixing "Cannot read properties of null (reading 'perf_metrics')".
- Strip `perf_metrics` in passthrough mode in `stream.js` before forwarding.

## Problem
When using Codex (OpenAI provider) in Cursor IDE, the UI could crash with `Cannot read properties of null (reading 'perf_metrics')`. The Codex API returns `usage.perf_metrics: null` in streamed responses; clients that access this field without null checks fail. Additionally, when source and target format are both openai-responses, the stream was emitted without `event:` prefix, breaking clients that rely on it.

## Files changed
- `open-sse/utils/streamHelpers.js` — `cleanUsagePayload` and `formatSSE` (event prefix for response.* types)
- `open-sse/utils/stream.js` — passthrough: strip `perf_metrics` from usage/response.usage

## How to test
1. Use Cursor with Override OpenAI Base URL pointing to 9router and Codex model.
2. Send a chat completion (no image).
3. Confirm no "perf_metrics" crash and stream completes correctly.

Fixes #223

Made with [Cursor](https://cursor.com)