### PR TITLE
fix(antigravity): strip built-in tools when functionDeclarations present to avoid 400

### DIFF
--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -303,7 +303,15 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
     }
 
     // Add toolConfig for Antigravity
-    if (geminiCLI.tools?.length > 0) {
+    // Strip built-in tools (google_search etc.) — v1internal rejects mixing them with functionDeclarations
+    if (envelope.request.tools?.length > 0) {
+      const GEMINI_BUILTIN_TOOLS = new Set(["google_search", "web_search", "search_web", "googleSearch"]);
+      const allDecls = envelope.request.tools.flatMap(t => t.functionDeclarations || []);
+      const customDecls = allDecls.filter(fn => !GEMINI_BUILTIN_TOOLS.has(fn.name));
+      envelope.request.tools = customDecls.length > 0 ? [{ functionDeclarations: customDecls }] : undefined;
+    }
+    const hasCustomTools = envelope.request.tools?.some(t => t.functionDeclarations?.length > 0);
+    if (hasCustomTools) {
       envelope.request.toolConfig = {
         functionCallingConfig: { mode: "VALIDATED" }
       };
@@ -400,9 +408,11 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
 
   // Convert Claude tools to Gemini functionDeclarations
   if (claudeRequest.tools && Array.isArray(claudeRequest.tools)) {
+    const GEMINI_BUILTIN_TOOLS = new Set(["google_search", "web_search", "search_web", "googleSearch"]);
     const functionDeclarations = [];
     for (const tool of claudeRequest.tools) {
       if (tool.name && tool.input_schema) {
+        if (GEMINI_BUILTIN_TOOLS.has(tool.name)) continue; // v1internal rejects mixing built-in with functionDeclarations
         const cleanedSchema = cleanJSONSchemaForAntigravity(tool.input_schema);
         functionDeclarations.push({
           name: sanitizeGeminiFunctionName(tool.name),


### PR DESCRIPTION
## Problem

Antigravity `v1internal` API (`cloudcode-pa.googleapis.com`) rejects requests that mix built-in tools (`google_search`) with `functionDeclarations`, returning `400 INVALID_ARGUMENT`:

```json
{"error": {"code": 400, "message": "Request contains an invalid argument.", "status": "INVALID_ARGUMENT"}}
```

This affects all clients (OpenClaw, Claude Code, Cline, etc.) that send `google_search` as a function tool alongside other tools — which is the default behavior for many AI agent frameworks.

## Root Cause

When a client sends `google_search` as a function tool in the `tools` array, 9router forwards it as a `functionDeclarations` entry to Antigravity. The `v1internal` protocol does not support `tool_config.include_server_side_tool_invocations`, so any mix of built-in tools and custom function declarations is rejected.

Reference: [lbjlaq/Antigravity-Manager#2331](https://github.com/lbjlaq/Antigravity-Manager/issues/2331), [PR#2356](https://github.com/lbjlaq/Antigravity-Manager/pull/2356)

## Fix

Strip `google_search`, `web_search`, `search_web` from `functionDeclarations` before sending to Antigravity in both paths:
- `wrapInCloudCodeEnvelope` (Gemini model path)
- `wrapInCloudCodeEnvelopeForClaude` (Claude model path)

`toolConfig` is only added when custom `functionDeclarations` remain after stripping.

## Behavior

- **With `google_search` + custom tools**: `google_search` is stripped, custom tools forwarded normally ✅
- **With only `google_search`**: tools removed entirely, plain chat request ✅  
- **With only custom tools**: unchanged behavior ✅