### PR TITLE
Add Webshare proxy pool import and sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ product
 # misc
 .DS_Store
 *.pem
+.sisyphus/
 
 # debug
 npm-debug.log*

--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -33,12 +33,16 @@ export default function ProxyPoolsPage() {
   const [showFormModal, setShowFormModal] = useState(false);
   const [showBatchImportModal, setShowBatchImportModal] = useState(false);
   const [showVercelModal, setShowVercelModal] = useState(false);
+  const [showWebshareSettingsModal, setShowWebshareSettingsModal] = useState(false);
   const [editingProxyPool, setEditingProxyPool] = useState(null);
   const [formData, setFormData] = useState(normalizeFormData());
   const [batchImportText, setBatchImportText] = useState("");
   const [vercelForm, setVercelForm] = useState({ vercelToken: "", projectName: "vercel-relay" });
   const [saving, setSaving] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [webshareSyncing, setWebshareSyncing] = useState(false);
+  const [webshareSaving, setWebshareSaving] = useState(false);
+  const [webshareTesting, setWebshareTesting] = useState(false);
   const [deploying, setDeploying] = useState(false);
   const [testingId, setTestingId] = useState(null);
   const [selectedIds, setSelectedIds] = useState([]);
@@ -46,6 +50,11 @@ export default function ProxyPoolsPage() {
   const [healthProgress, setHealthProgress] = useState({ current: 0, total: 0 });
   const [bulkBusy, setBulkBusy] = useState(false);
   const [confirmState, setConfirmState] = useState(null);
+  const [webshareApiKeyInput, setWebshareApiKeyInput] = useState("");
+  const [webshareAutoSyncEnabled, setWebshareAutoSyncEnabled] = useState(false);
+  const [webshareSyncIntervalMinutes, setWebshareSyncIntervalMinutes] = useState(60);
+  const [hasWebshareApiKey, setHasWebshareApiKey] = useState(false);
+  const [webshareLastSyncError, setWebshareLastSyncError] = useState("");
   const notify = useNotificationStore();
 
   const fetchProxyPools = useCallback(async () => {
@@ -64,7 +73,116 @@ export default function ProxyPoolsPage() {
 
   useEffect(() => {
     fetchProxyPools();
+    fetchWebshareStatus();
   }, [fetchProxyPools]);
+
+  const fetchWebshareStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/proxy-pools/webshare/status", { cache: "no-store" });
+      const data = await res.json();
+      if (!res.ok) return;
+      setHasWebshareApiKey(data.hasApiKey === true);
+      setWebshareAutoSyncEnabled(data.enabled === true);
+      setWebshareSyncIntervalMinutes(data.intervalMinutes || 60);
+      setWebshareLastSyncError(data.lastSyncError || "");
+    } catch (error) {
+      console.log("Error fetching Webshare status:", error);
+    }
+  }, []);
+
+  const openWebshareSettingsModal = () => {
+    setWebshareApiKeyInput("");
+    setShowWebshareSettingsModal(true);
+  };
+
+  const closeWebshareSettingsModal = () => {
+    if (webshareSaving || webshareTesting) return;
+    setShowWebshareSettingsModal(false);
+  };
+
+  const handleWebshareTestConnection = async () => {
+    const apiKey = webshareApiKeyInput.trim();
+    if (!apiKey) {
+      notify.warning("Enter Webshare API key to test connection");
+      return;
+    }
+
+    setWebshareTesting(true);
+    try {
+      const res = await fetch("/api/proxy-pools/webshare/test-connection", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ apiKey }),
+      });
+      const data = await res.json();
+      if (res.ok && data.ok) {
+        notify.success("Webshare connection successful");
+        return;
+      }
+      notify.error(data.error || "Webshare connection failed");
+    } catch (error) {
+      console.log("Error testing Webshare connection:", error);
+      notify.error("Webshare connection failed");
+    } finally {
+      setWebshareTesting(false);
+    }
+  };
+
+  const handleWebshareSettingsSave = async () => {
+    const payload = {
+      webshareAutoSyncEnabled: webshareAutoSyncEnabled === true,
+      webshareSyncIntervalMinutes: Math.max(15, Number(webshareSyncIntervalMinutes) || 60),
+    };
+    if (webshareApiKeyInput.trim()) {
+      payload.webshareApiKey = webshareApiKeyInput.trim();
+    }
+
+    setWebshareSaving(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        notify.error(data.error || "Failed to save Webshare settings");
+        return;
+      }
+      notify.success("Webshare settings saved");
+      await fetchWebshareStatus();
+      closeWebshareSettingsModal();
+    } catch (error) {
+      console.log("Error saving Webshare settings:", error);
+      notify.error("Failed to save Webshare settings");
+    } finally {
+      setWebshareSaving(false);
+    }
+  };
+
+  const handleWebshareSync = async () => {
+    setWebshareSyncing(true);
+    notify.warning("Syncing Webshare proxies...");
+    try {
+      const res = await fetch("/api/proxy-pools/webshare/import", { method: "POST" });
+      const data = await res.json();
+      if (!res.ok) {
+        notify.error(data.error || "Webshare sync failed");
+        return;
+      }
+      setWebshareLastSyncError("");
+      await fetchProxyPools();
+      await fetchWebshareStatus();
+      notify.success(
+        `Webshare sync done: Created ${data.created || 0}, Updated ${data.updated || 0}, Deactivated ${data.deactivated || 0}, Skipped ${data.skipped || 0}, Total ${data.total || 0}`
+      );
+    } catch (error) {
+      console.log("Error syncing Webshare:", error);
+      notify.error("Webshare sync failed");
+    } finally {
+      setWebshareSyncing(false);
+    }
+  };
 
   const resetForm = () => {
     setEditingProxyPool(null);
@@ -501,9 +619,42 @@ export default function ProxyPoolsPage() {
           <Button size="sm" variant="secondary" icon="upload" onClick={openBatchImportModal}>
             Batch Import
           </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            icon="settings"
+            onClick={openWebshareSettingsModal}
+            data-testid="webshare-settings-button"
+          >
+            Webshare Settings
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            icon={webshareSyncing ? "progress_activity" : "sync"}
+            onClick={handleWebshareSync}
+            disabled={webshareSyncing}
+            data-testid="webshare-sync-button"
+          >
+            {webshareSyncing ? "Syncing..." : "Sync Webshare"}
+          </Button>
           <Button size="sm" icon="add" onClick={openCreateModal}>Add Proxy Pool</Button>
         </div>
       </div>
+
+      {webshareLastSyncError ? (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-500 flex items-start gap-2">
+          <span className="material-symbols-outlined text-[18px] shrink-0">error</span>
+          <div className="flex-1 min-w-0">Webshare sync error: {webshareLastSyncError}</div>
+          <button
+            onClick={() => setWebshareLastSyncError("")}
+            className="text-xs underline underline-offset-2 hover:opacity-80"
+            type="button"
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
 
       <Card>
         <div className="mb-4 flex flex-wrap items-center gap-2">
@@ -588,6 +739,9 @@ export default function ProxyPoolsPage() {
                     {pool.type === "vercel" && (
                       <Badge variant="default" size="sm">vercel relay</Badge>
                     )}
+                    {pool.source === "webshare" && (
+                      <Badge variant="default" size="sm" data-testid="proxy-pool-source-webshare">webshare</Badge>
+                    )}
                     <Badge variant="default" size="sm">
                       {pool.boundConnectionCount || 0} bound
                     </Badge>
@@ -668,6 +822,61 @@ export default function ProxyPoolsPage() {
               {importing ? "Importing..." : "Import"}
             </Button>
             <Button fullWidth variant="ghost" onClick={closeBatchImportModal} disabled={importing}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={showWebshareSettingsModal}
+        title="Webshare Settings"
+        onClose={closeWebshareSettingsModal}
+      >
+        <div className="flex flex-col gap-4">
+          <Input
+            label="Webshare API Key"
+            value={webshareApiKeyInput}
+            onChange={(e) => setWebshareApiKeyInput(e.target.value)}
+            placeholder={hasWebshareApiKey ? "••••" : "ws_..."}
+            type="password"
+            data-testid="webshare-api-key-input"
+          />
+
+          <Button
+            variant="secondary"
+            onClick={handleWebshareTestConnection}
+            disabled={webshareTesting || !webshareApiKeyInput.trim()}
+            data-testid="webshare-test-connection-button"
+          >
+            {webshareTesting ? "Testing..." : "Test Connection"}
+          </Button>
+
+          <div className="flex flex-col gap-3 rounded-lg border border-border/50 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-medium text-sm">Auto Sync</p>
+              <p className="text-xs text-text-muted">Automatically import from Webshare on schedule.</p>
+            </div>
+            <Toggle
+              checked={webshareAutoSyncEnabled === true}
+              onChange={() => setWebshareAutoSyncEnabled((prev) => !prev)}
+              disabled={webshareSaving}
+            />
+          </div>
+
+          <Input
+            label="Sync Interval (minutes)"
+            type="number"
+            min={15}
+            value={String(webshareSyncIntervalMinutes || 60)}
+            onChange={(e) => setWebshareSyncIntervalMinutes(Math.max(15, Number(e.target.value) || 60))}
+          />
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <Button fullWidth onClick={handleWebshareSettingsSave} disabled={webshareSaving}>
+              {webshareSaving ? "Saving..." : "Save"}
+            </Button>
+            <Button fullWidth variant="ghost" onClick={closeWebshareSettingsModal} disabled={webshareSaving || webshareTesting}>
               Cancel
             </Button>
           </div>

--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -27,6 +27,13 @@ function normalizeFormData(data = {}) {
   };
 }
 
+function getSyncMessageTone(message, syncing) {
+  if (syncing) return "pending";
+  const normalized = (message || "").toLowerCase();
+  if (normalized.includes("failed") || normalized.includes("error") || normalized.includes("refusing")) return "error";
+  return "success";
+}
+
 export default function ProxyPoolsPage() {
   const [proxyPools, setProxyPools] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -57,6 +64,8 @@ export default function ProxyPoolsPage() {
   const [webshareLastSyncError, setWebshareLastSyncError] = useState("");
   const [webshareLastSyncAt, setWebshareLastSyncAt] = useState(null);
   const [webshareLastSyncStats, setWebshareLastSyncStats] = useState(null);
+  const [webshareTestResult, setWebshareTestResult] = useState(null);
+  const [webshareSyncMessage, setWebshareSyncMessage] = useState(null);
   const notify = useNotificationStore();
 
   const fetchProxyPools = useCallback(async () => {
@@ -96,21 +105,24 @@ export default function ProxyPoolsPage() {
 
   const openWebshareSettingsModal = () => {
     setWebshareApiKeyInput("");
+    setWebshareTestResult(null);
+    setWebshareSyncMessage(null);
     setShowWebshareSettingsModal(true);
   };
 
   const closeWebshareSettingsModal = () => {
-    if (webshareSaving || webshareTesting) return;
+    if (webshareSaving || webshareTesting || webshareSyncing) return;
     setShowWebshareSettingsModal(false);
   };
 
   const handleWebshareTestConnection = async () => {
     const apiKey = webshareApiKeyInput.trim();
     if (!apiKey) {
-      notify.warning("Enter Webshare API key to test connection");
+      setWebshareTestResult({ ok: false, message: "Enter Webshare API key to test connection" });
       return;
     }
 
+    setWebshareTestResult(null);
     setWebshareTesting(true);
     try {
       const res = await fetch("/api/proxy-pools/webshare/test-connection", {
@@ -120,15 +132,47 @@ export default function ProxyPoolsPage() {
       });
       const data = await res.json();
       if (res.ok && data.ok) {
-        notify.success("Webshare connection successful");
+        setWebshareTestResult({ ok: true, message: "Webshare test passed" });
         return;
       }
-      notify.error(data.error || "Webshare connection failed");
+      setWebshareTestResult({ ok: false, message: data.error || "Webshare test failed" });
     } catch (error) {
       console.log("Error testing Webshare connection:", error);
-      notify.error("Webshare connection failed");
+      setWebshareTestResult({ ok: false, message: "Webshare test failed" });
     } finally {
       setWebshareTesting(false);
+    }
+  };
+
+  const syncWebshareProxies = async ({ fromSave = false } = {}) => {
+    setWebshareSyncing(true);
+    setWebshareSyncMessage(fromSave ? "Settings saved. Syncing Webshare proxies..." : "Syncing Webshare proxies...");
+    try {
+      const res = await fetch("/api/proxy-pools/webshare/import", { method: "POST" });
+      const data = await res.json();
+      if (!res.ok) {
+        const message = data.error || "Webshare sync failed";
+        setWebshareSyncMessage(message);
+        notify.error(message);
+        return false;
+      }
+      setWebshareLastSyncError("");
+      await fetchProxyPools();
+      await fetchWebshareStatus();
+      setWebshareSyncMessage(
+        `Sync done: Created ${data.created || 0}, Updated ${data.updated || 0}, Deactivated ${data.deactivated || 0}, Skipped ${data.skipped || 0}, Total ${data.total || 0}`
+      );
+      notify.success(
+        `Webshare sync done: Created ${data.created || 0}, Updated ${data.updated || 0}, Deactivated ${data.deactivated || 0}, Skipped ${data.skipped || 0}, Total ${data.total || 0}`
+      );
+      return true;
+    } catch (error) {
+      console.log("Error syncing Webshare:", error);
+      setWebshareSyncMessage("Webshare sync failed");
+      notify.error("Webshare sync failed");
+      return false;
+    } finally {
+      setWebshareSyncing(false);
     }
   };
 
@@ -153,9 +197,16 @@ export default function ProxyPoolsPage() {
         notify.error(data.error || "Failed to save Webshare settings");
         return;
       }
-      notify.success("Webshare settings saved");
       await fetchWebshareStatus();
-      closeWebshareSettingsModal();
+      if (data.hasWebshareApiKey) {
+        const synced = await syncWebshareProxies({ fromSave: true });
+        if (synced) {
+          setShowWebshareSettingsModal(false);
+        }
+      } else {
+        notify.success("Webshare settings saved");
+        setShowWebshareSettingsModal(false);
+      }
     } catch (error) {
       console.log("Error saving Webshare settings:", error);
       notify.error("Failed to save Webshare settings");
@@ -165,27 +216,7 @@ export default function ProxyPoolsPage() {
   };
 
   const handleWebshareSync = async () => {
-    setWebshareSyncing(true);
-    notify.warning("Syncing Webshare proxies...");
-    try {
-      const res = await fetch("/api/proxy-pools/webshare/import", { method: "POST" });
-      const data = await res.json();
-      if (!res.ok) {
-        notify.error(data.error || "Webshare sync failed");
-        return;
-      }
-      setWebshareLastSyncError("");
-      await fetchProxyPools();
-      await fetchWebshareStatus();
-      notify.success(
-        `Webshare sync done: Created ${data.created || 0}, Updated ${data.updated || 0}, Deactivated ${data.deactivated || 0}, Skipped ${data.skipped || 0}, Total ${data.total || 0}`
-      );
-    } catch (error) {
-      console.log("Error syncing Webshare:", error);
-      notify.error("Webshare sync failed");
-    } finally {
-      setWebshareSyncing(false);
-    }
+    await syncWebshareProxies();
   };
 
   const resetForm = () => {
@@ -596,6 +627,7 @@ export default function ProxyPoolsPage() {
     () => proxyPools.filter((pool) => pool.isActive === true).length,
     [proxyPools]
   );
+  const webshareSyncTone = getSyncMessageTone(webshareSyncMessage, webshareSyncing);
 
   if (loading) {
     return (
@@ -616,33 +648,24 @@ export default function ProxyPoolsPage() {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-2 sm:flex sm:items-center">
-          <Button size="sm" variant="secondary" icon="cloud_upload" onClick={openVercelModal}>
+        <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+          <Button size="sm" variant="secondary" icon="cloud_upload" onClick={openVercelModal} className="shrink-0 whitespace-nowrap">
             Vercel Relay
           </Button>
-          <Button size="sm" variant="secondary" icon="upload" onClick={openBatchImportModal}>
-            Batch Import
-          </Button>
           <Button
             size="sm"
             variant="secondary"
-            icon="settings"
+            icon="travel_explore"
             onClick={openWebshareSettingsModal}
             data-testid="webshare-settings-button"
+            className="shrink-0 whitespace-nowrap"
           >
-            Webshare Settings
+            Webshare
           </Button>
-          <Button
-            size="sm"
-            variant="secondary"
-            icon={webshareSyncing ? "progress_activity" : "sync"}
-            onClick={handleWebshareSync}
-            disabled={webshareSyncing}
-            data-testid="webshare-sync-button"
-          >
-            {webshareSyncing ? "Syncing..." : "Sync Webshare"}
+          <Button size="sm" variant="secondary" icon="upload" onClick={openBatchImportModal} className="shrink-0 whitespace-nowrap">
+            Batch Import
           </Button>
-          <Button size="sm" icon="add" onClick={openCreateModal}>Add Proxy Pool</Button>
+          <Button size="sm" icon="add" onClick={openCreateModal} className="shrink-0 whitespace-nowrap">Add proxy</Button>
         </div>
       </div>
 
@@ -847,15 +870,39 @@ export default function ProxyPoolsPage() {
         onClose={closeWebshareSettingsModal}
       >
         <div className="flex flex-col gap-4">
-          <p className="text-xs text-text-muted">Sync pulls your Webshare proxy list. Missing proxies are deactivated, not deleted. IP rotation is not triggered.</p>
+          <p className="text-xs text-text-muted">Save stores the key and immediately syncs your Webshare proxy list. Missing proxies are deactivated, not deleted. IP rotation is not triggered.</p>
+          <div className="rounded-[10px] border border-border/50 bg-surface-2/60 px-3 py-2.5">
+            <div className="flex items-start gap-2">
+              <span className={`material-symbols-outlined mt-0.5 text-[16px] ${hasWebshareApiKey ? "text-green-500" : "text-text-muted"}`}>
+                {hasWebshareApiKey ? "check_circle" : "radio_button_unchecked"}
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-text-main">API key status</p>
+                <p className="text-xs text-text-muted">
+                  {hasWebshareApiKey
+                    ? "Saved key active. Leave the field empty to keep it."
+                    : "No key saved. Add a Webshare API key to enable sync."}
+                </p>
+              </div>
+            </div>
+          </div>
           <Input
             label="Webshare API Key"
             value={webshareApiKeyInput}
             onChange={(e) => setWebshareApiKeyInput(e.target.value)}
-            placeholder={hasWebshareApiKey ? "••••" : "ws_..."}
+            placeholder={hasWebshareApiKey ? "Leave empty to keep saved key" : "ws_..."}
+            hint={<a href="https://dashboard.webshare.io/userapi/keys" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Get API key →</a>}
             type="password"
             data-testid="webshare-api-key-input"
           />
+          {hasWebshareApiKey && webshareApiKeyInput.trim() ? (
+            <div className="rounded-[10px] border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-500">
+              <span className="inline-flex items-center gap-1.5">
+                <span className="material-symbols-outlined text-[14px]">warning</span>
+                This will replace the saved Webshare key. Future syncs will use the new account.
+              </span>
+            </div>
+          ) : null}
 
           <Button
             variant="secondary"
@@ -865,6 +912,42 @@ export default function ProxyPoolsPage() {
           >
             {webshareTesting ? "Testing..." : "Test Connection"}
           </Button>
+          {webshareTestResult ? (
+            <div className={`rounded-[10px] border px-3 py-2 text-xs ${webshareTestResult.ok ? "border-green-500/20 bg-green-500/5 text-green-500" : "border-red-500/20 bg-red-500/5 text-red-500"}`}>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="material-symbols-outlined text-[14px]">{webshareTestResult.ok ? "check_circle" : "error"}</span>
+                {webshareTestResult.message}
+              </span>
+            </div>
+          ) : null}
+
+          {webshareSyncMessage ? (
+            <div className={`rounded-[10px] border px-3 py-2 text-xs ${webshareSyncTone === "error" ? "border-red-500/20 bg-red-500/5 text-red-500" : webshareSyncTone === "pending" ? "border-amber-500/20 bg-amber-500/5 text-amber-500" : "border-green-500/20 bg-green-500/5 text-green-500"}`}>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="material-symbols-outlined text-[14px]">{webshareSyncTone === "pending" ? "progress_activity" : webshareSyncTone === "success" ? "check_circle" : "error"}</span>
+                {webshareSyncMessage}
+              </span>
+            </div>
+          ) : null}
+
+          <div className="rounded-lg border border-border/50 p-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-medium text-sm">Manual sync</p>
+                <p className="text-xs text-text-muted">Pull the latest Webshare proxy list without changing saved settings.</p>
+              </div>
+              <Button
+                variant="secondary"
+                icon={webshareSyncing ? "progress_activity" : "sync"}
+                onClick={handleWebshareSync}
+                disabled={webshareSyncing || webshareSaving}
+                data-testid="webshare-sync-button"
+                className="shrink-0 whitespace-nowrap"
+              >
+                {webshareSyncing ? "Syncing..." : "Sync now"}
+              </Button>
+            </div>
+          </div>
 
           <div className="flex flex-col gap-3 rounded-lg border border-border/50 p-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
@@ -887,8 +970,8 @@ export default function ProxyPoolsPage() {
           />
 
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            <Button fullWidth onClick={handleWebshareSettingsSave} disabled={webshareSaving}>
-              {webshareSaving ? "Saving..." : "Save"}
+            <Button fullWidth onClick={handleWebshareSettingsSave} disabled={webshareSaving || webshareSyncing}>
+              {webshareSaving ? "Saving..." : webshareSyncing ? "Syncing..." : "Save and sync"}
             </Button>
             <Button fullWidth variant="ghost" onClick={closeWebshareSettingsModal} disabled={webshareSaving || webshareTesting}>
               Cancel

--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -608,7 +608,7 @@ export default function ProxyPoolsPage() {
         <div className="min-w-0">
           <h1 className="text-xl font-semibold sm:text-2xl">Proxy Pools</h1>
           <p className="text-sm text-text-muted mt-1">
-            Manage reusable per-connection proxies and bind them to provider connections.
+            Manage reusable per-connection proxies and bind them to provider connections. Import proxies from Webshare or other sources.
           </p>
         </div>
 
@@ -834,6 +834,7 @@ export default function ProxyPoolsPage() {
         onClose={closeWebshareSettingsModal}
       >
         <div className="flex flex-col gap-4">
+          <p className="text-xs text-text-muted">Sync pulls your Webshare proxy list. Missing proxies are deactivated, not deleted. IP rotation is not triggered.</p>
           <Input
             label="Webshare API Key"
             value={webshareApiKeyInput}

--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -55,6 +55,8 @@ export default function ProxyPoolsPage() {
   const [webshareSyncIntervalMinutes, setWebshareSyncIntervalMinutes] = useState(60);
   const [hasWebshareApiKey, setHasWebshareApiKey] = useState(false);
   const [webshareLastSyncError, setWebshareLastSyncError] = useState("");
+  const [webshareLastSyncAt, setWebshareLastSyncAt] = useState(null);
+  const [webshareLastSyncStats, setWebshareLastSyncStats] = useState(null);
   const notify = useNotificationStore();
 
   const fetchProxyPools = useCallback(async () => {
@@ -85,6 +87,8 @@ export default function ProxyPoolsPage() {
       setWebshareAutoSyncEnabled(data.enabled === true);
       setWebshareSyncIntervalMinutes(data.intervalMinutes || 60);
       setWebshareLastSyncError(data.lastSyncError || "");
+      setWebshareLastSyncAt(data.lastSyncAt || null);
+      setWebshareLastSyncStats(data.lastSyncStats || null);
     } catch (error) {
       console.log("Error fetching Webshare status:", error);
     }
@@ -642,17 +646,26 @@ export default function ProxyPoolsPage() {
         </div>
       </div>
 
-      {webshareLastSyncError ? (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-sm text-red-500 flex items-start gap-2">
-          <span className="material-symbols-outlined text-[18px] shrink-0">error</span>
-          <div className="flex-1 min-w-0">Webshare sync error: {webshareLastSyncError}</div>
-          <button
-            onClick={() => setWebshareLastSyncError("")}
-            className="text-xs underline underline-offset-2 hover:opacity-80"
-            type="button"
-          >
-            Dismiss
-          </button>
+      {(webshareLastSyncError || webshareLastSyncAt) ? (
+        <div className={`rounded-lg border px-3 py-2 text-sm flex items-start gap-2 ${webshareLastSyncError ? "border-red-500/20 bg-red-500/5 text-red-500" : "border-black/10 dark:border-white/10 bg-black/[0.02] dark:bg-white/[0.02] text-text-muted"}`}>
+          <span className="material-symbols-outlined text-[18px] shrink-0">{webshareLastSyncError ? "error" : "sync"}</span>
+          <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+            {webshareLastSyncError ? (
+              <span>Webshare sync error: {webshareLastSyncError}</span>
+            ) : null}
+            {webshareLastSyncAt ? (
+              <span className="text-xs">Last synced: {formatDateTime(webshareLastSyncAt)}{webshareLastSyncStats ? ` · ${webshareLastSyncStats.created ?? 0} created, ${webshareLastSyncStats.updated ?? 0} updated, ${webshareLastSyncStats.deactivated ?? 0} deactivated` : ""}</span>
+            ) : null}
+          </div>
+          {webshareLastSyncError ? (
+            <button
+              onClick={() => setWebshareLastSyncError("")}
+              className="text-xs underline underline-offset-2 hover:opacity-80"
+              type="button"
+            >
+              Dismiss
+            </button>
+          ) : null}
         </div>
       ) : null}
 

--- a/src/app/api/proxy-pools/[id]/route.js
+++ b/src/app/api/proxy-pools/[id]/route.js
@@ -5,6 +5,7 @@ import {
   getProxyPoolById,
   updateProxyPool,
 } from "@/models";
+import { getSettings, updateSettings } from "@/lib/localDb";
 
 function normalizeProxyPoolUpdate(body = {}) {
   const updates = {};
@@ -112,6 +113,15 @@ export async function DELETE(request, { params }) {
         },
         { status: 409 }
       );
+    }
+
+    if (existing.source === "webshare" && existing.webshareId) {
+      const settings = await getSettings();
+      const deletedIds = Array.isArray(settings.webshareDeletedProxyIds) ? settings.webshareDeletedProxyIds : [];
+      const webshareId = String(existing.webshareId);
+      if (!deletedIds.includes(webshareId)) {
+        await updateSettings({ webshareDeletedProxyIds: [...deletedIds, webshareId] });
+      }
     }
 
     await deleteProxyPool(id);

--- a/src/app/api/proxy-pools/webshare/import/route.js
+++ b/src/app/api/proxy-pools/webshare/import/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import {
+  WebshareAuthError,
+  WebshareRateLimitError,
+} from "@/lib/webshare/webshareClient.js";
+import { runWebshareSync } from "@/lib/webshare/webshareSync.js";
+
+export async function POST() {
+  try {
+    const stats = await runWebshareSync({ trigger: "manual" });
+
+    return NextResponse.json({
+      created: stats.created,
+      updated: stats.updated,
+      deactivated: stats.deactivated,
+      skipped: stats.skipped,
+      total: stats.total,
+    });
+  } catch (error) {
+    console.log("Error importing Webshare proxies:", error);
+
+    if (error instanceof WebshareAuthError) {
+      return NextResponse.json({ error: "Webshare authentication failed" }, { status: 502 });
+    }
+
+    if (error instanceof WebshareRateLimitError) {
+      return NextResponse.json({ error: "Webshare rate limit exceeded" }, { status: 502 });
+    }
+
+    const message = error instanceof Error ? error.message : "Failed to import Webshare proxies";
+
+    if (message.includes("Refusing to deactivate all")) {
+      return NextResponse.json({ error: message }, { status: 409 });
+    }
+
+    if (message.includes("No Webshare API key")) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Failed to import Webshare proxies" }, { status: 500 });
+  }
+}

--- a/src/app/api/proxy-pools/webshare/status/route.js
+++ b/src/app/api/proxy-pools/webshare/status/route.js
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getSettings } from "@/lib/localDb.js";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const settings = await getSettings();
+
+    return NextResponse.json({
+      enabled: settings.webshareAutoSyncEnabled,
+      lastSyncAt: settings.webshareLastSyncAt,
+      lastSyncError: settings.webshareLastSyncError,
+      lastSyncStats: settings.webshareLastSyncStats,
+      intervalMinutes: settings.webshareSyncIntervalMinutes,
+      hasApiKey: !!settings.webshareApiKey,
+    });
+  } catch (error) {
+    console.log("Error fetching Webshare sync status:", error);
+    return NextResponse.json({ error: "Failed to fetch Webshare sync status" }, { status: 500 });
+  }
+}

--- a/src/app/api/proxy-pools/webshare/test-connection/route.js
+++ b/src/app/api/proxy-pools/webshare/test-connection/route.js
@@ -19,10 +19,10 @@ export async function POST(request) {
       },
     });
   } catch (error) {
-    console.log("Error testing Webshare connection:", error);
-    return NextResponse.json({
-      ok: false,
-      error: error instanceof Error && error.message ? error.message : "Failed to test Webshare connection",
-    });
+    console.log("Error testing Webshare connection:", error?.name ?? "unknown");
+    const isAuthError = error?.name === "WebshareAuthError";
+    const isRateLimit = error?.name === "WebshareRateLimitError";
+    const message = isAuthError ? "Authentication failed" : isRateLimit ? "Rate limit exceeded" : "Connection failed";
+    return NextResponse.json({ ok: false, error: message });
   }
 }

--- a/src/app/api/proxy-pools/webshare/test-connection/route.js
+++ b/src/app/api/proxy-pools/webshare/test-connection/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { getProfile } from "@/lib/webshare/webshareClient.js";
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const apiKey = typeof body?.apiKey === "string" ? body.apiKey.trim() : "";
+
+    if (!apiKey) {
+      return NextResponse.json({ ok: false, error: "apiKey required" });
+    }
+
+    const profile = await getProfile(apiKey);
+
+    return NextResponse.json({
+      ok: true,
+      profile: {
+        email: profile?.email ?? null,
+      },
+    });
+  } catch (error) {
+    console.log("Error testing Webshare connection:", error);
+    return NextResponse.json({
+      ok: false,
+      error: error instanceof Error && error.message ? error.message : "Failed to test Webshare connection",
+    });
+  }
+}

--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -14,8 +14,9 @@ const SETTINGS_RESPONSE_HEADERS = {
 export async function GET() {
   try {
     const settings = await getSettings();
-    const { password, oidcClientSecret, ...safeSettings } = settings;
+    const { password, oidcClientSecret, webshareApiKey, ...safeSettings } = settings;
     safeSettings.oidcConfigured = !!(safeSettings.oidcIssuerUrl && safeSettings.oidcClientId && oidcClientSecret);
+    safeSettings.hasWebshareApiKey = !!webshareApiKey;
     
     const enableRequestLogs = process.env.ENABLE_REQUEST_LOGS === "true";
     const enableTranslator = process.env.ENABLE_TRANSLATOR === "true";
@@ -70,6 +71,12 @@ export async function PATCH(request) {
       }
     }
 
+    if (Object.prototype.hasOwnProperty.call(body, "webshareApiKey")) {
+      if (!body.webshareApiKey || !String(body.webshareApiKey).trim()) {
+        delete body.webshareApiKey;
+      }
+    }
+
     const settings = await updateSettings(body);
 
     // Apply outbound proxy settings immediately (no restart required)
@@ -90,8 +97,9 @@ export async function PATCH(request) {
       resetComboRotation();
     }
 
-    const { password, oidcClientSecret, ...safeSettings } = settings;
+    const { password, oidcClientSecret, webshareApiKey, ...safeSettings } = settings;
     safeSettings.oidcConfigured = !!(safeSettings.oidcIssuerUrl && safeSettings.oidcClientId && oidcClientSecret);
+    safeSettings.hasWebshareApiKey = !!webshareApiKey;
     return NextResponse.json(safeSettings, { headers: SETTINGS_RESPONSE_HEADERS });
   } catch (error) {
     console.log("Error updating settings:", error);

--- a/src/lib/db/repos/proxyPoolsRepo.js
+++ b/src/lib/db/repos/proxyPoolsRepo.js
@@ -130,6 +130,8 @@ export async function upsertProxyPoolBySource({ source, sourceId, fields }) {
       result = merged;
     } else {
       const pool = {
+        // Spread all fields first so Webshare metadata (webshareUsername, webshareCountryCode, etc.) is preserved
+        ...fields,
         id: uuidv4(),
         source,
         sourceId,

--- a/src/lib/db/repos/proxyPoolsRepo.js
+++ b/src/lib/db/repos/proxyPoolsRepo.js
@@ -101,3 +101,54 @@ export async function deleteProxyPool(id) {
   });
   return removed;
 }
+
+export async function getProxyPoolsBySource(source) {
+  const allPools = await getProxyPools();
+  return allPools.filter(pool => pool.source === source);
+}
+
+export async function upsertProxyPoolBySource({ source, sourceId, fields }) {
+  const db = await getAdapter();
+  let result = null;
+  db.transaction(() => {
+    const allPools = db.all(`SELECT * FROM proxyPools`).map(rowToPool);
+    const existing = allPools.find(p => p.source === source && (p.sourceId === sourceId || p.webshareId === sourceId));
+    const now = new Date().toISOString();
+    
+    if (existing) {
+      const merged = {
+        ...existing,
+        ...fields,
+        source,
+        sourceId,
+        webshareId: sourceId,
+        id: existing.id,
+        createdAt: existing.createdAt,
+        updatedAt: now,
+      };
+      upsert(db, merged);
+      result = merged;
+    } else {
+      const pool = {
+        id: uuidv4(),
+        source,
+        sourceId,
+        webshareId: sourceId,
+        name: fields.name || `${source}-${sourceId}`,
+        proxyUrl: fields.proxyUrl || "",
+        noProxy: fields.noProxy || "",
+        type: fields.type || "http",
+        isActive: fields.isActive !== undefined ? fields.isActive : true,
+        strictProxy: fields.strictProxy === true,
+        testStatus: fields.testStatus || "unknown",
+        lastTestedAt: fields.lastTestedAt || null,
+        lastError: fields.lastError || null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      upsert(db, pool);
+      result = pool;
+    }
+  });
+  return result;
+}

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -36,6 +36,12 @@ const DEFAULT_SETTINGS = {
   rtkEnabled: true,
   cavemanEnabled: false,
   cavemanLevel: "full",
+  webshareApiKey: "",
+  webshareAutoSyncEnabled: false,
+  webshareSyncIntervalMinutes: 60,
+  webshareLastSyncAt: null,
+  webshareLastSyncError: null,
+  webshareLastSyncStats: null,
 };
 
 async function readRaw() {

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -42,6 +42,7 @@ const DEFAULT_SETTINGS = {
   webshareLastSyncAt: null,
   webshareLastSyncError: null,
   webshareLastSyncStats: null,
+  webshareDeletedProxyIds: [],
 };
 
 async function readRaw() {

--- a/src/lib/webshare/webshareClient.js
+++ b/src/lib/webshare/webshareClient.js
@@ -1,0 +1,241 @@
+const WEBSHARE_BASE_URL = "https://proxy.webshare.io/api/v2";
+const REQUEST_TIMEOUT_MS = 15000;
+const DEFAULT_RETRY_AFTER_SECONDS = 60;
+
+export class WebshareError extends Error {
+  constructor(message, options = {}) {
+    super(message, options.cause ? { cause: options.cause } : undefined);
+    this.name = "WebshareError";
+    this.status = options.status ?? null;
+  }
+}
+
+export class WebshareAuthError extends WebshareError {
+  constructor(message = "Webshare authentication failed", options = {}) {
+    super(message, options);
+    this.name = "WebshareAuthError";
+  }
+}
+
+export class WebshareRateLimitError extends WebshareError {
+  constructor(message = "Webshare API rate limit exceeded", options = {}) {
+    super(message, options);
+    this.name = "WebshareRateLimitError";
+  }
+}
+
+function sleep(ms, signal) {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      cleanup();
+      reject(signal?.reason ?? new DOMException("Operation aborted", "AbortError"));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function combineSignals(...signals) {
+  const activeSignals = signals.filter(Boolean);
+  if (activeSignals.length === 0) {
+    return undefined;
+  }
+  if (activeSignals.length === 1) {
+    return activeSignals[0];
+  }
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(activeSignals);
+  }
+
+  const controller = new AbortController();
+
+  const abortFrom = (sourceSignal) => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    controller.abort(sourceSignal.reason);
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+    signal.addEventListener("abort", () => abortFrom(signal), { once: true });
+  }
+
+  return controller.signal;
+}
+
+function getTimeoutSignal() {
+  if (typeof AbortSignal.timeout === "function") {
+    return AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  }
+
+  const controller = new AbortController();
+  setTimeout(() => {
+    controller.abort(new DOMException("Request timed out", "TimeoutError"));
+  }, REQUEST_TIMEOUT_MS);
+  return controller.signal;
+}
+
+function parseRetryAfterSeconds(response) {
+  const header = response.headers.get("Retry-After");
+  const seconds = Number.parseInt(header ?? "", 10);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds : DEFAULT_RETRY_AFTER_SECONDS;
+}
+
+async function parseJsonResponse(response) {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new WebshareError("Webshare API returned invalid JSON", { status: response.status });
+  }
+}
+
+function createHttpError(response) {
+  if (response.status === 401 || response.status === 403) {
+    return new WebshareAuthError("Webshare authentication failed", { status: response.status });
+  }
+
+  return new WebshareError(`Webshare API request failed with status ${response.status}`, {
+    status: response.status,
+  });
+}
+
+async function fetchWebshareJson(url, apiKey, { signal, allowRateLimitRetry = false } = {}) {
+  const timeoutSignal = getTimeoutSignal();
+  const requestSignal = combineSignals(signal, timeoutSignal);
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Token ${apiKey}`,
+      },
+      signal: requestSignal,
+      cache: "no-store",
+    });
+  } catch (error) {
+    if (error?.name === "AbortError" || error?.name === "TimeoutError") {
+      throw new WebshareError("Webshare API request timed out", { cause: error });
+    }
+    throw new WebshareError("Webshare API request failed", { cause: error });
+  }
+
+  if (response.status === 429) {
+    if (!allowRateLimitRetry) {
+      throw new WebshareRateLimitError("Webshare API rate limit exceeded", { status: 429 });
+    }
+
+    const retryAfterSeconds = parseRetryAfterSeconds(response);
+    await sleep(retryAfterSeconds * 1000, signal);
+
+    const retryTimeoutSignal = getTimeoutSignal();
+    const retrySignal = combineSignals(signal, retryTimeoutSignal);
+
+    let retryResponse;
+    try {
+      retryResponse = await fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Token ${apiKey}`,
+        },
+        signal: retrySignal,
+        cache: "no-store",
+      });
+    } catch (error) {
+      if (error?.name === "AbortError" || error?.name === "TimeoutError") {
+        throw new WebshareError("Webshare API request timed out", { cause: error });
+      }
+      throw new WebshareError("Webshare API request failed", { cause: error });
+    }
+
+    if (retryResponse.status === 429) {
+      throw new WebshareRateLimitError("Webshare API rate limit exceeded after retry", { status: 429 });
+    }
+
+    if (!retryResponse.ok) {
+      throw createHttpError(retryResponse);
+    }
+
+    return parseJsonResponse(retryResponse);
+  }
+
+  if (!response.ok) {
+    throw createHttpError(response);
+  }
+
+  return parseJsonResponse(response);
+}
+
+function normalizeProxy(proxy) {
+  const username = proxy.username ?? "";
+  const password = proxy.password ?? "";
+  const proxyAddress = proxy.proxy_address ?? "";
+  const port = proxy.port ?? "";
+
+  return {
+    webshareId: proxy.id,
+    username,
+    password,
+    proxyAddress,
+    port,
+    valid: proxy.valid,
+    countryCode: proxy.country_code,
+    cityName: proxy.city_name,
+    createdAt: proxy.created_at,
+    proxyUrl: `http://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${proxyAddress}:${port}`,
+  };
+}
+
+export async function getProfile(apiKey) {
+  return fetchWebshareJson(`${WEBSHARE_BASE_URL}/profile/`, apiKey);
+}
+
+export async function listProxiesAll(apiKey, { signal } = {}) {
+  const proxies = [];
+  // mode=direct required because backbone mode returns single endpoint instead of one endpoint per proxy.
+  let nextUrl = `${WEBSHARE_BASE_URL}/proxy/list/?mode=direct&page=1&page_size=100`;
+
+  while (nextUrl) {
+    const page = await fetchWebshareJson(nextUrl, apiKey, {
+      signal,
+      allowRateLimitRetry: true,
+    });
+
+    if (!page || !Array.isArray(page.results)) {
+      throw new WebshareError("Webshare proxy list response shape invalid");
+    }
+
+    proxies.push(...page.results.map(normalizeProxy));
+    nextUrl = page.next;
+  }
+
+  return proxies;
+}

--- a/src/lib/webshare/webshareScheduler.js
+++ b/src/lib/webshare/webshareScheduler.js
@@ -42,6 +42,7 @@ async function tickWebshareScheduler() {
       return;
     }
 
+    // Call service directly — HTTP self-fetch would 401 under requireLogin auth guard.
     await runWebshareSync({ trigger: "scheduler" });
   } catch (err) {
     await updateSettings({

--- a/src/lib/webshare/webshareScheduler.js
+++ b/src/lib/webshare/webshareScheduler.js
@@ -1,0 +1,61 @@
+import { getSettings, updateSettings } from "@/lib/localDb.js";
+import { runWebshareSync } from "./webshareSync.js";
+
+const g = global.__appSingleton ??= {
+  signalHandlersRegistered: false,
+  watchdogInterval: null,
+  networkMonitorInterval: null,
+  webshareSyncInterval: null,
+  lastNetworkFingerprint: null,
+  lastWatchdogTick: Date.now(),
+  lastOnline: null,
+  mitmStartInProgress: false,
+  tunnelAutoResumed: false,
+  tailscaleAutoResumed: false,
+};
+
+function getIntervalMs(settings) {
+  return (Number(settings.webshareSyncIntervalMinutes) || 60) * 60 * 1000;
+}
+
+function setWebshareInterval(intervalMs) {
+  g.webshareSyncInterval = setInterval(async () => {
+    await tickWebshareScheduler();
+  }, intervalMs);
+  g.webshareSyncInterval._webshareIntervalMs = intervalMs;
+  if (g.webshareSyncInterval.unref) g.webshareSyncInterval.unref();
+}
+
+async function tickWebshareScheduler() {
+  try {
+    const settings = await getSettings();
+    const webshareApiKey = settings.webshareApiKey?.trim();
+    const intervalMs = getIntervalMs(settings);
+
+    if (g.webshareSyncInterval?._webshareIntervalMs !== intervalMs) {
+      clearInterval(g.webshareSyncInterval);
+      g.webshareSyncInterval = null;
+      setWebshareInterval(intervalMs);
+    }
+
+    if (!settings.webshareAutoSyncEnabled || !webshareApiKey) {
+      return;
+    }
+
+    await runWebshareSync({ trigger: "scheduler" });
+  } catch (err) {
+    await updateSettings({
+      webshareLastSyncError: err instanceof Error ? err.message : String(err),
+    }).catch(() => {});
+  }
+}
+
+export function startWebshareScheduler() {
+  if (g.webshareSyncInterval) return;
+
+  setWebshareInterval(60 * 60 * 1000);
+
+  setTimeout(() => {
+    tickWebshareScheduler().catch(() => {});
+  }, 30000);
+}

--- a/src/lib/webshare/webshareSync.js
+++ b/src/lib/webshare/webshareSync.js
@@ -101,6 +101,7 @@ async function executeWebshareSync({ trigger }) {
       continue;
     }
 
+    // Never delete — mark inactive only to preserve provider connection bindings
     await updateProxyPool(pool.id, {
       isActive: false,
       webshareValid: false,

--- a/src/lib/webshare/webshareSync.js
+++ b/src/lib/webshare/webshareSync.js
@@ -1,0 +1,147 @@
+import { getSettings, updateSettings } from "@/lib/localDb.js";
+import {
+  getProxyPoolsBySource,
+  upsertProxyPoolBySource,
+  updateProxyPool,
+} from "@/lib/db/repos/proxyPoolsRepo.js";
+import {
+  listProxiesAll,
+  WebshareAuthError,
+  WebshareRateLimitError,
+} from "./webshareClient.js";
+
+global.__webshareSync ??= { inFlight: null };
+
+function createManagedFields(proxy) {
+  return {
+    name: `Webshare · ${proxy.countryCode ?? "??"} · ${proxy.proxyAddress}`,
+    proxyUrl: proxy.proxyUrl,
+    noProxy: "",
+    type: "http",
+    isActive: true,
+    strictProxy: false,
+    webshareUsername: proxy.username,
+    webshareCountryCode: proxy.countryCode,
+    webshareCityName: proxy.cityName,
+    webshareValid: proxy.valid,
+    webshareLastImportedAt: new Date().toISOString(),
+  };
+}
+
+function getErrorMessage(error) {
+  if (error instanceof WebshareAuthError || error instanceof WebshareRateLimitError) {
+    return error.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Unknown Webshare sync error";
+}
+
+async function executeWebshareSync({ trigger }) {
+  const settings = await getSettings();
+  const apiKey = settings.webshareApiKey?.trim();
+
+  if (!apiKey) {
+    throw new Error("No Webshare API key configured");
+  }
+
+  const remoteProxies = await listProxiesAll(apiKey);
+  const localPools = await getProxyPoolsBySource("webshare");
+
+  if (remoteProxies.length === 0 && localPools.length > 0) {
+    throw new Error("Refusing to deactivate all: Webshare returned empty list");
+  }
+
+  const stats = {
+    created: 0,
+    updated: 0,
+    deactivated: 0,
+    skipped: 0,
+    total: remoteProxies.length,
+    trigger,
+  };
+
+  const localByWebshareId = new Map(
+    localPools
+      .filter((pool) => pool.webshareId)
+      .map((pool) => [String(pool.webshareId), pool])
+  );
+  const remoteIds = new Set();
+
+  for (const proxy of remoteProxies) {
+    if (!proxy?.webshareId) {
+      stats.skipped += 1;
+      continue;
+    }
+
+    const sourceId = String(proxy.webshareId);
+    remoteIds.add(sourceId);
+
+    await upsertProxyPoolBySource({
+      source: "webshare",
+      sourceId,
+      fields: createManagedFields(proxy),
+    });
+
+    if (localByWebshareId.has(sourceId)) {
+      stats.updated += 1;
+    } else {
+      stats.created += 1;
+    }
+  }
+
+  const orphanedAt = new Date().toISOString();
+
+  for (const pool of localPools) {
+    const webshareId = pool?.webshareId ? String(pool.webshareId) : null;
+    if (!webshareId || remoteIds.has(webshareId)) {
+      continue;
+    }
+
+    await updateProxyPool(pool.id, {
+      isActive: false,
+      webshareValid: false,
+      webshareOrphanedAt: orphanedAt,
+    });
+    stats.deactivated += 1;
+  }
+
+  await updateSettings({
+    webshareLastSyncAt: new Date().toISOString(),
+    webshareLastSyncStats: {
+      created: stats.created,
+      updated: stats.updated,
+      deactivated: stats.deactivated,
+      skipped: stats.skipped,
+      total: stats.total,
+    },
+    webshareLastSyncError: null,
+    webshareSyncIntervalMinutes: settings.webshareSyncIntervalMinutes,
+  });
+
+  return stats;
+}
+
+export function runWebshareSync({ trigger }) {
+  if (global.__webshareSync.inFlight) {
+    return global.__webshareSync.inFlight;
+  }
+
+  global.__webshareSync.inFlight = (async () => {
+    try {
+      return await executeWebshareSync({ trigger });
+    } catch (error) {
+      await updateSettings({
+        webshareLastSyncError: getErrorMessage(error),
+      });
+      throw error;
+    } finally {
+      global.__webshareSync.inFlight = null;
+    }
+  })();
+
+  return global.__webshareSync.inFlight;
+}

--- a/src/lib/webshare/webshareSync.js
+++ b/src/lib/webshare/webshareSync.js
@@ -25,6 +25,7 @@ function createManagedFields(proxy) {
     webshareCityName: proxy.cityName,
     webshareValid: proxy.valid,
     webshareLastImportedAt: new Date().toISOString(),
+    webshareOrphanedAt: null,
   };
 }
 

--- a/src/lib/webshare/webshareSync.js
+++ b/src/lib/webshare/webshareSync.js
@@ -71,6 +71,11 @@ async function executeWebshareSync({ trigger }) {
       .filter((pool) => pool.webshareId)
       .map((pool) => [String(pool.webshareId), pool])
   );
+  const deletedWebshareIds = new Set(
+    Array.isArray(settings.webshareDeletedProxyIds)
+      ? settings.webshareDeletedProxyIds.map((id) => String(id))
+      : []
+  );
   const remoteIds = new Set();
 
   for (const proxy of remoteProxies) {
@@ -81,6 +86,11 @@ async function executeWebshareSync({ trigger }) {
 
     const sourceId = String(proxy.webshareId);
     remoteIds.add(sourceId);
+
+    if (deletedWebshareIds.has(sourceId)) {
+      stats.skipped += 1;
+      continue;
+    }
 
     await upsertProxyPoolBySource({
       source: "webshare",

--- a/src/lib/webshare/webshareSync.js
+++ b/src/lib/webshare/webshareSync.js
@@ -51,6 +51,7 @@ async function executeWebshareSync({ trigger }) {
   const remoteProxies = await listProxiesAll(apiKey);
   const localPools = await getProxyPoolsBySource("webshare");
 
+  // Guard: empty list likely means API outage or lapsed subscription — refuse to mass-deactivate.
   if (remoteProxies.length === 0 && localPools.length > 0) {
     throw new Error("Refusing to deactivate all: Webshare returned empty list");
   }

--- a/src/lib/webshare/webshareSync.test.js
+++ b/src/lib/webshare/webshareSync.test.js
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSettings = vi.fn();
+const updateSettings = vi.fn();
+const getProxyPoolsBySource = vi.fn();
+const upsertProxyPoolBySource = vi.fn();
+const updateProxyPool = vi.fn();
+const listProxiesAll = vi.fn();
+
+vi.mock("@/lib/localDb.js", () => ({
+  getSettings,
+  updateSettings,
+}));
+
+vi.mock("@/lib/db/repos/proxyPoolsRepo.js", () => ({
+  getProxyPoolsBySource,
+  upsertProxyPoolBySource,
+  updateProxyPool,
+}));
+
+vi.mock("./webshareClient.js", async () => {
+  const actual = await vi.importActual("./webshareClient.js");
+  return {
+    ...actual,
+    listProxiesAll,
+  };
+});
+
+describe("runWebshareSync", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.__webshareSync = { inFlight: null };
+
+    getSettings.mockResolvedValue({
+      webshareApiKey: "test-key",
+      webshareSyncIntervalMinutes: 30,
+    });
+    updateSettings.mockResolvedValue(undefined);
+    getProxyPoolsBySource.mockResolvedValue([]);
+    upsertProxyPoolBySource.mockResolvedValue(undefined);
+    updateProxyPool.mockResolvedValue(undefined);
+    listProxiesAll.mockResolvedValue([]);
+  });
+
+  it("uses stable webshareId upsert path so existing row id stays bound", async () => {
+    const localPools = [
+      {
+        id: "uuid-1",
+        source: "webshare",
+        sourceId: "A",
+        webshareId: "A",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        webshareUsername: "old-user",
+      },
+    ];
+    const upsertResults = [];
+
+    getProxyPoolsBySource.mockResolvedValue(localPools);
+    listProxiesAll.mockResolvedValue([
+      {
+        webshareId: "A",
+        username: "new-user",
+        proxyAddress: "1.2.3.4",
+        countryCode: "US",
+        cityName: "NYC",
+        valid: true,
+        proxyUrl: "http://new-user:new-pass@1.2.3.4:80",
+      },
+    ]);
+    upsertProxyPoolBySource.mockImplementation(async ({ source, sourceId, fields }) => {
+      const existing = localPools.find(
+        (pool) => pool.source === source && String(pool.webshareId) === String(sourceId)
+      );
+      const result = existing
+        ? { ...existing, ...fields, source, sourceId, webshareId: sourceId, id: existing.id }
+        : { source, sourceId, webshareId: sourceId, ...fields };
+      upsertResults.push(result);
+      return result;
+    });
+
+    const { runWebshareSync } = await import("./webshareSync.js");
+
+    const stats = await runWebshareSync({ trigger: "manual" });
+
+    expect(upsertProxyPoolBySource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "webshare",
+        sourceId: "A",
+      })
+    );
+    expect(upsertResults).toEqual([
+      expect.objectContaining({
+        id: "uuid-1",
+        webshareId: "A",
+        webshareUsername: "new-user",
+      }),
+    ]);
+    expect(updateProxyPool).not.toHaveBeenCalled();
+    expect(stats).toMatchObject({ created: 0, updated: 1, deactivated: 0, skipped: 0, total: 1 });
+  });
+
+  it("aborts on empty remote list before deactivating existing rows", async () => {
+    getProxyPoolsBySource.mockResolvedValue([
+      { id: "uuid-1", webshareId: "A", isActive: true },
+    ]);
+    listProxiesAll.mockResolvedValue([]);
+
+    const { runWebshareSync } = await import("./webshareSync.js");
+
+    await expect(runWebshareSync({ trigger: "manual" })).rejects.toThrow(
+      "Refusing to deactivate all"
+    );
+    expect(updateProxyPool).not.toHaveBeenCalled();
+  });
+
+  it("marks missing remote rows inactive without touching surviving rows", async () => {
+    getProxyPoolsBySource.mockResolvedValue([
+      { id: "uuid-1", webshareId: "A", isActive: true },
+      { id: "uuid-2", webshareId: "B", isActive: true },
+    ]);
+    listProxiesAll.mockResolvedValue([
+      {
+        webshareId: "B",
+        username: "user-b",
+        proxyAddress: "5.6.7.8",
+        countryCode: "SG",
+        cityName: "Singapore",
+        valid: true,
+        proxyUrl: "http://user-b:pass@5.6.7.8:80",
+      },
+    ]);
+
+    const { runWebshareSync } = await import("./webshareSync.js");
+
+    const stats = await runWebshareSync({ trigger: "manual" });
+
+    expect(upsertProxyPoolBySource).toHaveBeenCalledTimes(1);
+    expect(upsertProxyPoolBySource).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: "B" })
+    );
+    expect(updateProxyPool).toHaveBeenCalledTimes(1);
+    expect(updateProxyPool).toHaveBeenCalledWith(
+      "uuid-1",
+      expect.objectContaining({
+        isActive: false,
+        webshareValid: false,
+        webshareOrphanedAt: expect.any(String),
+      })
+    );
+    expect(updateProxyPool).not.toHaveBeenCalledWith(
+      "uuid-2",
+      expect.anything()
+    );
+    expect(stats).toMatchObject({ created: 0, updated: 1, deactivated: 1, skipped: 0, total: 1 });
+  });
+});

--- a/src/lib/webshare/webshareSync.test.js
+++ b/src/lib/webshare/webshareSync.test.js
@@ -34,6 +34,7 @@ describe("runWebshareSync", () => {
     getSettings.mockResolvedValue({
       webshareApiKey: "test-key",
       webshareSyncIntervalMinutes: 30,
+      webshareDeletedProxyIds: [],
     });
     updateSettings.mockResolvedValue(undefined);
     getProxyPoolsBySource.mockResolvedValue([]);
@@ -152,5 +153,33 @@ describe("runWebshareSync", () => {
       expect.anything()
     );
     expect(stats).toMatchObject({ created: 0, updated: 1, deactivated: 1, skipped: 0, total: 1 });
+  });
+
+  it("does not recreate Webshare proxies deleted by the user", async () => {
+    getSettings.mockResolvedValue({
+      webshareApiKey: "test-key",
+      webshareSyncIntervalMinutes: 30,
+      webshareDeletedProxyIds: ["A"],
+    });
+    getProxyPoolsBySource.mockResolvedValue([]);
+    listProxiesAll.mockResolvedValue([
+      {
+        webshareId: "A",
+        username: "user-a",
+        proxyAddress: "1.2.3.4",
+        countryCode: "US",
+        cityName: "NYC",
+        valid: true,
+        proxyUrl: "http://user-a:pass@1.2.3.4:80",
+      },
+    ]);
+
+    const { runWebshareSync } = await import("./webshareSync.js");
+
+    const stats = await runWebshareSync({ trigger: "manual" });
+
+    expect(upsertProxyPoolBySource).not.toHaveBeenCalled();
+    expect(updateProxyPool).not.toHaveBeenCalled();
+    expect(stats).toMatchObject({ created: 0, updated: 0, deactivated: 0, skipped: 1, total: 1 });
   });
 });

--- a/src/shared/services/initializeApp.js
+++ b/src/shared/services/initializeApp.js
@@ -18,6 +18,7 @@ import {
 } from "@/lib/tunnel/tunnelConfig";
 import { getMitmStatus, startMitm, loadEncryptedPassword, initDbHooks, restoreToolDNS, removeAllDNSEntriesSync } from "@/mitm/manager";
 import { syncToJson as syncMitmAliasCache } from "@/lib/mitmAliasCache";
+import { startWebshareScheduler } from "@/lib/webshare/webshareScheduler.js";
 
 // Inject correct paths and DB hooks into manager.js (CJS) from ESM context
 (function bootstrapMitm() {
@@ -39,6 +40,7 @@ const g = global.__appSingleton ??= {
   signalHandlersRegistered: false,
   watchdogInterval: null,
   networkMonitorInterval: null,
+  webshareSyncInterval: null,
   lastNetworkFingerprint: null,
   lastWatchdogTick: Date.now(),
   lastOnline: null,
@@ -85,6 +87,7 @@ export async function initializeApp() {
 
     startWatchdog();
     startNetworkMonitor();
+    startWebshareScheduler();
     autoStartMitm();
   } catch (error) {
     console.error("[InitApp] Error:", error);

--- a/tests/vitest.webshare.config.js
+++ b/tests/vitest.webshare.config.js
@@ -1,0 +1,18 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+export default {
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/lib/webshare/webshareSync.test.js"],
+    silent: false,
+  },
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "../src"),
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Add Webshare proxy import using one proxy pool row per Webshare proxy.
- Add manual and scheduled Webshare sync without changing runtime proxy resolution.
- Improve Proxy Pools UI for Webshare setup, testing, sync feedback, and deleted-proxy behavior.

## Changes
- Add Webshare settings fields, API-key masking, status API, import API, and test-connection API.
- Add Webshare client, sync orchestrator, scheduler wiring, and source-aware proxy-pool upsert helpers.
- Add Proxy Pools dashboard controls for Webshare:
  - Webshare setup modal
  - API key status and replacement warning
  - inline test connection result
  - manual sync inside modal
  - inline sync progress with final sync toast
  - Webshare source badges
- Preserve user intent when deleting imported Webshare proxies:
  - record deleted Webshare proxy IDs
  - skip tombstoned IDs on later syncs
  - keep provider bindings safe by deactivating missing remote proxies instead of deleting them
- Ignore `.sisyphus/` work-session files.

## Testing
- `NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run --reporter=verbose --config tests/vitest.webshare.config.js`
  - 4 tests passed
- `npm run build`
  - passed
- `lsp_diagnostics`
  - clean on changed files

## Notes
- Webshare sync uses the existing proxy pool model: one row maps to one proxy URL.
- Runtime proxy resolution is untouched.
- Build still logs existing `/var/lib/9router` fallback warnings when that directory is not writable.