### PR TITLE
fix(codex): strip unsupported n8n Responses API params

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -22,14 +22,34 @@ function generateSessionId() {
   return `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
 }
 
+function extractContentText(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map(c => c?.text || c?.output || "").filter(Boolean).join("\n");
+  }
+  return "";
+}
+
 // Extract text content from an input item
 function extractItemText(item) {
   if (!item) return "";
-  if (typeof item.content === "string") return item.content;
-  if (Array.isArray(item.content)) {
-    return item.content.map(c => c.text || c.output || "").filter(Boolean).join("");
-  }
-  return "";
+  return extractContentText(item.content).replace(/\n/g, "");
+}
+
+function moveSystemInputToInstructions(body) {
+  if (!Array.isArray(body.input)) return;
+
+  const systemTexts = [];
+  body.input = body.input.filter((item) => {
+    if (item?.role !== "system" && item?.role !== "developer") return true;
+    const text = extractContentText(item.content).trim();
+    if (text) systemTexts.push(text);
+    return false;
+  });
+
+  if (systemTexts.length === 0) return;
+  const existing = typeof body.instructions === "string" ? body.instructions.trim() : "";
+  body.instructions = [existing, ...systemTexts].filter(Boolean).join("\n\n");
 }
 
 // Resolve session_id from first assistant message + machineId to avoid cross-user collision
@@ -159,6 +179,9 @@ export class CodexExecutor extends BaseExecutor {
     const normalized = normalizeResponsesInput(body.input);
     if (normalized) body.input = normalized;
 
+    // Codex rejects system/developer roles inside input[]; send them as instructions instead.
+    moveSystemInputToInstructions(body);
+
     // Ensure input is present and non-empty (Codex API rejects empty input)
     if (!body.input || (Array.isArray(body.input) && body.input.length === 0)) {
       body.input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }];
@@ -217,6 +240,11 @@ export class CodexExecutor extends BaseExecutor {
     delete body.metadata; // Cursor sends this but Codex doesn't support it
     delete body.stream_options; // Cursor sends this but Codex doesn't support it
     delete body.safety_identifier; // Droid CLI sends this but Codex doesn't support it
+    delete body.background; // n8n Responses API sends background:false by default
+    delete body.parallel_tool_calls; // n8n/OpenAI clients send this but Codex doesn't support it
+    delete body.max_completion_tokens;
+    delete body.max_output_tokens;
+    delete body.truncation;
 
     return body;
   }

--- a/tests/unit/codex-request-sanitization.test.js
+++ b/tests/unit/codex-request-sanitization.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+import { CODEX_DEFAULT_INSTRUCTIONS } from "../../open-sse/config/codexInstructions.js";
+
+describe("CodexExecutor request sanitization", () => {
+  it("strips n8n Responses API defaults unsupported by Codex", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.3-codex",
+      input: "hello",
+      background: false,
+      parallel_tool_calls: true,
+      store: true,
+      truncation: "auto",
+      max_output_tokens: 1000,
+      max_completion_tokens: 1000,
+    };
+
+    const transformed = executor.transformRequest("gpt-5.3-codex", body, true, {});
+
+    expect(transformed).not.toHaveProperty("background");
+    expect(transformed).not.toHaveProperty("parallel_tool_calls");
+    expect(transformed).not.toHaveProperty("truncation");
+    expect(transformed).not.toHaveProperty("max_output_tokens");
+    expect(transformed).not.toHaveProperty("max_completion_tokens");
+    expect(transformed.store).toBe(false);
+  });
+
+  it("moves system/developer input messages into instructions", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.3-codex",
+      instructions: "Existing instruction",
+      input: [
+        {
+          role: "system",
+          content: [{ type: "input_text", text: "Return JSON only." }],
+        },
+        {
+          role: "developer",
+          content: "Be concise.",
+        },
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "Hello" }],
+        },
+      ],
+    };
+
+    const transformed = executor.transformRequest("gpt-5.3-codex", body, true, {});
+
+    expect(transformed.instructions).toBe("Existing instruction\n\nReturn JSON only.\n\nBe concise.");
+    expect(transformed.input).toHaveLength(1);
+    expect(transformed.input[0].role).toBe("user");
+  });
+
+  it("uses default instructions when system-only input is removed", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.3-codex",
+      input: [
+        {
+          role: "system",
+          content: [{ type: "input_text", text: "Return JSON only." }],
+        },
+      ],
+    };
+
+    const transformed = executor.transformRequest("gpt-5.3-codex", body, true, {});
+
+    expect(transformed.instructions).toContain("Return JSON only.");
+    expect(transformed.instructions).not.toBe(CODEX_DEFAULT_INSTRUCTIONS);
+    expect(transformed.input).toEqual([
+      { type: "message", role: "user", content: [{ type: "input_text", text: "..." }] },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #868.

## Summary
- Strip n8n/OpenAI Responses API fields that Codex backend rejects (`background`, `parallel_tool_calls`, `truncation`, max token aliases).
- Move `system`/`developer` input messages into `instructions` before forwarding to Codex.
- Add Codex request sanitization unit coverage.

## Tests
- `./tests/node_modules/.bin/vitest run --reporter=verbose tests/unit/codex-request-sanitization.test.js tests/unit/codex-image-fetch.test.js`
- Full suite with `tests/vitest.config.js` was run; existing unrelated failures remain in oauth-cursor-auto-import, rtk, translator-request-normalization, and claude-header-forwarding.