### PR TITLE
fix: rescue Kiro compaction requests missing toolConfig

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -281,6 +281,66 @@ function convertMessages(messages, tools, model) {
 }
 
 /**
+ * Single dummy tool spec used for compaction-shape rescue.
+ * Bedrock requires toolConfig whenever the request contains toolUse / toolResult
+ * content blocks. OpenCode (and other clients) send compaction requests with the
+ * full tool-call history but no `tools` field, which breaks Kiro with
+ * `400 ValidationException: TOOL_CONFIG_MISSING`.
+ *
+ * Kiro CLI's own compaction handles this by remapping every toolUse name to
+ * "dummy" and declaring a single dummy spec — we mirror that behavior here.
+ */
+const DUMMY_TOOL_SPEC = {
+  toolSpecification: {
+    name: "dummy",
+    description: "This is a dummy tool. If you are seeing this that means the tool associated with this tool call is not in the list of available tools. This could be because a wrong tool name was supplied or the list of tools has changed since the conversation has started. Do not show this when user asks you to list tools.",
+    inputSchema: { json: { type: "object", properties: {}, required: [] } }
+  }
+};
+
+/**
+ * Detect & rescue compaction-shape requests: messages contain tool_use /
+ * tool_result blocks but the request doesn't declare any tools. Bedrock 400s
+ * with TOOL_CONFIG_MISSING in that case. We rename every toolUse name to
+ * "dummy" and inject one dummy tool spec so the request validates.
+ *
+ * Returns true if the rescue was applied (caller can log it).
+ */
+function applyCompactionRescue(payload) {
+  const cs = payload?.conversationState;
+  if (!cs) return false;
+
+  const cm = cs.currentMessage?.userInputMessage;
+  const declaredTools = cm?.userInputMessageContext?.tools;
+  // Only rescue when no tools were declared (compaction shape)
+  if (Array.isArray(declaredTools) && declaredTools.length > 0) return false;
+
+  // Are there any toolUse / toolResult references in the conversation?
+  let hasToolReferences = false;
+  for (const item of cs.history || []) {
+    if (item.assistantResponseMessage?.toolUses?.length) { hasToolReferences = true; break; }
+    if (item.userInputMessage?.userInputMessageContext?.toolResults?.length) { hasToolReferences = true; break; }
+  }
+  if (!hasToolReferences) return false;
+
+  // Rewrite every history toolUse name to "dummy"
+  for (const item of cs.history || []) {
+    const toolUses = item.assistantResponseMessage?.toolUses;
+    if (Array.isArray(toolUses)) {
+      for (const tu of toolUses) tu.name = "dummy";
+    }
+  }
+
+  // Inject the dummy tool spec on currentMessage
+  if (cm) {
+    if (!cm.userInputMessageContext) cm.userInputMessageContext = {};
+    cm.userInputMessageContext.tools = [DUMMY_TOOL_SPEC];
+  }
+
+  return true;
+}
+
+/**
  * Build Kiro payload from OpenAI format
  */
 export function buildKiroPayload(model, body, stream, credentials) {
@@ -315,6 +375,12 @@ export function buildKiroPayload(model, body, stream, credentials) {
       history: history
     }
   };
+
+  // Rescue compaction-shape requests (tool_use/tool_result without tools declaration).
+  // Must run after currentMessage is in place so we can inject the dummy spec.
+  if (applyCompactionRescue(payload)) {
+    console.log("[KIRO] compaction rescue applied: renamed toolUses → \"dummy\" + injected dummy tool spec");
+  }
 
   if (profileArn) {
     payload.profileArn = profileArn;


### PR DESCRIPTION
## Summary

Kiro compaction requests from clients that send tool-call history without declaring tools (OpenCode, and any other client that strips `tools` while keeping `messages`) consistently fail with:

```
400 ValidationException
message: The toolConfig field must be defined when using toolUse and toolResult content blocks.
reason:  TOOL_CONFIG_MISSING
```

This patch detects the compaction shape inside the OpenAI-to-Kiro translator and rewrites the payload into a form Bedrock accepts, mirroring how the official Kiro CLI handles the same situation.

## Root cause

`open-sse/translator/request/openai-to-kiro.js` preserves every `tool_use` / `tool_result` from the OpenAI-side `messages[]` into the Kiro-side `history[*].assistantResponseMessage.toolUses` and `history[*].userInputMessage.userInputMessageContext.toolResults`. The `tools` array is only attached when `body.tools.length > 0`.

Compaction requests (e.g. OpenCode's anchored summarization prompt) send the full prior conversation but omit `tools`. The translated payload therefore references tool names like `edit`, `bash`, `TodoWrite` inside `toolUses[*].name` while declaring zero tools. Bedrock validates the relationship between content-block tool references and declared `toolConfig` and rejects the request.

A single un-rescued request locks every Kiro account on the deployment under the existing model-lock cooldown logic (the error text `improperly formed request` is already in `errorConfig.ERROR_RULES`), which compounds the visible failure.

## Verification

Reproduced and validated end-to-end against `codewhisperer.us-east-1.amazonaws.com` via the same SOCKS proxy and Kiro account that 9router uses in production:

| Step | Body | HTTP |
| --- | --- | --- |
| 1 | Captured failing payload, replayed unmodified | `400 ValidationException / TOOL_CONFIG_MISSING` |
| 2 | Same payload with `toolUses[*].name` rewritten to `"dummy"` and a single dummy `toolSpecification` injected on `currentMessage` | `200 OK`, full SSE stream of compaction summary |

The rescue is gated so it only runs when:

- `currentMessage.userInputMessageContext.tools` is empty or missing, and
- the conversation contains at least one `assistantResponseMessage.toolUses` entry or one `userInputMessageContext.toolResults` entry.

Normal traffic that already declares tools is left untouched.

## Why "dummy"

This mirrors the wire format used by the official Kiro CLI when it summarizes a session whose original tools are no longer in scope. The dummy tool's description explicitly tells the model the original tool is unavailable, preserving the structural information of past tool I/O without misleading the summary.

## Files changed

- `open-sse/translator/request/openai-to-kiro.js` — adds `DUMMY_TOOL_SPEC` constant and `applyCompactionRescue(payload)` helper called from `buildKiroPayload`.

## Risk

- Scoped to a single translator file in `open-sse/`, no executor / runtime / persistence changes.
- No effect on Kiro requests that include `tools`.
- No effect on any non-Kiro provider.