### PR TITLE
[codex] Improve proxy pool UX/UI

### DIFF
--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -4,6 +4,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge, Button, Card, CardSkeleton, Input, Modal, Toggle } from "@/shared/components";
 import { useNotificationStore } from "@/store/notificationStore";
 
+const BULK_ACTION_LABELS = {
+  test: "Test",
+  activate: "Activate",
+  deactivate: "Deactivate",
+  delete: "Delete",
+};
+
 function getStatusVariant(status) {
   if (status === "active") return "success";
   if (status === "error") return "error";
@@ -27,6 +34,52 @@ function normalizeFormData(data = {}) {
   };
 }
 
+function normalizeUrlForSearch(value) {
+  return (value || "").toLowerCase().trim();
+}
+
+function maskProxyUrl(proxyUrl) {
+  if (!proxyUrl) return "";
+
+  try {
+    const parsed = new URL(proxyUrl);
+    return `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ""}`;
+  } catch {
+    return proxyUrl;
+  }
+}
+
+function compareValues(left, right, order = "asc") {
+  const direction = order === "desc" ? -1 : 1;
+
+  if (typeof left === "number" && typeof right === "number") {
+    return (left - right) * direction;
+  }
+
+  const leftValue = (left ?? "").toString().toLowerCase();
+  const rightValue = (right ?? "").toString().toLowerCase();
+
+  if (leftValue < rightValue) return -1 * direction;
+  if (leftValue > rightValue) return 1 * direction;
+  return 0;
+}
+
+function SortHeader({ label, field, sortBy, sortOrder, onSort }) {
+  const isActive = sortBy === field;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(field)}
+      className="inline-flex items-center gap-1 hover:text-text-main transition-colors"
+    >
+      <span>{label}</span>
+      <span className="text-[11px] opacity-70">
+        {isActive ? (sortOrder === "asc" ? "↑" : "↓") : "↕"}
+      </span>
+    </button>
+  );
+}
+
 export default function ProxyPoolsPage() {
   const [proxyPools, setProxyPools] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -38,6 +91,12 @@ export default function ProxyPoolsPage() {
   const [saving, setSaving] = useState(false);
   const [importing, setImporting] = useState(false);
   const [testingId, setTestingId] = useState(null);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [selectedIds, setSelectedIds] = useState([]);
+  const [sortBy, setSortBy] = useState("updatedAt");
+  const [sortOrder, setSortOrder] = useState("desc");
+  const [bulkActionLoading, setBulkActionLoading] = useState("");
   const notify = useNotificationStore();
 
   const fetchProxyPools = useCallback(async () => {
@@ -46,17 +105,24 @@ export default function ProxyPoolsPage() {
       const data = await res.json();
       if (res.ok) {
         setProxyPools(data.proxyPools || []);
+      } else {
+        notify.error(data.error || "Failed to fetch proxy pools");
       }
     } catch (error) {
       console.log("Error fetching proxy pools:", error);
+      notify.error("Failed to fetch proxy pools");
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [notify]);
 
   useEffect(() => {
     fetchProxyPools();
   }, [fetchProxyPools]);
+
+  useEffect(() => {
+    setSelectedIds((prev) => prev.filter((id) => proxyPools.some((pool) => pool.id === id)));
+  }, [proxyPools]);
 
   const resetForm = () => {
     setEditingProxyPool(null);
@@ -75,8 +141,19 @@ export default function ProxyPoolsPage() {
   };
 
   const closeFormModal = () => {
+    if (saving) return;
     setShowFormModal(false);
     resetForm();
+  };
+
+  const handleSort = (field) => {
+    if (sortBy === field) {
+      setSortOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+      return;
+    }
+
+    setSortBy(field);
+    setSortOrder(field === "name" ? "asc" : "desc");
   };
 
   const handleSave = async () => {
@@ -109,19 +186,21 @@ export default function ProxyPoolsPage() {
       }
     } catch (error) {
       console.log("Error saving proxy pool:", error);
+      notify.error("Failed to save proxy pool");
     } finally {
       setSaving(false);
     }
   };
 
   const handleDelete = async (proxyPool) => {
-    const deleting = confirm(`Delete proxy pool \"${proxyPool.name}\"?`);
+    const deleting = confirm(`Delete proxy pool "${proxyPool.name}"?`);
     if (!deleting) return;
 
     try {
       const res = await fetch(`/api/proxy-pools/${proxyPool.id}`, { method: "DELETE" });
       if (res.ok) {
         setProxyPools((prev) => prev.filter((item) => item.id !== proxyPool.id));
+        setSelectedIds((prev) => prev.filter((id) => id !== proxyPool.id));
         notify.success("Proxy pool deleted");
         return;
       }
@@ -280,10 +359,132 @@ export default function ProxyPoolsPage() {
     }
   };
 
+  const filteredAndSortedProxyPools = useMemo(() => {
+    const query = normalizeUrlForSearch(search);
+    const filtered = proxyPools.filter((pool) => {
+      const matchesSearch = !query || [pool.name, pool.proxyUrl, pool.noProxy, pool.testStatus]
+        .some((value) => normalizeUrlForSearch(value).includes(query));
+
+      if (!matchesSearch) return false;
+
+      if (statusFilter === "active") return pool.isActive === true;
+      if (statusFilter === "inactive") return pool.isActive !== true;
+      if (statusFilter === "healthy") return pool.testStatus === "active";
+      if (statusFilter === "error") return pool.testStatus === "error";
+      if (statusFilter === "in-use") return (pool.boundConnectionCount || 0) > 0;
+      return true;
+    });
+
+    return [...filtered].sort((left, right) => {
+      if (sortBy === "boundConnectionCount") {
+        return compareValues(left.boundConnectionCount || 0, right.boundConnectionCount || 0, sortOrder);
+      }
+
+      if (sortBy === "lastTestedAt" || sortBy === "updatedAt") {
+        return compareValues(
+          new Date(left[sortBy] || 0).getTime(),
+          new Date(right[sortBy] || 0).getTime(),
+          sortOrder
+        );
+      }
+
+      if (sortBy === "isActive") {
+        return compareValues(left.isActive === true ? 1 : 0, right.isActive === true ? 1 : 0, sortOrder);
+      }
+
+      if (sortBy === "strictProxy") {
+        return compareValues(left.strictProxy === true ? 1 : 0, right.strictProxy === true ? 1 : 0, sortOrder);
+      }
+
+      return compareValues(left[sortBy], right[sortBy], sortOrder);
+    });
+  }, [proxyPools, search, statusFilter, sortBy, sortOrder]);
+
+  const selectedProxyPools = useMemo(
+    () => filteredAndSortedProxyPools.filter((pool) => selectedIds.includes(pool.id)),
+    [filteredAndSortedProxyPools, selectedIds]
+  );
+
   const activeCount = useMemo(
     () => proxyPools.filter((pool) => pool.isActive === true).length,
     [proxyPools]
   );
+
+  const healthyCount = useMemo(
+    () => proxyPools.filter((pool) => pool.testStatus === "active").length,
+    [proxyPools]
+  );
+
+  const visibleIds = filteredAndSortedProxyPools.map((pool) => pool.id);
+  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.includes(id));
+  const selectedBoundCount = selectedProxyPools.filter((pool) => (pool.boundConnectionCount || 0) > 0).length;
+
+  const toggleRowSelection = (id) => {
+    setSelectedIds((prev) => (
+      prev.includes(id)
+        ? prev.filter((value) => value !== id)
+        : [...prev, id]
+    ));
+  };
+
+  const toggleSelectAllVisible = () => {
+    if (allVisibleSelected) {
+      setSelectedIds((prev) => prev.filter((id) => !visibleIds.includes(id)));
+      return;
+    }
+
+    setSelectedIds((prev) => [...new Set([...prev, ...visibleIds])]);
+  };
+
+  const clearSelection = () => setSelectedIds([]);
+
+  const handleBulkAction = async (action) => {
+    if (selectedIds.length === 0 || bulkActionLoading) return;
+
+    if (action === "delete") {
+      const confirmed = confirm(
+        selectedBoundCount > 0
+          ? `Delete ${selectedIds.length} selected proxy pools? ${selectedBoundCount} item(s) are still bound and will be skipped.`
+          : `Delete ${selectedIds.length} selected proxy pools?`
+      );
+      if (!confirmed) return;
+    }
+
+    setBulkActionLoading(action);
+    try {
+      const res = await fetch("/api/proxy-pools/bulk", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, ids: selectedIds }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        notify.error(data.error || "Bulk action failed");
+        return;
+      }
+
+      await fetchProxyPools();
+
+      const blockedItems = (data.results || []).filter((item) => item.boundConnectionCount > 0);
+      const failedItems = (data.results || []).filter((item) => !item.ok && !item.boundConnectionCount);
+
+      if (blockedItems.length > 0) {
+        notify.warning(`${BULK_ACTION_LABELS[action]} completed with ${blockedItems.length} blocked item(s).`);
+      } else if (failedItems.length > 0) {
+        notify.warning(`${BULK_ACTION_LABELS[action]} completed with ${failedItems.length} failed item(s).`);
+      } else {
+        notify.success(`${BULK_ACTION_LABELS[action]} completed for ${data.summary?.successCount || 0} proxy pool(s).`);
+      }
+
+      clearSelection();
+    } catch (error) {
+      console.log("Error running bulk proxy action:", error);
+      notify.error("Bulk action failed");
+    } finally {
+      setBulkActionLoading("");
+    }
+  };
 
   if (loading) {
     return (
@@ -296,15 +497,15 @@ export default function ProxyPoolsPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
         <div>
           <h1 className="text-2xl font-semibold">Proxy Pools</h1>
           <p className="text-sm text-text-muted mt-1">
-            Manage reusable per-connection proxies and bind them to provider connections.
+            Manage reusable per-connection proxies and operate on multiple entries at once.
           </p>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <Button variant="secondary" icon="upload" onClick={openBatchImportModal}>
             Batch Import Proxies
           </Button>
@@ -312,80 +513,248 @@ export default function ProxyPoolsPage() {
         </div>
       </div>
 
-      <Card>
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <Badge variant="default">Total: {proxyPools.length}</Badge>
-            <Badge variant="success">Active: {activeCount}</Badge>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <Card className="p-4">
+          <p className="text-sm text-text-muted">Total Proxy Pools</p>
+          <p className="text-2xl font-semibold mt-1">{proxyPools.length}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-sm text-text-muted">Active at Runtime</p>
+          <p className="text-2xl font-semibold mt-1">{activeCount}</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-sm text-text-muted">Healthy on Last Test</p>
+          <p className="text-2xl font-semibold mt-1">{healthyCount}</p>
+        </Card>
+      </div>
+
+      <Card className="overflow-hidden">
+        <div className="p-4 border-b border-border/50 flex flex-col gap-4">
+          <div className="flex items-center gap-3 flex-wrap">
+            <div className="flex-1 min-w-[260px]">
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search by name, proxy URL, no_proxy, or status"
+                icon="search"
+              />
+            </div>
+
+            <div className="flex items-center gap-2 flex-wrap">
+              {[
+                { value: "all", label: "All" },
+                { value: "active", label: "Active" },
+                { value: "inactive", label: "Inactive" },
+                { value: "healthy", label: "Healthy" },
+                { value: "error", label: "Error" },
+                { value: "in-use", label: "In Use" },
+              ].map((filter) => (
+                <button
+                  key={filter.value}
+                  type="button"
+                  onClick={() => setStatusFilter(filter.value)}
+                  className={`px-3 h-8 rounded-full text-xs font-medium border transition-colors ${
+                    statusFilter === filter.value
+                      ? "bg-primary text-white border-primary"
+                      : "border-black/10 dark:border-white/10 text-text-muted hover:text-text-main hover:bg-black/5 dark:hover:bg-white/5"
+                  }`}
+                >
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <div className="flex items-center gap-2 flex-wrap">
+              <Badge variant="default">Visible: {filteredAndSortedProxyPools.length}</Badge>
+              <Badge variant="success">Selected: {selectedIds.length}</Badge>
+              {selectedBoundCount > 0 ? (
+                <Badge variant="error">{selectedBoundCount} selected in use</Badge>
+              ) : null}
+            </div>
+
+            <div className="flex items-center gap-2 flex-wrap">
+              <Button
+                size="sm"
+                variant="secondary"
+                icon="science"
+                onClick={() => handleBulkAction("test")}
+                disabled={selectedIds.length === 0}
+                loading={bulkActionLoading === "test"}
+              >
+                Test Selected
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                icon="check_circle"
+                onClick={() => handleBulkAction("activate")}
+                disabled={selectedIds.length === 0}
+                loading={bulkActionLoading === "activate"}
+              >
+                Activate
+              </Button>
+              <Button
+                size="sm"
+                variant="secondary"
+                icon="pause_circle"
+                onClick={() => handleBulkAction("deactivate")}
+                disabled={selectedIds.length === 0}
+                loading={bulkActionLoading === "deactivate"}
+              >
+                Deactivate
+              </Button>
+              <Button
+                size="sm"
+                variant="danger"
+                icon="delete"
+                onClick={() => handleBulkAction("delete")}
+                disabled={selectedIds.length === 0}
+                loading={bulkActionLoading === "delete"}
+              >
+                Delete
+              </Button>
+              {selectedIds.length > 0 ? (
+                <Button size="sm" variant="ghost" onClick={clearSelection}>
+                  Clear
+                </Button>
+              ) : null}
+            </div>
           </div>
         </div>
 
-        {proxyPools.length === 0 ? (
-          <div className="text-center py-10">
-            <p className="text-text-main font-medium mb-1">No proxy pool entries yet</p>
+        {filteredAndSortedProxyPools.length === 0 ? (
+          <div className="text-center py-12 px-6">
+            <p className="text-text-main font-medium mb-1">No proxy pools match the current view</p>
             <p className="text-sm text-text-muted mb-4">
-              Create a proxy pool entry, then assign it to connections.
+              Try adjusting the search or filter, or create a new proxy pool.
             </p>
             <Button icon="add" onClick={openCreateModal}>Add Proxy Pool</Button>
           </div>
         ) : (
-          <div className="flex flex-col divide-y divide-black/[0.04] dark:divide-white/[0.05]">
-            {proxyPools.map((pool) => (
-              <div key={pool.id} className="py-3 flex items-center justify-between gap-3 group">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <p className="text-sm font-medium truncate">{pool.name}</p>
-                    <Badge variant={getStatusVariant(pool.testStatus)} size="sm" dot>
-                      {pool.testStatus || "unknown"}
-                    </Badge>
-                    <Badge variant={pool.isActive ? "success" : "default"} size="sm">
-                      {pool.isActive ? "active" : "inactive"}
-                    </Badge>
-                    <Badge variant="default" size="sm">
-                      {pool.boundConnectionCount || 0} bound
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-text-muted truncate mt-1">{pool.proxyUrl}</p>
-                  {pool.noProxy ? (
-                    <p className="text-xs text-text-muted truncate">No proxy: {pool.noProxy}</p>
-                  ) : null}
-                  <p className="text-[11px] text-text-muted mt-1">
-                    Last tested: {formatDateTime(pool.lastTestedAt)}
-                    {pool.lastError ? ` · ${pool.lastError}` : ""}
-                  </p>
-                </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-bg-subtle/40 text-text-muted border-b border-border/50">
+                <tr>
+                  <th className="px-4 py-3 text-left w-12">
+                    <input
+                      type="checkbox"
+                      checked={allVisibleSelected}
+                      onChange={toggleSelectAllVisible}
+                      className="h-4 w-4 rounded border-black/20 dark:border-white/20"
+                    />
+                  </th>
+                  <th className="px-4 py-3 text-left"><SortHeader label="Proxy" field="name" sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} /></th>
+                  <th className="px-4 py-3 text-left"><SortHeader label="Status" field="testStatus" sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} /></th>
+                  <th className="px-4 py-3 text-left"><SortHeader label="Runtime" field="isActive" sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} /></th>
+                  <th className="px-4 py-3 text-left"><SortHeader label="Strict" field="strictProxy" sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} /></th>
+                  <th className="px-4 py-3 text-left"><SortHeader label="Bound" field="boundConnectionCount" sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} /></th>
+                  <th className="px-4 py-3 text-left"><SortHeader label="Last Tested" field="lastTestedAt" sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} /></th>
+                  <th className="px-4 py-3 text-left"><SortHeader label="Updated" field="updatedAt" sortBy={sortBy} sortOrder={sortOrder} onSort={handleSort} /></th>
+                  <th className="px-4 py-3 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {filteredAndSortedProxyPools.map((pool) => {
+                  const isSelected = selectedIds.includes(pool.id);
+                  const maskedUrl = maskProxyUrl(pool.proxyUrl);
 
-                <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <button
-                    onClick={() => handleTest(pool.id)}
-                    className="p-2 rounded hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-primary"
-                    title="Test proxy"
-                    disabled={testingId === pool.id}
-                  >
-                    <span
-                      className="material-symbols-outlined text-[18px]"
-                      style={testingId === pool.id ? { animation: "spin 1s linear infinite" } : undefined}
+                  return (
+                    <tr
+                      key={pool.id}
+                      className={`${isSelected ? "bg-primary/5" : "hover:bg-black/[0.02] dark:hover:bg-white/[0.03]"} transition-colors`}
                     >
-                      {testingId === pool.id ? "progress_activity" : "science"}
-                    </span>
-                  </button>
-                  <button
-                    onClick={() => openEditModal(pool)}
-                    className="p-2 rounded hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-primary"
-                    title="Edit"
-                  >
-                    <span className="material-symbols-outlined text-[18px]">edit</span>
-                  </button>
-                  <button
-                    onClick={() => handleDelete(pool)}
-                    className="p-2 rounded hover:bg-red-500/10 text-red-500"
-                    title="Delete"
-                  >
-                    <span className="material-symbols-outlined text-[18px]">delete</span>
-                  </button>
-                </div>
-              </div>
-            ))}
+                      <td className="px-4 py-4 align-top">
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleRowSelection(pool.id)}
+                          className="h-4 w-4 rounded border-black/20 dark:border-white/20"
+                        />
+                      </td>
+                      <td className="px-4 py-4 align-top min-w-[280px]">
+                        <div className="flex flex-col gap-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-medium text-text-main">{pool.name}</span>
+                            <Badge variant={getStatusVariant(pool.testStatus)} size="sm" dot>
+                              {pool.testStatus || "unknown"}
+                            </Badge>
+                          </div>
+                          <code className="text-xs text-text-muted bg-black/5 dark:bg-white/5 px-2 py-1 rounded w-fit">
+                            {maskedUrl}
+                          </code>
+                          {pool.noProxy ? (
+                            <p className="text-xs text-text-muted truncate" title={pool.noProxy}>
+                              no_proxy: {pool.noProxy}
+                            </p>
+                          ) : (
+                            <p className="text-xs text-text-muted">no_proxy: none</p>
+                          )}
+                          {pool.lastError ? (
+                            <p className="text-xs text-red-500 truncate" title={pool.lastError}>
+                              Last error: {pool.lastError}
+                            </p>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        <Badge variant={getStatusVariant(pool.testStatus)} size="sm">
+                          {pool.testStatus || "unknown"}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        <Badge variant={pool.isActive ? "success" : "default"} size="sm">
+                          {pool.isActive ? "active" : "inactive"}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        <Badge variant={pool.strictProxy ? "error" : "default"} size="sm">
+                          {pool.strictProxy ? "strict" : "fallback"}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        <Badge variant={(pool.boundConnectionCount || 0) > 0 ? "warning" : "default"} size="sm">
+                          {pool.boundConnectionCount || 0}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-4 align-top text-text-muted">{formatDateTime(pool.lastTestedAt)}</td>
+                      <td className="px-4 py-4 align-top text-text-muted">{formatDateTime(pool.updatedAt)}</td>
+                      <td className="px-4 py-4 align-top">
+                        <div className="flex items-center justify-end gap-1">
+                          <button
+                            onClick={() => handleTest(pool.id)}
+                            className="p-2 rounded hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-primary"
+                            title="Test proxy"
+                            disabled={testingId === pool.id}
+                          >
+                            <span
+                              className={`material-symbols-outlined text-[18px] ${testingId === pool.id ? "animate-spin" : ""}`}
+                            >
+                              {testingId === pool.id ? "progress_activity" : "science"}
+                            </span>
+                          </button>
+                          <button
+                            onClick={() => openEditModal(pool)}
+                            className="p-2 rounded hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-primary"
+                            title="Edit"
+                          >
+                            <span className="material-symbols-outlined text-[18px]">edit</span>
+                          </button>
+                          <button
+                            onClick={() => handleDelete(pool)}
+                            className="p-2 rounded hover:bg-red-500/10 text-red-500"
+                            title="Delete"
+                          >
+                            <span className="material-symbols-outlined text-[18px]">delete</span>
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         )}
       </Card>

--- a/src/app/api/proxy-pools/bulk/route.js
+++ b/src/app/api/proxy-pools/bulk/route.js
@@ -1,0 +1,117 @@
+import { NextResponse } from "next/server";
+import {
+  deleteProxyPool,
+  getProviderConnections,
+  getProxyPoolById,
+  updateProxyPool,
+} from "@/models";
+import { testProxyUrl } from "@/lib/network/proxyTest";
+
+const SUPPORTED_ACTIONS = new Set(["activate", "deactivate", "delete", "test"]);
+
+function countBoundConnections(connections = [], proxyPoolId) {
+  return connections.filter((connection) => connection?.providerSpecificData?.proxyPoolId === proxyPoolId).length;
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const action = typeof body?.action === "string" ? body.action.trim() : "";
+    const ids = Array.isArray(body?.ids)
+      ? [...new Set(body.ids.map((id) => String(id || "").trim()).filter(Boolean))]
+      : [];
+
+    if (!SUPPORTED_ACTIONS.has(action)) {
+      return NextResponse.json({ error: "Unsupported bulk action" }, { status: 400 });
+    }
+
+    if (ids.length === 0) {
+      return NextResponse.json({ error: "At least one proxy pool ID is required" }, { status: 400 });
+    }
+
+    const connections = action === "delete" ? await getProviderConnections() : [];
+    const results = [];
+
+    for (const id of ids) {
+      const proxyPool = await getProxyPoolById(id);
+
+      if (!proxyPool) {
+        results.push({
+          id,
+          ok: false,
+          error: "Proxy pool not found",
+        });
+        continue;
+      }
+
+      if (action === "activate" || action === "deactivate") {
+        const updated = await updateProxyPool(id, { isActive: action === "activate" });
+        results.push({
+          id,
+          ok: true,
+          proxyPool: updated,
+        });
+        continue;
+      }
+
+      if (action === "delete") {
+        const boundConnectionCount = countBoundConnections(connections, id);
+        if (boundConnectionCount > 0) {
+          results.push({
+            id,
+            ok: false,
+            error: "Proxy pool is currently in use",
+            boundConnectionCount,
+          });
+          continue;
+        }
+
+        await deleteProxyPool(id);
+        results.push({
+          id,
+          ok: true,
+        });
+        continue;
+      }
+
+      if (action === "test") {
+        const result = await testProxyUrl({ proxyUrl: proxyPool.proxyUrl });
+        const now = new Date().toISOString();
+
+        const updated = await updateProxyPool(id, {
+          testStatus: result.ok ? "active" : "error",
+          lastTestedAt: now,
+          lastError: result.ok ? null : (result.error || `Proxy test failed with status ${result.status}`),
+          isActive: result.ok,
+        });
+
+        results.push({
+          id,
+          ok: result.ok,
+          proxyPool: updated,
+          status: result.status,
+          statusText: result.statusText || null,
+          error: result.error || null,
+          elapsedMs: result.elapsedMs || 0,
+          testedAt: now,
+        });
+      }
+    }
+
+    const successCount = results.filter((item) => item.ok).length;
+    const failureCount = results.length - successCount;
+
+    return NextResponse.json({
+      action,
+      results,
+      summary: {
+        total: results.length,
+        successCount,
+        failureCount,
+      },
+    });
+  } catch (error) {
+    console.log("Error processing bulk proxy pool action:", error);
+    return NextResponse.json({ error: "Failed to process bulk action" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## What changed
- refactored the proxy pool page into a searchable, sortable table layout
- added row selection and bulk actions for test, activate, deactivate, and delete
- introduced a bulk proxy-pool API endpoint so multi-item operations run in one request
- improved row-level visibility for masked proxy host, strict mode, binding count, and last test status

## Why
The existing proxy pool screen supported only single-item CRUD comfortably. Managing many proxies was slow and error-prone, especially when operators needed to review status or apply the same action across multiple entries.

## Impact
- proxy pool management is faster for larger proxy lists
- destructive bulk delete now reports items still bound to connections instead of failing silently
- the dashboard UX is more aligned with operational workflows for proxy maintenance

## Validation
- started the app locally with `npm run dev` and verified `http://localhost:20128` responded with HTTP 200
- attempted a production build with `npx next build --webpack` on Windows, but the repo currently hits an environment-specific webpack error while scanning `C:\Users\Admin\Application Data` (`EPERM`)
