### PR TITLE
fix(oauth): align antigravity OAuth metadata to prevent Google blocking

### DIFF
--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -305,11 +305,7 @@ async function getGeminiSubscriptionInfo(accessToken, proxyOptions = null) {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          metadata: {
-            ideType: "IDE_UNSPECIFIED",
-            platform: "PLATFORM_UNSPECIFIED",
-            pluginType: "GEMINI",
-          },
+          metadata: CLIENT_METADATA,
         }),
         signal: controller.signal,
       },

--- a/src/lib/oauth/constants/oauth.js
+++ b/src/lib/oauth/constants/oauth.js
@@ -108,8 +108,8 @@ export const ANTIGRAVITY_CONFIG = {
   onboardUserEndpoint: "https://cloudcode-pa.googleapis.com/v1internal:onboardUser",
   loadCodeAssistUserAgent: "google-api-nodejs-client/9.15.1",
   loadCodeAssistApiClient: "google-cloud-sdk vscode_cloudshelleditor/0.1",
-  // String enum matches CLIProxyAPI Go source (internal/auth/antigravity/constants.go)
-  loadCodeAssistClientMetadata: JSON.stringify({ ideType: "IDE_UNSPECIFIED", platform: "PLATFORM_UNSPECIFIED", pluginType: "GEMINI" }),
+  // Numeric enums matching Antigravity binary ClientMetadata (see getOAuthClientMetadata below)
+  loadCodeAssistClientMetadata: JSON.stringify({ ideType: 9, platform: getOAuthPlatformEnum(), pluginType: 2 }),
 };
 
 /**

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -23,6 +23,7 @@ import {
   CLINE_CONFIG,
   GITLAB_CONFIG,
   CODEBUDDY_CONFIG,
+  getOAuthClientMetadata,
 } from "./constants/oauth";
 
 const BASE64_BLOCK_SIZE = 4;
@@ -306,7 +307,7 @@ const PROVIDERS = {
       return await response.json();
     },
     postExchange: async (tokens) => {
-      // Matches CLIProxyAPI Go source: string enum, no mode field
+      // Numeric enums matching Antigravity binary ClientMetadata
       const loadHeaders = {
         "Authorization": `Bearer ${tokens.access_token}`,
         "Content-Type": "application/json",
@@ -315,7 +316,7 @@ const PROVIDERS = {
         "Client-Metadata": ANTIGRAVITY_CONFIG.loadCodeAssistClientMetadata,
         "x-request-source": "local",
       };
-      const metadata = { ideType: "IDE_UNSPECIFIED", platform: "PLATFORM_UNSPECIFIED", pluginType: "GEMINI" };
+      const metadata = getOAuthClientMetadata();
 
       // Fetch user info
       const userInfoRes = await fetch(`${ANTIGRAVITY_CONFIG.userInfoUrl}?alt=json`, {

--- a/src/lib/oauth/services/antigravity.js
+++ b/src/lib/oauth/services/antigravity.js
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import open from "open";
-import { ANTIGRAVITY_CONFIG } from "../constants/oauth.js";
+import { ANTIGRAVITY_CONFIG, getOAuthClientMetadata } from "../constants/oauth.js";
 import { getServerCredentials } from "../config/index.js";
 import { startLocalServer } from "../utils/server.js";
 import { spinner as createSpinner } from "../utils/ui.js";
@@ -92,14 +92,10 @@ export class AntigravityService {
 
   /**
    * Get metadata object for loadCodeAssist / onboardUser API calls.
-   * Uses string enum values matching CLIProxyAPI Go source.
+   * Uses numeric enum values matching Antigravity binary ClientMetadata.
    */
   getMetadata() {
-    return {
-      ideType: "IDE_UNSPECIFIED",
-      platform: "PLATFORM_UNSPECIFIED",
-      pluginType: "GEMINI",
-    };
+    return getOAuthClientMetadata();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #1226

The Antigravity OAuth flow sent inconsistent client metadata between the **token acquisition phase** and the **API usage phase**. String enum values (`IDE_UNSPECIFIED`, `PLATFORM_UNSPECIFIED`) were used during OAuth token exchange + `loadCodeAssist` + `onboardUser`, while numeric enums (`ideType: 9`, `platform: <computed>`, `pluginType: 2`) were used in runtime API calls. Google detected this fingerprint mismatch and blocked 9router accounts.

## Root Cause

During the OAuth flow, the `Client-Metadata` header and request body sent:
```json
{"ideType": "IDE_UNSPECIFIED", "platform": "PLATFORM_UNSPECIFIED", "pluginType": "GEMINI"}
```

But subsequent API calls from `appConstants.js` sent:
```json
{"ideType": 9, "platform": 3, "pluginType": 2}
```

Google correlates the token with these inconsistent fingerprints and flags the account.

## Changes

All `IDE_UNSPECIFIED` / `PLATFORM_UNSPECIFIED` string enums replaced with the correct numeric values:

| File | Change |
|------|--------|
| `src/lib/oauth/constants/oauth.js` | `loadCodeAssistClientMetadata` now uses `getOAuthPlatformEnum()` + numeric `9`/`2` |
| `src/lib/oauth/services/antigravity.js` | `getMetadata()` now delegates to `getOAuthClientMetadata()` |
| `src/lib/oauth/providers.js` | `postExchange` metadata now uses `getOAuthClientMetadata()` |
| `open-sse/services/usage.js` | `getGeminiSubscriptionInfo` body now uses `CLIENT_METADATA` (already imported) |

All 4 sources now produce identical metadata: `{ ideType: 9, platform: <computed>, pluginType: 2 }`.

## Testing

Verified that:
- `JSON.parse(ANTIGRAVITY_CONFIG.loadCodeAssistClientMetadata)` produces valid JSON matching `getOAuthClientMetadata()` exactly
- `CLIENT_METADATA` from `appConstants.js` produces the same output
- `AntigravityService.getMetadata()` returns the same numeric enums
- Platform enum resolves to a valid value (0–5) on all OS
- **Zero remaining `IDE_UNSPECIFIED` / `PLATFORM_UNSPECIFIED` strings** in all 4 files

## Related
- #270 (auto-closed due to inactivity, same root cause)