### PR TITLE
fix: advance round-robin pointer past fallback-served model

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -25,6 +25,28 @@ function rotateModelsFromIndex(models, currentIndex) {
   return rotatedModels;
 }
 
+function readRotationState(rotationKey) {
+  const existing = comboRotationState.get(rotationKey);
+  if (typeof existing === "number") return { index: existing, consecutiveUseCount: 0 };
+  return existing || { index: 0, consecutiveUseCount: 0 };
+}
+
+/**
+ * Peek the next index that getRotatedModels would use without mutating state.
+ * Used by handleComboChat so it can correct rotation after a fallback hop.
+ *
+ * @param {string} comboName
+ * @param {number} modelsLength
+ * @param {string} strategy
+ * @returns {number} 0-based absolute index into the original models array
+ */
+export function peekRotationIndex(comboName, modelsLength, strategy) {
+  if (!modelsLength || modelsLength <= 0 || strategy !== "round-robin") return 0;
+  const rotationKey = comboName || "__default__";
+  const state = readRotationState(rotationKey);
+  return state.index % modelsLength;
+}
+
 /**
  * Get rotated model list based on strategy
  * @param {string[]} models - Array of model strings
@@ -40,10 +62,7 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
 
   const rotationKey = comboName || "__default__";
   const normalizedStickyLimit = normalizeStickyLimit(stickyLimit);
-  const existingState = comboRotationState.get(rotationKey);
-  const state = typeof existingState === "number"
-    ? { index: existingState, consecutiveUseCount: 0 }
-    : (existingState || { index: 0, consecutiveUseCount: 0 });
+  const state = readRotationState(rotationKey);
 
   const currentIndex = state.index % models.length;
   const rotatedModels = rotateModelsFromIndex(models, currentIndex);
@@ -65,6 +84,32 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
 }
 
 /**
+ * Override rotation state after a fallback hop served the request from a model
+ * other than the originally-selected one. Without this, the pointer advance
+ * baked into getRotatedModels (which assumes models[currentIndex] served the
+ * request) leaves the next request landing on the same fallback model again,
+ * defeating round-robin distribution.
+ *
+ * Sticky budget is reset to 0 because the originally-planned model is unhealthy.
+ * Spending more sticky requests on a model that just failed wastes the budget
+ * on a guaranteed-failing path.
+ *
+ * @param {string} comboName
+ * @param {number} currentIndex - The index that was peeked before getRotatedModels ran
+ * @param {number} usedRelativeIndex - Position in the rotated array of the model that succeeded (>0 means fallback occurred)
+ * @param {number} modelsLength
+ */
+export function commitRotationAfterFallback(comboName, currentIndex, usedRelativeIndex, modelsLength) {
+  if (!modelsLength || modelsLength <= 0) return;
+  const rotationKey = comboName || "__default__";
+  const usedAbsoluteIndex = (currentIndex + usedRelativeIndex) % modelsLength;
+  comboRotationState.set(rotationKey, {
+    index: (usedAbsoluteIndex + 1) % modelsLength,
+    consecutiveUseCount: 0,
+  });
+}
+
+/**
  * Reset in-memory rotation state when combo/settings change
  * @param {string} [comboName] - Combo name to reset; omit to clear all
  */
