### PR TITLE
fix(codex): preserve reasoning summary deltas

### DIFF
--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -568,10 +568,23 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     return null;
   }
 
-  // Reasoning events (convert to content or skip)
+  // Reasoning events from Responses API (Codex/CX) map to the
+  // OpenAI-compatible reasoning_content field.
   if (eventType === "response.reasoning_summary_text.delta") {
-    // Optionally include reasoning as content, or skip
-    return null;
+    const delta = data.delta || "";
+    if (!delta) return null;
+
+    return {
+      id: state.chatId,
+      object: "chat.completion.chunk",
+      created: state.created,
+      model: state.model || "unknown",
+      choices: [{
+        index: 0,
+        delta: { reasoning_content: delta },
+        finish_reason: null
+      }]
+    };
   }
 
   // Ignore other events

--- a/tests/unit/openai-responses-to-openai.test.js
+++ b/tests/unit/openai-responses-to-openai.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { openaiResponsesToOpenAIResponse } from "../../open-sse/translator/response/openai-responses.js";
+
+describe("openai-responses-to-openai — reasoning summary", () => {
+  it("maps Responses API reasoning summary deltas to OpenAI reasoning_content", () => {
+    const state = {};
+
+    const chunk = openaiResponsesToOpenAIResponse(
+      {
+        type: "response.reasoning_summary_text.delta",
+        delta: "thinking...",
+      },
+      state,
+    );
+
+    expect(chunk.choices[0].delta.reasoning_content).toBe("thinking...");
+    expect(chunk.choices[0].delta.content).toBeUndefined();
+    expect(chunk.choices[0].finish_reason).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes Codex/CX reasoning summaries being dropped when translating OpenAI Responses API stream events back to OpenAI-compatible Chat Completions chunks.

Codex emits reasoning summaries as:
```text
response.reasoning_summary_text.delta
```
but 9router previously ignored that event, so OpenAI-compatible clients such as OpenCode never received visible reasoning/thinking content.
This PR maps those deltas to:
```json
choices[0].delta.reasoning_content
```
which is the OpenAI-compatible convention used by reasoning-capable clients.
## Problem
The `openai-responses → openai` response translator had this behavior:
```js
if (eventType === "response.reasoning_summary_text.delta") {
  return null;
}
```
That meant Codex/CX reasoning summaries were discarded even when the upstream model produced them.
As a result, models like `cx/gpt-5.5`, `cx/gpt-5.4`, and high-effort Codex variants could produce reasoning internally, but downstream OpenAI-compatible clients only received final answer text.
## Changes
- Preserve `response.reasoning_summary_text.delta` events.
- Convert them into Chat Completions streaming chunks using `delta.reasoning_content`.
- Add a unit test covering the Responses API reasoning summary → OpenAI-compatible reasoning content mapping.
## Validation
Ran:
```bash
node --check open-sse/translator/response/openai-responses.js
npx vitest run tests/unit/openai-responses-to-openai.test.js --reporter=verbose
```
Result:
```text
Test Files  1 passed (1)
Tests       1 passed (1)
```
Also validated locally against 9router with `cx/gpt-5.5` and confirmed streaming output now includes:
```json
choices[0].delta.reasoning_content
```
while final answer text remains in:
```json
choices[0].delta.content
```