### PR TITLE
fix: show manual config option when OpenClaw detection fails (closes #579)

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/OpenClawToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/OpenClawToolCard.js
@@ -254,11 +254,19 @@ export default function OpenClawToolCard({
           )}
 
           {!checkingOpenclaw && openclawStatus && !openclawStatus.installed && (
-            <div className="flex items-center gap-3 p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
-              <span className="material-symbols-outlined text-yellow-500">warning</span>
-              <div className="flex-1">
-                <p className="font-medium text-yellow-600 dark:text-yellow-400">Open Claw CLI not installed</p>
-                <p className="text-sm text-text-muted">Please install Open Claw CLI to use this feature.</p>
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center gap-3 p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+                <span className="material-symbols-outlined text-yellow-500">warning</span>
+                <div className="flex-1">
+                  <p className="font-medium text-yellow-600 dark:text-yellow-400">Open Claw CLI not installed</p>
+                  <p className="text-sm text-text-muted">Please install Open Claw CLI to use this feature.</p>
+                </div>
+              </div>
+              {/* Show manual config option even when detection fails */}
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>
+                  <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>Manual Config
+                </Button>
               </div>
             </div>
           )}


### PR DESCRIPTION
Closes #579