### PR TITLE
Show DNS records need to add to hosts file

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/MitmToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/MitmToolCard.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { Card, Button, Badge, Input, ModelSelectModal } from "@/shared/components";
+import { TOOL_HOSTS } from "@/shared/constants/mitmToolHosts";
 import Image from "next/image";
 
 /**
@@ -34,6 +35,7 @@ export default function MitmToolCard({
   const [modalOpen, setModalOpen] = useState(false);
   const [currentEditingAlias, setCurrentEditingAlias] = useState(null);
 
+  const mitmHosts = TOOL_HOSTS[tool.id] ?? [];
   const isWindows = typeof navigator !== "undefined" && navigator.userAgent?.includes("Windows");
 
   useEffect(() => {
@@ -162,6 +164,19 @@ export default function MitmToolCard({
 
         {isExpanded && (
           <div className="mt-4 pt-4 border-t border-border flex flex-col gap-4">
+            {/* Hosts */}
+            {mitmHosts.length > 0 && (
+              <div className="mt-2 rounded-md border border-border bg-surface/50 px-2 py-1.5">
+                <p className="text-[10px] font-medium tracking-wide text-text-main/80 mb-1">
+                  Edit hosts file manually to add the following entries:
+                </p>
+                <ul className="list-none space-y-0.5 font-mono text-[10px] text-text-muted break-all">
+                  {mitmHosts.map((h) => (
+                    <li key={h}>127.0.0.1 {h}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
             {/* Info */}
             <div className="flex flex-col gap-0.5 text-[11px] text-text-muted px-1">
               <p>Toggle DNS to redirect {tool.name} traffic through 9Router via MITM.</p>

--- a/src/mitm/dns/dnsConfig.js
+++ b/src/mitm/dns/dnsConfig.js
@@ -3,14 +3,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { log, err } = require("../logger");
-
-// Per-tool DNS hosts mapping
-const TOOL_HOSTS = {
-  antigravity: ["daily-cloudcode-pa.googleapis.com", "cloudcode-pa.googleapis.com"],
-  copilot: ["api.individual.githubcopilot.com"],
-  kiro: ["q.us-east-1.amazonaws.com", "codewhisperer.us-east-1.amazonaws.com"],
-  cursor: ["api2.cursor.sh"],
-};
+const { TOOL_HOSTS } = require("../../shared/constants/mitmToolHosts");
 
 const IS_WIN = process.platform === "win32";
 const IS_MAC = process.platform === "darwin";
@@ -25,7 +18,7 @@ const HOSTS_FILE = IS_WIN
 function executeElevatedPowerShell(psScriptPath, timeoutMs = 30000) {
   const flagFile = path.join(os.tmpdir(), `ps_done_${Date.now()}.flag`);
   const psSQ = (s) => s.replace(/'/g, "''");
-  
+
   let psContent = fs.readFileSync(psScriptPath, "utf8");
   psContent += `\nSet-Content -Path '${psSQ(flagFile)}' -Value 'done' -Encoding UTF8\n`;
   fs.writeFileSync(psScriptPath, psContent, "utf8");

--- a/src/shared/constants/mitmToolHosts.js
+++ b/src/shared/constants/mitmToolHosts.js
@@ -1,0 +1,12 @@
+/**
+ * Per-tool DNS hosts — written to hosts file as 127.0.0.1 when MITM DNS is enabled.
+ * Kept in sync with MITM routing; shared by Node (dnsConfig) and dashboard UI.
+ */
+const TOOL_HOSTS = {
+  antigravity: ["daily-cloudcode-pa.googleapis.com", "cloudcode-pa.googleapis.com"],
+  copilot: ["api.individual.githubcopilot.com"],
+  kiro: ["q.us-east-1.amazonaws.com", "codewhisperer.us-east-1.amazonaws.com"],
+  cursor: ["api2.cursor.sh"],
+};
+
+module.exports = { TOOL_HOSTS };


### PR DESCRIPTION
Trong trường hợp ko thể chỉnh sửa được hosts file trên một vài hệ thống, danh sách các DNS records cần thêm vào hosts file nên được hiển thị ra để người dùng có thể dễ dàng thêm vào bằng tay.

<img width="458" height="208" alt="image" src="https://github.com/user-attachments/assets/e4659ed9-46ca-4e05-a209-f7272ab3b967" />
