### PR TITLE
Fix optional empty string tool arguments

### DIFF
--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -147,7 +147,7 @@ export function openaiToClaudeResponse(chunk, state) {
         stopTextBlock(state, results);
 
         const toolBlockIndex = state.nextBlockIndex++;
-        state.toolCalls.set(idx, { id: tc.id, name: tc.function?.name || "", blockIndex: toolBlockIndex });
+        state.toolCalls.set(idx, { id: tc.id, name: tc.function?.name || "", blockIndex: toolBlockIndex, args: "" });
         
         // Strip prefix from tool name for response
         let toolName = tc.function?.name || "";
@@ -170,11 +170,7 @@ export function openaiToClaudeResponse(chunk, state) {
       if (tc.function?.arguments) {
         const toolInfo = state.toolCalls.get(idx);
         if (toolInfo) {
-          results.push({
-            type: "content_block_delta",
-            index: toolInfo.blockIndex,
-            delta: { type: "input_json_delta", partial_json: tc.function.arguments }
-          });
+          toolInfo.args += tc.function.arguments;
         }
       }
     }
@@ -186,6 +182,14 @@ export function openaiToClaudeResponse(chunk, state) {
     stopTextBlock(state, results);
 
     for (const [, toolInfo] of state.toolCalls) {
+      const partialJson = sanitizeToolArguments(toolInfo.args, toolInfo.name, state.requestBody);
+      if (partialJson) {
+        results.push({
+          type: "content_block_delta",
+          index: toolInfo.blockIndex,
+          delta: { type: "input_json_delta", partial_json: partialJson }
+        });
+      }
       results.push({
         type: "content_block_stop",
         index: toolInfo.blockIndex
@@ -206,6 +210,30 @@ export function openaiToClaudeResponse(chunk, state) {
   }
 
   return results.length > 0 ? results : null;
+}
+
+function sanitizeToolArguments(args, toolName, requestBody) {
+  if (!args) return args;
+  try {
+    const parsed = JSON.parse(args);
+    const schema = findToolSchema(requestBody, toolName);
+    if (parsed && schema?.properties && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const required = new Set(schema.required || []);
+      for (const [key, value] of Object.entries(parsed)) {
+        if (value === "" && !required.has(key) && schema.properties[key]?.type === "string") {
+          delete parsed[key];
+        }
+      }
+      return JSON.stringify(parsed);
+    }
+  } catch { }
+  return args;
+}
+
+function findToolSchema(requestBody, toolName) {
+  if (!Array.isArray(requestBody?.tools)) return null;
+  const tool = requestBody.tools.find(t => t.name === toolName || t.function?.name === toolName);
+  return tool?.input_schema || tool?.function?.parameters || null;
 }
 
 // Convert OpenAI finish_reason to Claude stop_reason

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -52,7 +52,7 @@ export function createSSEStream(options = {}) {
   // Per-stream decoder with stream:true to correctly handle multi-byte chars split across chunks
   const decoder = new TextDecoder("utf-8", { fatal: false });
 
-  const state = mode === STREAM_MODE.TRANSLATE ? { ...initState(sourceFormat), provider, toolNameMap, model } : null;
+  const state = mode === STREAM_MODE.TRANSLATE ? { ...initState(sourceFormat), provider, toolNameMap, model, requestBody: body } : null;
 
   let totalContentLength = 0;
   let accumulatedContent = "";

--- a/tests/unit/openai-to-claude-tool-args.test.js
+++ b/tests/unit/openai-to-claude-tool-args.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { openaiToClaudeResponse } from "../../open-sse/translator/response/openai-to-claude.js";
+
+function createState() {
+  return {
+    messageStartSent: false,
+    nextBlockIndex: 0,
+    toolCalls: new Map(),
+    textBlockStarted: false,
+    textBlockClosed: false,
+    thinkingBlockStarted: false,
+    requestBody: {
+      tools: [
+        {
+          name: "Read",
+          input_schema: {
+            type: "object",
+            properties: {
+              file_path: { type: "string" },
+              pages: { type: "string" },
+              offset: { type: "number" },
+            },
+            required: ["file_path"],
+          },
+        },
+        {
+          name: "RequiredEmpty",
+          input_schema: {
+            type: "object",
+            properties: { value: { type: "string" } },
+            required: ["value"],
+          },
+        },
+      ],
+    },
+  };
+}
+
+function emitToolCall(state, name, args) {
+  openaiToClaudeResponse({
+    id: "chatcmpl_test",
+    model: "gpt-5.5-high",
+    choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", function: { name, arguments: "" } }] } }],
+  }, state);
+
+  openaiToClaudeResponse({
+    choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: args } }] } }],
+  }, state);
+
+  return openaiToClaudeResponse({
+    choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+  }, state);
+}
+
+function getArgs(done) {
+  const argDelta = done.find((item) => item.type === "content_block_delta" && item.delta?.type === "input_json_delta");
+  return argDelta.delta.partial_json;
+}
+
+describe("openaiToClaudeResponse tool arguments", () => {
+  it("removes optional empty string arguments before emitting final Claude tool input", () => {
+    const done = emitToolCall(
+      createState(),
+      "Read",
+      "{\"file_path\":\"/tmp/example.txt\",\"pages\":\"\",\"offset\":0}"
+    );
+
+    expect(JSON.parse(getArgs(done))).toEqual({ file_path: "/tmp/example.txt", offset: 0 });
+  });
+
+  it("preserves required empty string arguments", () => {
+    const done = emitToolCall(createState(), "RequiredEmpty", "{\"value\":\"\"}");
+
+    expect(JSON.parse(getArgs(done))).toEqual({ value: "" });
+  });
+
+  it("leaves malformed partial JSON unchanged", () => {
+    const done = emitToolCall(createState(), "Read", "{\"file_path");
+
+    expect(getArgs(done)).toBe("{\"file_path");
+  });
+});

