### PR TITLE
feat: add Kiro MITM translation with AWS EventStream binary encoding

### DIFF
--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -39,6 +39,7 @@ function ensureInitialized() {
   require("./request/antigravity-to-openai.js");
   require("./request/openai-responses.js");
   require("./request/openai-to-kiro.js");
+  require("./request/kiro-to-openai.js");
   require("./request/openai-to-cursor.js");
   require("./request/openai-to-ollama.js");
 
@@ -49,6 +50,7 @@ function ensureInitialized() {
   require("./response/openai-to-antigravity.js");
   require("./response/openai-responses.js");
   require("./response/kiro-to-openai.js");
+  require("./response/openai-to-kiro.js");
   require("./response/cursor-to-openai.js");
   require("./response/ollama-to-openai.js");
 }

--- a/open-sse/translator/request/kiro-to-openai.js
+++ b/open-sse/translator/request/kiro-to-openai.js
@@ -1,0 +1,166 @@
+/**
+ * Kiro to OpenAI Request Translator
+ * Converts Kiro/AWS CodeWhisperer format to OpenAI Chat Completions format
+ *
+ * Reverse of openai-to-kiro.js
+ */
+import { register } from "../index.js";
+import { FORMATS } from "../formats.js";
+
+const TS_PREFIX_RE = /^\[Context: Current time is .+?\]\n\n/;
+
+/**
+ * Convert Kiro toolSpecification to OpenAI function tool format
+ */
+function convertToolSpec(ts) {
+  const schema = ts.inputSchema?.json || {};
+  return {
+    type: "function",
+    function: {
+      name: ts.name,
+      description: ts.description || "",
+      parameters: Object.keys(schema).length === 0
+        ? { type: "object", properties: {}, required: [] }
+        : schema
+    }
+  };
+}
+
+/**
+ * Convert Kiro toolUse to OpenAI tool_call format
+ */
+function convertToolUse(tu) {
+  return {
+    id: tu.toolUseId,
+    type: "function",
+    function: {
+      name: tu.name,
+      arguments: typeof tu.input === "string" ? tu.input : JSON.stringify(tu.input)
+    }
+  };
+}
+
+/**
+ * Strip [Context: Current time is ...] prefix injected by openai-to-kiro
+ */
+function stripTimestamp(content) {
+  if (typeof content !== "string") return content;
+  return content.replace(TS_PREFIX_RE, "");
+}
+
+/**
+ * Convert Kiro images array to OpenAI content parts
+ * Returns null if no images, or array of image_url content parts
+ */
+function convertImages(images) {
+  if (!images || !Array.isArray(images) || images.length === 0) return null;
+  return images.map(img => ({
+    type: "image_url",
+    image_url: {
+      url: `data:image/${img.format};base64,${img.source.bytes}`
+    }
+  }));
+}
+
+/**
+ * Process a userInputMessage and push messages (tool results + user message)
+ */
+function processUserMessage(uim, messages) {
+  const ctx = uim.userInputMessageContext;
+
+  // Tool results become separate tool-role messages BEFORE the user message
+  if (ctx?.toolResults && Array.isArray(ctx.toolResults)) {
+    for (const tr of ctx.toolResults) {
+      const text = tr.content
+        ?.map(c => c.text || "")
+        .join("\n") || "";
+      messages.push({
+        role: "tool",
+        tool_call_id: tr.toolUseId,
+        content: text
+      });
+    }
+  }
+
+  // Build content: string or array of content parts
+  const rawContent = uim.content || "";
+  const stripped = stripTimestamp(rawContent);
+  const images = convertImages(uim.images);
+
+  if (images && images.length > 0) {
+    const parts = [...images];
+    if (stripped) parts.push({ type: "text", text: stripped });
+    messages.push({ role: "user", content: parts });
+  } else if (stripped) {
+    messages.push({ role: "user", content: stripped });
+  }
+  // If content is empty and no images, skip — don't push empty message
+}
+
+/**
+ * Process an assistantResponseMessage and push to messages array
+ */
+function processAssistantMessage(arm, messages) {
+  const msg = {
+    role: "assistant",
+    content: arm.content || ""
+  };
+
+  if (arm.toolUses && Array.isArray(arm.toolUses) && arm.toolUses.length > 0) {
+    msg.tool_calls = arm.toolUses.map(convertToolUse);
+  }
+
+  messages.push(msg);
+}
+
+/**
+ * Build OpenAI Chat Completions payload from Kiro conversationState format
+ */
+export function buildOpenAIPayload(model, body, stream, credentials) {
+  const cs = body.conversationState || {};
+  const history = cs.history || [];
+  const currentMessage = cs.currentMessage;
+  const inferenceConfig = body.inferenceConfig || {};
+
+  const messages = [];
+  let tools = [];
+
+  // Process history items (alternating userInputMessage / assistantResponseMessage)
+  for (const item of history) {
+    if (item.userInputMessage) {
+      processUserMessage(item.userInputMessage, messages);
+    } else if (item.assistantResponseMessage) {
+      processAssistantMessage(item.assistantResponseMessage, messages);
+    }
+  }
+
+  // Process currentMessage (the last user message, popped from history in original)
+  if (currentMessage?.userInputMessage) {
+    const uim = currentMessage.userInputMessage;
+    const ctx = uim.userInputMessageContext;
+
+    // Extract tools from currentMessage context (moved there by openai-to-kiro)
+    if (ctx?.tools && Array.isArray(ctx.tools)) {
+      tools = ctx.tools.map(t => convertToolSpec(t.toolSpecification));
+    }
+
+    processUserMessage(uim, messages);
+  }
+
+  // Assemble OpenAI body
+  const effectiveModel = model || currentMessage?.userInputMessage?.modelId || "";
+  const openaiBody = {
+    model: effectiveModel,
+    messages,
+    stream: stream !== undefined ? stream : true
+  };
+
+  if (tools.length > 0) openaiBody.tools = tools;
+  if (inferenceConfig.maxTokens) openaiBody.max_tokens = inferenceConfig.maxTokens;
+  if (inferenceConfig.temperature !== undefined) openaiBody.temperature = inferenceConfig.temperature;
+  if (inferenceConfig.topP !== undefined) openaiBody.top_p = inferenceConfig.topP;
+
+  return openaiBody;
+}
+
+register(FORMATS.KIRO, FORMATS.OPENAI, buildOpenAIPayload, null);

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -286,7 +286,7 @@ function convertMessages(messages, tools, model) {
 export function buildKiroPayload(model, body, stream, credentials) {
   const messages = body.messages || [];
   const tools = body.tools || [];
-  const maxTokens = 32000;
+  const maxTokens = body.max_tokens ?? 32000;
   const temperature = body.temperature;
   const topP = body.top_p;
 

--- a/open-sse/translator/response/openai-to-kiro.js
+++ b/open-sse/translator/response/openai-to-kiro.js
@@ -34,7 +34,64 @@ export function initKiroState() {
     toolCallInit: {},    // { [index]: { id, name } } — first frame emitted, tracks seen tools
     hasToolCalls: false, // Whether this response uses tool calls (affects termination)
     finishSent: false,   // Whether termination has been emitted
-    usage: null          // Accumulated usage from usage-only chunks
+    usage: null,         // Accumulated usage from usage-only chunks
+    inThink: false,      // Whether inside a <thinking>/<think> block across chunks
+    thinkBuf: ""         // Buffer for partial thinking content
+  };
+}
+
+/**
+ * Extract thinking blocks from text content.
+ * Handles both <thinking>...</thinking> and <think>...</think> tags,
+ * including partial tags split across SSE chunks.
+ */
+function extractThinking(text, state) {
+  if (!text) return { thinking: null, text: null };
+
+  let working = text;
+
+  // Prepend buffered partial thinking from previous chunk
+  if (state.inThink && state.thinkBuf) {
+    working = state.thinkBuf + working;
+    state.thinkBuf = "";
+    state.inThink = false;
+  }
+
+  // Match <thinking> or <think> opening tags
+  const startRe = /<thinking>|<think>/i;
+  const startMatch = working.match(startRe);
+
+  if (!startMatch) {
+    return { thinking: null, text: working };
+  }
+
+  const tag = startMatch[0].toLowerCase();
+  const closeTag = tag === "<think>" ? "</think>" : "</thinking>";
+  const startIdx = startMatch.index;
+  const endIdx = working.indexOf(closeTag, startIdx + tag.length);
+
+  if (endIdx === -1) {
+    // Opening tag without closing — buffer for next chunk
+    state.inThink = true;
+    state.thinkBuf = working.slice(startIdx);
+    const before = working.slice(0, startIdx).trim();
+    return { thinking: null, text: before || null };
+  }
+
+  // Complete block found
+  const thinking = working.slice(startIdx + tag.length, endIdx);
+  const before = working.slice(0, startIdx).trim();
+  const after = working.slice(endIdx + closeTag.length).trim();
+  const rest = [before, after].filter(Boolean).join("");
+
+  // Recursively process for more blocks
+  const recurse = rest
+    ? extractThinking(rest, { inThink: false, thinkBuf: "" })
+    : { thinking: null, text: null };
+
+  return {
+    thinking: thinking || null,
+    text: recurse.text || null
   };
 }
 
@@ -84,6 +141,16 @@ export function convertOpenAIToKiro(chunk, state) {
   // Flush: ensure clean stream termination
   if (!chunk) {
     if (state.finishSent) return null;
+    // Flush any remaining buffered thinking
+    if (state.inThink && state.thinkBuf) {
+      state.inThink = false;
+      const thinking = state.thinkBuf;
+      state.thinkBuf = "";
+      return encodeEventStream("reasoningContentEvent", {
+        content: thinking,
+        modelId: state.modelId || ""
+      });
+    }
     return encodeEventStream("messageStopEvent", {});
   }
 
@@ -140,12 +207,23 @@ export function convertOpenAIToKiro(chunk, state) {
     }));
   }
 
