### PR TITLE
fix: GitHub provider 401 auto-reauth broken due to missing clientId

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -168,7 +168,8 @@ export const PROVIDERS = {
       "X-Initiator": "user",
       "Accept": "application/json",
       "Content-Type": "application/json"
-    }
+    },
+    clientId: "Iv1.b507a08c87ecfe98"
   },
   kiro: {
     baseUrl: "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse",

--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -243,15 +243,19 @@ export class GithubExecutor extends BaseExecutor {
 
   async refreshGitHubToken(refreshToken, log) {
     try {
+      const params = {
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: this.config.clientId,
+      };
+      if (this.config.clientSecret) {
+        params.client_secret = this.config.clientSecret;
+      }
+
       const response = await fetch(OAUTH_ENDPOINTS.github.token, {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json" },
-        body: new URLSearchParams({
-          grant_type: "refresh_token",
-          refresh_token: refreshToken,
-          client_id: this.config.clientId,
-          client_secret: this.config.clientSecret
-        })
+        body: new URLSearchParams(params)
       });
       if (!response.ok) return null;
       const tokens = await response.json();

--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -373,18 +373,22 @@ export async function refreshIflowToken(refreshToken, log) {
  * Specialized refresh for GitHub Copilot OAuth tokens
  */
 export async function refreshGitHubToken(refreshToken, log) {
+  const params = {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: PROVIDERS.github.clientId,
+  };
+  if (PROVIDERS.github.clientSecret) {
+    params.client_secret = PROVIDERS.github.clientSecret;
+  }
+
   const response = await fetch(OAUTH_ENDPOINTS.github.token, {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
       Accept: "application/json",
     },
-    body: new URLSearchParams({
-      grant_type: "refresh_token",
-      refresh_token: refreshToken,
-      client_id: PROVIDERS.github.clientId,
-      client_secret: PROVIDERS.github.clientSecret,
-    }),
+    body: new URLSearchParams(params),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

- Add missing `clientId` (`Iv1.b507a08c87ecfe98`) to the `github` provider config in `open-sse/config/providers.js`
- Guard against `undefined` `clientSecret` in `refreshGitHubToken()` in both `GithubExecutor` and `tokenRefresh.js`

## Problem

When a GitHub Copilot token expired and the OAuth access token was also expired, the refresh flow failed because `PROVIDERS.github.clientId` was `undefined`. This caused `client_id=undefined` to be sent to GitHub's OAuth token endpoint, which rejected the request.

The `clientId` was already defined in `src/lib/oauth/constants/oauth.js` (used for initial login) but was missing from the `open-sse/config/providers.js` config (used by executors and token refresh).

## Test plan

- [ ] Verify GitHub provider authenticates successfully
- [ ] Wait for copilot token + OAuth token to expire
- [ ] Confirm auto-reauth kicks in on 401 and refreshes both tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Some personal words:
I encountered this problem since yesterday. When I click "test connection" in the edit dialog of the github provider, the connection is re-established. So I asked Claude Code to investigate this problem.