### PR TITLE
fix: use project-scoped Vertex URL for SA JSON auth, add ?alt=sse for streaming

### DIFF
--- a/open-sse/executors/vertex.js
+++ b/open-sse/executors/vertex.js
@@ -53,10 +53,19 @@ export class VertexExecutor extends BaseExecutor {
       return rawKey ? `${url}?key=${rawKey}` : url;
     }
 
-    // Gemini on Vertex: always use global publishers endpoint
+    // Gemini on Vertex
     const action = stream ? "streamGenerateContent" : "generateContent";
-    let url = `https://aiplatform.googleapis.com/v1/publishers/google/models/${model}:${action}`;
 
+    if (saJson) {
+      // SA JSON + Bearer token: must use project-scoped path to avoid RESOURCE_PROJECT_INVALID
+      const location = credentials?.providerSpecificData?.location || "us-central1";
+      let url = `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/publishers/google/models/${model}:${action}`;
+      if (stream) url += "?alt=sse";
+      return url;
+    }
+
+    // Raw API key: use global publishers endpoint with ?key= param
+    let url = `https://aiplatform.googleapis.com/v1/publishers/google/models/${model}:${action}`;
     if (rawKey) url += `?key=${rawKey}`;
     return url;
   }


### PR DESCRIPTION
Relates to #388\n\nWhen using SA JSON + Bearer token, Vertex AI requires a project-scoped URL. The old code used the global publishers endpoint which only works with a raw API key, causing RESOURCE_PROJECT_INVALID errors.\n\nChanges in open-sse/executors/vertex.js buildUrl():\n- SA JSON path: projects/{projectId}/locations/{location}/publishers/google/models/{model}:{action}\n- Appends ?alt=sse for streaming on SA JSON path\n- Location defaults to us-central1, overridable via providerSpecificData.location\n- Raw API key path unchanged (global publishers + ?key= param)