### PR TITLE
fix: translate max_tokens to max_completion_tokens for openai-compatible providers (closes #560)

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -273,6 +273,30 @@ export class DefaultExecutor extends BaseExecutor {
     // Kilocode uses device code flow, no refresh token support
     return null;
   }
+
+  // Newer OpenAI models (gpt-5+, o1, o3, o4) require max_completion_tokens instead of max_tokens
+  requiresMaxCompletionTokens(model) {
+    return /gpt-5|o[134]-/i.test(model);
+  }
+
+  // Some models (like gpt-5.4) don't support the temperature parameter
+  supportsTemperature(model) {
+    return !/gpt-5\.4/i.test(model);
+  }
+
+  transformRequest(model, body, stream, credentials) {
+    const transformed = { ...body };
+    // Translate max_tokens → max_completion_tokens for models that require it
+    if (this.requiresMaxCompletionTokens(model) && transformed.max_tokens !== undefined) {
+      transformed.max_completion_tokens = transformed.max_tokens;
+      delete transformed.max_tokens;
+    }
+    // Strip temperature for models that don't support it
+    if (!this.supportsTemperature(model) && transformed.temperature !== undefined) {
+      delete transformed.temperature;
+    }
+    return transformed;
+  }
 }
 
 export default DefaultExecutor;


### PR DESCRIPTION
When using an openai-compatible provider, OpenAI SDK requests with max_tokens were failing with HTTP 400 for newer models like gpt-5.4 and gpt-5-mini.

This fix adds transformRequest() to DefaultExecutor — used by all openai-compatible and unclassified providers — to:
1. Translate max_tokens to max_completion_tokens for newer OpenAI models (gpt-5+, o1, o3, o4)
2. Strip unsupported temperature values for models like gpt-5.4 that dont support it

Root cause: DefaultExecutor (used by openai-compatible-* providers) had no transformRequest() override, so it passed through the raw max_tokens field. The fix was already present in GithubExecutor but not in the default executor path.

Closes #560