### PR TITLE
fix: update Cursor client version to 3.1.0 for Composer 2

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -199,7 +199,7 @@ export const PROVIDERS = {
       "Content-Type": "application/connect+proto",
       "User-Agent": "connect-es/1.6.1"
     },
-    clientVersion: "1.1.3"
+    clientVersion: "3.1.0"
   },
   "kimi-coding": {
     baseUrl: KIMI_CODING_BASE_URL,

--- a/open-sse/utils/cursorChecksum.js
+++ b/open-sse/utils/cursorChecksum.js
@@ -128,7 +128,7 @@ export function buildCursorHeaders(accessToken, machineId = null, ghostMode = tr
     "x-amzn-trace-id": `Root=${crypto.randomUUID()}`,
     "x-client-key": clientKey,
     "x-cursor-checksum": checksum,
-    "x-cursor-client-version": "2.3.41",
+    "x-cursor-client-version": "3.1.0",
     "x-cursor-client-type": "ide",
     "x-cursor-client-os": os,
     "x-cursor-client-arch": arch,

--- a/src/lib/oauth/constants/oauth.js
+++ b/src/lib/oauth/constants/oauth.js
@@ -189,7 +189,7 @@ export const CURSOR_CONFIG = {
   agentEndpoint: "https://agent.api5.cursor.sh", // Privacy mode
   agentNonPrivacyEndpoint: "https://agentn.api5.cursor.sh", // Non-privacy mode
   // Client metadata
-  clientVersion: "0.48.6",
+  clientVersion: "3.1.0",
   clientType: "ide",
   // Token storage locations (for user reference)
   tokenStoragePaths: {


### PR DESCRIPTION
## Summary
- Cursor's API now rejects requests with `[400]: Update Required for Composer 2` due to outdated `x-cursor-client-version` header
- Bumps client version from `2.3.41` to `3.1.0` in all three locations: API request headers, OAuth flow, and provider config

## Test plan
- [x] Verified Composer 2 models no longer return 400 error after version bump
- [ ] Test streaming and non-streaming modes with Cursor provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)