### PR TITLE
fix: add API key support for OpenCode Go provider (closes #662)

### DIFF
--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -15,6 +15,10 @@ export async function POST(request) {
 
     let isValid = false;
     let error = null;
+    // Allow opencode without API key (free tier)
+    if (provider === "opencode" && !apiKey) {
+      return NextResponse.json({ valid: true, error: null });
+    }
 
     // Validate with each provider
     try {
@@ -165,6 +169,7 @@ export async function POST(request) {
         case "hyperbolic":
         case "ollama":
         case "ollama-local":
+        case "opencode":
         case "assemblyai":
         case "nanobanana":
         case "chutes":
@@ -184,6 +189,7 @@ export async function POST(request) {
             hyperbolic: "https://api.hyperbolic.xyz/v1/models",
             ollama: "https://ollama.com/api/tags",
             "ollama-local": "http://localhost:11434/api/tags",
+            opencode: "https://opencode.ai/zen/v1/models",
             assemblyai: "https://api.assemblyai.com/v1/account",
             nanobanana: "https://api.nanobananaapi.ai/v1/models",
             chutes: "https://llm.chutes.ai/v1/models",

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -9,7 +9,7 @@ export const FREE_PROVIDERS = {
   // codebuddy: { id: "codebuddy", alias: "cb", name: "CodeBuddy", icon: "smart_toy", color: "#006EFF" },
   // qoder: { id: "qoder", alias: "qd", name: "Qoder AI", icon: "water_drop", color: "#EC4899" },
   iflow: { id: "iflow", alias: "if", name: "iFlow AI", icon: "water_drop", color: "#6366F1" },
-  opencode: { id: "opencode", alias: "oc", name: "OpenCode", icon: "terminal", color: "#E87040", textIcon: "OC", noAuth: true, passthroughModels: true, modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" } },
+  opencode: { id: "opencode", alias: "oc", name: "OpenCode", icon: "terminal", color: "#E87040", textIcon: "OC", passthroughModels: true, modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" } },
 };
 
 // Free Tier Providers (has free access but may require account/API key)


### PR DESCRIPTION
Closes #662