### PR TITLE
fix(chatCore): default stream to false per OpenAI spec (#1260)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -58,7 +58,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = provider === "openai" || provider === "codex" || provider === "commandcode";
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  // OpenAI API spec: stream defaults to false when absent.
+  // Old check `body.stream !== false` evaluated `undefined !== false` to true,
+  // so every request without an explicit stream field was treated as streaming,
+  // returning text/event-stream to clients that expected application/json. See #1260.
+  let stream = providerRequiresStreaming ? true : (body.stream === true);
 
   // DeepSeek-TUI: interactive TUI panel sends stream:true and needs SSE.
   // Non-interactive mode (-p flag) sends without stream and can't parse SSE.


### PR DESCRIPTION
## Summary

Fixes #1260 with the exact one-line change proposed in that issue.

`open-sse/handlers/chatCore.js`:
```diff
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  let stream = providerRequiresStreaming ? true : (body.stream === true);
```

## Why

OpenAI API spec defines `stream` as defaulting to `false` when absent from the request body. The old condition `body.stream !== false` evaluates `undefined !== false` to `true`, so every request without an explicit `stream` field was treated as streaming. Clients that follow the spec then receive `text/event-stream` instead of `application/json` and crash when their JSON parser hits `data: {"id"...`.

`clientRequestedStreaming` already uses `body.stream === true` on the line above — the new condition is now consistent with it.

## Test plan

- [ ] Manual: `curl -X POST http://localhost:20128/v1/chat/completions -d '{"model":"haiku","messages":[{"role":"user","content":"hi"}]}'` → `content-type: application/json` (was `text/event-stream`)
- [ ] Manual: same request with `"stream":true` → still SSE
- [ ] Manual: `cx/gpt-5.5` route unchanged (already JSON, covered by `providerRequiresStreaming` short-circuit)
- [ ] Manual: deepseek-tui non-interactive heuristic unchanged
- [ ] Existing test suite passes (`tests/`)

## Real-world breakage

Filed from a real integration: agentmemory's OpenAI-compatible LLM provider (`src/providers/openai.ts` upstream) follows the spec and never sets `stream: false`. Every `mem::compress` call fails with:

```
[agentmemory] error Compression failed {"obsId":"...","error":"Unexpected token 'd', \"data: {\"id\"... is not valid JSON"}
```

After enough failures, agentmemory's circuit breaker trips and all subsequent compressions return `circuit_breaker_open`.

## Workaround for users on the current release

Until this merges:
- Add `stream: false` to the request body (works for clients that allow custom payload fields), or
- Send `Accept: application/json` (already honored on lines 71–76 of the same file)