### PR TITLE
 fix: keep Codex workspaces as separate connections

### DIFF
--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -357,21 +357,47 @@ export async function getProviderConnectionById(id) {
   return db.data.providerConnections.find(c => c.id === id) || null;
 }
 
+function getCodexWorkspaceIdentity(data) {
+  if (data.provider !== "codex" || data.authType !== "oauth") return null;
+  const specific = data.providerSpecificData || {};
+  const accountId = specific.chatgptAccountId;
+  const workspaceId = specific.organizationId || specific.workspaceId;
+  if (!accountId || !workspaceId) return null;
+  return { accountId, workspaceId };
+}
+
+function findExistingProviderConnection(connections, data) {
+  const codexIdentity = getCodexWorkspaceIdentity(data);
+  if (codexIdentity) {
+    return connections.findIndex((c) => {
+      const existingIdentity = getCodexWorkspaceIdentity(c);
+      return existingIdentity &&
+        existingIdentity.accountId === codexIdentity.accountId &&
+        existingIdentity.workspaceId === codexIdentity.workspaceId;
+    });
+  }
+
+  if (data.authType === "oauth" && data.email) {
+    return connections.findIndex(
+      c => c.provider === data.provider && c.authType === "oauth" && c.email === data.email
+    );
+  }
+
+  if (data.authType === "apikey" && data.name) {
+    return connections.findIndex(
+      c => c.provider === data.provider && c.authType === "apikey" && c.name === data.name
+    );
+  }
+
+  return -1;
+}
+
 export async function createProviderConnection(data) {
   const db = await getDb();
   const now = new Date().toISOString();
 
-  // Upsert: check existing by provider + email (oauth) or provider + name (apikey)
-  let existingIndex = -1;
-  if (data.authType === "oauth" && data.email) {
-    existingIndex = db.data.providerConnections.findIndex(
-      c => c.provider === data.provider && c.authType === "oauth" && c.email === data.email
-    );
-  } else if (data.authType === "apikey" && data.name) {
-    existingIndex = db.data.providerConnections.findIndex(
-      c => c.provider === data.provider && c.authType === "apikey" && c.name === data.name
-    );
-  }
+  // Upsert: Codex workspaces need account+workspace identity; other OAuth providers use email.
+  const existingIndex = findExistingProviderConnection(db.data.providerConnections, data);
 
   if (existingIndex !== -1) {
     db.data.providerConnections[existingIndex] = {
@@ -416,7 +442,7 @@ export async function createProviderConnection(data) {
   const optionalFields = [
     "displayName", "email", "globalPriority", "defaultModel",
     "accessToken", "refreshToken", "expiresAt", "tokenType",
-    "scope", "projectId", "apiKey", "testStatus",
+    "scope", "idToken", "projectId", "apiKey", "testStatus",
     "lastTested", "lastError", "lastErrorAt", "rateLimitedUntil", "expiresIn", "errorCode",
     "consecutiveUseCount"
   ];

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -52,15 +52,33 @@ function extractEmailFromAccessToken(accessToken) {
   return payload.email || payload.preferred_username || payload.sub || undefined;
 }
 
+function firstObject(value) {
+  if (Array.isArray(value)) return value.find((item) => item && typeof item === "object") || null;
+  if (value && typeof value === "object") return value;
+  return null;
+}
+
+function extractCodexOrganization(chatgpt) {
+  const organization = firstObject(chatgpt.organizations || chatgpt.organization || chatgpt.workspace || chatgpt.workspaces);
+  if (!organization) return {};
+  return {
+    organizationId: organization.id || organization.organization_id || organization.workspace_id,
+    organizationName: organization.name || organization.title || organization.display_name,
+  };
+}
+
 // Extract codex account info from id_token
 export function extractCodexAccountInfo(idToken) {
   const payload = decodeJwtPayload(idToken);
   if (!payload) return {};
   const chatgpt = payload["https://api.openai.com/auth"] || {};
+  const organization = extractCodexOrganization(chatgpt);
   return {
     email: payload.email,
     chatgptAccountId: chatgpt.chatgpt_account_id,
     chatgptPlanType: chatgpt.chatgpt_plan_type,
+    organizationId: organization.organizationId,
+    organizationName: organization.organizationName,
   };
 }
 
@@ -172,13 +190,16 @@ const PROVIDERS = {
       const mapped = {
         accessToken: tokens.access_token,
         refreshToken: tokens.refresh_token,
+        idToken: tokens.id_token,
         expiresIn: tokens.expires_in,
       };
       if (info.email) mapped.email = info.email;
-      if (info.chatgptAccountId || info.chatgptPlanType) {
+      if (info.chatgptAccountId || info.chatgptPlanType || info.organizationId || info.organizationName) {
         mapped.providerSpecificData = {
           chatgptAccountId: info.chatgptAccountId,
           chatgptPlanType: info.chatgptPlanType,
+          organizationId: info.organizationId,
+          organizationName: info.organizationName,
         };
       }
       return mapped;
@@ -1305,11 +1326,13 @@ export async function backfillCodexEmails() {
       if (!info.email && !info.chatgptAccountId) continue;
       const patch = {};
       if (!conn.email && info.email) patch.email = info.email;
-      if (info.chatgptAccountId || info.chatgptPlanType) {
+      if (info.chatgptAccountId || info.chatgptPlanType || info.organizationId || info.organizationName) {
         patch.providerSpecificData = {
           ...(conn.providerSpecificData || {}),
           chatgptAccountId: info.chatgptAccountId,
           chatgptPlanType: info.chatgptPlanType,
+          organizationId: info.organizationId,
+          organizationName: info.organizationName,
         };
       }
       if (Object.keys(patch).length) {

--- a/tests/unit/codex-provider-connections.test.js
+++ b/tests/unit/codex-provider-connections.test.js
@@ -1,0 +1,132 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalDataDir = process.env.DATA_DIR;
+let cleanup = () => {};
+
+async function setupTestDb() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-codex-connections-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  const db = await import("@/lib/localDb.js");
+
+  return {
+    ...db,
+    cleanup() {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeJwt(payload) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode(payload)}.`;
+}
+
+describe("Codex provider connections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    cleanup();
+    cleanup = () => {};
+    if (originalDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = originalDataDir;
+  });
+
+  it("keeps separate Codex workspaces for the same email", async () => {
+    const db = await setupTestDb();
+    cleanup = db.cleanup;
+
+    await db.createProviderConnection({
+      provider: "codex",
+      authType: "oauth",
+      email: "user@example.com",
+      accessToken: "workspace-a-access-token",
+      refreshToken: "workspace-a-refresh-token",
+      providerSpecificData: {
+        chatgptAccountId: "account-a",
+        organizationId: "workspace-a",
+      },
+    });
+
+    await db.createProviderConnection({
+      provider: "codex",
+      authType: "oauth",
+      email: "user@example.com",
+      accessToken: "workspace-b-access-token",
+      refreshToken: "workspace-b-refresh-token",
+      providerSpecificData: {
+        chatgptAccountId: "account-a",
+        organizationId: "workspace-b",
+      },
+    });
+
+    const connections = await db.getProviderConnections({ provider: "codex" });
+
+    expect(connections).toHaveLength(2);
+    expect(connections.map((c) => c.providerSpecificData.organizationId).sort()).toEqual([
+      "workspace-a",
+      "workspace-b",
+    ]);
+  });
+
+  it("updates the same Codex workspace when account and workspace match", async () => {
+    const db = await setupTestDb();
+    cleanup = db.cleanup;
+
+    const first = await db.createProviderConnection({
+      provider: "codex",
+      authType: "oauth",
+      email: "user@example.com",
+      accessToken: "old-token",
+      providerSpecificData: {
+        chatgptAccountId: "account-a",
+        organizationId: "workspace-a",
+      },
+    });
+
+    const second = await db.createProviderConnection({
+      provider: "codex",
+      authType: "oauth",
+      email: "user@example.com",
+      accessToken: "new-token",
+      providerSpecificData: {
+        chatgptAccountId: "account-a",
+        organizationId: "workspace-a",
+      },
+    });
+
+    const connections = await db.getProviderConnections({ provider: "codex" });
+
+    expect(second.id).toBe(first.id);
+    expect(connections).toHaveLength(1);
+    expect(connections[0].accessToken).toBe("new-token");
+  });
+
+  it("extracts Codex account and workspace metadata from id_token", async () => {
+    vi.resetModules();
+    const { extractCodexAccountInfo } = await import("@/lib/oauth/providers.js");
+    const idToken = makeJwt({
+      email: "user@example.com",
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "account-a",
+        chatgpt_plan_type: "plus",
+        organizations: [{ id: "workspace-a", name: "Workspace A" }],
+      },
+    });
+
+    expect(extractCodexAccountInfo(idToken)).toEqual({
+      email: "user@example.com",
+      chatgptAccountId: "account-a",
+      chatgptPlanType: "plus",
+      organizationId: "workspace-a",
+      organizationName: "Workspace A",
+    });
+  });
+});


### PR DESCRIPTION
Summary
   - Fixes Codex OAuth connection upsert so multiple workspaces under the same OpenAI account are not collapsed by email.
   - Extracts Codex workspace/organization metadata from `id_token` and uses `chatgptAccountId + organizationId` as the Codex-specific connection identity.
   - Adds regression coverage for same-email Codex connections across different workspaces.
    Problem
   Codex OAuth connections were upserted through the generic OAuth identity rule in `createProviderConnection()`, which uses `provider + email`.
   For a ChatGPT/OpenAI account with multiple workspaces, the selected workspace can differ while the email remains the same. Adding workspace B/C after workspace A would update the existing Codex connection instead of creating a new one, so the new workspace did not appear in `/dashboard/providers/codex`.
   
 Fix
   Codex now uses workspace-aware identity when metadata is available:
   `codex + chatgptAccountId + organizationId/workspaceId`
   Other OAuth providers continue to use the existing `provider + email` upsert behavior.

 Tests
   - Added `tests/unit/codex-provider-connections.test.js` for multi-workspace Codex storage and id_token metadata extraction.
   - Local test execution is blocked in this checkout because `vitest` is not installed in `package.json`, despite existing tests importing Vitest.