### PR TITLE
feat: add Azure OpenAI as a dedicated provider

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -338,4 +338,11 @@ export const PROVIDERS = {
     headers: { "x-opencode-client": "desktop" },
     noAuth: true
   },
+  // Azure OpenAI - requires azureEndpoint, apiVersion, deployment in providerSpecificData
+  // Uses api-key header for authentication instead of Bearer token
+  azure: {
+    baseUrl: "", // Constructed dynamically by AzureExecutor based on credentials
+    format: "openai",
+    headers: {}
+  },
 };

--- a/open-sse/executors/azure.js
+++ b/open-sse/executors/azure.js
@@ -1,0 +1,57 @@
+import { DefaultExecutor } from "./default.js";
+
+export class AzureExecutor extends DefaultExecutor {
+  constructor() {
+    super("azure");
+  }
+
+  buildUrl(model, stream, urlIndex = 0, credentials = null) {
+    const azureEndpoint = credentials?.providerSpecificData?.azureEndpoint
+      || process.env.AZURE_ENDPOINT
+      || "https://api.openai.com";
+
+    const apiVersion = credentials?.providerSpecificData?.apiVersion
+      || process.env.AZURE_API_VERSION
+      || "2024-10-01-preview";
+
+    const deployment = credentials?.providerSpecificData?.deployment
+      || model
+      || process.env.AZURE_DEPLOYMENT
+      || "gpt-4";
+
+    const endpoint = azureEndpoint.replace(/\/$/, "");
+    return `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`;
+  }
+
+  buildHeaders(credentials, stream = true) {
+    const headers = {
+      "Content-Type": "application/json",
+      ...this.config.headers
+    };
+
+    const apiKey = credentials?.apiKey
+      || credentials?.accessToken
+      || process.env.OPENAI_API_KEY;
+
+    if (apiKey) {
+      headers["api-key"] = apiKey;
+    }
+
+    const organization = credentials?.providerSpecificData?.organization
+      || process.env.AZURE_ORGANIZATION;
+
+    if (organization) {
+      headers["OpenAI-Organization"] = organization;
+    }
+
+    if (stream) {
+      headers["Accept"] = "text/event-stream";
+    }
+
+    return headers;
+  }
+
+  transformRequest(model, body, stream, credentials) {
+    return body;
+  }
+}

--- a/open-sse/executors/index.js
+++ b/open-sse/executors/index.js
@@ -1,4 +1,5 @@
 import { AntigravityExecutor } from "./antigravity.js";
+import { AzureExecutor } from "./azure.js";
 import { GeminiCLIExecutor } from "./gemini-cli.js";
 import { GithubExecutor } from "./github.js";
 import { IFlowExecutor } from "./iflow.js";
@@ -13,6 +14,7 @@ import { DefaultExecutor } from "./default.js";
 
 const executors = {
   antigravity: new AntigravityExecutor(),
+  azure: new AzureExecutor(),
   "gemini-cli": new GeminiCLIExecutor(),
   github: new GithubExecutor(),
   iflow: new IFlowExecutor(),
@@ -41,6 +43,7 @@ export function hasSpecializedExecutor(provider) {
 
 export { BaseExecutor } from "./base.js";
 export { AntigravityExecutor } from "./antigravity.js";
+export { AzureExecutor } from "./azure.js";
 export { GeminiCLIExecutor } from "./gemini-cli.js";
 export { GithubExecutor } from "./github.js";
 export { IFlowExecutor } from "./iflow.js";

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -7,11 +7,19 @@ import { Button, Badge, Input, Modal, Select } from "@/shared/components";
 export default function AddApiKeyModal({ isOpen, provider, providerName, isCompatible, isAnthropic, proxyPools, onSave, onClose }) {
   const NONE_PROXY_POOL_VALUE = "__none__";
 
+  const isAzure = provider === "azure";
+
   const [formData, setFormData] = useState({
     name: "",
     apiKey: "",
     priority: 1,
     proxyPoolId: NONE_PROXY_POOL_VALUE,
+  });
+  const [azureData, setAzureData] = useState({
+    azureEndpoint: "",
+    apiVersion: "2024-10-01-preview",
+    deployment: "",
+    organization: "",
   });
   const [validating, setValidating] = useState(false);
   const [validationResult, setValidationResult] = useState(null);
@@ -63,7 +71,12 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         priority: formData.priority,
         proxyPoolId: formData.proxyPoolId === NONE_PROXY_POOL_VALUE ? null : formData.proxyPoolId,
         testStatus: isValid ? "active" : "unknown",
-        providerSpecificData: undefined
+        providerSpecificData: isAzure ? {
+          azureEndpoint: azureData.azureEndpoint,
+          apiVersion: azureData.apiVersion,
+          deployment: azureData.deployment,
+          organization: azureData.organization,
+        } : undefined
       });
     } finally {
       setSaving(false);
@@ -108,6 +121,38 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
             }
           </p>
         )}
