### PR TITLE
fix: show actual computed cost in usage dashboard (closes #530)

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
+++ b/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
@@ -22,9 +22,8 @@ export default function OverviewCards({ stats }) {
         <span className="text-2xl font-bold text-success">{fmt(stats.totalCompletionTokens)}</span>
       </Card>
       <Card className="px-4 py-3 flex flex-col gap-1">
-        <span className="text-text-muted text-sm uppercase font-semibold">Est. Cost</span>
-        <span className="text-2xl font-bold text-warning">~{fmtCost(stats.totalCost)}</span>
-        <span className="text-[10px] text-text-muted">Estimated, not actual billing</span>
+        <span className="text-text-muted text-sm uppercase font-semibold">Actual Cost</span>
+        <span className="text-2xl font-bold text-warning">{fmtCost(stats.totalCost)}</span>
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
Replace misleading "Est. Cost ~" label with "Actual Cost" showing the real computed cost based on token pricing per model.

### Changes
- Remove "Est." prefix from cost card — costs ARE actual computed costs (input_tokens × pricing.input + output_tokens × pricing.output), not rough estimates
- Remove subtitle "Estimated, not actual billing" which contradicts the accurate calculation

### Issue
#530: The cost display used "Est. Cost" wording making it seem like an approximation, when it is actually correctly computed from per-model pricing rates. This reduces clarity for users tracking real spend.

Closes #530