### PR TITLE
fix(sse): drop empty data: null event between chunks

### DIFF
--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -149,9 +149,13 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
 // Translate response chunk: target -> openai -> source
 export function translateResponse(targetFormat, sourceFormat, chunk, state) {
   ensureInitialized();
-  // If same format, return as-is
+  // If same format, pass through — but never wrap a null flush chunk into
+  // an array. Callers signal "no more chunks, emit any state-derived final
+  // events" by passing chunk=null; for same-format streams there is nothing
+  // to emit, and leaking `null` downstream produces `data: null` SSE frames
+  // that crash strict clients (Vercel AI SDK zod, Factory Droid #1052).
   if (sourceFormat === targetFormat) {
-    return [chunk];
+    return chunk == null ? [] : [chunk];
   }
 
   let results = [chunk];

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -102,7 +102,10 @@ function cleanUsagePayload(payload) {
 
 // Format output as SSE
 export function formatSSE(data, sourceFormat) {
-  if (data === null || data === undefined) return "data: null\n\n";
+  // Skip null/undefined events entirely. Emitting "data: null" breaks
+  // AI SDK clients (Vercel @ai-sdk/openai expects every SSE data payload to
+  // be a JSON object and fails zod validation on bare null).
+  if (data === null || data === undefined) return "";
   if (data && data.done) return "data: [DONE]\n\n";
 
   // OpenAI Responses API format


### PR DESCRIPTION
## Summary

The OpenAI Responses streaming path emits a stray `data: null\n\n` SSE frame at the end of every same-source/same-target stream (typical for `cx/gpt-5.*` → codex/* where both ends speak `openai-responses`), right before `data: [DONE]`. Strict SSE clients crash on it:

- **Vercel AI SDK** (`@ai-sdk/openai`) — fails zod validation on bare `null`.
- **Factory Droid BYOK** — reports `BYOK Error: null is not an object (evaluating 'H.type')` (#1052).

## Root cause

`stream.js` and `bypassHandler.js` call `translateResponse(targetFormat, sourceFormat, null, state)` during flush to drain final state-derived events. In `translator/index.js` the same-format short path returned `[chunk]` unconditionally, so a `null` flush chunk became `[null]`, then `formatSSE(null)` rendered it as `data: null\n\n`.

## Fix

Two layers — fix the root cause AND a defensive guard:

- **`translator/index.js`** — same-format branch returns `[]` when chunk is null/undefined, so the null never reaches `formatSSE`.
- **`utils/streamHelpers.js`** — `formatSSE(null|undefined)` now returns `""` instead of `"data: null\n\n"`, so any future caller that leaks a null payload cannot break clients.

## Test plan

Verified locally on macOS against the fork's standalone build, A/B with the same `curl` request to `/v1/responses` (`cx/gpt-5.5`, `stream:true`):

| | `data: null` count | `data: [DONE]` | `response.completed` |
|---|---|---|---|
| **pre-fix** | **1** (at line 23, immediately before `[DONE]`) | ✓ | ✓ |
| **post-fix** | **0** | ✓ | ✓ |

Stream content is identical otherwise; the only difference is the spurious `data: null` frame is gone.

Also a unit-level direct test:
- `formatSSE(null)` → `""` ✓
- `formatSSE(undefined)` → `""` ✓
- `formatSSE({done: true})` → `"data: [DONE]\n\n"` ✓ (unchanged)
- `formatSSE({event, data})` → `"event: …\ndata: {…}\n\n"` ✓ (unchanged)
- Same-format translator with null chunk → `[]` ✓ (was `[null]`)

Fixes #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)