### PR TITLE
fix: coerce tool description to string in all translation paths

### DIFF
--- a/open-sse/translator/helpers/openaiHelper.js
+++ b/open-sse/translator/helpers/openaiHelper.js
@@ -87,7 +87,7 @@ export function filterToOpenAIFormat(body) {
           type: "function",
           function: {
             name: tool.name,
-            description: tool.description || "",
+            description: typeof tool.description === "string" ? tool.description : "",
             parameters: tool.input_schema || { type: "object", properties: {} }
           }
         };
@@ -99,7 +99,7 @@ export function filterToOpenAIFormat(body) {
           type: "function",
           function: {
             name: fn.name,
-            description: fn.description || "",
+            description: typeof fn.description === "string" ? fn.description : "",
             parameters: fn.parameters || { type: "object", properties: {} }
           }
         }));

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -59,7 +59,7 @@ export function claudeToOpenAIRequest(model, body, stream) {
       type: "function",
       function: {
         name: tool.name,
-        description: tool.description,
+        description: typeof tool.description === "string" ? tool.description : "",
         parameters: tool.input_schema || { type: "object", properties: {} }
       }
     }));

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -134,7 +134,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
           type: "function",
           function: {
             name,
-            description: tool.description,
+            description: typeof tool.description === "string" ? tool.description : "",
             parameters: tool.parameters,
             strict: tool.strict
           }
@@ -255,7 +255,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
         return {
           type: "function",
           name: tool.function.name,
-          description: tool.function.description,
+          description: typeof tool.function.description === "string" ? tool.function.description : "",
           parameters: tool.function.parameters,
           strict: tool.function.strict
         };


### PR DESCRIPTION
Closes #276. Coerce tool.description to guaranteed string (typeof check) in openaiHelper.js, claude-to-openai.js, and openai-responses.js. Fixes NVIDIA NIM 400 validation error when description is not a plain string.