### PR TITLE
fix: align codex oauth models and request contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ Quality: Production-ready models
 ```
 Combo: "always-on"
   1. cc/claude-opus-4-6        (best quality)
-  2. cx/gpt-5.2-codex          (second subscription)
+  2. cx/gpt-5.2                (second subscription)
   3. glm/glm-4.7               (cheap, resets daily)
   4. minimax/MiniMax-M2.1      (cheapest, 5h reset)
   5. if/kimi-k2-thinking       (free unlimited)
@@ -704,8 +704,10 @@ Dashboard → Providers → Connect Codex
 → 5-hour + weekly reset
 
 Models:
-  cx/gpt-5.2-codex
-  cx/gpt-5.1-codex-max
+  cx/gpt-5.4
+  cx/gpt-5.4-mini
+  cx/gpt-5.3-codex
+  cx/gpt-5.2
 ```
 
 ### Gemini CLI (FREE 180K/month!)
@@ -1062,8 +1064,10 @@ Notes:
 - `cc/claude-haiku-4-5-20251001`
 
 **Codex (`cx/`)** - Plus/Pro:
-- `cx/gpt-5.2-codex`
-- `cx/gpt-5.1-codex-max`
+- `cx/gpt-5.4`
+- `cx/gpt-5.4-mini`
+- `cx/gpt-5.3-codex`
+- `cx/gpt-5.2`
 
 **Gemini CLI (`gc/`)** - FREE:
 - `gc/gemini-3-flash-preview`

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -17,24 +17,9 @@ export const PROVIDER_MODELS = {
   ],
   cx: [  // OpenAI Codex
     { id: "gpt-5.4", name: "GPT 5.4" },
-    // GPT 5.3 Codex - all thinking levels
+    { id: "gpt-5.4-mini", name: "GPT 5.4 Mini" },
     { id: "gpt-5.3-codex", name: "GPT 5.3 Codex" },
-    { id: "gpt-5.3-codex-xhigh", name: "GPT 5.3 Codex (xHigh)" },
-    { id: "gpt-5.3-codex-high", name: "GPT 5.3 Codex (High)" },
-    { id: "gpt-5.3-codex-low", name: "GPT 5.3 Codex (Low)" },
-    { id: "gpt-5.3-codex-none", name: "GPT 5.3 Codex (None)" },
-    { id: "gpt-5.3-codex-spark", name: "GPT 5.3 Codex Spark" },
-    // Mini - medium and high only
-    { id: "gpt-5.1-codex-mini", name: "GPT 5.1 Codex Mini" },
-    { id: "gpt-5.1-codex-mini-high", name: "GPT 5.1 Codex Mini (High)" },
-    // Other models
-    { id: "gpt-5.2-codex", name: "GPT 5.2 Codex" },
     { id: "gpt-5.2", name: "GPT 5.2" },
-    { id: "gpt-5.1-codex-max", name: "GPT 5.1 Codex Max" },
-    { id: "gpt-5.1-codex", name: "GPT 5.1 Codex" },
-    { id: "gpt-5.1", name: "GPT 5.1" },
-    { id: "gpt-5-codex", name: "GPT 5 Codex" },
-    { id: "gpt-5-codex-mini", name: "GPT 5 Codex Mini" },
   ],
   gc: [  // Gemini CLI
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -187,6 +187,7 @@ export class CodexExecutor extends BaseExecutor {
     delete body.n;
     delete body.seed;
     delete body.max_tokens;
+    delete body.max_output_tokens;
     delete body.user; // Cursor sends this but Codex doesn't support it
     delete body.prompt_cache_retention; // Cursor sends this but Codex doesn't support it
     delete body.metadata; // Cursor sends this but Codex doesn't support it

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -24,10 +24,16 @@ const OAUTH_TEST_CONFIG = {
     authHeader: "Authorization",
     authPrefix: "Bearer ",
     extraHeaders: { "Content-Type": "application/json", "originator": "codex-cli", "User-Agent": "codex-cli/1.0.18 (macOS; arm64)" },
-    // Minimal invalid body — triggers fast 400 without consuming quota
-    body: JSON.stringify({ model: "gpt-5.3-codex", input: [], stream: false, store: false }),
-    // 400 (bad request) means auth succeeded; only 401/403 means token is bad
-    acceptStatuses: [400],
+    // Use a valid payload shape so schema errors do not mark the provider unavailable.
+    body: JSON.stringify({
+      model: "gpt-5.2",
+      instructions: "You are a coding assistant.",
+      input: [{ role: "user", content: [{ type: "input_text", text: "Reply with exactly: ok" }] }],
+      stream: true,
+      store: false,
+    }),
+    // 200 means the probe model is usable; 400 can still mean auth succeeded but the account is gated.
+    acceptStatuses: [200, 400],
     refreshable: true,
   },
   "gemini-cli": {


### PR DESCRIPTION
# 9Router Codex OAuth Fix Draft

Closes #718

## Proposed PR Title

Fix Codex OAuth request contract and narrow exposed ChatGPT-account models

## Summary

- use a valid Codex `/responses` probe payload during provider self-test
- remove unsupported `max_output_tokens` before dispatching Codex requests
- narrow the exposed `cx/*` model list to models verified to work with ChatGPT Plus OAuth on 2026-04-21

## Repro

1. Connect an OpenAI Codex OAuth account in 9Router with ChatGPT Plus.
2. Call `/api/providers/:id/test` or route a `cx/*` model through `/v1/responses`.
3. Observe false `unavailable` state or repeated 400 errors for models the account can actually use.

## Root Cause

- the Codex provider self-test used an invalid payload shape:
  - empty `input`
  - `stream: false`
  - no `instructions`
- the executor still forwarded `max_output_tokens`, which the current Codex backend rejects
- the UI exposed several `cx/*` models that ChatGPT-account OAuth currently rejects upstream

## Verified Working Models

- `cx/gpt-5.4`
- `cx/gpt-5.4-mini`
- `cx/gpt-5.3-codex`
- `cx/gpt-5.2`

## Verified Rejected Models

- `cx/gpt-5.3-codex-xhigh`
- `cx/gpt-5.3-codex-high`
- `cx/gpt-5.3-codex-low`
- `cx/gpt-5.3-codex-none`
- `cx/gpt-5.3-codex-spark`
- `cx/gpt-5.2-codex`
- `cx/gpt-5.1-codex-max`
- `cx/gpt-5.1-codex`
- `cx/gpt-5.1-codex-mini`
- `cx/gpt-5.1-codex-mini-high`
- `cx/gpt-5.1`
- `cx/gpt-5-codex`
- `cx/gpt-5-codex-mini`

## Files Changed In Upstream Draft

- `.tmp/9router-upstream/open-sse/executors/codex.js`
- `.tmp/9router-upstream/open-sse/config/providerModels.js`
- `.tmp/9router-upstream/src/app/api/providers/[id]/test/testUtils.js`
- `.tmp/9router-upstream/README.md`

## Suggested PR Body

This patch fixes a Codex OAuth mismatch against the current ChatGPT-backed Codex `/responses` backend.

Changes:

- send a valid payload during Codex provider self-test so accounts are not marked unavailable because of schema errors
- strip `max_output_tokens` before forwarding Codex requests
- narrow the exposed `cx/*` list to models that were verified working with ChatGPT Plus OAuth on 2026-04-21

Why:

- the previous self-test payload could fail even when the token was valid
- current backend contract requires `instructions`, list-form `input`, `stream: true`, and `store: false`
- several exposed Codex models are currently rejected upstream for ChatGPT-account OAuth and should not be offered as ready-to-use defaults
