### PR TITLE
feat: add MiniMax M2.7 model support

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -198,10 +198,12 @@ export const PROVIDER_MODELS = {
     { id: "kimi-latest", name: "Kimi Latest" },
   ],
   minimax: [
+    { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
     { id: "MiniMax-M2.1", name: "MiniMax M2.1" },
   ],
   "minimax-cn": [
+    { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
     { id: "MiniMax-M2.1", name: "MiniMax M2.1" },
   ],

--- a/src/shared/constants/pricing.js
+++ b/src/shared/constants/pricing.js
@@ -744,6 +744,20 @@ export const DEFAULT_PRICING = {
 
   // MiniMax
   minimax: {
+    "MiniMax-M2.7": {
+      input: 0.50,
+      output: 2.00,
+      cached: 0.25,
+      reasoning: 3.00,
+      cache_creation: 0.50
+    },
+    "MiniMax-M2.5": {
+      input: 0.50,
+      output: 2.00,
+      cached: 0.25,
+      reasoning: 3.00,
+      cache_creation: 0.50
+    },
     "MiniMax-M2.1": {
       input: 0.50,
       output: 2.00,


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 to `providerModels.js` (both minimax and minimax-cn arrays)
- Add pricing entries for MiniMax-M2.7 and M2.5 in `pricing.js`
- M2.7 is MiniMax's latest reasoning model with 204K context window

## Test plan
- [x] Verify MiniMax-M2.7 appears in model list at `/v1/models`
- [x] Verify pricing shows correctly in dashboard
- [x] Test chat completion with `MiniMax-M2.7` model ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)