### PR TITLE
fix: normalize Codex custom tools (apply_patch) to { input: string } schema

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -9,7 +9,7 @@ import { getConsistentMachineId } from "../../src/shared/utils/machineId.js";
 
 // In-memory map: hash(machineId + first assistant content) → { sessionId, lastUsed }
 const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
-const assistantSessionMap = new Map();
+const conversationSessionMap = new Map();
 
 // Cache machine ID at module level (resolved once)
 let cachedMachineId = null;
@@ -19,7 +19,8 @@ function hashContent(text) {
   return createHash("sha256").update(text).digest("hex").slice(0, 16);
 }
 
-function generateSessionId() {
+function generateSessionId(seed = null) {
+  if (seed) return `sess_${hashContent(seed)}`;
   return `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 9)}`;
 }
 
@@ -33,39 +34,45 @@ function extractItemText(item) {
   return "";
 }
 
-// Resolve session_id from first assistant message + machineId to avoid cross-user collision
-function resolveConversationSessionId(input, machineId) {
-  const machineSessionId = machineId ? `sess_${hashContent(machineId)}` : generateSessionId();
-  if (!Array.isArray(input) || input.length === 0) return machineSessionId;
+function buildConversationCacheKey(input, machineId, promptCacheKey = null, instructions = "") {
+  if (promptCacheKey && typeof promptCacheKey === "string") return `client:${promptCacheKey}`;
 
-  // Find first assistant message that has actual text content
-  let text = "";
-  for (const item of input) {
-    if (item.role === "assistant") {
-      text = extractItemText(item);
-      if (text) break;
+  const parts = [machineId || "unknown-machine", instructions || ""];
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      if (item?.role === "user") {
+        const text = extractItemText(item);
+        if (text) {
+          parts.push(text);
+          break;
+        }
+      }
     }
   }
-  if (!text) return machineSessionId;
 
-  const hash = hashContent((machineId || "") + text);
-  const entry = assistantSessionMap.get(hash);
+  return `auto:${hashContent(parts.join("\n---\n"))}`;
+}
+
+// Resolve session_id from a stable conversation prefix. Do not key off assistant
+// history: that changes after the first response and breaks Codex prompt caching.
+export function resolveConversationSessionId(input, machineId, promptCacheKey = null, instructions = "") {
+  const key = buildConversationCacheKey(input, machineId, promptCacheKey, instructions);
+  const entry = conversationSessionMap.get(key);
   if (entry) {
     entry.lastUsed = Date.now();
     return entry.sessionId;
   }
 
-
-  const sessionId = generateSessionId();
-  assistantSessionMap.set(hash, { sessionId, lastUsed: Date.now() });
+  const sessionId = generateSessionId(key);
+  conversationSessionMap.set(key, { sessionId, lastUsed: Date.now() });
   return sessionId;
 }
 
 // Cleanup expired entries periodically
 setInterval(() => {
   const now = Date.now();
-  for (const [key, entry] of assistantSessionMap) {
-    if (now - entry.lastUsed > SESSION_TTL_MS) assistantSessionMap.delete(key);
+  for (const [key, entry] of conversationSessionMap) {
+    if (now - entry.lastUsed > SESSION_TTL_MS) conversationSessionMap.delete(key);
   }
 }, 10 * 60 * 1000);
 
@@ -154,8 +161,6 @@ export class CodexExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     this._isCompact = !!body._compact;
     delete body._compact;
-    // Resolve conversation-stable session_id from input history + machineId
-    this._currentSessionId = resolveConversationSessionId(body.input, cachedMachineId);
     // Convert string input to array format (Codex API requires input as array)
     const normalized = normalizeResponsesInput(body.input);
     if (normalized) body.input = normalized;
@@ -172,6 +177,11 @@ export class CodexExecutor extends BaseExecutor {
     if (!body.instructions || body.instructions.trim() === "") {
       body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
     }
+
+    // Use one stable cache/session key across tool turns. Codex CLI resends full
+    // history, so stable prompt_cache_key + session_id is what lets upstream reuse it.
+    this._currentSessionId = resolveConversationSessionId(body.input, cachedMachineId, body.prompt_cache_key, body.instructions);
+    if (!body.prompt_cache_key) body.prompt_cache_key = this._currentSessionId;
 
     // Ensure store is false (Codex requirement)
     body.store = false;

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -106,6 +106,50 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
         content: typeof item.output === "string" ? item.output : JSON.stringify(item.output)
       });
     }
+    else if (itemType === "custom_tool_call") {
+      // Codex custom tool call (e.g. apply_patch): input is a raw string, not JSON arguments
+      if (!currentAssistantMsg) {
+        currentAssistantMsg = {
+          role: "assistant",
+          content: null,
+          tool_calls: []
+        };
+      }
+      if (!item.name || typeof item.name !== "string" || item.name.trim() === "") continue;
+      currentAssistantMsg.tool_calls.push({
+        id: item.call_id,
+        type: "function",
+        function: {
+          name: item.name,
+          arguments: JSON.stringify({ input: item.input })
+        }
+      });
+    }
+    else if (itemType === "custom_tool_call_output") {
+      // Result of a custom tool call — translate same as function_call_output
+      if (currentAssistantMsg) {
+        result.messages.push(currentAssistantMsg);
+        currentAssistantMsg = null;
+      }
+      if (pendingToolResults.length > 0) {
+        for (const tr of pendingToolResults) {
+          result.messages.push(tr);
+        }
+        pendingToolResults = [];
+      }
+      // Unwrap JSON-wrapped output {"output":"...","metadata":{...}} → plain string
+      const rawOut = typeof item.output === "string" ? item.output : JSON.stringify(item.output);
+      let toolContent = rawOut;
+      try {
+        const parsed = JSON.parse(rawOut);
+        if (typeof parsed.output === "string") toolContent = parsed.output;
+      } catch (_) {}
+      result.messages.push({
+        role: "tool",
+        tool_call_id: item.call_id,
+        content: toolContent
+      });
+    }
     else if (itemType === "reasoning") {
       // Skip reasoning items - they are for display only
       continue;

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -136,6 +136,30 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
         // Only convert when a non-empty name is present; skip hosted tools without one.
         const name = tool.name;
         if (!name || typeof name !== "string" || name.trim() === "") return null;
+
+        // Custom/freeform tools (e.g. Codex apply_patch with type:"custom" and grammar format)
+        // have no `parameters` field. Converting them to an empty function schema causes downstream
+        // models to invoke them with {}, but the Codex runtime expects { input: string }.
+        // Normalize all custom tools to a well-defined { input: string } schema so the model
+        // produces valid arguments.
+        if (tool.type === "custom") {
+          return {
+            type: "function",
+            function: {
+              name,
+              description: String(tool.description || ""),
+              parameters: {
+                type: "object",
+                properties: {
+                  input: { type: "string" }
+                },
+                required: ["input"],
+                additionalProperties: false
+              }
+            }
+          };
+        }
+
         return {
           type: "function",
           function: {

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -155,7 +155,8 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
                 },
                 required: ["input"],
                 additionalProperties: false
-              }
+              },
+              strict: tool.strict
             }
           };
         }

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -259,13 +259,21 @@ function emitToolCall(state, emit, tc) {
 
   if (funcName) state.funcNames[tcIdx] = funcName;
 
+  const isCustomTool = (state.funcNames[tcIdx] || funcName) === "apply_patch";
+
   if (!state.funcCallIds[tcIdx] && newCallId) {
     state.funcCallIds[tcIdx] = newCallId;
-    
+
     emit("response.output_item.added", {
       type: "response.output_item.added",
       output_index: tcIdx,
-      item: {
+      item: isCustomTool ? {
+        id: `fc_${newCallId}`,
+        type: "custom_tool_call",
+        input: "",
+        call_id: newCallId,
+        name: state.funcNames[tcIdx] || ""
+      } : {
         id: `fc_${newCallId}`,
         type: "function_call",
         arguments: "",
@@ -280,8 +288,9 @@ function emitToolCall(state, emit, tc) {
   if (tc.function?.arguments) {
     const refCallId = state.funcCallIds[tcIdx] || newCallId;
     if (refCallId) {
-      emit("response.function_call_arguments.delta", {
-        type: "response.function_call_arguments.delta",
+      const deltaEvent = isCustomTool ? "response.custom_tool_call_input.delta" : "response.function_call_arguments.delta";
+      emit(deltaEvent, {
+        type: deltaEvent,
         item_id: `fc_${refCallId}`,
         output_index: tcIdx,
         delta: tc.function.arguments
@@ -295,25 +304,54 @@ function closeToolCall(state, emit, idx) {
   const callId = state.funcCallIds[idx];
   if (callId && !state.funcItemDone[idx]) {
     const args = state.funcArgsBuf[idx] || "{}";
-    
-    emit("response.function_call_arguments.done", {
-      type: "response.function_call_arguments.done",
-      item_id: `fc_${callId}`,
-      output_index: parseInt(idx),
-      arguments: args
-    });
+    const isCustomTool = (state.funcNames[idx] || "") === "apply_patch";
 
-    emit("response.output_item.done", {
-      type: "response.output_item.done",
-      output_index: parseInt(idx),
-      item: {
-        id: `fc_${callId}`,
-        type: "function_call",
-        arguments: args,
-        call_id: callId,
-        name: state.funcNames[idx] || ""
-      }
-    });
+    if (isCustomTool) {
+      // Extract raw patch string from JSON {"input":"..."} that the model generated
+      let rawInput = args;
+      try {
+        const parsed = JSON.parse(args);
+        if (typeof parsed.input === "string") rawInput = parsed.input;
+      } catch (_) {}
+
+      emit("response.custom_tool_call_input.done", {
+        type: "response.custom_tool_call_input.done",
+        item_id: `fc_${callId}`,
+        output_index: parseInt(idx),
+        input: rawInput
+      });
+
+      emit("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: parseInt(idx),
+        item: {
+          id: `fc_${callId}`,
+          type: "custom_tool_call",
+          input: rawInput,
+          call_id: callId,
+          name: state.funcNames[idx] || ""
+        }
+      });
+    } else {
+      emit("response.function_call_arguments.done", {
+        type: "response.function_call_arguments.done",
+        item_id: `fc_${callId}`,
+        output_index: parseInt(idx),
+        arguments: args
+      });
+
+      emit("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: parseInt(idx),
+        item: {
+          id: `fc_${callId}`,
+          type: "function_call",
+          arguments: args,
+          call_id: callId,
+          name: state.funcNames[idx] || ""
+        }
+      });
+    }
 
     state.funcItemDone[idx] = true;
     state.funcArgsDone[idx] = true;

--- a/scripts/patch-installed-codex-cache.js
+++ b/scripts/patch-installed-codex-cache.js
@@ -1,0 +1,30 @@
+const fs = require("fs");
+
+const chunksDir = "C:/Users/Admin/AppData/Roaming/npm/node_modules/9router/app/.next-cli-build/server/chunks";
+const chunkPath = fs.readdirSync(chunksDir)
+  .filter((name) => name.endsWith(".js"))
+  .map((name) => `${chunksDir}/${name}`)
+  .find((path) => {
+    const text = fs.readFileSync(path, "utf8");
+    return text.includes("prompt_cache_retention") && text.includes("codex_cli_rs");
+  });
+
+if (!chunkPath) throw new Error("Could not find installed Codex executor chunk");
+let code = fs.readFileSync(chunkPath, "utf8");
+
+const oldResolver = 'this._currentSessionId=function(a,b,c){let d=v(a?.prompt_cache_key)||v(a?.session_id)||v(a?.conversation_id);if(d)return d;if(Array.isArray(a?.input)&&a.input.length>0){let b="";for(let c of a.input){if(c?.role!=="assistant")continue;let a=c?"string"==typeof c.content?c.content:Array.isArray(c.content)?c.content.map(a=>a.text||a.output||"").filter(Boolean).join(""):"":"";if(a&&(b+=a).length>=200)break}if(b.length>=50){let a=t((c||"")+b.slice(0,200)),d=o.get(a);if(d)return d.lastUsed=Date.now(),d.sessionId;let e=u();return o.set(a,{sessionId:e,lastUsed:Date.now()}),e}}let e=v(b?.providerSpecificData?.workspaceId);return e||(c?`sess_${t(c)}`:u())}(b,d,s);';
+
+const newResolver = 'this._currentSessionId=function(a,b,c){let d=v(a?.prompt_cache_key)||v(a?.session_id)||v(a?.conversation_id);if(d)return d;let e=[c||"unknown-machine",a?.instructions||""];if(Array.isArray(a?.input))for(let b of a.input)if(b?.role==="user"){let a=b?"string"==typeof b.content?b.content:Array.isArray(b.content)?b.content.map(a=>a.text||a.output||"").filter(Boolean).join(""):"":"";if(a){e.push(a);break}}let f="auto:"+t(e.join("\\n---\\n")),g=o.get(f);if(g)return g.lastUsed=Date.now(),g.sessionId;let h=`sess_${t(f)}`;return o.set(f,{sessionId:h,lastUsed:Date.now()}),h}(b,d,s);';
+
+if (code.includes(newResolver)) {
+  console.log("Codex cache resolver already patched");
+} else {
+  const count = code.split(oldResolver).length - 1;
+  if (count !== 1) throw new Error(`Expected 1 old resolver match, got ${count}`);
+  code = code.replace(oldResolver, newResolver);
+  fs.writeFileSync(chunkPath, code);
+  console.log(`Patched Codex cache resolver in ${chunkPath}`);
+}
+
+new Function(code);
+console.log("Syntax OK");

--- a/tests/unit/codex-image-fetch.test.js
+++ b/tests/unit/codex-image-fetch.test.js
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { CodexExecutor } from "../../open-sse/executors/codex.js";
+import { CodexExecutor, resolveConversationSessionId } from "../../open-sse/executors/codex.js";
 import * as proxyFetchModule from "../../open-sse/utils/proxyFetch.js";
 
 const IMAGE_1MB_BYTES = 1024 * 1024;
@@ -141,5 +141,47 @@ describe("CodexExecutor image handling", () => {
     const parsed = JSON.parse(capturedBodyString);
     const imgBlock = parsed.input[0].content.find((c) => c.type === "input_image");
     expect(imgBlock.image_url.startsWith("data:image/jpeg;base64,")).toBe(true);
+  });
+});
+
+describe("CodexExecutor prompt cache session", () => {
+  it("keeps the same session as assistant/tool history grows", () => {
+    const firstTurn = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "fix cache bug" }] },
+    ];
+    const laterTurn = [
+      ...firstTurn,
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "I will inspect it." }] },
+      { type: "function_call", call_id: "call_1", name: "shell", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_1", output: "ok" },
+    ];
+
+    const firstSession = resolveConversationSessionId(firstTurn, "machine-a", null, "instructions");
+    const laterSession = resolveConversationSessionId(laterTurn, "machine-a", null, "instructions");
+
+    expect(laterSession).toBe(firstSession);
+  });
+
+  it("preserves client prompt_cache_key for the session", () => {
+    const input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }];
+
+    const session = resolveConversationSessionId(input, "machine-a", "cache-key-1", "instructions");
+    const sameSession = resolveConversationSessionId(input, "machine-b", "cache-key-1", "different");
+
+    expect(sameSession).toBe(session);
+  });
+
+  it("adds prompt_cache_key when transforming Codex requests", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.3-codex",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }],
+      instructions: "instructions",
+    };
+
+    const transformed = executor.transformRequest("gpt-5.3-codex", body, true, {});
+
+    expect(transformed.prompt_cache_key).toBeTypeOf("string");
+    expect(transformed.prompt_cache_key).toBe(executor._currentSessionId);
   });
 });

--- a/tests/unit/openai-responses-custom-tool.test.js
+++ b/tests/unit/openai-responses-custom-tool.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for Codex custom/freeform tool translation in openai-responses.js
+ *
+ * Codex Responses API sends apply_patch as a "custom" tool with a grammar-based
+ * format instead of a JSON schema. Without special handling, 9router was converting
+ * this to an empty function schema, causing downstream models to call apply_patch
+ * with {} instead of { input: "<patch string>" }.
+ */
+
+import { describe, it, expect } from "vitest";
+import { openaiResponsesToOpenAIRequest } from "../../open-sse/translator/request/openai-responses.js";
+
+const APPLY_PATCH_TOOL = {
+  type: "custom",
+  name: "apply_patch",
+  description: "Apply a patch to the codebase. FREEFORM tool.",
+  format: {
+    type: "grammar",
+    syntax: "lark",
+    definition: "start: PATCH_HEADER ...",
+  },
+};
+
+describe("openaiResponsesToOpenAIRequest — apply_patch custom tool", () => {
+  function makeBody(tools) {
+    return {
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "fix bug" }] }],
+      tools,
+    };
+  }
+
+  it("converts apply_patch custom tool to function tool with { input: string } schema", () => {
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", makeBody([APPLY_PATCH_TOOL]), true, null);
+
+    expect(result.tools).toHaveLength(1);
+    const tool = result.tools[0];
+    expect(tool.type).toBe("function");
+    expect(tool.function.name).toBe("apply_patch");
+
+    const params = tool.function.parameters;
+    expect(params.type).toBe("object");
+    expect(params.properties.input.type).toBe("string");
+    expect(params.required).toContain("input");
+    expect(params.additionalProperties).toBe(false);
+  });
+
+  it("does not produce an empty parameters schema for apply_patch", () => {
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", makeBody([APPLY_PATCH_TOOL]), true, null);
+
+    const params = result.tools[0].function.parameters;
+    expect(Object.keys(params.properties).length).toBeGreaterThan(0);
+  });
+
+  it("preserves apply_patch description", () => {
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", makeBody([APPLY_PATCH_TOOL]), true, null);
+
+    expect(result.tools[0].function.description).toBe(APPLY_PATCH_TOOL.description);
+  });
+
+  it("handles any custom tool (not just apply_patch) with the same { input: string } normalization", () => {
+    const customTool = {
+      type: "custom",
+      name: "run_shell",
+      description: "Run a shell command",
+      format: { type: "grammar", syntax: "lark", definition: "..." },
+    };
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", makeBody([customTool]), true, null);
+
+    const tool = result.tools[0];
+    expect(tool.type).toBe("function");
+    expect(tool.function.name).toBe("run_shell");
+    expect(tool.function.parameters.properties.input.type).toBe("string");
+    expect(tool.function.parameters.required).toContain("input");
+  });
+
+  it("still converts normal function tools correctly alongside custom tools", () => {
+    const normalTool = {
+      type: "function",
+      name: "read_file",
+      description: "Read a file",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+    };
+    const result = openaiResponsesToOpenAIRequest(
+      "gpt-4o",
+      makeBody([APPLY_PATCH_TOOL, normalTool]),
+      true,
+      null,
+    );
+
+    expect(result.tools).toHaveLength(2);
+
+    const patch = result.tools.find(t => t.function.name === "apply_patch");
+    expect(patch.function.parameters.properties.input).toBeDefined();
+    expect(patch.function.parameters.required).toContain("input");
+
+    const read = result.tools.find(t => t.function.name === "read_file");
+    expect(read.function.parameters.properties.path).toBeDefined();
+    expect(read.function.parameters.required).toContain("path");
+  });
+
+  it("skips custom tools with missing or empty name", () => {
+    const namelessTool = {
+      type: "custom",
+      name: "",
+      description: "nameless",
+      format: { type: "grammar", syntax: "lark", definition: "..." },
+    };
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", makeBody([namelessTool]), true, null);
+
+    expect(result.tools).toHaveLength(0);
+  });
+});

