### PR TITLE
feat: add service_tier fast mode pass-through for Codex

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -224,6 +224,9 @@ export class CodexExecutor extends BaseExecutor {
     delete body.stream_options; // Cursor sends this but Codex doesn't support it
     delete body.safety_identifier; // Droid CLI sends this but Codex doesn't support it
 
+    // Preserve service_tier for Fast Mode support (e.g. service_tier: "fast")
+    // Codex CLI sends this when fast_mode is enabled in config.toml
+
     return body;
   }
 }

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -283,6 +283,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.temperature !== undefined) result.temperature = body.temperature;
   if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
+  if (body.service_tier !== undefined) result.service_tier = body.service_tier;
 
   return result;
 }


### PR DESCRIPTION
## Summary

- Pass through `service_tier` parameter in the OpenAI-to-Responses translator so Codex CLI fast mode (`service_tier: "fast"`) is forwarded to upstream
- Explicitly document that `service_tier` is intentionally preserved in CodexExecutor (not stripped like other unsupported params)

## Details

When Codex CLI has `fast_mode = true` in config, it sends `service_tier: "fast"` in the request body. Previously this parameter was lost during Chat Completions to Responses API translation in `openaiToOpenAIResponsesRequest()` because only `temperature`, `max_tokens`, and `top_p` were passed through.

### Changes

1. **open-sse/translator/request/openai-responses.js** - Added `service_tier` to the pass-through fields
2. **open-sse/executors/codex.js** - Added comment clarifying `service_tier` is intentionally preserved for fast mode
