### PR TITLE
Proper fixes for "I can't use the tool 'exec_ide' here"

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -1,6 +1,7 @@
 import { FORMATS } from "../../translator/formats.js";
 import { needsTranslation } from "../../translator/index.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
+import { decloakToolNames } from "../../utils/claudeCloaking.js";
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
@@ -161,9 +162,15 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   appendLog({ tokens: usage, status: "200 OK" });
   saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
 
+  // Decloak AFTER provider-response logging so logs preserve upstream fidelity
+  // (debugging the cloak system itself needs to see what upstream actually sent).
+  // Runs before translation so translator sees real tool names. Covers Claude→Claude
+  // passthrough and Claude→OpenAI translation. See claudeCloaking.js for "exec_ide" symptom.
+  const decloakedBody = decloakToolNames(responseBody, toolNameMap);
+
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
-    ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat)
-    : responseBody;
+    ? translateNonStreamingResponse(decloakedBody, targetFormat, sourceFormat)
+    : decloakedBody;
 
   // Fix finish_reason for tool_calls: some providers return non-standard values (e.g. "other")
   if (translatedResponse?.choices?.[0]) {

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -33,7 +33,9 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
     return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  // sourceFormat + toolNameMap must flow through to passthrough so the
+  // pipeline can decloak Claude tool names on the way back to the client.
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, sourceFormat, toolNameMap);
 }
 
 /**

--- a/open-sse/utils/claudeCloaking.js
+++ b/open-sse/utils/claudeCloaking.js
@@ -66,16 +66,54 @@ export function cloakClaudeTools(body) {
   };
 }
 
-// Decloak tool_use names in non-streaming Claude response body (INPUT side)
-export function decloakToolNames(body, toolNameMap) {
-  if (!toolNameMap?.size || !Array.isArray(body?.content)) return body;
-  const content = body.content.map(block => {
-    if (block?.type === "tool_use" && toolNameMap.has(block.name)) {
-      return { ...block, name: toolNameMap.get(block.name) };
+/**
+ * Reverse cloakClaudeTools() on any Claude-format node headed back to the client.
+ *
+ * Walks recursively and renames every `tool_use` block whose `name` is in
+ * `toolNameMap`. Shape-agnostic on purpose: works for streaming SSE chunks
+ * (content_block_start.content_block), full non-streaming response bodies
+ * (content[] arrays), message history, and any nested envelope a future
+ * Claude API revision might use.
+ *
+ * MUST run on every client-bound path when cloakClaudeTools() touched the
+ * request. If it doesn't, clients see "_ide"-suffixed tool names, their
+ * registry has no match, and the model refuses:
+ *   "I can't use the tool 'exec_ide' here because it isn't available.
+ *    I need to stop retrying it and answer without that tool."
+ *
+ * @param {*} node - Any JSON-serializable value (object, array, primitive).
+ * @param {Map<string,string>|null} toolNameMap - cloaked → original name.
+ * @returns {*} The node with tool_use names restored. Returns the same
+ *   reference if nothing changed (structural sharing, GC-friendly).
+ */
+export function decloakToolNames(node, toolNameMap) {
+  if (!toolNameMap?.size || !node || typeof node !== "object") return node;
+
+  if (Array.isArray(node)) {
+    let changed = false;
+    const next = node.map(child => {
+      const mapped = decloakToolNames(child, toolNameMap);
+      if (mapped !== child) changed = true;
+      return mapped;
+    });
+    return changed ? next : node;
+  }
+
+  if (node.type === "tool_use" && typeof node.name === "string") {
+    const original = toolNameMap.get(node.name);
+    if (original && original !== node.name) {
+      return { ...node, name: original };
     }
-    return block;
-  });
-  return { ...body, content };
+  }
+
+  let changed = false;
+  const next = {};
+  for (const key of Object.keys(node)) {
+    const mapped = decloakToolNames(node[key], toolNameMap);
+    if (mapped !== node[key]) changed = true;
+    next[key] = mapped;
+  }
+  return changed ? next : node;
 }
 
 // CC decoy tools — Claude Code native tool names, marked unavailable

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -3,11 +3,34 @@ import { FORMATS } from "../translator/formats.js";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
+import { decloakToolNames } from "./claudeCloaking.js";
 
 export { COLORS, formatSSE };
 
 // sharedEncoder is stateless — safe to share across streams
 const sharedEncoder = new TextEncoder();
