### PR TITLE
fix(executors): parse retryAfter timestamp for precise backoff on 429

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -15,6 +15,36 @@ export class DefaultExecutor extends BaseExecutor {
     return injectReasoningContent({ provider: this.provider, model, body });
   }
 
+  /**
+   * Override parseError to extract precise resetsAtMs from MiniMax 429 errors.
+   * MiniMax returns: { error: { message: "...", retryAfter: "2025-05-02T12:00:00Z", ... } }
+   * Without this, the base class returns no resetsAtMs → exponential backoff instead of precise wait.
+   */
+  parseError(response, bodyText) {
+    if (response.status === 429 && bodyText) {
+      try {
+        const json = JSON.parse(bodyText);
+        const err = json?.error || json;
+        const retryAfter = err?.retryAfter;
+        if (retryAfter) {
+          const ms = new Date(retryAfter).getTime();
+          const now = Date.now();
+          if (ms > now) {
+            return { status: 429, message: err.message || bodyText, resetsAtMs: ms };
+          }
+        }
+        const retryMs = err?.retry_after_ms || err?.retryAfterMs;
+        if (typeof retryMs === "number" && retryMs > 0) {
+          const resetsAtMs = now + retryMs;
+          if (resetsAtMs > now) {
+            return { status: 429, message: err.message || bodyText, resetsAtMs };
+          }
+        }
+      } catch { /* fall through to default */ }
+    }
+    return super.parseError(response, bodyText);
+  }
+
   buildUrl(model, stream, urlIndex = 0, credentials = null) {
     if (this.provider?.startsWith?.("openai-compatible-")) {
       const baseUrl = credentials?.providerSpecificData?.baseUrl || "https://api.openai.com/v1";

--- a/open-sse/executors/opencode-go.js
+++ b/open-sse/executors/opencode-go.js
@@ -38,4 +38,35 @@ export class OpenCodeGoExecutor extends BaseExecutor {
   transformRequest(model, body) {
     return injectReasoningContent({ provider: this.provider, model, body });
   }
+
+  /**
+   * Override parseError to extract precise resetsAtMs from MiniMax 429 errors.
+   * MiniMax returns: { error: { message: "...", retryAfter: "2025-05-02T12:00:00Z", ... } }
+   * Without this, the base class returns no resetsAtMs → exponential backoff instead of precise wait.
+   */
+  parseError(response, bodyText) {
+    if (response.status === 429 && bodyText) {
+      try {
+        const json = JSON.parse(bodyText);
+        const err = json?.error || json;
+        const retryAfter = err?.retryAfter;
+        if (retryAfter) {
+          const ms = new Date(retryAfter).getTime();
+          const now = Date.now();
+          if (ms > now) {
+            return { status: 429, message: err.message || bodyText, resetsAtMs: ms };
+          }
+        }
+        // Also accept retry_after_ms as numeric milliseconds (some providers use this)
+        const retryMs = err?.retry_after_ms || err?.retryAfterMs;
+        if (typeof retryMs === "number" && retryMs > 0) {
+          const resetsAtMs = now + retryMs;
+          if (resetsAtMs > now) {
+            return { status: 429, message: err.message || bodyText, resetsAtMs };
+          }
+        }
+      } catch { /* fall through to default */ }
+    }
+    return super.parseError(response, bodyText);
+  }
 }


### PR DESCRIPTION
## Summary
- Override `parseError()` in `DefaultExecutor` and `OpenCodeGoExecutor` to extract `retryAfter` ISO timestamp from MiniMax (and similar providers) 429 responses
- Returns precise `resetsAtMs` instead of falling back to exponential backoff guessing
- Handles both `retryAfter` (ISO string) and `retry_after_ms` / `retryAfterMs` (numeric ms)

## Test plan
- [ ] Send a 429 from MiniMax with `retryAfter` field → verify `resetsAtMs` is set to the parsed timestamp
- [ ] Send a 429 without `retryAfter` → verify falls through to default exponential backoff
- [ ] Verify both executors (default.js + opencode-go.js) behave identically

Closes #878