### PR TITLE
fix: detect Claude format for /v1/messages + sanitize tool descriptions

### DIFF
--- a/open-sse/translator/formats.js
+++ b/open-sse/translator/formats.js
@@ -21,6 +21,9 @@ export function detectFormatByEndpoint(pathname, body) {
   // /v1/responses is always openai-responses
   if (pathname.includes("/v1/responses")) return FORMATS.OPENAI_RESPONSES;
 
+  // /v1/messages is always Claude
+  if (pathname.includes("/v1/messages")) return FORMATS.CLAUDE;
+
   // /v1/chat/completions + input[] → treat as openai (Cursor CLI sends Responses body via chat endpoint)
   if (pathname.includes("/v1/chat/completions") && Array.isArray(body?.input)) {
     return FORMATS.OPENAI;

--- a/open-sse/translator/helpers/openaiHelper.js
+++ b/open-sse/translator/helpers/openaiHelper.js
@@ -87,7 +87,7 @@ export function filterToOpenAIFormat(body) {
           type: "function",
           function: {
             name: tool.name,
-            description: tool.description || "",
+            description: String(tool.description || ""),
             parameters: tool.input_schema || { type: "object", properties: {} }
           }
         };
@@ -99,7 +99,7 @@ export function filterToOpenAIFormat(body) {
           type: "function",
           function: {
             name: fn.name,
-            description: fn.description || "",
+            description: String(fn.description || ""),
             parameters: fn.parameters || { type: "object", properties: {} }
           }
         }));

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -59,7 +59,7 @@ export function claudeToOpenAIRequest(model, body, stream) {
       type: "function",
       function: {
         name: tool.name,
-        description: tool.description,
+        description: String(tool.description || ""),
         parameters: tool.input_schema || { type: "object", properties: {} }
       }
     }));

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -134,7 +134,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
           type: "function",
           function: {
             name,
-            description: tool.description,
+            description: String(tool.description || ""),
             parameters: tool.parameters,
             strict: tool.strict
           }
@@ -255,7 +255,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
         return {
           type: "function",
           name: tool.function.name,
-          description: tool.function.description,
+          description: String(tool.function.description || ""),
           parameters: tool.function.parameters,
           strict: tool.function.strict
         };


### PR DESCRIPTION
## Summary

Two fixes for request translation issues:

**1. Source format detection for `/v1/messages`** (`open-sse/translator/formats.js`)
Requests hitting the Claude Messages API path (`/v1/messages`) were not detected as Claude format — they fell through to OpenAI format detection, which stripped Claude-specific response features like `server_tool_use` and `web_search_tool_result`.

**2. Tool description sanitization** (4 files)
Some providers (NVIDIA NIM, strict Codex validation) reject tool schemas where `description` is null, undefined, or not a string. Added `String(... || "")` coercion at all tool translation boundaries.

## Changes
- `open-sse/translator/formats.js` — add `/v1/messages` → CLAUDE format detection
- `open-sse/translator/request/claude-to-openai.js` — coerce tool description
- `open-sse/translator/helpers/openaiHelper.js` — coerce tool description (3 locations)
- `open-sse/translator/request/openai-responses.js` — coerce tool description (2 locations)

## Testing
Verified syntax on all changed files. Tested on a local VM.

Partially fixes #276