### PR TITLE
fix: add deprecation warning for Gemini CLI provider

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -489,6 +489,7 @@ export default function ProvidersPage() {
 
 function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
   const { connected, error, errorCode, errorTime, allDisabled } = stats;
+  const isDeprecated = !!provider.deprecated;
 
   const dotColors = {
     free: "bg-green-500",
@@ -571,6 +572,12 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
             )}
           </div>
         </div>
+        {isDeprecated && (
+          <div className="mt-2 flex items-start gap-1.5 px-2 py-1.5 rounded-md bg-amber-500/10 border border-amber-500/20 text-amber-600 dark:text-amber-400">
+            <span className="material-symbols-outlined text-[14px] mt-0.5 shrink-0">warning</span>
+            <p className="text-[10px] leading-snug">{provider.deprecationNotice}</p>
+          </div>
+        )}
       </Card>
     </Link>
   );

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -4,7 +4,7 @@
 export const FREE_PROVIDERS = {
   iflow: { id: "iflow", alias: "if", name: "iFlow AI", icon: "water_drop", color: "#6366F1" },
   qwen: { id: "qwen", alias: "qw", name: "Qwen Code", icon: "psychology", color: "#10B981" },
-  "gemini-cli": { id: "gemini-cli", alias: "gc", name: "Gemini CLI", icon: "terminal", color: "#4285F4" },
+  "gemini-cli": { id: "gemini-cli", alias: "gc", name: "Gemini CLI", icon: "terminal", color: "#4285F4", deprecated: true, deprecationNotice: "Google has tightened Gemini CLI abuse detection and restricted Pro models to paid accounts (Mar 25, 2026). Using this provider may violate ToS and risk account bans." },
   kiro: { id: "kiro", alias: "kr", name: "Kiro AI", icon: "psychology_alt", color: "#FF6B35" },
 };
 


### PR DESCRIPTION
Closes #362\n\nGoogle has tightened Gemini CLI abuse detection and restricted Pro models to paid subscribers starting March 25, 2026. Users risk ToS violations and account bans.\n\n**Changes:**\n- Added deprecated + deprecationNotice fields to gemini-cli in FREE_PROVIDERS\n- ProviderCard now renders an amber warning banner when provider.deprecated is true\n\nExisting paid users are unaffected; this surfaces the risk clearly in the dashboard for free-tier users.