### PR TITLE
fix: handle OpenClaw object-format model in cli-tools/openclaw-settings route

### DIFF
--- a/src/app/api/cli-tools/openclaw-settings/route.js
+++ b/src/app/api/cli-tools/openclaw-settings/route.js
@@ -9,6 +9,15 @@ import os from "os";
 
 const execAsync = promisify(exec);
 
+// OpenClaw 2026.5.x writes agents[].model as either a plain string
+// (legacy) or as an object `{ primary, fallbacks }`. Normalize to the
+// string id so downstream consumers can call `.startsWith()` safely.
+const resolveAgentModel = (m) => {
+  if (typeof m === "string") return m;
+  if (m && typeof m === "object") return m.primary ?? "";
+  return "";
+};
+
 const getOpenClawDir = () => path.join(os.homedir(), ".openclaw");
 const getOpenClawSettingsPath = () => path.join(getOpenClawDir(), "openclaw.json");
 
@@ -79,12 +88,14 @@ export async function GET() {
 
     const settings = await readSettings();
 
-    // Enrich agents list with current per-agent model from models.json
+    // Enrich agents list with current per-agent model from models.json.
+    // Coerce agent.model to its string id when OpenClaw stores it as
+    // `{ primary, fallbacks }` so downstream `.startsWith()` calls work.
     const agentList = settings?.agents?.list || [];
     const enrichedAgents = await Promise.all(
       agentList.map(async (agent) => {
         const agentModel = agent.agentDir ? await readAgentModel(agent.agentDir) : null;
-        return { ...agent, currentModel: agentModel };
+        return { ...agent, model: resolveAgentModel(agent.model), currentModel: agentModel };
       })
     );
 
@@ -169,10 +180,11 @@ export async function POST(request) {
       settings.agents.defaults.models[`9router/${m}`] = {};
     });
 
-    // Remove old 9router model from each agent in agents.list
+    // Remove old 9router model from each agent in agents.list. The
+    // model field may be a plain string or `{ primary, fallbacks }`.
     if (settings.agents.list) {
       settings.agents.list = settings.agents.list.map((agent) => {
-        if (agent.model?.startsWith("9router/")) {
+        if (resolveAgentModel(agent.model).startsWith("9router/")) {
           const { model: _, ...rest } = agent;
           return rest;
         }


### PR DESCRIPTION
## Summary

Normalize `agent.model` in `src/app/api/cli-tools/openclaw-settings/route.js` so the dashboard and POST handler work when OpenClaw 2026.5.x writes the field as `{ primary, fallbacks }` instead of a plain string. Without this, the GET enrichment ships an object down to the client and the POST `.startsWith("9router/")` filter throws `TypeError: model?.startsWith is not a function`.

## Why this matters

Issue #1196 reports `TypeError: model?.startsWith is not a function` on the status poll loop and "not configured" in the dashboard when the local OpenClaw config holds `model: { primary: "...", fallbacks: [...] }`. The reporter included the stack trace, the config shape, and the expected behavior (read the active id from `model.primary`).

## Implementation notes

Added a `resolveAgentModel` helper at the top of `src/app/api/cli-tools/openclaw-settings/route.js`:

- Returns the string unchanged when `typeof m === "string"`.
- Returns `m.primary ?? ""` when `m` is an object.
- Returns `""` otherwise (covers `undefined`, `null`, `{}`).

Applied in two places:

1. GET enrichment loop: the `model` field on each enriched agent is now coerced to its string id, so the dashboard receives a string.
2. POST `9router/` cleanup: the `.startsWith("9router/")` check now runs on the resolved string.

The plan's `Files:` scope also listed `src/app/api/cli-tools/all-statuses/route.js`, but that file is a pure dispatcher that does not inspect model fields itself - the normalized values reach it through the openclaw GET it invokes, so no change was needed there.

## Testing

- `npm run lint` clean on the changed file.
- Verified the three test scenarios from the issue by reading the diff:
  - String form: `resolveAgentModel("custom-localhost-20128/gh/gpt-4o-mini")` returns the input; existing path unchanged.
  - Object form: `resolveAgentModel({ primary: "9router/...", fallbacks: [...] })` returns `"9router/..."`; the `.startsWith("9router/")` filter matches.
  - Missing model (`undefined`, `null`, `{}`): returns `""`; `.startsWith` is a no-op and no exception is thrown.

Fixes #1196
