### PR TITLE
feat: add per-API-key device/connection tracking

### DIFF
--- a/src/app/api/keys/devices/route.js
+++ b/src/app/api/keys/devices/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getDeviceCount, getDeviceDetails } from "@/lib/deviceTracker";
+import { getApiKeys } from "@/lib/localDb";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/keys/devices - List active device details by API key
+export async function GET() {
+  try {
+    const apiKeys = await getApiKeys();
+    const devices = {};
+
+    for (const apiKey of apiKeys) {
+      devices[apiKey.key] = {
+        count: getDeviceCount(apiKey.key),
+        details: getDeviceDetails(apiKey.key),
+      };
+    }
+
+    return NextResponse.json({ devices });
+  } catch (error) {
+    console.error("[API] Failed to get API key devices:", error);
+    return NextResponse.json({ error: "Failed to fetch API key devices" }, { status: 500 });
+  }
+}

--- a/src/app/api/keys/devices/route.js
+++ b/src/app/api/keys/devices/route.js
@@ -4,17 +4,25 @@ import { getApiKeys } from "@/lib/localDb";
 
 export const dynamic = "force-dynamic";
 
+function getKeyPreview(key) {
+  if (!key || typeof key !== "string") return "";
+  return `${key.slice(0, 8)}...${key.slice(-4)}`;
+}
+
 // GET /api/keys/devices - List active device details by API key
 export async function GET() {
   try {
     const apiKeys = await getApiKeys();
-    const devices = {};
+    const devices = [];
 
     for (const apiKey of apiKeys) {
-      devices[apiKey.key] = {
+      devices.push({
+        id: apiKey.id,
+        name: apiKey.name,
+        keyPreview: getKeyPreview(apiKey.key),
         count: getDeviceCount(apiKey.key),
         details: getDeviceDetails(apiKey.key),
-      };
+      });
     }
 
     return NextResponse.json({ devices });

--- a/src/lib/deviceTracker.js
+++ b/src/lib/deviceTracker.js
@@ -1,0 +1,198 @@
+import crypto from "crypto";
+
+const DEFAULT_TTL_MS = 30 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 60 * 1000;
+const TTL_ENV_NAME = "DEVICE_TRACKER_TTL_MS";
+
+function parseTtlMs() {
+  const rawValue = process.env[TTL_ENV_NAME];
+  if (!rawValue) return DEFAULT_TTL_MS;
+
+  const parsedValue = Number(rawValue);
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    console.warn(`[deviceTracker] Invalid ${TTL_ENV_NAME} value "${rawValue}"; using ${DEFAULT_TTL_MS}ms`);
+    return DEFAULT_TTL_MS;
+  }
+
+  return parsedValue;
+}
+
+const ttlMs = parseTtlMs();
+
+if (!global._apiKeyDeviceTracker) {
+  global._apiKeyDeviceTracker = {
+    devicesByApiKey: new Map(),
+    cleanupTimer: null,
+  };
+  console.log(`[deviceTracker] Initialized in-memory tracker with TTL ${ttlMs}ms`);
+}
+
+const tracker = global._apiKeyDeviceTracker;
+
+function getHeaderValue(request, headerName) {
+  return request?.headers?.get?.(headerName)?.trim() || "";
+}
+
+function extractIp(request) {
+  const forwardedFor = getHeaderValue(request, "x-forwarded-for");
+  if (forwardedFor) {
+    const firstIp = forwardedFor.split(",")[0]?.trim();
+    if (firstIp) return firstIp;
+  }
+
+  return getHeaderValue(request, "x-real-ip")
+    || getHeaderValue(request, "cf-connecting-ip")
+    || getHeaderValue(request, "fastly-client-ip")
+    || "unknown";
+}
+
+function extractUserAgent(request) {
+  return getHeaderValue(request, "user-agent") || "unknown";
+}
+
+function createFingerprint(ip, userAgent) {
+  return crypto.createHash("sha256").update(`${ip}|${userAgent}`).digest("hex");
+}
+
+function getVisibleCounts() {
+  const counts = {};
+
+  for (const [apiKey, devices] of tracker.devicesByApiKey.entries()) {
+    counts[apiKey] = devices.size;
+  }
+
+  return counts;
+}
+
+function countsAreEqual(before, after) {
+  const beforeKeys = Object.keys(before);
+  const afterKeys = Object.keys(after);
+
+  if (beforeKeys.length !== afterKeys.length) return false;
+
+  for (const apiKey of beforeKeys) {
+    if (before[apiKey] !== after[apiKey]) return false;
+  }
+
+  return true;
+}
+
+function expireDevices(now = Date.now()) {
+  let expiredCount = 0;
+
+  for (const [apiKey, devices] of tracker.devicesByApiKey.entries()) {
+    for (const [fingerprint, record] of devices.entries()) {
+      if (now - record.lastSeen > ttlMs) {
+        devices.delete(fingerprint);
+        expiredCount += 1;
+      }
+    }
+
+    if (devices.size === 0) {
+      tracker.devicesByApiKey.delete(apiKey);
+    }
+  }
+
+  if (expiredCount > 0) {
+    console.log(`[deviceTracker] Expired ${expiredCount} stale device${expiredCount === 1 ? "" : "s"}`);
+  }
+}
+
+function emitDeviceCountUpdate() {
+  import("@/lib/usageDb.js")
+    .then(({ statsEmitter }) => statsEmitter.emit("update"))
+    .catch((error) => {
+      console.error("[deviceTracker] Failed to emit stats update:", error.message);
+    });
+}
+
+function expireAndEmitIfChanged(now = Date.now()) {
+  const beforeCounts = getVisibleCounts();
+  expireDevices(now);
+  const afterCounts = getVisibleCounts();
+
+  if (!countsAreEqual(beforeCounts, afterCounts)) {
+    emitDeviceCountUpdate();
+    return true;
+  }
+
+  return false;
+}
+
+function ensureCleanupTimer() {
+  if (tracker.cleanupTimer) return;
+
+  tracker.cleanupTimer = setInterval(() => {
+    expireAndEmitIfChanged();
+  }, CLEANUP_INTERVAL_MS);
+
+  tracker.cleanupTimer.unref?.();
+}
+
+ensureCleanupTimer();
+
+export function trackDevice(apiKey, request) {
+  if (!apiKey || typeof apiKey !== "string") {
+    console.warn("[deviceTracker] Skipped tracking because apiKey is missing or invalid");
+    return null;
+  }
+
+  const now = Date.now();
+  const beforeCounts = getVisibleCounts();
+
+  expireDevices(now);
+
+  const ip = extractIp(request);
+  const userAgent = extractUserAgent(request);
+  const fingerprint = createFingerprint(ip, userAgent);
+
+  let devices = tracker.devicesByApiKey.get(apiKey);
+  if (!devices) {
+    devices = new Map();
+    tracker.devicesByApiKey.set(apiKey, devices);
+  }
+
+  const existingRecord = devices.get(fingerprint);
+  if (existingRecord) {
+    existingRecord.lastSeen = now;
+  } else {
+    devices.set(fingerprint, { fingerprint, ip, userAgent, lastSeen: now });
+    console.log(`[deviceTracker] Tracked new device for API key ${apiKey.slice(0, 8)}...`);
+  }
+
+  const afterCounts = getVisibleCounts();
+  if (!countsAreEqual(beforeCounts, afterCounts)) {
+    emitDeviceCountUpdate();
+  }
+
+  return fingerprint;
+}
+
+export function getDeviceCount(apiKey) {
+  expireAndEmitIfChanged();
+
+  if (!apiKey || typeof apiKey !== "string") return 0;
+
+  return tracker.devicesByApiKey.get(apiKey)?.size || 0;
+}
+
+export function getDeviceDetails(apiKey) {
+  expireAndEmitIfChanged();
+
+  if (!apiKey || typeof apiKey !== "string") return [];
+
+  const devices = tracker.devicesByApiKey.get(apiKey);
+  if (!devices) return [];
+
+  return Array.from(devices.values()).map((record) => ({
+    fingerprint: record.fingerprint,
+    ip: record.ip,
+    userAgent: record.userAgent,
+    lastSeen: record.lastSeen,
+  }));
+}
+
+export function getAllDeviceCounts() {
+  expireAndEmitIfChanged();
+  return { ...getVisibleCounts() };
+}

--- a/src/lib/deviceTracker.js
+++ b/src/lib/deviceTracker.js
@@ -2,7 +2,12 @@ import crypto from "crypto";
 
 const DEFAULT_TTL_MS = 30 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 60 * 1000;
+const DEFAULT_MAX_DEVICES_PER_API_KEY = 1000;
+const DEFAULT_MAX_TOTAL_DEVICES = 10000;
+const MAX_STORED_USER_AGENT_LENGTH = 256;
 const TTL_ENV_NAME = "DEVICE_TRACKER_TTL_MS";
+const MAX_PER_KEY_ENV_NAME = "DEVICE_TRACKER_MAX_DEVICES_PER_KEY";
+const MAX_TOTAL_ENV_NAME = "DEVICE_TRACKER_MAX_TOTAL_DEVICES";
 
 function parseTtlMs() {
   const rawValue = process.env[TTL_ENV_NAME];
@@ -17,7 +22,22 @@ function parseTtlMs() {
   return parsedValue;
 }
 
+function parsePositiveIntegerEnv(envName, defaultValue) {
+  const rawValue = process.env[envName];
+  if (!rawValue) return defaultValue;
+
+  const parsedValue = Number(rawValue);
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    console.warn(`[deviceTracker] Invalid ${envName} value "${rawValue}"; using ${defaultValue}`);
+    return defaultValue;
+  }
+
+  return parsedValue;
+}
+
 const ttlMs = parseTtlMs();
+const maxDevicesPerApiKey = parsePositiveIntegerEnv(MAX_PER_KEY_ENV_NAME, DEFAULT_MAX_DEVICES_PER_API_KEY);
+const maxTotalDevices = parsePositiveIntegerEnv(MAX_TOTAL_ENV_NAME, DEFAULT_MAX_TOTAL_DEVICES);
 
 if (!global._apiKeyDeviceTracker) {
   global._apiKeyDeviceTracker = {
@@ -34,16 +54,18 @@ function getHeaderValue(request, headerName) {
 }
 
 function extractIp(request) {
+  const edgeIp = getHeaderValue(request, "cf-connecting-ip")
+    || getHeaderValue(request, "x-real-ip")
+    || getHeaderValue(request, "fastly-client-ip");
+  if (edgeIp) return edgeIp;
+
   const forwardedFor = getHeaderValue(request, "x-forwarded-for");
   if (forwardedFor) {
     const firstIp = forwardedFor.split(",")[0]?.trim();
     if (firstIp) return firstIp;
   }
 
-  return getHeaderValue(request, "x-real-ip")
-    || getHeaderValue(request, "cf-connecting-ip")
-    || getHeaderValue(request, "fastly-client-ip")
-    || "unknown";
+  return "unknown";
 }
 
 function extractUserAgent(request) {
@@ -52,6 +74,83 @@ function extractUserAgent(request) {
 
 function createFingerprint(ip, userAgent) {
   return crypto.createHash("sha256").update(`${ip}|${userAgent}`).digest("hex");
+}
+
+function truncateUserAgent(userAgent) {
+  if (userAgent.length <= MAX_STORED_USER_AGENT_LENGTH) return userAgent;
+  return `${userAgent.slice(0, MAX_STORED_USER_AGENT_LENGTH)}...`;
+}
+
+function maskIp(ip) {
+  if (!ip || ip === "unknown") return "unknown";
+
+  const ipv4Parts = ip.split(".");
+  if (ipv4Parts.length === 4 && ipv4Parts.every((part) => /^\d{1,3}$/.test(part))) {
+    return `${ipv4Parts[0]}.${ipv4Parts[1]}.x.x`;
+  }
+
+  if (ip.includes(":")) {
+    const visibleGroups = ip.split(":").filter(Boolean).slice(0, 3).join(":");
+    return visibleGroups ? `${visibleGroups}:...` : "unknown";
+  }
+
+  return "masked";
+}
+
+function getTotalDeviceCount() {
+  let count = 0;
+
+  for (const devices of tracker.devicesByApiKey.values()) {
+    count += devices.size;
+  }
+
+  return count;
+}
+
+function deleteDevice(apiKey, fingerprint) {
+  const devices = tracker.devicesByApiKey.get(apiKey);
+  if (!devices) return false;
+
+  const deleted = devices.delete(fingerprint);
+  if (devices.size === 0) tracker.devicesByApiKey.delete(apiKey);
+
+  return deleted;
+}
+
+function findOldestDevice(apiKey = null) {
+  let oldest = null;
+  const entries = apiKey
+    ? [[apiKey, tracker.devicesByApiKey.get(apiKey)]]
+    : tracker.devicesByApiKey.entries();
+
+  for (const [entryApiKey, devices] of entries) {
+    if (!devices) continue;
+
+    for (const [fingerprint, record] of devices.entries()) {
+      if (!oldest || record.lastSeen < oldest.lastSeen) {
+        oldest = { apiKey: entryApiKey, fingerprint, lastSeen: record.lastSeen };
+      }
+    }
+  }
+
+  return oldest;
+}
+
+function evictOldestDevice(apiKey = null) {
+  const oldest = findOldestDevice(apiKey);
+  if (!oldest) return false;
+
+  return deleteDevice(oldest.apiKey, oldest.fingerprint);
+}
+
+function enforceDeviceLimits(apiKey, devices) {
+  while (devices.size >= maxDevicesPerApiKey) {
+    if (!evictOldestDevice(apiKey)) break;
+  }
+
+  while (getTotalDeviceCount() >= maxTotalDevices) {
+    if (!evictOldestDevice()) break;
+  }
 }
 
 function getVisibleCounts() {
@@ -156,7 +255,14 @@ export function trackDevice(apiKey, request) {
   if (existingRecord) {
     existingRecord.lastSeen = now;
   } else {
-    devices.set(fingerprint, { fingerprint, ip, userAgent, lastSeen: now });
+    enforceDeviceLimits(apiKey, devices);
+    if (!tracker.devicesByApiKey.has(apiKey)) tracker.devicesByApiKey.set(apiKey, devices);
+    devices.set(fingerprint, {
+      fingerprint,
+      ip: maskIp(ip),
+      userAgent: truncateUserAgent(userAgent),
+      lastSeen: now,
+    });
     console.log(`[deviceTracker] Tracked new device for API key ${apiKey.slice(0, 8)}...`);
   }
 
@@ -185,7 +291,7 @@ export function getDeviceDetails(apiKey) {
   if (!devices) return [];
 
   return Array.from(devices.values()).map((record) => ({
-    fingerprint: record.fingerprint,
+    fingerprint: record.fingerprint.slice(0, 12),
     ip: record.ip,
     userAgent: record.userAgent,
     lastSeen: record.lastSeen,

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -510,6 +510,14 @@ export async function getUsageStats(period = "all") {
     apiKeyMap[key.key] = { name: key.name, id: key.id, createdAt: key.createdAt };
   }
 
+  let deviceCounts = {};
+  try {
+    const { getAllDeviceCounts } = await import("@/lib/deviceTracker.js");
+    deviceCounts = getAllDeviceCounts();
+  } catch (error) {
+    console.error("[usageDb] Failed to load device counts:", error.message);
+  }
+
   // Recent requests (always from live history)
   const seen = new Set();
   const recentRequests = [...history]
@@ -659,7 +667,7 @@ export async function getUsageStats(period = "all") {
         const keyName = keyInfo?.name || (apiKeyVal ? apiKeyVal.slice(0, 8) + "..." : "Local (No API Key)");
         const apiKeyKey = apiKeyVal || "local-no-key";
         if (!stats.byApiKey[akKey]) {
-          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKey: apiKeyVal, keyName, apiKeyKey, lastUsed: dateKey };
+          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKey: apiKeyVal, keyName, apiKeyKey, deviceCount: apiKeyVal ? deviceCounts[apiKeyVal] || 0 : 0, lastUsed: dateKey };
         }
         stats.byApiKey[akKey].requests += akData.requests || 0;
         stats.byApiKey[akKey].promptTokens += akData.promptTokens || 0;
@@ -770,14 +778,14 @@ export async function getUsageStats(period = "all") {
         const keyName = keyInfo?.name || entry.apiKey.slice(0, 8) + "...";
         const apiKeyModelKey = `${entry.apiKey}|${entry.model}|${entry.provider || "unknown"}`;
         if (!stats.byApiKey[apiKeyModelKey]) {
-          stats.byApiKey[apiKeyModelKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: entry.model, provider: providerDisplayName, apiKey: entry.apiKey, keyName, apiKeyKey: entry.apiKey, lastUsed: entry.timestamp };
+          stats.byApiKey[apiKeyModelKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: entry.model, provider: providerDisplayName, apiKey: entry.apiKey, keyName, apiKeyKey: entry.apiKey, deviceCount: deviceCounts[entry.apiKey] || 0, lastUsed: entry.timestamp };
         }
         const ake = stats.byApiKey[apiKeyModelKey];
         ake.requests++; ake.promptTokens += promptTokens; ake.completionTokens += completionTokens; ake.cost += entryCost;
         if (new Date(entry.timestamp) > new Date(ake.lastUsed)) ake.lastUsed = entry.timestamp;
       } else {
         if (!stats.byApiKey["local-no-key"]) {
-          stats.byApiKey["local-no-key"] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: entry.model, provider: providerDisplayName, apiKey: null, keyName: "Local (No API Key)", apiKeyKey: "local-no-key", lastUsed: entry.timestamp };
+          stats.byApiKey["local-no-key"] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: entry.model, provider: providerDisplayName, apiKey: null, keyName: "Local (No API Key)", apiKeyKey: "local-no-key", deviceCount: 0, lastUsed: entry.timestamp };
         }
         const ake = stats.byApiKey["local-no-key"];
         ake.requests++; ake.promptTokens += promptTokens; ake.completionTokens += completionTokens; ake.cost += entryCost;
@@ -798,6 +806,12 @@ export async function getUsageStats(period = "all") {
 
   // Calculate totalRequests from period-filtered data (not lifetime)
   stats.totalRequests = Object.values(stats.byProvider).reduce((sum, p) => sum + (p.requests || 0), 0);
+
+  for (const row of Object.values(stats.byApiKey || {})) {
+    if (typeof row.deviceCount !== "number" || !Number.isFinite(row.deviceCount) || row.deviceCount < 0) {
+      row.deviceCount = 0;
+    }
+  }
 
   return stats;
 }

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -137,6 +137,37 @@ function groupDataByKey(data, keyField) {
   return Object.values(groups);
 }
 
+function mergeApiKeyDeviceCounts(existingByApiKey, incomingByApiKey) {
+  if (!existingByApiKey || !incomingByApiKey) return existingByApiKey;
+
+  const incomingCounts = new Map();
+  for (const [key, row] of Object.entries(incomingByApiKey)) {
+    const apiKey = row?.apiKeyKey || row?.apiKey || key;
+    if (!apiKey || apiKey === "local-no-key") continue;
+
+    incomingCounts.set(apiKey, Math.max(incomingCounts.get(apiKey) || 0, row.deviceCount || 0));
+  }
+
+  if (incomingCounts.size === 0) return existingByApiKey;
+
+  let changed = false;
+  const nextByApiKey = {};
+
+  for (const [key, row] of Object.entries(existingByApiKey)) {
+    const apiKey = row?.apiKeyKey || row?.apiKey || key;
+    const nextDeviceCount = incomingCounts.get(apiKey);
+
+    if (typeof nextDeviceCount === "number" && row.deviceCount !== nextDeviceCount) {
+      nextByApiKey[key] = { ...row, deviceCount: nextDeviceCount };
+      changed = true;
+    } else {
+      nextByApiKey[key] = row;
+    }
+  }
+
+  return changed ? nextByApiKey : existingByApiKey;
+}
+
 const MODEL_COLUMNS = [
   { field: "rawModel", label: "Model" },
   { field: "provider", label: "Provider" },
@@ -238,21 +269,25 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       });
   }, [period]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // SSE connection - real-time updates for activeRequests + recentRequests only
+  // SSE connection - merge live fields without overwriting period-filtered totals
   useEffect(() => {
     const es = new EventSource("/api/usage/stream");
 
     es.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data);
-        // Always merge only real-time fields, never overwrite full stats from REST
-        setStats((prev) => ({
-          ...(prev || {}),
-          activeRequests: data.activeRequests,
-          recentRequests: data.recentRequests,
-          errorProvider: data.errorProvider,
-          pending: data.pending,
-        }));
+        setStats((prev) => {
+          if (!prev?.byApiKey) return data;
+
+          return {
+            ...prev,
+            activeRequests: data.activeRequests,
+            recentRequests: data.recentRequests,
+            errorProvider: data.errorProvider,
+            pending: data.pending,
+            byApiKey: mergeApiKeyDeviceCounts(prev.byApiKey, data.byApiKey),
+          };
+        });
         setLoading(false);
       } catch (err) {
         console.error("[SSE CLIENT] parse error:", err);

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -115,7 +115,7 @@ function groupDataByKey(data, keyField) {
     if (!groups[gk]) {
       groups[gk] = {
         groupKey: gk,
-        summary: { requests: 0, promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0, inputCost: 0, outputCost: 0, lastUsed: null, pending: 0 },
+        summary: { requests: 0, promptTokens: 0, completionTokens: 0, totalTokens: 0, cost: 0, inputCost: 0, outputCost: 0, lastUsed: null, pending: 0, deviceCount: 0 },
         items: [],
       };
     }
@@ -128,6 +128,7 @@ function groupDataByKey(data, keyField) {
     s.inputCost += item.inputCost || 0;
     s.outputCost += item.outputCost || 0;
     s.pending += item.pending || 0;
+    s.deviceCount = Math.max(s.deviceCount || 0, item.deviceCount || 0);
     if (item.lastUsed && (!s.lastUsed || new Date(item.lastUsed) > new Date(s.lastUsed))) {
       s.lastUsed = item.lastUsed;
     }
@@ -156,6 +157,7 @@ const API_KEY_COLUMNS = [
   { field: "rawModel", label: "Model" },
   { field: "provider", label: "Provider" },
   { field: "requests", label: "Requests", align: "right" },
+  { field: "deviceCount", label: "Devices", align: "right" },
   { field: "lastUsed", label: "Last Used", align: "right" },
 ];
 
@@ -347,6 +349,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
               <td className="px-6 py-3 text-text-muted">—</td>
               <td className="px-6 py-3 text-text-muted">—</td>
               <td className="px-6 py-3 text-right">{fmt(group.summary.requests)}</td>
+              <td className="px-6 py-3 text-right">{fmt(group.summary.deviceCount)}</td>
               <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(group.summary.lastUsed)}</td>
             </>
           ),
@@ -356,6 +359,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
               <td className="px-6 py-3">{item.rawModel}</td>
               <td className="px-6 py-3"><Badge variant="neutral" size="sm">{item.provider}</Badge></td>
               <td className="px-6 py-3 text-right">{fmt(item.requests)}</td>
+              <td className="px-6 py-3 text-right">{fmt(item.deviceCount)}</td>
               <td className="px-6 py-3 text-right text-text-muted whitespace-nowrap">{fmtTime(item.lastUsed)}</td>
             </>
           ),

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -9,6 +9,7 @@ import {
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
 import { getSettings } from "@/lib/localDb";
+import { trackDevice } from "@/lib/deviceTracker.js";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -67,17 +68,21 @@ export async function handleChat(request, clientRawRequest = null) {
 
   // Enforce API key if enabled in settings
   const settings = await getSettings();
+  let validApiKeyForTracking = false;
   if (settings.requireApiKey) {
     if (!apiKey) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
+    validApiKeyForTracking = await isValidApiKey(apiKey);
+    if (!validApiKeyForTracking) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
     }
+  } else if (apiKey) {
+    validApiKeyForTracking = await isValidApiKey(apiKey);
   }
+  if (validApiKeyForTracking) trackDevice(apiKey, request);
 
   if (!modelStr) {
     log.warn("CHAT", "Missing model");

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -6,6 +6,7 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
+import { trackDevice } from "@/lib/deviceTracker.js";
 import { getModelInfo } from "../services/model.js";
 import { handleEmbeddingsCore } from "open-sse/handlers/embeddingsCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -43,17 +44,21 @@ export async function handleEmbeddings(request) {
 
   // Enforce API key if enabled in settings
   const settings = await getSettings();
+  let validApiKeyForTracking = false;
   if (settings.requireApiKey) {
     if (!apiKey) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
+    validApiKeyForTracking = await isValidApiKey(apiKey);
+    if (!validApiKeyForTracking) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
     }
+  } else if (apiKey) {
+    validApiKeyForTracking = await isValidApiKey(apiKey);
   }
+  if (validApiKeyForTracking) trackDevice(apiKey, request);
 
   if (!modelStr) {
     log.warn("EMBEDDINGS", "Missing model");

--- a/src/sse/handlers/search.js
+++ b/src/sse/handlers/search.js
@@ -6,6 +6,7 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { getSettings, getCombos } from "@/lib/localDb";
+import { trackDevice } from "@/lib/deviceTracker.js";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
 import { handleSearchCore } from "open-sse/handlers/search/index.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -46,17 +47,21 @@ export async function handleSearch(request) {
 
   // Enforce API key if enabled in settings
   const settings = await getSettings();
+  let validApiKeyForTracking = false;
   if (settings.requireApiKey) {
     if (!apiKey) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
+    validApiKeyForTracking = await isValidApiKey(apiKey);
+    if (!validApiKeyForTracking) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
     }
+  } else if (apiKey) {
+    validApiKeyForTracking = await isValidApiKey(apiKey);
   }
+  if (validApiKeyForTracking) trackDevice(apiKey, request);
 
   if (!providerInput || typeof providerInput !== "string") {
     log.warn("SEARCH", "Missing provider/model");

--- a/src/sse/handlers/tts.js
+++ b/src/sse/handlers/tts.js
@@ -3,6 +3,7 @@ import {
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
+import { trackDevice } from "@/lib/deviceTracker.js";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleTtsCore } from "open-sse/handlers/ttsCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -32,13 +33,17 @@ export async function handleTts(request) {
   const language = body.language || ""; // Optional language hint (currently used by Gemini)
   log.request("POST", `${url.pathname} | ${modelStr} | format=${responseFormat}${language ? ` | lang=${language}` : ""}`);
 
+  const apiKey = extractApiKey(request);
   const settings = await getSettings();
+  let validApiKeyForTracking = false;
   if (settings.requireApiKey) {
-    const apiKey = extractApiKey(request);
     if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    validApiKeyForTracking = await isValidApiKey(apiKey);
+    if (!validApiKeyForTracking) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  } else if (apiKey) {
+    validApiKeyForTracking = await isValidApiKey(apiKey);
   }
+  if (validApiKeyForTracking) trackDevice(apiKey, request);
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   if (!body.input) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: input");


### PR DESCRIPTION
## Summary

Closes #930

- Add in-memory device tracker module (`deviceTracker.js`) with SHA-256 fingerprinting, 30-min TTL auto-expiry
- Track unique connected devices per API key across all SSE handlers (chat, search, TTS, embeddings)  
- New `GET /api/keys/devices` endpoint for querying device counts per key
- Extend usage stats with `deviceCount` in `byApiKey` entries
- Add "Devices" column to API Key tab in the dashboard

## Changes

| File | Change |
|------|--------|
| `src/lib/deviceTracker.js` | **New** — Device tracker with SHA-256 fingerprint, TTL expiry, global singleton |
| `src/app/api/keys/devices/route.js` | **New** — `GET /api/keys/devices` API endpoint |
| `src/lib/usageDb.js` | Extended `getUsageStats()` to include `deviceCount` per API key |
| `src/shared/components/UsageStats.js` | Added "Devices" column to API Key tab |
| `src/sse/handlers/chat.js` | Added `trackDevice()` call after API key validation |
| `src/sse/handlers/search.js` | Added `trackDevice()` call after API key validation |
| `src/sse/handlers/tts.js` | Added `trackDevice()` call after API key validation |
| `src/sse/handlers/embeddings.js` | Added `trackDevice()` call after API key validation |

## Testing
- `npm run build` passes
- Device tracking verified: same device = 1, different UA = 2, separate keys scoped independently
- `/api/keys/devices` returns valid JSON with correct shape
- Usage stats (`/api/usage/stats`) still works correctly for all periods