### PR TITLE
Add upstream model sync for providers

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/SyncProviderModelsModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/SyncProviderModelsModal.js
@@ -1,0 +1,253 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button, Modal } from "@/shared/components";
+
+function normalizeModel(item) {
+  if (!item) return null;
+  if (typeof item === "string") return { id: item, name: item };
+  const id = item.id || item.modelId || item.model || item.name;
+  if (!id) return null;
+  return {
+    id,
+    name: item.name || item.modelName || item.displayName || id,
+    description: item.description || "",
+    maxInputTokens: item.maxInputTokens || item.contextLength || item.contextWindow || 0,
+  };
+}
+
+function defaultAlias(modelId, passthroughModels) {
+  return passthroughModels ? modelId.split("/").pop() : modelId;
+}
+
+export default function SyncProviderModelsModal({
+  isOpen,
+  connections,
+  existingModelIds,
+  providerDisplayAlias,
+  passthroughModels,
+  onAddModels,
+  onClose,
+}) {
+  const activeConnections = useMemo(
+    () => connections.filter((conn) => conn.isActive !== false),
+    [connections]
+  );
+  const [connectionId, setConnectionId] = useState("");
+  const [models, setModels] = useState([]);
+  const [selected, setSelected] = useState({});
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [warning, setWarning] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setConnectionId(activeConnections[0]?.id || "");
+    setModels([]);
+    setSelected({});
+    setQuery("");
+    setError("");
+    setWarning("");
+  }, [activeConnections, isOpen]);
+
+  const fetchModels = async (id = connectionId) => {
+    if (!id || loading) return;
+    setLoading(true);
+    setError("");
+    setWarning("");
+    try {
+      const res = await fetch(`/api/providers/${id}/models`, { cache: "no-store" });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || `HTTP ${res.status}`);
+        return;
+      }
+      const nextModels = (data.models || []).map(normalizeModel).filter(Boolean);
+      setModels(nextModels);
+      setSelected({});
+      setWarning(data.warning || "");
+      if (nextModels.length === 0 && !data.warning) setWarning("Upstream returned an empty model list.");
+    } catch (err) {
+      setError(err.message || "Failed to sync models");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen && connectionId) fetchModels(connectionId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, connectionId]);
+
+  const existingSet = useMemo(() => new Set(existingModelIds), [existingModelIds]);
+  const filteredModels = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return models;
+    return models.filter((model) =>
+      [model.id, model.name, model.description].some((value) =>
+        String(value || "").toLowerCase().includes(term)
+      )
+    );
+  }, [models, query]);
+
+  const selectedModels = useMemo(
+    () => models.filter((model) => selected[model.id] && !existingSet.has(model.id)),
+    [existingSet, models, selected]
+  );
+
+  const toggleModel = (modelId) => {
+    if (existingSet.has(modelId)) return;
+    setSelected((prev) => ({ ...prev, [modelId]: !prev[modelId] }));
+  };
+
+  const selectAllVisible = () => {
+    const next = { ...selected };
+    filteredModels.forEach((model) => {
+      if (!existingSet.has(model.id)) next[model.id] = true;
+    });
+    setSelected(next);
+  };
+
+  const clearSelection = () => setSelected({});
+
+  const handleAdd = async () => {
+    if (selectedModels.length === 0 || saving) return;
+    setSaving(true);
+    setError("");
+    try {
+      await onAddModels(selectedModels.map((model) => ({
+        id: model.id,
+        alias: defaultAlias(model.id, passthroughModels),
+      })));
+      onClose();
+    } catch (err) {
+      setError(err.message || "Failed to add selected models");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Sync Upstream Models" size="full">
+      <div className="flex max-h-[72vh] flex-col gap-4">
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+          <div>
+            <label className="mb-1 block text-xs text-text-muted">Connection</label>
+            <select
+              value={connectionId}
+              onChange={(event) => setConnectionId(event.target.value)}
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none"
+            >
+              {activeConnections.map((conn) => (
+                <option key={conn.id} value={conn.id}>
+                  {conn.name || conn.email || conn.id}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button
+            size="sm"
+            variant="secondary"
+            icon="sync"
+            loading={loading}
+            onClick={() => fetchModels()}
+            disabled={!connectionId || loading}
+          >
+            {loading ? "Syncing..." : "Refresh"}
+          </Button>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center">
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search model id or name"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none"
+          />
+          <Button size="sm" variant="ghost" icon="done_all" onClick={selectAllVisible} disabled={filteredModels.length === 0}>
+            Select Visible
+          </Button>
+          <Button size="sm" variant="ghost" icon="close" onClick={clearSelection} disabled={selectedModels.length === 0}>
+            Clear
+          </Button>
+        </div>
+
+        {error && <p className="break-words rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-500">{error}</p>}
+        {warning && !error && <p className="break-words rounded-lg border border-yellow-500/20 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-600 dark:text-yellow-400">{warning}</p>}
+
+        <div className="min-h-[220px] overflow-y-auto rounded-lg border border-border">
+          {loading ? (
+            <div className="flex h-56 items-center justify-center text-sm text-text-muted">
+              <span className="material-symbols-outlined mr-2 animate-spin text-[18px]">progress_activity</span>
+              Syncing upstream models...
+            </div>
+          ) : filteredModels.length === 0 ? (
+            <div className="flex h-56 items-center justify-center text-sm text-text-muted">
+              No upstream models to show.
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              {filteredModels.map((model) => {
+                const exists = existingSet.has(model.id);
+                const checked = !!selected[model.id] && !exists;
+                return (
+                  <button
+                    key={model.id}
+                    type="button"
+                    onClick={() => toggleModel(model.id)}
+                    disabled={exists}
+                    className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-3 py-2.5 text-left transition-colors hover:bg-sidebar/60 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <span className={`flex h-5 w-5 items-center justify-center rounded border text-[13px] ${checked ? "border-primary bg-primary text-white" : "border-border text-transparent"}`}>
+                      <span className="material-symbols-outlined text-[14px]">check</span>
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm font-medium text-text-main">{model.id}</span>
+                      <span className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-xs text-text-muted">
+                        <span className="truncate">{model.name}</span>
+                        {model.maxInputTokens > 0 && <span>{Math.round(model.maxInputTokens / 1000)}K ctx</span>}
+                      </span>
+                    </span>
+                    <span className="rounded bg-sidebar px-1.5 py-0.5 font-mono text-[11px] text-text-muted">
+                      {exists ? "added" : `${providerDisplayAlias}/${model.id}`}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col-reverse gap-2 border-t border-border-subtle pt-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-text-muted">
+            {models.length} upstream model{models.length === 1 ? "" : "s"} · {selectedModels.length} selected
+          </p>
+          <div className="grid grid-cols-2 gap-2 sm:flex">
+            <Button size="sm" variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
+            <Button size="sm" icon="add" onClick={handleAdd} loading={saving} disabled={selectedModels.length === 0 || saving}>
+              {saving ? "Adding..." : "Add Selected"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+SyncProviderModelsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  connections: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+    email: PropTypes.string,
+    isActive: PropTypes.bool,
+  })).isRequired,
+  existingModelIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+  providerDisplayAlias: PropTypes.string.isRequired,
+  passthroughModels: PropTypes.bool,
+  onAddModels: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/app/(dashboard)/dashboard/providers/[id]/SyncProviderModelsModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/SyncProviderModelsModal.js
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
 import { Button, Modal } from "@/shared/components";
 
 function normalizeModel(item) {

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -16,6 +16,7 @@ import ConnectionRow from "./ConnectionRow";
 import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
+import SyncProviderModelsModal from "./SyncProviderModelsModal";
 
 export default function ProviderDetailPage() {
   const params = useParams();
@@ -39,6 +40,7 @@ export default function ProviderDetailPage() {
   const [modelsTestError, setModelsTestError] = useState("");
   const [testingModelId, setTestingModelId] = useState(null);
   const [showAddCustomModel, setShowAddCustomModel] = useState(false);
+  const [showSyncModels, setShowSyncModels] = useState(false);
   const [selectedConnectionIds, setSelectedConnectionIds] = useState([]);
   const [bulkProxyPoolId, setBulkProxyPoolId] = useState("__none__");
   const [bulkUpdatingProxy, setBulkUpdatingProxy] = useState(false);
@@ -342,6 +344,39 @@ export default function ProviderDetailPage() {
     } catch (error) {
       console.log("Error deleting alias:", error);
     }
+  };
+
+  const resolveAvailableAlias = (preferredAlias, usedAliases) => {
+    const cleanAlias = preferredAlias || "model";
+    if (!usedAliases.has(cleanAlias)) return cleanAlias;
+    const prefixed = `${providerDisplayAlias}-${cleanAlias}`;
+    if (!usedAliases.has(prefixed)) return prefixed;
+    let index = 2;
+    while (usedAliases.has(`${prefixed}-${index}`)) index += 1;
+    return `${prefixed}-${index}`;
+  };
+
+  const handleAddSyncedModels = async (items) => {
+    const usedAliases = new Set(Object.keys(modelAliases));
+    const usedModels = new Set(Object.values(modelAliases));
+
+    for (const item of items) {
+      if (!item?.id) continue;
+      const fullModel = `${providerStorageAlias}/${item.id}`;
+      if (usedModels.has(fullModel)) continue;
+      const alias = resolveAvailableAlias(item.alias || item.id, usedAliases);
+      const res = await fetch("/api/models/alias", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: fullModel, alias }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || `Failed to add ${item.id}`);
+      usedAliases.add(alias);
+      usedModels.add(fullModel);
+    }
+
+    await fetchAliases();
   };
 
   const handleDelete = async (id) => {
@@ -705,7 +740,7 @@ export default function ProviderDetailPage() {
         // Only show if not already in hardcoded list
         // For passthroughModels, include all aliases (model IDs may contain slashes like "anthropic/claude-3")
         if (providerInfo.passthroughModels) return !models.some((m) => m.id === modelId);
-        return !models.some((m) => m.id === modelId) && alias === modelId;
+        return !models.some((m) => m.id === modelId);
       })
       .map(([alias, fullModel]) => ({
         id: fullModel.slice(`${providerStorageAlias}/`.length),
@@ -766,6 +801,16 @@ export default function ProviderDetailPage() {
         >
           <span className="material-symbols-outlined text-sm">add</span>
           Add Model
+        </button>
+
+        <button
+          onClick={() => setShowSyncModels(true)}
+          disabled={!connections.some((conn) => conn.isActive !== false)}
+          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-blue-500/40 px-3 py-2 text-xs text-blue-600 transition-colors hover:border-blue-500 hover:bg-blue-500/5 disabled:cursor-not-allowed disabled:opacity-50 dark:text-blue-400 sm:w-auto"
+          title={connections.some((conn) => conn.isActive !== false) ? "Sync models from upstream" : "Add an active connection before syncing"}
+        >
+          <span className="material-symbols-outlined text-sm">sync</span>
+          Sync Models
         </button>
 
         {/* Suggested models from provider API — show only models not yet added */}
@@ -1132,6 +1177,11 @@ export default function ProviderDetailPage() {
             const activeIds = allIds.filter((id) => !disabledModelIds.includes(id));
             return (
               <div className="flex gap-2">
+                {connections.some((conn) => conn.isActive !== false) && (
+                  <Button size="sm" variant="secondary" icon="sync" onClick={() => setShowSyncModels(true)}>
+                    Sync Models
+                  </Button>
+                )}
                 {disabledModelIds.length > 0 && (
                   <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll}>
                     Active All
@@ -1251,6 +1301,23 @@ export default function ProviderDetailPage() {
         message={confirmState?.message}
         variant="danger"
       />
+      {!isCompatible && (
+        <SyncProviderModelsModal
+          isOpen={showSyncModels}
+          connections={connections}
+          existingModelIds={[
+            ...models.map((model) => model.id),
+            ...kiloFreeModels.map((model) => model.id),
+            ...Object.values(modelAliases)
+              .filter((fullModel) => fullModel.startsWith(`${providerStorageAlias}/`))
+              .map((fullModel) => fullModel.slice(`${providerStorageAlias}/`.length)),
+          ]}
+          providerDisplayAlias={providerDisplayAlias}
+          passthroughModels={!!providerInfo.passthroughModels}
+          onAddModels={handleAddSyncedModels}
+          onClose={() => setShowSyncModels(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -297,7 +297,7 @@ export async function GET(request, { params }) {
         const accessToken = connection.accessToken;
         const refreshToken = connection.refreshToken;
 
-        if (accessToken && profileArn) {
+        if (accessToken) {
           try {
             const models = await kiroService.listAvailableModels(accessToken, profileArn);
             return NextResponse.json({
@@ -317,7 +317,8 @@ export async function GET(request, { params }) {
                   expiresIn: refreshed.expiresIn,
                 });
 
-                const models = await kiroService.listAvailableModels(refreshed.accessToken, profileArn);
+                const refreshedProfileArn = refreshed.profileArn || profileArn;
+                const models = await kiroService.listAvailableModels(refreshed.accessToken, refreshedProfileArn);
                 return NextResponse.json({
                   provider: connection.provider,
                   connectionId: connection.id,

--- a/src/lib/oauth/services/kiro.js
+++ b/src/lib/oauth/services/kiro.js
@@ -259,6 +259,12 @@ export class KiroService {
   async listAvailableModels(accessToken, profileArn) {
     const endpoint = "https://codewhisperer.us-east-1.amazonaws.com";
     const target = "AmazonCodeWhispererService.ListAvailableModels";
+    const body = {
+      origin: "AI_EDITOR",
+    };
+    if (profileArn) {
+      body.profileArn = profileArn;
+    }
 
     const response = await fetch(endpoint, {
       method: "POST",
@@ -268,10 +274,7 @@ export class KiroService {
         "Authorization": `Bearer ${accessToken}`,
         "Accept": "application/json",
       },
-      body: JSON.stringify({
-        origin: "AI_EDITOR",
-        profileArn,
-      }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {
@@ -280,14 +283,26 @@ export class KiroService {
     }
 
     const data = await response.json();
-    return (data.models || []).map(m => ({
-      id: m.modelId,
-      name: m.modelName || m.modelId,
-      description: m.description,
-      rateMultiplier: m.rateMultiplier,
-      rateUnit: m.rateUnit,
-      maxInputTokens: m.tokenLimits?.maxInputTokens || 0,
-    }));
+    const models = data.models
+      || data.availableModels
+      || data.modelSummaries
+      || data.modelMetadataList
+      || data.modelConfigurations
+      || data.items
+      || [];
+
+    return models.map(m => {
+      const id = m.modelId || m.id || m.model || m.name;
+      if (!id) return null;
+      return {
+        id,
+        name: m.modelName || m.displayName || m.name || id,
+        description: m.description,
+        rateMultiplier: m.rateMultiplier,
+        rateUnit: m.rateUnit,
+        maxInputTokens: m.tokenLimits?.maxInputTokens || m.maxInputTokens || m.contextLength || 0,
+      };
+    }).filter(Boolean);
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a provider detail modal to sync models from an active upstream connection
- let users search, select, and add upstream models into local model aliases
- wire Sync Models actions into the provider model management UI
- fix Kiro upstream model discovery when `profileArn` is absent and accept multiple upstream list response shapes

## Files in this PR
- `src/app/(dashboard)/dashboard/providers/[id]/SyncProviderModelsModal.js`
- `src/app/(dashboard)/dashboard/providers/[id]/page.js`
- `src/app/api/providers/[id]/models/route.js`
- `src/lib/oauth/services/kiro.js`

## Verification
- `git diff --check`
- verified deployed fix on Fly: Kiro Account 5 `/api/providers/{id}/models` returned 9 upstream models instead of an empty list