### PR TITLE
Add captain-definition for easy deployment on Caprover

### DIFF
--- a/captain-definition
+++ b/captain-definition
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 2,
+  "dockerfilePath": "./Dockerfile"
+}


### PR DESCRIPTION
With this single file, it becomes very easy to deploy this service on a Caprover instance
All that needs to be done to do so on the caprover dashboard is:
- Create a new app with persistance
- Set these envs: PORT=20128
HOSTNAME=0.0.0.0
NEXT_PUBLIC_BASE_URL=https://your-domain-here.com
DATA_DIR=/app/data
- Add a persistent directory with /app/data
- Set CONTAINER HTTP PORT to 20128, enable HTTPS and websockets
- Go in deployment -> Method 3 -> Set the git url to this repo on branch main and add your github email and a PAT
- Save and force build
If this PR goes through I will make a One-Click-app profile for it