### PR TITLE
fix: custom provider prefix conflicts with built-in alias

### DIFF
--- a/src/sse/services/model.js
+++ b/src/sse/services/model.js
@@ -19,28 +19,24 @@ export async function getModelInfo(modelStr) {
   const parsed = parseModel(modelStr);
 
   if (!parsed.isAlias) {
-    if (parsed.provider === parsed.providerAlias) {
-      // Check OpenAI Compatible nodes
-      const openaiNodes = await getProviderNodes({ type: "openai-compatible" });
-      const matchedOpenAI = openaiNodes.find((node) => node.prefix === parsed.providerAlias);
-      if (matchedOpenAI) {
-        return { provider: matchedOpenAI.id, model: parsed.model };
-      }
-
-      // Check Anthropic Compatible nodes
-      const anthropicNodes = await getProviderNodes({ type: "anthropic-compatible" });
-      const matchedAnthropic = anthropicNodes.find((node) => node.prefix === parsed.providerAlias);
-      if (matchedAnthropic) {
-        return { provider: matchedAnthropic.id, model: parsed.model };
-      }
-
-      // Check Custom Embedding nodes
-      const embeddingNodes = await getProviderNodes({ type: "custom-embedding" });
-      const matchedEmbedding = embeddingNodes.find((node) => node.prefix === parsed.providerAlias);
-      if (matchedEmbedding) {
-        return { provider: matchedEmbedding.id, model: parsed.model };
-      }
+    const openaiNodes = await getProviderNodes({ type: "openai-compatible" });
+    const matchedOpenAI = openaiNodes.find((node) => node.prefix === parsed.providerAlias);
+    if (matchedOpenAI) {
+      return { provider: matchedOpenAI.id, model: parsed.model };
     }
+
+    const anthropicNodes = await getProviderNodes({ type: "anthropic-compatible" });
+    const matchedAnthropic = anthropicNodes.find((node) => node.prefix === parsed.providerAlias);
+    if (matchedAnthropic) {
+      return { provider: matchedAnthropic.id, model: parsed.model };
+    }
+
+    const embeddingNodes = await getProviderNodes({ type: "custom-embedding" });
+    const matchedEmbedding = embeddingNodes.find((node) => node.prefix === parsed.providerAlias);
+    if (matchedEmbedding) {
+      return { provider: matchedEmbedding.id, model: parsed.model };
+    }
+
     return {
       provider: parsed.provider,
       model: parsed.model


### PR DESCRIPTION
## Bug

When a custom OpenAI-compatible provider uses a prefix that matches a built-in alias (e.g. `ark` → `volcengine-ark`), `resolveProviderAlias()` in `parseModel()` converts the prefix to the built-in provider ID. This causes the provider-node matching condition `parsed.provider === parsed.providerAlias` to be `false`, skipping the custom node lookup entirely.

The request is then routed to the wrong built-in provider, which has no credentials, resulting in a `404 model_not_found` error.

## Reproduce

1. Create an OpenAI Compatible provider-node with prefix `ark`
2. Add an API key connection
3. Use model `ark/gpt-5.4` from Claude Code
4. Request is routed to `volcengine-ark` instead of the custom node → 404

## Fix

Remove the `parsed.provider === parsed.providerAlias` guard in `getModelInfo()`. Always check provider-node prefix matching using the original user input (`parsed.providerAlias`) first, before falling back to the resolved alias.

This ensures custom provider-nodes take priority over built-in alias resolution, regardless of whether the prefix collides with an alias in `ALIAS_TO_PROVIDER_ID`.

## Impact

- Custom provider-nodes with any prefix (including those matching built-in aliases) now work correctly
- If no provider-node matches the prefix, behavior falls back to the existing alias resolution as before
- No breaking changes for existing configurations with non-conflicting prefixes