### PR TITLE
fix: Qwen tool_choice conflict with thinking/reasoning mode

### DIFF
--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -142,6 +142,23 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
     }
   }
 
+  if (
+    result.tool_choice &&
+    result.tool_choice !== "auto" &&
+    (provider === "qw" || provider === "alicode" || provider === "alicode-intl")
+  ) {
+    const hasThinkingMode =
+      !!result.reasoning_effort ||
+      !!result.thinking?.budget_tokens ||
+      !!result.thinking?.max_tokens ||
+      result.thinking?.type === "enabled" ||
+      (result.reasoning?.effort && result.reasoning.effort !== "none") ||
+      !!result.enable_thinking;
+    if (hasThinkingMode) {
+      result.tool_choice = "auto";
+    }
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Qwen API đang bị reject với lỗi 400 khi client gửi `tool_choice: "required"` (hoặc object) kèm theo thinking mode. Lỗi này xảy ra với các provider dùng DashScope backend (qw, alicode, alicode-intl).

Fix này thêm một check nhỏ trong `translateRequest()` để force `tool_choice` về `"auto"` khi phát hiện thinking mode trên các provider DashScope. Không ảnh hưởng đến các provider khác.