### PR TITLE
fix: correct stale combo name validation comments to include dot

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -5,7 +5,7 @@ import { Card, Button, Modal, Input, CardSkeleton, ModelSelectModal, Toggle } fr
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 
-// Validate combo name: only a-z, A-Z, 0-9, -, _
+// Validate combo name: only a-z, A-Z, 0-9, -, _, .
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
 
 export default function CombosPage() {

--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
 
-// Validate combo name: only a-z, A-Z, 0-9, -, _
+// Validate combo name: only a-z, A-Z, 0-9, -, _, .
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
 
 // GET /api/combos/[id] - Get combo by ID

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -3,7 +3,7 @@ import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
 
 export const dynamic = "force-dynamic";
 
-// Validate combo name: only a-z, A-Z, 0-9, -, _
+// Validate combo name: only a-z, A-Z, 0-9, -, _, .
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
 
 // GET /api/combos - Get all combos


### PR DESCRIPTION
Closes #353\n\nThe regex VALID_NAME_REGEX already allows dots in combo names, but the comments in all three files still said "only a-z, A-Z, 0-9, -, _" without mentioning the dot. This caused confusion for users trying to use model names like gpt-5.4.\n\nChanged:\n- src/app/api/combos/route.js\n- src/app/api/combos/[id]/route.js\n- src/app/(dashboard)/dashboard/combos/page.js\n\nNo logic changes — purely aligns the comments with the actual allowed character set.