### PR TITLE
fix(ui): make Pagination responsive on mobile

### DIFF
--- a/src/shared/components/Pagination.js
+++ b/src/shared/components/Pagination.js
@@ -37,20 +37,20 @@ export default function Pagination({
   return (
     <div
       className={cn(
-        "flex flex-col sm:flex-row items-center justify-between gap-4 py-4",
+        "flex flex-col items-stretch justify-between gap-3 px-4 py-4 sm:flex-row sm:items-center sm:gap-4",
         className
       )}
     >
       {/* Info text */}
       {totalItems > 0 && (
-        <div className="text-sm text-text-muted">
+        <div className="text-center text-sm text-text-muted sm:text-left">
           Showing <span className="font-medium text-text-main">{startItem}</span> to{" "}
           <span className="font-medium text-text-main">{endItem}</span> of{" "}
           <span className="font-medium text-text-main">{totalItems}</span> results
         </div>
       )}
 
-      <div className="flex items-center gap-4">
+      <div className="flex w-full items-center justify-between gap-3 sm:w-auto sm:justify-end sm:gap-4">
         {/* Page size selector */}
         {onPageSizeChange && (
           <div className="flex items-center gap-2">
@@ -59,7 +59,7 @@ export default function Pagination({
               value={pageSize}
               onChange={(e) => onPageSizeChange(Number(e.target.value))}
               className={cn(
-                "h-9 rounded-lg border border-black/10 dark:border-white/10 bg-surface",
+                "h-9 rounded-lg border border-black/10 dark:border-white/10 bg-surface px-2",
                 "text-sm text-text-main focus:outline-none focus:ring-2 focus:ring-primary/20",
                 "cursor-pointer"
               )}
@@ -75,71 +75,99 @@ export default function Pagination({
         )}
 
         {totalPages > 1 && (
-          <div className="flex items-center gap-1">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onPageChange(currentPage - 1)}
-              disabled={currentPage === 1}
-              className="w-9 px-0"
-            >
-              <span className="material-symbols-outlined text-[18px]">chevron_left</span>
-            </Button>
-
-            {pageNumbers[0] > 1 && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onPageChange(1)}
-                  className="w-9 px-0"
-                >
-                  1
-                </Button>
-                {pageNumbers[0] > 2 && (
-                  <span className="text-text-muted px-1">...</span>
-                )}
-              </>
-            )}
-
-            {pageNumbers.map((page) => (
+          <>
+            {/* Mobile: prev / current of total / next */}
+            <div className="flex items-center gap-1 sm:hidden">
               <Button
-                key={page}
-                variant={currentPage === page ? "primary" : "ghost"}
+                variant="outline"
                 size="sm"
-                onClick={() => onPageChange(page)}
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={currentPage === 1}
                 className="w-9 px-0"
               >
-                {page}
+                <span className="material-symbols-outlined text-[18px]">chevron_left</span>
               </Button>
-            ))}
+              <span className="whitespace-nowrap px-2 text-sm text-text-muted">
+                <span className="font-medium text-text-main">{currentPage}</span> / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={currentPage === totalPages}
+                className="w-9 px-0"
+              >
+                <span className="material-symbols-outlined text-[18px]">chevron_right</span>
+              </Button>
+            </div>
 
-            {pageNumbers[pageNumbers.length - 1] < totalPages && (
-              <>
-                {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
-                  <span className="text-text-muted px-1">...</span>
-                )}
+            {/* Desktop: full numbered pagination */}
+            <div className="hidden items-center gap-1 sm:flex">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={currentPage === 1}
+                className="w-9 px-0"
+              >
+                <span className="material-symbols-outlined text-[18px]">chevron_left</span>
+              </Button>
+
+              {pageNumbers[0] > 1 && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onPageChange(1)}
+                    className="w-9 px-0"
+                  >
+                    1
+                  </Button>
+                  {pageNumbers[0] > 2 && (
+                    <span className="text-text-muted px-1">...</span>
+                  )}
+                </>
+              )}
+
+              {pageNumbers.map((page) => (
                 <Button
-                  variant="ghost"
+                  key={page}
+                  variant={currentPage === page ? "primary" : "ghost"}
                   size="sm"
-                  onClick={() => onPageChange(totalPages)}
+                  onClick={() => onPageChange(page)}
                   className="w-9 px-0"
                 >
-                  {totalPages}
+                  {page}
                 </Button>
-              </>
-            )}
+              ))}
 
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onPageChange(currentPage + 1)}
-              disabled={currentPage === totalPages}
-              className="w-9 px-0"
-            >
-              <span className="material-symbols-outlined text-[18px]">chevron_right</span>
-            </Button>
-          </div>
+              {pageNumbers[pageNumbers.length - 1] < totalPages && (
+                <>
+                  {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
+                    <span className="text-text-muted px-1">...</span>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onPageChange(totalPages)}
+                    className="w-9 px-0"
+                  >
+                    {totalPages}
+                  </Button>
+                </>
+              )}
+
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={currentPage === totalPages}
+                className="w-9 px-0"
+              >
+                <span className="material-symbols-outlined text-[18px]">chevron_right</span>
+              </Button>
+            </div>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
Fixes #1146 

## Summary
- Fixes pagination row overflowing the viewport on mobile (Usage > Details tab)
- On `<640px`, replaces the full numbered list with a compact `[< current / total >]` indicator and lays out the controls row with `justify-between` (Rows: select on the left, page nav on the right)
- Adds horizontal padding (`px-4`) to the pagination wrapper so it no longer sits flush against the `Card` edge
- Full numbered pagination is preserved at `sm:` and above — no desktop regression

## Before / After

**Before (mobile)** — `Rows:` clipped left, `>` clipped right:
<img width="334" height="718" alt="image" src="https://github.com/user-attachments/assets/2cee3718-ff44-4932-aae9-3c3a65d38352" />

**After (mobile)** — controls fit, `[<] 1 / 3 [>]` compact indicator:
<img width="337" height="716" alt="image" src="https://github.com/user-attachments/assets/4912c785-6b58-40ba-86f6-aca60e5926f8" />

## Files changed
- [`src/shared/components/Pagination.js`](src/shared/components/Pagination.js)

## Test plan
- [x] Open `/dashboard/usage?tab=details` on a 390px viewport — verify pagination fits, both arrows reachable, rows-select usable
- [x] Verify on a 640px+ viewport — full numbered list still renders with prev/next chevrons
- [x] Verify with `totalItems` small enough that `totalPages === 1` — only the rows-select is shown (no page nav)
- [x] Verify with `totalItems = 0` — pagination block isn't rendered
- [x] Tab/keyboard navigation still works through Rows select → prev → page button(s) → next
