### PR TITLE
fix: Add reasoning_content placeholder for DeepSeek thinking models

### DIFF
--- a/open-sse/executors/opencode-go.js
+++ b/open-sse/executors/opencode-go.js
@@ -10,6 +10,17 @@ const BASE = "https://opencode.ai/zen/go/v1";
 // OpenAI-format clients don't send it -> upstream 400. Inject a non-empty placeholder.
 const KIMI_REASONING_PLACEHOLDER = " ";
 
+// DeepSeek models with thinking mode require reasoning_content from prior assistant messages
+// to be passed back. This set contains DeepSeek models that require this handling.
+const DEEPSEEK_THINKING_MODELS = new Set([
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "deepseek-r1",
+  "deepseek-r1-distill-llama-70b",
+  "deepseek-r1-distill-qwen-32b",
+  "deepseek-r1-distill-qwen-7b",
+]);
+
 export class OpenCodeGoExecutor extends BaseExecutor {
   constructor() {
     super("opencode-go", PROVIDERS["opencode-go"]);
@@ -39,13 +50,32 @@ export class OpenCodeGoExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body) {
-    if (!model?.startsWith?.("kimi-") || !body?.messages) return body;
-    const messages = body.messages.map(m => {
-      if (m?.role === "assistant" && Array.isArray(m.tool_calls) && !("reasoning_content" in m)) {
-        return { ...m, reasoning_content: KIMI_REASONING_PLACEHOLDER };
-      }
-      return m;
-    });
-    return { ...body, messages };
+    if (!body?.messages) return body;
+
+    // Handle Kimi (Moonshot) - requires reasoning_content on assistant tool_call messages
+    if (model?.startsWith?.("kimi-")) {
+      const messages = body.messages.map(m => {
+        if (m?.role === "assistant" && Array.isArray(m.tool_calls) && !("reasoning_content" in m)) {
+          return { ...m, reasoning_content: KIMI_REASONING_PLACEHOLDER };
+        }
+        return m;
+      });
+      return { ...body, messages };
+    }
+
+    // Handle DeepSeek thinking models - add reasoning_content placeholder to assistant messages
+    // DeepSeek API requires reasoning_content from previous turns to be passed back when thinking is enabled
+    // OpenAI-format clients don't send it, so we inject a placeholder to satisfy the API requirement
+    if (DEEPSEEK_THINKING_MODELS.has(model)) {
+      const messages = body.messages.map(m => {
+        if (m?.role === "assistant" && !("reasoning_content" in m) && (m?.content || m?.tool_calls)) {
+          return { ...m, reasoning_content: KIMI_REASONING_PLACEHOLDER };
+        }
+        return m;
+      });
+      return { ...body, messages };
+    }
+
+    return body;
   }
 }


### PR DESCRIPTION
- Inject reasoning_content in assistant messages for DeepSeek models with thinking mode (deepseek-v4-pro, deepseek-v4-flash)
- Resolves error: 'The reasoning_content in the thinking mode must be passed back to the API'
- Fixes issue #773