### PR TITLE
feat: add per-connection convertDeveloperRole config via UI

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -415,10 +415,10 @@ export const PROVIDER_MODELS = {
     { id: "gpt-oss-120b-250805", name: "GPT-OSS-120B" },
   ],
   deepseek: [
-    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
-    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
-    { id: "deepseek-chat", name: "DeepSeek V3.2 Chat" },
-    { id: "deepseek-reasoner", name: "DeepSeek V3.2 Reasoner" },
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", filterToolTypes: true },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", filterToolTypes: true },
+    { id: "deepseek-chat", name: "DeepSeek V3.2 Chat", filterToolTypes: true },
+    { id: "deepseek-reasoner", name: "DeepSeek V3.2 Reasoner", filterToolTypes: true },
   ],
   commandcode: [
     { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" },
@@ -734,4 +734,11 @@ export function getModelStrip(alias, modelId) {
 export function getModelConvertDeveloperRole(alias, modelId) {
   const entry = PROVIDER_MODELS[alias]?.find(m => m.id === modelId);
   return !!entry?.convertDeveloperRole;
+}
+
+// Check if model should filter unsupported tool types (web_search, code_interpreter, etc.)
+// Set filterToolTypes: true on a model entry to enable this
+export function getModelFilterToolTypes(alias, modelId) {
+  const entry = PROVIDER_MODELS[alias]?.find(m => m.id === modelId);
+  return !!entry?.filterToolTypes;
 }

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -134,7 +134,7 @@ export const PROVIDER_MODELS = {
     // { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
     { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
     { id: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
-    { id: "deepseek-3.2", name: "DeepSeek 3.2", strip: ["image", "audio"] },
+    { id: "deepseek-3.2", name: "DeepSeek 3.2", strip: ["image", "audio"], convertDeveloperRole: true },
     { id: "qwen3-coder-next", name: "Qwen3 Coder Next", strip: ["image", "audio"] },
     { id: "glm-5", name: "GLM 5" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
@@ -727,4 +727,11 @@ export function getModelsByProviderId(providerId) {
 export function getModelStrip(alias, modelId) {
   const entry = PROVIDER_MODELS[alias]?.find(m => m.id === modelId);
   return entry?.strip || [];
+}
+
+// Check if model should convert developer role to system
+// Set convertDeveloperRole: true on a model entry to enable this
+export function getModelConvertDeveloperRole(alias, modelId) {
+  const entry = PROVIDER_MODELS[alias]?.find(m => m.id === modelId);
+  return !!entry?.convertDeveloperRole;
 }

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -26,7 +26,7 @@ import { compressMessages, formatRtkLog } from "../rtk/index.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, cavemanEnabled, cavemanLevel, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, cavemanEnabled, cavemanLevel, sourceFormatOverride, providerThinking, convertDeveloperRole }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -40,7 +40,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const modelTargetFormat = getModelTargetFormat(alias, model);
   const targetFormat = modelTargetFormat || getTargetFormat(provider);
   const stripList = getModelStrip(alias, model);
-  const convertDeveloperRole = getModelConvertDeveloperRole(alias, model);
+  const modelConvertDeveloperRole = getModelConvertDeveloperRole(alias, model);
 
   // Inject provider-level thinking config override (only if client hasn't set)
   // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
@@ -96,7 +96,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   // Per-model: convert developer role to system (before RTK/token savers)
-  if (convertDeveloperRole) {
+  // Priority: connection-level config > model-level config
+  if (convertDeveloperRole || modelConvertDeveloperRole) {
     for (const arr of [translatedBody.messages, translatedBody.input, translatedBody.contents, translatedBody?.request?.contents]) {
       if (Array.isArray(arr)) {
         for (const msg of arr) {
@@ -104,7 +105,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
         }
       }
     }
-    log?.debug?.("ROLE", "developer → system (per-model config)");
+    log?.debug?.("ROLE", `developer → system (connection=${!!convertDeveloperRole}, model=${!!modelConvertDeveloperRole})`);
   }
 
   // Token savers: applied at the final body just before dispatch

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -5,7 +5,7 @@ import { COLORS } from "../utils/stream.js";
 import { createStreamController } from "../utils/streamHandler.js";
 import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
-import { getModelTargetFormat, getModelStrip, getModelConvertDeveloperRole, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
+import { getModelTargetFormat, getModelStrip, getModelConvertDeveloperRole, getModelFilterToolTypes, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
@@ -41,6 +41,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const targetFormat = modelTargetFormat || getTargetFormat(provider);
   const stripList = getModelStrip(alias, model);
   const modelConvertDeveloperRole = getModelConvertDeveloperRole(alias, model);
+  const modelFilterToolTypes = getModelFilterToolTypes(alias, model);
 
   // Inject provider-level thinking config override (only if client hasn't set)
   // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
@@ -106,6 +107,23 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       }
     }
     log?.debug?.("ROLE", `developer → system (connection=${!!convertDeveloperRole}, model=${!!modelConvertDeveloperRole})`);
+  }
+
+  // Per-model: filter unsupported tool types (web_search, code_interpreter, etc.)
+  // Priority: connection-level config > model-level config
+  const filterToolTypes = !!credentials?.providerSpecificData?.filterToolTypes || modelFilterToolTypes;
+  if (filterToolTypes && translatedBody.tools && Array.isArray(translatedBody.tools)) {
+    const filtered = translatedBody.tools.filter(t => !t.type || t.type === "function");
+    if (filtered.length < translatedBody.tools.length) {
+      log?.debug?.("TOOLS", `filtered ${translatedBody.tools.length - filtered.length} unsupported tool types`);
+      translatedBody.tools = filtered;
+      if (translatedBody.tool_choice && typeof translatedBody.tool_choice === "object" && translatedBody.tool_choice.type === "tool") {
+        const name = translatedBody.tool_choice.function?.name;
+        if (name && !filtered.some(t => t.function?.name === name)) {
+          translatedBody.tool_choice = "auto";
+        }
+      }
+    }
   }
 
   // Token savers: applied at the final body just before dispatch

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -111,16 +111,22 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Per-model: filter unsupported tool types (web_search, code_interpreter, etc.)
   // Priority: connection-level config > model-level config
+  // Only filter if no existing tool interaction in message history
   const filterToolTypes = !!credentials?.providerSpecificData?.filterToolTypes || modelFilterToolTypes;
   if (filterToolTypes && translatedBody.tools && Array.isArray(translatedBody.tools)) {
-    const filtered = translatedBody.tools.filter(t => !t.type || t.type === "function");
-    if (filtered.length < translatedBody.tools.length) {
-      log?.debug?.("TOOLS", `filtered ${translatedBody.tools.length - filtered.length} unsupported tool types`);
-      translatedBody.tools = filtered;
-      if (translatedBody.tool_choice && typeof translatedBody.tool_choice === "object" && translatedBody.tool_choice.type === "tool") {
-        const name = translatedBody.tool_choice.function?.name;
-        if (name && !filtered.some(t => t.function?.name === name)) {
-          translatedBody.tool_choice = "auto";
+    const hasToolHistory = translatedBody.messages?.some(m =>
+      m.role === "tool" || (m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0)
+    );
+    if (!hasToolHistory) {
+      const filtered = translatedBody.tools.filter(t => !t.type || t.type === "function");
+      if (filtered.length < translatedBody.tools.length) {
+        log?.debug?.("TOOLS", `filtered ${translatedBody.tools.length - filtered.length} unsupported tool types`);
+        translatedBody.tools = filtered;
+        if (translatedBody.tool_choice && typeof translatedBody.tool_choice === "object" && translatedBody.tool_choice.type === "tool") {
+          const name = translatedBody.tool_choice.function?.name;
+          if (name && !filtered.some(t => t.function?.name === name)) {
+            translatedBody.tool_choice = "auto";
+          }
         }
       }
     }

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -86,7 +86,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     log?.debug?.("PASSTHROUGH", `${clientTool} → ${provider} | native lossless`);
     translatedBody = { ...body, model };
   } else {
+    const msgRoles = (body.messages || []).map(m => m.role + (m.tool_calls ? `(tc:${m.tool_calls.length})` : "") + (m.tool_call_id ? `(tid:${m.tool_call_id.slice(-8)})` : "")).join(", ");
+    log?.debug?.("TRANSLATE", `Before translate: ${body.messages?.length || 0} msgs [${msgRoles}]`);
     translatedBody = translateRequest(sourceFormat, targetFormat, model, body, stream, credentials, provider, reqLogger, stripList, connectionId, clientTool);
+    const msgRoles2 = (translatedBody?.messages || []).map(m => m.role + (m.tool_calls ? `(tc:${m.tool_calls.length})` : "") + (m.tool_call_id ? `(tid:${m.tool_call_id.slice(-8)})` : "")).join(", ");
+    log?.debug?.("TRANSLATE", `After translate: ${translatedBody?.messages?.length || 0} msgs [${msgRoles2}]`);
     if (!translatedBody) {
       trackPendingRequest(model, provider, connectionId, false, true);
       return createErrorResult(HTTP_STATUS.BAD_REQUEST, `Failed to translate request for ${sourceFormat} → ${targetFormat}`);

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -111,22 +111,16 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Per-model: filter unsupported tool types (web_search, code_interpreter, etc.)
   // Priority: connection-level config > model-level config
-  // Only filter if no existing tool interaction in message history
   const filterToolTypes = !!credentials?.providerSpecificData?.filterToolTypes || modelFilterToolTypes;
   if (filterToolTypes && translatedBody.tools && Array.isArray(translatedBody.tools)) {
-    const hasToolHistory = translatedBody.messages?.some(m =>
-      m.role === "tool" || (m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0)
-    );
-    if (!hasToolHistory) {
-      const filtered = translatedBody.tools.filter(t => !t.type || t.type === "function");
-      if (filtered.length < translatedBody.tools.length) {
-        log?.debug?.("TOOLS", `filtered ${translatedBody.tools.length - filtered.length} unsupported tool types`);
-        translatedBody.tools = filtered;
-        if (translatedBody.tool_choice && typeof translatedBody.tool_choice === "object" && translatedBody.tool_choice.type === "tool") {
-          const name = translatedBody.tool_choice.function?.name;
-          if (name && !filtered.some(t => t.function?.name === name)) {
-            translatedBody.tool_choice = "auto";
-          }
+    const filtered = translatedBody.tools.filter(t => !t.type || t.type === "function");
+    if (filtered.length < translatedBody.tools.length) {
+      log?.debug?.("TOOLS", `filtered ${translatedBody.tools.length - filtered.length} unsupported tool types`);
+      translatedBody.tools = filtered;
+      if (translatedBody.tool_choice && typeof translatedBody.tool_choice === "object" && translatedBody.tool_choice.type === "tool") {
+        const name = translatedBody.tool_choice.function?.name;
+        if (name && !filtered.some(t => t.function?.name === name)) {
+          translatedBody.tool_choice = "auto";
         }
       }
     }

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -5,7 +5,7 @@ import { COLORS } from "../utils/stream.js";
 import { createStreamController } from "../utils/streamHandler.js";
 import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
-import { getModelTargetFormat, getModelStrip, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
+import { getModelTargetFormat, getModelStrip, getModelConvertDeveloperRole, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
@@ -40,6 +40,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const modelTargetFormat = getModelTargetFormat(alias, model);
   const targetFormat = modelTargetFormat || getTargetFormat(provider);
   const stripList = getModelStrip(alias, model);
+  const convertDeveloperRole = getModelConvertDeveloperRole(alias, model);
 
   // Inject provider-level thinking config override (only if client hasn't set)
   // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
@@ -92,6 +93,18 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     toolNameMap = translatedBody._toolNameMap;
     delete translatedBody._toolNameMap;
     translatedBody.model = model;
+  }
+
+  // Per-model: convert developer role to system (before RTK/token savers)
+  if (convertDeveloperRole) {
+    for (const arr of [translatedBody.messages, translatedBody.input, translatedBody.contents, translatedBody?.request?.contents]) {
+      if (Array.isArray(arr)) {
+        for (const msg of arr) {
+          if (msg && msg.role === "developer") msg.role = "system";
+        }
+      }
+    }
+    log?.debug?.("ROLE", "developer → system (per-model config)");
   }
 
   // Token savers: applied at the final body just before dispatch

--- a/open-sse/handlers/responsesHandler.js
+++ b/open-sse/handlers/responsesHandler.js
@@ -4,6 +4,7 @@
  */
 
 import { handleChatCore } from "./chatCore.js";
+import { FORMATS } from "../translator/formats.js";
 import { convertResponsesApiFormat } from "../translator/helpers/responsesApiHelper.js";
 import { createResponsesApiTransformStream } from "../transformer/responsesTransformer.js";
 import { convertResponsesStreamToJson } from "../transformer/streamToJsonConverter.js";
@@ -42,7 +43,7 @@ export async function handleResponsesCore({ body, modelInfo, credentials, log, o
     onRequestSuccess,
     onDisconnect,
     connectionId,
-    sourceFormatOverride: "openai-responses"
+    sourceFormatOverride: FORMATS.OPENAI
   });
 
   if (!result.success || !result.response) {

--- a/open-sse/index.js
+++ b/open-sse/index.js
@@ -14,6 +14,7 @@ export {
   getModelTargetFormat,
   getModelStrip,
   getModelConvertDeveloperRole,
+  getModelFilterToolTypes,
   PROVIDER_ID_TO_ALIAS,
   getModelsByProviderId
 } from "./config/providerModels.js";

--- a/open-sse/index.js
+++ b/open-sse/index.js
@@ -12,6 +12,8 @@ export {
   isValidModel,
   findModelName,
   getModelTargetFormat,
+  getModelStrip,
+  getModelConvertDeveloperRole,
   PROVIDER_ID_TO_ALIAS,
   getModelsByProviderId
 } from "./config/providerModels.js";

--- a/open-sse/translator/formats.js
+++ b/open-sse/translator/formats.js
@@ -20,8 +20,8 @@ export const FORMATS = {
  * Returns null to fall back to body-based detection.
  */
 export function detectFormatByEndpoint(pathname, body) {
-  // /v1/responses is always openai-responses
-  if (pathname.includes("/v1/responses")) return FORMATS.OPENAI_RESPONSES;
+  // /v1/responses — body is converted to Chat Completions in handleChat, treat as openai
+  if (pathname.includes("/v1/responses")) return FORMATS.OPENAI;
 
   // /v1/messages is always Claude
   if (pathname.includes("/v1/messages")) return FORMATS.CLAUDE;

--- a/open-sse/translator/formats.js
+++ b/open-sse/translator/formats.js
@@ -20,8 +20,8 @@ export const FORMATS = {
  * Returns null to fall back to body-based detection.
  */
 export function detectFormatByEndpoint(pathname, body) {
-  // /v1/responses — body is converted to Chat Completions in handleChat, treat as openai
-  if (pathname.includes("/v1/responses")) return FORMATS.OPENAI;
+  // /v1/responses is always openai-responses (SSE response needs Responses API format)
+  if (pathname.includes("/v1/responses")) return FORMATS.OPENAI_RESPONSES;
 
   // /v1/messages is always Claude
   if (pathname.includes("/v1/messages")) return FORMATS.CLAUDE;

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -103,7 +103,8 @@ function fixOrphanedToolMessages(body) {
   }
   if (!hasTools && !hasToolCalls) return;
 
-  // Pass 1: collect all tool messages by tool_call_id, skipping them from the output
+  // Pass 1: collect all tool messages by tool_call_id, skipping them from the output.
+  // Also skip tool messages without tool_call_id (can't be matched, useless downstream).
   const toolMessages = {}; // tool_call_id → tool message
   const nonToolMessages = [];
   for (let i = 0; i < body.messages.length; i++) {
@@ -171,7 +172,13 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
 
   // Fix orphaned tool messages (DeepSeek requires every tool message has preceding tool_calls)
   try {
+    if (result.messages && Array.isArray(result.messages)) {
+      console.log(`[TRANSLATOR] Before fix: ${result.messages.length} msgs, order:`, result.messages.map(m => m.role + (m.tool_calls ? `(tc:${m.tool_calls.length})` : "") + (m.tool_call_id ? `(tid:${m.tool_call_id.slice(-8)})` : "")) );
+    }
     fixOrphanedToolMessages(result);
+    if (result.messages && Array.isArray(result.messages)) {
+      console.log(`[TRANSLATOR] After fix: ${result.messages.length} msgs, order:`, result.messages.map(m => m.role + (m.tool_calls ? `(tc:${m.tool_calls.length})` : "") + (m.tool_call_id ? `(tid:${m.tool_call_id.slice(-8)})` : "")) );
+    }
   } catch (e) {
     console.error("[TRANSLATOR] fixOrphanedToolMessages error:", e.message);
   }

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -106,9 +106,6 @@ function fixOrphanedToolMessages(body) {
   }
   body.messages = body.messages.filter(m => !m.invalid);
 }
-    }
-  }
-}
 
 // Translate request: source -> openai -> target
 export function translateRequest(sourceFormat, targetFormat, model, body, stream = true, credentials = null, provider = null, reqLogger = null, stripList = [], connectionId = null, clientTool = null) {

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -94,6 +94,15 @@ function filterUnsupportedTools(body, targetFormat) {
 function fixOrphanedToolMessages(body) {
   if (!body.messages || !Array.isArray(body.messages)) return;
 
+  // Quick check: skip if no tool messages or tool_calls exist
+  let hasTools = false, hasToolCalls = false;
+  for (let i = 0; i < body.messages.length && (!hasTools || !hasToolCalls); i++) {
+    const msg = body.messages[i];
+    if (msg.role === "tool" && msg.tool_call_id) hasTools = true;
+    if (msg.role === "assistant" && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) hasToolCalls = true;
+  }
+  if (!hasTools && !hasToolCalls) return;
+
   // Pass 1: collect all tool messages by tool_call_id, skipping them from the output
   const toolMessages = {}; // tool_call_id → tool message
   const nonToolMessages = [];

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -170,7 +170,11 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
   fixMissingToolResponses(result);
 
   // Fix orphaned tool messages (DeepSeek requires every tool message has preceding tool_calls)
-  fixOrphanedToolMessages(result);
+  try {
+    fixOrphanedToolMessages(result);
+  } catch (e) {
+    console.error("[TRANSLATOR] fixOrphanedToolMessages error:", e.message);
+  }
 
   // If same format, skip translation steps
   if (sourceFormat !== targetFormat) {

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -88,38 +88,42 @@ function filterUnsupportedTools(body, targetFormat) {
   }
 }
 
-// Fix orphaned tool messages: remove tool messages that don't have preceding assistant with matching tool_calls.
-// DeepSeek also requires tool messages to immediately follow their assistant with no non-tool messages in between.
+// Restructure messages: ensure tool results immediately follow their assistant with matching tool_calls.
+// DeepSeek requires tool messages to be contiguous with their preceding assistant.
 function fixOrphanedToolMessages(body) {
   if (!body.messages || !Array.isArray(body.messages)) return;
 
-  // First pass: mark tool messages that have a valid assistant with matching tool_call_id
-  // and no non-tool/non-assistant messages between them
+  const restructured = [];
+  const pendingTools = {}; // tool_call_id → tool message (waiting to be placed after assistant)
+  let removed = 0;
+
   for (let i = 0; i < body.messages.length; i++) {
     const msg = body.messages[i];
-    if (msg.role !== "tool" || !msg.tool_call_id) continue;
 
-    let found = false;
-    // Walk backwards from the tool message to find a preceding assistant with matching tool_calls
-    for (let j = i - 1; j >= 0; j--) {
-      const prev = body.messages[j];
-      if (prev.role === "assistant" && Array.isArray(prev.tool_calls)) {
-        if (prev.tool_calls.some(tc => tc.id === msg.tool_call_id)) {
-          found = true;
-        }
-        break; // Stop at the first assistant (matching or not)
-      }
-      if (prev.role !== "tool") break; // Non-tool, non-assistant blocks the chain
+    if (msg.role === "tool" && msg.tool_call_id) {
+      // Collect tool messages, place them after matching assistant later
+      pendingTools[msg.tool_call_id] = msg;
+      continue;
     }
-    if (!found) msg.invalid = true;
+
+    restructured.push(msg);
+
+    // If this is an assistant with tool_calls, immediately append matching tool results
+    if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
+      for (const tc of msg.tool_calls) {
+        if (tc.id && pendingTools[tc.id]) {
+          restructured.push(pendingTools[tc.id]);
+          delete pendingTools[tc.id];
+        }
+      }
+    }
   }
 
-  // Also find tool messages whose assistant has already been split by a non-tool message
-  // Re-scan: mark orphaned tool messages that follow a system/user message after an assistant
-  const removed = body.messages.filter(m => m.invalid).length;
-  if (removed > 0) {
-    body.messages = body.messages.filter(m => !m.invalid);
-    console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages`);
+  // Count orphaned tool messages (no matching assistant found)
+  removed = Object.keys(pendingTools).length;
+  if (removed > 0 || restructured.length !== body.messages.length) {
+    body.messages = restructured;
+    if (removed > 0) console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages`);
   }
 }
 

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -89,41 +89,57 @@ function filterUnsupportedTools(body, targetFormat) {
 }
 
 // Restructure messages: ensure tool results immediately follow their assistant with matching tool_calls.
-// DeepSeek requires tool messages to be contiguous with their preceding assistant.
+// DeepSeek requires tool messages to be contiguous with their preceding assistant,
+// and every tool_call_id in an assistant must have a corresponding tool message immediately after.
 function fixOrphanedToolMessages(body) {
   if (!body.messages || !Array.isArray(body.messages)) return;
 
-  const restructured = [];
-  const pendingTools = {}; // tool_call_id → tool message (waiting to be placed after assistant)
-  let removed = 0;
-
+  // Pass 1: collect all tool messages by tool_call_id, skipping them from the output
+  const toolMessages = {}; // tool_call_id → tool message
+  const nonToolMessages = [];
   for (let i = 0; i < body.messages.length; i++) {
     const msg = body.messages[i];
-
     if (msg.role === "tool" && msg.tool_call_id) {
-      // Collect tool messages, place them after matching assistant later
-      pendingTools[msg.tool_call_id] = msg;
-      continue;
+      toolMessages[msg.tool_call_id] = msg;
+    } else {
+      nonToolMessages.push(msg);
     }
+  }
 
-    restructured.push(msg);
-
-    // If this is an assistant with tool_calls, immediately append matching tool results
-    if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
-      for (const tc of msg.tool_calls) {
-        if (tc.id && pendingTools[tc.id]) {
-          restructured.push(pendingTools[tc.id]);
-          delete pendingTools[tc.id];
+  // Pass 2: rebuild, inserting tool messages immediately after their assistant.
+  // Also filter out tool_calls that lack matching tool responses.
+  const restructured = [];
+  let removed = 0;
+  for (const msg of nonToolMessages) {
+    if (msg.role === "assistant" && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+      // Only keep tool_calls that have matching tool messages
+      const matchedCalls = msg.tool_calls.filter(tc => tc.id && toolMessages[tc.id]);
+      const unmatched = msg.tool_calls.length - matchedCalls.length;
+      if (unmatched > 0) {
+        console.log(`[TRANSLATOR] Stripping ${unmatched} tool_calls with no matching tool message`);
+        // If NO tool_calls could be matched, skip this assistant message entirely
+        if (matchedCalls.length === 0) {
+          removed += msg.tool_calls.length;
+          continue;
         }
+        msg.tool_calls = matchedCalls;
       }
+      restructured.push(msg);
+      // Immediately append matching tool results
+      for (const tc of matchedCalls) {
+        restructured.push(toolMessages[tc.id]);
+        delete toolMessages[tc.id];
+      }
+    } else {
+      restructured.push(msg);
     }
   }
 
   // Count orphaned tool messages (no matching assistant found)
-  removed = Object.keys(pendingTools).length;
+  removed = Object.keys(toolMessages).length;
   if (removed > 0 || restructured.length !== body.messages.length) {
     body.messages = restructured;
-    if (removed > 0) console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages`);
+    if (removed > 0) console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages (no matching assistant)`);
   }
 }
 

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -71,6 +71,24 @@ function stripContentTypes(body, stripList = []) {
   }
 }
 
+// Strip unsupported tool types for providers that only support "function" tools
+// e.g. DeepSeek, OpenAI-compatible APIs reject web_search, code_interpreter
+function filterUnsupportedTools(body, targetFormat) {
+  if (targetFormat !== FORMATS.OPENAI) return;
+  if (!body.tools || !Array.isArray(body.tools)) return;
+  const filtered = body.tools.filter(t => !t.type || t.type === "function");
+  if (filtered.length < body.tools.length) {
+    body.tools = filtered;
+    // Also clean up tool_choice if it references a removed tool
+    if (body.tool_choice && typeof body.tool_choice === "object" && body.tool_choice.type === "tool") {
+      const name = body.tool_choice.function?.name;
+      if (name && !filtered.some(t => t.function?.name === name)) {
+        body.tool_choice = "auto";
+      }
+    }
+  }
+}
+
 // Translate request: source -> openai -> target
 export function translateRequest(sourceFormat, targetFormat, model, body, stream = true, credentials = null, provider = null, reqLogger = null, stripList = [], connectionId = null, clientTool = null) {
   ensureInitialized();

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -88,23 +88,39 @@ function filterUnsupportedTools(body, targetFormat) {
   }
 }
 
-// Fix orphaned tool messages: remove tool messages that don't have preceding assistant with matching tool_calls
+// Fix orphaned tool messages: remove tool messages that don't have preceding assistant with matching tool_calls.
+// DeepSeek also requires tool messages to immediately follow their assistant with no non-tool messages in between.
 function fixOrphanedToolMessages(body) {
   if (!body.messages || !Array.isArray(body.messages)) return;
-  const validCallIds = new Set();
-  for (const msg of body.messages) {
-    if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
-      for (const tc of msg.tool_calls) {
-        if (tc.id) validCallIds.add(tc.id);
+
+  // First pass: mark tool messages that have a valid assistant with matching tool_call_id
+  // and no non-tool/non-assistant messages between them
+  for (let i = 0; i < body.messages.length; i++) {
+    const msg = body.messages[i];
+    if (msg.role !== "tool" || !msg.tool_call_id) continue;
+
+    let found = false;
+    // Walk backwards from the tool message to find a preceding assistant with matching tool_calls
+    for (let j = i - 1; j >= 0; j--) {
+      const prev = body.messages[j];
+      if (prev.role === "assistant" && Array.isArray(prev.tool_calls)) {
+        if (prev.tool_calls.some(tc => tc.id === msg.tool_call_id)) {
+          found = true;
+        }
+        break; // Stop at the first assistant (matching or not)
       }
+      if (prev.role !== "tool") break; // Non-tool, non-assistant blocks the chain
     }
+    if (!found) msg.invalid = true;
   }
-  for (const msg of body.messages) {
-    if (msg.role === "tool" && msg.tool_call_id && !validCallIds.has(msg.tool_call_id)) {
-      msg.invalid = true;
-    }
+
+  // Also find tool messages whose assistant has already been split by a non-tool message
+  // Re-scan: mark orphaned tool messages that follow a system/user message after an assistant
+  const removed = body.messages.filter(m => m.invalid).length;
+  if (removed > 0) {
+    body.messages = body.messages.filter(m => !m.invalid);
+    console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages`);
   }
-  body.messages = body.messages.filter(m => !m.invalid);
 }
 
 // Translate request: source -> openai -> target

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -137,10 +137,8 @@ function fixOrphanedToolMessages(body) {
 
   // Count orphaned tool messages (no matching assistant found)
   removed = Object.keys(toolMessages).length;
-  if (removed > 0 || restructured.length !== body.messages.length) {
-    body.messages = restructured;
-    if (removed > 0) console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages (no matching assistant)`);
-  }
+  body.messages = restructured;
+  if (removed > 0) console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages (no matching assistant)`);
 }
 
 // Translate request: source -> openai -> target

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -137,7 +137,9 @@ function fixOrphanedToolMessages(body) {
 
   // Count orphaned tool messages (no matching assistant found)
   removed = Object.keys(toolMessages).length;
-  body.messages = restructured;
+  // Mutate in-place to preserve array reference (SSE handlers may hold references)
+  body.messages.length = 0;
+  for (const msg of restructured) body.messages.push(msg);
   if (removed > 0) console.log(`[TRANSLATOR] Removed ${removed} orphaned tool messages (no matching assistant)`);
 }
 

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -79,12 +79,33 @@ function filterUnsupportedTools(body, targetFormat) {
   const filtered = body.tools.filter(t => !t.type || t.type === "function");
   if (filtered.length < body.tools.length) {
     body.tools = filtered;
-    // Also clean up tool_choice if it references a removed tool
     if (body.tool_choice && typeof body.tool_choice === "object" && body.tool_choice.type === "tool") {
       const name = body.tool_choice.function?.name;
       if (name && !filtered.some(t => t.function?.name === name)) {
         body.tool_choice = "auto";
       }
+    }
+  }
+}
+
+// Fix orphaned tool messages: remove tool messages that don't have preceding assistant with matching tool_calls
+function fixOrphanedToolMessages(body) {
+  if (!body.messages || !Array.isArray(body.messages)) return;
+  const validCallIds = new Set();
+  for (const msg of body.messages) {
+    if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
+      for (const tc of msg.tool_calls) {
+        if (tc.id) validCallIds.add(tc.id);
+      }
+    }
+  }
+  for (const msg of body.messages) {
+    if (msg.role === "tool" && msg.tool_call_id && !validCallIds.has(msg.tool_call_id)) {
+      msg.invalid = true;
+    }
+  }
+  body.messages = body.messages.filter(m => !m.invalid);
+}
     }
   }
 }
@@ -105,6 +126,9 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
   
   // Fix missing tool responses (insert empty tool_result if needed)
   fixMissingToolResponses(result);
+
+  // Fix orphaned tool messages (DeepSeek requires every tool message has preceding tool_calls)
+  fixOrphanedToolMessages(result);
 
   // If same format, skip translation steps
   if (sourceFormat !== targetFormat) {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -145,6 +145,10 @@ export function createSSEStream(options = {}) {
               }
             } catch { }
           }
+          else if (trimmed.startsWith("data:") && trimmed.slice(5).trim() === "[DONE]") {
+            // Upstream [DONE] — suppress, flush handler emits its own
+            continue;
+          }
 
           if (!injectedUsage) {
             if (line.startsWith("data:") && !line.startsWith("data: ")) {
@@ -279,13 +283,13 @@ export function createSSEStream(options = {}) {
             appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
           }
           
-          // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
-          // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
-          //   data: [DONE]\n\n
-          // Without it they can hang until timeout and trigger failover.
-          const doneOutput = "data: [DONE]\n\n";
-          reqLogger?.appendConvertedChunk?.(doneOutput);
-          controller.enqueue(sharedEncoder.encode(doneOutput));
+           // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
+           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
+           //   data: [DONE]\n\n
+           // Without it they can hang until timeout and trigger failover.
+           const doneOutput = "data: [DONE]\n\n";
+           reqLogger?.appendConvertedChunk?.(doneOutput);
+           controller.enqueue(sharedEncoder.encode(doneOutput));
 
           if (onStreamComplete) {
             onStreamComplete({

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -58,6 +58,7 @@ export function createSSEStream(options = {}) {
   let accumulatedContent = "";
   let accumulatedThinking = "";
   let ttftAt = null;
+  let doneSent = false;
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -172,6 +173,7 @@ export function createSSEStream(options = {}) {
         // For Ollama: done=true is the final chunk with finish_reason/usage, must translate
         // For other formats: done=true is the [DONE] sentinel, skip
         if (parsed && parsed.done && targetFormat !== FORMATS.OLLAMA) {
+          doneSent = true;
           const output = "data: [DONE]\n\n";
           reqLogger?.appendConvertedChunk?.(output);
           controller.enqueue(sharedEncoder.encode(output));
@@ -339,9 +341,11 @@ export function createSSEStream(options = {}) {
           }
         }
 
-        const doneOutput = "data: [DONE]\n\n";
-        reqLogger?.appendConvertedChunk?.(doneOutput);
-        controller.enqueue(sharedEncoder.encode(doneOutput));
+        if (!doneSent) {
+          const doneOutput = "data: [DONE]\n\n";
+          reqLogger?.appendConvertedChunk?.(doneOutput);
+          controller.enqueue(sharedEncoder.encode(doneOutput));
+        }
 
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);

--- a/src/app/api/providers/[id]/route.js
+++ b/src/app/api/providers/[id]/route.js
@@ -55,8 +55,8 @@ async function normalizeProxyPoolUpdate(proxyPoolIdInput) {
   return { hasProxyPoolField: true, proxyPoolId };
 }
 
-function shouldMergeProviderSpecificData(existing, incoming, hasLegacyProxy, hasProxyPoolField) {
-  return existing !== undefined || incoming !== undefined || hasLegacyProxy || hasProxyPoolField;
+function shouldMergeProviderSpecificData(existing, incoming, hasLegacyProxy, hasProxyPoolField, hasConvertDeveloperRole) {
+  return existing !== undefined || incoming !== undefined || hasLegacyProxy || hasProxyPoolField || hasConvertDeveloperRole;
 }
 
 // GET /api/providers/[id] - Get single connection
@@ -132,12 +132,14 @@ export async function PUT(request, { params }) {
         existing.providerSpecificData,
         providerSpecificData,
         proxyConfig.hasAnyProxyField,
-        proxyPoolResult.hasProxyPoolField
+        proxyPoolResult.hasProxyPoolField,
+        body.convertDeveloperRole !== undefined
       )
     ) {
       updateData.providerSpecificData = {
         ...(existing.providerSpecificData || {}),
         ...(providerSpecificData || {}),
+        ...(body.convertDeveloperRole !== undefined ? { convertDeveloperRole: body.convertDeveloperRole } : {}),
       };
 
       if (proxyConfig.hasAnyProxyField) {

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -23,6 +23,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
   });
   const [cloudflareData, setCloudflareData] = useState({ accountId: "" });
   const [convertDeveloperRole, setConvertDeveloperRole] = useState(false);
+  const [filterToolTypes, setFilterToolTypes] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [validating, setValidating] = useState(false);
@@ -49,6 +50,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
         setCloudflareData({ accountId: connection.providerSpecificData.accountId || "" });
       }
       setConvertDeveloperRole(!!connection.providerSpecificData?.convertDeveloperRole);
+      setFilterToolTypes(!!connection.providerSpecificData?.filterToolTypes);
       setTestResult(null);
       setValidationResult(null);
     }
@@ -158,6 +160,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
         ...(updates.providerSpecificData || {}),
         ...(connection?.providerSpecificData || {}),
         convertDeveloperRole,
+        filterToolTypes,
       };
       
       await onSave(updates);
@@ -192,19 +195,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
 
         {!isOAuth && (
           <>
-        <div className="flex items-center justify-between bg-sidebar/50 p-3 rounded-lg">
-          <div>
-            <p className="text-sm font-medium">Convert Developer Role → System</p>
-            <p className="text-xs text-text-muted">Convert `developer` role messages to `system` before sending to provider</p>
-          </div>
-          <Toggle
-            size="sm"
-            checked={convertDeveloperRole}
-            onChange={setConvertDeveloperRole}
-          />
-        </div>
-
-        <div className="flex gap-2">
+            <div className="flex gap-2">
               <Input
                 label="API Key"
                 type="password"
@@ -227,6 +218,30 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
             )}
           </>
         )}
+
+        <div className="flex items-center justify-between bg-sidebar/50 p-3 rounded-lg">
+          <div>
+            <p className="text-sm font-medium">Convert Developer Role → System</p>
+            <p className="text-xs text-text-muted">Convert `developer` role messages to `system` before sending to provider</p>
+          </div>
+          <Toggle
+            size="sm"
+            checked={convertDeveloperRole}
+            onChange={setConvertDeveloperRole}
+          />
+        </div>
+
+        <div className="flex items-center justify-between bg-sidebar/50 p-3 rounded-lg">
+          <div>
+            <p className="text-sm font-medium">Filter Unsupported Tools</p>
+            <p className="text-xs text-text-muted">Strip tool types like web_search, code_interpreter that this provider doesn't support</p>
+          </div>
+          <Toggle
+            size="sm"
+            checked={filterToolTypes}
+            onChange={setFilterToolTypes}
+          />
+        </div>
 
         {isAzure && (
           <div className="bg-sidebar/50 p-4 rounded-lg border border-accent/20">

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -6,6 +6,7 @@ import Modal from "@/shared/components/Modal";
 import Input from "@/shared/components/Input";
 import Button from "@/shared/components/Button";
 import Badge from "@/shared/components/Badge";
+import Toggle from "@/shared/components/Toggle";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 
 export default function EditConnectionModal({ isOpen, connection, proxyPools, onSave, onClose }) {
@@ -21,6 +22,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
     organization: "",
   });
   const [cloudflareData, setCloudflareData] = useState({ accountId: "" });
+  const [convertDeveloperRole, setConvertDeveloperRole] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [validating, setValidating] = useState(false);
@@ -46,6 +48,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       if (connection.provider === "cloudflare-ai" && connection.providerSpecificData) {
         setCloudflareData({ accountId: connection.providerSpecificData.accountId || "" });
       }
+      setConvertDeveloperRole(!!connection.providerSpecificData?.convertDeveloperRole);
       setTestResult(null);
       setValidationResult(null);
     }
@@ -151,6 +154,12 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
         updates.providerSpecificData = { accountId: cloudflareData.accountId };
       }
       
+      updates.providerSpecificData = {
+        ...(updates.providerSpecificData || {}),
+        ...(connection?.providerSpecificData || {}),
+        convertDeveloperRole,
+      };
+      
       await onSave(updates);
     } finally {
       setSaving(false);
@@ -183,7 +192,19 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
 
         {!isOAuth && (
           <>
-            <div className="flex gap-2">
+        <div className="flex items-center justify-between bg-sidebar/50 p-3 rounded-lg">
+          <div>
+            <p className="text-sm font-medium">Convert Developer Role → System</p>
+            <p className="text-xs text-text-muted">Convert `developer` role messages to `system` before sending to provider</p>
+          </div>
+          <Toggle
+            size="sm"
+            checked={convertDeveloperRole}
+            onChange={setConvertDeveloperRole}
+          />
+        </div>
+
+        <div className="flex gap-2">
               <Input
                 label="API Key"
                 type="password"

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -34,6 +34,15 @@ export async function handleChat(request, clientRawRequest = null) {
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
   }
 
+  // Convert Responses API format to Chat Completions format early
+  // This prevents the OPENAI_RESPONSES SSE transform pipeline that can cause ResponseAborted
+  const isResponsesApi = body.input && !body.messages;
+  if (isResponsesApi) {
+    const { convertResponsesApiFormat } = await import("open-sse/translator/helpers/responsesApiHelper.js");
+    body = convertResponsesApiFormat(body);
+    log.debug("FORMAT", "Responses API → Chat Completions (converted)");
+  }
+
   // Build clientRawRequest for logging (if not provided)
   if (!clientRawRequest) {
     const url = new URL(request.url);

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -214,6 +214,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       cavemanEnabled: !!chatSettings.cavemanEnabled,
       cavemanLevel: chatSettings.cavemanLevel || "full",
       providerThinking,
+      convertDeveloperRole: !!refreshedCredentials.providerSpecificData?.convertDeveloperRole,
       // Detect source format by endpoint + body
       sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,
       onCredentialsRefreshed: async (newCreds) => {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -39,8 +39,11 @@ export async function handleChat(request, clientRawRequest = null) {
   const isResponsesApi = body.input && !body.messages;
   if (isResponsesApi) {
     const { convertResponsesApiFormat } = await import("open-sse/translator/helpers/responsesApiHelper.js");
+    const itemTypes = (body.input || []).map(item => item.type || item.role || "?").join(",");
+    log.debug("FORMAT", `Responses API → Chat Completions | input items: [${itemTypes}]`);
     body = convertResponsesApiFormat(body);
-    log.debug("FORMAT", "Responses API → Chat Completions (converted)");
+    const msgRoles = (body.messages || []).map(m => m.role + (m.tool_calls ? `(tc:${m.tool_calls.length})` : "") + (m.tool_call_id ? `(tid:${m.tool_call_id.slice(-8)})` : "")).join(", ");
+    log.debug("FORMAT", `Responses API converted: [${msgRoles}]`);
   }
 
   // Build clientRawRequest for logging (if not provided)


### PR DESCRIPTION
## Summary

Thêm cấu hình `convertDeveloperRole` cho từng connection qua giao diện UI.
Khi bật, tự động chuyển `role: "developer"` → `role: "system"` trước khi gửi đến provider đích.

## Cách dùng

Dashboard → Providers → chọn provider → Edit connection → bật toggle
**"Convert Developer Role → System"** → Save.

## Thay đổi

### Backend
- `open-sse/config/providerModels.js` — thêm `getModelConvertDeveloperRole()` 
- `open-sse/handlers/chatCore.js` — áp dụng conversion (ưu tiên connection config, fallback model config)
- `open-sse/index.js` — export helper
- `src/sse/handlers/chat.js` — truyền flag từ credentials vào chatCore
- `src/app/api/providers/[id]/route.js` — merge `convertDeveloperRole` vào `providerSpecificData`

### Frontend
- `src/shared/components/EditConnectionModal.js` — thêm toggle UI trong modal edit connection

## Hỗ trợ format

- OpenAI (`messages[]`)
- Anthropic/Claude (`messages[]`)
- Gemini (`contents[]`)