### PR TITLE
Wire dashboard views to the shared translation runtime

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/CLIToolsPageClient.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/CLIToolsPageClient.js
@@ -5,6 +5,7 @@ import { Card, CardSkeleton } from "@/shared/components";
 import { CLI_TOOLS } from "@/shared/constants/cliTools";
 import { getModelsByProviderId, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
 import { ClaudeToolCard, CodexToolCard, DroidToolCard, OpenClawToolCard, DefaultToolCard, OpenCodeToolCard } from "./components";
+import { translate } from "@/i18n/runtime";
 
 const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL;
 
@@ -194,8 +195,8 @@ export default function CLIToolsPageClient({ machineId }) {
           <div className="flex items-center gap-3">
             <span className="material-symbols-outlined text-yellow-500">warning</span>
             <div>
-              <p className="font-medium text-yellow-600 dark:text-yellow-400">No active providers</p>
-              <p className="text-sm text-text-muted">Please add and connect providers first to configure CLI tools.</p>
+              <p className="font-medium text-yellow-600 dark:text-yellow-400">{translate("No active providers")}</p>
+              <p className="text-sm text-text-muted">{translate("Please add and connect providers first to configure CLI tools.")}</p>
             </div>
           </div>
         </Card>

--- a/src/app/(dashboard)/dashboard/cli-tools/components/ClaudeToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/ClaudeToolCard.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Card, Button, ModelSelectModal, ManualConfigModal } from "@/shared/components";
 import Image from "next/image";
+import { translate } from "@/i18n/runtime";
 
 const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL;
 
@@ -145,10 +146,10 @@ export default function ClaudeToolCard({
       });
       const data = await res.json();
       if (res.ok) {
-        setMessage({ type: "success", text: "Settings applied successfully!" });
+        setMessage({ type: "success", text: translate("Settings applied successfully!") });
         setClaudeStatus(prev => ({ ...prev, hasBackup: true, settings: { ...prev?.settings, env } }));
       } else {
-        setMessage({ type: "error", text: data.error || "Failed to apply settings" });
+        setMessage({ type: "error", text: data.error || translate("Failed to apply settings") });
       }
     } catch (error) {
       setMessage({ type: "error", text: error.message });
@@ -164,11 +165,11 @@ export default function ClaudeToolCard({
       const res = await fetch("/api/cli-tools/claude-settings", { method: "DELETE" });
       const data = await res.json();
       if (res.ok) {
-        setMessage({ type: "success", text: "Settings reset successfully!" });
+        setMessage({ type: "success", text: translate("Settings reset successfully!") });
         tool.defaultModels.forEach((model) => onModelMappingChange(model.alias, model.defaultValue || ""));
         setSelectedApiKey("");
       } else {
-        setMessage({ type: "error", text: data.error || "Failed to reset settings" });
+        setMessage({ type: "error", text: data.error || translate("Failed to reset settings") });
       }
     } catch (error) {
       setMessage({ type: "error", text: error.message });
@@ -215,9 +216,9 @@ export default function ClaudeToolCard({
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <h3 className="font-medium text-sm">{tool.name}</h3>
-              {configStatus === "configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 rounded-full">Connected</span>}
-              {configStatus === "not_configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 rounded-full">Not configured</span>}
-              {configStatus === "other" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 rounded-full">Other</span>}
+              {configStatus === "configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 rounded-full">{translate("Connected")}</span>}
+              {configStatus === "not_configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 rounded-full">{translate("Not configured")}</span>}
+              {configStatus === "other" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 rounded-full">{translate("Other")}</span>}
             </div>
             <p className="text-xs text-text-muted truncate">{tool.description}</p>
           </div>
@@ -230,7 +231,7 @@ export default function ClaudeToolCard({
           {checkingClaude && (
             <div className="flex items-center gap-2 text-text-muted">
               <span className="material-symbols-outlined animate-spin">progress_activity</span>
-              <span>Checking Claude CLI...</span>
+              <span>{translate("Checking Claude CLI...")}</span>
             </div>
           )}
 
@@ -239,23 +240,23 @@ export default function ClaudeToolCard({
               <div className="flex items-center gap-3 p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
                 <span className="material-symbols-outlined text-yellow-500">warning</span>
                 <div className="flex-1">
-                  <p className="font-medium text-yellow-600 dark:text-yellow-400">Claude CLI not installed</p>
-                  <p className="text-sm text-text-muted">Please install Claude CLI to use this feature.</p>
+                  <p className="font-medium text-yellow-600 dark:text-yellow-400">{translate("Claude CLI not installed")}</p>
+                  <p className="text-sm text-text-muted">{translate("Please install Claude CLI to use this feature.")}</p>
                 </div>
                 <Button variant="outline" size="sm" onClick={() => setShowInstallGuide(!showInstallGuide)}>
                   <span className="material-symbols-outlined text-[18px] mr-1">{showInstallGuide ? "expand_less" : "help"}</span>
-                  {showInstallGuide ? "Hide" : "How to Install"}
+                  {showInstallGuide ? translate("Hide") : translate("How to Install")}
                 </Button>
               </div>
               {showInstallGuide && (
                 <div className="p-4 bg-surface border border-border rounded-lg">
-                  <h4 className="font-medium mb-3">Installation Guide</h4>
+                  <h4 className="font-medium mb-3">{translate("Installation Guide")}</h4>
                   <div className="space-y-3 text-sm">
                     <div>
-                      <p className="text-text-muted mb-1">macOS / Linux / Windows:</p>
+                      <p className="text-text-muted mb-1">{translate("macOS / Linux / Windows:")}</p>
                       <code className="block px-3 py-2 bg-black/5 dark:bg-white/5 rounded font-mono text-xs">npm install -g @anthropic-ai/claude-code</code>
                     </div>
-                    <p className="text-text-muted">After installation, run <code className="px-1 bg-black/5 dark:bg-white/5 rounded">claude</code> to verify.</p>
+                    <p className="text-text-muted">{translate("After installation, run")} <code className="px-1 bg-black/5 dark:bg-white/5 rounded">claude</code> {translate("to verify.")}</p>
                   </div>
                 </div>
               )}
@@ -268,7 +269,7 @@ export default function ClaudeToolCard({
                 {/* Current Base URL */}
                 {claudeStatus?.settings?.env?.ANTHROPIC_BASE_URL && (
                   <div className="flex items-center gap-2">
-                    <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">Current</span>
+                    <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{translate("Current")}</span>
                     <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
                     <span className="flex-1 px-2 py-1.5 text-xs text-text-muted truncate">
                       {claudeStatus.settings.env.ANTHROPIC_BASE_URL}
@@ -278,7 +279,7 @@ export default function ClaudeToolCard({
 
                 {/* Base URL */}
                 <div className="flex items-center gap-2">
-                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">Base URL</span>
+                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{translate("Base URL")}</span>
                   <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
                   <input 
                     type="text" 
@@ -288,7 +289,7 @@ export default function ClaudeToolCard({
                     className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50" 
                   />
                   {customBaseUrl && customBaseUrl !== baseUrl && (
-                    <button onClick={() => setCustomBaseUrl("")} className="p-1 text-text-muted hover:text-primary rounded transition-colors" title="Reset to default">
+                    <button onClick={() => setCustomBaseUrl("")} className="p-1 text-text-muted hover:text-primary rounded transition-colors" title={translate("Reset to default")}>
                       <span className="material-symbols-outlined text-[14px]">restart_alt</span>
                     </button>
                   )}
@@ -296,7 +297,7 @@ export default function ClaudeToolCard({
 
                 {/* API Key */}
                 <div className="flex items-center gap-2">
-                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">API Key</span>
+                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{translate("API Key")}</span>
                   <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
                   {apiKeys.length > 0 ? (
                     <select value={selectedApiKey} onChange={(e) => setSelectedApiKey(e.target.value)} className="flex-1 px-2 py-1.5 bg-surface rounded text-xs border border-border focus:outline-none focus:ring-1 focus:ring-primary/50">
@@ -304,7 +305,7 @@ export default function ClaudeToolCard({
                     </select>
                   ) : (
                     <span className="flex-1 text-xs text-text-muted px-2 py-1.5">
-                      {cloudEnabled ? "No API keys - Create one in Keys page" : "sk_9router (default)"}
+                      {cloudEnabled ? translate("No API keys - Create one in Keys page") : "sk_9router (default)"}
                     </span>
                   )}
                 </div>
@@ -315,8 +316,8 @@ export default function ClaudeToolCard({
                     <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{model.name}</span>
                     <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
                     <input type="text" value={modelMappings[model.alias] || ""} onChange={(e) => onModelMappingChange(model.alias, e.target.value)} placeholder="provider/model-id" className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50" />
-                    <button onClick={() => openModelSelector(model.alias)} disabled={!hasActiveProviders} className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>Select Model</button>
-                    {modelMappings[model.alias] && <button onClick={() => onModelMappingChange(model.alias, "")} className="p-1 text-text-muted hover:text-red-500 rounded transition-colors" title="Clear"><span className="material-symbols-outlined text-[14px]">close</span></button>}
+                    <button onClick={() => openModelSelector(model.alias)} disabled={!hasActiveProviders} className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>{translate("Select Model")}</button>
+                    {modelMappings[model.alias] && <button onClick={() => onModelMappingChange(model.alias, "")} className="p-1 text-text-muted hover:text-red-500 rounded transition-colors" title={translate("Clear")}><span className="material-symbols-outlined text-[14px]">close</span></button>}
                   </div>
                 ))}
               </div>
@@ -330,13 +331,13 @@ export default function ClaudeToolCard({
 
               <div className="flex items-center gap-2">
                 <Button variant="primary" size="sm" onClick={handleApplySettings} disabled={!hasActiveProviders} loading={applying}>
-                  <span className="material-symbols-outlined text-[14px] mr-1">save</span>Apply
+                  <span className="material-symbols-outlined text-[14px] mr-1">save</span>{translate("Apply")}
                 </Button>
                 <Button variant="outline" size="sm" onClick={handleResetSettings} disabled={!claudeStatus?.has9Router} loading={restoring}>
-                  <span className="material-symbols-outlined text-[14px] mr-1">restore</span>Reset
+                  <span className="material-symbols-outlined text-[14px] mr-1">restore</span>{translate("Reset")}
                 </Button>
                 <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>
-                  <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>Manual Config
+                  <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>{translate("Manual Config")}
                 </Button>
               </div>
             </>
@@ -344,12 +345,12 @@ export default function ClaudeToolCard({
         </div>
       )}
 
-      <ModelSelectModal isOpen={modalOpen} onClose={() => setModalOpen(false)} onSelect={handleModelSelect} selectedModel={currentEditingAlias ? modelMappings[currentEditingAlias] : null} activeProviders={activeProviders} modelAliases={modelAliases} title={`Select model for ${currentEditingAlias}`} />
-      
+      <ModelSelectModal isOpen={modalOpen} onClose={() => setModalOpen(false)} onSelect={handleModelSelect} selectedModel={currentEditingAlias ? modelMappings[currentEditingAlias] : null} activeProviders={activeProviders} modelAliases={modelAliases} title={`${translate("Select model for")} ${currentEditingAlias}`} />
+
       <ManualConfigModal
         isOpen={showManualConfigModal}
         onClose={() => setShowManualConfigModal(false)}
-        title="Claude CLI - Manual Configuration"
+        title={translate("Claude CLI - Manual Configuration")}
         configs={getManualConfigs()}
       />
     </Card>

--- a/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Card, Button, ModelSelectModal, ManualConfigModal } from "@/shared/components";
 import Image from "next/image";
+import { translate } from "@/i18n/runtime";
 
 export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, apiKeys, activeProviders, cloudEnabled, initialStatus }) {
   const [codexStatus, setCodexStatus] = useState(initialStatus || null);
@@ -100,10 +101,10 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
       });
       const data = await res.json();
       if (res.ok) {
-        setMessage({ type: "success", text: "Settings applied successfully!" });
+        setMessage({ type: "success", text: translate("Settings applied successfully!") });
         checkCodexStatus();
       } else {
-        setMessage({ type: "error", text: data.error || "Failed to apply settings" });
+        setMessage({ type: "error", text: data.error || translate("Failed to apply settings") });
       }
     } catch (error) {
       setMessage({ type: "error", text: error.message });
@@ -119,11 +120,11 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
       const res = await fetch("/api/cli-tools/codex-settings", { method: "DELETE" });
       const data = await res.json();
       if (res.ok) {
-        setMessage({ type: "success", text: "Settings reset successfully!" });
+        setMessage({ type: "success", text: translate("Settings reset successfully!") });
         setSelectedModel("");
         checkCodexStatus();
       } else {
-        setMessage({ type: "error", text: data.error || "Failed to reset settings" });
+        setMessage({ type: "error", text: data.error || translate("Failed to reset settings") });
       }
     } catch (error) {
       setMessage({ type: "error", text: error.message });
@@ -178,9 +179,9 @@ wire_api = "responses"
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <h3 className="font-medium text-sm">{tool.name}</h3>
-              {configStatus === "configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 rounded-full">Connected</span>}
-              {configStatus === "not_configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 rounded-full">Not configured</span>}
-              {configStatus === "other" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 rounded-full">Other</span>}
+              {configStatus === "configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 rounded-full">{translate("Connected")}</span>}
+              {configStatus === "not_configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 rounded-full">{translate("Not configured")}</span>}
+              {configStatus === "other" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 rounded-full">{translate("Other")}</span>}
             </div>
             <p className="text-xs text-text-muted truncate">{tool.description}</p>
           </div>
@@ -193,7 +194,7 @@ wire_api = "responses"
           {checkingCodex && (
             <div className="flex items-center gap-2 text-text-muted">
               <span className="material-symbols-outlined animate-spin">progress_activity</span>
-              <span>Checking Codex CLI...</span>
+              <span>{translate("Checking Codex CLI...")}</span>
             </div>
           )}
 
@@ -202,27 +203,27 @@ wire_api = "responses"
               <div className="flex items-center gap-3 p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
                 <span className="material-symbols-outlined text-yellow-500">warning</span>
                 <div className="flex-1">
-                  <p className="font-medium text-yellow-600 dark:text-yellow-400">Codex CLI not installed</p>
-                  <p className="text-sm text-text-muted">Please install Codex CLI to use auto-apply feature.</p>
+                  <p className="font-medium text-yellow-600 dark:text-yellow-400">{translate("Codex CLI not installed")}</p>
+                  <p className="text-sm text-text-muted">{translate("Please install Codex CLI to use auto-apply feature.")}</p>
                 </div>
                 <Button variant="outline" size="sm" onClick={() => setShowInstallGuide(!showInstallGuide)}>
                   <span className="material-symbols-outlined text-[18px] mr-1">{showInstallGuide ? "expand_less" : "help"}</span>
-                  {showInstallGuide ? "Hide" : "How to Install"}
+                  {showInstallGuide ? translate("Hide") : translate("How to Install")}
                 </Button>
               </div>
               {showInstallGuide && (
                 <div className="p-4 bg-surface border border-border rounded-lg">
-                  <h4 className="font-medium mb-3">Installation Guide</h4>
+                  <h4 className="font-medium mb-3">{translate("Installation Guide")}</h4>
                   <div className="space-y-3 text-sm">
                     <div>
-                      <p className="text-text-muted mb-1">macOS / Linux / Windows:</p>
+                      <p className="text-text-muted mb-1">{translate("macOS / Linux / Windows:")}</p>
                       <code className="block px-3 py-2 bg-black/5 dark:bg-white/5 rounded font-mono text-xs">npm install -g @openai/codex</code>
                     </div>
-                    <p className="text-text-muted">After installation, run <code className="px-1 bg-black/5 dark:bg-white/5 rounded">codex</code> to verify.</p>
+                    <p className="text-text-muted">{translate("After installation, run")} <code className="px-1 bg-black/5 dark:bg-white/5 rounded">codex</code> {translate("to verify.")}</p>
                     <div className="pt-2 border-t border-border">
                       <p className="text-text-muted text-xs">
-                        Codex uses <code className="px-1 bg-black/5 dark:bg-white/5 rounded">~/.codex/auth.json</code> with <code className="px-1 bg-black/5 dark:bg-white/5 rounded">OPENAI_API_KEY</code>. 
-                        Click &quot;Apply&quot; to auto-configure.
+                        {translate("Codex uses")} <code className="px-1 bg-black/5 dark:bg-white/5 rounded">~/.codex/auth.json</code> {translate("with")} <code className="px-1 bg-black/5 dark:bg-white/5 rounded">OPENAI_API_KEY</code>.
+                        {translate("Click \"Apply\" to auto-configure.")}
                       </p>
                     </div>
                   </div>
@@ -240,7 +241,7 @@ wire_api = "responses"
                   const currentBaseUrl = parsed ? parsed[1] : null;
                   return currentBaseUrl ? (
                     <div className="flex items-center gap-2">
-                      <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">Current</span>
+                      <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{translate("Current")}</span>
                       <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
                       <span className="flex-1 px-2 py-1.5 text-xs text-text-muted truncate">
                         {currentBaseUrl}
@@ -251,17 +252,17 @@ wire_api = "responses"
 
                 {/* Base URL */}
                 <div className="flex items-center gap-2">
-                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">Base URL</span>
+                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{translate("Base URL")}</span>
                   <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
-                  <input 
-                    type="text" 
-                    value={getDisplayUrl()} 
-                    onChange={(e) => setCustomBaseUrl(e.target.value)} 
-                    placeholder="https://.../v1" 
-                    className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50" 
+                  <input
+                    type="text"
+                    value={getDisplayUrl()}
+                    onChange={(e) => setCustomBaseUrl(e.target.value)}
+                    placeholder="https://.../v1"
+                    className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50"
                   />
                   {customBaseUrl && customBaseUrl !== `${baseUrl}/v1` && (
-                    <button onClick={() => setCustomBaseUrl("")} className="p-1 text-text-muted hover:text-primary rounded transition-colors" title="Reset to default">
+                    <button onClick={() => setCustomBaseUrl("")} className="p-1 text-text-muted hover:text-primary rounded transition-colors" title={translate("Reset to default")}>
                       <span className="material-symbols-outlined text-[14px]">restart_alt</span>
                     </button>
                   )}
@@ -269,7 +270,7 @@ wire_api = "responses"
 
                 {/* API Key */}
                 <div className="flex items-center gap-2">
-                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">API Key</span>
+                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{translate("API Key")}</span>
                   <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
                   {apiKeys.length > 0 ? (
                     <select value={selectedApiKey} onChange={(e) => setSelectedApiKey(e.target.value)} className="flex-1 px-2 py-1.5 bg-surface rounded text-xs border border-border focus:outline-none focus:ring-1 focus:ring-primary/50">
@@ -277,18 +278,18 @@ wire_api = "responses"
                     </select>
                   ) : (
                     <span className="flex-1 text-xs text-text-muted px-2 py-1.5">
-                      {cloudEnabled ? "No API keys - Create one in Keys page" : "sk_9router (default)"}
+                      {cloudEnabled ? translate("No API keys - Create one in Keys page") : "sk_9router (default)"}
                     </span>
                   )}
                 </div>
 
                 {/* Model */}
                 <div className="flex items-center gap-2">
-                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">Model</span>
+                  <span className="w-32 shrink-0 text-sm font-semibold text-text-main text-right">{translate("Model")}</span>
                   <span className="material-symbols-outlined text-text-muted text-[14px]">arrow_forward</span>
                   <input type="text" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)} placeholder="provider/model-id" className="flex-1 px-2 py-1.5 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50" />
-                  <button onClick={() => setModalOpen(true)} disabled={!activeProviders?.length} className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${activeProviders?.length ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>Select Model</button>
-                  {selectedModel && <button onClick={() => setSelectedModel("")} className="p-1 text-text-muted hover:text-red-500 rounded transition-colors" title="Clear"><span className="material-symbols-outlined text-[14px]">close</span></button>}
+                  <button onClick={() => setModalOpen(true)} disabled={!activeProviders?.length} className={`px-2 py-1.5 rounded border text-xs transition-colors shrink-0 whitespace-nowrap ${activeProviders?.length ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>{translate("Select Model")}</button>
+                  {selectedModel && <button onClick={() => setSelectedModel("")} className="p-1 text-text-muted hover:text-red-500 rounded transition-colors" title={translate("Clear")}><span className="material-symbols-outlined text-[14px]">close</span></button>}
                 </div>
               </div>
 
@@ -301,13 +302,13 @@ wire_api = "responses"
 
               <div className="flex items-center gap-2">
                 <Button variant="primary" size="sm" onClick={handleApplySettings} disabled={!selectedApiKey || !selectedModel} loading={applying}>
-                  <span className="material-symbols-outlined text-[14px] mr-1">save</span>Apply
+                  <span className="material-symbols-outlined text-[14px] mr-1">save</span>{translate("Apply")}
                 </Button>
                 <Button variant="outline" size="sm" onClick={handleResetSettings} disabled={!codexStatus.has9Router} loading={restoring}>
-                  <span className="material-symbols-outlined text-[14px] mr-1">restore</span>Reset
+                  <span className="material-symbols-outlined text-[14px] mr-1">restore</span>{translate("Reset")}
                 </Button>
                 <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>
-                  <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>Manual Config
+                  <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>{translate("Manual Config")}
                 </Button>
               </div>
             </>
@@ -322,13 +323,13 @@ wire_api = "responses"
         selectedModel={selectedModel}
         activeProviders={activeProviders}
         modelAliases={modelAliases}
-        title="Select Model for Codex"
+        title={translate("Select Model for Codex")}
       />
 
       <ManualConfigModal
         isOpen={showManualConfigModal}
         onClose={() => setShowManualConfigModal(false)}
-        title="Codex CLI - Manual Configuration"
+        title={translate("Codex CLI - Manual Configuration")}
         configs={getManualConfigs()}
       />
     </Card>

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Card, Button, Modal, Input, CardSkeleton, ModelSelectModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
+import { translate } from "@/i18n/runtime";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
@@ -52,7 +53,7 @@ export default function CombosPage() {
         setShowCreateModal(false);
       } else {
         const err = await res.json();
-        alert(err.error || "Failed to create combo");
+        alert(err.error || translate("Failed to create combo"));
       }
     } catch (error) {
       console.log("Error creating combo:", error);
@@ -71,7 +72,7 @@ export default function CombosPage() {
         setEditingCombo(null);
       } else {
         const err = await res.json();
-        alert(err.error || "Failed to update combo");
+        alert(err.error || translate("Failed to update combo"));
       }
     } catch (error) {
       console.log("Error updating combo:", error);
@@ -79,7 +80,7 @@ export default function CombosPage() {
   };
 
   const handleDelete = async (id) => {
-    if (!confirm("Delete this combo?")) return;
+    if (!confirm(translate("Delete this combo?"))) return;
     try {
       const res = await fetch(`/api/combos/${id}`, { method: "DELETE" });
       if (res.ok) {
@@ -104,13 +105,13 @@ export default function CombosPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold">Combos</h1>
+          <h1 className="text-2xl font-semibold">{translate("Combos")}</h1>
           <p className="text-sm text-text-muted mt-1">
-            Create model combos with fallback support
+            {translate("Create model combos with fallback support")}
           </p>
         </div>
         <Button icon="add" onClick={() => setShowCreateModal(true)}>
-          Create Combo
+          {translate("Create Combo")}
         </Button>
       </div>
 
@@ -121,10 +122,10 @@ export default function CombosPage() {
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 text-primary mb-4">
               <span className="material-symbols-outlined text-[32px]">layers</span>
             </div>
-            <p className="text-text-main font-medium mb-1">No combos yet</p>
-            <p className="text-sm text-text-muted mb-4">Create model combos with fallback support</p>
+            <p className="text-text-main font-medium mb-1">{translate("No combos yet")}</p>
+            <p className="text-sm text-text-muted mb-4">{translate("Create model combos with fallback support")}</p>
             <Button icon="add" onClick={() => setShowCreateModal(true)}>
-              Create Combo
+              {translate("Create Combo")}
             </Button>
           </div>
         </Card>
@@ -179,7 +180,7 @@ function ComboCard({ combo, copied, onCopy, onEdit, onDelete }) {
               <button
                 onClick={(e) => { e.stopPropagation(); onCopy(combo.name, `combo-${combo.id}`); }}
                 className="p-0.5 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary transition-colors opacity-0 group-hover:opacity-100"
-                title="Copy combo name"
+                title={translate("Copy combo name")}
               >
                 <span className="material-symbols-outlined text-[14px]">
                   {copied === `combo-${combo.id}` ? "check" : "content_copy"}
@@ -188,7 +189,7 @@ function ComboCard({ combo, copied, onCopy, onEdit, onDelete }) {
             </div>
             <div className="flex items-center gap-1 mt-0.5 flex-wrap">
               {combo.models.length === 0 ? (
-                <span className="text-xs text-text-muted italic">No models</span>
+                <span className="text-xs text-text-muted italic">{translate("No models")}</span>
               ) : (
                 combo.models.slice(0, 3).map((model, index) => (
                   <code key={index} className="text-[10px] font-mono bg-black/5 dark:bg-white/5 px-1.5 py-0.5 rounded text-text-muted">
@@ -197,7 +198,7 @@ function ComboCard({ combo, copied, onCopy, onEdit, onDelete }) {
                 ))
               )}
               {combo.models.length > 3 && (
-                <span className="text-[10px] text-text-muted">+{combo.models.length - 3} more</span>
+                <span className="text-[10px] text-text-muted">+{combo.models.length - 3} {translate("more")}</span>
               )}
             </div>
           </div>
@@ -208,14 +209,14 @@ function ComboCard({ combo, copied, onCopy, onEdit, onDelete }) {
           <button
             onClick={onEdit}
             className="p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary transition-colors"
-            title="Edit"
+            title={translate("Edit")}
           >
             <span className="material-symbols-outlined text-[16px]">edit</span>
           </button>
           <button
             onClick={onDelete}
             className="p-1.5 hover:bg-red-500/10 rounded text-red-500 transition-colors"
-            title="Delete"
+            title={translate("Delete")}
           >
             <span className="material-symbols-outlined text-[16px]">delete</span>
           </button>
@@ -261,7 +262,7 @@ function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown
         <div
           className="flex-1 min-w-0 px-1.5 py-0.5 text-xs font-mono text-text-main truncate cursor-text hover:bg-black/5 dark:hover:bg-white/5 rounded"
           onClick={() => setEditing(true)}
-          title="Click to edit"
+          title={translate("Click to edit")}
         >
           {model}
         </div>
@@ -273,7 +274,7 @@ function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown
           onClick={onMoveUp}
           disabled={isFirst}
           className={`p-0.5 rounded ${isFirst ? "text-text-muted/20 cursor-not-allowed" : "text-text-muted hover:text-primary hover:bg-black/5 dark:hover:bg-white/5"}`}
-          title="Move up"
+          title={translate("Move up")}
         >
           <span className="material-symbols-outlined text-[12px]">arrow_upward</span>
         </button>
@@ -281,7 +282,7 @@ function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown
           onClick={onMoveDown}
           disabled={isLast}
           className={`p-0.5 rounded ${isLast ? "text-text-muted/20 cursor-not-allowed" : "text-text-muted hover:text-primary hover:bg-black/5 dark:hover:bg-white/5"}`}
-          title="Move down"
+          title={translate("Move down")}
         >
           <span className="material-symbols-outlined text-[12px]">arrow_downward</span>
         </button>
@@ -291,7 +292,7 @@ function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown
       <button
         onClick={onRemove}
         className="p-0.5 hover:bg-red-500/10 rounded text-text-muted hover:text-red-500 transition-all"
-        title="Remove"
+        title={translate("Remove")}
       >
         <span className="material-symbols-outlined text-[12px]">close</span>
       </button>
@@ -325,11 +326,11 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
 
   const validateName = (value) => {
     if (!value.trim()) {
-      setNameError("Name is required");
+      setNameError(translate("Name is required"));
       return false;
     }
     if (!VALID_NAME_REGEX.test(value)) {
-      setNameError("Only letters, numbers, - and _ allowed");
+      setNameError(translate("Only letters, numbers, - and _ allowed"));
       return false;
     }
     setNameError("");
@@ -381,31 +382,31 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
       <Modal
         isOpen={isOpen}
         onClose={onClose}
-        title={isEdit ? "Edit Combo" : "Create Combo"}
+        title={isEdit ? translate("Edit Combo") : translate("Create Combo")}
       >
         <div className="flex flex-col gap-3">
           {/* Name */}
           <div>
             <Input
-              label="Combo Name"
+              label={translate("Combo Name")}
               value={name}
               onChange={handleNameChange}
               placeholder="my-combo"
               error={nameError}
             />
             <p className="text-[10px] text-text-muted mt-0.5">
-              Only letters, numbers, - and _ allowed
+              {translate("Only letters, numbers, - and _ allowed")}
             </p>
           </div>
 
           {/* Models */}
           <div>
-            <label className="text-sm font-medium mb-1.5 block">Models</label>
+            <label className="text-sm font-medium mb-1.5 block">{translate("Models")}</label>
 
             {models.length === 0 ? (
               <div className="text-center py-4 border border-dashed border-black/10 dark:border-white/10 rounded-lg bg-black/[0.01] dark:bg-white/[0.01]">
                 <span className="material-symbols-outlined text-text-muted text-xl mb-1">layers</span>
-                <p className="text-xs text-text-muted">No models added yet</p>
+                <p className="text-xs text-text-muted">{translate("No models added yet")}</p>
               </div>
             ) : (
               <div className="flex flex-col gap-1 max-h-[200px] overflow-y-auto">
@@ -435,14 +436,14 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
               className="w-full mt-2 py-2 border border-dashed border-black/10 dark:border-white/10 rounded-lg text-xs text-text-muted hover:text-primary hover:border-primary/30 transition-colors flex items-center justify-center gap-1"
             >
               <span className="material-symbols-outlined text-[16px]">add</span>
-              Add Model
+              {translate("Add Model")}
             </button>
           </div>
 
           {/* Actions */}
           <div className="flex gap-2 pt-1">
             <Button onClick={onClose} variant="ghost" fullWidth size="sm">
-              Cancel
+              {translate("Cancel")}
             </Button>
             <Button
               onClick={handleSave}
@@ -450,7 +451,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
               size="sm"
               disabled={!name.trim() || !!nameError || saving}
             >
-              {saving ? "Saving..." : isEdit ? "Save" : "Create"}
+              {saving ? translate("Saving...") : isEdit ? translate("Save") : translate("Create")}
             </Button>
           </div>
         </div>
@@ -463,7 +464,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders }) {
         onSelect={handleAddModel}
         activeProviders={activeProviders}
         modelAliases={modelAliases}
-        title="Add Model to Combo"
+        title={translate("Add Model to Combo")}
       />
     </>
   );

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -5,6 +5,7 @@ import { Card, Button, Toggle, Input } from "@/shared/components";
 import { useTheme } from "@/shared/hooks/useTheme";
 import { cn } from "@/shared/utils/cn";
 import { APP_CONFIG } from "@/shared/constants/config";
+import { translate } from "@/i18n/runtime";
 
 export default function ProfilePage() {
   const { theme, setTheme, isDark } = useTheme();
@@ -62,12 +63,12 @@ export default function ProfilePage() {
       const data = await res.json();
       if (res.ok) {
         setSettings((prev) => ({ ...prev, ...data }));
-        setProxyStatus({ type: "success", message: "Proxy settings applied" });
+        setProxyStatus({ type: "success", message: translate("Proxy settings applied") });
       } else {
-        setProxyStatus({ type: "error", message: data.error || "Failed to update proxy settings" });
+        setProxyStatus({ type: "error", message: data.error || translate("Failed to update proxy settings") });
       }
     } catch (err) {
-      setProxyStatus({ type: "error", message: "An error occurred" });
+      setProxyStatus({ type: "error", message: translate("An error occurred") });
     } finally {
       setProxyLoading(false);
     }
@@ -78,7 +79,7 @@ export default function ProfilePage() {
 
     const proxyUrl = (proxyForm.outboundProxyUrl || "").trim();
     if (!proxyUrl) {
-      setProxyStatus({ type: "error", message: "Please enter a Proxy URL to test" });
+      setProxyStatus({ type: "error", message: translate("Please enter a Proxy URL to test") });
       return;
     }
 
@@ -96,16 +97,16 @@ export default function ProfilePage() {
       if (res.ok && data?.ok) {
         setProxyStatus({
           type: "success",
-          message: `Proxy test OK (${data.status}) in ${data.elapsedMs}ms`,
+          message: `${translate("Proxy test OK")} (${data.status}) in ${data.elapsedMs}ms`,
         });
       } else {
         setProxyStatus({
           type: "error",
-          message: data?.error || "Proxy test failed",
+          message: data?.error || translate("Proxy test failed"),
         });
       }
     } catch (err) {
-      setProxyStatus({ type: "error", message: "An error occurred" });
+      setProxyStatus({ type: "error", message: translate("An error occurred") });
     } finally {
       setProxyTestLoading(false);
     }
@@ -128,13 +129,13 @@ export default function ProfilePage() {
         setProxyForm((prev) => ({ ...prev, outboundProxyEnabled: data?.outboundProxyEnabled === true }));
         setProxyStatus({
           type: "success",
-          message: outboundProxyEnabled ? "Proxy enabled" : "Proxy disabled",
+          message: outboundProxyEnabled ? translate("Proxy enabled") : translate("Proxy disabled"),
         });
       } else {
-        setProxyStatus({ type: "error", message: data.error || "Failed to update proxy settings" });
+        setProxyStatus({ type: "error", message: data.error || translate("Failed to update proxy settings") });
       }
     } catch (err) {
-      setProxyStatus({ type: "error", message: "An error occurred" });
+      setProxyStatus({ type: "error", message: translate("An error occurred") });
     } finally {
       setProxyLoading(false);
     }
@@ -143,7 +144,7 @@ export default function ProfilePage() {
   const handlePasswordChange = async (e) => {
     e.preventDefault();
     if (passwords.new !== passwords.confirm) {
-      setPassStatus({ type: "error", message: "Passwords do not match" });
+      setPassStatus({ type: "error", message: translate("Passwords do not match") });
       return;
     }
 
@@ -163,13 +164,13 @@ export default function ProfilePage() {
       const data = await res.json();
 
       if (res.ok) {
-        setPassStatus({ type: "success", message: "Password updated successfully" });
+        setPassStatus({ type: "success", message: translate("Password updated successfully") });
         setPasswords({ current: "", new: "", confirm: "" });
       } else {
-        setPassStatus({ type: "error", message: data.error || "Failed to update password" });
+        setPassStatus({ type: "error", message: data.error || translate("Failed to update password") });
       }
     } catch (err) {
-      setPassStatus({ type: "error", message: "An error occurred" });
+      setPassStatus({ type: "error", message: translate("An error occurred") });
     } finally {
       setPassLoading(false);
     }
@@ -345,8 +346,8 @@ export default function ProfilePage() {
                 <span className="material-symbols-outlined text-2xl">computer</span>
               </div>
               <div>
-                <h2 className="text-xl font-semibold">Local Mode</h2>
-                <p className="text-text-muted">Running on your machine</p>
+                <h2 className="text-xl font-semibold">{translate("Local Mode")}</h2>
+                <p className="text-text-muted">{translate("Running on your machine")}</p>
               </div>
             </div>
             <div className="inline-flex p-1 rounded-lg bg-black/5 dark:bg-white/5">
@@ -373,7 +374,7 @@ export default function ProfilePage() {
           <div className="flex flex-col gap-3 pt-4 border-t border-border">
             <div className="flex items-center justify-between p-3 rounded-lg bg-bg border border-border">
               <div>
-                <p className="font-medium">Database Location</p>
+                <p className="font-medium">{translate("Database Location")}</p>
                 <p className="text-sm text-text-muted font-mono">~/.9router/db.json</p>
               </div>
             </div>
@@ -384,7 +385,7 @@ export default function ProfilePage() {
                 onClick={handleExportDatabase}
                 loading={dbLoading}
               >
-                Download Backup
+                {translate("Download Backup")}
               </Button>
               <Button
                 variant="outline"
@@ -392,7 +393,7 @@ export default function ProfilePage() {
                 onClick={() => importFileRef.current?.click()}
                 disabled={dbLoading}
               >
-                Import Backup
+                {translate("Import Backup")}
               </Button>
               <input
                 ref={importFileRef}
@@ -416,14 +417,14 @@ export default function ProfilePage() {
             <div className="p-2 rounded-lg bg-primary/10 text-primary">
               <span className="material-symbols-outlined text-[20px]">shield</span>
             </div>
-            <h3 className="text-lg font-semibold">Security</h3>
+            <h3 className="text-lg font-semibold">{translate("Security")}</h3>
           </div>
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Require login</p>
+                <p className="font-medium">{translate("Require login")}</p>
                 <p className="text-sm text-text-muted">
-                  When ON, dashboard requires password. When OFF, access without login.
+                  {translate("When ON, dashboard requires password. When OFF, access without login.")}
                 </p>
               </div>
               <Toggle
@@ -436,10 +437,10 @@ export default function ProfilePage() {
               <form onSubmit={handlePasswordChange} className="flex flex-col gap-4 pt-4 border-t border-border/50">
                 {settings.hasPassword && (
                   <div className="flex flex-col gap-2">
-                    <label className="text-sm font-medium">Current Password</label>
+                    <label className="text-sm font-medium">{translate("Current Password")}</label>
                     <Input
                       type="password"
-                      placeholder="Enter current password"
+                      placeholder={translate("Enter current password")}
                       value={passwords.current}
                       onChange={(e) => setPasswords({ ...passwords, current: e.target.value })}
                       required
@@ -455,20 +456,20 @@ export default function ProfilePage() {
                 )} */}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="flex flex-col gap-2">
-                    <label className="text-sm font-medium">New Password</label>
+                    <label className="text-sm font-medium">{translate("New Password")}</label>
                     <Input
                       type="password"
-                      placeholder="Enter new password"
+                      placeholder={translate("Enter new password")}
                       value={passwords.new}
                       onChange={(e) => setPasswords({ ...passwords, new: e.target.value })}
                       required
                     />
                   </div>
                   <div className="flex flex-col gap-2">
-                    <label className="text-sm font-medium">Confirm New Password</label>
+                    <label className="text-sm font-medium">{translate("Confirm New Password")}</label>
                     <Input
                       type="password"
-                      placeholder="Confirm new password"
+                      placeholder={translate("Confirm new password")}
                       value={passwords.confirm}
                       onChange={(e) => setPasswords({ ...passwords, confirm: e.target.value })}
                       required
@@ -484,7 +485,7 @@ export default function ProfilePage() {
 
                 <div className="pt-2">
                   <Button type="submit" variant="primary" loading={passLoading}>
-                    {settings.hasPassword ? "Update Password" : "Set Password"}
+                    {settings.hasPassword ? translate("Update Password") : translate("Set Password")}
                   </Button>
                 </div>
               </form>
@@ -498,14 +499,14 @@ export default function ProfilePage() {
             <div className="p-2 rounded-lg bg-blue-500/10 text-blue-500">
               <span className="material-symbols-outlined text-[20px]">route</span>
             </div>
-            <h3 className="text-lg font-semibold">Routing Strategy</h3>
+            <h3 className="text-lg font-semibold">{translate("Routing Strategy")}</h3>
           </div>
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Round Robin</p>
+                <p className="font-medium">{translate("Round Robin")}</p>
                 <p className="text-sm text-text-muted">
-                  Cycle through accounts to distribute load
+                  {translate("Cycle through accounts to distribute load")}
                 </p>
               </div>
               <Toggle
@@ -519,9 +520,9 @@ export default function ProfilePage() {
             {settings.fallbackStrategy === "round-robin" && (
               <div className="flex items-center justify-between pt-2 border-t border-border/50">
                 <div>
-                  <p className="font-medium">Sticky Limit</p>
+                  <p className="font-medium">{translate("Sticky Limit")}</p>
                   <p className="text-sm text-text-muted">
-                    Calls per account before switching
+                    {translate("Calls per account before switching")}
                   </p>
                 </div>
                 <Input
@@ -538,8 +539,8 @@ export default function ProfilePage() {
 
             <p className="text-xs text-text-muted italic pt-2 border-t border-border/50">
               {settings.fallbackStrategy === "round-robin"
-                ? `Currently distributing requests across all available accounts with ${settings.stickyRoundRobinLimit || 3} calls per account.`
-                : "Currently using accounts in priority order (Fill First)."}
+                ? `${translate("Currently distributing requests across all available accounts with")} ${settings.stickyRoundRobinLimit || 3} ${translate("calls per account.")}`
+                : translate("Currently using accounts in priority order (Fill First).")}
             </p>
           </div>
         </Card>
@@ -550,14 +551,14 @@ export default function ProfilePage() {
             <div className="p-2 rounded-lg bg-purple-500/10 text-purple-500">
               <span className="material-symbols-outlined text-[20px]">wifi</span>
             </div>
-            <h3 className="text-lg font-semibold">Network</h3>
+            <h3 className="text-lg font-semibold">{translate("Network")}</h3>
           </div>
 
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Outbound Proxy</p>
-                <p className="text-sm text-text-muted">Enable proxy for OAuth + provider outbound requests.</p>
+                <p className="font-medium">{translate("Outbound Proxy")}</p>
+                <p className="text-sm text-text-muted">{translate("Enable proxy for OAuth + provider outbound requests.")}</p>
               </div>
               <Toggle
                 checked={settings.outboundProxyEnabled === true}
@@ -569,25 +570,25 @@ export default function ProfilePage() {
             {settings.outboundProxyEnabled === true && (
               <form onSubmit={updateOutboundProxy} className="flex flex-col gap-4 pt-2 border-t border-border/50">
                 <div className="flex flex-col gap-2">
-                  <label className="font-medium">Proxy URL</label>
+                  <label className="font-medium">{translate("Proxy URL")}</label>
                   <Input
                     placeholder="http://127.0.0.1:7897"
                     value={proxyForm.outboundProxyUrl}
                     onChange={(e) => setProxyForm((prev) => ({ ...prev, outboundProxyUrl: e.target.value }))}
                     disabled={loading || proxyLoading}
                   />
-                  <p className="text-sm text-text-muted">Leave empty to inherit existing env proxy (if any).</p>
+                  <p className="text-sm text-text-muted">{translate("Leave empty to inherit existing env proxy (if any).")}</p>
                 </div>
 
                 <div className="flex flex-col gap-2 pt-2 border-t border-border/50">
-                  <label className="font-medium">No Proxy</label>
+                  <label className="font-medium">{translate("No Proxy")}</label>
                   <Input
                     placeholder="localhost,127.0.0.1"
                     value={proxyForm.outboundNoProxy}
                     onChange={(e) => setProxyForm((prev) => ({ ...prev, outboundNoProxy: e.target.value }))}
                     disabled={loading || proxyLoading}
                   />
-                  <p className="text-sm text-text-muted">Comma-separated hostnames/domains to bypass the proxy.</p>
+                  <p className="text-sm text-text-muted">{translate("Comma-separated hostnames/domains to bypass the proxy.")}</p>
                 </div>
 
                 <div className="pt-2 border-t border-border/50 flex items-center gap-2">
@@ -598,10 +599,10 @@ export default function ProfilePage() {
                     disabled={loading || proxyLoading}
                     onClick={testOutboundProxy}
                   >
-                    Test proxy URL
+                    {translate("Test proxy URL")}
                   </Button>
                   <Button type="submit" variant="primary" loading={proxyLoading}>
-                    Apply
+                    {translate("Apply")}
                   </Button>
                 </div>
               </form>
@@ -621,14 +622,14 @@ export default function ProfilePage() {
             <div className="p-2 rounded-lg bg-orange-500/10 text-orange-500">
               <span className="material-symbols-outlined text-[20px]">monitoring</span>
             </div>
-            <h3 className="text-lg font-semibold">Observability</h3>
+            <h3 className="text-lg font-semibold">{translate("Observability")}</h3>
           </div>
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Enable Observability</p>
+                <p className="font-medium">{translate("Enable Observability")}</p>
                 <p className="text-sm text-text-muted">
-                  Turn request detail recording on/off globally
+                  {translate("Turn request detail recording on/off globally")}
                 </p>
               </div>
               <Toggle
@@ -641,9 +642,9 @@ export default function ProfilePage() {
             <div className={cn("flex flex-col gap-4", !observabilityEnabled && "opacity-60")}>
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Max Records</p>
+                <p className="font-medium">{translate("Max Records")}</p>
                 <p className="text-sm text-text-muted">
-                  Maximum request detail records to keep (older records are auto-deleted)
+                  {translate("Maximum request detail records to keep (older records are auto-deleted)")}
                 </p>
               </div>
               <Input
@@ -660,9 +661,9 @@ export default function ProfilePage() {
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Batch Size</p>
+                <p className="font-medium">{translate("Batch Size")}</p>
                 <p className="text-sm text-text-muted">
-                  Number of items to accumulate before writing to database (higher = better performance)
+                  {translate("Number of items to accumulate before writing to database (higher = better performance)")}
                 </p>
               </div>
               <Input
@@ -679,9 +680,9 @@ export default function ProfilePage() {
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Flush Interval (ms)</p>
+                <p className="font-medium">{translate("Flush Interval (ms)")}</p>
                 <p className="text-sm text-text-muted">
-                  Maximum time to wait before flushing buffer (prevents data loss during low traffic)
+                  {translate("Maximum time to wait before flushing buffer (prevents data loss during low traffic)")}
                 </p>
               </div>
               <Input
@@ -698,9 +699,9 @@ export default function ProfilePage() {
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium">Max JSON Size (KB)</p>
+                <p className="font-medium">{translate("Max JSON Size (KB)")}</p>
                 <p className="text-sm text-text-muted">
-                  Maximum size for each JSON field (request/response) before truncation
+                  {translate("Maximum size for each JSON field (request/response) before truncation")}
                 </p>
               </div>
               <Input
@@ -716,7 +717,7 @@ export default function ProfilePage() {
             </div>
 
             <p className="text-xs text-text-muted italic pt-2 border-t border-border/50">
-              Current: Keeps {settings.observabilityMaxRecords || 1000} records, batches every {settings.observabilityBatchSize || 20} requests, max {settings.observabilityMaxJsonSize || 1024}KB per field
+              {translate("Current: Keeps")} {settings.observabilityMaxRecords || 1000} {translate("records, batches every")} {settings.observabilityBatchSize || 20} {translate("requests, max")} {settings.observabilityMaxJsonSize || 1024}KB {translate("per field")}
             </p>
             </div>
           </div>
@@ -725,7 +726,7 @@ export default function ProfilePage() {
         {/* App Info */}
         <div className="text-center text-sm text-text-muted py-4">
           <p>{APP_CONFIG.name} v{APP_CONFIG.version}</p>
-          <p className="mt-1">Local Mode - All data stored on your machine</p>
+          <p className="mt-1">{translate("Local Mode - All data stored on your machine")}</p>
         </div>
       </div>
     </div>

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -10,18 +10,19 @@ import Link from "next/link";
 import { getErrorCode, getRelativeTime } from "@/shared/utils";
 import { useNotificationStore } from "@/store/notificationStore";
 import ModelAvailabilityBadge from "./components/ModelAvailabilityBadge";
+import { translate } from "@/i18n/runtime";
 
 function getStatusDisplay(connected, error, errorCode) {
   const parts = [];
   if (connected > 0) {
     parts.push(
       <Badge key="connected" variant="success" size="sm" dot>
-        {connected} Connected
+        {connected} {translate("Connected")}
       </Badge>
     );
   }
   if (error > 0) {
-    const errText = errorCode ? `${error} Error (${errorCode})` : `${error} Error`;
+    const errText = errorCode ? `${error} ${translate("Error")} (${errorCode})` : `${error} ${translate("Error")}`;
     parts.push(
       <Badge key="error" variant="error" size="sm" dot>
         {errText}
@@ -29,7 +30,7 @@ function getStatusDisplay(connected, error, errorCode) {
     );
   }
   if (parts.length === 0) {
-    return <span className="text-text-muted">No connections</span>;
+    return <span className="text-text-muted">{translate("No connections")}</span>;
   }
   return parts;
 }
@@ -207,7 +208,7 @@ export default function ProvidersPage() {
       <div className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">
-            OAuth Providers
+            {translate("OAuth Providers")}
           </h2>
           <div className="flex items-center gap-2">
             <ModelAvailabilityBadge />
@@ -219,13 +220,13 @@ export default function ProvidersPage() {
                   ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
                   : "bg-bg border-border text-text-muted hover:text-text-main hover:border-primary/40"
               }`}
-              title="Test all OAuth connections"
-              aria-label="Test all OAuth connections"
+              title={translate("Test all OAuth connections")}
+              aria-label={translate("Test all OAuth connections")}
             >
               <span className={`material-symbols-outlined text-[14px]${testingMode === "oauth" ? " animate-spin" : ""}`}>
                 {testingMode === "oauth" ? "sync" : "play_arrow"}
               </span>
-              {testingMode === "oauth" ? "Testing..." : "Test All"}
+              {testingMode === "oauth" ? translate("Testing...") : translate("Test All")}
             </button>
           </div>
         </div>
@@ -247,7 +248,7 @@ export default function ProvidersPage() {
       <div className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">
-            Free Providers
+            {translate("Free Providers")}
           </h2>
           <button
             onClick={() => handleBatchTest("free")}
@@ -257,13 +258,13 @@ export default function ProvidersPage() {
                 ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
                 : "bg-bg border-border text-text-muted hover:text-text-main hover:border-primary/40"
               }`}
-              title="Test all Free connections"
-            aria-label="Test all Free provider connections"
+              title={translate("Test all Free connections")}
+            aria-label={translate("Test all Free provider connections")}
           >
             <span className={`material-symbols-outlined text-[14px]${testingMode === "free" ? " animate-spin" : ""}`}>
               {testingMode === "free" ? "sync" : "play_arrow"}
             </span>
-            {testingMode === "free" ? "Testing..." : "Test All"}
+            {testingMode === "free" ? translate("Testing...") : translate("Test All")}
           </button>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
@@ -284,7 +285,7 @@ export default function ProvidersPage() {
       <div className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">
-            API Key Providers{" "}
+            {translate("API Key Providers")}{" "}
           </h2>
           <button
             onClick={() => handleBatchTest("apikey")}
@@ -294,13 +295,13 @@ export default function ProvidersPage() {
                 ? "bg-primary/20 border-primary/40 text-primary animate-pulse"
                 : "bg-bg border-border text-text-muted hover:text-text-main hover:border-primary/40"
               }`}
-              title="Test all API Key connections"
-            aria-label="Test all API Key connections"
+              title={translate("Test all API Key connections")}
+            aria-label={translate("Test all API Key connections")}
           >
             <span className={`material-symbols-outlined text-[14px]${testingMode === "apikey" ? " animate-spin" : ""}`}>
               {testingMode === "apikey" ? "sync" : "play_arrow"}
             </span>
-            {testingMode === "apikey" ? "Testing..." : "Test All"}
+            {testingMode === "apikey" ? translate("Testing...") : translate("Test All")}
           </button>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
@@ -321,7 +322,7 @@ export default function ProvidersPage() {
       <div className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">
-            API Key Compatible Providers{" "}
+            {translate("API Key Compatible Providers")}{" "}
           </h2>
           <div className="flex gap-2">
             {/* {(compatibleProviders.length > 0 || anthropicCompatibleProviders.length > 0) && (
@@ -342,7 +343,7 @@ export default function ProvidersPage() {
               </button>
             )} */}
             <Button size="sm" icon="add" onClick={() => setShowAddAnthropicCompatibleModal(true)}>
-              Add Anthropic Compatible
+              {translate("Add Anthropic Compatible")}
             </Button>
             <Button
               size="sm"
@@ -351,16 +352,16 @@ export default function ProvidersPage() {
               onClick={() => setShowAddCompatibleModal(true)}
               className="!bg-white !text-black hover:!bg-gray-100"
             >
-              Add OpenAI Compatible
+              {translate("Add OpenAI Compatible")}
             </Button>
           </div>
         </div>
         {compatibleProviders.length === 0 && anthropicCompatibleProviders.length === 0 ? (
           <div className="text-center py-8 border border-dashed border-border rounded-xl">
             <span className="material-symbols-outlined text-[32px] text-text-muted mb-2">extension</span>
-            <p className="text-text-muted text-sm">No compatible providers added yet</p>
+            <p className="text-text-muted text-sm">{translate("No compatible providers added yet")}</p>
             <p className="text-text-muted text-xs mt-1">
-              Use the buttons above to add OpenAI or Anthropic compatible endpoints
+              {translate("Use the buttons above to add OpenAI or Anthropic compatible endpoints")}
             </p>
           </div>
         ) : (
@@ -408,11 +409,11 @@ export default function ProvidersPage() {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="sticky top-0 z-10 flex items-center justify-between px-5 py-3 border-b border-border bg-surface/95 backdrop-blur-sm rounded-t-xl">
-              <h3 className="font-semibold">Test Results</h3>
+              <h3 className="font-semibold">{translate("Test Results")}</h3>
               <button
                 onClick={() => setTestResults(null)}
                 className="p-1 rounded-lg hover:bg-bg text-text-muted hover:text-text-main transition-colors"
-                aria-label="Close test results"
+                aria-label={translate("Close test results")}
               >
                 <span className="material-symbols-outlined text-lg">close</span>
               </button>
@@ -476,7 +477,7 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
                   <Badge variant="default" size="sm">
                     <span className="flex items-center gap-1">
                       <span className="material-symbols-outlined text-[12px]">pause_circle</span>
-                      Disabled
+                      {translate("Disabled")}
                     </span>
                   </Badge>
                 ) : (
@@ -502,7 +503,7 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
                   size="sm"
                   checked={!allDisabled}
                   onChange={() => {}}
-                  title={allDisabled ? "Enable provider" : "Disable provider"}
+                  title={allDisabled ? translate("Enable provider") : translate("Disable provider")}
                 />
               </div>
             )}
@@ -588,7 +589,7 @@ function ApiKeyProviderCard({ providerId, provider, stats, authType, onToggle })
                   <Badge variant="default" size="sm">
                     <span className="flex items-center gap-1">
                       <span className="material-symbols-outlined text-[12px]">pause_circle</span>
-                      Disabled
+                      {translate("Disabled")}
                     </span>
                   </Badge>
                 ) : (
@@ -596,11 +597,11 @@ function ApiKeyProviderCard({ providerId, provider, stats, authType, onToggle })
                     {getStatusDisplay(connected, error, errorCode)}
                     {isCompatible && (
                       <Badge variant="default" size="sm">
-                        {provider.apiType === "responses" ? "Responses" : "Chat"}
+                        {provider.apiType === "responses" ? translate("Responses API") : translate("Chat Completions")}
                       </Badge>
                     )}
                     {isAnthropicCompatible && (
-                      <Badge variant="default" size="sm">Messages</Badge>
+                      <Badge variant="default" size="sm">{translate("Messages")}</Badge>
                     )}
                     {errorTime && <span className="text-text-muted">{errorTime}</span>}
                   </>
@@ -622,7 +623,7 @@ function ApiKeyProviderCard({ providerId, provider, stats, authType, onToggle })
                   size="sm"
                   checked={!allDisabled}
                   onChange={() => {}}
-                  title={allDisabled ? "Enable provider" : "Disable provider"}
+                  title={allDisabled ? translate("Enable provider") : translate("Disable provider")}
                 />
               </div>
             )}
@@ -665,8 +666,8 @@ function AddOpenAICompatibleModal({ isOpen, onClose, onCreated }) {
   const [validationResult, setValidationResult] = useState(null);
 
   const apiTypeOptions = [
-    { value: "chat", label: "Chat Completions" },
-    { value: "responses", label: "Responses API" },
+    { value: "chat", label: translate("Chat Completions") },
+    { value: "responses", label: translate("Responses API") },
   ];
 
   useEffect(() => {
@@ -721,38 +722,38 @@ function AddOpenAICompatibleModal({ isOpen, onClose, onCreated }) {
   };
 
   return (
-    <Modal isOpen={isOpen} title="Add OpenAI Compatible" onClose={onClose}>
+    <Modal isOpen={isOpen} title={translate("Add OpenAI Compatible")} onClose={onClose}>
       <div className="flex flex-col gap-4">
         <Input
-          label="Name"
+          label={translate("Name")}
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           placeholder="OpenAI Compatible (Prod)"
-          hint="Required. A friendly label for this node."
+          hint={translate("Required. A friendly label for this node.")}
         />
         <Input
-          label="Prefix"
+          label={translate("Prefix")}
           value={formData.prefix}
           onChange={(e) => setFormData({ ...formData, prefix: e.target.value })}
           placeholder="oc-prod"
-          hint="Required. Used as the provider prefix for model IDs."
+          hint={translate("Required. Used as the provider prefix for model IDs.")}
         />
         <Select
-          label="API Type"
+          label={translate("API Type")}
           options={apiTypeOptions}
           value={formData.apiType}
           onChange={(e) => setFormData({ ...formData, apiType: e.target.value })}
         />
         <Input
-          label="Base URL"
+          label={translate("Base URL")}
           value={formData.baseUrl}
           onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
           placeholder="https://api.openai.com/v1"
-          hint="Use the base URL (ending in /v1) for your OpenAI-compatible API."
+          hint={translate("Use the base URL (ending in /v1) for your OpenAI-compatible API.")}
         />
         <div className="flex gap-2">
           <Input
-            label="API Key (for Check)"
+            label={translate("API Key (for Check)")}
             type="password"
             value={checkKey}
             onChange={(e) => setCheckKey(e.target.value)}
@@ -760,20 +761,20 @@ function AddOpenAICompatibleModal({ isOpen, onClose, onCreated }) {
           />
           <div className="pt-6">
             <Button onClick={handleValidate} disabled={!checkKey || validating || !formData.baseUrl.trim()} variant="secondary">
-              {validating ? "Checking..." : "Check"}
+              {validating ? translate("Checking...") : translate("Check")}
             </Button>
           </div>
         </div>
         {validationResult && (
           <Badge variant={validationResult === "success" ? "success" : "error"}>
-            {validationResult === "success" ? "Valid" : "Invalid"}
+            {validationResult === "success" ? translate("Valid") : translate("Invalid")}
           </Badge>
         )}
         <div className="flex gap-2">
           <Button onClick={handleSubmit} fullWidth disabled={!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim() || submitting}>
-            {submitting ? "Creating..." : "Create"}
+            {submitting ? translate("Creating...") : translate("Create")}
           </Button>
-          <Button onClick={onClose} variant="ghost" fullWidth>Cancel</Button>
+          <Button onClick={onClose} variant="ghost" fullWidth>{translate("Cancel")}</Button>
         </div>
       </div>
     </Modal>
@@ -850,32 +851,32 @@ function AddAnthropicCompatibleModal({ isOpen, onClose, onCreated }) {
   };
 
   return (
-    <Modal isOpen={isOpen} title="Add Anthropic Compatible" onClose={onClose}>
+    <Modal isOpen={isOpen} title={translate("Add Anthropic Compatible")} onClose={onClose}>
       <div className="flex flex-col gap-4">
         <Input
-          label="Name"
+          label={translate("Name")}
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           placeholder="Anthropic Compatible (Prod)"
-          hint="Required. A friendly label for this node."
+          hint={translate("Required. A friendly label for this node.")}
         />
         <Input
-          label="Prefix"
+          label={translate("Prefix")}
           value={formData.prefix}
           onChange={(e) => setFormData({ ...formData, prefix: e.target.value })}
           placeholder="ac-prod"
-          hint="Required. Used as the provider prefix for model IDs."
+          hint={translate("Required. Used as the provider prefix for model IDs.")}
         />
         <Input
-          label="Base URL"
+          label={translate("Base URL")}
           value={formData.baseUrl}
           onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
           placeholder="https://api.anthropic.com/v1"
-          hint="Use the base URL (ending in /v1) for your Anthropic-compatible API. The system will append /messages."
+          hint={translate("Use the base URL (ending in /v1) for your Anthropic-compatible API. The system will append /messages.")}
         />
         <div className="flex gap-2">
           <Input
-            label="API Key (for Check)"
+            label={translate("API Key (for Check)")}
             type="password"
             value={checkKey}
             onChange={(e) => setCheckKey(e.target.value)}
@@ -883,20 +884,20 @@ function AddAnthropicCompatibleModal({ isOpen, onClose, onCreated }) {
           />
           <div className="pt-6">
             <Button onClick={handleValidate} disabled={!checkKey || validating || !formData.baseUrl.trim()} variant="secondary">
-              {validating ? "Checking..." : "Check"}
+              {validating ? translate("Checking...") : translate("Check")}
             </Button>
           </div>
         </div>
         {validationResult && (
           <Badge variant={validationResult === "success" ? "success" : "error"}>
-            {validationResult === "success" ? "Valid" : "Invalid"}
+            {validationResult === "success" ? translate("Valid") : translate("Invalid")}
           </Badge>
         )}
         <div className="flex gap-2">
           <Button onClick={handleSubmit} fullWidth disabled={!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim() || submitting}>
-            {submitting ? "Creating..." : "Create"}
+            {submitting ? translate("Creating...") : translate("Create")}
           </Button>
-          <Button onClick={onClose} variant="ghost" fullWidth>Cancel</Button>
+          <Button onClick={onClose} variant="ghost" fullWidth>{translate("Cancel")}</Button>
         </div>
       </div>
     </Modal>
@@ -914,29 +915,29 @@ function ProviderTestResultsView({ results }) {
     return (
       <div className="text-center py-6">
         <span className="material-symbols-outlined text-red-500 text-[32px] mb-2 block">error</span>
-        <p className="text-sm text-red-400">{results.error}</p>
+        <p className="text-sm text-red-400">{translate(results.error)}</p>
       </div>
     );
   }
 
   const { summary, mode } = results;
   const items = results.results || [];
-  const modeLabel = { oauth: "OAuth", free: "Free", apikey: "API Key", provider: "Provider", all: "All" }[mode] || mode;
+  const modeLabel = { oauth: translate("OAuth"), free: translate("Free"), apikey: translate("API Key"), provider: translate("Provider"), all: translate("All") }[mode] || mode;
 
   return (
     <div className="flex flex-col gap-3">
       {summary && (
         <div className="flex items-center gap-3 text-xs mb-1">
-          <span className="text-text-muted">{modeLabel} Test</span>
+          <span className="text-text-muted">{modeLabel} {translate("Test")}</span>
           <span className="px-2 py-0.5 rounded bg-emerald-500/15 text-emerald-400 font-medium">
-            {summary.passed} passed
+            {summary.passed} {translate("passed")}
           </span>
           {summary.failed > 0 && (
             <span className="px-2 py-0.5 rounded bg-red-500/15 text-red-400 font-medium">
-              {summary.failed} failed
+              {summary.failed} {translate("failed")}
             </span>
           )}
-          <span className="text-text-muted ml-auto">{summary.total} tested</span>
+          <span className="text-text-muted ml-auto">{summary.total} {translate("tested")}</span>
         </div>
       )}
       {items.map((r, i) => (
@@ -959,13 +960,13 @@ function ProviderTestResultsView({ results }) {
               r.valid ? "bg-emerald-500/15 text-emerald-400" : "bg-red-500/15 text-red-400"
             }`}
           >
-            {r.valid ? "OK" : r.diagnosis?.type || "ERROR"}
+            {r.valid ? translate("OK") : r.diagnosis?.type || translate("ERROR")}
           </span>
         </div>
       ))}
       {items.length === 0 && (
         <div className="text-center py-4 text-text-muted text-sm">
-          No active connections found for this group.
+          {translate("No active connections found for this group.")}
         </div>
       )}
     </div>

--- a/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
+++ b/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
@@ -2,6 +2,7 @@
 
 import PropTypes from "prop-types";
 import Card from "@/shared/components/Card";
+import { translate } from "@/i18n/runtime";
 
 const fmt = (n) => new Intl.NumberFormat().format(n || 0);
 const fmtCost = (n) => `$${(n || 0).toFixed(2)}`;
@@ -10,21 +11,21 @@ export default function OverviewCards({ stats }) {
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
       <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Total Requests</span>
+        <span className="text-text-muted text-sm uppercase font-semibold">{translate("Total Requests")}</span>
         <span className="text-2xl font-bold">{fmt(stats.totalRequests)}</span>
       </Card>
       <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Total Input Tokens</span>
+        <span className="text-text-muted text-sm uppercase font-semibold">{translate("Total Input Tokens")}</span>
         <span className="text-2xl font-bold text-primary">{fmt(stats.totalPromptTokens)}</span>
       </Card>
       <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Output Tokens</span>
+        <span className="text-text-muted text-sm uppercase font-semibold">{translate("Output Tokens")}</span>
         <span className="text-2xl font-bold text-success">{fmt(stats.totalCompletionTokens)}</span>
       </Card>
       <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Est. Cost</span>
+        <span className="text-text-muted text-sm uppercase font-semibold">{translate("Est. Cost")}</span>
         <span className="text-2xl font-bold text-warning">~{fmtCost(stats.totalCost)}</span>
-        <span className="text-[10px] text-text-muted">Estimated, not actual billing</span>
+        <span className="text-[10px] text-text-muted">{translate("Estimated, not actual billing")}</span>
       </Card>
     </div>
   );

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaProgressBar.js
@@ -2,6 +2,7 @@
 
 import { cn } from "@/shared/utils/cn";
 import { formatResetTime } from "./utils";
+import { translate } from "@/i18n/runtime";
 
 // Calculate color based on remaining percentage
 const getColorClasses = (remainingPercentage) => {
@@ -35,22 +36,22 @@ const getColorClasses = (remainingPercentage) => {
 // Format reset time display
 const formatResetTimeDisplay = (resetTime) => {
   if (!resetTime) return null;
-  
+
   try {
     const resetDate = new Date(resetTime);
     const now = new Date();
     const isToday = resetDate.toDateString() === now.toDateString();
     const isTomorrow = resetDate.toDateString() === new Date(now.getTime() + 86400000).toDateString();
-    
+
     const timeStr = resetDate.toLocaleTimeString(undefined, {
       hour: "2-digit",
       minute: "2-digit",
       hour12: true,
     });
-    
-    if (isToday) return `Today, ${timeStr}`;
-    if (isTomorrow) return `Tomorrow, ${timeStr}`;
-    
+
+    if (isToday) return `${translate("Today")}, ${timeStr}`;
+    if (isTomorrow) return `${translate("Tomorrow")}, ${timeStr}`;
+
     return resetDate.toLocaleString(undefined, {
       month: "short",
       day: "numeric",
@@ -106,12 +107,12 @@ export default function QuotaProgressBar({
       {/* Usage details and countdown */}
       <div className="flex items-center justify-between text-xs text-text-muted">
         <span>
-          {used.toLocaleString()} / {total.toLocaleString()} requests
+          {used.toLocaleString()} / {total.toLocaleString()} {translate("requests")}
         </span>
         {countdown !== "-" && (
           <div className="flex items-center gap-1">
             <span>•</span>
-            <span className="font-medium">Reset in {countdown}</span>
+            <span className="font-medium">{translate("Reset in")} {countdown}</span>
           </div>
         )}
       </div>
@@ -119,7 +120,7 @@ export default function QuotaProgressBar({
       {/* Reset time display */}
       {resetDisplay && (
         <div className="text-xs text-text-muted/70">
-          Reset at {resetDisplay}
+          {translate("Reset at")} {resetDisplay}
         </div>
       )}
     </div>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
@@ -1,35 +1,36 @@
 "use client";
 
 import { formatResetTime, calculatePercentage } from "./utils";
+import { translate } from "@/i18n/runtime";
 
 /**
  * Format reset time display (Today, 12:00 PM)
  */
 function formatResetTimeDisplay(resetTime) {
   if (!resetTime) return null;
-  
+
   try {
     const date = new Date(resetTime);
     const now = new Date();
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
-    
+
     let dayStr = "";
     if (date >= today && date < tomorrow) {
-      dayStr = "Today";
+      dayStr = translate("Today");
     } else if (date >= tomorrow && date < new Date(tomorrow.getTime() + 24 * 60 * 60 * 1000)) {
-      dayStr = "Tomorrow";
+      dayStr = translate("Tomorrow");
     } else {
       dayStr = date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
     }
-    
-    const timeStr = date.toLocaleTimeString("en-US", { 
-      hour: "numeric", 
+
+    const timeStr = date.toLocaleTimeString("en-US", {
+      hour: "numeric",
       minute: "2-digit",
-      hour12: true 
+      hour12: true
     });
-    
+
     return `${dayStr}, ${timeStr}`;
   } catch {
     return null;
@@ -70,11 +71,105 @@ function getColorClasses(remainingPercentage) {
 /**
  * Quota Table Component - Table-based display for quota data
  */
-export default function QuotaTable({ quotas = [] }) {
+function getWarmupErrorMap(warmupState) {
+  const models = warmupState?.models || {};
+  const errorMap = new Map();
+
+  for (const [modelId, state] of Object.entries(models)) {
+    if (state?.status === "error" && state?.lastError) {
+      errorMap.set(modelId, state);
+      if (state.modelName) {
+        errorMap.set(state.modelName, state);
+      }
+    }
+  }
+
+  return errorMap;
+}
+
+/**
+ * Format relative time (e.g., "5 minutes ago", "1 hour ago")
+ */
+function formatRelativeTime(dateString) {
+  if (!dateString) return null;
+
+  try {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now - date;
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMinutes / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffMinutes < 1) return translate("Just now");
+    if (diffMinutes < 60) return `${diffMinutes}${translate("m ago")}`;
+    if (diffHours < 24) return `${diffHours}${translate("h ago")}`;
+    return `${diffDays}${translate("d ago")}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get warmup status display for a connection
+ */
+function getWarmupStatusDisplay(warmupState) {
+  if (!warmupState) return null;
+
+  const { skipped, skipReason, exhaustedQuotas, lastRunAt, models } = warmupState;
+
+  // Check if skipped due to quota exhausted
+  if (skipped && skipReason === "quota_exhausted") {
+    return {
+      type: "skipped",
+      icon: "pause_circle",
+      color: "text-yellow-600 dark:text-yellow-400",
+      bgColor: "bg-yellow-500/10",
+      borderColor: "border-yellow-500/20",
+      message: translate("Quota exhausted"),
+      details: exhaustedQuotas?.join(", ") || "",
+    };
+  }
+
+  // Check for errors
+  const errorModels = Object.values(models || {}).filter(m => m.status === "error");
+  if (errorModels.length > 0) {
+    return {
+      type: "error",
+      icon: "error",
+      color: "text-red-600 dark:text-red-400",
+      bgColor: "bg-red-500/10",
+      borderColor: "border-red-500/20",
+      message: translate("Refresh failed"),
+      details: "",
+    };
+  }
+
+  // Check for success (all models succeeded)
+  const modelList = Object.values(models || {});
+  if (modelList.length > 0 && modelList.every(m => m.status === "success")) {
+    return {
+      type: "success",
+      icon: "check_circle",
+      color: "text-green-600 dark:text-green-400",
+      bgColor: "bg-green-500/10",
+      borderColor: "border-green-500/20",
+      message: translate("Refresh successful"),
+      details: "",
+      lastRunAt,
+    };
+  }
+
+  return null;
+}
+
+export default function QuotaTable({ quotas = [], warmupState = null }) {
   if (!quotas || quotas.length === 0) {
     return null;
   }
 
+  const warmupErrorMap = getWarmupErrorMap(warmupState);
+  const warmupStatus = getWarmupStatusDisplay(warmupState);
   return (
     <div className="overflow-x-auto">
       <table className="w-full table-fixed">
@@ -92,6 +187,14 @@ export default function QuotaTable({ quotas = [] }) {
             const colors = getColorClasses(remaining);
             const countdown = formatResetTime(quota.resetAt);
             const resetDisplay = formatResetTimeDisplay(quota.resetAt);
+            const warmupError = warmupErrorMap.get(quota.modelKey) || warmupErrorMap.get(quota.name) || null;
+            if (warmupError) {
+              warmupErrorMap.delete(quota.modelKey);
+              warmupErrorMap.delete(quota.name);
+              if (warmupError.modelName) {
+                warmupErrorMap.delete(warmupError.modelName);
+              }
+            }
 
             return (
               <tr 
@@ -133,11 +236,11 @@ export default function QuotaTable({ quotas = [] }) {
 
                 {/* Reset Time */}
                 <td className="py-2 px-3">
-                  {countdown !== "-" || resetDisplay ? (
-                    <div className="space-y-0.5">
+                  {(countdown !== "-" || resetDisplay || warmupError) ? (
+                    <div className="space-y-1">
                       {countdown !== "-" && (
                         <div className="text-sm text-text-primary font-medium">
-                          in {countdown}
+                          {translate("in")} {countdown}
                         </div>
                       )}
                       {resetDisplay && (
@@ -145,9 +248,17 @@ export default function QuotaTable({ quotas = [] }) {
                           {resetDisplay}
                         </div>
                       )}
+                      {warmupError && (
+                        <div className="flex items-start gap-1.5 text-xs">
+                          <span className="material-symbols-outlined text-[14px] text-red-500 shrink-0 mt-0.5">error</span>
+                          <span className="text-red-600 dark:text-red-400 leading-relaxed">
+                            {warmupError.lastError}
+                          </span>
+                        </div>
+                      )}
                     </div>
                   ) : (
-                    <div className="text-sm text-text-muted italic">N/A</div>
+                    <div className="text-sm text-text-muted italic">{translate("N/A")}</div>
                   )}
                 </td>
               </tr>
@@ -155,6 +266,43 @@ export default function QuotaTable({ quotas = [] }) {
           })}
         </tbody>
       </table>
+      {/* Warmup Status Display */}
+      {warmupStatus && (
+        <div className={`mt-3 rounded-lg border ${warmupStatus.borderColor} ${warmupStatus.bgColor} p-3`}>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className={`material-symbols-outlined text-[18px] ${warmupStatus.color}`}>{warmupStatus.icon}</span>
+              <div className="flex items-center gap-2">
+                <span className={`text-sm font-medium ${warmupStatus.color}`}>{warmupStatus.message}</span>
+                {warmupStatus.details && (
+                  <span className="text-xs text-text-muted">({warmupStatus.details})</span>
+                )}
+              </div>
+            </div>
+            {warmupStatus.lastRunAt && (
+              <span className="text-xs text-text-muted">
+                {formatRelativeTime(warmupStatus.lastRunAt)}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {Array.from(new Set(warmupErrorMap.values())).length > 0 && (
+        <div className="mt-3 rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+          <div className="flex items-start gap-2">
+            <span className="material-symbols-outlined text-[16px] text-red-500 shrink-0 mt-0.5">error_outline</span>
+            <div className="space-y-1">
+              {Array.from(new Set(warmupErrorMap.values())).map((state) => (
+                <div key={`${state.modelName || "unknown"}-${state.lastRunAt || "never"}`} className="text-xs text-red-600 dark:text-red-400">
+                  <span className="font-medium">{state.modelName || translate("Unknown model")}:</span>{" "}
+                  <span className="opacity-90">{state.lastError}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
@@ -9,6 +9,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
+import { translate } from "@/i18n/runtime";
 
 function getProviderConfig(providerId) {
   return AI_PROVIDERS[providerId] || { color: "#6b7280", name: providerId };
@@ -224,7 +225,7 @@ export default function ProviderTopology({ providers = [], activeRequests = [], 
     <div className="w-full rounded-lg border border-border bg-bg-subtle/30" style={{ height: 480 }}>
       {providers.length === 0 ? (
         <div className="h-full flex items-center justify-center text-text-muted text-sm">
-          No providers connected
+          {translate("No providers connected")}
         </div>
       ) : (
         <ReactFlow

--- a/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
+++ b/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
@@ -7,6 +7,7 @@ import Drawer from "@/shared/components/Drawer";
 import Pagination from "@/shared/components/Pagination";
 import { cn } from "@/shared/utils/cn";
 import { AI_PROVIDERS, getProviderByAlias } from "@/shared/constants/providers";
+import { translate } from "@/i18n/runtime";
 
 let providerNameCache = null;
 let providerNodesCache = null;
@@ -167,7 +168,7 @@ export default function RequestDetailsTab() {
       <Card padding="md">
         <div className="flex flex-wrap gap-4">
           <div className="flex flex-col gap-2">
-            <label htmlFor="provider-filter" className="text-sm font-medium text-text-main">Provider</label>
+            <label htmlFor="provider-filter" className="text-sm font-medium text-text-main">{translate("Provider")}</label>
             <select
               id="provider-filter"
               value={filters.provider}
@@ -178,7 +179,7 @@ export default function RequestDetailsTab() {
                 "cursor-pointer min-w-[150px]"
               )}
             >
-              <option value="">All Providers</option>
+              <option value="">{translate("All Providers")}</option>
               {providers.map((provider) => (
                 <option key={provider.id} value={provider.id}>
                   {provider.name}
@@ -186,9 +187,9 @@ export default function RequestDetailsTab() {
               ))}
             </select>
           </div>
-          
+
           <div className="flex flex-col gap-2">
-            <label htmlFor="start-date-filter" className="text-sm font-medium text-text-main">Start Date</label>
+            <label htmlFor="start-date-filter" className="text-sm font-medium text-text-main">{translate("Start Date")}</label>
             <input
               id="start-date-filter"
               type="datetime-local"
@@ -202,7 +203,7 @@ export default function RequestDetailsTab() {
           </div>
 
           <div className="flex flex-col gap-2">
-            <label htmlFor="end-date-filter" className="text-sm font-medium text-text-main">End Date</label>
+            <label htmlFor="end-date-filter" className="text-sm font-medium text-text-main">{translate("End Date")}</label>
             <input
               id="end-date-filter"
               type="datetime-local"
@@ -214,15 +215,15 @@ export default function RequestDetailsTab() {
               )}
             />
           </div>
-          
+
           <div className="flex flex-col gap-2">
-            <span className="text-sm font-medium text-text-main opacity-0" aria-hidden="true">Clear</span>
-            <Button 
-              variant="ghost" 
+            <span className="text-sm font-medium text-text-main opacity-0" aria-hidden="true">{translate("Clear")}</span>
+            <Button
+              variant="ghost"
               onClick={handleClearFilters}
               disabled={!filters.provider && !filters.startDate && !filters.endDate}
             >
-              Clear Filters
+              {translate("Clear Filters")}
             </Button>
           </div>
         </div>
@@ -233,13 +234,13 @@ export default function RequestDetailsTab() {
           <table className="w-full">
             <thead>
               <tr className="border-b border-black/5 dark:border-white/5">
-                <th className="text-left p-4 text-sm font-semibold text-text-main">Timestamp</th>
-                <th className="text-left p-4 text-sm font-semibold text-text-main">Model</th>
-                <th className="text-left p-4 text-sm font-semibold text-text-main">Provider</th>
-                <th className="text-right p-4 text-sm font-semibold text-text-main">Input Tokens</th>
-                <th className="text-right p-4 text-sm font-semibold text-text-main">Output Tokens</th>
-                <th className="text-left p-4 text-sm font-semibold text-text-main">Latency</th>
-                <th className="text-center p-4 text-sm font-semibold text-text-main">Action</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">{translate("Timestamp")}</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">{translate("Model")}</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">{translate("Provider")}</th>
+                <th className="text-right p-4 text-sm font-semibold text-text-main">{translate("Input Tokens")}</th>
+                <th className="text-right p-4 text-sm font-semibold text-text-main">{translate("Output Tokens")}</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">{translate("Latency")}</th>
+                <th className="text-center p-4 text-sm font-semibold text-text-main">{translate("Action")}</th>
               </tr>
             </thead>
             <tbody>
@@ -248,14 +249,14 @@ export default function RequestDetailsTab() {
                   <td colSpan="7" className="p-8 text-center text-text-muted">
                     <div className="flex items-center justify-center gap-2">
                       <span className="material-symbols-outlined animate-spin text-[20px]">progress_activity</span>
-                      Loading...
+                      {translate("Loading...")}
                     </div>
                   </td>
                 </tr>
               ) : details.length === 0 ? (
                 <tr>
                   <td colSpan="7" className="p-8 text-center text-text-muted">
-                    No request details found
+                    {translate("No request details found")}
                   </td>
                 </tr>
               ) : (
@@ -283,8 +284,8 @@ export default function RequestDetailsTab() {
                     </td>
                     <td className="p-4 text-sm text-text-muted">
                       <div className="flex flex-col gap-0.5">
-                        <div>TTFT: <span className="font-mono">{detail.latency?.ttft || 0}ms</span></div>
-                        <div>Total: <span className="font-mono">{detail.latency?.total || 0}ms</span></div>
+                        <div>{translate("TTFT")}: <span className="font-mono">{detail.latency?.ttft || 0}ms</span></div>
+                        <div>{translate("Total")}: <span className="font-mono">{detail.latency?.total || 0}ms</span></div>
                       </div>
                     </td>
                     <td className="p-4 text-center">
@@ -293,7 +294,7 @@ export default function RequestDetailsTab() {
                         size="sm"
                         onClick={() => handleViewDetail(detail)}
                       >
-                        Detail
+                        {translate("Detail")}
                       </Button>
                     </td>
                   </tr>
@@ -319,30 +320,30 @@ export default function RequestDetailsTab() {
       <Drawer
         isOpen={isDrawerOpen}
         onClose={() => setIsDrawerOpen(false)}
-        title="Request Details"
+        title={translate("Request Details")}
         width="lg"
       >
         {selectedDetail && (
           <div className="space-y-6">
             <div className="grid grid-cols-2 gap-4 text-sm">
               <div>
-                <span className="text-text-muted">ID:</span>{" "}
+                <span className="text-text-muted">{translate("ID")}:</span>{" "}
                 <span className="text-text-main font-mono">{selectedDetail.id}</span>
               </div>
               <div>
-                <span className="text-text-muted">Timestamp:</span>{" "}
+                <span className="text-text-muted">{translate("Timestamp")}:</span>{" "}
                 <span className="text-text-main">{new Date(selectedDetail.timestamp).toLocaleString()}</span>
               </div>
               <div>
-                 <span className="text-text-muted">Provider:</span>{" "}
+                 <span className="text-text-muted">{translate("Provider")}:</span>{" "}
                  <span className="text-text-main font-medium">{getProviderName(selectedDetail.provider, providerNameCache)}</span>
                </div>
               <div>
-                <span className="text-text-muted">Model:</span>{" "}
+                <span className="text-text-muted">{translate("Model")}:</span>{" "}
                 <span className="text-text-main font-mono">{selectedDetail.model}</span>
               </div>
               <div>
-                <span className="text-text-muted">Status:</span>{" "}
+                <span className="text-text-muted">{translate("Status")}:</span>{" "}
                 <span className={cn(
                   "font-medium",
                   selectedDetail.status === "success" ? "text-green-600" : "text-red-600"
@@ -351,19 +352,19 @@ export default function RequestDetailsTab() {
                 </span>
               </div>
               <div>
-                <span className="text-text-muted">Latency:</span>{" "}
+                <span className="text-text-muted">{translate("Latency")}:</span>{" "}
                 <span className="text-text-main font-mono">
-                  TTFT {selectedDetail.latency?.ttft || 0}ms / Total {selectedDetail.latency?.total || 0}ms
+                  {translate("TTFT")} {selectedDetail.latency?.ttft || 0}ms / {translate("Total")} {selectedDetail.latency?.total || 0}ms
                 </span>
               </div>
               <div>
-                <span className="text-text-muted">Input Tokens:</span>{" "}
+                <span className="text-text-muted">{translate("Input Tokens")}:</span>{" "}
                 <span className="text-text-main font-mono">
                   {selectedDetail.tokens?.prompt_tokens?.toLocaleString() || 0}
                 </span>
               </div>
               <div>
-                <span className="text-text-muted">Output Tokens:</span>{" "}
+                <span className="text-text-muted">{translate("Output Tokens")}:</span>{" "}
                 <span className="text-text-main font-mono">
                   {selectedDetail.tokens?.completion_tokens?.toLocaleString() || 0}
                 </span>
@@ -371,14 +372,14 @@ export default function RequestDetailsTab() {
             </div>
             
             <div className="space-y-4">
-              <CollapsibleSection title="1. Client Request (Input)" defaultOpen={true} icon="input">
+              <CollapsibleSection title={translate("1. Client Request (Input)")} defaultOpen={true} icon="input">
                 <pre className="bg-black/5 dark:bg-white/5 p-4 rounded-lg overflow-auto max-h-[300px] text-xs font-mono text-text-main border border-black/5 dark:border-white/5">
                   {JSON.stringify(selectedDetail.request, null, 2)}
                 </pre>
               </CollapsibleSection>
 
               {selectedDetail.providerRequest && (
-                <CollapsibleSection title="2. Provider Request (Translated)" icon="translate">
+                <CollapsibleSection title={translate("2. Provider Request (Translated)")} icon="translate">
                   <pre className="bg-black/5 dark:bg-white/5 p-4 rounded-lg overflow-auto max-h-[300px] text-xs font-mono text-text-main border border-black/5 dark:border-white/5">
                     {JSON.stringify(selectedDetail.providerRequest, null, 2)}
                   </pre>
@@ -386,7 +387,7 @@ export default function RequestDetailsTab() {
               )}
 
               {selectedDetail.providerResponse && (
-                <CollapsibleSection title="3. Provider Response (Raw)" icon="data_object">
+                <CollapsibleSection title={translate("3. Provider Response (Raw)")} icon="data_object">
                   <pre className="bg-black/5 dark:bg-white/5 p-4 rounded-lg overflow-auto max-h-[300px] text-xs font-mono text-text-main border border-black/5 dark:border-white/5">
                     {typeof selectedDetail.providerResponse === 'object'
                       ? JSON.stringify(selectedDetail.providerResponse, null, 2)
@@ -395,25 +396,25 @@ export default function RequestDetailsTab() {
                   </pre>
                 </CollapsibleSection>
               )}
-              
-              <CollapsibleSection title="4. Client Response (Final)" defaultOpen={true} icon="output">
+
+              <CollapsibleSection title={translate("4. Client Response (Final)")} defaultOpen={true} icon="output">
                 {selectedDetail.response?.thinking && (
                   <div className="mb-4">
                     <h4 className="font-semibold text-text-main mb-2 flex items-center gap-2 text-xs uppercase tracking-wide opacity-70">
                       <span className="material-symbols-outlined text-[16px]">psychology</span>
-                      Thinking Process
+                      {translate("Thinking Process")}
                     </h4>
                     <pre className="bg-amber-50 dark:bg-amber-950/30 p-4 rounded-lg overflow-auto max-h-[200px] text-xs font-mono text-amber-900 dark:text-amber-100 border border-amber-200 dark:border-amber-800">
                       {selectedDetail.response.thinking}
                     </pre>
                   </div>
                 )}
-                
+
                 <h4 className="font-semibold text-text-main mb-2 text-xs uppercase tracking-wide opacity-70">
-                  Content
+                  {translate("Content")}
                 </h4>
                 <pre className="bg-black/5 dark:bg-white/5 p-4 rounded-lg overflow-auto max-h-[300px] text-xs font-mono text-text-main border border-black/5 dark:border-white/5">
-                  {selectedDetail.response?.content || "[No content]"}
+                  {selectedDetail.response?.content || `[${translate("No content")}]`}
                 </pre>
               </CollapsibleSection>
             </div>

--- a/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
+++ b/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
@@ -13,6 +13,7 @@ import {
   Legend,
 } from "recharts";
 import Card from "@/shared/components/Card";
+import { translate } from "@/i18n/runtime";
 
 const fmtTokens = (n) => {
   if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
@@ -55,20 +56,20 @@ export default function UsageChart({ period = "7d" }) {
           onClick={() => setViewMode("tokens")}
           className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "tokens" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}
         >
-          Tokens
+          {translate("Tokens")}
         </button>
         <button
           onClick={() => setViewMode("cost")}
           className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "cost" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}
         >
-          Cost
+          {translate("Cost")}
         </button>
       </div>
 
       {loading ? (
-        <div className="h-48 flex items-center justify-center text-text-muted text-sm">Loading...</div>
+        <div className="h-48 flex items-center justify-center text-text-muted text-sm">{translate("Loading...")}</div>
       ) : !hasData ? (
-        <div className="h-48 flex items-center justify-center text-text-muted text-sm">No data for this period</div>
+        <div className="h-48 flex items-center justify-center text-text-muted text-sm">{translate("No data for this period")}</div>
       ) : (
         <ResponsiveContainer width="100%" height={200}>
           <AreaChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>

--- a/src/app/(dashboard)/dashboard/usage/components/UsageTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/UsageTable.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo, Fragment } from "react";
 import PropTypes from "prop-types";
 import Card from "@/shared/components/Card";
 import Badge from "@/shared/components/Badge";
+import { translate } from "@/i18n/runtime";
 
 const fmt = (n) => new Intl.NumberFormat().format(n || 0);
 const fmtCost = (n) => `$${(n || 0).toFixed(2)}`;
@@ -132,15 +133,15 @@ export default function UsageTable({
   const valueColumns = useMemo(() => {
     if (viewMode === "tokens") {
       return [
-        { field: "promptTokens", label: "Input Tokens" },
-        { field: "completionTokens", label: "Output Tokens" },
-        { field: "totalTokens", label: "Total Tokens" },
+        { field: "promptTokens", label: translate("Input Tokens") },
+        { field: "completionTokens", label: translate("Output Tokens") },
+        { field: "totalTokens", label: translate("Total Tokens") },
       ];
     }
     return [
-      { field: "promptTokens", label: "Input Cost" },
-      { field: "completionTokens", label: "Output Cost" },
-      { field: "cost", label: "Total Cost" },
+      { field: "promptTokens", label: translate("Input Cost") },
+      { field: "completionTokens", label: translate("Output Cost") },
+      { field: "cost", label: translate("Total Cost") },
     ];
   }, [viewMode]);
 

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -8,13 +8,14 @@ import OverviewCards from "@/app/(dashboard)/dashboard/usage/components/Overview
 import UsageTable, { fmt, fmtTime } from "@/app/(dashboard)/dashboard/usage/components/UsageTable";
 import ProviderTopology from "@/app/(dashboard)/dashboard/usage/components/ProviderTopology";
 import UsageChart from "@/app/(dashboard)/dashboard/usage/components/UsageChart";
+import { translate } from "@/i18n/runtime";
 
 function timeAgo(timestamp) {
   const diff = Math.floor((Date.now() - new Date(timestamp)) / 1000);
-  if (diff < 60) return `${diff}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
+  if (diff < 60) return `${diff}${translate("s ago")}`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}${translate("m ago")}`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}${translate("h ago")}`;
+  return `${Math.floor(diff / 86400)}${translate("d ago")}`;
 }
 
 // Auto-update time display every second without re-rendering parent
@@ -34,20 +35,20 @@ function RecentRequests({ requests = [] }) {
     <Card className="flex flex-col overflow-hidden" padding="sm" style={{ height: 480 }}>
       {/* Header */}
       <div className="px-1 py-2 border-b border-border shrink-0">
-        <span className="text-xs font-semibold text-text-muted uppercase tracking-wide">Recent Requests</span>
+        <span className="text-xs font-semibold text-text-muted uppercase tracking-wide">{translate("Recent Requests")}</span>
       </div>
 
       {!requests.length ? (
-        <div className="flex-1 flex items-center justify-center text-text-muted text-sm">No requests yet.</div>
+        <div className="flex-1 flex items-center justify-center text-text-muted text-sm">{translate("No requests yet.")}</div>
       ) : (
         <div className="flex-1 overflow-y-auto">
           <table className="w-full text-xs border-collapse">
             <thead className="sticky top-0 bg-bg z-10">
               <tr className="border-b border-border">
                 <th className="py-1.5 text-left font-semibold text-text-muted w-2"></th>
-                <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
-                <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
-                <th className="py-1.5 text-right font-semibold text-text-muted">When</th>
+                <th className="py-1.5 text-left font-semibold text-text-muted">{translate("Model")}</th>
+                <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">{translate("In / Out")}</th>
+                <th className="py-1.5 text-right font-semibold text-text-muted">{translate("When")}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
@@ -166,11 +167,11 @@ const ENDPOINT_COLUMNS = [
   { field: "lastUsed", label: "Last Used", align: "right" },
 ];
 
-const TABLE_OPTIONS = [
-  { value: "model", label: "Usage by Model" },
-  { value: "account", label: "Usage by Account" },
-  { value: "apiKey", label: "Usage by API Key" },
-  { value: "endpoint", label: "Usage by Endpoint" },
+const getTableOptions = () => [
+  { value: "model", label: translate("Usage by Model") },
+  { value: "account", label: translate("Usage by Account") },
+  { value: "apiKey", label: translate("Usage by API Key") },
+  { value: "endpoint", label: translate("Usage by Endpoint") },
 ];
 
 const PERIODS = [
@@ -276,7 +277,7 @@ export default function UsageStats() {
           columns: MODEL_COLUMNS,
           groupedData: groupDataByKey(sortData(stats.byModel, pendingMap, sortBy, sortOrder), "rawModel"),
           storageKey: "usage-stats:expanded-models",
-          emptyMessage: "No usage recorded yet.",
+          emptyMessage: translate("No usage recorded yet."),
           renderSummaryCells: (group) => (
             <>
               <td className="px-6 py-3 text-text-muted">—</td>
@@ -309,7 +310,7 @@ export default function UsageStats() {
           columns: ACCOUNT_COLUMNS,
           groupedData: groupDataByKey(sortData(stats.byAccount, pendingMap, sortBy, sortOrder), "accountName"),
           storageKey: "usage-stats:expanded-accounts",
-          emptyMessage: "No account-specific usage recorded yet.",
+          emptyMessage: translate("No account-specific usage recorded yet."),
           renderSummaryCells: (group) => (
             <>
               <td className="px-6 py-3 text-text-muted">—</td>
@@ -334,7 +335,7 @@ export default function UsageStats() {
           columns: API_KEY_COLUMNS,
           groupedData: groupDataByKey(sortData(stats.byApiKey, {}, sortBy, sortOrder), "keyName"),
           storageKey: "usage-stats:expanded-apikeys",
-          emptyMessage: "No API key usage recorded yet.",
+          emptyMessage: translate("No API key usage recorded yet."),
           renderSummaryCells: (group) => (
             <>
               <td className="px-6 py-3 text-text-muted">—</td>
@@ -360,7 +361,7 @@ export default function UsageStats() {
           columns: ENDPOINT_COLUMNS,
           groupedData: groupDataByKey(sortData(stats.byEndpoint, {}, sortBy, sortOrder), "endpoint"),
           storageKey: "usage-stats:expanded-endpoints",
-          emptyMessage: "No endpoint usage recorded yet.",
+          emptyMessage: translate("No endpoint usage recorded yet."),
           renderSummaryCells: (group) => (
             <>
               <td className="px-6 py-3 text-text-muted">—</td>
@@ -383,7 +384,7 @@ export default function UsageStats() {
     }
   }, [stats, tableView, sortBy, sortOrder]);
 
-  if (!stats && !loading) return <div className="text-text-muted">Failed to load usage statistics.</div>;
+  if (!stats && !loading) return <div className="text-text-muted">{translate("Failed to load usage statistics.")}</div>;
 
   const spinner = (
     <div className="flex items-center justify-center py-12 text-text-muted">
@@ -439,7 +440,7 @@ export default function UsageStats() {
             onChange={(e) => setTableView(e.target.value)}
             className="px-3 py-1.5 rounded-lg border border-border bg-bg-subtle text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/50"
           >
-            {TABLE_OPTIONS.map((opt) => (
+            {getTableOptions().map((opt) => (
               <option key={opt.value} value={opt.value}>{opt.label}</option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- connect dashboard views to the shared translation runtime
- replace hard-coded dashboard copy with translation lookups across the existing UI
- keep this PR focused on dashboard i18n wiring only

## Validation
- ran `npm run build`
- verified the branch contains exactly one commit on top of upstream master
- passed open-source commit guardrail checks for staged and range modes

## Notes
This PR is limited to dashboard i18n integration and intentionally excludes unrelated quota, API, database, and init changes.
