### PR TITLE
Fix Cowork model selection and Windows CLI packaging

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -42,6 +42,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "esbuild": "^0.25.12",
     "nodemon": "^3.1.14"
   }
 }

--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -8,6 +8,17 @@ const cliDir = path.resolve(__dirname, "..");
 const appDir = path.resolve(cliDir, "..");
 const rootDir = path.resolve(appDir, "..");
 const cliAppDir = path.join(cliDir, "app");
+const buildHomeDir = path.join(cliDir, ".build-home");
+const buildDistDirName = ".next-cli-build";
+const buildDistDir = path.join(appDir, buildDistDirName);
+
+function shouldUseWorkspaceTracingRoot() {
+  const appNodeModules = path.join(appDir, "node_modules");
+  const rootNodeModules = path.join(rootDir, "node_modules");
+
+  // Only widen tracing when dependencies are actually hoisted above appDir.
+  return !fs.existsSync(appNodeModules) && fs.existsSync(rootNodeModules);
+}
 
 // Exclude patterns for files/folders we don't want to copy
 const EXCLUDE_PATTERNS = [
@@ -81,14 +92,22 @@ function copyRecursive(src, dest) {
 
 console.log("📦 Building 9Router CLI package with Next.js...\n");
 
+fs.mkdirSync(buildHomeDir, { recursive: true });
+fs.mkdirSync(path.join(buildHomeDir, "AppData", "Roaming"), { recursive: true });
+fs.mkdirSync(path.join(buildHomeDir, "AppData", "Local"), { recursive: true });
+
 // Step 0: Sync version from app/cli/package.json to app/package.json
 console.log("0️⃣  Syncing version to app/package.json...");
 const cliPkg = JSON.parse(fs.readFileSync(path.join(cliDir, "package.json"), "utf8"));
 const appPkgPath = path.join(appDir, "package.json");
 const appPkg = JSON.parse(fs.readFileSync(appPkgPath, "utf8"));
-appPkg.version = cliPkg.version;
-fs.writeFileSync(appPkgPath, JSON.stringify(appPkg, null, 2) + "\n");
-console.log(`✅ Version synced: ${cliPkg.version}\n`);
+if (appPkg.version !== cliPkg.version) {
+  appPkg.version = cliPkg.version;
+  fs.writeFileSync(appPkgPath, JSON.stringify(appPkg, null, 2) + "\n");
+  console.log(`✅ Version synced: ${cliPkg.version}\n`);
+} else {
+  console.log(`✅ Version already synced: ${cliPkg.version}\n`);
+}
 
 // Step 1: Build app with Next.js (workspace tracing root → traced node_modules in standalone).
 console.log("1️⃣  Building Next.js app...");
@@ -96,7 +115,15 @@ try {
   execSync("npm run build", {
     stdio: "inherit",
     cwd: appDir,
-    env: { ...process.env, NEXT_TRACING_ROOT_MODE: "workspace" }
+    env: {
+      ...process.env,
+      HOME: buildHomeDir,
+      USERPROFILE: buildHomeDir,
+      APPDATA: path.join(buildHomeDir, "AppData", "Roaming"),
+      LOCALAPPDATA: path.join(buildHomeDir, "AppData", "Local"),
+      NEXT_DIST_DIR: buildDistDirName,
+      NEXT_TRACING_ROOT_MODE: shouldUseWorkspaceTracingRoot() ? "workspace" : "project",
+    }
   });
   console.log("✅ Next.js build completed\n");
 } catch (error) {
@@ -112,21 +139,25 @@ if (fs.existsSync(cliAppDir)) {
 console.log("✅ Cleaned\n");
 
 // Step 3: Copy Next.js standalone build to app/cli/app.
-// With workspace tracing root, Next places app files under .next/standalone/app/ and traced
-// node_modules under .next/standalone/node_modules/ (slim, tracing-pruned).
+// Newer Next.js standalone output writes server.js/package.json plus .next/, src/, and
+// node_modules/ directly under .next/standalone. Older builds may still use a nested app/.
 console.log("3️⃣  Copying Next.js standalone build to app/cli/app...");
 const standaloneRoot = path.join(appDir, ".next", "standalone");
-const standaloneApp = path.join(standaloneRoot, "app");
+const standaloneRootResolved = path.join(buildDistDir, "standalone");
+const standaloneRootToUse = fs.existsSync(standaloneRootResolved) ? standaloneRootResolved : standaloneRoot;
+const standaloneApp = fs.existsSync(path.join(standaloneRootToUse, "server.js"))
+  ? standaloneRootToUse
+  : path.join(standaloneRootToUse, "app");
 if (!fs.existsSync(standaloneApp)) {
-  console.error("❌ Next.js standalone build not found at .next/standalone/app");
-  console.error("Make sure output: 'standalone' is set in next.config.js");
+  console.error("❌ Next.js standalone build not found under .next/standalone");
+  console.error("Expected either .next/standalone/server.js or .next/standalone/app/");
   process.exit(1);
 }
 copyRecursive(standaloneApp, cliAppDir);
 
-// Copy traced node_modules from standalone root into CLI bundle
-const standaloneNodeModules = path.join(standaloneRoot, "node_modules");
-if (fs.existsSync(standaloneNodeModules)) {
+// Older nested-app layout stores traced node_modules at standalone root.
+const standaloneNodeModules = path.join(standaloneRootToUse, "node_modules");
+if (standaloneApp !== standaloneRootToUse && fs.existsSync(standaloneNodeModules)) {
   copyRecursive(standaloneNodeModules, path.join(cliAppDir, "node_modules"));
 }
 console.log("✅ Copied standalone build\n");
@@ -166,9 +197,10 @@ console.log("");
 // Step 4: Copy static files
 console.log("4️⃣  Copying static files...");
 const staticSrc = path.join(appDir, ".next", "static");
-const staticDest = path.join(cliAppDir, ".next", "static");
-if (fs.existsSync(staticSrc)) {
-  copyRecursive(staticSrc, staticDest);
+const staticSrcResolved = path.join(buildDistDir, "static");
+const staticDest = path.join(cliAppDir, buildDistDirName, "static");
+if (fs.existsSync(staticSrcResolved) || fs.existsSync(staticSrc)) {
+  copyRecursive(fs.existsSync(staticSrcResolved) ? staticSrcResolved : staticSrc, staticDest);
   console.log("✅ Copied static files\n");
 } else {
   console.log("⏭️  No static files found\n");
@@ -188,9 +220,10 @@ if (fs.existsSync(publicSrc)) {
 // Step 6: Copy vendor-chunks (required for production)
 console.log("6️⃣  Copying vendor-chunks...");
 const vendorChunksSrc = path.join(appDir, ".next", "server", "vendor-chunks");
-const vendorChunksDest = path.join(cliAppDir, ".next", "server", "vendor-chunks");
-if (fs.existsSync(vendorChunksSrc)) {
-  copyRecursive(vendorChunksSrc, vendorChunksDest);
+const vendorChunksSrcResolved = path.join(buildDistDir, "server", "vendor-chunks");
+const vendorChunksDest = path.join(cliAppDir, buildDistDirName, "server", "vendor-chunks");
+if (fs.existsSync(vendorChunksSrcResolved) || fs.existsSync(vendorChunksSrc)) {
+  copyRecursive(fs.existsSync(vendorChunksSrcResolved) ? vendorChunksSrcResolved : vendorChunksSrc, vendorChunksDest);
   console.log("✅ Copied vendor-chunks\n");
 } else {
   console.log("⏭️  No vendor-chunks found\n");

--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -149,8 +149,11 @@ const standaloneApp = fs.existsSync(path.join(standaloneRootToUse, "server.js"))
   ? standaloneRootToUse
   : path.join(standaloneRootToUse, "app");
 if (!fs.existsSync(standaloneApp)) {
-  console.error("❌ Next.js standalone build not found under .next/standalone");
-  console.error("Expected either .next/standalone/server.js or .next/standalone/app/");
+  console.error("❌ Next.js standalone build not found.");
+  console.error(`Checked standalone roots: "${standaloneRootResolved}" and "${standaloneRoot}"`);
+  console.error(
+    `Expected either "${path.join(standaloneRootToUse, "server.js")}" or "${path.join(standaloneRootToUse, "app")}"`
+  );
   process.exit(1);
 }
 copyRecursive(standaloneApp, cliAppDir);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,7 @@ const tracingRoot = process.env.NEXT_TRACING_ROOT_MODE === "workspace"
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  distDir: process.env.NEXT_DIST_DIR || ".next",
   output: "standalone",
   serverExternalPackages: ["better-sqlite3", "sql.js", "node:sqlite", "bun:sqlite"],
   turbopack: {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack --port 20128",
-    "build": "NODE_ENV=production next build --webpack",
-    "start": "NODE_ENV=production next start",
+    "build": "next build --webpack",
+    "start": "next start",
     "dev:bun": "bun --bun next dev --webpack --port 20128",
-    "build:bun": "NODE_ENV=production bun --bun next build --webpack",
-    "start:bun": "NODE_ENV=production bun ./.next/standalone/server.js"
+    "build:bun": "bun --bun next build --webpack",
+    "start:bun": "bun ./.next/standalone/server.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,12 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
+    "@tailwindcss/postcss": {
+      base: projectRoot,
+    },
   },
 };
-

--- a/src/app/(dashboard)/dashboard/cli-tools/components/CoworkToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CoworkToolCard.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Card, Button, ManualConfigModal, ComboFormModal, McpMarketplaceModal } from "@/shared/components";
+import { Card, Button, ManualConfigModal, ComboFormModal, McpMarketplaceModal, ModelSelectModal } from "@/shared/components";
 import Image from "next/image";
 import BaseUrlSelect from "./BaseUrlSelect";
 import ApiKeySelect from "./ApiKeySelect";
@@ -43,7 +43,9 @@ export default function CoworkToolCard({
   const [plugins, setPlugins] = useState([]);
   const [localPlugins, setLocalPlugins] = useState([]);
   const [customPlugins, setCustomPlugins] = useState([]);
+  const [modelAliases, setModelAliases] = useState({});
   const [comboModalOpen, setComboModalOpen] = useState(false);
+  const [modelSelectOpen, setModelSelectOpen] = useState(false);
   const [marketplaceOpen, setMarketplaceOpen] = useState(false);
   const [addMcpOpen, setAddMcpOpen] = useState(false);
   const [addMcpForm, setAddMcpForm] = useState({ type: "url", name: "", url: "", command: "", args: "" });
@@ -60,6 +62,16 @@ export default function CoworkToolCard({
 
   useEffect(() => {
     if (isExpanded && !status) checkStatus();
+  }, [isExpanded]);
+
+  useEffect(() => {
+    if (!isExpanded) return;
+    fetch("/api/models/alias")
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => {
+        if (data) setModelAliases(data.aliases || {});
+      })
+      .catch(() => {});
   }, [isExpanded]);
 
   useEffect(() => {
@@ -168,6 +180,17 @@ export default function CoworkToolCard({
     } catch (error) {
       setMessage({ type: "error", text: error.message });
     }
+  };
+
+  const handleAddModel = (model) => {
+    const value = model?.value || model?.name || model;
+    if (!value || selectedModels.includes(value)) return;
+    setSelectedModels((prev) => [...prev, value]);
+  };
+
+  const handleRemoveModel = (model) => {
+    const value = model?.value || model?.name || model;
+    setSelectedModels((prev) => prev.filter((item) => item !== value));
   };
 
   const handleReset = async () => {
@@ -320,6 +343,13 @@ export default function CoworkToolCard({
                         ))
                       )}
                     </div>
+                    <button
+                      onClick={() => setModelSelectOpen(true)}
+                      disabled={!hasActiveProviders}
+                      className={`shrink-0 px-2 py-1.5 rounded border text-xs whitespace-nowrap transition-colors ${hasActiveProviders ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}
+                    >
+                      Select Model
+                    </button>
                     <button onClick={() => setComboModalOpen(true)} disabled={!hasActiveProviders} className={`shrink-0 px-2 py-1.5 rounded border text-xs whitespace-nowrap transition-colors ${hasActiveProviders ? "bg-primary/10 border-primary/40 text-primary hover:bg-primary/20 cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>+ Combo</button>
                   </div>
                 </div>
@@ -499,6 +529,18 @@ export default function CoworkToolCard({
         activeProviders={activeProviders}
         forcePrefix="claude-"
         title="Create Cowork Combo"
+      />
+
+      <ModelSelectModal
+        isOpen={modelSelectOpen}
+        onClose={() => setModelSelectOpen(false)}
+        onSelect={handleAddModel}
+        onDeselect={handleRemoveModel}
+        activeProviders={activeProviders}
+        modelAliases={modelAliases}
+        title="Select Cowork Model"
+        addedModelValues={selectedModels}
+        closeOnSelect={false}
       />
 
       <McpMarketplaceModal


### PR DESCRIPTION
## Summary
- add direct model selection to the Cowork CLI tool card
- make the CLI packaging/build flow work reliably on Windows and with newer Next standalone output
- copy static assets into the runtime dist dir used by the packaged CLI app

## Details
This PR fixes two issues that surfaced while testing the packaged local app on Windows.

### Cowork UI
The Cowork card only exposed model choice indirectly through Combo creation. This PR adds a direct Select Model flow using the existing ModelSelectModal, while keeping Combo support for advanced usage.

### Windows packaging/runtime
The CLI packaging flow had several Windows-specific problems:
- Unix-style env assignment in root build scripts
- Tailwind/PostCSS scanning wandering into Windows user profile compatibility paths
- build-time home/AppData leakage during Next build
- mismatch between the packaged runtime dist dir and where static assets were copied
- newer Next standalone output layout compatibility in uild-cli.js
- missing sbuild dev dependency for the MITM build step

After these changes, the packaged app serves the dashboard with its static assets correctly, and the global CLI package can be built/installed successfully on Windows.

## Validation
- built the CLI tarball successfully from the project
- installed the tarball globally
- launched the packaged 9router CLI
- verified http://localhost:20128/dashboard returned the expected Next page with static asset references
