### PR TITLE
feat: add support for configurable tunnel transport protocols to fix 1033 Cloudflare Tunnel error

### DIFF
--- a/src/lib/tunnel/cloudflared.js
+++ b/src/lib/tunnel/cloudflared.js
@@ -12,6 +12,8 @@ const IS_WINDOWS = os.platform() === "win32";
 const BIN_NAME = IS_WINDOWS ? `${BINARY_NAME}.exe` : BINARY_NAME;
 const BIN_PATH = path.join(BIN_DIR, BIN_NAME);
 const POWERSHELL_HIDDEN_COMMAND = "powershell -NoProfile -NonInteractive -WindowStyle Hidden -Command";
+const DEFAULT_QUICK_TUNNEL_PROTOCOL = "http2";
+const QUICK_TUNNEL_PROTOCOLS = new Set(["http2", "quic", "auto"]);
 
 const GITHUB_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/latest/download";
 
@@ -284,10 +286,16 @@ export async function spawnQuickTunnel(localPort, onUrlUpdate) {
     } catch (e) { /* ignore */ }
   };
 
-  const child = spawn(binaryPath, ["tunnel", "--url", `http://localhost:${localPort}`, "--config", configPath, "--no-autoupdate"], {
+  const requestedProtocol = String(process.env.TUNNEL_TRANSPORT_PROTOCOL || process.env.CLOUDFLARED_PROTOCOL || DEFAULT_QUICK_TUNNEL_PROTOCOL).trim().toLowerCase();
+  const tunnelProtocol = QUICK_TUNNEL_PROTOCOLS.has(requestedProtocol) ? requestedProtocol : DEFAULT_QUICK_TUNNEL_PROTOCOL;
+  const child = spawn(binaryPath, ["tunnel", "--url", `http://127.0.0.1:${localPort}`, "--config", configPath, "--no-autoupdate"], {
     detached: false,
     windowsHide: true,
-    stdio: ["ignore", "pipe", "pipe"]
+    env: {
+      ...process.env,
+      TUNNEL_TRANSPORT_PROTOCOL: tunnelProtocol,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
   });
 
   cloudflaredProcess = child;


### PR DESCRIPTION
- Introduced DEFAULT_QUICK_TUNNEL_PROTOCOL and QUICK_TUNNEL_PROTOCOLS to allow users to specify the transport protocol for quick tunnels.
- Updated spawnQuickTunnel function to utilize the specified protocol from environment variables, defaulting to HTTP/2 if not provided.
- Enhanced the child process environment to include the selected tunnel transport protocol.

This PR fixes the intermittent 1033 Cloudflare Tunnel error seen when 9router is exposed through Cloudflare Quick Tunnel, especially on corporate networks protected by FortiGate. 
The root cause is that the current implementation lets cloudflared use its default transport and targets localhost, which can be less reliable in restricted network environments. This change makes Quick Tunnel default to http2, validates transport overrides (http2, quic, auto), passes the selected transport explicitly through TUNNEL_TRANSPORT_PROTOCOL, and switches the local target from localhost to 127.0.0.1. 
Together, these changes make tunnel startup and resolution more stable behind enterprise firewalls while preserving manual override support for other environments.

<img width="562" height="936" alt="Screenshot 2026-05-04 at 13 36 42" src="https://github.com/user-attachments/assets/8971aa28-ac90-4997-a57e-cfe9f7ac996f" />
