### PR TITLE
feat(cli-tools): add Pi auto configuration

### DIFF
--- a/public/providers/pi.svg
+++ b/public/providers/pi.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <!-- P shape: outer boundary clockwise, inner hole counter-clockwise -->
+  <path fill="#fff" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <!-- i dot -->
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/src/app/(dashboard)/dashboard/cli-tools/[toolId]/ToolDetailClient.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/[toolId]/ToolDetailClient.js
@@ -9,7 +9,7 @@ import {
   ClaudeToolCard, CodexToolCard, DroidToolCard, OpenClawToolCard,
   HermesToolCard, DefaultToolCard, OpenCodeToolCard, CoworkToolCard,
   CopilotToolCard, ClineToolCard, KiloToolCard, DeepSeekTuiToolCard,
-  JcodeToolCard,
+  JcodeToolCard, PiToolCard,
 } from "../components";
 
 const CLOUD_URL = process.env.NEXT_PUBLIC_CLOUD_URL;
@@ -139,6 +139,8 @@ export default function ToolDetailClient({ toolId, machineId }) {
         return <DeepSeekTuiToolCard {...commonProps} activeProviders={getActiveProviders()} hasActiveProviders={hasActiveProviders} cloudEnabled={cloudEnabled} />;
       case "jcode":
         return <JcodeToolCard {...commonProps} activeProviders={getActiveProviders()} hasActiveProviders={hasActiveProviders} cloudEnabled={cloudEnabled} />;
+      case "pi":
+        return <PiToolCard {...commonProps} activeProviders={getActiveProviders()} hasActiveProviders={hasActiveProviders} cloudEnabled={cloudEnabled} />;
       default:
         return <DefaultToolCard toolId={toolId} {...commonProps} activeProviders={getActiveProviders()} cloudEnabled={cloudEnabled} tunnelEnabled={tunnelEnabled} />;
     }

