### PR TITLE
feat(opencode-go): DeepSeek V4 Pro effort selector & developer role fix

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -182,6 +182,8 @@ export const PROVIDER_MODELS = {
     { id: "mimo-v2-omni", name: "MiMo V2 Omni" },
     { id: "minimax-m2.7", name: "MiniMax M2.7", targetFormat: "claude" },
     { id: "minimax-m2.5", name: "MiniMax M2.5", targetFormat: "claude" },
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
   ],
   oc: [  // OpenCode
     // { id: "nemotron-3-super-free", name: "Nemotron 3 Super" },

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -12,6 +12,7 @@ import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { getExecutor } from "../executors/index.js";
 import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDetail.js";
+import { applyProviderThinkingOverride } from "./chatCore/providerThinking.js";
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
@@ -41,19 +42,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const targetFormat = modelTargetFormat || getTargetFormat(provider);
   const stripList = getModelStrip(alias, model);
 
-  // Inject provider-level thinking config override (only if client hasn't set)
-  // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
-  if (providerThinking?.mode && providerThinking.mode !== "auto") {
-    const mode = providerThinking.mode;
-    if (mode === "on" && !body.thinking) {
-      console.log("Injecting provider-level thinking config override: on");
-      body = { ...body, thinking: { type: "enabled", budget_tokens: 10000 } };
-    } else if (mode === "off" && !body.thinking) {
-      body = { ...body, thinking: { type: "disabled" } };
-    } else if (!body.reasoning_effort) {
-      body = { ...body, reasoning_effort: mode };
-    }
-  }
+  // Apply provider-level thinking/reasoning override
+  body = applyProviderThinkingOverride({ body, provider, model, providerThinking });
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = provider === "openai" || provider === "codex" || provider === "commandcode";

--- a/open-sse/handlers/chatCore/providerThinking.js
+++ b/open-sse/handlers/chatCore/providerThinking.js
@@ -1,0 +1,36 @@
+/**
+ * Apply provider-level thinking/reasoning overrides.
+ * Pure function — does not mutate the input body.
+ */
+export function applyProviderThinkingOverride({ body, provider, model, providerThinking }) {
+  // DeepSeek models reject developer role — convert to system before dispatch
+  const isOcgDeepseek = provider === "opencode-go" && model?.startsWith("deepseek-v4");
+  if (isOcgDeepseek && Array.isArray(body.messages)) {
+    body = {
+      ...body,
+      messages: body.messages.map((m) => m.role === "developer" ? { ...m, role: "system" } : m),
+    };
+  }
+
+  if (!providerThinking?.mode || providerThinking.mode === "auto") return body;
+
+  const mode = providerThinking.mode;
+
+  // Extended thinking: on/off toggle
+  if (mode === "on" && !body.thinking) {
+    return { ...body, thinking: { type: "enabled", budget_tokens: 10000 } };
+  }
+  if (mode === "off" && !body.thinking) {
+    return { ...body, thinking: { type: "disabled" } };
+  }
+
+  // DeepSeek V4 Pro: effort modes require both thinking.enabled AND reasoning_effort
+  const isOcgDeepseekV4Pro = provider === "opencode-go" && model === "deepseek-v4-pro";
+  if (isOcgDeepseekV4Pro) {
+    const withThinking = body.thinking ? body : { ...body, thinking: { type: "enabled" } };
+    return withThinking.reasoning_effort ? withThinking : { ...withThinking, reasoning_effort: mode };
+  }
+
+  // Generic effort: just set reasoning_effort
+  return body.reasoning_effort ? body : { ...body, reasoning_effort: mode };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -998,7 +998,7 @@ export default function ProviderDetailPage() {
                 </Button>
               )}
               {/* Thinking config */}
-              {/* {thinkingConfig && (
+              {thinkingConfig && (
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-text-muted font-medium">Thinking</span>
                   <select
@@ -1007,11 +1007,11 @@ export default function ProviderDetailPage() {
                     className="text-xs px-2 py-1 border border-border rounded-md bg-background focus:outline-none focus:border-primary"
                   >
                     {thinkingConfig.options.map((opt) => (
-                      <option key={opt} value={opt}>{opt.charAt(0).toUpperCase() + opt.slice(1)}</option>
+                      <option key={opt} value={opt}>{opt === "auto" ? "Default" : opt.charAt(0).toUpperCase() + opt.slice(1)}</option>
                     ))}
                   </select>
                 </div>
-              )} */}
+              )}
               {/* Round Robin toggle */}
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-xs text-text-muted font-medium">Round Robin</span>

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -37,7 +37,11 @@ export const THINKING_CONFIG = {
   effort: {
     options: ["auto", "none", "low", "medium", "high"],
     defaultMode: "auto"
-  }
+  },
+  deepseek: {
+    options: ["auto", "low", "medium", "high", "max"],
+    defaultMode: "auto",
+  },
 };
 
 // OAuth Providers
