### PR TITLE
fix: force Agent mode when Claude CLI routes through Cursor provider

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -132,7 +132,9 @@ export class CursorExecutor extends BaseExecutor {
     const messages = body.messages || [];
     const tools = body.tools || [];
     const reasoningEffort = body.reasoning_effort || null;
-    return generateCursorBody(messages, model, tools, reasoningEffort);
+    // Force Agent mode when the source client is Claude CLI (Ask mode blocks command execution)
+    const forceAgentMode = body._forceAgentMode === true;
+    return generateCursorBody(messages, model, tools, reasoningEffort, forceAgentMode);
   }
 
   async makeFetchRequest(url, headers, body, signal, proxyOptions = null) {

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -90,6 +90,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     toolNameMap = translatedBody._toolNameMap;
     delete translatedBody._toolNameMap;
     translatedBody.model = model;
+    // Tag the source client so Cursor executor can force Agent mode
+    // (Claude CLI → Cursor requires Agent mode to execute commands; Ask mode blocks it)
+    if (clientTool) {
+      translatedBody._sourceClient = clientTool;
+    }
   }
 
   const executor = getExecutor(provider);

--- a/open-sse/translator/request/openai-to-cursor.js
+++ b/open-sse/translator/request/openai-to-cursor.js
@@ -5,6 +5,9 @@
  * Important: Cursor can loop when tool outputs are sent via protobuf tool_results
  * with partial schema mismatches. For stability, tool outputs are represented as
  * structured text blocks in user messages.
+ *
+ * Agent-mode enforcement: When the source client is Claude CLI, force Agent mode
+ * (not Ask mode) so Cursor executes commands instead of refusing with "cannot run it".
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
@@ -171,10 +174,19 @@ export function buildCursorRequest(model, body, stream, credentials) {
   const messages = convertMessages(body.messages || []);
   // Strip fields irrelevant to Cursor (OpenAI/Anthropic-specific)
   const { user, metadata, tool_choice, stream_options, system, ...rest } = body;
+
+  // Force Agent mode when source client is Claude CLI.
+  // Without this, Cursor treats the request as "Ask Mode" and refuses to run commands
+  // with "Cannot run it — this is currently unavailable in Ask Mode".
+  // Claude CLI sets user-agent to include "claude-cli", which we detect via body._sourceClient.
+  const isClaudeCLI = body._sourceClient === "claude";
+
   return {
     ...rest,
     messages,
-    max_tokens: 32000
+    max_tokens: 32000,
+    // When Claude CLI is the source, set _forceAgentMode so encodeRequest uses UNIFIED_MODE.AGENT
+    ...(isClaudeCLI ? { _forceAgentMode: true } : {})
   };
 }
 

--- a/open-sse/utils/cursorProtobuf.js
+++ b/open-sse/utils/cursorProtobuf.js
@@ -447,9 +447,11 @@ export function encodeMcpTool(tool) {
 
 // ==================== REQUEST BUILDING ====================
 
-export function encodeRequest(messages, modelName, tools = [], reasoningEffort = null) {
+export function encodeRequest(messages, modelName, tools = [], reasoningEffort = null, forceAgentMode = false) {
   const hasTools = tools?.length > 0;
-  const isAgentic = hasTools;
+  // Agent mode: always on when tools are present, OR when forceAgentMode is set
+  // (e.g. for Claude CLI → Cursor, where Ask mode would block command execution)
+  const isAgentic = hasTools || forceAgentMode;
   const formattedMessages = [];
   const messageIds = [];
   const normalizedMessages = [];
@@ -583,8 +585,8 @@ export function encodeRequest(messages, modelName, tools = [], reasoningEffort =
   );
 }
 
-export function buildChatRequest(messages, modelName, tools = [], reasoningEffort = null) {
-  return encodeField(FIELD.REQUEST, WIRE_TYPE.LEN, encodeRequest(messages, modelName, tools, reasoningEffort));
+export function buildChatRequest(messages, modelName, tools = [], reasoningEffort = null, forceAgentMode = false) {
+  return encodeField(FIELD.REQUEST, WIRE_TYPE.LEN, encodeRequest(messages, modelName, tools, reasoningEffort, forceAgentMode));
 }
 
 /**
@@ -646,10 +648,10 @@ export function wrapConnectRPCFrame(payload, compress = false) {
   return frame;
 }
 
-export function generateCursorBody(messages, modelName, tools = [], reasoningEffort = null) {
-  log("BODY", `Generating: ${messages.length} msgs, model=${modelName}, tools=${tools.length}, reasoning=${reasoningEffort || "none"}`);
+export function generateCursorBody(messages, modelName, tools = [], reasoningEffort = null, forceAgentMode = false) {
+  log("BODY", `Generating: ${messages.length} msgs, model=${modelName}, tools=${tools.length}, reasoning=${reasoningEffort || "none"}, forceAgentMode=${forceAgentMode}`);
   
-  const protobuf = buildChatRequest(messages, modelName, tools, reasoningEffort);
+  const protobuf = buildChatRequest(messages, modelName, tools, reasoningEffort, forceAgentMode);
   const framed = wrapConnectRPCFrame(protobuf, false); // Cursor doesn't support compressed requests
   
   log("BODY", `Protobuf=${protobuf.length}B, Framed=${framed.length}B`);


### PR DESCRIPTION
When Claude CLI routes through Cursor provider, Cursor enters Ask Mode instead of Agent Mode and refuses to execute commands (closes #643).

**Root cause**: Cursor's protobuf  field was set to CHAT (1) when no tools were detected. Claude CLI wraps commands in a way that doesn't appear as explicit tools to 9router's translation, causing Cursor to enter Ask Mode and block command execution.

**Fix**: Propagate  flag through the translation chain (chatCore → openai-to-cursor → cursor executor → cursorProtobuf) so Claude CLI → Cursor always uses Agent mode (UNIFIED_MODE = 2), enabling command execution.

Files changed:
- open-sse/handlers/chatCore.js
- open-sse/translator/request/openai-to-cursor.js
- open-sse/executors/cursor.js
- open-sse/utils/cursorProtobuf.js