### PR TITLE
feat: add drag-and-drop reordering for combo models

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "start:bun": "NODE_ENV=production bun ./.next/standalone/server.js"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@xyflow/react": "^12.10.1",
     "bcryptjs": "^3.0.3",

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -1,6 +1,10 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { restrictToVerticalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import { Card, Button, Modal, Input, CardSkeleton, ModelSelectModal, Toggle, ConfirmModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
@@ -283,15 +287,20 @@ function ComboCard({ combo, copied, onCopy, onEdit, onDelete, roundRobinEnabled,
   );
 }
 
-// Inline editable model item
-function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown, onRemove }) {
+function ModelItem({ id, index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown, onRemove }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    // no transition — prevents the CSS settle animation fighting React's re-render on drop
+    opacity: isDragging ? 0.4 : 1,
+    zIndex: isDragging ? 999 : undefined,
+  };
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(model);
-
   const commit = () => {
     const trimmed = draft.trim();
     if (trimmed && trimmed !== model) onEdit(trimmed);
-    else setDraft(model); // revert if empty or unchanged
+    else setDraft(model);
     setEditing(false);
   };
 
@@ -301,7 +310,26 @@ function ModelItem({ index, model, isFirst, isLast, onEdit, onMoveUp, onMoveDown
   };
 
   return (
-    <div className="group flex min-w-0 items-center gap-1.5 rounded-md bg-black/[0.02] px-2 py-1 transition-colors hover:bg-black/[0.04] dark:bg-white/[0.02] dark:hover:bg-white/[0.04]">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 bg-black/[0.02] hover:bg-black/[0.04] dark:bg-white/[0.02] dark:hover:bg-white/[0.04] transition-colors ${isDragging ? "shadow-md ring-1 ring-primary/30" : ""}`}
+    >
+      {/* Drag handle */}
+      <button
+        {...attributes}
+        {...listeners}
+        type="button"
+        className="cursor-grab touch-none p-0.5 rounded text-text-muted hover:text-primary active:cursor-grabbing shrink-0"
+        title="Drag to reorder"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+          <circle cx="9" cy="4" r="2"/><circle cx="15" cy="4" r="2"/>
+          <circle cx="9" cy="12" r="2"/><circle cx="15" cy="12" r="2"/>
+          <circle cx="9" cy="20" r="2"/><circle cx="15" cy="20" r="2"/>
+        </svg>
+      </button>
+
       {/* Index badge */}
       <span className="text-[10px] font-medium text-text-muted w-3 text-center shrink-0">{index + 1}</span>
 
@@ -365,6 +393,25 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
   const [saving, setSaving] = useState(false);
   const [nameError, setNameError] = useState("");
   const [modelAliases, setModelAliases] = useState({});
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  // Use stable index-based IDs so duplicates and similar names are handled correctly
+  const modelItems = models.map((model, i) => ({ uid: `item-${i}`, model }));
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = modelItems.findIndex((m) => m.uid === active.id);
+      const newIndex = modelItems.findIndex((m) => m.uid === over.id);
+      if (oldIndex !== -1 && newIndex !== -1) {
+        setModels((prev) => arrayMove(prev, oldIndex, newIndex));
+      }
+    }
+  };
 
   const fetchModalData = async () => {
     try {
@@ -470,25 +517,30 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
                 <p className="text-xs text-text-muted">No models added yet</p>
               </div>
             ) : (
-            <div className="flex max-h-[55vh] min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[350px]">
-                {models.map((model, index) => (
-                  <ModelItem
-                    key={index}
-                    index={index}
-                    model={model}
-                    isFirst={index === 0}
-                    isLast={index === models.length - 1}
-                    onEdit={(newVal) => {
-                      const updated = [...models];
-                      updated[index] = newVal;
-                      setModels(updated);
-                    }}
-                    onMoveUp={() => handleMoveUp(index)}
-                    onMoveDown={() => handleMoveDown(index)}
-                    onRemove={() => handleRemoveModel(index)}
-                  />
-                ))}
-              </div>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} modifiers={[restrictToVerticalAxis, restrictToParentElement]}>
+              <SortableContext items={modelItems.map((m) => m.uid)} strategy={verticalListSortingStrategy}>
+                <div className="flex max-h-[55vh] min-w-0 flex-col gap-1 overflow-y-auto sm:max-h-[350px]">
+                  {modelItems.map(({ uid, model }, index) => (
+                    <ModelItem
+                      key={uid}
+                      id={uid}
+                      index={index}
+                      model={model}
+                      isFirst={index === 0}
+                      isLast={index === modelItems.length - 1}
+                      onEdit={(newVal) => {
+                        const updated = [...models];
+                        updated[index] = newVal;
+                        setModels(updated);
+                      }}
+                      onMoveUp={() => handleMoveUp(index)}
+                      onMoveDown={() => handleMoveDown(index)}
+                      onRemove={() => handleRemoveModel(index)}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
             )}
 
             {/* Add Model button */}


### PR DESCRIPTION
Closes #1056

## Summary

Implements drag-and-drop reordering for models in the combo create/edit modal, using `@dnd-kit` as proposed in the issue.

- Users can grab the ⠿ handle on any model row and drag it to a new position
- Arrow up/down buttons are kept intact as an accessibility fallback
- Keyboard reordering works out of the box via `KeyboardSensor` (Tab to focus handle, Space to pick up, arrows to move, Space/Enter to drop)
- Drag is constrained to vertical axis and to the list container bounds — no runaway items

## Implementation Notes

**Library choice:** `@dnd-kit` (Option 2 from the issue) — better UX, built-in accessibility, and the project already has precedent with `@xyflow/react`.

**Scope:** Changes are isolated to `src/app/(dashboard)/dashboard/combos/page.js`. The page-level `ComboFormModal` is a local copy distinct from `src/shared/components/ComboFormModal.js` (used by CoworkToolCard), so the shared component is untouched.

**Key decisions:**
- Index-based sortable IDs (`item-0`, `item-1`, …) instead of model string IDs — handles combos with duplicate or near-identical model names correctly
- `transition` omitted from dnd-kit style — prevents a CSS settle animation from fighting React's re-render on drop, giving a clean instant snap
- `PointerSensor` with `activationConstraint: { distance: 5 }` — 5px threshold distinguishes a drag from a click-to-edit or button click
- `restrictToVerticalAxis` + `restrictToParentElement` — keeps the dragged item within the list container at all times

## Changes

| File | What changed |
|---|---|
| `package.json` | Added `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`, `@dnd-kit/modifiers` |
| `src/app/(dashboard)/dashboard/combos/page.js` | `ModelItem` wired to `useSortable`; grip handle added; `ComboFormModal` wrapped with `DndContext` + `SortableContext` |

## Screenshots

<!-- Please add screenshots or a screen recording here -->

| | |
|---|---|
| **Before** | <img width="452" height="551" alt="before" src="https://github.com/user-attachments/assets/21c43ebd-be2f-4f61-9740-fd5ae67b069b" /> |
| **After - Idle state** | <img width="457" height="548" alt="after (idle)" src="https://github.com/user-attachments/assets/b294a3fe-52e6-4a32-8d4f-dd704eae5998" /> |
| **After - During drag** | <img width="450" height="553" alt="after (during drag)" src="https://github.com/user-attachments/assets/9479961b-c450-46d5-9bf5-c5b95d41fd11" /> |
| **After - After drop** | <img width="446" height="552" alt="after (after drop)" src="https://github.com/user-attachments/assets/13eaa82f-1446-4dd5-a0cb-3b297c569ef3" /> |

## Checklist

- [x] Arrow buttons kept as fallback (accessibility)
- [x] Keyboard navigation supported
- [x] Touch supported (via PointerSensor)
- [x] Drag constrained to list bounds
- [x] Build passes (`next build --webpack`)
- [x] Shared `ComboFormModal` untouched