### PR TITLE
feat: add provider-wide model disable flow

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -588,8 +588,8 @@ export default function ProviderDetailPage() {
       });
       if (!res.ok) {
         console.log("Error disabling model:", res.status);
-        await fetchConnections();
       }
+      await fetchConnections();
     } catch (error) {
       console.log("Error disabling model:", error);
       await fetchConnections();
@@ -618,8 +618,8 @@ export default function ProviderDetailPage() {
       });
       if (!res.ok) {
         console.log("Error enabling model:", res.status);
-        await fetchConnections();
       }
+      await fetchConnections();
     } catch (error) {
       console.log("Error enabling model:", error);
       await fetchConnections();

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -40,6 +40,7 @@ export default function ProviderDetailPage() {
   const [thinkingMode, setThinkingMode] = useState("auto");
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
+  const [togglingModelId, setTogglingModelId] = useState(null);
   const { copied, copy } = useCopyToClipboard();
 
   const providerInfo = providerNode
@@ -563,6 +564,70 @@ export default function ProviderDetailPage() {
     }
   };
 
+  // All connections for a provider carry identical disabledModels (Task 1 invariant), so first is representative.
+  const disabledModels = connections[0]?.providerSpecificData?.disabledModels || [];
+  const disabledModelsSet = new Set(disabledModels);
+
+  const handleDisableModel = async (modelId) => {
+    if (togglingModelId) return;
+    const connectionId = connections.find((c) => c.isActive !== false)?.id || connections[0]?.id;
+    if (!connectionId) return;
+    setTogglingModelId(modelId);
+    const next = [...new Set([...disabledModels, modelId])];
+    setConnections((prev) =>
+      prev.map((c) => ({
+        ...c,
+        providerSpecificData: { ...(c.providerSpecificData || {}), disabledModels: next },
+      }))
+    );
+    try {
+      const res = await fetch(`/api/providers/${connectionId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ disableModel: modelId }),
+      });
+      if (!res.ok) {
+        console.log("Error disabling model:", res.status);
+        await fetchConnections();
+      }
+    } catch (error) {
+      console.log("Error disabling model:", error);
+      await fetchConnections();
+    } finally {
+      setTogglingModelId(null);
+    }
+  };
+
+  const handleEnableModel = async (modelId) => {
+    if (togglingModelId) return;
+    const connectionId = connections.find((c) => c.isActive !== false)?.id || connections[0]?.id;
+    if (!connectionId) return;
+    setTogglingModelId(modelId);
+    const next = disabledModels.filter((m) => m !== modelId);
+    setConnections((prev) =>
+      prev.map((c) => ({
+        ...c,
+        providerSpecificData: { ...(c.providerSpecificData || {}), disabledModels: next },
+      }))
+    );
+    try {
+      const res = await fetch(`/api/providers/${connectionId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enableModel: modelId }),
+      });
+      if (!res.ok) {
+        console.log("Error enabling model:", res.status);
+        await fetchConnections();
+      }
+    } catch (error) {
+      console.log("Error enabling model:", error);
+      await fetchConnections();
+    } finally {
+      setTogglingModelId(null);
+    }
+  };
+
   const renderModelsSection = () => {
     if (isCompatible) {
       return (
@@ -576,6 +641,10 @@ export default function ProviderDetailPage() {
           onDeleteAlias={handleDeleteAlias}
           connections={connections}
           isAnthropic={isAnthropicCompatible}
+          disabledModels={disabledModels}
+          onDisableModel={connections.length > 0 ? handleDisableModel : undefined}
+          onEnableModel={connections.length > 0 ? handleEnableModel : undefined}
+          togglingModelId={togglingModelId}
         />
       );
     }
@@ -624,6 +693,10 @@ export default function ProviderDetailPage() {
               onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
               isTesting={testingModelId === model.id}
               isFree={model.isFree}
+              isDisabled={disabledModelsSet.has(model.id)}
+              onDisable={connections.length > 0 ? () => handleDisableModel(model.id) : undefined}
+              onEnable={connections.length > 0 ? () => handleEnableModel(model.id) : undefined}
+              isToggling={togglingModelId === model.id}
             />
           );
         })}
