### PR TITLE
Polish provider breadcrumbs and custom provider actions

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -233,7 +233,7 @@ export default function ProvidersPage() {
     .filter((node) => node.type === "openai-compatible")
     .map((node) => ({
       id: node.id,
-      name: node.name || "OpenAI Compatible",
+      name: node.name || "OpenAI Provider",
       color: "#10A37F",
       textIcon: "OC",
       apiType: node.apiType,
@@ -244,7 +244,7 @@ export default function ProvidersPage() {
     .filter((node) => node.type === "anthropic-compatible")
     .map((node) => ({
       id: node.id,
-      name: node.name || "Anthropic Compatible",
+      name: node.name || "Anthropic Provider",
       color: "#D97757",
       textIcon: "AC",
     }))
@@ -296,25 +296,29 @@ export default function ProvidersPage() {
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h2 className="text-lg sm:text-xl font-semibold flex items-center gap-2 leading-tight">
-            Custom Providers (OpenAI/Anthropic Compatible){" "}
+            Custom Providers
           </h2>
           <div className="grid grid-cols-1 gap-2 sm:flex sm:w-auto">
             <Button
               size="sm"
-              icon="add"
               onClick={() => setShowAddAnthropicCompatibleModal(true)}
               className="w-full sm:w-auto"
             >
-              Add Anthropic Compatible
+              <span className="flex items-center justify-center gap-2">
+                <img src="/providers/anthropic-m.png" alt="" className="size-4 rounded" />
+                <span>Anthropic Compatible</span>
+              </span>
             </Button>
             <Button
               size="sm"
               variant="secondary"
-              icon="add"
               onClick={() => setShowAddCompatibleModal(true)}
               className="w-full !bg-white !text-black hover:!bg-gray-100 sm:w-auto"
             >
-              Add OpenAI Compatible
+              <span className="flex items-center justify-center gap-2">
+                <img src="/providers/oai-cc.png" alt="" className="size-4 rounded" />
+                <span>OpenAI Compatible</span>
+              </span>
             </Button>
           </div>
         </div>
@@ -322,7 +326,7 @@ export default function ProvidersPage() {
         anthropicCompatibleProviders.length === 0 ? (
           <div className="flex items-center justify-center gap-2 py-2 border border-dashed border-border rounded-xl text-text-muted text-sm">
             <span className="material-symbols-outlined text-[18px]">extension</span>
-            <span>No custom providers — use buttons above to add OpenAI/Anthropic compatible endpoints</span>
+            <span>No custom providers — use buttons above to add endpoints</span>
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 xl:grid-cols-4">
@@ -854,7 +858,7 @@ function AddOpenAICompatibleModal({ isOpen, onClose, onCreated }) {
         setValidationResult(null);
       }
     } catch (error) {
-      console.log("Error creating OpenAI Compatible node:", error);
+      console.log("Error creating OpenAI provider node:", error);
     } finally {
       setSubmitting(false);
     }
@@ -908,13 +912,13 @@ function AddOpenAICompatibleModal({ isOpen, onClose, onCreated }) {
   };
 
   return (
-    <Modal isOpen={isOpen} title="Add OpenAI Compatible" onClose={onClose}>
+    <Modal isOpen={isOpen} title="Add OpenAI Provider" onClose={onClose}>
       <div className="flex flex-col gap-4">
         <Input
           label="Name"
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          placeholder="OpenAI Compatible (Prod)"
+          placeholder="OpenAI Provider (Prod)"
           hint="Required. A friendly label for this node."
         />
         <Input
@@ -939,7 +943,7 @@ function AddOpenAICompatibleModal({ isOpen, onClose, onCreated }) {
             setFormData({ ...formData, baseUrl: e.target.value })
           }
           placeholder="https://api.openai.com/v1"
-          hint="Use the base URL (ending in /v1) for your OpenAI-compatible API."
+          hint="Use the base URL ending in /v1."
         />
         <Input
           label="API Key (for Check)"
@@ -1044,7 +1048,7 @@ function AddAnthropicCompatibleModal({ isOpen, onClose, onCreated }) {
         setValidationResult(null);
       }
     } catch (error) {
-      console.log("Error creating Anthropic Compatible node:", error);
+      console.log("Error creating Anthropic provider node:", error);
     } finally {
       setSubmitting(false);
     }
@@ -1098,13 +1102,13 @@ function AddAnthropicCompatibleModal({ isOpen, onClose, onCreated }) {
   };
 
   return (
-    <Modal isOpen={isOpen} title="Add Anthropic Compatible" onClose={onClose}>
+    <Modal isOpen={isOpen} title="Add Anthropic Provider" onClose={onClose}>
       <div className="flex flex-col gap-4">
         <Input
           label="Name"
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          placeholder="Anthropic Compatible (Prod)"
+          placeholder="Anthropic Provider (Prod)"
           hint="Required. A friendly label for this node."
         />
         <Input
@@ -1121,7 +1125,7 @@ function AddAnthropicCompatibleModal({ isOpen, onClose, onCreated }) {
             setFormData({ ...formData, baseUrl: e.target.value })
           }
           placeholder="https://api.anthropic.com/v1"
-          hint="Use the base URL (ending in /v1) for your Anthropic-compatible API. The system will append /messages."
+          hint="Use the base URL ending in /v1. The system will append /messages."
         />
         <Input
           label="API Key (for Check)"

--- a/src/shared/components/Header.js
+++ b/src/shared/components/Header.js
@@ -2,7 +2,6 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import { useMemo } from "react";
-import Link from "next/link";
 import PropTypes from "prop-types";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import HeaderMenu from "@/shared/components/HeaderMenu";
@@ -26,7 +25,6 @@ const getPageInfo = (pathname) => {
       title: provider?.name || providerId,
       description: "",
       breadcrumbs: [
-        { label: "Media Providers", href: `/dashboard/media-providers/${kindId}` },
         { label: kindConfig?.label || kindId, href: `/dashboard/media-providers/${kindId}` },
         { label: provider?.name || providerId, image: `/providers/${providerId}.png` },
       ],
@@ -51,7 +49,7 @@ const getPageInfo = (pathname) => {
   if (providerMatch) {
     const providerId = providerMatch[1];
     const providerInfo =
-      OAUTH_PROVIDERS[providerId] || APIKEY_PROVIDERS[providerId];
+      OAUTH_PROVIDERS[providerId] || APIKEY_PROVIDERS[providerId] || AI_PROVIDERS[providerId];
     if (providerInfo) {
       return {
         title: providerInfo.name,
@@ -205,45 +203,37 @@ export default function Header({ onMenuClick, showMenuButton = true }) {
 
       {/* Page title with breadcrumbs */}
       <div className="flex flex-col min-w-0 flex-1">
-        {breadcrumbs.length > 0 ? (
-          <div className="flex items-center gap-2">
-            {breadcrumbs.map((crumb, index) => (
-              <div
-                key={`${crumb.label}-${crumb.href || "current"}`}
-                className="flex items-center gap-2"
-              >
-                {index > 0 && (
-                  <span className="material-symbols-outlined text-text-muted text-base">
-                    chevron_right
-                  </span>
-                )}
-                {crumb.href ? (
-                  <Link
-                    href={crumb.href}
-                    className="text-text-muted hover:text-primary transition-colors"
-                  >
-                    {crumb.label}
-                  </Link>
-                ) : (
-                  <div className="flex items-center gap-2">
-                    {crumb.image && (
-                      <ProviderIcon
-                        src={crumb.image}
-                        alt={crumb.label}
-                        size={28}
-                        className="object-contain rounded max-w-[28px] max-h-[28px]"
-                        fallbackText={crumb.label.slice(0, 2).toUpperCase()}
-                      />
-                    )}
-                    <h1 className="text-base lg:text-2xl font-semibold text-text-main tracking-tight truncate">
-                      {translate(crumb.label)}
-                    </h1>
+        {breadcrumbs.length > 0 ? (() => {
+          const current = breadcrumbs[breadcrumbs.length - 1];
+          const parent = [...breadcrumbs].reverse().find((crumb) => crumb.href);
+          return (
+            <div className="flex min-w-0 items-center gap-2 lg:gap-3">
+              <div className="flex min-w-0 items-center gap-2.5">
+                {current.image && (
+                  <div className="flex size-8 shrink-0 items-center justify-center rounded-xl border border-border-subtle bg-bg/70 shadow-sm lg:size-9">
+                    <ProviderIcon
+                      src={current.image}
+                      alt={current.label}
+                      size={30}
+                      className="object-contain rounded-lg max-w-[30px] max-h-[30px]"
+                      fallbackText={current.label.slice(0, 2).toUpperCase()}
+                    />
                   </div>
                 )}
+                <div className="min-w-0">
+                  <h1 className="truncate text-base font-semibold tracking-tight text-text-main lg:text-2xl">
+                    {translate(current.label)}
+                  </h1>
+                  {parent && (
+                    <p className="hidden text-xs text-text-muted lg:block">
+                      {translate(parent.label)} settings
+                    </p>
+                  )}
+                </div>
               </div>
-            ))}
-          </div>
-        ) : title ? (
+            </div>
+          );
+        })() : title ? (
           <div>
             <div className="flex items-center gap-2">
               {icon && (


### PR DESCRIPTION
## Summary
- Simplify provider detail breadcrumbs into a compact header with provider icon and parent context.
- Keep provider lookup compatible with OAuth/API-key providers while preserving fallback to provider metadata.
- Polish the Custom Providers action area with provider icons and concise OpenAI/Anthropic Compatible button labels.
- Shorten add-provider modal wording without changing provider-node API behavior.

## Scope
This PR intentionally only touches the provider header/custom-provider UI:
- `src/shared/components/Header.js`
- `src/app/(dashboard)/dashboard/providers/page.js`

No provider routing, model fetching, validation, or persistence logic is changed.

## Testing
- `npm run build`
- verified `/api/version` still reports `0.4.20` in sandbox.
