### PR TITLE
fix: prevent duplicate model aliases on import

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -1197,6 +1197,9 @@ function CompatibleModelsSection({ providerStorageAlias, providerDisplayAlias, m
   };
 
   const resolveAlias = (modelId) => {
+    const fullModel = `${providerStorageAlias}/${modelId}`;
+    // Skip if this exact model already has an alias
+    if (Object.values(modelAliases).includes(fullModel)) return null;
     const baseAlias = generateDefaultAlias(modelId);
     if (!modelAliases[baseAlias]) return baseAlias;
     const prefixedAlias = `${providerDisplayAlias}-${baseAlias}`;


### PR DESCRIPTION
## Summary
- Model import now checks if the underlying model value already has an alias before creating a new one
- Previously, re-importing models would create duplicate aliases (e.g., `gpt-4o` and `oc-prod-gpt-4o`) pointing to the same underlying model
- The fix adds a value-side check in `resolveAlias` — if any existing alias already maps to the same `provider/model`, the import skips it

Fixes #180