@@ -82,10 +127,10 @@ export function resetComboRotation(comboName) {
 export function getComboModelsFromData(modelStr, combosData) {
   // Don't check if it's in provider/model format
   if (modelStr.includes("/")) return null;
-  
+
   // Handle both array and object formats
   const combos = Array.isArray(combosData) ? combosData : (combosData?.combos || []);
-  
+
   const combo = combos.find(c => c.name === modelStr);
   if (combo && combo.models && combo.models.length > 0) {
     return combo.models;
@@ -106,9 +151,15 @@ export function getComboModelsFromData(modelStr, combosData) {
  * @returns {Promise<Response>}
  */
 export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1 }) {
+  // Snapshot the rotation pointer BEFORE getRotatedModels advances it. Needed
+  // so we can correct the pointer if a fallback hop ends up serving from a
+  // different model than originally selected.
+  const isRotating = comboStrategy === "round-robin" && models && models.length > 1;
+  const currentIndex = isRotating ? peekRotationIndex(comboName, models.length, comboStrategy) : 0;
+
   // Apply rotation strategy if enabled
   const rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
-  
+
   let lastError = null;
   let earliestRetryAfter = null;
   let lastStatus = null;
@@ -119,10 +170,17 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
 
     try {
       const result = await handleSingleModel(body, modelStr);
-      
+
       // Success (2xx) - return response
       if (result.ok) {
         log.info("COMBO", `Model ${modelStr} succeeded`);
+        // Fallback hop succeeded. Advance rotation past the model that actually
+        // served the request so the next call skips it instead of immediately
+        // re-trying the same fallback model. Skipped when i === 0 because
+        // getRotatedModels already advanced correctly for that case.
+        if (isRotating && i > 0) {
+          commitRotationAfterFallback(comboName, currentIndex, i, models.length);
+        }
         return result;
       }
 
@@ -152,6 +210,12 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
 
       if (!shouldFallback) {
         log.warn("COMBO", `Model ${modelStr} failed (no fallback)`, { status: result.status });
+        // Same correction logic as the success path: this model served the
+        // final response (even if it's a non-retryable error), so advance
+        // rotation past it.
+        if (isRotating && i > 0) {
+          commitRotationAfterFallback(comboName, currentIndex, i, models.length);
+        }
         return result;
       }
 
@@ -176,7 +240,13 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
     }
   }
 
-  // All models failed
+  // All models failed. Advance rotation past the last attempted model so the
+  // next request doesn't restart on a known-failing model (it gives the next
+  // entry a chance instead).
+  if (isRotating) {
+    commitRotationAfterFallback(comboName, currentIndex, rotatedModels.length - 1, models.length);
+  }
+
   // Use 503 (Service Unavailable) rather than 406 (Not Acceptable) — 406 implies
   // the request itself is invalid, but here the providers are simply unavailable
   // or have no active credentials. 503 is more accurate and retryable by clients.

--- a/tests/unit/combo-routing.test.js
+++ b/tests/unit/combo-routing.test.js
@@ -1,6 +1,26 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { getRotatedModels, resetComboRotation } from "../../open-sse/services/combo.js";
+import {
+  getRotatedModels,
+  handleComboChat,
+  resetComboRotation,
+} from "../../open-sse/services/combo.js";
+
+const silentLog = { info: () => {}, warn: () => {}, error: () => {} };
+
+function okResponse(model) {
+  return new Response(JSON.stringify({ ok: true, model }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function failResponse(status, message = "rate limited") {
+  return new Response(JSON.stringify({ error: { message } }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 describe("combo round-robin routing", () => {
   beforeEach(() => {
@@ -54,5 +74,89 @@ describe("combo round-robin routing", () => {
 
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
+  });
+});
+
+describe("combo round-robin pointer after fallback hop", () => {
+  beforeEach(() => {
+    resetComboRotation();
+  });
+
+  it("advances past the model that actually served the request (not the originally-selected one)", async () => {
+    // models: [a, b, c]  index starts at 2 (c)
+    // req 1: rotation selects c → c fails → b fallback → b succeeds (i=1 in rotated=[c,a,b])
+    //        fix must advance pointer past b (absolute index 1) → next = c (idx 2)
+    //        WITHOUT fix: pointer would land on a (idx 0 = currentIndex+1=3%3=0)
+    const models = ["provider/model-a", "provider/model-b", "provider/model-c"];
+
+    // Force pointer to index=2 by calling getRotatedModels twice (sticky=1)
+    getRotatedModels(models, "test-combo", "round-robin", 1); // index → a (0) → advances to 1
+    getRotatedModels(models, "test-combo", "round-robin", 1); // index → b (1) → advances to 2
+    // Now state.index = 2 → next rotation starts from c
+
+    const callLog = [];
+
+    // req N: rotation = [c, a, b], c fails, a fails, b succeeds
+    await handleComboChat({
+      body: {},
+      models,
+      comboName: "test-combo",
+      comboStrategy: "round-robin",
+      comboStickyLimit: 1,
+      log: silentLog,
+      handleSingleModel: async (_body, modelStr) => {
+        callLog.push(modelStr);
+        if (modelStr === "provider/model-c") return failResponse(429);
+        if (modelStr === "provider/model-a") return failResponse(429);
+        return okResponse(modelStr); // b succeeds
+      },
+    });
+
+    // Without fix: next rotation starts from a (absolute 0 = (2+1)%3)
+    // With fix: next rotation starts from c (absolute 2 = (1+1)%3, where b is absolute 1)
+    callLog.length = 0;
+    await handleComboChat({
+      body: {},
+      models,
+      comboName: "test-combo",
+      comboStrategy: "round-robin",
+      comboStickyLimit: 1,
+      log: silentLog,
+      handleSingleModel: async (_body, modelStr) => {
+        callLog.push(modelStr);
+        return okResponse(modelStr);
+      },
+    });
+
+    // Next request must start from c (the model after b in the original list)
+    expect(callLog[0]).toBe("provider/model-c");
+  });
+
+  it("normal path (no fallback) still advances pointer by one", async () => {
+    const models = ["provider/model-a", "provider/model-b", "provider/model-c"];
+    const firstChoices = [];
+
+    for (let n = 0; n < 3; n++) {
+      const callLog = [];
+      await handleComboChat({
+        body: {},
+        models,
+        comboName: "test-no-fallback",
+        comboStrategy: "round-robin",
+        comboStickyLimit: 1,
+        log: silentLog,
+        handleSingleModel: async (_body, modelStr) => {
+          callLog.push(modelStr);
+          return okResponse(modelStr);
+        },
+      });
+      firstChoices.push(callLog[0]);
+    }
+
+    expect(firstChoices).toEqual([
+      "provider/model-a",
+      "provider/model-b",
+      "provider/model-c",
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

When a combo uses `fallbackStrategy: round-robin` and the scheduled model fails (e.g. `cc/claude-sonnet-4-6` returning 429), the request correctly falls through to the next model. **However, the rotation pointer was already advanced by `+1` from the *originally-selected* index before the fallback loop even ran.**

Result: the next request hits the same fallback model again, causing it to be served twice in a row (or more) while the originally-planned model is skipped entirely.

### Minimal repro

Combo `[a, b, c]`, pointer at `c` (index 2), `stickyLimit=1`:

```
req N:   scheduled=c → fail → fallback=a → fail → fallback=b → ok
         getRotatedModels already set next index = (2+1)%3 = 0 = a
req N+1: starts from a  ← b served req N, should advance past b → start from c
```

This was observed live with `glm-first` combo where `cc/claude-sonnet-4-6` repeatedly 429s:

```
[COMBO] Trying model 1/5: cc/claude-sonnet-4-6   ← index=4, fails
[COMBO] Trying model 2/5: glm/glm-5.1            ← fallback, succeeds
[COMBO] Trying model 1/5: glm/glm-5.1            ← next req hits same model again
```

## Fix

Snapshot the rotation index before `getRotatedModels` runs. On success inside the fallback loop, if `i > 0` (a fallback hop was used), call `commitRotationAfterFallback` to overwrite the state advance — pointing the next request past the model that **actually served** the response.

The same correction applies when:
- A non-retryable error terminates early (`shouldFallback=false`)
- All models are exhausted (pointer advances past last tried model)

## Changes

- `open-sse/services/combo.js`
  - Add `peekRotationIndex` — reads state without mutating (used by `handleComboChat`)
  - Add `commitRotationAfterFallback` — corrects pointer to absolute index of served model + 1
  - `handleComboChat` — snapshot index before `getRotatedModels`, call commit when `i > 0`
  - `getRotatedModels` — unchanged externally; internal `readRotationState` helper extracted

- `tests/unit/combo-routing.test.js`
  - New describe block: two tests covering fallback-hop correction and no-fallback normal path
  - All 6 tests pass

## Test output

```
✓ combo round-robin routing > keeps existing one-request round-robin behavior by default
✓ combo round-robin routing > sticks to each combo model for the configured number of requests
✓ combo round-robin routing > tracks sticky rotation independently per combo
✓ combo round-robin routing > does not rotate fallback combos
✓ combo round-robin pointer after fallback hop > advances past the model that actually served the request
✓ combo round-robin pointer after fallback hop > normal path (no fallback) still advances pointer by one

Test Files  1 passed (1)
     Tests  6 passed (6)
```