### PR TITLE
fix: strip enumDescriptions from tool schema in antigravity-to-openai (closes #566)

### DIFF
--- a/open-sse/translator/request/antigravity-to-openai.js
+++ b/open-sse/translator/request/antigravity-to-openai.js
@@ -98,10 +98,18 @@ function normalizeSchemaTypes(schema) {
     result.type = result.type.toLowerCase();
   }
 
+  // Strip enumDescriptions - upstream API doesn't support it
   if (result.properties) {
     const normalized = {};
     for (const [key, val] of Object.entries(result.properties)) {
-      normalized[key] = normalizeSchemaTypes(val);
+      // Remove enumDescriptions from property
+      if (val && typeof val === "object") {
+        const cleaned = { ...val };
+        delete cleaned.enumDescriptions;
+        normalized[key] = normalizeSchemaTypes(cleaned);
+      } else {
+        normalized[key] = normalizeSchemaTypes(val);
+      }
     }
     result.properties = normalized;
   }


### PR DESCRIPTION
Closes #566