### PR TITLE
fix: inject placeholder message when Responses API input[] is empty

### DIFF
--- a/open-sse/translator/helpers/responsesApiHelper.js
+++ b/open-sse/translator/helpers/responsesApiHelper.js
@@ -1,6 +1,8 @@
 /**
  * Normalize Responses API input to array format.
  * Accepts string or array, returns array of message items.
+ * An empty array is treated like an empty string — providers require at least one user
+ * message, so we inject a placeholder rather than forwarding an empty messages[].
  * @param {string|Array} input - raw input from Responses API body
  * @returns {Array|null} normalized array or null if invalid
  */
@@ -9,7 +11,13 @@ export function normalizeResponsesInput(input) {
     const text = input.trim() === "" ? "..." : input;
     return [{ type: "message", role: "user", content: [{ type: "input_text", text }] }];
   }
-  if (Array.isArray(input)) return input;
+  if (Array.isArray(input)) {
+    // Empty input[] would produce messages:[] which all providers reject (#389)
+    if (input.length === 0) {
+      return [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }];
+    }
+    return input;
+  }
   return null;
 }
 


### PR DESCRIPTION
Closes #389\n\n## Problem\nWhen a client (e.g. Fabric-AI) calls POST /v1/responses with an empty input:[] array, normalizeResponsesInput returned the empty array unchanged. The translator then produced messages:[] which upstream providers reject with:\n400: messages: at least one message is required\n9router surfaced this as a 406.\n\n## Fix\nIn normalizeResponsesInput, treat input:[] the same as input:"" — inject a placeholder user message so the request is always valid.\n\n## Files changed\n- open-sse/translator/helpers/responsesApiHelper.js — 1 guard added