### PR TITLE
Fix: Codex image support - convert image_url to input_image format

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -34,6 +34,21 @@ export class CodexExecutor extends BaseExecutor {
       body.input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }];
     }
 
+    // Normalize image content: image_url → input_image (Responses API format)
+    if (Array.isArray(body.input)) {
+      for (const item of body.input) {
+        if (Array.isArray(item.content)) {
+          item.content = item.content.map(c => {
+            if (c.type === "image_url") {
+              const url = typeof c.image_url === "string" ? c.image_url : c.image_url?.url;
+              return { type: "input_image", image_url: url, detail: c.image_url?.detail || "auto" };
+            }
+            return c;
+          });
+        }
+      }
+    }
+
     // Ensure streaming is enabled (Codex API requires it)
     body.stream = true;
 

--- a/open-sse/translator/helpers/responsesApiHelper.js
+++ b/open-sse/translator/helpers/responsesApiHelper.js
@@ -56,11 +56,15 @@ export function convertResponsesApiFormat(body) {
         pendingToolResults = [];
       }
 
-      // Convert content: input_text → text, output_text → text
+      // Convert content: input_text → text, output_text → text, input_image → image_url
       const content = Array.isArray(item.content)
         ? item.content.map(c => {
           if (c.type === "input_text") return { type: "text", text: c.text };
           if (c.type === "output_text") return { type: "text", text: c.text };
+          if (c.type === "input_image") {
+            const url = c.image_url || c.file_id || "";
+            return { type: "image_url", image_url: { url, detail: c.detail || "auto" } };
+          }
           return c;
         })
         : item.content;

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -48,11 +48,15 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
         pendingToolResults = [];
       }
 
-      // Convert content: input_text → text, output_text → text
+      // Convert content: input_text → text, output_text → text, input_image → image_url
       const content = Array.isArray(item.content)
         ? item.content.map(c => {
           if (c.type === "input_text") return { type: "text", text: c.text };
           if (c.type === "output_text") return { type: "text", text: c.text };
+          if (c.type === "input_image") {
+            const url = c.image_url || c.file_id || "";
+            return { type: "image_url", image_url: { url, detail: c.detail || "auto" } };
+          }
           return c;
         })
         : item.content;
@@ -186,7 +190,14 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
         : Array.isArray(msg.content)
           ? msg.content.map(c => {
             if (c.type === "text") return { type: contentType, text: c.text };
-            if (c.type === "image_url") return { type: "image_url", image_url: c.image_url };
+            // Convert Chat Completions image_url → Responses API input_image
+            // Responses API expects: { type: "input_image", image_url: "<url string>" }
+            // Chat Completions sends: { type: "image_url", image_url: { url: "...", detail: "..." } }
+            if (c.type === "image_url") {
+              const url = typeof c.image_url === "string" ? c.image_url : c.image_url?.url;
+              return { type: "input_image", image_url: url, detail: c.image_url?.detail || "auto" };
+            }
+            if (c.type === "input_image") return c;
             // Serialize any unknown type (tool_use, tool_result, thinking, etc.) as text
             const text = c.text || c.content || JSON.stringify(c);
             return { type: contentType, text: typeof text === "string" ? text : JSON.stringify(text) };


### PR DESCRIPTION
## Summary
- Translate Chat Completions `image_url` content to Responses API `input_image` when sending to Codex.
- `image_url` in Responses API must be a string; Chat Completions sends `{ url, detail }` object.
- Bidirectional conversion in translator and safety net in Codex executor.

## Problem
Clients (e.g. curl, Codex CLI) sending images via 9router to Codex were failing because the proxy forwarded Chat Completions format (`type: "image_url"`, `image_url: { url, detail }`) while the Codex Responses API expects `type: "input_image"` and `image_url` as a string (per OpenAI docs).

## Files changed
- `open-sse/translator/request/openai-responses.js` — `image_url` → `input_image` (and `input_image` → `image_url` in reverse path)
- `open-sse/translator/helpers/responsesApiHelper.js` — `input_image` → `image_url` in Responses→Chat conversion
- `open-sse/executors/codex.js` — normalize image content in input items before sending to Codex API

## How to test
```bash
curl -X POST http://localhost:20128/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer YOUR_9ROUTER_KEY" \
  -d '{"model": "cx/gpt-5.3-codex", "messages": [{"role": "user", "content": [{"type": "text", "text": "describe this"}, {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}]}], "stream": false}'
```
Expect 200 and a description of the image from Codex.

**Note:** Cursor IDE has a known bug where image requests bypass the Override OpenAI Base URL and are sent to api.openai.com; this fix is effective for other clients that route through the proxy.

Made with [Cursor](https://cursor.com)