### PR TITLE
Fix Docker Node.js runtime error caused by outputFileTracingRoot change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV DATA_DIR=/app/data
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/standalone/app ./
 COPY --from=builder /app/open-sse ./open-sse
 # Next file tracing can omit sibling files; MITM runs server.js as a separate process.
 COPY --from=builder /app/src/mitm ./src/mitm


### PR DESCRIPTION
### Background

A previous adjustment changed `outputFileTracingRoot` in `next.config.mjs` 

from `projectRoot` to `monorepoRoot` in order to allow standalone build 

to trace dependencies across the monorepo.

### Problem

After this change, the 9router Docker image fails to start with Node.js v22.22.2.

The error is:

```
node:internal/modules/cjs/loader:1386
throw err;
^

Error: Cannot find module ‘/app/server.js’
at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15)
at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19)
at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22)
at Function._load (node:internal/modules/cjs/loader:1192:37)
at TracingChannel.traceSync (node:diagnostics_channel:328:14)
at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
at Function.executeUserEntryPoint [as runMain] (node:internal/main/run_main_module:171:5)
at node:internal/main/run_main_module:36:49 {
code: ‘MODULE_NOT_FOUND’,
requireStack: []
}
```