### PR TITLE
Security: Dangerous unauthenticated global package installation endpoint

### DIFF
--- a/src/app/api/9remote/install/route.js
+++ b/src/app/api/9remote/install/route.js
@@ -1,25 +1,4 @@
 import { NextResponse } from "next/server";
-import { exec } from "child_process";
-import { join, dirname } from "path";
-
-// Use npm from the same Node.js that runs Next.js — ensures 9remote
-// lands in the correct global bin (nvm or system, whichever is active)
-const npmBin = join(dirname(process.execPath), "npm");
-
-function installPackage() {
-  return new Promise((resolve, reject) => {
-    exec(`"${npmBin}" install -g 9remote`, { windowsHide: true }, (err, stdout, stderr) => {
-      if (err) reject(new Error(stderr || err.message));
-      else resolve(stdout);
-    });
-  });
-}
-
 export async function POST() {
-  try {
-    await installPackage();
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
-  }
+  return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
 }


### PR DESCRIPTION
## Problem

The install route executes `npm install -g 9remote` via `child_process.exec` on POST with no visible auth checks. This allows remote triggering of privileged package installation, creating severe supply-chain and host-compromise risk.

**Severity**: `critical`
**File**: `src/app/api/9remote/install/route.js`

## Solution

Remove this endpoint from production. If absolutely required, enforce admin authentication, CSRF protection, strict allowlisting, rate limiting, audit logging, and run in a sandboxed non-privileged worker instead of the web process.

## Changes

- `src/app/api/9remote/install/route.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
