### PR TITLE
Disable 9remote by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ ENABLE_REQUEST_LOGS=false
 OBSERVABILITY_ENABLED=true
 AUTH_COOKIE_SECURE=false
 REQUIRE_API_KEY=false
+NINE_REMOTE_ENABLED=false
+NEXT_PUBLIC_NINE_REMOTE_ENABLED=false
+NINE_REMOTE_URL=http://localhost:2208
+NEXT_PUBLIC_NINE_REMOTE_URL=http://localhost:2208
 
 # Cloud sync variables
 # Must point to this running instance so internal sync jobs can call /api/sync/cloud.

--- a/src/app/api/9remote/install/route.js
+++ b/src/app/api/9remote/install/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { exec } from "child_process";
 import { join, dirname } from "path";
+import { isNineRemoteEnabled } from "@/lib/nineRemoteConfig";
 
 // Use npm from the same Node.js that runs Next.js — ensures 9remote
 // lands in the correct global bin (nvm or system, whichever is active)
@@ -16,6 +17,10 @@ function installPackage() {
 }
 
 export async function POST() {
+  if (!isNineRemoteEnabled()) {
+    return NextResponse.json({ ok: false, error: "9Remote is disabled" }, { status: 404 });
+  }
+
   try {
     await installPackage();
     return NextResponse.json({ ok: true });

--- a/src/app/api/9remote/start/route.js
+++ b/src/app/api/9remote/start/route.js
@@ -3,10 +3,15 @@ import { spawn } from "child_process";
 import { join, dirname } from "path";
 import os from "os";
 import { setRemoteProcess } from "@/lib/9remoteManager";
+import { isNineRemoteEnabled } from "@/lib/nineRemoteConfig";
 
 const bin9remote = join(dirname(process.execPath), "9remote");
 
 export async function POST() {
+  if (!isNineRemoteEnabled()) {
+    return NextResponse.json({ ok: false, error: "9Remote is disabled" }, { status: 404 });
+  }
+
   try {
     const nodeDir = dirname(process.execPath);
     const existingPath = process.env.PATH || "";

--- a/src/app/api/9remote/status/route.js
+++ b/src/app/api/9remote/status/route.js
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import { existsSync } from "fs";
 import { join, dirname } from "path";
+import { getNineRemoteServerUrl, isNineRemoteEnabled } from "@/lib/nineRemoteConfig";
 
 const bin9remote = join(dirname(process.execPath), "9remote");
-const AGENT_URL = "http://localhost:2208";
 
 async function isRunning() {
   try {
-    const res = await fetch(`${AGENT_URL}/api/health`, {
+    const res = await fetch(`${getNineRemoteServerUrl()}/api/health`, {
       signal: AbortSignal.timeout(1500),
     });
     return res.ok;
@@ -17,9 +17,13 @@ async function isRunning() {
 }
 
 export async function GET() {
+  if (!isNineRemoteEnabled()) {
+    return NextResponse.json({ enabled: false, installed: false, running: false }, { status: 404 });
+  }
+
   const running = await isRunning();
-  if (running) return NextResponse.json({ installed: true, running: true });
+  if (running) return NextResponse.json({ enabled: true, installed: true, running: true });
 
   const installed = existsSync(bin9remote);
-  return NextResponse.json({ installed, running: false });
+  return NextResponse.json({ enabled: true, installed, running: false });
 }

--- a/src/lib/nineRemoteConfig.js
+++ b/src/lib/nineRemoteConfig.js
@@ -1,0 +1,24 @@
+const DEFAULT_NINE_REMOTE_URL = "http://localhost:2208";
+
+function trimTrailingSlash(url) {
+  return typeof url === "string" ? url.replace(/\/+$/, "") : "";
+}
+
+export function isNineRemoteEnabled() {
+  return process.env.NINE_REMOTE_ENABLED === "true"
+    || process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED === "true";
+}
+
+export function getNineRemotePublicUrl() {
+  return trimTrailingSlash(
+    process.env.NEXT_PUBLIC_NINE_REMOTE_URL || DEFAULT_NINE_REMOTE_URL
+  );
+}
+
+export function getNineRemoteServerUrl() {
+  return trimTrailingSlash(
+    process.env.NINE_REMOTE_URL
+    || process.env.NEXT_PUBLIC_NINE_REMOTE_URL
+    || DEFAULT_NINE_REMOTE_URL
+  );
+}

--- a/src/shared/components/NineRemoteButton.js
+++ b/src/shared/components/NineRemoteButton.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import NineRemoteModal from "./NineRemoteModal";
+import { getNineRemotePublicUrl, isNineRemoteEnabled } from "@/lib/nineRemoteConfig";
 
 // step 0-4 từ 9remote SSE: 0=Stopped,1=Preparing,2=Connecting,3=Tunneling,4=Ready
 const STEP = { STOPPED: 0, PREPARING: 1, CONNECTING: 2, TUNNELING: 3, READY: 4 };
@@ -19,11 +20,13 @@ const stepStyle = (step, installed) => {
 };
 
 export default function NineRemoteButton() {
+  const enabled = isNineRemoteEnabled();
   const [isOpen, setIsOpen] = useState(false);
   const [installed, setInstalled] = useState(false);
   const [step, setStep] = useState(STEP.STOPPED);
   const esRef = useRef(null);
   const retryRef = useRef(null);
+  const remoteBaseUrl = getNineRemotePublicUrl();
 
   const scheduleRetry = () => {
     clearTimeout(retryRef.current);
@@ -31,10 +34,12 @@ export default function NineRemoteButton() {
   };
 
   const connect = () => {
+    if (!enabled) return;
+
     esRef.current?.close();
     clearTimeout(retryRef.current);
 
-    const es = new EventSource("http://localhost:2208/api/ui/events");
+    const es = new EventSource(`${remoteBaseUrl}/api/ui/events`);
 
     es.onmessage = (e) => {
       try {
@@ -57,6 +62,8 @@ export default function NineRemoteButton() {
   };
 
   useEffect(() => {
+    if (!enabled) return undefined;
+
     // Check installed once on mount (no polling, just 1 call)
     fetch("/api/9remote/status")
       .then((r) => r.json())
@@ -69,13 +76,15 @@ export default function NineRemoteButton() {
       esRef.current?.close();
       clearTimeout(retryRef.current);
     };
-  }, []);
+  }, [enabled, remoteBaseUrl]);
 
   // When modal closes, reconnect SSE immediately (user may have just started 9remote)
   const handleClose = () => {
     setIsOpen(false);
     setTimeout(connect, 800);
   };
+
+  if (!enabled) return null;
 
   const { color, glow } = stepStyle(step, installed);
   const isPulsing = installed && step >= STEP.PREPARING && step <= STEP.TUNNELING;

--- a/src/shared/components/NineRemoteModal.js
+++ b/src/shared/components/NineRemoteModal.js
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
+import { getNineRemotePublicUrl } from "@/lib/nineRemoteConfig";
 
 const S = {
   CHECKING: "checking",
@@ -29,6 +30,7 @@ const BULLETS = [
 ];
 
 export default function NineRemoteModal({ isOpen, onClose, onInstalled }) {
+  const remoteBaseUrl = getNineRemotePublicUrl();
   const [state, setState] = useState(S.CHECKING);
   const [errorMsg, setErrorMsg] = useState("");
   const pollRef = useRef(null);
@@ -119,7 +121,7 @@ export default function NineRemoteModal({ isOpen, onClose, onInstalled }) {
         <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
         <div className="relative rounded-xl overflow-hidden shadow-2xl animate-in fade-in zoom-in-95 duration-200" style={{ width: 480, height: "90vh" }}>
           <iframe
-            src="http://localhost:2208"
+            src={remoteBaseUrl}
             className="border-0 block w-full h-full"
             title="9Remote UI"
           />

--- a/tests/unit/nine-remote-config.test.js
+++ b/tests/unit/nine-remote-config.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+describe("9remote config", () => {
+  const originalEnabled = process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED;
+  const originalPublicUrl = process.env.NEXT_PUBLIC_NINE_REMOTE_URL;
+  const originalServerUrl = process.env.NINE_REMOTE_URL;
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED;
+    delete process.env.NEXT_PUBLIC_NINE_REMOTE_URL;
+    delete process.env.NINE_REMOTE_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED;
+    else process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED = originalEnabled;
+
+    if (originalPublicUrl === undefined) delete process.env.NEXT_PUBLIC_NINE_REMOTE_URL;
+    else process.env.NEXT_PUBLIC_NINE_REMOTE_URL = originalPublicUrl;
+
+    if (originalServerUrl === undefined) delete process.env.NINE_REMOTE_URL;
+    else process.env.NINE_REMOTE_URL = originalServerUrl;
+  });
+
+  it("is disabled by default", async () => {
+    const { isNineRemoteEnabled } = await import("../../src/lib/nineRemoteConfig.js");
+
+    expect(isNineRemoteEnabled()).toBe(false);
+  });
+
+  it("enables 9remote only when explicit env flag is true", async () => {
+    process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED = "true";
+
+    const { isNineRemoteEnabled } = await import("../../src/lib/nineRemoteConfig.js");
+
+    expect(isNineRemoteEnabled()).toBe(true);
+  });
+
+  it("uses env overrides for public and server urls", async () => {
+    process.env.NEXT_PUBLIC_NINE_REMOTE_URL = "https://remote.example.com";
+    process.env.NINE_REMOTE_URL = "http://127.0.0.1:2209";
+
+    const { getNineRemotePublicUrl, getNineRemoteServerUrl } = await import("../../src/lib/nineRemoteConfig.js");
+
+    expect(getNineRemotePublicUrl()).toBe("https://remote.example.com");
+    expect(getNineRemoteServerUrl()).toBe("http://127.0.0.1:2209");
+  });
+});

--- a/tests/unit/nine-remote-status.test.js
+++ b/tests/unit/nine-remote-status.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((body, init) => ({
+      status: init?.status || 200,
+      body,
+      json: async () => body,
+    })),
+  },
+}));
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(() => true),
+}));
+
+describe("GET /api/9remote/status", () => {
+  const originalEnabled = process.env.NINE_REMOTE_ENABLED;
+  const originalPublicEnabled = process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.NINE_REMOTE_ENABLED;
+    delete process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalEnabled === undefined) delete process.env.NINE_REMOTE_ENABLED;
+    else process.env.NINE_REMOTE_ENABLED = originalEnabled;
+
+    if (originalPublicEnabled === undefined) delete process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED;
+    else process.env.NEXT_PUBLIC_NINE_REMOTE_ENABLED = originalPublicEnabled;
+  });
+
+  it("returns disabled by default", async () => {
+    const mod = await import("../../src/app/api/9remote/status/route.js");
+
+    const response = await mod.GET();
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      enabled: false,
+      installed: false,
+      running: false,
+    });
+  });
+});

--- a/tests/vitest.config.js
+++ b/tests/vitest.config.js
@@ -14,6 +14,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@": resolve(__dirname, "../src"),
       // Resolve open-sse/* imports to the actual local package
       "open-sse": resolve(__dirname, "../open-sse"),
     },


### PR DESCRIPTION
  ## Summary
  Disable 9Remote by default and make it env-configurable.

  ## Changes
  - hide 9Remote UI unless explicitly enabled
  - add env flags for enable/disable and public/server 9Remote URLs
  - stop hardcoding `localhost:2208`
  - gate 9Remote API routes when disabled
  - add targeted tests for config defaults and disabled status route

  ## Test
  - `cd tests && npm test -- unit/nine-remote-config.test.js unit/nine-remote-status.test.js`
