### PR TITLE
feat(cursor): add API key import with proactive token refresh

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -1,29 +1,29 @@
-import { BaseExecutor } from "./base.js";
-import { PROVIDERS } from "../config/providers.js";
-import { HTTP_STATUS } from "../config/runtimeConfig.js";
+import { BaseExecutor } from "./base.js"
+import { PROVIDERS } from "../config/providers.js"
+import { HTTP_STATUS } from "../config/runtimeConfig.js"
 import {
   generateCursorBody,
   parseConnectRPCFrame,
   extractTextFromResponse
-} from "../utils/cursorProtobuf.js";
-import { buildCursorHeaders } from "../utils/cursorChecksum.js";
-import { estimateUsage } from "../utils/usageTracking.js";
-import { FORMATS } from "../translator/formats.js";
-import { proxyAwareFetch } from "../utils/proxyFetch.js";
-import zlib from "zlib";
+} from "../utils/cursorProtobuf.js"
+import { buildCursorHeaders } from "../utils/cursorChecksum.js"
+import { estimateUsage } from "../utils/usageTracking.js"
+import { FORMATS } from "../translator/formats.js"
+import { proxyAwareFetch } from "../utils/proxyFetch.js"
+import zlib from "zlib"
 
 // Detect cloud environment
 const isCloudEnv = () => {
-  if (typeof caches !== "undefined" && typeof caches === "object") return true;
-  if (typeof EdgeRuntime !== "undefined") return true;
-  return false;
-};
+  if (typeof caches !== "undefined" && typeof caches === "object") return true
+  if (typeof EdgeRuntime !== "undefined") return true
+  return false
+}
 
 // Lazy import http2 (only in Node.js environment)
-let http2 = null;
+let http2 = null
 if (!isCloudEnv()) {
   try {
-    http2 = await import("http2");
+    http2 = await import("http2")
   } catch {
     // http2 not available
   }
@@ -34,23 +34,23 @@ const COMPRESS_FLAG = {
   GZIP: 0x01,
   TRAILER: 0x02,
   GZIP_TRAILER: 0x03
-};
+}
 
-const CURSOR_STREAM_DEBUG = process.env.CURSOR_STREAM_DEBUG === "1";
+const CURSOR_STREAM_DEBUG = process.env.CURSOR_STREAM_DEBUG === "1"
 const debugLog = (...args) => {
-  if (CURSOR_STREAM_DEBUG) console.log(...args);
-};
+  if (CURSOR_STREAM_DEBUG) console.log(...args)
+}
 
 function decompressPayload(payload, flags) {
   // Check if payload is JSON error (starts with {"error")
   if (payload.length > 10 && payload[0] === 0x7b && payload[1] === 0x22) {
     try {
-      const text = payload.toString("utf-8");
+      const text = payload.toString("utf-8")
       if (text.startsWith('{"error"')) {
-        debugLog(`[DECOMPRESS] Detected JSON error, skipping decompression`);
-        return payload;
+        debugLog(`[DECOMPRESS] Detected JSON error, skipping decompression`)
+        return payload
       }
-    } catch {}
+    } catch { }
   }
 
   if (
@@ -60,39 +60,39 @@ function decompressPayload(payload, flags) {
   ) {
     // Primary: try gzip decompression (standard gzip header 0x1f 0x8b)
     try {
-      return zlib.gunzipSync(payload);
+      return zlib.gunzipSync(payload)
     } catch (gzipErr) {
       // Fallback: TRAILER and GZIP_TRAILER frames sometimes use raw zlib deflate format
       try {
-        return zlib.inflateSync(payload);
+        return zlib.inflateSync(payload)
       } catch (deflateErr) {
         // Last resort: try raw deflate (no zlib header)
         try {
-          return zlib.inflateRawSync(payload);
+          return zlib.inflateRawSync(payload)
         } catch (rawErr) {
           debugLog(
             `[DECOMPRESS ERROR] flags=${flags}, payloadSize=${payload.length}, gzip=${gzipErr.message}, deflate=${deflateErr.message}, raw=${rawErr.message}`
-          );
+          )
           debugLog(
             `[DECOMPRESS ERROR] First 50 bytes (hex):`,
             payload.slice(0, 50).toString("hex")
-          );
-          return payload;
+          )
+          return payload
         }
       }
     }
   }
-  return payload;
+  return payload
 }
 
 function createErrorResponse(jsonError) {
   const errorMsg = jsonError?.error?.details?.[0]?.debug?.details?.title
     || jsonError?.error?.details?.[0]?.debug?.details?.detail
     || jsonError?.error?.message
-    || "API Error";
-  
-  const isRateLimit = jsonError?.error?.code === "resource_exhausted";
-  
+    || "API Error"
+
+  const isRateLimit = jsonError?.error?.code === "resource_exhausted"
+
   return new Response(JSON.stringify({
     error: {
       message: errorMsg,
@@ -102,40 +102,40 @@ function createErrorResponse(jsonError) {
   }), {
     status: isRateLimit ? HTTP_STATUS.RATE_LIMITED : HTTP_STATUS.BAD_REQUEST,
     headers: { "Content-Type": "application/json" }
-  });
+  })
 }
 
 export class CursorExecutor extends BaseExecutor {
   constructor() {
-    super("cursor", PROVIDERS.cursor);
+    super("cursor", PROVIDERS.cursor)
   }
 
   buildUrl() {
-    return `${this.config.baseUrl}${this.config.chatPath}`;
+    return `${this.config.baseUrl}${this.config.chatPath}`
   }
 
   buildHeaders(credentials) {
-    const accessToken = credentials.accessToken;
-    const machineId = credentials.providerSpecificData?.machineId;
-    const ghostMode = credentials.providerSpecificData?.ghostMode !== false;
+    const accessToken = credentials.accessToken
+    const machineId = credentials.providerSpecificData?.machineId
+    const ghostMode = credentials.providerSpecificData?.ghostMode !== false
 
     if (!machineId) {
-      throw new Error("Machine ID is required for Cursor API");
+      throw new Error("Machine ID is required for Cursor API")
     }
 
-    return buildCursorHeaders(accessToken, machineId, ghostMode);
+    return buildCursorHeaders(accessToken, machineId, ghostMode)
   }
 
   transformRequest(model, body, stream, credentials) {
     // Messages are already translated by chatCore (claude→openai→cursor)
     // Do NOT call buildCursorRequest again — double-translation drops tool_results
-    const messages = body.messages || [];
-    const tools = body.tools || [];
-    const reasoningEffort = body.reasoning_effort || null;
+    const messages = body.messages || []
+    const tools = body.tools || []
+    const reasoningEffort = body.reasoning_effort || null
     // Detect Claude Code UA to force Agent mode (issue #643)
-    const ua = credentials?.rawHeaders?.["user-agent"] || "";
-    const forceAgentMode = ua.includes("claude-cli") || ua.includes("claude-code") || ua.includes("Claude Code");
-    return generateCursorBody(messages, model, tools, reasoningEffort, forceAgentMode);
+    const ua = credentials?.rawHeaders?.["user-agent"] || ""
+    const forceAgentMode = ua.includes("claude-cli") || ua.includes("claude-code") || ua.includes("Claude Code")
+    return generateCursorBody(messages, model, tools, reasoningEffort, forceAgentMode)
   }
 
   async makeFetchRequest(url, headers, body, signal, proxyOptions = null) {
@@ -144,44 +144,44 @@ export class CursorExecutor extends BaseExecutor {
       headers,
       body,
       signal
-    }, proxyOptions);
+    }, proxyOptions)
 
     return {
       status: response.status,
       headers: Object.fromEntries(response.headers.entries()),
       body: Buffer.from(await response.arrayBuffer())
-    };
+    }
   }
 
   makeHttp2Request(url, headers, body, signal) {
     if (!http2) {
-      throw new Error("http2 module not available");
+      throw new Error("http2 module not available")
     }
 
-    const HTTP2_TIMEOUT_MS = 60000; // 60s max — prevent hung sessions
+    const HTTP2_TIMEOUT_MS = 60000 // 60s max — prevent hung sessions
 
     return new Promise((resolve, reject) => {
-      const urlObj = new URL(url);
-      const client = http2.connect(`https://${urlObj.host}`);
-      const chunks = [];
-      let responseHeaders = {};
-      let settled = false;
+      const urlObj = new URL(url)
+      const client = http2.connect(`https://${urlObj.host}`)
+      const chunks = []
+      let responseHeaders = {}
+      let settled = false
 
       // Ensure client is always closed on settle
       const finish = (fn) => (...args) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(hangTimeout);
-        client.close();
-        fn(...args);
-      };
+        if (settled) return
+        settled = true
+        clearTimeout(hangTimeout)
+        client.close()
+        fn(...args)
+      }
 
       // Hard timeout: close session if server never responds
       const hangTimeout = setTimeout(finish(() => {
-        reject(new Error("HTTP/2 request timed out"));
-      }), HTTP2_TIMEOUT_MS);
+        reject(new Error("HTTP/2 request timed out"))
+      }), HTTP2_TIMEOUT_MS)
 
-      client.on("error", finish(reject));
+      client.on("error", finish(reject))
 
       const req = client.request({
         ":method": "POST",
@@ -189,42 +189,42 @@ export class CursorExecutor extends BaseExecutor {
         ":authority": urlObj.host,
         ":scheme": "https",
         ...headers
-      });
+      })
 
