### PR TITLE
fix: enable Happy Eyeballs (autoSelectFamily) in proxyAwareFetch

### DIFF
--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -1,8 +1,16 @@
 import { Readable } from "stream";
+import { Agent } from "undici";
 import { MEMORY_CONFIG } from "../config/runtimeConfig.js";
 
 const originalFetch = globalThis.fetch;
 const proxyDispatchers = new Map();
+
+const directAgent = new Agent({
+  connect: {
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeout: 1000,
+  },
+});
 
 // DNS cache — use Map to avoid prototype pollution via malformed hostnames
 const DNS_CACHE = new Map();
@@ -133,7 +141,13 @@ async function getDispatcher(proxyUrl) {
       proxyDispatchers.delete(proxyDispatchers.keys().next().value);
     }
     const { ProxyAgent } = await import("undici");
-    proxyDispatchers.set(normalized, new ProxyAgent({ uri: normalized }));
+    proxyDispatchers.set(normalized, new ProxyAgent({
+      uri: normalized,
+      connect: {
+        autoSelectFamily: true,
+        autoSelectFamilyAttemptTimeout: 1000,
+      },
+    }));
   }
 
   return proxyDispatchers.get(normalized);
@@ -210,7 +224,7 @@ export async function proxyAwareFetch(url, options = {}, proxyOptions = null) {
       "x-relay-target": `${parsed.protocol}//${parsed.host}`,
       "x-relay-path": `${parsed.pathname}${parsed.search}`,
     };
-    return originalFetch(vercelRelayUrl, { ...options, headers: relayHeaders });
+    return originalFetch(vercelRelayUrl, { ...options, headers: relayHeaders, dispatcher: directAgent });
   }
 
   const connectionProxyUrl = resolveConnectionProxyUrl(targetUrl, proxyOptions);
@@ -251,11 +265,11 @@ export async function proxyAwareFetch(url, options = {}, proxyOptions = null) {
         throw new Error(`[ProxyFetch] Proxy required but failed (strictProxy=true): ${proxyError.message}`);
       }
       console.warn(`[ProxyFetch] Proxy failed, falling back to direct: ${proxyError.message}`);
-      return originalFetch(url, options);
+      return originalFetch(url, { ...options, dispatcher: directAgent });
     }
   }
 
-  return originalFetch(url, options);
+  return originalFetch(url, { ...options, dispatcher: directAgent });
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1237

Enable [RFC 8305 (Happy Eyeballs)](https://datatracker.ietf.org/doc/html/rfc8305) in `proxyAwareFetch` by setting `autoSelectFamily: true` on undici dispatchers. This prevents `ETIMEDOUT` failures when IPv6 routes are unreachable but IPv4 works.

## Problem

Node.js undici does not implement Happy Eyeballs by default. When DNS returns IPv6 addresses (e.g. NAT64 `64:ff9b::`) that are unreachable, fetch fails with `ETIMEDOUT` instead of falling back to IPv4. This causes persistent 502 errors for providers like MiniMax. `curl` succeeds from the same machine because it has built-in Happy Eyeballs.

## Changes

- `open-sse/utils/proxyFetch.js`:
  - Add a shared `directAgent` (undici `Agent`) with `autoSelectFamily: true` and `autoSelectFamilyAttemptTimeout: 1000`
  - Apply same connect options to `ProxyAgent` instances
  - Use `directAgent` as dispatcher for all direct (non-proxy) `originalFetch` calls

## Testing

Verified on a machine where IPv6 NAT64 is unreachable:

```
# Before fix
node fetch → ETIMEDOUT (628ms)
curl       → HTTP 404 (491ms, connected)

# After fix
node fetch with autoSelectFamily → HTTP 404 (1248ms, connected via IPv4 fallback)
```

Build passes (`npm run build` clean).