### PR TITLE
feat(api-keys): enhance API key management with daily token limits, e…

### DIFF
--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -115,6 +115,7 @@ try {
       LOCALAPPDATA: path.join(buildHomeDir, "AppData", "Local"),
       NEXT_DIST_DIR: buildDistDirName,
       NEXT_TRACING_ROOT_MODE: "workspace",
+      NINE_ROUTER_SKIP_SYSTEM_TAILSCALE_PROBE: "1",
     }
   });
   console.log("✅ Next.js build completed\n");
@@ -137,12 +138,15 @@ console.log("3️⃣  Copying Next.js standalone build to app/cli/app...");
 const standaloneRoot = path.join(appDir, ".next", "standalone");
 const standaloneRootResolved = path.join(buildDistDir, "standalone");
 const standaloneRootToUse = fs.existsSync(standaloneRootResolved) ? standaloneRootResolved : standaloneRoot;
-const standaloneApp = fs.existsSync(path.join(standaloneRootToUse, "server.js"))
-  ? standaloneRootToUse
-  : path.join(standaloneRootToUse, "app");
-if (!fs.existsSync(standaloneApp)) {
+const standaloneCandidates = [
+  standaloneRootToUse,
+  path.join(standaloneRootToUse, "app"),
+  path.join(standaloneRootToUse, path.basename(appDir)),
+];
+const standaloneApp = standaloneCandidates.find((candidate) => fs.existsSync(path.join(candidate, "server.js")));
+if (!standaloneApp) {
   console.error("❌ Next.js standalone build not found under .next/standalone");
-  console.error("Expected either .next/standalone/server.js or .next/standalone/app/");
+  console.error("Expected .next/standalone/server.js, .next/standalone/app/server.js, or .next/standalone/<project>/server.js");
   process.exit(1);
 }
 copyRecursive(standaloneApp, cliAppDir);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,7 +18,11 @@ const nextConfig = {
   },
   outputFileTracingRoot: tracingRoot,
   outputFileTracingExcludes: {
-    "*": ["./gitbook/**/*"]
+    "*": [
+      "./gitbook/**/*",
+      "C:/Program Files/Tailscale/**/*",
+      "C:\\Program Files\\Tailscale\\**/*"
+    ]
   },
   images: {
     unoptimized: true

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal } from "@/shared/components";
+import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal, ModelMultiSelectField } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 
 const TUNNEL_BENEFITS = [
@@ -45,10 +45,12 @@ export default function APIPageClient({ machineId }) {
   const [newKeyName, setNewKeyName] = useState("");
   const [newDailyTokenLimit, setNewDailyTokenLimit] = useState("");
   const [newExpiresAt, setNewExpiresAt] = useState("");
-  const [newAllowedModels, setNewAllowedModels] = useState("");
+  const [newAllowedModels, setNewAllowedModels] = useState([]);
   const [editingKey, setEditingKey] = useState(null);
   const [createdKey, setCreatedKey] = useState(null);
   const [confirmState, setConfirmState] = useState(null);
+  const [activeProviders, setActiveProviders] = useState([]);
+  const [modelAliases, setModelAliases] = useState({});
 
   const [requireApiKey, setRequireApiKey] = useState(false);
   const [requireLogin, setRequireLogin] = useState(true);
@@ -123,6 +125,8 @@ export default function APIPageClient({ machineId }) {
       clearInterval(interval);
       document.removeEventListener("visibilitychange", onVisible);
     };
+    // Run once on mount; handlers intentionally read current refs/state setters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Browser-side periodic ping: probes tunnel/tailscale URLs directly so UI stays
@@ -167,7 +171,7 @@ export default function APIPageClient({ machineId }) {
   }, []);
 
   // Trust user intent (settingsEnabled): UI stays "enabled" while watchdog restarts process
-  const syncTunnelStatus = async () => {
+  async function syncTunnelStatus() {
     try {
       const statusRes = await fetch("/api/tunnel/status", { cache: "no-store" });
       if (!statusRes.ok) return;
@@ -186,9 +190,9 @@ export default function APIPageClient({ machineId }) {
       setTsEnabled(tsEn);
       updateReachable(!!data.tailscale?.reachable, tsClientReachableRef, tsMissRef, setTsReachable, tsEverReachableRef, setTsEverReachable);
     } catch { /* ignore poll errors */ }
-  };
+  }
 
-  const loadSettings = async () => {
+  async function loadSettings() {
     setTunnelChecking(true);
     try {
       const [settingsRes, statusRes] = await Promise.all([
@@ -226,7 +230,7 @@ export default function APIPageClient({ machineId }) {
     } finally {
       setTunnelChecking(false);
     }
-  };
+  }
 
   const handleTunnelDashboardAccess = async (value) => {
     try {
@@ -289,19 +293,29 @@ export default function APIPageClient({ machineId }) {
     patchSetting({ cavemanLevel: level });
   };
 
-  const fetchData = async () => {
+  async function fetchData() {
     try {
-      const keysRes = await fetch("/api/keys");
+      const [keysRes, providersRes, aliasesRes] = await Promise.all([
+        fetch("/api/keys"),
+        fetch("/api/providers"),
+        fetch("/api/models/alias"),
+      ]);
       const keysData = await keysRes.json();
-      if (keysRes.ok) {
-        setKeys(keysData.keys || []);
+      if (keysRes.ok) setKeys(keysData.keys || []);
+      if (providersRes.ok) {
+        const providersData = await providersRes.json();
+        setActiveProviders(providersData.connections || []);
+      }
+      if (aliasesRes.ok) {
+        const aliasesData = await aliasesRes.json();
+        setModelAliases(aliasesData.aliases || {});
       }
     } catch (error) {
       console.log("Error fetching data:", error);
     } finally {
       setLoading(false);
     }
-  };
+  }
 
   // u2500u2500u2500 Cloudflare Tunnel handlers
   // Ping tunnel health until reachable, also check backend status to detect process die
@@ -642,23 +656,18 @@ export default function APIPageClient({ machineId }) {
     }
   };
 
-  const parseAllowedModelsInput = (value) => value
-    .split(/[\n,]/)
-    .map((model) => model.trim())
-    .filter(Boolean);
-
   const resetKeyPolicyForm = () => {
     setNewKeyName("");
     setNewDailyTokenLimit("");
     setNewExpiresAt("");
-    setNewAllowedModels("");
+    setNewAllowedModels([]);
   };
 
   const buildKeyPolicyPayload = () => ({
     name: newKeyName.trim(),
     dailyTokenLimit: newDailyTokenLimit === "" ? 0 : Number(newDailyTokenLimit),
     expiresAt: newExpiresAt || null,
-    allowedModels: parseAllowedModelsInput(newAllowedModels),
+    allowedModels: newAllowedModels,
   });
 
   const handleCreateKey = async () => {
@@ -688,7 +697,7 @@ export default function APIPageClient({ machineId }) {
     setNewKeyName(key.name || "");
     setNewDailyTokenLimit(key.dailyTokenLimit ? String(key.dailyTokenLimit) : "");
     setNewExpiresAt(key.expiresAt ? key.expiresAt.slice(0, 10) : "");
-    setNewAllowedModels(Array.isArray(key.allowedModels) ? key.allowedModels.join("\n") : "");
+    setNewAllowedModels(Array.isArray(key.allowedModels) ? key.allowedModels : []);
   };
 
   const handleUpdateKeyPolicy = async () => {
@@ -784,14 +793,7 @@ export default function APIPageClient({ machineId }) {
     });
   };
 
-  const [baseUrl, setBaseUrl] = useState("/v1");
-
-  // Hydration fix: Only access window on client side
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      setBaseUrl(`${window.location.origin}/v1`);
-    }
-  }, []);
+  const baseUrl = typeof window !== "undefined" ? `${window.location.origin}/v1` : "/v1";
 
   if (loading) {
     return (
@@ -1276,16 +1278,16 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewExpiresAt(e.target.value)}
             hint="Leave empty for no expiry"
           />
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium text-text-main">Allowed Models</label>
-            <textarea
-              value={newAllowedModels}
-              onChange={(e) => setNewAllowedModels(e.target.value)}
-              placeholder="openai/gpt-4o\nanthropic/claude-3-5-sonnet"
-              className="w-full min-h-24 py-2.5 px-3 text-sm text-text-main bg-surface-2 rounded-[10px] border border-transparent placeholder-text-muted/70 focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40 transition-all duration-150 ease-out"
-            />
-            <p className="text-xs text-text-muted">One model per line or comma. Empty = all models.</p>
-          </div>
+          <ModelMultiSelectField
+            label="Allowed Models"
+            value={newAllowedModels}
+            onChange={setNewAllowedModels}
+            activeProviders={activeProviders}
+            modelAliases={modelAliases}
+            title="Select Allowed Models"
+            hint="Empty = all models. Pick provider/model or an existing combo."
+            addLabel="Add Allowed Model"
+          />
           <div className="flex gap-2">
             <Button onClick={handleCreateKey} fullWidth disabled={!newKeyName.trim()}>
               Create
@@ -1336,16 +1338,16 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewExpiresAt(e.target.value)}
             hint="Leave empty for no expiry"
           />
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium text-text-main">Allowed Models</label>
-            <textarea
-              value={newAllowedModels}
-              onChange={(e) => setNewAllowedModels(e.target.value)}
-              placeholder="openai/gpt-4o\nanthropic/claude-3-5-sonnet"
-              className="w-full min-h-24 py-2.5 px-3 text-sm text-text-main bg-surface-2 rounded-[10px] border border-transparent placeholder-text-muted/70 focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40 transition-all duration-150 ease-out"
-            />
-            <p className="text-xs text-text-muted">One model per line or comma. Empty = all models.</p>
-          </div>
+          <ModelMultiSelectField
+            label="Allowed Models"
+            value={newAllowedModels}
+            onChange={setNewAllowedModels}
+            activeProviders={activeProviders}
+            modelAliases={modelAliases}
+            title="Select Allowed Models"
+            hint="Empty = all models. Pick provider/model or an existing combo."
+            addLabel="Add Allowed Model"
+          />
           <div className="flex gap-2">
             <Button onClick={handleUpdateKeyPolicy} fullWidth disabled={!newKeyName.trim()}>
               Save

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -43,6 +43,10 @@ export default function APIPageClient({ machineId }) {
   const [loading, setLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
+  const [newDailyTokenLimit, setNewDailyTokenLimit] = useState("");
+  const [newExpiresAt, setNewExpiresAt] = useState("");
+  const [newAllowedModels, setNewAllowedModels] = useState("");
+  const [editingKey, setEditingKey] = useState(null);
   const [createdKey, setCreatedKey] = useState(null);
   const [confirmState, setConfirmState] = useState(null);
 
@@ -638,6 +642,25 @@ export default function APIPageClient({ machineId }) {
     }
   };
 
+  const parseAllowedModelsInput = (value) => value
+    .split(/[\n,]/)
+    .map((model) => model.trim())
+    .filter(Boolean);
+
+  const resetKeyPolicyForm = () => {
+    setNewKeyName("");
+    setNewDailyTokenLimit("");
+    setNewExpiresAt("");
+    setNewAllowedModels("");
+  };
+
+  const buildKeyPolicyPayload = () => ({
+    name: newKeyName.trim(),
+    dailyTokenLimit: newDailyTokenLimit === "" ? 0 : Number(newDailyTokenLimit),
+    expiresAt: newExpiresAt || null,
+    allowedModels: parseAllowedModelsInput(newAllowedModels),
+  });
+
   const handleCreateKey = async () => {
     if (!newKeyName.trim()) return;
 
@@ -645,18 +668,45 @@ export default function APIPageClient({ machineId }) {
       const res = await fetch("/api/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newKeyName }),
+        body: JSON.stringify(buildKeyPolicyPayload()),
       });
       const data = await res.json();
 
       if (res.ok) {
         setCreatedKey(data.key);
         await fetchData();
-        setNewKeyName("");
+        resetKeyPolicyForm();
         setShowAddModal(false);
       }
     } catch (error) {
       console.log("Error creating key:", error);
+    }
+  };
+
+  const openEditKeyModal = (key) => {
+    setEditingKey(key);
+    setNewKeyName(key.name || "");
+    setNewDailyTokenLimit(key.dailyTokenLimit ? String(key.dailyTokenLimit) : "");
+    setNewExpiresAt(key.expiresAt ? key.expiresAt.slice(0, 10) : "");
+    setNewAllowedModels(Array.isArray(key.allowedModels) ? key.allowedModels.join("\n") : "");
+  };
+
+  const handleUpdateKeyPolicy = async () => {
+    if (!editingKey || !newKeyName.trim()) return;
+    try {
+      const res = await fetch(`/api/keys/${editingKey.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildKeyPolicyPayload()),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setKeys(prev => prev.map(k => k.id === editingKey.id ? data.key : k));
+        setEditingKey(null);
+        resetKeyPolicyForm();
+      }
+    } catch (error) {
+      console.log("Error updating key policy:", error);
     }
   };
 
@@ -701,6 +751,28 @@ export default function APIPageClient({ machineId }) {
   const maskKey = (fullKey) => {
     if (!fullKey) return "";
     return fullKey.length > 8 ? fullKey.slice(0, 8) + "..." : fullKey;
+  };
+
+  const formatTokenLimit = (value) => {
+    const limit = Number(value || 0);
+    return limit > 0 ? `${limit.toLocaleString()} tokens/day` : "No token limit";
+  };
+
+  const formatUsageToday = (key) => {
+    const usage = key.usageToday;
+    if (!usage) return "Usage today unavailable";
+    const used = Number(usage.usedTokens || 0).toLocaleString();
+    if (usage.isUnlimited) return `${used} used today · Unlimited`;
+    const limit = Number(usage.dailyTokenLimit || 0).toLocaleString();
+    const remaining = Number(usage.remainingTokens || 0).toLocaleString();
+    return `${used} / ${limit} used · ${remaining} remaining`;
+  };
+
+  const usageBarClass = (usage) => {
+    if (!usage || usage.isUnlimited) return "bg-primary";
+    if (usage.usagePercent >= 100) return "bg-red-500";
+    if (usage.usagePercent >= 80) return "bg-amber-500";
+    return "bg-primary";
   };
 
   const toggleKeyVisibility = (keyId) => {
@@ -1103,6 +1175,31 @@ export default function APIPageClient({ machineId }) {
                   <p className="text-xs text-text-muted mt-1">
                     Created {new Date(key.createdAt).toLocaleDateString()}
                   </p>
+                  <div className="flex flex-wrap gap-1.5 mt-2 text-[11px] text-text-muted">
+                    <span className="px-2 py-0.5 rounded-full bg-surface-2 border border-border-subtle">
+                      {formatTokenLimit(key.dailyTokenLimit)}
+                    </span>
+                    <span className="px-2 py-0.5 rounded-full bg-surface-2 border border-border-subtle">
+                      {key.expiresAt ? `Expires ${new Date(key.expiresAt).toLocaleDateString()}` : "No expiry"}
+                    </span>
+                    <span className="px-2 py-0.5 rounded-full bg-surface-2 border border-border-subtle">
+                      {Array.isArray(key.allowedModels) && key.allowedModels.length > 0 ? `${key.allowedModels.length} models allowed` : "All models"}
+                    </span>
+                  </div>
+                  <div className="mt-2 max-w-md">
+                    <div className="flex items-center justify-between gap-3 text-[11px] text-text-muted mb-1">
+                      <span>{formatUsageToday(key)}</span>
+                      {key.usageToday && !key.usageToday.isUnlimited && (
+                        <span>{key.usageToday.usagePercent}%</span>
+                      )}
+                    </div>
+                    <div className="h-1.5 rounded-full bg-surface-2 overflow-hidden border border-border-subtle">
+                      <div
+                        className={`h-full rounded-full transition-all ${usageBarClass(key.usageToday)}`}
+                        style={{ width: `${key.usageToday?.isUnlimited ? 0 : key.usageToday?.usagePercent || 0}%` }}
+                      />
+                    </div>
+                  </div>
                   {key.isActive === false && (
                     <p className="text-xs text-orange-500 mt-1">Paused</p>
                   )}
@@ -1128,6 +1225,13 @@ export default function APIPageClient({ machineId }) {
                     title={key.isActive ? "Pause key" : "Resume key"}
                   />
                   <button
+                    onClick={() => openEditKeyModal(key)}
+                    className="p-2 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
+                    title="Edit key limits"
+                  >
+                    <span className="material-symbols-outlined text-[18px]">tune</span>
+                  </button>
+                  <button
                     onClick={() => handleDeleteKey(key.id)}
                     className="p-2 hover:bg-red-500/10 rounded text-red-500 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
                   >
@@ -1146,7 +1250,7 @@ export default function APIPageClient({ machineId }) {
         title="Create API Key"
         onClose={() => {
           setShowAddModal(false);
-          setNewKeyName("");
+          resetKeyPolicyForm();
         }}
       >
         <div className="flex flex-col gap-4">
@@ -1156,6 +1260,32 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewKeyName(e.target.value)}
             placeholder="Production Key"
           />
+          <Input
+            label="Daily Token Limit"
+            type="number"
+            min="0"
+            value={newDailyTokenLimit}
+            onChange={(e) => setNewDailyTokenLimit(e.target.value)}
+            placeholder="0 = unlimited"
+            hint="Resets daily using server local date"
+          />
+          <Input
+            label="Expires At"
+            type="date"
+            value={newExpiresAt}
+            onChange={(e) => setNewExpiresAt(e.target.value)}
+            hint="Leave empty for no expiry"
+          />
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Allowed Models</label>
+            <textarea
+              value={newAllowedModels}
+              onChange={(e) => setNewAllowedModels(e.target.value)}
+              placeholder="openai/gpt-4o\nanthropic/claude-3-5-sonnet"
+              className="w-full min-h-24 py-2.5 px-3 text-sm text-text-main bg-surface-2 rounded-[10px] border border-transparent placeholder-text-muted/70 focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40 transition-all duration-150 ease-out"
+            />
+            <p className="text-xs text-text-muted">One model per line or comma. Empty = all models.</p>
+          </div>
           <div className="flex gap-2">
             <Button onClick={handleCreateKey} fullWidth disabled={!newKeyName.trim()}>
               Create
@@ -1163,7 +1293,67 @@ export default function APIPageClient({ machineId }) {
             <Button
               onClick={() => {
                 setShowAddModal(false);
-                setNewKeyName("");
+                resetKeyPolicyForm();
+              }}
+              variant="ghost"
+              fullWidth
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Edit Key Policy Modal */}
+      <Modal
+        isOpen={!!editingKey}
+        title="Edit API Key Limits"
+        onClose={() => {
+          setEditingKey(null);
+          resetKeyPolicyForm();
+        }}
+      >
+        <div className="flex flex-col gap-4">
+          <Input
+            label="Key Name"
+            value={newKeyName}
+            onChange={(e) => setNewKeyName(e.target.value)}
+            placeholder="Production Key"
+          />
+          <Input
+            label="Daily Token Limit"
+            type="number"
+            min="0"
+            value={newDailyTokenLimit}
+            onChange={(e) => setNewDailyTokenLimit(e.target.value)}
+            placeholder="0 = unlimited"
+            hint="Resets daily using server local date"
+          />
+          <Input
+            label="Expires At"
+            type="date"
+            value={newExpiresAt}
+            onChange={(e) => setNewExpiresAt(e.target.value)}
+            hint="Leave empty for no expiry"
+          />
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Allowed Models</label>
+            <textarea
+              value={newAllowedModels}
+              onChange={(e) => setNewAllowedModels(e.target.value)}
+              placeholder="openai/gpt-4o\nanthropic/claude-3-5-sonnet"
+              className="w-full min-h-24 py-2.5 px-3 text-sm text-text-main bg-surface-2 rounded-[10px] border border-transparent placeholder-text-muted/70 focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40 transition-all duration-150 ease-out"
+            />
+            <p className="text-xs text-text-muted">One model per line or comma. Empty = all models.</p>
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={handleUpdateKeyPolicy} fullWidth disabled={!newKeyName.trim()}>
+              Save
+            </Button>
+            <Button
+              onClick={() => {
+                setEditingKey(null);
+                resetKeyPolicyForm();
               }}
               variant="ghost"
               fullWidth

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -1,6 +1,38 @@
 import { NextResponse } from "next/server";
 import { deleteApiKey, getApiKeyById, updateApiKey } from "@/lib/localDb";
 
+function parseAllowedModels(value) {
+  if (Array.isArray(value)) return Array.from(new Set(value.map((m) => typeof m === "string" ? m.trim() : "").filter(Boolean)));
+  if (typeof value === "string") {
+    return Array.from(new Set(value.split(/[\n,]/).map((m) => m.trim()).filter(Boolean)));
+  }
+  return [];
+}
+
+function addPolicyPatch(body, updateData) {
+  if (Object.prototype.hasOwnProperty.call(body, "name")) updateData.name = body.name;
+  if (Object.prototype.hasOwnProperty.call(body, "dailyTokenLimit")) {
+    const dailyTokenLimit = body.dailyTokenLimit === "" || body.dailyTokenLimit == null ? 0 : Number(body.dailyTokenLimit);
+    if (!Number.isInteger(dailyTokenLimit) || dailyTokenLimit < 0) {
+      return "dailyTokenLimit must be a non-negative integer";
+    }
+    updateData.dailyTokenLimit = dailyTokenLimit;
+  }
+  if (Object.prototype.hasOwnProperty.call(body, "expiresAt")) {
+    if (!body.expiresAt) {
+      updateData.expiresAt = null;
+    } else {
+      const date = new Date(body.expiresAt);
+      if (Number.isNaN(date.getTime())) return "expiresAt must be a valid date";
+      updateData.expiresAt = date.toISOString();
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(body, "allowedModels")) {
+    updateData.allowedModels = parseAllowedModels(body.allowedModels);
+  }
+  return null;
+}
+
 // GET /api/keys/[id] - Get single key
 export async function GET(request, { params }) {
   try {
@@ -30,6 +62,10 @@ export async function PUT(request, { params }) {
 
     const updateData = {};
     if (isActive !== undefined) updateData.isActive = isActive;
+    const policyError = addPolicyPatch(body, updateData);
+    if (policyError) {
+      return NextResponse.json({ error: policyError }, { status: 400 });
+    }
 
     const updated = await updateApiKey(id, updateData);
 

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -1,14 +1,51 @@
 import { NextResponse } from "next/server";
 import { getApiKeys, createApiKey } from "@/lib/localDb";
+import { getApiKeyDailyUsageSummary } from "@/lib/usageDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 
 export const dynamic = "force-dynamic";
+
+function parseAllowedModels(value) {
+  if (Array.isArray(value)) return Array.from(new Set(value.map((m) => typeof m === "string" ? m.trim() : "").filter(Boolean)));
+  if (typeof value === "string") {
+    return Array.from(new Set(value.split(/[\n,]/).map((m) => m.trim()).filter(Boolean)));
+  }
+  return [];
+}
+
+function parsePolicy(body) {
+  const dailyTokenLimit = body.dailyTokenLimit === "" || body.dailyTokenLimit == null ? 0 : Number(body.dailyTokenLimit);
+  if (!Number.isInteger(dailyTokenLimit) || dailyTokenLimit < 0) {
+    return { error: "dailyTokenLimit must be a non-negative integer" };
+  }
+
+  let expiresAt = null;
+  if (body.expiresAt) {
+    const date = new Date(body.expiresAt);
+    if (Number.isNaN(date.getTime())) return { error: "expiresAt must be a valid date" };
+    expiresAt = date.toISOString();
+  }
+
+  return {
+    policy: {
+      dailyTokenLimit,
+      expiresAt,
+      allowedModels: parseAllowedModels(body.allowedModels),
+    },
+  };
+}
 
 // GET /api/keys - List API keys
 export async function GET() {
   try {
     const keys = await getApiKeys();
-    return NextResponse.json({ keys });
+    const keysWithUsage = await Promise.all(
+      keys.map(async (key) => ({
+        ...key,
+        usageToday: await getApiKeyDailyUsageSummary(key),
+      }))
+    );
+    return NextResponse.json({ keys: keysWithUsage });
   } catch (error) {
     console.log("Error fetching keys:", error);
     return NextResponse.json({ error: "Failed to fetch keys" }, { status: 500 });
@@ -25,15 +62,23 @@ export async function POST(request) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
+    const parsed = parsePolicy(body);
+    if (parsed.error) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
-    const apiKey = await createApiKey(name, machineId);
+    const apiKey = await createApiKey(name, machineId, parsed.policy);
 
     return NextResponse.json({
       key: apiKey.key,
       name: apiKey.name,
       id: apiKey.id,
       machineId: apiKey.machineId,
+      dailyTokenLimit: apiKey.dailyTokenLimit,
+      expiresAt: apiKey.expiresAt,
+      allowedModels: apiKey.allowedModels,
     }, { status: 201 });
   } catch (error) {
     console.log("Error creating key:", error);

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -5,8 +5,10 @@ import {
   isAnthropicCompatibleProvider,
   isOpenAICompatibleProvider,
 } from "@/shared/constants/providers";
-import { getProviderConnections, getCombos, getCustomModels, getModelAliases } from "@/lib/localDb";
+import { getProviderConnections, getCombos, getCustomModels, getModelAliases, getSettings, validateApiKey } from "@/lib/localDb";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
+import { extractApiKey } from "@/sse/services/auth.js";
+import { loadApiKeyPolicy, filterModelsByApiKeyPolicy } from "@/sse/services/apiKeyPolicy.js";
 
 const parseOpenAIStyleModels = (data) => {
   if (Array.isArray(data)) return data;
@@ -386,9 +388,25 @@ export async function OPTIONS() {
  * GET /v1/models - OpenAI compatible models list (LLM/chat models only by default).
  * For other capabilities use /v1/models/{kind} (image, tts, stt, embedding, image-to-text, web).
  */
-export async function GET() {
+export async function GET(request) {
   try {
-    const data = await buildModelsList([LLM_KIND]);
+    const settings = await getSettings();
+    const apiKey = extractApiKey(request);
+    let apiKeyRecord = null;
+
+    if (settings.requireApiKey) {
+      if (!apiKey || !(await validateApiKey(apiKey))) {
+        return Response.json(
+          { error: { message: apiKey ? "Invalid API key" : "Missing API key", type: "authentication_error" } },
+          { status: 401, headers: { "Access-Control-Allow-Origin": "*" } }
+        );
+      }
+      apiKeyRecord = await loadApiKeyPolicy(apiKey);
+    } else if (apiKey && await validateApiKey(apiKey)) {
+      apiKeyRecord = await loadApiKeyPolicy(apiKey);
+    }
+
+    const data = filterModelsByApiKeyPolicy(await buildModelsList([LLM_KIND]), apiKeyRecord);
     return Response.json({ object: "list", data }, {
       headers: { "Access-Control-Allow-Origin": "*" },
     });

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -1,5 +1,5 @@
 // Public API barrel — all DB functions
-import { getAdapter } from "./driver.js";
+import { getAdapter, getAdapterSync } from "./driver.js";
 import { stringifyJson, parseJson } from "./helpers/jsonCol.js";
 
 // Settings
@@ -29,7 +29,7 @@ export {
 
 // API keys
 export {
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByKey, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
 } from "./repos/apiKeysRepo.js";
 
 // Combos
@@ -58,7 +58,7 @@ export {
 // Usage
 export {
   statsEmitter, trackPendingRequest, getActiveRequests,
-  saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
+  saveRequestUsage, getApiKeyDailyTokenUsage, getApiKeyDailyUsageSummary, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
 } from "./repos/usageRepo.js";
 
@@ -77,7 +77,17 @@ export async function exportDb() {
     providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
-    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
+    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({
+      id: r.id,
+      key: r.key,
+      name: r.name,
+      machineId: r.machineId,
+      isActive: r.isActive === 1,
+      dailyTokenLimit: r.dailyTokenLimit || 0,
+      expiresAt: r.expiresAt || null,
+      allowedModels: parseJson(r.allowedModels, []),
+      createdAt: r.createdAt,
+    })),
     combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), createdAt: r.createdAt, updatedAt: r.updatedAt })),
     modelAliases: {},
     customModels: [],
@@ -137,8 +147,18 @@ export async function importDb(payload) {
     }
     for (const k of payload.apiKeys || []) {
       db.run(
-        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, dailyTokenLimit, expiresAt, allowedModels, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          k.id,
+          k.key,
+          k.name || null,
+          k.machineId || null,
+          k.isActive === false ? 0 : 1,
+          Number.isFinite(Number(k.dailyTokenLimit)) ? Math.max(0, Math.floor(Number(k.dailyTokenLimit))) : 0,
+          k.expiresAt || null,
+          stringifyJson(Array.isArray(k.allowedModels) ? Array.from(new Set(k.allowedModels.map((m) => typeof m === "string" ? m.trim() : "").filter(Boolean))) : []),
+          k.createdAt || new Date().toISOString(),
+        ]
       );
     }
     for (const c of payload.combos || []) {
@@ -164,6 +184,8 @@ export async function importDb(payload) {
 
   return await exportDb();
 }
+
+export { getAdapterSync };
 
 // Eager init helper (optional)
 export async function initDb() {

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -114,8 +114,18 @@ function importLegacyMain(adapter, data) {
   }
   for (const k of data.apiKeys || []) {
     adapter.run(
-      `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-      [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+      `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, dailyTokenLimit, expiresAt, allowedModels, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        k.id,
+        k.key,
+        k.name || null,
+        k.machineId || null,
+        k.isActive === false ? 0 : 1,
+        Number.isFinite(Number(k.dailyTokenLimit)) ? Math.max(0, Math.floor(Number(k.dailyTokenLimit))) : 0,
+        k.expiresAt || null,
+        stringifyJson(Array.isArray(k.allowedModels) ? Array.from(new Set(k.allowedModels.map((m) => typeof m === "string" ? m.trim() : "").filter(Boolean))) : []),
+        k.createdAt || new Date().toISOString(),
+      ]
     );
   }
   for (const c of data.combos || []) {

--- a/src/lib/db/migrations/002-api-key-limits.js
+++ b/src/lib/db/migrations/002-api-key-limits.js
@@ -1,0 +1,18 @@
+export default {
+  version: 2,
+  name: "api-key-limits",
+  up(db) {
+    const existing = db.all(`PRAGMA table_info(apiKeys)`);
+    const columns = new Set(existing.map((row) => row.name));
+
+    if (!columns.has("dailyTokenLimit")) {
+      db.exec(`ALTER TABLE apiKeys ADD COLUMN dailyTokenLimit INTEGER DEFAULT 0`);
+    }
+    if (!columns.has("expiresAt")) {
+      db.exec(`ALTER TABLE apiKeys ADD COLUMN expiresAt TEXT`);
+    }
+    if (!columns.has("allowedModels")) {
+      db.exec(`ALTER TABLE apiKeys ADD COLUMN allowedModels TEXT DEFAULT '[]'`);
+    }
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-api-key-limits.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -1,5 +1,43 @@
 import { v4 as uuidv4 } from "uuid";
 import { getAdapter } from "../driver.js";
+import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+
+function normalizeDailyTokenLimit(value) {
+  const n = Number(value || 0);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.floor(n);
+}
+
+function normalizeExpiresAt(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function normalizeAllowedModels(value) {
+  const list = Array.isArray(value) ? value : parseJson(value, []);
+  if (!Array.isArray(list)) return [];
+  return Array.from(
+    new Set(
+      list
+        .map((model) => (typeof model === "string" ? model.trim() : ""))
+        .filter(Boolean)
+    )
+  );
+}
+
+export function normalizeApiKeyPolicy(data = {}) {
+  return {
+    dailyTokenLimit: normalizeDailyTokenLimit(data.dailyTokenLimit),
+    expiresAt: normalizeExpiresAt(data.expiresAt),
+    allowedModels: normalizeAllowedModels(data.allowedModels),
+  };
+}
+
+function isExpired(expiresAt) {
+  return !!expiresAt && new Date(expiresAt).getTime() <= Date.now();
+}
 
 function rowToKey(row) {
   if (!row) return null;
@@ -9,6 +47,9 @@ function rowToKey(row) {
     name: row.name,
     machineId: row.machineId,
     isActive: row.isActive === 1 || row.isActive === true,
+    dailyTokenLimit: normalizeDailyTokenLimit(row.dailyTokenLimit),
+    expiresAt: normalizeExpiresAt(row.expiresAt),
+    allowedModels: normalizeAllowedModels(row.allowedModels),
     createdAt: row.createdAt,
   };
 }
@@ -25,22 +66,40 @@ export async function getApiKeyById(id) {
   return rowToKey(row);
 }
 
-export async function createApiKey(name, machineId) {
+export async function getApiKeyByKey(key) {
+  const db = await getAdapter();
+  const row = db.get(`SELECT * FROM apiKeys WHERE key = ?`, [key]);
+  return rowToKey(row);
+}
+
+export async function createApiKey(name, machineId, options = {}) {
   if (!machineId) throw new Error("machineId is required");
   const db = await getAdapter();
   const { generateApiKeyWithMachine } = await import("@/shared/utils/apiKey");
   const result = generateApiKeyWithMachine(machineId);
+  const policy = normalizeApiKeyPolicy(options);
   const apiKey = {
     id: uuidv4(),
     name,
     key: result.key,
     machineId,
     isActive: true,
+    ...policy,
     createdAt: new Date().toISOString(),
   };
   db.run(
-    `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.createdAt]
+    `INSERT INTO apiKeys(id, key, name, machineId, isActive, dailyTokenLimit, expiresAt, allowedModels, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      apiKey.id,
+      apiKey.key,
+      apiKey.name,
+      apiKey.machineId,
+      1,
+      apiKey.dailyTokenLimit,
+      apiKey.expiresAt,
+      stringifyJson(apiKey.allowedModels),
+      apiKey.createdAt,
+    ]
   );
   return apiKey;
 }
@@ -51,10 +110,30 @@ export async function updateApiKey(id, data) {
   db.transaction(() => {
     const row = db.get(`SELECT * FROM apiKeys WHERE id = ?`, [id]);
     if (!row) return;
-    const merged = { ...rowToKey(row), ...data };
+    const existing = rowToKey(row);
+    const policyPatch = {};
+    if (Object.prototype.hasOwnProperty.call(data, "dailyTokenLimit")) {
+      policyPatch.dailyTokenLimit = normalizeDailyTokenLimit(data.dailyTokenLimit);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "expiresAt")) {
+      policyPatch.expiresAt = normalizeExpiresAt(data.expiresAt);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "allowedModels")) {
+      policyPatch.allowedModels = normalizeAllowedModels(data.allowedModels);
+    }
+    const merged = { ...existing, ...data, ...policyPatch };
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ? WHERE id = ?`,
-      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, id]
+      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, dailyTokenLimit = ?, expiresAt = ?, allowedModels = ? WHERE id = ?`,
+      [
+        merged.key,
+        merged.name,
+        merged.machineId,
+        merged.isActive ? 1 : 0,
+        merged.dailyTokenLimit,
+        merged.expiresAt,
+        stringifyJson(merged.allowedModels),
+        id,
+      ]
     );
     result = merged;
   });
@@ -68,8 +147,7 @@ export async function deleteApiKey(id) {
 }
 
 export async function validateApiKey(key) {
-  const db = await getAdapter();
-  const row = db.get(`SELECT isActive FROM apiKeys WHERE key = ?`, [key]);
+  const row = await getApiKeyByKey(key);
   if (!row) return false;
-  return row.isActive === 1 || row.isActive === true;
+  return row.isActive && !isExpired(row.expiresAt);
 }

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -286,6 +286,50 @@ export async function saveRequestUsage(entry) {
   }
 }
 
+function getLocalDayBounds(date = new Date()) {
+  const d = date instanceof Date ? date : new Date(date);
+  const start = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const end = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1);
+  return { start, end };
+}
+
+function getNextLocalMidnightIso(date = new Date()) {
+  return getLocalDayBounds(date).end.toISOString();
+}
+
+export async function getApiKeyDailyTokenUsage(apiKey, date = new Date()) {
+  if (!apiKey) return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  const db = await getAdapter();
+  const { start, end } = getLocalDayBounds(date);
+  const row = db.get(
+    `SELECT COALESCE(SUM(promptTokens), 0) AS promptTokens, COALESCE(SUM(completionTokens), 0) AS completionTokens FROM usageHistory WHERE apiKey = ? AND timestamp >= ? AND timestamp < ?`,
+    [apiKey, start.toISOString(), end.toISOString()]
+  );
+  const promptTokens = Number(row?.promptTokens || 0);
+  const completionTokens = Number(row?.completionTokens || 0);
+  return { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens };
+}
+
+export async function getApiKeyDailyUsageSummary(apiKeyOrRecord, date = new Date()) {
+  const apiKey = typeof apiKeyOrRecord === "string" ? apiKeyOrRecord : apiKeyOrRecord?.key;
+  const dailyTokenLimit = Number(typeof apiKeyOrRecord === "object" ? apiKeyOrRecord?.dailyTokenLimit || 0 : 0);
+  const usage = await getApiKeyDailyTokenUsage(apiKey, date);
+  const isUnlimited = !Number.isFinite(dailyTokenLimit) || dailyTokenLimit <= 0;
+  const remainingTokens = isUnlimited ? null : Math.max(0, dailyTokenLimit - usage.totalTokens);
+  const usagePercent = isUnlimited ? 0 : Math.min(100, Math.round((usage.totalTokens / dailyTokenLimit) * 100));
+
+  return {
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    usedTokens: usage.totalTokens,
+    dailyTokenLimit: isUnlimited ? 0 : dailyTokenLimit,
+    remainingTokens,
+    usagePercent,
+    isUnlimited,
+    resetAt: getNextLocalMidnightIso(date),
+  };
+}
+
 export async function getUsageHistory(filter = {}) {
   const db = await getAdapter();
   const conds = [];
@@ -544,9 +588,8 @@ export async function getUsageStats(period = "all") {
     );
 
     for (const r of filtered) {
-      const tokens = parseJson(r.tokens, {}) || {};
-      const promptTokens = tokens.prompt_tokens || 0;
-      const completionTokens = tokens.completion_tokens || 0;
+      const promptTokens = r.promptTokens || 0;
+      const completionTokens = r.completionTokens || 0;
       const entryCost = r.cost || 0;
       const providerDisplayName = providerNodeNameMap[r.provider] || r.provider;
 

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -1,5 +1,5 @@
 // Latest schema version — bumped when a migration is added in ./migrations/
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -78,6 +78,9 @@ export const TABLES = {
       name: "TEXT",
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
+      dailyTokenLimit: "INTEGER DEFAULT 0",
+      expiresAt: "TEXT",
+      allowedModels: "TEXT DEFAULT '[]'",
       createdAt: "TEXT NOT NULL",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -10,7 +10,7 @@ export {
   createProviderNode, updateProviderNode, deleteProviderNode,
   getProxyPools, getProxyPoolById,
   createProxyPool, updateProxyPool, deleteProxyPool,
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByKey, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
   getCombos, getComboById, getComboByName,
   createCombo, updateCombo, deleteCombo,
   getModelAliases, setModelAlias, deleteModelAlias,

--- a/src/lib/tunnel/tailscale.js
+++ b/src/lib/tunnel/tailscale.js
@@ -14,6 +14,7 @@ const BIN_DIR = path.join(DATA_DIR, "bin");
 const IS_MAC = os.platform() === "darwin";
 const IS_LINUX = os.platform() === "linux";
 const IS_WINDOWS = os.platform() === "win32";
+const SKIP_SYSTEM_TAILSCALE_PROBE = process.env.NINE_ROUTER_SKIP_SYSTEM_TAILSCALE_PROBE === "1";
 const TAILSCALE_BIN = path.join(BIN_DIR, IS_WINDOWS ? "tailscale.exe" : "tailscale");
 
 // Custom socket for userspace-networking mode (no root required)
@@ -21,8 +22,13 @@ const TAILSCALE_DIR = path.join(DATA_DIR, "tailscale");
 export const TAILSCALE_SOCKET = path.join(TAILSCALE_DIR, "tailscaled.sock");
 const SOCKET_FLAG = IS_WINDOWS ? [] : ["--socket", TAILSCALE_SOCKET];
 
-// Well-known Windows install path
-const WINDOWS_TAILSCALE_BIN = "C:\\Program Files\\Tailscale\\tailscale.exe";
+// Well-known Windows install path. Build dynamically so Next file tracing does not
+// try to copy C:\\Program Files into standalone CLI bundles on Windows.
+function getWindowsTailscaleBin() {
+  if (!IS_WINDOWS || SKIP_SYSTEM_TAILSCALE_PROBE) return null;
+  const programFiles = process.env.ProgramFiles || `${"C:"}${path.sep}Program Files`;
+  return path.join(programFiles, "Tailscale", "tailscale.exe");
+}
 
 // Common Unix install paths to probe synchronously (system tailscale)
 const UNIX_TAILSCALE_CANDIDATES = [
@@ -41,7 +47,9 @@ const funnelUrlCache = { value: null, port: null, fetchedAt: 0, refreshing: fals
 
 function fallbackBin() {
   if (fs.existsSync(TAILSCALE_BIN)) return TAILSCALE_BIN;
-  if (IS_WINDOWS && fs.existsSync(WINDOWS_TAILSCALE_BIN)) return WINDOWS_TAILSCALE_BIN;
+  if (SKIP_SYSTEM_TAILSCALE_PROBE) return null;
+  const windowsTailscaleBin = getWindowsTailscaleBin();
+  if (windowsTailscaleBin && fs.existsSync(windowsTailscaleBin)) return windowsTailscaleBin;
   if (!IS_WINDOWS) return UNIX_TAILSCALE_CANDIDATES.find((p) => fs.existsSync(p)) || null;
   return null;
 }
@@ -49,6 +57,12 @@ function fallbackBin() {
 function bgRefreshBin() {
   if (binCache.refreshing) return;
   binCache.refreshing = true;
+  if (SKIP_SYSTEM_TAILSCALE_PROBE) {
+    binCache.value = fallbackBin();
+    binCache.fetchedAt = Date.now();
+    binCache.refreshing = false;
+    return;
+  }
   execAsync("which tailscale 2>/dev/null || where tailscale 2>nul", { windowsHide: true, timeout: PROBE_TIMEOUT_MS })
     .then(({ stdout }) => {
       const sys = stdout.trim();
@@ -67,11 +81,15 @@ function getTailscaleBin() {
   // First call: synchronously probe common install paths (no exec, no event-loop block)
   if (binCache.value === undefined) {
     if (fs.existsSync(TAILSCALE_BIN)) binCache.value = TAILSCALE_BIN;
-    else if (IS_WINDOWS && fs.existsSync(WINDOWS_TAILSCALE_BIN)) binCache.value = WINDOWS_TAILSCALE_BIN;
-    else if (!IS_WINDOWS) {
-      const found = UNIX_TAILSCALE_CANDIDATES.find((p) => fs.existsSync(p));
-      binCache.value = found || null;
-    } else binCache.value = null;
+    else if (SKIP_SYSTEM_TAILSCALE_PROBE) binCache.value = null;
+    else {
+      const windowsTailscaleBin = getWindowsTailscaleBin();
+      if (windowsTailscaleBin && fs.existsSync(windowsTailscaleBin)) binCache.value = windowsTailscaleBin;
+      else if (!IS_WINDOWS) {
+        const found = UNIX_TAILSCALE_CANDIDATES.find((p) => fs.existsSync(p));
+        binCache.value = found || null;
+      } else binCache.value = null;
+    }
   }
   return binCache.value;
 }
@@ -399,7 +417,8 @@ async function installTailscaleWindows(log) {
   const maxWait = 10000;
   const start = Date.now();
   while (Date.now() - start < maxWait) {
-    if (fs.existsSync(WINDOWS_TAILSCALE_BIN)) {
+    const windowsTailscaleBin = getWindowsTailscaleBin();
+    if (windowsTailscaleBin && fs.existsSync(windowsTailscaleBin)) {
       log("Installation complete.");
       return;
     }

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -1,7 +1,7 @@
 // Shim → re-export from new SQLite-based DB layer (src/lib/db/)
 export {
   statsEmitter, trackPendingRequest, getActiveRequests,
-  saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
+  saveRequestUsage, getApiKeyDailyTokenUsage, getApiKeyDailyUsageSummary, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
   saveRequestDetail, getRequestDetails, getRequestDetailById,
 } from "@/lib/db/index.js";

--- a/src/shared/components/ModelMultiSelectField.js
+++ b/src/shared/components/ModelMultiSelectField.js
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import ModelSelectModal from "./ModelSelectModal";
+
+export default function ModelMultiSelectField({
+  label = "Models",
+  value = [],
+  onChange,
+  activeProviders = [],
+  modelAliases = {},
+  title = "Select Models",
+  hint = "Empty = all models.",
+  addLabel = "Add Model",
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedModels = Array.isArray(value) ? value : [];
+
+  const handleSelect = (model) => {
+    if (!model?.value || selectedModels.includes(model.value)) return;
+    onChange([...selectedModels, model.value]);
+  };
+
+  const handleDeselect = (model) => {
+    if (!model?.value) return;
+    onChange(selectedModels.filter((item) => item !== model.value));
+  };
+
+  const handleRemove = (modelValue) => {
+    onChange(selectedModels.filter((item) => item !== modelValue));
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-sm font-medium text-text-main">{label}</label>
+      {selectedModels.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border-subtle bg-surface-2/60 px-3 py-3 text-center text-xs text-text-muted">
+          All models allowed
+        </div>
+      ) : (
+        <div className="flex max-h-40 flex-col gap-1.5 overflow-y-auto rounded-lg border border-border-subtle bg-surface-2/60 p-2">
+          {selectedModels.map((model) => (
+            <div key={model} className="flex min-w-0 items-center gap-2 rounded-md bg-surface px-2 py-1.5 text-xs">
+              <code className="min-w-0 flex-1 truncate font-mono text-text-main" title={model}>{model}</code>
+              <button
+                type="button"
+                onClick={() => handleRemove(model)}
+                className="rounded p-0.5 text-text-muted transition-colors hover:bg-red-500/10 hover:text-red-500"
+                title="Remove model"
+              >
+                <span className="material-symbols-outlined text-[14px]">close</span>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="flex w-full items-center justify-center gap-1 rounded-lg border border-dashed border-border-subtle py-2 text-xs font-medium text-primary transition-colors hover:border-primary/50 hover:text-primary"
+      >
+        <span className="material-symbols-outlined text-[16px]">add</span>
+        {addLabel}
+      </button>
+      {hint && <p className="text-xs text-text-muted">{hint}</p>}
+      <ModelSelectModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onSelect={handleSelect}
+        onDeselect={handleDeselect}
+        activeProviders={activeProviders}
+        modelAliases={modelAliases}
+        title={title}
+        addedModelValues={selectedModels}
+        closeOnSelect={false}
+      />
+    </div>
+  );
+}

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -15,6 +15,7 @@ export { default as Header } from "./Header";
 export { default as Footer } from "./Footer";
 export { default as OAuthModal } from "./OAuthModal";
 export { default as ModelSelectModal } from "./ModelSelectModal";
+export { default as ModelMultiSelectField } from "./ModelMultiSelectField";
 export { default as ManualConfigModal } from "./ManualConfigModal";
 export { default as ComboFormModal } from "./ComboFormModal";
 export { default as McpMarketplaceModal } from "./McpMarketplaceModal";

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -19,6 +19,13 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+import {
+  loadApiKeyPolicy,
+  checkApiKeyExpiry,
+  checkApiKeyDailyTokenLimit,
+  checkApiKeyModelAccess,
+  checkApiKeyComboModelAccess,
+} from "../services/apiKeyPolicy.js";
 
 /**
  * Handle chat completion request
@@ -67,6 +74,7 @@ export async function handleChat(request, clientRawRequest = null) {
 
   // Enforce API key if enabled in settings
   const settings = await getSettings();
+  let apiKeyRecord = null;
   if (settings.requireApiKey) {
     if (!apiKey) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
@@ -76,6 +84,22 @@ export async function handleChat(request, clientRawRequest = null) {
     if (!valid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    }
+    apiKeyRecord = await loadApiKeyPolicy(apiKey);
+    const expiryCheck = checkApiKeyExpiry(apiKeyRecord);
+    if (!expiryCheck.allowed) {
+      log.warn("AUTH", expiryCheck.message);
+      return errorResponse(expiryCheck.status, expiryCheck.message);
+    }
+    const quotaCheck = await checkApiKeyDailyTokenLimit(apiKeyRecord);
+    if (!quotaCheck.allowed) {
+      log.warn("AUTH", quotaCheck.message);
+      const response = errorResponse(quotaCheck.status, quotaCheck.message);
+      response.headers.set("X-Api-Key-Token-Limit", String(quotaCheck.limit));
+      response.headers.set("X-Api-Key-Token-Used", String(quotaCheck.usage.totalTokens));
+      response.headers.set("X-Api-Key-Token-Remaining", String(quotaCheck.remaining));
+      response.headers.set("X-Api-Key-Token-Reset", quotaCheck.resetAt);
+      return response;
     }
   }
 
@@ -92,6 +116,12 @@ export async function handleChat(request, clientRawRequest = null) {
   // Check if model is a combo (has multiple models with fallback)
   const comboModels = await getComboModels(modelStr);
   if (comboModels) {
+    const modelCheck = checkApiKeyComboModelAccess(apiKeyRecord, modelStr, comboModels);
+    if (!modelCheck.allowed) {
+      log.warn("AUTH", modelCheck.message);
+      return errorResponse(modelCheck.status, modelCheck.message);
+    }
+
     // Check for combo-specific strategy first, fallback to global
     const comboStrategies = settings.comboStrategies || {};
     const comboSpecificStrategy = comboStrategies[modelStr]?.fallbackStrategy;
@@ -102,7 +132,7 @@ export async function handleChat(request, clientRawRequest = null) {
     return handleComboChat({
       body,
       models: comboModels,
-      handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
+      handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey, apiKeyRecord),
       log,
       comboName: modelStr,
       comboStrategy,
@@ -111,13 +141,13 @@ export async function handleChat(request, clientRawRequest = null) {
   }
 
   // Single model request
-  return handleSingleModelChat(body, modelStr, clientRawRequest, request, apiKey);
+  return handleSingleModelChat(body, modelStr, clientRawRequest, request, apiKey, apiKeyRecord);
 }
 
 /**
  * Handle single model chat request
  */
-async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null) {
+async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null, apiKeyRecord = null) {
   const modelInfo = await getModelInfo(modelStr);
 
   // If provider is null, this might be a combo name - check and handle
@@ -135,7 +165,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       return handleComboChat({
         body,
         models: comboModels,
-        handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
+        handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey, apiKeyRecord),
         log,
         comboName: modelStr,
         comboStrategy,
@@ -147,6 +177,14 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   }
 
   const { provider, model } = modelInfo;
+  const modelCheck = checkApiKeyModelAccess(apiKeyRecord, {
+    requestedModel: modelStr,
+    resolvedModels: [`${provider}/${model}`],
+  });
+  if (!modelCheck.allowed) {
+    log.warn("AUTH", modelCheck.message);
+    return errorResponse(modelCheck.status, modelCheck.message);
+  }
 
   // Log model routing (alias → actual model)
   if (modelStr !== `${provider}/${model}`) {

--- a/src/sse/services/apiKeyPolicy.js
+++ b/src/sse/services/apiKeyPolicy.js
@@ -1,0 +1,96 @@
+import { getApiKeyByKey } from "@/lib/localDb";
+import { getApiKeyDailyTokenUsage } from "@/lib/usageDb";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+
+function normalizeModelId(model) {
+  return typeof model === "string" ? model.trim().toLowerCase() : "";
+}
+
+function nextLocalMidnightIso(date = new Date()) {
+  const next = new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1);
+  return next.toISOString();
+}
+
+export async function loadApiKeyPolicy(apiKey) {
+  if (!apiKey) return null;
+  return getApiKeyByKey(apiKey);
+}
+
+export function checkApiKeyExpiry(apiKeyRecord, now = new Date()) {
+  if (!apiKeyRecord) {
+    return { allowed: false, status: HTTP_STATUS.UNAUTHORIZED, message: "Invalid API key" };
+  }
+  if (!apiKeyRecord.isActive) {
+    return { allowed: false, status: HTTP_STATUS.UNAUTHORIZED, message: "API key is inactive" };
+  }
+  if (apiKeyRecord.expiresAt && new Date(apiKeyRecord.expiresAt).getTime() <= now.getTime()) {
+    return { allowed: false, status: HTTP_STATUS.UNAUTHORIZED, message: "API key has expired" };
+  }
+  return { allowed: true };
+}
+
+export function checkApiKeyModelAccess(apiKeyRecord, { requestedModel, resolvedModels = [] } = {}) {
+  const allowedModels = Array.isArray(apiKeyRecord?.allowedModels) ? apiKeyRecord.allowedModels : [];
+  const allowedSet = new Set(allowedModels.map(normalizeModelId).filter(Boolean));
+  if (allowedSet.size === 0) return { allowed: true };
+
+  const candidates = [requestedModel, ...resolvedModels].map(normalizeModelId).filter(Boolean);
+  const allowed = candidates.length > 0 && candidates.some((model) => allowedSet.has(model));
+  if (allowed) return { allowed: true };
+
+  return {
+    allowed: false,
+    status: HTTP_STATUS.FORBIDDEN,
+    message: `Model is not allowed for this API key: ${requestedModel || resolvedModels[0] || "unknown"}`,
+  };
+}
+
+export function checkApiKeyComboModelAccess(apiKeyRecord, comboName, comboModels = []) {
+  const allowedModels = Array.isArray(apiKeyRecord?.allowedModels) ? apiKeyRecord.allowedModels : [];
+  const allowedSet = new Set(allowedModels.map(normalizeModelId).filter(Boolean));
+  if (allowedSet.size === 0) return { allowed: true };
+  if (allowedSet.has(normalizeModelId(comboName))) return { allowed: true };
+
+  const normalizedModels = comboModels.map(normalizeModelId).filter(Boolean);
+  const allComboModelsAllowed = normalizedModels.length > 0 && normalizedModels.every((model) => allowedSet.has(model));
+  if (allComboModelsAllowed) return { allowed: true };
+
+  return {
+    allowed: false,
+    status: HTTP_STATUS.FORBIDDEN,
+    message: `Combo is not allowed for this API key: ${comboName || "unknown"}`,
+  };
+}
+
+export async function checkApiKeyDailyTokenLimit(apiKeyRecord, date = new Date()) {
+  const limit = Number(apiKeyRecord?.dailyTokenLimit || 0);
+  if (!Number.isFinite(limit) || limit <= 0) return { allowed: true };
+
+  const usage = await getApiKeyDailyTokenUsage(apiKeyRecord.key, date);
+  if (usage.totalTokens < limit) {
+    return {
+      allowed: true,
+      limit,
+      usage,
+      remaining: Math.max(0, limit - usage.totalTokens),
+      resetAt: nextLocalMidnightIso(date),
+    };
+  }
+
+  return {
+    allowed: false,
+    status: HTTP_STATUS.RATE_LIMITED,
+    message: `API key daily token limit exceeded (${usage.totalTokens}/${limit})`,
+    limit,
+    usage,
+    remaining: 0,
+    resetAt: nextLocalMidnightIso(date),
+  };
+}
+
+export function filterModelsByApiKeyPolicy(models, apiKeyRecord) {
+  const allowedModels = Array.isArray(apiKeyRecord?.allowedModels) ? apiKeyRecord.allowedModels : [];
+  const allowedSet = new Set(allowedModels.map(normalizeModelId).filter(Boolean));
+  if (allowedSet.size === 0) return models;
+  return models.filter((model) => allowedSet.has(normalizeModelId(model?.id)));
+}

--- a/tests/unit/api-key-policy.test.js
+++ b/tests/unit/api-key-policy.test.js
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+const originalDataDir = process.env.DATA_DIR;
+let tempDir;
+let db;
+let policy;
+
+async function loadFreshDb() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-api-key-policy-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+  policy = await import("@/sse/services/apiKeyPolicy.js");
+}
+
+beforeAll(async () => {
+  await loadFreshDb();
+});
+
+afterAll(() => {
+  db?.getAdapterSync?.()?.close?.();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = null;
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("API key policy", () => {
+  it("treats an empty allowedModels list as allowing every model", async () => {
+    const key = await db.createApiKey("all-models", "machine-abc", { allowedModels: [] });
+    const loaded = await policy.loadApiKeyPolicy(key.key);
+
+    const result = policy.checkApiKeyModelAccess(loaded, {
+      requestedModel: "anthropic/claude-3-5-sonnet",
+      resolvedModels: ["anthropic/claude-3-5-sonnet"],
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks chat models that are not in the API key allowlist", async () => {
+    const key = await db.createApiKey("openai-only", "machine-abc", {
+      allowedModels: ["openai/gpt-4o"],
+    });
+    const loaded = await policy.loadApiKeyPolicy(key.key);
+
+    const result = policy.checkApiKeyModelAccess(loaded, {
+      requestedModel: "anthropic/claude-3-5-sonnet",
+      resolvedModels: ["anthropic/claude-3-5-sonnet"],
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  it("blocks combo when only one child model is allowlisted", async () => {
+    const key = await db.createApiKey("partial-combo", "machine-abc", {
+      allowedModels: ["openai/gpt-4o"],
+    });
+    const loaded = await policy.loadApiKeyPolicy(key.key);
+
+    const result = policy.checkApiKeyComboModelAccess(loaded, "my-combo", [
+      "openai/gpt-4o",
+      "anthropic/claude-3-5-sonnet",
+    ]);
+
+    expect(result.allowed).toBe(false);
+    expect(result.status).toBe(403);
+  });
+
+  it("reports daily token quota when usage reaches the API key limit", async () => {
+    const key = await db.createApiKey("limited", "machine-abc", { dailyTokenLimit: 150 });
+    await db.saveRequestUsage({
+      provider: "openai",
+      model: "gpt-4o",
+      apiKey: key.key,
+      endpoint: "/v1/chat/completions",
+      status: "ok",
+      tokens: { prompt_tokens: 100, completion_tokens: 50 },
+    });
+
+    const loaded = await policy.loadApiKeyPolicy(key.key);
+    const result = await policy.checkApiKeyDailyTokenLimit(loaded);
+
+    expect(result.allowed).toBe(false);
+    expect(result.status).toBe(429);
+    expect(result.usage.totalTokens).toBe(150);
+    expect(result.limit).toBe(150);
+  });
+});

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -18,6 +18,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+  sqliteDb?.getAdapterSync?.()?.close?.();
   if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
   if (originalDataDir === undefined) delete process.env.DATA_DIR;
   else process.env.DATA_DIR = originalDataDir;
@@ -63,6 +64,27 @@ describe("DB SQLite layer — public API parity", () => {
     const deleted = await sqliteDb.deleteApiKey(k.id);
     expect(deleted).toBe(true);
     expect(await sqliteDb.getApiKeyById(k.id)).toBeNull();
+  });
+
+  it("apiKeys: policy fields persist and expired keys are invalid", async () => {
+    const future = new Date(Date.now() + 86400000).toISOString();
+    const k = await sqliteDb.createApiKey("policy-key", "machine-abc", {
+      dailyTokenLimit: 1234,
+      expiresAt: future,
+      allowedModels: ["openai/gpt-4o", "anthropic/claude-3-5-sonnet", "openai/gpt-4o"],
+    });
+
+    expect(k.dailyTokenLimit).toBe(1234);
+    expect(k.expiresAt).toBe(future);
+    expect(k.allowedModels).toEqual(["openai/gpt-4o", "anthropic/claude-3-5-sonnet"]);
+
+    const byKey = await sqliteDb.getApiKeyByKey(k.key);
+    expect(byKey.allowedModels).toEqual(["openai/gpt-4o", "anthropic/claude-3-5-sonnet"]);
+
+    const expired = await sqliteDb.createApiKey("expired-key", "machine-abc", {
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    expect(await sqliteDb.validateApiKey(expired.key)).toBe(false);
   });
 
   it("providerConnections: CRUD + reorder by priority", async () => {
@@ -201,6 +223,68 @@ describe("DB SQLite layer — public API parity", () => {
     expect(stats.byProvider.openai.promptTokens).toBeGreaterThanOrEqual(300);
   });
 
+  it("usage: getApiKeyDailyTokenUsage sums prompt and completion tokens for one key", async () => {
+    await sqliteDb.saveRequestUsage({
+      provider: "openai", model: "gpt-4o", apiKey: "sk-test-a",
+      tokens: { prompt_tokens: 80, completion_tokens: 20 },
+      endpoint: "/v1/chat/completions", status: "ok",
+    });
+    await sqliteDb.saveRequestUsage({
+      provider: "openai", model: "gpt-4o", apiKey: "sk-test-a",
+      tokens: { prompt_tokens: 10, completion_tokens: 5 },
+      endpoint: "/v1/chat/completions", status: "ok",
+    });
+    await sqliteDb.saveRequestUsage({
+      provider: "openai", model: "gpt-4o", apiKey: "sk-test-b",
+      tokens: { prompt_tokens: 999, completion_tokens: 1 },
+      endpoint: "/v1/chat/completions", status: "ok",
+    });
+
+    const usage = await sqliteDb.getApiKeyDailyTokenUsage("sk-test-a");
+    expect(usage.promptTokens).toBe(90);
+    expect(usage.completionTokens).toBe(25);
+    expect(usage.totalTokens).toBe(115);
+  });
+
+  it("usage: getApiKeyDailyUsageSummary reports remaining tokens and percent", async () => {
+    const key = await sqliteDb.createApiKey("usage-summary", "machine-abc", { dailyTokenLimit: 200 });
+    await sqliteDb.saveRequestUsage({
+      provider: "openai", model: "gpt-4o", apiKey: key.key,
+      tokens: { prompt_tokens: 70, completion_tokens: 30 },
+      endpoint: "/v1/chat/completions", status: "ok",
+    });
+
+    const summary = await sqliteDb.getApiKeyDailyUsageSummary(key);
+    expect(summary.usedTokens).toBe(100);
+    expect(summary.dailyTokenLimit).toBe(200);
+    expect(summary.remainingTokens).toBe(100);
+    expect(summary.usagePercent).toBe(50);
+    expect(summary.isUnlimited).toBe(false);
+    expect(summary.resetAt).toBeDefined();
+
+    const unlimited = await sqliteDb.getApiKeyDailyUsageSummary({ ...key, dailyTokenLimit: 0 });
+    expect(unlimited.isUnlimited).toBe(true);
+    expect(unlimited.remainingTokens).toBeNull();
+    expect(unlimited.usagePercent).toBe(0);
+  });
+
+  it("usage: today stats use the same normalized token counts as API key summary", async () => {
+    const key = await sqliteDb.createApiKey("input-output-summary", "machine-abc", { dailyTokenLimit: 200 });
+    await sqliteDb.saveRequestUsage({
+      provider: "anthropic", model: "claude-test", apiKey: key.key,
+      tokens: { input_tokens: 40, output_tokens: 60 },
+      endpoint: "/v1/messages", status: "ok",
+    });
+
+    const summary = await sqliteDb.getApiKeyDailyUsageSummary(key);
+    const stats = await sqliteDb.getUsageStats("today");
+    const byApiKeyEntry = Object.values(stats.byApiKey).find((entry) => entry.apiKey === key.key);
+
+    expect(summary.usedTokens).toBe(100);
+    expect(stats.totalPromptTokens + stats.totalCompletionTokens).toBeGreaterThanOrEqual(100);
+    expect(byApiKeyEntry.promptTokens + byApiKeyEntry.completionTokens).toBe(100);
+  });
+
   it("usage: pending tracking in-memory", () => {
     sqliteDb.trackPendingRequest("gpt-4", "openai", "c1", true);
     expect(global._pendingRequests.byModel["gpt-4 (openai)"]).toBe(1);
@@ -238,13 +322,22 @@ describe("DB SQLite layer — public API parity", () => {
 
     // Add marker, export, import a different payload, verify reset
     await sqliteDb.setModelAlias("marker", "before");
+    const policyKey = await sqliteDb.createApiKey("export-policy", "machine-abc", {
+      dailyTokenLimit: 777,
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+      allowedModels: ["openai/gpt-4o"],
+    });
     const snap = await sqliteDb.exportDb();
 
     await sqliteDb.setModelAlias("marker", "after");
+    await sqliteDb.updateApiKey(policyKey.id, { dailyTokenLimit: 1, allowedModels: [] });
     expect((await sqliteDb.getModelAliases()).marker).toBe("after");
 
     await sqliteDb.importDb(snap);
     expect((await sqliteDb.getModelAliases()).marker).toBe("before");
+    const restored = await sqliteDb.getApiKeyById(policyKey.id);
+    expect(restored.dailyTokenLimit).toBe(777);
+    expect(restored.allowedModels).toEqual(["openai/gpt-4o"]);
   });
 
   it("pricing: user pricing merged with constants", async () => {


### PR DESCRIPTION
## Summary
- Add per-API-key daily token limits, expiry dates, and model allowlists.
- Enforce limits for chat-like endpoints and filter `/v1/models` by API key.
- Show per-key daily usage, remaining tokens, and quota progress in dashboard.

## Scope
- Applies to chat/responses/messages and `/v1/models`.
- Does not enforce limits for embeddings/images/TTS/STT in this PR.

## Tests
- `cd tests && npx vitest run --reporter=verbose api-key-policy.test.js db-sqlite-vs-lowdb.test.js`
- Result: 27 passed.

## Notes
- Full test suite has pre-existing failures outside this change.
- `npm run build` fails on this Windows environment due to `EPERM scandir C:\Users\DELL\Application Data`.