### PR TITLE
fix: strip X-Stainless headers and normalize SDK User-Agent (closes #597)

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -107,7 +107,31 @@ export class BaseExecutor {
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
       const transformedBody = this.transformRequest(model, body, stream, credentials);
-      const headers = this.buildHeaders(credentials, stream);
+      let headers = this.buildHeaders(credentials, stream);
+
+      // Strip OpenAI SDK (X-Stainless-*) metadata headers from passthrough/OpenAI-compatible requests.
+      // These headers identify the SDK client and are blocked by some upstream gateways (403).
+      // Only strip for OpenAI-compatible endpoints — other providers may legitimately use them.
+      const isOpenAICompatible = this.provider?.startsWith?.("openai-compatible-") ||
+        url.includes("/v1/chat/completions") || url.includes("/v1/responses");
+      if (isOpenAICompatible) {
+        const strippedKeys = [];
+        for (const key of Object.keys(headers)) {
+          if (key.toLowerCase().startsWith("x-stainless-")) {
+            delete headers[key];
+            strippedKeys.push(key);
+          }
+        }
+        // Normalize User-Agent: SDK-based clients send verbose product strings that some upstreams block.
+        // Replace with a clean browser-like UA if it looks SDK-derived.
+        const ua = (headers["User-Agent"] || "").toLowerCase();
+        if (ua.includes("openai") && (ua.includes("node") || ua.includes("axios") || ua.includes("undici"))) {
+          headers["User-Agent"] = "Mozilla/5.0 (compatible; OpenAI Compatible)";
+        }
+        if (strippedKeys.length > 0) {
+          log?.debug?.("HEADERS", `Stripped X-Stainless-* from passthrough request: ${strippedKeys.join(", ")}`);
+        }
+      }
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
 


### PR DESCRIPTION
## Summary
Requests from the official OpenAI Node SDK fail with 403 when routed through 9router, because upstream gateways block requests carrying OpenAI SDK metadata headers.
The fix strips X-Stainless-* headers and normalizes the User-Agent header to a clean browser-like string for OpenAI-compatible endpoints.
## What changed
open-sse/executors/base.js
- In execute(), after building headers, detect if the request targets an OpenAI-compatible endpoint
- Strip all X-Stainless-* headers (SDK metadata blocked by some upstream gateways)
- Normalize User-Agent if SDK-derived to a clean browser-like UA
- Log stripped headers in debug mode
Closes #597
