### PR TITLE
feat(dashboard-guard): allow remote same-origin access for tunnel enable authenticated sessions

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -76,10 +76,15 @@ const LOCAL_ONLY_PATHS = [
   "/api/tunnel/tailscale-login",
   "/api/tunnel/tailscale-start-daemon",
   "/api/tunnel/tailscale-check",
-  "/api/tunnel/enable",
-  "/api/tunnel/disable",
   "/api/oauth/cursor/auto-import",
   "/api/oauth/kiro/auto-import",
+];
+
+// Tunnel toggles are safe to expose to an authenticated dashboard browser on the same origin,
+// even when the dashboard itself is served from a non-loopback host such as a VPS IP/domain.
+const REMOTE_BROWSER_LOCAL_ALLOWED_PATHS = [
+  "/api/tunnel/enable",
+  "/api/tunnel/disable",
 ];
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
@@ -99,6 +104,18 @@ function isLocalRequest(request) {
     } catch { return false; }
   }
   return true;
+}
+
+function isSameOriginBrowserRequest(request) {
+  const host = request.headers.get("host");
+  const origin = request.headers.get("origin");
+  if (!host || !origin) return false;
+  try {
+    const originUrl = new URL(origin);
+    return originUrl.host.toLowerCase() === host.toLowerCase();
+  } catch {
+    return false;
+  }
 }
 
 function isPublicLlmApi(pathname) {
@@ -127,6 +144,11 @@ async function canAccessLocalOnlyRoute(request) {
   if (await hasValidCliToken(request)) return true;
   // Browser on host: loopback Host + Origin (blocks tunnel/CSRF) + JWT cookie (blocks unauth raw clients)
   if (isLocalRequest(request) && await hasValidToken(request)) return true;
+  if (
+    REMOTE_BROWSER_LOCAL_ALLOWED_PATHS.some((p) => request.nextUrl.pathname.startsWith(p)) &&
+    isSameOriginBrowserRequest(request) &&
+    await hasValidToken(request)
+  ) return true;
   return false;
 }
 
@@ -158,6 +180,7 @@ function isPublicApi(pathname) {
 
 export const __test__ = {
   isLocalRequest,
+  isSameOriginBrowserRequest,
   isPublicLlmApi,
   extractApiKey,
   canAccessPublicLlmApi,

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -153,6 +153,33 @@ describe("dashboard guard local-only access", () => {
 
     expect(response).toBe(mocks.nextResponse);
   });
+
+  it("allows remote same-origin tunnel enable for authenticated dashboard browser", async () => {
+    mocks.verifyDashboardAuthToken.mockResolvedValue(true);
+    const req = request("/api/tunnel/enable", {
+      host: "192.0.2.37:20128",
+      origin: "http://192.0.2.37:20128",
+    });
+    req.cookies.get.mockReturnValue({ value: "jwt-token" });
+
+    const response = await proxy(req);
+
+    expect(response).toBe(mocks.nextResponse);
+  });
+
+  it("keeps other local-only routes blocked for remote authenticated browser sessions", async () => {
+    mocks.verifyDashboardAuthToken.mockResolvedValue(true);
+    const req = request("/api/mcp/filesystem/sse", {
+      host: "192.0.2.37:20128",
+      origin: "http://192.0.2.37:20128",
+    });
+    req.cookies.get.mockReturnValue({ value: "jwt-token" });
+
+    const response = await proxy(req);
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Local only: CLI token required");
+  });
 });
 
 describe("dashboard guard helpers", () => {


### PR DESCRIPTION
## Summary

This PR updates the local-only route guard so that authenticated dashboard browser sessions can enable or disable tunnels when accessing the dashboard through a remote same-origin VPS address.

Previously, calls to `/api/tunnel/enable` or `/api/tunnel/disable` from a remote dashboard browser session were incorrectly blocked with:

```json
{
  "error": "Local only: CLI token required"
}
```

This happened even when the request had a valid dashboard authentication token and the request origin matched the host.

### Problem

Tunnel enable/disable APIs need to be accessible from an authenticated dashboard browser session, including when the dashboard is running on a VPS and accessed remotely through the same origin.

However, these routes were treated like other local-only APIs and required a CLI token, causing legitimate authenticated browser requests to fail.

### Changes
- Allow /api/tunnel/enable and /api/tunnel/disable for authenticated dashboard browser sessions when the request is same-origin.
- Keep other local-only routes protected for remote browser sessions.
- Preserve the existing CLI-token requirement for routes that should remain local-only.

### Tests
Added coverage for:
- Allowing a remote same-origin authenticated browser request to /api/tunnel/enable.
- Ensuring other local-only routes, such as /api/mcp/filesystem/sse, remain blocked for remote authenticated browser sessions without a CLI token.

### Expected Behavior
Authenticated dashboard users can now enable or disable tunnels from a VPS-hosted dashboard, while unrelated local-only APIs remain protected.