### PR TITLE
feat(ui): add Done button to ModelSelectModal in combo creation

### DIFF
--- a/src/shared/components/ComboFormModal.js
+++ b/src/shared/components/ComboFormModal.js
@@ -86,6 +86,9 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
   const handleAddModel = (model) => {
     if (!models.includes(model.value)) setModels([...models, model.value]);
   };
+  const handleDeselectModel = (model) => {
+    setModels(models.filter((m) => m !== model.value));
+  };
   const handleRemoveModel = (i) => setModels(models.filter((_, idx) => idx !== i));
   const handleMoveUp = (i) => {
     if (i === 0) return;
@@ -164,8 +167,10 @@ export default function ComboFormModal({ isOpen, combo, onClose, onSave, activeP
       </Modal>
 
       <ModelSelectModal isOpen={showModelSelect} onClose={() => setShowModelSelect(false)}
-        onSelect={handleAddModel} activeProviders={activeProviders} modelAliases={modelAliases}
-        title="Add Model to Combo" kindFilter={kindFilter} />
+        onSelect={handleAddModel} onDeselect={handleDeselectModel}
+        activeProviders={activeProviders} modelAliases={modelAliases}
+        title="Add Model to Combo" kindFilter={kindFilter}
+        addedModelValues={models} closeOnSelect={false} />
     </>
   );
 }

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -3,6 +3,7 @@
 import { useState, useMemo, useEffect } from "react";
 import PropTypes from "prop-types";
 import Modal from "./Modal";
+import Button from "./Button";
 import { getModelsByProviderId } from "@/shared/constants/models";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, AI_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, getProviderAlias } from "@/shared/constants/providers";
 
@@ -370,6 +371,19 @@ export default function ModelSelectModal({
       title={title}
       size="md"
       className="p-4!"
+      footer={
+        !closeOnSelect ? (
+          <Button
+            onClick={() => {
+              onClose();
+              setSearchQuery("");
+            }}
+            fullWidth
+          >
+            Done
+          </Button>
+        ) : null
+      }
     >
       {/* Search - compact */}
       <div className="mb-3">


### PR DESCRIPTION
## Problem
When adding models to a combo, the ModelSelectModal has no clear way to confirm selections. Users can only close the modal by clicking the X button or clicking outside, which is confusing — especially when adding multiple models.
## Solution
- Add a "Done" button in the modal footer when `closeOnSelect={false}` (multi-select mode)
- Pass `closeOnSelect={false}` and `addedModelValues` to ModelSelectModal in ComboFormModal
- Add `onDeselect` handler so users can click a selected model to remove it
- Preserves existing single-select behavior (auto-close on selection) for other usages
## Changes
- `src/shared/components/ModelSelectModal.js`: Import Button, add conditional footer with "Done" button
- `src/shared/components/ComboFormModal.js`: Add deselect handler, pass `closeOnSelect={false}`, `addedModelValues`, and `onDeselect` props
## User Experience
**Before:** 
<img width="537" height="669" alt="before" src="https://github.com/user-attachments/assets/94d50b60-ab5b-4ff3-9259-2ac9c2135e87" />
**After (dark theme):**
<img width="517" height="727" alt="after (dark theme)" src="https://github.com/user-attachments/assets/9e8e5f07-30b5-445f-a8cb-a4bd5606d17b" />
**After (light theme):**
<img width="604" height="764" alt="after (light theme)" src="https://github.com/user-attachments/assets/0b37577c-9da6-49cb-801e-92a1654dbb01" />
## Testing
- ✅ Combo creation: Can add/remove multiple models, "Done" button closes modal
- ✅ Keyboard: Escape key still closes modal
- ✅ Mobile: Done button is full-width and tappable