### PR TITLE
fix: handle anthropic-compatible providers in BaseExecutor

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -29,6 +29,11 @@ export class BaseExecutor {
       const path = this.provider.includes("responses") ? "/responses" : "/chat/completions";
       return `${normalized}${path}`;
     }
+    if (this.provider?.startsWith?.("anthropic-compatible-")) {
+      const baseUrl = credentials?.providerSpecificData?.baseUrl || "https://api.anthropic.com/v1";
+      const normalized = baseUrl.replace(/\/$/, "");
+      return `${normalized}/messages`;
+    }
     const baseUrls = this.getBaseUrls();
     return baseUrls[urlIndex] || baseUrls[0] || this.config.baseUrl;
   }
@@ -39,10 +44,23 @@ export class BaseExecutor {
       ...this.config.headers
     };
 
-    if (credentials.accessToken) {
-      headers["Authorization"] = `Bearer ${credentials.accessToken}`;
-    } else if (credentials.apiKey) {
-      headers["Authorization"] = `Bearer ${credentials.apiKey}`;
+    if (this.provider?.startsWith?.("anthropic-compatible-")) {
+      // Anthropic-compatible providers use x-api-key header
+      if (credentials.apiKey) {
+        headers["x-api-key"] = credentials.apiKey;
+      } else if (credentials.accessToken) {
+        headers["Authorization"] = `Bearer ${credentials.accessToken}`;
+      }
+      if (!headers["anthropic-version"]) {
+        headers["anthropic-version"] = "2023-06-01";
+      }
+    } else {
+      // Standard Bearer token auth for other providers
+      if (credentials.accessToken) {
+        headers["Authorization"] = `Bearer ${credentials.accessToken}`;
+      } else if (credentials.apiKey) {
+        headers["Authorization"] = `Bearer ${credentials.apiKey}`;
+      }
     }
 
     if (stream) {


### PR DESCRIPTION
## Bug Description
When testing an **Anthropic-compatible** synthetic provider (custom providers that use Anthropic's API format), the test API call fails and returns documentation instead of a valid API response.

## Root Cause
The `BaseExecutor` class in `open-sse/executors/base.js` only handled `openai-compatible-*` providers in the `buildUrl()` and `buildHeaders()` methods, but not `anthropic-compatible-*` providers.

### Issues Fixed:
1. **buildUrl()**: Didn't append `/messages` path for anthropic-compatible providers, causing requests to hit the wrong endpoint
2. **buildHeaders()**: Used Bearer token auth instead of `x-api-key` header required by Anthropic-compatible APIs, and didn't include the required `anthropic-version` header

## Changes
- Added URL construction for `anthropic-compatible-*` providers to append `/messages` path
- Added header handling for `x-api-key` and `anthropic-version` headers for Anthropic-compatible providers
- Maintained backward compatibility with existing OpenAI-compatible providers

## Testing
To test this fix:
1. Create an Anthropic-compatible provider node (e.g., a custom provider with Anthropic API format)
2. Add a connection with an API key
3. Click "Test" on a model - it should now return success instead of documentation

## Files Changed
- `open-sse/executors/base.js` - Fixed `buildUrl()` and `buildHeaders()` methods

---

This fix ensures that synthetic Anthropic-compatible providers work correctly with the test functionality, just like OpenAI-compatible providers already do.