### PR TITLE
feat(kiro): bulk refresh-token import + thinking/agentic variants

### DIFF
--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -131,23 +131,50 @@ if (fs.existsSync(cliAppDir)) {
 console.log("✅ Cleaned\n");
 
 // Step 3: Copy Next.js standalone build to app/cli/app.
-// Newer Next.js standalone output writes server.js/package.json plus .next/, src/, and
-// node_modules/ directly under .next/standalone. Older builds may still use a nested app/.
+// Layout history (newest → oldest):
+//   1. Next 16 + workspace tracing root: writes server.js/package.json/.next/src/node_modules
+//      under .next/standalone/<workspaceFolderName>/  (e.g. .next/standalone/9router/).
+//   2. Next 13–15: directly under .next/standalone/ (server.js at the root).
+//   3. Pre-13 nested layout: under .next/standalone/app/.
+// We probe each in turn so the same script keeps working across upgrades.
 console.log("3️⃣  Copying Next.js standalone build to app/cli/app...");
 const standaloneRoot = path.join(appDir, ".next", "standalone");
 const standaloneRootResolved = path.join(buildDistDir, "standalone");
 const standaloneRootToUse = fs.existsSync(standaloneRootResolved) ? standaloneRootResolved : standaloneRoot;
-const standaloneApp = fs.existsSync(path.join(standaloneRootToUse, "server.js"))
-  ? standaloneRootToUse
-  : path.join(standaloneRootToUse, "app");
-if (!fs.existsSync(standaloneApp)) {
+
+function findStandaloneApp(root) {
+  if (!fs.existsSync(root)) return null;
+  // 1. Flat layout: .next/standalone/server.js
+  if (fs.existsSync(path.join(root, "server.js"))) return root;
+  // 2. Nested-by-workspace-folder layout: .next/standalone/<folder>/server.js
+  //    Pick the first subdir that has a server.js; usually only one (the
+  //    workspace folder name = `9router`).
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === "node_modules") continue; // never the app
+    if (fs.existsSync(path.join(root, entry.name, "server.js"))) {
+      return path.join(root, entry.name);
+    }
+  }
+  // 3. Legacy nested-app layout: .next/standalone/app/
+  if (fs.existsSync(path.join(root, "app"))) return path.join(root, "app");
+  return null;
+}
+
+const standaloneApp = findStandaloneApp(standaloneRootToUse);
+if (!standaloneApp) {
   console.error("❌ Next.js standalone build not found under .next/standalone");
-  console.error("Expected either .next/standalone/server.js or .next/standalone/app/");
+  console.error("Expected one of:");
+  console.error("  - .next/standalone/server.js");
+  console.error("  - .next/standalone/<workspaceFolder>/server.js");
+  console.error("  - .next/standalone/app/");
   process.exit(1);
 }
+console.log(`   using standalone root: ${path.relative(appDir, standaloneApp) || "."}`);
 copyRecursive(standaloneApp, cliAppDir);
 