-  // Handle text content — emitted as assistantResponseEvent
+  // Handle text content — extract thinking blocks, emit rest as assistantResponseEvent
   if (delta.content) {
-    frames.push(encodeEventStream("assistantResponseEvent", {
-      content: delta.content,
-      modelId
-    }));
+    const { thinking, text } = extractThinking(delta.content, state);
+
+    if (thinking) {
+      frames.push(encodeEventStream("reasoningContentEvent", {
+        content: thinking,
+        modelId
+      }));
+    }
+
+    if (text) {
+      frames.push(encodeEventStream("assistantResponseEvent", {
+        content: text,
+        modelId
+      }));
+    }
   }
 
   // Handle finish_reason

--- a/open-sse/translator/response/openai-to-kiro.js
+++ b/open-sse/translator/response/openai-to-kiro.js
@@ -1,0 +1,163 @@
+/**
+ * OpenAI to Kiro Response Translator
+ * Converts OpenAI SSE chat.completion.chunk objects to AWS EventStream binary frames
+ *
+ * Reverse of kiro-to-openai.js
+ */
+import { EventStreamCodec } from "@smithy/eventstream-codec";
+import { toUtf8, fromUtf8 } from "@smithy/util-utf8";
+import { register } from "../index.js";
+import { FORMATS } from "../formats.js";
+
+const codec = new EventStreamCodec(toUtf8, fromUtf8);
+
+/**
+ * Encode a Kiro event as an AWS EventStream binary frame
+ */
+function encodeEventStream(eventType, payload) {
+  return codec.encode({
+    headers: {
+      ":message-type": { type: "string", value: "event" },
+      ":event-type": { type: "string", value: eventType },
+      ":content-type": { type: "string", value: "application/json" }
+    },
+    body: fromUtf8(JSON.stringify(payload))
+  });
+}
+
+/**
+ * Initialize state for the Kiro response translator
+ */
+export function initKiroState() {
+  return {
+    modelId: null,       // Model name from first chunk (included in every content frame)
+    toolCallInit: {},    // { [index]: { id, name } } — first frame emitted, tracks seen tools
+    hasToolCalls: false, // Whether this response uses tool calls (affects termination)
+    finishSent: false,   // Whether termination has been emitted
+    usage: null          // Accumulated usage from usage-only chunks
+  };
+}
+
+/**
+ * Emit termination frames. For tool-call responses, emits stop:true per tool.
+ * For text-only responses, emits messageStopEvent.
+ */
+function emitFinish(state) {
+  const frames = [];
+
+  if (state.hasToolCalls) {
+    // Tool-call response: emit stop:true for each tool
+    for (const idx of Object.keys(state.toolCallInit).sort()) {
+      const tc = state.toolCallInit[idx];
+      frames.push(encodeEventStream("toolUseEvent", {
+        name: tc.name,
+        stop: true,
+        toolUseId: tc.id
+      }));
+    }
+  } else {
+    // Text-only response: emit messageStopEvent
+    frames.push(encodeEventStream("messageStopEvent", {}));
+  }
+  state.finishSent = true;
+
+  // Emit usage if available
+  if (state.usage) {
+    frames.push(encodeEventStream("usageEvent", {
+      inputTokens: state.usage.prompt_tokens || 0,
+      outputTokens: state.usage.completion_tokens || 0
+    }));
+  }
+
+  state.toolCallInit = {};
+  return frames.length > 0 ? frames : null;
+}
+
+/**
+ * Convert an OpenAI SSE chunk to AWS EventStream binary frame(s)
+ *
+ * @param {object|null} chunk - Parsed OpenAI chat.completion.chunk, or null for flush
+ * @param {object} state - Mutable state object from initKiroState()
+ * @returns {Uint8Array|Uint8Array[]|null} Binary EventStream frame(s) or null to skip
+ */
+export function convertOpenAIToKiro(chunk, state) {
+  // Flush: ensure clean stream termination
+  if (!chunk) {
+    if (state.finishSent) return null;
+    return encodeEventStream("messageStopEvent", {});
+  }
+
+  const frames = [];
+  const choice = chunk.choices?.[0];
+  const delta = choice?.delta || {};
+
+  // Capture modelId from first chunk (real API includes it in every content frame)
+  if (!state.modelId && chunk.model) {
+    state.modelId = chunk.model;
+  }
+  const modelId = state.modelId || "";
+
+  // Handle usage (may arrive standalone or with other chunks)
+  if (chunk.usage) {
+    state.usage = chunk.usage;
+  }
+
+  // Handle tool calls — stream incrementally, matching real API format:
+  // Frame 1: {name, toolUseId}  (first appearance, no input)
+  // Frame N: {input: "<fragment>", name, toolUseId}  (incremental arg fragments)
+  // Frame final: {name, stop: true, toolUseId}  (completion, emitted in emitFinish)
+  if (delta.tool_calls) {
+    state.hasToolCalls = true;
+    for (const tc of delta.tool_calls) {
+      const idx = tc.index ?? 0;
+
+      if (tc.id && tc.function?.name && !state.toolCallInit[idx]) {
+        // First appearance: emit frame with name + id, no input
+        state.toolCallInit[idx] = { id: tc.id, name: tc.function.name };
+        frames.push(encodeEventStream("toolUseEvent", {
+          name: tc.function.name,
+          toolUseId: tc.id
+        }));
+      }
+
+      // Emit incremental input fragment
+      if (tc.function?.arguments) {
+        const init = state.toolCallInit[idx];
+        frames.push(encodeEventStream("toolUseEvent", {
+          input: tc.function.arguments,
+          name: init?.name || tc.function?.name || "",
+          toolUseId: init?.id || tc.id || ""
+        }));
+      }
+    }
+  }
+
+  // Handle explicit reasoning_content (type-specific thinking channel)
+  if (delta.reasoning_content) {
+    frames.push(encodeEventStream("reasoningContentEvent", {
+      content: delta.reasoning_content,
+      modelId
+    }));
+  }
+
+  // Handle text content — emitted as assistantResponseEvent
+  if (delta.content) {
+    frames.push(encodeEventStream("assistantResponseEvent", {
+      content: delta.content,
+      modelId
+    }));
+  }
+
+  // Handle finish_reason
+  if (choice?.finish_reason) {
+    const finishFrames = emitFinish(state);
+    if (finishFrames) {
+      frames.push(...(Array.isArray(finishFrames) ? finishFrames : [finishFrames]));
+    }
+  }
+
+  if (frames.length === 0) return null;
+  return frames.length === 1 ? frames[0] : frames;
+}
+
+register(FORMATS.OPENAI, FORMATS.KIRO, null, convertOpenAIToKiro);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@smithy/eventstream-codec": "^4.2.14",
+    "@smithy/util-utf8": "^4.2.2",
     "@xyflow/react": "^12.10.1",
     "bcryptjs": "^3.0.3",
     "confbox": "^0.2.4",

