### PR TITLE
fix(cx): stabilize Codex continue sessions

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -26,6 +26,23 @@ function withCodexReviewModels(models) {
   });
 }
 
+const CODEX_EFFORT_LEVELS = ['xhigh', 'high', 'low', 'none'];
+
+function withCodexEffortVariants(modelIds) {
+  const targetSet = new Set(modelIds);
+  return (models) => models.flatMap((model) => {
+    if (!targetSet.has(model.id) || (model.type || "llm") !== "llm") return [model];
+    return [
+      model,
+      ...CODEX_EFFORT_LEVELS.map(level => ({
+        ...model,
+        id: `${model.id}-${level}`,
+        name: `${model.name} (${level === 'xhigh' ? 'xHigh' : level.charAt(0).toUpperCase() + level.slice(1)})`,
+      })),
+    ];
+  });
+}
+
 export const PROVIDER_MODELS = {
   // OAuth Providers (using alias)
   cc: [  // Claude Code
@@ -36,7 +53,7 @@ export const PROVIDER_MODELS = {
     { id: "claude-sonnet-4-5-20250929", name: "Claude 4.5 Sonnet" },
     { id: "claude-haiku-4-5-20251001", name: "Claude 4.5 Haiku" },
   ],
-  cx: withCodexReviewModels([  // OpenAI Codex
+  cx: withCodexReviewModels(withCodexEffortVariants(["gpt-5.5", "gpt-5.4"])([  // OpenAI Codex
     { id: "gpt-5.5", name: "GPT 5.5" },
     { id: "gpt-5.4", name: "GPT 5.4" },
     // GPT 5.3 Codex - all thinking levels
@@ -61,7 +78,7 @@ export const PROVIDER_MODELS = {
     { id: "gpt-5.4-image", name: "GPT 5.4 Image", type: "image", capabilities: ["text2img", "edit"], params: ["size", "quality", "background", "image_detail", "output_format"] },
     { id: "gpt-5.3-image", name: "GPT 5.3 Image", type: "image", capabilities: ["text2img", "edit"], params: ["size", "quality", "background", "image_detail", "output_format"] },
     { id: "gpt-5.2-image", name: "GPT 5.2 Image", type: "image", capabilities: ["text2img", "edit"], params: ["size", "quality", "background", "image_detail", "output_format"] },
-  ]),
+  ])),
   gc: [  // Gemini CLI
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
     { id: "gemini-3-pro-preview", name: "Gemini 3 Pro Preview" },

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -26,7 +26,7 @@ function withCodexReviewModels(models) {
   });
 }
 
-const CODEX_EFFORT_LEVELS = ['xhigh', 'high', 'low', 'none'];
+const CODEX_EFFORT_LEVELS = ['xhigh', 'high', 'medium', 'low'];
 
 function withCodexEffortVariants(modelIds) {
   const targetSet = new Set(modelIds);

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { BaseExecutor } from "./base.js";
 import { CODEX_DEFAULT_INSTRUCTIONS } from "../config/codexInstructions.js";
 import { PROVIDERS } from "../config/providers.js";
@@ -6,10 +6,6 @@ import { normalizeResponsesInput } from "../translator/helpers/responsesApiHelpe
 import { fetchImageAsBase64 } from "../translator/helpers/imageHelper.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { getConsistentMachineId } from "../../src/shared/utils/machineId.js";
-
-// In-memory map: hash(machineId + first assistant content) → { sessionId, lastUsed }
-const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
-const assistantSessionMap = new Map();
 
 // Cache machine ID at module level (resolved once)
 let cachedMachineId = null;
@@ -19,55 +15,16 @@ function hashContent(text) {
   return createHash("sha256").update(text).digest("hex").slice(0, 16);
 }
 
-function generateSessionId() {
-  return `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
+const processSessionSeed = randomUUID();
+
+function resolveCodexSessionId(credentials, machineId) {
+  const stableSeed =
+    credentials?.connectionId ||
+    credentials?.email ||
+    machineId ||
+    processSessionSeed;
+  return `sess_${hashContent(String(stableSeed))}`;
 }
-
-// Extract text content from an input item
-function extractItemText(item) {
-  if (!item) return "";
-  if (typeof item.content === "string") return item.content;
-  if (Array.isArray(item.content)) {
-    return item.content.map(c => c.text || c.output || "").filter(Boolean).join("");
-  }
-  return "";
-}
-
-// Resolve session_id from first assistant message + machineId to avoid cross-user collision
-function resolveConversationSessionId(input, machineId) {
-  const machineSessionId = machineId ? `sess_${hashContent(machineId)}` : generateSessionId();
-  if (!Array.isArray(input) || input.length === 0) return machineSessionId;
-
-  // Find first assistant message that has actual text content
-  let text = "";
-  for (const item of input) {
-    if (item.role === "assistant") {
-      text = extractItemText(item);
-      if (text) break;
-    }
-  }
-  if (!text) return machineSessionId;
-
-  const hash = hashContent((machineId || "") + text);
-  const entry = assistantSessionMap.get(hash);
-  if (entry) {
-    entry.lastUsed = Date.now();
-    return entry.sessionId;
-  }
-
-
-  const sessionId = generateSessionId();
-  assistantSessionMap.set(hash, { sessionId, lastUsed: Date.now() });
-  return sessionId;
-}
-
-// Cleanup expired entries periodically
-setInterval(() => {
-  const now = Date.now();
-  for (const [key, entry] of assistantSessionMap) {
-    if (now - entry.lastUsed > SESSION_TTL_MS) assistantSessionMap.delete(key);
-  }
-}, 10 * 60 * 1000);
 
 /**
  * Codex Executor - handles OpenAI Codex API (Responses API format)
@@ -154,8 +111,9 @@ export class CodexExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     this._isCompact = !!body._compact;
     delete body._compact;
-    // Resolve conversation-stable session_id from input history + machineId
-    this._currentSessionId = resolveConversationSessionId(body.input, cachedMachineId);
+    // Keep session_id stable across resumed Codex sessions. Reasoning encrypted
+    // content can be tied to this header, so it must not change when history grows.
+    this._currentSessionId = resolveCodexSessionId(credentials, cachedMachineId);
     // Convert string input to array format (Codex API requires input as array)
     const normalized = normalizeResponsesInput(body.input);
     if (normalized) body.input = normalized;

--- a/open-sse/translator/helpers/openaiHelper.js
+++ b/open-sse/translator/helpers/openaiHelper.js
@@ -6,6 +6,13 @@ export const VALID_OPENAI_MESSAGE_TYPES = ["text", "image_url", "image", "tool_c
 
 // Filter messages to OpenAI standard format
 // Remove: thinking, redacted_thinking, signature, and other non-OpenAI blocks
+function normalizeOpenAIContentBlocks(blocks) {
+  if (blocks.every(block => block.type === "text")) {
+    return blocks.map(block => block.text || "").join("\n");
+  }
+  return blocks;
+}
+
 export function filterToOpenAIFormat(body) {
   if (!body.messages || !Array.isArray(body.messages)) return body;
   
@@ -47,7 +54,7 @@ export function filterToOpenAIFormat(body) {
         filteredContent.push({ type: "text", text: "" });
       }
       
-      return { ...msg, content: filteredContent };
+      return { ...msg, content: normalizeOpenAIContentBlocks(filteredContent) };
     }
     
     return msg;
@@ -124,4 +131,3 @@ export function filterToOpenAIFormat(body) {
 
   return body;
 }
-

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -110,6 +110,14 @@ function fixMissingToolResponses(messages) {
 }
 
 // Convert single Claude message - returns single message or array of messages
+function contentFromParts(parts) {
+  if (parts.length === 0) return "";
+  if (parts.every(part => part.type === "text")) {
+    return parts.map(part => part.text || "").join("\n");
+  }
+  return parts;
+}
+
 function convertClaudeMessage(msg) {
   const role = msg.role === "user" || msg.role === "tool" ? "user" : "assistant";
   
@@ -177,10 +185,7 @@ function convertClaudeMessage(msg) {
     // If has tool results, return array of tool messages
     if (toolResults.length > 0) {
       if (parts.length > 0) {
-        const textContent = parts.length === 1 && parts[0].type === "text" 
-          ? parts[0].text 
-          : parts;
-        return [...toolResults, { role: "user", content: textContent }];
+        return [...toolResults, { role: "user", content: contentFromParts(parts) }];
       }
       return toolResults;
     }
@@ -189,9 +194,7 @@ function convertClaudeMessage(msg) {
     if (toolCalls.length > 0) {
       const result = { role: "assistant" };
       if (parts.length > 0) {
-        result.content = parts.length === 1 && parts[0].type === "text" 
-          ? parts[0].text 
-          : parts;
+        result.content = contentFromParts(parts);
       }
       result.tool_calls = toolCalls;
       return result;
@@ -201,7 +204,7 @@ function convertClaudeMessage(msg) {
     if (parts.length > 0) {
       return {
         role,
-        content: parts.length === 1 && parts[0].type === "text" ? parts[0].text : parts
+        content: contentFromParts(parts)
       };
     }
     
@@ -229,4 +232,3 @@ function convertToolChoice(choice) {
 
 // Register
 register(FORMATS.CLAUDE, FORMATS.OPENAI, claudeToOpenAIRequest, null);
-

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -17,6 +17,15 @@ export function parseSSELine(line, format = null) {
     return null;
   }
 
+  const trimmed = line.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch (error) {
+      return null;
+    }
+  }
+
   // Standard SSE format: "data: {...}"
   if (line.charCodeAt(0) !== 100) return null; // 'd' = 100
 

--- a/src/shared/utils/machineId.js
+++ b/src/shared/utils/machineId.js
@@ -1,4 +1,8 @@
-import { machineIdSync } from 'node-machine-id';
+import { randomUUID } from 'crypto';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { machineIdSync } = require('node-machine-id');
 
 /**
  * Get consistent machine ID using node-machine-id with salt
@@ -20,7 +24,7 @@ export async function getConsistentMachineId(salt = null) {
   } catch (error) {
     console.log('Error getting machine ID:', error);
     // Fallback to random ID if node-machine-id fails
-    return crypto.randomUUID ? crypto.randomUUID() : 
+    return randomUUID ? randomUUID() :
       'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
         const r = Math.random() * 16 | 0;
         const v = c == 'x' ? r : (r & 0x3 | 0x8);
@@ -40,7 +44,7 @@ export async function getRawMachineId() {
   } catch (error) {
     console.log('Error getting raw machine ID:', error);
     // Fallback to random ID if node-machine-id fails
-    return crypto.randomUUID ? crypto.randomUUID() : 
+    return randomUUID ? randomUUID() :
       'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
         const r = Math.random() * 16 | 0;
         const v = c == 'x' ? r : (r & 0x3 | 0x8);

--- a/tests/unit/codex-image-fetch.test.js
+++ b/tests/unit/codex-image-fetch.test.js
@@ -143,3 +143,32 @@ describe("CodexExecutor image handling", () => {
     expect(imgBlock.image_url.startsWith("data:image/jpeg;base64,")).toBe(true);
   });
 });
+
+describe("CodexExecutor session handling", () => {
+  it("keeps session_id stable when a Codex session is continued", () => {
+    const executor = new CodexExecutor();
+    const credentials = { accessToken: "test", connectionId: "conn-codex-1" };
+
+    executor.transformRequest("gpt-5.5-medium", {
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "first" }] }],
+    }, true, credentials);
+    const firstSessionId = executor.buildHeaders(credentials, true).session_id;
+
+    executor.transformRequest("gpt-5.5-medium", {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "first" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "answer" }] },
+        {
+          type: "reasoning",
+          id: "rs_1",
+          encrypted_content: "encrypted-reasoning",
+          summary: [],
+        },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+      ],
+    }, true, credentials);
+    const continuedSessionId = executor.buildHeaders(credentials, true).session_id;
+
+    expect(continuedSessionId).toBe(firstSessionId);
+  });
+});

--- a/tests/unit/provider-models-codex-effort.test.js
+++ b/tests/unit/provider-models-codex-effort.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getModelQuotaFamily,
+  getModelUpstreamId,
+  getProviderModels,
+} from "../../open-sse/config/providerModels.js";
+
+describe("Codex provider GPT-5.5/GPT-5.4 effort variants", () => {
+  const models = getProviderModels("cx");
+  const modelIds = new Set(models.map((model) => model.id));
+
+  it("includes the target base models", () => {
+    expect(modelIds.has("gpt-5.5")).toBe(true);
+    expect(modelIds.has("gpt-5.4")).toBe(true);
+  });
+
+  it.each(["gpt-5.5", "gpt-5.4"])(
+    "generates xhigh, high, medium, and low variants for %s",
+    (baseModelId) => {
+      expect(modelIds.has(`${baseModelId}-xhigh`)).toBe(true);
+      expect(modelIds.has(`${baseModelId}-high`)).toBe(true);
+      expect(modelIds.has(`${baseModelId}-medium`)).toBe(true);
+      expect(modelIds.has(`${baseModelId}-low`)).toBe(true);
+    },
+  );
+
+  it("does not generate none variants for GPT-5.5 or GPT-5.4", () => {
+    expect(modelIds.has("gpt-5.5-none")).toBe(false);
+    expect(modelIds.has("gpt-5.4-none")).toBe(false);
+  });
+
+  it("does not generate medium effort variants for non-target base models", () => {
+    expect(modelIds.has("gpt-5.2-medium")).toBe(false);
+    expect(modelIds.has("gpt-5.3-codex-medium")).toBe(false);
+  });
+
+  it("includes generated review variants for effort variants", () => {
+    expect(modelIds.has("gpt-5.5-xhigh-review")).toBe(true);
+    expect(modelIds.has("gpt-5.5-medium-review")).toBe(true);
+  });
+
+  it("preserves effort suffixes when resolving Codex review upstream model IDs", () => {
+    expect(getModelUpstreamId("cx", "gpt-5.5-medium-review")).toBe("gpt-5.5-medium");
+  });
+
+  it("marks Codex review variants with the review quota family", () => {
+    expect(getModelQuotaFamily("cx", "gpt-5.5-medium-review")).toBe("review");
+  });
+});


### PR DESCRIPTION
## Summary

- Builds on #865 by keeping Codex session_id stable across resumed conversations.
- Fixes node-machine-id loading in the Next server bundle.
- Normalizes text-only Claude/OpenAI payloads and raw NDJSON stream parsing uncovered during local verification.
- Preserves GPT-5.5/GPT-5.4 Codex effort aliases and review metadata from the original PR branch.

## Verification

- npx --yes vitest run tests/unit/translator-request-normalization.test.js tests/unit/codex-image-fetch.test.js tests/unit/provider-models-codex-effort.test.js
- npm run build
- Local dev server on http://localhost:20128
  - /api/health returned {"ok":true}
  - / redirected to /dashboard
  - /api/v1/models included cx/gpt-5.5-medium and cx/gpt-5.4-xhigh
- Local Codex continuation simulation confirmed session_id stays stable while model suffix maps to upstream model and reasoning effort.
