### PR TITLE
feat(CLI Tools): add jcode integration with auto-configuration

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/CLIToolsPageClient.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/CLIToolsPageClient.js
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Card, CardSkeleton } from "@/shared/components";
 import { CLI_TOOLS } from "@/shared/constants/cliTools";
 import { getModelsByProviderId, PROVIDER_ID_TO_ALIAS } from "@/shared/constants/models";
-import { ClaudeToolCard, CodexToolCard, DroidToolCard, OpenClawToolCard, HermesToolCard, DefaultToolCard, OpenCodeToolCard, CoworkToolCard, CopilotToolCard, ClineToolCard, KiloToolCard, MitmLinkCard } from "./components";
+import { ClaudeToolCard, CodexToolCard, DroidToolCard, OpenClawToolCard, HermesToolCard, DefaultToolCard, OpenCodeToolCard, CoworkToolCard, CopilotToolCard, ClineToolCard, KiloToolCard, JcodeToolCard, MitmLinkCard } from "./components";
 import { MITM_TOOLS } from "@/shared/constants/cliTools";
 
 const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL;
@@ -194,6 +194,8 @@ export default function CLIToolsPageClient({ machineId }) {
         return <ClineToolCard key={toolId} {...commonProps} activeProviders={getActiveProviders()} cloudEnabled={cloudEnabled} initialStatus={toolStatuses.cline} />;
       case "kilo":
         return <KiloToolCard key={toolId} {...commonProps} activeProviders={getActiveProviders()} cloudEnabled={cloudEnabled} initialStatus={toolStatuses.kilo} />;
+      case "jcode":
+        return <JcodeToolCard key={toolId} {...commonProps} activeProviders={getActiveProviders()} hasActiveProviders={hasActiveProviders} cloudEnabled={cloudEnabled} initialStatus={toolStatuses.jcode} />;
       default:
         return <DefaultToolCard key={toolId} toolId={toolId} {...commonProps} activeProviders={getActiveProviders()} cloudEnabled={cloudEnabled} tunnelEnabled={tunnelEnabled} />;
     }

