### PR TITLE
fix: skip disabled providers in combo fallback

### DIFF
--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -148,8 +148,8 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }
       if (excludeConnectionIds.size === 0) {
-        log.error("AUTH", `No credentials for provider: ${provider}`);
-        return errorResponse(HTTP_STATUS.BAD_REQUEST, `No credentials for provider: ${provider}`);
+        log.warn("AUTH", `No active credentials for provider: ${provider}`);
+        return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
       }
       log.warn("CHAT", "No more accounts available", { provider });
       return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");


### PR DESCRIPTION
## Summary

- When a combo model includes a provider with only disabled credentials, return `404` (fallbackable) instead of `400` (hard error), so the combo handler skips to the next model
- Changed log level from `error` to `warn` since disabled credentials are an expected state

Fixes #334
Fixes #164
Fixes #25

## Problem

A combo like `antigravity/opus → github/opus` would fail with `406: No credentials for provider: github` when GitHub credentials were disabled. The `400` status from `handleSingleModelChat` was treated as non-fallbackable by the combo handler, killing the client.

## Change

**1 file, 2 lines changed** — `src/sse/handlers/chat.js`

`HTTP_STATUS.BAD_REQUEST` → `HTTP_STATUS.NOT_FOUND` for the "no credentials" case when no connections have been tried yet. `checkFallbackError` already handles `NOT_FOUND` as fallbackable with a `notFound` cooldown.

## Test plan

- [ ] Create a combo with a provider that has all credentials disabled
- [ ] Verify the combo skips the disabled provider and tries the next model
- [ ] Verify providers with no credentials at all also get skipped
- [ ] Verify providers with active credentials still work normally