### PR TITLE
fix: preserve Claude thinking signatures

### DIFF
--- a/open-sse/translator/helpers/claudeHelper.js
+++ b/open-sse/translator/helpers/claudeHelper.js
@@ -160,10 +160,13 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
           let hasToolUse = false;
           let hasThinking = false;
 
-          // Always replace signature for all thinking blocks
+          // Preserve real Anthropic signatures echoed by clients; only synthesize
+          // a fallback signature for upstreams that omit one.
           for (const block of msg.content) {
             if (block.type === "thinking" || block.type === "redacted_thinking") {
-              block.signature = DEFAULT_THINKING_CLAUDE_SIGNATURE;
+              if (!block.signature) {
+                block.signature = DEFAULT_THINKING_CLAUDE_SIGNATURE;
+              }
               hasThinking = true;
             }
             if (block.type === "tool_use") hasToolUse = true;


### PR DESCRIPTION
## Summary
- preserve existing Anthropic thinking/redacted-thinking signatures echoed by clients
- keep the current fallback dummy signature only when upstream/client content has no signature
- avoids replacing valid session-scoped signatures with the default placeholder during multi-turn Claude requests

Fixes #885

## Validation
- `node --input-type=module` assertions for preserving an existing thinking signature and adding the fallback when missing
- `npx eslint open-sse/translator/helpers/claudeHelper.js`
- `npx next build --webpack` with PowerShell production env workaround

## Note
This is separate from #875, which addresses empty thinking blocks. This PR only handles signature preservation.