### PR TITLE
fix: add missing .unref() to Codex cleanup interval and response.body null guard for Cursor

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -62,12 +62,14 @@ function resolveConversationSessionId(input, machineId) {
 }
 
 // Cleanup expired entries periodically
-setInterval(() => {
+const _cleanupTimer = setInterval(() => {
   const now = Date.now();
   for (const [key, entry] of assistantSessionMap) {
     if (now - entry.lastUsed > SESSION_TTL_MS) assistantSessionMap.delete(key);
   }
 }, 10 * 60 * 1000);
+// Allow Node.js to exit even if interval is still active (matches sessionManager.js)
+if (_cleanupTimer.unref) _cleanupTimer.unref();
 
 /**
  * Codex Executor - handles OpenAI Codex API (Responses API format)

--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -238,6 +238,20 @@ export class CursorExecutor extends BaseExecutor {
         return { response: errorResponse, url, headers, transformedBody: body };
       }
 
+      if (!response.body) {
+        const errorResponse = new Response(JSON.stringify({
+          error: {
+            message: `[${response.status}]: Empty response body from Cursor`,
+            type: "server_error",
+            code: ""
+          }
+        }), {
+          status: response.status || 502,
+          headers: { "Content-Type": "application/json" }
+        });
+        return { response: errorResponse, url, headers, transformedBody: body };
+      }
+
       const transformedResponse = stream !== false
         ? this.transformProtobufToSSE(response.body, model, body)
         : this.transformProtobufToJSON(response.body, model, body);


### PR DESCRIPTION
## Summary

Two minor fixes that prevent real production issues:

### 1. `codex.js` — missing `.unref()` on cleanup interval
The `setInterval` that cleans expired session entries from `assistantSessionMap` does not call `.unref()`, which prevents Node.js from exiting gracefully when all other work is done. The same pattern in `sessionManager.js` already correctly calls `.unref()`.

Without this fix, a standalone 9router process that should exit after serving requests will hang indefinitely because the cleanup timer keeps the event loop alive.

### 2. `cursor.js` — missing `response.body` null guard
After a successful HTTP 200 from the Cursor backend, `response.body` is accessed directly without checking for `null`. Other executors in the codebase (`github.js`, `kiro.js`, `grok-web.js`, `perplexity-web.js`) all guard against this case. If Cursor returns an empty body (edge case under load), the unguarded access throws a `TypeError` and crashes the request handler.

## Testing
- Verified both files parse correctly
- Confirmed the `.unref()` pattern matches `sessionManager.js` (line 28)
- Confirmed the `response.body` null check pattern matches `github.js` (line 257)
