### PR TITLE
Fix BytePlus endpoint and hide disabled models

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -162,7 +162,7 @@ export const PROVIDERS = {
     headers: {}
   },
   byteplus: {
-    baseUrl: "https://ark.ap-southeast.bytepluses.com/api/coding/v3/chat/completions",
+    baseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3/chat/completions",
     format: "openai",
     headers: {}
   },

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -179,7 +179,7 @@ const PROVIDER_MODELS_CONFIG = {
     parseResponse: (data) => data.data || []
   },
   "volcengine-ark": createOpenAIModelsConfig("https://ark.cn-beijing.volces.com/api/coding/v3/models"),
-  byteplus: createOpenAIModelsConfig("https://ark.ap-southeast.bytepluses.com/api/coding/v3/models"),
+  byteplus: createOpenAIModelsConfig("https://ark.ap-southeast.bytepluses.com/api/v3/models"),
 
   // OpenAI-compatible API key providers
   deepseek: createOpenAIModelsConfig("https://api.deepseek.com/models"),

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -6,6 +6,7 @@ import {
   isOpenAICompatibleProvider,
 } from "@/shared/constants/providers";
 import { getProviderConnections, getCombos, getCustomModels, getModelAliases } from "@/lib/localDb";
+import { getDisabledModels } from "@/lib/disabledModelsDb";
 
 const parseOpenAIStyleModels = (data) => {
   if (Array.isArray(data)) return data;
@@ -149,6 +150,13 @@ export async function buildModelsList(kindFilter) {
     modelAliases = await getModelAliases();
   } catch (e) {
     console.log("Could not fetch model aliases");
+  }
+
+  let disabledModels = {};
+  try {
+    disabledModels = await getDisabledModels();
+  } catch (e) {
+    console.log("Could not fetch disabled models");
   }
 
   const activeConnectionByProvider = new Map();
@@ -296,8 +304,17 @@ export async function buildModelsList(kindFilter) {
         .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
 
       const mergedModelIds = Array.from(new Set([...modelIds, ...customModelIds, ...aliasModelIds]));
+      const disabledForProvider = new Set([
+        ...(disabledModels[outputAlias] || []),
+        ...(disabledModels[staticAlias] || []),
+        ...(disabledModels[providerId] || []),
+      ]);
 
       for (const modelId of mergedModelIds) {
+        if (disabledForProvider.has(modelId) || disabledForProvider.has(`${outputAlias}/${modelId}`)) {
+          continue;
+        }
+
         // Resolve kind: prefer static metadata, otherwise infer from ID heuristics
         const kind = staticModelKindById.get(modelId) || inferKindFromUnknownModelId(modelId);
         if (!kindFilter.includes(kind)) continue;

--- a/src/shared/constants/config.js
+++ b/src/shared/constants/config.js
@@ -67,7 +67,7 @@ export const PROVIDER_ENDPOINTS = {
   alicode: "https://coding.dashscope.aliyuncs.com/v1/chat/completions",
   "alicode-intl": "https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions",
   "volcengine-ark": "https://ark.cn-beijing.volces.com/api/coding/v3/chat/completions",
-  byteplus: "https://ark.ap-southeast.bytepluses.com/api/coding/v3/chat/completions",
+  byteplus: "https://ark.ap-southeast.bytepluses.com/api/v3/chat/completions",
   openai: "https://api.openai.com/v1/chat/completions",
   anthropic: "https://api.anthropic.com/v1/messages",
   gemini: "https://generativelanguage.googleapis.com/v1beta/models",


### PR DESCRIPTION
## Summary
- Switch BytePlus ModelArk API calls from the Coding Plan `/api/coding/v3` path to the normal ModelArk `/api/v3` data-plane path.
- Make `/v1/models` respect `/api/models/disabled`, so disabled provider models are not exposed as OpenAI-compatible models.
- Leave the NVIDIA provider UI/custom model inconsistency as follow-up under #897 because it is a broader UI/data-source issue.

Fixes part of #897.

## Test
- `git diff --check`
- `npm install --no-package-lock`
- `npm run build`