### PR TITLE
fix: handle permission denied when creating DATA_DIR

### DIFF
--- a/src/lib/dataDir.js
+++ b/src/lib/dataDir.js
@@ -1,14 +1,35 @@
+import fs from "node:fs";
 import path from "path";
 import os from "os";
 
 const APP_NAME = "9router";
 
-export function getDataDir() {
-  if (process.env.DATA_DIR) return process.env.DATA_DIR;
+function getDefaultDataDir() {
   if (process.platform === "win32") {
     return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), APP_NAME);
   }
   return path.join(os.homedir(), `.${APP_NAME}`);
+}
+
+export function getDataDir() {
+  const configured = process.env.DATA_DIR;
+  if (configured) {
+    try {
+      fs.mkdirSync(configured, { recursive: true });
+      return configured;
+    } catch (error) {
+      if (error?.code === "EACCES" || error?.code === "EPERM") {
+        console.warn(
+          `[DATA_DIR] Cannot use configured DATA_DIR='${configured}' because it is not writable. Falling back to default user directory.`,
+        );
+      } else {
+        console.warn(
+          `[DATA_DIR] Unable to initialize configured DATA_DIR='${configured}': ${error?.message}. Falling back to default user directory.`,
+        );
+      }
+    }
+  }
+  return getDefaultDataDir();
 }
 
 export const DATA_DIR = getDataDir();

--- a/src/mitm/paths.js
+++ b/src/mitm/paths.js
@@ -1,13 +1,33 @@
+const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
-// Single source of truth for data directory — matches localDb.js logic
-function getDataDir() {
-  if (process.env.DATA_DIR) return process.env.DATA_DIR;
+function getDefaultDataDir() {
   if (process.platform === "win32") {
     return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), "9router");
   }
   return path.join(os.homedir(), ".9router");
+}
+
+function getDataDir() {
+  const configured = process.env.DATA_DIR;
+  if (configured) {
+    try {
+      fs.mkdirSync(configured, { recursive: true });
+      return configured;
+    } catch (error) {
+      if (error?.code === "EACCES" || error?.code === "EPERM") {
+        console.warn(
+          `[DATA_DIR] Cannot use configured DATA_DIR='${configured}' because it is not writable. Falling back to default user directory.`,
+        );
+      } else {
+        console.warn(
+          `[DATA_DIR] Unable to initialize configured DATA_DIR='${configured}': ${error?.message}. Falling back to default user directory.`,
+        );
+      }
+    }
+  }
+  return getDefaultDataDir();
 }
 
 const DATA_DIR = getDataDir();

--- a/tests/unit/dataDir.test.js
+++ b/tests/unit/dataDir.test.js
@@ -1,0 +1,27 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+const originalDataDir = process.env.DATA_DIR;
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("DATA_DIR fallback", () => {
+  it("falls back to the default user directory when configured DATA_DIR is not writable", async () => {
+    process.env.DATA_DIR = path.join(os.tmpdir(), "9router-unwritable");
+    vi.spyOn(fs, "mkdirSync").mockImplementation(() => {
+      const error = new Error("permission denied");
+      error.code = "EACCES";
+      throw error;
+    });
+
+    const { DATA_DIR } = await import("@/lib/dataDir.js");
+    expect(DATA_DIR).toBe(path.join(os.homedir(), ".9router"));
+  });
+});


### PR DESCRIPTION
- Add permission denied fallback in DATA_DIR initialization
- Falls back to default user directory (~/.9router) if configured DATA_DIR is not writable
- Apply same fallback logic to mitm/paths.js for consistency
- Logs informative warning when fallback occurs
- Added unit test to verify fallback behavior

Fixes the error: EACCES: permission denied, mkdir '/var/lib/9router/db'