### PR TITLE
feat: add audio input support for Gemini translation

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.js
+++ b/open-sse/translator/helpers/geminiHelper.js
@@ -57,6 +57,23 @@ export function convertOpenAIContentToParts(content) {
         parts.push({
           fileData: { fileUri: item.image_url.url, mimeType: "image/*" }
         });
+      } else if (item.type === "input_audio" && item.input_audio?.data) {
+        const format = item.input_audio.format || "wav";
+        const mimeType = format === "mp3" ? "audio/mpeg" : `audio/${format}`;
+        parts.push({
+          inlineData: { mime_type: mimeType, data: item.input_audio.data }
+        });
+      } else if (item.type === "audio_url" && item.audio_url?.url?.startsWith("data:")) {
+        const url = item.audio_url.url;
+        const commaIndex = url.indexOf(",");
+        if (commaIndex !== -1) {
+          const mimePart = url.substring(5, commaIndex);
+          const data = url.substring(commaIndex + 1);
+          const mimeType = mimePart.split(";")[0];
+          parts.push({
+            inlineData: { mime_type: mimeType, data: data }
+          });
+        }
       }
     }
   }

--- a/open-sse/translator/helpers/openaiHelper.js
+++ b/open-sse/translator/helpers/openaiHelper.js
@@ -1,7 +1,7 @@
 // OpenAI helper functions for translator
 
 // Valid OpenAI content block types
-export const VALID_OPENAI_CONTENT_TYPES = ["text", "image_url", "image"];
+export const VALID_OPENAI_CONTENT_TYPES = ["text", "image_url", "image", "input_audio", "audio_url"];
 export const VALID_OPENAI_MESSAGE_TYPES = ["text", "image_url", "image", "tool_calls", "tool_result"];
 
 // Filter messages to OpenAI standard format


### PR DESCRIPTION
## Summary

- Add `input_audio` and `audio_url` content type handlers to `convertOpenAIContentToParts()` for OpenAI→Gemini audio conversion
- Add audio types to `VALID_OPENAI_CONTENT_TYPES` so they pass through `filterToOpenAIFormat()` for OpenAI-target routes

Closes #912

## Changes

### `open-sse/translator/helpers/geminiHelper.js`

Added two new branches in `convertOpenAIContentToParts()`:

1. **`input_audio`** — Converts `{type: "input_audio", input_audio: {data, format}}` → `{inlineData: {mime_type: "audio/<format>", data}}`
2. **`audio_url`** — Converts `{type: "audio_url", audio_url: {url: "data:audio/wav;base64,..."}}` → `{inlineData: {mime_type, data}}` (same data-URL parsing pattern as existing `image_url` handler)

### `open-sse/translator/helpers/openaiHelper.js`

Added `"input_audio"` and `"audio_url"` to `VALID_OPENAI_CONTENT_TYPES` array so audio parts are not stripped by `filterToOpenAIFormat()` when routing to OpenAI-compatible targets.

## Affected Paths

| Translation Path | Audio Support |
|-----------------|---------------|
| OpenAI → Antigravity (Gemini models) | ✅ via `convertOpenAIContentToParts()` |
| OpenAI → Gemini (standard API) | ✅ via `convertOpenAIContentToParts()` |
| OpenAI → Gemini CLI | ✅ via `convertOpenAIContentToParts()` |
| OpenAI → OpenAI (passthrough) | ✅ via `VALID_OPENAI_CONTENT_TYPES` |

## Testing

Tested by sending a WAV audio file through the Antigravity Gemini path. The `cloudcode-pa.googleapis.com` endpoint confirmed audio processing with `promptTokensDetails: {modality: "AUDIO", tokenCount: 25}`.