--- a/src/mitm/handlers/base.js
+++ b/src/mitm/handlers/base.js
@@ -65,4 +65,162 @@ async function pipeSSE(routerRes, res, dumper) {
   }
 }
 
-module.exports = { fetchRouter, pipeSSE };
+/**
+ * Pipe SSE stream from router, transforming each chunk through a user function.
+ * Reads SSE data: lines, parses JSON, calls transformFn(parsed, state),
+ * and writes returned SSE strings to the client response.
+ *
+ * @param {Response} routerRes - Fetch Response from 9Router
+ * @param {http.ServerResponse} res - Client response
+ * @param {Function} transformFn - (parsedChunk, state) => string|string[]|null
+ * @param {object} state - Mutable state object shared across chunks and flush
+ */
+async function pipeTransformedSSE(routerRes, res, transformFn, state) {
+  const ct = routerRes.headers.get("content-type") || "application/json";
+  const resHeaders = { "Content-Type": ct, "Cache-Control": "no-cache", "Connection": "keep-alive" };
+  if (ct.includes("text/event-stream")) resHeaders["X-Accel-Buffering"] = "no";
+  res.writeHead(200, resHeaders);
+
+  if (!routerRes.body) {
+    res.end(await routerRes.text().catch(() => ""));
+    return;
+  }
+
+  const reader = routerRes.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || !trimmed.startsWith("data:")) continue;
+
+      const data = trimmed.slice(5).trim();
+      if (data === "[DONE]") continue;
+
+      if (process.env.DEBUG_MITM) {
+        console.log(`[MITM] SSE in: ${data.slice(0, 200)}`);
+      }
+
+      try {
+        const parsed = JSON.parse(data);
+        const result = transformFn(parsed, state);
+        if (result != null) {
+          const outputs = Array.isArray(result) ? result : [result];
+          for (const output of outputs) {
+            if (process.env.DEBUG_MITM) {
+              const len = output.length || output.byteLength || 0;
+              console.log(`[MITM] write binary frame (${len}B) first 20B: ${Array.from(output.slice(0, 20)).join(',')}`);
+            }
+            res.write(Buffer.from(output));
+          }
+        }
+      } catch {
+        // Skip unparseable lines
+      }
+    }
+  }
+
+  // Flush: pass null to signal stream end
+  try {
+    const flushed = transformFn(null, state);
+    if (flushed != null) {
+      const outputs = Array.isArray(flushed) ? flushed : [flushed];
+      for (const output of outputs) {
+        res.write(output);
+      }
+    }
+  } catch { /* ignore flush errors */ }
+
+  res.end();
+}
+
+/**
+ * Pipe SSE stream from router, transforming each chunk through a user function,
+ * and writing binary EventStream frames to the client.
+ *
+ * Reads SSE data: lines, parses JSON, calls transformFn(parsed, state),
+ * and writes returned Uint8Array frames to the client response.
+ *
+ * @param {Response} routerRes - Fetch Response from 9Router
+ * @param {http.ServerResponse} res - Client response
+ * @param {Function} transformFn - (parsedChunk, state) => Uint8Array|Uint8Array[]|null
+ * @param {object} state - Mutable state object shared across chunks and flush
+ */
+async function pipeTransformedEventStream(routerRes, res, transformFn, state) {
+  const resHeaders = {
+    "Content-Type": "application/vnd.amazon.eventstream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive"
+  };
+  res.writeHead(200, resHeaders);
+
+  if (!routerRes.body) {
+    res.end(await routerRes.text().catch(() => ""));
+    return;
+  }
+
+  const reader = routerRes.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || !trimmed.startsWith("data:")) continue;
+
+      const data = trimmed.slice(5).trim();
+      if (data === "[DONE]") continue;
+
+      if (process.env.DEBUG_MITM) {
+        console.log(`[MITM] SSE in: ${data.slice(0, 200)}`);
+      }
+
+      try {
+        const parsed = JSON.parse(data);
+        const result = transformFn(parsed, state);
+        if (result != null) {
+          const outputs = Array.isArray(result) ? result : [result];
+          for (const output of outputs) {
+            if (process.env.DEBUG_MITM) {
+              const len = output.length || output.byteLength || 0;
+              console.log(`[MITM] write binary frame (${len}B) first 20B: ${Array.from(output.slice(0, 20)).join(',')}`);
+            }
+            res.write(Buffer.from(output));
+          }
+        }
+      } catch {
+        // Skip unparseable lines
+      }
+    }
+  }
+
+  // Flush: pass null to signal stream end
+  try {
+    const flushed = transformFn(null, state);
+    if (flushed != null) {
+      const outputs = Array.isArray(flushed) ? flushed : [flushed];
+      for (const output of outputs) {
+        res.write(output);
+      }
+    }
+  } catch { /* ignore flush errors */ }
+
+  res.end();
+}
+
+module.exports = { fetchRouter, pipeSSE, pipeTransformedSSE, pipeTransformedEventStream };

--- a/src/mitm/handlers/kiro.js
+++ b/src/mitm/handlers/kiro.js
@@ -1,18 +1,47 @@
 const { err } = require("../logger");
