### PR TITLE
fix: enhance stall detection in stream handling for improved disconne…

### DIFF
--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -85,7 +85,12 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
 
 /**
  * Create transform stream with disconnect detection
- * Wraps existing transform stream and adds abort capability
+ * Wraps existing transform stream and adds abort capability.
+ *
+ * Stall detection lives in pipeWithDisconnect (tied to upstream byte
+ * activity), not here — output of the transform stream may be silent
+ * for long periods while raw bytes still flow (e.g. Kiro EventStream
+ * binary frames buffering, Claude reasoning streams).
  */
 export function createDisconnectAwareStream(transformStream, streamController) {
   const reader = transformStream.readable.getReader();
@@ -99,18 +104,7 @@ export function createDisconnectAwareStream(transformStream, streamController) {
       }
 
       try {
-        // Race between chunk arrival and stall timeout
-        let stallTimer;
-        const stallPromise = new Promise((_, reject) => {
-          stallTimer = setTimeout(() => reject(new Error("stream stall timeout")), STREAM_STALL_TIMEOUT_MS);
-        });
-
-        let done, value;
-        try {
-          ({ done, value } = await Promise.race([reader.read(), stallPromise]));
-        } finally {
-          clearTimeout(stallTimer);
-        }
+        const { done, value } = await reader.read();
 
         if (done) {
           streamController.handleComplete();
@@ -135,13 +129,49 @@ export function createDisconnectAwareStream(transformStream, streamController) {
 }
 
 /**
- * Pipe provider response through transform with disconnect detection
+ * Pipe provider response through transform with disconnect detection.
+ *
+ * Stall watchdog tracks raw upstream byte activity, not transform output.
+ * Reasoning models (Claude thinking via Kiro, etc.) can produce zero SSE
+ * output for long stretches while partial EventStream frames keep arriving.
+ * Measuring stall on the transform output caused false stalls and the
+ * "failed to pipe response" error in Next.
+ *
+ * Any upstream chunk resets the timer. If no bytes arrive for
+ * STREAM_STALL_TIMEOUT_MS, abort the underlying fetch via the controller.
+ *
  * @param {Response} providerResponse - Response from provider
  * @param {TransformStream} transformStream - Transform stream for SSE
  * @param {object} streamController - Stream controller from createStreamController
  */
 export function pipeWithDisconnect(providerResponse, transformStream, streamController) {
-  const transformedBody = providerResponse.body.pipeThrough(transformStream);
+  let stallTimer = null;
+  const armStall = () => {
+    if (stallTimer) clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      stallTimer = null;
+      streamController.handleError?.(new Error("stream stall timeout"));
+      streamController.abort?.();
+    }, STREAM_STALL_TIMEOUT_MS);
+  };
+  const clearStall = () => {
+    if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
+  };
+
+  armStall();
+
+  const upstreamTap = new TransformStream({
+    transform(chunk, controller) {
+      armStall();
+      controller.enqueue(chunk);
+    },
+    flush() { clearStall(); }
+  });
+
+  const transformedBody = providerResponse.body
+    .pipeThrough(upstreamTap)
+    .pipeThrough(transformStream);
+
   return createDisconnectAwareStream(
     { readable: transformedBody, writable: { getWriter: () => ({ abort: () => Promise.resolve() }) } },
     streamController

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -146,16 +146,29 @@ export function createDisconnectAwareStream(transformStream, streamController) {
  */
 export function pipeWithDisconnect(providerResponse, transformStream, streamController) {
   let stallTimer = null;
+  const clearStall = () => {
+    if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
+  };
   const armStall = () => {
-    if (stallTimer) clearTimeout(stallTimer);
+    clearStall();
     stallTimer = setTimeout(() => {
       stallTimer = null;
       streamController.handleError?.(new Error("stream stall timeout"));
       streamController.abort?.();
     }, STREAM_STALL_TIMEOUT_MS);
   };
-  const clearStall = () => {
-    if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
+
+  // Wrap controller so every termination path clears the stall timer.
+  // Without this, abort/cancel/downstream-error paths leave the timer armed
+  // and a stale abort could fire after the request has already ended.
+  const wrappedController = {
+    signal: streamController.signal,
+    startTime: streamController.startTime,
+    isConnected: () => streamController.isConnected(),
+    handleComplete: () => { clearStall(); streamController.handleComplete(); },
+    handleError: (e) => { clearStall(); streamController.handleError(e); },
+    handleDisconnect: (r) => { clearStall(); streamController.handleDisconnect(r); },
+    abort: () => { clearStall(); streamController.abort(); }
   };
 
   armStall();
@@ -174,7 +187,7 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
 
   return createDisconnectAwareStream(
     { readable: transformedBody, writable: { getWriter: () => ({ abort: () => Promise.resolve() }) } },
-    streamController
+    wrappedController
   );
 }
 


### PR DESCRIPTION
This pull request refactors the stream stall detection logic in `open-sse/utils/streamHandler.js` to make it more reliable and prevent false-positive stream stalls, especially for providers that may send upstream data with long silent periods in the transform output. The main change is moving the stall detection from the transform output to the raw upstream byte stream, ensuring the stream is only aborted if no upstream bytes arrive for the configured timeout.

**Stream stall detection improvements:**

* Moved stall detection logic from `createDisconnectAwareStream` to `pipeWithDisconnect`, so the stall timer now tracks raw upstream byte activity instead of transform output. This prevents false stalls when upstream data is present but the transform stream is silent (e.g., Claude/Kiro reasoning streams). [[1]](diffhunk://#diff-c07cee1572fa3bc6c7a3f9219efbfce5bc38a9b57fd2992c39137c71a84467e4L88-R93) [[2]](diffhunk://#diff-c07cee1572fa3bc6c7a3f9219efbfce5bc38a9b57fd2992c39137c71a84467e4L138-R174)
* Removed the stall timeout race in `createDisconnectAwareStream`, simplifying the function to only read from the transform stream without managing its own stall timer.

**Documentation updates:**

* Clarified comments in both functions to explain the new stall detection approach and the reason for the change, improving maintainability and understanding for future contributors. [[1]](diffhunk://#diff-c07cee1572fa3bc6c7a3f9219efbfce5bc38a9b57fd2992c39137c71a84467e4L88-R93) [[2]](diffhunk://#diff-c07cee1572fa3bc6c7a3f9219efbfce5bc38a9b57fd2992c39137c71a84467e4L138-R174)

Reference issue #1229 