### PR TITLE
feat: promote successful combo model to first position

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -55,6 +55,7 @@ export default function APIPageClient({ machineId }) {
   const [rtkEnabled, setRtkEnabledState] = useState(true);
   const [cavemanEnabled, setCavemanEnabled] = useState(false);
   const [cavemanLevel, setCavemanLevel] = useState("full");
+  const [comboAutoPromoteEnabled, setComboAutoPromoteEnabled] = useState(false);
 
   // Cloudflare Tunnel state
   const [tunnelChecking, setTunnelChecking] = useState(true);
@@ -220,6 +221,7 @@ export default function APIPageClient({ machineId }) {
         setRtkEnabledState(data.rtkEnabled !== false);
         setCavemanEnabled(!!data.cavemanEnabled);
         setCavemanLevel(data.cavemanLevel || "full");
+        setComboAutoPromoteEnabled(!!data.comboAutoPromoteEnabled);
       }
       if (statusRes.ok) {
         const data = await statusRes.json();
@@ -302,6 +304,11 @@ export default function APIPageClient({ machineId }) {
   const handleCavemanLevel = (level) => {
     setCavemanLevel(level);
     patchSetting({ cavemanLevel: level });
+  };
+
+  const handleComboAutoPromoteEnabled = (value) => {
+    setComboAutoPromoteEnabled(value);
+    patchSetting({ comboAutoPromoteEnabled: value });
   };
 
   const fetchData = async () => {
@@ -1048,6 +1055,28 @@ export default function APIPageClient({ machineId }) {
               onChange={() => handleCavemanEnabled(!cavemanEnabled)}
             />
           </div>
+        </div>
+      </Card>
+
+      {/* Combo Routing */}
+      <Card id="combo-routing">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold flex items-center gap-2">
+            <span className="material-symbols-outlined text-primary">alt_route</span>
+            Combo Routing
+          </h2>
+        </div>
+        <div className="flex items-center justify-between pt-2 gap-4">
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">Auto-promote successful combo model</p>
+            <p className="text-sm text-text-muted">
+              When a combo model responds successfully, move it to position #1 for future requests.
+            </p>
+          </div>
+          <Toggle
+            checked={comboAutoPromoteEnabled}
+            onChange={() => handleComboAutoPromoteEnabled(!comboAutoPromoteEnabled)}
+          />
         </div>
       </Card>
 

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -15,6 +15,7 @@ const DEFAULT_SETTINGS = {
   comboStrategy: "fallback",
   comboStickyRoundRobinLimit: 1,
   comboStrategies: {},
+  comboAutoPromoteEnabled: false,
   requireLogin: true,
   tunnelDashboardAccess: true,
   authMode: "password",

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -28,6 +28,8 @@ function makeSingleModelHandler(clientRawRequest, request, apiKey, comboName) {
   return async (b, m) => {
     const res = await handleSingleModelChat(b, m, clientRawRequest, request, apiKey);
     if (res && res.ok && comboName) {
+      const settings = await getSettings();
+      if (!settings.comboAutoPromoteEnabled) return res;
       try {
         const currentCombo = await getComboByName(comboName);
         if (currentCombo && currentCombo.models && currentCombo.models.length > 0) {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -8,7 +8,7 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
-import { getSettings } from "@/lib/localDb";
+import { getSettings, getComboByName, updateCombo } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -19,6 +19,33 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+
+/**
+ * Helper to wrap single model handler with auto-promotion logic.
+ * When a model succeeds, it gets promoted to the first position in the combo models array in DB.
+ */
+function makeSingleModelHandler(clientRawRequest, request, apiKey, comboName) {
+  return async (b, m) => {
+    const res = await handleSingleModelChat(b, m, clientRawRequest, request, apiKey);
+    if (res && res.ok && comboName) {
+      try {
+        const currentCombo = await getComboByName(comboName);
+        if (currentCombo && currentCombo.models && currentCombo.models.length > 0) {
+          const currentModels = [...currentCombo.models];
+          if (currentModels[0] !== m) {
+            const filtered = currentModels.filter(x => x !== m);
+            const newModels = [m, ...filtered];
+            await updateCombo(currentCombo.id, { models: newModels });
+            log.info("COMBO", `Model "${m}" succeeded, promoted to first position in combo "${comboName}"`);
+          }
+        }
+      } catch (dbErr) {
+        log.warn("COMBO", `Failed to promote model "${m}" in combo "${comboName}": ${dbErr.message}`);
+      }
+    }
+    return res;
+  };
+}
 
 /**
  * Handle chat completion request
@@ -102,7 +129,7 @@ export async function handleChat(request, clientRawRequest = null) {
     return handleComboChat({
       body,
       models: comboModels,
-      handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
+      handleSingleModel: makeSingleModelHandler(clientRawRequest, request, apiKey, modelStr),
       log,
       comboName: modelStr,
       comboStrategy,
@@ -135,7 +162,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       return handleComboChat({
         body,
         models: comboModels,
-        handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
+        handleSingleModel: makeSingleModelHandler(clientRawRequest, request, apiKey, modelStr),
         log,
         comboName: modelStr,
         comboStrategy,


### PR DESCRIPTION
Auto-promote successful combo model to first position.

When a model inside a combo returns a successful response, 9Router now automatically moves that model to the first position in the combo model list. This makes future combo requests prefer the last working model first, reducing repeated fallback attempts and improving routing efficiency.
