### PR TITLE
fix: Next standalone Docker start path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV DATA_DIR=/app/data
 
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/public ./app/public
+COPY --from=builder /app/.next/static ./app/.next/static
 COPY --from=builder /app/open-sse ./open-sse
 # Next file tracing can omit sibling files; MITM runs server.js as a separate process.
 COPY --from=builder /app/src/mitm ./src/mitm
@@ -47,4 +47,4 @@ RUN apk --no-cache upgrade && apk --no-cache add su-exec && \
 EXPOSE 20128
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["node", "server.js"]
+CMD ["node", "app/server.js"]


### PR DESCRIPTION
## Summary
- update the Docker runtime command to start Next's standalone server from `app/server.js`
- copy `public` and `.next/static` into the nested `app/` directory expected by the standalone output

## Root Cause
After the Next/Dokploy upgrade, the standalone build output placed `server.js` under `/app/app/server.js`, while the image still ran `node server.js` from `/app`. The container exited with `MODULE_NOT_FOUND`, which made Traefik return 502 for the Dokploy route.

## Validation
- rebuilt the Docker image successfully with `docker build -t 9router-p79yfv:latest /etc/dokploy/applications/9router-p79yfv/code`
- redeployed the Dokploy swarm service and verified the container stayed running
- checked `https://9router.hydrogendioxide.net/api/health` returned `{"ok":true}` through Traefik
