### PR TITLE
fix: show custom models in combo picker for providers with short aliases

### DIFF
--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -3,8 +3,8 @@
 import { useState, useMemo, useEffect } from "react";
 import PropTypes from "prop-types";
 import Modal from "./Modal";
-import { getModelsByProviderId, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
-import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
+import { getModelsByProviderId } from "@/shared/constants/models";
+import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, getProviderAlias } from "@/shared/constants/providers";
 
 // Provider order: OAuth first, then Free Tier, then API Key (matches dashboard/providers)
 const PROVIDER_ORDER = [
@@ -85,7 +85,10 @@ export default function ModelSelectModal({
     });
 
     sortedProviderIds.forEach((providerId) => {
-      const alias = PROVIDER_ID_TO_ALIAS[providerId] || providerId;
+      // Must match the prefix the provider detail page uses when writing modelAliases
+      // (getProviderAlias), otherwise custom models for providers with short aliases
+      // like deepseek ("ds"), perplexity ("pplx"), etc. would be filtered out.
+      const alias = getProviderAlias(providerId);
       const providerInfo = allProviders[providerId] || { name: providerId, color: "#666" };
       const isCustomProvider = isOpenAICompatibleProvider(providerId) || isAnthropicCompatibleProvider(providerId);
 


### PR DESCRIPTION
## Summary

When users add a custom model to an API-key provider with a short alias (e.g. DeepSeek → `ds`) from the dashboard, the model saves and tests successfully but never appears in the combo model picker.

## Root cause

Two independent provider-alias mappings diverge for a subset of API-key providers:

- **Write path** — `src/app/(dashboard)/dashboard/providers/[id]/page.js` uses `getProviderAlias(providerId)` (from `src/shared/constants/providers.js`, reading `AI_PROVIDERS[id].alias`). For DeepSeek this returns `"ds"`, so the alias is stored as `modelAliases["foo"] = "ds/foo"`.
- **Read path** — `src/shared/components/ModelSelectModal.js` filters custom models with `PROVIDER_ID_TO_ALIAS[providerId]` (from `open-sse/config/providerModels.js`, only covers OAuth short aliases). For DeepSeek this returns `"deepseek"`, so `"ds/foo".startsWith("deepseek/")` is false and the model is filtered out.

Routing itself is unaffected — `open-sse/services/model.js` `ALIAS_TO_PROVIDER_ID` explicitly accepts both `ds` and `deepseek` → `deepseek`, which is why `Test` succeeds and real requests route correctly. The bug is display-only in the combo picker.

## Affected providers

Any provider where `AI_PROVIDERS[id].alias !== id` and the id is not in `OAUTH_ALIASES`:

`deepseek` (ds), `perplexity` (pplx), `hyperbolic` (hyp), `blackbox` (bb), `chutes` (ch), `huggingface` (hf), `deepgram` (dg), `assemblyai` (aai), `nanobanana` (nb), `elevenlabs` (el), `brave-search` (brave), `vertex-partner` (vxp), `opencode-go` (ocg), `volcengine-ark` (ark).

## Fix

Align the combo picker with the write path by using `getProviderAlias(providerId)`. Since routing accepts both prefixes, no data migration is needed — existing orphaned `ds/…` entries become visible immediately.

Providers where `getProviderAlias(id) === PROVIDER_ID_TO_ALIAS[id]` (most of them) are unaffected.

## Test plan

- [ ] Dashboard → API Key Providers → DeepSeek → Add Custom Model (e.g. `deepseek-chat-custom`) → Save
- [ ] Combo form → Select Model → DeepSeek group now lists the custom model with a `custom` badge
- [ ] Existing combos referencing built-in DeepSeek models still render and route correctly
- [ ] Non-short-alias providers (OpenAI, Anthropic, Claude, etc.) behave unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)