### PR TITLE
fix: skip empty name function calls for Codex (closes #444)

### DIFF
--- a/open-sse/translator/helpers/responsesApiHelper.js
+++ b/open-sse/translator/helpers/responsesApiHelper.js
@@ -87,6 +87,8 @@ export function convertResponsesApiFormat(body) {
           tool_calls: []
         };
       }
+      // Skip items with empty/missing name — upstream APIs reject nameless tool calls (#444)
+      if (!item.name || typeof item.name !== "string" || item.name.trim() === "") continue;
       currentAssistantMsg.tool_calls.push({
         id: item.call_id,
         type: "function",

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -75,6 +75,8 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
           tool_calls: []
         };
       }
+      // Skip items with empty/missing name — Codex/OpenAI reject nameless tool calls (#444)
+      if (!item.name || typeof item.name !== "string" || item.name.trim() === "") continue;
       currentAssistantMsg.tool_calls.push({
         id: item.call_id,
         type: "function",


### PR DESCRIPTION
Closes #444