### PR TITLE
fix: strip stream_options for non-streaming Qwen requests to avoid 400 error

### DIFF
--- a/open-sse/executors/qwen.js
+++ b/open-sse/executors/qwen.js
@@ -90,6 +90,10 @@ export class QwenExecutor extends DefaultExecutor {
     if (stream && next?.messages && !next.stream_options) {
       next.stream_options = { include_usage: true };
     }
+    // Strip stream_options for non-streaming Qwen requests — Qwen returns 400 if stream_options is set without stream:true
+    if (!stream && next?.stream_options !== undefined) {
+      delete next.stream_options;
+    }
     next = sanitizeQwenThinkingToolChoice(next);
     return ensureQwenSystemMessage(next);
   }


### PR DESCRIPTION
Closes #557