### PR TITLE
fix: retry transient errors before falling through combo chain

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -5,6 +5,11 @@
 import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 
+// Maximum delay (ms) to wait before retrying a transiently failed model
+const COMBO_RETRY_MAX_DELAY_MS = 10_000;
+// Maximum number of retries per model for transient errors
+const COMBO_RETRY_MAX_ATTEMPTS = 2;
+
 /**
  * Get combo models from combos data
  * @param {string} modelStr - Model string to check
@@ -14,14 +19,45 @@ import { unavailableResponse } from "../utils/error.js";
 export function getComboModelsFromData(modelStr, combosData) {
   // Don't check if it's in provider/model format
   if (modelStr.includes("/")) return null;
-  
+
   // Handle both array and object formats
   const combos = Array.isArray(combosData) ? combosData : (combosData?.combos || []);
-  
+
   const combo = combos.find(c => c.name === modelStr);
   if (combo && combo.models && combo.models.length > 0) {
     return combo.models;
   }
+  return null;
+}
+
+/**
+ * Extract retry delay in milliseconds from a failed response.
+ * Checks both the Retry-After header and the JSON body's retryAfter field.
+ * @param {Response} result - The failed response
+ * @returns {Promise<number|null>} Delay in ms, or null if not retryable
+ */
+async function extractRetryDelayMs(result) {
+  // Check Retry-After header first (value in seconds)
+  const retryAfterHeader = result.headers?.get?.("Retry-After");
+  if (retryAfterHeader) {
+    const seconds = Number(retryAfterHeader);
+    if (!isNaN(seconds) && seconds > 0) {
+      return seconds * 1000;
+    }
+  }
+
+  // Check JSON body for retryAfter (ISO timestamp)
+  try {
+    const errorBody = await result.clone().json();
+    const retryAfter = errorBody?.retryAfter;
+    if (retryAfter) {
+      const delayMs = new Date(retryAfter).getTime() - Date.now();
+      if (delayMs > 0) return delayMs;
+    }
+  } catch {
+    // Ignore parse errors
+  }
+
   return null;
 }
 
