### PR TITLE
fix(kiro): reasoning output and add model import

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { HTTP_STATUS, RETRY_CONFIG, DEFAULT_RETRY_CONFIG, resolveRetryEntry } from "../config/runtimeConfig.js";
+import { splitKiroThinkingContent, flushKiroThinkingContent } from "../utils/kiroThinking.js";
 
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
@@ -123,11 +124,7 @@ export class KiroExecutor extends BaseExecutor {
           if (!state.totalContentLength) state.totalContentLength = 0;
           if (!state.contextUsagePercentage) state.contextUsagePercentage = 0;
 
-          // Handle assistantResponseEvent
-          if (eventType === "assistantResponseEvent" && event.payload?.content) {
-            const content = event.payload.content;
-            state.totalContentLength += content.length;
-            
+          const enqueueOpenAIChunk = (delta, finish_reason = null) => {
             const chunk = {
               id: responseId,
               object: "chat.completion.chunk",
@@ -135,14 +132,29 @@ export class KiroExecutor extends BaseExecutor {
               model,
               choices: [{
                 index: 0,
-                delta: chunkIndex === 0
-                  ? { role: "assistant", content }
-                  : { content },
-                finish_reason: null
+                delta: chunkIndex === 0 ? { role: "assistant", ...delta } : delta,
+                finish_reason
               }]
             };
             chunkIndex++;
             controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            return chunk;
+          };
+
+          // Handle assistantResponseEvent
+          if (eventType === "assistantResponseEvent" && event.payload?.content) {
+            const content = event.payload.content;
+            const segments = splitKiroThinkingContent(content, state);
+            for (const segment of segments) {
+              state.totalContentLength += segment.text.length;
+              if (segment.type === "reasoning") {
+                state.hasReasoningContent = true;
+                state.reasoningChunkCount++;
+                enqueueOpenAIChunk({ reasoning_content: segment.text });
+              } else {
+                enqueueOpenAIChunk({ content: segment.text });
+              }
+            }
           }
 
           // Handle reasoningContentEvent (Kiro thinking / reasoning)
@@ -280,6 +292,17 @@ export class KiroExecutor extends BaseExecutor {
 
           // Handle messageStopEvent
           if (eventType === "messageStopEvent") {
+            for (const segment of flushKiroThinkingContent(state)) {
+              state.totalContentLength += segment.text.length;
+              if (segment.type === "reasoning") {
+                state.hasReasoningContent = true;
+                state.reasoningChunkCount++;
+                enqueueOpenAIChunk({ reasoning_content: segment.text });
+              } else {
+                enqueueOpenAIChunk({ content: segment.text });
+              }
+            }
+
             const chunk = {
               id: responseId,
               object: "chat.completion.chunk",
@@ -376,6 +399,30 @@ export class KiroExecutor extends BaseExecutor {
       },
 
       flush(controller) {
+        for (const segment of flushKiroThinkingContent(state)) {
+          state.totalContentLength += segment.text.length;
+          const delta = segment.type === "reasoning"
+            ? { ...(chunkIndex === 0 ? { role: "assistant" } : {}), reasoning_content: segment.text }
+            : { ...(chunkIndex === 0 ? { role: "assistant" } : {}), content: segment.text };
+          if (segment.type === "reasoning") {
+            state.hasReasoningContent = true;
+            state.reasoningChunkCount++;
+          }
+          const pendingChunk = {
+            id: responseId,
+            object: "chat.completion.chunk",
+            created,
+            model,
+            choices: [{
+              index: 0,
+              delta,
+              finish_reason: null
+            }]
+          };
+          chunkIndex++;
+          controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(pendingChunk)}\n\n`));
+        }
+
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;

--- a/open-sse/translator/response/kiro-to-openai.js
+++ b/open-sse/translator/response/kiro-to-openai.js
@@ -4,6 +4,27 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
+import { splitKiroThinkingContent, flushKiroThinkingContent } from "../../utils/kiroThinking.js";
+
+function createKiroOpenAIChunk(state, delta, finishReason = null) {
+  const openaiChunk = {
+    id: state.responseId,
+    object: "chat.completion.chunk",
+    created: state.created,
+    model: state.model || "kiro",
+    choices: [{
+      index: 0,
+      delta: {
+        ...(state.chunkIndex === 0 ? { role: "assistant" } : {}),
+        ...delta
+      },
+      finish_reason: finishReason
+    }]
+  };
+
+  state.chunkIndex++;
+  return openaiChunk;
+}
 
 /**
  * Parse Kiro SSE event and convert to OpenAI format
@@ -66,23 +87,16 @@ export function convertKiroToOpenAI(chunk, state) {
     const content = data.assistantResponseEvent?.content || data.content || "";
     if (!content) return null;
 
-    const openaiChunk = {
-      id: state.responseId,
-      object: "chat.completion.chunk",
-      created: state.created,
-      model: state.model || "kiro",
-      choices: [{
-        index: 0,
-        delta: {
-          ...(state.chunkIndex === 0 ? { role: "assistant" } : {}),
-          content: content
-        },
-        finish_reason: null
-      }]
-    };
-
-    state.chunkIndex++;
-    return openaiChunk;
+    const results = [];
+    for (const segment of splitKiroThinkingContent(content, state)) {
+      results.push(createKiroOpenAIChunk(
+        state,
+        segment.type === "reasoning"
+          ? { reasoning_content: segment.text }
+          : { content: segment.text }
+      ));
+    }
+    return results.length > 0 ? results : null;
   }
 
   // Handle reasoning/thinking events.
@@ -153,6 +167,13 @@ export function convertKiroToOpenAI(chunk, state) {
   // Handle completion/done events
   if (eventType === "messageStopEvent" || eventType === "done" || data.messageStopEvent) {
     state.finishReason = "stop"; // Mark for usage injection in stream.js
+
+    const flushed = flushKiroThinkingContent(state).map(segment => createKiroOpenAIChunk(
+      state,
+      segment.type === "reasoning"
+        ? { reasoning_content: segment.text }
+        : { content: segment.text }
+    ));
     
     const openaiChunk = {
       id: state.responseId,
@@ -169,6 +190,10 @@ export function convertKiroToOpenAI(chunk, state) {
     // Include usage in final chunk if available
     if (state.usage && typeof state.usage === "object") {
       openaiChunk.usage = state.usage;
+    }
+
+    if (flushed.length > 0) {
+      return [...flushed, openaiChunk];
     }
 
     return openaiChunk;

--- a/open-sse/utils/kiroThinking.js
+++ b/open-sse/utils/kiroThinking.js
@@ -1,0 +1,75 @@
+const THINKING_START = "<thinking>";
+const THINKING_END = "</thinking>";
+
+function longestPrefixSuffix(text, prefix) {
+  const max = Math.min(text.length, prefix.length - 1);
+  for (let len = max; len > 0; len--) {
+    if (text.endsWith(prefix.slice(0, len))) return len;
+  }
+  return 0;
+}
+
+function pushSegment(segments, type, text) {
+  if (!text) return;
+  const last = segments[segments.length - 1];
+  if (last?.type === type) {
+    last.text += text;
+  } else {
+    segments.push({ type, text });
+  }
+}
+
+/**
+ * Split Kiro assistant text into normal content and OpenAI reasoning deltas.
+ *
+ * Some Kiro thinking models stream reasoning inside literal
+ * <thinking>...</thinking> tags in assistantResponseEvent.content instead of
+ * sending reasoningContentEvent. Keep parsing state so tags split across chunks
+ * are removed and their inner text is surfaced as reasoning_content.
+ */
+export function splitKiroThinkingContent(content, state = {}) {
+  const segments = [];
+  let text = `${state.kiroThinkingPending || ""}${content || ""}`;
+  state.kiroThinkingPending = "";
+
+  while (text) {
+    if (state.kiroInThinkingBlock) {
+      const endIndex = text.indexOf(THINKING_END);
+      if (endIndex >= 0) {
+        pushSegment(segments, "reasoning", text.slice(0, endIndex));
+        text = text.slice(endIndex + THINKING_END.length);
+        state.kiroInThinkingBlock = false;
+        continue;
+      }
+
+      const keep = longestPrefixSuffix(text, THINKING_END);
+      const emitEnd = keep ? text.length - keep : text.length;
+      pushSegment(segments, "reasoning", text.slice(0, emitEnd));
+      state.kiroThinkingPending = keep ? text.slice(emitEnd) : "";
+      break;
+    }
+
+    const startIndex = text.indexOf(THINKING_START);
+    if (startIndex >= 0) {
+      pushSegment(segments, "content", text.slice(0, startIndex));
+      text = text.slice(startIndex + THINKING_START.length);
+      state.kiroInThinkingBlock = true;
+      continue;
+    }
+
+    const keep = longestPrefixSuffix(text, THINKING_START);
+    const emitEnd = keep ? text.length - keep : text.length;
+    pushSegment(segments, "content", text.slice(0, emitEnd));
+    state.kiroThinkingPending = keep ? text.slice(emitEnd) : "";
+    break;
+  }
+
+  return segments;
+}
+
+export function flushKiroThinkingContent(state = {}) {
+  const pending = state.kiroThinkingPending || "";
+  state.kiroThinkingPending = "";
+  if (!pending) return [];
+  return [{ type: state.kiroInThinkingBlock ? "reasoning" : "content", text: pending }];
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -48,6 +48,8 @@ export default function ProviderDetailPage() {
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
   const [disabledModelIds, setDisabledModelIds] = useState([]);
+  const [importedProviderModels, setImportedProviderModels] = useState([]);
+  const [importingProviderModels, setImportingProviderModels] = useState(false);
   const [confirmState, setConfirmState] = useState(null);
   const { copied, copy } = useCopyToClipboard();
 
@@ -136,6 +138,117 @@ export default function ProviderDetailPage() {
       if (res.ok) await fetchDisabledModels();
     } catch (error) {
       console.log("Error enabling all models:", error);
+    }
+  };
+
+  const resolveImportedModelAlias = (modelId, currentAliases) => {
+    const baseAlias = modelId.includes("/") ? modelId.split("/").pop() : modelId;
+    const candidates = [baseAlias, modelId, `${providerStorageAlias}-${baseAlias}`]
+      .filter(Boolean)
+      .filter((value, index, arr) => arr.indexOf(value) === index);
+
+    for (const candidate of candidates) {
+      if (!currentAliases[candidate] || currentAliases[candidate] === `${providerStorageAlias}/${modelId}`) {
+        return candidate;
+      }
+    }
+    return null;
+  };
+
+  const handleImportProviderModels = async () => {
+    if (importingProviderModels) return;
+    const activeConnection = connections.find((conn) => conn.isActive !== false);
+    if (!activeConnection) {
+      alert("Add an active Kiro connection before importing models.");
+      return;
+    }
+
+    setImportingProviderModels(true);
+    setModelsTestError("");
+    try {
+      const res = await fetch(`/api/providers/${activeConnection.id}/models`, { cache: "no-store" });
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || "Failed to import models");
+        return;
+      }
+
+      const remoteModels = Array.isArray(data.models)
+        ? data.models
+          .map((model) => {
+            const id = model?.id || model?.name || model?.model;
+            if (!id) return null;
+            return {
+              ...model,
+              id,
+              name: model?.name || model?.displayName || id,
+            };
+          })
+          .filter(Boolean)
+        : [];
+      if (remoteModels.length === 0) {
+        alert(data.warning || "No models returned from provider.");
+        return;
+      }
+
+      setImportedProviderModels(remoteModels);
+
+      let importedCount = 0;
+      let skippedCount = 0;
+      let reactivatedCount = 0;
+      const nextAliases = { ...modelAliases };
+      const disabledIds = new Set(disabledModelIds);
+
+      for (const model of remoteModels) {
+        const modelId = model.id;
+
+        const fullModel = `${providerStorageAlias}/${modelId}`;
+        if (Object.values(nextAliases).includes(fullModel)) {
+          skippedCount += 1;
+          continue;
+        }
+
+        const alias = resolveImportedModelAlias(modelId, nextAliases);
+        if (!alias) {
+          skippedCount += 1;
+          continue;
+        }
+
+        const aliasRes = await fetch("/api/models/alias", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: fullModel, alias }),
+        });
+
+        if (aliasRes.ok) {
+          nextAliases[alias] = fullModel;
+          importedCount += 1;
+        } else {
+          skippedCount += 1;
+        }
+      }
+
+      for (const model of remoteModels) {
+        if (!disabledIds.has(model.id)) continue;
+        const enableRes = await fetch(`/api/models/disabled?providerAlias=${encodeURIComponent(providerStorageAlias)}&id=${encodeURIComponent(model.id)}`, { method: "DELETE" });
+        if (enableRes.ok) {
+          reactivatedCount += 1;
+        }
+      }
+
+      await fetchAliases();
+      if (reactivatedCount > 0) await fetchDisabledModels();
+
+      if (importedCount === 0 && reactivatedCount === 0) {
+        alert(data.warning || `No new models were added.${skippedCount ? ` ${skippedCount} already existed or conflicted.` : ""}`);
+      } else if (data.warning) {
+        alert(`Imported ${importedCount} model(s), re-enabled ${reactivatedCount} model(s). Warning: ${data.warning}`);
+      }
+    } catch (error) {
+      console.log("Error importing provider models:", error);
+      alert("Failed to import models from provider.");
+    } finally {
+      setImportingProviderModels(false);
     }
   };
 
@@ -689,9 +802,10 @@ export default function ProviderDetailPage() {
     }
     // Combine hardcoded models with Kilo free models (deduplicated)
     // Exclude non-llm models (embedding, tts, etc.) — they have dedicated pages under media-providers
+    const baseModels = providerId === "kiro" && importedProviderModels.length > 0 ? importedProviderModels : models;
     const allModels = [
-      ...models,
-      ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
+      ...baseModels,
+      ...kiloFreeModels.filter((fm) => !baseModels.some((m) => m.id === fm.id)),
     ].filter((m) => !m.type || m.type === "llm");
     const disabledSet = new Set(disabledModelIds);
     const displayModels = allModels.filter((m) => !disabledSet.has(m.id));
@@ -704,8 +818,8 @@ export default function ProviderDetailPage() {
         const modelId = fullModel.slice(prefix.length);
         // Only show if not already in hardcoded list
         // For passthroughModels, include all aliases (model IDs may contain slashes like "anthropic/claude-3")
-        if (providerInfo.passthroughModels) return !models.some((m) => m.id === modelId);
-        return !models.some((m) => m.id === modelId) && alias === modelId;
+        if (providerInfo.passthroughModels) return !baseModels.some((m) => m.id === modelId);
+        return !baseModels.some((m) => m.id === modelId) && alias === modelId;
       })
       .map(([alias, fullModel]) => ({
         id: fullModel.slice(`${providerStorageAlias}/`.length),
@@ -771,7 +885,7 @@ export default function ProviderDetailPage() {
         {/* Suggested models from provider API — show only models not yet added */}
         {suggestedModels.length > 0 && (() => {
           const addedFullModels = new Set(Object.values(modelAliases));
-          const hardcodedIds = new Set(models.map((m) => m.id));
+          const hardcodedIds = new Set(baseModels.map((m) => m.id));
           const notAdded = suggestedModels.filter(
             (m) => !addedFullModels.has(`${providerStorageAlias}/${m.id}`) && !hardcodedIds.has(m.id)
           );
@@ -1126,12 +1240,24 @@ export default function ProviderDetailPage() {
           </h2>
           {!isCompatible && (() => {
             const allIds = [
-              ...models,
-              ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
+              ...(providerId === "kiro" && importedProviderModels.length > 0 ? importedProviderModels : models),
+              ...kiloFreeModels.filter((fm) => !(providerId === "kiro" && importedProviderModels.length > 0 ? importedProviderModels : models).some((m) => m.id === fm.id)),
             ].filter((m) => !m.type || m.type === "llm").map((m) => m.id);
             const activeIds = allIds.filter((id) => !disabledModelIds.includes(id));
             return (
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
+                {providerId === "kiro" && (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    icon="download"
+                    onClick={handleImportProviderModels}
+                    disabled={importingProviderModels || !connections.some((conn) => conn.isActive !== false)}
+                    title={connections.some((conn) => conn.isActive !== false) ? "Import live models from Kiro" : "Add an active Kiro connection first"}
+                  >
+                    {importingProviderModels ? "Importing..." : "Import Models"}
+                  </Button>
+                )}
                 {disabledModelIds.length > 0 && (
                   <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll}>
                     Active All


### PR DESCRIPTION
## Summary
- Fixes Kiro thinking/reasoning segment handling so streamed OpenAI-compatible responses preserve reasoning output correctly.
- Adds Kiro provider model import support in the dashboard.
- Adds alias resolution for imported Kiro models during provider model setup.

## Screenshots
Before reasoning/thinking fix:
<img width="1456" height="1034" alt="image" src="https://github.com/user-attachments/assets/9b19f43a-6c69-4eb3-88d3-fd714a8fe234" />

After reasoning/thinking fix:
<img width="1456" height="1034" alt="image" src="https://github.com/user-attachments/assets/8919ff65-08ea-4de1-b742-aeb5eb61435a" />

Import models button:
<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/b2d894cd-cba0-44b7-abd7-bd6fdaa6c7a6" />

## Notes
- Reasoning/thinking output was previously implemented incorrectly and now streams through the Kiro response path properly.
- Model import support is scoped to Kiro provider models.

## Commits
- fix(kiro): handle thinking segments
- feat(kiro): import provider models