-      req.on("response", (hdrs) => { responseHeaders = hdrs; });
-      req.on("data", (chunk) => { chunks.push(chunk); });
+      req.on("response", (hdrs) => { responseHeaders = hdrs })
+      req.on("data", (chunk) => { chunks.push(chunk) })
       req.on("end", finish(() => {
         resolve({
           status: responseHeaders[":status"],
           headers: responseHeaders,
           body: Buffer.concat(chunks)
-        });
-      }));
-      req.on("error", finish(reject));
+        })
+      }))
+      req.on("error", finish(reject))
 
       if (signal) {
-        const onAbort = finish(() => reject(new Error("Request aborted")));
-        signal.addEventListener("abort", onAbort, { once: true });
+        const onAbort = finish(() => reject(new Error("Request aborted")))
+        signal.addEventListener("abort", onAbort, { once: true })
       }
 
-      req.write(body);
-      req.end();
-    });
+      req.write(body)
+      req.end()
+    })
   }
 
   async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
-    const url = this.buildUrl();
-    const headers = this.buildHeaders(credentials);
-    const transformedBody = this.transformRequest(model, body, stream, credentials);
+    const url = this.buildUrl()
+    const headers = this.buildHeaders(credentials)
+    const transformedBody = this.transformRequest(model, body, stream, credentials)
 
     try {
-      const shouldForceFetch = proxyOptions?.enabled === true || proxyOptions?.connectionProxyEnabled === true || !!proxyOptions?.vercelRelayUrl;
+      const shouldForceFetch = proxyOptions?.enabled === true || proxyOptions?.connectionProxyEnabled === true || !!proxyOptions?.vercelRelayUrl
       const response = (http2 && !shouldForceFetch)
         ? await this.makeHttp2Request(url, headers, transformedBody, signal)
-        : await this.makeFetchRequest(url, headers, transformedBody, signal, proxyOptions);
+        : await this.makeFetchRequest(url, headers, transformedBody, signal, proxyOptions)
 
       if (response.status !== 200) {
-        const errorText = response.body?.toString() || "Unknown error";
+        const errorText = response.body?.toString() || "Unknown error"
         const errorResponse = new Response(JSON.stringify({
           error: {
             message: `[${response.status}]: ${errorText}`,
@@ -234,15 +234,15 @@ export class CursorExecutor extends BaseExecutor {
         }), {
           status: response.status,
           headers: { "Content-Type": "application/json" }
-        });
-        return { response: errorResponse, url, headers, transformedBody: body };
+        })
+        return { response: errorResponse, url, headers, transformedBody: body }
       }
 
       const transformedResponse = stream !== false
         ? this.transformProtobufToSSE(response.body, model, body)
-        : this.transformProtobufToJSON(response.body, model, body);
+        : this.transformProtobufToJSON(response.body, model, body)
 
-      return { response: transformedResponse, url, headers, transformedBody: body };
+      return { response: transformedResponse, url, headers, transformedBody: body }
     } catch (error) {
       const errorResponse = new Response(JSON.stringify({
         error: {
@@ -253,81 +253,81 @@ export class CursorExecutor extends BaseExecutor {
       }), {
         status: HTTP_STATUS.SERVER_ERROR,
         headers: { "Content-Type": "application/json" }
-      });
-      return { response: errorResponse, url, headers, transformedBody: body };
+      })
+      return { response: errorResponse, url, headers, transformedBody: body }
     }
   }
 
   transformProtobufToJSON(buffer, model, body) {
-    const responseId = `chatcmpl-cursor-${Date.now()}`;
-    const created = Math.floor(Date.now() / 1000);
+    const responseId = `chatcmpl-cursor-${Date.now()}`
+    const created = Math.floor(Date.now() / 1000)
 
-    let offset = 0;
-    let totalContent = "";
-    const toolCalls = [];
-    const toolCallsMap = new Map(); // Track streaming tool calls by ID
-    const finalizedIds = new Set();
-    let frameCount = 0;
+    let offset = 0
+    let totalContent = ""
+    const toolCalls = []
+    const toolCallsMap = new Map() // Track streaming tool calls by ID
+    const finalizedIds = new Set()
+    let frameCount = 0
 
-    debugLog(`[CURSOR BUFFER] Total length: ${buffer.length} bytes`);
+    debugLog(`[CURSOR BUFFER] Total length: ${buffer.length} bytes`)
 
     while (offset < buffer.length) {
       if (offset + 5 > buffer.length) {
         debugLog(
           `[CURSOR BUFFER] Reached end, offset=${offset}, remaining=${buffer.length - offset}`
-        );
-        break;
+        )
+        break
       }
 
-      const flags = buffer[offset];
-      const length = buffer.readUInt32BE(offset + 1);
+      const flags = buffer[offset]
+      const length = buffer.readUInt32BE(offset + 1)
 
       debugLog(
         `[CURSOR BUFFER] Frame ${frameCount + 1}: flags=0x${flags.toString(16).padStart(2, "0")}, length=${length}`
-      );
+      )
 
       if (offset + 5 + length > buffer.length) {
         debugLog(
           `[CURSOR BUFFER] Incomplete frame, offset=${offset}, length=${length}, buffer.length=${buffer.length}`
-        );
-        break;
+        )
+        break
       }
 
-      let payload = buffer.slice(offset + 5, offset + 5 + length);
-      offset += 5 + length;
-      frameCount++;
+      let payload = buffer.slice(offset + 5, offset + 5 + length)
+      offset += 5 + length
+      frameCount++
 
-      payload = decompressPayload(payload, flags);
+      payload = decompressPayload(payload, flags)
       if (!payload) {
-        debugLog(`[CURSOR BUFFER] Frame ${frameCount}: decompression failed, skipping`);
-        continue;
+        debugLog(`[CURSOR BUFFER] Frame ${frameCount}: decompression failed, skipping`)
+        continue
       }
 
       // Check for JSON error frames (byte guard: skip toString on non-JSON frames)
       if (payload.length > 0 && payload[0] === 0x7b) {
         try {
-          const text = payload.toString("utf-8");
+          const text = payload.toString("utf-8")
           if (text.includes('"error"')) {
-            const hasContent = totalContent || toolCallsMap.size > 0;
+            const hasContent = totalContent || toolCallsMap.size > 0
             debugLog(
               `[CURSOR BUFFER] Error frame (hasContent=${hasContent}): ${text.slice(0, 500)}`
-            );
+            )
             if (hasContent) {
-              break;
+              break
             }
-            return createErrorResponse(JSON.parse(text));
+            return createErrorResponse(JSON.parse(text))
           }
-        } catch {}
+        } catch { }
       }
 
-      const result = extractTextFromResponse(new Uint8Array(payload));
-      debugLog(`[CURSOR DECODED] Frame ${frameCount}:`, result);
+      const result = extractTextFromResponse(new Uint8Array(payload))
+      debugLog(`[CURSOR DECODED] Frame ${frameCount}:`, result)
 
       if (result.error) {
-        const hasContent = totalContent || toolCallsMap.size > 0;
-        debugLog(`[CURSOR BUFFER] Decoded error (hasContent=${hasContent}): ${result.error}`);
+        const hasContent = totalContent || toolCallsMap.size > 0
+        debugLog(`[CURSOR BUFFER] Decoded error (hasContent=${hasContent}): ${result.error}`)
         if (hasContent) {
-          break;
+          break
         }
         return new Response(
           JSON.stringify({
@@ -341,26 +341,26 @@ export class CursorExecutor extends BaseExecutor {
             status: HTTP_STATUS.RATE_LIMITED,
             headers: { "Content-Type": "application/json" }
           }
-        );
+        )
       }
 
       if (result.toolCall) {
-        const tc = result.toolCall;
+        const tc = result.toolCall
 
         if (toolCallsMap.has(tc.id)) {
           // Accumulate arguments for existing tool call
-          const existing = toolCallsMap.get(tc.id);
-          existing.function.arguments += tc.function.arguments;
-          existing.isLast = tc.isLast;
+          const existing = toolCallsMap.get(tc.id)
+          existing.function.arguments += tc.function.arguments
+          existing.isLast = tc.isLast
         } else {
           // New tool call
-          toolCallsMap.set(tc.id, { ...tc });
+          toolCallsMap.set(tc.id, { ...tc })
         }
 
         // Push to final array when isLast is true
         if (tc.isLast) {
-          const finalToolCall = toolCallsMap.get(tc.id);
-          finalizedIds.add(tc.id);
+          const finalToolCall = toolCallsMap.get(tc.id)
+          finalizedIds.add(tc.id)
           toolCalls.push({
             id: finalToolCall.id,
             type: finalToolCall.type,
@@ -368,22 +368,22 @@ export class CursorExecutor extends BaseExecutor {
               name: finalToolCall.function.name,
               arguments: finalToolCall.function.arguments
             }
-          });
+          })
         }
       }
 