-const { fetchRouter, pipeSSE } = require("./base");
+const { fetchRouter, pipeTransformedEventStream } = require("./base");
+const path = require("path");
+
+// Resolve paths to translator modules (ESM) from CommonJS context
+const KIRO_TO_OPENAI_PATH = path.resolve(
+  __dirname, "../../../open-sse/translator/request/kiro-to-openai.js"
+);
+const OPENAI_TO_KIRO_PATH = path.resolve(
+  __dirname, "../../../open-sse/translator/response/openai-to-kiro.js"
+);
 
 /**
- * Intercept Kiro request — replace model and forward to router
+ * Intercept Kiro request:
+ * 1. Parse Kiro body
+ * 2. Convert Kiro -> OpenAI via request translator
+ * 3. Send OpenAI body to 9Router
+ * 4. Pipe SSE response through OpenAI -> Kiro EventStream encoder
  */
 async function intercept(req, res, bodyBuffer, mappedModel) {
   try {
     const body = JSON.parse(bodyBuffer.toString());
-    body.model = mappedModel;
-    const routerRes = await fetchRouter(body, "/v1/chat/completions", req.headers);
-    await pipeSSE(routerRes, res);
+
+    // Dynamic import ESM translator modules from CommonJS
+    const [{ buildOpenAIPayload }, { convertOpenAIToKiro, initKiroState }] =
+      await Promise.all([
+        import(KIRO_TO_OPENAI_PATH),
+        import(OPENAI_TO_KIRO_PATH)
+      ]);
+
+    // Convert Kiro -> OpenAI
+    const openaiBody = buildOpenAIPayload(mappedModel, body, true, null);
+
+    // Send to 9Router
+    const routerRes = await fetchRouter(openaiBody, "/v1/chat/completions", req.headers);
+
+    // Pipe SSE with EventStream binary transformation
+    const state = initKiroState();
+    await pipeTransformedEventStream(routerRes, res, convertOpenAIToKiro, state);
   } catch (error) {
     err(`[Kiro] ${error.message}`);
-    if (!res.headersSent) res.writeHead(500, { "Content-Type": "application/json" });
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+    }
     res.end(JSON.stringify({ error: { message: error.message, type: "mitm_error" } }));
   }
 }

--- a/tests/unit/kiro-translator.test.js
+++ b/tests/unit/kiro-translator.test.js
@@ -306,15 +306,32 @@ describe("convertOpenAIToKiro (openai → kiro EventStream)", () => {
     expect(payload.modelId).toBe("gpt-5");
   });
 
