### PR TITLE
fix(translator): strip temperature for Claude models with extended thinking

### DIFF
--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -18,7 +18,21 @@ export function openaiToClaudeRequest(model, body, stream) {
   };
 
   // Temperature
-  if (body.temperature !== undefined) {
+  //
+  // Claude's Messages API rejects `temperature` when extended thinking is active.
+  // Two cases where thinking is on:
+  //   (a) Caller passes `body.thinking` or `body.reasoning_effort` (handled below
+  //       — `result.thinking` becomes truthy, and we strip temperature at the end).
+  //   (b) The request targets Claude OAuth (claude-code), which always sends
+  //       `Anthropic-Beta: ...,interleaved-thinking-2025-05-14,...` in headers.
+  //       The model is forced into thinking server-side, but neither `body.thinking`
+  //       nor `result.thinking` will be set, so we must detect this by model name.
+  //       This affects claude-opus-4.x and claude-sonnet-4.x (the families that
+  //       support extended thinking).
+  //
+  // For models that don't force thinking (haiku, older sonnets), preserve temperature.
+  const modelForcesThinking = /claude-(?:opus|sonnet)-4/i.test(model);
+  if (body.temperature !== undefined && !modelForcesThinking) {
     result.temperature = body.temperature;
   }
 
@@ -196,6 +210,14 @@ Respond ONLY with the JSON object, no other text.`);
     } else if (budget) {
       result.thinking = { type: "enabled", budget_tokens: budget };
     }
+  }
+
+  // Final guard: Claude rejects `temperature` whenever extended thinking is
+  // enabled. If we set `result.thinking` above from `body.thinking` or
+  // `body.reasoning_effort`, drop temperature defensively (the model-based
+  // strip earlier already covers Claude OAuth's forced-thinking case).
+  if (result.thinking && result.temperature !== undefined) {
+    delete result.temperature;
   }
 
   // Attach toolNameMap to result for response translation

--- a/tests/unit/openai-to-claude.test.js
+++ b/tests/unit/openai-to-claude.test.js
@@ -121,4 +121,82 @@ describe("openaiToClaudeRequest", () => {
       expect(systemText).toContain("You must respond with valid JSON");
     });
   });
+
+  describe("temperature handling", () => {
+    // Claude's Messages API rejects `temperature` when extended thinking is
+    // active. Claude OAuth (claude-code) always sends `interleaved-thinking`
+    // in Anthropic-Beta, which forces server-side thinking on opus-4 and
+    // sonnet-4. The translator can't see headers, so it strips by model name.
+
+    it("strips temperature for claude-opus-4 family (forced thinking)", () => {
+      const body = {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0.7
+      };
+
+      const result = openaiToClaudeRequest("claude-opus-4-7", body, false);
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it("strips temperature for claude-sonnet-4 family (forced thinking)", () => {
+      const body = {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0.7
+      };
+
+      const result = openaiToClaudeRequest("claude-sonnet-4-5", body, false);
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it("preserves temperature for non-thinking models (haiku, older sonnets)", () => {
+      const body = {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0.5
+      };
+
+      const haiku = openaiToClaudeRequest("claude-haiku-5-20251001", body, false);
+      expect(haiku.temperature).toBe(0.5);
+
+      const sonnet35 = openaiToClaudeRequest("claude-3-5-sonnet-20241022", body, false);
+      expect(sonnet35.temperature).toBe(0.5);
+    });
+
+    it("strips temperature when body.thinking is explicitly set", () => {
+      const body = {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0.7,
+        thinking: { type: "enabled", budget_tokens: 4096 }
+      };
+
+      // Use a non-thinking-forced model so the model-based strip doesn't fire;
+      // the final guard should catch this case.
+      const result = openaiToClaudeRequest("claude-haiku-5-20251001", body, false);
+      expect(result.temperature).toBeUndefined();
+      expect(result.thinking).toBeDefined();
+    });
+
+    it("strips temperature when reasoning_effort triggers thinking", () => {
+      const body = {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0.7,
+        reasoning_effort: "medium"
+      };
+
+      const result = openaiToClaudeRequest("claude-haiku-5-20251001", body, false);
+      expect(result.temperature).toBeUndefined();
+      expect(result.thinking).toEqual({ type: "enabled", budget_tokens: 8192 });
+    });
+
+    it("preserves temperature when reasoning_effort=none on non-thinking model", () => {
+      const body = {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0.7,
+        reasoning_effort: "none"
+      };
+
+      const result = openaiToClaudeRequest("claude-haiku-5-20251001", body, false);
+      expect(result.temperature).toBe(0.7);
+      expect(result.thinking).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Claude's Messages API returns `400 invalid_request_error: \`temperature\` is deprecated` whenever extended thinking is active for a request, but the OpenAI → Claude translator in `open-sse/translator/request/openai-to-claude.js` unconditionally copies `body.temperature` into the Claude payload. This breaks two real-world cases:

**Case A — caller explicitly enables thinking.** When a client sends `thinking: { type: "enabled", ... }` or `reasoning_effort: "medium"`, `openaiToClaudeRequest()` already sets `result.thinking`, but `result.temperature` was also set earlier and never removed.

**Case B — Claude OAuth (`claude-code`) provider.** The `claude` executor in `open-sse/executors/default.js` always sends:

```
Anthropic-Beta: claude-code-20250219,interleaved-thinking-2025-05-14,...
```

(see `open-sse/config/providers.js` `CLAUDE_API_HEADERS` / `CLAUDE_CLI_SPOOF_HEADERS`). This forces server-side extended thinking on `claude-opus-4.x` and `claude-sonnet-4.x` even when the client never sets `body.thinking`. The translator can't see headers, so the only signal it has is the model name.

## Reproduction

OpenAI-format client → 9router → `cc/claude-opus-4-7` with any non-default temperature:

```bash
curl -sS http://127.0.0.1:20128/v1/chat/completions \
  -H 'Authorization: Bearer ***' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "claude/claude-opus-4-7",
    "messages": [{"role":"user","content":"hi"}],
    "temperature": 0.7,
    "max_tokens": 32
  }'
```

Response (pre-fix):

```
400 {"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated"}}
```

This affects every OpenAI-compatible client routed through 9router to a Claude 4.x model with a non-default `temperature` — Factory Droid, custom clients, JCode, etc.

## Fix

Two-part guard in `openaiToClaudeRequest()`:

1. **Model-based strip** — skip copying `temperature` when the target model matches `claude-(?:opus|sonnet)-4` (the families with forced server-side thinking on OAuth). This mirrors the existing pattern in `open-sse/executors/github.js`:

   ```js
   supportsTemperature(model) {
     return !/gpt-5\.4/i.test(model);
   }
   ```
   (added in #536 for `gpt-5.4`.)

2. **Defensive final-pass** — after `result.thinking` is potentially set from `body.thinking` or `body.reasoning_effort`, strip `result.temperature` if it slipped through.

Models without forced thinking (haiku, sonnet-3.5, older opus) keep `temperature` unless the caller explicitly enables thinking.

## Tests

Adds 6 unit tests in `tests/unit/openai-to-claude.test.js`:

- ✅ strips temperature for `claude-opus-4-7` (forced thinking)
- ✅ strips temperature for `claude-sonnet-4-5` (forced thinking)
- ✅ preserves temperature for `claude-haiku-5-*` and `claude-3-5-sonnet-*`
- ✅ strips temperature when `body.thinking` is explicit (on non-forced model)
- ✅ strips temperature when `reasoning_effort=medium` triggers thinking
- ✅ preserves temperature when `reasoning_effort=none` on non-forced model

Full result on this branch:

```
tests/unit/openai-to-claude.test.js (10 tests) ✓ 6ms
Test Files  1 passed (1)
     Tests  10 passed (10)
```

Suite-wide: 322 passing vs 316 on `main` — net +6 passing, no regressions (the 24 pre-existing failures in `main` are unrelated to this change; reproduced by `git stash && npx vitest run`).

## Notes

- The regex intentionally matches `claude-opus-4` and `claude-sonnet-4` with any tail (so `claude-opus-4-7`, `claude-sonnet-4-5`, `claude-opus-4.7`, etc. all match). If future Claude 4.x sub-families ship *without* forced thinking, this regex would need narrowing.
- An alternative would be to do the strip inside the `claude` executor (`default.js`) instead of the translator. I chose the translator because (a) the translator is where the `temperature` field is born for OpenAI-format inputs and (b) `claude`-format providers like `agentrouter` that also send `interleaved-thinking` would benefit from the same strip without separate plumbing.
