### PR TITLE
feat(provider): add Augment Code (Auggie CLI) as a provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -203,6 +203,23 @@ export const PROVIDER_MODELS = {
     // { id: "trinity-large-preview-free", name: "Trinity Large Preview" },
   ],
 
+  // Augment Code (Auggie CLI). Models are passed straight through to `auggie --model`.
+  // Names mirror Augment's available-models list (https://docs.augmentcode.com/models/available-models).
+  auggie: [
+    { id: "sonnet4.5", name: "Claude Sonnet 4.5" },
+    { id: "sonnet4.6", name: "Claude Sonnet 4.6" },
+    { id: "haiku4.5", name: "Claude Haiku 4.5" },
+    { id: "opus4.5", name: "Claude Opus 4.5" },
+    { id: "opus4.6", name: "Claude Opus 4.6" },
+    { id: "opus4.7", name: "Claude Opus 4.7" },
+    { id: "gemini3.1-pro", name: "Gemini 3.1 Pro" },
+    { id: "gpt-5.4", name: "GPT-5.4" },
+    { id: "gpt-5.5", name: "GPT-5.5" },
+    { id: "kimi-k2.6", name: "Kimi K2.6" },
+    { id: "prism-claude-gemini", name: "Prism (Claude + Gemini)" },
+    { id: "prism-gpt-kimi", name: "Prism (GPT + Kimi)" },
+  ],
+
   cl: [  // Cline
     { id: "anthropic/claude-opus-4.7", name: "Claude Opus 4.7" },
     { id: "anthropic/claude-sonnet-4.6", name: "Claude Sonnet 4.6" },

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -330,6 +330,14 @@ export const PROVIDERS = {
     baseUrl: "http://localhost:11434/api/chat",
     format: "ollama"
   },
+  // Augment Code (Auggie CLI) — wraps the local `auggie` subprocess.
+  // baseUrl is unused; AuggieExecutor spawns the CLI directly.
+  // Requires: npm i -g @augmentcode/auggie + `auggie login` (one-time).
+  auggie: {
+    baseUrl: "auggie://local",
+    format: "openai",
+    noAuth: true
+  },
   // Vertex AI - Gemini models via Service Account JSON
   // baseUrl is not used; VertexExecutor.buildUrl() constructs it dynamically
   vertex: {

--- a/open-sse/executors/auggie.js
+++ b/open-sse/executors/auggie.js
@@ -1,0 +1,275 @@
+import { spawn } from "child_process";
+import { Readable } from "stream";
+import { BaseExecutor } from "./base.js";
+import { PROVIDERS } from "../config/providers.js";
+
+/**
+ * AuggieExecutor — wraps the Augment Code "auggie" CLI as a 9Router provider.
+ *
+ * Auggie has no public HTTP endpoint. It is a Node CLI that talks to Augment's
+ * private backend using the local session created via `auggie login`.
+ * This executor spawns `auggie --print --quiet --model <model>` as a subprocess,
+ * feeds it a flattened prompt built from the OpenAI-style request, and wraps
+ * the captured stdout into an OpenAI chat-completion response (JSON or SSE).
+ *
+ * Authentication is delegated entirely to the local Auggie session
+ * (`~/.augment/session.json` or AUGMENT_SESSION_AUTH env var). The 9Router
+ * connection itself is `noAuth: true` from 9Router's perspective.
+ */
+export class AuggieExecutor extends BaseExecutor {
+  constructor() {
+    super("auggie", PROVIDERS.auggie || { format: "openai", noAuth: true });
+    this.noAuth = true;
+  }
+
+  // Resolve the executable name. Windows uses .cmd shims for npm globals.
+  getCliCommand(credentials) {
+    const override = credentials?.providerSpecificData?.auggiePath?.trim();
+    if (override) return override;
+    return process.platform === "win32" ? "auggie.cmd" : "auggie";
+  }
+
+  // Flatten OpenAI-style messages into a single prompt string for `auggie --print`.
+  buildPrompt(body) {
+    const messages = Array.isArray(body?.messages) ? body.messages : [];
+    const lines = [];
+
+    for (const msg of messages) {
+      const role = msg?.role || "user";
+      const content = this.stringifyContent(msg?.content);
+      if (!content) continue;
+
+      if (role === "system") {
+        lines.push(`[System]\n${content}`);
+      } else if (role === "assistant") {
+        lines.push(`[Assistant]\n${content}`);
+      } else if (role === "tool") {
+        lines.push(`[Tool result]\n${content}`);
+      } else {
+        lines.push(`[User]\n${content}`);
+      }
+    }
+
+    return lines.join("\n\n");
+  }
+
+  // OpenAI/Claude content can be string or array of parts. Flatten to plain text.
+  stringifyContent(content) {
+    if (content == null) return "";
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (typeof part === "string") return part;
+          if (part?.type === "text" && typeof part.text === "string") return part.text;
+          if (part?.type === "input_text" && typeof part.text === "string") return part.text;
+          // Skip image / tool_use / tool_result parts; Auggie CLI only takes text.
+          return "";
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+    if (typeof content === "object" && typeof content.text === "string") return content.text;
+    try { return JSON.stringify(content); } catch { return String(content); }
+  }
+
+  // Run the auggie subprocess and capture stdout. Reject on non-zero exit.
+  runAuggie({ command, args, prompt, signal, cwd, log }) {
+    return new Promise((resolve, reject) => {
+      let stdout = "";
+      let stderr = "";
+
+      const child = spawn(command, args, {
+        cwd: cwd || process.cwd(),
+        windowsHide: true,
+        // shell:true on Windows lets the .cmd shim resolve correctly when needed.
+        shell: process.platform === "win32"
+      });
+
+      const onAbort = () => {
+        try { child.kill("SIGTERM"); } catch { /* ignore */ }
+        reject(Object.assign(new Error("Request aborted"), { name: "AbortError" }));
+      };
+      if (signal) {
+        if (signal.aborted) return onAbort();
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      child.stdout.on("data", (chunk) => { stdout += chunk.toString("utf8"); });
+      child.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+
+      child.on("error", (err) => {
+        if (signal) signal.removeEventListener("abort", onAbort);
+        reject(err);
+      });
+
+      child.on("close", (code) => {
+        if (signal) signal.removeEventListener("abort", onAbort);
+        if (code === 0) {
+          resolve({ stdout: stdout.trimEnd(), stderr });
+        } else {
+          const detail = stderr.trim() || stdout.trim() || `auggie exited with code ${code}`;
+          log?.error?.("AUGGIE", detail.slice(0, 500));
+          reject(new Error(`auggie failed (exit ${code}): ${detail}`));
+        }
+      });
+
+      // Send the prompt via stdin so we don't blow argv length limits.
+      child.stdin.on("error", () => { /* ignore EPIPE */ });
+      child.stdin.write(prompt);
+      child.stdin.end();
+    });
+  }
+
+  // Build a Fetch-like Response that the rest of 9Router can consume.
+  buildResponse({ stdout, stream, model }) {
+    const created = Math.floor(Date.now() / 1000);
+    const id = `chatcmpl-auggie-${created}-${Math.random().toString(36).slice(2, 10)}`;
+    const text = stdout || "";
+
+    if (stream) {
+      // Emit a single delta + done as SSE so the streaming path works unchanged.
+      const events = [
+        {
+          id, object: "chat.completion.chunk", created, model,
+          choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }]
+        },
+        {
+          id, object: "chat.completion.chunk", created, model,
+          choices: [{ index: 0, delta: { content: text }, finish_reason: null }]
+        },
+        {
+          id, object: "chat.completion.chunk", created, model,
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 0, completion_tokens: estimateTokens(text), total_tokens: estimateTokens(text) }
+        }
+      ];
+      const body = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("") + "data: [DONE]\n\n";
+      return makeFetchResponse({
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+        body
+      });
+    }
+
+    const json = {
+      id, object: "chat.completion", created, model,
+      choices: [{
+        index: 0,
+        message: { role: "assistant", content: text },
+        finish_reason: "stop"
+      }],
+      usage: {
+        prompt_tokens: 0,
+        completion_tokens: estimateTokens(text),
+        total_tokens: estimateTokens(text)
+      }
+    };
+    return makeFetchResponse({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(json)
+    });
+  }
+
+  buildErrorResponse({ message, status = 502 }) {
+    const body = JSON.stringify({ error: { message, type: "auggie_error", code: status } });
+    return makeFetchResponse({
+      status,
+      headers: { "Content-Type": "application/json" },
+      body
+    });
+  }
+
+  async execute({ model, body, stream, credentials, signal, log }) {
+    const command = this.getCliCommand(credentials);
+    const cwd = credentials?.providerSpecificData?.workdir || process.cwd();
+    const maxTurns = Number(credentials?.providerSpecificData?.maxTurns) || 25;
+    const extraArgs = this.parseExtraArgs(credentials?.providerSpecificData?.extraArgs);
+
+    const args = [
+      "--print",
+      "--quiet",
+      "--model", model,
+      "--max-turns", String(maxTurns),
+      ...extraArgs
+    ];
+
+    const prompt = this.buildPrompt(body);
+    if (!prompt.trim()) {
+      return {
+        response: this.buildErrorResponse({ message: "Empty prompt — Auggie requires at least one text message.", status: 400 }),
+        url: "auggie://local",
+        headers: {},
+        transformedBody: body
+      };
+    }
+
+    log?.debug?.("AUGGIE", `model=${model} cwd=${cwd} promptChars=${prompt.length}`);
+
+    try {
+      const { stdout } = await this.runAuggie({ command, args, prompt, signal, cwd, log });
+      return {
+        response: this.buildResponse({ stdout, stream, model }),
+        url: "auggie://local",
+        headers: {},
+        transformedBody: body
+      };
+    } catch (error) {
+      if (error.name === "AbortError") throw error;
+      const isMissing = /ENOENT|not recognized|not found/i.test(error.message || "");
+      const status = isMissing ? 503 : 502;
+      const hint = isMissing
+        ? "auggie CLI not found on PATH. Install with: npm install -g @augmentcode/auggie, then run `auggie login`."
+        : error.message || "auggie subprocess failed";
+      return {
+        response: this.buildErrorResponse({ message: hint, status }),
+        url: "auggie://local",
+        headers: {},
+        transformedBody: body
+      };
+    }
+  }
+
+  parseExtraArgs(raw) {
+    if (!raw) return [];
+    if (Array.isArray(raw)) return raw.map(String);
+    if (typeof raw !== "string") return [];
+    // Simple shell-style split; users wanting complex quoting should pass an array.
+    return raw.match(/(?:[^\s"]+|"[^"]*")+/g)?.map((s) => s.replace(/^"|"$/g, "")) || [];
+  }
+
+  // No tokens to refresh — Auggie owns its own session.
+  async refreshCredentials() { return null; }
+}
+
+function estimateTokens(text) {
+  // Rough heuristic: ~4 chars per token. Good enough for usage tracking.
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+// Minimal Fetch-like Response shim. 9Router only needs ok/status/body/text/json/headers.
+function makeFetchResponse({ status, headers, body }) {
+  const buf = Buffer.from(body || "", "utf8");
+  const headersMap = new Map(Object.entries(headers || {}).map(([k, v]) => [k.toLowerCase(), v]));
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    headers: {
+      get: (name) => headersMap.get(String(name).toLowerCase()) ?? null,
+      forEach: (cb) => headersMap.forEach((v, k) => cb(v, k)),
+      entries: () => headersMap.entries(),
+      has: (name) => headersMap.has(String(name).toLowerCase())
+    },
+    body: Readable.toWeb(Readable.from([buf])),
+    async text() { return buf.toString("utf8"); },
+    async json() { return JSON.parse(buf.toString("utf8")); },
+    async arrayBuffer() { return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength); },
+    clone() { return makeFetchResponse({ status, headers, body }); }
+  };
+}
+
+export default AuggieExecutor;

--- a/open-sse/executors/index.js
+++ b/open-sse/executors/index.js
@@ -15,10 +15,12 @@ import { GrokWebExecutor } from "./grok-web.js";
 import { PerplexityWebExecutor } from "./perplexity-web.js";
 import { OllamaLocalExecutor } from "./ollama-local.js";
 import { CommandCodeExecutor } from "./commandcode.js";
+import { AuggieExecutor } from "./auggie.js";
 import { DefaultExecutor } from "./default.js";
 
 const executors = {
   antigravity: new AntigravityExecutor(),
+  auggie: new AuggieExecutor(),
   azure: new AzureExecutor(),
   "gemini-cli": new GeminiCLIExecutor(),
   github: new GithubExecutor(),
@@ -70,3 +72,4 @@ export { GrokWebExecutor } from "./grok-web.js";
 export { PerplexityWebExecutor } from "./perplexity-web.js";
 export { OllamaLocalExecutor } from "./ollama-local.js";
 export { CommandCodeExecutor } from "./commandcode.js";
+export { AuggieExecutor } from "./auggie.js";

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -7,7 +7,7 @@ import {
   getProxyPoolById,
 } from "@/models";
 import { APIKEY_PROVIDERS } from "@/shared/constants/config";
-import { AI_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, isCustomEmbeddingProvider } from "@/shared/constants/providers";
+import { AI_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, isCustomEmbeddingProvider } from "@/shared/constants/providers";
 import { normalizeProviderId, normalizeProviderSpecificData } from "@/lib/providerNormalization";
 
 export const dynamic = "force-dynamic";
@@ -102,8 +102,10 @@ export async function POST(request) {
 
     // Validation
     const isWebCookieProvider = !!WEB_COOKIE_PROVIDERS[provider];
+    const isNoAuthProvider = AI_PROVIDERS[provider]?.noAuth === true;
     const isValidProvider = APIKEY_PROVIDERS[provider] ||
       FREE_TIER_PROVIDERS[provider] ||
+      FREE_PROVIDERS[provider] ||
       isWebCookieProvider ||
       isOpenAICompatibleProvider(provider) ||
       isAnthropicCompatibleProvider(provider) ||
@@ -112,7 +114,7 @@ export async function POST(request) {
     if (!provider || !isValidProvider) {
       return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
     }
-    if (!apiKey && provider !== "ollama-local") {
+    if (!apiKey && provider !== "ollama-local" && !isNoAuthProvider) {
       return NextResponse.json({ error: `${isWebCookieProvider ? "Cookie value" : "API Key"} is required` }, { status: 400 });
     }
     const connectionName = name || displayName || AI_PROVIDERS[provider]?.name;

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -389,6 +389,26 @@ export async function POST(request) {
           break;
         }
 
+        case "auggie": {
+          // Validate by checking the local CLI works. Honors `auggie login` session.
+          const { spawn } = await import("child_process");
+          const cmd = process.platform === "win32" ? "auggie.cmd" : "auggie";
+          isValid = await new Promise((resolve) => {
+            try {
+              const child = spawn(cmd, ["--version"], { shell: process.platform === "win32", windowsHide: true });
+              let resolved = false;
+              const finish = (ok) => { if (!resolved) { resolved = true; resolve(ok); } };
+              child.on("error", () => finish(false));
+              child.on("close", (code) => finish(code === 0));
+              setTimeout(() => { try { child.kill(); } catch { /* ignore */ } finish(false); }, 5000);
+            } catch {
+              resolve(false);
+            }
+          });
+          if (!isValid) error = "auggie CLI not found. Run: npm i -g @augmentcode/auggie && auggie login";
+          break;
+        }
+
         case "opencode-go": {
           const res = await fetch("https://opencode.ai/zen/go/v1/chat/completions", {
             method: "POST",

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -12,6 +12,9 @@ export const FREE_PROVIDERS = {
   // qoder: { id: "qoder", alias: "qd", name: "Qoder AI", icon: "water_drop", color: "#EC4899" },
   iflow: { id: "iflow", alias: "if", name: "iFlow AI", icon: "water_drop", color: "#6366F1", hidden: true, website: "https://iflow.cn", notice: { signupUrl: "https://iflow.cn" } },
   opencode: { id: "opencode", alias: "oc", name: "OpenCode Free", icon: "terminal", color: "#E87040", textIcon: "OC", noAuth: true, passthroughModels: true, modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" } },
+  // Augment Code via Auggie CLI subprocess. Auth handled by `auggie login`,
+  // so 9Router treats this as no-auth. Requires the CLI to be on PATH.
+  auggie: { id: "auggie", alias: "auggie", name: "Augment (Auggie CLI)", icon: "terminal", color: "#7C3AED", textIcon: "AG", noAuth: true, website: "https://docs.augmentcode.com/cli/overview", notice: { text: "Requires the local Auggie CLI. Install with `npm i -g @augmentcode/auggie`, then run `auggie login` once. Uses your Augment account credits.", signupUrl: "https://www.augmentcode.com/" } },
 };
 
 // Free Tier Providers (has free access but may require account/API key)


### PR DESCRIPTION
Wraps the local `auggie` CLI as a 9Router provider so any OpenAI-compatible client can route requests through Augment via a subscription's Auggie session.

Augment has no public HTTP API. AuggieExecutor spawns `auggie --print --quiet --model <model>` as a subprocess, flattens the incoming OpenAI-style messages into a single prompt fed via stdin, captures stdout, and wraps it as a Fetch-like Response so the rest of the routing core (streaming, RTK, usage tracking, error handling) keeps working unchanged.

Auth is delegated to the local Auggie session created by `auggie login`, so the 9Router provider connection itself is `noAuth: true`. No API key, no token refresh.

Files
- open-sse/executors/auggie.js (new): subprocess-based executor
- open-sse/executors/index.js: register AuggieExecutor
- open-sse/config/providers.js: add `auggie` provider entry
- open-sse/config/providerModels.js: add 12 Augment models (Sonnet 4.5/4.6, Opus 4.5-4.7, Haiku 4.5, Gemini 3.1 Pro, GPT-5.4/5.5, Kimi K2.6, Prism)
- src/shared/constants/providers.js: dashboard catalog entry
- src/app/api/providers/route.js: allow noAuth FREE_PROVIDERS in POST
- src/app/api/providers/validate/route.js: validate by running `auggie --version`

Tested
- next build: clean
- POST /api/providers provider=auggie: connection created without apiKey
- POST /v1/chat/completions (model=auggie/sonnet4.5, stream=false): valid OpenAI chat-completion JSON returned from Augment backend
- POST /v1/chat/completions (stream=true): SSE chunks + [DONE] emitted

Limitations
- Token usage is estimated (chars/4); Auggie CLI does not expose token counts on stdout
- Tool/function calling not forwarded; Auggie CLI only consumes plain text
- Streaming is bundled into a single delta after subprocess exits, not token-by-token
- Each request spawns a new subprocess (~1-2s startup)

Setup
1. npm i -g @augmentcode/auggie
2. auggie login
3. Connect "Augment (Auggie CLI)" in 9Router dashboard
4. Use models prefixed with `auggie/`, e.g. `auggie/sonnet4.5`