### PR TITLE
fix(ui): show API key row actions on mobile

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -1084,7 +1084,7 @@ export default function APIPageClient({ machineId }) {
                     </code>
                     <button
                       onClick={() => toggleKeyVisibility(key.id)}
-                      className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-0 group-hover:opacity-100 transition-all"
+                      className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
                       title={visibleKeys.has(key.id) ? "Hide key" : "Show key"}
                     >
                       <span className="material-symbols-outlined text-[14px]">
@@ -1093,7 +1093,7 @@ export default function APIPageClient({ machineId }) {
                     </button>
                     <button
                       onClick={() => copy(key.key, key.id)}
-                      className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-0 group-hover:opacity-100 transition-all"
+                      className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
                     >
                       <span className="material-symbols-outlined text-[14px]">
                         {copied === key.id ? "check" : "content_copy"}
@@ -1129,7 +1129,7 @@ export default function APIPageClient({ machineId }) {
                   />
                   <button
                     onClick={() => handleDeleteKey(key.id)}
-                    className="p-2 hover:bg-red-500/10 rounded text-red-500 opacity-0 group-hover:opacity-100 transition-all"
+                    className="p-2 hover:bg-red-500/10 rounded text-red-500 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
                   >
                     <span className="material-symbols-outlined text-[18px]">delete</span>
                   </button>


### PR DESCRIPTION
Fixes #1110.

## What was wrong

The three icon buttons on every API key row — show/hide, copy, delete — were invisible on phones. They used `opacity-0 group-hover:opacity-100`, which is a hover-reveal pattern: fine on a mouse, broken on touch because `:hover` never fires there. So on mobile the buttons were sitting at `opacity: 0`, unreachable. You couldn't reveal a masked key, couldn't copy it, couldn't delete it.

Desktop behavior was fine and I didn't want to lose it — those icons make the row noisy on a wide screen if they're always visible — so this keeps the hover-reveal on desktop and just turns it off below `sm`.

## Fix

Change `opacity-0 group-hover:opacity-100` to `opacity-100 sm:opacity-0 sm:group-hover:opacity-100` on all three buttons. Below 640px they're always visible. At 640px and up the original hover-reveal is back.

Same pattern is already used in:
- `dashboard/providers/page.js`
- `dashboard/providers/[id]/ModelRow.js`
- `dashboard/media-providers/[kind]/page.js`

So this is consistent with the rest of the dashboard.

## Changes

`src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js`, three lines:
- L1087 — show/hide key toggle
- L1096 — copy key button
- L1132 — delete key button

## Evidence

**Before — mobile, buttons missing:**

![Before — mobile]
<img width="340" height="719" alt="image" src="https://github.com/user-attachments/assets/9ce2c9b1-1394-4d0d-84f0-fedf77fda9d4" />


**After — mobile, buttons visible:**
<img width="333" height="711" alt="image" src="https://github.com/user-attachments/assets/f66ed86b-990b-47d3-b275-7a5b6b6914e2" />


**Desktop (unchanged) — buttons still hover-revealed:**

![Desktop](https://private-user-images.githubusercontent.com/34785758/592215279-83ea14d1-9ee3-4c39-9e66-24d0c90ed09f.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Nzg3Mjk5MjgsIm5iZiI6MTc3ODcyOTYyOCwicGF0aCI6Ii8zNDc4NTc1OC81OTIyMTUyNzktODNlYTE0ZDEtOWVlMy00YzM5LTllNjYtMjRkMGM5MGVkMDlmLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTE0VDAzMzM0OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTdkZjEyMzE5YWY1MmEwNzRmNTc0MmNjMmVlOWMyZWIxMzU1ZDJmZDA5ZGFkMTc4NWQwMzJkNjY2YTcwZjJhMWUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.ZrFYnAu7ukZaM0fEST7inn7JtmqhqzptXTc8xTdt8CY)

## Test plan

Tested in Chrome DevTools at iPhone 14 (390×844) and on a real phone:

- [x] `/dashboard/endpoint` on a ≤640px viewport: all three buttons visible next to each API key
- [x] Tap show/hide → masked key flips to the full value, tap again to mask
- [x] Tap copy → key copied, icon flips to the check state
- [x] Tap delete → confirm dialog opens, key removed on confirm
- [x] Resize to ≥640px: buttons go back to opacity-0 and only show on row hover
- [x] Light and dark mode both look right
- [x] `npm run build` passes