+        {isAzure && (
+          <div className="bg-sidebar/50 p-4 rounded-lg border border-accent/20">
+            <h3 className="font-semibold mb-3 text-sm">Azure OpenAI Configuration</h3>
+            <div className="flex flex-col gap-3">
+              <Input
+                label="Azure Endpoint"
+                value={azureData.azureEndpoint}
+                onChange={(e) => setAzureData({ ...azureData, azureEndpoint: e.target.value })}
+                placeholder="https://your-resource.openai.azure.com"
+              />
+              <Input
+                label="Deployment Name"
+                value={azureData.deployment}
+                onChange={(e) => setAzureData({ ...azureData, deployment: e.target.value })}
+                placeholder="gpt-4"
+              />
+              <Input
+                label="API Version"
+                value={azureData.apiVersion}
+                onChange={(e) => setAzureData({ ...azureData, apiVersion: e.target.value })}
+                placeholder="2024-10-01-preview"
+              />
+              <Input
+                label="Organization (Optional)"
+                value={azureData.organization}
+                onChange={(e) => setAzureData({ ...azureData, organization: e.target.value })}
+                placeholder="Organization ID"
+              />
+            </div>
+          </div>
+        )}
+
         <Input
           label="Priority"
           type="number"
@@ -137,7 +182,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         </p>
 
         <div className="flex gap-2">
-          <Button onClick={handleSubmit} fullWidth disabled={!formData.name || !formData.apiKey || saving}>
+          <Button onClick={handleSubmit} fullWidth disabled={!formData.name || !formData.apiKey || (isAzure && (!azureData.azureEndpoint || !azureData.deployment)) || saving}>
             {saving ? "Saving..." : "Save"}
           </Button>
           <Button onClick={onClose} variant="ghost" fullWidth>

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -25,13 +25,19 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   const [validationResult, setValidationResult] = useState(null);
   const [saving, setSaving] = useState(false);
 
+  const validatePayload = () => {
+    const payload = { provider, apiKey: formData.apiKey };
+    if (isAzure) payload.providerSpecificData = azureData;
+    return payload;
+  };
+
   const handleValidate = async () => {
     setValidating(true);
     try {
       const res = await fetch("/api/providers/validate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider, apiKey: formData.apiKey }),
+        body: JSON.stringify(validatePayload()),
       });
       const data = await res.json();
       setValidationResult(data.valid ? "success" : "failed");
@@ -54,7 +60,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         const res = await fetch("/api/providers/validate", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ provider, apiKey: formData.apiKey }),
+          body: JSON.stringify(validatePayload()),
         });
         const data = await res.json();
         isValid = !!data.valid;
@@ -144,7 +150,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
                 placeholder="2024-10-01-preview"
               />
               <Input
-                label="Organization (Optional)"
+                label="Organization"
                 value={azureData.organization}
                 onChange={(e) => setAzureData({ ...azureData, organization: e.target.value })}
                 placeholder="Organization ID"
@@ -182,7 +188,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         </p>
 
         <div className="flex gap-2">
