### PR TITLE
Security: Unauthenticated server shutdown endpoint enables denial of service

### DIFF
--- a/src/app/api/shutdown/route.js
+++ b/src/app/api/shutdown/route.js
@@ -1,6 +1,18 @@
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 
 export async function POST() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ success: false, message: "Not allowed in production" }, { status: 403 });
+  }
+
+  const secret = process.env.SHUTDOWN_SECRET;
+  const authorization = headers().get("authorization");
+
+  if (!secret || authorization !== `Bearer ${secret}`) {
+    return NextResponse.json({ success: false, message: "Unauthorized" }, { status: 401 });
+  }
+
   const response = NextResponse.json({ success: true, message: "Shutting down..." });
 
   setTimeout(() => {


### PR DESCRIPTION
## Problem

The shutdown API calls `process.exit(0)` on POST without any authentication or authorization checks. Any party that can reach this endpoint can terminate the server process, causing immediate service disruption.

**Severity**: `critical`
**File**: `src/app/api/shutdown/route.js`

## Solution

Require strong authentication and role-based authorization before shutdown actions. Prefer removing this endpoint in production, or gate it behind an admin-only secret, localhost-only binding, and explicit environment checks (`NODE_ENV !== 'production'`).

## Changes

- `src/app/api/shutdown/route.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
