### PR TITLE
fix: reject circular combo references

### DIFF
--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
+import { getCombos, getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
+import { validateComboReferences } from "@/lib/comboValidation";
 import { resetComboRotation } from "open-sse/services/combo.js";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
@@ -27,6 +28,11 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
+    const prev = await getComboById(id);
+
+    if (!prev) {
+      return NextResponse.json({ error: "Combo not found" }, { status: 404 });
+    }
     
     // Validate name format if provided
     if (body.name) {
@@ -40,15 +46,18 @@ export async function PUT(request, { params }) {
         return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
       }
     }
+
+    const nextName = body.name ?? prev.name;
+    const nextModels = body.models ?? prev.models ?? [];
+    const combos = await getCombos();
+    const validation = validateComboReferences({ comboId: id, name: nextName, models: nextModels, combos });
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
     
     // Capture previous name to invalidate rotation state on rename
-    const prev = await getComboById(id);
     const combo = await updateCombo(id, body);
     
-    if (!combo) {
-      return NextResponse.json({ error: "Combo not found" }, { status: 404 });
-    }
-
     // Invalidate rotation state (models/strategy/name may have changed)
     if (prev?.name) resetComboRotation(prev.name);
     if (combo.name && combo.name !== prev?.name) resetComboRotation(combo.name);

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
+import { validateComboReferences } from "@/lib/comboValidation";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,12 @@ export async function POST(request) {
     const existing = await getComboByName(name);
     if (existing) {
       return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
+    }
+
+    const combos = await getCombos();
+    const validation = validateComboReferences({ name, models: models || [], combos });
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
     }
 
     const combo = await createCombo({ name, models: models || [], kind: kind || null });

--- a/src/lib/comboValidation.js
+++ b/src/lib/comboValidation.js
@@ -1,0 +1,71 @@
+function normalizeModelName(model) {
+  if (typeof model === "string") return model.trim();
+  if (model && typeof model.value === "string") return model.value.trim();
+  return "";
+}
+
+function buildComboMap(combos, candidate) {
+  const comboMap = new Map();
+
+  for (const combo of combos || []) {
+    if (!combo?.name || combo.id === candidate.id) continue;
+    comboMap.set(combo.name, combo);
+  }
+
+  comboMap.set(candidate.name, candidate);
+  return comboMap;
+}
+
+export function validateComboReferences({ comboId = null, name, models = [], combos = [] }) {
+  const comboName = typeof name === "string" ? name.trim() : "";
+  if (!comboName) return { valid: false, error: "Name is required" };
+
+  const candidate = {
+    id: comboId,
+    name: comboName,
+    models: Array.isArray(models) ? models.map(normalizeModelName).filter(Boolean) : []
+  };
+  const comboMap = buildComboMap(combos, candidate);
+
+  if (candidate.models.includes(comboName)) {
+    return { valid: false, error: "Combo cannot include itself as a model" };
+  }
+
+  const visiting = new Set();
+
+  function visit(currentName, path) {
+    if (currentName === comboName && path.length > 0) {
+      return [...path, comboName];
+    }
+    if (visiting.has(currentName)) {
+      return [...path, currentName];
+    }
+
+    const combo = comboMap.get(currentName);
+    if (!combo) return null;
+
+    visiting.add(currentName);
+    const comboModels = Array.isArray(combo.models) ? combo.models : [];
+
+    for (const model of comboModels) {
+      const modelName = normalizeModelName(model);
+      if (!comboMap.has(modelName)) continue;
+
+      const cycle = visit(modelName, [...path, currentName]);
+      if (cycle) return cycle;
+    }
+
+    visiting.delete(currentName);
+    return null;
+  }
+
+  const cycle = visit(comboName, []);
+  if (cycle) {
+    return {
+      valid: false,
+      error: `Combo models cannot contain circular references: ${cycle.join(" -> ")}`
+    };
+  }
+
+  return { valid: true };
+}


### PR DESCRIPTION
## Summary
- reject combos that include themselves as a model
- reject indirect circular combo references before create/update
- share combo reference validation across create and edit APIs

Fixes #860

## Validation
- `node --input-type=module` assertions for direct self-reference, indirect cycles, nested cycles, and valid combo references
- `npx eslint src/lib/comboValidation.js src/app/api/combos/route.js 'src/app/api/combos/[id]/route.js'`
- `npx next build --webpack` with PowerShell production env workaround