### PR TITLE
fix Anthropic-Compatible Stream Missing Thinking Block Close Marker

### DIFF
--- a/open-sse/translator/response/claude-to-openai.js
+++ b/open-sse/translator/response/claude-to-openai.js
@@ -95,7 +95,7 @@ export function claudeToOpenAIResponse(chunk, state) {
         break;
       }
       if (state.inThinkingBlock && chunk.index === state.currentBlockIndex) {
-        results.push(createChunk(state, { reasoning_content: "" }));
+        results.push(createChunk(state, { content: "</think>" }));
         state.inThinkingBlock = false;
       }
       state.textBlockStarted = false;


### PR DESCRIPTION
# Bug Report: Anthropic-Compatible Stream Missing Thinking Block Close Marker

## Summary
When streaming responses from anthropic-compatible providers (Claude format), clients remained stuck in "loading/thinking" state even though the backend stream completed successfully.

## Impact
- **Client-side**: Users see indefinite "thinking" indicator despite response being complete
- **Backend**: Logs show stream completed normally (`complete` status with duration)
- **Affected providers**: Any using `anthropic-compatible-*` with Claude native SSE format

## Root Cause Analysis

### The Translation Flow
```
Anthropic SSE → claude-to-openai.js → OpenAI SSE → Client
   (thinking)        (convert)         (stream)
```

### The Bug
In [open-sse/translator/response/claude-to-openai.js](cci:7://file:///Users/quanle96/Documents/9router/open-sse/translator/response/claude-to-openai.js:0:0-0:0), when a Claude `thinking` block ends:

**Before (buggy)**:
```javascript
// content_block_stop for thinking block
results.push(createChunk(state, { reasoning_content: "" }));
```

**Problem**: An empty `reasoning_content` delta doesn't signal "thinking complete" to clients. The thinking block was opened with `content: "