### PR TITLE
fix(cli): stop tryRestart orphan race breaking Hide to Tray

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -255,8 +255,21 @@ function killAllAppProcesses(appPort) {
         }
       }
 
-      // Kill all found processes
+      // Kill all found processes.
+      //
+      // SIGSTOP-then-SIGKILL on Unix: if we just walk the list and SIGKILL each
+      // PID in turn, killing the next-server child first lets the parent cli.js's
+      // `server.on("close")` handler fire and run tryRestart() — spawning a new
+      // next-server with a fresh PID that's not in our kill list. The orphan
+      // keeps holding port :20128 and breaks Hide-to-Tray takeover. Freezing
+      // every matched parent first (SIGSTOP) blocks tryRestart from ever
+      // firing, so the subsequent SIGKILL is race-free.
       if (pids.length > 0) {
+        if (platform !== "win32") {
+          pids.forEach(pid => {
+            try { execSync(`kill -STOP ${pid} 2>/dev/null`, { stdio: 'ignore', timeout: 1000 }); } catch { /* already gone */ }
+          });
+        }
         pids.forEach(pid => {
           try {
             if (platform === "win32") {
@@ -709,6 +722,11 @@ function startServer(latestVersion) {
           console.log(`   • Open Dashboard`);
           console.log(`   • Quit\n`);
 
+          // Mark shutting down BEFORE cleanup: cleanup() SIGKILLs our own
+          // next-server, which would otherwise trip server.on("close") →
+          // tryRestart() and spawn a stray server that fights the detached
+          // tray process for port :20128.
+          isShuttingDown = true;
           // Exit current process - background process takes over
           cleanup();
           process.exit(0);


### PR DESCRIPTION
## Summary

Choosing **Hide to Tray** from the interactive menu intermittently left no tray icon (or a flickering one) plus a stray `next-server` holding `:20128`. Running `9router --tray` directly always worked.

Fixes #1197

## Root cause

`killAllAppProcesses()` SIGKILLs matched PIDs one-by-one via `execSync` (~10ms apart). When a cli.js parent and its next-server child are both matched and the **child dies first**, the parent's `server.on("close")` handler fires `tryRestart()` in the inter-kill gap — spawning a fresh next-server whose PID was never in the kill list. The orphan keeps `:20128` bound, so the detached `9router --tray` Hide spawns can't take over and its tray never appears. The Hide flow stacks enough overlapping instances (autostart tray + foreground menu + Hide spawn) to trigger this reliably, which is why it surfaced as an "only after updating" report.

## Fix (`cli/cli.js`, +19/-1)

- **`killAllAppProcesses`**: SIGSTOP every matched PID before the SIGKILL pass. A frozen parent cannot run `tryRestart()`, so killing the child first can no longer respawn an orphan. SIGKILL still terminates stopped processes. Windows path unchanged.
- **Hide handler**: set `isShuttingDown = true` before `cleanup()` so SIGKILLing our own next-server during handoff can't trip `tryRestart()` either.

## Test plan

Deterministic A/B isolating the exact race — worst-case ordering (child killed before parent) with execSync-equivalent ~12ms inter-kill latency, 8 trials per variant:

| variant | trials leaving an orphan next-server |
|---|---|
| current code (SIGKILL only) | **8 / 8** |
| SIGSTOP-then-SIGKILL (this PR) | **0 / 8** |

End-to-end: PTY-driven `existing tray → foreground 9router → Hide to Tray`. With the patched cli.js installed over the local v0.4.45, every run where the harness drove the menu cleanly produced a healthy tray (cli.js + next-server + tray binary) on `:20128`. `node -c` + `eslint cli/cli.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)