### PR TITLE
fix: add GLM-5 and MiniMax-M2.5 models to Kiro provider (closes #580)

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -111,6 +111,8 @@ export const PROVIDER_MODELS = {
     { id: "deepseek-3.2", name: "DeepSeek 3.2", strip: ["image", "audio"] },
     { id: "deepseek-3.1", name: "DeepSeek 3.1", strip: ["image", "audio"] },
     { id: "qwen3-coder-next", name: "Qwen3 Coder Next", strip: ["image", "audio"] },
+    { id: "glm-5", name: "GLM 5" },
+    { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
   ],
   cu: [  // Cursor IDE
     { id: "default", name: "Auto (Server Picks)" },


### PR DESCRIPTION
Closes #580