### PR TITLE
Fix quota reset timestamp parsing for Unix seconds

### DIFF
--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -78,13 +78,17 @@ function parseResetTime(resetValue) {
       return resetValue.toISOString();
     }
 
-    // If it's a number (Unix timestamp in milliseconds)
+    // Unix timestamps from provider APIs may be seconds or milliseconds.
     if (typeof resetValue === 'number') {
-      return new Date(resetValue).toISOString();
+      return new Date(resetValue < 1e12 ? resetValue * 1000 : resetValue).toISOString();
     }
 
-    // If it's a string (ISO date or any parseable date string)
+    // If it's a numeric string, treat it like a Unix timestamp too.
     if (typeof resetValue === 'string') {
+      if (/^\d+$/.test(resetValue)) {
+        const timestamp = Number(resetValue);
+        return new Date(timestamp < 1e12 ? timestamp * 1000 : timestamp).toISOString();
+      }
       return new Date(resetValue).toISOString();
     }
 


### PR DESCRIPTION
## Summary

Fixes quota reset timestamp parsing so provider APIs that return Unix timestamps in seconds, milliseconds, or numeric strings are handled correctly.

## Why

Previously numeric reset values were always passed directly to `new Date(...)`, which treats numbers as milliseconds. If a provider returns Unix seconds, the UI can display an incorrect 1970-era reset date.

## Changes

- Detect numeric Unix timestamps in seconds vs milliseconds.
- Support numeric string timestamps the same way.
- Preserve existing ISO/parseable string behavior.

## Testing

Not run; small parsing-only change.