### PR TITLE
Fix build docker file bị lỗi.

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,7 @@ const nextConfig = {
   turbopack: {
     root: projectRoot
   },
-  outputFileTracingRoot: monorepoRoot,
+  outputFileTracingRoot: projectRoot,
   outputFileTracingExcludes: {
     "*": ["./app/gitbook/**/*", "./gitbook/**/*"]
   },


### PR DESCRIPTION
Docker file sử dụng monorepoRoot dẫn tới bị lỗi.
node:internal/modules/cjs/loader:1386 throw err; ^ Error: Cannot find module '/app/server.js' at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15) at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19) at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22) at Function._load (node:internal/modules/cjs/loader:1192:37) at TracingChannel.traceSync (node:diagnostics_channel:328:14) at wrapModuleLoad (node:internal/modules/cjs/loader:237:24) at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5) at node:internal/main/run_main_module:36:49 { code: 'MODULE_NOT_FOUND', requireStack: [] } Node.js v22.22.2