### PR TITLE
fix: clamp Responses API call_id to 64 characters

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -8,6 +8,10 @@ import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { normalizeResponsesInput } from "../helpers/responsesApiHelper.js";
 
+// Responses API enforces max 64 chars on call_id (#393)
+const MAX_CALL_ID_LEN = 64;
+const clampCallId = (id) => (typeof id === "string" && id.length > MAX_CALL_ID_LEN ? id.substring(0, MAX_CALL_ID_LEN) : id);
+
 /**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format
  */
@@ -221,7 +225,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
       for (const tc of msg.tool_calls) {
         result.input.push({
           type: "function_call",
-          call_id: tc.id,
+          call_id: clampCallId(tc.id),
           name: tc.function?.name || "",
           arguments: tc.function?.arguments || "{}"
         });
@@ -237,7 +241,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
           : JSON.stringify(msg.content);
       result.input.push({
         type: "function_call_output",
-        call_id: msg.tool_call_id,
+        call_id: clampCallId(msg.tool_call_id),
         output
       });
     }


### PR DESCRIPTION
Responses API rejects call_id values longer than 64 characters with: Invalid input[].call_id: string too long. Expected max length 64. When upstream providers return tool call IDs longer than 64 chars, 9router was forwarding them as-is into Responses API function_call and function_call_output input items, causing a 400 error. Fix: Added a clampCallId() helper that truncates any call_id to 64 characters before writing it into the Responses API payload. Files changed: open-sse/translator/request/openai-responses.js (+4 lines). Closes #393