### PR TITLE
fix: support HTTP/HTTPS image URLs in request translators

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.js
+++ b/open-sse/translator/helpers/geminiHelper.js
@@ -54,6 +54,10 @@ export function convertOpenAIContentToParts(content) {
             inlineData: { mime_type: mimeType, data: data }
           });
         }
+      } else if (item.type === "image_url" && item.image_url?.url && (item.image_url.url.startsWith("http://") || item.image_url.url.startsWith("https://"))) {
+        parts.push({
+          fileData: { fileUri: item.image_url.url, mimeType: "image/*" }
+        });
       }
     }
   }

--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -216,6 +216,11 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map()) {
               type: "image",
               source: { type: "base64", media_type: match[1], data: match[2] }
             });
+          } else if (url.startsWith("http://") || url.startsWith("https://")) {
+            blocks.push({
+              type: "image",
+              source: { type: "url", url }
+            });
           }
         } else if (part.type === "image" && part.source) {
           blocks.push({ type: "image", source: part.source });


### PR DESCRIPTION
## Summary

- Adds HTTP/HTTPS image URL support to the OpenAI-to-Claude request translator using Claude's `source: { type: "url" }` format
- Adds HTTP/HTTPS image URL support to the Gemini helper using `fileData: { fileUri }` format
- Previously only `data:` base64 URLs were handled; HTTP/HTTPS URLs were silently dropped

Fixes #208