+
+// Rewrite cloaked tool names in a single complete SSE line. Passes through
+// lines that aren't `data:` carriers, the [DONE] sentinel, or don't carry a
+// tool_use at all. Returns the same string reference if nothing changed.
+//
+// Applied at the INPUT side of the transform (raw Claude SSE bytes, one
+// complete line at a time), so the translator never sees cloaked names
+// and downstream stages can stay format-agnostic. See claudeCloaking.js
+// for the full "exec_ide" symptom writeup.
+function decloakSSELine(line, toolNameMap) {
+  if (!line.startsWith("data:") || !line.includes("tool_use")) return line;
+  const payload = line.slice(5).trim();
+  if (!payload || payload === "[DONE]") return line;
+  try {
+    const parsed = JSON.parse(payload);
+    const decloaked = decloakToolNames(parsed, toolNameMap);
+    if (decloaked === parsed) return line;
+    return "data: " + JSON.stringify(decloaked);
+  } catch {
+    return line;
+  }
+}
 
 /**
  * Stream modes
@@ -59,6 +82,23 @@ export function createSSEStream(options = {}) {
   let accumulatedThinking = "";
   let ttftAt = null;
 
+  // Single-point guarantee: if cloaking was applied on the request path,
+  // every raw provider-SSE line is decloaked before it hits the buffer-
+  // consuming for-loop (or flush). Since cloakClaudeTools() only fires
+  // when provider === "claude", a populated toolNameMap implies Claude-
+  // shape bytes on the wire — we don't need a sourceFormat check. Doing
+  // the work on the INPUT side means the translator always sees real
+  // tool names, so passthrough AND every translate target (OpenAI,
+  // Gemini, etc.) are covered by the same line of code without knowing
+  // their output tool shapes. See claudeCloaking.js for the full
+  // "exec_ide" symptom writeup.
+  const shouldDecloak = toolNameMap?.size > 0;
+
+  function emit(output, controller) {
+    reqLogger?.appendConvertedChunk?.(output);
+    controller.enqueue(sharedEncoder.encode(output));
+  }
+
   return new TransformStream({
     transform(chunk, controller) {
       if (!ttftAt) {
@@ -70,6 +110,12 @@ export function createSSEStream(options = {}) {
 
       const lines = buffer.split("\n");
       buffer = lines.pop() || "";
+
+      if (shouldDecloak) {
+        for (let i = 0; i < lines.length; i++) {
+          lines[i] = decloakSSELine(lines[i], toolNameMap);
+        }
+      }
 
       for (const line of lines) {
         const trimmed = line.trim();
@@ -154,8 +200,7 @@ export function createSSEStream(options = {}) {
             }
           }
 
-          reqLogger?.appendConvertedChunk?.(output);
-          controller.enqueue(sharedEncoder.encode(output));
+          emit(output, controller);
           continue;
         }
 
@@ -169,8 +214,7 @@ export function createSSEStream(options = {}) {
         // For other formats: done=true is the [DONE] sentinel, skip
         if (parsed && parsed.done && targetFormat !== FORMATS.OLLAMA) {
           const output = "data: [DONE]\n\n";
-          reqLogger?.appendConvertedChunk?.(output);
-          controller.enqueue(sharedEncoder.encode(output));
+          emit(output, controller);
           continue;
         }
 
@@ -246,8 +290,7 @@ export function createSSEStream(options = {}) {
             }
 
             const output = formatSSE(item, sourceFormat);
-            reqLogger?.appendConvertedChunk?.(output);
-            controller.enqueue(sharedEncoder.encode(output));
+            emit(output, controller);
           }
         }
       }
@@ -261,12 +304,12 @@ export function createSSEStream(options = {}) {
 
         if (mode === STREAM_MODE.PASSTHROUGH) {
           if (buffer) {
-            let output = buffer;
-            if (buffer.startsWith("data:") && !buffer.startsWith("data: ")) {
-              output = "data: " + buffer.slice(5);
+            const decloaked = shouldDecloak ? decloakSSELine(buffer, toolNameMap) : buffer;
+            let output = decloaked;
+            if (decloaked.startsWith("data:") && !decloaked.startsWith("data: ")) {
+              output = "data: " + decloaked.slice(5);
             }
-            reqLogger?.appendConvertedChunk?.(output);
-            controller.enqueue(sharedEncoder.encode(output));
+            emit(output, controller);
           }
 
           if (!hasValidUsage(usage) && totalContentLength > 0) {
@@ -283,9 +326,7 @@ export function createSSEStream(options = {}) {
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
           //   data: [DONE]\n\n
           // Without it they can hang until timeout and trigger failover.
-          const doneOutput = "data: [DONE]\n\n";
-          reqLogger?.appendConvertedChunk?.(doneOutput);
-          controller.enqueue(sharedEncoder.encode(doneOutput));
+          emit("data: [DONE]\n\n", controller);
 
           if (onStreamComplete) {
             onStreamComplete({
@@ -297,7 +338,8 @@ export function createSSEStream(options = {}) {
         }
 
         if (buffer.trim()) {
-          const parsed = parseSSELine(buffer.trim());
+          const decloaked = shouldDecloak ? decloakSSELine(buffer, toolNameMap) : buffer;
+          const parsed = parseSSELine(decloaked.trim());
           if (parsed && !parsed.done) {
             const translated = translateResponse(targetFormat, sourceFormat, parsed, state);
 
@@ -310,9 +352,7 @@ export function createSSEStream(options = {}) {
 
             if (translated?.length > 0) {
               for (const item of translated) {
-                const output = formatSSE(item, sourceFormat);
-                reqLogger?.appendConvertedChunk?.(output);
-                controller.enqueue(sharedEncoder.encode(output));
+                emit(formatSSE(item, sourceFormat), controller);
               }
             }
           }
@@ -329,15 +369,11 @@ export function createSSEStream(options = {}) {
 
         if (flushed?.length > 0) {
           for (const item of flushed) {
-            const output = formatSSE(item, sourceFormat);
-            reqLogger?.appendConvertedChunk?.(output);
-            controller.enqueue(sharedEncoder.encode(output));
+            emit(formatSSE(item, sourceFormat), controller);
           }
         }
 
-        const doneOutput = "data: [DONE]\n\n";
-        reqLogger?.appendConvertedChunk?.(doneOutput);
-        controller.enqueue(sharedEncoder.encode(doneOutput));
+        emit("data: [DONE]\n\n", controller);
 
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);
@@ -378,11 +414,13 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, sourceFormat = null, toolNameMap = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
+    sourceFormat,
     provider,
     reqLogger,
+    toolNameMap,
     model,
     connectionId,
     body,

--- a/tests/unit/claude-cloaking.test.js
+++ b/tests/unit/claude-cloaking.test.js
@@ -1,0 +1,275 @@
+/**
+ * Regression: Claude passthrough streaming leaked cloaked tool names to clients.
+ *
+ * Symptom seen by Claude Code / OpenClaw users:
+ *   "I can't use the tool 'exec_ide' here because it isn't available.
+ *    I need to stop retrying it and answer without that tool."
+ *   (Also seen as web_search_ide, read_ide, write_ide, etc.)
+ *
+ * Why it happened: 9router cloaks client tool names with a _ide suffix on the
+ * request path (anti-ban against the upstream provider), then is supposed to
+ * strip the suffix on the response path. For Claude /v1/messages passthrough,
+ * the strip never ran — upstream `content_block_start` events containing
+ * `"name":"read_ide"` reached the client unchanged, and the model's own tool
+ * registry has no `read_ide`, so it refused to invoke them.
+ *
+ * Contract under test: given a `toolNameMap` of cloaked → original names, the
+ * SSE pipeline MUST NOT emit any cloaked name to the client — regardless of
+ * whether the event is processed on the transform path or stranded in the
+ * flush buffer at end-of-stream.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// Stub the usage DB so stream.js can load without touching sqlite.
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(() => Promise.resolve()),
+  saveRequestUsage: vi.fn(),
+}));
+
+const { createPassthroughStreamWithLogger, createSSETransformStreamWithLogger } = await import("open-sse/utils/stream.js");
+const { FORMATS } = await import("open-sse/translator/formats.js");
+const { decloakToolNames } = await import("open-sse/utils/claudeCloaking.js");
+
+async function runStream(stream, inputs) {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const writer = stream.writable.getWriter();
+  const reader = stream.readable.getReader();
+
+  const chunks = [];
+  const readAll = (async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push(decoder.decode(value));
+    }
+  })();
+
+  for (const input of inputs) await writer.write(encoder.encode(input));
+  await writer.close();
+  await readAll;
+
+  return chunks.join("");
+}
+
+describe("Claude passthrough cloak/decloak symmetry", () => {
+  it("does not leak *_ide tool names when a content_block_start lands in the flush buffer", async () => {
+    // Map cloaked → original. This mirrors what cloakClaudeTools() builds.
+    const toolNameMap = new Map([
+      ["read_ide", "read"],
+      ["exec_ide", "exec"],
+      ["web_search_ide", "web_search"],
+    ]);
+
+    // Upstream SSE: event: line is newline-terminated, but the data: line is NOT.
+    // The data: line therefore sits in the transform's internal buffer until
+    // the writer closes, at which point the flush handler must decloak it.
+    const event =
+      "event: content_block_start\n" +
+      'data: {"type":"content_block_start","index":0,' +
+      '"content_block":{"type":"tool_use","id":"toolu_01","name":"read_ide","input":{}}}';
+
+    // Public wrapper signature:
+    //   createPassthroughStreamWithLogger(
+    //     provider, reqLogger, model, connectionId, body,
+    //     onStreamComplete, apiKey, sourceFormat, toolNameMap
+    //   )
+    // sourceFormat + toolNameMap are the new tail params — the fix must
+    // thread them through so passthrough mode can decloak Claude events.
+    const stream = createPassthroughStreamWithLogger(
+      null, null, null, null, null, null, null,
+      FORMATS.CLAUDE, toolNameMap,
+    );
+
+    const output = await runStream(stream, [event]);
+
+    // Invariant: no cloaked name ever reaches the client.
+    expect(output).not.toMatch(/_ide/);
+    // And the real tool name IS present.
+    expect(output).toContain('"name":"read"');
+  });
+
+  it("does not leak *_ide tool names when translating Claude stream to OpenAI client", async () => {
+    // Scenario: OpenAI client → Claude provider. Client sent OpenAI-format
+    // tools[], 9router translated to Claude request and cloaked "read" →
+    // "read_ide" on the wire. Claude's SSE response carries "read_ide" in
+    // tool_use events. The translator converts those to OpenAI tool_calls
+    // — but if decloak runs at emit() time (output side), the Claude walker
+    // never matches the post-translation OpenAI shape (`function.name`),
+    // so the cloaked name reaches the client anyway.
+    //
+    // Invariant: decloak must happen on the INPUT side (raw Claude SSE
+    // lines) before translation, so the walker's Claude-shape-only
+    // knowledge is sufficient regardless of client format.
+    const toolNameMap = new Map([["read_ide", "read"]]);
+
+    // Full, newline-terminated Claude SSE sequence for a single tool_use.
+    // No flush-buffer contribution — this test targets the transform path,
+    // not the flush regression test 1 already covers.
+    const input =
+      "event: message_start\n" +
+      'data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-3","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}\n' +
+      "\n" +
+      "event: content_block_start\n" +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"read_ide","input":{}}}\n' +
+      "\n" +
+      "event: content_block_delta\n" +
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":\\"/tmp\\"}"}}\n' +
+      "\n" +
+      "event: content_block_stop\n" +
+      'data: {"type":"content_block_stop","index":0}\n' +
+      "\n" +
+      "event: message_delta\n" +
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":5}}\n' +
+      "\n" +
+      "event: message_stop\n" +
+      'data: {"type":"message_stop"}\n' +
+      "\n";
+
+    // createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, ...)
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.CLAUDE, FORMATS.OPENAI, null, null, toolNameMap,
+    );
+
+    const output = await runStream(stream, [input]);
+
+    // Invariant: no cloaked name ever reaches the client.
+    expect(output).not.toMatch(/_ide/);
+    // And the real tool name IS present in the translated OpenAI output.
+    expect(output).toContain('"name":"read"');
+    // The tool_use block itself survives translation (guards against a
+    // trivially-wrong impl that simply deletes the cloaked block).
+    expect(output).toContain("toolu_01");
+  });
+
+  it("handles cloaked names split across chunk boundaries (real TCP framing)", async () => {
+    // Real network framing doesn't respect SSE line boundaries. Bytes for
+    // a single JSON line can arrive split anywhere — including inside the
+    // cloaked name itself. The design invariant is: decloak runs on
+    // COMPLETE lines only (after buffer.split("\n")), so partials in the
+    // buffer are benign. A future refactor that moved decloak to raw
+    // chunk text (pre-buffering) would regress on this shape — this test
+    // pins that invariant.
+    const toolNameMap = new Map([["read_ide", "read"]]);
+
+    const fullInput =
+      "event: content_block_start\n" +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_42","name":"read_ide","input":{}}}\n' +
+      "\n";
+
+    // Split the input at an awkward point — mid-cloaked-name — across chunks.
+    const splitAt = fullInput.indexOf("read_i") + 4; // between "read" and "_ide"
+    const chunks = [fullInput.slice(0, splitAt), fullInput.slice(splitAt)];
+
+    const stream = createPassthroughStreamWithLogger(
+      null, null, null, null, null, null, null,
+      FORMATS.CLAUDE, toolNameMap,
+    );
+
+    const output = await runStream(stream, chunks);
+
+    expect(output).not.toMatch(/_ide/);
+    expect(output).toContain('"name":"read"');
+    expect(output).toContain("toolu_42");
+  });
+
+  it("decloaks translate-mode flush buffer (Claude provider → OpenAI client, no trailing newline)", async () => {
+    // Mirror of test 1 but in translate mode: the final data: line is not
+    // newline-terminated, so it sits in the transform's internal buffer
+    // until writer.close(). The translate-branch flush must decloak that
+    // leftover buffer before running it through parseSSELine/translator.
+    const toolNameMap = new Map([["exec_ide", "exec"]]);
+
+    const event =
+      "event: content_block_start\n" +
+      'data: {"type":"content_block_start","index":0,' +
+      '"content_block":{"type":"tool_use","id":"toolu_99","name":"exec_ide","input":{}}}';
+
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.CLAUDE, FORMATS.OPENAI, null, null, toolNameMap,
+    );
+
+    const output = await runStream(stream, [event]);
+
+    expect(output).not.toMatch(/_ide/);
+  });
+
+  it("decloaks with CRLF line endings (trimStart left trailing \\r, breaking JSON.parse)", async () => {
+    // SSE spec allows \r\n, \r, or \n. buffer.split("\n") leaves a
+    // trailing \r on each line when upstream uses CRLF. A payload like
+    // `{"name":"read_ide"}\r` is not valid JSON, so trimStart()-only
+    // handling silently falls into the catch path and returns the original
+    // cloaked line. Full trim() is required.
+    const toolNameMap = new Map([["read_ide", "read"]]);
+
+    const input =
+      "event: content_block_start\r\n" +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_crlf","name":"read_ide","input":{}}}\r\n' +
+      "\r\n";
+
+    const stream = createPassthroughStreamWithLogger(
+      null, null, null, null, null, null, null,
+      FORMATS.CLAUDE, toolNameMap,
+    );
+
+    const output = await runStream(stream, [input]);
+
+    expect(output).not.toMatch(/_ide/);
+    expect(output).toContain('"name":"read"');
+  });
+
+  it("passes cloaked names through unchanged when toolNameMap is empty (gate check)", async () => {
+    // The gate is `toolNameMap?.size > 0`. A refactor to `toolNameMap != null`
+    // would silently start decloaking when there's nothing to decloak (and
+    // could mis-rewrite real tool names named `_ide` by coincidence on
+    // hypothetical future clients). Pin the gate behavior: empty map means
+    // no decloak runs — the caller knew they had nothing to rewrite.
+    const emptyMap = new Map();
+
+    const event =
+      "event: content_block_start\n" +
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"some_tool","input":{}}}\n' +
+      "\n";
+
+    const stream = createPassthroughStreamWithLogger(
+      null, null, null, null, null, null, null,
+      FORMATS.CLAUDE, emptyMap,
+    );
+
+    const output = await runStream(stream, [event]);
+
+    // Nothing to rewrite — name passes through exactly as upstream sent.
+    expect(output).toContain('"name":"some_tool"');
+  });
+
+  it("decloaks non-streaming Claude response bodies (content[] with tool_use)", () => {
+    // Non-streaming /v1/messages returns a full message object with content[].
+    // Same cloak→decloak invariant must hold: nonStreamingHandler.js passes
+    // this body through decloakToolNames before the Response is sent, so the
+    // single walker has to cover this shape too.
+    const toolNameMap = new Map([
+      ["read_ide", "read"],
+      ["exec_ide", "exec"],
+    ]);
+
+    const body = {
+      id: "msg_01",
+      type: "message",
+      role: "assistant",
+      content: [
+        { type: "text", text: "I'll look at the file." },
+        { type: "tool_use", id: "toolu_01", name: "read_ide", input: { path: "/tmp/x" } },
+        { type: "tool_use", id: "toolu_02", name: "exec_ide", input: { cmd: "ls" } },
+      ],
+      stop_reason: "tool_use",
+    };
+
+    const result = decloakToolNames(body, toolNameMap);
+
+    expect(result.content[1].name).toBe("read");
+    expect(result.content[2].name).toBe("exec");
+    expect(JSON.stringify(result)).not.toMatch(/_ide/);
+  });
+});


### PR DESCRIPTION
## What users see

```
I can't use the tool 'exec_ide' here because it isn't available.
I need to stop retrying it and answer without that tool.
```

(Also seen as `read_ide`, `write_ide`, `web_search_ide`, etc.) The model
silently refuses to invoke its own tools and the user's session stalls.

## Why it happens

`cloakClaudeTools()` rewrites tool names with a `_ide` suffix on the
**request** path (anti-ban against the upstream provider). The **response**
path is supposed to strip the suffix before the client sees it. For a few
client-bound paths the strip never ran — `content_block_start` events
containing `"name":"read_ide"` reached the client unchanged, the client's
tool registry has no `read_ide`, and the model refused.

## Where the cloaked names were leaking

- Streaming SSE `content_block_start` chunks (passthrough mode and translate-to-OpenAI mode)
- End-of-stream flush buffer when a tool name event was stranded across chunk boundaries
- Message history echoed back in conversation context
- Any nested envelope a future Claude API revision might introduce

Commit `5abc9e5` ("add GPT 5.5 model") added a narrow `decloakToolNames`
that only walks `body.content[]` on non-streaming responses — the
streaming and history paths still leak.

## The fix

Replace the narrow non-streaming-only `decloakToolNames` with a recursive,
shape-agnostic version. It walks any JSON node, renames every `tool_use`
block whose name appears in the cloak map, and uses structural sharing
so unchanged subtrees aren't re-allocated.

Wired into every client-bound path:

- `stream.js` — raw SSE lines decloaked on the **input** side of the
  transform, before parsing or translation, so every downstream stage
  (translator, emitter, passthrough, flush) sees real tool names
  regardless of client format
- Both flush branches in `stream.js` — covers events stranded at end-of-stream
- `nonStreamingHandler.js` — full response body, decloaked once after
  the raw-response log, before translation
- `chatCore.js` — message history responses
- Handles CRLF line endings (trim, not trimStart)

## Why recursive

A non-recursive walk has to be updated every time Claude introduces a
new response shape. The recursive version is bug-agnostic to envelope
changes — it finds `tool_use` blocks wherever they live, including any
shape upstream hasn't shipped yet.

## Tests

`tests/unit/claude-cloaking.test.js` — 7 regression tests:

- Passthrough streaming (Claude → Claude)
- Translate-to-OpenAI streaming
- Non-streaming response body
- Chunk-boundary splits (line spans two chunks)
- Translate-mode flush (stranded buffer at end-of-stream)
- Empty cloak-map gate (no-op when nothing was cloaked)
- CRLF line endings

## Supersedes

Closes the bug class addressed narrowly by `5abc9e5`. Replaces #722
(prior submission of the same fix; closed in favor of this one against a
fresh base).