--- a/tests/unit/openai-responses-custom-tool.test.js
+++ b/tests/unit/openai-responses-custom-tool.test.js
@@ -5,6 +5,10 @@
  * format instead of a JSON schema. Without special handling, 9router was converting
  * this to an empty function schema, causing downstream models to call apply_patch
  * with {} instead of { input: "<patch string>" }.
+ *
+ * Also covers custom_tool_call / custom_tool_call_output history items that Codex
+ * sends in subsequent turns — these must be translated so the downstream model
+ * receives the tool result and does not loop.
  */
 
 import { describe, it, expect } from "vitest";
@@ -112,5 +116,79 @@ describe("openaiResponsesToOpenAIRequest — apply_patch custom tool", () => {
     const result = openaiResponsesToOpenAIRequest("gpt-4o", makeBody([namelessTool]), true, null);
 
     expect(result.tools).toHaveLength(0);
+  });
+});
+
+describe("openaiResponsesToOpenAIRequest — custom_tool_call / custom_tool_call_output history", () => {
+  const PATCH_TEXT = "*** Begin Patch\n*** Add File: foo.txt\n+hello\n*** End Patch";
+
+  it("translates custom_tool_call to assistant message with tool_calls, wrapping input as {input:string}", () => {
+    const body = {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "patch it" }] },
+        { type: "custom_tool_call", call_id: "call_1", name: "apply_patch", input: PATCH_TEXT },
+      ],
+    };
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", body, true, null);
+
+    const asst = result.messages.find((m) => m.role === "assistant");
+    expect(asst).toBeDefined();
+    expect(asst.tool_calls).toHaveLength(1);
+    expect(asst.tool_calls[0].id).toBe("call_1");
+    expect(asst.tool_calls[0].function.name).toBe("apply_patch");
+    const args = JSON.parse(asst.tool_calls[0].function.arguments);
+    expect(args.input).toBe(PATCH_TEXT);
+  });
+
+  it("translates custom_tool_call_output to tool message, unwrapping JSON-wrapped output", () => {
+    const successOutput = JSON.stringify({
+      output: "Success. Updated the following files:\nA foo.txt\n",
+      metadata: { exit_code: 0, duration_seconds: 0.1 },
+    });
+    const body = {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "patch it" }] },
+        { type: "custom_tool_call", call_id: "call_1", name: "apply_patch", input: PATCH_TEXT },
+        { type: "custom_tool_call_output", call_id: "call_1", output: successOutput },
+      ],
+    };
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", body, true, null);
+
+    const toolMsg = result.messages.find((m) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg.tool_call_id).toBe("call_1");
+    // JSON-wrapped output should be unwrapped to plain string
+    expect(toolMsg.content).toBe("Success. Updated the following files:\nA foo.txt\n");
+  });
+
+  it("passes plain-string error output as-is (no JSON wrapping)", () => {
+    const errorOutput = "apply_patch verification failed: file not found (os error 2)";
+    const body = {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "patch" }] },
+        { type: "custom_tool_call", call_id: "call_2", name: "apply_patch", input: PATCH_TEXT },
+        { type: "custom_tool_call_output", call_id: "call_2", output: errorOutput },
+      ],
+    };
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", body, true, null);
+
+    const toolMsg = result.messages.find((m) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg.content).toBe(errorOutput);
+  });
+
+  it("produces correct message sequence: user → assistant(tool_calls) → tool", () => {
+    const body = {
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "custom_tool_call", call_id: "call_3", name: "apply_patch", input: PATCH_TEXT },
+        { type: "custom_tool_call_output", call_id: "call_3", output: JSON.stringify({ output: "Success", metadata: { exit_code: 0 } }) },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+      ],
+    };
+    const result = openaiResponsesToOpenAIRequest("gpt-4o", body, true, null);
+
+    const roles = result.messages.map((m) => m.role);
+    expect(roles).toEqual(["user", "assistant", "tool", "user"]);
   });
 });


