### PR TITLE
fix: retry /responses endpoint when GitHub returns model not supported (closes #470)

### DIFF
--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -124,7 +124,7 @@ export class GithubExecutor extends BaseExecutor {
     if (result.response.status === HTTP_STATUS.BAD_REQUEST) {
       const errorBody = await result.response.clone().text();
 
-      if (errorBody.includes("not accessible via the /chat/completions endpoint")) {
+      if (errorBody.includes("not accessible via the /chat/completions endpoint") || errorBody.includes("The requested model is not supported")) {
         log?.warn("GITHUB", `Model ${model} requires /responses. Switching...`);
         this.knownCodexModels.add(model);
         return this.executeWithResponsesEndpoint(options);


### PR DESCRIPTION
Closes #470