### PR TITLE
feat(providers): add Gitlawb Opengateway as no-auth free provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -538,6 +538,15 @@ export const PROVIDER_MODELS = {
     { id: "mimo-v2-omni", name: "MiMo V2 Omni" },
     { id: "mimo-v2-flash", name: "MiMo V2 Flash" },
   ],
+  // Gitlawb Opengateway — Xiaomi MiMo route. Same model family as xiaomi-mimo
+  // but proxied through the free, no-auth gateway.
+  "gitlawb-opengateway": [
+    { id: "mimo-v2.5-pro", name: "MiMo V2.5 Pro" },
+    { id: "mimo-v2.5", name: "MiMo V2.5" },
+    { id: "mimo-v2-pro", name: "MiMo V2 Pro" },
+    { id: "mimo-v2-omni", name: "MiMo V2 Omni" },
+    { id: "mimo-v2-flash", name: "MiMo V2 Flash" },
+  ],
   "xiaomi-tokenplan": [
     { id: "mimo-v2.5-pro", name: "MiMo V2.5 Pro" },
     { id: "mimo-v2.5", name: "MiMo V2.5" },

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -358,6 +358,14 @@ export const PROVIDERS = {
     headers: { "x-opencode-client": "desktop" },
     noAuth: true
   },
+  // Gitlawb Opengateway — free OpenAI-compatible proxy that fronts Xiaomi MiMo.
+  // The /v1/xiaomi-mimo route only accepts mimo-* models (the gateway itself also
+  // exposes other vendor sub-routes, but this provider entry pins Xiaomi MiMo).
+  "gitlawb-opengateway": {
+    baseUrl: "https://opengateway.gitlawb.com/v1/xiaomi-mimo/chat/completions",
+    format: "openai",
+    noAuth: true
+  },
   "opencode-go": {
     baseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
     format: "openai",

--- a/src/app/api/providers/suggested-models/route.js
+++ b/src/app/api/providers/suggested-models/route.js
@@ -18,6 +18,13 @@ const FILTERS = {
     models
       .filter((m) => m.id?.endsWith("-free"))
       .map((m) => ({ id: m.id, name: m.id })),
+
+  // Generic passthrough for any OpenAI-shape `/models` response: `{ data: [{ id, ... }] }`.
+  // Used by the Gitlawb Opengateway provider.
+  "openai-list": (models) =>
+    models
+      .filter((m) => m.id)
+      .map((m) => ({ id: m.id, name: m.id })),
 };
 
 export async function GET(request) {

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -12,6 +12,7 @@ export const FREE_PROVIDERS = {
   // qoder: { id: "qoder", alias: "qd", name: "Qoder AI", icon: "water_drop", color: "#EC4899" },
   iflow: { id: "iflow", alias: "if", name: "iFlow AI", icon: "water_drop", color: "#6366F1", hidden: true, website: "https://iflow.cn", notice: { signupUrl: "https://iflow.cn" } },
   opencode: { id: "opencode", alias: "oc", name: "OpenCode Free", icon: "terminal", color: "#E87040", textIcon: "OC", noAuth: true, passthroughModels: true, modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" } },
+  "gitlawb-opengateway": { id: "gitlawb-opengateway", alias: "ogw", name: "Gitlawb Opengateway (Xiaomi MiMo)", icon: "router", color: "#FF6900", textIcon: "GW", noAuth: true, modelsFetcher: { url: "https://opengateway.gitlawb.com/v1/xiaomi-mimo/models", type: "openai-list" }, website: "https://opengateway.gitlawb.com", notice: { text: "Free Gitlawb Opengateway proxy — no API key required. Serves Xiaomi MiMo models (mimo-v2.5-pro, mimo-v2-flash, etc.) via the /v1/xiaomi-mimo route." } },
 };
 
 // Free Tier Providers (has free access but may require account/API key)


### PR DESCRIPTION
Exposes the free, no-API-key https://opengateway.gitlawb.com/v1/xiaomi-mimo gateway as a first-class provider (id: gitlawb-opengateway, alias: ogw), following the same no-auth pattern used by 'opencode'.

Once connected (one click, no key required), the provider is reachable through 9router's local OpenAI-compatible endpoint, so Hermes, OpenClaw, and any other CLI tool that already routes through 9router can use it without modification.

Changes:
- src/shared/constants/providers.js: add FREE_PROVIDERS entry with noAuth, modelsFetcher (type: openai-list)
- open-sse/config/providers.js: add backend baseUrl + noAuth flag
- open-sse/config/providerModels.js: add fallback Xiaomi MiMo model list
- src/app/api/providers/suggested-models/route.js: add generic 'openai-list' filter that maps an OpenAI /models response to [{id, name}] suggestions