### PR TITLE
fix: forward client headers in native passthrough mode

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -94,7 +94,46 @@ export class BaseExecutor {
     return { status: response.status, message: bodyText || `HTTP ${response.status}` };
   }
 
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+  /**
+   * Build headers for passthrough mode: forward client's original headers,
+   * only swapping auth and ensuring required beta flags.
+   */
+  buildPassthroughHeaders(clientHeaders, credentials, stream) {
+    const headers = { ...clientHeaders };
+
+    // Remove hop-by-hop and transport headers that should not be forwarded
+    for (const h of ["host", "content-length", "connection", "transfer-encoding", "accept-encoding"]) {
+      delete headers[h];
+    }
+
+    // Swap auth: remove client auth (authenticated to 9router), add upstream auth
+    delete headers["authorization"];
+    delete headers["x-api-key"];
+
+    if (credentials.apiKey) {
+      headers["x-api-key"] = credentials.apiKey;
+    } else if (credentials.accessToken) {
+      headers["authorization"] = `Bearer ${credentials.accessToken}`;
+    }
+
+    // Ensure oauth beta flag when using OAuth access token
+    if (credentials.accessToken) {
+      const existing = headers["anthropic-beta"] || "";
+      if (!existing.includes("oauth-2025-04-20")) {
+        headers["anthropic-beta"] = existing
+          ? `${existing},oauth-2025-04-20`
+          : "oauth-2025-04-20";
+      }
+    }
+
+    if (stream) {
+      headers["accept"] = "text/event-stream";
+    }
+
+    return headers;
+  }
+
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null, passthrough = false, clientHeaders = null }) {
     const fallbackCount = this.getFallbackCount();
     let lastError = null;
     let lastStatus = 0;
@@ -106,7 +145,9 @@ export class BaseExecutor {
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
       const transformedBody = this.transformRequest(model, body, stream, credentials);
-      const headers = this.buildHeaders(credentials, stream);
+      const headers = (passthrough && clientHeaders)
+        ? this.buildPassthroughHeaders(clientHeaders, credentials, stream)
+        : this.buildHeaders(credentials, stream);
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -125,7 +125,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Execute request
   let providerResponse, providerUrl, providerHeaders, finalBody;
   try {
-    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, passthrough, clientHeaders: passthrough ? clientRawRequest?.headers : undefined });
     providerResponse = result.response;
     providerUrl = result.url;
     providerHeaders = result.headers;
@@ -164,7 +164,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
           try { await onCredentialsRefreshed(newCredentials); } catch (e) { log?.warn?.("TOKEN", `onCredentialsRefreshed failed: ${e.message}`); }
         }
         try {
-          const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+          const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, passthrough, clientHeaders: passthrough ? clientRawRequest?.headers : undefined });
           if (retryResult.response.ok) { providerResponse = retryResult.response; providerUrl = retryResult.url; }
         } catch { log?.warn?.("TOKEN", `${provider.toUpperCase()} | retry after refresh failed`); }
       } else {


### PR DESCRIPTION
## Summary

- In native passthrough mode (e.g. Claude Code → Claude API), 9router was rebuilding request headers from static config + cached values instead of forwarding the client's original headers
- This caused extra `anthropic-beta` flags (e.g. `token-efficient-tools-2026-03-28`) to be injected into upstream API requests via the union merge logic in `DefaultExecutor.buildHeaders`, even though the client never sent them
- The extra beta flags altered model behavior, causing unicode encoding anomalies in tool call arguments (e.g. `u8fd9` instead of `这` in `partial_json` deltas)

## Changes

**`open-sse/executors/base.js`**
- Added `buildPassthroughHeaders()` method that starts from the client's original headers, strips hop-by-hop headers, swaps auth credentials, and ensures the `oauth-2025-04-20` beta flag when using OAuth
- Updated `execute()` to accept `passthrough` and `clientHeaders` params, using `buildPassthroughHeaders` when both are present

**`open-sse/handlers/chatCore.js`**
- Passes `passthrough` flag and `clientRawRequest.headers` to `executor.execute()` at both call sites (initial request + retry-after-refresh)

## Root cause

The static `Anthropic-Beta` header in `providers.js` includes flags like `token-efficient-tools-2026-03-28` that are not present in Claude Code's own requests. The header merge logic (union of static + cached flags) injected these into every upstream request. With this fix, passthrough requests forward the client's exact headers — only auth is swapped.

## Test plan

- [x] Verified with Claude Code 2.1.97 → `cc/claude-opus-4-6` passthrough: Chinese unicode characters now render correctly in tool call arguments
- [x] Non-passthrough requests continue to use `buildHeaders()` with static config as before
- [x] OAuth access token requests get `oauth-2025-04-20` beta flag injected automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)