-      if (result.text) totalContent += result.text;
+      if (result.text) totalContent += result.text
     }
 
     debugLog(
       `[CURSOR BUFFER] Parsed ${frameCount} frames, toolCallsMap size: ${toolCallsMap.size}, finalized toolCalls: ${toolCalls.length}`
-    );
+    )
 
     // Finalize all remaining tool calls in map (in case stream ended without isLast=true)
     for (const [id, tc] of toolCallsMap.entries()) {
       // Check if already in final array
       if (!finalizedIds.has(id)) {
-        debugLog(`[CURSOR BUFFER] Finalizing incomplete tool call: ${id}, isLast=${tc.isLast}`);
+        debugLog(`[CURSOR BUFFER] Finalizing incomplete tool call: ${id}, isLast=${tc.isLast}`)
         toolCalls.push({
           id: tc.id,
           type: tc.type,
@@ -391,23 +391,23 @@ export class CursorExecutor extends BaseExecutor {
             name: tc.function.name,
             arguments: tc.function.arguments
           }
-        });
+        })
       }
     }
 
-    debugLog(`[CURSOR BUFFER] Final toolCalls count: ${toolCalls.length}`);
+    debugLog(`[CURSOR BUFFER] Final toolCalls count: ${toolCalls.length}`)
 
 
     const message = {
       role: "assistant",
       content: totalContent || null
-    };
-
-    if (toolCalls.length > 0) {
-      message.tool_calls = toolCalls;
     }
 
-    const usage = estimateUsage(body, totalContent.length, FORMATS.OPENAI);
+    if (toolCalls.length > 0) {
+      message.tool_calls = toolCalls
+    }
+
+    const usage = estimateUsage(body, totalContent.length, FORMATS.OPENAI)
 
     const completion = {
       id: responseId,
@@ -420,86 +420,86 @@ export class CursorExecutor extends BaseExecutor {
         finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop"
       }],
       usage
-    };
+    }
 
     return new Response(JSON.stringify(completion), {
       status: 200,
       headers: { "Content-Type": "application/json" }
-    });
+    })
   }
 
   transformProtobufToSSE(buffer, model, body) {
-    const responseId = `chatcmpl-cursor-${Date.now()}`;
-    const created = Math.floor(Date.now() / 1000);
+    const responseId = `chatcmpl-cursor-${Date.now()}`
+    const created = Math.floor(Date.now() / 1000)
 
-    const chunks = [];
-    let offset = 0;
-    let totalContent = "";
-    const toolCalls = [];
-    const toolCallsMap = new Map(); // Track streaming tool calls by ID
-    const finalizedIds = new Set();
-    const emittedToolCallIds = new Set();
-    let frameCount = 0;
+    const chunks = []
+    let offset = 0
+    let totalContent = ""
+    const toolCalls = []
+    const toolCallsMap = new Map() // Track streaming tool calls by ID
+    const finalizedIds = new Set()
+    const emittedToolCallIds = new Set()
+    let frameCount = 0
 
-    debugLog(`[CURSOR BUFFER SSE] Total length: ${buffer.length} bytes`);
+    debugLog(`[CURSOR BUFFER SSE] Total length: ${buffer.length} bytes`)
 
     while (offset < buffer.length) {
       if (offset + 5 > buffer.length) {
         debugLog(
           `[CURSOR BUFFER SSE] Reached end, offset=${offset}, remaining=${buffer.length - offset}`
-        );
-        break;
+        )
+        break
       }
 
-      const flags = buffer[offset];
-      const length = buffer.readUInt32BE(offset + 1);
+      const flags = buffer[offset]
+      const length = buffer.readUInt32BE(offset + 1)
 
       debugLog(
         `[CURSOR BUFFER SSE] Frame ${frameCount + 1}: flags=0x${flags.toString(16).padStart(2, "0")}, length=${length}`
-      );
+      )
 
       if (offset + 5 + length > buffer.length) {
         debugLog(
           `[CURSOR BUFFER SSE] Incomplete frame, offset=${offset}, length=${length}, buffer.length=${buffer.length}`
-        );
-        break;
+        )
+        break
       }
 
-      let payload = buffer.slice(offset + 5, offset + 5 + length);
-      offset += 5 + length;
-      frameCount++;
+      let payload = buffer.slice(offset + 5, offset + 5 + length)
+      offset += 5 + length
+      frameCount++
 
-      payload = decompressPayload(payload, flags);
+      payload = decompressPayload(payload, flags)
       if (!payload) {
-        debugLog(`[CURSOR BUFFER SSE] Frame ${frameCount}: decompression failed, skipping`);
-        continue;
+        debugLog(`[CURSOR BUFFER SSE] Frame ${frameCount}: decompression failed, skipping`)
+        continue
       }
 
       // Check for JSON error frames (byte-guard: only decode if starts with '{')
       if (payload[0] === 0x7b) {
         try {
-          const text = payload.toString("utf-8");
+          const text = payload.toString("utf-8")
           if (text.includes('"error"')) {
-            const hasContent = chunks.length > 0 || totalContent || toolCallsMap.size > 0;
+            const hasContent = chunks.length > 0 || totalContent || toolCallsMap.size > 0
             debugLog(
               `[CURSOR BUFFER SSE] Error frame (hasContent=${hasContent}): ${text.slice(0, 500)}`
-            );
+            )
             if (hasContent) {
-              break;
+              break
             }
-            return createErrorResponse(JSON.parse(text));
+            return createErrorResponse(JSON.parse(text))
           }
-        } catch {}
+        } catch { }
       }
 
-      const result = extractTextFromResponse(new Uint8Array(payload));
-      debugLog(`[CURSOR DECODED SSE] Frame ${frameCount}:`, result);
+      const result = extractTextFromResponse(new Uint8Array(payload))
+      debugLog(`[CURSOR DECODED SSE] Frame ${frameCount}:`, result)
 
       if (result.error) {
-        const hasContent = chunks.length > 0 || totalContent || toolCallsMap.size > 0;
-        debugLog(`[CURSOR BUFFER SSE] Decoded error (hasContent=${hasContent}): ${result.error}`);
+        const hasContent = chunks.length > 0 || totalContent || toolCallsMap.size > 0
+        debugLog(`[CURSOR BUFFER SSE] Decoded error (hasContent=${hasContent}): ${result.error}`)
         if (hasContent) {
-          break;
+          break
         }
         return new Response(
           JSON.stringify({
@@ -513,11 +513,11 @@ export class CursorExecutor extends BaseExecutor {
             status: HTTP_STATUS.RATE_LIMITED,
             headers: { "Content-Type": "application/json" }
           }
-        );
+        )
       }
 
       if (result.toolCall) {
-        const tc = result.toolCall;
+        const tc = result.toolCall
 
         if (chunks.length === 0) {
           chunks.push(
@@ -534,19 +534,19 @@ export class CursorExecutor extends BaseExecutor {
                 }
               ]
             })}\n\n`
-          );
+          )
         }
 
         if (toolCallsMap.has(tc.id)) {
           // Accumulate arguments for existing tool call
-          const existing = toolCallsMap.get(tc.id);
-          const oldArgsLen = existing.function.arguments.length;
-          existing.function.arguments += tc.function.arguments;
-          existing.isLast = tc.isLast;
+          const existing = toolCallsMap.get(tc.id)
+          const oldArgsLen = existing.function.arguments.length
+          existing.function.arguments += tc.function.arguments
+          existing.isLast = tc.isLast
 
           // Stream the delta arguments
           if (tc.function.arguments) {
-            emittedToolCallIds.add(tc.id);
+            emittedToolCallIds.add(tc.id)
             chunks.push(
               `data: ${JSON.stringify({
                 id: responseId,
@@ -573,17 +573,17 @@ export class CursorExecutor extends BaseExecutor {
                   }
                 ]
               })}\n\n`
-            );
+            )
           }
         } else {
           // New tool call - assign index and add to map
-          const toolCallIndex = toolCalls.length;
-          finalizedIds.add(tc.id);
-          toolCalls.push({ ...tc, index: toolCallIndex });
-          toolCallsMap.set(tc.id, { ...tc, index: toolCallIndex });
+          const toolCallIndex = toolCalls.length
+          finalizedIds.add(tc.id)
+          toolCalls.push({ ...tc, index: toolCallIndex })
+          toolCallsMap.set(tc.id, { ...tc, index: toolCallIndex })
 
           // Stream initial tool call with name
-          emittedToolCallIds.add(tc.id);
+          emittedToolCallIds.add(tc.id)
           chunks.push(
             `data: ${JSON.stringify({
               id: responseId,
@@ -610,12 +610,12 @@ export class CursorExecutor extends BaseExecutor {
                 }
               ]
             })}\n\n`
-          );
+          )
         }
       }
 
       if (result.text) {
-        totalContent += result.text;
+        totalContent += result.text
         chunks.push(
           `data: ${JSON.stringify({
             id: responseId,
@@ -633,19 +633,19 @@ export class CursorExecutor extends BaseExecutor {
               }
             ]
           })}\n\n`
-        );
+        )
       }
     }
 
     debugLog(
       `[CURSOR BUFFER SSE] Parsed ${frameCount} frames, toolCallsMap size: ${toolCallsMap.size}, toolCalls array: ${toolCalls.length}`
-    );
+    )
 
     // Finalize all remaining tool calls in map (stream may have ended without isLast=true)
     for (const [id, tc] of toolCallsMap.entries()) {
       if (!finalizedIds.has(id)) {
-        debugLog(`[CURSOR BUFFER SSE] Finalizing incomplete tool call: ${id}, isLast=${tc.isLast}`);
-        const toolCallIndex = toolCalls.length;
+        debugLog(`[CURSOR BUFFER SSE] Finalizing incomplete tool call: ${id}, isLast=${tc.isLast}`)
+        const toolCallIndex = toolCalls.length
         toolCalls.push({
           id: tc.id,
           type: tc.type,
@@ -654,7 +654,7 @@ export class CursorExecutor extends BaseExecutor {
             name: tc.function.name,
             arguments: tc.function.arguments
           }
-        });
+        })
 
         // Emit SSE chunk for the finalized tool call if not already emitted
         if (!emittedToolCallIds.has(tc.id)) {
@@ -684,7 +684,7 @@ export class CursorExecutor extends BaseExecutor {
                 }
               ]
             })}\n\n`
