### PR TITLE
feat: add webhook notifications and error history for provider errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@toanalien/ahha": "^0.1.1",
     "@xyflow/react": "^12.10.1",
     "bcryptjs": "^3.0.3",
     "confbox": "^0.2.4",

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -24,6 +24,15 @@ export default function ProfilePage() {
   const [proxyStatus, setProxyStatus] = useState({ type: "", message: "" });
   const [proxyLoading, setProxyLoading] = useState(false);
   const [proxyTestLoading, setProxyTestLoading] = useState(false);
+  const [webhookForm, setWebhookForm] = useState({
+    webhookEnabled: false,
+    webhookUrls: "",
+    webhookThrottleMs: 5,
+    webhookErrorCodes: [401, 403, 429, 500, 502, 503],
+  });
+  const [webhookStatus, setWebhookStatus] = useState({ type: "", message: "" });
+  const [webhookLoading, setWebhookLoading] = useState(false);
+  const [webhookTestLoading, setWebhookTestLoading] = useState(false);
 
   useEffect(() => {
     fetch("/api/settings")
@@ -34,6 +43,12 @@ export default function ProfilePage() {
           outboundProxyEnabled: data?.outboundProxyEnabled === true,
           outboundProxyUrl: data?.outboundProxyUrl || "",
           outboundNoProxy: data?.outboundNoProxy || "",
+        });
+        setWebhookForm({
+          webhookEnabled: data?.webhookEnabled === true,
+          webhookUrls: (data?.webhookUrls || []).join("\n"),
+          webhookThrottleMs: Math.round((data?.webhookThrottleMs || 300000) / 60000),
+          webhookErrorCodes: data?.webhookErrorCodes || [401, 403, 429, 500, 502, 503],
         });
         setLoading(false);
       })
@@ -138,6 +153,96 @@ export default function ProfilePage() {
     } finally {
       setProxyLoading(false);
     }
