### PR TITLE
fix(docker): keep /app/server.js and bundle next at runtime (#1096)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ COPY --from=builder /app/open-sse ./open-sse
 COPY --from=builder /app/src/mitm ./src/mitm
 # Standalone node_modules may omit deps only required by the MITM child process.
 COPY --from=builder /app/node_modules/node-forge ./node_modules/node-forge
+# Ensure `next` is available at runtime in case tracing did not include it.
+COPY --from=builder /app/node_modules/next ./node_modules/next
 
 RUN mkdir -p /app/data && chown -R node:node /app && \
   mkdir -p /app/data-home && chown node:node /app/data-home && \

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,19 +1,16 @@
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 
 const projectRoot = dirname(fileURLToPath(import.meta.url));
-// Workspace root (one level up from app/) — where npm hoists deps.
-// Next.js tracing must scan from here to find "next", "react", etc.
-const workspaceRoot = join(projectRoot, "..");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   serverExternalPackages: ["better-sqlite3", "sql.js", "node:sqlite", "bun:sqlite"],
   turbopack: {
-    root: workspaceRoot
+    root: projectRoot
   },
-  outputFileTracingRoot: workspaceRoot,
+  outputFileTracingRoot: projectRoot,
   outputFileTracingExcludes: {
     "*": ["./gitbook/**/*"]
   },


### PR DESCRIPTION
## Summary

Re-fixes the broken Docker image reported in #1096 (originally #1064). Two things are needed together — fixing only one trades the bug for the other, which is what has happened across the last few releases.

- Revert `outputFileTracingRoot` from `workspaceRoot` back to `projectRoot` in `next.config.mjs` so the standalone build emits `server.js` at the project root rather than nested under `app/`.
- Copy `node_modules/next` from the builder into the runner image, mirroring the existing `node-forge` pattern, so `next` resolves at runtime even if file tracing omits it.

## Background

| Release | `outputFileTracingRoot` | `/app/server.js` | `require('next')` |
|---|---|---|---|
| v0.4.30 | `projectRoot` | ✅ | ✅ |
| v0.4.31 – v0.4.33 | `monorepoRoot` | ❌ (nested at `/app/app/server.js`) | n/a (never reached) |
| #1067 merged | `projectRoot` | ✅ | ❌ ("Cannot find module 'next'") |
| v0.4.36 – v0.4.37 | `workspaceRoot` (rename of `monorepoRoot`) | ❌ (#1064 returns) | n/a |
| This PR | `projectRoot` + explicit `next` COPY | ✅ | ✅ |

## Changes

**`next.config.mjs`** — drop the `workspaceRoot` indirection:

```diff
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 
 const projectRoot = dirname(fileURLToPath(import.meta.url));
-const workspaceRoot = join(projectRoot, "..");
...
-  turbopack: { root: workspaceRoot },
-  outputFileTracingRoot: workspaceRoot,
+  turbopack: { root: projectRoot },
+  outputFileTracingRoot: projectRoot,
```

**`Dockerfile`** — one new line in the runner stage:

```diff
 COPY --from=builder /app/node_modules/node-forge ./node_modules/node-forge
+# Ensure `next` is available at runtime in case tracing did not include it.
+COPY --from=builder /app/node_modules/next ./node_modules/next
```

## Test plan

- [x] `docker build -t 9router-fix .`
- [x] `docker run --rm --entrypoint sh 9router-fix -c "ls -la /app/server.js"` → file present (7203 bytes)
- [x] `ls /app` is clean — no `proc`/`root`/`usr` and no nested `app/` directory
- [x] `docker run --rm -p 20128:20128 9router-fix` → `▲ Next.js 16.2.6 ✓ Ready in 0ms`, DB migrations apply, `curl :20128` returns 307

## References

- Fixes #1096
- Original report: #1064
- Previous fix that was reverted in v0.4.36: #1067 (commit `692d1fd`)
- Revert commit: `7ccf8c5` (v0.4.36 release)