-          <Button onClick={handleSubmit} fullWidth disabled={!formData.name || !formData.apiKey || (isAzure && (!azureData.azureEndpoint || !azureData.deployment)) || saving}>
+          <Button onClick={handleSubmit} fullWidth disabled={!formData.name || !formData.apiKey || (isAzure && (!azureData.azureEndpoint || !azureData.deployment || !azureData.organization)) || saving}>
             {saving ? "Saving..." : "Save"}
           </Button>
           <Button onClick={onClose} variant="ghost" fullWidth>

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -365,6 +365,21 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
 
   try {
     switch (connection.provider) {
+      case "azure": {
+        const psd = connection.providerSpecificData || {};
+        const endpoint = (psd.azureEndpoint || "").replace(/\/$/, "");
+        const deployment = psd.deployment || "gpt-4";
+        const apiVersion = psd.apiVersion || "2024-10-01-preview";
+        const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`;
+        const headers = { "api-key": connection.apiKey, "Content-Type": "application/json" };
+        if (psd.organization) headers["OpenAI-Organization"] = psd.organization;
+        const res = await fetchWithConnectionProxy(url, {
+          method: "POST", headers,
+          body: JSON.stringify({ messages: [{ role: "user", content: "test" }], max_completion_tokens: 1 }),
+        }, effectiveProxy);
+        const valid = res.status !== 401 && res.status !== 403;
+        return { valid, error: valid ? null : "Invalid API key or Azure configuration" };
+      }
       case "openai": {
         const res = await fetchWithConnectionProxy("https://api.openai.com/v1/models", { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy);
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -114,7 +114,7 @@ export async function POST(request) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
-    let providerSpecificData = null;
+    let providerSpecificData = body.providerSpecificData || null;
 
     if (isOpenAICompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -62,6 +62,35 @@ export async function POST(request) {
         });
       }
 
+      if (provider === "azure") {
+        const { providerSpecificData } = body;
+        const endpoint = (providerSpecificData?.azureEndpoint || "").replace(/\/$/, "");
+        const deployment = providerSpecificData?.deployment || "gpt-4";
+        const apiVersion = providerSpecificData?.apiVersion || "2024-10-01-preview";
+        const organization = providerSpecificData?.organization;
+
+        const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`;
+        const headers = {
+          "api-key": apiKey,
+          "Content-Type": "application/json",
+        };
+        if (organization) headers["OpenAI-Organization"] = organization;
+
+        const azureRes = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            messages: [{ role: "user", content: "test" }],
+            max_tokens: 1,
+          }),
+        });
+        isValid = azureRes.status !== 401 && azureRes.status !== 403;
+        return NextResponse.json({
+          valid: isValid,
+          error: isValid ? null : "Invalid API key or Azure configuration",
+        });
+      }
+
       switch (provider) {
         case "openai":
           const openaiRes = await fetch("https://api.openai.com/v1/models", {

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -14,6 +14,12 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
     priority: 1,
     apiKey: "",
   });
+  const [azureData, setAzureData] = useState({
+    azureEndpoint: "",
+    apiVersion: "2024-10-01-preview",
+    deployment: "",
+    organization: "",
+  });
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [validating, setValidating] = useState(false);
@@ -27,12 +33,22 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
         priority: connection.priority || 1,
         apiKey: "",
       });
+      // Load Azure-specific data if present
+      if (connection.provider === "azure" && connection.providerSpecificData) {
+        setAzureData({
+          azureEndpoint: connection.providerSpecificData.azureEndpoint || "",
+          apiVersion: connection.providerSpecificData.apiVersion || "2024-10-01-preview",
+          deployment: connection.providerSpecificData.deployment || "",
+          organization: connection.providerSpecificData.organization || "",
+        });
+      }
       setTestResult(null);
       setValidationResult(null);
     }
   }, [connection]);
 
   const isOAuth = connection?.authType === "oauth";
+  const isAzure = connection?.provider === "azure";
   const isCompatible = connection
     ? (isOpenAICompatibleProvider(connection.provider) || isAnthropicCompatibleProvider(connection.provider))
     : false;
@@ -106,6 +122,17 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
           updates.lastErrorAt = null;
         }
       }
+      
+      // Add Azure-specific data if this is an Azure connection
+      if (isAzure) {
+        updates.providerSpecificData = {
+          azureEndpoint: azureData.azureEndpoint,
+          apiVersion: azureData.apiVersion,
+          deployment: azureData.deployment,
+          organization: azureData.organization,
+        };
+      }
+      
       await onSave(updates);
     } finally {
       setSaving(false);
@@ -162,7 +189,43 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
           </>
         )}
 