+  };
+
+  const updateWebhookEnabled = async (enabled) => {
+    setWebhookLoading(true);
+    setWebhookStatus({ type: "", message: "" });
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ webhookEnabled: enabled }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setSettings((prev) => ({ ...prev, ...data }));
+        setWebhookForm((prev) => ({ ...prev, webhookEnabled: enabled }));
+        setWebhookStatus({ type: "success", message: enabled ? "Webhook enabled" : "Webhook disabled" });
+      } else {
+        setWebhookStatus({ type: "error", message: data.error || "Failed to update" });
+      }
+    } catch {
+      setWebhookStatus({ type: "error", message: "An error occurred" });
+    } finally {
+      setWebhookLoading(false);
+    }
+  };
+
+  const saveWebhookSettings = async (e) => {
+    e.preventDefault();
+    setWebhookLoading(true);
+    setWebhookStatus({ type: "", message: "" });
+    try {
+      const urls = webhookForm.webhookUrls.split("\n").map(u => u.trim()).filter(Boolean);
+      const throttleMs = Math.max(1, webhookForm.webhookThrottleMs) * 60000;
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          webhookUrls: urls,
+          webhookThrottleMs: throttleMs,
+          webhookErrorCodes: webhookForm.webhookErrorCodes,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setSettings((prev) => ({ ...prev, ...data }));
+        setWebhookStatus({ type: "success", message: "Webhook settings saved" });
+      } else {
+        setWebhookStatus({ type: "error", message: data.error || "Failed to save" });
+      }
+    } catch {
+      setWebhookStatus({ type: "error", message: "An error occurred" });
+    } finally {
+      setWebhookLoading(false);
+    }
+  };
+
+  const testWebhook = async () => {
+    const urls = webhookForm.webhookUrls.split("\n").map(u => u.trim()).filter(Boolean);
+    if (urls.length === 0) {
+      setWebhookStatus({ type: "error", message: "Please enter at least one webhook URL" });
+      return;
+    }
+    setWebhookTestLoading(true);
+    setWebhookStatus({ type: "", message: "" });
+    try {
+      const res = await fetch("/api/settings/webhook-test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ urls }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setWebhookStatus({ type: "success", message: "Test notification sent successfully" });
+      } else {
+        setWebhookStatus({ type: "error", message: data.error || "Test failed" });
+      }
+    } catch {
+      setWebhookStatus({ type: "error", message: "An error occurred" });
+    } finally {
+      setWebhookTestLoading(false);
+    }
+  };
+
+  const toggleErrorCode = (code) => {
+    setWebhookForm((prev) => {
+      const codes = prev.webhookErrorCodes.includes(code)
+        ? prev.webhookErrorCodes.filter(c => c !== code)
+        : [...prev.webhookErrorCodes, code];
+      return { ...prev, webhookErrorCodes: codes };
+    });
   };
 
   const handlePasswordChange = async (e) => {
@@ -647,6 +752,108 @@ export default function ProfilePage() {
               onChange={updateObservabilityEnabled}
               disabled={loading}
             />
+          </div>
+        </Card>
+
+        {/* Webhook Notifications */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-pink-500/10 text-pink-500">
+              <span className="material-symbols-outlined text-[20px]">notifications</span>
+            </div>
+            <h3 className="text-lg font-semibold">Notifications</h3>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-medium">Webhook Notifications</p>
+                <p className="text-sm text-text-muted">
+                  Send alerts via webhook when provider errors occur (401, 429, etc.)
+                </p>
+              </div>
+              <Toggle
+                checked={webhookForm.webhookEnabled}
+                onChange={() => updateWebhookEnabled(!webhookForm.webhookEnabled)}
+                disabled={loading || webhookLoading}
+              />
+            </div>
+
+            {webhookForm.webhookEnabled && (
+              <form onSubmit={saveWebhookSettings} className="flex flex-col gap-4 pt-2 border-t border-border/50">
+                <div className="flex flex-col gap-2">
+                  <label className="font-medium">Webhook URLs</label>
+                  <textarea
+                    className="w-full px-3 py-2 rounded-lg border border-border bg-bg text-text-main text-sm font-mono min-h-[80px] resize-y focus:outline-none focus:ring-2 focus:ring-primary/50"
+                    placeholder={"generic+https://example.com/webhook\nslack://hook:TOKEN@webhook\ndiscord://TOKEN@WEBHOOK_ID"}
+                    value={webhookForm.webhookUrls}
+                    onChange={(e) => setWebhookForm((prev) => ({ ...prev, webhookUrls: e.target.value }))}
+                    disabled={loading || webhookLoading}
+                  />
+                  <p className="text-sm text-text-muted">
+                    One URL per line. Supports: Slack, Discord, Telegram, Webhook, Ntfy (powered by ahha)
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-2 pt-2 border-t border-border/50">
+                  <label className="font-medium">Throttle (minutes)</label>
+                  <Input
+                    type="number"
+                    min="1"
+                    max="60"
+                    value={webhookForm.webhookThrottleMs}
+                    onChange={(e) => setWebhookForm((prev) => ({ ...prev, webhookThrottleMs: parseInt(e.target.value) || 5 }))}
+                    disabled={loading || webhookLoading}
+                    className="w-24"
+                  />
+                  <p className="text-sm text-text-muted">
+                    Same error won&apos;t send duplicate notifications within this window
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-2 pt-2 border-t border-border/50">
+                  <label className="font-medium">Error Codes to Notify</label>
+                  <div className="flex flex-wrap gap-2">
+                    {[401, 403, 429, 500, 502, 503].map((code) => (
+                      <button
+                        key={code}
+                        type="button"
+                        onClick={() => toggleErrorCode(code)}
+                        className={cn(
+                          "px-3 py-1 rounded-md text-sm font-mono border transition-colors",
+                          webhookForm.webhookErrorCodes.includes(code)
+                            ? "bg-primary/10 border-primary/30 text-primary"
+                            : "bg-bg border-border text-text-muted hover:border-primary/30"
+                        )}
+                      >
+                        {code}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="pt-2 border-t border-border/50 flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    loading={webhookTestLoading}
+                    disabled={loading || webhookLoading}
+                    onClick={testWebhook}
+                  >
+                    Test Webhook
+                  </Button>
+                  <Button type="submit" variant="primary" loading={webhookLoading}>
+                    Save
+                  </Button>
+                </div>
+              </form>
+            )}
+
+            {webhookStatus.message && (
+              <p className={`text-sm ${webhookStatus.type === "error" ? "text-red-500" : "text-green-500"} pt-2 border-t border-border/50`}>
+                {webhookStatus.message}
+              </p>
+            )}
           </div>
         </Card>
 

--- a/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import PropTypes from "prop-types";
 import { Card, Badge, Button, Modal, Select, Toggle, EditConnectionModal } from "@/shared/components";
+import ErrorHistoryModal from "./ErrorHistoryModal";
 
 // ── CooldownTimer ──────────────────────────────────────────────
 function CooldownTimer({ until }) {
@@ -29,7 +30,7 @@ function CooldownTimer({ until }) {
 CooldownTimer.propTypes = { until: PropTypes.string.isRequired };
 
 // ── ConnectionRow ──────────────────────────────────────────────
-function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete }) {
+function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, onShowErrorHistory }) {
   const [showProxyDropdown, setShowProxyDropdown] = useState(false);
   const [updatingProxy, setUpdatingProxy] = useState(false);
   const [isCooldown, setIsCooldown] = useState(false);
@@ -159,6 +160,10 @@ function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMov
               )}
             </div>
           )}
+          <button onClick={onShowErrorHistory} className="flex flex-col items-center px-2 py-1 rounded hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-orange-500" title="Error History">
+            <span className="material-symbols-outlined text-[18px]">error_outline</span>
+            <span className="text-[10px] leading-tight">Errors</span>
+          </button>
           <button onClick={onEdit} className="flex flex-col items-center px-2 py-1 rounded hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-primary">
             <span className="material-symbols-outlined text-[18px]">edit</span>
             <span className="text-[10px] leading-tight">Edit</span>
@@ -195,6 +200,7 @@ ConnectionRow.propTypes = {
   onUpdateProxy: PropTypes.func,
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
+  onShowErrorHistory: PropTypes.func.isRequired,
 };
 
 // ── AddApiKeyModal ─────────────────────────────────────────────
@@ -306,6 +312,8 @@ export default function ConnectionsCard({ providerId, isOAuth }) {
   const [showAddModal, setShowAddModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedConnection, setSelectedConnection] = useState(null);
+  const [showErrorHistoryModal, setShowErrorHistoryModal] = useState(false);
+  const [errorHistoryConnection, setErrorHistoryConnection] = useState(null);
   const [providerStrategy, setProviderStrategy] = useState(null);
   const [providerStickyLimit, setProviderStickyLimit] = useState("1");
 
@@ -446,6 +454,7 @@ export default function ConnectionsCard({ providerId, isOAuth }) {
                   onUpdateProxy={(poolId) => handleUpdateProxy(conn.id, poolId)}
                   onEdit={() => { setSelectedConnection(conn); setShowEditModal(true); }}
                   onDelete={() => handleDelete(conn.id)}
+                  onShowErrorHistory={() => { setErrorHistoryConnection(conn); setShowErrorHistoryModal(true); }}
                 />
               ))}
             </div>
@@ -469,6 +478,12 @@ export default function ConnectionsCard({ providerId, isOAuth }) {
         proxyPools={proxyPools}
         onSave={handleUpdateConnection}
         onClose={() => setShowEditModal(false)}
+      />
+      <ErrorHistoryModal
+        isOpen={showErrorHistoryModal}
+        connectionId={errorHistoryConnection?.id}
+        connectionName={errorHistoryConnection?.displayName || errorHistoryConnection?.name || errorHistoryConnection?.email || errorHistoryConnection?.id}
+        onClose={() => setShowErrorHistoryModal(false)}
       />
     </>
   );

--- a/src/app/(dashboard)/dashboard/providers/components/ErrorHistoryModal.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ErrorHistoryModal.js
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import { Modal, Button, Badge } from "@/shared/components";
+
+export default function ErrorHistoryModal({ isOpen, connectionId, connectionName, onClose }) {
+  const [records, setRecords] = useState([]);
+  const [pagination, setPagination] = useState({ page: 1, totalPages: 0, totalItems: 0 });
+  const [loading, setLoading] = useState(false);
+
+  const fetchHistory = useCallback(async (page = 1) => {
+    if (!connectionId) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/error-history?connectionId=${connectionId}&page=${page}&pageSize=10`);
+      const data = await res.json();
+      setRecords(data.records || []);
+      setPagination(data.pagination || { page: 1, totalPages: 0, totalItems: 0 });
+    } catch (err) {
+      console.error("Failed to fetch error history:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [connectionId]);
+
+  useEffect(() => {
+    if (isOpen && connectionId) fetchHistory(1);
+  }, [isOpen, connectionId, fetchHistory]);
+
+  const handleClear = async () => {
+    if (!confirm("Clear all error history for this connection?")) return;
+    try {
+      await fetch(`/api/error-history?connectionId=${connectionId}`, { method: "DELETE" });
+      setRecords([]);
+      setPagination({ page: 1, totalPages: 0, totalItems: 0 });
+    } catch (err) {
+      console.error("Failed to clear error history:", err);
+    }
+  };
+
+  const formatTime = (ts) => {
+    try {
+      const d = new Date(ts);
+      return d.toLocaleString();
+    } catch {
+      return ts;
+    }
+  };
+
+  const getStatusColor = (code) => {
+    if (code === 401 || code === 403) return "text-red-500";
+    if (code === 429) return "text-orange-500";
+    if (code >= 500) return "text-yellow-600 dark:text-yellow-400";
+    return "text-text-muted";
+  };
+
+  return (
+    <Modal isOpen={isOpen} title={`Error History — ${connectionName || connectionId}`} onClose={onClose} size="lg">
+      <div className="flex flex-col gap-3">
+        {loading ? (
+          <div className="h-20 animate-pulse bg-black/5 dark:bg-white/5 rounded-lg" />
+        ) : records.length === 0 ? (
+          <p className="text-sm text-text-muted text-center py-6">No error history</p>
+        ) : (
+          <>
+            <div className="text-xs text-text-muted mb-1">{pagination.totalItems} error(s) total</div>
+            <div className="flex flex-col divide-y divide-border max-h-[400px] overflow-y-auto">
+              {records.map((r) => (
+                <div key={r.id} className="py-2 flex flex-col gap-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className={`font-mono text-sm font-bold ${getStatusColor(r.statusCode)}`}>{r.statusCode}</span>
+                    <span className="text-xs text-text-muted">{r.provider}/{r.model}</span>
+                    <span className="text-xs text-text-muted ml-auto">{formatTime(r.timestamp)}</span>
+                    {r.notified && <Badge variant="success" size="sm">notified</Badge>}
+                  </div>
+                  <p className="text-xs text-text-main break-all">{r.errorMessage}</p>
+                </div>
+              ))}
+            </div>
+
+            {pagination.totalPages > 1 && (
+              <div className="flex items-center justify-center gap-2 pt-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={!pagination.hasPrev}
+                  onClick={() => fetchHistory(pagination.page - 1)}
+                >
+                  Prev
+                </Button>
+                <span className="text-xs text-text-muted">
+                  {pagination.page} / {pagination.totalPages}
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={!pagination.hasNext}
+                  onClick={() => fetchHistory(pagination.page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2 border-t border-border">
+          {records.length > 0 && (
+            <Button size="sm" variant="ghost" onClick={handleClear}>
+              Clear History
+            </Button>
+          )}
+          <Button size="sm" variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+ErrorHistoryModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  connectionId: PropTypes.string,
+  connectionName: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/app/api/error-history/route.js
+++ b/src/app/api/error-history/route.js
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getErrorHistory, clearErrorHistory } from "@/lib/errorHistoryDb";
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const filter = {
+      connectionId: searchParams.get("connectionId") || undefined,
+      provider: searchParams.get("provider") || undefined,
+      statusCode: searchParams.get("statusCode") || undefined,
+      page: searchParams.get("page") || 1,
+      pageSize: searchParams.get("pageSize") || 20,
+    };
+
+    const result = await getErrorHistory(filter);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function DELETE(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const connectionId = searchParams.get("connectionId") || null;
+    await clearErrorHistory(connectionId);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/settings/webhook-test/route.js
+++ b/src/app/api/settings/webhook-test/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { sendTestNotification } from "@/lib/notificationService";
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const urls = body.urls || (body.url ? [body.url] : []);
+
+    if (urls.length === 0) {
+      return NextResponse.json({ success: false, error: "No webhook URLs provided" }, { status: 400 });
+    }
+
+    const result = await sendTestNotification(urls);
+    return NextResponse.json(result);
+  } catch (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+}

--- a/src/lib/errorHistoryDb.js
+++ b/src/lib/errorHistoryDb.js
@@ -1,0 +1,174 @@
+import { Low } from "lowdb";
+import { JSONFile } from "lowdb/node";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+
+const isCloud = typeof caches !== "undefined" && typeof caches === "object";
+
+const MAX_RECORDS = 500;
+const BATCH_SIZE = 10;
+const FLUSH_INTERVAL_MS = 3000;
+
+function getUserDataDir() {
+  if (isCloud) return "/tmp";
+  if (process.env.DATA_DIR) return process.env.DATA_DIR;
+  const homeDir = os.homedir();
+  if (process.platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(homeDir, "AppData", "Roaming"), "9router");
+  }
+  return path.join(homeDir, ".9router");
+}
+
+const DATA_DIR = getUserDataDir();
+const DB_FILE = isCloud ? null : path.join(DATA_DIR, "error-history.json");
+
+if (!isCloud && !fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+
+let dbInstance = null;
+
+async function getDb() {
+  if (isCloud) return null;
+  if (!dbInstance) {
+    const adapter = new JSONFile(DB_FILE);
+    const db = new Low(adapter, { records: [] });
+    await db.read();
+    if (!db.data?.records) db.data = { records: [] };
+    dbInstance = db;
+  }
+  return dbInstance;
+}
+
+// Batch write queue
+let writeBuffer = [];
+let flushTimer = null;
+let isFlushing = false;
+
+async function flushToDatabase() {
+  if (isCloud || isFlushing || writeBuffer.length === 0) return;
+
+  isFlushing = true;
+  try {
+    const items = [...writeBuffer];
+    writeBuffer = [];
+
+    const db = await getDb();
+
+    for (const item of items) {
+      db.data.records.push(item);
+    }
+
+    // Sort desc by timestamp, prune to max
+    db.data.records.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+    if (db.data.records.length > MAX_RECORDS) {
+      db.data.records = db.data.records.slice(0, MAX_RECORDS);
+    }
+
+    await db.write();
+  } catch (err) {
+    console.error("[errorHistoryDb] Batch write failed:", err.message);
+  } finally {
+    isFlushing = false;
+  }
+}
+
+/**
+ * Save an error record to history.
+ */
+export async function saveErrorRecord({ connectionId, connectionName, provider, model, statusCode, errorMessage, notified = false }) {
+  if (isCloud) return;
+
+  const record = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    connectionId,
+    connectionName: connectionName || connectionId,
+    provider,
+    model,
+    statusCode,
+    errorMessage: typeof errorMessage === "string" ? errorMessage.slice(0, 500) : String(errorMessage),
+    timestamp: new Date().toISOString(),
+    notified,
+  };
+
+  writeBuffer.push(record);
+
+  if (writeBuffer.length >= BATCH_SIZE) {
+    await flushToDatabase();
+    if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+  } else if (!flushTimer) {
+    flushTimer = setTimeout(() => {
+      flushToDatabase().catch(() => {});
+      flushTimer = null;
+    }, FLUSH_INTERVAL_MS);
+  }
+}
+
+/**
+ * Get error history with optional filters and pagination.
+ */
+export async function getErrorHistory(filter = {}) {
+  if (isCloud) {
+    return { records: [], pagination: { page: 1, pageSize: 20, totalItems: 0, totalPages: 0, hasNext: false, hasPrev: false } };
+  }
+
+  // Flush pending writes first
+  if (writeBuffer.length > 0) await flushToDatabase();
+
+  const db = await getDb();
+  let records = [...db.data.records];
+
+  if (filter.connectionId) records = records.filter(r => r.connectionId === filter.connectionId);
+  if (filter.provider) records = records.filter(r => r.provider === filter.provider);
+  if (filter.statusCode) records = records.filter(r => r.statusCode === Number(filter.statusCode));
+
+  records.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+
+  const totalItems = records.length;
+  const page = Number(filter.page) || 1;
+  const pageSize = Number(filter.pageSize) || 20;
+  const totalPages = Math.ceil(totalItems / pageSize);
+  const paged = records.slice((page - 1) * pageSize, page * pageSize);
+
+  return {
+    records: paged,
+    pagination: { page, pageSize, totalItems, totalPages, hasNext: page < totalPages, hasPrev: page > 1 },
+  };
+}
+
+/**
+ * Clear error history, optionally filtered by connectionId.
+ */
+export async function clearErrorHistory(connectionId = null) {
+  if (isCloud) return;
+
+  // Flush pending writes first
+  if (writeBuffer.length > 0) await flushToDatabase();
+
+  const db = await getDb();
+  if (connectionId) {
+    db.data.records = db.data.records.filter(r => r.connectionId !== connectionId);
+  } else {
+    db.data.records = [];
+  }
+  await db.write();
+}
+
+// Graceful shutdown
+const _shutdownHandler = async () => {
+  if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+  if (writeBuffer.length > 0) await flushToDatabase();
+};
+
+function ensureShutdownHandler() {
+  if (isCloud) return;
+  process.off("beforeExit", _shutdownHandler);
+  process.off("SIGINT", _shutdownHandler);
+  process.off("SIGTERM", _shutdownHandler);
+  process.on("beforeExit", _shutdownHandler);
+  process.on("SIGINT", _shutdownHandler);
+  process.on("SIGTERM", _shutdownHandler);
+}
+
+ensureShutdownHandler();

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -69,6 +69,10 @@ const defaultData = {
     outboundProxyUrl: "",
     outboundNoProxy: "",
     mitmRouterBaseUrl: DEFAULT_MITM_ROUTER_BASE,
+    webhookEnabled: false,
+    webhookUrls: [],
+    webhookThrottleMs: 300000,
+    webhookErrorCodes: [401, 403, 429, 500, 502, 503],
   },
   pricing: {} // NEW: pricing configuration
 };
@@ -105,6 +109,10 @@ function cloneDefaultData() {
       outboundProxyUrl: "",
       outboundNoProxy: "",
       mitmRouterBaseUrl: DEFAULT_MITM_ROUTER_BASE,
+      webhookEnabled: false,
+      webhookUrls: [],
+      webhookThrottleMs: 300000,
+      webhookErrorCodes: [401, 403, 429, 500, 502, 503],
     },
     pricing: {},
   };

--- a/src/lib/notificationService.js
+++ b/src/lib/notificationService.js
@@ -1,0 +1,83 @@
+import { getSettings } from "@/lib/localDb";
+
+const isCloud = typeof caches !== "undefined" && typeof caches === "object";
+
+// Throttle map: key -> last notified timestamp
+const throttleMap = new Map();
+
+// Cached sender instance
+let cachedSender = null;
+let cachedUrls = null;
+
+async function getSender(urls) {
+  if (!urls || urls.length === 0) return null;
+
+  const urlsKey = JSON.stringify(urls);
+  if (cachedSender && cachedUrls === urlsKey) return cachedSender;
+
+  try {
+    const { createSender } = await import("@toanalien/ahha");
+    cachedSender = createSender(urls, { strategy: "broadcast" });
+    cachedUrls = urlsKey;
+    return cachedSender;
+  } catch (err) {
+    console.error("[notificationService] Failed to create sender:", err.message);
+    return null;
+  }
+}
+
+/**
+ * Send provider error notification via configured webhooks.
+ * Fire-and-forget, throttled per connectionId:statusCode.
+ */
+export async function notifyProviderError({ provider, model, connectionId, connectionName, statusCode, errorMessage }) {
+  if (isCloud) return;
+
+  try {
+    const settings = await getSettings();
+    if (!settings.webhookEnabled) return;
+
+    const urls = settings.webhookUrls;
+    if (!urls || urls.length === 0) return;
+
+    const errorCodes = settings.webhookErrorCodes || [401, 403, 429, 500, 502, 503];
+    if (!errorCodes.includes(statusCode)) return;
+
+    // Throttle check
+    const throttleMs = settings.webhookThrottleMs || 300000;
+    const throttleKey = `${connectionId}:${statusCode}`;
+    const lastSent = throttleMap.get(throttleKey) || 0;
+    if (Date.now() - lastSent < throttleMs) return;
+
+    const sender = await getSender(urls);
+    if (!sender) return;
+
+    const timestamp = new Date().toISOString();
+    const message = `[9Router] ${provider}/${model} error ${statusCode} on "${connectionName}": ${errorMessage} (${timestamp})`;
+
+    throttleMap.set(throttleKey, Date.now());
+    await sender.send(message);
+  } catch (err) {
+    console.error("[notificationService] Send failed:", err.message);
+  }
+}
+
+/**
+ * Send a test notification to verify webhook configuration.
+ * @param {string[]} urls - ahha-compatible URL strings
+ * @returns {Promise<{ success: boolean, error?: string }>}
+ */
+export async function sendTestNotification(urls) {
+  try {
+    const { createSender } = await import("@toanalien/ahha");
+    const sender = createSender(urls, { strategy: "broadcast" });
+    const results = await sender.send("[9Router] Test notification - webhook configured successfully");
+    const failed = results.filter(r => !r.success);
+    if (failed.length > 0) {
+      return { success: false, error: failed.map(r => r.error?.message || "Unknown error").join("; ") };
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -2,6 +2,8 @@ import { getProviderConnections, validateApiKey, updateProviderConnection, getSe
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { resolveProviderId } from "@/shared/constants/providers.js";
+import { notifyProviderError } from "@/lib/notificationService.js";
+import { saveErrorRecord } from "@/lib/errorHistoryDb.js";
 import * as log from "../utils/logger.js";
 
 // Mutex to prevent race conditions during account selection
@@ -190,6 +192,10 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   if (provider && status && reason) {
     console.error(`❌ ${provider} [${status}]: ${reason}`);
   }
+
+  // Save error history and send webhook notification (fire-and-forget)
+  saveErrorRecord({ connectionId, connectionName: connName, provider, model, statusCode: status, errorMessage: reason }).catch(() => {});
+  notifyProviderError({ provider, model, connectionId, connectionName: connName, statusCode: status, errorMessage: reason }).catch(() => {});
 
   return { shouldFallback: true, cooldownMs };
 }


### PR DESCRIPTION
When providers return errors (401, 429, 5xx, etc.), errors are now saved to a persistent history and optionally sent as webhook notifications via ahha library (supports Slack, Discord, Telegram, generic webhooks, Ntfy).

- Add notificationService with throttling and configurable error codes
- Add errorHistoryDb for persistent per-connection error tracking
- Add webhook settings UI in Profile > Notifications
- Add error history modal in provider ConnectionsCard
- Hook into markAccountUnavailable for fire-and-forget notifications

<img width="1100" height="1256" alt="Screenshot 2026-04-06 at 17 46 04" src="https://github.com/user-attachments/assets/d3c73dd8-9d3a-45e2-b663-2f0fe71c0709" />

<img width="1267" height="835" alt="Screenshot 2026-04-06 at 17 46 24" src="https://github.com/user-attachments/assets/728dfbf2-8f43-4f19-b207-f01c09b3f026" />
