### PR TITLE
fix: normalize developer role to system for OpenAI-format providers

### DIFF
--- a/open-sse/translator/helpers/openaiHelper.js
+++ b/open-sse/translator/helpers/openaiHelper.js
@@ -10,6 +10,9 @@ export function filterToOpenAIFormat(body) {
   if (!body.messages || !Array.isArray(body.messages)) return body;
   
   body.messages = body.messages.map(msg => {
+    // Normalize developer role to system (many providers don't support developer)
+    if (msg.role === "developer") msg = { ...msg, role: "system" };
+    
     // Keep tool messages as-is (OpenAI format)
     if (msg.role === "tool") return msg;
     


### PR DESCRIPTION
## Problem
Deepseek API rejects messages with `role: "developer"` — only accepts `system`, `user`, `assistant`, `tool`, `latest_reminder`. Issue #773.

## Root Cause
`filterToOpenAIFormat()` in `open-sse/translator/helpers/openaiHelper.js` normalizes content blocks but never touches message roles. When `sourceFormat === targetFormat
 === "openai"`, translator skips format conversion and only calls `filterToOpenAIFormat()` — leaving `developer` role intact all the way to Deepseek.

Other executors (perplexity-web, grok-web) already handle this with `if (role === "developer") role = "system"`, but Deepseek uses `DefaultExecutor` which has no role
 normalization.

## Fix
One line in `filterToOpenAIFormat()` — normalize `developer` → `system` before role-specific logic. This fixes the issue for all OpenAI-format providers (Deepseek, Groq,
 Mistral, Perplexity, Together, Fireworks, Cerebras, xAI, NVIDIA, etc.).

Closes #773