-  it("passes <thinking> tags through as text content (no extraction)", () => {
+  it("extracts <thinking> tags into reasoningContentEvent, rest as text", () => {
     const chunk = makeOpenAIChunk({
       choice: { delta: { content: "<thinking>Let me think...</thinking>Here is the answer" } }
     });
     const state = initKiroState();
-    const { eventType, payload } = decodeFirst(convertOpenAIToKiro(chunk, state));
-    // Text content is passed through as-is — reasoningContentEvent is only for delta.reasoning_content
-    expect(eventType).toBe("assistantResponseEvent");
-    expect(payload.content).toBe("<thinking>Let me think...</thinking>Here is the answer");
+    const decoded = decodeAll(convertOpenAIToKiro(chunk, state));
+    // Thinking extracted to reasoningContentEvent
+    const reasoning = decoded.find(d => d.eventType === "reasoningContentEvent");
+    expect(reasoning).toBeDefined();
+    expect(reasoning.payload.content).toBe("Let me think...");
+    // Remaining text as assistantResponseEvent
+    const text = decoded.find(d => d.eventType === "assistantResponseEvent");
+    expect(text).toBeDefined();
+    expect(text.payload.content).toBe("Here is the answer");
+  });
+
+  it("handles <think> tag variant", () => {
+    const chunk = makeOpenAIChunk({
+      choice: { delta: { content: "<think>reasoning</think>response" } }
+    });
+    const state = initKiroState();
+    const decoded = decodeAll(convertOpenAIToKiro(chunk, state));
+    const reasoning = decoded.find(d => d.eventType === "reasoningContentEvent");
+    expect(reasoning.payload.content).toBe("reasoning");
+    const text = decoded.find(d => d.eventType === "assistantResponseEvent");
+    expect(text.payload.content).toBe("response");
   });
 
   it("emits reasoningContentEvent for delta.reasoning_content", () => {
@@ -653,7 +670,7 @@ describe("response round-trip: kiro → openai → kiro (EventStream)", () => {
     expect(payload.modelId).toBeDefined();
   });
 
-  it("round-trips reasoningContentEvent", () => {
+  it("round-trips reasoningContentEvent — extracts <thinking> back to reasoning", () => {
     const kiroEvent = makeKiroSSE("reasoningContentEvent", {
       reasoningContentEvent: { content: "Let me think about this" }
     });
@@ -662,13 +679,11 @@ describe("response round-trip: kiro → openai → kiro (EventStream)", () => {
     // kiro→openai wraps reasoning in <thinking> tags
     expect(openaiChunk.choices[0].delta.content).toBe("<thinking>Let me think about this</thinking>");
 
-    // openai→kiro for text with <thinking> passes through as assistantResponseEvent
-    // (only delta.reasoning_content triggers reasoningContentEvent)
+    // openai→kiro extracts <thinking> back to reasoningContentEvent
     const state2 = initKiroState();
     const { eventType, payload } = decodeFirst(convertOpenAIToKiro(openaiChunk, state2));
-    expect(eventType).toBe("assistantResponseEvent");
-    expect(payload.content).toContain("<thinking>");
-    expect(payload.content).toContain("Let me think about this");
+    expect(eventType).toBe("reasoningContentEvent");
+    expect(payload.content).toBe("Let me think about this");
   });
 
   it("round-trips messageStopEvent", () => {

--- a/tests/unit/kiro-translator.test.js
+++ b/tests/unit/kiro-translator.test.js
@@ -1,0 +1,743 @@
+import { describe, it, expect } from "vitest";
+import { EventStreamCodec } from "@smithy/eventstream-codec";
+import { toUtf8, fromUtf8 } from "@smithy/util-utf8";
+import { buildOpenAIPayload } from "../../open-sse/translator/request/kiro-to-openai.js";
+import { convertOpenAIToKiro, initKiroState } from "../../open-sse/translator/response/openai-to-kiro.js";
+import { buildKiroPayload } from "../../open-sse/translator/request/openai-to-kiro.js";
+import { convertKiroToOpenAI } from "../../open-sse/translator/response/kiro-to-openai.js";
+
+// ── EventStream decode helper ──────────────────────────────
+
+const codec = new EventStreamCodec(toUtf8, fromUtf8);
+
+/** Decode a binary EventStream frame and return { eventType, payload } */
+function decodeFrame(frame) {
+  const msg = codec.decode(frame);
+  const eventType = msg.headers[":event-type"]?.value || "";
+  const payload = JSON.parse(toUtf8(msg.body));
+  return { eventType, payload };
+}
+
+function decodeFirst(result) {
+  const frame = Array.isArray(result) ? result[0] : result;
+  return decodeFrame(frame);
+}
+
+function decodeAll(result) {
+  if (!result) return [];
+  const frames = Array.isArray(result) ? result : [result];
+  return frames.map(f => decodeFrame(f));
+}
+
+// ── Test fixtures ──────────────────────────────────────────
+
+const makeKiroBody = (overrides = {}) => ({
+  conversationState: {
+    chatTriggerType: "MANUAL",
+    conversationId: "test-conv-id",
+    currentMessage: {
+      userInputMessage: {
+        content: "What is the weather in Paris?",
+        modelId: "claude-sonnet-4-6",
+        origin: "AI_EDITOR"
+      }
+    },
+    history: [],
+    ...overrides.conversationState
+  },
+  inferenceConfig: {
+    maxTokens: 32000,
+    temperature: 0.7,
+    topP: 0.9
+  },
+  ...overrides.topLevel
+});
+
+const makeOpenAIChunk = (overrides = {}) => ({
+  id: "chatcmpl-test",
+  object: "chat.completion.chunk",
+  created: 1717000000,
+  model: "gpt-5",
+  choices: [{
+    index: 0,
+    delta: {},
+    finish_reason: null,
+    ...overrides.choice
+  }],
+  ...overrides.topLevel
+});
+
+// ── Request: kiro → openai ────────────────────────────────
+
+describe("buildOpenAIPayload (kiro → openai)", () => {
+  it("converts a basic text message", () => {
+    const result = buildOpenAIPayload("mapped-model", makeKiroBody(), true, null);
+
+    expect(result.model).toBe("mapped-model");
+    expect(result.stream).toBe(true);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toEqual({
+      role: "user",
+      content: "What is the weather in Paris?"
+    });
+  });
+
+  it("prefers model parameter over body modelId", () => {
+    const body = makeKiroBody();
+    const result = buildOpenAIPayload("mapped-gpt-5", body, true, null);
+    expect(result.model).toBe("mapped-gpt-5");
+  });
+
+  it("falls back to body modelId when model parameter is falsy", () => {
+    const result = buildOpenAIPayload("", makeKiroBody(), true, null);
+    expect(result.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("strips timestamp prefix from content", () => {
+    const body = makeKiroBody();
+    body.conversationState.currentMessage.userInputMessage.content =
+      "[Context: Current time is 2026-04-29T10:30:00.000Z]\n\nWhat is the weather?";
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.messages[0].content).toBe("What is the weather?");
+  });
+
+  it("maps inferenceConfig to OpenAI fields", () => {
+    const body = makeKiroBody();
+    body.inferenceConfig = { maxTokens: 8000, temperature: 0.3, topP: 0.95 };
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.max_tokens).toBe(8000);
+    expect(result.temperature).toBe(0.3);
+    expect(result.top_p).toBe(0.95);
+  });
+
+  it("omits inferenceConfig fields when absent", () => {
+    const body = makeKiroBody({ topLevel: { inferenceConfig: undefined } });
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.max_tokens).toBeUndefined();
+    expect(result.temperature).toBeUndefined();
+    expect(result.top_p).toBeUndefined();
+  });
+
+  it("converts tools from currentMessage context", () => {
+    const body = makeKiroBody();
+    body.conversationState.currentMessage.userInputMessage.userInputMessageContext = {
+      tools: [{
+        toolSpecification: {
+          name: "get_weather",
+          description: "Get current weather for a city",
+          inputSchema: {
+            json: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"]
+            }
+          }
+        }
+      }]
+    };
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]).toEqual({
+      type: "function",
+      function: {
+        name: "get_weather",
+        description: "Get current weather for a city",
+        parameters: {
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"]
+        }
+      }
+    });
+  });
+
+  it("converts tool results to separate tool-role messages", () => {
+    const body = makeKiroBody();
+    body.conversationState.currentMessage.userInputMessage.userInputMessageContext = {
+      toolResults: [{
+        toolUseId: "call_abc123",
+        status: "success",
+        content: [{ text: "Paris: 22°C, sunny" }]
+      }]
+    };
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toEqual({
+      role: "tool",
+      tool_call_id: "call_abc123",
+      content: "Paris: 22°C, sunny"
+    });
+    expect(result.messages[1]).toEqual({
+      role: "user",
+      content: "What is the weather in Paris?"
+    });
+  });
+
+  it("converts images to base64 data URI content parts", () => {
+    const body = makeKiroBody();
+    body.conversationState.currentMessage.userInputMessage.images = [{
+      format: "png",
+      source: { bytes: "aGVsbG8=" }
+    }];
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(Array.isArray(result.messages[0].content)).toBe(true);
+    expect(result.messages[0].content[0]).toEqual({
+      type: "image_url",
+      image_url: { url: "data:image/png;base64,aGVsbG8=" }
+    });
+    expect(result.messages[0].content[1]).toEqual({
+      type: "text",
+      text: "What is the weather in Paris?"
+    });
+  });
+
+  it("handles images without accompanying text", () => {
+    const body = makeKiroBody();
+    body.conversationState.currentMessage.userInputMessage.content = "";
+    body.conversationState.currentMessage.userInputMessage.images = [{
+      format: "jpeg",
+      source: { bytes: "aW1hZ2U=" }
+    }];
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(Array.isArray(result.messages[0].content)).toBe(true);
+    expect(result.messages[0].content).toHaveLength(1);
+    expect(result.messages[0].content[0].type).toBe("image_url");
+  });
+
+  it("handles empty history gracefully", () => {
+    const result = buildOpenAIPayload("m", makeKiroBody(), true, null);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it("processes history items into messages", () => {
+    const body = makeKiroBody();
+    body.conversationState.history = [
+      { userInputMessage: { content: "Hello, can you help me?", modelId: "claude-sonnet-4-6" } },
+      { assistantResponseMessage: { content: "Of course! What do you need?" } },
+      { userInputMessage: { content: "Tell me about Paris", modelId: "claude-sonnet-4-6" } },
+      { assistantResponseMessage: { content: "Paris is the capital of France." } }
+    ];
+    body.conversationState.currentMessage.userInputMessage.content = "What is the weather there?";
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.messages).toHaveLength(5);
+    expect(result.messages[0]).toEqual({ role: "user", content: "Hello, can you help me?" });
+    expect(result.messages[1]).toEqual({ role: "assistant", content: "Of course! What do you need?" });
+    expect(result.messages[2]).toEqual({ role: "user", content: "Tell me about Paris" });
+    expect(result.messages[3]).toEqual({ role: "assistant", content: "Paris is the capital of France." });
+    expect(result.messages[4]).toEqual({ role: "user", content: "What is the weather there?" });
+  });
+
+  it("converts assistant toolUses to tool_calls", () => {
+    const body = makeKiroBody();
+    body.conversationState.history = [
+      { userInputMessage: { content: "What is the weather in Paris?", modelId: "claude-sonnet-4-6" } },
+      {
+        assistantResponseMessage: {
+          content: "Let me check the weather.",
+          toolUses: [{ toolUseId: "call_xxx", name: "get_weather", input: { city: "Paris" } }]
+        }
+      }
+    ];
+    body.conversationState.currentMessage.userInputMessage.content = "continue";
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.messages[1].role).toBe("assistant");
+    expect(result.messages[1].tool_calls).toHaveLength(1);
+    expect(result.messages[1].tool_calls[0]).toEqual({
+      id: "call_xxx",
+      type: "function",
+      function: { name: "get_weather", arguments: '{"city":"Paris"}' }
+    });
+  });
+
+  it("handles empty toolSpecification inputSchema", () => {
+    const body = makeKiroBody();
+    body.conversationState.currentMessage.userInputMessage.userInputMessageContext = {
+      tools: [{
+        toolSpecification: {
+          name: "simple_tool",
+          description: "A simple tool",
+          inputSchema: { json: {} }
+        }
+      }]
+    };
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.tools[0].function.parameters).toEqual({
+      type: "object", properties: {}, required: []
+    });
+  });
+
+  it("handles missing conversationState gracefully", () => {
+    const result = buildOpenAIPayload("m", {}, true, null);
+    expect(result.model).toBe("m");
+    expect(result.messages).toHaveLength(0);
+    expect(result.stream).toBe(true);
+  });
+
+  it("skips empty user content after stripping timestamp", () => {
+    const body = makeKiroBody();
+    body.conversationState.currentMessage.userInputMessage.content =
+      "[Context: Current time is 2026-04-29T10:30:00.000Z]\n\n";
+    const result = buildOpenAIPayload("m", body, true, null);
+    expect(result.messages).toHaveLength(0);
+  });
+
+  it("defaults stream to true when not provided", () => {
+    const result = buildOpenAIPayload("m", makeKiroBody(), undefined, null);
+    expect(result.stream).toBe(true);
+  });
+
+  it("sets stream to false when explicitly false", () => {
+    const result = buildOpenAIPayload("m", makeKiroBody(), false, null);
+    expect(result.stream).toBe(false);
+  });
+});
+
+// ── Response: openai → kiro (binary EventStream) ──────────
+
+describe("convertOpenAIToKiro (openai → kiro EventStream)", () => {
+  it("converts text content to assistantResponseEvent with modelId", () => {
+    const chunk = makeOpenAIChunk({
+      choice: { delta: { content: "Hello, how can I help?" } }
+    });
+    const state = initKiroState();
+    const { eventType, payload } = decodeFirst(convertOpenAIToKiro(chunk, state));
+    expect(eventType).toBe("assistantResponseEvent");
+    expect(payload.content).toBe("Hello, how can I help?");
+    expect(payload.modelId).toBe("gpt-5");
+  });
+
+  it("passes <thinking> tags through as text content (no extraction)", () => {
+    const chunk = makeOpenAIChunk({
+      choice: { delta: { content: "<thinking>Let me think...</thinking>Here is the answer" } }
+    });
+    const state = initKiroState();
+    const { eventType, payload } = decodeFirst(convertOpenAIToKiro(chunk, state));
+    // Text content is passed through as-is — reasoningContentEvent is only for delta.reasoning_content
+    expect(eventType).toBe("assistantResponseEvent");
+    expect(payload.content).toBe("<thinking>Let me think...</thinking>Here is the answer");
+  });
+
+  it("emits reasoningContentEvent for delta.reasoning_content", () => {
+    const chunk = makeOpenAIChunk({
+      choice: { delta: { reasoning_content: "Step-by-step analysis" } }
+    });
+    const state = initKiroState();
+    const { eventType, payload } = decodeFirst(convertOpenAIToKiro(chunk, state));
+    expect(eventType).toBe("reasoningContentEvent");
+    expect(payload.content).toBe("Step-by-step analysis");
+    expect(payload.modelId).toBe("gpt-5");
+  });
+
+  it("emits both reasoning and text when both delta fields present", () => {
+    const chunk = makeOpenAIChunk({
+      choice: {
+        delta: { reasoning_content: "Let me think...", content: "Here is the answer" }
+      }
+    });
+    const state = initKiroState();
+    const decoded = decodeAll(convertOpenAIToKiro(chunk, state));
+    expect(decoded).toHaveLength(2);
+    expect(decoded[0].eventType).toBe("reasoningContentEvent");
+    expect(decoded[0].payload.content).toBe("Let me think...");
+    expect(decoded[1].eventType).toBe("assistantResponseEvent");
+    expect(decoded[1].payload.content).toBe("Here is the answer");
+  });
+
+  it("streams tool calls incrementally with stop:true at finish", () => {
+    const state = initKiroState();
+
+    // First chunk: id + name → emits {name, toolUseId} frame (no input)
+    let result = convertOpenAIToKiro(makeOpenAIChunk({
+      choice: {
+        delta: {
+          tool_calls: [{
+            index: 0, id: "call_abc", type: "function",
+            function: { name: "get_weather", arguments: "" }
+          }]
+        }
+      }
+    }), state);
+    const decoded1 = decodeAll(result);
+    expect(decoded1).toHaveLength(1);
+    expect(decoded1[0].eventType).toBe("toolUseEvent");
+    expect(decoded1[0].payload.name).toBe("get_weather");
+    expect(decoded1[0].payload.toolUseId).toBe("call_abc");
+    expect(decoded1[0].payload.input).toBeUndefined(); // first frame has no input
+
+    // Second chunk: arguments delta → emits {input: "<fragment>", ...}
+    result = convertOpenAIToKiro(makeOpenAIChunk({
+      choice: {
+        delta: {
+          tool_calls: [{ index: 0, function: { arguments: '{"city":"Paris"}' } }]
+        }
+      }
+    }), state);
+    const decoded2 = decodeAll(result);
+    expect(decoded2).toHaveLength(1);
+    expect(decoded2[0].eventType).toBe("toolUseEvent");
+    expect(decoded2[0].payload.input).toBe('{"city":"Paris"}');
+
+    // Finish: emits {name, stop: true, toolUseId} (NOT messageStopEvent)
+    result = convertOpenAIToKiro(makeOpenAIChunk({
+      choice: { delta: {}, finish_reason: "tool_calls" }
+    }), state);
+    const decoded3 = decodeAll(result);
+    const stopFrame = decoded3.find(d => d.payload.stop === true);
+    expect(stopFrame).toBeDefined();
+    expect(stopFrame.eventType).toBe("toolUseEvent");
+    expect(stopFrame.payload.toolUseId).toBe("call_abc");
+    expect(decoded3.find(d => d.eventType === "messageStopEvent")).toBeUndefined();
+  });
+
+  it("emits messageStopEvent on finish_reason stop", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: {}, finish_reason: "stop" } });
+    const { eventType } = decodeFirst(convertOpenAIToKiro(chunk, initKiroState()));
+    expect(eventType).toBe("messageStopEvent");
+  });
+
+  it("emits messageStopEvent on finish_reason length", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: {}, finish_reason: "length" } });
+    const { eventType } = decodeFirst(convertOpenAIToKiro(chunk, initKiroState()));
+    expect(eventType).toBe("messageStopEvent");
+  });
+
+  it("emits usageEvent with correct token mapping", () => {
+    const state = initKiroState();
+    let result = convertOpenAIToKiro(makeOpenAIChunk({
+      topLevel: { usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 } }
+    }), state);
+    expect(result).toBeNull();
+
+    result = convertOpenAIToKiro(makeOpenAIChunk({
+      choice: { delta: {}, finish_reason: "stop" }
+    }), state);
+
+    const decoded = decodeAll(result);
+    const usageEvent = decoded.find(d => d.eventType === "usageEvent");
+    expect(usageEvent).toBeDefined();
+    expect(usageEvent.payload.inputTokens).toBe(100);
+    expect(usageEvent.payload.outputTokens).toBe(50);
+  });
+
+  it("skips empty content", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: { content: "" } } });
+    expect(convertOpenAIToKiro(chunk, initKiroState())).toBeNull();
+  });
+
+  it("streams multiple tool calls incrementally", () => {
+    const state = initKiroState();
+
+    // Tool 1 first appearance
+    let decoded = decodeAll(convertOpenAIToKiro(makeOpenAIChunk({
+      choice: {
+        delta: {
+          tool_calls: [{
+            index: 0, id: "call_1", type: "function",
+            function: { name: "get_weather", arguments: '{"city":"Paris"}' }
+          }]
+        }
+      }
+    }), state));
+    // First frame: {name, toolUseId}, second frame: {input, name, toolUseId}
+    expect(decoded).toHaveLength(2);
+    expect(decoded[0].payload.name).toBe("get_weather");
+    expect(decoded[0].payload.input).toBeUndefined();
+    expect(decoded[1].payload.input).toBe('{"city":"Paris"}');
+
+    // Tool 2 first appearance
+    decoded = decodeAll(convertOpenAIToKiro(makeOpenAIChunk({
+      choice: {
+        delta: {
+          tool_calls: [{
+            index: 1, id: "call_2", type: "function",
+            function: { name: "get_time", arguments: '{"timezone":"CET"}' }
+          }]
+        }
+      }
+    }), state));
+    expect(decoded[0].payload.name).toBe("get_time");
+    expect(decoded[0].payload.input).toBeUndefined();
+    expect(decoded[1].payload.input).toBe('{"timezone":"CET"}');
+
+    // Finish: two stop frames
+    decoded = decodeAll(convertOpenAIToKiro(makeOpenAIChunk({
+      choice: { delta: {}, finish_reason: "tool_calls" }
+    }), state));
+    const stops = decoded.filter(d => d.payload.stop === true);
+    expect(stops).toHaveLength(2);
+    expect(stops[0].payload.toolUseId).toBe("call_1");
+    expect(stops[1].payload.toolUseId).toBe("call_2");
+  });
+
+  it("handles usage arriving with finish chunk", () => {
+    const chunk = makeOpenAIChunk({
+      choice: { delta: {}, finish_reason: "stop" },
+      topLevel: { usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 } }
+    });
+    const decoded = decodeAll(convertOpenAIToKiro(chunk, initKiroState()));
+    expect(decoded.find(d => d.eventType === "usageEvent")).toBeDefined();
+    expect(decoded.find(d => d.eventType === "messageStopEvent")).toBeDefined();
+  });
+
+  it("emits messageStopEvent on flush when not previously sent", () => {
+    const { eventType } = decodeFirst(convertOpenAIToKiro(null, initKiroState()));
+    expect(eventType).toBe("messageStopEvent");
+  });
+
+  it("returns null on flush when finish already sent", () => {
+    const state = initKiroState();
+    state.finishSent = true;
+    expect(convertOpenAIToKiro(null, state)).toBeNull();
+  });
+
+  it("passes tool call arguments through as raw string", () => {
+    const state = initKiroState();
+    // First appearance (id+name) and first input fragment arrive in same delta
+    const decoded = decodeAll(convertOpenAIToKiro(makeOpenAIChunk({
+      choice: {
+        delta: {
+          tool_calls: [{
+            index: 0, id: "call_raw", type: "function",
+            function: { name: "raw_tool", arguments: "not valid json" }
+          }]
+        }
+      }
+    }), state));
+    // First frame: init (no input), second frame: input fragment
+    expect(decoded[0].payload.name).toBe("raw_tool");
+    expect(decoded[0].payload.input).toBeUndefined();
+    expect(decoded[1].payload.input).toBe("not valid json");
+  });
+
+  it("handles chunk with no choices array", () => {
+    const chunk = { id: "chatcmpl-test", object: "chat.completion.chunk", created: 1717000000, model: "gpt-5" };
+    expect(convertOpenAIToKiro(chunk, initKiroState())).toBeNull();
+  });
+
+  it("includes :message-type header in every frame", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: { content: "Hello" } } });
+    const result = convertOpenAIToKiro(chunk, initKiroState());
+    const frame = Array.isArray(result) ? result[0] : result;
+    const msg = codec.decode(frame);
+    expect(msg.headers[":message-type"].value).toBe("event");
+    expect(msg.headers[":content-type"].value).toBe("application/json");
+  });
+});
+
+// ── Round-trip: openai → kiro → openai ─────────────────────
+
+describe("round-trip: openai → kiro → openai", () => {
+  it("preserves messages, tools, and config through round-trip", () => {
+    const openaiBody = {
+      model: "gpt-5",
+      messages: [
+        { role: "user", content: "What is the weather in Paris?" },
+        {
+          role: "assistant", content: "Let me check.",
+          tool_calls: [{
+            id: "call_1", type: "function",
+            function: { name: "get_weather", arguments: '{"city":"Paris"}' }
+          }]
+        },
+        { role: "tool", tool_call_id: "call_1", content: "Paris: 22°C, sunny" },
+        { role: "user", content: "Thanks!" }
+      ],
+      tools: [{
+        type: "function",
+        function: {
+          name: "get_weather", description: "Get weather for a city",
+          parameters: {
+            type: "object", properties: { city: { type: "string" } }, required: ["city"]
+          }
+        }
+      }],
+      max_tokens: 8000, temperature: 0.5, top_p: 0.95, stream: true
+    };
+
+    const kiroPayload = buildKiroPayload(openaiBody.model, openaiBody, true, null);
+    const result = buildOpenAIPayload(openaiBody.model, kiroPayload, true, null);
+
+    expect(result.messages.length).toBeGreaterThanOrEqual(3);
+    const roles = result.messages.map(m => m.role);
+    expect(roles).toContain("user");
+    expect(roles).toContain("assistant");
+    expect(roles).toContain("tool");
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].function.name).toBe("get_weather");
+    expect(result.max_tokens).toBe(8000);
+    expect(result.temperature).toBe(0.5);
+    expect(result.top_p).toBe(0.95);
+    expect(result.model).toBe("gpt-5");
+  });
+
+  it("handles conversation with only user messages", () => {
+    const openaiBody = {
+      model: "gpt-5",
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi! How can I help?" },
+        { role: "user", content: "Tell me a joke" }
+      ],
+      stream: true
+    };
+    const kiroPayload = buildKiroPayload(openaiBody.model, openaiBody, true, null);
+    const result = buildOpenAIPayload(openaiBody.model, kiroPayload, true, null);
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0].role).toBe("user");
+    expect(result.messages[1].role).toBe("assistant");
+    expect(result.messages[2].role).toBe("user");
+  });
+});
+
+// ── Round-trip: kiro → openai → kiro ──────────────────────
+
+describe("round-trip: kiro → openai → kiro", () => {
+  it("preserves structural fidelity through round-trip", () => {
+    const kiroBody = makeKiroBody();
+    kiroBody.conversationState.history = [
+      { userInputMessage: { content: "Hello", modelId: "claude-sonnet-4-6" } },
+      { assistantResponseMessage: { content: "Hi there!" } }
+    ];
+    kiroBody.conversationState.currentMessage.userInputMessage.content = "How are you?";
+    kiroBody.conversationState.currentMessage.userInputMessage.userInputMessageContext = {
+      tools: [{
+        toolSpecification: {
+          name: "greet", description: "Greet the user",
+          inputSchema: { json: { type: "object", properties: {}, required: [] } }
+        }
+      }]
+    };
+    const openaiBody = buildOpenAIPayload("claude-sonnet-4-6", kiroBody, true, null);
+    const result = buildKiroPayload(openaiBody.model, openaiBody, true, null);
+    expect(result.conversationState.currentMessage.userInputMessage).toBeDefined();
+    expect(result.conversationState.currentMessage.userInputMessage.content).toContain("How are you?");
+    expect(result.conversationState.history.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("preserves model name in modelId field", () => {
+    const kiroBody = makeKiroBody();
+    const openaiBody = buildOpenAIPayload("my-model", kiroBody, true, null);
+    const result = buildKiroPayload("my-model", openaiBody, true, null);
+    expect(result.conversationState.currentMessage.userInputMessage.modelId).toBe("my-model");
+  });
+
+  it("preserves inference config in round-trip", () => {
+    const kiroBody = makeKiroBody();
+    kiroBody.inferenceConfig = { maxTokens: 4000, temperature: 0.2, topP: 1.0 };
+    const openaiBody = buildOpenAIPayload("m", kiroBody, true, null);
+    expect(openaiBody.max_tokens).toBe(4000);
+    expect(openaiBody.temperature).toBe(0.2);
+    expect(openaiBody.top_p).toBe(1.0);
+  });
+});
+
+// ── Response round-trip: kiro → openai → kiro (EventStream)
+
+describe("response round-trip: kiro → openai → kiro (EventStream)", () => {
+  function makeKiroSSE(eventType, data) {
+    return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
+
+  it("round-trips assistantResponseEvent", () => {
+    const kiroEvent = makeKiroSSE("assistantResponseEvent", {
+      assistantResponseEvent: { content: "Hello world" }
+    });
+    const state1 = {};
+    const openaiChunk = convertKiroToOpenAI(kiroEvent, state1);
+    expect(openaiChunk.choices[0].delta.content).toBe("Hello world");
+
+    const state2 = initKiroState();
+    const { eventType, payload } = decodeFirst(convertOpenAIToKiro(openaiChunk, state2));
+    expect(eventType).toBe("assistantResponseEvent");
+    expect(payload.content).toBe("Hello world");
+    expect(payload.modelId).toBeDefined();
+  });
+
+  it("round-trips reasoningContentEvent", () => {
+    const kiroEvent = makeKiroSSE("reasoningContentEvent", {
+      reasoningContentEvent: { content: "Let me think about this" }
+    });
+    const state1 = {};
+    const openaiChunk = convertKiroToOpenAI(kiroEvent, state1);
+    // kiro→openai wraps reasoning in <thinking> tags
+    expect(openaiChunk.choices[0].delta.content).toBe("<thinking>Let me think about this</thinking>");
+
+    // openai→kiro for text with <thinking> passes through as assistantResponseEvent
+    // (only delta.reasoning_content triggers reasoningContentEvent)
+    const state2 = initKiroState();
+    const { eventType, payload } = decodeFirst(convertOpenAIToKiro(openaiChunk, state2));
+    expect(eventType).toBe("assistantResponseEvent");
+    expect(payload.content).toContain("<thinking>");
+    expect(payload.content).toContain("Let me think about this");
+  });
+
+  it("round-trips messageStopEvent", () => {
+    const kiroEvent = makeKiroSSE("messageStopEvent", { messageStopEvent: {} });
+    const state1 = {};
+    const openaiChunk = convertKiroToOpenAI(kiroEvent, state1);
+    expect(openaiChunk.choices[0].finish_reason).toBe("stop");
+    const { eventType } = decodeFirst(convertOpenAIToKiro(openaiChunk, initKiroState()));
+    expect(eventType).toBe("messageStopEvent");
+  });
+
+  it("round-trips toolUseEvent through incremental streaming", () => {
+    // Kiro toolUseEvent with complete input → becomes OpenAI tool_calls delta
+    const kiroEvent = makeKiroSSE("toolUseEvent", {
+      toolUseEvent: { toolUseId: "call_test", name: "get_weather", input: { city: "Paris" } }
+    });
+    const state1 = {};
+    const openaiChunk = convertKiroToOpenAI(kiroEvent, state1);
+    expect(openaiChunk.choices[0].delta.tool_calls[0].function.name).toBe("get_weather");
+
+    // OpenAI delta → kiro incremental frames
+    const state2 = initKiroState();
+    // First: init frame (no input) + input frame (stringified args)
+    const decodedInit = decodeAll(convertOpenAIToKiro(openaiChunk, state2));
+    expect(decodedInit[0].eventType).toBe("toolUseEvent");
+    expect(decodedInit[0].payload.name).toBe("get_weather");
+    expect(decodedInit[0].payload.input).toBeUndefined();
+    expect(decodedInit[1].payload.input).toBe('{"city":"Paris"}');
+
+    // Finish: stop frame
+    const decodedStop = decodeAll(convertOpenAIToKiro(makeOpenAIChunk({
+      choice: { delta: {}, finish_reason: "tool_calls" }
+    }), state2));
+    expect(decodedStop[0].payload.stop).toBe(true);
+    expect(decodedStop[0].payload.toolUseId).toBe("call_test");
+  });
+});
+
+// ── Binary frame validation ────────────────────────────────
+
+describe("EventStream binary frame output", () => {
+  it("produces valid binary frames decodable by EventStreamCodec", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: { content: "Hello" } } });
+    const result = convertOpenAIToKiro(chunk, initKiroState());
+    const frame = Array.isArray(result) ? result[0] : result;
+    expect(frame).toBeInstanceOf(Uint8Array);
+    const msg = codec.decode(frame);
+    expect(msg.headers).toBeDefined();
+  });
+
+  it("produces frames with correct :event-type header", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: { content: "Test" } } });
+    const { eventType, payload } = decodeFirst(convertOpenAIToKiro(chunk, initKiroState()));
+    expect(eventType).toBe("assistantResponseEvent");
+    expect(payload).toBeDefined();
+  });
+
+  it("produces non-empty frames", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: { content: "Hello" } } });
+    const result = convertOpenAIToKiro(chunk, initKiroState());
+    const frame = Array.isArray(result) ? result[0] : result;
+    expect(frame.length).toBeGreaterThan(0);
+  });
+
+  it("correctly decodes the payload as JSON", () => {
+    const chunk = makeOpenAIChunk({ choice: { delta: { content: "Hello world" } } });
+    const result = convertOpenAIToKiro(chunk, initKiroState());
+    const msg = codec.decode(Array.isArray(result) ? result[0] : result);
+    const body = JSON.parse(toUtf8(msg.body));
+    expect(body.content).toBe("Hello world");
+  });
+});


### PR DESCRIPTION
## Summary
- Add **kiro→openai** request translator reversing `conversationState` to OpenAI Chat Completions format
- Add **openai→kiro** response translator encoding binary AWS EventStream frames via `@smithy/eventstream-codec`
- Wire Kiro MITM handler to translate payloads before routing to 9Router and encode responses as `application/vnd.amazon.eventstream`
- Match real AWS CodeWhisperer API format: `modelId` in every content frame, incremental tool call streaming with `stop:true` completion signal
- Fix hardcoded `maxTokens` in existing `openai-to-kiro` to preserve `body.max_tokens` through round-trips
- 47 unit tests covering request/response conversion, round-trips, and binary frame validation

## Test plan
- [x] `cd tests && npm test -- kiro-translator` — 47/47 passing
- [x] End-to-end: MITM proxy with Kiro client against real model