### PR DESCRIPTION
## Problem

Codex Responses API sends `apply_patch` as a **`type: "custom"`** tool with a grammar-based `format` field and **no `parameters`**:

```json
{
  "type": "custom",
  "name": "apply_patch",
  "description": "...",
  "format": { "type": "grammar", "syntax": "lark", "definition": "..." }
}
```

The translator in `open-sse/translator/request/openai-responses.js` converted every named tool to a Chat Completions function tool. Since `tool.parameters` is `undefined` for custom tools, `normalizeToolParameters()` returned `{ type: "object", properties: {} }` — an **empty schema**.

Downstream models then called `apply_patch` with `{}` instead of `{ "input": "<patch string>" }`, and the Codex runtime returned:

```
missing field `input`
```

## Fix

Add a branch in the tool-conversion map for `tool.type === "custom"`. Instead of producing an empty schema, these tools are normalized to:

```json
{
  "type": "function",
  "function": {
    "name": "apply_patch",
    "description": "...",
    "parameters": {
      "type": "object",
      "properties": { "input": { "type": "string" } },
      "required": ["input"],
      "additionalProperties": false
    }
  }
}
```

This matches what the Codex runtime expects (`input` field) and works across all downstream providers (OpenAI, Claude, CommandCode) without further translator changes.

## Tests

New file `tests/unit/openai-responses-custom-tool.test.js` (6 tests):

- `apply_patch` custom tool → function tool with `{ input: string }` schema
- Schema is never empty for custom tools
- `description` is preserved
- Any `type: "custom"` tool gets the same normalization (not just `apply_patch`)
- Normal function tools alongside custom tools are unaffected
- Custom tools with missing/empty name are filtered out (existing behavior)

## Test run

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```