### PR TITLE
feat: add OpenCode provider support (closes #378)

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -207,6 +207,11 @@ export const PROVIDERS = {
     format: "openai",
     headers: {}
   },
+  opencode: {
+    baseUrl: "http://localhost:4096/v1/chat/completions",
+    format: "openai",
+    headers: {}
+  },
   cline: {
     baseUrl: "https://api.cline.bot/api/v1/chat/completions",
     format: "openai",

--- a/open-sse/services/model.js
+++ b/open-sse/services/model.js
@@ -12,6 +12,7 @@ const ALIAS_TO_PROVIDER_ID = {
   kc: "kilocode",
   kmc: "kimi-coding",
   cl: "cline",
+  oc: "opencode",
   // API Key providers
   openai: "openai",
   anthropic: "anthropic",

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -18,6 +18,7 @@ export const OAUTH_PROVIDERS = {
   // "kimi-coding": { id: "kimi-coding", alias: "kmc", name: "Kimi Coding", icon: "psychology", color: "#1E40AF", textIcon: "KC" },
   kilocode: { id: "kilocode", alias: "kc", name: "Kilo Code", icon: "code", color: "#FF6B35", textIcon: "KC" },
   cline: { id: "cline", alias: "cl", name: "Cline", icon: "smart_toy", color: "#5B9BD5", textIcon: "CL" },
+  opencode: { id: "opencode", alias: "oc", name: "OpenCode", icon: "terminal", color: "#E87040", textIcon: "OC" },
 };
 
 export const APIKEY_PROVIDERS = {


### PR DESCRIPTION
## Summary

Adds [OpenCode](https://github.com/opencode-ai/opencode) as a supported provider. OpenCode is an open-source terminal AI coding assistant with a local OpenAI-compatible API.

## Changes

| File | Change |
|------|--------|
| `open-sse/config/providers.js` | Add `opencode` with `baseUrl: http://localhost:4096/v1/chat/completions`, `format: openai` |
| `open-sse/services/model.js` | Add alias `oc` → `opencode` |
| `src/shared/constants/providers.js` | Add `opencode` to subscription providers |

## Usage

After adding OpenCode as a provider in 9Router settings, route requests with the `oc/` prefix:
```
oc/claude-sonnet-4-5
oc/gpt-4o
```

OpenCode defaults to `http://localhost:4096` — users can override the URL in provider settings.

Closes #378