### PR TITLE
fix: handle undefined navigator.clipboard with fallback

### DIFF
--- a/src/shared/hooks/useCopyToClipboard.js
+++ b/src/shared/hooks/useCopyToClipboard.js
@@ -12,7 +12,21 @@ export function useCopyToClipboard(resetDelay = 2000) {
   const timeoutRef = useRef(null);
 
   const copy = useCallback((text, id = "default") => {
-    navigator.clipboard.writeText(text);
+    const write = async () => {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+    };
+    write();
     setCopied(id);
 
     if (timeoutRef.current) {


### PR DESCRIPTION
- Add optional chaining check for navigator.clipboard
- Fallback to textarea + execCommand for SSR/non-HTTPS contexts
- Fixes TypeError when clipboard API is unavailable