### PR TITLE
fix: keep play_arrow spinning instead of switching to sync/progress_activity

### DIFF
--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/page.js
@@ -263,7 +263,7 @@ function EmbeddingExampleCard({ providerId }) {
                 className="flex items-center gap-1.5 px-3 py-1 rounded-lg bg-primary text-white text-xs font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span className="material-symbols-outlined text-[14px]" style={running ? { animation: "spin 1s linear infinite" } : undefined}>
-                  {running ? "progress_activity" : "play_arrow"}
+                  play_arrow
                 </span>
                 {running ? "Running..." : "Run"}
               </button>
@@ -699,7 +699,7 @@ function TtsExampleCard({ providerId }) {
                   className="flex items-center gap-1.5 px-3 py-1 rounded-lg bg-primary text-white text-xs font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <span className="material-symbols-outlined text-[14px]" style={running ? { animation: "spin 1s linear infinite" } : undefined}>
-                    {running ? "progress_activity" : "play_arrow"}
+                    play_arrow
                   </span>
                   {running ? "Generating..." : "Run"}
                 </button>
@@ -959,7 +959,7 @@ function GenericExampleCard({ providerId, kind }) {
                 className="flex items-center gap-1.5 px-3 py-1 rounded-lg bg-primary text-white text-xs font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span className="material-symbols-outlined text-[14px]" style={running ? { animation: "spin 1s linear infinite" } : undefined}>
-                  {running ? "progress_activity" : "play_arrow"}
+                  play_arrow
                 </span>
                 {running ? "Running..." : "Run"}
               </button>

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -267,7 +267,7 @@ export default function ProvidersPage() {
               <span
                 className={`material-symbols-outlined text-[14px]${testingMode === "oauth" ? " animate-spin" : ""}`}
               >
-                {testingMode === "oauth" ? "sync" : "play_arrow"}
+                play_arrow
               </span>
               {testingMode === "oauth" ? "Testing..." : "Test All"}
             </button>
@@ -307,7 +307,7 @@ export default function ProvidersPage() {
             <span
               className={`material-symbols-outlined text-[14px]${testingMode === "free" ? " animate-spin" : ""}`}
             >
-              {testingMode === "free" ? "sync" : "play_arrow"}
+              play_arrow
             </span>
             {testingMode === "free" ? "Testing..." : "Test All"}
           </button>
@@ -356,7 +356,7 @@ export default function ProvidersPage() {
             <span
               className={`material-symbols-outlined text-[14px]${testingMode === "apikey" ? " animate-spin" : ""}`}
             >
-              {testingMode === "apikey" ? "sync" : "play_arrow"}
+              play_arrow
             </span>
             {testingMode === "apikey" ? "Testing..." : "Test All"}
           </button>
@@ -395,7 +395,7 @@ export default function ProvidersPage() {
                 title="Test all Compatible connections"
               >
                 <span className={`material-symbols-outlined text-[14px]${testingMode === "compatible" ? " animate-spin" : ""}`}>
-                  {testingMode === "compatible" ? "sync" : "play_arrow"}
+                  play_arrow
                 </span>
                 {testingMode === "compatible" ? "Testing..." : "Test All"}
               </button>


### PR DESCRIPTION
## Summary

- `sync` icon has counter-clockwise arrows by design, causing the spin animation to appear counter-clockwise even though CSS rotates clockwise (`rotate(360deg)`)
- `progress_activity` icon switching was inconsistent across pages
- Both `providers/page.js` and `media-providers/[kind]/[id]/page.js` now keep `play_arrow` as the icon in all states — only `animate-spin` is toggled when loading

## Affected files

- `src/app/(dashboard)/dashboard/providers/page.js` — 3 active buttons (OAuth, Free, API Key)
- `src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/page.js` — 3 run buttons (Embeddings, Image-to-Text, STT)

## Test plan

- [ ] Click "Test All" on any provider group — arrow should spin **clockwise**
- [ ] Click "Run" on any media provider example — arrow should spin **clockwise**
- [ ] Verify button label still switches between idle and loading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)