### PR TITLE
fix: add missing type:string to enum properties in Gemini tool schema translation

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.js
+++ b/open-sse/translator/helpers/geminiHelper.js
@@ -138,12 +138,16 @@ function convertConstToEnum(obj) {
   }
 }
 
-// Convert enum values to strings (Gemini requires string enum values)
+// Convert enum values to strings (Gemini requires string enum values + explicit type:"string")
 function convertEnumValuesToStrings(obj) {
   if (!obj || typeof obj !== "object") return;
 
   if (obj.enum && Array.isArray(obj.enum)) {
     obj.enum = obj.enum.map(v => String(v));
+    // Gemini API requires type:"string" when enum is present — without it returns 400
+    if (!obj.type) {
+      obj.type = "string";
+    }
   }
 
   for (const value of Object.values(obj)) {


### PR DESCRIPTION
Fixes #359.

## Problem

When converting OpenAI/Anthropic tool schemas to Gemini format, enum properties were being converted to string values (correct) but the required `type: "string"` declaration was not being added.

Gemini API returns `400 Bad Request: function declaration enum only allowed for STRING type` when an enum property is missing the `type` field. This broke Claude Code tools, Droid tools, and any tool using enum parameters with Gemini/Antigravity providers.

## Fix

In `convertEnumValuesToStrings()` in `open-sse/translator/helpers/geminiHelper.js` — when an `enum` array is present and no `type` is set, default to `type: "string"`.

## Testing

Any tool call with an enum parameter to a Gemini/Antigravity model should now work without 400 errors.