### PR TITLE
fix: migrate Cohere provider to v2 API (fixes HTTP 405)

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -291,8 +291,8 @@ export const PROVIDERS = {
     format: "openai"
   },
   cohere: {
-    baseUrl: "https://api.cohere.ai/v1/chat/completions",
-    format: "openai"
+    baseUrl: "https://api.cohere.com/v2/chat",
+    format: "cohere"
   },
   nebius: {
     baseUrl: "https://api.studio.nebius.ai/v1/chat/completions",

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -122,6 +122,35 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
     return ollamaBodyToOpenAI(responseBody);
   }
 
+  // Cohere v2 — non-OpenAI response shape
+  if (targetFormat === FORMATS.COHERE) {
+    const msg = responseBody?.message;
+    const textContent = Array.isArray(msg?.content)
+      ? msg.content.filter(c => c.type === "text").map(c => c.text).join("")
+      : (typeof msg?.content === "string" ? msg.content : "");
+
+    const rawReason = responseBody.finish_reason || "COMPLETE";
+    const finishReason = rawReason === "COMPLETE" ? "stop" : rawReason.toLowerCase();
+
+    const result = {
+      id: `chatcmpl-${responseBody.id || Date.now()}`,
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: responseBody.model || "command-a-03-2025",
+      choices: [{ index: 0, message: { role: "assistant", content: textContent }, finish_reason: finishReason }]
+    };
+
+    const tokens = responseBody.usage?.tokens || responseBody.usage?.billed_units;
+    if (tokens) {
+      result.usage = {
+        prompt_tokens: tokens.input_tokens ?? 0,
+        completion_tokens: tokens.output_tokens ?? 0,
+        total_tokens: (tokens.input_tokens ?? 0) + (tokens.output_tokens ?? 0)
+      };
+    }
+    return result;
+  }
+
   return responseBody;
 }
 

