### PR TITLE
fix: normalize Ollama Local provider input

### DIFF
--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -7,7 +7,8 @@ import {
   getProxyPoolById,
 } from "@/models";
 import { APIKEY_PROVIDERS } from "@/shared/constants/config";
-import { FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, isCustomEmbeddingProvider } from "@/shared/constants/providers";
+import { AI_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, isCustomEmbeddingProvider } from "@/shared/constants/providers";
+import { normalizeProviderId, normalizeProviderSpecificData } from "@/lib/providerNormalization";
 
 export const dynamic = "force-dynamic";
 
@@ -86,7 +87,8 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { provider, apiKey, name, priority, globalPriority, defaultModel, testStatus } = body;
+    const provider = normalizeProviderId(body.provider);
+    const { apiKey, name, displayName, priority, globalPriority, defaultModel, testStatus } = body;
     const proxyConfig = normalizeProxyConfig(body);
     if (proxyConfig.error) {
       return NextResponse.json({ error: proxyConfig.error }, { status: 400 });
@@ -113,11 +115,12 @@ export async function POST(request) {
     if (!apiKey && provider !== "ollama-local") {
       return NextResponse.json({ error: `${isWebCookieProvider ? "Cookie value" : "API Key"} is required` }, { status: 400 });
     }
-    if (!name) {
+    const connectionName = name || displayName || AI_PROVIDERS[provider]?.name;
+    if (!connectionName) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
-    let providerSpecificData = body.providerSpecificData || null;
+    let providerSpecificData = normalizeProviderSpecificData(provider, body, body.providerSpecificData);
 
     if (isOpenAICompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);
@@ -184,7 +187,7 @@ export async function POST(request) {
     const newConnection = await createProviderConnection({
       provider,
       authType: isWebCookieProvider ? "cookie" : "apikey",
-      name,
+      name: connectionName,
       apiKey: apiKey || "",
       priority: priority || 1,
       globalPriority: globalPriority || null,

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -5,6 +5,7 @@ import { getDefaultModel } from "open-sse/config/providerModels.js";
 import { resolveOllamaLocalHost, PROVIDERS } from "open-sse/config/providers.js";
 import { openaiToCommandCode } from "open-sse/translator/request/openai-to-commandcode.js";
 import { PROVIDER_ENDPOINTS } from "@/shared/constants/config";
+import { normalizeProviderId } from "@/lib/providerNormalization";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
@@ -84,7 +85,8 @@ async function probeMediaProvider(provider, apiKey) {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { provider, apiKey, providerSpecificData } = body;
+    const provider = normalizeProviderId(body.provider);
+    const { apiKey, providerSpecificData } = body;
 
     const isNoAuth = AI_PROVIDERS[provider]?.noAuth === true;
     if (!provider || (!apiKey && provider !== "ollama-local" && !isNoAuth)) {

--- a/src/lib/providerNormalization.js
+++ b/src/lib/providerNormalization.js
@@ -1,0 +1,36 @@
+import { AI_PROVIDERS } from "../shared/constants/providers.js";
+
+export function normalizeProviderId(provider) {
+  if (typeof provider !== "string") return provider;
+
+  const trimmed = provider.trim();
+  if (AI_PROVIDERS[trimmed]) return trimmed;
+
+  const slug = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  if (AI_PROVIDERS[slug]) return slug;
+
+  const providerByName = Object.values(AI_PROVIDERS).find(
+    (entry) => entry.name?.toLowerCase() === trimmed.toLowerCase()
+  );
+  return providerByName?.id || trimmed;
+}
+
+export function normalizeProviderSpecificData(provider, body = {}, providerSpecificData = null) {
+  const next = providerSpecificData && typeof providerSpecificData === "object"
+    ? { ...providerSpecificData }
+    : {};
+
+  if (provider === "ollama-local") {
+    const baseUrl = (
+      next.baseUrl ||
+      body.baseUrl ||
+      body.baseURL ||
+      body.ollamaHostUrl ||
+      ""
+    ).trim();
+
+    if (baseUrl) next.baseUrl = baseUrl;
+  }
+
+  return Object.keys(next).length > 0 ? next : null;
+}


### PR DESCRIPTION
## Summary
- normalize provider labels/slugs such as `Ollama Local` and `ollama_local` to `ollama-local`
- accept legacy/manual Ollama Local host fields (`baseURL`, `baseUrl`, `ollamaHostUrl`) and store them as `providerSpecificData.baseUrl`
- allow provider creation to fall back to `displayName` or provider display name when older UI payloads omit `name`
- apply the same provider-id normalization in provider validation

Fixes #809

## Validation
- `node --input-type=module` assertions for provider-id normalization and Ollama Local host normalization
- `npx eslint src/lib/providerNormalization.js src/app/api/providers/route.js src/app/api/providers/validate/route.js`
- `npx next build --webpack` with PowerShell production env workaround