### PR TITLE
fix: Add API v1 routes to middleware matcher

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -10,5 +10,6 @@ export const config = {
     "/api/keys/:path*",
     "/api/providers/client",
     "/api/provider-nodes/validate",
+    "/api/v1/:path*",
   ],
 };


### PR DESCRIPTION
## Summary

The API proxy endpoints under `/api/v1/` were not being processed by the authentication middleware, leading to HTTP 401 errors due to a missing API key. This change updates the middleware configuration to include `/api/v1/:path*` in the path matcher, ensuring that authentication is correctly applied to all API proxy requests.

## Changes

- **src/proxy.js**: Add the `/api/v1/:path*` pattern to the middleware matcher. This ensures that requests to the AI provider proxy endpoints are properly authenticated by the `dashboardGuard` middleware, resolving the 'Missing API key' errors.

## Related Issue

Closes #494