--- a/open-sse/translator/formats.js
+++ b/open-sse/translator/formats.js
@@ -12,7 +12,8 @@ export const FORMATS = {
   KIRO: "kiro",
   CURSOR: "cursor",
   OLLAMA: "ollama",
-  COMMANDCODE: "commandcode"
+  COMMANDCODE: "commandcode",
+  COHERE: "cohere"
 };
 
 /**

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -52,6 +52,7 @@ function ensureInitialized() {
   require("./response/cursor-to-openai.js");
   require("./response/ollama-to-openai.js");
   require("./response/commandcode-to-openai.js");
+  require("./response/cohere-to-openai.js");
 }
 
 // Strip specific content types from messages (explicit opt-in via strip[] in PROVIDER_MODELS)

--- a/open-sse/translator/response/cohere-to-openai.js
+++ b/open-sse/translator/response/cohere-to-openai.js
@@ -1,0 +1,72 @@
+import { register } from "../index.js";
+import { FORMATS } from "../formats.js";
+
+/**
+ * Convert a Cohere v2 streaming chunk to OpenAI chat.completion.chunk format.
+ *
+ * Cohere v2 SSE emits typed events:
+ *   - message-start: starts the response, provides id and role
+ *   - content-start / content-delta / content-end: text content blocks
+ *   - message-end: finish_reason + usage
+ *
+ * Other event types (tool-*, citation-*, etc.) are ignored until full support is added.
+ */
+export function cohereToOpenAIResponse(chunk, state) {
+  if (!chunk) return null;
+
+  const type = chunk.type;
+
+  if (type === "message-start") {
+    const delta = chunk.delta?.message || {};
+    state.messageId = chunk.id || `chatcmpl-${Date.now()}`;
+    state.model = chunk.model || "command-a-03-2025";
+    return {
+      id: state.messageId,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: state.model,
+      choices: [{ index: 0, delta: { role: delta.role || "assistant" }, finish_reason: null }]
+    };
+  }
+
+  if (type === "content-delta") {
+    const text = chunk.delta?.message?.content?.text;
+    if (typeof text !== "string") return null;
+    return {
+      id: state.messageId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: state.model || "command-a-03-2025",
+      choices: [{ index: chunk.index ?? 0, delta: { content: text }, finish_reason: null }]
+    };
+  }
+
+  if (type === "message-end") {
+    const rawReason = chunk.delta?.finish_reason || "COMPLETE";
+    const finishReason = rawReason === "COMPLETE" ? "stop" : rawReason.toLowerCase();
+
+    const usage = chunk.delta?.usage?.tokens || chunk.delta?.usage?.billed_units;
+    const result = {
+      id: state.messageId || `chatcmpl-${Date.now()}`,
+      object: "chat.completion.chunk",
+      created: Math.floor(Date.now() / 1000),
+      model: state.model || "command-a-03-2025",
+      choices: [{ index: 0, delta: {}, finish_reason: finishReason }]
+    };
+
+    if (usage) {
+      result.usage = {
+        prompt_tokens: usage.input_tokens ?? 0,
+        completion_tokens: usage.output_tokens ?? 0,
+        total_tokens: (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0)
+      };
+      state.usage = result.usage;
+    }
+    return result;
+  }
+
+  // Ignore content-start, content-end, and other event types
+  return null;
+}
+
+register(FORMATS.COHERE, FORMATS.OPENAI, null, cohereToOpenAIResponse);

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -190,7 +190,7 @@ const PROVIDER_MODELS_CONFIG = {
   together: createOpenAIModelsConfig("https://api.together.xyz/v1/models"),
   fireworks: createOpenAIModelsConfig("https://api.fireworks.ai/inference/v1/models"),
   cerebras: createOpenAIModelsConfig("https://api.cerebras.ai/v1/models"),
-  cohere: createOpenAIModelsConfig("https://api.cohere.ai/v1/models"),
+  cohere: createOpenAIModelsConfig("https://api.cohere.com/v1/models"),
   nebius: createOpenAIModelsConfig("https://api.studio.nebius.ai/v1/models"),
   siliconflow: createOpenAIModelsConfig("https://api.siliconflow.cn/v1/models"),
   hyperbolic: createOpenAIModelsConfig("https://api.hyperbolic.xyz/v1/models"),

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -515,7 +515,7 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
       }
       case "cohere": {
-        const res = await fetchWithConnectionProxy("https://api.cohere.ai/v1/models", { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy);
+        const res = await fetchWithConnectionProxy("https://api.cohere.com/v1/models", { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy);
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
       }
       case "nebius": {

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -364,7 +364,7 @@ export async function POST(request) {
             together: "https://api.together.xyz/v1/models",
             fireworks: "https://api.fireworks.ai/inference/v1/models",
             cerebras: "https://api.cerebras.ai/v1/models",
-            cohere: "https://api.cohere.ai/v1/models",
+            cohere: "https://api.cohere.com/v1/models",
             nebius: "https://api.studio.nebius.ai/v1/models",
             siliconflow: "https://api.siliconflow.cn/v1/models",
             hyperbolic: "https://api.hyperbolic.xyz/v1/models",


### PR DESCRIPTION
## Problem

The Cohere provider is broken — all chat requests return `405 Method Not Allowed`.

**Root cause**: Cohere deprecated their v1 `/chat/completions` endpoint and migrated to a v2 API at `api.cohere.com` with a different response schema.

- Old: `https://api.cohere.ai/v1/chat/completions` → **405** (deprecated)
- New: `https://api.cohere.com/v2/chat` → **200** ✅

Cohere v2 also uses a different response format — `message.content[{type,text}]` instead of OpenAI's `choices[].message.content`, and SSE uses typed events (`message-start`, `content-delta`, `message-end`) instead of OpenAI-style delta chunks.

## Changes

| File | Change |
|---|---|
| `open-sse/config/providers.js` | Update `baseUrl` to `api.cohere.com/v2/chat`, `format` to `"cohere"` |
| `open-sse/translator/formats.js` | Add `COHERE: "cohere"` format constant |
| `open-sse/translator/response/cohere-to-openai.js` | **New file** — converts Cohere v2 streaming events to OpenAI chunks |
| `open-sse/translator/index.js` | Register the new translator |
| `open-sse/handlers/chatCore/nonStreamingHandler.js` | Add Cohere v2 → OpenAI non-streaming translation |
| `src/.../validate/route.js` | Domain `api.cohere.ai` → `api.cohere.com` |
| `src/.../models/route.js` | Domain `api.cohere.ai` → `api.cohere.com` |
| `src/.../testUtils.js` | Domain `api.cohere.ai` → `api.cohere.com` |

## How Cohere v2 SSE Streaming Works

Cohere v2 emits typed SSE events:
```
event: message-start
data: {"id":"...","type":"message-start","delta":{"message":{"role":"assistant"}}}

event: content-delta  
data: {"type":"content-delta","index":0,"delta":{"message":{"content":{"type":"text","text":"Hello"}}}}

event: message-end
data: {"type":"message-end","delta":{"finish_reason":"COMPLETE","usage":{"tokens":{"input_tokens":10,"output_tokens":5}}}}
```

The new `cohere-to-openai.js` translator handles each event type and maps it to the appropriate OpenAI chunk format.

## Testing

- Verified `api.cohere.com/v2/chat` returns HTTP 200 with `command-a-03-2025`
- Verified `api.cohere.com/v1/models` returns HTTP 200 (models listing works)
- `api.cohere.com/v2/chat/completions` also returns 405 — v2 only works at `/v2/chat`