@@ -644,6 +717,10 @@ export default function ProviderDetailPage() {
             isTesting={testingModelId === model.id}
             isCustom
             isFree={false}
+            isDisabled={disabledModelsSet.has(model.id)}
+            onDisable={connections.length > 0 ? () => handleDisableModel(model.id) : undefined}
+            onEnable={connections.length > 0 ? () => handleEnableModel(model.id) : undefined}
+            isToggling={togglingModelId === model.id}
           />
         ))}
 
@@ -1045,33 +1122,39 @@ export default function ProviderDetailPage() {
   );
 }
 
-function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCustom, isFree, onDeleteAlias, onTest, isTesting }) {
-  const borderColor = testStatus === "ok"
+function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCustom, isFree, onDeleteAlias, onTest, isTesting, isDisabled, onDisable, onEnable, isToggling }) {
+  const borderColor = isDisabled
+    ? "border-black/[0.06] dark:border-white/[0.06]"
+    : testStatus === "ok"
     ? "border-green-500/40"
     : testStatus === "error"
     ? "border-red-500/40"
     : "border-border";
 
-  const iconColor = testStatus === "ok"
+  const iconColor = isDisabled
+    ? undefined
+    : testStatus === "ok"
     ? "#22c55e"
     : testStatus === "error"
     ? "#ef4444"
     : undefined;
 
   return (
-    <div className={`group px-3 py-2 rounded-lg border ${borderColor} hover:bg-sidebar/50`}>
+    <div className={`group px-3 py-2 rounded-lg border ${borderColor} hover:bg-sidebar/50 ${isDisabled ? "opacity-50" : ""}`}>
       <div className="flex items-center gap-2">
         <span
-          className="material-symbols-outlined text-base"
+          className={`material-symbols-outlined text-base ${isDisabled ? "text-text-muted" : ""}`}
           style={iconColor ? { color: iconColor } : undefined}
         >
-          {testStatus === "ok" ? "check_circle" : testStatus === "error" ? "cancel" : "smart_toy"}
+          {isDisabled ? "block" : testStatus === "ok" ? "check_circle" : testStatus === "error" ? "cancel" : "smart_toy"}
         </span>
-        <div className="flex flex-col gap-1">
-          <code className="text-xs text-text-muted font-mono bg-sidebar px-1.5 py-0.5 rounded">{fullModel}</code>
-          {model.name && <span className="text-[9px] text-text-muted/70 italic pl-1">{model.name}</span>}
-        </div>
-        {onTest && (
+        <code className={`text-xs font-mono bg-sidebar px-1.5 py-0.5 rounded ${isDisabled ? "text-text-muted line-through" : "text-text-muted"}`}>{fullModel}</code>
+        {isDisabled && (
+          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-black/5 dark:bg-white/10 text-text-muted">
+            disabled
+          </span>
+        )}
+        {!isDisabled && onTest && (
           <div className="relative group/btn">
             <button
               onClick={onTest}
@@ -1090,7 +1173,7 @@ function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCusto
         <div className="relative group/btn">
           <button
             onClick={() => onCopy(fullModel, `model-${model.id}`)}
-            className="p-0.5 hover:bg-sidebar rounded text-text-muted hover:text-primary"
+            className="p-0.5 hover:bg-sidebar rounded text-text-muted hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity"
           >
             <span className="material-symbols-outlined text-sm">
               {copied === `model-${model.id}` ? "check" : "content_copy"}
@@ -1100,10 +1183,27 @@ function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCusto
             {copied === `model-${model.id}` ? "Copied!" : "Copy"}
           </span>
         </div>
-        {isCustom && (
+        {(onDisable || onEnable) && (
+          <div className="relative group/btn ml-auto">
+            <button
+              onClick={isDisabled ? onEnable : onDisable}
+              disabled={isToggling}
+              className={`p-0.5 rounded transition-opacity ${isToggling ? "opacity-50 cursor-not-allowed" : "opacity-0 group-hover:opacity-100"} ${isDisabled ? "hover:bg-green-500/10 text-text-muted hover:text-green-600" : "hover:bg-orange-500/10 text-text-muted hover:text-orange-600"}`}
+              title={isDisabled ? "Enable model" : "Disable model"}
+            >
+              <span className="material-symbols-outlined text-sm">
+                {isToggling ? "progress_activity" : isDisabled ? "check_circle" : "block"}
+              </span>
+            </button>
+            <span className="pointer-events-none absolute mt-1 top-5 right-0 text-[10px] text-text-muted whitespace-nowrap opacity-0 group-hover/btn:opacity-100 transition-opacity">
+              {isDisabled ? "Enable" : "Disable"}
+            </span>
+          </div>
+        )}
+        {isCustom && !isDisabled && (
           <button
             onClick={onDeleteAlias}
-            className="p-0.5 hover:bg-red-500/10 rounded text-text-muted hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity ml-auto"
+            className="p-0.5 hover:bg-red-500/10 rounded text-text-muted hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
             title="Remove custom model"
           >
             <span className="material-symbols-outlined text-sm">close</span>
@@ -1128,6 +1228,10 @@ ModelRow.propTypes = {
   onDeleteAlias: PropTypes.func,
   onTest: PropTypes.func,
   isTesting: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  onDisable: PropTypes.func,
+  onEnable: PropTypes.func,
+  isToggling: PropTypes.bool,
 };
 
 function PassthroughModelsSection({ providerAlias, modelAliases, copied, onCopy, onSetAlias, onDeleteAlias }) {
@@ -1226,33 +1330,42 @@ PassthroughModelsSection.propTypes = {
   onDeleteAlias: PropTypes.func.isRequired,
 };
 
-function PassthroughModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias, onTest, testStatus, isTesting }) {
-  const borderColor = testStatus === "ok"
+function PassthroughModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias, onTest, testStatus, isTesting, isDisabled, onDisable, onEnable, isToggling }) {
+  const borderColor = isDisabled
+    ? "border-black/[0.06] dark:border-white/[0.06]"
+    : testStatus === "ok"
     ? "border-green-500/40"
     : testStatus === "error"
     ? "border-red-500/40"
     : "border-border";
 
-  const iconColor = testStatus === "ok"
+  const iconColor = isDisabled
+    ? undefined
+    : testStatus === "ok"
     ? "#22c55e"
     : testStatus === "error"
     ? "#ef4444"
     : undefined;
 
   return (
-    <div className={`flex items-center gap-3 p-3 rounded-lg border ${borderColor} hover:bg-sidebar/50`}>
+    <div className={`group flex items-center gap-3 p-3 rounded-lg border ${borderColor} hover:bg-sidebar/50 ${isDisabled ? "opacity-50" : ""}`}>
       <span
-        className="material-symbols-outlined text-base text-text-muted"
+        className={`material-symbols-outlined text-base ${isDisabled ? "text-text-muted" : "text-text-muted"}`}
         style={iconColor ? { color: iconColor } : undefined}
       >
-        {testStatus === "ok" ? "check_circle" : testStatus === "error" ? "cancel" : "smart_toy"}
+        {isDisabled ? "block" : testStatus === "ok" ? "check_circle" : testStatus === "error" ? "cancel" : "smart_toy"}
       </span>
 
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium truncate">{modelId}</p>
+        <p className={`text-sm font-medium truncate ${isDisabled ? "line-through text-text-muted" : ""}`}>{modelId}</p>
 
-        <div className="flex items-center gap-1 mt-1">
-        <code className="text-xs text-text-muted font-mono bg-sidebar px-1.5 py-0.5 rounded">{fullModel}</code>
+        <div className="flex items-center gap-1 mt-1 flex-wrap">
+          <code className="text-xs text-text-muted font-mono bg-sidebar px-1.5 py-0.5 rounded">{fullModel}</code>
+          {isDisabled && (
+            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-black/5 dark:bg-white/10 text-text-muted">
+              disabled
+            </span>
+          )}
           <div className="relative group/btn">
             <button
               onClick={() => onCopy(fullModel, `model-${modelId}`)}
@@ -1266,7 +1379,7 @@ function PassthroughModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias
               {copied === `model-${modelId}` ? "Copied!" : "Copy"}
             </span>
           </div>
-          {onTest && (
+          {!isDisabled && onTest && (
             <div className="relative group/btn">
               <button
                 onClick={onTest}
@@ -1285,10 +1398,27 @@ function PassthroughModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias
         </div>
       </div>
 
-      {/* Delete button */}
+      {(onDisable || onEnable) && (
+        <div className="relative group/btn">
+          <button
+            onClick={isDisabled ? onEnable : onDisable}
+            disabled={isToggling}
+            className={`p-1 rounded transition-opacity ${isToggling ? "opacity-50 cursor-not-allowed" : "opacity-0 group-hover:opacity-100"} ${isDisabled ? "hover:bg-green-500/10 text-text-muted hover:text-green-600" : "hover:bg-orange-500/10 text-text-muted hover:text-orange-600"}`}
+            title={isDisabled ? "Enable model" : "Disable model"}
+          >
+            <span className="material-symbols-outlined text-sm">
+              {isToggling ? "progress_activity" : isDisabled ? "check_circle" : "block"}
+            </span>
+          </button>
+          <span className="pointer-events-none absolute top-7 right-0 text-[10px] text-text-muted whitespace-nowrap opacity-0 group-hover/btn:opacity-100 transition-opacity">
+            {isDisabled ? "Enable" : "Disable"}
+          </span>
+        </div>
+      )}
+
       <button
         onClick={onDeleteAlias}
-        className="p-1 hover:bg-red-50 rounded text-red-500"
+        className="p-1 hover:bg-red-50 dark:hover:bg-red-500/10 rounded text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
         title="Remove model"
       >
         <span className="material-symbols-outlined text-sm">delete</span>
@@ -1306,9 +1436,13 @@ PassthroughModelRow.propTypes = {
   onTest: PropTypes.func,
   testStatus: PropTypes.oneOf(["ok", "error"]),
   isTesting: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  onDisable: PropTypes.func,
+  onEnable: PropTypes.func,
+  isToggling: PropTypes.bool,
 };
 
-function CompatibleModelsSection({ providerStorageAlias, providerDisplayAlias, modelAliases, copied, onCopy, onSetAlias, onDeleteAlias, connections, isAnthropic }) {
+function CompatibleModelsSection({ providerStorageAlias, providerDisplayAlias, modelAliases, copied, onCopy, onSetAlias, onDeleteAlias, connections, isAnthropic, disabledModels, onDisableModel, onEnableModel, togglingModelId }) {
   const [newModel, setNewModel] = useState("");
   const [adding, setAdding] = useState(false);
   const [importing, setImporting] = useState(false);
@@ -1464,6 +1598,10 @@ function CompatibleModelsSection({ providerStorageAlias, providerDisplayAlias, m
               onTest={connections.length > 0 ? () => handleTestModel(modelId) : undefined}
               testStatus={modelTestResults[modelId]}
               isTesting={testingModelId === modelId}
+              isDisabled={(disabledModels || []).includes(modelId)}
+              onDisable={onDisableModel ? () => onDisableModel(modelId) : undefined}
+              onEnable={onEnableModel ? () => onEnableModel(modelId) : undefined}
+              isToggling={togglingModelId === modelId}
             />
           ))}
         </div>
@@ -1485,6 +1623,10 @@ CompatibleModelsSection.propTypes = {
     isActive: PropTypes.bool,
   })).isRequired,
   isAnthropic: PropTypes.bool,
+  disabledModels: PropTypes.arrayOf(PropTypes.string),
+  onDisableModel: PropTypes.func,
+  onEnableModel: PropTypes.func,
+  togglingModelId: PropTypes.string,
 };
 
 function CooldownTimer({ until }) {
@@ -2207,4 +2349,3 @@ AddCustomModelModal.propTypes = {
   onSave: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
-

--- a/src/app/api/providers/[id]/route.js
+++ b/src/app/api/providers/[id]/route.js
@@ -4,6 +4,7 @@ import {
   getProxyPoolById,
   updateProviderConnection,
   deleteProviderConnection,
+  updateProviderDisabledModels,
 } from "@/models";
 
 function normalizeProxyConfig(body = {}) {
@@ -185,5 +186,99 @@ export async function DELETE(request, { params }) {
   } catch (error) {
     console.log("Error deleting connection:", error);
     return NextResponse.json({ error: "Failed to delete connection" }, { status: 500 });
+  }
+}
+
+// PATCH /api/providers/[id] - Provider-wide model disable mutations
+// Body (exactly one variant):
+//   { disabledModels: string[] }  — replace the full provider-wide disabled list
+//   { disableModel: string }       — idempotent add of a single bare model ID
+//   { enableModel: string }        — remove a single bare model ID from the disabled list
+export async function PATCH(request, { params }) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+
+    const connection = await getProviderConnectionById(id);
+    if (!connection) {
+      return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+    }
+
+    const providerId = connection.provider;
+    if (!providerId) {
+      return NextResponse.json({ error: "Connection has no provider" }, { status: 400 });
+    }
+
+    // Detect which variant(s) the caller provided
+    const hasDisabledModels = Object.prototype.hasOwnProperty.call(body, "disabledModels");
+    const hasDisableModel = Object.prototype.hasOwnProperty.call(body, "disableModel");
+    const hasEnableModel = Object.prototype.hasOwnProperty.call(body, "enableModel");
+    const variantCount = [hasDisabledModels, hasDisableModel, hasEnableModel].filter(Boolean).length;
+
+    if (variantCount === 0) {
+      return NextResponse.json(
+        { error: "Body must contain exactly one of: disabledModels (array), disableModel (string), enableModel (string)" },
+        { status: 400 }
+      );
+    }
+    if (variantCount > 1) {
+      return NextResponse.json(
+        { error: "Body must contain exactly one of: disabledModels, disableModel, enableModel — not multiple" },
+        { status: 400 }
+      );
+    }
+
+    // Current provider-wide disabled list (any one connection is representative per Task 1 invariant)
+    const currentDisabled = Array.isArray(connection.providerSpecificData?.disabledModels)
+      ? [...connection.providerSpecificData.disabledModels]
+      : [];
+
+    let nextDisabled;
+
+    if (hasDisabledModels) {
+      if (!Array.isArray(body.disabledModels)) {
+        return NextResponse.json({ error: "disabledModels must be an array" }, { status: 400 });
+      }
+      // Trim, reject blanks, deduplicate
+      nextDisabled = [...new Set(
+        body.disabledModels
+          .filter((m) => typeof m === "string")
+          .map((m) => m.trim())
+          .filter((m) => m)
+      )];
+    } else if (hasDisableModel) {
+      if (typeof body.disableModel !== "string") {
+        return NextResponse.json({ error: "disableModel must be a string" }, { status: 400 });
+      }
+      const modelId = body.disableModel.trim();
+      if (!modelId) {
+        return NextResponse.json({ error: "disableModel must not be blank" }, { status: 400 });
+      }
+      // Idempotent add
+      nextDisabled = currentDisabled.includes(modelId)
+        ? currentDisabled
+        : [...currentDisabled, modelId];
+    } else {
+      // hasEnableModel
+      if (typeof body.enableModel !== "string") {
+        return NextResponse.json({ error: "enableModel must be a string" }, { status: 400 });
+      }
+      const modelId = body.enableModel.trim();
+      if (!modelId) {
+        return NextResponse.json({ error: "enableModel must not be blank" }, { status: 400 });
+      }
+      nextDisabled = currentDisabled.filter((m) => m !== modelId);
+    }
+
+    const updatedCount = await updateProviderDisabledModels(providerId, nextDisabled);
+
+    return NextResponse.json({
+      providerId,
+      disabledModels: nextDisabled,
+      updatedConnections: updatedCount,
+    });
+  } catch (error) {
+    console.log("Error updating provider disabled models:", error);
+    return NextResponse.json({ error: "Failed to update provider disabled models" }, { status: 500 });
   }
 }

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -156,6 +156,11 @@ export async function GET() {
         ).trim();
         const providerModels = PROVIDER_MODELS[staticAlias] || [];
         const enabledModels = conn?.providerSpecificData?.enabledModels;
+        const disabledModelsSet = new Set(
+          Array.isArray(conn?.providerSpecificData?.disabledModels)
+            ? conn.providerSpecificData.disabledModels
+            : [],
+        );
         const hasExplicitEnabledModels =
           Array.isArray(enabledModels) && enabledModels.length > 0;
         const isCompatibleProvider =
@@ -191,7 +196,8 @@ export async function GET() {
             }
             return modelId;
           })
-          .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
+          .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "")
+          .filter((modelId) => !disabledModelsSet.has(modelId));
 
         for (const modelId of modelIds) {
           models.push({

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -745,7 +745,7 @@ export async function reorderProviderConnections(providerId) {
 /**
  * Update provider-wide disabled models list.
  * Writes disabledModels (array of bare model IDs) into providerSpecificData
- * for ALL active connections belonging to the given provider, then does a
+ * for ALL connections belonging to the given provider (active and inactive), then does a
  * single safeWrite.
  *
  * @param {string} providerId  - provider identifier (e.g. "gemini", "openai")
@@ -759,7 +759,6 @@ export async function updateProviderDisabledModels(providerId, disabledModels) {
 
   db.data.providerConnections.forEach((c, index) => {
     if (c.provider !== providerId) return;
-    if (c.isActive === false) return;
 
     db.data.providerConnections[index] = {
       ...c,

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -742,6 +742,40 @@ export async function reorderProviderConnections(providerId) {
   await safeWrite(db);
 }
 
+/**
+ * Update provider-wide disabled models list.
+ * Writes disabledModels (array of bare model IDs) into providerSpecificData
+ * for ALL active connections belonging to the given provider, then does a
+ * single safeWrite.
+ *
+ * @param {string} providerId  - provider identifier (e.g. "gemini", "openai")
+ * @param {string[]} disabledModels - bare model IDs to disable, e.g. ["gemini-2.0-flash"]
+ * @returns {Promise<number>} number of connections that were updated
+ */
+export async function updateProviderDisabledModels(providerId, disabledModels) {
+  const db = await getDb();
+  const now = new Date().toISOString();
+  let updatedCount = 0;
+
+  db.data.providerConnections.forEach((c, index) => {
+    if (c.provider !== providerId) return;
+    if (c.isActive === false) return;
+
+    db.data.providerConnections[index] = {
+      ...c,
+      providerSpecificData: {
+        ...(c.providerSpecificData || {}),
+        disabledModels: Array.isArray(disabledModels) ? [...disabledModels] : [],
+      },
+      updatedAt: now,
+    };
+    updatedCount++;
+  });
+
+  await safeWrite(db);
+  return updatedCount;
+}
+
 // ============ Model Aliases ============
 
 /**

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -5,6 +5,7 @@ export {
   createProviderConnection,
   updateProviderConnection,
   deleteProviderConnection,
+  updateProviderDisabledModels,
   getProviderNodes,
   getProviderNodeById,
   createProviderNode,

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -88,6 +88,12 @@ export default function ModelSelectModal({
       const alias = PROVIDER_ID_TO_ALIAS[providerId] || providerId;
       const providerInfo = allProviders[providerId] || { name: providerId, color: "#666" };
       const isCustomProvider = isOpenAICompatibleProvider(providerId) || isAnthropicCompatibleProvider(providerId);
+      const connection = activeProviders.find(p => p.provider === providerId);
+      const disabledModels = new Set(
+        Array.isArray(connection?.providerSpecificData?.disabledModels)
+          ? connection.providerSpecificData.disabledModels
+          : []
+      );
 
       if (providerInfo.passthroughModels) {
         const aliasModels = Object.entries(modelAliases)
@@ -96,7 +102,8 @@ export default function ModelSelectModal({
             id: fullModel.replace(`${alias}/`, ""),
             name: aliasName,
             value: fullModel,
-          }));
+          }))
+          .filter((model) => !disabledModels.has(model.id));
 
         if (aliasModels.length > 0) {
           // Check for custom name from providerNodes (for compatible providers)
@@ -112,7 +119,6 @@ export default function ModelSelectModal({
         }
       } else if (isCustomProvider) {
         // Find connection object to get prefix synchronously without waiting for providerNodes fetch
-        const connection = activeProviders.find(p => p.provider === providerId);
         const matchedNode = providerNodes.find(node => node.id === providerId);
         const displayName = connection?.name || matchedNode?.name || providerInfo.name;
         const nodePrefix = connection?.providerSpecificData?.prefix || matchedNode?.prefix || providerId;
@@ -125,7 +131,8 @@ export default function ModelSelectModal({
             id: fullModel.replace(`${providerId}/`, ""),
             name: aliasName,
             value: `${nodePrefix}/${fullModel.replace(`${providerId}/`, "")}`,
-          }));
+          }))
+          .filter((model) => !disabledModels.has(model.id));
 
         // Always show compatible providers that are connected, even with no aliases.
         // When no aliases exist, show a placeholder so users know it's available.
@@ -160,10 +167,13 @@ export default function ModelSelectModal({
           .map(([aliasName, fullModel]) => {
             const modelId = fullModel.replace(`${alias}/`, "");
             return { id: modelId, name: aliasName, value: fullModel, isCustom: true };
-          });
+          })
+          .filter((model) => !disabledModels.has(model.id));
 
         const allModels = [
-          ...hardcodedModels.map((m) => ({ id: m.id, name: m.name, value: `${alias}/${m.id}` })),
+          ...hardcodedModels
+            .filter((model) => !disabledModels.has(model.id))
+            .map((m) => ({ id: m.id, name: m.name, value: `${alias}/${m.id}` })),
           ...customModels,
         ];
 
@@ -361,4 +371,3 @@ ModelSelectModal.propTypes = {
   title: PropTypes.string,
   modelAliases: PropTypes.object,
 };
-

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -8,7 +8,7 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
-import { getSettings } from "@/lib/localDb";
+import { getSettings, getProviderConnections } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -137,6 +137,16 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   }
 
   const { provider, model } = modelInfo;
+
+  // Guard: reject disabled models before routing (provider-wide, covers aliases)
+  const activeConnections = await getProviderConnections({ provider, isActive: true });
+  if (activeConnections.length > 0) {
+    const disabledModels = activeConnections[0].providerSpecificData?.disabledModels;
+    if (Array.isArray(disabledModels) && disabledModels.includes(model)) {
+      log.warn("CHAT", `Model ${model} is disabled for provider: ${provider}`);
+      return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
+    }
+  }
 
   // Log model routing (alias → actual model)
   if (modelStr !== `${provider}/${model}`) {


### PR DESCRIPTION
## Summary
- add provider-wide disabled model storage and mutation flow without changing the flat alias schema
- hide disabled models from `/v1/models`, reject direct and alias-resolved requests for disabled models, and keep combo execution aligned with absent-model semantics
- add disable/enable controls on the provider page, preserve disabled state across `/models` import, and exclude disabled models from combo search results

## Why
Temporarily stopping use of a provider model currently requires destructive remove/re-add behavior, and imports from `/models` can reintroduce models in inconsistent ways. This change makes disable state explicit, non-destructive, and enforced consistently across discovery, runtime, UI, import, and combo selection.

## Notes
- disabled state is provider-wide rather than account-specific
- `disabledModels` stores bare model IDs and takes precedence over `enabledModels`
- the provider-wide disabled list is mirrored across all connections for the provider so newly reactivated connections inherit the same state
- branch includes the combo-search follow-up so disabled models are treated consistently in the combo modal too