### PR TITLE
fix: enable Codex Apply/Reset buttons when CLI is installed (closes #591)

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
@@ -350,10 +350,10 @@ model = "${effectiveSubagentModel}"
               )}
 
               <div className="flex items-center gap-2">
-                <Button variant="primary" size="sm" onClick={handleApplySettings} disabled={!selectedApiKey || !selectedModel} loading={applying}>
+                <Button variant="primary" size="sm" onClick={handleApplySettings} disabled={(!selectedApiKey && (cloudEnabled && apiKeys.length > 0)) || !selectedModel} loading={applying}>
                   <span className="material-symbols-outlined text-[14px] mr-1">save</span>Apply
                 </Button>
-                <Button variant="outline" size="sm" onClick={handleResetSettings} disabled={!codexStatus.has9Router} loading={restoring}>
+                <Button variant="outline" size="sm" onClick={handleResetSettings} disabled={restoring} loading={restoring}>
                   <span className="material-symbols-outlined text-[14px] mr-1">restore</span>Reset
                 </Button>
                 <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>


### PR DESCRIPTION
Closes #591

**Issue:** Codex CLI card showed Connected but Apply and Reset buttons were unavailable/disabled, making it impossible to configure or reset settings even when the CLI was installed.

**Root Cause:** 
- Apply button was disabled when selectedApiKey was empty — but sk_9router is a valid default key for local 9router, so it should be enabled even without an explicit selection
- Reset button was disabled when has9Router was false — but users should always be able to reset, even if 9router was not previously configured

**Fix:**
- Apply: enable when model is selected AND (API key is selected OR no cloud enabled with sk_9router default OR no keys available)
- Reset: always enabled when CLI is installed (remove the has9Router check)
- Buttons remain disabled while loading (applying/restoring states)