### PR TITLE
fix missing 'node-forge' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lowdb": "^7.0.1",
     "monaco-editor": "^0.55.1",
     "next": "^16.1.6",
+    "node-forge": "^1.3.1",
     "node-machine-id": "^1.1.12",
     "open": "^11.0.0",
     "ora": "^9.1.0",


### PR DESCRIPTION
Missing 'node-forge' in package.json.
'node-forge' is used in src/mitm/cert/rootCA.js 