### PR TITLE
Fix: support OpenAI's max_completion_tokens parameter (model testing)

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -12,6 +12,11 @@ export class DefaultExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body) {
+    // OpenAI API now requires max_completion_tokens instead of max_tokens
+    if (this.provider === "openai" && body.max_tokens !== undefined) {
+      body = { ...body, max_completion_tokens: body.max_tokens };
+      delete body.max_tokens;
+    }
     return injectReasoningContent({ provider: this.provider, model, body });
   }
 

--- a/src/app/api/models/test/route.js
+++ b/src/app/api/models/test/route.js
@@ -52,9 +52,9 @@ export async function POST(request) {
       headers,
       body: JSON.stringify({
         model,
-        max_tokens: 1,
+        max_tokens: 10,
         stream: false,
-        messages: [{ role: "user", content: "hi" }],
+        messages: [{ role: "user", content: "ping" }],
       }),
       signal: AbortSignal.timeout(15000),
     });
@@ -63,7 +63,9 @@ export async function POST(request) {
     const rawText = await res.text().catch(() => "");
     let parsed = null;
     try {
-      parsed = rawText ? JSON.parse(rawText) : null;
+      // Strip SSE markers (data: [DONE]) if present
+      const cleanText = rawText.replace(/\ndata: \[DONE\]\s*$/, "").trim();
+      parsed = cleanText ? JSON.parse(cleanText) : null;
     } catch {}
 
     if (!res.ok) {
@@ -108,8 +110,16 @@ export async function POST(request) {
       });
     }
 
-    return NextResponse.json({ ok: true, latencyMs, error: null, status: res.status });
+    return NextResponse.json({
+      ok: true,
+      latencyMs,
+      error: null,
+      status: res.status,
+    });
   } catch (err) {
-    return NextResponse.json({ ok: false, error: err.message }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: err.message },
+      { status: 500 },
+    );
   }
 }


### PR DESCRIPTION



OpenAI API recently changed their parameter format, now requiring max_completion_tokens instead of max_tokens for chat completions. This was causing HTTP 400 errors when testing OpenAI models via the UI test button.

Changes:
- Add parameter transformation in DefaultExecutor for OpenAI provider to convert max_tokens → max_completion_tokens before sending requests
- Increase test endpoint token limit from 1 to 10 tokens to allow models to avoid 'Could not finish the message because max_tokens or model output limit was reached. Please try again with higher max_tokens' error
- Strip SSE markers (data: [DONE]) from responses before JSON parsing to fix parsing errors when OpenAI forces streaming but client expects JSON
- Improve test prompt from hi to ping for more predictable responses

Before:
<img width="1353" height="971" alt="2026-05-12-151134_hyprshot" src="https://github.com/user-attachments/assets/c49e2ee6-168c-43a8-ac9b-f2d53e683c79" />
…el test endpoint

After:
<img width="1376" height="846" alt="2026-05-12-150947_hyprshot" src="https://github.com/user-attachments/assets/b98b53c3-c57d-478a-b149-7e87616d76ff" />

This fix ensures that:
1. OpenAI model tests work correctly in the UI
2. Requests appear in Usage/Recent Requests as expected
3. The parameter transformation only applies to official OpenAI provider, not OpenAI-compatible providers