### PR TITLE
Update providerModels.js

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -415,7 +415,7 @@ export const PROVIDER_MODELS = {
     { id: "command-a-03-2025", name: "Command A (Mar 2025)" },
   ],
   nvidia: [
-    { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5" },
+    { id: "minimaxai/minimax-m2.7", name: "Minimax M2.7" },
     { id: "z-ai/glm4.7", name: "GLM 4.7" },
     { id: "nvidia/nv-embedqa-e5-v5", name: "NV EmbedQA E5 v5", type: "embedding" },
   ],


### PR DESCRIPTION
KIMI K2.5 will be deprecated on 05/05/2026. Update latest Minimax version