### PR TITLE
fix: prevent cached settings responses

### DIFF
--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -4,6 +4,13 @@ import { applyOutboundProxyEnv } from "@/lib/network/outboundProxy";
 import { resetComboRotation } from "open-sse/services/combo.js";
 import bcrypt from "bcryptjs";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const SETTINGS_RESPONSE_HEADERS = {
+  "Cache-Control": "no-store"
+};
+
 export async function GET() {
   try {
     const settings = await getSettings();
@@ -17,7 +24,7 @@ export async function GET() {
       enableRequestLogs,
       enableTranslator,
       hasPassword: !!password
-    });
+    }, { headers: SETTINGS_RESPONSE_HEADERS });
   } catch (error) {
     console.log("Error getting settings:", error);
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -77,7 +84,7 @@ export async function PATCH(request) {
     }
 
     const { password, ...safeSettings } = settings;
-    return NextResponse.json(safeSettings);
+    return NextResponse.json(safeSettings, { headers: SETTINGS_RESPONSE_HEADERS });
   } catch (error) {
     console.log("Error updating settings:", error);
     return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- force `/api/settings` to run dynamically instead of being cached/prerendered
- return settings GET/PATCH responses with `Cache-Control: no-store`
- keeps persisted settings such as Caveman mode visible after refresh or restart

Fixes #942

## Validation
- `npx eslint src/app/api/settings/route.js`
- `npx next build --webpack` with PowerShell production env workaround

## Note
The Endpoint page itself already reads Caveman from `/api/settings`; this makes that API response always fresh so the UI does not fall back to stale/default values.