-        {!isCompatible && (
+        {isAzure && (
+          <div className="bg-sidebar/50 p-4 rounded-lg border border-accent/20">
+            <h3 className="font-semibold mb-3 text-sm">Azure OpenAI Configuration</h3>
+            <div className="flex flex-col gap-3">
+              <Input
+                label="Azure Endpoint"
+                value={azureData.azureEndpoint}
+                onChange={(e) => setAzureData({ ...azureData, azureEndpoint: e.target.value })}
+                placeholder="https://your-resource.openai.azure.com"
+                hint="Your Azure OpenAI resource endpoint URL"
+              />
+              <Input
+                label="Deployment Name"
+                value={azureData.deployment}
+                onChange={(e) => setAzureData({ ...azureData, deployment: e.target.value })}
+                placeholder="gpt-4"
+                hint="The deployment name in your Azure resource"
+              />
+              <Input
+                label="API Version"
+                value={azureData.apiVersion}
+                onChange={(e) => setAzureData({ ...azureData, apiVersion: e.target.value })}
+                placeholder="2024-10-01-preview"
+                hint="Azure OpenAI API version to use"
+              />
+              <Input
+                label="Organization (Optional)"
+                value={azureData.organization}
+                onChange={(e) => setAzureData({ ...azureData, organization: e.target.value })}
+                placeholder="Organization ID"
+                hint="Optional: Your Azure organization ID"
+              />
+            </div>
+          </div>
+        )}
+
+        {!isCompatible && !isAzure && (
           <div className="flex items-center gap-3">
             <Button onClick={handleTest} variant="secondary" disabled={testing}>
               {testing ? "Testing..." : "Test Connection"}
@@ -202,3 +265,4 @@ EditConnectionModal.propTypes = {
   onSave: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
+

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -76,7 +76,11 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       const res = await fetch("/api/providers/validate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: connection.provider, apiKey: formData.apiKey }),
+        body: JSON.stringify({
+          provider: connection.provider,
+          apiKey: formData.apiKey,
+          ...(isAzure ? { providerSpecificData: azureData } : {}),
+        }),
       });
       const data = await res.json();
       setValidationResult(data.valid ? "success" : "failed");
@@ -105,7 +109,11 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
             const res = await fetch("/api/providers/validate", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ provider: connection.provider, apiKey: formData.apiKey }),
+              body: JSON.stringify({
+                provider: connection.provider,
+                apiKey: formData.apiKey,
+                ...(isAzure ? { providerSpecificData: azureData } : {}),
+              }),
             });
             const data = await res.json();
             isValid = !!data.valid;

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -215,11 +215,11 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
                 hint="Azure OpenAI API version to use"
               />
               <Input
-                label="Organization (Optional)"
+                label="Organization"
                 value={azureData.organization}
                 onChange={(e) => setAzureData({ ...azureData, organization: e.target.value })}
                 placeholder="Organization ID"
-                hint="Optional: Your Azure organization ID"
+                hint="Required for billing"
               />
             </div>
           </div>

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -61,7 +61,7 @@ export const APIKEY_PROVIDERS = {
   "alicode-intl": { id: "alicode-intl", alias: "alicode-intl", name: "Alibaba Intl", icon: "cloud", color: "#FF6A00", textIcon: "ALi" },
   openai: { id: "openai", alias: "openai", name: "OpenAI", icon: "auto_awesome", color: "#10A37F", textIcon: "OA", website: "https://platform.openai.com", serviceKinds: ["llm", "embedding", "tts", "image", "imageToText", "webSearch"], thinkingConfig: THINKING_CONFIG.effort },
   anthropic: { id: "anthropic", alias: "anthropic", name: "Anthropic", icon: "smart_toy", color: "#D97757", textIcon: "AN", website: "https://console.anthropic.com", serviceKinds: ["llm", "imageToText"] },
-
+  azure: { id: "azure", alias: "azure", name: "Azure OpenAI", icon: "cloud", color: "#0078D4", textIcon: "AZ", website: "https://azure.microsoft.com/en-us/products/ai-services/openai-service", hasProviderSpecificData: true },
 
   deepseek: { id: "deepseek", alias: "ds", name: "DeepSeek", icon: "bolt", color: "#4D6BFE", textIcon: "DS", website: "https://deepseek.com" },
   groq: { id: "groq", alias: "groq", name: "Groq", icon: "speed", color: "#F55036", textIcon: "GQ", website: "https://groq.com", serviceKinds: ["llm", "imageToText"] },


### PR DESCRIPTION
## Summary
- Add `AzureExecutor` that builds Azure-style deployment URLs (`{endpoint}/openai/deployments/{deployment}/chat/completions?api-version={version}`) and uses `api-key` header auth
- Add Azure provider config in `open-sse/config/providers.js` with OpenAI-compatible format
- Add dashboard UI fields (endpoint, deployment, API version, organization) in `EditConnectionModal`
- Register Azure in `APIKEY_PROVIDERS` with `hasProviderSpecificData: true`

## How it works
Azure OpenAI differs from standard OpenAI in two ways:
1. **URL**: deployment-based path with `api-version` query param instead of `/v1/chat/completions`
2. **Auth**: `api-key` header instead of `Authorization: Bearer`

The executor reads config from `providerSpecificData` (set via dashboard) with env var fallbacks (`AZURE_ENDPOINT`, `AZURE_API_VERSION`, `AZURE_DEPLOYMENT`).

Tested against UMich UMGPT Azure OpenAI endpoint (gpt-5.2 deployment).

## Test plan
- [ ] Add Azure provider in dashboard with endpoint, API key, deployment name
- [ ] Verify chat completions route through Azure executor
- [ ] Verify streaming responses work
- [ ] Verify non-Azure providers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)