### PR TITLE
fix: treat Kiro 400 'improperly formed request' as model-unavailable (closes #384)

### DIFF
--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -32,6 +32,12 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
       return { shouldFallback: true, cooldownMs: COOLDOWN_MS.requestNotAllowed };
     }
 
+    // Kiro: "improperly formed request" = model not available on this account tier
+    // Treat as paymentRequired (long cooldown) so the model is locked and fallback occurs
+    if (lowerError.includes("improperly formed request")) {
+      return { shouldFallback: true, cooldownMs: COOLDOWN_MS.paymentRequired };
+    }
+
     // Rate limit keywords - exponential backoff
     if (
       lowerError.includes("rate limit") ||


### PR DESCRIPTION
## Problem

Kiro returns HTTP 400 with `Improperly formed request (reset after Xs)` when a model is not available on that account's subscription tier (e.g. `claude-sonnet-4.5` on a free-tier account).

Previously `checkFallbackError` had no specific match for this error text, so it fell through to `COOLDOWN_MS.transient` (30s). This caused:
- All accounts locked for only 30s before retrying
- Rapid retry storms across all accounts
- All accounts locked simultaneously with no real fallback to next provider

## Fix

Detect `improperly formed request` in `checkFallbackError` and return `COOLDOWN_MS.paymentRequired` (2 min model lock). This ensures:
1. The model is locked on that account for 2 min (proper cooldown matching Kiro's actual reset window)
2. The next available account is tried immediately
3. If all accounts hit the same 400, 9Router falls through to the next provider in the combo

## Change

`open-sse/services/accountFallback.js` — 6 lines added to `checkFallbackError`

Fixes #384