### PR TITLE
feat(rtk): add build output filter for npm/cargo/pip/maven

### DIFF
--- a/open-sse/rtk/autodetect.js
+++ b/open-sse/rtk/autodetect.js
@@ -1,9 +1,10 @@
 // Port of auto_detect_filter (rtk/src/cmds/system/pipe_cmd.rs:132-188) + JS extras
-// Order: git-diff → git-status → grep → find → tree → ls → search-list
+// Order: git-diff → git-status → build-output → grep → find → tree → ls → search-list
 //        → read-numbered → dedup-log → smart-truncate → null
 import { DETECT_WINDOW, READ_NUMBERED_MIN_HIT_RATIO, SMART_TRUNCATE_MIN_LINES } from "./constants.js";
 import { gitDiff } from "./filters/gitDiff.js";
 import { gitStatus } from "./filters/gitStatus.js";
+import { buildOutput } from "./filters/buildOutput.js";
 import { grep } from "./filters/grep.js";
 import { find } from "./filters/find.js";
 import { dedupLog } from "./filters/dedupLog.js";
@@ -16,7 +17,8 @@ import { searchList, SEARCH_LIST_HEADER_RE } from "./filters/searchList.js";
 const RE_GIT_DIFF = /^diff --git /m;
 const RE_GIT_DIFF_HUNK = /^@@ /m;
 const RE_GIT_STATUS = /^On branch |^nothing to commit|^Changes (not |to be )|^Untracked files:/m;
-const RE_PORCELAIN = /^[ MADRCU?!][ MADRCU?!] \S/m;
+const RE_PORCELAIN = /^[MADRCU?!][ MADRCU?!] \S/m;  // Fixed: first char must be status code (not space)
+const RE_BUILD_OUTPUT = /^(npm (warn|error|ERR!)|yarn (warn|error)|\s*Compiling\s+\S+|\s*Downloading\s+\S+|added \d+ package|\[ERROR\]|BUILD (SUCCESS|FAILED)|\s*Finished\s+|Successfully (installed|built)|ERROR:)/im;
 const RE_TREE_GLYPH = /[├└]──|│  /;
 const RE_LS_ROW = /^[-dlbcps][rwx-]{9}/m;
 const RE_LS_TOTAL = /^total \d+$/m;
