### PR TITLE
fix: use providerId for passthrough model alias lookup (closes #483)

### DIFF
--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -85,9 +85,9 @@ export default function ModelSelectModal({
 
       if (providerInfo.passthroughModels) {
         const aliasModels = Object.entries(modelAliases)
-          .filter(([, fullModel]) => fullModel.startsWith(`${alias}/`))
+          .filter(([, fullModel]) => fullModel.startsWith(`${providerId}/`))
           .map(([aliasName, fullModel]) => ({
-            id: fullModel.replace(`${alias}/`, ""),
+            id: fullModel.replace(`${providerId}/`, ""),
             name: aliasName,
             value: fullModel,
           }));


### PR DESCRIPTION
Closes #483