### PR TITLE
feat(codex): bulk-import accounts from JSON files

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/CodexBulkImportModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/CodexBulkImportModal.js
@@ -1,0 +1,297 @@
+"use client";
+
+import { useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { Button, Modal, Badge } from "@/shared/components";
+
+const ACCEPT = ".json,application/json";
+
+/**
+ * Bulk-import Codex (OpenAI) accounts from one or more uploaded JSON files.
+ *
+ * Each file may contain a single account object or an array of them. Server
+ * normalizes / validates / persists; this component just gathers files and
+ * surfaces the result.
+ */
+export default function CodexBulkImportModal({ isOpen, onSuccess, onClose }) {
+  const [files, setFiles] = useState(/** @type {File[]} */ ([]));
+  const [submitting, setSubmitting] = useState(false);
+  const [parseError, setParseError] = useState("");
+  const [result, setResult] = useState(null);
+  const inputRef = useRef(null);
+
+  const reset = () => {
+    setFiles([]);
+    setParseError("");
+    setResult(null);
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    reset();
+    onClose?.();
+  };
+
+  const fileKey = (f) => `${f.name}::${f.size}`;
+
+  const handleFilesAdd = (e) => {
+    const incoming = Array.from(e.target.files || []);
+    if (!incoming.length) return;
+    setFiles((prev) => {
+      const seen = new Set(prev.map(fileKey));
+      const merged = [...prev];
+      for (const f of incoming) {
+        const k = fileKey(f);
+        if (!seen.has(k)) {
+          merged.push(f);
+          seen.add(k);
+        }
+      }
+      return merged;
+    });
+    setParseError("");
+    setResult(null);
+    // Allow re-selecting the same file later by clearing the input element.
+    if (inputRef.current) inputRef.current.value = "";
+  };
+
+  const handleRemoveFile = (index) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+    setResult(null);
+  };
+
+  const handleClearAll = () => {
+    setFiles([]);
+    setResult(null);
+    setParseError("");
+  };
+
+  const handleSubmit = async () => {
+    if (!files.length || submitting) return;
+    setSubmitting(true);
+    setParseError("");
+    setResult(null);
+
+    /** @type {{file: string, error: string}[]} */
+    const parseErrors = [];
+    /** @type {unknown[]} */
+    const accounts = [];
+
+    for (const file of files) {
+      let text;
+      try {
+        text = await file.text();
+      } catch (e) {
+        parseErrors.push({ file: file.name, error: `Read failed: ${e?.message || e}` });
+        continue;
+      }
+      let parsed;
+      try {
+        parsed = JSON.parse(text);
+      } catch (e) {
+        parseErrors.push({ file: file.name, error: `Invalid JSON: ${e?.message || e}` });
+        continue;
+      }
+      if (Array.isArray(parsed)) accounts.push(...parsed);
+      else accounts.push(parsed);
+    }
+
+    if (accounts.length === 0) {
+      setSubmitting(false);
+      setParseError(
+        parseErrors.length > 0
+          ? parseErrors.map((p) => `${p.file}: ${p.error}`).join("\n")
+          : "No accounts found in selected files",
+      );
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/oauth/codex/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ accounts }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setParseError(data?.error || `Import failed (${res.status})`);
+      } else {
+        const merged = { ...data, parseErrors };
+        setResult(merged);
+        if (data.imported > 0) onSuccess?.();
+      }
+    } catch (e) {
+      setParseError(`Network error: ${e?.message || e}`);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Bulk Import Codex Accounts"
+    >
+      <div className="flex flex-col gap-4">
+        <p className="text-xs text-text-muted leading-relaxed">
+          Upload one or more <code>.json</code> files. Supports both flat exports
+          and the Codex CLI <code>auth.json</code> shape (tokens nested under{" "}
+          <code>tokens</code>). Each file may contain a single account or an
+          array. Required: <code>access_token</code>, <code>refresh_token</code>,
+          and either an <code>id_token</code> we can decode or a top-level{" "}
+          <code>email</code>.
+        </p>
+
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="text-xs text-text-muted">JSON files</label>
+            {files.length > 0 && (
+              <button
+                type="button"
+                onClick={handleClearAll}
+                disabled={submitting}
+                className="text-xs text-text-muted hover:text-red-500 disabled:opacity-50"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+          <input
+            ref={inputRef}
+            type="file"
+            multiple
+            accept={ACCEPT}
+            onChange={handleFilesAdd}
+            disabled={submitting}
+            className="block w-full text-sm text-text-main file:mr-3 file:py-1.5 file:px-3 file:rounded file:border-0 file:bg-primary file:text-white hover:file:bg-primary/90 file:cursor-pointer"
+          />
+
+          {files.length > 0 && (
+            <div className="mt-2 max-h-48 overflow-y-auto rounded border border-border bg-sidebar/40">
+              <ul className="divide-y divide-border">
+                {files.map((f, i) => (
+                  <li
+                    key={`${fileKey(f)}::${i}`}
+                    className="flex items-center justify-between gap-2 px-2 py-1.5 text-xs"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="material-symbols-outlined text-[16px] text-text-muted shrink-0">
+                        description
+                      </span>
+                      <span className="truncate font-mono text-text-main" title={f.name}>
+                        {f.name}
+                      </span>
+                      <span className="shrink-0 text-text-muted">
+                        {formatBytes(f.size)}
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveFile(i)}
+                      disabled={submitting}
+                      title="Remove"
+                      className="shrink-0 rounded p-0.5 text-text-muted hover:bg-red-500/10 hover:text-red-500 disabled:opacity-50"
+                    >
+                      <span className="material-symbols-outlined text-[16px]">
+                        close
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {files.length > 0 && (
+            <p className="mt-2 text-xs text-text-muted">
+              {files.length} file{files.length === 1 ? "" : "s"} ready
+            </p>
+          )}
+        </div>
+
+        {parseError && (
+          <pre className="whitespace-pre-wrap break-words text-xs text-red-500 bg-red-500/5 border border-red-500/20 rounded p-2 max-h-40 overflow-auto">
+            {parseError}
+          </pre>
+        )}
+
+        {result && (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap gap-2 items-center">
+              <Badge variant={result.failed > 0 ? "warning" : "success"}>
+                {result.imported} imported
+              </Badge>
+              {result.failed > 0 && (
+                <Badge variant="error">{result.failed} failed</Badge>
+              )}
+              {result.parseErrors?.length > 0 && (
+                <Badge variant="error">
+                  {result.parseErrors.length} unparseable
+                </Badge>
+              )}
+              <span className="text-xs text-text-muted">
+                of {result.total} record{result.total === 1 ? "" : "s"}
+              </span>
+            </div>
+
+            {result.parseErrors?.length > 0 && (
+              <div className="text-xs">
+                <p className="text-text-muted mb-1">File parse errors:</p>
+                <ul className="list-disc pl-5 space-y-0.5 text-red-500">
+                  {result.parseErrors.map((p, i) => (
+                    <li key={i}>
+                      <span className="font-mono">{p.file}</span>: {p.error}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {result.results?.some((r) => !r.ok) && (
+              <div className="text-xs">
+                <p className="text-text-muted mb-1">Record errors:</p>
+                <ul className="list-disc pl-5 space-y-0.5 text-red-500 max-h-40 overflow-auto">
+                  {result.results
+                    .filter((r) => !r.ok)
+                    .map((r) => (
+                      <li key={r.index}>
+                        #{r.index + 1}: {r.error}
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <Button
+            onClick={handleSubmit}
+            fullWidth
+            disabled={!files.length || submitting}
+          >
+            {submitting ? "Importing..." : `Import ${files.length || ""}`.trim()}
+          </Button>
+          <Button onClick={handleClose} variant="ghost" fullWidth disabled={submitting}>
+            {result ? "Close" : "Cancel"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+CodexBulkImportModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onSuccess: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
+};
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -16,6 +16,7 @@ import ConnectionRow from "./ConnectionRow";
 import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
+import CodexBulkImportModal from "./CodexBulkImportModal";
 
 export default function ProviderDetailPage() {
   const params = useParams();
@@ -50,6 +51,7 @@ export default function ProviderDetailPage() {
   const [disabledModelIds, setDisabledModelIds] = useState([]);
   const [confirmState, setConfirmState] = useState(null);
   const [showAgRiskModal, setShowAgRiskModal] = useState(false);
+  const [showCodexBulkImportModal, setShowCodexBulkImportModal] = useState(false);
   const { copied, copy } = useCopyToClipboard();
 
   const AG_RISK_STORAGE_KEY = "ag_risk_confirmed";
@@ -1095,6 +1097,17 @@ export default function ProviderDetailPage() {
                     Cookie
                   </Button>
                 )}
+                {!isCompatible && providerId === "codex" && (
+                  <Button
+                    size="sm"
+                    icon="upload"
+                    variant="secondary"
+                    onClick={() => setShowCodexBulkImportModal(true)}
+                    title="Import accounts from JSON files"
+                  >
+                    Import JSON
+                  </Button>
+                )}
                 <Button
                   size="sm"
                   icon="add"
@@ -1119,6 +1132,18 @@ export default function ProviderDetailPage() {
                       className="w-full sm:w-auto"
                     >
                       Cookie
+                    </Button>
+                  )}
+                  {providerId === "codex" && (
+                    <Button
+                      size="sm"
+                      icon="upload"
+                      variant="secondary"
+                      onClick={() => setShowCodexBulkImportModal(true)}
+                      title="Import accounts from JSON files"
+                      className="w-full sm:w-auto"
+                    >
+                      Import JSON
                     </Button>
                   )}
                   <Button
@@ -1257,6 +1282,13 @@ export default function ProviderDetailPage() {
             setShowAddCustomModel(false);
           }}
           onClose={() => setShowAddCustomModel(false)}
+        />
+      )}
+      {providerId === "codex" && (
+        <CodexBulkImportModal
+          isOpen={showCodexBulkImportModal}
+          onSuccess={fetchConnections}
+          onClose={() => setShowCodexBulkImportModal(false)}
         />
       )}
 

--- a/src/app/api/oauth/codex/import/route.js
+++ b/src/app/api/oauth/codex/import/route.js
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import {
+  normalizeCodexImportRecord,
+  flattenCodexImportPayload,
+} from "@/lib/oauth/services/codexImport";
+import { createProviderConnection } from "@/models";
+
+/**
+ * POST /api/oauth/codex/import
+ *
+ * Body:
+ *   { accounts: object | object[] }
+ *
+ * Each account is the raw JSON record produced by codex CLI / token-exporter
+ * tools (id_token, access_token, refresh_token, account_id, email, expired, ...).
+ * Returns a per-record summary so partial successes are surfaced to the UI.
+ */
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid or empty JSON body" },
+      { status: 400 },
+    );
+  }
+
+  if (!body || typeof body !== "object" || body.accounts === undefined) {
+    return NextResponse.json(
+      { error: "Body must include `accounts` (object or array)" },
+      { status: 400 },
+    );
+  }
+
+  const flat = flattenCodexImportPayload(body.accounts);
+  if (!flat.ok) {
+    return NextResponse.json({ error: flat.error }, { status: 400 });
+  }
+  if (flat.records.length === 0) {
+    return NextResponse.json(
+      { error: "No accounts found in payload" },
+      { status: 400 },
+    );
+  }
+
+  const results = [];
+  let imported = 0;
+  let failed = 0;
+
+  for (let i = 0; i < flat.records.length; i++) {
+    const norm = normalizeCodexImportRecord(flat.records[i]);
+    if (!norm.ok) {
+      failed += 1;
+      results.push({ index: i, ok: false, error: norm.error });
+      continue;
+    }
+    try {
+      const conn = await createProviderConnection(norm.payload);
+      imported += 1;
+      results.push({
+        index: i,
+        ok: true,
+        connectionId: conn.id,
+        email: conn.email,
+      });
+    } catch (error) {
+      failed += 1;
+      results.push({
+        index: i,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return NextResponse.json({
+    success: failed === 0,
+    imported,
+    failed,
+    total: flat.records.length,
+    results,
+  });
+}

--- a/src/lib/db/repos/connectionsRepo.js
+++ b/src/lib/db/repos/connectionsRepo.js
@@ -4,7 +4,7 @@ import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 
 const OPTIONAL_FIELDS = [
   "displayName", "email", "globalPriority", "defaultModel",
-  "accessToken", "refreshToken", "expiresAt", "tokenType",
+  "accessToken", "refreshToken", "idToken", "expiresAt", "tokenType",
   "scope", "projectId", "apiKey", "testStatus",
   "lastTested", "lastError", "lastErrorAt", "rateLimitedUntil", "expiresIn", "errorCode",
   "consecutiveUseCount",
@@ -190,7 +190,7 @@ export async function cleanupProviderConnections() {
   const db = await getAdapter();
   const fieldsToCheck = [
     "displayName", "email", "globalPriority", "defaultModel",
-    "accessToken", "refreshToken", "expiresAt", "tokenType",
+    "accessToken", "refreshToken", "idToken", "expiresAt", "tokenType",
     "scope", "projectId", "apiKey", "testStatus",
     "lastTested", "lastError", "lastErrorAt", "rateLimitedUntil", "expiresIn",
     "consecutiveUseCount",

--- a/src/lib/oauth/services/codexImport.js
+++ b/src/lib/oauth/services/codexImport.js
@@ -1,0 +1,182 @@
+/**
+ * Codex (OpenAI) bulk-import normalization
+ *
+ * Accepts the JSON shape produced by Codex CLI / common token-export tools and
+ * returns a {@link createProviderConnection} payload (or a typed error).
+ *
+ * Pure: no I/O, no network. Safe to unit-test.
+ */
+
+const REQUIRED_FIELDS = ["access_token", "refresh_token"];
+
+// 10 days, the typical OpenAI access-token lifetime when no `expired` is supplied.
+const DEFAULT_EXPIRY_MS = 10 * 24 * 60 * 60 * 1000;
+
+const BASE64_BLOCK_SIZE = 4;
+
+/**
+ * Decode a JWT payload to a plain object (no signature verification).
+ *
+ * Mirrors the helper in `providers.js` but is kept local so this module has no
+ * runtime dependency on the larger OAuth module graph.
+ *
+ * @param {unknown} jwt
+ * @returns {Record<string, unknown> | null}
+ */
+function decodeJwtPayload(jwt) {
+  try {
+    if (!jwt || typeof jwt !== "string") return null;
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return null;
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const missingPadding =
+      (BASE64_BLOCK_SIZE - (base64.length % BASE64_BLOCK_SIZE)) %
+      BASE64_BLOCK_SIZE;
+    const padded = base64 + "=".repeat(missingPadding);
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function extractCodexAccountInfo(idToken) {
+  const payload = decodeJwtPayload(idToken);
+  if (!payload) return {};
+  const chatgpt =
+    /** @type {Record<string, unknown>} */ (
+      payload["https://api.openai.com/auth"]
+    ) || {};
+  return {
+    email: typeof payload.email === "string" ? payload.email : undefined,
+    chatgptAccountId:
+      typeof chatgpt.chatgpt_account_id === "string"
+        ? chatgpt.chatgpt_account_id
+        : undefined,
+    chatgptPlanType:
+      typeof chatgpt.chatgpt_plan_type === "string"
+        ? chatgpt.chatgpt_plan_type
+        : undefined,
+  };
+}
+
+/**
+ * @param {unknown} input — single record from the uploaded JSON
+ * @returns {{ ok: true, payload: object } | { ok: false, error: string }}
+ */
+export function normalizeCodexImportRecord(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, error: "Record is not an object" };
+  }
+  const rec = /** @type {Record<string, unknown>} */ (unwrapCodexAuthJson(input));
+
+  // Allow type field to be missing or "codex"; reject anything else explicitly so
+  // users don't accidentally import claude/gemini exports through this path.
+  if (rec.type !== undefined && rec.type !== null && rec.type !== "codex") {
+    return { ok: false, error: `Unsupported type: ${String(rec.type)}` };
+  }
+
+  for (const f of REQUIRED_FIELDS) {
+    if (typeof rec[f] !== "string" || !rec[f]) {
+      return { ok: false, error: `Missing required field: ${f}` };
+    }
+  }
+
+  const accessToken = String(rec.access_token);
+  const refreshToken = String(rec.refresh_token);
+  const idToken = typeof rec.id_token === "string" ? rec.id_token : undefined;
+
+  // Prefer JWT-derived account info, fall back to top-level fields.
+  const fromJwt = idToken ? extractCodexAccountInfo(idToken) : {};
+  const email = pickString(fromJwt.email, rec.email);
+
+  if (!email) {
+    return { ok: false, error: "Missing email (and id_token does not contain one)" };
+  }
+
+  const chatgptAccountId = pickString(fromJwt.chatgptAccountId, rec.account_id);
+  const chatgptPlanType = pickString(fromJwt.chatgptPlanType);
+
+  const expiresAt = parseExpiry(rec.expired) || parseAccessTokenExp(accessToken);
+
+  const providerSpecificData = {};
+  if (chatgptAccountId) providerSpecificData.chatgptAccountId = chatgptAccountId;
+  if (chatgptPlanType) providerSpecificData.chatgptPlanType = chatgptPlanType;
+
+  /** @type {Record<string, unknown>} */
+  const payload = {
+    provider: "codex",
+    authType: "oauth",
+    accessToken,
+    refreshToken,
+    email,
+    expiresAt,
+    testStatus: "active",
+  };
+  if (idToken) payload.idToken = idToken;
+  if (Object.keys(providerSpecificData).length > 0) {
+    payload.providerSpecificData = providerSpecificData;
+  }
+
+  return { ok: true, payload };
+}
+
+/**
+ * Flatten the user-uploaded JSON into an array of candidate records.
+ * Accepts a single record or an array; rejects anything else.
+ *
+ * @param {unknown} parsed
+ * @returns {{ ok: true, records: unknown[] } | { ok: false, error: string }}
+ */
+export function flattenCodexImportPayload(parsed) {
+  if (Array.isArray(parsed)) {
+    return { ok: true, records: parsed };
+  }
+  if (parsed && typeof parsed === "object") {
+    return { ok: true, records: [parsed] };
+  }
+  return { ok: false, error: "JSON must be an object or an array of objects" };
+}
+
+function pickString(...candidates) {
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim()) return c.trim();
+  }
+  return undefined;
+}
+
+function parseExpiry(value) {
+  if (typeof value === "string" && value) {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return new Date(ms).toISOString();
+  }
+  return undefined;
+}
+
+function parseAccessTokenExp(accessToken) {
+  const payload = decodeJwtPayload(accessToken);
+  const exp = payload && typeof payload.exp === "number" ? payload.exp : null;
+  if (exp && Number.isFinite(exp)) {
+    return new Date(exp * 1000).toISOString();
+  }
+  return new Date(Date.now() + DEFAULT_EXPIRY_MS).toISOString();
+}
+
+/**
+ * Codex CLI persists tokens to `auth.json` with the OAuth fields nested under
+ * a `tokens` object: `{ auth_mode, OPENAI_API_KEY, tokens: { id_token, ... } }`.
+ * Flatten that into the same shape as the simple top-level export so the rest
+ * of the normalizer can stay unchanged.
+ *
+ * @param {object} rec
+ * @returns {object}
+ */
+function unwrapCodexAuthJson(rec) {
+  const tokens = /** @type {Record<string, unknown> | undefined} */ (rec.tokens);
+  if (!tokens || typeof tokens !== "object" || Array.isArray(tokens)) {
+    return rec;
+  }
+  if (typeof tokens.access_token !== "string") return rec;
+  // Tokens take priority; carry through siblings (email / account_id / expired)
+  // only when the nested object doesn't already define them.
+  return { ...rec, ...tokens };
+}

--- a/tests/unit/codex-bulk-import.test.js
+++ b/tests/unit/codex-bulk-import.test.js
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the codex bulk-import normalizer.
+ *
+ * Pure helpers, no I/O. We craft small synthetic id_tokens by base64-url-
+ * encoding a header/payload/signature triple — only the payload is decoded.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  normalizeCodexImportRecord,
+  flattenCodexImportPayload,
+} from "@/lib/oauth/services/codexImport";
+
+function b64url(obj) {
+  return Buffer.from(JSON.stringify(obj))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function makeIdToken(payload) {
+  const header = b64url({ alg: "RS256", typ: "JWT" });
+  const body = b64url(payload);
+  return `${header}.${body}.signature`;
+}
+
+const FULL_RECORD = {
+  id_token: makeIdToken({
+    email: "test-jwt@example.com",
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: "acct-from-jwt",
+      chatgpt_plan_type: "plus",
+    },
+  }),
+  access_token: "access-xyz",
+  refresh_token: "refresh-xyz",
+  account_id: "acct-from-record",
+  email: "test-record@example.com",
+  type: "codex",
+  expired: "2026-05-22T10:34:04+07:00",
+};
+
+describe("normalizeCodexImportRecord", () => {
+  it("normalizes a full Codex export record", () => {
+    const result = normalizeCodexImportRecord(FULL_RECORD);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const { payload } = result;
+    expect(payload.provider).toBe("codex");
+    expect(payload.authType).toBe("oauth");
+    expect(payload.accessToken).toBe("access-xyz");
+    expect(payload.refreshToken).toBe("refresh-xyz");
+    expect(payload.idToken).toBe(FULL_RECORD.id_token);
+    expect(payload.testStatus).toBe("active");
+    // JWT email wins over the record-level email.
+    expect(payload.email).toBe("test-jwt@example.com");
+    expect(payload.providerSpecificData).toEqual({
+      chatgptAccountId: "acct-from-jwt",
+      chatgptPlanType: "plus",
+    });
+    // ISO-formatted, parses back to the right instant.
+    expect(new Date(payload.expiresAt).toISOString()).toBe(payload.expiresAt);
+    expect(Date.parse(payload.expiresAt)).toBe(Date.parse(FULL_RECORD.expired));
+  });
+
+  it("falls back to record email when id_token has none", () => {
+    const idToken = makeIdToken({
+      "https://api.openai.com/auth": { chatgpt_account_id: "x" },
+    });
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "fallback@example.com",
+      id_token: idToken,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.payload.email).toBe("fallback@example.com");
+    expect(result.payload.providerSpecificData?.chatgptAccountId).toBe("x");
+  });
+
+  it("falls back to account_id when id_token is missing", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "no-jwt@example.com",
+      account_id: "acct-top-level",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.payload.providerSpecificData?.chatgptAccountId).toBe(
+      "acct-top-level",
+    );
+    expect(result.payload.idToken).toBeUndefined();
+  });
+
+  it("synthesizes expiresAt when `expired` is missing", () => {
+    const before = Date.now();
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+    });
+    const after = Date.now();
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const expiresMs = Date.parse(result.payload.expiresAt);
+    expect(expiresMs).toBeGreaterThan(before);
+    // Default lifetime is 10 days; allow a generous upper bound.
+    expect(expiresMs).toBeLessThanOrEqual(after + 11 * 24 * 60 * 60 * 1000);
+  });
+
+  it("rejects invalid `expired` strings by falling back to default", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+      expired: "not-a-date",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Number.isFinite(Date.parse(result.payload.expiresAt))).toBe(true);
+  });
+
+  it("rejects records missing required fields", () => {
+    expect(normalizeCodexImportRecord({}).ok).toBe(false);
+    expect(
+      normalizeCodexImportRecord({ access_token: "a", email: "x@y.z" }).ok,
+    ).toBe(false);
+    expect(
+      normalizeCodexImportRecord({
+        access_token: "a",
+        refresh_token: "r",
+      }).ok,
+    ).toBe(false); // no email anywhere
+  });
+
+  it("rejects records with non-codex `type`", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+      type: "claude",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/Unsupported type/);
+  });
+
+  it("rejects non-objects", () => {
+    expect(normalizeCodexImportRecord(null).ok).toBe(false);
+    expect(normalizeCodexImportRecord("foo").ok).toBe(false);
+    expect(normalizeCodexImportRecord([]).ok).toBe(false);
+  });
+
+  it("omits providerSpecificData when no account info is present", () => {
+    const result = normalizeCodexImportRecord({
+      access_token: "a",
+      refresh_token: "r",
+      email: "x@example.com",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.payload.providerSpecificData).toBeUndefined();
+  });
+
+  it("unwraps the codex CLI auth.json shape", () => {
+    const idToken = makeIdToken({
+      email: "cli@example.com",
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "acct-cli",
+        chatgpt_plan_type: "free",
+      },
+    });
+    // Access token's `exp` is the only expiry signal in auth.json.
+    const expEpoch = Math.floor(Date.now() / 1000) + 3600;
+    const accessToken = makeIdToken({ exp: expEpoch });
+    const authJson = {
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: idToken,
+        access_token: accessToken,
+        refresh_token: "rt-cli",
+        account_id: "acct-cli",
+      },
+      last_refresh: "2026-05-16T11:35:58.322795500Z",
+    };
+    const result = normalizeCodexImportRecord(authJson);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.payload.accessToken).toBe(accessToken);
+    expect(result.payload.refreshToken).toBe("rt-cli");
+    expect(result.payload.idToken).toBe(idToken);
+    expect(result.payload.email).toBe("cli@example.com");
+    expect(result.payload.providerSpecificData).toEqual({
+      chatgptAccountId: "acct-cli",
+      chatgptPlanType: "free",
+    });
+    // Falls back to the access_token's `exp` claim when no `expired` field exists.
+    expect(Date.parse(result.payload.expiresAt)).toBe(expEpoch * 1000);
+  });
+
+  it("rejects auth.json when nested tokens are incomplete", () => {
+    const result = normalizeCodexImportRecord({
+      auth_mode: "chatgpt",
+      tokens: { id_token: "x" }, // missing access_token + refresh_token
+    });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("flattenCodexImportPayload", () => {
+  it("wraps a single object", () => {
+    const result = flattenCodexImportPayload({ a: 1 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.records).toEqual([{ a: 1 }]);
+  });
+
+  it("passes arrays through", () => {
+    const result = flattenCodexImportPayload([{ a: 1 }, { b: 2 }]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.records).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it("rejects scalars", () => {
+    expect(flattenCodexImportPayload("nope").ok).toBe(false);
+    expect(flattenCodexImportPayload(42).ok).toBe(false);
+    expect(flattenCodexImportPayload(null).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a bulk-import flow for Codex (OpenAI) accounts. Users upload one or more JSON files in either of two shapes — a flat token export or the Codex CLI `auth.json` layout — and each record is normalized + upserted as a `codex` OAuth connection.

## What's new

- **`POST /api/oauth/codex/import`** — accepts `{ accounts: object | object[] }` and returns a per-record summary so partial failures surface to the caller:

  ```json
  { "success": true, "imported": 3, "failed": 1, "total": 4, "results": [...] }
  ```

- **`CodexBulkImportModal`** wired into the Codex provider page. Multi-file picker with:
  - scrollable list of selected files (filename, size, per-row remove, clear-all)
  - append-on-pick (re-opening the picker doesn't replace the existing list)
  - name+size dedupe so dropping the same export twice is a no-op
  - inline reporting of file-parse errors, record-validation errors, and import counts

- **`normalizeCodexImportRecord`** — pure helper. Detects the CLI `auth.json` shape and unwraps the nested `tokens` object, validates the required tokens, decodes `id_token` to recover `email` / `chatgpt_account_id` / `chatgpt_plan_type`, and synthesizes `expiresAt` from `expired` → access-token `exp` → 10-day fallback.

## Schemas accepted

Flat export:

```jsonc
{
  "access_token":  "eyJ…",  // required
  "refresh_token": "rt_…",  // required
  "id_token":      "eyJ…",  // preferred — email + chatgpt account info decoded from this

  // Optional fallbacks when id_token is absent or doesn't carry the field:
  "email":      "you@host", // used if id_token has no email claim
  "account_id": "b7fe…"     // used as chatgpt_account_id when id_token is missing
}
```

Codex CLI `auth.json`:

```jsonc
{
  "auth_mode": "chatgpt",
  "OPENAI_API_KEY": null,
  "tokens": {
    "id_token":      "eyJ…",
    "access_token":  "eyJ…",
    "refresh_token": "rt_…",
    "account_id":    "77f0…"
  },
  "last_refresh": "1970-01-01T00:00:00Z"
}
```

A record needs **either** an `id_token` we can decode for an email **or** a top-level `email`. Re-importing an account whose email already exists merges via `createProviderConnection`'s OAuth-by-email dedupe path — refresh tokens get rotated in place rather than duplicating rows.

## Files touched

| File | Reason |
|---|---|
| `src/lib/oauth/services/codexImport.js` | Pure normalizer + payload flattener (no I/O, unit-testable) |
| `src/app/api/oauth/codex/import/route.js` | New POST endpoint |
| `src/app/(dashboard)/dashboard/providers/[id]/CodexBulkImportModal.js` | Multi-file modal |
| `src/app/(dashboard)/dashboard/providers/[id]/page.js` | "Import JSON" button on the codex provider page |
| `src/lib/db/repos/connectionsRepo.js` | `idToken` added to `OPTIONAL_FIELDS` and `cleanupProviderConnections` so it persists, matching the existing CLI write path that `backfillCodexEmails` already reads from |
| `tests/unit/codex-bulk-import.test.js` | 14 tests covering both schemas, JWT/email/account fallbacks, malformed input, default + JWT-derived expiry, type guards, payload flattening |

## Verification

- `vitest run unit/codex-bulk-import.test.js` → 14/14 pass
- `npm run build` → clean; new route registered as `ƒ /api/oauth/codex/import`

## Notes

- The button only appears on `/dashboard/providers/codex`; other providers are unaffected.
- The endpoint is mounted under `/api/oauth/...` so it inherits the same dashboard auth guard the rest of the OAuth routes use.
