### PR TITLE
fix(kiro): forward images to currentMessage in buildKiroPayload

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -307,6 +307,9 @@ export function buildKiroPayload(model, body, stream, credentials) {
           content: finalContent,
           modelId: model,
           origin: "AI_EDITOR",
+          ...(currentMessage?.userInputMessage?.images?.length > 0 && {
+            images: currentMessage.userInputMessage.images
+          }),
           ...(currentMessage?.userInputMessage?.userInputMessageContext && {
             userInputMessageContext: currentMessage.userInputMessage.userInputMessageContext
           })

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for open-sse/translator/request/openai-to-kiro.js
+ *
+ * Tests cover:
+ *  - buildKiroPayload() - basic message conversion
+ *  - Image forwarding fix: images in currentMessage must be included in payload
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildKiroPayload } from "../../open-sse/translator/request/openai-to-kiro.js";
+
+describe("buildKiroPayload", () => {
+  describe("basic message conversion", () => {
+    it("should convert a simple text message", () => {
+      const body = {
+        messages: [{ role: "user", content: "Hello" }]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      expect(currentMsg.userInputMessage.content).toContain("Hello");
+      expect(currentMsg.userInputMessage.modelId).toBe("claude-sonnet-4.6");
+      expect(currentMsg.userInputMessage.origin).toBe("AI_EDITOR");
+    });
+
+    it("should not include images field when no images are present", () => {
+      const body = {
+        messages: [{ role: "user", content: "No images here" }]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      expect(currentMsg.userInputMessage.images).toBeUndefined();
+    });
+  });
+
+  describe("image forwarding", () => {
+    it("should forward base64 image from image_url content part", () => {
+      const fakeBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const body = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Describe this image" },
+              { type: "image_url", image_url: { url: `data:image/png;base64,${fakeBase64}` } }
+            ]
+          }
+        ]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      expect(currentMsg.userInputMessage.images).toBeDefined();
+      expect(currentMsg.userInputMessage.images).toHaveLength(1);
+      expect(currentMsg.userInputMessage.images[0].format).toBe("png");
+      expect(currentMsg.userInputMessage.images[0].source.bytes).toBe(fakeBase64);
+    });
+
+    it("should forward multiple base64 images", () => {
+      const fakeBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const body = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Compare these images" },
+              { type: "image_url", image_url: { url: `data:image/jpeg;base64,${fakeBase64}` } },
+              { type: "image_url", image_url: { url: `data:image/png;base64,${fakeBase64}` } }
+            ]
+          }
+        ]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      expect(currentMsg.userInputMessage.images).toHaveLength(2);
+      expect(currentMsg.userInputMessage.images[0].format).toBe("jpeg");
+      expect(currentMsg.userInputMessage.images[1].format).toBe("png");
+    });
+
+    it("should not include images field when images array is empty", () => {
+      const body = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Just text" }
+            ]
+          }
+        ]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      expect(currentMsg.userInputMessage.images).toBeUndefined();
+    });
+
+    it("should include both images and text content together", () => {
+      const fakeBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const body = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "What is in this image?" },
+              { type: "image_url", image_url: { url: `data:image/jpeg;base64,${fakeBase64}` } }
+            ]
+          }
+        ]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      expect(currentMsg.userInputMessage.content).toContain("What is in this image?");
+      expect(currentMsg.userInputMessage.images).toHaveLength(1);
+    });
+
+    it("should treat http image URLs as text fallback (Kiro only supports base64)", () => {
+      const body = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Look at this" },
+              { type: "image_url", image_url: { url: "https://example.com/photo.jpg" } }
+            ]
+          }
+        ]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      // HTTP URLs are not supported by Kiro — converted to text placeholder
+      expect(currentMsg.userInputMessage.images).toBeUndefined();
+      expect(currentMsg.userInputMessage.content).toContain("[Image: https://example.com/photo.jpg]");
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`buildKiroPayload()` silently dropped images when building the final request payload.

In `convertMessages()`, base64 images from `image_url` content parts are correctly parsed and stored in `userInputMessage.images`. However, when `buildKiroPayload()` constructs the final `currentMessage`, it only spread `content` and `userInputMessageContext` — the `images` field was never forwarded.

This caused vision requests to always fail with "I don't see any image attached" even when a valid base64 image was provided.

## Fix

Add a conditional spread for `images` into `currentMessage.userInputMessage`, using the same pattern already used for `userInputMessageContext`:

```js
...(currentMessage?.userInputMessage?.images?.length > 0 && {
  images: currentMessage.userInputMessage.images
}),
```

## Tests

Added `tests/unit/openai-to-kiro.test.js` with 7 test cases covering:
- Basic text message conversion
- No `images` field when no images present
- Single base64 image forwarding
- Multiple base64 images forwarding
- Empty content array (no images)
- Text + image coexistence
- HTTP URL fallback to text placeholder (Kiro only supports base64)

All 7 tests pass. Existing test suite unaffected.