-// Older nested-app layout stores traced node_modules at standalone root.
+// When the standalone app sits one level deep, the traced node_modules is at
+// the standalone root and must be merged in alongside the app files.
 const standaloneNodeModules = path.join(standaloneRootToUse, "node_modules");
 if (standaloneApp !== standaloneRootToUse && fs.existsSync(standaloneNodeModules)) {
   copyRecursive(standaloneNodeModules, path.join(cliAppDir, "node_modules"));

--- a/cli/src/cli/menus/providers.js
+++ b/cli/src/cli/menus/providers.js
@@ -76,8 +76,34 @@ const PROVIDER_MODELS = {
     { id: "grok-code-fast-1" },
   ],
   kr: [
+    // Base
     { id: "claude-sonnet-4.5" },
     { id: "claude-haiku-4.5" },
+    { id: "deepseek-3.2" },
+    { id: "qwen3-coder-next" },
+    { id: "glm-5" },
+    { id: "MiniMax-M2.5" },
+    // Thinking
+    { id: "claude-sonnet-4.5-thinking" },
+    { id: "claude-haiku-4.5-thinking" },
+    { id: "deepseek-3.2-thinking" },
+    { id: "qwen3-coder-next-thinking" },
+    { id: "glm-5-thinking" },
+    { id: "MiniMax-M2.5-thinking" },
+    // Agentic
+    { id: "claude-sonnet-4.5-agentic" },
+    { id: "claude-haiku-4.5-agentic" },
+    { id: "deepseek-3.2-agentic" },
+    { id: "qwen3-coder-next-agentic" },
+    { id: "glm-5-agentic" },
+    { id: "MiniMax-M2.5-agentic" },
+    // Thinking + Agentic
+    { id: "claude-sonnet-4.5-thinking-agentic" },
+    { id: "claude-haiku-4.5-thinking-agentic" },
+    { id: "deepseek-3.2-thinking-agentic" },
+    { id: "qwen3-coder-next-thinking-agentic" },
+    { id: "glm-5-thinking-agentic" },
+    { id: "MiniMax-M2.5-thinking-agentic" },
   ],
   openai: [
     { id: "gpt-4o" },

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -132,7 +132,17 @@ export const PROVIDER_MODELS = {
     { id: "text-embedding-3-large", name: "Text Embedding 3 Large (GitHub)", type: "embedding" },
   ],
   kr: [  // Kiro AI
-    // --- Base Claude variants ---
+    // --- Base models ---
+    // Same upstream model id Kiro accepts. The `-thinking`, `-agentic`, and
+    // `-thinking-agentic` rows below are 9router synthetic variants:
+    //   * `-thinking`  → injects `<thinking_mode>enabled</thinking_mode>` so
+    //                     Kiro emits reasoningContentEvent frames.
+    //   * `-agentic`   → injects the chunked-write system prompt to dodge
+    //                     Kiro's 2-3 min server timeout on big writes.
+    //   * `-thinking-agentic` → both.
+    // The translator strips these suffixes before the request leaves this
+    // process. See `open-sse/config/kiroConstants.js` and
+    // `open-sse/services/kiroModels.js`.
     // { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
     { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
     { id: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
@@ -140,16 +150,29 @@ export const PROVIDER_MODELS = {
     { id: "qwen3-coder-next", name: "Qwen3 Coder Next", strip: ["image", "audio"] },
     { id: "glm-5", name: "GLM 5" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
-    // --- Thinking variants (alias to base; thinking is enabled at request time
+    // --- Thinking variants (alias to base; thinking turns on at request time
     //     via <thinking_mode>enabled</thinking_mode> system-prompt injection) ---
     { id: "claude-sonnet-4.5-thinking", name: "Claude Sonnet 4.5 (Thinking)" },
     { id: "claude-haiku-4.5-thinking", name: "Claude Haiku 4.5 (Thinking)" },
+    { id: "deepseek-3.2-thinking", name: "DeepSeek 3.2 (Thinking)", strip: ["image", "audio"] },
+    { id: "qwen3-coder-next-thinking", name: "Qwen3 Coder Next (Thinking)", strip: ["image", "audio"] },
+    { id: "glm-5-thinking", name: "GLM 5 (Thinking)" },
+    { id: "MiniMax-M2.5-thinking", name: "MiniMax M2.5 (Thinking)" },
     // --- Agentic variants (synthetic; same upstream model + chunked-write
     //     system prompt to dodge Kiro's 2-3 min server timeout on big writes) ---
     { id: "claude-sonnet-4.5-agentic", name: "Claude Sonnet 4.5 (Agentic)" },
     { id: "claude-haiku-4.5-agentic", name: "Claude Haiku 4.5 (Agentic)" },
+    { id: "deepseek-3.2-agentic", name: "DeepSeek 3.2 (Agentic)", strip: ["image", "audio"] },
+    { id: "qwen3-coder-next-agentic", name: "Qwen3 Coder Next (Agentic)", strip: ["image", "audio"] },
+    { id: "glm-5-agentic", name: "GLM 5 (Agentic)" },
+    { id: "MiniMax-M2.5-agentic", name: "MiniMax M2.5 (Agentic)" },
+    // --- Thinking + Agentic combined ---
     { id: "claude-sonnet-4.5-thinking-agentic", name: "Claude Sonnet 4.5 (Thinking + Agentic)" },
     { id: "claude-haiku-4.5-thinking-agentic", name: "Claude Haiku 4.5 (Thinking + Agentic)" },
+    { id: "deepseek-3.2-thinking-agentic", name: "DeepSeek 3.2 (Thinking + Agentic)", strip: ["image", "audio"] },
+    { id: "qwen3-coder-next-thinking-agentic", name: "Qwen3 Coder Next (Thinking + Agentic)", strip: ["image", "audio"] },
+    { id: "glm-5-thinking-agentic", name: "GLM 5 (Thinking + Agentic)" },
+    { id: "MiniMax-M2.5-thinking-agentic", name: "MiniMax M2.5 (Thinking + Agentic)" },
   ],
   cu: [  // Cursor IDE
     { id: "default", name: "Auto (Server Picks)" },

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { HTTP_STATUS, RETRY_CONFIG, DEFAULT_RETRY_CONFIG, resolveRetryEntry } from "../config/runtimeConfig.js";
+import { splitInlineThinking, flushPendingThinking } from "./kiroThinking.js";
 
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
@@ -68,8 +69,18 @@ export class KiroExecutor extends BaseExecutor {
 
       // Success - transform and return
       // For Kiro, we need to transform the binary EventStream to SSE
-      // Create a TransformStream to convert binary to SSE text
-      const transformedResponse = this.transformEventStreamToSSE(response, model);
+      // Create a TransformStream to convert binary to SSE text.
+      //
+      // We pass a `thinkingExpected` hint based on the request body. When the
+      // user enabled thinking, Claude on Kiro streams its reasoning **inline**
+      // as `<thinking>…</thinking>` blocks inside `assistantResponseEvent`
+      // rather than as separate `reasoningContentEvent` frames. The transform
+      // stream uses this flag to split that inline reasoning back into the
+      // OpenAI `delta.reasoning_content` channel.
+      const upstreamUserContent =
+        transformedBody?.conversationState?.currentMessage?.userInputMessage?.content || "";
+      const thinkingExpected = upstreamUserContent.includes("<thinking_mode>enabled</thinking_mode>");
+      const transformedResponse = this.transformEventStreamToSSE(response, model, { thinkingExpected });
       return { response: transformedResponse, url, headers, transformedBody };
     }
   }
@@ -77,8 +88,19 @@ export class KiroExecutor extends BaseExecutor {
   /**
    * Transform AWS EventStream binary response to SSE text stream
    * Using TransformStream instead of ReadableStream.pull() to avoid Workers timeout
+   *
+   * @param {Response} response  Upstream raw fetch response (binary EventStream).
+   * @param {string}   model     Logical model id (kept in OpenAI chunks for clients).
+   * @param {object}   [opts]
+   * @param {boolean}  [opts.thinkingExpected=false]
+   *   When true, scan inbound `assistantResponseEvent.content` for inline
+   *   `<thinking>…</thinking>` blocks and split them out into the OpenAI
+   *   `delta.reasoning_content` channel. Required for Claude on Kiro because
+   *   it streams reasoning inline (not as `reasoningContentEvent`) when
+   *   `<thinking_mode>enabled</thinking_mode>` is in the system prompt.
    */
-  transformEventStreamToSSE(response, model) {
+  transformEventStreamToSSE(response, model, opts = {}) {
+    const thinkingExpected = !!opts.thinkingExpected;
     let buffer = new Uint8Array(0);
     let chunkIndex = 0;
     const responseId = `chatcmpl-${Date.now()}`;
@@ -90,7 +112,91 @@ export class KiroExecutor extends BaseExecutor {
       hasReasoningContent: false,
       reasoningChunkCount: 0,
       toolCallIndex: 0,
-      seenToolIds: new Map()
+      seenToolIds: new Map(),
+      // Inline-thinking splitter state. `thinkingMode === true` means we are
+      // currently inside a `<thinking>…</thinking>` block, so subsequent text
+      // should be routed to `delta.reasoning_content`. `pendingTag` carries
+      // an unfinished tag fragment (e.g. `<thi`) across frames.
+      thinkingMode: false,
+      pendingTag: ""
+    };
+
+    // ---- Helpers ----------------------------------------------------------
+    // We declare these as locals (not arrow methods on `state`) so the
+    // TransformStream's `transform` function can call them directly via
+    // closure. They mutate `state.thinkingMode`, `state.pendingTag`, and
+    // emit OpenAI-shaped chunks via the supplied `controller`.
+    /**
+     * Emit a content delta. Sends `role: "assistant"` on the very first chunk
+     * of any kind (matching OpenAI's wire format).
+     */
+    const emitContent = (controller, content) => {
+      if (!content) return;
+      const chunkOut = {
+        id: responseId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: chunkIndex === 0
+            ? { role: "assistant", content }
+            : { content },
+          finish_reason: null
+        }]
+      };
+      chunkIndex++;
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunkOut)}\n\n`));
+    };
+
+    /**
+     * Emit a reasoning delta. Behaves like emitContent but writes the text to
+     * `delta.reasoning_content` so downstream translators (Anthropic /
+     * thinking_blocks, Claude SSE, etc.) can re-wrap it correctly.
+     */
+    const emitReasoning = (controller, reasoning) => {
+      if (!reasoning) return;
+      state.hasReasoningContent = true;
+      const reasoningDelta =
+        state.reasoningChunkCount === 0 && chunkIndex === 0
+          ? { role: "assistant", reasoning_content: reasoning }
+          : { reasoning_content: reasoning };
+      const chunkOut = {
+        id: responseId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: reasoningDelta,
+          finish_reason: null
+        }]
+      };
+      chunkIndex++;
+      state.reasoningChunkCount++;
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunkOut)}\n\n`));
+    };
+
+    /**
+     * Stream-safe `<thinking>` / `</thinking>` splitter.
+     *
+     * Walks one `assistantResponseEvent.content` slice at a time and emits
+     * either content or reasoning chunks based on the current mode. It carries
+     * a `pendingTag` buffer across slices so a tag split between frames
+     * (e.g. `…</think` then `ing>foo`) is still recognised.
+     *
+     * The splitter is only engaged when `thinkingExpected === true`. For
+     * non-thinking requests we keep the original passthrough path so any
+     * literal `<thinking>` text the user asked for in their answer is left
+     * alone.
+     */
+    const runSplitter = (controller, raw) => {
+      splitInlineThinking(
+        state,
+        raw,
+        (s) => emitContent(controller, s),
+        (s) => emitReasoning(controller, s)
+      );
     };
 
     const transformStream = new TransformStream({
@@ -127,22 +233,16 @@ export class KiroExecutor extends BaseExecutor {
           if (eventType === "assistantResponseEvent" && event.payload?.content) {
             const content = event.payload.content;
             state.totalContentLength += content.length;
-            
-            const chunk = {
-              id: responseId,
-              object: "chat.completion.chunk",
-              created,
-              model,
-              choices: [{
-                index: 0,
-                delta: chunkIndex === 0
-                  ? { role: "assistant", content }
-                  : { content },
-                finish_reason: null
-              }]
-            };
-            chunkIndex++;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+
+            if (thinkingExpected) {
+              // Claude on Kiro emits reasoning inline as `<thinking>…</thinking>`
+              // when the system prompt enables thinking. Split it into the
+              // OpenAI reasoning_content channel so downstream consumers see
+              // the same shape they would get from a native reasoning model.
+              runSplitter(controller, content);
+            } else {
+              emitContent(controller, content);
+            }
           }
 
           // Handle reasoningContentEvent (Kiro thinking / reasoning)
@@ -376,6 +476,14 @@ export class KiroExecutor extends BaseExecutor {
       },
 
       flush(controller) {
+        // Drain any pending inline-thinking tag fragment so we don't drop
+        // trailing characters when the stream ends mid-tag (e.g. `<thi`).
+        flushPendingThinking(
+          state,
+          (s) => emitContent(controller, s),
+          (s) => emitReasoning(controller, s)
+        );
+
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;

--- a/open-sse/executors/kiroThinking.js
+++ b/open-sse/executors/kiroThinking.js
@@ -1,0 +1,100 @@
+/**
+ * Inline `<thinking>` splitter for Claude on Kiro.
+ *
+ * Background:
+ *   When `<thinking_mode>enabled</thinking_mode>` is in the system prompt,
+ *   Claude on Kiro emits its reasoning **inline** as `<thinking>…</thinking>`
+ *   blocks inside `assistantResponseEvent.content`, rather than as separate
+ *   `reasoningContentEvent` frames. To match the OpenAI streaming shape that
+ *   downstream translators (Anthropic /thinking_blocks, Claude SSE, etc.)
+ *   expect, we split that inline reasoning back out and route it to the
+ *   `delta.reasoning_content` channel instead of `delta.content`.
+ *
+ * The implementation is split into pure functions so it can be unit-tested
+ * without dragging in the rest of the executor stack (proxy-agent, AWS
+ * EventStream parser, etc.). The KiroExecutor wires these helpers into its
+ * TransformStream by passing controller-bound emit callbacks.
+ */
+
+/**
+ * Stream-safe splitter. Walks one slice of upstream content at a time and
+ * routes characters to either the content channel or the reasoning channel
+ * based on the current `<thinking>` state.
+ *
+ * State is mutated on `state` so a tag split between frames (e.g. `…</think`
+ * followed by `ing>foo`) is still recognised:
+ *   - `state.thinkingMode` (boolean): true while inside a `<thinking>` block.
+ *   - `state.pendingTag` (string): trailing characters held back because they
+ *     might be the start of a tag we'll see complete on the next call.
+ *
+ * @param {{ thinkingMode: boolean, pendingTag: string }} state
+ *   Mutable state carried across calls. Initialise with
+ *   `{ thinkingMode: false, pendingTag: "" }`.
+ * @param {string} raw
+ *   Next slice from `assistantResponseEvent.content`. May be empty/null/undefined.
+ * @param {(s: string) => void} onContent
+ *   Called with text that should land in `delta.content`.
+ * @param {(s: string) => void} onReasoning
+ *   Called with text that should land in `delta.reasoning_content`.
+ */
+export function splitInlineThinking(state, raw, onContent, onReasoning) {
+  let text = (state.pendingTag || "") + (raw || "");
+  state.pendingTag = "";
+
+  // Maximum length of an unfinished tag we might still complete on the next
+  // frame: `</thinking>` is the longest at 11 chars.
+  const PARTIAL_MAX = 11;
+
+  while (text.length > 0) {
+    const target = state.thinkingMode ? "</thinking>" : "<thinking>";
+    const idx = text.indexOf(target);
+
+    if (idx === -1) {
+      // No full target tag in `text`. Look for a possible partial at the end
+      // so we can complete it on the next frame.
+      let holdFrom = text.length;
+      for (let i = Math.max(0, text.length - PARTIAL_MAX); i < text.length; i++) {
+        const tail = text.slice(i);
+        if (target.startsWith(tail) && tail.length > 0) {
+          holdFrom = i;
+          break;
+        }
+      }
+      const flushable = text.slice(0, holdFrom);
+      if (flushable) {
+        if (state.thinkingMode) onReasoning(flushable);
+        else onContent(flushable);
+      }
+      state.pendingTag = text.slice(holdFrom);
+      return;
+    }
+
+    // Found a complete target tag. Flush everything before it in the current
+    // mode, flip the mode, and keep walking the remainder.
+    const before = text.slice(0, idx);
+    if (before) {
+      if (state.thinkingMode) onReasoning(before);
+      else onContent(before);
+    }
+    state.thinkingMode = !state.thinkingMode;
+    text = text.slice(idx + target.length);
+  }
+}
+
+/**
+ * Drain whatever is left in `state.pendingTag` at end-of-stream. Routes the
+ * leftover characters to whichever channel matches the current
+ * `state.thinkingMode` so we don't silently lose data when the stream ends
+ * mid-tag (e.g. `<thi`).
+ *
+ * @param {{ thinkingMode: boolean, pendingTag: string }} state
+ * @param {(s: string) => void} onContent
+ * @param {(s: string) => void} onReasoning
+ */
+export function flushPendingThinking(state, onContent, onReasoning) {
+  if (!state.pendingTag) return;
+  const leftover = state.pendingTag;
+  state.pendingTag = "";
+  if (state.thinkingMode) onReasoning(leftover);
+  else onContent(leftover);
+}

--- a/src/app/api/oauth/kiro/auto-import/route.js
+++ b/src/app/api/oauth/kiro/auto-import/route.js
@@ -5,75 +5,86 @@ import { join } from "path";
 
 /**
  * GET /api/oauth/kiro/auto-import
- * Auto-detect and extract Kiro refresh token from AWS SSO cache
+ *
+ * Auto-detect Kiro refresh token(s) from the AWS SSO cache.
+ *
+ * Query params:
+ *   - all=1 → return every refresh token found across the cache directory
+ *
+ * Single-token shape (default, backwards compatible):
+ *   { found: true, refreshToken, source }
+ *   { found: false, error }
+ *
+ * Multi-token shape (when `?all=1`):
+ *   { found: true, count, tokens: [{ refreshToken, source }] }
+ *   { found: false, error }
  */
-export async function GET() {
+export async function GET(request) {
   try {
+    const { searchParams } = new URL(request.url);
+    const wantAll = ["1", "true", "yes"].includes(
+      (searchParams.get("all") || "").toLowerCase()
+    );
+
     const cachePath = join(homedir(), ".aws/sso/cache");
 
-    // Try to read cache directory
     let files;
     try {
       files = await readdir(cachePath);
-    } catch (error) {
+    } catch {
       return NextResponse.json({
         found: false,
         error: "AWS SSO cache not found. Please login to Kiro IDE first.",
       });
     }
 
-    // Look for kiro-auth-token.json or any .json file with refreshToken
-    let refreshToken = null;
-    let foundFile = null;
+    // Read every JSON file in the cache and collect any Kiro-shaped tokens.
+    // Sort `kiro-auth-token.json` first so single-token mode prefers it.
+    const sortedFiles = [
+      ...files.filter((f) => f === "kiro-auth-token.json"),
+      ...files.filter((f) => f !== "kiro-auth-token.json" && f.endsWith(".json")),
+    ];
 
-    // First try kiro-auth-token.json
-    const kiroTokenFile = "kiro-auth-token.json";
-    if (files.includes(kiroTokenFile)) {
+    const tokens = [];
+    const seen = new Set();
+    for (const file of sortedFiles) {
       try {
-        const content = await readFile(join(cachePath, kiroTokenFile), "utf-8");
+        const content = await readFile(join(cachePath, file), "utf-8");
         const data = JSON.parse(content);
-        if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
-          refreshToken = data.refreshToken;
-          foundFile = kiroTokenFile;
+        if (
+          typeof data?.refreshToken === "string"
+          && data.refreshToken.startsWith("aorAAAAAG")
+          && !seen.has(data.refreshToken)
+        ) {
+          seen.add(data.refreshToken);
+          tokens.push({ refreshToken: data.refreshToken, source: file });
+          if (!wantAll) break;
         }
-      } catch (error) {
-        // Continue to search other files
+      } catch {
+        // Skip unreadable / non-JSON files.
       }
     }
 
-    // If not found, search all .json files
-    if (!refreshToken) {
-      for (const file of files) {
-        if (!file.endsWith(".json")) continue;
-
-        try {
-          const content = await readFile(join(cachePath, file), "utf-8");
-          const data = JSON.parse(content);
-
-          // Look for Kiro refresh token (starts with aorAAAAAG)
-          if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
-            refreshToken = data.refreshToken;
-            foundFile = file;
-            break;
-          }
-        } catch (error) {
-          // Skip invalid JSON files
-          continue;
-        }
-      }
-    }
-
-    if (!refreshToken) {
+    if (tokens.length === 0) {
       return NextResponse.json({
         found: false,
         error: "Kiro token not found in AWS SSO cache. Please login to Kiro IDE first.",
       });
     }
 
+    if (wantAll) {
+      return NextResponse.json({
+        found: true,
+        count: tokens.length,
+        tokens,
+      });
+    }
+
+    // Single-token shape — backwards compatible.
     return NextResponse.json({
       found: true,
-      refreshToken,
-      source: foundFile,
+      refreshToken: tokens[0].refreshToken,
+      source: tokens[0].source,
     });
   } catch (error) {
     console.log("Kiro auto-import error:", error);

--- a/src/app/api/oauth/kiro/import/helpers.js
+++ b/src/app/api/oauth/kiro/import/helpers.js
@@ -1,0 +1,69 @@
+/**
+ * Helpers for the bulk Kiro refresh-token import endpoint.
+ *
+ * Extracted from `route.js` so they can be unit-tested without spinning up a
+ * Next.js request lifecycle. Next.js treats every named export from a route
+ * file as a route method, so non-method helpers must live in a sibling file.
+ */
+
+/**
+ * Normalise the inbound POST payload into a deduplicated, trimmed token list.
+ *
+ * Accepts:
+ *   { refreshToken: "aorAAAAAG..." }
+ *   { refreshToken: "aorAAAAAG...\naorAAAAAG..." }      // newline / comma / semicolon separated
+ *   { refreshTokens: ["aorAAAAAG...", "aorAAAAAG..."] }
+ *   { refreshTokens: "aorAAAAAG...\naorAAAAAG..." }
+ *
+ * @param {unknown} payload  Parsed JSON body.
+ * @returns {string[]} Deduplicated, trimmed, non-empty refresh tokens.
+ */
+export function collectRefreshTokens(payload) {
+  if (!payload || typeof payload !== "object") return [];
+
+  const raw = [];
+  if (Array.isArray(payload.refreshTokens)) {
+    for (const t of payload.refreshTokens) {
+      if (typeof t === "string") raw.push(t);
+    }
+  } else if (typeof payload.refreshTokens === "string") {
+    raw.push(...splitTokens(payload.refreshTokens));
+  }
+
+  if (typeof payload.refreshToken === "string") {
+    raw.push(...splitTokens(payload.refreshToken));
+  }
+
+  const seen = new Set();
+  const out = [];
+  for (const t of raw) {
+    const trimmed = t.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Split a string of tokens. Tolerates any whitespace, commas, or semicolons
+ * between tokens so users can paste from spreadsheets, env files, or Kiro's
+ * `kiro-auth-token.json`.
+ */
+export function splitTokens(input) {
+  return input
+    .split(/[\s,;]+/g)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Mask a refresh token for inclusion in API responses and logs. Keeps the
+ * leading 8 chars (provider prefix) and the last 4 chars (rotation hint), so
+ * users can identify which token was processed without leaking the full value.
+ */
+export function maskToken(token) {
+  if (typeof token !== "string" || token.length < 12) return "***";
+  return `${token.slice(0, 8)}…${token.slice(-4)}`;
+}

--- a/src/app/api/oauth/kiro/import/route.js
+++ b/src/app/api/oauth/kiro/import/route.js
@@ -1,31 +1,85 @@
 import { NextResponse } from "next/server";
 import { KiroService } from "@/lib/oauth/services/kiro";
 import { createProviderConnection } from "@/models";
+import { collectRefreshTokens, maskToken } from "./helpers";
 
 /**
  * POST /api/oauth/kiro/import
- * Import and validate refresh token from Kiro IDE
+ *
+ * Accepts a single refresh token or many at once. The single-token shape is
+ * preserved for backwards compatibility with older clients.
+ *
+ * Request shapes:
+ *   { "refreshToken": "aorAAAAAG..." }
+ *   { "refreshTokens": ["aorAAAAAG...", "aorAAAAAG..."] }
+ *   { "refreshTokens": "aorAAAAAG...\naorAAAAAG..." }   // newline / whitespace / comma / semicolon separated
+ *
+ * Response (200 when at least one token was imported, 422 otherwise):
+ *   {
+ *     success: boolean,
+ *     imported: [{ id, email, refreshToken: "<masked>" }],
+ *     failed:   [{ refreshToken: "<masked>", error: string }],
+ *     // Single-token success path also includes `connection` for backwards compat.
+ *     connection?: { id, provider, email }
+ *   }
  */
 export async function POST(request) {
+  let payload;
   try {
-    const { refreshToken } = await request.json();
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-    if (!refreshToken || typeof refreshToken !== "string") {
-      return NextResponse.json(
-        { error: "Refresh token is required" },
-        { status: 400 }
-      );
-    }
+  const tokens = collectRefreshTokens(payload);
+  if (tokens.length === 0) {
+    return NextResponse.json(
+      { error: "Refresh token is required" },
+      { status: 400 }
+    );
+  }
 
-    const kiroService = new KiroService();
+  const kiroService = new KiroService();
+  // Validate + persist each token in parallel. One bad token must not block
+  // the rest.
+  const results = await Promise.all(
+    tokens.map((rt) => importOne(rt, kiroService))
+  );
 
-    // Validate and refresh token
-    const tokenData = await kiroService.validateImportToken(refreshToken.trim());
+  const imported = [];
+  const failed = [];
+  for (const r of results) {
+    if (r.ok) imported.push(r.payload);
+    else failed.push(r.payload);
+  }
 
-    // Extract email from JWT if available
+  const wasSingle = tokens.length === 1 && !Array.isArray(payload?.refreshTokens);
+  const success = imported.length > 0;
+
+  const body = { success, imported, failed };
+  if (wasSingle && success) {
+    // Preserve the legacy single-token response shape so existing clients keep
+    // working without changes.
+    body.connection = {
+      id: imported[0].id,
+      provider: "kiro",
+      email: imported[0].email,
+    };
+  }
+
+  return NextResponse.json(body, { status: success ? 200 : 422 });
+}
+
+/**
+ * Validate and persist a single refresh token. Failures are returned (not
+ * thrown) so `Promise.all` won't short-circuit when one token is bad.
+ */
+async function importOne(refreshToken, kiroService) {
+  const masked = maskToken(refreshToken);
+  try {
+    const tokenData = await kiroService.validateImportToken(refreshToken);
     const email = kiroService.extractEmailFromJWT(tokenData.accessToken);
 
-    // Save to database
     const connection = await createProviderConnection({
       provider: "kiro",
       authType: "oauth",
@@ -41,16 +95,22 @@ export async function POST(request) {
       testStatus: "active",
     });
 
-    return NextResponse.json({
-      success: true,
-      connection: {
+    return {
+      ok: true,
+      payload: {
         id: connection.id,
-        provider: connection.provider,
         email: connection.email,
+        refreshToken: masked,
       },
-    });
+    };
   } catch (error) {
-    console.log("Kiro import token error:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.log("Kiro import token error:", error?.message || error);
+    return {
+      ok: false,
+      payload: {
+        refreshToken: masked,
+        error: error?.message || String(error),
+      },
+    };
   }
 }

--- a/src/shared/components/KiroAuthModal.js
+++ b/src/shared/components/KiroAuthModal.js
@@ -1,43 +1,66 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import { Modal, Button, Input } from "@/shared/components";
 
 /**
  * Kiro Auth Method Selection Modal
- * Auto-detects token from AWS SSO cache or allows manual import
+ * Auto-detects token from AWS SSO cache or allows manual import.
+ *
+ * Manual import accepts multiple refresh tokens at once — paste one per line
+ * (or whitespace / comma / semicolon separated). Each token is validated and
+ * persisted independently; the modal reports a per-token summary on completion.
  */
 export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
   const [selectedMethod, setSelectedMethod] = useState(null);
   const [idcStartUrl, setIdcStartUrl] = useState("");
   const [idcRegion, setIdcRegion] = useState("us-east-1");
-  const [refreshToken, setRefreshToken] = useState("");
+  const [refreshTokens, setRefreshTokens] = useState("");
   const [error, setError] = useState(null);
   const [importing, setImporting] = useState(false);
   const [autoDetecting, setAutoDetecting] = useState(false);
-  const [autoDetected, setAutoDetected] = useState(false);
+  const [autoDetected, setAutoDetected] = useState(0);
+  const [importResult, setImportResult] = useState(null);
 
-  // Auto-detect token when import method is selected
+  // Live token count (handles whitespace / comma / semicolon separators).
+  const tokenCount = useMemo(() => {
+    return refreshTokens
+      .split(/[\s,;]+/g)
+      .map((t) => t.trim())
+      .filter(Boolean).length;
+  }, [refreshTokens]);
+
+  // Auto-detect token(s) from AWS SSO cache when import method is selected.
   useEffect(() => {
     if (selectedMethod !== "import" || !isOpen) return;
 
     const autoDetect = async () => {
       setAutoDetecting(true);
       setError(null);
-      setAutoDetected(false);
+      setAutoDetected(0);
+      setImportResult(null);
 
       try {
-        const res = await fetch("/api/oauth/kiro/auto-import");
+        const res = await fetch("/api/oauth/kiro/auto-import?all=1");
         const data = await res.json();
 
         if (data.found) {
-          setRefreshToken(data.refreshToken);
-          setAutoDetected(true);
+          const list = Array.isArray(data.tokens) && data.tokens.length > 0
+            ? data.tokens.map((t) => t.refreshToken)
+            : data.refreshToken
+              ? [data.refreshToken]
+              : [];
+          if (list.length > 0) {
+            setRefreshTokens(list.join("\n"));
+            setAutoDetected(list.length);
+          } else {
+            setError(data.error || "No tokens found in AWS SSO cache");
+          }
         } else {
           setError(data.error || "Could not auto-detect token");
         }
-      } catch (err) {
+      } catch {
         setError("Failed to auto-detect token");
       } finally {
         setAutoDetecting(false);
@@ -50,41 +73,74 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
   const handleMethodSelect = (method) => {
     setSelectedMethod(method);
     setError(null);
+    setImportResult(null);
   };
 
   const handleBack = () => {
     setSelectedMethod(null);
     setError(null);
+    setImportResult(null);
+    setRefreshTokens("");
   };
 
-  const handleImportToken = async () => {
-    if (!refreshToken.trim()) {
-      setError("Please enter a refresh token");
+  const handleImportTokens = async () => {
+    const tokens = refreshTokens
+      .split(/[\s,;]+/g)
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    if (tokens.length === 0) {
+      setError("Please paste at least one refresh token");
       return;
     }
 
     setImporting(true);
     setError(null);
+    setImportResult(null);
 
     try {
       const res = await fetch("/api/oauth/kiro/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refreshToken: refreshToken.trim() }),
+        body: JSON.stringify({ refreshTokens: tokens }),
       });
 
       const data = await res.json();
 
-      if (!res.ok) {
-        throw new Error(data.error || "Import failed");
+      // The API returns 200/422 with imported/failed arrays. 4xx/5xx with an
+      // `error` field only happens for malformed payloads.
+      if (!data || (typeof data.success !== "boolean" && data.error)) {
+        throw new Error(data?.error || "Import failed");
       }
 
-      // Success - notify parent to refresh connections
-      onMethodSelect("import");
+      const imported = Array.isArray(data.imported) ? data.imported : [];
+      const failed = Array.isArray(data.failed) ? data.failed : [];
+      setImportResult({ imported, failed });
+
+      if (imported.length === 0 && failed.length > 0) {
+        setError(
+          failed.length === 1
+            ? failed[0].error || "Token validation failed"
+            : `All ${failed.length} tokens failed to import`
+        );
+      }
+      // Stay open so the user can review the per-token outcome. The "Done"
+      // button below calls onMethodSelect("import") which triggers parent
+      // refresh + close.
     } catch (err) {
       setError(err.message);
     } finally {
       setImporting(false);
+    }
+  };
+
+  const handleImportDone = () => {
+    if (importResult && importResult.imported.length > 0) {
+      // Tell parent to refresh its connection list and close the modal.
+      onMethodSelect("import");
+    } else {
+      // No imports succeeded — just go back to method selection.
+      handleBack();
     }
   };
 
@@ -184,7 +240,7 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
                 <div className="flex-1">
                   <h3 className="font-semibold mb-1">Import Token</h3>
                   <p className="text-sm text-text-muted">
-                    Paste refresh token from Kiro IDE.
+                    Paste one or more refresh tokens from Kiro IDE. Bulk import supported.
                   </p>
                 </div>
               </div>
@@ -307,7 +363,7 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
                     progress_activity
                   </span>
                 </div>
-                <h3 className="text-lg font-semibold mb-2">Auto-detecting token...</h3>
+                <h3 className="text-lg font-semibold mb-2">Auto-detecting tokens...</h3>
                 <p className="text-sm text-text-muted">
                   Reading from AWS SSO cache
                 </p>
@@ -318,24 +374,26 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
             {!autoDetecting && (
               <>
                 {/* Success message if auto-detected */}
-                {autoDetected && (
+                {autoDetected > 0 && !importResult && (
                   <div className="bg-green-50 dark:bg-green-900/20 p-3 rounded-lg border border-green-200 dark:border-green-800">
                     <div className="flex gap-2">
                       <span className="material-symbols-outlined text-green-600 dark:text-green-400">check_circle</span>
                       <p className="text-sm text-green-800 dark:text-green-200">
-                        Token auto-detected from Kiro IDE successfully!
+                        {autoDetected === 1
+                          ? "Token auto-detected from Kiro IDE successfully!"
+                          : `${autoDetected} tokens auto-detected from AWS SSO cache.`}
                       </p>
                     </div>
                   </div>
                 )}
 
                 {/* Info message if not auto-detected */}
-                {!autoDetected && !error && (
+                {autoDetected === 0 && !error && !importResult && (
                   <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg border border-blue-200 dark:border-blue-800">
                     <div className="flex gap-2">
                       <span className="material-symbols-outlined text-blue-600 dark:text-blue-400">info</span>
                       <p className="text-sm text-blue-800 dark:text-blue-200">
-                        Kiro IDE not detected. Please paste your refresh token manually.
+                        Kiro IDE not detected. Paste one or more refresh tokens below — one per line.
                       </p>
                     </div>
                   </div>
@@ -343,28 +401,86 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
 
                 <div>
                   <label className="block text-sm font-medium mb-2">
-                    Refresh Token <span className="text-red-500">*</span>
+                    Refresh Tokens <span className="text-red-500">*</span>
                   </label>
-                  <Input
-                    value={refreshToken}
-                    onChange={(e) => setRefreshToken(e.target.value)}
-                    placeholder="Token will be auto-filled..."
-                    className="font-mono text-sm"
+                  <textarea
+                    value={refreshTokens}
+                    onChange={(e) => setRefreshTokens(e.target.value)}
+                    placeholder={"aorAAAAAG...\naorAAAAAG...\naorAAAAAG..."}
+                    rows={6}
+                    spellCheck={false}
+                    className="w-full py-2.5 px-3 text-sm font-mono text-text-main bg-surface-2 rounded-[10px] border border-transparent placeholder-text-muted/70 focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40 transition-all duration-150 ease-out resize-y"
                   />
+                  <p className="text-xs text-text-muted mt-1">
+                    {tokenCount > 0
+                      ? `${tokenCount} token${tokenCount === 1 ? "" : "s"} ready to import`
+                      : "Paste one or more refresh tokens. Separate by newline, comma, or whitespace."}
+                  </p>
                 </div>
 
-                {error && (
+                {/* Per-token result summary */}
+                {importResult && (
+                  <div className="space-y-2">
+                    {importResult.imported.length > 0 && (
+                      <div className="bg-green-50 dark:bg-green-900/20 p-3 rounded-lg border border-green-200 dark:border-green-800">
+                        <p className="text-sm font-medium text-green-800 dark:text-green-200 mb-1">
+                          ✓ Imported {importResult.imported.length} token{importResult.imported.length === 1 ? "" : "s"}
+                        </p>
+                        <ul className="text-xs text-green-700 dark:text-green-300 space-y-0.5 font-mono">
+                          {importResult.imported.map((r, i) => (
+                            <li key={`ok-${i}`}>
+                              {r.refreshToken}
+                              {r.email ? ` — ${r.email}` : ""}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {importResult.failed.length > 0 && (
+                      <div className="bg-red-50 dark:bg-red-900/20 p-3 rounded-lg border border-red-200 dark:border-red-800">
+                        <p className="text-sm font-medium text-red-800 dark:text-red-200 mb-1">
+                          ✗ Failed {importResult.failed.length} token{importResult.failed.length === 1 ? "" : "s"}
+                        </p>
+                        <ul className="text-xs text-red-700 dark:text-red-300 space-y-0.5">
+                          {importResult.failed.map((r, i) => (
+                            <li key={`err-${i}`}>
+                              <span className="font-mono">{r.refreshToken}</span>
+                              {": "}
+                              <span>{r.error}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {error && !importResult && (
                   <div className="bg-red-50 dark:bg-red-900/20 p-3 rounded-lg border border-red-200 dark:border-red-800">
                     <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
                   </div>
                 )}
 
                 <div className="flex gap-2">
-                  <Button onClick={handleImportToken} fullWidth disabled={importing || !refreshToken.trim()}>
-                    {importing ? "Importing..." : "Import Token"}
-                  </Button>
-                  <Button onClick={handleBack} variant="ghost" fullWidth>
-                    Back
+                  {!importResult && (
+                    <Button
+                      onClick={handleImportTokens}
+                      fullWidth
+                      disabled={importing || tokenCount === 0}
+                    >
+                      {importing
+                        ? "Importing..."
+                        : tokenCount > 1
+                          ? `Import ${tokenCount} Tokens`
+                          : "Import Token"}
+                    </Button>
+                  )}
+                  <Button
+                    onClick={importResult ? handleImportDone : handleBack}
+                    variant={importResult ? "primary" : "ghost"}
+                    fullWidth
+                  >
+                    {importResult ? "Done" : "Back"}
                   </Button>
                 </div>
               </>

--- a/tests/unit/kiro.thinking-splitter.test.js
+++ b/tests/unit/kiro.thinking-splitter.test.js
@@ -1,0 +1,183 @@
+// Unit tests for the inline-thinking splitter used by KiroExecutor.
+//
+// Claude on Kiro emits its reasoning **inline** as `<thinking>…</thinking>`
+// blocks inside `assistantResponseEvent.content` rather than as separate
+// `reasoningContentEvent` frames. The splitter must:
+//   1. Route text inside `<thinking>` tags to the reasoning channel.
+//   2. Route everything else to the content channel.
+//   3. Survive tags split across SSE chunks (e.g. `…</think` + `ing>foo`).
+//   4. Survive the stream ending mid-tag and not lose those trailing chars.
+//   5. Be idempotent on tag-less input (regular non-thinking responses).
+
+import { describe, it, expect } from "vitest";
+import {
+  splitInlineThinking,
+  flushPendingThinking,
+} from "../../open-sse/executors/kiroThinking.js";
+
+/** Build a fresh state + recorders for each test. */
+function makeHarness() {
+  const state = { thinkingMode: false, pendingTag: "" };
+  const content = [];
+  const reasoning = [];
+  const onContent = (s) => content.push(s);
+  const onReasoning = (s) => reasoning.push(s);
+  /** Feed one slice. */
+  const feed = (raw) => splitInlineThinking(state, raw, onContent, onReasoning);
+  /** Drain at end-of-stream. */
+  const flush = () => flushPendingThinking(state, onContent, onReasoning);
+  return {
+    state,
+    feed,
+    flush,
+    get content() { return content.join(""); },
+    get reasoning() { return reasoning.join(""); },
+  };
+}
+
+describe("splitInlineThinking", () => {
+  it("passes through plain content with no tags", () => {
+    const h = makeHarness();
+    h.feed("Bonjour, this is just an answer.");
+    h.flush();
+    expect(h.content).toBe("Bonjour, this is just an answer.");
+    expect(h.reasoning).toBe("");
+    expect(h.state.thinkingMode).toBe(false);
+    expect(h.state.pendingTag).toBe("");
+  });
+
+  it("splits a single-shot input with one full block", () => {
+    const h = makeHarness();
+    h.feed("Hello <thinking>secret thoughts</thinking> world");
+    h.flush();
+    expect(h.content).toBe("Hello  world");
+    expect(h.reasoning).toBe("secret thoughts");
+    expect(h.state.thinkingMode).toBe(false);
+  });
+
+  it("handles a tag split across two slices (open tag)", () => {
+    // The opening `<thinking>` arrives across two reads.
+    const h = makeHarness();
+    h.feed("Hi <thi");
+    expect(h.content).toBe("Hi "); // only the safe prefix is flushed
+    expect(h.state.pendingTag).toBe("<thi");
+
+    h.feed("nking>thoughts</thinking> bye");
+    h.flush();
+    expect(h.content).toBe("Hi  bye");
+    expect(h.reasoning).toBe("thoughts");
+    expect(h.state.pendingTag).toBe("");
+  });
+
+  it("handles a tag split across two slices (close tag)", () => {
+    const h = makeHarness();
+    h.feed("<thinking>step 1</thi");
+    expect(h.reasoning).toBe("step 1");
+    expect(h.state.thinkingMode).toBe(true);
+    expect(h.state.pendingTag).toBe("</thi");
+
+    h.feed("nking>final answer");
+    h.flush();
+    expect(h.content).toBe("final answer");
+    expect(h.reasoning).toBe("step 1");
+    expect(h.state.thinkingMode).toBe(false);
+  });
+
+  it("handles a tag split character-by-character", () => {
+    const h = makeHarness();
+    const stream = "before <thinking>hidden</thinking>after";
+    for (const ch of stream) h.feed(ch);
+    h.flush();
+    expect(h.content).toBe("before after");
+    expect(h.reasoning).toBe("hidden");
+    expect(h.state.thinkingMode).toBe(false);
+    expect(h.state.pendingTag).toBe("");
+  });
+
+  it("handles multiple thinking blocks in sequence", () => {
+    const h = makeHarness();
+    h.feed("<thinking>plan A</thinking>step1<thinking>plan B</thinking>step2");
+    h.flush();
+    expect(h.content).toBe("step1step2");
+    expect(h.reasoning).toBe("plan Aplan B");
+    expect(h.state.thinkingMode).toBe(false);
+  });
+
+  it("emits leftover content when the stream ends mid-tag", () => {
+    // Stream truncated inside a partial open tag — must not silently drop.
+    const h = makeHarness();
+    h.feed("ok <thi");
+    expect(h.state.pendingTag).toBe("<thi");
+    h.flush();
+    // We are not in thinking mode, so the leftover goes to content.
+    expect(h.content).toBe("ok <thi");
+    expect(h.reasoning).toBe("");
+  });
+
+  it("emits leftover reasoning when the stream ends mid-close-tag", () => {
+    // We are inside <thinking> and the stream ends mid `</thi`.
+    const h = makeHarness();
+    h.feed("<thinking>partial</thi");
+    expect(h.state.thinkingMode).toBe(true);
+    expect(h.state.pendingTag).toBe("</thi");
+    h.flush();
+    // Leftover stays in the reasoning channel because we never saw the close.
+    expect(h.reasoning).toBe("partial</thi");
+    expect(h.content).toBe("");
+  });
+
+  it("does not consume tag-shaped content that isn't a real tag boundary", () => {
+    // A `<` followed by something that doesn't match `<thinking>` should
+    // eventually flow through as content.
+    const h = makeHarness();
+    h.feed("a<b>c</b>d");
+    h.flush();
+    expect(h.content).toBe("a<b>c</b>d");
+    expect(h.reasoning).toBe("");
+  });
+
+  it("only holds back trailing characters that look like a partial OPEN tag (outside thinking mode)", () => {
+    // Outside thinking mode the splitter only watches for `<thinking>`. A
+    // partial `<think` at the end must be held; everything before it flushes.
+    const h = makeHarness();
+    h.feed("answer text <think");
+    expect(h.content).toBe("answer text "); // safe prefix flushed eagerly
+    expect(h.state.pendingTag).toBe("<think");
+
+    h.feed("ing>secret</thinking>tail");
+    h.flush();
+    expect(h.content).toBe("answer text tail");
+    expect(h.reasoning).toBe("secret");
+  });
+
+  it("does not hold back partial CLOSE tag while outside thinking mode", () => {
+    // Outside thinking mode `</thinking>` is irrelevant — a stray `</think`
+    // is just normal content and flushes immediately on the next slice.
+    const h = makeHarness();
+    h.feed("answer text </think");
+    h.feed(" something else");
+    h.flush();
+    expect(h.content).toBe("answer text </think something else");
+    expect(h.reasoning).toBe("");
+  });
+
+  it("survives empty / null slices", () => {
+    const h = makeHarness();
+    h.feed("");
+    h.feed(undefined);
+    h.feed(null);
+    h.feed("hello");
+    h.flush();
+    expect(h.content).toBe("hello");
+    expect(h.reasoning).toBe("");
+  });
+
+  it("flushPendingThinking is a no-op when nothing is pending", () => {
+    const h = makeHarness();
+    h.feed("just content");
+    h.flush();
+    h.flush();
+    expect(h.content).toBe("just content");
+    expect(h.reasoning).toBe("");
+  });
+});

--- a/tests/unit/kiroImport.helpers.test.js
+++ b/tests/unit/kiroImport.helpers.test.js
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the bulk Kiro refresh-token import helpers.
+ *
+ * These cover the pure parsing/masking layer extracted from the route handler
+ * so the logic can be exercised without spinning up a Next.js request, the
+ * KiroService, or the SQLite store.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  collectRefreshTokens,
+  splitTokens,
+  maskToken,
+} from "../../src/app/api/oauth/kiro/import/helpers.js";
+
+describe("collectRefreshTokens", () => {
+  it("returns an empty array for null / non-object payloads", () => {
+    expect(collectRefreshTokens(null)).toEqual([]);
+    expect(collectRefreshTokens(undefined)).toEqual([]);
+    expect(collectRefreshTokens("not-an-object")).toEqual([]);
+    expect(collectRefreshTokens(42)).toEqual([]);
+  });
+
+  it("returns an empty array when neither field is present", () => {
+    expect(collectRefreshTokens({})).toEqual([]);
+    expect(collectRefreshTokens({ refreshToken: 123 })).toEqual([]);
+  });
+
+  it("accepts the legacy single-token shape", () => {
+    expect(collectRefreshTokens({ refreshToken: "aorAAAAAG-token-1" }))
+      .toEqual(["aorAAAAAG-token-1"]);
+  });
+
+  it("trims surrounding whitespace from a single token", () => {
+    expect(collectRefreshTokens({ refreshToken: "  aorAAAAAG-token-1  " }))
+      .toEqual(["aorAAAAAG-token-1"]);
+  });
+
+  it("splits a refreshToken string on whitespace, commas, and semicolons", () => {
+    expect(
+      collectRefreshTokens({
+        refreshToken: "aorAAAAAG-1\naorAAAAAG-2 aorAAAAAG-3,aorAAAAAG-4;aorAAAAAG-5",
+      })
+    ).toEqual([
+      "aorAAAAAG-1",
+      "aorAAAAAG-2",
+      "aorAAAAAG-3",
+      "aorAAAAAG-4",
+      "aorAAAAAG-5",
+    ]);
+  });
+
+  it("accepts an array refreshTokens shape", () => {
+    expect(
+      collectRefreshTokens({
+        refreshTokens: ["aorAAAAAG-1", "aorAAAAAG-2"],
+      })
+    ).toEqual(["aorAAAAAG-1", "aorAAAAAG-2"]);
+  });
+
+  it("ignores non-string entries inside the refreshTokens array", () => {
+    expect(
+      collectRefreshTokens({
+        refreshTokens: ["aorAAAAAG-1", null, 42, "aorAAAAAG-2", undefined],
+      })
+    ).toEqual(["aorAAAAAG-1", "aorAAAAAG-2"]);
+  });
+
+  it("accepts a string refreshTokens shape and splits it", () => {
+    expect(
+      collectRefreshTokens({
+        refreshTokens: "aorAAAAAG-1\n\naorAAAAAG-2",
+      })
+    ).toEqual(["aorAAAAAG-1", "aorAAAAAG-2"]);
+  });
+
+  it("merges both fields when present", () => {
+    expect(
+      collectRefreshTokens({
+        refreshTokens: ["aorAAAAAG-1"],
+        refreshToken: "aorAAAAAG-2 aorAAAAAG-3",
+      })
+    ).toEqual(["aorAAAAAG-1", "aorAAAAAG-2", "aorAAAAAG-3"]);
+  });
+
+  it("deduplicates tokens (first occurrence wins)", () => {
+    expect(
+      collectRefreshTokens({
+        refreshTokens: ["aorAAAAAG-1", "aorAAAAAG-1", "aorAAAAAG-2"],
+        refreshToken: "aorAAAAAG-2",
+      })
+    ).toEqual(["aorAAAAAG-1", "aorAAAAAG-2"]);
+  });
+
+  it("drops empty strings and whitespace-only entries", () => {
+    expect(
+      collectRefreshTokens({
+        refreshTokens: ["", "   ", "aorAAAAAG-1", "\t\n"],
+      })
+    ).toEqual(["aorAAAAAG-1"]);
+  });
+});
+
+describe("splitTokens", () => {
+  it("splits on mixed separators", () => {
+    expect(splitTokens("a b\nc\td,e;f")).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+    ]);
+  });
+
+  it("collapses runs of separators", () => {
+    expect(splitTokens("a,,;\n\n b")).toEqual(["a", "b"]);
+  });
+
+  it("returns an empty array for an empty / whitespace-only string", () => {
+    expect(splitTokens("")).toEqual([]);
+    expect(splitTokens("   \n\t")).toEqual([]);
+  });
+});
+
+describe("maskToken", () => {
+  it("returns *** for short or non-string values", () => {
+    expect(maskToken("")).toBe("***");
+    expect(maskToken("short")).toBe("***");
+    expect(maskToken(null)).toBe("***");
+    expect(maskToken(undefined)).toBe("***");
+    expect(maskToken(12345)).toBe("***");
+    // Exactly 11 chars is below the 12-char threshold.
+    expect(maskToken("12345678901")).toBe("***");
+  });
+
+  it("keeps the leading 8 chars and trailing 4 chars for full tokens", () => {
+    // 12-char minimum: prefix(8) + suffix(4)
+    expect(maskToken("aorAAAAAGabcd")).toBe("aorAAAAA…abcd");
+    expect(
+      maskToken("aorAAAAAG-this-is-a-much-longer-refresh-token-XXXX")
+    ).toBe("aorAAAAA…XXXX");
+  });
+});


### PR DESCRIPTION
## Summary

Two related improvements to the Kiro provider, plus a small CLI build fix that fell out of testing.

### 1. Bulk refresh-token import

`POST /api/oauth/kiro/import` now accepts many tokens at once. The legacy single-token shape (and its `connection` response field) is preserved.

```json
{ "refreshToken": "aorAAAAAG..." }                              // legacy
{ "refreshTokens": ["aorAAAAAG-1", "aorAAAAAG-2"] }             // new — array
{ "refreshTokens": "aorAAAAAG-1\naorAAAAAG-2 aorAAAAAG-3" }     // new — split on whitespace/comma/semicolon
```

Each token is validated and persisted in parallel; per-token results return as `{ imported: [...], failed: [...] }`. Status is 200 if any succeed, 422 otherwise.

`GET /api/oauth/kiro/auto-import?all=1` walks every `~/.aws/sso/cache/*.json`, sorted with `kiro-auth-token.json` first and deduplicated by token.

`KiroAuthModal` swaps the single Input for a textarea with a live token count, calls `?all=1` for autodetect, and renders an imported/failed summary.

### 2. Thinking / agentic model variants

Added `-thinking`, `-agentic`, and `-thinking-agentic` synthetic model IDs for every Kiro base model (claude-sonnet-4.5, claude-haiku-4.5, deepseek-3.2, qwen3-coder-next, glm-5, MiniMax-M2.5) in both web (`open-sse/config/providerModels.js`) and CLI (`cli/src/cli/menus/providers.js`).

Suffixes are stripped before the upstream request leaves the process and inject Kiro's standard system-prompt sentinels.

### 3. Inline-thinking emission (Claude on Kiro)

Live testing surfaced that **Claude on Kiro emits reasoning inline as `<thinking>...</thinking>` inside `assistantResponseEvent.content`**, not as separate `reasoningContentEvent` frames. The new `open-sse/executors/kiroThinking.js` is a stream-safe state-machine splitter that holds back up to 11 trailing chars of a potential partial tag across SSE chunks, so tags split across slices are joined correctly. Only engaged when the request contains `<system-reminder>thinking</system-reminder>`; non-thinking flows are untouched.

### 4. CLI build fix (separate commit)

Next.js 16 with workspace tracing root writes the standalone bundle one level deep (`.next/standalone/9router/server.js`) instead of at the top. `build-cli.js` now probes all three layouts (flat, nested-by-workspace-folder, legacy nested-app) so the same script keeps working across Next upgrades.

## Tests

- 13 tests for the inline-thinking splitter (cross-chunk splits, char-by-char streaming, leftover flush, partial-tag holdback, false-positive tag-shaped text)
- 16 tests for the import helpers (legacy/array/string shapes, mixed separators, dedupe, trim, malformed payloads, mask format)
- 29/29 new tests pass; ESLint clean across all modified files

```
$ vitest run unit/kiro.thinking-splitter.test.js unit/kiroImport.helpers.test.js
 ✓ unit/kiro.thinking-splitter.test.js (13 tests)
 ✓ unit/kiroImport.helpers.test.js     (16 tests)
 Test Files  2 passed (2)
      Tests  29 passed (29)
```

Pre-existing failures in `unit/rtk.test.js` and `unit/oauth-cursor-auto-import.test.js` are unrelated to this work and exist on `master` at v0.4.55.

## Commits

1. `feat(kiro): bulk refresh-token import + thinking/agentic model variants`
2. `fix(cli): detect Next.js 16 standalone layout under workspace folder`
