### PR TITLE
fix: allow per-connection refresh lead time override via providerSpecificData.refreshLeadMs (closes #593)

### DIFF
--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -4,8 +4,12 @@ import { OAUTH_ENDPOINTS, GITHUB_COPILOT, REFRESH_LEAD_MS } from "../config/appC
 // Default token expiry buffer (refresh if expires within 5 minutes)
 export const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
-// Get provider-specific refresh lead time, falls back to default buffer
-export function getRefreshLeadMs(provider) {
+// Get provider-specific refresh lead time, falls back to default buffer.
+// Accepts optional per-connection override from providerSpecificData.refreshLeadMs.
+export function getRefreshLeadMs(provider, providerSpecificData) {
+  if (providerSpecificData?.refreshLeadMs != null) {
+    return providerSpecificData.refreshLeadMs;
+  }
   return REFRESH_LEAD_MS[provider] || TOKEN_EXPIRY_BUFFER_MS;
 }
 

--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -197,7 +197,7 @@ export async function checkAndRefreshToken(provider, credentials) {
     const now       = Date.now();
     const remaining = expiresAt - now;
 
-    const refreshLead = _getRefreshLeadMs(provider);
+    const refreshLead = _getRefreshLeadMs(provider, creds.providerSpecificData);
     if (remaining < refreshLead) {
       log.info("TOKEN_REFRESH", "Token expiring soon, refreshing proactively", {
         provider,


### PR DESCRIPTION
## Summary

Issue #593 requested the ability to manually configure the **Provider Connection timeout renewal** time, as the current hardcoded renewal interval was too short.

### Fix

Modified `getRefreshLeadMs()` in `open-sse/services/tokenRefresh.js` to accept an optional per-connection override via `providerSpecificData.refreshLeadMs`:

```js
// Before
export function getRefreshLeadMs(provider) {
  return REFRESH_LEAD_MS[provider] || TOKEN_EXPIRY_BUFFER_MS;
}

// After
export function getRefreshLeadMs(provider, providerSpecificData) {
  if (providerSpecificData?.refreshLeadMs != null) {
    return providerSpecificData.refreshLeadMs;
  }
  return REFRESH_LEAD_MS[provider] || TOKEN_EXPIRY_BUFFER_MS;
}
```

The caller in `src/sse/services/tokenRefresh.js` (`checkAndRefreshToken`) now passes `creds.providerSpecificData` so per-connection overrides take effect.

### Usage

To set a custom renewal lead time for a connection, set `providerSpecificData.refreshLeadMs` (in milliseconds) on the connection. For example, to extend the renewal lead to 30 minutes:

```
providerSpecificData: { refreshLeadMs: 30 * 60 * 1000 }
```

If not set, defaults to the provider-specific defaults from `REFRESH_LEAD_MS` or the global `TOKEN_EXPIRY_BUFFER_MS` (5 minutes).

Closes #593