### PR TITLE
Add provider pool scoping for API keys

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { Card, Button, Input, Modal, CardSkeleton, Toggle } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+import { AI_PROVIDERS } from "@/shared/constants/providers";
 
 const TUNNEL_BENEFITS = [
   { icon: "public", title: "Access Anywhere", desc: "Use your API from any network" },
@@ -25,6 +26,12 @@ export default function APIPageClient({ machineId }) {
   const [loading, setLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyAllowedProviders, setNewKeyAllowedProviders] = useState([]);
+  const [providerConnections, setProviderConnections] = useState([]);
+  const [providerPools, setProviderPools] = useState([]);
+  const [newPoolName, setNewPoolName] = useState("");
+  const [newPoolProviderIds, setNewPoolProviderIds] = useState([]);
+  const [newKeyProviderPoolId, setNewKeyProviderPoolId] = useState("");
   const [createdKey, setCreatedKey] = useState(null);
 
   const [requireApiKey, setRequireApiKey] = useState(false);
@@ -216,10 +223,22 @@ export default function APIPageClient({ machineId }) {
 
   const fetchData = async () => {
     try {
-      const keysRes = await fetch("/api/keys");
+      const [keysRes, providersRes, poolsRes] = await Promise.all([
+        fetch("/api/keys"),
+        fetch("/api/providers"),
+        fetch("/api/provider-pools"),
+      ]);
       const keysData = await keysRes.json();
       if (keysRes.ok) {
         setKeys(keysData.keys || []);
+      }
+      if (providersRes.ok) {
+        const providersData = await providersRes.json();
+        setProviderConnections(providersData.connections || []);
+      }
+      if (poolsRes.ok) {
+        const poolsData = await poolsRes.json();
+        setProviderPools(poolsData.pools || []);
       }
     } catch (error) {
       console.log("Error fetching data:", error);
@@ -574,7 +593,11 @@ export default function APIPageClient({ machineId }) {
       const res = await fetch("/api/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newKeyName }),
+        body: JSON.stringify({
+          name: newKeyName,
+          allowedProviders: newKeyAllowedProviders,
+          providerPoolId: newKeyProviderPoolId || null,
+        }),
       });
       const data = await res.json();
 
@@ -582,6 +605,8 @@ export default function APIPageClient({ machineId }) {
         setCreatedKey(data.key);
         await fetchData();
         setNewKeyName("");
+        setNewKeyAllowedProviders([]);
+        setNewKeyProviderPoolId("");
         setShowAddModal(false);
       }
     } catch (error) {
@@ -621,6 +646,88 @@ export default function APIPageClient({ machineId }) {
     } catch (error) {
       console.log("Error toggling key:", error);
     }
+  };
+
+  const handleUpdateKeyProviders = async (id, allowedProviders) => {
+    try {
+      const res = await fetch(`/api/keys/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowedProviders }),
+      });
+      if (res.ok) {
+        setKeys(prev => prev.map(k => k.id === id ? { ...k, allowedProviders } : k));
+      }
+    } catch (error) {
+      console.log("Error updating key providers:", error);
+    }
+  };
+
+  const handleUpdateKeyPool = async (id, providerPoolId) => {
+    try {
+      const normalizedPoolId = providerPoolId || null;
+      const res = await fetch(`/api/keys/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerPoolId: normalizedPoolId }),
+      });
+      if (res.ok) {
+        setKeys(prev => prev.map(k => k.id === id ? { ...k, providerPoolId: normalizedPoolId } : k));
+      }
+    } catch (error) {
+      console.log("Error updating key provider pool:", error);
+    }
+  };
+
+  const handleCreateProviderPool = async () => {
+    if (!newPoolName.trim()) return;
+    try {
+      const res = await fetch("/api/provider-pools", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newPoolName, providerIds: newPoolProviderIds }),
+      });
+      if (res.ok) {
+        setNewPoolName("");
+        setNewPoolProviderIds([]);
+        await fetchData();
+      }
+    } catch (error) {
+      console.log("Error creating provider pool:", error);
+    }
+  };
+
+  const handleDeleteProviderPool = async (id) => {
+    if (!confirm("Delete this provider pool?")) return;
+    try {
+      const res = await fetch(`/api/provider-pools/${id}`, { method: "DELETE" });
+      if (res.ok) await fetchData();
+    } catch (error) {
+      console.log("Error deleting provider pool:", error);
+    }
+  };
+
+  const providerOptions = Array.from(
+    new Map(
+      providerConnections.map((connection) => {
+        const providerId = connection.provider;
+        const providerInfo = AI_PROVIDERS[providerId];
+        return [
+          providerId,
+          {
+            id: providerId,
+            name: providerInfo?.name || connection.name || providerId,
+          },
+        ];
+      })
+    ).values()
+  ).sort((a, b) => a.name.localeCompare(b.name));
+
+  const getProviderScopeText = (allowedProviders = []) => {
+    if (!allowedProviders.length) return "All providers";
+    return allowedProviders
+      .map((providerId) => AI_PROVIDERS[providerId]?.name || providerId)
+      .join(", ");
   };
 
   const maskKey = (fullKey) => {
@@ -981,6 +1088,25 @@ export default function APIPageClient({ machineId }) {
                   <p className="text-xs text-text-muted mt-1">
                     Created {new Date(key.createdAt).toLocaleDateString()}
                   </p>
+                  <details className="mt-2">
+                    <summary className="cursor-pointer text-xs text-text-muted hover:text-primary">
+                      Provider scope: {key.providerPoolId ? `Pool: ${providerPools.find((p) => p.id === key.providerPoolId)?.name || "Unknown"}` : getProviderScopeText(key.allowedProviders)}
+                    </summary>
+                    <div className="mt-2 flex flex-col gap-2">
+                      <ProviderPoolSelect
+                        providerPools={providerPools}
+                        value={key.providerPoolId || ""}
+                        onChange={(poolId) => handleUpdateKeyPool(key.id, poolId)}
+                      />
+                      {!key.providerPoolId && (
+                        <ProviderScopeSelector
+                          providerOptions={providerOptions}
+                          selectedProviders={key.allowedProviders || []}
+                          onChange={(allowedProviders) => handleUpdateKeyProviders(key.id, allowedProviders)}
+                        />
+                      )}
+                    </div>
+                  </details>
                   {key.isActive === false && (
                     <p className="text-xs text-orange-500 mt-1">Paused</p>
                   )}
@@ -1013,6 +1139,27 @@ export default function APIPageClient({ machineId }) {
         )}
       </Card>
 
+      {/* Provider Pools */}
+      <Card>
+        <h2 className="text-lg font-semibold mb-4">Provider Pools</h2>
+        <div className="flex flex-col gap-3">
+          <Input label="Pool name" value={newPoolName} onChange={(e) => setNewPoolName(e.target.value)} placeholder="e.g. Premium providers" />
+          <ProviderScopeSelector providerOptions={providerOptions} selectedProviders={newPoolProviderIds} onChange={setNewPoolProviderIds} />
+          <Button onClick={handleCreateProviderPool} disabled={!newPoolName.trim()}>Create Pool</Button>
+          <div className="flex flex-col gap-2">
+            {providerPools.map((pool) => (
+              <div key={pool.id} className="flex items-center justify-between rounded border border-border px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium">{pool.name}</p>
+                  <p className="text-xs text-text-muted">{getProviderScopeText(pool.providerIds || [])}</p>
+                </div>
+                <button onClick={() => handleDeleteProviderPool(pool.id)} className="text-red-500 text-xs hover:underline">Delete</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card>
+
       {/* Add Key Modal */}
       <Modal
         isOpen={showAddModal}
@@ -1020,6 +1167,7 @@ export default function APIPageClient({ machineId }) {
         onClose={() => {
           setShowAddModal(false);
           setNewKeyName("");
+          setNewKeyAllowedProviders([]);
         }}
       >
         <div className="flex flex-col gap-4">
@@ -1029,6 +1177,18 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewKeyName(e.target.value)}
             placeholder="Production Key"
           />
+          <ProviderPoolSelect
+            providerPools={providerPools}
+            value={newKeyProviderPoolId}
+            onChange={setNewKeyProviderPoolId}
+          />
+          {!newKeyProviderPoolId && (
+            <ProviderScopeSelector
+              providerOptions={providerOptions}
+              selectedProviders={newKeyAllowedProviders}
+              onChange={setNewKeyAllowedProviders}
+            />
+          )}
           <div className="flex gap-2">
             <Button onClick={handleCreateKey} fullWidth disabled={!newKeyName.trim()}>
               Create
@@ -1037,6 +1197,8 @@ export default function APIPageClient({ machineId }) {
               onClick={() => {
                 setShowAddModal(false);
                 setNewKeyName("");
+                setNewKeyAllowedProviders([]);
+                setNewKeyProviderPoolId("");
               }}
               variant="ghost"
               fullWidth
@@ -1287,6 +1449,76 @@ function StatusAlert({ status, className = "" }) {
   );
 }
 
+function ProviderPoolSelect({ providerPools, value, onChange }) {
+  return (
+    <div className="rounded-lg border border-border p-3">
+      <p className="text-sm font-medium mb-1">Provider pool</p>
+      <p className="text-xs text-text-muted mb-2">Choose a pool, or leave empty to allow all providers.</p>
+      <select
+        className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="">No pool (all providers)</option>
+        {providerPools.map((pool) => (
+          <option key={pool.id} value={pool.id}>{pool.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function ProviderScopeSelector({ providerOptions, selectedProviders, onChange, className = "" }) {
+  const toggleProvider = (providerId) => {
+    const next = selectedProviders.includes(providerId)
+      ? selectedProviders.filter((id) => id !== providerId)
+      : [...selectedProviders, providerId];
+    onChange(next);
+  };
+
+  return (
+    <div className={`rounded-lg border border-border p-3 ${className}`}>
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div>
+          <p className="text-sm font-medium">Allowed providers</p>
+          <p className="text-xs text-text-muted">
+            Leave empty to allow this key to use every provider.
+          </p>
+        </div>
+        {selectedProviders.length > 0 && (
+          <button
+            type="button"
+            onClick={() => onChange([])}
+            className="text-xs text-primary hover:underline shrink-0"
+          >
+            Allow all
+          </button>
+        )}
+      </div>
+      {providerOptions.length === 0 ? (
+        <p className="text-xs text-text-muted">No providers configured yet. This key will allow all providers.</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {providerOptions.map((provider) => (
+            <button
+              key={provider.id}
+              type="button"
+              onClick={() => toggleProvider(provider.id)}
+              className={`px-2.5 py-1 rounded-full border text-xs transition-colors ${
+                selectedProviders.includes(provider.id)
+                  ? "bg-primary text-white border-primary"
+                  : "border-border text-text-muted hover:text-primary hover:border-primary/50"
+              }`}
+            >
+              {provider.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /** Inline tooltip, Claude Code CLI style */
 function Tooltip({ text }) {
   return (
@@ -1323,4 +1555,10 @@ function SecurityWarning({ message, action }) {
 
 APIPageClient.propTypes = {
   machineId: PropTypes.string.isRequired,
+};
+
+ProviderPoolSelect.propTypes = {
+  providerPools: PropTypes.array.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -21,7 +21,7 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { isActive } = body;
+    const { isActive, allowedProviders, providerPoolId } = body;
 
     const existing = await getApiKeyById(id);
     if (!existing) {
@@ -30,6 +30,15 @@ export async function PUT(request, { params }) {
 
     const updateData = {};
     if (isActive !== undefined) updateData.isActive = isActive;
+    if (allowedProviders !== undefined) {
+      if (!Array.isArray(allowedProviders)) {
+        return NextResponse.json({ error: "allowedProviders must be an array" }, { status: 400 });
+      }
+      updateData.allowedProviders = allowedProviders;
+    }
+    if (providerPoolId !== undefined) {
+      updateData.providerPoolId = providerPoolId || null;
+    }
 
     const updated = await updateApiKey(id, updateData);
 

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -19,7 +19,7 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name } = body;
+    const { name, allowedProviders = [], providerPoolId = null } = body;
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -27,7 +27,7 @@ export async function POST(request) {
 
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
-    const apiKey = await createApiKey(name, machineId);
+    const apiKey = await createApiKey(name, machineId, allowedProviders, providerPoolId);
 
     return NextResponse.json({
       key: apiKey.key,

--- a/src/app/api/provider-pools/[id]/route.js
+++ b/src/app/api/provider-pools/[id]/route.js
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { getProviderPoolById, updateProviderPool, deleteProviderPool } from "@/lib/localDb";
+
+export async function GET(request, { params }) {
+  try {
+    const { id } = await params;
+    const pool = await getProviderPoolById(id);
+    if (!pool) {
+      return NextResponse.json({ error: "Provider pool not found" }, { status: 404 });
+    }
+    return NextResponse.json({ pool });
+  } catch (error) {
+    console.log("Error fetching provider pool:", error);
+    return NextResponse.json({ error: "Failed to fetch provider pool" }, { status: 500 });
+  }
+}
+
+export async function PUT(request, { params }) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { name, providerIds } = body;
+
+    const updateData = {};
+    if (name !== undefined) {
+      if (!name || !name.trim()) {
+        return NextResponse.json({ error: "Name is required" }, { status: 400 });
+      }
+      updateData.name = name.trim();
+    }
+
+    if (providerIds !== undefined) {
+      if (!Array.isArray(providerIds)) {
+        return NextResponse.json({ error: "providerIds must be an array" }, { status: 400 });
+      }
+      updateData.providerIds = providerIds;
+    }
+
+    const updated = await updateProviderPool(id, updateData);
+    if (!updated) {
+      return NextResponse.json({ error: "Provider pool not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ pool: updated });
+  } catch (error) {
+    console.log("Error updating provider pool:", error);
+    return NextResponse.json({ error: "Failed to update provider pool" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  try {
+    const { id } = await params;
+    const ok = await deleteProviderPool(id);
+    if (!ok) {
+      return NextResponse.json({ error: "Provider pool not found" }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.log("Error deleting provider pool:", error);
+    return NextResponse.json({ error: "Failed to delete provider pool" }, { status: 500 });
+  }
+}

--- a/src/app/api/provider-pools/route.js
+++ b/src/app/api/provider-pools/route.js
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getProviderPools, createProviderPool } from "@/lib/localDb";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const pools = await getProviderPools();
+    return NextResponse.json({ pools });
+  } catch (error) {
+    console.log("Error fetching provider pools:", error);
+    return NextResponse.json({ error: "Failed to fetch provider pools" }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { name, providerIds = [] } = body;
+
+    if (!name || !name.trim()) {
+      return NextResponse.json({ error: "Name is required" }, { status: 400 });
+    }
+
+    if (!Array.isArray(providerIds)) {
+      return NextResponse.json({ error: "providerIds must be an array" }, { status: 400 });
+    }
+
+    const pool = await createProviderPool({
+      name: name.trim(),
+      providerIds,
+    });
+
+    return NextResponse.json({ pool }, { status: 201 });
+  } catch (error) {
+    console.log("Error creating provider pool:", error);
+    return NextResponse.json({ error: "Failed to create provider pool" }, { status: 500 });
+  }
+}

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -46,6 +46,7 @@ function cloneDefaultData() {
     providerConnections: [],
     providerNodes: [],
     proxyPools: [],
+    providerPools: [],
     modelAliases: {},
     customModels: [],
     mitmAlias: {},
@@ -96,11 +97,19 @@ function ensureDbShape(data) {
       }
     }
 
-    // Migrate existing API keys to have isActive
+    // Migrate existing API keys to have isActive + allowedProviders
     if (key === "apiKeys" && Array.isArray(next.apiKeys)) {
       for (const apiKey of next.apiKeys) {
         if (apiKey.isActive === undefined || apiKey.isActive === null) {
           apiKey.isActive = true;
+          changed = true;
+        }
+        if (!Array.isArray(apiKey.allowedProviders)) {
+          apiKey.allowedProviders = [];
+          changed = true;
+        }
+        if (apiKey.providerPoolId === undefined) {
+          apiKey.providerPoolId = null;
           changed = true;
         }
       }
@@ -623,7 +632,7 @@ function generateShortKey() {
   return result;
 }
 
-export async function createApiKey(name, machineId) {
+export async function createApiKey(name, machineId, allowedProviders = [], providerPoolId = null) {
   if (!machineId) throw new Error("machineId is required");
 
   const db = await getDb();
@@ -638,6 +647,8 @@ export async function createApiKey(name, machineId) {
     key: result.key,
     machineId: machineId,
     isActive: true,
+    allowedProviders: Array.isArray(allowedProviders) ? allowedProviders : [],
+    providerPoolId: providerPoolId || null,
     createdAt: now,
   };
 
@@ -670,10 +681,70 @@ export async function updateApiKey(id, data) {
   return db.data.apiKeys[index];
 }
 
-export async function validateApiKey(key) {
+export async function getApiKeyRecord(key) {
   const db = await getDb();
-  const found = db.data.apiKeys.find(k => k.key === key);
+  return db.data.apiKeys.find(k => k.key === key) || null;
+}
+
+export async function validateApiKey(key) {
+  const found = await getApiKeyRecord(key);
   return found && found.isActive !== false;
+}
+
+export async function getProviderPools() {
+  const db = await getDb();
+  return db.data.providerPools || [];
+}
+
+export async function getProviderPoolById(id) {
+  const pools = await getProviderPools();
+  return pools.find((pool) => pool.id === id) || null;
+}
+
+export async function createProviderPool(data) {
+  const db = await getDb();
+  if (!db.data.providerPools) db.data.providerPools = [];
+  const now = new Date().toISOString();
+  const pool = {
+    id: uuidv4(),
+    name: data.name,
+    providerIds: Array.isArray(data.providerIds) ? data.providerIds : [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.data.providerPools.push(pool);
+  await safeWrite(db);
+  return pool;
+}
+
+export async function updateProviderPool(id, data) {
+  const db = await getDb();
+  if (!db.data.providerPools) db.data.providerPools = [];
+  const index = db.data.providerPools.findIndex((pool) => pool.id === id);
+  if (index === -1) return null;
+  db.data.providerPools[index] = {
+    ...db.data.providerPools[index],
+    ...data,
+    providerIds: Array.isArray(data.providerIds) ? data.providerIds : db.data.providerPools[index].providerIds,
+    updatedAt: new Date().toISOString(),
+  };
+  await safeWrite(db);
+  return db.data.providerPools[index];
+}
+
+export async function deleteProviderPool(id) {
+  const db = await getDb();
+  if (!db.data.providerPools) db.data.providerPools = [];
+  const index = db.data.providerPools.findIndex((pool) => pool.id === id);
+  if (index === -1) return false;
+  db.data.providerPools.splice(index, 1);
+  if (Array.isArray(db.data.apiKeys)) {
+    for (const key of db.data.apiKeys) {
+      if (key.providerPoolId === id) key.providerPoolId = null;
+    }
+  }
+  await safeWrite(db);
+  return true;
 }
 
 export async function cleanupProviderConnections() {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -6,6 +6,7 @@ import {
   clearAccountError,
   extractApiKey,
   isValidApiKey,
+  isApiKeyAllowedForProvider,
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
 import { getSettings } from "@/lib/localDb";
@@ -147,6 +148,15 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   }
 
   const { provider, model } = modelInfo;
+
+  const settings = await getSettings();
+  if (settings.requireApiKey && apiKey) {
+    const allowed = await isApiKeyAllowedForProvider(apiKey, provider);
+    if (!allowed) {
+      log.warn("AUTH", `API key not allowed for provider: ${provider}`);
+      return errorResponse(HTTP_STATUS.FORBIDDEN, `API key is not allowed to use provider: ${provider}`);
+    }
+  }
 
   // Log model routing (alias → actual model)
   if (modelStr !== `${provider}/${model}`) {

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -4,6 +4,7 @@ import {
   clearAccountError,
   extractApiKey,
   isValidApiKey,
+  isApiKeyAllowedForProvider,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
@@ -72,6 +73,14 @@ export async function handleEmbeddings(request) {
   }
 
   const { provider, model } = modelInfo;
+
+  if (settings.requireApiKey && apiKey) {
+    const allowed = await isApiKeyAllowedForProvider(apiKey, provider);
+    if (!allowed) {
+      log.warn("AUTH", `API key not allowed for provider: ${provider}`);
+      return errorResponse(HTTP_STATUS.FORBIDDEN, `API key is not allowed to use provider: ${provider}`);
+    }
+  }
 
   if (modelStr !== `${provider}/${model}`) {
     log.info("ROUTING", `${modelStr} → ${provider}/${model}`);

--- a/src/sse/handlers/fetch.js
+++ b/src/sse/handlers/fetch.js
@@ -4,6 +4,7 @@ import {
   clearAccountError,
   extractApiKey,
   isValidApiKey,
+  isApiKeyAllowedForProvider,
 } from "../services/auth.js";
 import { getSettings, getCombos } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
@@ -116,6 +117,14 @@ async function handleSingleProviderFetch(body, providerInput, request, apiKey, s
   if (!providerConfig) {
     log.warn("FETCH", "Provider does not support web fetch", { provider: providerId });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, `Provider ${providerId} does not support web fetch`);
+  }
+
+  if (settings.requireApiKey && apiKey) {
+    const allowed = await isApiKeyAllowedForProvider(apiKey, providerId);
+    if (!allowed) {
+      log.warn("AUTH", `API key not allowed for provider: ${providerId}`);
+      return errorResponse(HTTP_STATUS.FORBIDDEN, `API key is not allowed to use provider: ${providerId}`);
+    }
   }
 
   if (providerInput !== providerId) {

--- a/src/sse/handlers/imageGeneration.js
+++ b/src/sse/handlers/imageGeneration.js
@@ -4,6 +4,7 @@ import {
   clearAccountError,
   extractApiKey,
   isValidApiKey,
+  isApiKeyAllowedForProvider,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
@@ -48,6 +49,11 @@ export async function handleImageGeneration(request) {
   if (!modelInfo.provider) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");
 
   const { provider, model } = modelInfo;
+
+  if (settings.requireApiKey && apiKey) {
+    const allowed = await isApiKeyAllowedForProvider(apiKey, provider);
+    if (!allowed) return errorResponse(HTTP_STATUS.FORBIDDEN, `API key is not allowed to use provider: ${provider}`);
+  }
 
   // noAuth providers — no credential needed
   if (NO_AUTH_PROVIDERS.has(provider)) {

--- a/src/sse/handlers/search.js
+++ b/src/sse/handlers/search.js
@@ -4,6 +4,7 @@ import {
   clearAccountError,
   extractApiKey,
   isValidApiKey,
+  isApiKeyAllowedForProvider,
 } from "../services/auth.js";
 import { getSettings, getCombos } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
@@ -106,6 +107,14 @@ async function handleSingleProviderSearch(body, providerInput, request, apiKey, 
   if (!supportsSearch) {
     log.warn("SEARCH", "Provider does not support web search", { provider: providerId });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, `Provider ${providerId} does not support web search`);
+  }
+
+  if (settings.requireApiKey && apiKey) {
+    const allowed = await isApiKeyAllowedForProvider(apiKey, providerId);
+    if (!allowed) {
+      log.warn("AUTH", `API key not allowed for provider: ${providerId}`);
+      return errorResponse(HTTP_STATUS.FORBIDDEN, `API key is not allowed to use provider: ${providerId}`);
+    }
   }
 
   if (providerInput !== providerId) {

--- a/src/sse/handlers/tts.js
+++ b/src/sse/handlers/tts.js
@@ -1,5 +1,5 @@
 import {
-  extractApiKey, isValidApiKey,
+  extractApiKey, isValidApiKey, isApiKeyAllowedForProvider,
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
@@ -46,6 +46,12 @@ export async function handleTts(request) {
 
   const { provider, model } = modelInfo;
   log.info("ROUTING", `Provider: ${provider}, Voice: ${model}`);
+
+  if (settings.requireApiKey) {
+    const apiKey = extractApiKey(request);
+    const allowed = await isApiKeyAllowedForProvider(apiKey, provider);
+    if (!allowed) return errorResponse(HTTP_STATUS.FORBIDDEN, `API key is not allowed to use provider: ${provider}`);
+  }
 
   // noAuth providers — no credential needed
   if (!CREDENTIALED_PROVIDERS.has(provider)) {

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,4 +1,4 @@
-import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings } from "@/lib/localDb";
+import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getApiKeyRecord, getProviderPoolById } from "@/lib/localDb";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
@@ -304,4 +304,24 @@ export function extractApiKey(request) {
 export async function isValidApiKey(apiKey) {
   if (!apiKey) return false;
   return await validateApiKey(apiKey);
+}
+
+export async function isApiKeyAllowedForProvider(apiKey, provider) {
+  if (!apiKey || !provider) return false;
+  const record = await getApiKeyRecord(apiKey);
+  if (!record || record.isActive === false) return false;
+
+  if (record.providerPoolId) {
+    const pool = await getProviderPoolById(record.providerPoolId);
+    if (!pool) return false;
+    const poolProviders = Array.isArray(pool.providerIds) ? pool.providerIds : [];
+    return poolProviders.includes(provider);
+  }
+
+  const allowed = Array.isArray(record.allowedProviders) ? record.allowedProviders : [];
+  if (allowed.length > 0) {
+    return allowed.includes(provider);
+  }
+
+  return true; // no pool + no allowedProviders => all providers
 }

--- a/tests/unit/api-key-provider-scope.test.js
+++ b/tests/unit/api-key-provider-scope.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((body, init) => ({
+      status: init?.status || 200,
+      body,
+      json: async () => body,
+    })),
+  },
+}));
+
+import { isApiKeyAllowedForProvider } from "../../src/sse/services/auth.js";
+import {
+  createApiKey,
+  updateApiKey,
+  getApiKeys,
+  createProviderPool,
+  updateProviderPool,
+  deleteProviderPool,
+  getProviderPoolById,
+  getApiKeyRecord,
+} from "../../src/lib/localDb.js";
+
+import { POST as createProviderPoolRoute, GET as listProviderPoolsRoute } from "../../src/app/api/provider-pools/route.js";
+import {
+  PUT as updateProviderPoolRoute,
+  DELETE as deleteProviderPoolRoute,
+} from "../../src/app/api/provider-pools/[id]/route.js";
+
+describe("api key provider scope", () => {
+  it("allows all providers when allowedProviders is empty", async () => {
+    const key = await createApiKey(`test-all-${Date.now()}`, "machine-test");
+    const allowed = await isApiKeyAllowedForProvider(key.key, "openai");
+
+    expect(allowed).toBe(true);
+  });
+
+  it("only allows listed providers when restricted", async () => {
+    const key = await createApiKey(`test-scope-${Date.now()}`, "machine-test", ["openai", "anthropic"]);
+
+    const allowOpenai = await isApiKeyAllowedForProvider(key.key, "openai");
+    const allowAnthropic = await isApiKeyAllowedForProvider(key.key, "anthropic");
+    const allowGemini = await isApiKeyAllowedForProvider(key.key, "gemini");
+
+    expect(allowOpenai).toBe(true);
+    expect(allowAnthropic).toBe(true);
+    expect(allowGemini).toBe(false);
+  });
+
+  it("uses provider pool when selected", async () => {
+    const pool = await createProviderPool({
+      name: `pool-${Date.now()}`,
+      providerIds: ["openai"],
+    });
+
+    const key = await createApiKey(`test-pool-${Date.now()}`, "machine-test", ["anthropic"], pool.id);
+
+    const allowOpenai = await isApiKeyAllowedForProvider(key.key, "openai");
+    const allowAnthropic = await isApiKeyAllowedForProvider(key.key, "anthropic");
+
+    expect(allowOpenai).toBe(true);
+    expect(allowAnthropic).toBe(false);
+
+    await deleteProviderPool(pool.id);
+  });
+
+  it("falls back to legacy allowedProviders when no pool", async () => {
+    const key = await createApiKey(`test-legacy-${Date.now()}`, "machine-test", ["anthropic"]);
+    const allowOpenai = await isApiKeyAllowedForProvider(key.key, "openai");
+    const allowAnthropic = await isApiKeyAllowedForProvider(key.key, "anthropic");
+
+    expect(allowOpenai).toBe(false);
+    expect(allowAnthropic).toBe(true);
+  });
+
+  it("denies inactive keys", async () => {
+    const key = await createApiKey(`test-inactive-${Date.now()}`, "machine-test", ["openai"]);
+    await updateApiKey(key.id, { isActive: false });
+
+    const allowed = await isApiKeyAllowedForProvider(key.key, "openai");
+
+    expect(allowed).toBe(false);
+  });
+
+  it("denies when selected provider pool is missing", async () => {
+    const key = await createApiKey(`test-missing-pool-${Date.now()}`, "machine-test", [], "missing-pool-id");
+
+    const allowed = await isApiKeyAllowedForProvider(key.key, "openai");
+
+    expect(allowed).toBe(false);
+  });
+
+  it("deleting a provider pool unsets providerPoolId on referencing api keys", async () => {
+    const pool = await createProviderPool({
+      name: `pool-delete-${Date.now()}`,
+      providerIds: ["openai"],
+    });
+    const key = await createApiKey(`test-delete-pool-${Date.now()}`, "machine-test", [], pool.id);
+
+    await deleteProviderPool(pool.id);
+
+    const reloaded = await getApiKeyRecord(key.key);
+    expect(reloaded.providerPoolId).toBeNull();
+    expect(await isApiKeyAllowedForProvider(key.key, "gemini")).toBe(true);
+  });
+
+  it("creates, lists, updates, and deletes provider pools through API routes", async () => {
+    const createResponse = await createProviderPoolRoute({
+      json: async () => ({ name: "  Test Pool Route  ", providerIds: ["openai"] }),
+    });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body.pool.name).toBe("Test Pool Route");
+    expect(createResponse.body.pool.providerIds).toEqual(["openai"]);
+
+    const poolId = createResponse.body.pool.id;
+    const listResponse = await listProviderPoolsRoute();
+    expect(listResponse.body.pools.some((pool) => pool.id === poolId)).toBe(true);
+
+    const updateResponse = await updateProviderPoolRoute(
+      { json: async () => ({ name: "Updated Pool", providerIds: ["anthropic", "gemini"] }) },
+      { params: Promise.resolve({ id: poolId }) },
+    );
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.pool.name).toBe("Updated Pool");
+    expect(updateResponse.body.pool.providerIds).toEqual(["anthropic", "gemini"]);
+
+    const deleteResponse = await deleteProviderPoolRoute({}, { params: Promise.resolve({ id: poolId }) });
+    expect(deleteResponse.status).toBe(200);
+    expect(deleteResponse.body.success).toBe(true);
+    expect(await getProviderPoolById(poolId)).toBeNull();
+  });
+
+  it("validates provider pool route input", async () => {
+    const missingName = await createProviderPoolRoute({ json: async () => ({ name: "", providerIds: [] }) });
+    expect(missingName.status).toBe(400);
+
+    const invalidProviders = await createProviderPoolRoute({ json: async () => ({ name: "Bad", providerIds: "openai" }) });
+    expect(invalidProviders.status).toBe(400);
+
+    const missingPool = await updateProviderPoolRoute(
+      { json: async () => ({ name: "Missing" }) },
+      { params: Promise.resolve({ id: "missing-provider-pool" }) },
+    );
+    expect(missingPool.status).toBe(404);
+  });
+
+  it("exposes allowedProviders as an array for existing keys", async () => {
+    const keys = await getApiKeys();
+
+    for (const key of keys) {
+      expect(Array.isArray(key.allowedProviders)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add reusable provider pools that group provider IDs for API key scoping.
- Allow API keys to optionally select a `providerPoolId`; when unset, keys keep the existing all-providers behavior.
- Preserve legacy `allowedProviders` enforcement for existing scoped keys that do not use a pool.
- Enforce provider scope across chat, embeddings, search, fetch, TTS, and image generation handlers.
- Add dashboard controls for creating/deleting provider pools and assigning pools to API keys.

## Backward compatibility
- Existing API keys are migrated with `allowedProviders: []` and `providerPoolId: null` when missing.
- No selected pool means all providers are allowed, matching current behavior.
- Missing referenced pools deny provider access instead of silently falling back.

## Verification
- `NODE_PATH=tests/node_modules tests/node_modules/.bin/vitest run --reporter=verbose --config ./tests/vitest.config.js tests/unit/api-key-provider-scope.test.js`
- `npm run build`
- Manual dashboard smoke test: provider pool section loads, API routes return 200, and key list shows provider scope labels.
