### PR TITLE
fix: allow per-connection refresh lead time override via providerSpecificData.refreshLeadMs (closes #593)

### DIFF
--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -5,7 +5,11 @@ import { OAUTH_ENDPOINTS, GITHUB_COPILOT, REFRESH_LEAD_MS } from "../config/appC
 export const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
 // Get provider-specific refresh lead time, falls back to default buffer
-export function getRefreshLeadMs(provider) {
+// Accepts optional providerSpecificData to allow per-connection override via refreshLeadMs
+export function getRefreshLeadMs(provider, providerSpecificData = null) {
+  if (providerSpecificData?.refreshLeadMs && typeof providerSpecificData.refreshLeadMs === "number" && providerSpecificData.refreshLeadMs > 0) {
+    return providerSpecificData.refreshLeadMs;
+  }
   return REFRESH_LEAD_MS[provider] || TOKEN_EXPIRY_BUFFER_MS;
 }
 

--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -197,7 +197,7 @@ export async function checkAndRefreshToken(provider, credentials) {
     const now       = Date.now();
     const remaining = expiresAt - now;
 
-    const refreshLead = _getRefreshLeadMs(provider);
+    const refreshLead = _getRefreshLeadMs(provider, creds.providerSpecificData);
     if (remaining < refreshLead) {
       log.info("TOKEN_REFRESH", "Token expiring soon, refreshing proactively", {
         provider,


### PR DESCRIPTION
Closes #593