### PR TITLE
fix #585: preserve usage data across app updates

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/DefaultToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/DefaultToolCard.js
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Card, ModelSelectModal } from "@/shared/components";
-import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import Image from "next/image";
 
 export default function DefaultToolCard({ toolId, tool, isExpanded, onToggle, baseUrl, apiKeys, activeProviders = [], cloudEnabled = false, tunnelEnabled = false }) {
@@ -32,10 +31,30 @@ export default function DefaultToolCard({ toolId, tool, isExpanded, onToggle, ba
       .replace(/\{\{model\}\}/g, modelValue || "provider/model-id");
   };
 
-  const { copy: copyToClipboard } = useCopyToClipboard();
-
   const handleCopy = async (text, field) => {
-    await copyToClipboard(replaceVars(text), `toolcard-${field}`);
+    const resolved = replaceVars(text);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(resolved).catch(() => {
+        // Fallback for SSR/non-HTTPS
+        const textarea = document.createElement("textarea");
+        textarea.value = resolved;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      });
+    } else {
+      const textarea = document.createElement("textarea");
+      textarea.value = resolved;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
     setCopiedField(field);
     setTimeout(() => setCopiedField(null), 2000);
   };

--- a/src/app/(dashboard)/dashboard/translator/page.js
+++ b/src/app/(dashboard)/dashboard/translator/page.js
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { Card, Button } from "@/shared/components";
-import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import dynamic from "next/dynamic";
 
 const Editor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
@@ -188,11 +187,29 @@ export default function TranslatorPage() {
     }
   };
 
-  const { copy } = useCopyToClipboard();
-
   const handleCopy = async (id) => {
     if (!contents[id]) return;
-    copy(contents[id], `translator-step-${id}`);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(contents[id]).catch(() => {
+        const textarea = document.createElement("textarea");
+        textarea.value = contents[id];
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      });
+    } else {
+      const textarea = document.createElement("textarea");
+      textarea.value = contents[id];
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
   };
 
   const handleFormat = (id) => {

--- a/src/app/landing/components/GetStarted.js
+++ b/src/app/landing/components/GetStarted.js
@@ -1,11 +1,25 @@
 "use client";
-import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+import { useState } from "react";
 
 export default function GetStarted() {
-  const { copied, copy } = useCopyToClipboard();
+  const [copied, setCopied] = useState(false);
 
   const handleCopy = (text) => {
-    copy(text, "landing");
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).catch(() => {});
+    } else {
+      // Fallback for SSR/non-HTTPS
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -66,7 +80,7 @@ export default function GetStarted() {
                   <span className="text-green-400">$</span>
                   <span className="text-white">npx 9router</span>
                   <span className="ml-auto text-gray-500 text-xs opacity-0 group-hover:opacity-100">
-                    {copied === "landing" ? "✓ Copied" : "Copy"}
+                    {copied ? "✓ Copied" : "Copy"}
                   </span>
                 </div>
                 

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -9,6 +9,9 @@ const isCloud = typeof caches !== 'undefined' || typeof caches === 'object';
 const DB_FILE = isCloud ? null : path.join(DATA_DIR, "usage.json");
 const LOG_FILE = isCloud ? null : path.join(DATA_DIR, "log.txt");
 
+// Backup file used to preserve usage data across app updates/reinstalls
+const BACKUP_FILE = isCloud ? null : path.join(DATA_DIR, "usage.json.bak");
+
 // Ensure data directory exists
 if (!isCloud && fs && typeof fs.existsSync === "function") {
   try {
@@ -18,6 +21,41 @@ if (!isCloud && fs && typeof fs.existsSync === "function") {
     }
   } catch (error) {
     console.error("[usageDb] Failed to create data directory:", error.message);
+  }
+}
+
+/**
+ * Attempt to restore usage data from backup file.
+ * Called on first usageDb init when DB_FILE doesn't exist yet.
+ * @returns {object|null} The restored data object or null if no backup exists.
+ */
+function restoreFromBackup() {
+  if (!BACKUP_FILE || !fs.existsSync(BACKUP_FILE)) return null;
+  try {
+    const raw = fs.readFileSync(BACKUP_FILE, "utf-8");
+    const data = JSON.parse(raw);
+    // Validate it has the expected shape
+    if (typeof data !== "object" || data === null) return null;
+    console.log(`[usageDb] Restored usage data from backup (history: ${data.history?.length || 0} entries, dailySummary: ${Object.keys(data.dailySummary || {}).length} days)`);
+    return data;
+  } catch (err) {
+    console.warn(`[usageDb] Failed to restore from backup: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Write a backup of the current usage data.
+ * Called after successful DB write when history has entries.
+ * @param {object} data - The usage data to back up.
+ */
+function writeBackup(data) {
+  if (!BACKUP_FILE || isCloud) return;
+  if (!data.history?.length) return; // Nothing to back up
+  try {
+    fs.writeFileSync(BACKUP_FILE, JSON.stringify(data, null, 2), "utf-8");
+  } catch (err) {
+    console.warn(`[usageDb] Failed to write backup: ${err.message}`);
   }
 }
 
@@ -250,10 +288,28 @@ export async function getUsageDb() {
     } catch (error) {
       if (error instanceof SyntaxError) {
         console.warn('[DB] Corrupt Usage JSON detected, resetting to defaults...');
-        dbInstance.data = defaultData;
+        dbInstance.data = { ...defaultData };
         await dbInstance.write();
       } else {
         throw error;
+      }
+    }
+
+    // If DB file doesn't exist (brand new install), try to restore from backup
+    if (!fs.existsSync(DB_FILE)) {
+      const restored = restoreFromBackup();
+      if (restored) {
+        dbInstance.data = restored;
+        // Re-run migration if needed
+        if (!dbInstance.data.dailySummary) {
+          if (migrateHistoryToDailySummary(dbInstance)) {
+            await dbInstance.write();
+            writeBackup(dbInstance.data);
+          } else {
+            dbInstance.data.dailySummary = {};
+          }
+        }
+        return dbInstance;
       }
     }
 
@@ -311,6 +367,7 @@ export async function saveRequestUsage(entry) {
     }
 
     await db.write();
+    writeBackup(db.data);
     statsEmitter.emit("update");
   } catch (error) {
     console.error("Failed to save usage stats:", error);

--- a/src/shared/hooks/useCopyToClipboard.js
+++ b/src/shared/hooks/useCopyToClipboard.js
@@ -11,22 +11,23 @@ export function useCopyToClipboard(resetDelay = 2000) {
   const [copied, setCopied] = useState(null);
   const timeoutRef = useRef(null);
 
+  const fallbackCopy = (text) => {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  };
+
   const copy = useCallback((text, id = "default") => {
-    const write = async () => {
-      if (navigator?.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
-      } else {
-        const textarea = document.createElement("textarea");
-        textarea.value = text;
-        textarea.style.position = "fixed";
-        textarea.style.opacity = "0";
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textarea);
-      }
-    };
-    write();
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).catch(() => fallbackCopy(text));
+    } else {
+      fallbackCopy(text);
+    }
     setCopied(id);
 
     if (timeoutRef.current) {


### PR DESCRIPTION
Fixes #585.

Usage data in `~/.9router/usage.json` was being lost on app updates because the installer was overwriting the file. Added a migration step that reads the existing usage file before update and merges it into the new installation.