### PR TITLE
fix(chat): empty assistant content for Codex non-streaming Responses SSE

### DIFF
--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -1,4 +1,4 @@
-import { convertResponsesStreamToJson } from "../../transformer/streamToJsonConverter.js";
+import { convertResponsesStreamToJson, isResponsesSseDebug } from "../../transformer/streamToJsonConverter.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
@@ -51,6 +51,31 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
   return result;
 }
 
+function textFromResponsesMessageItem(item) {
+  if (!item?.content || !Array.isArray(item.content)) return "";
+  const byType = item.content.find((c) => c.type === "output_text");
+  if (typeof byType?.text === "string") return byType.text;
+  const anyText = item.content.find((c) => typeof c.text === "string");
+  if (typeof anyText?.text === "string") return anyText.text;
+  return "";
+}
+
+/**
+ * Codex / Responses API may emit many alternating reasoning + message items.
+ * Early message blocks often have empty output_text; the user-visible answer is usually in the last non-empty message.
+ */
+function pickAssistantMessageForChatCompletion(output) {
+  if (!Array.isArray(output)) return { msgItem: null, textContent: null };
+  const messages = output.filter((item) => item?.type === "message");
+  if (messages.length === 0) return { msgItem: null, textContent: null };
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const text = textFromResponsesMessageItem(messages[i]);
+    if (text.length > 0) return { msgItem: messages[i], textContent: text };
+  }
+  const last = messages[messages.length - 1];
+  return { msgItem: last, textContent: textFromResponsesMessageItem(last) };
+}
+
 /**
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
@@ -79,8 +104,24 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       appendLog({ tokens: usage, status: "200 OK" });
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
 
-      const msgItem = jsonResponse.output?.find(item => item.type === "message");
-      const textContent = msgItem?.content?.find(c => c.type === "output_text")?.text || msgItem?.content?.[0]?.text || null;
+      const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      if (isResponsesSseDebug()) {
+        const messageIndices = (jsonResponse.output || [])
+          .map((item, i) => (item?.type === "message" ? i : null))
+          .filter((i) => i !== null);
+        const pickedIndex = msgItem != null ? jsonResponse.output.indexOf(msgItem) : -1;
+        console.log("[ResponsesSSE→JSON] extract assistant text → chat.completion", {
+          provider,
+          model,
+          responseId: jsonResponse.id,
+          outputTypes: (jsonResponse.output || []).map((item) => item?.type),
+          messageOutputIndices: messageIndices,
+          pickedMessageIndex: pickedIndex,
+          contentPartTypes: Array.isArray(msgItem?.content) ? msgItem.content.map((c) => c?.type) : null,
+          resolvedTextLength: (textContent || "").length,
+          usage: jsonResponse.usage
+        });
+      }
       const totalLatency = Date.now() - requestStartTime;
 
       saveRequestDetail(buildRequestDetail({
@@ -133,6 +174,20 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
     const sseText = await providerResponse.text();
     const parsed = parseSSEToOpenAIResponse(sseText, model);
     if (!parsed) return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
+
+    if (isResponsesSseDebug()) {
+      const msg = parsed.choices?.[0]?.message;
+      const dataLines = sseText.split("\n").filter((l) => l.trim().startsWith("data:")).length;
+      console.log("[ChatSSE→JSON] parseSSEToOpenAIResponse", {
+        provider,
+        model,
+        dataLines,
+        contentLength: typeof msg?.content === "string" ? msg.content.length : 0,
+        reasoningLength: typeof msg?.reasoning_content === "string" ? msg.reasoning_content.length : 0,
+        finish_reason: parsed.choices?.[0]?.finish_reason,
+        usage: parsed.usage
+      });
+    }
 
     if (onRequestSuccess) await onRequestSuccess();
 

--- a/open-sse/transformer/streamToJsonConverter.js
+++ b/open-sse/transformer/streamToJsonConverter.js
@@ -4,6 +4,10 @@
  * Used when client requests non-streaming but provider forces streaming (e.g., Codex)
  */
 
+export function isResponsesSseDebug() {
+  return typeof process !== "undefined" && process.env?.DEBUG_RESPONSES_SSE_TO_JSON === "true";
+}
+
 /**
  * Process a single SSE message and update state accordingly.
  */
@@ -36,6 +40,9 @@ function processSSEMessage(msg, state) {
     }
   } else if (eventType === "response.failed") {
     state.status = "failed";
+  } else if (state._debug) {
+    state._skippedEvents ??= {};
+    state._skippedEvents[eventType] = (state._skippedEvents[eventType] || 0) + 1;
   }
 }
 
@@ -55,12 +62,14 @@ export async function convertResponsesStreamToJson(stream) {
   const decoder = new TextDecoder();
   let buffer = "";
 
+  const debug = isResponsesSseDebug();
   const state = {
     responseId: "",
     created: Math.floor(Date.now() / 1000),
     status: "in_progress",
     usage: { ...EMPTY_RESPONSE },
-    items: new Map()
+    items: new Map(),
+    _debug: debug
   };
 
   try {
@@ -90,6 +99,27 @@ export async function convertResponsesStreamToJson(stream) {
   const maxIndex = state.items.size > 0 ? Math.max(...state.items.keys()) : -1;
   for (let i = 0; i <= maxIndex; i++) {
     output.push(state.items.get(i) || { type: "message", content: [], role: "assistant" });
+  }
+
+  if (debug) {
+    const outputSummary = output.map((item, i) => ({
+      index: i,
+      type: item?.type,
+      role: item?.role,
+      contentParts: Array.isArray(item?.content)
+        ? item.content.map((p) => ({
+            type: p?.type,
+            textLen: typeof p?.text === "string" ? p.text.length : undefined
+          }))
+        : null
+    }));
+    console.log("[ResponsesSSE→JSON] convertResponsesStreamToJson", {
+      responseId: state.responseId,
+      status: state.status || "completed",
+      usage: state.usage,
+      skippedEventCounts: state._skippedEvents || {},
+      outputSummary
+    });
   }
 
   return {


### PR DESCRIPTION
Root cause: Codex/OpenAI Responses streams multiple alternating reasoning and message output items. The first message block often has output_text parts with empty strings; the visible answer lives in a later message. We used output.find(type === "message"), which always picked that empty first block.

Fix: walk message items from the end and use the last message whose extracted text is non-empty; fall back to the final message if all are empty.

Debug (opt-in): set DEBUG_RESPONSES_SSE_TO_JSON=true to log skipped SSE event counts (e.g. deltas we do not merge), per-output-item summaries, and how we resolve assistant text for chat.completion. Also log the Chat Completions SSE aggregation path for the same flag.

Made-with: Cursor