### PR TITLE
fix(security): harden public API and local-only access gates

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getSettings } from "@/lib/localDb";
+import { getSettings, validateApiKey } from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { verifyDashboardAuthToken } from "@/lib/auth/dashboardSession";
 
@@ -32,7 +32,7 @@ const PUBLIC_API_PATHS = [
 ];
 
 // Public top-level prefixes (LLM API endpoints with their own API key auth).
-const PUBLIC_PREFIXES = ["/v1", "/v1beta"];
+const PUBLIC_PREFIXES = ["/v1", "/v1beta", "/api/v1", "/api/v1beta"];
 
 // Always require JWT token regardless of requireLogin setting
 const ALWAYS_PROTECTED = [
@@ -90,8 +90,6 @@ function isLoopbackHostname(h) {
   return LOOPBACK_HOSTS.has(name);
 }
 
-// Same-host gate: Host header must be loopback AND (if present) Origin must match.
-// Defends against tunnel/LAN access, remote browser CSRF, and cross-site form posts.
 function isLocalRequest(request) {
   if (!isLoopbackHostname(request.headers.get("host"))) return false;
   const origin = request.headers.get("origin");
@@ -101,6 +99,32 @@ function isLocalRequest(request) {
     } catch { return false; }
   }
   return true;
+}
+
+function isPublicLlmApi(pathname) {
+  return PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+function extractApiKey(request) {
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
+  return request.headers.get("x-api-key");
+}
+
+async function hasValidApiKey(request) {
+  const apiKey = extractApiKey(request);
+  if (!apiKey) return false;
+  return await validateApiKey(apiKey);
+}
+
+async function canAccessPublicLlmApi(request) {
+  if (isLocalRequest(request)) return true;
+  if (await hasValidCliToken(request)) return true;
+  return await hasValidApiKey(request);
+}
+
+async function canAccessLocalOnlyRoute(request) {
+  return await hasValidCliToken(request);
 }
 
 async function hasValidToken(request) {
@@ -125,17 +149,25 @@ async function isAuthenticated(request) {
 }
 
 function isPublicApi(pathname) {
-  if (PUBLIC_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) return true;
+  if (isPublicLlmApi(pathname)) return true;
   return PUBLIC_API_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 }
+
+export const __test__ = {
+  isLocalRequest,
+  isPublicLlmApi,
+  extractApiKey,
+  canAccessPublicLlmApi,
+  canAccessLocalOnlyRoute,
+};
 
 export async function proxy(request) {
   const { pathname } = request.nextUrl;
 
   // Local-only gate for spawn-capable / host-secret routes.
   if (LOCAL_ONLY_PATHS.some((p) => pathname.startsWith(p))) {
-    if (!isLocalRequest(request)) {
-      return NextResponse.json({ error: "Local only: loopback access required" }, { status: 403 });
+    if (!(await canAccessLocalOnlyRoute(request))) {
+      return NextResponse.json({ error: "Local only: CLI token required" }, { status: 403 });
     }
   }
 
@@ -144,6 +176,11 @@ export async function proxy(request) {
     if (await hasValidCliToken(request) || await hasValidToken(request))
       return NextResponse.next();
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (isPublicLlmApi(pathname)) {
+    if (await canAccessPublicLlmApi(request)) return NextResponse.next();
+    return NextResponse.json({ error: "API key required for remote API access" }, { status: 401 });
   }
 
   // Deny-by-default for /api/* — public allow-list bypasses, everything else requires auth.

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  nextResponse: Symbol("next"),
+  jsonResponse: vi.fn((body, init) => ({
+    status: init?.status || 200,
+    body,
+  })),
+  getSettings: vi.fn(),
+  validateApiKey: vi.fn(),
+  getConsistentMachineId: vi.fn(),
+  verifyDashboardAuthToken: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    next: vi.fn(() => mocks.nextResponse),
+    json: mocks.jsonResponse,
+    redirect: vi.fn((url) => ({ status: 307, url })),
+  },
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+  validateApiKey: mocks.validateApiKey,
+}));
+
+vi.mock("@/shared/utils/machineId", () => ({
+  getConsistentMachineId: mocks.getConsistentMachineId,
+}));
+
+vi.mock("@/lib/auth/dashboardSession", () => ({
+  verifyDashboardAuthToken: mocks.verifyDashboardAuthToken,
+}));
+
+const { proxy, __test__ } = await import("../../src/dashboardGuard.js");
+
+function request(pathname, headers = {}) {
+  const normalizedHeaders = new Headers(headers);
+  return {
+    nextUrl: { pathname },
+    headers: normalizedHeaders,
+    cookies: { get: vi.fn(() => undefined) },
+    url: `http://localhost${pathname}`,
+  };
+}
+
+describe("dashboard guard public LLM API access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({ requireLogin: true });
+    mocks.validateApiKey.mockResolvedValue(false);
+    mocks.getConsistentMachineId.mockResolvedValue("cli-token");
+    mocks.verifyDashboardAuthToken.mockResolvedValue(false);
+  });
+
+  it("allows loopback public LLM API without API key", async () => {
+    const response = await proxy(request("/v1/chat/completions", { host: "localhost:20128" }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects remote rewritten public LLM API without API key", async () => {
+    const response = await proxy(request("/api/v1/chat/completions", { host: "router.example.com" }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("API key required for remote API access");
+  });
+
+  it("allows loopback rewritten public LLM API without API key", async () => {
+    const response = await proxy(request("/api/v1/chat/completions", { host: "localhost:20128" }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).not.toHaveBeenCalled();
+  });
+
+  it("rejects remote beta public LLM API without API key", async () => {
+    const response = await proxy(request("/v1beta/models", { host: "router.example.com" }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("API key required for remote API access");
+  });
+
+  it("rejects remote rewritten beta public LLM API without API key", async () => {
+    const response = await proxy(request("/api/v1beta/models", { host: "router.example.com" }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("API key required for remote API access");
+  });
+
+  it("allows remote public LLM API with valid bearer API key", async () => {
+    mocks.validateApiKey.mockResolvedValue(true);
+
+    const response = await proxy(request("/api/v1/chat/completions", {
+      host: "router.example.com",
+      authorization: "Bearer sk-valid",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-valid");
+  });
+
+  it("allows remote public LLM API with valid x-api-key", async () => {
+    mocks.validateApiKey.mockResolvedValue(true);
+
+    const response = await proxy(request("/v1/web/fetch", {
+      host: "router.example.com",
+      "x-api-key": "sk-valid",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-valid");
+  });
+
+  it("allows remote rewritten beta public LLM API with valid API key", async () => {
+    mocks.validateApiKey.mockResolvedValue(true);
+
+    const response = await proxy(request("/api/v1beta/models", {
+      host: "router.example.com",
+      "x-api-key": "sk-valid",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-valid");
+  });
+});
+
+describe("dashboard guard local-only access", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({ requireLogin: false });
+    mocks.validateApiKey.mockResolvedValue(false);
+    mocks.getConsistentMachineId.mockResolvedValue("cli-token");
+    mocks.verifyDashboardAuthToken.mockResolvedValue(false);
+  });
+
+  it("rejects local-only route with spoofed loopback headers but no CLI token", async () => {
+    const response = await proxy(request("/api/mcp/filesystem/sse", {
+      host: "localhost:20128",
+      origin: "http://localhost:20128",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Local only: CLI token required");
+  });
+
+  it("allows local-only route with valid CLI token", async () => {
+    const response = await proxy(request("/api/mcp/filesystem/sse", {
+      host: "router.example.com",
+      "x-9r-cli-token": "cli-token",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+  });
+});
+
+describe("dashboard guard helpers", () => {
+  it("extracts bearer API keys before x-api-key", () => {
+    const apiRequest = request("/v1/chat/completions", {
+      authorization: "Bearer bearer-key",
+      "x-api-key": "header-key",
+    });
+
+    expect(__test__.extractApiKey(apiRequest)).toBe("bearer-key");
+  });
+});


### PR DESCRIPTION
This PR fixes two security boundary issues in `dashboardGuard`:

1. Remote-style `/v1` LLM API requests could be served without `Authorization` or `x-api-key`.
2. Local-only routes trusted spoofable `Host` / `Origin` headers before falling through to generic API auth.

The fix gates public LLM API prefixes before the generic `/api/*` allowlist and requires a capability for sensitive local-only routes.

## Proof: old behavior

### Finding 1: `/v1/chat/completions` accepted no-key remote-style requests

Command:

```cmd
curl.exe -i -X POST http://127.0.0.1:20128/v1/chat/completions ^
  -H "Content-Type: application/json" ^
  -d "{\"model\":\"cx/gpt-5.5\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}]}"
```

Old result:

```text
HTTP/1.1 200 OK
access-control-allow-origin: *
content-type: application/json

{"object":"chat.completion","model":"gpt-5.5","choices":[{"message":{"content":"Test received."}}],"usage":{"total_tokens":2490}}
```
<img width="941" height="226" alt="image" src="https://github.com/user-attachments/assets/a8e66adb-ac10-46b8-9e02-cf7af067886f" />


Why this is a bug:

- No `Authorization` header was sent.
- No `x-api-key` header was sent.
- The request reached the provider and consumed tokens.
- If the app is exposed over LAN/tunnel/proxy with `requireApiKey=false`, remote callers can use configured provider quota.

### Finding 2: local-only gate accepted spoofed localhost headers

Command:

```cmd
curl.exe -i http://127.0.0.1:20128/api/mcp/filesystem/sse ^
  -H "Host: localhost:20128" ^
  -H "Origin: http://localhost:20128"
```

Old result:

```text
HTTP/1.1 401 Unauthorized
content-type: application/json

{"error":"Unauthorized"}
```
<img width="511" height="169" alt="image" src="https://github.com/user-attachments/assets/0cb7bf16-acff-41f2-b450-934acb88b217" />


Why this matters:

- This does not prove full unauthenticated MCP access.
- It proves the local-only gate did not reject spoofed `Host` / `Origin` with a local-only `403`.
- The request passed the local-only check and was rejected later by generic API auth.
- If login is disabled, or the caller has a dashboard session, the local-only boundary can be bypassed.

## Root cause

Public LLM prefixes were treated as public before remote/local context was enforced.

Local-only routes used client-controlled headers as locality proof:

```text
Host: localhost
Origin: http://localhost
```

Those headers are not a security boundary.

## Fix

- Gate public LLM API prefixes before generic `/api/*` handling:
  - `/v1`
  - `/v1beta`
  - `/api/v1`
  - `/api/v1beta`
- Allow public LLM API access only when one is true:
  - request is loopback/local
  - request has valid `x-9r-cli-token`
  - request has valid API key via `Authorization: Bearer <key>` or `x-api-key`
- Require valid `x-9r-cli-token` for `LOCAL_ONLY_PATHS`.
- Stop using spoofable `Host` / `Origin` as local-only authorization proof.

## Tests

Added `tests/unit/dashboard-guard.test.js` covering:

- loopback `/v1` no-key allowed
- remote `/api/v1` no-key rejected
- loopback `/api/v1` no-key allowed
- remote `/v1beta` no-key rejected
- remote `/api/v1beta` no-key rejected
- remote valid Bearer API key allowed
- remote valid `x-api-key` allowed
- local-only route with spoofed `Host` / `Origin` rejected
- local-only route with valid CLI token allowed

Validation:

```powershell
Set-Location "D:\CODE\GITCLONE\9router\tests"
npm exec -- vitest run unit/dashboard-guard.test.js --config vitest.config.js --reporter=verbose --no-color
```

Result:

```text
Test Files  1 passed
Tests       11 passed
```

Also passed:

```powershell
git diff --check
```