### PR TITLE
fix: merge consecutive userInputMessages in openai-to-kiro translator (closes #510)

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -254,6 +254,20 @@ function convertMessages(messages, tools, model) {
     }
   });
 
+  // Merge consecutive user messages (Kiro requires alternating user/assistant)
+  const mergedHistory = [];
+  for (let i = 0; i < history.length; i++) {
+    const current = history[i];
+    if (current.userInputMessage &&
+        mergedHistory.length > 0 &&
+        mergedHistory[mergedHistory.length - 1].userInputMessage) {
+      const prev = mergedHistory[mergedHistory.length - 1];
+      prev.userInputMessage.content += "\n\n" + current.userInputMessage.content;
+    } else {
+      mergedHistory.push(current);
+    }
+  }
+
   // Inject tools into currentMessage AFTER cleanup
   if (firstHistoryTools && currentMessage?.userInputMessage &&
       !currentMessage.userInputMessage.userInputMessageContext?.tools) {
@@ -263,7 +277,7 @@ function convertMessages(messages, tools, model) {
     currentMessage.userInputMessage.userInputMessageContext.tools = firstHistoryTools;
   }
 
-  return { history, currentMessage };
+  return { history: mergedHistory, currentMessage };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #510 — `kr/claude-sonnet-4.5` fails with `400 Improperly formed request` through 9router while other Kiro models work.

## Root Cause

The openai-to-kiro request translator had the **consecutive user message merging logic removed** in a recent refactor. The Kiro/AWS CodeWhisperer API requires alternating user/assistant message patterns. When multiple userInputMessage entries exist in the history without proper merging (e.g., from tool result messages interleaved with user messages), Kiro rejects the request as malformed.

The log showed `0 msgs` for claude-sonnet-4.5 — meaning the conversationState payload was being constructed with invalid message sequencing that Kiro's API rejected.

## Fix

Re-add the consecutive user message merging step in `convertMessages()` that merges adjacent `userInputMessage` entries in the history by concatenating their content with `\n\n`.

This restores parity with the previous working implementation (openai-to-kiro.old.js).

## Testing

- Minimal test request (1 user message, no system, no tools) should work
- Multi-turn conversations with tool calls should work  
- Other Kiro models (claude-haiku-4.5, deepseek-3.2, qwen3-coder-next) unaffected