### PR TITLE
fix(github): sync top-level copilotToken after proactive refresh

### DIFF
--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -255,6 +255,7 @@ export async function checkAndRefreshToken(provider, credentials) {
         });
 
         creds.providerSpecificData = updatedSpecific;
+        creds.copilotToken = copilotToken.token;
       }
     }
   }


### PR DESCRIPTION
## Summary

  - `checkAndRefreshToken()` in `src/sse/services/tokenRefresh.js` refreshed the Copilot token into `creds.providerSpecificData.copilotToken` but did not update the top-level `creds.copilotToken`
  - `GithubExecutor.buildHeaders()` reads `credentials.copilotToken` (top-level), not from `providerSpecificData`
  - Result: after every proactive Copilot token refresh, requests were sent with the old expired token → `401 IDE token expired`
  - Fix: one added line — `creds.copilotToken = copilotToken.token` — to keep both locations in sync

Some personal words:
In recent days I saw `❌ github [401]: [401]: IDE token expired: unauthorized: token expired`. And an Claude Code looked into it.