### PR TITLE
fix: coerce string numeric JSON Schema constraints to integers in tool translation

### DIFF
--- a/open-sse/translator/helpers/openaiHelper.js
+++ b/open-sse/translator/helpers/openaiHelper.js
@@ -88,7 +88,7 @@ export function filterToOpenAIFormat(body) {
           function: {
             name: tool.name,
             description: tool.description || "",
-            parameters: tool.input_schema || { type: "object", properties: {} }
+            parameters: coerceSchemaNumericConstraints(tool.input_schema || { type: "object", properties: {} })
           }
         };
       }
@@ -100,7 +100,7 @@ export function filterToOpenAIFormat(body) {
           function: {
             name: fn.name,
             description: fn.description || "",
-            parameters: fn.parameters || { type: "object", properties: {} }
+            parameters: coerceSchemaNumericConstraints(fn.parameters || { type: "object", properties: {} })
           }
         }));
       }
@@ -123,5 +123,42 @@ export function filterToOpenAIFormat(body) {
   }
 
   return body;
+}
+
+// JSON Schema keywords whose values must be integers (not strings)
+const NUMERIC_SCHEMA_KEYWORDS = [
+  "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum",
+  "minLength", "maxLength", "minItems", "maxItems",
+  "minProperties", "maxProperties", "multipleOf"
+];
+
+/**
+ * Recursively coerce string numeric values for integer-typed JSON Schema keywords.
+ * Fixes errors like: '[codex] Invalid schema: '64' is not of type 'integer''
+ * when MCP tools or clients serialize numeric constraints as strings.
+ */
+export function coerceSchemaNumericConstraints(schema) {
+  if (!schema || typeof schema !== "object") return schema;
+
+  if (Array.isArray(schema)) {
+    for (const item of schema) coerceSchemaNumericConstraints(item);
+    return schema;
+  }
+
+  for (const key of NUMERIC_SCHEMA_KEYWORDS) {
+    if (typeof schema[key] === "string") {
+      const parsed = Number(schema[key]);
+      if (!isNaN(parsed)) schema[key] = parsed;
+    }
+  }
+
+  // Recurse into nested schemas
+  for (const value of Object.values(schema)) {
+    if (value && typeof value === "object") {
+      coerceSchemaNumericConstraints(value);
+    }
+  }
+
+  return schema;
 }
 

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -1,6 +1,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.js";
+import { coerceSchemaNumericConstraints } from "../helpers/openaiHelper.js";
 
 // Convert Claude request to OpenAI format
 export function claudeToOpenAIRequest(model, body, stream) {
@@ -59,8 +60,8 @@ export function claudeToOpenAIRequest(model, body, stream) {
       type: "function",
       function: {
         name: tool.name,
-        description: tool.description,
-        parameters: tool.input_schema || { type: "object", properties: {} }
+        description: typeof tool.description === "string" ? tool.description : "",
+        parameters: coerceSchemaNumericConstraints(tool.input_schema || { type: "object", properties: {} })
       }
     }));
   }

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -7,6 +7,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { normalizeResponsesInput } from "../helpers/responsesApiHelper.js";
+import { coerceSchemaNumericConstraints } from "../helpers/openaiHelper.js";
 
 /**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format
@@ -134,8 +135,8 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
           type: "function",
           function: {
             name,
-            description: tool.description,
-            parameters: tool.parameters,
+            description: typeof tool.description === "string" ? tool.description : "",
+            parameters: coerceSchemaNumericConstraints(tool.parameters),
             strict: tool.strict
           }
         };
@@ -255,8 +256,8 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
         return {
           type: "function",
           name: tool.function.name,
-          description: tool.function.description,
-          parameters: tool.function.parameters,
+          description: typeof tool.function.description === "string" ? tool.function.description : "",
+          parameters: coerceSchemaNumericConstraints(tool.function.parameters),
           strict: tool.function.strict
         };
       }


### PR DESCRIPTION
Closes #273. Also addresses #276 (non-string tool description). Adds coerceSchemaNumericConstraints() to openaiHelper.js that recursively converts string-valued numeric schema keywords (maxLength, minItems, etc.) to actual numbers. Applied in all three tool translation paths: openaiHelper.filterToOpenAIFormat, claude-to-openai.js, and openai-responses.js (both directions). Also coerces description to guaranteed string.