### PR TITLE
Patch: Sanitize Gemini tool schemas during OpenAI translation

### DIFF
--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -178,19 +178,21 @@ function openaiToGeminiBase(model, body, stream) {
     for (const t of body.tools) {
       // Check if already in Anthropic/Claude format (no type field, direct name/description/input_schema)
       if (t.name && t.input_schema) {
+        const cleanedSchema = cleanJSONSchemaForAntigravity(structuredClone(t.input_schema || { type: "object", properties: {} }));
         functionDeclarations.push({
           name: t.name,
           description: t.description || "",
-          parameters: t.input_schema || { type: "object", properties: {} }
+          parameters: cleanedSchema
         });
       }
       // OpenAI format
       else if (t.type === "function" && t.function) {
         const fn = t.function;
+        const cleanedSchema = cleanJSONSchemaForAntigravity(structuredClone(fn.parameters || { type: "object", properties: {} }));
         functionDeclarations.push({
           name: fn.name,
           description: fn.description || "",
-          parameters: fn.parameters || { type: "object", properties: {} }
+          parameters: cleanedSchema
         });
       }
     }


### PR DESCRIPTION
Apply cleanJSONSchemaForAntigravity to both Anthropic and OpenAI format tool schemas before converting to Gemini function declarations

# Fix Applied

I patched the Gemini request translator so tool schemas are sanitized in the **shared** `OpenAI -> Gemini` path, not just in the CLI/Antigravity path.

## Root Cause

- **Claude endpoint requests** in this stack are translated through:
  - `Claude -> OpenAI -> Gemini`
- The shared Gemini tool conversion in [open-sse/translator/request/openai-to-gemini.js](cci:7://file:///Users/quanle96/Documents/9router/open-sse/translator/request/openai-to-gemini.js:0:0-0:0) was forwarding raw `input_schema` / `parameters`.
- That allowed Gemini-incompatible JSON Schema fields like:
  - `"$schema"`
  - `additionalProperties`
- Gemini then rejected the payload with the `Unknown name ... at tools[0].function_declarations[0].parameters` error you saw.

## What I Changed

- **File:** [open-sse/translator/request/openai-to-gemini.js](cci:7://file:///Users/quanle96/Documents/9router/open-sse/translator/request/openai-to-gemini.js:0:0-0:0)
- **Change:** sanitize tool schemas during tool conversion for both:
  - Claude-style tools: `input_schema`
  - OpenAI-style tools: `function.parameters`
