### PR TITLE
fix: keep usage > details pagination inside mobile viewport

### DIFF
--- a/src/shared/components/Pagination.js
+++ b/src/shared/components/Pagination.js
@@ -37,7 +37,7 @@ export default function Pagination({
   return (
     <div
       className={cn(
-        "flex flex-col sm:flex-row items-center justify-between gap-4 py-4",
+        "flex flex-col sm:flex-row items-center justify-between gap-4 py-4 px-2",
         className
       )}
     >
@@ -50,7 +50,7 @@ export default function Pagination({
         </div>
       )}
 
-      <div className="flex items-center gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4">
         {/* Page size selector */}
         {onPageSizeChange && (
           <div className="flex items-center gap-2">
@@ -92,12 +92,12 @@ export default function Pagination({
                   variant="ghost"
                   size="sm"
                   onClick={() => onPageChange(1)}
-                  className="w-9 px-0"
+                  className="w-9 px-0 hidden sm:inline-flex"
                 >
                   1
                 </Button>
                 {pageNumbers[0] > 2 && (
-                  <span className="text-text-muted px-1">...</span>
+                  <span className="text-text-muted px-1 hidden sm:inline">...</span>
                 )}
               </>
             )}
@@ -108,7 +108,10 @@ export default function Pagination({
                 variant={currentPage === page ? "primary" : "ghost"}
                 size="sm"
                 onClick={() => onPageChange(page)}
-                className="w-9 px-0"
+                className={cn(
+                  "w-9 px-0",
+                  currentPage === page ? "inline-flex" : "hidden sm:inline-flex"
+                )}
               >
                 {page}
               </Button>
@@ -117,13 +120,13 @@ export default function Pagination({
             {pageNumbers[pageNumbers.length - 1] < totalPages && (
               <>
                 {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
-                  <span className="text-text-muted px-1">...</span>
+                  <span className="text-text-muted px-1 hidden sm:inline">...</span>
                 )}
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => onPageChange(totalPages)}
-                  className="w-9 px-0"
+                  className="w-9 px-0 hidden sm:inline-flex"
                 >
                   {totalPages}
                 </Button>


### PR DESCRIPTION
## Summary

Tailwind-class fix in `src/shared/components/Pagination.js` so the pagination row in Dashboard > Usage > Details stays inside the card on mobile viewports. Hides the numeric page buttons, ellipses, and first/last anchors below `sm`, wraps the inner controls, and adds `px-2` so the `Rows:` label and next chevron are no longer clipped.

## Why this matters

Issue #1146 reports that on mobile (<=390px) the pagination row in Usage > Details overflows the viewport on both sides: the `Rows:` label is clipped on the left and the next chevron is clipped on the right because the rows-per-page select plus the full `< 1 2 3 4 5 ... 100 >` numbered list render in a single flex row with no horizontal padding. The reporter included a screenshot and offered a PR.

## Implementation notes

The plan pointed at `src/app/(dashboard)/dashboard/usage/details/page.js`, which does not exist in this version of the repo. The plan explicitly allowed the fix to land in the child component instead. Usage > Details is rendered by `src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js`, which imports a single shared `Pagination` from `src/shared/components/Pagination.js`. That `Pagination` has one consumer (verified by grep), so the four CSS adjustments from the plan were applied directly there:

- `px-2` on the outer container so labels and chevrons clear the card edge.
- `flex-wrap` + `justify-center` on the inner controls so the rows-per-page select wraps under the page list at narrow widths.
- `hidden sm:inline-flex` on the numeric page buttons, the first/last anchor buttons, and the ellipses so they only render at >=640px. The current page button stays visible on mobile via a conditional class.
- Desktop layout above `sm` is unchanged.

## Testing

- `npm run lint` clean on the changed file.
- Walked through the diff against the test scenarios from the issue:
  - 320-390px: only the `Rows:` select, prev/next chevrons, and the current-page indicator render; the numeric list and ellipses are hidden, so the row fits in a 320px viewport.
  - 640px and up: numeric buttons, ellipses, and first/last anchors reappear; layout matches current desktop behavior.
- Keyboard tab order is preserved: hidden buttons are removed from the layout (Tailwind `hidden`), not just visually offscreen.

Fixes #1146
