### PR TITLE
fix: incorrect finish_reason for tool calls in OpenAI Responses translator

### DIFF
--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -355,6 +355,14 @@ function flushEvents(state) {
   return events;
 }
 
+// currentToolCallId is intentionally sticky for the current turn so flush/completion
+  // can still finalize as tool_calls even if the tool call was emitted before stream end.
+function computeFinishReason(state) {
+   return state.toolCallIndex > 0 || state.currentToolCallId
+    ? "tool_calls"
+    : "stop";
+}
+
 /**
  * Translate OpenAI Responses API chunk to OpenAI Chat Completions format
  * This is for when Codex returns data and we need to send it to an OpenAI-compatible client
@@ -362,21 +370,30 @@ function flushEvents(state) {
 export function openaiResponsesToOpenAIResponse(chunk, state) {
   if (!chunk) {
     // Flush: send final chunk with finish_reason
-    if (!state.finishReasonSent && state.started) {
-      state.finishReasonSent = true;
-      return {
-        id: state.chatId || `chatcmpl-${Date.now()}`,
-        object: "chat.completion.chunk",
-        created: state.created || Math.floor(Date.now() / 1000),
-        model: state.model || "unknown",
-        choices: [{
-          index: 0,
-          delta: {},
-          finish_reason: "stop"
-        }]
-      };
+    if (state.finishReasonSent || !state.started) return null;
+
+    const finishReason = computeFinishReason(state);
+
+    state.finishReasonSent = true;
+    state.finishReason = finishReason;
+
+    const finalChunk = {
+      id: state.chatId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: state.created || Math.floor(Date.now() / 1000),
+      model: state.model || "unknown",
+      choices: [{
+        index: 0,
+        delta: {},
+        finish_reason: finishReason
+      }]
+    };
+
+    if (state.usage && typeof state.usage === "object") {
+      finalChunk.usage = state.usage;
     }
-    return null;
+
+    return finalChunk;
   }
 
   // Handle different event types from Responses API
@@ -504,8 +521,10 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     }
     
     if (!state.finishReasonSent) {
+      const finishReason = computeFinishReason(state);
+
       state.finishReasonSent = true;
-      state.finishReason = "stop"; // Mark for usage injection in stream.js
+      state.finishReason = finishReason; // Mark for usage injection in stream.js
       
       const finalChunk = {
         id: state.chatId,
@@ -515,7 +534,7 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
         choices: [{
           index: 0,
           delta: {},
-          finish_reason: "stop"
+          finish_reason: finishReason
         }]
       };
       
@@ -568,4 +587,3 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 // Register both directions
 register(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, null, openaiToOpenAIResponsesResponse);
 register(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI, null, openaiResponsesToOpenAIResponse);
-


### PR DESCRIPTION
## Problem
  In some tool-calling flows, clients stop right after the first tool call instead of continuing with the tool result.

  ## Root cause
  The OpenAI Responses -> Chat Completions translator was finalizing the turn with `finish_reason: "stop"` even when the model had already emitted
  a tool/function call.
  For OpenAI-compatible clients, that signals the turn is fully complete, so they stop too early.

  ## Solution
  This change makes the translator return `finish_reason: "tool_calls"` for turns that contain a tool/function call, while keeping `finish_reason:
  "stop"` for normal text-only responses.

  ## Scope
  This only affects tool-calling behavior in the OpenAI Responses translation path.
  Regular non-tool responses should continue to behave the same.

## Test
  Verified with:
  - [x] a text-only request still ending with `finish_reason: "stop"`
  - [x] a direct tool-call request ending with `finish_reason: "tool_calls"`
  - [x] an end-to-end skill flow that now continues after the first tool call
  - [x] an end-to-end normal tool flow that now continues after tool execution and returns the final response

  After this change:
  - tool-call turns end with `tool_calls`
  - the client continues after tool execution
  - text-only turns still end with `stop`