### PR TITLE
fix: only strip reasoning_content when content is non-empty

### DIFF
--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -210,10 +210,15 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       status: "success"
     }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
-    // Strip reasoning_content — breaks JSON parsers in some clients (e.g. Firecrawl AI SDK)
+    // Strip reasoning_content only when content is non-empty.
+    // When content is empty (e.g. thinking models that used all tokens for reasoning),
+    // reasoning_content is the only useful output and must be preserved.
+    // Previously this was unconditional, which broke Qwen3.5, Claude extended thinking, etc.
     if (parsed?.choices) {
       for (const choice of parsed.choices) {
-        if (choice?.message) delete choice.message.reasoning_content;
+        if (choice?.message?.reasoning_content && choice.message.content) {
+          delete choice.message.reasoning_content;
+        }
       }
     }
 


### PR DESCRIPTION
sseToJsonHandler.js unconditionally deleted reasoning_content from all non-streaming responses (added for Firecrawl SDK compatibility). This breaks thinking models (Qwen3.5, Claude extended thinking, etc.) where the model may use all tokens for reasoning, leaving content empty.

When reasoning_content is stripped in that case, the response appears completely empty to the client.

Fix: only strip reasoning_content when the response also has non-empty content, so that reasoning output is preserved when it is the only useful output.