### PR TITLE
[codex] handle missing db.json on first run

### DIFF
--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -101,6 +101,29 @@ function cloneDefaultData() {
   };
 }
 
+function ensureDataDirExists() {
+  if (isCloud) return;
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+function ensureDbFileExists() {
+  if (isCloud) return;
+
+  ensureDataDirExists();
+
+  if (fs.existsSync(DB_FILE)) return;
+
+  try {
+    fs.writeFileSync(DB_FILE, JSON.stringify(cloneDefaultData(), null, 2), {
+      flag: "wx",
+    });
+  } catch (error) {
+    if (error.code !== "EEXIST") {
+      throw error;
+    }
+  }
+}
+
 function ensureDbShape(data) {
   const defaults = cloneDefaultData();
   const next = data && typeof data === "object" ? data : {};
@@ -183,6 +206,7 @@ async function safeRead(db) {
 
   let release = null;
   try {
+    ensureDbFileExists();
     // Acquire lock before reading
     release = await lockfile.lock(DB_FILE, LOCK_OPTIONS);
     await db.read();
@@ -214,6 +238,7 @@ async function safeWrite(db) {
 
   let release = null;
   try {
+    ensureDbFileExists();
     // Acquire lock before writing
     release = await lockfile.lock(DB_FILE, LOCK_OPTIONS);
     await db.write();
@@ -249,6 +274,7 @@ export async function getDb() {
   }
 
   if (!dbInstance) {
+    ensureDbFileExists();
     const adapter = new JSONFile(DB_FILE);
     dbInstance = new Low(adapter, cloneDefaultData());
   }


### PR DESCRIPTION
## Summary
Fix first-run startup and auth/settings failures when `${DATA_DIR}/db.json` does not exist yet.

Closes #440

## What changed
- ensure the data directory exists before DB access
- create `db.json` with the default schema if it is missing
- call that bootstrap logic before initial adapter creation and before lock/read/write operations

## Why
The local DB layer uses `proper-lockfile` around `${DATA_DIR}/db.json`. On a clean install, the directory may exist while the file does not, and the lock path attempts to `lstat` the file before it has been created. That breaks server init and any request path that reads settings.

## Impact
- outbound proxy initialization no longer logs an `ENOENT` on first run
- `GET /api/settings` returns default settings instead of `500`
- `POST /api/auth/login` no longer fails because settings bootstrap cleanly

## Validation
- `npx eslint src/lib/localDb.js`
- deleted `~/.9router/db.json` and verified the settings layer recreated it and returned default values