@@ -41,55 +77,79 @@ export async function handleComboChat({ body, models, handleSingleModel, log }) 
 
   for (let i = 0; i < models.length; i++) {
     const modelStr = models[i];
-    log.info("COMBO", `Trying model ${i + 1}/${models.length}: ${modelStr}`);
+    let retryAttempt = 0;
 
-    try {
-      const result = await handleSingleModel(body, modelStr);
-      
-      // Success (2xx) - return response
-      if (result.ok) {
-        log.info("COMBO", `Model ${modelStr} succeeded`);
-        return result;
-      }
+    while (retryAttempt <= COMBO_RETRY_MAX_ATTEMPTS) {
+      const attemptLabel = retryAttempt > 0
+        ? `Retrying model ${i + 1}/${models.length}: ${modelStr} (attempt ${retryAttempt + 1})`
+        : `Trying model ${i + 1}/${models.length}: ${modelStr}`;
+      log.info("COMBO", attemptLabel);
 
-      // Extract error info from response
-      let errorText = result.statusText || "";
-      let retryAfter = null;
       try {
-        const errorBody = await result.clone().json();
-        errorText = errorBody?.error?.message || errorBody?.error || errorBody?.message || errorText;
-        retryAfter = errorBody?.retryAfter || null;
-      } catch {
-        // Ignore JSON parse errors
-      }
+        const result = await handleSingleModel(body, modelStr);
 
-      // Track earliest retryAfter across all combo models
-      if (retryAfter && (!earliestRetryAfter || new Date(retryAfter) < new Date(earliestRetryAfter))) {
-        earliestRetryAfter = retryAfter;
-      }
+        // Success (2xx) - return response
+        if (result.ok) {
+          log.info("COMBO", `Model ${modelStr} succeeded`);
+          return result;
+        }
 
-      // Normalize error text to string (Worker-safe)
-      if (typeof errorText !== "string") {
-        try { errorText = JSON.stringify(errorText); } catch { errorText = String(errorText); }
-      }
+        // Extract retry delay for potential transient retry
+        const retryDelayMs = await extractRetryDelayMs(result);
 
-      // Check if should fallback to next model
-      const { shouldFallback } = checkFallbackError(result.status, errorText);
-      
-      if (!shouldFallback) {
-        log.warn("COMBO", `Model ${modelStr} failed (no fallback)`, { status: result.status });
-        return result;
-      }
+        // Extract error info from response
+        let errorText = result.statusText || "";
+        let retryAfter = null;
+        try {
+          const errorBody = await result.clone().json();
+          errorText = errorBody?.error?.message || errorBody?.error || errorBody?.message || errorText;
+          retryAfter = errorBody?.retryAfter || null;
+        } catch {
+          // Ignore JSON parse errors
+        }
 
-      // Fallback to next model
-      lastError = errorText || String(result.status);
-      if (!lastStatus) lastStatus = result.status;
-      log.warn("COMBO", `Model ${modelStr} failed, trying next`, { status: result.status });
-    } catch (error) {
-      // Catch unexpected exceptions to ensure fallback continues
-      lastError = error.message || String(error);
-      if (!lastStatus) lastStatus = 500;
-      log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError });
+        // Track earliest retryAfter across all combo models
+        if (retryAfter && (!earliestRetryAfter || new Date(retryAfter) < new Date(earliestRetryAfter))) {
+          earliestRetryAfter = retryAfter;
+        }
+
+        // Normalize error text to string (Worker-safe)
+        if (typeof errorText !== "string") {
+          try { errorText = JSON.stringify(errorText); } catch { errorText = String(errorText); }
+        }
+
+        // Check if should fallback to next model
+        const { shouldFallback } = checkFallbackError(result.status, errorText);
+
+        if (!shouldFallback) {
+          log.warn("COMBO", `Model ${modelStr} failed (no fallback)`, { status: result.status });
+          return result;
+        }
+
+        // If the retry delay is short enough, wait and retry the same model
+        if (
+          retryDelayMs &&
+          retryDelayMs <= COMBO_RETRY_MAX_DELAY_MS &&
+          retryAttempt < COMBO_RETRY_MAX_ATTEMPTS
+        ) {
+          log.info("COMBO", `Model ${modelStr} temporarily unavailable, retrying in ${Math.ceil(retryDelayMs / 1000)}s`);
+          await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+          retryAttempt++;
+          continue;
+        }
+
+        // Fallback to next model
+        lastError = errorText || String(result.status);
+        if (!lastStatus) lastStatus = result.status;
+        log.warn("COMBO", `Model ${modelStr} failed, trying next`, { status: result.status });
+        break;
+      } catch (error) {
+        // Catch unexpected exceptions to ensure fallback continues
+        lastError = error.message || String(error);
+        if (!lastStatus) lastStatus = 500;
+        log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError });
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- When all API keys for a provider are temporarily locked (e.g., 503 "No capacity"), wait for the short cooldown and retry the same model before falling through to the next combo model
- Adds `extractRetryDelayMs()` helper to read `Retry-After` header and `retryAfter` body field
- Configurable: max 10s delay, max 2 retry attempts per model

Fixes #335

## Problem

A combo like `antigravity/opus → github/opus` would immediately fall through to GitHub when both Antigravity keys got transient 503s with 1-2 second cooldowns. Simply waiting 1-2 seconds would have let the request succeed on Antigravity, but instead it hit GitHub (which may have no active credentials), killing the client.

## How it works

Inside `handleComboChat`, after a model fails with a fallbackable error:

1. Extract retry delay from `Retry-After` header or `retryAfter` in the JSON body
2. If delay ≤ `COMBO_RETRY_MAX_DELAY_MS` (10s) and attempts < `COMBO_RETRY_MAX_ATTEMPTS` (2): wait, then retry the same model
3. If delay is too long, retries exhausted, or no retry info: fall through to next model (existing behavior)
4. Permanent errors (401, 403, etc.) are never retried — `shouldFallback` check runs first

## Change

**1 file changed** — `open-sse/services/combo.js`

The `for` loop over models now wraps each attempt in a `while` loop that handles retries. All existing behavior is preserved when no `Retry-After` is present.

## Test plan

- [ ] Combo with a provider that returns 503 with short Retry-After → should retry and succeed
- [ ] Combo with a provider that returns 503 with long Retry-After (>10s) → should fall through immediately
- [ ] Combo with a provider that returns 401 → should not retry, fall through immediately
- [ ] Combo where retries are exhausted → should fall through to next model
- [ ] Combo with no Retry-After header → existing behavior preserved (immediate fallthrough)
- [ ] Normal (non-combo) requests → unaffected