### PR TITLE
fix(usage): correct stats truncation at 10k history cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ NODE_ENV=production
 API_KEY_SECRET=endpoint-proxy-api-key-secret
 MACHINE_ID_SALT=endpoint-proxy-salt
 ENABLE_REQUEST_LOGS=false
+MAX_USAGE_HISTORY=10000
 OBSERVABILITY_ENABLED=true
 AUTH_COOKIE_SECURE=false
 REQUIRE_API_KEY=false

--- a/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
+++ b/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
@@ -7,25 +7,37 @@ const fmt = (n) => new Intl.NumberFormat().format(n || 0);
 const fmtCost = (n) => `$${(n || 0).toFixed(2)}`;
 
 export default function OverviewCards({ stats }) {
+  const isTruncated = stats.historyRetained >= stats.maxHistory;
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-      <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Total Requests</span>
-        <span className="text-2xl font-bold">{fmt(stats.totalRequests)}</span>
-      </Card>
-      <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Total Input Tokens</span>
-        <span className="text-2xl font-bold text-primary">{fmt(stats.totalPromptTokens)}</span>
-      </Card>
-      <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Output Tokens</span>
-        <span className="text-2xl font-bold text-success">{fmt(stats.totalCompletionTokens)}</span>
-      </Card>
-      <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Est. Cost</span>
-        <span className="text-2xl font-bold text-warning">~{fmtCost(stats.totalCost)}</span>
-        <span className="text-[10px] text-text-muted">Estimated, not actual billing</span>
-      </Card>
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card className="px-4 py-3 flex flex-col gap-1">
+          <span className="text-text-muted text-sm uppercase font-semibold">Requests</span>
+          <span className="text-2xl font-bold">{fmt(stats.totalRequests)}</span>
+          {stats.totalRequestsLifetime > stats.totalRequests && (
+            <span className="text-[10px] text-text-muted">Lifetime: {fmt(stats.totalRequestsLifetime)}</span>
+          )}
+        </Card>
+        <Card className="px-4 py-3 flex flex-col gap-1">
+          <span className="text-text-muted text-sm uppercase font-semibold">Total Input Tokens</span>
+          <span className="text-2xl font-bold text-primary">{fmt(stats.totalPromptTokens)}</span>
+        </Card>
+        <Card className="px-4 py-3 flex flex-col gap-1">
+          <span className="text-text-muted text-sm uppercase font-semibold">Output Tokens</span>
+          <span className="text-2xl font-bold text-success">{fmt(stats.totalCompletionTokens)}</span>
+        </Card>
+        <Card className="px-4 py-3 flex flex-col gap-1">
+          <span className="text-text-muted text-sm uppercase font-semibold">Est. Cost</span>
+          <span className="text-2xl font-bold text-warning">~{fmtCost(stats.totalCost)}</span>
+          <span className="text-[10px] text-text-muted">Estimated, not actual billing</span>
+        </Card>
+      </div>
+      {isTruncated && (
+        <p className="text-[11px] text-text-muted">
+          Stats based on last {fmt(stats.maxHistory)} retained requests. Set <code className="text-[10px]">MAX_USAGE_HISTORY</code> env to increase.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -64,6 +64,9 @@ if (!isCloud && fs && typeof fs.existsSync === "function") {
   }
 }
 
+// Configurable history cap via env (default 10 000)
+const MAX_HISTORY = Math.max(1000, parseInt(process.env.MAX_USAGE_HISTORY, 10) || 10000);
+
 // Default data structure
 const defaultData = {
   history: [],
@@ -218,6 +221,12 @@ export async function getUsageDb() {
       dbInstance.data = defaultData;
       await dbInstance.write();
     }
+
+    // Backfill totalRequestsLifetime for legacy DBs that don't have it
+    if (typeof dbInstance.data.totalRequestsLifetime !== "number") {
+      dbInstance.data.totalRequestsLifetime = (dbInstance.data.history || []).length;
+      await dbInstance.write();
+    }
   }
   return dbInstance;
 }
@@ -251,7 +260,6 @@ export async function saveRequestUsage(entry) {
     db.data.totalRequestsLifetime += 1;
 
     // Cap history to prevent unbounded memory/disk growth
-    const MAX_HISTORY = 10000;
     if (db.data.history.length > MAX_HISTORY) {
       db.data.history.splice(0, db.data.history.length - MAX_HISTORY);
     }
@@ -529,9 +537,14 @@ export async function getUsageStats(period = "all") {
   const lifetimeTotalRequests = typeof db.data.totalRequestsLifetime === "number"
     ? db.data.totalRequestsLifetime
     : history.length;
+  const totalHistoryRetained = (db.data.history || []).length;
 
   const stats = {
-    totalRequests: lifetimeTotalRequests,
+    // Period-filtered request count (matches breakdown tables)
+    totalRequests: history.length,
+    totalRequestsLifetime: lifetimeTotalRequests,
+    historyRetained: totalHistoryRetained,
+    maxHistory: MAX_HISTORY,
     totalPromptTokens: 0,
     totalCompletionTokens: 0,
     totalCost: 0,


### PR DESCRIPTION
## Summary

- **Total Requests** card showed max 10,000 instead of actual lifetime count when history exceeded the cap
- All breakdown stats (by model, by API key, by provider, etc.) only reflected the last 10k retained entries — not the selected time period
- `totalRequestsLifetime` was not initialized on DB read for legacy databases that predate the field

## Changes

- `totalRequests` now returns the **period-filtered** count (matching breakdown tables); new `totalRequestsLifetime` field carries the lifetime counter
- Backfill `totalRequestsLifetime` on first DB read for legacy databases
- Make `MAX_HISTORY` configurable via `MAX_USAGE_HISTORY` env var (default 10,000, min 1,000)
- UI shows "Lifetime: N" subtitle when lifetime differs from filtered count
- UI shows truncation notice when history is at capacity with env var hint

## Files changed

- `src/lib/usageDb.js` — core fix: configurable cap, backfill, period-accurate stats
- `src/app/(dashboard)/dashboard/usage/components/OverviewCards.js` — UI: lifetime count + truncation notice
- `.env.example` — document `MAX_USAGE_HISTORY`

## Test plan

- [ ] Start with >10k requests in usage.json, verify Total Requests shows correct period count and lifetime subtitle
- [ ] Verify breakdown tables (by model, by API key) match the displayed total
- [ ] Set `MAX_USAGE_HISTORY=50000`, restart, verify cap increases
- [ ] Test with fresh DB (no `totalRequestsLifetime` field) — should backfill on first load