### PR TITLE
feat: allow [ and ] characters in combo names

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -5,8 +5,8 @@ import { Card, Button, Modal, Input, CardSkeleton, ModelSelectModal, Toggle } fr
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 
-// Validate combo name: only a-z, A-Z, 0-9, -, _
-const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
+// Validate combo name: only a-z, A-Z, 0-9, -, _, ., [, ]
+const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-\[\]]+$/;
 
 export default function CombosPage() {
   const [combos, setCombos] = useState([]);
@@ -370,7 +370,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
       return false;
     }
     if (!VALID_NAME_REGEX.test(value)) {
-      setNameError("Only letters, numbers, -, _ and . allowed");
+      setNameError("Only letters, numbers, -, _, ., [ and ] allowed");
       return false;
     }
     setNameError("");

--- a/src/app/(dashboard)/dashboard/media-providers/combo/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/combo/[id]/page.js
@@ -15,7 +15,7 @@ function parseModelEntry(entry) {
   return { providerId: entry.slice(0, idx), model: entry.slice(idx + 1) };
 }
 
-const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
+const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-\[\]]+$/;
 
 const KIND_LABELS = {
   webSearch: "Web Search",
@@ -96,7 +96,7 @@ export default function ComboDetailPage() {
 
   const validateName = (v) => {
     if (!v.trim()) { setNameError("Name is required"); return false; }
-    if (!VALID_NAME_REGEX.test(v)) { setNameError("Only letters, numbers, -, _ and ."); return false; }
+    if (!VALID_NAME_REGEX.test(v)) { setNameError("Only letters, numbers, -, _, ., [ and ]"); return false; }
     setNameError("");
     return true;
   };

--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
 import { resetComboRotation } from "open-sse/services/combo.js";
 
-// Validate combo name: only a-z, A-Z, 0-9, -, _
-const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
+// Validate combo name: only a-z, A-Z, 0-9, -, _, ., [, ]
+const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-\[\]]+$/;
 
 // GET /api/combos/[id] - Get combo by ID
 export async function GET(request, { params }) {
@@ -31,7 +31,7 @@ export async function PUT(request, { params }) {
     // Validate name format if provided
     if (body.name) {
       if (!VALID_NAME_REGEX.test(body.name)) {
-        return NextResponse.json({ error: "Name can only contain letters, numbers, -, _ and ." }, { status: 400 });
+        return NextResponse.json({ error: "Name can only contain letters, numbers, -, _, ., [ and ]" }, { status: 400 });
       }
       
       // Check if name already exists (exclude current combo)

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -3,8 +3,8 @@ import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
 
 export const dynamic = "force-dynamic";
 
-// Validate combo name: only a-z, A-Z, 0-9, -, _
-const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
+// Validate combo name: only a-z, A-Z, 0-9, -, _, ., [, ]
+const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-\[\]]+$/;
 
 // GET /api/combos - Get all combos
 export async function GET() {
@@ -29,7 +29,7 @@ export async function POST(request) {
 
     // Validate name format
     if (!VALID_NAME_REGEX.test(name)) {
-      return NextResponse.json({ error: "Name can only contain letters, numbers, -, _ and ." }, { status: 400 });
+      return NextResponse.json({ error: "Name can only contain letters, numbers, -, _, ., [ and ]" }, { status: 400 });
     }
 
     // Check if name already exists


### PR DESCRIPTION
Fixes #904

## Summary

Extend the combo-name validation regex to permit `[` and `]` in addition to the existing letters, digits, `-`, `_`, and `.`. This enables users to organize combos using bracket-style naming conventions (e.g. `[free]my-combo`, `claude[opus]`).

## Changes

The `VALID_NAME_REGEX` pattern is duplicated in 4 places (server validation + client-side form validation). All four were updated together to keep validation consistent end-to-end.

| File | Role |
|------|------|
| `src/app/api/combos/route.js` | `POST /api/combos` — server-side create |
| `src/app/api/combos/[id]/route.js` | `PUT /api/combos/[id]` — server-side update |
| `src/app/(dashboard)/dashboard/combos/page.js` | Combos dashboard form |
| `src/app/(dashboard)/dashboard/media-providers/combo/[id]/page.js` | Media-providers combo edit form |

Regex changed from `/^[a-zA-Z0-9_.\-]+$/` to `/^[a-zA-Z0-9_.\-\[\]]+$/`. Error messages updated to mention the new allowed characters.

## Caveat

Combo names appear in URL paths when used as model identifiers in `/v1/*` requests. `[` and `]` are reserved characters per RFC 3986 and may be URL-encoded by some clients/proxies. Users adopting bracket-style names should expect URL encoding behavior in some clients.

## Test plan

- [ ] Create a combo with `[` / `]` in the name via the dashboard UI — saves successfully, no validation error
- [ ] Update an existing combo's name to include `[` / `]` via UI — saves successfully
- [ ] `POST /api/combos` with body `{"name": "test[1]", "models": []}` returns 201
- [ ] `PUT /api/combos/<id>` with body `{"name": "test[2]"}` returns 200
- [ ] `POST /api/combos` with name containing `@` (still disallowed) returns 400
- [ ] Use the bracket-named combo as a model in a `/v1/chat/completions` request