--- a/src/app/(dashboard)/dashboard/cli-tools/components/JcodeToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/JcodeToolCard.js
@@ -1,0 +1,380 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Card, Button, ModelSelectModal, ManualConfigModal } from "@/shared/components";
+import Image from "next/image";
+import BaseUrlSelect from "./BaseUrlSelect";
+import ApiKeySelect from "./ApiKeySelect";
+import { matchKnownEndpoint } from "./cliEndpointMatch";
+
+export default function JcodeToolCard({
+  tool,
+  isExpanded,
+  onToggle,
+  baseUrl,
+  hasActiveProviders,
+  apiKeys,
+  activeProviders,
+  cloudEnabled,
+  initialStatus,
+  tunnelEnabled,
+  tunnelPublicUrl,
+  tailscaleEnabled,
+  tailscaleUrl,
+}) {
+  const [jcodeStatus, setJcodeStatus] = useState(initialStatus || null);
+  const [checkingJcode, setCheckingJcode] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+  const [message, setMessage] = useState(null);
+  const [selectedApiKey, setSelectedApiKey] = useState("");
+  const [selectedModel, setSelectedModel] = useState("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modelAliases, setModelAliases] = useState({});
+  const [showManualConfigModal, setShowManualConfigModal] = useState(false);
+  const [customBaseUrl, setCustomBaseUrl] = useState("");
+  const hasInitializedModel = useRef(false);
+
+  const getConfigStatus = () => {
+    if (!jcodeStatus?.installed) return null;
+    if (!jcodeStatus?.has9Router) return "not_configured";
+    const currentProvider = jcodeStatus.config?.providers?.["9router"];
+    if (!currentProvider) return "not_configured";
+    return matchKnownEndpoint(currentProvider.base_url, { tunnelPublicUrl, tailscaleUrl }) ? "configured" : "other";
+  };
+
+  const configStatus = getConfigStatus();
+
+  useEffect(() => {
+    if (apiKeys?.length > 0 && !selectedApiKey) {
+      setSelectedApiKey(apiKeys[0].key);
+    }
+  }, [apiKeys, selectedApiKey]);
+
+  useEffect(() => {
+    if (initialStatus) setJcodeStatus(initialStatus);
+  }, [initialStatus]);
+
+  useEffect(() => {
+    if (isExpanded && !jcodeStatus) {
+      checkJcodeStatus();
+      fetchModelAliases();
+    }
+    if (isExpanded) fetchModelAliases();
+  }, [isExpanded]);
+
+  const fetchModelAliases = async () => {
+    try {
+      const res = await fetch("/api/models/alias");
+      const data = await res.json();
+      if (res.ok) setModelAliases(data.aliases || {});
+    } catch (error) {
+      console.log("Error fetching model aliases:", error);
+    }
+  };
+
+  useEffect(() => {
+    if (jcodeStatus?.installed && !hasInitializedModel.current) {
+      hasInitializedModel.current = true;
+      const provider = jcodeStatus.config?.providers?.["9router"];
+      if (provider) {
+        if (provider.default_model) {
+          setSelectedModel(provider.default_model);
+        }
+        // Try to match API key from env file
+        const envApiKey = jcodeStatus.envApiKey;
+        if (envApiKey && apiKeys?.some(k => k.key === envApiKey)) {
+          setSelectedApiKey(envApiKey);
+        }
+      }
+    }
+  }, [jcodeStatus, apiKeys]);
+
+  const checkJcodeStatus = async () => {
+    setCheckingJcode(true);
+    try {
+      const res = await fetch("/api/cli-tools/jcode-settings");
+      const data = await res.json();
+      setJcodeStatus(data);
+    } catch (error) {
+      setJcodeStatus({ installed: false, error: error.message });
+    } finally {
+      setCheckingJcode(false);
+    }
+  };
+
+  const normalizeLocalhost = (url) => url.replace("://localhost", "://127.0.0.1");
+
+  const getLocalBaseUrl = () => {
+    if (typeof window !== "undefined") {
+      return normalizeLocalhost(window.location.origin);
+    }
+    return "http://127.0.0.1:20128";
+  };
+
+  const getEffectiveBaseUrl = () => {
+    const url = customBaseUrl || getLocalBaseUrl();
+    return url.endsWith("/v1") ? url : `${url}/v1`;
+  };
+
+  const getDisplayUrl = () => {
+    const url = customBaseUrl || getLocalBaseUrl();
+    return url.endsWith("/v1") ? url : `${url}/v1`;
+  };
+
+  const handleApplySettings = async () => {
+    setApplying(true);
+    setMessage(null);
+    try {
+      const keyToUse = selectedApiKey?.trim()
+        || (apiKeys?.length > 0 ? apiKeys[0].key : null)
+        || (!cloudEnabled ? "sk_9router" : null);
+
+      const res = await fetch("/api/cli-tools/jcode-settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          baseUrl: getEffectiveBaseUrl(),
+          apiKey: keyToUse,
+          models: selectedModel ? [selectedModel] : [],
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setMessage({ type: "success", text: "Settings applied successfully!" });
+        checkJcodeStatus();
+      } else {
+        setMessage({ type: "error", text: data.error || "Failed to apply settings" });
+      }
+    } catch (error) {
+      setMessage({ type: "error", text: error.message });
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const handleResetSettings = async () => {
+    setRestoring(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/cli-tools/jcode-settings", { method: "DELETE" });
+      const data = await res.json();
+      if (res.ok) {
+        setMessage({ type: "success", text: "Settings reset successfully!" });
+        setSelectedModel("");
+        setSelectedApiKey("");
+        checkJcodeStatus();
+      } else {
+        setMessage({ type: "error", text: data.error || "Failed to reset settings" });
+      }
+    } catch (error) {
+      setMessage({ type: "error", text: error.message });
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  const handleModelSelect = (model) => {
+    setSelectedModel(model.value);
+    setModalOpen(false);
+  };
+
+  const getManualConfigs = () => {
+    const keyToUse = (selectedApiKey && selectedApiKey.trim())
+      ? selectedApiKey
+      : (!cloudEnabled ? "sk_9router" : "<API_KEY_FROM_DASHBOARD>");
+
+    const configToml = `[providers.9router]
+type = "openai-compatible"
+base_url = "${getEffectiveBaseUrl()}"
+auth = "bearer"
+api_key_env = "JCODE_9ROUTER_API_KEY"
+env_file = "provider-9router.env"
+default_model = "${selectedModel || "cc/claude-opus-4-7"}"
+requires_api_key = true
+
+[[providers.9router.models]]
+id = "${selectedModel || "cc/claude-opus-4-7"}"`;
+
+    const envContent = `JCODE_9ROUTER_API_KEY="${keyToUse}"`;
+
+    return [
+      {
+        filename: "~/.jcode/config.toml",
+        content: configToml,
+      },
+      {
+        filename: "~/.config/jcode/provider-9router.env",
+        content: envContent,
+      },
+    ];
+  };
+
+  return (
+    <Card padding="xs" className="overflow-hidden">
+      <div className="flex items-start justify-between gap-3 hover:cursor-pointer sm:items-center" onClick={onToggle}>
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="size-8 flex items-center justify-center shrink-0">
+            <span className="material-symbols-outlined text-[32px]" style={{ color: tool.color }}>terminal</span>
+          </div>
+          <div className="min-w-0">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h3 className="font-medium text-sm">{tool.name}</h3>
+              {configStatus === "configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 rounded-full">Connected</span>}
+              {configStatus === "not_configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 rounded-full">Not configured</span>}
+              {configStatus === "other" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 rounded-full">Other</span>}
+            </div>
+            <p className="text-xs text-text-muted truncate">{tool.description}</p>
+          </div>
+        </div>
+        <span className={`material-symbols-outlined text-text-muted text-[20px] transition-transform ${isExpanded ? "rotate-180" : ""}`}>expand_more</span>
+      </div>
+
+      {isExpanded && (
+        <div className="mt-4 pt-4 border-t border-border flex flex-col gap-4">
+          {checkingJcode && (
+            <div className="flex items-center gap-2 text-text-muted">
+              <span className="material-symbols-outlined animate-spin">progress_activity</span>
+              <span>Checking jcode CLI...</span>
+            </div>
+          )}
+
+          {!checkingJcode && jcodeStatus && !jcodeStatus.installed && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-3 p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+                <div className="flex items-start gap-3">
+                  <span className="material-symbols-outlined text-yellow-500">warning</span>
+                  <div className="flex-1">
+                    <p className="font-medium text-yellow-600 dark:text-yellow-400">jcode CLI not detected locally</p>
+                    <p className="text-sm text-text-muted mt-1">Install jcode to enable automatic configuration:</p>
+                    <code className="block mt-2 p-2 bg-black/20 rounded text-xs font-mono">
+                      curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash
+                    </code>
+                    <p className="text-sm text-text-muted mt-2">Manual configuration is still available if 9router is deployed on a remote server.</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 pl-9">
+                  <Button variant="secondary" size="sm" onClick={() => setShowManualConfigModal(true)} className="!bg-yellow-500/20 !border-yellow-500/40 !text-yellow-700 dark:!text-yellow-300 hover:!bg-yellow-500/30">
+                    <span className="material-symbols-outlined text-[18px] mr-1">content_copy</span>
+                    Manual Config
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {!checkingJcode && jcodeStatus?.installed && (
+            <>
+              <div className="flex flex-col gap-2">
+                {/* Info notes */}
+                {tool.notes && tool.notes.length > 0 && (
+                  <div className="flex flex-col gap-2 mb-2">
+                    {tool.notes.map((note, idx) => (
+                      <div key={idx} className={`flex items-start gap-2 p-2 rounded text-xs ${
+                        note.type === "info" ? "bg-blue-500/10 text-blue-600 dark:text-blue-400" :
+                        note.type === "warning" ? "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400" :
+                        "bg-gray-500/10 text-text-muted"
+                      }`}>
+                        <span className="material-symbols-outlined text-[14px] mt-0.5">
+                          {note.type === "info" ? "info" : note.type === "warning" ? "warning" : "help"}
+                        </span>
+                        <span>{note.text}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Endpoint (selector) */}
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Select Endpoint</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <BaseUrlSelect
+                    value={customBaseUrl || getDisplayUrl()}
+                    onChange={setCustomBaseUrl}
+                    requiresExternalUrl={tool.requiresExternalUrl}
+                    tunnelEnabled={tunnelEnabled}
+                    tunnelPublicUrl={tunnelPublicUrl}
+                    tailscaleEnabled={tailscaleEnabled}
+                    tailscaleUrl={tailscaleUrl}
+                  />
+                </div>
+
+                {/* Current configured */}
+                {jcodeStatus?.config?.providers?.["9router"]?.base_url && (
+                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                    <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Current</span>
+                    <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                    <span className="min-w-0 truncate rounded bg-surface/40 px-2 py-2 text-xs text-text-muted sm:py-1.5">
+                      {jcodeStatus.config.providers["9router"].base_url}
+                    </span>
+                  </div>
+                )}
+
+                {/* API Key */}
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">API Key</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <ApiKeySelect value={selectedApiKey} onChange={setSelectedApiKey} apiKeys={apiKeys} cloudEnabled={cloudEnabled} />
+                </div>
+
+                {/* Default Model */}
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Default Model</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <div className="relative w-full min-w-0">
+                    <input type="text" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)} placeholder="cc/claude-opus-4-7" className="w-full min-w-0 pl-2 pr-7 py-2 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5" />
+                    {selectedModel && <button onClick={() => setSelectedModel("")} className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 text-text-muted hover:text-red-500 rounded transition-colors" title="Clear"><span className="material-symbols-outlined text-[14px]">close</span></button>}
+                  </div>
+                  <button onClick={() => setModalOpen(true)} disabled={!hasActiveProviders} className={`w-full sm:w-auto rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 whitespace-nowrap sm:shrink-0 ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>Select</button>
+                </div>
+
+                {/* Usage hint */}
+                <div className="flex flex-col gap-1 p-3 bg-blue-500/5 border border-blue-500/20 rounded-lg">
+                  <p className="text-xs font-medium text-blue-600 dark:text-blue-400">Usage:</p>
+                  <code className="text-xs font-mono text-text-muted">jcode --provider-profile 9router</code>
+                  <code className="text-xs font-mono text-text-muted">jcode --provider-profile 9router --model {selectedModel || "cc/claude-opus-4-7"}</code>
+                </div>
+              </div>
+
+              {message && (
+                <div className={`flex items-center gap-2 px-2 py-1.5 rounded text-xs ${message.type === "success" ? "bg-green-500/10 text-green-600" : "bg-red-500/10 text-red-600"}`}>
+                  <span className="material-symbols-outlined text-[14px]">{message.type === "success" ? "check_circle" : "error"}</span>
+                  <span>{message.text}</span>
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center">
+                <Button variant="primary" size="sm" onClick={handleApplySettings} disabled={!selectedModel} loading={applying}>
+                  <span className="material-symbols-outlined text-[14px] mr-1">save</span>Apply
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleResetSettings} disabled={!jcodeStatus?.has9Router} loading={restoring}>
+                  <span className="material-symbols-outlined text-[14px] mr-1">restore</span>Reset
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>
+                  <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>Manual Config
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <ModelSelectModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSelect={handleModelSelect}
+        selectedModel={selectedModel}
+        activeProviders={activeProviders}
+        modelAliases={modelAliases}
+        title="Select Model for jcode"
+      />
+
+      <ManualConfigModal
+        isOpen={showManualConfigModal}
+        onClose={() => setShowManualConfigModal(false)}
+        title="jcode - Manual Configuration"
+        configs={getManualConfigs()}
+      />
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/cli-tools/components/index.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/index.js
@@ -10,6 +10,7 @@ export { default as CoworkToolCard } from "./CoworkToolCard";
 export { default as CopilotToolCard } from "./CopilotToolCard";
 export { default as ClineToolCard } from "./ClineToolCard";
 export { default as KiloToolCard } from "./KiloToolCard";
+export { default as JcodeToolCard } from "./JcodeToolCard";
 export { default as MitmServerCard } from "./MitmServerCard";
 export { default as MitmToolCard } from "./MitmToolCard";
 export { default as MitmLinkCard } from "./MitmLinkCard";

--- a/src/app/api/cli-tools/all-statuses/route.js
+++ b/src/app/api/cli-tools/all-statuses/route.js
@@ -11,6 +11,7 @@ import { GET as coworkGet } from "../cowork-settings/route";
 import { GET as copilotGet } from "../copilot-settings/route";
 import { GET as clineGet } from "../cline-settings/route";
 import { GET as kiloGet } from "../kilo-settings/route";
+import { GET as jcodeGet } from "../jcode-settings/route";
 
 const STATUS_GETTERS = {
   claude: claudeGet,
@@ -23,6 +24,7 @@ const STATUS_GETTERS = {
   copilot: copilotGet,
   cline: clineGet,
   kilo: kiloGet,
+  jcode: jcodeGet,
 };
 
 // Batch endpoint: gather all CLI tool statuses in one round-trip

--- a/src/app/api/cli-tools/jcode-settings/route.js
+++ b/src/app/api/cli-tools/jcode-settings/route.js
@@ -1,0 +1,216 @@
+"use server";
+
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { parseTOML, stringifyTOML } from "confbox";
+
+const execAsync = promisify(exec);
+
+const getJcodeConfigDir = () => path.join(os.homedir(), ".jcode");
+const getConfigPath = () => path.join(getJcodeConfigDir(), "config.toml");
+
+const getProviderEnvPath = () => {
+  const configDir = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  return path.join(configDir, "jcode", "provider-9router.env");
+};
+
+const checkJcodeInstalled = async () => {
+  try {
+    const isWindows = os.platform() === "win32";
+    const command = isWindows ? "where jcode" : "which jcode";
+    await execAsync(command, { windowsHide: true });
+    return true;
+  } catch {
+    try {
+      await fs.access(getJcodeConfigDir());
+      return true;
+    } catch {
+      return false;
+    }
+  }
+};
+
+const readConfig = async () => {
+  try {
+    const configPath = getConfigPath();
+    const content = await fs.readFile(configPath, "utf-8");
+    return parseTOML(content);
+  } catch (error) {
+    return { providers: {} };
+  }
+};
+
+const has9RouterConfig = (config) => {
+  if (!config || !config.providers) return false;
+
+  const providers = config.providers;
+
+  if (providers["9router"]) return true;
+
+  for (const [name, provider] of Object.entries(providers)) {
+    if (provider.base_url && provider.base_url.includes("localhost:20128")) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const writeConfig = async (config) => {
+  const configPath = getConfigPath();
+  const content = stringifyTOML(config);
+  await fs.writeFile(configPath, content, "utf-8");
+};
+
+const readProviderEnv = async () => {
+  try {
+    const envPath = getProviderEnvPath();
+    const content = await fs.readFile(envPath, "utf-8");
+    const env = {};
+
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      const eqIndex = trimmed.indexOf("=");
+      if (eqIndex > 0) {
+        const key = trimmed.slice(0, eqIndex).trim();
+        let value = trimmed.slice(eqIndex + 1).trim();
+
+        if ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+
+        env[key] = value;
+      }
+    }
+
+    return env;
+  } catch {
+    return {};
+  }
+};
+
+const writeProviderEnv = async (env) => {
+  const envPath = getProviderEnvPath();
+  let content = "# jcode provider environment variables\n";
+
+  for (const [key, value] of Object.entries(env)) {
+    content += `${key}="${value}"\n`;
+  }
+
+  await fs.writeFile(envPath, content, "utf-8");
+};
+
+export async function GET() {
+  const isInstalled = await checkJcodeInstalled();
+
+  if (!isInstalled) {
+    return NextResponse.json({
+      installed: false,
+      message: "jcode not installed. Install via: curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash",
+    });
+  }
+
+  const config = await readConfig();
+  const has9Router = has9RouterConfig(config);
+
+  return NextResponse.json({
+    installed: true,
+    config,
+    has9Router,
+    configPath: getConfigPath(),
+  });
+}
+
+export async function POST(request) {
+  try {
+    const { baseUrl, apiKey, models } = await request.json();
+
+    if (!baseUrl || !apiKey) {
+      return NextResponse.json(
+        { error: "baseUrl and apiKey are required" },
+        { status: 400 }
+      );
+    }
+
+    const normalizedBaseUrl = baseUrl.endsWith("/v1")
+      ? baseUrl
+      : `${baseUrl}/v1`;
+
+    let config = await readConfig();
+
+    if (!config.providers) {
+      config.providers = {};
+    }
+
+    config.providers["9router"] = {
+      type: "openai-compatible",
+      base_url: normalizedBaseUrl,
+      auth: "bearer",
+      api_key_env: "JCODE_9ROUTER_API_KEY",
+      env_file: "provider-9router.env",
+      default_model: models && models.length > 0 ? models[0] : "cc/claude-opus-4-7",
+      requires_api_key: true,
+    };
+
+    const configDir = getJcodeConfigDir();
+    await fs.mkdir(configDir, { recursive: true });
+
+    await writeConfig(config);
+
+    const xdgConfigDir = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+    const jcodeConfigDir = path.join(xdgConfigDir, "jcode");
+    await fs.mkdir(jcodeConfigDir, { recursive: true });
+
+    const env = await readProviderEnv();
+    env.JCODE_9ROUTER_API_KEY = apiKey;
+    await writeProviderEnv(env);
+
+    return NextResponse.json({
+      success: true,
+      message: "jcode configured successfully. Use: jcode --provider-profile 9router",
+      configPath: getConfigPath(),
+    });
+  } catch (error) {
+    console.error("Error configuring jcode:", error);
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE() {
+  try {
+    const config = await readConfig();
+
+    if (!config.providers) {
+      return NextResponse.json({ success: true, message: "No configuration to remove" });
+    }
+
+    delete config.providers["9router"];
+
+    await writeConfig(config);
+
+    const env = await readProviderEnv();
+    delete env.JCODE_9ROUTER_API_KEY;
+    await writeProviderEnv(env);
+
+    return NextResponse.json({
+      success: true,
+      message: "9router configuration removed from jcode",
+    });
+  } catch (error) {
+    console.error("Error removing jcode configuration:", error);
+    return NextResponse.json(
+      { error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -294,6 +294,35 @@ amp --model "{{model}}"
 }`,
     },
   },
+  jcode: {
+    id: "jcode",
+    name: "jcode",
+    icon: "terminal",
+    color: "#FF6B35",
+    description: "High-performance Rust-based coding agent harness",
+    configType: "custom",
+    docsUrl: "https://github.com/1jehuang/jcode",
+    notes: [
+      {
+        type: "info",
+        text: "jcode is a Rust-based coding agent with semantic memory, multi-agent swarms, and extreme performance (27.8 MB RAM, 14ms boot)."
+      },
+      {
+        type: "info",
+        text: "Configure 9router as an OpenAI-compatible provider to route all jcode requests through 9router's optimization layer."
+      },
+      {
+        type: "warning",
+        text: "Requires jcode installed. Install via: curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash"
+      },
+    ],
+    defaultModels: [
+      { id: "claude-opus-4-7", name: "Claude Opus 4.7", alias: "opus", defaultValue: "cc/claude-opus-4-7" },
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", alias: "sonnet", defaultValue: "cc/claude-sonnet-4-6" },
+      { id: "gpt-5.5", name: "GPT 5.5", alias: "gpt5", defaultValue: "cx/gpt-5.5" },
+      { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro", alias: "gemini", defaultValue: "gemini/gemini-3.1-pro" },
+    ],
+  },
   // HIDDEN: gemini-cli
   // "gemini-cli": {
   //   id: "gemini-cli",


### PR DESCRIPTION
Add full jcode CLI tool support with automatic configuration management:
- New JcodeToolCard component with model selection and endpoint config
- API routes for reading/writing ~/.jcode/config.toml and provider env files
- Support for both automatic and manual configuration workflows
- Integration with existing provider and API key management

jcode is a Rust-based coding agent harness that can now route through 9router.

jcode in CLI Tools section
<img width="1850" height="932" alt="image" src="https://github.com/user-attachments/assets/55de4fdf-ffef-4329-9f83-63d1bee47536" />

jcode using 9router
<img width="735" height="475" alt="image" src="https://github.com/user-attachments/assets/30411f43-076c-479c-8221-43a31607ecea" />
