### PR TITLE
fix(security): scope OAuth callback postMessage targets and re-enable TLS verification on DNS-bypass fetch

### DIFF
--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -155,8 +155,13 @@ async function createBypassRequest(parsedUrl, realIP, options) {
     socket.connect(HTTPS_PORT, realIP, () => {
       const reqOptions = {
         socket,
+        // SNI + cert hostname are validated against the hostname the caller
+        // asked for, not the IP we connected to. This keeps the DNS-bypass
+        // (avoiding /etc/hosts MITM) while still rejecting on-path attackers
+        // that present a different cert. The MITM_BYPASS_HOSTS targets are
+        // all public-CA-issued (Google / GitHub / AWS / Cursor) so default
+        // verification works without any extra trust store.
         servername: parsedUrl.hostname,
-        rejectUnauthorized: false,
         path: parsedUrl.pathname + parsedUrl.search,
         method: options.method || "POST",
         headers: {

--- a/src/app/callback/page.js
+++ b/src/app/callback/page.js
@@ -26,19 +26,29 @@ function CallbackContent() {
 
     let relayed = false;
 
-    // Check if this callback is from expected origin/port
+    // Trusted origins that may receive this callback. The OAuth code/state
+    // must only be relayed to the dashboard window we expect to be the opener
+    // (same origin) or the Codex helper that listens on a fixed loopback port.
+    // Any other origin is treated as hostile (drive-by attacker that opened
+    // the popup against the well-known redirect_uri to phish the code).
     const expectedOrigins = [
       window.location.origin, // Same origin (for most providers)
       "http://localhost:1455", // Codex specific port
     ];
-    
+
     // Method 1: postMessage to opener (popup mode)
+    // Send once per expected origin. The browser delivers the message only
+    // when the opener's origin matches the targetOrigin we pass — using "*"
+    // here would leak the code/state to any opener (e.g. an attacker page
+    // that opened this URL in a popup), so iterate over the allowlist.
     if (window.opener) {
-      try {
-        window.opener.postMessage({ type: "oauth_callback", data: callbackData }, "*");
-        relayed = true;
-      } catch (e) {
-        console.log("postMessage failed:", e);
+      for (const origin of expectedOrigins) {
+        try {
+          window.opener.postMessage({ type: "oauth_callback", data: callbackData }, origin);
+          relayed = true;
+        } catch (e) {
+          console.log("postMessage failed:", e);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Two findings in the same surface area (auth + transport between 9router and upstream LLM APIs), bundled into one PR. Both have feasible patches verified locally; no behavioural change for legitimate flows.

## Findings

### 1. Wildcard \`postMessage\` leaks OAuth code/state to attacker-opened popup (HIGH)

**Location:** \`src/app/callback/page.js:38\`

The OAuth callback page posts \`{ code, state, error, fullUrl }\` to \`window.opener\` with target origin \`\"*\"\`. The \`expectedOrigins\` list was already computed in the file (same-origin + Codex's fixed \`localhost:1455\`) but never actually used.

**Impact.** Any page that opens this callback URL in a popup with a valid OAuth flow (using 9router's well-known client_id and the registered \`http://localhost:20128/callback\` redirect_uri) receives the live OAuth code and state on the popup's \`window.opener.postMessage\` event. The receiving side (\`OAuthModal.js:328\`) does check \`event.origin\` for localhost / same-origin — but that protects only the dashboard from accepting hostile messages; it does not protect the popup from sending the code to an arbitrary opener.

**Concretely:** drive-by attacker page calls \`window.open('https://provider.com/oauth/authorize?...&redirect_uri=http://localhost:20128/callback&...')\`, the user authenticates with the upstream provider, the popup is redirected to \`http://localhost:20128/callback?code=…\`, and the callback page posts the code straight back to the attacker page. The attacker exchanges the code for an upstream LLM API token.

**Fix.** Iterate over \`expectedOrigins\` and pass each as the target origin. The browser delivers the message only when the opener's origin matches the targetOrigin we pass, so the leak path is closed and the legitimate flow still works for both same-origin (most providers) and \`http://localhost:1455\` (Codex).

CWE-1385 / CWE-942.

### 2. \`rejectUnauthorized: false\` on the DNS-bypass HTTPS request (MEDIUM)

**Location:** \`open-sse/utils/proxyFetch.js:159\`

\`createBypassRequest()\` is the fallback path that handles \`MITM_BYPASS_HOSTS\`: cloudcode-pa.googleapis.com, daily-cloudcode-pa.googleapis.com, api.individual.githubcopilot.com, q.us-east-1.amazonaws.com, codewhisperer.us-east-1.amazonaws.com, api2.cursor.sh. It resolves the real IP via Google DNS (8.8.8.8 / 8.8.4.4), opens a raw socket to that IP on 443, then issues an HTTPS request with \`servername: parsedUrl.hostname\` so SNI is correct.

**Impact.** With \`rejectUnauthorized: false\`, an on-path attacker (public WiFi, compromised router, ISP-level interception, hostile VPN) can present any cert and 9router accepts it — even though SNI is correct. Result: the attacker reads the user's upstream LLM API credentials and prompts on the very endpoints the comment is trying to harden against MITM.

**Fix.** Drop \`rejectUnauthorized: false\`. The hosts in \`MITM_BYPASS_HOSTS\` are all served by public CAs (Google / GitHub / AWS / Cursor), so default cert validation works without any extra trust store. The DNS-bypass goal (avoid \`/etc/hosts\` spoofing) is unaffected — that's accomplished by resolving via Google DNS and connecting by IP, not by disabling cert checks.

CWE-295.

## Verification

- \`node --check open-sse/utils/proxyFetch.js\` — clean.
- \`@babel/parser\` (with \`jsx\` plugin) parses \`src/app/callback/page.js\` cleanly post-patch.
- Re-ran semgrep (\`p/javascript\`, \`p/security-audit\`, \`p/owasp-top-ten\`) on both patched files: 0 findings (down from the wildcard-postmessage warning + the bypass-tls-verification warning).
- No tests in the repo for these paths; static + parser verification only.

## Detected by

Aeon + semgrep
- \`javascript.browser.security.wildcard-postmessage-configuration\` (#1)
- \`problem-based-packs.insecure-transport.js-node.bypass-tls-verification\` (#2)

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Happy to split into two PRs or adjust the wording / scope if you'd prefer.