### PR TITLE
fix(antigravity): drop literal <think>/</think> markers from Claude→OpenAI stream

### DIFF
--- a/open-sse/translator/response/claude-to-openai.js
+++ b/open-sse/translator/response/claude-to-openai.js
@@ -44,7 +44,6 @@ export function claudeToOpenAIResponse(chunk, state) {
       } else if (block?.type === "thinking") {
         state.inThinkingBlock = true;
         state.currentBlockIndex = chunk.index;
-        results.push(createChunk(state, { content: "<think>" }));
       } else if (block?.type === "tool_use") {
         const toolCallIndex = state.toolCallIndex++;
         // Restore original tool name from mapping (Claude OAuth)
@@ -95,7 +94,6 @@ export function claudeToOpenAIResponse(chunk, state) {
         break;
       }
       if (state.inThinkingBlock && chunk.index === state.currentBlockIndex) {
-        results.push(createChunk(state, { content: "</think>" }));
         state.inThinkingBlock = false;
       }
       state.textBlockStarted = false;


### PR DESCRIPTION
Fixes #1061.

--

When using the Antigravity IDE → 9router MITM → any Claude-format provider with
thinking enabled, the assistant's persisted visible text accumulates empty
`<think></think>` shells. Antigravity's server-side loop detector trips on the
repeated literal and forces retries — each retry costing ~180k input tokens
for a typical context.

--

Tested via:
- [x] Antigravity IDE + Claude Code provider, thinking enabled, multi-turn
      conversation: no `<think></think>` shells in assistant text, no
      loop-detection retries.
- [x] Other clients (OpenAI/Codex/Cursor) hitting Claude provider: unchanged.
- [x] `reasoning_content` still streams correctly for thinking-aware clients.