### PR TITLE
fix(antigravity): bound Gemini thinking budget for -low/-high model aliases

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -86,6 +86,26 @@ export class AntigravityExecutor extends BaseExecutor {
       generationConfig.maxOutputTokens = MAX_ANTIGRAVITY_OUTPUT_TOKENS;
     }
 
+    // Antigravity model aliases encode a thinking tier as a suffix (e.g.
+    // gemini-3.1-pro-low / gemini-3.1-pro-high). A Gemini reasoning model with
+    // no explicit thinkingConfig spends its entire output budget on hidden
+    // reasoning tokens and emits (near-)empty content (decolua/9router#803).
+    // Derive a bounded thinkingBudget from the suffix (only when the client did
+    // not set one) and guarantee enough output headroom for the visible answer
+    // + tool calls. Budgets mirror openai-to-gemini.js ({low:1024, medium:8192,
+    // high:32768}); AG caps output at MAX_ANTIGRAVITY_OUTPUT_TOKENS.
+    const tierMatch = /-(low|medium|high)$/.exec(model || "");
+    const isGeminiModel = /gemini/i.test(model || "");
+    if (isGeminiModel && tierMatch && generationConfig.thinkingConfig?.thinkingBudget == null) {
+      const TIER_BUDGET = { low: 1024, medium: 8192, high: 32768 };
+      const budget = Math.min(TIER_BUDGET[tierMatch[1]], MAX_ANTIGRAVITY_OUTPUT_TOKENS - 2048);
+      generationConfig.thinkingConfig = { ...(generationConfig.thinkingConfig || {}), thinkingBudget: budget };
+      const minOut = Math.min(MAX_ANTIGRAVITY_OUTPUT_TOKENS, budget + 4096);
+      if (!(generationConfig.maxOutputTokens >= minOut)) {
+        generationConfig.maxOutputTokens = MAX_ANTIGRAVITY_OUTPUT_TOKENS;
+      }
+    }
+
     const transformedRequest = {
       ...requestWithoutTools,
       generationConfig,

--- a/tests/unit/antigravity-thinking-budget.test.js
+++ b/tests/unit/antigravity-thinking-budget.test.js
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for AntigravityExecutor.transformRequest — Gemini thinking-budget injection.
+ *
+ * Bug: Antigravity model aliases encode a thinking tier as a suffix
+ * (gemini-3.1-pro-low / -high). Without an explicit generationConfig.thinkingConfig,
+ * Gemini reasoning models spend their whole output budget on hidden reasoning tokens
+ * and emit (near-)empty content. transformRequest must derive a bounded thinkingBudget
+ * from the suffix (only when the client did not set one) and guarantee output headroom.
+ *
+ * Budget tiers mirror open-sse/translator/request/openai-to-gemini.js
+ * ({ low:1024, medium:8192, high:32768 }); AG output cap = 16384.
+ */
+import { describe, it, expect } from "vitest";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
+
+const ex = new AntigravityExecutor();
+const creds = { projectId: "proj-1", email: "e@x.io", connectionId: "c1" };
+
+function mkBody(generationConfig = {}) {
+  return {
+    request: {
+      sessionId: "sess-1",
+      contents: [{ role: "user", parts: [{ text: "hi" }] }],
+      generationConfig,
+    },
+  };
+}
+const gc = (model, generationConfig = {}) =>
+  ex.transformRequest(model, mkBody(generationConfig), true, creds).request.generationConfig;
+
+describe("AntigravityExecutor.transformRequest — thinking-budget injection", () => {
+  it("injects low thinkingBudget for gemini-3.1-pro-low and guarantees output headroom", () => {
+    const g = gc("gemini-3.1-pro-low");
+    expect(g.thinkingConfig).toBeDefined();
+    expect(g.thinkingConfig.thinkingBudget).toBe(1024);
+    expect(g.maxOutputTokens).toBe(16384);
+  });
+
+  it("injects a clamped high thinkingBudget for gemini-3.1-pro-high", () => {
+    const g = gc("gemini-3.1-pro-high");
+    // high tier (32768) clamped so >=2048 tokens remain for visible output within the 16384 cap
+    expect(g.thinkingConfig.thinkingBudget).toBe(14336);
+    expect(g.maxOutputTokens).toBe(16384);
+  });
+
+  it("does NOT override a client-provided thinkingConfig.thinkingBudget", () => {
+    const g = gc("gemini-3.1-pro-low", { thinkingConfig: { thinkingBudget: 512 } });
+    expect(g.thinkingConfig.thinkingBudget).toBe(512);
+  });
+
+  it("does NOT inject for non-gemini models routed via Antigravity (claude)", () => {
+    const g = gc("claude-opus-4-6-thinking");
+    expect(g.thinkingConfig).toBeUndefined();
+  });
+
+  it("does NOT inject for a gemini model without a thinking-tier suffix (flash)", () => {
+    const g = gc("gemini-3-flash");
+    expect(g.thinkingConfig).toBeUndefined();
+  });
+
+  it("still clamps an oversized client maxOutputTokens to the AG cap", () => {
+    const g = gc("gemini-3.1-pro-low", { maxOutputTokens: 999999 });
+    expect(g.maxOutputTokens).toBe(16384);
+    expect(g.thinkingConfig.thinkingBudget).toBe(1024);
+  });
+
+  it("preserves a sufficiently large client maxOutputTokens", () => {
+    const g = gc("gemini-3.1-pro-low", { maxOutputTokens: 12000 });
+    expect(g.maxOutputTokens).toBe(12000);
+    expect(g.thinkingConfig.thinkingBudget).toBe(1024);
+  });
+});


### PR DESCRIPTION
## Problem

`AntigravityExecutor.transformRequest` rewrites the model id but never sets a
Gemini `generationConfig.thinkingConfig`. Antigravity model aliases encode a
thinking tier as a suffix (`gemini-3.1-pro-low`, `gemini-3.1-pro-high`), but
with no explicit `thinkingConfig` a Gemini reasoning model spends its **entire
output budget on hidden reasoning tokens** and emits (near-)empty content.

Observed via the router request log: a trivial prompt (`"Reply with exactly:
PONG"`) routed to `gemini-3.1-pro-low` returned `completion_tokens: 132` with
`reasoning_tokens: 130` (~2 visible tokens), surfaced to the client as
`[Empty streaming response]`, sometimes after 40+ s. This makes the
`gemini-3.1-pro-*` Antigravity aliases effectively unusable.

Refs #803 (*MITM Antigravity does not work for gemini 3.1 pro models*);
related symptom in #1061.

## Fix

`transformRequest` now derives a bounded `thinkingBudget` from the alias suffix
**only when the client did not set one**:

| suffix    | thinkingBudget |
|-----------|----------------|
| `-low`    | 1024           |
| `-medium` | 8192           |
| `-high`   | 32768          |

Budgets mirror the existing map in
`open-sse/translator/request/openai-to-gemini.js`. The budget is clamped so
that ≥2048 tokens of the Antigravity output cap (`MAX_ANTIGRAVITY_OUTPUT_TOKENS`)
remain for the visible answer, and `maxOutputTokens` is raised to guarantee
headroom. Non-Gemini Antigravity models (claude / gpt-oss) and suffix-less
Gemini (`gemini-3-flash`) are untouched; a client-provided `thinkingConfig` is
always preserved.

## Tests

Adds `tests/unit/antigravity-thinking-budget.test.js` (7 cases): low/high
injection, high-tier clamping, output headroom, client-override preservation,
and the non-injection cases (claude, flash). Full unit suite: **323 passed**
vs **316 passed** baseline (+7, zero regressions; the pre-existing unrelated
failures are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
