### PR TITLE
fix: prevent SSE listener leak in console-logs stream

### DIFF
--- a/src/app/api/translator/console-logs/stream/route.js
+++ b/src/app/api/translator/console-logs/stream/route.js
@@ -4,10 +4,23 @@ export const dynamic = "force-dynamic";
 
 initConsoleLogCapture();
 
-export async function GET() {
+export async function GET(request) {
   const encoder = new TextEncoder();
   const emitter = getConsoleEmitter();
-  const state = { closed: false, send: null, keepalive: null };
+  const state = { closed: false, send: null, sendClear: null, keepalive: null };
+
+  // Idempotent: safe to call from request.signal abort, cancel(), or enqueue failure.
+  const cleanup = () => {
+    if (state.closed) return;
+    state.closed = true;
+    if (state.send) emitter.off("line", state.send);
+    if (state.sendClear) emitter.off("clear", state.sendClear);
+    if (state.keepalive) clearInterval(state.keepalive);
+  };
+
+  // request.signal fires reliably on client disconnect; ReadableStream.cancel()
+  // is not always invoked in Next.js, which caused listeners to accumulate.
+  request.signal.addEventListener("abort", cleanup, { once: true });
 
   const stream = new ReadableStream({
     start(controller) {
@@ -23,7 +36,7 @@ export async function GET() {
         try {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "line", line })}\n\n`));
         } catch {
-          state.closed = true;
+          cleanup();
         }
       };
 
@@ -33,7 +46,7 @@ export async function GET() {
         try {
           controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "clear" })}\n\n`));
         } catch {
-          state.closed = true;
+          cleanup();
         }
       };
 
@@ -46,17 +59,13 @@ export async function GET() {
         try {
           controller.enqueue(encoder.encode(": ping\n\n"));
         } catch {
-          state.closed = true;
-          clearInterval(state.keepalive);
+          cleanup();
         }
       }, 25000);
     },
 
     cancel() {
-      state.closed = true;
-      emitter.off("line", state.send);
-      emitter.off("clear", state.sendClear);
-      clearInterval(state.keepalive);
+      cleanup();
     },
   });
 


### PR DESCRIPTION
## Summary

`MaxListenersExceededWarning: Possible EventTarget memory leak detected. 51 line listeners added to [EventEmitter]` (same for `clear`) appears after many client reconnects on the console-logs SSE endpoint. Node memory grows slowly alongside the listener count.

## Root cause

`src/app/api/translator/console-logs/stream/route.js` attaches `line` / `clear` listeners on the singleton `consoleEmitter` inside `ReadableStream.start()`, and only removes them in `cancel()`. In Next.js 16 / Node fetch runtime, `ReadableStream.cancel()` is not reliably invoked when the client aborts the connection (tab close, navigation, reload), so listeners accumulate every time the dashboard reconnects. The buffered-logs emitter has `setMaxListeners(50)`, so the warning fires on the 51st leaked connection.

`request.signal` (the `AbortSignal` on the `Request`) does fire on client disconnect — it is the authoritative disconnect source here.

## Fix

- Add `request.signal.addEventListener("abort", cleanup, { once: true })` as the primary disconnect hook.
- Keep `cancel()` as a fallback.
- Make the cleanup idempotent via a `state.closed` guard so abort, cancel, and enqueue-failure paths can all call it safely.
- Centralize `emitter.off(...)` + `clearInterval(keepalive)` inside the single `cleanup()` function.

No behavior change for clients; only server-side listener bookkeeping is affected. The `usage/stream` SSE route has the same pattern and is a candidate for the same fix in a follow-up — this PR keeps the change minimal and focused on the one route where the warning is observed.

## Test plan

- [ ] Start the app, open the dashboard, then reload the page 60+ times (or open/close the console-logs drawer rapidly)
- [ ] `listenerCount("line")` on the emitter should return to ~1 after each client disconnect, not accumulate
- [ ] No `MaxListenersExceededWarning` in server logs
- [ ] Log lines still stream live to the UI; `clear` action still reaches connected clients
- [ ] 25s keepalive ping still fires on idle connections; interval is cleared on disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)