-          );
+          )
         }
       }
     }
@@ -704,10 +704,10 @@ export class CursorExecutor extends BaseExecutor {
             }
           ]
         })}\n\n`
-      );
+      )
     }
 
-    const usage = estimateUsage(body, totalContent.length, FORMATS.OPENAI);
+    const usage = estimateUsage(body, totalContent.length, FORMATS.OPENAI)
 
     chunks.push(
       `data: ${JSON.stringify({
@@ -724,8 +724,8 @@ export class CursorExecutor extends BaseExecutor {
         ],
         usage
       })}\n\n`
-    );
-    chunks.push("data: [DONE]\n\n");
+    )
+    chunks.push("data: [DONE]\n\n")
 
     return new Response(chunks.join(""), {
       status: 200,
@@ -734,12 +734,77 @@ export class CursorExecutor extends BaseExecutor {
         "Cache-Control": "no-cache",
         "Connection": "keep-alive"
       }
-    });
+    })
   }
 
-  async refreshCredentials() {
-    return null;
+  /**
+   * Refresh Cursor access token.
+   *
+   * Supported strategy:
+   *   - API key flow (authMethod === "apikey"): re-exchange the long-lived
+   *     Cursor API key (`key_...`) at POST /auth/exchange_user_api_key.
+   *     This mirrors what cursor-agent CLI does internally.
+   *
+   * Legacy IDE-import flow (authMethod === "imported") has no refresh path —
+   * the user must re-run auto-import while Cursor IDE is logged in.
+   */
+  async refreshCredentials(credentials, log, proxyOptions = null) {
+    const psd = credentials?.providerSpecificData || {}
+    const apiKey = psd.apiKey
+    if (!apiKey) return null
+
+    try {
+      const res = await proxyAwareFetch(
+        "https://api2.cursor.sh/auth/exchange_user_api_key",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: "{}",
+        },
+        proxyOptions
+      )
+
+      if (!res.ok) {
+        log?.warn?.("TOKEN", `Cursor exchange_user_api_key failed: HTTP ${res.status}`)
+        return null
+      }
+
+      const data = await res.json()
+      const accessToken = data?.accessToken
+      if (!accessToken) {
+        log?.warn?.("TOKEN", "Cursor exchange response missing accessToken")
+        return null
+      }
+
+      let expiresIn = 3600
+      try {
+        const exp = JSON.parse(
+          Buffer.from(accessToken.split(".")[1], "base64").toString()
+        ).exp
+        if (Number.isFinite(exp)) {
+          expiresIn = Math.max(60, exp - Math.floor(Date.now() / 1000))
+        }
+      } catch {
+        // Non-JWT token; keep default expiresIn
+      }
+
+      log?.info?.("TOKEN", "Cursor refreshed via API key")
+
+      return {
+        accessToken,
+        refreshToken: data.refreshToken || credentials.refreshToken || null,
+        expiresIn,
+        // Preserve machineId / apiKey / authMethod / ghostMode
+        providerSpecificData: { ...psd },
+      }
+    } catch (e) {
+      log?.error?.("TOKEN", `Cursor refresh error: ${e.message}`)
+      return null
+    }
   }
 }
 
-export default CursorExecutor;
+export default CursorExecutor

--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -85,22 +85,48 @@ function decompressPayload(payload, flags) {
   return payload
 }
 
+// Detect Cursor "not logged in" / auth failures so chatCore's 401/403 branch
+// can run the standard refresh-and-retry flow. Cursor reports these as HTTP
+// 400 with code=ERROR_NOT_LOGGED_IN, which would otherwise bypass refresh.
+function isCursorAuthError(text) {
+  if (!text || typeof text !== "string") return false
+  return /ERROR_NOT_LOGGED_IN|ERROR_UNAUTHORIZED|Authentication error/i.test(text)
+}
+
 function createErrorResponse(jsonError) {
   const errorMsg = jsonError?.error?.details?.[0]?.debug?.details?.title
     || jsonError?.error?.details?.[0]?.debug?.details?.detail
     || jsonError?.error?.message
     || "API Error"
 
-  const isRateLimit = jsonError?.error?.code === "resource_exhausted"
+  const code = jsonError?.error?.code
+    || jsonError?.error?.details?.[0]?.debug?.error
+    || ""
+
+  const isRateLimit = code === "resource_exhausted"
+  const isAuth = isCursorAuthError(code) || isCursorAuthError(errorMsg)
+
+  let status
+  let type
+  if (isAuth) {
+    status = HTTP_STATUS.UNAUTHORIZED
+    type = "authentication_error"
+  } else if (isRateLimit) {
+    status = HTTP_STATUS.RATE_LIMITED
+    type = "rate_limit_error"
+  } else {
+    status = HTTP_STATUS.BAD_REQUEST
+    type = "api_error"
+  }
 
   return new Response(JSON.stringify({
     error: {
       message: errorMsg,
-      type: isRateLimit ? "rate_limit_error" : "api_error",
-      code: jsonError?.error?.details?.[0]?.debug?.error || "unknown"
+      type,
+      code: jsonError?.error?.details?.[0]?.debug?.details?.error || jsonError?.error?.details?.[0]?.debug?.error || code || "unknown"
     }
   }), {
-    status: isRateLimit ? HTTP_STATUS.RATE_LIMITED : HTTP_STATUS.BAD_REQUEST,
+    status,
     headers: { "Content-Type": "application/json" }
   })
 }
@@ -225,14 +251,19 @@ export class CursorExecutor extends BaseExecutor {
 
       if (response.status !== 200) {
         const errorText = response.body?.toString() || "Unknown error"
+        // Remap Cursor's "not logged in" (delivered as HTTP 400) to 401 so the
+        // shared chatCore 401/403 branch can drive refreshCredentials + retry.
+        const remappedStatus = (response.status === 400 && isCursorAuthError(errorText))
+          ? HTTP_STATUS.UNAUTHORIZED
+          : response.status
         const errorResponse = new Response(JSON.stringify({
           error: {
             message: `[${response.status}]: ${errorText}`,
-            type: "invalid_request_error",
+            type: remappedStatus === HTTP_STATUS.UNAUTHORIZED ? "authentication_error" : "invalid_request_error",
             code: ""
           }
         }), {
-          status: response.status,
+          status: remappedStatus,
           headers: { "Content-Type": "application/json" }
         })
         return { response: errorResponse, url, headers, transformedBody: body }

--- a/scripts/cursor-chat.mjs
+++ b/scripts/cursor-chat.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Cursor: Send a chat request using an access token.
+ *
+ * Reuses 9router's own CursorExecutor so headers (x-cursor-checksum, etc.) and
+ * the protobuf body are produced exactly like the running service does.
+ *
+ * Usage:
+ *   node scripts/cursor-chat.mjs \
+ *     --token <JWT> \
+ *     --machine-id <UUID> \
+ *     [--model claude-4.5-sonnet] \
+ *     [--prompt "Hello"] \
+ *     [--stream]
+ *
+ * Env fallback:
+ *   CURSOR_ACCESS_TOKEN, CURSOR_MACHINE_ID, CURSOR_MODEL, CURSOR_PROMPT
+ *
+ * Tip: get token+machineId from `scripts/cursor-exchange-key.mjs`.
+ */
+
+import { CursorExecutor } from "../open-sse/executors/cursor.js";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+
+const accessToken = (args.token || process.env.CURSOR_ACCESS_TOKEN || "").trim();
+const machineId = (args["machine-id"] || process.env.CURSOR_MACHINE_ID || "").trim();
+const model = (args.model || process.env.CURSOR_MODEL || "claude-4.5-sonnet").trim();
+const prompt = (args.prompt || process.env.CURSOR_PROMPT || "Say hi in one short sentence.").trim();
+const stream = !!args.stream;
+
+if (!accessToken || !machineId) {
+  console.error("Usage:");
+  console.error("  node scripts/cursor-chat.mjs --token <JWT> --machine-id <UUID> [--model <name>] [--prompt <text>] [--stream]");
+  console.error("Env: CURSOR_ACCESS_TOKEN, CURSOR_MACHINE_ID, CURSOR_MODEL, CURSOR_PROMPT");
+  process.exit(1);
+}
+
+const credentials = {
+  accessToken,
+  providerSpecificData: {
+    machineId,
+    ghostMode: true,
+  },
+};
+
+const body = {
+  model,
+  stream,
+  messages: [
+    { role: "user", content: prompt },
+  ],
+};
+
+const executor = new CursorExecutor();
+
+const t0 = Date.now();
+const { response } = await executor.execute({
+  model,
+  body,
+  stream,
+  credentials,
+});
+const ms = Date.now() - t0;
+
+console.error(`[cursor-chat] HTTP ${response.status} in ${ms}ms`);
+
+if (response.status !== 200) {
+  const text = await response.text();
+  console.error(text);
+  process.exit(2);
+}
+
+if (stream) {
+  // SSE: print raw stream so the user can see chunks as the executor emits them
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    process.stdout.write(decoder.decode(value, { stream: true }));
+  }
+  process.stdout.write("\n");
+} else {
+  const json = await response.json();
+  const content = json?.choices?.[0]?.message?.content || "";
+  console.log("--- content ---");
+  console.log(content);
+  console.log("--- raw ---");
+  console.log(JSON.stringify(json, null, 2));
+}

--- a/scripts/cursor-exchange-key.mjs
+++ b/scripts/cursor-exchange-key.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Cursor: API Key -> Access Token (JWT)
+ *
+ * Exchanges a long-lived Cursor user API key (`crsr_...`) for a short-lived
+ * JWT access token. Same call cursor-agent CLI uses internally and the same
+ * call 9router uses on import / refresh.
+ *
+ * Usage:
+ *   node scripts/cursor-exchange-key.mjs <CURSOR_API_KEY>
+ *   CURSOR_API_KEY=crsr_xxx node scripts/cursor-exchange-key.mjs
+ *
+ * Output (JSON, stdout):
+ *   {
+ *     accessToken, refreshToken, machineId,
+ *     expiresAt, expiresInSec, userId, email
+ *   }
+ */
+
+import crypto from "node:crypto";
+
+const ENDPOINT = "https://api2.cursor.sh/auth/exchange_user_api_key";
+
+const apiKey = (process.argv[2] || process.env.CURSOR_API_KEY || "").trim();
+
+if (!apiKey) {
+  console.error("Usage: node scripts/cursor-exchange-key.mjs <CURSOR_API_KEY>");
+  console.error("   or: CURSOR_API_KEY=crsr_xxx node scripts/cursor-exchange-key.mjs");
+  process.exit(1);
+}
+if (!apiKey.startsWith("crsr_")) {
+  console.error("Error: Cursor API key must start with 'crsr_'");
+  process.exit(1);
+}
+
+function decodeJwt(token) {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    return JSON.parse(Buffer.from(payload, "base64").toString("utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+const res = await fetch(ENDPOINT, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  },
+  body: "{}",
+});
+
+if (!res.ok) {
+  const text = await res.text().catch(() => "");
+  console.error(`Cursor rejected the API key (HTTP ${res.status}): ${text.slice(0, 500)}`);
+  process.exit(2);
+}
+
+const data = await res.json();
+const accessToken = data?.accessToken;
+const refreshToken = data?.refreshToken || null;
+
+if (!accessToken) {
+  console.error("Cursor response missing accessToken:", JSON.stringify(data));
+  process.exit(3);
+}
+
+const claims = decodeJwt(accessToken) || {};
+const expSeconds = Number.isFinite(claims.exp)
+  ? claims.exp
+  : Math.floor(Date.now() / 1000) + 3600;
+
+const out = {
+  accessToken,
+  refreshToken,
+  machineId: crypto.randomUUID(),
+  expiresAt: new Date(expSeconds * 1000).toISOString(),
+  expiresInSec: expSeconds - Math.floor(Date.now() / 1000),
+  userId: claims.sub || claims.user_id || null,
+  email: claims.email || null,
+};
+
+console.log(JSON.stringify(out, null, 2));

--- a/scripts/cursor-refresh-token.mjs
+++ b/scripts/cursor-refresh-token.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Cursor: Refresh access token using the stored long-lived API key.
+ *
+ * Thin wrapper around CursorExecutor.refreshCredentials() — i.e. the *exact*
+ * code path 9router uses on proactive refresh / 401 fallback.
+ *
+ * Usage:
+ *   node scripts/cursor-refresh-token.mjs --api-key <crsr_...> [--machine-id <UUID>]
+ *
+ * Env fallback:
+ *   CURSOR_API_KEY, CURSOR_MACHINE_ID
+ *
+ * Output (JSON, stdout): { accessToken, refreshToken, expiresIn, expiresAt,
+ *                         providerSpecificData }
+ */
+
+import crypto from "node:crypto";
+import { CursorExecutor } from "../open-sse/executors/cursor.js";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+const apiKey = (args["api-key"] || process.env.CURSOR_API_KEY || "").trim();
+const machineId = (args["machine-id"] || process.env.CURSOR_MACHINE_ID || crypto.randomUUID()).trim();
+
+if (!apiKey) {
+  console.error("Usage:");
+  console.error("  node scripts/cursor-refresh-token.mjs --api-key <crsr_...> [--machine-id <UUID>]");
+  console.error("Env: CURSOR_API_KEY, CURSOR_MACHINE_ID");
+  process.exit(1);
+}
+if (!apiKey.startsWith("crsr_")) {
+  console.error("Error: Cursor API key must start with 'crsr_'");
+  process.exit(1);
+}
+
+const credentials = {
+  providerSpecificData: {
+    apiKey,
+    machineId,
+    authMethod: "apikey",
+  },
+};
+
+const log = {
+  info: (tag, msg) => console.error(`[${tag}] ${msg}`),
+  warn: (tag, msg) => console.error(`[${tag}] WARN ${msg}`),
+  error: (tag, msg) => console.error(`[${tag}] ERROR ${msg}`),
+};
+
+const executor = new CursorExecutor();
+const result = await executor.refreshCredentials(credentials, log);
+
+if (!result?.accessToken) {
+  console.error("Refresh failed: no accessToken returned");
+  process.exit(2);
+}
+
+const out = {
+  ...result,
+  expiresAt: new Date(Date.now() + result.expiresIn * 1000).toISOString(),
+};
+
+console.log(JSON.stringify(out, null, 2));

--- a/src/app/api/oauth/cursor/import-apikey/route.js
+++ b/src/app/api/oauth/cursor/import-apikey/route.js
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server"
+import crypto from "crypto"
+import { CursorService } from "@/lib/oauth/services/cursor"
+import { createProviderConnection } from "@/models"
+
+/**
+ * POST /api/oauth/cursor/import-apikey
+ *
+ * Import a Cursor "user API key" (`key_...`) and exchange it for a JWT.
+ *
+ * Why this exists:
+ *   The legacy /api/oauth/cursor/import flow stores the JWT extracted from
+ *   Cursor IDE's local SQLite. That JWT expires after ~1h and there is no
+ *   refresh path without Cursor IDE running (the IDE renews the row
+ *   in state.vscdb internally).
+ *
+ *   This route stores the long-lived `key_...` instead, allowing the
+ *   CursorExecutor.refreshCredentials() to mint a fresh JWT on demand
+ *   by re-calling POST https://api2.cursor.sh/auth/exchange_user_api_key
+ *   — the exact same mechanism cursor-agent CLI uses internally.
+ *
+ * Request body:
+ *   - apiKey: string  (long-lived Cursor user API key, starts with "key_")
+ *   - label?: string  (optional display name for the connection)
+ *   - machineId?: string  (optional; auto-generated UUID if absent)
+ */
+export async function POST(request) {
+  try {
+    const { apiKey, label, machineId: providedMachineId } = await request.json()
+
+    if (!apiKey || typeof apiKey !== "string" || !apiKey.trim()) {
+      return NextResponse.json({ error: "API key is required" }, { status: 400 })
+    }
+
+    const key = apiKey.trim()
+    if (!key.startsWith("crsr_")) {
+      return NextResponse.json(
+        { error: "Invalid Cursor API key format (expected to start with 'crsr_')" },
+        { status: 400 }
+      )
+    }
+
+    // 1. Exchange API key for an initial JWT to validate.
+    const res = await fetch("https://api2.cursor.sh/auth/exchange_user_api_key", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: "{}",
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      return NextResponse.json(
+        { error: `Cursor rejected the API key (HTTP ${res.status}): ${text.slice(0, 200)}` },
+        { status: 401 }
+      )
+    }
+
+    const data = await res.json()
+    const accessToken = data?.accessToken
+    const refreshToken = data?.refreshToken || null
+    if (!accessToken) {
+      return NextResponse.json(
+        { error: "Cursor response missing accessToken" },
+        { status: 502 }
+      )
+    }
+
+    // 2. Decode JWT exp for accurate expiresAt; fall back to 1h.
+    let expSeconds = Math.floor(Date.now() / 1000) + 3600
+    try {
+      const decoded = JSON.parse(
+        Buffer.from(accessToken.split(".")[1], "base64").toString()
+      )
+      if (Number.isFinite(decoded?.exp)) expSeconds = decoded.exp
+    } catch {
+      // non-JWT token, keep fallback
+    }
+
+    // 3. Try to extract identity (email / sub) from JWT for connection naming
+    //    & dedup by email inside createProviderConnection.
+    const cursorService = new CursorService()
+    const userInfo = cursorService.extractUserInfo(accessToken)
+
+    // 4. machineId: API-key flow has no real serviceMachineId — generate a
+    //    stable random UUID per connection. Cursor's checksum header only
+    //    needs a UUID-shaped value; the server does not bind it to anything.
+    const machineId =
+      (providedMachineId && providedMachineId.trim()) || crypto.randomUUID()
+
+    // 5. Persist. The long-lived `apiKey` lives in providerSpecificData so
+    //    CursorExecutor.refreshCredentials() can re-exchange it on 401/403.
+    const connection = await createProviderConnection({
+      provider: "cursor",
+      authType: "oauth",
+      accessToken,
+      refreshToken,
+      expiresAt: new Date(expSeconds * 1000).toISOString(),
+      email: userInfo?.email || (label ? label.trim() : null),
+      providerSpecificData: {
+        machineId,
+        apiKey: key,
+        authMethod: "apikey",
+        provider: "API Key",
+        userId: userInfo?.userId || null,
+      },
+      testStatus: "active",
+    })
+
+    return NextResponse.json({
+      success: true,
+      connection: {
+        id: connection.id,
+        provider: connection.provider,
+        email: connection.email,
+      },
+    })
+  } catch (error) {
+    console.log("Cursor import-apikey error:", error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/src/shared/components/CursorAuthModal.js
+++ b/src/shared/components/CursorAuthModal.js
@@ -1,67 +1,120 @@
-"use client";
+"use client"
 
-import { useState, useEffect } from "react";
-import PropTypes from "prop-types";
-import { Modal, Button, Input } from "@/shared/components";
+import { useState, useEffect } from "react"
+import PropTypes from "prop-types"
+import { Modal, Button, Input } from "@/shared/components"
 
 /**
  * Cursor Auth Modal
- * Auto-detect and import token from Cursor IDE's local SQLite database
+ *
+ * Two import modes:
+ *   - "ide":    auto-detect tokens from Cursor IDE's local SQLite. No refresh
+ *               path — relies on Cursor IDE keeping the row fresh.
+ *   - "apikey": exchange a long-lived Cursor user API key (`key_...`) for a
+ *               JWT. 9router can then auto-refresh on 401/403 by re-calling
+ *               /auth/exchange_user_api_key. Recommended for headless /
+ *               multi-account service deployments.
  */
 export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
-  const [accessToken, setAccessToken] = useState("");
-  const [machineId, setMachineId] = useState("");
-  const [error, setError] = useState(null);
-  const [importing, setImporting] = useState(false);
-  const [autoDetecting, setAutoDetecting] = useState(false);
-  const [autoDetected, setAutoDetected] = useState(false);
-  const [windowsManual, setWindowsManual] = useState(false);
+  const [mode, setMode] = useState("ide") // "ide" | "apikey"
+
+  // IDE mode state
+  const [accessToken, setAccessToken] = useState("")
+  const [machineId, setMachineId] = useState("")
+  const [autoDetecting, setAutoDetecting] = useState(false)
+  const [autoDetected, setAutoDetected] = useState(false)
+  const [windowsManual, setWindowsManual] = useState(false)
+
+  // API key mode state
+  const [apiKey, setApiKey] = useState("")
+  const [apiKeyLabel, setApiKeyLabel] = useState("")
+
+  // Shared state
+  const [error, setError] = useState(null)
+  const [importing, setImporting] = useState(false)
 
   const runAutoDetect = async () => {
-    setAutoDetecting(true);
-    setError(null);
-    setAutoDetected(false);
-    setWindowsManual(false);
+    setAutoDetecting(true)
+    setError(null)
+    setAutoDetected(false)
+    setWindowsManual(false)
 
     try {
-      const res = await fetch("/api/oauth/cursor/auto-import");
-      const data = await res.json();
+      const res = await fetch("/api/oauth/cursor/auto-import")
+      const data = await res.json()
 
       if (data.found) {
-        setAccessToken(data.accessToken);
-        setMachineId(data.machineId);
-        setAutoDetected(true);
+        setAccessToken(data.accessToken)
+        setMachineId(data.machineId)
+        setAutoDetected(true)
       } else if (data.windowsManual) {
-        setWindowsManual(true);
+        setWindowsManual(true)
       } else {
-        setError(data.error || "Could not auto-detect tokens");
+        setError(data.error || "Could not auto-detect tokens")
       }
     } catch (err) {
-      setError("Failed to auto-detect tokens");
+      setError("Failed to auto-detect tokens")
     } finally {
-      setAutoDetecting(false);
+      setAutoDetecting(false)
     }
-  };
+  }
 
-  // Auto-detect tokens when modal opens
+  // Auto-detect tokens when modal opens (only in IDE mode)
   useEffect(() => {
-    if (!isOpen) return;
-    runAutoDetect();
-  }, [isOpen]);
+    if (!isOpen) return
+    if (mode !== "ide") return
+    runAutoDetect()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, mode])
+
+  const handleImportApiKey = async () => {
+    if (!apiKey.trim()) {
+      setError("Please enter a Cursor API key")
+      return
+    }
+    if (!apiKey.trim().startsWith("crsr_")) {
+      setError("Cursor API key must start with 'crsr_'")
+      return
+    }
+
+    setImporting(true)
+    setError(null)
+
+    try {
+      const res = await fetch("/api/oauth/cursor/import-apikey", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          apiKey: apiKey.trim(),
+          label: apiKeyLabel.trim() || undefined,
+        }),
+      })
+
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || "Import failed")
+
+      onSuccess?.()
+      onClose()
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setImporting(false)
+    }
+  }
 
   const handleImportToken = async () => {
     if (!accessToken.trim()) {
-      setError("Please enter an access token");
-      return;
+      setError("Please enter an access token")
+      return
     }
 
     if (!machineId.trim()) {
-      setError("Please enter a machine ID");
-      return;
+      setError("Please enter a machine ID")
+      return
     }
 
-    setImporting(true);
-    setError(null);
+    setImporting(true)
+    setError(null)
 
     try {
       const res = await fetch("/api/oauth/cursor/import", {
@@ -71,28 +124,107 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
           accessToken: accessToken.trim(),
           machineId: machineId.trim(),
         }),
-      });
+      })
 
-      const data = await res.json();
+      const data = await res.json()
 
       if (!res.ok) {
-        throw new Error(data.error || "Import failed");
+        throw new Error(data.error || "Import failed")
       }
 
-      onSuccess?.();
-      onClose();
+      onSuccess?.()
+      onClose()
     } catch (err) {
-      setError(err.message);
+      setError(err.message)
     } finally {
-      setImporting(false);
+      setImporting(false)
     }
-  };
+  }
+
+  const tabBtn = (key, label) => (
+    <button
+      type="button"
+      onClick={() => { setMode(key); setError(null) }}
+      className={`flex-1 px-3 py-2 text-sm font-medium border-b-2 transition-colors ${mode === key
+        ? "border-primary text-primary"
+        : "border-transparent text-text-muted hover:text-text"
+        }`}
+    >
+      {label}
+    </button>
+  )
 
   return (
-    <Modal isOpen={isOpen} title="Connect Cursor IDE" onClose={onClose}>
+    <Modal isOpen={isOpen} title="Connect Cursor" onClose={onClose}>
       <div className="flex flex-col gap-4">
-        {/* Auto-detecting state */}
-        {autoDetecting && (
+        {/* Mode tabs */}
+        <div className="flex border-b border-border -mt-2">
+          {tabBtn("ide", "From Cursor IDE")}
+          {tabBtn("apikey", "From API Key")}
+        </div>
+
+        {/* API key mode */}
+        {mode === "apikey" && (
+          <div className="flex flex-col gap-3">
+            <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg border border-blue-200 dark:border-blue-800">
+              <p className="text-sm text-blue-800 dark:text-blue-200">
+                Paste a long-lived Cursor user API key (<code className="font-mono">crsr_...</code>).
+                9router will exchange it for a JWT and auto-refresh on expiry —
+                no Cursor IDE required.
+              </p>
+              <p className="text-xs text-blue-700 dark:text-blue-300 mt-1">
+                Get one at <span className="font-mono">cursor.com → Settings → Integrations → API Keys</span>.
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Cursor API Key <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="crsr_..."
+                rows={3}
+                className="w-full px-3 py-2 text-sm font-mono border border-border rounded-lg bg-background focus:outline-none focus:border-primary resize-none"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                Label (optional)
+              </label>
+              <Input
+                value={apiKeyLabel}
+                onChange={(e) => setApiKeyLabel(e.target.value)}
+                placeholder="e.g. account-1@example.com"
+                className="text-sm"
+              />
+            </div>
+
+            {error && (
+              <div className="bg-red-50 dark:bg-red-900/20 p-3 rounded-lg border border-red-200 dark:border-red-800">
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              <Button
+                onClick={handleImportApiKey}
+                fullWidth
+                disabled={importing || !apiKey.trim()}
+              >
+                {importing ? "Importing..." : "Exchange & Import"}
+              </Button>
+              <Button onClick={onClose} variant="ghost" fullWidth>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* IDE mode — original auto-detect flow */}
+        {mode === "ide" && autoDetecting && (
           <div className="text-center py-6">
             <div className="size-16 mx-auto mb-4 rounded-full bg-primary/10 flex items-center justify-center">
               <span className="material-symbols-outlined text-3xl text-primary animate-spin">
@@ -107,7 +239,7 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
         )}
 
         {/* Form (shown after auto-detect completes) */}
-        {!autoDetecting && (
+        {mode === "ide" && !autoDetecting && (
           <>
             {/* Success message if auto-detected */}
             {autoDetected && (
@@ -202,11 +334,11 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
         )}
       </div>
     </Modal>
-  );
+  )
 }
 
 CursorAuthModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onSuccess: PropTypes.func,
   onClose: PropTypes.func.isRequired,
-};
+}

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,12 +1,12 @@
-import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings } from "@/lib/localDb";
-import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
-import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
-import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
-import * as log from "../utils/logger.js";
+import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings } from "@/lib/localDb"
+import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy"
+import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js"
+import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js"
+import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js"
+import * as log from "../utils/logger.js"
 
 // Mutex to prevent race conditions during account selection
-let selectionMutex = Promise.resolve();
+let selectionMutex = Promise.resolve()
 
 /**
  * Get provider credentials from localDb
@@ -19,24 +19,24 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
   // Normalize to Set for consistent handling
   const excludeSet = excludeConnectionIds instanceof Set
     ? excludeConnectionIds
-    : (excludeConnectionIds ? new Set([excludeConnectionIds]) : new Set());
-  const preferredConnectionId = options?.preferredConnectionId || null;
+    : (excludeConnectionIds ? new Set([excludeConnectionIds]) : new Set())
+  const preferredConnectionId = options?.preferredConnectionId || null
   // Acquire mutex to prevent race conditions
-  const currentMutex = selectionMutex;
-  let resolveMutex;
-  selectionMutex = new Promise(resolve => { resolveMutex = resolve; });
+  const currentMutex = selectionMutex
+  let resolveMutex
+  selectionMutex = new Promise(resolve => { resolveMutex = resolve })
 
   try {
-    await currentMutex;
+    await currentMutex
 
     // Resolve alias to provider ID (e.g., "kc" -> "kilocode")
-    const providerId = resolveProviderId(provider);
+    const providerId = resolveProviderId(provider)
 
     // Inject a virtual connection for no-auth free providers (with optional proxy pool from settings)
     if (FREE_PROVIDERS[providerId]?.noAuth) {
-      const settings = await getSettings();
-      const override = (settings.providerStrategies || {})[providerId] || {};
-      const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: override.proxyPoolId || "" });
+      const settings = await getSettings()
+      const override = (settings.providerStrategies || {})[providerId] || {}
+      const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: override.proxyPoolId || "" })
       return {
         id: "noauth",
         connectionName: "Public",
@@ -49,119 +49,120 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
           connectionProxyPoolId: resolvedProxy.proxyPoolId || null,
           vercelRelayUrl: resolvedProxy.vercelRelayUrl || "",
         },
-      };
+      }
     }
 
-    const connections = await getProviderConnections({ provider: providerId, isActive: true });
-    log.debug("AUTH", `${provider} | total connections: ${connections.length}, excludeIds: ${excludeSet.size > 0 ? [...excludeSet].join(",") : "none"}, model: ${model || "any"}`);
+    const connections = await getProviderConnections({ provider: providerId, isActive: true })
+    log.debug("AUTH", `${provider} | total connections: ${connections.length}, excludeIds: ${excludeSet.size > 0 ? [...excludeSet].join(",") : "none"}, model: ${model || "any"}`)
 
     if (connections.length === 0) {
-      log.warn("AUTH", `No credentials for ${provider}`);
-      return null;
+      log.warn("AUTH", `No credentials for ${provider}`)
+      return null
     }
 
     // Filter out model-locked and excluded connections
     const availableConnections = connections.filter(c => {
-      if (excludeSet.has(c.id)) return false;
-      if (isModelLockActive(c, model)) return false;
-      return true;
-    });
+      if (excludeSet.has(c.id)) return false
+      if (isModelLockActive(c, model)) return false
+      return true
+    })
 
-    log.debug("AUTH", `${provider} | available: ${availableConnections.length}/${connections.length}`);
+    log.debug("AUTH", `${provider} | available: ${availableConnections.length}/${connections.length}`)
     connections.forEach(c => {
-      const excluded = excludeSet.has(c.id);
-      const locked = isModelLockActive(c, model);
+      const excluded = excludeSet.has(c.id)
+      const locked = isModelLockActive(c, model)
       if (excluded || locked) {
-        const lockUntil = getEarliestModelLockUntil(c);
-        log.debug("AUTH", `  → ${c.id?.slice(0, 8)} | ${excluded ? "excluded" : ""} ${locked ? `modelLocked(${model}) until ${lockUntil}` : ""}`);
+        const lockUntil = getEarliestModelLockUntil(c)
+        log.debug("AUTH", `  → ${c.id?.slice(0, 8)} | ${excluded ? "excluded" : ""} ${locked ? `modelLocked(${model}) until ${lockUntil}` : ""}`)
       }
-    });
+    })
 
     if (availableConnections.length === 0) {
       // Find earliest lock expiry across all connections for retry timing
-      const lockedConns = connections.filter(c => isModelLockActive(c, model));
-      const expiries = lockedConns.map(c => getEarliestModelLockUntil(c)).filter(Boolean);
-      const earliest = expiries.sort()[0] || null;
+      const lockedConns = connections.filter(c => isModelLockActive(c, model))
+      const expiries = lockedConns.map(c => getEarliestModelLockUntil(c)).filter(Boolean)
+      const earliest = expiries.sort()[0] || null
       if (earliest) {
-        const earliestConn = lockedConns[0];
-        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(earliest)}) | lastError=${earliestConn?.lastError?.slice(0, 50)}`);
+        const earliestConn = lockedConns[0]
+        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(earliest)}) | lastError=${earliestConn?.lastError?.slice(0, 50)}`)
         return {
           allRateLimited: true,
           retryAfter: earliest,
           retryAfterHuman: formatRetryAfter(earliest),
           lastError: earliestConn?.lastError || null,
           lastErrorCode: earliestConn?.errorCode || null
-        };
+        }
       }
-      log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`);
-      return null;
+      log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`)
+      return null
     }
 
-    const settings = await getSettings();
+    const settings = await getSettings()
     // Per-provider strategy overrides global setting
-    const providerOverride = (settings.providerStrategies || {})[providerId] || {};
-    const strategy = providerOverride.fallbackStrategy || settings.fallbackStrategy || "fill-first";
+    const providerOverride = (settings.providerStrategies || {})[providerId] || {}
+    const strategy = providerOverride.fallbackStrategy || settings.fallbackStrategy || "fill-first"
 
-    let connection;
+    let connection
     // Pin to preferred connection if specified and available
     if (preferredConnectionId) {
-      connection = availableConnections.find((c) => c.id === preferredConnectionId);
+      connection = availableConnections.find((c) => c.id === preferredConnectionId)
       if (connection) {
-        log.info("AUTH", `${provider} | pinned to ${connection.id?.slice(0, 8)} (${connection.name || connection.email || "unnamed"})`);
+        log.info("AUTH", `${provider} | pinned to ${connection.id?.slice(0, 8)} (${connection.name || connection.email || "unnamed"})`)
       }
     }
     if (connection) {
       // skip strategy
     } else if (strategy === "round-robin") {
-      const stickyLimit = providerOverride.stickyRoundRobinLimit || settings.stickyRoundRobinLimit || 3;
+      const stickyLimit = providerOverride.stickyRoundRobinLimit || settings.stickyRoundRobinLimit || 3
 
       // Sort by lastUsed (most recent first) to find current candidate
       const byRecency = [...availableConnections].sort((a, b) => {
-        if (!a.lastUsedAt && !b.lastUsedAt) return (a.priority || 999) - (b.priority || 999);
-        if (!a.lastUsedAt) return 1;
-        if (!b.lastUsedAt) return -1;
-        return new Date(b.lastUsedAt) - new Date(a.lastUsedAt);
-      });
+        if (!a.lastUsedAt && !b.lastUsedAt) return (a.priority || 999) - (b.priority || 999)
+        if (!a.lastUsedAt) return 1
+        if (!b.lastUsedAt) return -1
+        return new Date(b.lastUsedAt) - new Date(a.lastUsedAt)
+      })
 
-      const current = byRecency[0];
-      const currentCount = current?.consecutiveUseCount || 0;
+      const current = byRecency[0]
+      const currentCount = current?.consecutiveUseCount || 0
 
       if (current && current.lastUsedAt && currentCount < stickyLimit) {
         // Stay with current account
-        connection = current;
+        connection = current
         // Update lastUsedAt and increment count (await to ensure persistence)
         await updateProviderConnection(connection.id, {
           lastUsedAt: new Date().toISOString(),
           consecutiveUseCount: (connection.consecutiveUseCount || 0) + 1
-        });
+        })
       } else {
         // Pick the least recently used (excluding current if possible)
         const sortedByOldest = [...availableConnections].sort((a, b) => {
-          if (!a.lastUsedAt && !b.lastUsedAt) return (a.priority || 999) - (b.priority || 999);
-          if (!a.lastUsedAt) return -1;
-          if (!b.lastUsedAt) return 1;
-          return new Date(a.lastUsedAt) - new Date(b.lastUsedAt);
-        });
+          if (!a.lastUsedAt && !b.lastUsedAt) return (a.priority || 999) - (b.priority || 999)
+          if (!a.lastUsedAt) return -1
+          if (!b.lastUsedAt) return 1
+          return new Date(a.lastUsedAt) - new Date(b.lastUsedAt)
+        })
 
-        connection = sortedByOldest[0];
+        connection = sortedByOldest[0]
 
         // Update lastUsedAt and reset count to 1 (await to ensure persistence)
         await updateProviderConnection(connection.id, {
           lastUsedAt: new Date().toISOString(),
           consecutiveUseCount: 1
-        });
+        })
       }
     } else {
       // Default: fill-first (already sorted by priority in getProviderConnections)
-      connection = availableConnections[0];
+      connection = availableConnections[0]
     }
 
-    const resolvedProxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});
+    const resolvedProxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {})
 
     return {
       apiKey: connection.apiKey,
       accessToken: connection.accessToken,
       refreshToken: connection.refreshToken,
+      expiresAt: connection.expiresAt,
       projectId: connection.projectId,
       connectionName: connection.displayName || connection.name || connection.email || connection.id,
       copilotToken: connection.providerSpecificData?.copilotToken,
@@ -179,9 +180,9 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       lastError: connection.lastError,
       // Pass full connection for clearAccountError to read modelLock_* keys
       _connection: connection
-    };
+    }
   } finally {
-    if (resolveMutex) resolveMutex();
+    if (resolveMutex) resolveMutex()
   }
 }
 
@@ -196,24 +197,24 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
  * @returns {{ shouldFallback: boolean, cooldownMs: number }}
  */
 export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null) {
-  if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 };
-  const connections = await getProviderConnections({ provider });
-  const conn = connections.find(c => c.id === connectionId);
-  const backoffLevel = conn?.backoffLevel || 0;
+  if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 }
+  const connections = await getProviderConnections({ provider })
+  const conn = connections.find(c => c.id === connectionId)
+  const backoffLevel = conn?.backoffLevel || 0
 
   // Provider-specific precise cooldown (e.g. codex usage_limit_reached resets_at) overrides backoff
-  let shouldFallback, cooldownMs, newBackoffLevel;
+  let shouldFallback, cooldownMs, newBackoffLevel
   if (resetsAtMs && resetsAtMs > Date.now()) {
-    shouldFallback = true;
-    cooldownMs = Math.min(resetsAtMs - Date.now(), MAX_RATE_LIMIT_COOLDOWN_MS);
-    newBackoffLevel = 0;
+    shouldFallback = true
+    cooldownMs = Math.min(resetsAtMs - Date.now(), MAX_RATE_LIMIT_COOLDOWN_MS)
+    newBackoffLevel = 0
   } else {
-    ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));
+    ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel))
   }
-  if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
+  if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 }
 
-  const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
-  const lockUpdate = buildModelLockUpdate(model, cooldownMs);
+  const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error"
+  const lockUpdate = buildModelLockUpdate(model, cooldownMs)
 
   await updateProviderConnection(connectionId, {
     ...lockUpdate,
@@ -222,17 +223,17 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     errorCode: status,
     lastErrorAt: new Date().toISOString(),
     backoffLevel: newBackoffLevel ?? backoffLevel
-  });
+  })
 
-  const lockKey = Object.keys(lockUpdate)[0];
-  const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8);
-  log.warn("AUTH", `${connName} locked ${lockKey} for ${Math.round(cooldownMs / 1000)}s [${status}]`);
+  const lockKey = Object.keys(lockUpdate)[0]
+  const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8)
+  log.warn("AUTH", `${connName} locked ${lockKey} for ${Math.round(cooldownMs / 1000)}s [${status}]`)
 
   if (provider && status && reason) {
-    console.error(`❌ ${provider} [${status}]: ${reason}`);
+    console.error(`❌ ${provider} [${status}]: ${reason}`)
   }
 
-  return { shouldFallback: true, cooldownMs };
+  return { shouldFallback: true, cooldownMs }
 }
 
 /**
@@ -245,38 +246,38 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
  * @param {string|null} model - model that succeeded
  */
 export async function clearAccountError(connectionId, currentConnection, model = null) {
-  if (!connectionId || connectionId === "noauth") return;
-  const conn = currentConnection._connection || currentConnection;
-  const now = Date.now();
-  const allLockKeys = Object.keys(conn).filter(k => k.startsWith("modelLock_"));
+  if (!connectionId || connectionId === "noauth") return
+  const conn = currentConnection._connection || currentConnection
+  const now = Date.now()
+  const allLockKeys = Object.keys(conn).filter(k => k.startsWith("modelLock_"))
 
-  if (!conn.testStatus && !conn.lastError && allLockKeys.length === 0) return;
+  if (!conn.testStatus && !conn.lastError && allLockKeys.length === 0) return
 
   // Keys to clear: current model's lock + all expired locks
   const keysToClear = allLockKeys.filter(k => {
-    if (model && k === `modelLock_${model}`) return true; // succeeded model
-    if (model && k === "modelLock___all") return true;    // account-level lock
-    const expiry = conn[k];
-    return expiry && new Date(expiry).getTime() <= now;   // expired
-  });
+    if (model && k === `modelLock_${model}`) return true // succeeded model
+    if (model && k === "modelLock___all") return true    // account-level lock
+    const expiry = conn[k]
+    return expiry && new Date(expiry).getTime() <= now   // expired
+  })
 
-  if (keysToClear.length === 0 && conn.testStatus !== "unavailable" && !conn.lastError) return;
+  if (keysToClear.length === 0 && conn.testStatus !== "unavailable" && !conn.lastError) return
 
   // Check if any active locks remain after clearing
   const remainingActiveLocks = allLockKeys.filter(k => {
-    if (keysToClear.includes(k)) return false;
-    const expiry = conn[k];
-    return expiry && new Date(expiry).getTime() > now;
-  });
+    if (keysToClear.includes(k)) return false
+    const expiry = conn[k]
+    return expiry && new Date(expiry).getTime() > now
+  })
 
-  const clearObj = Object.fromEntries(keysToClear.map(k => [k, null]));
+  const clearObj = Object.fromEntries(keysToClear.map(k => [k, null]))
 
   // Only reset error state if no active locks remain
   if (remainingActiveLocks.length === 0) {
-    Object.assign(clearObj, { testStatus: "active", lastError: null, lastErrorAt: null, backoffLevel: 0 });
+    Object.assign(clearObj, { testStatus: "active", lastError: null, lastErrorAt: null, backoffLevel: 0 })
   }
 
-  await updateProviderConnection(connectionId, clearObj);
+  await updateProviderConnection(connectionId, clearObj)
 }
 
 /**
@@ -284,24 +285,24 @@ export async function clearAccountError(connectionId, currentConnection, model =
  */
 export function extractApiKey(request) {
   // Check Authorization header first
-  const authHeader = request.headers.get("Authorization");
+  const authHeader = request.headers.get("Authorization")
   if (authHeader?.startsWith("Bearer ")) {
-    return authHeader.slice(7);
+    return authHeader.slice(7)
   }
 
   // Check Anthropic x-api-key header
-  const xApiKey = request.headers.get("x-api-key");
+  const xApiKey = request.headers.get("x-api-key")
   if (xApiKey) {
-    return xApiKey;
+    return xApiKey
   }
 
-  return null;
+  return null
 }
 
 /**
  * Validate API key (optional - for local use can skip)
  */
 export async function isValidApiKey(apiKey) {
-  if (!apiKey) return false;
-  return await validateApiKey(apiKey);
+  if (!apiKey) return false
+  return await validateApiKey(apiKey)
 }

--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -23,6 +23,7 @@ import {
   refreshKiroToken as _refreshKiroToken,
   getRefreshLeadMs as _getRefreshLeadMs
 } from "open-sse/services/tokenRefresh.js";
+import { getExecutor } from "open-sse/executors/index.js";
 
 export const TOKEN_EXPIRY_BUFFER_MS = BUFFER_MS;
 
@@ -205,7 +206,20 @@ export async function checkAndRefreshToken(provider, credentials) {
         refreshLeadMs: refreshLead,
       });
 
-      const newCreds = await getAccessToken(provider, creds);
+      let newCreds = await getAccessToken(provider, creds);
+
+      // Fallback: executor-based refresh for providers like cursor that
+      // use non-standard refresh mechanisms (e.g., API key exchange)
+      if (!newCreds?.accessToken) {
+        const executor = getExecutor(provider);
+        if (executor?.refreshCredentials) {
+          const execCreds = await executor.refreshCredentials(creds, log);
+          if (execCreds?.accessToken) {
+            newCreds = execCreds;
+          }
+        }
+      }
+
       if (newCreds?.accessToken) {
         const mergedCreds = {
           ...newCreds,


### PR DESCRIPTION
## Summary
- New `/api/oauth/cursor/import-apikey` route: exchange `crsr_` API keys for JWT via Cursor auth endpoint
- `CursorAuthModal` gains "From API Key" tab alongside existing IDE auto-detect mode
- `CursorExecutor.refreshCredentials()` re-exchanges API key for fresh JWT on token expiry
- `checkAndRefreshToken` falls back to executor-based refresh, enabling proactive token refresh for providers like cursor that use non-standard OAuth mechanisms

## Motivation

I had Claude reverse-engineer the Cursor CLI authentication flow and discovered that Cursor internally uses `POST https://api2.cursor.sh/auth/exchange_user_api_key` to exchange a user API key (starting with `crsr_`) for a JWT. The key insight is that this endpoint supports repeated calls for token refresh — it's not a one-time exchange.

The existing IDE-based import flow relies on extracting tokens from Cursor IDE's local SQLite database (`state.vscdb`), but those tokens expire with no refresh path without the IDE running. With the API key approach, 9router can import a long-lived key once and refresh the JWT proactively, making it viable for headless / multi-account deployments.

## Test plan
- [x] Import a Cursor API key via the modal (From API Key tab)
- [x] Verify connection appears and status is active
- [x] Make a chat request through the connection
- [x] Verify token auto-refreshes on expiry without 401 round-trip

Please review — feedback welcome!

🤖 Generated with [Claude Code](https://claude.com/claude-code)