### PR TITLE
fix: respect PORT env in internal model-test fetch

### DIFF
--- a/src/app/api/models/test/route.js
+++ b/src/app/api/models/test/route.js
@@ -8,7 +8,7 @@ export async function POST(request) {
     const { model, kind } = await request.json();
     if (!model) return NextResponse.json({ error: "Model required" }, { status: 400 });
 
-    const baseUrl = `http://127.0.0.1:${UPDATER_CONFIG.appPort}`;
+    const baseUrl = `http://127.0.0.1:${process.env.PORT || UPDATER_CONFIG.appPort}`;
 
     // Get an active internal API key for auth (if requireApiKey is enabled)
     let apiKey = null;

--- a/src/app/api/providers/[id]/test-models/route.js
+++ b/src/app/api/providers/[id]/test-models/route.js
@@ -65,7 +65,7 @@ export async function POST(request, { params }) {
 
     let models = getProviderModels(alias);
 
-    const baseUrl = `http://127.0.0.1:${UPDATER_CONFIG.appPort}`;
+    const baseUrl = `http://127.0.0.1:${process.env.PORT || UPDATER_CONFIG.appPort}`;
 
     // Compatible providers: fetch live model list
     if (isCompatible && models.length === 0) {


### PR DESCRIPTION
### Bug

Internal model-test routes hard-code port `20128` and ignore `process.env.PORT`. When the app is started with a different port (e.g. `PORT=20129`), Next.js listens on `PORT` but the internal `fetch` still targets `127.0.0.1:20128`, so the call lands on nothing (or a different service) and the endpoint returns `{"ok":false,"error":"fetch failed"}`.

### Affected files

- `src/app/api/models/test/route.js:11`
- `src/app/api/providers/[id]/test-models/route.js:68`

Both build `baseUrl` from `UPDATER_CONFIG.appPort` (hard-coded `20128` in `src/shared/constants/config.js:31`) instead of the actual listening port.

```js
const baseUrl = `http://127.0.0.1:${UPDATER_CONFIG.appPort}`;
```

### Reproduce

1. Set `PORT=20129` in `.env` (or any value ≠ 20128).
2. Start the app (`pm2 start npm --name 9router -- start`) — confirms listening on `:20129`.
3. Call:
   ```bash
   curl -X POST http://127.0.0.1:20129/api/models/test \
     -H 'Content-Type: application/json' \
     -H 'Cookie: auth_token=...' \
     --data-raw '{"model":"kr/claude-sonnet-4.5"}'
   ```
4. Response: `HTTP 500 {"ok":false,"error":"fetch failed"}`.

`ss -tlnp` shows nothing listening on `:20128`; the app is only on `:20129`.

### Expected

The internal fetch should target whichever port the app is actually listening on.

### Fix

Fall back to `UPDATER_CONFIG.appPort` only when `process.env.PORT` is unset:

```js
const baseUrl = `http://127.0.0.1:${process.env.PORT || UPDATER_CONFIG.appPort}`;
```

Applied to both routes above.

### Environment

- 9router master (`7ad538b`)
- Node v24.15.0, pm2 fork mode, `NODE_ENV=production`
- `.env`: `PORT=20129`
