### PR TITLE
fix: externalize better-sqlite3 for standalone builds

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  serverExternalPackages: ["better-sqlite3"],
   images: {
     unoptimized: true
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@monaco-editor/react": "^4.7.0",
     "@xyflow/react": "^12.10.1",
     "bcryptjs": "^3.0.3",
-    "better-sqlite3": "^12.6.2",
     "confbox": "^0.2.4",
     "express": "^5.2.1",
     "fs": "^0.0.1-security",
@@ -37,6 +36,9 @@
     "undici": "^7.19.2",
     "uuid": "^13.0.0",
     "zustand": "^5.0.10"
+  },
+  "optionalDependencies": {
+    "better-sqlite3": "^12.6.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",


### PR DESCRIPTION
## Summary
- Moves `better-sqlite3` from `dependencies` to `optionalDependencies` so npm install doesn't fail on platforms without native build tools (e.g., Docker Alpine, CI runners without python/make/g++)
- Adds `better-sqlite3` to `serverExternalPackages` in next.config.mjs so Next.js doesn't attempt to bundle the native addon into webpack chunks

## Approach
`better-sqlite3` is a native Node.js addon that requires compilation during install. When it's a hard dependency, install fails on platforms missing build tools. Moving it to `optionalDependencies` means npm will try to install it but won't fail if compilation fails — the existing 3-tier fallback in the code (SQLite → JSON file → in-memory) handles the missing module gracefully.

The `serverExternalPackages` config tells Next.js standalone output to keep native modules external rather than trying to bundle them through webpack, which avoids the "cannot find module" errors in production builds.

## Test plan
- [ ] Verify `npm install` succeeds even when `better-sqlite3` compilation fails
- [ ] Verify `next build` completes without webpack errors for better-sqlite3
- [ ] Verify the SQLite fallback chain still works when better-sqlite3 is available
- [ ] Verify the JSON file fallback works when better-sqlite3 is not available

Fixes #243
Fixes #184