@@ -65,7 +69,7 @@ export const APIKEY_PROVIDERS = {
   "volcengine-ark": { id: "volcengine-ark", alias: "ark", name: "Volcengine Ark", icon: "cloud", color: "#1677FF", textIcon: "ARK", website: "https://ark.cn-beijing.volces.com", notice: { apiKeyUrl: "https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey" } },
   openai: { id: "openai", alias: "openai", name: "OpenAI", icon: "auto_awesome", color: "#10A37F", textIcon: "OA", website: "https://platform.openai.com", notice: { apiKeyUrl: "https://platform.openai.com/api-keys" }, serviceKinds: ["llm", "embedding", "tts", "stt", "image", "imageToText", "webSearch"], thinkingConfig: THINKING_CONFIG.effort, searchViaChat: { defaultModel: "gpt-4o-mini", pricingUrl: "https://openai.com/api/pricing" }, ttsConfig: { baseUrl: "https://api.openai.com/v1/audio/speech", authType: "apikey", authHeader: "bearer", format: "openai", models: [{ id: "tts-1", name: "TTS-1" }, { id: "tts-1-hd", name: "TTS-1 HD" }, { id: "gpt-4o-mini-tts", name: "GPT-4o Mini TTS" }] }, sttConfig: { baseUrl: "https://api.openai.com/v1/audio/transcriptions", authType: "apikey", authHeader: "bearer", format: "openai", models: [{ id: "whisper-1", name: "Whisper 1" }, { id: "gpt-4o-transcribe", name: "GPT-4o Transcribe" }, { id: "gpt-4o-mini-transcribe", name: "GPT-4o Mini Transcribe" }] }, embeddingConfig: { baseUrl: "https://api.openai.com/v1/embeddings", authType: "apikey", authHeader: "bearer", models: [{ id: "text-embedding-3-small", name: "Text Embedding 3 Small", dimensions: 1536 }, { id: "text-embedding-3-large", name: "Text Embedding 3 Large", dimensions: 3072 }, { id: "text-embedding-ada-002", name: "Text Embedding Ada 002", dimensions: 1536 }] } },
   anthropic: { id: "anthropic", alias: "anthropic", name: "Anthropic", icon: "smart_toy", color: "#D97757", textIcon: "AN", website: "https://console.anthropic.com", notice: { apiKeyUrl: "https://console.anthropic.com/settings/keys" }, serviceKinds: ["llm", "imageToText"] },
-  "opencode-go": { id: "opencode-go", alias: "ocg", name: "OpenCode Go", icon: "terminal", color: "#E87040", textIcon: "OC", website: "https://opencode.ai/auth", notice: { text: "OpenCode Go subscription: $5/mo (then $10/mo). Access to Kimi, GLM, Qwen, MiMo, MiniMax models.", apiKeyUrl: "https://opencode.ai/auth" } },
+  "opencode-go": { id: "opencode-go", alias: "ocg", name: "OpenCode Go", icon: "terminal", color: "#E87040", textIcon: "OC", website: "https://opencode.ai/auth", notice: { text: "OpenCode Go subscription: $5/mo (then $10/mo). Access to Kimi, GLM, Qwen, MiMo, MiniMax models.", apiKeyUrl: "https://opencode.ai/auth" }, thinkingConfig: THINKING_CONFIG.deepseek },
   azure: { id: "azure", alias: "azure", name: "Azure OpenAI", icon: "cloud", color: "#0078D4", textIcon: "AZ", website: "https://azure.microsoft.com/en-us/products/ai-services/openai-service", notice: { apiKeyUrl: "https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI" }, hasProviderSpecificData: true },
 
   deepseek: { id: "deepseek", alias: "ds", name: "DeepSeek", icon: "bolt", color: "#4D6BFE", textIcon: "DS", website: "https://deepseek.com", notice: { apiKeyUrl: "https://platform.deepseek.com/api_keys" } },

--- a/tests/unit/opencode-go-deepseek-effort.test.js
+++ b/tests/unit/opencode-go-deepseek-effort.test.js
@@ -1,0 +1,204 @@
+import { describe, it, expect } from "vitest";
+import { THINKING_CONFIG, AI_PROVIDERS } from "../../src/shared/constants/providers.js";
+import { getProviderModels } from "../../open-sse/config/providerModels.js";
+
+describe("opencode-go model catalog", () => {
+  const ids = getProviderModels("opencode-go").map((m) => m.id);
+
+  it("includes deepseek-v4-pro", () => {
+    expect(ids).toContain("deepseek-v4-pro");
+  });
+
+  it("includes deepseek-v4-flash", () => {
+    expect(ids).toContain("deepseek-v4-flash");
+  });
+});
+
+describe("opencode-go thinking config", () => {
+  it("defines THINKING_CONFIG.deepseek options", () => {
+    expect(THINKING_CONFIG.deepseek).toEqual({
+      options: ["auto", "low", "medium", "high", "max"],
+      defaultMode: "auto",
+    });
+  });
+
+  it("attaches deepseek thinking config to opencode-go", () => {
+    expect(AI_PROVIDERS["opencode-go"].thinkingConfig).toBe(THINKING_CONFIG.deepseek);
+  });
+});
+
+import { applyProviderThinkingOverride } from "../../open-sse/handlers/chatCore/providerThinking.js";
+
+describe("applyProviderThinkingOverride", () => {
+  const baseBody = { messages: [{ role: "user", content: "hi" }] };
+
+  it("returns unchanged body for auto mode", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "auto" },
+    });
+    expect(out).toEqual(baseBody);
+  });
+
+  it("sets thinking enabled + low effort for deepseek-v4-pro", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "low" },
+    });
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("low");
+  });
+
+  it("sets thinking enabled + medium effort for deepseek-v4-pro", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "medium" },
+    });
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("medium");
+  });
+
+  it("sets thinking enabled + high effort for deepseek-v4-pro", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "high" },
+    });
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("sets thinking enabled + max effort for deepseek-v4-pro", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "max" },
+    });
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("max");
+  });
+
+  it("does not override existing client reasoning_effort", () => {
+    const out = applyProviderThinkingOverride({
+      body: { ...baseBody, reasoning_effort: "low" },
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "max" },
+    });
+    expect(out.reasoning_effort).toBe("low");
+  });
+
+  it("does not override existing client thinking", () => {
+    const out = applyProviderThinkingOverride({
+      body: { ...baseBody, thinking: { type: "disabled" } },
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "high" },
+    });
+    expect(out.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("does not apply deepseek logic to non-deepseek opencode-go models", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "opencode-go",
+      model: "kimi-k2.6",
+      providerThinking: { mode: "high" },
+    });
+    expect(out.thinking).toBeUndefined();
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("handles on mode for extended thinking providers", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "codex",
+      model: "gpt-5.5",
+      providerThinking: { mode: "on" },
+    });
+    expect(out.thinking).toEqual({ type: "enabled", budget_tokens: 10000 });
+  });
+
+  it("handles off mode for extended thinking providers", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "codex",
+      model: "gpt-5.5",
+      providerThinking: { mode: "off" },
+    });
+    expect(out.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("returns unchanged body when providerThinking is null", () => {
+    const out = applyProviderThinkingOverride({
+      body: baseBody,
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: null,
+    });
+    expect(out).toEqual(baseBody);
+  });
+});
+
+describe("applyProviderThinkingOverride — developer role conversion", () => {
+  it("converts developer role to system for opencode-go deepseek-v4-pro", () => {
+    const body = {
+      messages: [
+        { role: "developer", content: "You are concise" },
+        { role: "user", content: "hi" },
+      ],
+    };
+    const out = applyProviderThinkingOverride({
+      body,
+      provider: "opencode-go",
+      model: "deepseek-v4-pro",
+      providerThinking: { mode: "auto" },
+    });
+    expect(out.messages).toHaveLength(2);
+    expect(out.messages[0].role).toBe("system");
+    expect(out.messages[0].content).toBe("You are concise");
+  });
+
+  it("converts developer role to system for opencode-go deepseek-v4-flash", () => {
+    const body = {
+      messages: [
+        { role: "developer", content: "You are concise" },
+        { role: "user", content: "hi" },
+      ],
+    };
+    const out = applyProviderThinkingOverride({
+      body,
+      provider: "opencode-go",
+      model: "deepseek-v4-flash",
+      providerThinking: { mode: "auto" },
+    });
+    expect(out.messages).toHaveLength(2);
+    expect(out.messages[0].role).toBe("system");
+    expect(out.messages[0].content).toBe("You are concise");
+  });
+
+  it("does not convert developer for non-deepseek opencode-go models", () => {
+    const body = {
+      messages: [
+        { role: "developer", content: "You are concise" },
+        { role: "user", content: "hi" },
+      ],
+    };
+    const out = applyProviderThinkingOverride({
+      body,
+      provider: "opencode-go",
+      model: "kimi-k2.6",
+      providerThinking: { mode: "auto" },
+    });
+    expect(out.messages).toHaveLength(2);
+    expect(out.messages[0].role).toBe("developer");
+  });
+});


### PR DESCRIPTION
## Summary

Add `ocg/deepseek-v4-pro` and `ocg/deepseek-v4-flash` to OpenCode Go, with a provider-level reasoning effort selector (Default / Low / Medium / High / Max).

## Changes

- **Model catalog**: Added `deepseek-v4-pro` and `deepseek-v4-flash` to `opencode-go` in `providerModels.js`
- **Provider config**: Added `THINKING_CONFIG.deepseek` with `auto/low/medium/high/max` options, attached to `opencode-go`
- **Request helper**: Extracted inline thinking override logic from `chatCore.js` into `providerThinking.js`
  - DeepSeek V4 Pro effort modes set both `thinking: { type: "enabled" }` and `reasoning_effort`
  - Converts `developer` role messages to `system` for DeepSeek models only (DeepSeek API rejects `developer` role)
  - Preserves existing client-supplied `thinking` and `reasoning_effort` values
- **Provider page UI**: Re-enabled the thinking/reasoning selector dropdown, displays `auto` as "Default"
- **Tests**: 18 unit tests covering model catalog, config wiring, all effort modes, edge cases, and developer role conversion

## Testing

All 18 new tests pass. 