### PR TITLE
fix(tray): switch macOS/Linux tray to systray2 fork (fixes #1079)

### DIFF
--- a/cli/hooks/trayRuntime.js
+++ b/cli/hooks/trayRuntime.js
@@ -1,27 +1,34 @@
-// Lazy install systray for macOS/Linux into USER_DATA_DIR/runtime/node_modules.
+// Lazy install systray2 for macOS/Linux into USER_DATA_DIR/runtime/node_modules.
 // Windows uses PowerShell NotifyIcon (no binary) → no systray needed.
 // This keeps the published npm tarball free of unsigned Go binaries that
 // trigger antivirus false positives (e.g. Kaspersky flagging tray_windows.exe).
+//
+// We use the maintained `systray2` fork. The original `systray@1.0.5` package
+// bundles a 2017 x86_64 Go binary whose Mach-O headers are rejected by modern
+// dyld (macOS 14+), so the tray silently fails to register on Apple Silicon.
 const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { getRuntimeDir, getRuntimeNodeModules } = require("./sqliteRuntime");
 
-const SYSTRAY_VERSION = "1.0.5";
+const SYSTRAY_PKG = "systray2";
+const SYSTRAY_VERSION = "2.1.4";
+const LEGACY_SYSTRAY_PKG = "systray";
 
 function hasSystray() {
-  return fs.existsSync(path.join(getRuntimeNodeModules(), "systray", "package.json"));
+  return fs.existsSync(path.join(getRuntimeNodeModules(), SYSTRAY_PKG, "package.json"));
 }
 
-// Remove legacy systray from all known locations on Windows (AV false positive cleanup)
-function cleanupWindowsSystray({ silent = false } = {}) {
-  if (process.platform !== "win32") return;
-  // 1) Runtime dir: %APPDATA%\9router\runtime\node_modules\systray
-  // 2) npm global nested: <npm_prefix>\node_modules\9router\node_modules\systray
-  //    __dirname here = <npm_prefix>\node_modules\9router\hooks → up 1 = pkg root
+// Remove the legacy `systray` package from all known locations.
+// On Windows it was an AV false-positive risk; on macOS/Linux its bundled
+// binary is broken on modern OS versions.
+function cleanupLegacySystray({ silent = false } = {}) {
+  // 1) Runtime dir: ~/.9router/runtime/node_modules/systray (or %APPDATA% on Win)
+  // 2) npm global nested: <npm_prefix>/node_modules/9router/node_modules/systray
+  //    __dirname here = <pkg root>/hooks → up 1 = pkg root
   const targets = [
-    path.join(getRuntimeNodeModules(), "systray"),
-    path.join(__dirname, "..", "node_modules", "systray")
+    path.join(getRuntimeNodeModules(), LEGACY_SYSTRAY_PKG),
+    path.join(__dirname, "..", "node_modules", LEGACY_SYSTRAY_PKG)
   ];
   for (const dir of targets) {
     if (fs.existsSync(dir)) {
@@ -32,6 +39,21 @@ function cleanupWindowsSystray({ silent = false } = {}) {
         if (!silent) console.warn(`[9router][runtime] failed to remove ${dir}: ${e.message}`);
       }
     }
+  }
+}
+
+// systray2's npm tarball sometimes ships the bundled Go binary without the
+// executable bit set on macOS, causing spawn() to fail with EACCES. Set +x
+// best-effort so the tray actually starts.
+function chmodSystrayBin({ silent = false } = {}) {
+  if (process.platform === "win32") return;
+  const binName = process.platform === "darwin" ? "tray_darwin_release" : "tray_linux_release";
+  const binPath = path.join(getRuntimeNodeModules(), SYSTRAY_PKG, "traybin", binName);
+  if (!fs.existsSync(binPath)) return;
+  try {
+    fs.chmodSync(binPath, 0o755);
+  } catch (e) {
+    if (!silent) console.warn(`[9router][runtime] chmod tray bin failed: ${e.message}`);
   }
 }
 
@@ -63,20 +85,25 @@ function npmInstall(pkgs, { silent = false } = {}) {
   return res.status === 0;
 }
 
-// Public: ensure systray is installed on macOS/Linux only.
+// Public: ensure systray2 is installed on macOS/Linux only.
 // Windows skips entirely (uses PowerShell tray).
 function ensureTrayRuntime({ silent = false } = {}) {
+  // Always evict the legacy `systray` package — its binary is broken on
+  // modern macOS and an AV false-positive on Windows.
+  cleanupLegacySystray({ silent });
+
   if (process.platform === "win32") {
-    cleanupWindowsSystray({ silent });
     return { systray: false, skipped: true };
   }
   if (hasSystray()) {
-    if (!silent) console.log("[9router][runtime] systray OK");
+    chmodSystrayBin({ silent });
+    if (!silent) console.log("[9router][runtime] systray2 OK");
     return { systray: true };
   }
-  const ok = npmInstall([`systray@${SYSTRAY_VERSION}`], { silent });
+  const ok = npmInstall([`${SYSTRAY_PKG}@${SYSTRAY_VERSION}`], { silent });
+  if (ok) chmodSystrayBin({ silent });
   if (!ok && !silent) {
-    console.warn("[9router][runtime] systray install failed (tray will be disabled)");
+    console.warn("[9router][runtime] systray2 install failed (tray will be disabled)");
   }
   return { systray: ok && hasSystray() };
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -24,7 +24,7 @@
     "react-dom": "19.2.1"
   },
   "comment_sqlite": "sql.js + better-sqlite3 are NOT bundled here. They are installed into ~/.9router/runtime/node_modules by hooks/postinstall.js (and re-checked at runtime by cli.js). This avoids Windows EBUSY errors when updating the global CLI, since native .node files no longer live under the locked install dir.",
-  "comment_systray": "systray is NOT bundled here. It is lazy-installed into ~/.9router/runtime/node_modules by hooks/postinstall.js on macOS/Linux only. Windows uses PowerShell NotifyIcon (zero binary). This avoids shipping the unsigned Go binary tray_windows.exe that triggers antivirus false positives (Kaspersky).",
+  "comment_systray": "systray2 is NOT bundled here. It is lazy-installed into ~/.9router/runtime/node_modules by hooks/postinstall.js on macOS/Linux only. Windows uses PowerShell NotifyIcon (zero binary). This avoids shipping unsigned Go binaries that trigger antivirus false positives (Kaspersky). We use the systray2 fork because the legacy systray@1.0.5 ships a 2017 x86_64 binary that fails on modern macOS dyld.",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/cli/src/cli/tray/tray.js
+++ b/cli/src/cli/tray/tray.js
@@ -140,37 +140,75 @@ function initWindowsTray(options) {
 
 /**
  * macOS/Linux tray via systray binary
+ *
+ * Prefers `systray2` (active fork of `systray`, ships newer
+ * getlantern/systray-portable binaries that work on macOS 14+ and Apple
+ * Silicon under Rosetta). Falls back to legacy `systray@1.0.5` if systray2
+ * is not available, though that binary's Mach-O headers are rejected by
+ * modern dyld and the icon will not appear.
  */
 function resolveSystray() {
-  // Try local first (dev), then runtime dir (production lazy install)
-  try {
-    return require("systray").default;
-  } catch (e) {}
+  let runtimeDir = null;
   try {
     const { getRuntimeNodeModules } = require("../../../hooks/sqliteRuntime");
-    const systrayPath = path.join(getRuntimeNodeModules(), "systray");
-    return require(systrayPath).default;
-  } catch (e) {
-    return null;
+    runtimeDir = getRuntimeNodeModules();
+  } catch (e) {}
+
+  // 1) systray2 in runtime dir (where ensureTrayRuntime installs it)
+  if (runtimeDir) {
+    try { return { mod: require(path.join(runtimeDir, "systray2")).default, isV2: true }; } catch (e) {}
   }
+  // 2) systray2 resolvable from the package's own node_modules / NODE_PATH
+  try { return { mod: require("systray2").default, isV2: true }; } catch (e) {}
+  // 3) Legacy systray fallback (unlikely to render on modern macOS)
+  try { return { mod: require("systray").default, isV2: false }; } catch (e) {}
+  if (runtimeDir) {
+    try { return { mod: require(path.join(runtimeDir, "systray")).default, isV2: false }; } catch (e) {}
+  }
+  return null;
+}
+
+function chmodTrayBin(pkgName) {
+  // systray2's npm tarball occasionally lands without +x on the bundled Go
+  // binary (observed on macOS). spawn() then fails with EACCES. Best-effort
+  // chmod on every init avoids a hard-to-diagnose silent tray failure.
+  try {
+    const { getRuntimeNodeModules } = require("../../../hooks/sqliteRuntime");
+    const binName = process.platform === "darwin" ? "tray_darwin_release" : "tray_linux_release";
+    const candidates = [
+      path.join(getRuntimeNodeModules(), pkgName, "traybin", binName),
+      path.join(__dirname, "..", "..", "..", "node_modules", pkgName, "traybin", binName)
+    ];
+    for (const p of candidates) {
+      if (fs.existsSync(p)) fs.chmodSync(p, 0o755);
+    }
+  } catch (e) {}
 }
 
 function initUnixTray(options) {
   const { port } = options;
   try {
-    const SysTray = resolveSystray();
-    if (!SysTray) return null;
+    const resolved = resolveSystray();
+    if (!resolved) return null;
+    const { mod: SysTray, isV2 } = resolved;
+
+    chmodTrayBin(isV2 ? "systray2" : "systray");
+
     const autostartEnabled = getAutostartEnabled();
     const items = buildMenuItems(port, autostartEnabled);
 
     const menu = {
       icon: getIconBase64(),
+      // The bundled icon.png is a full-color RGBA logo. Don't mark it as a
+      // template icon: macOS would then render it as a solid white square
+      // because template mode only uses the alpha channel.
+      isTemplateIcon: false,
       title: "",
       tooltip: `9Router - Port ${port}`,
       items
     };
 
-    trayInstance = new SysTray({ menu, debug: false, copyDir: true });
+    trayInstance = new SysTray({ menu, debug: false, copyDir: false });
     isWinTray = false;
 
     trayInstance.onClick((action) => {
@@ -187,11 +225,21 @@ function initUnixTray(options) {
       });
     });
 
-    trayInstance.onReady(() => {});
-    trayInstance.onError(() => {});
+    if (isV2) {
+      // systray2 exposes a ready() promise instead of onReady/onError. Surface
+      // failures (binary crash, EACCES, etc.) so users can see why the icon
+      // didn't appear instead of getting a misleading "running in tray" log.
+      trayInstance.ready().catch((err) => {
+        process.stderr.write(`[9router] tray failed to start: ${err && err.message ? err.message : err}\n`);
+      });
+    } else {
+      trayInstance.onReady(() => {});
+      trayInstance.onError(() => {});
+    }
 
     return trayInstance;
   } catch (err) {
+    process.stderr.write(`[9router] tray init error: ${err.message}\n`);
     return null;
   }
 }
@@ -207,7 +255,10 @@ function killTray() {
   if (instance) {
     try {
       if (wasWin) instance.kill();
-      else instance.kill(true);
+      // systray2.kill(true) defaults to calling process.exit(0) which aborts
+      // the rest of cleanup (server SIGKILL, MITM/tunnel cleanup). Pass false
+      // so callers stay in control of process exit.
+      else instance.kill(false);
     } catch (e) {}
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1079 — the system tray icon does not appear on macOS 14+ / Apple Silicon because the bundled `systray@1.0.5` binary has malformed Mach-O headers that modern dyld rejects. Switches the runtime tray library to the maintained `systray2` fork, which ships newer getlantern/systray-portable binaries that work on Apple Silicon under Rosetta.

## What was broken

On macOS 26 / Apple M1 Max:

```
$ DEBUG=systray* node -e "..."  # debug binary
STDERR: dyld[55622]: segment '__DWARF' filesize exceeds vmsize in
        /Users/.../node_modules/systray/traybin/tray_darwin
PROC EXIT: null SIGABRT
```

The release binary doesn't crash but its NSStatusBar registration silently fails — `onReady` never fires and no icon appears. Because `tray.js` wrapped the whole init in `catch (err) { return null }`, the CLI still printed `Router is now running in system tray` while doing nothing.

## What this PR changes

**`cli/hooks/trayRuntime.js`**
- Install `systray2@2.1.4` (not `systray@1.0.5`) into `~/.9router/runtime/node_modules`.
- Always purge the legacy `systray` package — its binary is broken on macOS and an AV false-positive on Windows.
- Renamed the cleanup helper to `cleanupLegacySystray` (the old name only handled Windows).
- `chmod +x` the bundled Go binary in case the npm tarball drops the executable bit (observed on macOS).

**`cli/src/cli/tray/tray.js`**
- `resolveSystray()` prefers `systray2` (returns `{ mod, isV2 }`) with the legacy systray as a fallback.
- `initUnixTray()` uses the new `.ready()` promise API and now **surfaces failures to stderr** instead of silently returning `null`. This is the most important user-facing fix — currently anyone hitting a tray problem has no diagnostic at all.
- Sets `isTemplateIcon: false` for darwin — the bundled `icon.png` is a full-color RGBA logo (3% transparent pixels); template mode would render it as a solid white square because macOS template icons only use the alpha channel.
- Sets `copyDir: false` — systray2 manages its own binary location and doesn't need the extra copy step.
- `killTray()` passes `false` to systray2's `kill` so it doesn't call `process.exit(0)` before the rest of cleanup (server SIGKILL, MITM/tunnel cleanup) runs.

**`cli/package.json`**
- Updated `comment_systray` to describe the new package choice and the rationale.

## Test plan

- [x] `node --check` on every modified file
- [x] On macOS 26.5 + Apple M1 Max, with a fresh `~/.9router/runtime/node_modules`:
  - `node hooks/postinstall.js` installs `systray2@2.1.4` and removes any prior legacy `systray`.
  - `9router --tray --skip-update -p 20128` boots the server and `tray_darwin_release` from `systray2` shows up in `ps`.
  - **Menubar icon renders correctly in full color** (verified visually).
  - HTTP `GET /login` returns 200.
- [ ] Windows path is unchanged in behaviour (still skips tray runtime, uses PowerShell NotifyIcon). The legacy cleanup path now runs on every OS but the path-existence guards make it a no-op when there's nothing to remove.
- [ ] Linux: not yet personally verified — would appreciate a confirm from someone with a Linux desktop, but the change is symmetric with darwin (same binary distribution mechanism in systray2).

## Backwards compatibility

- The legacy `systray` package directory will be auto-removed from `~/.9router/runtime/node_modules` and from `<pkg>/node_modules/systray` on first run after the upgrade. No user action required.
- No public API change; `initTray()` / `killTray()` signatures unchanged.
- The fallback to legacy `systray` is kept so this doesn't hard-fail if `systray2` cannot install (offline machine that already had the old one cached, etc.) — but with errors now surfaced, users will see why it didn't work.