### PR TITLE
Fix zoom controls contrast in topology view

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
@@ -304,7 +304,7 @@ export default function ProviderTopology({ providers = [], activeRequests = [], 
           nodesConnectable={false}
           elementsSelectable={false}
         >
-          <Controls showInteractive={false} />
+          <Controls showInteractive={false} className="react-flow-controls-custom" />
         </ReactFlow>
       )}
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -427,6 +427,30 @@ button {
   opacity: 0.04;
 }
 
+/* React Flow controls: match app theme */
+.react-flow-controls-custom {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+
+.react-flow-controls-custom button {
+  background: var(--color-surface);
+  color: var(--color-text-main);
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.react-flow-controls-custom button:last-child {
+  border-bottom: 0;
+}
+
+.react-flow-controls-custom button:hover {
+  background: var(--color-bg-alt);
+}
+
 /* Changelog markdown body */
 .changelog-body h1 {
   font-size: 1.4rem;


### PR DESCRIPTION
## Description
Fix zoom controls contrast in provider topology view. Controls now match app theme (light/dark mode) instead of default white background.

## Changes
- Add custom class to ReactFlow Controls component
- Add theme-aware CSS styling for zoom buttons (background, border, text colors)

## Before/After
- Before: White zoom controls with poor contrast
- After: Controls use app surface/border/text colors, readable in both themes

<img width="668" height="480" alt="image" src="https://github.com/user-attachments/assets/4670a62f-c8a0-4ee2-9937-b6ec5f866baf" />