@@ -27,6 +29,9 @@ export function autoDetectFilter(text) {
 
   if (RE_GIT_DIFF.test(head) || RE_GIT_DIFF_HUNK.test(head)) return gitDiff;
   if (RE_GIT_STATUS.test(head) || isMostlyPorcelain(head)) return gitStatus;
+
+  // Build output: npm, cargo, pip, maven, gradle
+  if (RE_BUILD_OUTPUT.test(head)) return buildOutput;
 
   const lines = head.split("\n");
   const nonEmpty = lines.filter(l => l.trim().length > 0);

--- a/open-sse/rtk/constants.js
+++ b/open-sse/rtk/constants.js
@@ -50,5 +50,6 @@ export const FILTERS = {
   DEDUP_LOG: "dedup-log",
   SMART_TRUNCATE: "smart-truncate",
   READ_NUMBERED: "read-numbered",
-  SEARCH_LIST: "search-list"
+  SEARCH_LIST: "search-list",
+  BUILD_OUTPUT: "build-output"
 };

--- a/open-sse/rtk/filters/buildOutput.js
+++ b/open-sse/rtk/filters/buildOutput.js
@@ -1,0 +1,137 @@
+// Compress build tool output (npm, cargo, pip, maven, gradle, etc.)
+// Keeps: errors, warnings, final summary
+// Strips: progress logs, verbose "Compiling X" lists, download logs
+
+export function buildOutput(input) {
+  const lines = input.split("\n");
+  if (lines.length === 0) return input;
+
+  const errors = [];
+  const warnings = [];
+  let summary = null;
+  let deprecatedCount = 0;
+  let compilingCount = 0;
+  let downloadingCount = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // npm/yarn errors
+    if (/^npm (ERR!|error)/i.test(trimmed) || /^yarn error/i.test(trimmed)) {
+      errors.push(line);
+      continue;
+    }
+
+    // npm/yarn warnings (count deprecations, keep other warnings)
+    if (/^npm warn deprecated/i.test(trimmed)) {
+      deprecatedCount++;
+      continue;
+    }
+    if (/^npm warn/i.test(trimmed) || /^yarn warn/i.test(trimmed)) {
+      warnings.push(line);
+      continue;
+    }
+
+    // cargo/rust errors
+    if (/^error(\[|:)/i.test(trimmed) || trimmed.startsWith("error -->")) {
+      errors.push(line);
+      continue;
+    }
+
+    // cargo/rust warnings
+    if (/^warning(\[|:)/i.test(trimmed) || trimmed.startsWith("warning -->")) {
+      warnings.push(line);
+      continue;
+    }
+
+    // pip errors
+    if (/^ERROR:/i.test(trimmed)) {
+      errors.push(line);
+      continue;
+    }
+
+    // maven/gradle errors
+    if (/^\[ERROR\]/i.test(trimmed) || /^BUILD FAILED/i.test(trimmed)) {
+      errors.push(line);
+      continue;
+    }
+
+    // maven/gradle warnings
+    if (/^\[WARNING\]/i.test(trimmed)) {
+      warnings.push(line);
+      continue;
+    }
+
+    // Count verbose progress lines (don't keep them)
+    if (/^\s*Compiling\s+\S+/i.test(trimmed)) {
+      compilingCount++;
+      continue;
+    }
+    if (/^\s*Downloading\s+\S+/i.test(trimmed) || /^Fetching\s+/i.test(trimmed)) {
+      downloadingCount++;
+      continue;
+    }
+
+    // Final summary lines (keep these)
+    if (
+      /^(added|removed|changed|audited|installed)\s+\d+\s+package/i.test(trimmed) ||
+      /^\s*Finished\s+/i.test(trimmed) ||
+      /^BUILD SUCCESS/i.test(trimmed) ||
+      /^\d+\s+(vulnerabilities|packages?|warnings?|errors?)/i.test(trimmed) ||
+      /^Successfully (installed|built)/i.test(trimmed) ||
+      /^To address .* issues/i.test(trimmed) ||
+      /^Run `npm (audit|fund)`/i.test(trimmed) ||
+      /packages are looking for funding/i.test(trimmed)
+    ) {
+      summary = summary ? `${summary}\n${line}` : line;
+      continue;
+    }
+  }
+
+  // Build compressed output
+  let out = "";
+
+  // Deprecation summary
+  if (deprecatedCount > 0) {
+    out += `npm warn deprecated: ${deprecatedCount} package${deprecatedCount > 1 ? "s" : ""}\n`;
+  }
+
+  // Progress summary
+  if (compilingCount > 0) {
+    out += `Compiled ${compilingCount} package${compilingCount > 1 ? "s" : ""}\n`;
+  }
+  if (downloadingCount > 0) {
+    out += `Downloaded ${downloadingCount} package${downloadingCount > 1 ? "s" : ""}\n`;
+  }
+
+  // Warnings (keep first 5)
+  if (warnings.length > 0) {
+    out += warnings.slice(0, 5).join("\n") + "\n";
+    if (warnings.length > 5) {
+      out += `... +${warnings.length - 5} more warnings\n`;
+    }
+  }
+
+  // Errors (keep all)
+  if (errors.length > 0) {
+    out += errors.join("\n") + "\n";
+  }
+
+  // Final summary
+  if (summary) {
+    out += summary + "\n";
+  }
+
+  // Fallback: if we stripped everything, return a minimal summary
+  if (!out.trim()) {
+    if (compilingCount > 0 || downloadingCount > 0) {
+      return `Build completed (${compilingCount} compiled, ${downloadingCount} downloaded)`;
+    }
+    return input; // Safety: return original if we can't parse it
+  }
+
+  return out.replace(/\n+$/, "");
+}
+
+buildOutput.filterName = "build-output";


### PR DESCRIPTION
# Add Build Output RTK Filter
## Problem
Build tool output (npm, cargo, pip, maven, gradle) is currently not compressed by RTK, wasting tokens on verbose progress logs that don't help the LLM make decisions.
**Current behavior:**
- `npm install` output: 0% compression (674 bytes → 674 bytes)
- `cargo build` output: 0% compression + **misdetected as `git-status`** (397 bytes → 397 bytes)
**Root causes:**
1. No filter exists for build output patterns
2. `RE_PORCELAIN` regex has false positive: `   Compiling` lines (with leading spaces) match git porcelain format `^[ MADRCU?!][ MADRCU?!] \S`
## Solution
### 1. Add `buildOutput.js` filter
Detects and compresses output from:
- npm, yarn (warnings, errors, deprecations, summary)
- cargo, rust (Compiling, warnings, errors, Finished)
- pip (errors, success messages)
- maven, gradle (BUILD SUCCESS/FAILED, errors, warnings)

**Strategy:**
- Count and summarize verbose lines (deprecations, "Compiling X", downloads)
- Keep all errors (verbatim)
- Keep first 5 warnings (truncate rest)
- Keep final summary lines (package counts, vulnerabilities, build time)
### 2. Fix `RE_PORCELAIN` false positive
Changed `^[ MADRCU?!]` to `^[MADRCU?!]` — first character must be a status code, not a space.
**Why this matters:** Cargo output like `   Compiling proc-macro2 v1.0.95` was matching the old regex because:
- pos0 = SPACE matches `[ MADRCU?!]`
- pos1 = SPACE matches `[ MADRCU?!]`
- pos2 = SPACE matches literal space
- pos3 = C matches `\S`
This caused cargo builds to be incorrectly processed by `gitStatus` filter (though the safety net prevented corruption).
### 3. Add detection logic
Added `RE_BUILD_OUTPUT` regex that matches:
- npm/yarn: `npm warn`, `npm error`, `added N packages`
- cargo: `\s*Compiling`, `\s*Finished` (with optional leading whitespace)
- pip: `ERROR:`, `Successfully installed`
- maven/gradle: `[ERROR]`, `BUILD SUCCESS/FAILED`
## Evidence
### Test 1: npm install with deprecation warnings
**Input (674 bytes):**
```
npm warn deprecated har-validator@5.1.5: this library is no longer supported
npm warn deprecated uuid@3.4.0: uuid@10 and below is no longer supported...
npm warn deprecated request@2.88.2: request has been deprecated...
added 47 packages, and audited 48 packages in 13s
3 packages are looking for funding
  run `npm fund` for details
4 vulnerabilities (2 moderate, 2 critical)
Some issues need review, and may require choosing
a different dependency.
Run `npm audit` for details.
```
**Output (217 bytes, 67.8% savings):**
```
npm warn deprecated: 3 packages
added 47 packages, and audited 48 packages in 13s
3 packages are looking for funding
  run `npm fund` for details
4 vulnerabilities (2 moderate, 2 critical)
Run `npm audit` for details.
```
**LLM still knows:**
- ✅ 3 packages deprecated (count)
- ✅ 47 packages added, 48 audited
- ✅ 4 vulnerabilities (2 moderate, 2 critical)
- ✅ Action needed: run `npm audit`
---
### Test 2: cargo build (success)
**Input (397 bytes):**
```
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling quote v1.0.40
   Compiling syn v2.0.104
   Compiling serde v1.0.219
   Compiling serde_derive v1.0.219
   Compiling serde_json v1.0.140
   Compiling tokio v1.45.0
   Compiling hyper v1.6.0
   Compiling my-project v0.1.0 (/home/user/my-project)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.34s
```
**Output (93 bytes, 76.6% savings):**
```
Compiled 10 packages
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.34s
```
**LLM still knows:**
- ✅ Build succeeded
- ✅ 10 packages compiled
- ✅ Took 12.34s
- ✅ Dev profile used
---
## Testing
Verified locally with real build outputs:
```bash
node test-build-compression.mjs
```
**Results:**
- npm install (warnings): **67.8% savings** (674 → 217 bytes)
- cargo build: **76.6% savings** (397 → 93 bytes)
- Cargo no longer misdetected as git-status ✅
## Impact
Every build command in AI coding tools (OpenCode, Cursor, Cline, etc.) currently wastes ~300-500 bytes of tokens per request. With this filter:
- **50-77% token savings** on build output
- **No loss of actionable information** (errors, warnings, outcomes preserved)
- **Fixes false positive bug** (cargo misdetection)
For a typical coding session with 10 builds, this saves **3,000-5,000 tokens** — directly aligned with 9router's core token-saving purpose.
## Files Changed
- `open-sse/rtk/filters/buildOutput.js` — new filter (136 lines)
- `open-sse/rtk/autodetect.js` — add detection + fix porcelain regex
- `open-sse/rtk/constants.js` — add `BUILD_OUTPUT` constant