### PR TITLE
feat: add OpenCode as provider connection (no OAuth)

### DIFF
--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -499,6 +499,11 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         const res = await fetchWithConnectionProxy("https://llm.chutes.ai/v1/models", { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy);
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
       }
+      case "opencode": {
+        const baseUrl = connection.providerSpecificData?.baseUrl || "http://localhost:4096/v1";
+        const res = await fetchWithConnectionProxy(`${baseUrl.replace(/\/$/, "")}/models`, { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy).catch(() => null);
+        return { valid: res?.ok ?? false, error: res?.ok ? null : "OpenCode server not running on port 4096" };
+      }
       default:
         return { valid: false, error: "Provider test not supported" };
     }

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -7,7 +7,12 @@ import {
   getProxyPoolById,
 } from "@/models";
 import { APIKEY_PROVIDERS } from "@/shared/constants/config";
-import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
+import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider, OAUTH_PROVIDERS } from "@/shared/constants/providers";
+
+// Local CLI tools that expose an OpenAI-compatible API on localhost
+const LOCAL_CLI_PROVIDERS = {
+  opencode: { baseUrl: "http://localhost:4096/v1" },
+};
 
 export const dynamic = "force-dynamic";
 
@@ -61,7 +66,7 @@ export async function GET() {
 
     // Hide sensitive fields, enrich name for compatible providers
     const safeConnections = connections.map(c => {
-      const isCompatible = isOpenAICompatibleProvider(c.provider) || isAnthropicCompatibleProvider(c.provider);
+      const isCompatible = isOpenAICompatibleProvider(c.provider) || isAnthropicCompatibleProvider(c.provider) || LOCAL_CLI_PROVIDERS[c.provider];
       const name = isCompatible
         ? (nodeNameMap[c.provider] || c.providerSpecificData?.nodeName || c.provider)
         : c.name;
@@ -101,7 +106,8 @@ export async function POST(request) {
     // Validation
     const isValidProvider = APIKEY_PROVIDERS[provider] ||
       isOpenAICompatibleProvider(provider) ||
-      isAnthropicCompatibleProvider(provider);
+      isAnthropicCompatibleProvider(provider) ||
+      LOCAL_CLI_PROVIDERS[provider];
 
     if (!provider || !isValidProvider) {
       return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
@@ -147,6 +153,17 @@ export async function POST(request) {
         prefix: node.prefix,
         baseUrl: node.baseUrl,
         nodeName: node.name,
+      };
+    } else if (LOCAL_CLI_PROVIDERS[provider]) {
+      const localConfig = LOCAL_CLI_PROVIDERS[provider];
+      const existingConnections = await getProviderConnections({ provider });
+      if (existingConnections.length > 0) {
+        return NextResponse.json({ error: `Only one connection is allowed for ${provider}` }, { status: 400 });
+      }
+
+      providerSpecificData = {
+        baseUrl: localConfig.baseUrl,
+        nodeName: OAUTH_PROVIDERS[provider]?.name || provider,
       };
     }
 

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -196,6 +196,16 @@ export async function POST(request) {
           break;
         }
 
+        case "opencode": {
+          // OpenCode runs a local OpenAI-compatible server
+          const opencodeRes = await fetch("http://localhost:4096/v1/models", {
+            headers: { "Authorization": `Bearer ${apiKey}` },
+          }).catch(() => null);
+          isValid = opencodeRes?.ok ?? false;
+          error = isValid ? null : "OpenCode server not running on port 4096";
+          break;
+        }
+
         case "deepgram": {
           const res = await fetch("https://api.deepgram.com/v1/projects", {
             headers: { "Authorization": `Token ${apiKey}` },


### PR DESCRIPTION
## Problem

OpenCode is listed in the dashboard CLI Tools page as a connectable provider, but clicking "Connect" fails with **"Unknown provider: opencode"**.

The issue: OpenCode is defined in `OAUTH_PROVIDERS` but has no OAuth service implementation. The POST `/api/providers` handler only validates `APIKEY_PROVIDERS`, `openai-compatible-*`, and `anthropic-compatible-*` providers.

## Solution

OpenCode runs a **local OpenAI-compatible server on port 4096** — it doesn't need OAuth. This PR treats it as a local CLI provider (like an API key provider with a hardcoded localhost URL).

### Changes

1. **`src/app/api/providers/route.js`**
   - Added `LOCAL_CLI_PROVIDERS` map with OpenCode's local baseUrl
   - Updated validation to accept local CLI providers
   - Added provider-specific data handling for local CLI providers (sets baseUrl + nodeName)
   - Updated GET handler name enrichment for local CLI providers

2. **`src/app/api/providers/validate/route.js`**
   - Added `opencode` case that checks if the local OpenCode server is running on port 4096

3. **`src/app/api/providers/[id]/test/testUtils.js`**
   - Added `opencode` test case that pings the local server's `/models` endpoint

## How it works

1. User clicks "Connect OpenCode" in the dashboard
2. Dashboard POSTs to `/api/providers` with `provider: "opencode"`
3. Backend validates it as a local CLI provider
4. Connection created with `baseUrl: "http://localhost:4096/v1"`
5. 9router routes requests to OpenCode's local API
6. OpenCode forwards to its configured upstream providers

The translator config already has OpenCode defined with the correct URL and format — no changes needed there.
