### PR TITLE
fix: show manual config option when Claude CLI detection fails (closes #589)

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/ClaudeToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/ClaudeToolCard.js
@@ -256,13 +256,19 @@ export default function ClaudeToolCard({
               <div className="flex items-center gap-3 p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
                 <span className="material-symbols-outlined text-yellow-500">warning</span>
                 <div className="flex-1">
-                  <p className="font-medium text-yellow-600 dark:text-yellow-400">Claude CLI not installed</p>
-                  <p className="text-sm text-text-muted">Please install Claude CLI to use this feature.</p>
+                  <p className="font-medium text-yellow-600 dark:text-yellow-400">Claude CLI not detected locally</p>
+                  <p className="text-sm text-text-muted">Manual configuration is still available if 9router is deployed on a remote server.</p>
                 </div>
-                <Button variant="outline" size="sm" onClick={() => setShowInstallGuide(!showInstallGuide)}>
-                  <span className="material-symbols-outlined text-[18px] mr-1">{showInstallGuide ? "expand_less" : "help"}</span>
-                  {showInstallGuide ? "Hide" : "How to Install"}
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>
+                    <span className="material-symbols-outlined text-[18px] mr-1">content_copy</span>
+                    Manual Config
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => setShowInstallGuide(!showInstallGuide)}>
+                    <span className="material-symbols-outlined text-[18px] mr-1">{showInstallGuide ? "expand_less" : "help"}</span>
+                    {showInstallGuide ? "Hide" : "How to Install"}
+                  </Button>
+                </div>
               </div>
               {showInstallGuide && (
                 <div className="p-4 bg-surface border border-border rounded-lg">


### PR DESCRIPTION
## Summary
When 9router is deployed on a remote server, the CLI Tools page shows the message "Claude CLI not installed / Please install Claude CLI to use this feature" and hides the Manual Config button, even when the user has Claude installed on that remote server.

## Fix
- Changed the message from "not installed" to "not detected locally" with an explanation that manual config is still available for remote deployments
- Always show the "Manual Config" button regardless of CLI detection status
- The "How to Install" button remains for local installation instructions

Closes #589