### PR TITLE
fix(claude): stop leaking think tags in OpenAI streams

### DIFF
--- a/open-sse/translator/response/claude-to-openai.js
+++ b/open-sse/translator/response/claude-to-openai.js
@@ -44,7 +44,6 @@ export function claudeToOpenAIResponse(chunk, state) {
       } else if (block?.type === "thinking") {
         state.inThinkingBlock = true;
         state.currentBlockIndex = chunk.index;
-        results.push(createChunk(state, { content: "<think>" }));
       } else if (block?.type === "tool_use") {
         const toolCallIndex = state.toolCallIndex++;
         // Restore original tool name from mapping (Claude OAuth)
@@ -95,7 +94,6 @@ export function claudeToOpenAIResponse(chunk, state) {
         break;
       }
       if (state.inThinkingBlock && chunk.index === state.currentBlockIndex) {
-        results.push(createChunk(state, { content: "</think>" }));
         state.inThinkingBlock = false;
       }
       state.textBlockStarted = false;

--- a/tests/unit/claude-to-openai.test.js
+++ b/tests/unit/claude-to-openai.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { claudeToOpenAIResponse } from "../../open-sse/translator/response/claude-to-openai.js";
+
+function collect(events) {
+  const state = {
+    toolCalls: new Map(),
+    toolNameMap: new Map(),
+  };
+  return events.flatMap((event) => claudeToOpenAIResponse(event, state) || []);
+}
+
+describe("claude-to-openai thinking blocks", () => {
+  it("maps Anthropic thinking deltas to reasoning_content without leaking think tags as content", () => {
+    const chunks = collect([
+      {
+        type: "message_start",
+        message: { id: "msg_test", model: "MiniMax-M2.7" },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "thinking", thinking: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "thinking..." },
+      },
+      {
+        type: "content_block_stop",
+        index: 0,
+      },
+      {
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "text", text: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 1,
+        delta: { type: "text_delta", text: "final answer" },
+      },
+    ]);
+
+    const deltas = chunks.map((chunk) => chunk.choices[0].delta);
+
+    expect(deltas).toContainEqual({ role: "assistant" });
+    expect(deltas).toContainEqual({ reasoning_content: "thinking..." });
+    expect(deltas).toContainEqual({ content: "final answer" });
+    expect(deltas).not.toContainEqual({ content: "<think>" });
+    expect(deltas).not.toContainEqual({ content: "</think>" });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Claude-compatible streaming responses leaking literal `<think>` / `</think>` tags into OpenAI-compatible clients.

Some Claude-format providers, such as MiniMax through the Anthropic-compatible `/messages` API, already return structured thinking blocks. 9router was correctly mapping `thinking_delta` to `reasoning_content`, but it was also emitting literal `<think>` markers as normal `content` chunks.

That caused OpenAI-compatible clients such as OpenCode to receive both:

- structured reasoning via `reasoning_content`
- visible fake `<think></think>` text via `content`

This PR removes those fake content markers and keeps the structured reasoning stream only.

## Problem

Direct MiniMax Anthropic-compatible responses are clean and use native thinking events like:

```text
content_block_start type=thinking
content_block_delta type=thinking_delta
```

But after passing through 9router, the translated OpenAI-compatible stream looked like this:

```json
{"delta":{"content":"<think>"}}
{"delta":{"reasoning_content":"The user wants a brief description of the repository..."}}
{"delta":{"content":"</think>"}}
{"delta":{"content":"A reusable component library with a StarterKit/Logo showcase..."}}
```

This produced visible leaks in OpenCode such as:

```text
<think></think>
Already covered this — check my previous message. But here's the condensed version:
...

Thinking: The user is asking what I know about this repo...
```

The same issue can affect any Claude-compatible provider that emits Anthropic `thinking` blocks and is translated into an OpenAI-compatible stream.

## Root Cause

In `open-sse/translator/response/claude-to-openai.js`, thinking blocks were translated in two ways at the same time.

Correct translation:

```json
{"delta":{"reasoning_content":"..."}}
```

Incorrect extra output:

```json
{"delta":{"content":"<think>"}}
{"delta":{"content":"</think>"}}
```

Those literal markers should not be emitted as normal assistant content for OpenAI-compatible clients.

## Changes

- stop emitting literal `<think>` and `</think>` content chunks in `claude-to-openai`
- keep Anthropic `thinking_delta` mapped to OpenAI-compatible `reasoning_content`
- add a unit test covering this behavior

## Before

```json
{"delta":{"content":"<think>"}}
{"delta":{"reasoning_content":"thinking..."}}
{"delta":{"content":"</think>"}}
{"delta":{"content":"final answer"}}
```

## After

```json
{"delta":{"reasoning_content":"thinking..."}}
{"delta":{"content":"final answer"}}
```

## Validation

Ran:

```bash
node --check open-sse/translator/response/claude-to-openai.js
npx vitest run tests/unit/claude-to-openai.test.js tests/unit/openai-responses-to-openai.test.js tests/unit/commandcode-to-openai.test.js --reporter=verbose
```

Result:

```text
Test Files  3 passed (3)
Tests       11 passed (11)
```

Also re-tested locally against 9router with MiniMax and confirmed:

- no leaked `<think></think>` content
- reasoning still arrives through `reasoning_content`
- final answer content is preserved


## BEFORE
<img width="831" height="190" alt="image" src="https://github.com/user-attachments/assets/874ca298-93f1-46e2-be9d-9764ccbcace7" />


## AFTER
<img width="805" height="277" alt="image" src="https://github.com/user-attachments/assets/2fdebd45-edb0-4155-8048-04357987dd12" />

