### PR TITLE
feat: tool capability awareness for built-in tools

### DIFF
--- a/open-sse/config/toolCapabilities.js
+++ b/open-sse/config/toolCapabilities.js
@@ -15,15 +15,58 @@ export const BUILT_IN_TOOLS = {
 
 // Which providers support which built-in tools natively
 // Key = provider ID (from providers.js), value = set of supported tool types
+//
+// Categories:
+//   PASS-THROUGH: provider accepts the Anthropic tool format directly
+//   IMPLICIT:     provider does web search on all queries (no tool needed)
+//   NATIVE:       provider has its own web search but in a DIFFERENT format
+//                 (translation needed — not yet implemented, see FUTURE_TRANSLATABLE)
+//   NONE:         provider has no web search capability
 const PROVIDER_TOOL_SUPPORT = {
+  // --- PASS-THROUGH (Anthropic-compatible, accept web_search_20250305 as-is) ---
   claude: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
   anthropic: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
-  // Providers using Claude-compatible APIs that pass through to Anthropic
+  // Claude-compatible API proxies that pass through to Anthropic backends
   glm: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
   kimi: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
   minimax: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
   "minimax-cn": new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
   "kimi-coding": new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+};
+
+// Providers with native web search in a DIFFERENT format.
+// These could theoretically translate Anthropic web_search into their native
+// format, but that translation is not yet implemented.
+//
+// When implemented, these providers would move from "strip + notify" to
+// "translate and pass through" behavior.
+//
+// Provider          | Native format                              | Notes
+// -----------------|--------------------------------------------|------
+// gemini           | tools: [{ google_search: {} }]             | Google Search grounding via GenerateContent API
+// gemini-cli       | same as gemini                             | Cloud Code uses same Gemini API
+// antigravity      | same as gemini                             | Google's tool, uses Gemini backend
+// vertex           | same as gemini                             | Vertex AI Gemini models
+// xai              | tools: [{ type: "web_search" }]            | Grok web_search via /v1/responses
+// perplexity       | implicit (all queries search the web)      | No tool needed — Sonar models always search
+// openai           | tools: [{ type: "web_search" }]            | Only in Responses API, not chat completions
+// codex            | tools: [{ type: "web_search" }]            | Uses OpenAI Responses API format
+// cohere           | connectors (external RAG setup)            | Not a simple tool — requires connector config
+//
+// NOT translatable (no native web search):
+// deepseek, groq, mistral, together, fireworks, cerebras, nvidia,
+// github (Copilot), kiro, cursor, ollama, nebius, siliconflow,
+// hyperbolic, alicode, alicode-intl, glm-cn, openrouter, kilocode,
+// opencode, cline, nanobanana, chutes, vertex-partner, qwen, iflow
+export const FUTURE_TRANSLATABLE = {
+  gemini: { tool: "google_search", format: "gemini" },
+  "gemini-cli": { tool: "google_search", format: "gemini" },
+  antigravity: { tool: "google_search", format: "gemini" },
+  vertex: { tool: "google_search", format: "gemini" },
+  xai: { tool: "web_search", format: "xai-responses" },
+  perplexity: { tool: null, format: "implicit" },
+  openai: { tool: "web_search", format: "openai-responses" },
+  codex: { tool: "web_search", format: "openai-responses" },
 };
 
 /**

--- a/open-sse/config/toolCapabilities.js
+++ b/open-sse/config/toolCapabilities.js
@@ -1,0 +1,72 @@
+// Tool capability map — which providers support which built-in tools natively
+//
+// Built-in tools are server-side tools handled by the provider itself
+// (e.g. Anthropic's web_search_20250305). When a request includes a built-in
+// tool and the target provider doesn't support it, 9router needs to decide
+// what to do: strip it, translate it, or route it elsewhere.
+//
+// This module is the single source of truth for that decision.
+
+// Tools that providers handle server-side (not user-defined function tools)
+export const BUILT_IN_TOOLS = {
+  WEB_SEARCH: "web_search_20250305",
+  WEB_FETCH: "web_fetch_20250305",
+};
+
+// Which providers support which built-in tools natively
+// Key = provider ID (from providers.js), value = set of supported tool types
+const PROVIDER_TOOL_SUPPORT = {
+  claude: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+  anthropic: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+  // Providers using Claude-compatible APIs that pass through to Anthropic
+  glm: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+  kimi: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+  minimax: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+  "minimax-cn": new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+  "kimi-coding": new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+};
+
+/**
+ * Check if a provider supports a specific built-in tool natively.
+ * @param {string} provider - Provider ID (e.g. "claude", "openai", "gemini")
+ * @param {string} toolType - Tool type string (e.g. "web_search_20250305")
+ * @returns {boolean}
+ */
+export function supportsBuiltInTool(provider, toolType) {
+  const supported = PROVIDER_TOOL_SUPPORT[provider];
+  return supported ? supported.has(toolType) : false;
+}
+
+/**
+ * Check if a tool is a built-in tool (not a user-defined function tool).
+ * Built-in tools have a `type` field that is NOT "function".
+ * @param {object} tool - Tool object from the request
+ * @returns {boolean}
+ */
+export function isBuiltInTool(tool) {
+  return !!(tool.type && tool.type !== "function");
+}
+
+/**
+ * Get all built-in tools from a tools array.
+ * @param {Array} tools - Tools array from request body
+ * @returns {Array} Built-in tools found
+ */
+export function extractBuiltInTools(tools) {
+  if (!Array.isArray(tools)) return [];
+  return tools.filter(isBuiltInTool);
+}
+
+/**
+ * Get the names of unsupported built-in tools for a given provider.
+ * @param {string} provider - Provider ID
+ * @param {Array} tools - Tools array from request body
+ * @returns {string[]} Names/types of unsupported built-in tools
+ */
+export function getUnsupportedBuiltInTools(provider, tools) {
+  if (!Array.isArray(tools)) return [];
+  const builtIn = extractBuiltInTools(tools);
+  return builtIn
+    .filter(tool => !supportsBuiltInTool(provider, tool.type || tool.name))
+    .map(tool => tool.type || tool.name);
+}

--- a/open-sse/config/toolCapabilities.js
+++ b/open-sse/config/toolCapabilities.js
@@ -23,15 +23,12 @@ export const BUILT_IN_TOOLS = {
 //                 (translation needed — not yet implemented, see FUTURE_TRANSLATABLE)
 //   NONE:         provider has no web search capability
 const PROVIDER_TOOL_SUPPORT = {
-  // --- PASS-THROUGH (Anthropic-compatible, accept web_search_20250305 as-is) ---
+  // --- PASS-THROUGH (Anthropic servers, accept web_search_20250305 as-is) ---
   claude: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
   anthropic: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
-  // Claude-compatible API proxies that pass through to Anthropic backends
-  glm: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
-  kimi: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
-  minimax: new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
-  "minimax-cn": new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
-  "kimi-coding": new Set([BUILT_IN_TOOLS.WEB_SEARCH, BUILT_IN_TOOLS.WEB_FETCH]),
+  // Note: glm, kimi, minimax use Claude wire format but their backends are NOT
+  // Anthropic — they have their own model-driven search or no search at all.
+  // Do NOT add them here; they go in FUTURE_TRANSLATABLE or get stripped.
 };
 
 // Providers with native web search in a DIFFERENT format.
@@ -43,30 +40,44 @@ const PROVIDER_TOOL_SUPPORT = {
 //
 // Provider          | Native format                              | Notes
 // -----------------|--------------------------------------------|------
-// gemini           | tools: [{ google_search: {} }]             | Google Search grounding via GenerateContent API
+// gemini           | tools: [{ googleSearch: {} }]              | Google Search grounding
 // gemini-cli       | same as gemini                             | Cloud Code uses same Gemini API
 // antigravity      | same as gemini                             | Google's tool, uses Gemini backend
 // vertex           | same as gemini                             | Vertex AI Gemini models
 // xai              | tools: [{ type: "web_search" }]            | Grok web_search via /v1/responses
-// perplexity       | implicit (all queries search the web)      | No tool needed — Sonar models always search
-// openai           | tools: [{ type: "web_search" }]            | Only in Responses API, not chat completions
-// codex            | tools: [{ type: "web_search" }]            | Uses OpenAI Responses API format
-// cohere           | connectors (external RAG setup)            | Not a simple tool — requires connector config
+// perplexity       | web_search_options: {} (automatic)          | Sonar models always search, can configure
+// openai           | tools: [{ type: "web_search_preview" }]    | Responses API only, not chat completions
+// groq             | model: "groq/compound" (automatic)          | Server-side search on compound models
+// qwen             | enable_search: true (DashScope param)       | Alibaba DashScope API specific
+// mistral          | tools: [{ type: "web_search" }]            | Agents API only, not chat completions
+// openrouter       | plugins: [{ type: "web_search" }]          | Plugin system, works across models
+// glm              | model-driven agentic tool use               | GLM-4.5/4.7 have browsing capabilities
+// kimi             | model-native search/browse                  | K2/K2.5 have built-in search + browsing
 //
 // NOT translatable (no native web search):
-// deepseek, groq, mistral, together, fireworks, cerebras, nvidia,
-// github (Copilot), kiro, cursor, ollama, nebius, siliconflow,
-// hyperbolic, alicode, alicode-intl, glm-cn, openrouter, kilocode,
-// opencode, cline, nanobanana, chutes, vertex-partner, qwen, iflow
+// deepseek, together, fireworks, cerebras, nvidia, github (Copilot),
+// kiro, cursor, ollama-local, nebius, siliconflow, hyperbolic,
+// alicode, alicode-intl, glm-cn, kilocode, opencode, cline,
+// nanobanana, chutes, vertex-partner, iflow, minimax, minimax-cn,
+// kimi-coding
+//
+// DEPRECATED web search:
+// cohere — connectors removed September 2025
+// codex — OpenAI explicitly does NOT support web_search on codex models
 export const FUTURE_TRANSLATABLE = {
-  gemini: { tool: "google_search", format: "gemini" },
-  "gemini-cli": { tool: "google_search", format: "gemini" },
-  antigravity: { tool: "google_search", format: "gemini" },
-  vertex: { tool: "google_search", format: "gemini" },
+  gemini: { tool: "googleSearch", format: "gemini" },
+  "gemini-cli": { tool: "googleSearch", format: "gemini" },
+  antigravity: { tool: "googleSearch", format: "gemini" },
+  vertex: { tool: "googleSearch", format: "gemini" },
   xai: { tool: "web_search", format: "xai-responses" },
   perplexity: { tool: null, format: "implicit" },
-  openai: { tool: "web_search", format: "openai-responses" },
-  codex: { tool: "web_search", format: "openai-responses" },
+  openai: { tool: "web_search_preview", format: "openai-responses" },
+  groq: { tool: null, format: "compound-model" },
+  qwen: { tool: null, format: "dashscope-param" },
+  mistral: { tool: "web_search", format: "agents-api" },
+  openrouter: { tool: "web_search", format: "plugins" },
+  glm: { tool: null, format: "model-agentic" },
+  kimi: { tool: null, format: "model-native" },
 };
 
 /**

--- a/open-sse/translator/helpers/claudeHelper.js
+++ b/open-sse/translator/helpers/claudeHelper.js
@@ -2,6 +2,7 @@
 import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../config/defaultThinkingSignature.js";
 import { adjustMaxTokens } from "./maxTokensHelper.js";
 import { applyCloaking } from "../../utils/claudeCloaking.js";
+import { supportsBuiltInTool, isBuiltInTool, getUnsupportedBuiltInTools } from "../../config/toolCapabilities.js";
 
 // Check if message has valid non-empty content
 export function hasValidContent(msg) {
@@ -166,11 +167,33 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null) {
     }
   }
 
-  // 3. Tools: filter built-in tools for non-Anthropic providers, then handle cache_control
+  // 3. Tools: handle built-in tools based on provider capabilities, then cache_control
   if (body.tools && Array.isArray(body.tools)) {
-    // Strip built-in tools (e.g. web_search_20250305) for providers that don't support them
-    if (provider !== "claude") {
-      body.tools = body.tools.filter(tool => !tool.type || tool.type === "function");
+    // Check which built-in tools this provider doesn't support
+    const unsupported = getUnsupportedBuiltInTools(provider, body.tools);
+
+    if (unsupported.length > 0) {
+      // Strip unsupported built-in tools
+      body.tools = body.tools.filter(tool => {
+        if (!isBuiltInTool(tool)) return true;
+        const toolId = tool.type || tool.name;
+        return !unsupported.includes(toolId);
+      });
+
+      // Tell the model which tools are unavailable on this provider
+      const toolNames = unsupported.map(t => t.replace(/_\d+$/, "").replace(/_/g, " ")).join(", ");
+      const notice = `Note: ${toolNames} is not available on this provider. Do not attempt to use it. Answer using your existing knowledge instead.`;
+
+      if (body.system && Array.isArray(body.system)) {
+        body.system.push({ type: "text", text: notice });
+      } else if (typeof body.system === "string") {
+        body.system = [
+          { type: "text", text: body.system },
+          { type: "text", text: notice }
+        ];
+      } else {
+        body.system = [{ type: "text", text: notice }];
+      }
     }
 
     body.tools = body.tools.map((tool, i) => {

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -3,6 +3,7 @@ import { ensureToolCallIds, fixMissingToolResponses } from "./helpers/toolCallHe
 import { prepareClaudeRequest } from "./helpers/claudeHelper.js";
 import { filterToOpenAIFormat } from "./helpers/openaiHelper.js";
 import { normalizeThinkingConfig } from "../services/provider.js";
+import { isBuiltInTool, getUnsupportedBuiltInTools } from "../config/toolCapabilities.js";
 
 // Registry for translators
 const requestRegistry = new Map();
@@ -88,6 +89,32 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
   // Always normalize to clean OpenAI format when target is OpenAI
   // This handles hybrid requests (e.g., OpenAI messages + Claude tools)
   if (targetFormat === FORMATS.OPENAI) {
+    // Strip unsupported built-in tools and notify model
+    if (provider && result.tools && Array.isArray(result.tools)) {
+      const unsupported = getUnsupportedBuiltInTools(provider, result.tools);
+      if (unsupported.length > 0) {
+        result.tools = result.tools.filter(tool => !isBuiltInTool(tool));
+
+        const toolNames = unsupported.map(t => t.replace(/_\d+$/, "").replace(/_/g, " ")).join(", ");
+        const notice = `Note: ${toolNames} is not available on this provider. Do not attempt to use it. Answer using your existing knowledge instead.`;
+
+        // Inject as system message
+        if (result.messages && Array.isArray(result.messages)) {
+          const lastSystemIdx = result.messages.findLastIndex(m => m.role === "system");
+          if (lastSystemIdx >= 0) {
+            const sysMsg = result.messages[lastSystemIdx];
+            if (typeof sysMsg.content === "string") {
+              sysMsg.content = sysMsg.content + "\n\n" + notice;
+            } else {
+              result.messages.splice(lastSystemIdx + 1, 0, { role: "system", content: notice });
+            }
+          } else {
+            result.messages.unshift({ role: "system", content: notice });
+          }
+        }
+      }
+    }
+
     result = filterToOpenAIFormat(result);
   }
 

--- a/tests/unit/tool-capabilities.test.js
+++ b/tests/unit/tool-capabilities.test.js
@@ -40,9 +40,9 @@ describe("Tool Capabilities", () => {
       expect(supportsBuiltInTool("anthropic", BUILT_IN_TOOLS.WEB_SEARCH)).toBe(true);
     });
 
-    it("should return true for Claude-compatible providers", () => {
+    it("should return false for Claude-wire-format providers (not actual Anthropic)", () => {
       for (const provider of ["glm", "kimi", "minimax", "minimax-cn", "kimi-coding"]) {
-        expect(supportsBuiltInTool(provider, BUILT_IN_TOOLS.WEB_SEARCH)).toBe(true);
+        expect(supportsBuiltInTool(provider, BUILT_IN_TOOLS.WEB_SEARCH)).toBe(false);
       }
     });
 
@@ -245,11 +245,11 @@ describe("Tool stripping with system message injection", () => {
       expect(result.system).toBeUndefined();
     });
 
-    it("should preserve web_search for Claude-compatible providers", async () => {
+    it("should preserve web_search for actual Anthropic providers only", async () => {
       const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
       prepareClaudeRequest = mod.prepareClaudeRequest;
 
-      for (const provider of ["glm", "kimi", "minimax", "anthropic"]) {
+      for (const provider of ["claude", "anthropic"]) {
         const body = {
           messages: [{ role: "user", content: [{ type: "text", text: "search" }] }],
           tools: [{ type: "web_search_20250305" }],
@@ -260,14 +260,32 @@ describe("Tool stripping with system message injection", () => {
         expect(hasWebSearch).toBe(true);
       }
     });
+
+    it("should strip web_search for Claude-wire-format providers that are not Anthropic", async () => {
+      const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
+      prepareClaudeRequest = mod.prepareClaudeRequest;
+
+      for (const provider of ["glm", "kimi", "minimax"]) {
+        const body = {
+          messages: [{ role: "user", content: [{ type: "text", text: "search" }] }],
+          tools: [{ type: "web_search_20250305" }],
+        };
+
+        const result = prepareClaudeRequest(structuredClone(body), provider);
+        // Should be stripped since these are not actual Anthropic backends
+        expect(result.tools).toBeUndefined();
+        // Should have system notice
+        expect(result.system).toBeDefined();
+      }
+    });
   });
 });
 
 describe("FUTURE_TRANSLATABLE provider map", () => {
-  it("should document Gemini family as google_search format", () => {
+  it("should document Gemini family as googleSearch format", () => {
     for (const provider of ["gemini", "gemini-cli", "antigravity", "vertex"]) {
       expect(FUTURE_TRANSLATABLE[provider]).toBeDefined();
-      expect(FUTURE_TRANSLATABLE[provider].tool).toBe("google_search");
+      expect(FUTURE_TRANSLATABLE[provider].tool).toBe("googleSearch");
       expect(FUTURE_TRANSLATABLE[provider].format).toBe("gemini");
     }
   });
@@ -284,17 +302,29 @@ describe("FUTURE_TRANSLATABLE provider map", () => {
     expect(FUTURE_TRANSLATABLE.perplexity.format).toBe("implicit");
   });
 
-  it("should document OpenAI and Codex as web_search with openai-responses format", () => {
-    for (const provider of ["openai", "codex"]) {
-      expect(FUTURE_TRANSLATABLE[provider]).toBeDefined();
-      expect(FUTURE_TRANSLATABLE[provider].tool).toBe("web_search");
-      expect(FUTURE_TRANSLATABLE[provider].format).toBe("openai-responses");
-    }
+  it("should document OpenAI as web_search_preview with openai-responses format", () => {
+    expect(FUTURE_TRANSLATABLE.openai).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.openai.tool).toBe("web_search_preview");
+    expect(FUTURE_TRANSLATABLE.openai.format).toBe("openai-responses");
+  });
+
+  it("should document Groq, Qwen, Mistral, OpenRouter as having native search", () => {
+    expect(FUTURE_TRANSLATABLE.groq).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.qwen).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.mistral).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.openrouter).toBeDefined();
+  });
+
+  it("should document GLM and Kimi as model-native search", () => {
+    expect(FUTURE_TRANSLATABLE.glm).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.glm.format).toBe("model-agentic");
+    expect(FUTURE_TRANSLATABLE.kimi).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.kimi.format).toBe("model-native");
   });
 
   it("should not include providers without native web search", () => {
-    const noSearch = ["deepseek", "groq", "mistral", "together", "fireworks",
-      "cerebras", "nvidia", "github", "kiro", "cursor", "ollama"];
+    const noSearch = ["deepseek", "together", "fireworks",
+      "cerebras", "nvidia", "github", "kiro", "cursor"];
     for (const provider of noSearch) {
       expect(FUTURE_TRANSLATABLE[provider]).toBeUndefined();
     }

--- a/tests/unit/tool-capabilities.test.js
+++ b/tests/unit/tool-capabilities.test.js
@@ -16,6 +16,7 @@ import {
   extractBuiltInTools,
   getUnsupportedBuiltInTools,
   BUILT_IN_TOOLS,
+  FUTURE_TRANSLATABLE,
 } from "../../open-sse/config/toolCapabilities.js";
 
 describe("Tool Capabilities", () => {
@@ -259,5 +260,43 @@ describe("Tool stripping with system message injection", () => {
         expect(hasWebSearch).toBe(true);
       }
     });
+  });
+});
+
+describe("FUTURE_TRANSLATABLE provider map", () => {
+  it("should document Gemini family as google_search format", () => {
+    for (const provider of ["gemini", "gemini-cli", "antigravity", "vertex"]) {
+      expect(FUTURE_TRANSLATABLE[provider]).toBeDefined();
+      expect(FUTURE_TRANSLATABLE[provider].tool).toBe("google_search");
+      expect(FUTURE_TRANSLATABLE[provider].format).toBe("gemini");
+    }
+  });
+
+  it("should document xAI as web_search with xai-responses format", () => {
+    expect(FUTURE_TRANSLATABLE.xai).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.xai.tool).toBe("web_search");
+    expect(FUTURE_TRANSLATABLE.xai.format).toBe("xai-responses");
+  });
+
+  it("should document Perplexity as implicit (no tool needed)", () => {
+    expect(FUTURE_TRANSLATABLE.perplexity).toBeDefined();
+    expect(FUTURE_TRANSLATABLE.perplexity.tool).toBeNull();
+    expect(FUTURE_TRANSLATABLE.perplexity.format).toBe("implicit");
+  });
+
+  it("should document OpenAI and Codex as web_search with openai-responses format", () => {
+    for (const provider of ["openai", "codex"]) {
+      expect(FUTURE_TRANSLATABLE[provider]).toBeDefined();
+      expect(FUTURE_TRANSLATABLE[provider].tool).toBe("web_search");
+      expect(FUTURE_TRANSLATABLE[provider].format).toBe("openai-responses");
+    }
+  });
+
+  it("should not include providers without native web search", () => {
+    const noSearch = ["deepseek", "groq", "mistral", "together", "fireworks",
+      "cerebras", "nvidia", "github", "kiro", "cursor", "ollama"];
+    for (const provider of noSearch) {
+      expect(FUTURE_TRANSLATABLE[provider]).toBeUndefined();
+    }
   });
 });

--- a/tests/unit/tool-capabilities.test.js
+++ b/tests/unit/tool-capabilities.test.js
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for tool capability awareness
+ *
+ * Tests cover:
+ *  - Tool capability map correctness
+ *  - Built-in tool detection
+ *  - Unsupported tool identification per provider
+ *  - Integration with claudeHelper.prepareClaudeRequest
+ *  - Integration with translator index for OpenAI-format targets
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  supportsBuiltInTool,
+  isBuiltInTool,
+  extractBuiltInTools,
+  getUnsupportedBuiltInTools,
+  BUILT_IN_TOOLS,
+} from "../../open-sse/config/toolCapabilities.js";
+
+describe("Tool Capabilities", () => {
+  describe("BUILT_IN_TOOLS constants", () => {
+    it("should define web_search and web_fetch", () => {
+      expect(BUILT_IN_TOOLS.WEB_SEARCH).toBe("web_search_20250305");
+      expect(BUILT_IN_TOOLS.WEB_FETCH).toBe("web_fetch_20250305");
+    });
+  });
+
+  describe("supportsBuiltInTool", () => {
+    it("should return true for Claude provider with web_search", () => {
+      expect(supportsBuiltInTool("claude", BUILT_IN_TOOLS.WEB_SEARCH)).toBe(true);
+    });
+
+    it("should return true for Claude provider with web_fetch", () => {
+      expect(supportsBuiltInTool("claude", BUILT_IN_TOOLS.WEB_FETCH)).toBe(true);
+    });
+
+    it("should return true for anthropic provider with web_search", () => {
+      expect(supportsBuiltInTool("anthropic", BUILT_IN_TOOLS.WEB_SEARCH)).toBe(true);
+    });
+
+    it("should return true for Claude-compatible providers", () => {
+      for (const provider of ["glm", "kimi", "minimax", "minimax-cn", "kimi-coding"]) {
+        expect(supportsBuiltInTool(provider, BUILT_IN_TOOLS.WEB_SEARCH)).toBe(true);
+      }
+    });
+
+    it("should return false for OpenAI provider", () => {
+      expect(supportsBuiltInTool("openai", BUILT_IN_TOOLS.WEB_SEARCH)).toBe(false);
+    });
+
+    it("should return false for providers not in the map", () => {
+      for (const provider of ["gemini", "github", "nvidia", "deepseek", "groq", "xai"]) {
+        expect(supportsBuiltInTool(provider, BUILT_IN_TOOLS.WEB_SEARCH)).toBe(false);
+      }
+    });
+
+    it("should return false for unknown tool types", () => {
+      expect(supportsBuiltInTool("claude", "unknown_tool_v1")).toBe(false);
+    });
+
+    it("should return false for unknown providers", () => {
+      expect(supportsBuiltInTool("nonexistent", BUILT_IN_TOOLS.WEB_SEARCH)).toBe(false);
+    });
+  });
+
+  describe("isBuiltInTool", () => {
+    it("should identify built-in tools by type", () => {
+      expect(isBuiltInTool({ type: "web_search_20250305" })).toBe(true);
+      expect(isBuiltInTool({ type: "web_fetch_20250305" })).toBe(true);
+    });
+
+    it("should not flag function tools as built-in", () => {
+      expect(isBuiltInTool({ type: "function", function: { name: "my_tool" } })).toBe(false);
+    });
+
+    it("should not flag tools without type as built-in", () => {
+      expect(isBuiltInTool({ name: "my_tool", description: "test" })).toBe(false);
+    });
+  });
+
+  describe("extractBuiltInTools", () => {
+    it("should extract only built-in tools from mixed array", () => {
+      const tools = [
+        { type: "web_search_20250305", max_uses: 3 },
+        { type: "function", function: { name: "read_file" } },
+        { type: "web_fetch_20250305" },
+        { name: "custom_tool", description: "test", input_schema: {} },
+      ];
+      const result = extractBuiltInTools(tools);
+      expect(result).toHaveLength(2);
+      expect(result[0].type).toBe("web_search_20250305");
+      expect(result[1].type).toBe("web_fetch_20250305");
+    });
+
+    it("should return empty array for no built-in tools", () => {
+      const tools = [
+        { type: "function", function: { name: "read_file" } },
+      ];
+      expect(extractBuiltInTools(tools)).toHaveLength(0);
+    });
+
+    it("should handle null/undefined input", () => {
+      expect(extractBuiltInTools(null)).toHaveLength(0);
+      expect(extractBuiltInTools(undefined)).toHaveLength(0);
+    });
+  });
+
+  describe("getUnsupportedBuiltInTools", () => {
+    const toolsWithWebSearch = [
+      { type: "web_search_20250305", max_uses: 3 },
+      { type: "function", function: { name: "read_file" } },
+    ];
+
+    it("should return empty for Claude (supports web_search)", () => {
+      expect(getUnsupportedBuiltInTools("claude", toolsWithWebSearch)).toHaveLength(0);
+    });
+
+    it("should return web_search for OpenAI (does not support it)", () => {
+      const result = getUnsupportedBuiltInTools("openai", toolsWithWebSearch);
+      expect(result).toEqual(["web_search_20250305"]);
+    });
+
+    it("should return web_search for Gemini", () => {
+      const result = getUnsupportedBuiltInTools("gemini", toolsWithWebSearch);
+      expect(result).toEqual(["web_search_20250305"]);
+    });
+
+    it("should return multiple unsupported tools", () => {
+      const tools = [
+        { type: "web_search_20250305" },
+        { type: "web_fetch_20250305" },
+        { type: "function", function: { name: "tool" } },
+      ];
+      const result = getUnsupportedBuiltInTools("openai", tools);
+      expect(result).toHaveLength(2);
+      expect(result).toContain("web_search_20250305");
+      expect(result).toContain("web_fetch_20250305");
+    });
+
+    it("should not include function tools as unsupported", () => {
+      const tools = [
+        { type: "function", function: { name: "my_tool" } },
+      ];
+      expect(getUnsupportedBuiltInTools("openai", tools)).toHaveLength(0);
+    });
+  });
+});
+
+describe("Tool stripping with system message injection", () => {
+  // Test the actual prepareClaudeRequest behavior
+  describe("prepareClaudeRequest - Claude format targets", () => {
+    // Dynamic import to handle module loading
+    let prepareClaudeRequest;
+
+    it("should preserve built-in tools for Claude provider", async () => {
+      const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
+      prepareClaudeRequest = mod.prepareClaudeRequest;
+
+      const body = {
+        messages: [{ role: "user", content: [{ type: "text", text: "search for X" }] }],
+        tools: [
+          { type: "web_search_20250305", max_uses: 3 },
+          { name: "my_tool", description: "test", input_schema: { type: "object" } },
+        ],
+      };
+
+      const result = prepareClaudeRequest(structuredClone(body), "claude");
+      // web_search should still be there
+      const hasWebSearch = result.tools.some(t => t.type === "web_search_20250305");
+      expect(hasWebSearch).toBe(true);
+    });
+
+    it("should strip web_search for OpenAI-target provider using Claude format", async () => {
+      const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
+      prepareClaudeRequest = mod.prepareClaudeRequest;
+
+      const body = {
+        messages: [{ role: "user", content: [{ type: "text", text: "search for X" }] }],
+        tools: [
+          { type: "web_search_20250305", max_uses: 3 },
+          { name: "my_tool", description: "test", input_schema: { type: "object" } },
+        ],
+      };
+
+      const result = prepareClaudeRequest(structuredClone(body), "nvidia");
+      // web_search should be stripped
+      const hasWebSearch = result.tools.some(t => t.type === "web_search_20250305");
+      expect(hasWebSearch).toBe(false);
+      // function tool should remain
+      expect(result.tools.some(t => t.name === "my_tool")).toBe(true);
+    });
+
+    it("should inject system message when stripping tools", async () => {
+      const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
+      prepareClaudeRequest = mod.prepareClaudeRequest;
+
+      const body = {
+        messages: [{ role: "user", content: [{ type: "text", text: "search for X" }] }],
+        tools: [
+          { type: "web_search_20250305", max_uses: 3 },
+          { name: "my_tool", description: "test", input_schema: { type: "object" } },
+        ],
+      };
+
+      const result = prepareClaudeRequest(structuredClone(body), "deepseek");
+      // Should have system message about unavailable tools
+      expect(result.system).toBeDefined();
+      expect(Array.isArray(result.system)).toBe(true);
+      const systemText = result.system.map(s => s.text).join(" ");
+      expect(systemText).toContain("not available on this provider");
+      expect(systemText).toContain("web search");
+    });
+
+    it("should append to existing system message array", async () => {
+      const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
+      prepareClaudeRequest = mod.prepareClaudeRequest;
+
+      const body = {
+        system: [{ type: "text", text: "You are a helpful assistant." }],
+        messages: [{ role: "user", content: [{ type: "text", text: "search" }] }],
+        tools: [{ type: "web_search_20250305" }],
+      };
+
+      const result = prepareClaudeRequest(structuredClone(body), "groq");
+      expect(result.system.length).toBeGreaterThan(1);
+      expect(result.system[0].text).toBe("You are a helpful assistant.");
+      expect(result.system[result.system.length - 1].text).toContain("not available");
+    });
+
+    it("should not inject system message when no tools are stripped", async () => {
+      const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
+      prepareClaudeRequest = mod.prepareClaudeRequest;
+
+      const body = {
+        messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+        tools: [
+          { name: "my_tool", description: "test", input_schema: { type: "object" } },
+        ],
+      };
+
+      const result = prepareClaudeRequest(structuredClone(body), "openai");
+      // No system message should be injected (no built-in tools to strip)
+      expect(result.system).toBeUndefined();
+    });
+
+    it("should preserve web_search for Claude-compatible providers", async () => {
+      const mod = await import("../../open-sse/translator/helpers/claudeHelper.js");
+      prepareClaudeRequest = mod.prepareClaudeRequest;
+
+      for (const provider of ["glm", "kimi", "minimax", "anthropic"]) {
+        const body = {
+          messages: [{ role: "user", content: [{ type: "text", text: "search" }] }],
+          tools: [{ type: "web_search_20250305" }],
+        };
+
+        const result = prepareClaudeRequest(structuredClone(body), provider);
+        const hasWebSearch = result.tools.some(t => t.type === "web_search_20250305");
+        expect(hasWebSearch).toBe(true);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Version 1 of #402

## What changed

Built-in tools like `web_search_20250305` were silently stripped for non-Claude providers. Now 9router:

1. Checks a capability map to know which providers support which built-in tools
2. Strips unsupported tools but injects a system message telling the model what's unavailable
3. Documents every provider's native web search format for future translation work

## Why

When a combo falls through from Claude to another provider, the model had no idea web search was even requested. Now it gets told "web search is not available on this provider" so it can respond accordingly.

## Provider research

Every provider in 9router was researched. Results in `toolCapabilities.js`:

| Category | Providers |
|----------|-----------|
| **Pass-through** (accept Anthropic format) | claude, anthropic |
| **Has native search, different format** (future translation) | gemini family (googleSearch), xai (web_search), perplexity (implicit), openai (web_search_preview), groq (compound models), qwen (enable_search), mistral (agents API), openrouter (plugins), glm (model-agentic), kimi (model-native) |
| **No web search** | deepseek, together, fireworks, cerebras, nvidia, github, kiro, cursor, minimax, and others |
| **Deprecated** | cohere (connectors removed Sep 2025), codex (explicitly unsupported) |

## Backward compatible

Without any config changes, behavior is identical to before — tools still get stripped for unsupported providers. The only difference is the model now knows about it.

## Tests

34 new tests. Verified locally and in an isolated k8s environment (Node 22).

## Open questions

A few things I'd like your input on @decolua before going further:

- **System message wording** — currently injects "Note: web search is not available on this provider. Do not attempt to use it." Is there a better phrasing you'd prefer?
- **Claude-wire providers** (glm, kimi, minimax) — I excluded them from pass-through since their backends aren't Anthropic. If any of them actually do accept `web_search_20250305`, happy to add them back.
- **FUTURE_TRANSLATABLE map** — I documented native formats for 13 providers. If any of the format details are wrong or you want to prioritize certain providers for actual translation, let me know and I'll update.

Point out anything you want changed and I'll implement it.