### PR TITLE
fix: catch ENOENT when sh is missing in minimal Docker images (closes #460)

### DIFF
--- a/src/mitm/dns/dnsConfig.js
+++ b/src/mitm/dns/dnsConfig.js
@@ -70,6 +70,16 @@ function isSudoAvailable() {
   }
 }
 
+/** True when /bin/sh exists (missing in some minimal Docker images). */
+function isShAvailable() {
+  try {
+    execSync("command -v sh", { stdio: "ignore", windowsHide: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Execute command with sudo password via stdin (macOS/Linux only).
  * Without sudo in PATH (containers), runs via sh — same user, no elevation.
@@ -77,6 +87,10 @@ function isSudoAvailable() {
 function execWithPassword(command, password) {
   return new Promise((resolve, reject) => {
     const useSudo = isSudoAvailable();
+    const hasSh = isShAvailable();
+    if (!hasSh) {
+      return reject(new Error("sh is not available in this environment (minimal Docker image?). Cannot execute shell commands."));
+    }
     const child = useSudo
       ? spawn("sudo", ["-S", "sh", "-c", command], { stdio: ["pipe", "pipe", "pipe"], windowsHide: true })
       : spawn("sh", ["-c", command], { stdio: ["ignore", "pipe", "pipe"], windowsHide: true });


### PR DESCRIPTION
## Summary

Fixes a crash when starting the MITM server in minimal Docker images (e.g., Alpine) where /bin/sh is not available.

## Root Cause

spawn("sh", ...) throws ENOENT when sh doesn't exist. This error propagated as an uncaught exception.

## Fix

Added isShAvailable() check in src/mitm/dns/dnsConfig.js that gracefully rejects with a descriptive message instead of crashing.

Closes #460