### PR TITLE
fix(models): use public v1 endpoints for reachability tests

### DIFF
--- a/src/app/api/models/test/route.js
+++ b/src/app/api/models/test/route.js
@@ -29,7 +29,7 @@ export async function POST(request) {
 
     // Route to appropriate endpoint based on kind
     if (kind === "embedding") {
-      const res = await fetch(`${baseUrl}/api/v1/embeddings`, {
+      const res = await fetch(`${baseUrl}/v1/embeddings`, {
         method: "POST",
         headers,
         body: JSON.stringify({ model, input: "test" }),
@@ -52,7 +52,7 @@ export async function POST(request) {
     }
 
     // Default: chat completions
-    const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
+    const res = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: "POST",
       headers,
       body: JSON.stringify({

--- a/src/app/api/providers/[id]/test-models/route.js
+++ b/src/app/api/providers/[id]/test-models/route.js
@@ -25,7 +25,7 @@ async function pingModel(modelId, baseUrl, apiKey, cliToken) {
     const headers = { "Content-Type": "application/json" };
     if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
     if (cliToken) headers["x-9r-cli-token"] = cliToken;
-    const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
+    const res = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: "POST",
       headers,
       body: JSON.stringify({
@@ -53,7 +53,7 @@ async function pingModel(modelId, baseUrl, apiKey, cliToken) {
 /**
  * POST /api/providers/[id]/test-models
  * id = connectionId — used only to resolve provider + model list.
- * Actual requests go through /api/v1/chat/completions (open-sse handles everything).
+ * Actual requests go through /v1/chat/completions (open-sse handles everything).
  */
 export async function POST(request, { params }) {
   try {

--- a/tests/unit/model-test-public-v1.test.js
+++ b/tests/unit/model-test-public-v1.test.js
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readRepoFile(path) {
+  return readFileSync(fileURLToPath(new URL(`../../${path}`, import.meta.url)), "utf8");
+}
+
+describe("model test routes", () => {
+  it("uses the public /v1 endpoints for internal model reachability checks", () => {
+    const route = readRepoFile("src/app/api/models/test/route.js");
+
+    expect(route).toContain("`${baseUrl}/v1/chat/completions`");
+    expect(route).toContain("`${baseUrl}/v1/embeddings`");
+    expect(route).not.toContain("`${baseUrl}/api/v1/chat/completions`");
+    expect(route).not.toContain("`${baseUrl}/api/v1/embeddings`");
+  });
+
+  it("uses the public /v1 endpoint when testing provider model lists", () => {
+    const route = readRepoFile("src/app/api/providers/[id]/test-models/route.js");
+
+    expect(route).toContain("`${baseUrl}/v1/chat/completions`");
+    expect(route).not.toContain("`${baseUrl}/api/v1/chat/completions`");
+  });
+});


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Route model reachability checks through the public `/v1` API endpoints instead of the dashboard-protected `/api/v1` paths
- Update provider model-list testing to use `/v1/chat/completions` consistently
- Add a regression test that guards these internal model test routes from switching back to `/api/v1`

Fixes decolua/9router#1156.

## Test Plan
- `node --check /tmp/9router_1156_patchwork/src/app/api/models/test/route.js`
- `node --check /tmp/9router_1156_patchwork/src/app/api/providers/[id]/test-models/route.js`
- `node --check /tmp/9router_1156_patchwork/tests/unit/model-test-public-v1.test.js`
- Local regression assertion that model test routes contain `/v1/...` and do not contain `/api/v1/...`

## Notes
- This keeps the change narrow to the internal model testing paths reported in #1156.