--- a/tests/unit/stream-read-pages-e2e.test.js
+++ b/tests/unit/stream-read-pages-e2e.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
+import "../../open-sse/translator/response/openai-to-claude.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function makeBody(tool) {
+  return {
+    model: "cx/gpt-5.5-high[1m]",
+    stream: true,
+    messages: [{ role: "user", content: [{ type: "text", text: "read the file" }] }],
+    tools: [tool],
+  };
+}
+
+async function transformToolCall(tool, toolName, args) {
+  const body = makeBody(tool);
+  const chunks = [
+    `data: ${JSON.stringify({ id: "chatcmpl_e2e", model: "gpt-5.5-high", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: toolName, arguments: "" } }] } }] })}\n\n`,
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: args } }] } }] })}\n\n`,
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+
+  const input = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+
+  const transform = createSSETransformStreamWithLogger(
+    FORMATS.OPENAI,
+    FORMATS.CLAUDE,
+    "codex",
+    null,
+    null,
+    "cx/gpt-5.5-high[1m]",
+    "e2e-conn",
+    body,
+    null,
+    null,
+  );
+
+  const reader = input.pipeThrough(transform).getReader();
+  let output = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+  output += decoder.decode();
+  return output;
+}
+
+function extractArgs(output) {
+  globalThis.__lastOutput = output;
+  const partials = [];
+  for (const line of output.split("\n")) {
+    if (!line.startsWith("data: ")) continue;
+    const payload = line.slice(6).trim();
+    if (!payload || payload === "[DONE]") continue;
+    const event = JSON.parse(payload);
+    if (!event) continue;
+    if (event.type === "content_block_delta" && event.delta?.type === "input_json_delta") {
+      partials.push(event.delta.partial_json);
+    }
+  }
+  expect(partials.length).toBeGreaterThan(0);
+  return JSON.parse(partials.join(""));
+}
+
+describe("OpenAI stream to Claude Read args E2E", () => {
+  it("handles Read pages empty string according to EXPECT_FIXED", async () => {
+    const output = await transformToolCall(
+      {
+        name: "Read",
+        input_schema: {
+          type: "object",
+          properties: {
+            file_path: { type: "string" },
+            offset: { type: "number" },
+            limit: { type: "number" },
+            pages: { type: "string" },
+          },
+          required: ["file_path"],
+        },
+      },
+      "Read",
+      JSON.stringify({ file_path: "/tmp/example.txt", offset: 0, limit: 120, pages: "" }),
+    );
+
+    const args = extractArgs(output);
+    expect(args.file_path).toBe("/tmp/example.txt");
+    expect(args.offset).toBe(0);
+    expect(args.limit).toBe(120);
+
+    if (process.env.EXPECT_FIXED === "1") {
+      expect(args).not.toHaveProperty("pages");
+    } else {
+      expect(args.pages).toBe("");
+    }
+  });
+
+  it("preserves required empty strings when fixed", async () => {
+    if (process.env.EXPECT_FIXED !== "1") return;
+
+    const output = await transformToolCall(
+      {
+        name: "RequiredEmpty",
+        input_schema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+        },
+      },
+      "RequiredEmpty",
+      JSON.stringify({ value: "" }),
+    );
+
+    expect(extractArgs(output)).toEqual({ value: "" });
+  });
+});


### PR DESCRIPTION
## Summary
- Buffer OpenAI-routed tool-call arguments before emitting Claude `input_json_delta` events.
- Remove empty-string values only for optional string fields according to the original tool schema.
- Add focused translator and stream-level tests covering the Claude Code `Read.pages` failure.

Fixes #1278.

## Test plan
- `cd tests && EXPECT_FIXED=1 npx vitest run --reporter=verbose unit/stream-read-pages-e2e.test.js unit/openai-to-claude-tool-args.test.js`
- Also verified the same stream-level harness fails against the baseline when expecting `pages` to be omitted.