### PR TITLE
feat: add per-account proxy pool selection in EditConnectionModal

### DIFF
--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -26,6 +26,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
   const [validating, setValidating] = useState(false);
   const [validationResult, setValidationResult] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [selectedProxyPoolId, setSelectedProxyPoolId] = useState("__none__");
 
   useEffect(() => {
     if (connection) {
@@ -46,6 +47,8 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       if (connection.provider === "cloudflare-ai" && connection.providerSpecificData) {
         setCloudflareData({ accountId: connection.providerSpecificData.accountId || "" });
       }
+      // Load proxy pool from providerSpecificData
+      setSelectedProxyPoolId(connection.providerSpecificData?.proxyPoolId || "__none__");
       setTestResult(null);
       setValidationResult(null);
     }
@@ -141,14 +144,24 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       // Add Azure-specific data if this is an Azure connection
       if (isAzure) {
         updates.providerSpecificData = {
+          ...connection.providerSpecificData,
           azureEndpoint: azureData.azureEndpoint,
           apiVersion: azureData.apiVersion,
           deployment: azureData.deployment,
           organization: azureData.organization,
+          proxyPoolId: selectedProxyPoolId,
         };
-      }
-      if (isCloudflareAi) {
-        updates.providerSpecificData = { accountId: cloudflareData.accountId };
+      } else if (isCloudflareAi) {
+        updates.providerSpecificData = {
+          ...connection.providerSpecificData,
+          accountId: cloudflareData.accountId,
+          proxyPoolId: selectedProxyPoolId,
+        };
+      } else {
+        updates.providerSpecificData = {
+          ...connection.providerSpecificData,
+          proxyPoolId: selectedProxyPoolId,
+        };
       }
       
       await onSave(updates);
@@ -255,6 +268,24 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
             )}
           </div>
         )}
+
+        {/* Proxy Pool per account */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-medium text-text-muted">Proxy (per account)</label>
+          <select
+            value={selectedProxyPoolId}
+            onChange={(e) => setSelectedProxyPoolId(e.target.value)}
+            className="bg-sidebar border border-accent/20 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent"
+          >
+            <option value="__none__">-- Không dùng proxy --</option>
+            {(proxyPools || []).filter(p => p.isActive !== false).map((pool) => (
+              <option key={pool.id} value={pool.id}>{pool.name} ({pool.proxyUrl})</option>
+            ))}
+          </select>
+          {selectedProxyPoolId && selectedProxyPoolId !== "__none__" && (
+            <p className="text-xs text-green-400">✓ Account này sẽ dùng proxy riêng</p>
+          )}
+        </div>
 
         <div className="flex gap-2">
           <Button onClick={handleSubmit} fullWidth disabled={saving}>{saving ? "Saving..." : "Save"}</Button>


### PR DESCRIPTION
## Problem

When using multiple accounts for the same provider (e.g., multiple Codex accounts), 
all accounts share the same outbound proxy. This can cause issues where multiple 
accounts appear to originate from the same IP, increasing the risk of account bans 
or rate limiting.

## Solution

Add a proxy pool selector in the **Edit Connection** modal, allowing users to assign 
a specific proxy pool to each individual account.

This leverages the existing `resolveConnectionProxyConfig()` infrastructure in 
`connectionProxy.js` which already reads `providerSpecificData.proxyPoolId` — 
only the UI was missing.

## Changes

- `src/shared/components/EditConnectionModal.js`: Added proxy pool dropdown that 
  reads from the existing `proxyPools` prop and saves the selected pool ID into 
  `providerSpecificData.proxyPoolId`

## How to use

1. Go to **Proxy Pools** → add one proxy per account
2. Go to **Providers** → click edit (pencil icon) on each account
3. Select the desired proxy from the **"Proxy (per account)"** dropdown
4. Save

## Notes

- No backend changes required — existing `connectionProxy.js` logic handles routing
- Falls back to direct connection if proxy fails (when `strictProxy` is disabled)
- Fully backward compatible — existing connections without a proxy pool are unaffected