### PR TITLE
fix: improve dropdown text readability in dark theme on usage page

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
+++ b/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
@@ -183,6 +183,7 @@ export default function RequestDetailsTab() {
                 "text-sm text-text-main focus:outline-none focus:ring-2 focus:ring-primary/20",
                 "w-full min-w-0 cursor-pointer"
               )}
+              style={{ colorScheme: 'auto' }}
             >
               <option value="">All Providers</option>
               {providers.map((provider) => (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,6 +114,22 @@
   color-scheme: dark;
 }
 
+/* ============================================================
+   Fix native select dropdowns in dark mode
+   ============================================================ */
+select {
+  color-scheme: light;
+}
+
+.dark select {
+  color-scheme: dark;
+}
+
+.dark select option {
+  background-color: var(--color-surface);
+  color: var(--color-text-main);
+}
+
 @theme inline {
   /* Brand scale */
   --color-brand-50: var(--color-brand-50);

--- a/src/shared/components/Pagination.js
+++ b/src/shared/components/Pagination.js
@@ -63,6 +63,7 @@ export default function Pagination({
                 "text-sm text-text-main focus:outline-none focus:ring-2 focus:ring-primary/20",
                 "cursor-pointer"
               )}
+              style={{ colorScheme: 'auto' }}
             >
               {[10, 20, 50].map((size) => (
                 <option key={size} value={size}>

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -455,7 +455,8 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
           <select
             value={tableView}
             onChange={(e) => setTableView(e.target.value)}
-            className="w-full rounded-lg border border-border bg-bg-subtle px-3 py-1.5 text-sm font-medium text-text focus:outline-none focus:ring-2 focus:ring-primary/50 sm:w-auto"
+            className="w-full rounded-lg border border-border bg-surface px-3 py-1.5 text-sm font-medium text-text-main focus:outline-none focus:ring-2 focus:ring-primary/50 sm:w-auto"
+            style={{ colorScheme: 'auto' }}
           >
             {TABLE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>{opt.label}</option>


### PR DESCRIPTION
## 🐛 Bug Fix: Dark Theme Dropdown Text Colors
### Problem
Dropdown menus on the usage page show unreadable text in dark theme because browser default styling overrides the dark theme colors.
**Affected dropdowns:**
- Provider filter dropdown
- Table view selector (Model/Account/API Key/Endpoint)  
- Pagination page size selector
### Root Cause
Native `<select>` and `<option>` elements don't properly inherit CSS custom properties for dark mode. Browser defaults (white background, black text) are applied regardless of parent styling.
### Solution
1. **Global CSS fix:** Added `color-scheme` property to signal dark mode to browsers
2. **Explicit option styling:** Styled `<option>` elements with dark theme colors
3. **Component fixes:** Updated UsageStats to use correct CSS variables (`bg-surface`, `text-text-main`)
### Changes
- ✅ `src/app/globals.css` - Added dark mode select/option styling
- ✅ `src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js` - Added colorScheme style
- ✅ `src/shared/components/UsageStats.js` - Fixed CSS variables + added colorScheme style
- ✅ `src/shared/components/Pagination.js` - Added colorScheme style
### Testing
- [x] Tested in Chrome with dark theme - dropdowns readable ✅
- [x] Verified light theme still works correctly ✅
- [x] All dropdown functionality works as expected ✅
- [x] No visual regressions ✅
### Screenshots
**Before (Dark Theme):**
<img width="752" height="246" alt="dropdown issue" src="https://github.com/user-attachments/assets/2261acc2-9d60-4023-a5ca-ada88b7d26a3" />
**After (Dark Theme):**
<img width="744" height="236" alt="after fixing" src="https://github.com/user-attachments/assets/89934b00-0ba2-4f5f-9649-87775f6a68b3" />
**Light Theme (Unchanged):**
<img width="769" height="251" alt="light theme" src="https://github.com/user-attachments/assets/b5b0f0a7-746e-4f46-ab3d-2d1f282e4a4c" />
### Notes
- This PR focuses on the usage page only (user-reported issue)
- CLI tools dropdowns can be fixed in a follow-up PR if needed
- Uses CSS standards (`color-scheme` property) for browser compatibility
- Total changes: 4 files, 20 insertions, 1 deletion