### PR TITLE
feat(cx): add GPT-5.5 Pro and GPT-5.4 Pro models with pricing

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -38,7 +38,9 @@ export const PROVIDER_MODELS = {
   ],
   cx: withCodexReviewModels([  // OpenAI Codex
     { id: "gpt-5.5", name: "GPT 5.5" },
+    { id: "gpt-5.5-pro", name: "GPT 5.5 Pro" },
     { id: "gpt-5.4", name: "GPT 5.4" },
+    { id: "gpt-5.4-pro", name: "GPT 5.4 Pro" },
     // GPT 5.3 Codex - all thinking levels
     { id: "gpt-5.3-codex", name: "GPT 5.3 Codex" },
     { id: "gpt-5.3-codex-xhigh", name: "GPT 5.3 Codex (xHigh)" },

--- a/src/shared/constants/pricing.js
+++ b/src/shared/constants/pricing.js
@@ -52,6 +52,10 @@ export const MODEL_PRICING = {
   "gpt-5.3-codex-low":           { input: 4.00,  output: 16.00, cached: 2.00,  reasoning: 24.00,  cache_creation: 4.00  },
   "gpt-5.3-codex-none":          { input: 3.00,  output: 12.00, cached: 1.50,  reasoning: 18.00,  cache_creation: 3.00  },
   "gpt-5.3-codex-spark":         { input: 3.00,  output: 12.00, cached: 0.30,  reasoning: 12.00,  cache_creation: 3.00  },
+  "gpt-5.4":                      { input: 2.50,  output: 15.00, cached: 0.25,  reasoning: 22.50,  cache_creation: 2.50  },
+  "gpt-5.4-pro":                  { input: 30.00, output: 180.00, cached: 3.00, reasoning: 270.00, cache_creation: 30.00 },
+  "gpt-5.5":                      { input: 5.00,  output: 30.00, cached: 0.50,  reasoning: 45.00,  cache_creation: 5.00  },
+  "gpt-5.5-pro":                  { input: 30.00, output: 180.00, cached: 3.00, reasoning: 270.00, cache_creation: 30.00 },
   "o1":                           { input: 15.00, output: 60.00, cached: 7.50,  reasoning: 90.00,  cache_creation: 15.00 },
   "o1-mini":                      { input: 3.00,  output: 12.00, cached: 1.50,  reasoning: 18.00,  cache_creation: 3.00  },
 
@@ -154,6 +158,8 @@ export const PATTERN_PRICING = [
   { pattern: "gemini-*",        pricing: { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  } },
 
   // --- GPT (specific trước, chung sau) ---
+  { pattern: "gpt-5.5-*",       pricing: { input: 5.00,  output: 30.00, cached: 0.50,  reasoning: 45.00,  cache_creation: 5.00  } },
+  { pattern: "gpt-5.4-*",       pricing: { input: 2.50,  output: 15.00, cached: 0.25,  reasoning: 22.50,  cache_creation: 2.50  } },
   { pattern: "gpt-5.3-*",       pricing: { input: 6.00,  output: 24.00, cached: 3.00,  reasoning: 36.00,  cache_creation: 6.00  } },
   { pattern: "gpt-5.2-*",       pricing: { input: 5.00,  output: 20.00, cached: 2.50,  reasoning: 30.00,  cache_creation: 5.00  } },
   { pattern: "gpt-5.1-*",       pricing: { input: 4.00,  output: 16.00, cached: 2.00,  reasoning: 24.00,  cache_creation: 4.00  } },


### PR DESCRIPTION
## Summary

- Adds `gpt-5.5-pro` and `gpt-5.4-pro` to the `cx` (Codex) provider model list for ChatGPT Pro subscribers
- Adds explicit pricing entries for `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, and `gpt-5.5-pro` (based on [models.dev](https://models.dev) data)
- Adds fallback pricing patterns for `gpt-5.5-*` and `gpt-5.4-*` variants

## Context

The Codex backend at `chatgpt.com/backend-api/codex/responses` accepts `gpt-5.5-pro` and `gpt-5.4-pro` for Pro subscribers, but they were missing from the hardcoded model list. The [opencode](https://github.com/nicepkg/opencode) project discovers them dynamically, confirming they're valid model IDs.

**Pricing from models.dev:**

| Model | Input $/1M | Output $/1M | Cache Read $/1M |
|-------|-----------|------------|-----------------|
| gpt-5.4 | $2.50 | $15.00 | $0.25 |
| gpt-5.4-pro | $30.00 | $180.00 | — |
| gpt-5.5 | $5.00 | $30.00 | $0.50 |
| gpt-5.5-pro | $30.00 | $180.00 | — |

## Files Changed

- `open-sse/config/providerModels.js` — 2 new model entries in `cx` provider
- `src/shared/constants/pricing.js` — 4 explicit entries + 2 fallback patterns

## Note

These Pro models require a **ChatGPT Pro subscription** — they will likely return errors for Plus-only accounts. The executor doesn't need changes since model IDs pass through as-is.

Closes #890

cc @decolua