--- a/src/app/(dashboard)/dashboard/cli-tools/components/PiToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/PiToolCard.js
@@ -1,0 +1,321 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Card, Button, ModelSelectModal, ManualConfigModal } from "@/shared/components";
+import Image from "next/image";
+import BaseUrlSelect from "./BaseUrlSelect";
+import ApiKeySelect from "./ApiKeySelect";
+import { matchKnownEndpoint } from "./cliEndpointMatch";
+
+const ENDPOINT = "/api/cli-tools/pi-settings";
+
+export default function PiToolCard({
+  tool,
+  isExpanded,
+  onToggle,
+  baseUrl,
+  apiKeys,
+  activeProviders,
+  cloudEnabled,
+  initialStatus,
+  tunnelEnabled,
+  tunnelPublicUrl,
+  tailscaleEnabled,
+  tailscaleUrl,
+}) {
+  const [piStatus, setPiStatus] = useState(initialStatus || null);
+  const [checking, setChecking] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+  const [message, setMessage] = useState(null);
+  const [showInstallGuide, setShowInstallGuide] = useState(false);
+  const [selectedApiKey, setSelectedApiKey] = useState("");
+  const [selectedModel, setSelectedModel] = useState("");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modelAliases, setModelAliases] = useState({});
+  const [showManualConfigModal, setShowManualConfigModal] = useState(false);
+  const [customBaseUrl, setCustomBaseUrl] = useState("");
+  const hasInitialized = useRef(false);
+
+  useEffect(() => {
+    if (apiKeys?.length > 0 && !selectedApiKey) setSelectedApiKey(apiKeys[0].key);
+  }, [apiKeys, selectedApiKey]);
+
+  useEffect(() => {
+    if (initialStatus) setPiStatus(initialStatus);
+  }, [initialStatus]);
+
+  useEffect(() => {
+    if (isExpanded && !piStatus) {
+      checkStatus();
+      fetchModelAliases();
+    }
+    if (isExpanded) fetchModelAliases();
+  }, [isExpanded]);
+
+  useEffect(() => {
+    if (piStatus?.installed && !hasInitialized.current) {
+      hasInitialized.current = true;
+      const provider = piStatus.config?.providers?.["9router"];
+      const firstModel = Array.isArray(provider?.models) ? provider.models[0]?.id : "";
+      if (firstModel) setSelectedModel(firstModel);
+      if (provider?.apiKey && apiKeys?.some(k => k.key === provider.apiKey)) setSelectedApiKey(provider.apiKey);
+    }
+  }, [piStatus, apiKeys]);
+
+  const fetchModelAliases = async () => {
+    try {
+      const res = await fetch("/api/models/alias");
+      const data = await res.json();
+      if (res.ok) setModelAliases(data.aliases || {});
+    } catch (error) {
+      console.log("Error fetching model aliases:", error);
+    }
+  };
+
+  const checkStatus = async () => {
+    setChecking(true);
+    try {
+      const res = await fetch(ENDPOINT);
+      const data = await res.json();
+      setPiStatus(data);
+    } catch (error) {
+      setPiStatus({ installed: false, error: error.message });
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const getEffectiveBaseUrl = () => {
+    const url = customBaseUrl || `${baseUrl}/v1`;
+    return url.endsWith("/v1") ? url : `${url}/v1`;
+  };
+
+  const getDisplayUrl = () => customBaseUrl || `${baseUrl}/v1`;
+
+  const getConfigStatus = () => {
+    if (!piStatus?.installed) return null;
+    const provider = piStatus.config?.providers?.["9router"];
+    if (!provider?.baseUrl) return "not_configured";
+    return matchKnownEndpoint(provider.baseUrl, { tunnelPublicUrl, tailscaleUrl }) ? "configured" : "other";
+  };
+
+  const configStatus = getConfigStatus();
+
+  const isPlaceholderModel = (value) => /\/model-id$/.test(value || "");
+
+  const handleApply = async () => {
+    if (isPlaceholderModel(selectedModel)) {
+      setMessage({ type: "error", text: "Please replace the placeholder with a real model ID before applying." });
+      return;
+    }
+
+    setApplying(true);
+    setMessage(null);
+    try {
+      const keyToUse = selectedApiKey?.trim()
+        || (apiKeys?.length > 0 ? apiKeys[0].key : null)
+        || (!cloudEnabled ? "sk_9router" : null);
+
+      const res = await fetch(ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          baseUrl: getEffectiveBaseUrl(),
+          apiKey: keyToUse,
+          model: selectedModel,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setMessage({ type: "success", text: "Settings applied successfully!" });
+        checkStatus();
+      } else {
+        setMessage({ type: "error", text: data.error || "Failed to apply settings" });
+      }
+    } catch (error) {
+      setMessage({ type: "error", text: error.message });
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setRestoring(true);
+    setMessage(null);
+    try {
+      const res = await fetch(ENDPOINT, { method: "DELETE" });
+      const data = await res.json();
+      if (res.ok) {
+        setMessage({ type: "success", text: "Settings reset successfully!" });
+        setSelectedModel("");
+        checkStatus();
+      } else {
+        setMessage({ type: "error", text: data.error || "Failed to reset settings" });
+      }
+    } catch (error) {
+      setMessage({ type: "error", text: error.message });
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  const handleModelSelect = (model) => {
+    setSelectedModel(model.value);
+    setModalOpen(false);
+  };
+
+  const getManualConfigs = () => {
+    const keyToUse = selectedApiKey?.trim() || (!cloudEnabled ? "sk_9router" : "<API_KEY_FROM_DASHBOARD>");
+    return [
+      {
+        filename: "~/.pi/agent/models.json",
+        content: JSON.stringify({
+          providers: {
+            "9router": {
+              baseUrl: getEffectiveBaseUrl(),
+              api: "openai-completions",
+              apiKey: keyToUse,
+              authHeader: true,
+              models: [
+                {
+                  id: selectedModel || "provider/model-id",
+                  name: `${selectedModel || "provider/model-id"} via 9Router`,
+                  reasoning: true,
+                  input: ["text", "image"],
+                  contextWindow: 200000,
+                  maxTokens: 32000,
+                },
+              ],
+            },
+          },
+        }, null, 2),
+      },
+    ];
+  };
+
+  return (
+    <Card padding="xs" className="overflow-hidden">
+      <div className="flex items-start justify-between gap-3 hover:cursor-pointer sm:items-center" onClick={onToggle}>
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="size-8 flex items-center justify-center shrink-0 rounded-lg bg-black">
+            <Image src={tool.image || "/providers/pi.svg"} alt={tool.name} width={32} height={32} className="size-8 object-contain rounded-lg" sizes="32px" onError={(e) => { e.target.style.display = "none"; }} />
+          </div>
+          <div className="min-w-0">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
+              <h3 className="font-medium text-sm">{tool.name}</h3>
+              {configStatus === "configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 rounded-full">Connected</span>}
+              {configStatus === "not_configured" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 rounded-full">Not configured</span>}
+              {configStatus === "other" && <span className="px-1.5 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 rounded-full">Other</span>}
+            </div>
+            <p className="text-xs text-text-muted truncate">{tool.description}</p>
+          </div>
+        </div>
+        <span className={`material-symbols-outlined text-text-muted text-[20px] transition-transform ${isExpanded ? "rotate-180" : ""}`}>expand_more</span>
+      </div>
+
+      {isExpanded && (
+        <div className="mt-4 pt-4 border-t border-border flex flex-col gap-4">
+          {checking && (
+            <div className="flex items-center gap-2 text-text-muted">
+              <span className="material-symbols-outlined animate-spin">progress_activity</span>
+              <span>Checking Pi...</span>
+            </div>
+          )}
+
+          {!checking && piStatus && !piStatus.installed && (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-3 p-4 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+                <div className="flex items-start gap-3">
+                  <span className="material-symbols-outlined text-yellow-500">warning</span>
+                  <div className="flex-1">
+                    <p className="font-medium text-yellow-600 dark:text-yellow-400">Pi not detected locally</p>
+                    <p className="text-sm text-text-muted">Manual configuration is still available if 9router is deployed on a remote server.</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 pl-9">
+                  <Button variant="secondary" size="sm" onClick={() => setShowManualConfigModal(true)} className="!bg-yellow-500/20 !border-yellow-500/40 !text-yellow-700 dark:!text-yellow-300 hover:!bg-yellow-500/30">
+                    <span className="material-symbols-outlined text-[18px] mr-1">content_copy</span>
+                    Manual Config
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => setShowInstallGuide(!showInstallGuide)}>
+                    <span className="material-symbols-outlined text-[18px] mr-1">{showInstallGuide ? "expand_less" : "help"}</span>
+                    {showInstallGuide ? "Hide" : "How to Install"}
+                  </Button>
+                </div>
+              </div>
+              {showInstallGuide && (
+                <div className="p-4 bg-surface border border-border rounded-lg">
+                  <h4 className="font-medium mb-3">Installation Guide</h4>
+                  <div className="space-y-3 text-sm">
+                    <code className="block px-3 py-2 bg-black/5 dark:bg-white/5 rounded font-mono text-xs">npm install -g @earendil-works/pi-coding-agent</code>
+                    <p className="text-text-muted">After installation, run <code className="px-1 bg-black/5 dark:bg-white/5 rounded">pi</code> to verify.</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {!checking && piStatus?.installed && (
+            <>
+              <div className="flex flex-col gap-2">
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Select Endpoint</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <BaseUrlSelect value={customBaseUrl || getDisplayUrl()} onChange={setCustomBaseUrl} tunnelEnabled={tunnelEnabled} tunnelPublicUrl={tunnelPublicUrl} tailscaleEnabled={tailscaleEnabled} tailscaleUrl={tailscaleUrl} />
+                </div>
+
+                {piStatus.config?.providers?.["9router"]?.baseUrl && (
+                  <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                    <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Current</span>
+                    <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                    <span className="min-w-0 truncate rounded bg-surface/40 px-2 py-2 text-xs text-text-muted sm:py-1.5">{piStatus.config.providers["9router"].baseUrl}</span>
+                  </div>
+                )}
+
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">API Key</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <ApiKeySelect value={selectedApiKey} onChange={setSelectedApiKey} apiKeys={apiKeys} cloudEnabled={cloudEnabled} />
+                </div>
+
+                <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
+                  <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Model</span>
+                  <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
+                  <div className="relative w-full min-w-0">
+                    <input type="text" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)} placeholder="provider/model-id" className="w-full min-w-0 pl-2 pr-7 py-2 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5" />
+                    {selectedModel && <button onClick={() => setSelectedModel("")} className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 text-text-muted hover:text-red-500 rounded transition-colors" title="Clear"><span className="material-symbols-outlined text-[14px]">close</span></button>}
+                  </div>
+                  <button onClick={() => setModalOpen(true)} className="w-full sm:w-auto rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 whitespace-nowrap sm:shrink-0 bg-surface border-border text-text-main hover:border-primary cursor-pointer">Select Model</button>
+                </div>
+              </div>
+
+              {message && (
+                <div className={`flex items-center gap-2 px-2 py-1.5 rounded text-xs ${message.type === "success" ? "bg-green-500/10 text-green-600" : "bg-red-500/10 text-red-600"}`}>
+                  <span className="material-symbols-outlined text-[14px]">{message.type === "success" ? "check_circle" : "error"}</span>
+                  <span>{message.text}</span>
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center">
+                <Button variant="primary" size="sm" onClick={handleApply} disabled={!selectedModel || isPlaceholderModel(selectedModel) || (!selectedApiKey && cloudEnabled)} loading={applying}>
+                  <span className="material-symbols-outlined text-[14px] mr-1">save</span>Apply
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleReset} disabled={restoring} loading={restoring}>
+                  <span className="material-symbols-outlined text-[14px] mr-1">restore</span>Reset
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>
+                  <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>Manual Config
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <ModelSelectModal isOpen={modalOpen} onClose={() => setModalOpen(false)} onSelect={handleModelSelect} selectedModel={selectedModel} activeProviders={activeProviders} modelAliases={modelAliases} title="Select Model for Pi" />
+
+      <ManualConfigModal isOpen={showManualConfigModal} onClose={() => setShowManualConfigModal(false)} title="Pi - Manual Configuration" configs={getManualConfigs()} />
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/cli-tools/components/index.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/index.js
@@ -12,6 +12,7 @@ export { default as ClineToolCard } from "./ClineToolCard";
 export { default as KiloToolCard } from "./KiloToolCard";
 export { default as DeepSeekTuiToolCard } from "./DeepSeekTuiToolCard";
 export { default as JcodeToolCard } from "./JcodeToolCard";
+export { default as PiToolCard } from "./PiToolCard";
 export { default as MitmServerCard } from "./MitmServerCard";
 export { default as MitmToolCard } from "./MitmToolCard";
 export { default as MitmLinkCard } from "./MitmLinkCard";

--- a/src/app/api/cli-tools/all-statuses/route.js
+++ b/src/app/api/cli-tools/all-statuses/route.js
@@ -13,6 +13,7 @@ import { GET as clineGet } from "../cline-settings/route";
 import { GET as kiloGet } from "../kilo-settings/route";
 import { GET as deepseekTuiGet } from "../deepseek-tui-settings/route";
 import { GET as jcodeGet } from "../jcode-settings/route";
+import { GET as piGet } from "../pi-settings/route";
 
 const STATUS_GETTERS = {
   claude: claudeGet,
@@ -27,6 +28,7 @@ const STATUS_GETTERS = {
   kilo: kiloGet,
   "deepseek-tui": deepseekTuiGet,
   jcode: jcodeGet,
+  pi: piGet,
 };
 
 // Batch endpoint: gather all CLI tool statuses in one round-trip

--- a/src/app/api/cli-tools/pi-settings/route.js
+++ b/src/app/api/cli-tools/pi-settings/route.js
@@ -1,0 +1,146 @@
+"use server";
+
+import { NextResponse } from "next/server";
+import { exec } from "child_process";
+import { promisify } from "util";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+const execAsync = promisify(exec);
+
+const PROVIDER_ID = "9router";
+
+const getPiDir = () => path.join(os.homedir(), ".pi", "agent");
+const getPiModelsPath = () => path.join(getPiDir(), "models.json");
+
+const checkPiInstalled = async () => {
+  try {
+    const isWindows = os.platform() === "win32";
+    const command = isWindows ? "where pi" : "which pi";
+    await execAsync(command, { windowsHide: true });
+    return true;
+  } catch {
+    try {
+      await fs.access(getPiModelsPath());
+      return true;
+    } catch {
+      return false;
+    }
+  }
+};
+
+const readModelsConfig = async () => {
+  try {
+    const content = await fs.readFile(getPiModelsPath(), "utf-8");
+    return JSON.parse(content);
+  } catch (error) {
+    if (error.code === "ENOENT") return { providers: {} };
+    throw error;
+  }
+};
+
+const has9RouterConfig = (config) => !!config?.providers?.[PROVIDER_ID];
+
+export async function GET() {
+  try {
+    const installed = await checkPiInstalled();
+
+    if (!installed) {
+      return NextResponse.json({
+        installed: false,
+        config: null,
+        message: "Pi Agent is not installed",
+      });
+    }
+
+    const config = await readModelsConfig();
+
+    return NextResponse.json({
+      installed: true,
+      config,
+      has9Router: has9RouterConfig(config),
+      configPath: getPiModelsPath(),
+    });
+  } catch (error) {
+    console.log("Error checking Pi settings:", error);
+    return NextResponse.json({ error: "Failed to check Pi settings" }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    const { baseUrl, apiKey, model } = await request.json();
+
+    if (!baseUrl || !apiKey || !model) {
+      return NextResponse.json({ error: "baseUrl, apiKey and model are required" }, { status: 400 });
+    }
+
+    if (/\/model-id$/.test(model)) {
+      return NextResponse.json({ error: "Please select or enter a real model ID before applying" }, { status: 400 });
+    }
+
+    const normalizedBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+
+    await fs.mkdir(getPiDir(), { recursive: true });
+
+    const config = await readModelsConfig();
+    if (!config.providers) config.providers = {};
+
+    const existingModels = Array.isArray(config.providers[PROVIDER_ID]?.models)
+      ? config.providers[PROVIDER_ID].models.filter((entry) => entry?.id && entry.id !== model)
+      : [];
+
+    config.providers[PROVIDER_ID] = {
+      ...config.providers[PROVIDER_ID],
+      baseUrl: normalizedBaseUrl,
+      api: "openai-completions",
+      apiKey,
+      authHeader: true,
+      models: [
+        {
+          id: model,
+          name: `${model} via 9Router`,
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: 200000,
+          maxTokens: 32000,
+        },
+        ...existingModels,
+      ],
+    };
+
+    await fs.writeFile(getPiModelsPath(), `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+
+    return NextResponse.json({
+      success: true,
+      message: "Pi Agent settings applied successfully! Run pi and select the 9router model with /model.",
+      configPath: getPiModelsPath(),
+    });
+  } catch (error) {
+    console.log("Error updating Pi settings:", error);
+    return NextResponse.json({ error: "Failed to update Pi settings" }, { status: 500 });
+  }
+}
+
+export async function DELETE() {
+  try {
+    const config = await readModelsConfig();
+
+    if (config.providers) {
+      delete config.providers[PROVIDER_ID];
+      if (Object.keys(config.providers).length === 0) delete config.providers;
+    }
+
+    await fs.mkdir(getPiDir(), { recursive: true });
+    await fs.writeFile(getPiModelsPath(), `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+
+    return NextResponse.json({
+      success: true,
+      message: "9Router settings removed from Pi Agent",
+    });
+  } catch (error) {
+    console.log("Error resetting Pi settings:", error);
+    return NextResponse.json({ error: "Failed to reset Pi settings" }, { status: 500 });
+  }
+}

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -190,6 +190,15 @@ export default function ModelSelectModal({
           }
         }
 
+        if (!kindFilter && combined.length === 0) {
+          combined = [{
+            id: "deepseek-v4-flash-free",
+            name: "DeepSeek V4 Flash Free",
+            value: `${alias}/deepseek-v4-flash-free`,
+            isPlaceholder: true,
+          }];
+        }
+
         if (combined.length > 0) {
           // Check for custom name from providerNodes (for compatible providers)
           const matchedNode = providerNodes.find(node => node.id === providerId);

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -114,6 +114,50 @@ export const CLI_TOOLS = {
     description: "OpenCode AI Terminal Assistant",
     configType: "custom",
   },
+  pi: {
+    id: "pi",
+    name: "Pi",
+    image: "/providers/pi.svg",
+    color: "#111111",
+    description: "Pi terminal coding harness via 9Router",
+    docsUrl: "https://pi.dev",
+    configType: "custom",
+    defaultCommand: "pi",
+    notes: [
+      { type: "info", text: "Pi reads custom OpenAI-compatible providers from ~/.pi/agent/models.json. Add 9Router there, then select the 9Router model from Pi's /model menu." },
+      { type: "warning", text: "Config path: Linux/macOS ~/.pi/agent/models.json • Windows %USERPROFILE%\\.pi\\agent\\models.json" },
+    ],
+    guideSteps: [
+      { step: 1, title: "Install Pi", desc: "npm install -g @earendil-works/pi-coding-agent" },
+      { step: 2, title: "API Key", type: "apiKeySelector" },
+      { step: 3, title: "Base URL", value: "{{baseUrl}}", copyable: true },
+      { step: 4, title: "Select Model", type: "modelSelector" },
+      { step: 5, title: "Save Config", desc: "Copy the JSON below to ~/.pi/agent/models.json, then run pi and choose the model with /model." },
+    ],
+    codeBlock: {
+      language: "json",
+      code: `{
+  "providers": {
+    "9router": {
+      "baseUrl": "{{baseUrl}}",
+      "api": "openai-completions",
+      "apiKey": "{{apiKey}}",
+      "authHeader": true,
+      "models": [
+        {
+          "id": "{{model}}",
+          "name": "{{model}} via 9Router",
+          "reasoning": true,
+          "input": ["text", "image"],
+          "contextWindow": 200000,
+          "maxTokens": 32000
+        }
+      ]
+    }
+  }
+}`,
+    },
+  },
   cowork: {
     id: "cowork",
     name: "Claude Cowork",


### PR DESCRIPTION
## Summary

- Add Pi to the CLI Tools dashboard with the official Pi logo from pi.dev.
- Add an auto-configuration flow that writes a 9Router provider into `~/.pi/agent/models.json`.
- Add Pi status detection to the batched CLI tools status endpoint.
- Allow no-auth passthrough providers to surface a usable OpenCode Free model fallback in the model selector.

## Details

Pi supports custom OpenAI-compatible providers through `~/.pi/agent/models.json`. This PR adds first-class dashboard support for that flow, matching the existing auto-configuration pattern used by other agentic CLIs.

The new Pi configuration route:

- detects Pi via `which pi` / `where pi` or an existing Pi models config file
- merges a `9router` provider without replacing unrelated providers
- writes the selected model as a Pi custom model
- stores the selected 9Router API key and enables bearer authorization
- removes only the `9router` provider on reset
- rejects placeholder model IDs before writing config

The Pi card supports:

- endpoint selection
- API key selection
- model selection
- current configuration display
- apply/reset actions
- manual config fallback

For fresh/local environments without configured providers, the model selector can still surface a no-auth OpenCode Free fallback (`oc/deepseek-v4-flash-free`) so users can test Pi through 9Router without first adding external credentials.

## Validation

- Built successfully with isolated data/home directories:

```bash
DATA_DIR=/tmp/9router-build-data HOME=/tmp/9router-build-home npm run build
```

- Verified Pi model discovery against isolated config:

```bash
HOME=/tmp/9router-dev-home PI_TELEMETRY=0 pi --list-models 9router
```

- Verified real Pi request through 9Router using OpenCode Free:

```bash
HOME=/tmp/9router-dev-home PI_TELEMETRY=0 timeout 120 pi \
  --model 9router/oc/deepseek-v4-flash-free \
  --no-tools --no-extensions --no-skills --no-prompt-templates \
  --no-context-files --no-session \
  -p 'Reply exactly: PI_9ROUTER_OK'
```

Output:

```text
PI_9ROUTER_OK
```
