### PR TITLE
fix: add ?alt=sse to Vertex streaming URL

### DIFF
--- a/open-sse/executors/vertex.js
+++ b/open-sse/executors/vertex.js
@@ -54,10 +54,12 @@ export class VertexExecutor extends BaseExecutor {
     }
 
     // Gemini on Vertex: always use global publishers endpoint
-    const action = stream ? "streamGenerateContent" : "generateContent";
+    // ?alt=sse is required for proper SSE streaming (matches every other Gemini executor)
+    const action = stream ? "streamGenerateContent?alt=sse" : "generateContent";
     let url = `https://aiplatform.googleapis.com/v1/publishers/google/models/${model}:${action}`;
 
-    if (rawKey) url += `?key=${rawKey}`;
+    // rawKey goes as a query param; use & because ?alt=sse already starts the query string
+    if (rawKey) url += `&key=${rawKey}`;
     return url;
   }
 


### PR DESCRIPTION
Closes #388\n\n## Problem\n\nWhen using Vertex AI with streaming enabled, the bridge was calling streamGenerateContent without the required ?alt=sse query parameter. This caused the client to receive unusable non-SSE stream output.\n\n## Root cause\n\nVertexExecutor.buildUrl() used streamGenerateContent for streaming, while every other Gemini-based executor in the codebase (gemini, gemini-cli, antigravity) already uses streamGenerateContent?alt=sse. The Vertex executor was the only one missing this parameter.\n\n## Fix\n\nChanged the streaming action to streamGenerateContent?alt=sse in VertexExecutor.buildUrl(), consistent with all other Gemini executors. Updated the raw-key query-string separator from ? to & to correctly append after ?alt=sse.\n\n## Change\n\nopen-sse/executors/vertex.js — 2 lines changed in buildUrl().