### PR TITLE
fix: verify Cursor installation on Linux before auto-import

### DIFF
--- a/src/app/api/oauth/cursor/auto-import/route.js
+++ b/src/app/api/oauth/cursor/auto-import/route.js
@@ -154,6 +154,27 @@ export async function GET() {
       });
     }
 
+    // On Linux, verify Cursor is actually installed (not just leftover config)
+    if (platform === "linux") {
+      let cursorInstalled = false;
+      try {
+        await execFileAsync("which", ["cursor"], { timeout: 5000 });
+        cursorInstalled = true;
+      } catch {
+        try {
+          const desktopFile = join(homedir(), ".local/share/applications/cursor.desktop");
+          await access(desktopFile, constants.R_OK);
+          cursorInstalled = true;
+        } catch { /* not found */ }
+      }
+      if (!cursorInstalled) {
+        return NextResponse.json({
+          found: false,
+          error: "Cursor config files found but Cursor IDE does not appear to be installed. Skipping auto-import.",
+        });
+      }
+    }
+
     // Strategy 1: better-sqlite3 bundled → then global install fallback
     let Database = null;
     try {


### PR DESCRIPTION
## Summary
- On Linux, the Cursor auto-import now verifies that Cursor IDE is actually installed before importing tokens
- Previously, leftover config files from a removed Cursor installation would trigger a false positive, creating a phantom Cursor provider connection
- The check uses `which cursor` and falls back to checking for a `.desktop` file in `~/.local/share/applications/`

Fixes #313