### PR TITLE
fix: make db.json to SQLite migration atomic with row-count assertion

### DIFF
--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -11,6 +11,17 @@ import { stringifyJson } from "./helpers/jsonCol.js";
 // Marker file: prevents re-importing legacy JSON when user wipes data.sqlite.
 const MIGRATED_MARKER = path.join(DB_DIR, ".migrated-from-json");
 
+// Thrown by importLegacyMain when row-count assertion fails.
+// The legacy db.json is left intact and the marker is not written so the
+// next boot can retry (or the user can restore from backup).
+export class MigrationAborted extends Error {
+  constructor(message, droppedRows) {
+    super(message);
+    this.name = "MigrationAborted";
+    this.droppedRows = droppedRows;
+  }
+}
+
 // Track per-adapter so reusing same adapter skips re-run, but new adapter (after reset) re-runs.
 const _migratedAdapters = new WeakSet();
 
@@ -91,11 +102,30 @@ function importLegacyMain(adapter, data) {
   if (data.settings) {
     adapter.run(`INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`, [stringifyJson(data.settings)]);
   }
-  for (const c of data.providerConnections || []) {
+  const droppedConnections = [];
+  const inputConnections = data.providerConnections || [];
+  for (const c of inputConnections) {
     const { id, provider, authType, name, email, priority, isActive, createdAt, updatedAt, ...rest } = c;
-    adapter.run(
-      `INSERT OR REPLACE INTO providerConnections(id, provider, authType, name, email, priority, isActive, data, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [id, provider, authType || "oauth", name || null, email || null, priority || null, isActive === false ? 0 : 1, stringifyJson(rest), createdAt || new Date().toISOString(), updatedAt || new Date().toISOString()]
+    try {
+      adapter.run(
+        `INSERT OR REPLACE INTO providerConnections(id, provider, authType, name, email, priority, isActive, data, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [id, provider, authType || "oauth", name || null, email || null, priority || null, isActive === false ? 0 : 1, stringifyJson(rest), createdAt || new Date().toISOString(), updatedAt || new Date().toISOString()]
+      );
+    } catch (err) {
+      droppedConnections.push({ id: id ?? null, provider: provider ?? null, name: name ?? null, reason: err.message });
+    }
+  }
+  // Row-count assertion: if any providerConnections rows failed to insert,
+  // abort the migration so the legacy db.json stays the source of truth.
+  const insertedCount = adapter.get(`SELECT COUNT(*) as c FROM providerConnections`)?.c ?? 0;
+  if (insertedCount !== inputConnections.length) {
+    console.warn(
+      `[DB][migrate] providerConnections row-count mismatch: expected ${inputConnections.length}, got ${insertedCount}. Dropped rows:`,
+      droppedConnections
+    );
+    throw new MigrationAborted(
+      `providerConnections row-count mismatch: expected ${inputConnections.length}, got ${insertedCount}`,
+      droppedConnections
     );
   }
   for (const n of data.providerNodes || []) {
@@ -210,14 +240,25 @@ export async function runMigrationOnce(adapter) {
     const backupDir = makeBackupDir("migrate-from-json");
     for (const f of Object.values(LEGACY_FILES)) backupFile(f, backupDir);
 
-    adapter.transaction(() => {
-      importLegacyMain(adapter, legacyMain);
-      importLegacyUsage(adapter, legacyUsage);
-      importLegacyDisabled(adapter, legacyDisabled);
-      importLegacyDetails(adapter, legacyDetails);
-      setMetaSync(adapter, "appVersion", getAppVersion());
-      setMetaSync(adapter, "migratedAt", new Date().toISOString());
-    });
+    try {
+      adapter.transaction(() => {
+        importLegacyMain(adapter, legacyMain);
+        importLegacyUsage(adapter, legacyUsage);
+        importLegacyDisabled(adapter, legacyDisabled);
+        importLegacyDetails(adapter, legacyDetails);
+        setMetaSync(adapter, "appVersion", getAppVersion());
+        setMetaSync(adapter, "migratedAt", new Date().toISOString());
+      });
+    } catch (err) {
+      if (err instanceof MigrationAborted) {
+        // Transaction was rolled back by the throw; leave legacy db.json
+        // intact and skip the marker so the app keeps reading from JSON
+        // (or the user can retry after fixing the offending rows).
+        console.error(`[DB][migrate] aborted: ${err.message} | legacy JSON kept | backup: ${backupDir}`);
+        return;
+      }
+      throw err;
+    }
 
     try { fs.writeFileSync(MIGRATED_MARKER, new Date().toISOString()); } catch {}
     pruneOldBackups();

--- a/tests/unit/db-migration-chain.test.js
+++ b/tests/unit/db-migration-chain.test.js
@@ -83,6 +83,47 @@ describe("Schema migrations", () => {
     expect(aliases).toHaveLength(1);
   });
 
+  it("legacy db.json with invalid providerConnection → aborts migration and leaves db.json intact", async () => {
+    // 5 valid + 1 invalid (missing id, will violate PRIMARY KEY) providerConnections
+    const validConn = (id, provider) => ({
+      id,
+      provider,
+      authType: "oauth",
+      name: `${provider}-${id}`,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    const legacy = {
+      providerConnections: [
+        validConn("c1", "nvidia"),
+        validConn("c2", "gemini"),
+        validConn("c3", "kiro"),
+        validConn("c4", "fireworks"),
+        validConn("c5", "fireworks"),
+        // invalid: null id violates PRIMARY KEY on providerConnections.id
+        { id: null, provider: "broken", authType: "oauth", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      ],
+    };
+    const legacyJsonPath = path.join(tempDir, "db.json");
+    const legacyJsonContent = JSON.stringify(legacy);
+    fs.writeFileSync(legacyJsonPath, legacyJsonContent);
+
+    const { getAdapter } = await import("@/lib/db/driver.js");
+    const db = await getAdapter();
+
+    // After abort the providerConnections table should be empty (transaction rolled back)
+    const rows = db.all(`SELECT * FROM providerConnections`);
+    expect(rows).toHaveLength(0);
+
+    // Legacy db.json must be untouched
+    expect(fs.existsSync(legacyJsonPath)).toBe(true);
+    expect(fs.readFileSync(legacyJsonPath, "utf-8")).toBe(legacyJsonContent);
+
+    // Marker should NOT have been written so the next boot can retry
+    const marker = path.join(tempDir, "db", ".migrated-from-json");
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
   it("auto-sync re-creates missing index when DB lacks it", async () => {
     const { getAdapter } = await import("@/lib/db/driver.js");
     const db = await getAdapter();


### PR DESCRIPTION
## Summary

Make the `db.json` to SQLite migration in `src/lib/db/migrate.js` fail closed when `providerConnections` row counts diverge. The migration now collects per-row insert failures, asserts the post-loop `COUNT(*)` matches the input array length, and lets the surrounding transaction roll back on mismatch so the legacy `db.json` is preserved byte-for-byte.

## Why this matters

Issue #1192 reports that upgrading from 0.4.41 to 0.4.50 silently dropped five `providerConnections` rows (`nvidia/nvidia`, `gemini/hermes`, `kiro/Account 1`, `fireworks/hermes`, `fireworks/bruko`) and started returning HTTP 401 for models that had been routing via fallback chains. The reporter's expected behavior: assert row counts, abort on mismatch, leave `db.json` intact, and log every dropped row with a reason.

## Implementation notes

- The migration already runs inside `adapter.transaction`. The SQLite transaction rollback acts as the atomic-swap mechanism; on `MigrationAborted` the partial inserts disappear and the final SQLite table state is empty, functionally equivalent to the temp-file plus rename pattern suggested in the issue and matching the existing driver convention.
- Wrapped the per-row `providerConnections` insert in `try`/`catch`, collecting `{ id, provider, name, reason }` for any row that fails.
- After the loop, `SELECT COUNT(*) FROM providerConnections` is compared against the input array length. On mismatch, the dropped-row list is logged and `MigrationAborted` is thrown.
- The outer `try`/`catch` in `runMigrationOnce` catches `MigrationAborted`, logs it, and returns without writing the `.migrated-from-json` marker. Next boot the app reads from `db.json` again as the issue requires.

## Testing

Added `tests/unit/db-migration-chain.test.js` covering the mismatch path:

- Fixture: 5 valid `providerConnections` plus one row that triggers a primary-key violation.
- Asserts:
  - the `providerConnections` SQLite table is empty after rollback,
  - `db.json` is byte-identical to the pre-migration state,
  - the `.migrated-from-json` marker file is absent.

`package.json` does not currently expose a `test` script, so the test was added per the plan but not executed locally.

Fixes #1192
