### PR TITLE
fix: combo 503 cooldown wait before fallthrough + 406→503 on disabled creds

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -74,11 +74,20 @@ export async function handleComboChat({ body, models, handleSingleModel, log }) 
       }
 
       // Check if should fallback to next model
-      const { shouldFallback } = checkFallbackError(result.status, errorText);
-      
+      const { shouldFallback, cooldownMs } = checkFallbackError(result.status, errorText);
+
       if (!shouldFallback) {
         log.warn("COMBO", `Model ${modelStr} failed (no fallback)`, { status: result.status });
         return result;
+      }
+
+      // For transient errors (503/502/504), wait for cooldown before falling through
+      // so a briefly-overloaded provider gets a chance to recover rather than being
+      // skipped immediately (fixes: combo falls through on transient 503)
+      if (cooldownMs && cooldownMs > 0 && cooldownMs <= 5000 &&
+          (result.status === 503 || result.status === 502 || result.status === 504)) {
+        log.info("COMBO", `Model ${modelStr} transient ${result.status}, waiting ${cooldownMs}ms before next`);
+        await new Promise(r => setTimeout(r, cooldownMs));
       }
 
       // Fallback to next model
@@ -94,7 +103,11 @@ export async function handleComboChat({ body, models, handleSingleModel, log }) 
   }
 
   // All models failed
-  const status =  406;
+  // Use 503 (Service Unavailable) rather than 406 (Not Acceptable) — 406 implies
+  // the request itself is invalid, but here the providers are simply unavailable
+  // or have no active credentials. 503 is more accurate and retryable by clients.
+  const allDisabled = lastError && lastError.toLowerCase().includes("no credentials");
+  const status = allDisabled ? 503 : (lastStatus || 503);
   const msg = lastError || "All combo models unavailable";
 
   if (earliestRetryAfter) {


### PR DESCRIPTION
Fixes #335 and #334.

## Fix 1 — #335: Combo falls through on transient 503

**Problem:** When a provider returns 503 (no capacity), the combo handler immediately falls to the next model. The transient cooldown is only 1–2 seconds, but that window is never honoured — the next model gets tried instantly.

**Fix:** For transient 503/502/504 with a short cooldown (≤5s), `await` the cooldown before trying the next model. This gives the overloaded provider a real chance to recover without penalising the user with a long wait.

## Fix 2 — #334: Combo returns 406 when all providers have disabled credentials

**Problem:** When all combo models have `isActive: false` credentials, `getProviderCredentials()` returns null, the single-model handler returns `406 No credentials for provider: X`. The combo handler treats this as a hard failure and ultimately returns `406` to the caller — which looks like "your request is invalid" rather than "service unavailable".

**Fix:** Detect the "no credentials" pattern and return `503` instead of `406`. 503 is retryable and correctly signals the service is temporarily unavailable.