### PR TITLE
feat(xai): add xAI Grok provider with OAuth + API key auth

### DIFF
--- a/cli/commands/xai-login.js
+++ b/cli/commands/xai-login.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * xAI (Grok) CLI Login
+ *
+ * Source of truth for OAuth details: router-for-me/CLIProxyAPI internal/cmd/xai_login.go
+ * Persistence is delegated to the running 9router server API so this command can
+ * run as a standalone Node script without importing Next.js app internals.
+ */
+
+const http = require("http");
+const readline = require("readline");
+const { spawn } = require("child_process");
+const api = require("../src/cli/api/client.js");
+
+const DEFAULT_PORT = 20128;
+const XAI_LOOPBACK_PORT = 56121;
+const XAI_CALLBACK_PATH = "/callback";
+const XAI_REDIRECT_URI = `http://127.0.0.1:${XAI_LOOPBACK_PORT}${XAI_CALLBACK_PATH}`;
+
+function parseArgs(argv) {
+  const opts = { apiKey: null, port: DEFAULT_PORT, host: "localhost" };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--api-key" && i + 1 < argv.length) {
+      opts.apiKey = argv[++i];
+    } else if ((arg === "--port" || arg === "-p") && i + 1 < argv.length) {
+      opts.port = Number.parseInt(argv[++i], 10) || DEFAULT_PORT;
+    } else if ((arg === "--host" || arg === "-H") && i + 1 < argv.length) {
+      opts.host = argv[++i] || "localhost";
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  console.log(`Usage: xai-login [options]
+
+Options:
+  --api-key <KEY>     Save a direct xAI API key instead of OAuth.
+  -p, --port <port>   9router server port (default: ${DEFAULT_PORT}).
+  -H, --host <host>   9router server host (default: localhost).
+  -h, --help          Show this help.
+
+Without --api-key, the OAuth PKCE flow uses ${XAI_REDIRECT_URI}.
+The 9router server must be running so credentials can be saved.
+`);
+}
+
+function openBrowser(url) {
+  const command = process.platform === "darwin"
+    ? "open"
+    : process.platform === "win32"
+      ? "cmd"
+      : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  const child = spawn(command, args, { detached: true, stdio: "ignore" });
+  child.on("error", () => {});
+  child.unref();
+}
+
+function startCallbackServer() {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, "http://127.0.0.1");
+      if (url.pathname !== XAI_CALLBACK_PATH) {
+        res.writeHead(404);
+        res.end("Not found");
+        return;
+      }
+
+      const params = Object.fromEntries(url.searchParams);
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end("<!doctype html><title>xAI connected</title><p>xAI authentication complete. You can close this tab.</p>");
+      server.emit("xai-callback", params);
+    });
+
+    server.listen(XAI_LOOPBACK_PORT, "127.0.0.1", () => {
+      resolve({
+        close: () => server.close(),
+        waitForCallback: () => new Promise((resolveCallback, rejectCallback) => {
+          const timeout = setTimeout(() => rejectCallback(new Error("Authentication timeout")), 300000);
+          server.once("xai-callback", (params) => {
+            clearTimeout(timeout);
+            resolveCallback(params);
+          });
+        }),
+      });
+    });
+    server.on("error", (err) => {
+      if (err.code === "EADDRINUSE") {
+        reject(new Error(`Port ${XAI_LOOPBACK_PORT} is already in use`));
+      } else {
+        reject(err);
+      }
+    });
+  });
+}
+
+function promptManualCode() {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question("Paste the xAI callback Token (or press Enter to keep waiting): ", (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function waitForCallbackOrManualCode(callbackServer, state) {
+  const callbackPromise = callbackServer.waitForCallback().then((params) => ({ type: "callback", params }));
+  let manualPromptTimer = null;
+  const manualPromptPromise = new Promise((resolve) => {
+    manualPromptTimer = setTimeout(() => {
+      promptManualCode().then((code) => resolve({ type: "manual", code }));
+    }, 15000);
+  });
+
+  const first = await Promise.race([callbackPromise, manualPromptPromise]);
+  if (first.type === "callback") {
+    clearTimeout(manualPromptTimer);
+    return first.params;
+  }
+
+  if (first.code) {
+    if (first.code.includes("://") || first.code.includes("?") || first.code.includes("code=")) {
+      throw new Error("Paste only the xAI callback Token");
+    }
+    return { code: first.code, state };
+  }
+
+  return (await callbackPromise).params;
+}
+
+async function saveApiKey(apiKey) {
+  const result = await api.createApiKeyProvider({
+    provider: "xai",
+    name: "xAI API Key",
+    apiKey,
+    priority: 1,
+    testStatus: "unknown",
+  });
+  if (!result.success) throw new Error(result.error);
+  return result.data.connection;
+}
+
+async function getAuthData() {
+  const path = `/api/oauth/xai/authorize?redirect_uri=${encodeURIComponent(XAI_REDIRECT_URI)}`;
+  const result = await api.makeRequest("GET", path);
+  if (!result.success) throw new Error(result.error);
+  return result.data;
+}
+
+async function exchangeCode({ code, state, codeVerifier }) {
+  const result = await api.makeRequest("POST", "/api/oauth/xai/exchange", {
+    code,
+    state,
+    codeVerifier,
+    redirectUri: XAI_REDIRECT_URI,
+  });
+  if (!result.success) throw new Error(result.error);
+  return result.data.connection;
+}
+
+async function runOAuth() {
+  const authData = await getAuthData();
+  const callbackServer = await startCallbackServer();
+  try {
+    console.log("Opening browser for xAI authentication...");
+    console.log(`If browser does not open, visit:\n${authData.authUrl}\n`);
+    openBrowser(authData.authUrl);
+
+    const params = await waitForCallbackOrManualCode(callbackServer, authData.state);
+    if (params.error) throw new Error(params.error_description || params.error);
+    if (!params.code) throw new Error("No authorization code received");
+    if (params.state !== authData.state) throw new Error("Invalid state parameter");
+
+    return await exchangeCode({
+      code: params.code,
+      state: params.state,
+      codeVerifier: authData.codeVerifier,
+    });
+  } finally {
+    callbackServer.close();
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  api.configure({ host: opts.host, port: opts.port });
+
+  if (opts.apiKey) {
+    const connection = await saveApiKey(opts.apiKey);
+    console.log("xAI API key saved as connection %s.", connection.id);
+    return;
+  }
+
+  const connection = await runOAuth();
+  console.log("xAI OAuth saved as connection %s.", connection.id);
+  if (connection.email || connection.displayName) {
+    console.log("Account: %s", connection.email || connection.displayName);
+  }
+}
+
+main().catch((err) => {
+  console.error("xai-login failed:", err?.message || err);
+  process.exit(1);
+});

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,10 +3,12 @@
   "version": "0.4.59",
   "description": "9Router CLI - Start and manage 9Router server",
   "bin": {
-    "9router": "./cli.js"
+    "9router": "./cli.js",
+    "xai-login": "./commands/xai-login.js"
   },
   "files": [
     "cli.js",
+    "commands",
     "src",
     "hooks",
     "app",

--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -5,19 +5,29 @@ import { proxyAwareFetch } from "../utils/proxyFetch.js";
 // xAI refresh — wraps the class method from src/lib/oauth/services/xai.js so
 // the token-refresh switches below can stay flat (one function per provider).
 let _xaiServiceSingleton = null;
-async function refreshXaiToken(refreshToken, log) {
+async function refreshXaiToken(refreshToken, log, providerSpecificData = {}) {
   if (!refreshToken) return null;
   try {
     if (!_xaiServiceSingleton) {
       const mod = await import("../../src/lib/oauth/services/xai.js");
       _xaiServiceSingleton = new mod.XaiService();
     }
-    const tokens = await _xaiServiceSingleton.refreshAccessToken(refreshToken);
+    const tokenEndpoint = providerSpecificData.tokenEndpoint || "https://auth.x.ai/oauth2/token";
+    const tokens = await _xaiServiceSingleton.refreshAccessToken(refreshToken, tokenEndpoint);
+    const refreshedProviderSpecificData = {
+      ...providerSpecificData,
+      authKind: "oauth",
+      baseUrl: "https://api.x.ai/v1",
+      tokenEndpoint,
+      lastRefresh: new Date().toISOString(),
+    };
+    if (tokens.id_token) refreshedProviderSpecificData.idToken = tokens.id_token;
     return {
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token || refreshToken,
       expiresIn: tokens.expires_in,
       idToken: tokens.id_token,
+      providerSpecificData: refreshedProviderSpecificData,
     };
   } catch (e) {
     log?.warn?.("TOKEN_REFRESH", `xai refresh failed: ${e?.message || e}`);
@@ -595,7 +605,7 @@ async function _getAccessTokenInternal(provider, credentials, log) {
       );
 
     case "xai":
-      return await refreshXaiToken(credentials.refreshToken, log);
+      return await refreshXaiToken(credentials.refreshToken, log, credentials.providerSpecificData);
 
     case "vertex":
     case "vertex-partner": {
@@ -642,7 +652,7 @@ export async function refreshTokenByProvider(provider, credentials, log) {
         log
       );
     case "xai":
-      return refreshXaiToken(credentials.refreshToken, log);
+      return refreshXaiToken(credentials.refreshToken, log, credentials.providerSpecificData);
     case "vertex":
     case "vertex-partner": {
       const saJson = parseVertexSaJson(credentials.apiKey);
@@ -683,10 +693,18 @@ export function formatProviderCredentials(provider, credentials, log) {
     case "iflow":
     case "openai":
     case "openrouter":
-    case "xai":
       return {
         apiKey: credentials.apiKey,
         accessToken: credentials.accessToken
+      };
+
+    case "xai":
+      return {
+        apiKey: credentials.apiKey,
+        accessToken: credentials.accessToken,
+        refreshToken: credentials.refreshToken,
+        expiresAt: credentials.expiresAt,
+        providerSpecificData: credentials.providerSpecificData
       };
 
     case "antigravity":

--- a/src/app/api/oauth/[provider]/[action]/route.js
+++ b/src/app/api/oauth/[provider]/[action]/route.js
@@ -194,7 +194,7 @@ export async function POST(request, { params }) {
         const info = extractCodexAccountInfo(code);
 
         // Also decode JWT directly for ChatGPT website tokens which use
-        // top-level account_id/plan_type instead of nested openai auth claims
+        // top-level account_id/plan_type instead of nested openai auth claims.
         let directPayload = {};
         try {
           const b64 = code.split(".")[1].replace(/-/g, "+").replace(/_/g, "/");

--- a/src/app/api/providers/client/route.js
+++ b/src/app/api/providers/client/route.js
@@ -3,6 +3,7 @@ import { getProviderConnections } from "@/lib/localDb";
 import { backfillCodexEmails } from "@/lib/oauth/providers";
 import { USAGE_APIKEY_PROVIDERS, USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
 
+// Whitelist: only safe metadata fields exposed to UI
 const SAFE_FIELDS = [
   "id", "provider", "authType", "name", "email", "displayName",
   "priority", "globalPriority", "isActive", "defaultModel",
@@ -11,6 +12,7 @@ const SAFE_FIELDS = [
   "createdAt", "updatedAt",
 ];
 
+// providerSpecificData fields safe to expose (non-secret config only)
 const SAFE_PSD_FIELDS = [
   "baseUrl", "azureEndpoint", "deployment", "apiVersion", "accountId",
   "region", "projectId", "resourceUrl", "proxyPoolId",
@@ -24,6 +26,7 @@ const MAX_PAGE_SIZE = 500;
 
 function maskName(name) {
   if (typeof name !== "string" || name.length <= 16) return name;
+  // Names like "hahask-uDUOg90..." may embed API keys — mask if looks like key
   if (/[a-zA-Z0-9_-]{32,}/.test(name)) return `${name.slice(0, 8)}***`;
   return name;
 }
@@ -73,6 +76,7 @@ function sortConnections(connections, sort) {
   });
 }
 
+// GET /api/providers/client - List connections for dashboard UI (whitelist only)
 export async function GET(request) {
   try {
     await backfillCodexEmails();

--- a/src/app/api/v1/videos/[id]/route.js
+++ b/src/app/api/v1/videos/[id]/route.js
@@ -1,0 +1,29 @@
+import { videosGet } from "@/lib/providers/xai/videos.js";
+import { persistXaiAccount, resolveXaiAccount } from "../_xaiAccount.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+/** GET /v1/videos/{id} — poll status of an async video job (xAI) */
+export async function GET(request, { params }) {
+  const { id } = await params;
+  const account = await resolveXaiAccount(request);
+  if (!account) return Response.json({ error: "No xAI connection" }, { status: 401 });
+
+  try {
+    const json = await videosGet({ id, account, persist: persistXaiAccount });
+    return Response.json(json);
+  } catch (err) {
+    return Response.json(
+      { error: err?.message || String(err) },
+      { status: err?.status || 500 }
+    );
+  }
+}

--- a/src/app/api/v1/videos/_xaiAccount.js
+++ b/src/app/api/v1/videos/_xaiAccount.js
@@ -1,0 +1,51 @@
+import { getProviderCredentials } from "@/sse/services/auth.js";
+import {
+  checkAndRefreshToken,
+  updateProviderCredentials,
+} from "@/sse/services/tokenRefresh.js";
+
+function accountFromConnection(connection) {
+  if (!connection || connection.allRateLimited) return null;
+  return {
+    authType: connection.authType || (connection.apiKey ? "apikey" : "oauth"),
+    apiKey: connection.apiKey,
+    accessToken: connection.accessToken,
+    refreshToken: connection.refreshToken,
+    expiresAt: connection.expiresAt,
+    connectionId: connection.connectionId,
+    providerSpecificData: connection.providerSpecificData,
+  };
+}
+
+function expiresInFromExpiresAt(expiresAt) {
+  if (!expiresAt) return undefined;
+  const expiresAtMs = new Date(expiresAt).getTime();
+  if (!Number.isFinite(expiresAtMs)) return undefined;
+  return Math.max(1, Math.floor((expiresAtMs - Date.now()) / 1000));
+}
+
+export async function resolveXaiAccount(request) {
+  const preferred = request.headers.get("x-connection-id") || null;
+  const connection = await getProviderCredentials("xai", null, null, {
+    preferredConnectionId: preferred,
+  });
+  if (!connection || connection.allRateLimited) return null;
+
+  const refreshed = await checkAndRefreshToken("xai", connection).catch(() => connection);
+  return accountFromConnection(refreshed);
+}
+
+export async function persistXaiAccount(account) {
+  if (!account?.connectionId) return;
+
+  const updates = {};
+  if (account.accessToken) updates.accessToken = account.accessToken;
+  if (account.refreshToken) updates.refreshToken = account.refreshToken;
+  if (account.providerSpecificData) updates.providerSpecificData = account.providerSpecificData;
+
+  const expiresIn = account.expiresIn ?? expiresInFromExpiresAt(account.expiresAt);
+  if (expiresIn) updates.expiresIn = expiresIn;
+
+  if (Object.keys(updates).length === 0) return;
+  await updateProviderCredentials(account.connectionId, updates);
+}

--- a/src/app/api/v1/videos/edits/route.js
+++ b/src/app/api/v1/videos/edits/route.js
@@ -1,0 +1,41 @@
+import { videosEdit } from "@/lib/providers/xai/videos.js";
+import { persistXaiAccount, resolveXaiAccount } from "../_xaiAccount.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+/** POST /v1/videos/edits — multipart upload, xAI only */
+export async function POST(request) {
+  const account = await resolveXaiAccount(request);
+  if (!account) return Response.json({ error: "No xAI connection" }, { status: 401 });
+
+  let formData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return Response.json({ error: "Invalid multipart body" }, { status: 400 });
+  }
+
+  try {
+    const idem = request.headers.get("Idempotency-Key") || undefined;
+    const json = await videosEdit({
+      formData,
+      account,
+      idempotencyKey: idem,
+      persist: persistXaiAccount,
+    });
+    return Response.json(json);
+  } catch (err) {
+    return Response.json(
+      { error: err?.message || String(err) },
+      { status: err?.status || 500 }
+    );
+  }
+}

--- a/src/app/api/v1/videos/extensions/route.js
+++ b/src/app/api/v1/videos/extensions/route.js
@@ -1,0 +1,41 @@
+import { videosExtend } from "@/lib/providers/xai/videos.js";
+import { persistXaiAccount, resolveXaiAccount } from "../_xaiAccount.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+/** POST /v1/videos/extensions — multipart upload, xAI only */
+export async function POST(request) {
+  const account = await resolveXaiAccount(request);
+  if (!account) return Response.json({ error: "No xAI connection" }, { status: 401 });
+
+  let formData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return Response.json({ error: "Invalid multipart body" }, { status: 400 });
+  }
+
+  try {
+    const idem = request.headers.get("Idempotency-Key") || undefined;
+    const json = await videosExtend({
+      formData,
+      account,
+      idempotencyKey: idem,
+      persist: persistXaiAccount,
+    });
+    return Response.json(json);
+  } catch (err) {
+    return Response.json(
+      { error: err?.message || String(err) },
+      { status: err?.status || 500 }
+    );
+  }
+}

--- a/src/app/api/v1/videos/generations/route.js
+++ b/src/app/api/v1/videos/generations/route.js
@@ -1,0 +1,40 @@
+import { videosGenerate } from "@/lib/providers/xai/videos.js";
+import { persistXaiAccount, resolveXaiAccount } from "../_xaiAccount.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const account = await resolveXaiAccount(request);
+  if (!account) return Response.json({ error: "No xAI connection" }, { status: 401 });
+
+  try {
+    const idem = request.headers.get("Idempotency-Key") || undefined;
+    const json = await videosGenerate({
+      request: body,
+      account,
+      idempotencyKey: idem,
+      persist: persistXaiAccount,
+    });
+    return Response.json(json);
+  } catch (err) {
+    return Response.json(
+      { error: err?.message || String(err) },
+      { status: err?.status || 500 }
+    );
+  }
+}

--- a/src/lib/oauth/constants/xai.js
+++ b/src/lib/oauth/constants/xai.js
@@ -31,9 +31,6 @@ export const XAI_PKCE_VERIFIER_BYTES = 96;
 // Refresh tokens this many seconds before expiry
 export const XAI_REFRESH_LEAD_SECONDS = 5 * 60;
 
-// User-Agent — mirror Go grok-cli UA. Version is best-effort; xAI does not pin a specific version.
-export const XAI_USER_AGENT = "grok-cli/9router";
-
 /**
  * Aggregated config object — mirrors the shape of CLAUDE_CONFIG/CODEX_CONFIG in oauth.js.
  * Includes both the discovery-derived defaults and the static fallbacks used when
@@ -56,6 +53,5 @@ export const XAI_CONFIG = {
   callbackPath: XAI_CALLBACK_PATH,
   pkceVerifierBytes: XAI_PKCE_VERIFIER_BYTES,
   refreshLeadSeconds: XAI_REFRESH_LEAD_SECONDS,
-  userAgent: XAI_USER_AGENT,
   codeChallengeMethod: "S256",
 };

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -27,56 +27,12 @@ import {
   getOAuthClientMetadata,
 } from "./constants/oauth";
 import { XAI_CONFIG, XAI_PKCE_VERIFIER_BYTES } from "./constants/xai";
-
-// Inlined from services/xai.js to keep web route bundle free of `open` (CLI-only) package
-let cachedXaiDiscovery = null;
-
-function validateXaiOAuthEndpoint(rawUrl, field) {
-  const value = String(rawUrl || "").trim();
-  if (!value) throw new Error(`xai discovery ${field} is empty`);
-  let parsed;
-  try { parsed = new URL(value); } catch (err) {
-    throw new Error(`xai discovery ${field} is invalid: ${err.message}`);
-  }
-  if (parsed.protocol !== "https:") throw new Error(`xai discovery ${field} must use https: ${value}`);
-  const host = parsed.hostname.toLowerCase().trim();
-  if (host !== "x.ai" && !host.endsWith(".x.ai")) {
-    throw new Error(`xai discovery ${field} host ${host} is not on x.ai`);
-  }
-  return value;
-}
-
-async function discoverXaiEndpoints() {
-  if (cachedXaiDiscovery) return cachedXaiDiscovery;
-  try {
-    const res = await fetch(XAI_CONFIG.discoveryUrl, { headers: { Accept: "application/json" } });
-    if (res.ok) {
-      const data = await res.json();
-      cachedXaiDiscovery = {
-        authorizeUrl: validateXaiOAuthEndpoint(data.authorization_endpoint, "authorization_endpoint"),
-        tokenUrl: validateXaiOAuthEndpoint(data.token_endpoint, "token_endpoint"),
-      };
-      return cachedXaiDiscovery;
-    }
-  } catch { /* fall through to static fallback */ }
-  cachedXaiDiscovery = { authorizeUrl: XAI_CONFIG.authorizeUrl, tokenUrl: XAI_CONFIG.tokenUrl };
-  return cachedXaiDiscovery;
-}
-
-function decodeXaiIdTokenEmail(idToken) {
-  if (!idToken || typeof idToken !== "string") return undefined;
-  const parts = idToken.split(".");
-  if (parts.length !== 3) return undefined;
-  try {
-    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
-    const padding = (BASE64_BLOCK_SIZE - (base64.length % BASE64_BLOCK_SIZE)) % BASE64_BLOCK_SIZE;
-    const json = Buffer.from(base64 + "=".repeat(padding), "base64").toString("utf8");
-    const payload = JSON.parse(json);
-    return payload.email || payload.preferred_username || payload.sub || undefined;
-  } catch {
-    return undefined;
-  }
-}
+import {
+  decodeIdTokenClaims as decodeXaiIdTokenClaims,
+  decodeIdTokenEmail as decodeXaiIdTokenEmail,
+  discoverEndpoints as discoverXaiEndpoints,
+  validateTokenResponse as validateXaiTokenResponse,
+} from "./services/xai";
 
 const BASE64_BLOCK_SIZE = 4;
 
@@ -105,15 +61,15 @@ function extractEmailFromAccessToken(accessToken) {
   return payload.email || payload.preferred_username || payload.sub || undefined;
 }
 
-// Extract codex account info from id_token or access token
+// Extract codex account info from id_token
 export function extractCodexAccountInfo(idToken) {
   const payload = decodeJwtPayload(idToken);
   if (!payload) return {};
   const chatgpt = payload["https://api.openai.com/auth"] || {};
   return {
     email: payload.email,
-    chatgptAccountId: chatgpt.chatgpt_account_id || payload.account_id,
-    chatgptPlanType: chatgpt.chatgpt_plan_type || payload.plan_type,
+    chatgptAccountId: chatgpt.chatgpt_account_id,
+    chatgptPlanType: chatgpt.chatgpt_plan_type,
   };
 }
 
@@ -291,20 +247,31 @@ const PROVIDERS = {
         const error = await response.text();
         throw new Error(`xAI token exchange failed: ${error}`);
       }
-      return await response.json();
+      return validateXaiTokenResponse(await response.json(), "exchange response");
     },
-    mapTokens: (tokens) => {
+    mapTokens: (tokens, extra, context = {}) => {
+      const { email, subject } = decodeXaiIdTokenClaims(tokens.id_token);
+      const expiresAt = tokens.expires_in
+        ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+        : undefined;
       const mapped = {
         accessToken: tokens.access_token,
         refreshToken: tokens.refresh_token,
         expiresIn: tokens.expires_in,
+        tokenType: tokens.token_type,
         scope: tokens.scope,
       };
-      const email = decodeXaiIdTokenEmail(tokens.id_token);
-      if (email) mapped.email = email;
-      if (tokens.id_token) {
-        mapped.providerSpecificData = { idToken: tokens.id_token };
-      }
+      if (expiresAt) mapped.expiresAt = expiresAt;
+      if (email || subject) mapped.email = email || subject;
+      mapped.providerSpecificData = {
+        ...(tokens.id_token ? { idToken: tokens.id_token } : {}),
+        ...(subject ? { sub: subject } : {}),
+        ...(context.redirectUri ? { redirectUri: context.redirectUri } : {}),
+        ...(context.tokenUrl ? { tokenEndpoint: context.tokenUrl } : {}),
+        baseUrl: XAI_CONFIG.apiBaseUrl,
+        authKind: "oauth",
+        lastRefresh: new Date().toISOString(),
+      };
       return mapped;
     },
   },
@@ -1352,7 +1319,7 @@ export async function exchangeTokens(providerName, code, redirectUri, codeVerifi
     extra = await provider.postExchange(tokens);
   }
 
-  return provider.mapTokens(tokens, extra);
+  return provider.mapTokens(tokens, extra, { redirectUri, codeVerifier, state, meta, tokenUrl: config.tokenUrl });
 }
 
 /**

--- a/src/lib/oauth/services/xai.js
+++ b/src/lib/oauth/services/xai.js
@@ -52,46 +52,53 @@ export function validateOAuthEndpoint(rawUrl, field) {
 export async function discoverEndpoints() {
   if (cachedDiscovery) return cachedDiscovery;
 
-  try {
-    const res = await fetch(XAI_CONFIG.discoveryUrl, {
-      headers: { Accept: "application/json" },
-    });
-    if (res.ok) {
-      const data = await res.json();
-      cachedDiscovery = {
-        authorizeUrl: validateOAuthEndpoint(data.authorization_endpoint, "authorization_endpoint"),
-        tokenUrl: validateOAuthEndpoint(data.token_endpoint, "token_endpoint"),
-      };
-      return cachedDiscovery;
-    }
-  } catch {
-    // fall through to static fallback
+  const res = await fetch(XAI_CONFIG.discoveryUrl, {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new Error(`xai discovery failed with status ${res.status}: ${await res.text()}`);
   }
 
+  const data = await res.json();
   cachedDiscovery = {
-    authorizeUrl: XAI_CONFIG.authorizeUrl,
-    tokenUrl: XAI_CONFIG.tokenUrl,
+    authorizeUrl: validateOAuthEndpoint(data.authorization_endpoint, "authorization_endpoint"),
+    tokenUrl: validateOAuthEndpoint(data.token_endpoint, "token_endpoint"),
   };
   return cachedDiscovery;
+}
+
+export function validateTokenResponse(tokens, operation) {
+  if (!tokens?.access_token || typeof tokens.access_token !== "string" || tokens.access_token.trim() === "") {
+    throw new Error(`xAI token ${operation} missing access_token`);
+  }
+  return tokens;
 }
 
 /**
  * Decode the `email` claim from an id_token JWT. No signature verification —
  * mirrors CLIProxyAPI Go behavior. Returns undefined if not parseable.
  */
-export function decodeIdTokenEmail(idToken) {
-  if (!idToken || typeof idToken !== "string") return undefined;
+export function decodeIdTokenClaims(idToken) {
+  if (!idToken || typeof idToken !== "string") return {};
   const parts = idToken.split(".");
-  if (parts.length !== 3) return undefined;
+  if (parts.length !== 3) return {};
   try {
     const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
     const padding = (BASE64_BLOCK_SIZE - (base64.length % BASE64_BLOCK_SIZE)) % BASE64_BLOCK_SIZE;
     const json = Buffer.from(base64 + "=".repeat(padding), "base64").toString("utf8");
     const payload = JSON.parse(json);
-    return payload.email || payload.preferred_username || payload.sub || undefined;
+    return {
+      email: payload.email || payload.preferred_username || undefined,
+      subject: payload.sub || undefined,
+    };
   } catch {
-    return undefined;
+    return {};
   }
+}
+
+export function decodeIdTokenEmail(idToken) {
+  const { email, subject } = decodeIdTokenClaims(idToken);
+  return email || subject || undefined;
 }
 
 export class XaiService extends OAuthService {
@@ -146,15 +153,17 @@ export class XaiService extends OAuthService {
       const err = await res.text();
       throw new Error(`xAI token exchange failed: ${err}`);
     }
-    return await res.json();
+    return validateTokenResponse(await res.json(), "exchange response");
   }
 
   /**
    * Refresh an access token using a refresh_token.
    */
-  async refreshAccessToken(refreshToken) {
-    const { tokenUrl } = await discoverEndpoints();
-    const res = await fetch(tokenUrl, {
+  async refreshAccessToken(refreshToken, tokenUrl) {
+    const endpoint = tokenUrl
+      ? validateOAuthEndpoint(tokenUrl, "token_endpoint")
+      : (await discoverEndpoints()).tokenUrl;
+    const res = await fetch(endpoint, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -170,7 +179,7 @@ export class XaiService extends OAuthService {
       const err = await res.text();
       throw new Error(`xAI token refresh failed: ${err}`);
     }
-    return await res.json();
+    return validateTokenResponse(await res.json(), "refresh response");
   }
 
   /**
@@ -188,48 +197,51 @@ export class XaiService extends OAuthService {
       const { port, close } = await startLocalServer((params) => {
         callbackParams = params;
       }, XAI_CONFIG.loopbackPort);
-      const redirectUri = `http://127.0.0.1:${port}${XAI_CONFIG.callbackPath}`;
-      spinner.succeed(`Local server started on port ${port}`);
+      try {
+        const redirectUri = `http://127.0.0.1:${port}${XAI_CONFIG.callbackPath}`;
+        spinner.succeed(`Local server started on port ${port}`);
 
-      const codeVerifier = generateCodeVerifier(XAI_PKCE_VERIFIER_BYTES);
-      const codeChallenge = generateCodeChallenge(codeVerifier);
-      const state = generateState();
-      const authUrl = this.buildXaiAuthUrl(redirectUri, state, codeChallenge, authorizeUrl);
+        const codeVerifier = generateCodeVerifier(XAI_PKCE_VERIFIER_BYTES);
+        const codeChallenge = generateCodeChallenge(codeVerifier);
+        const state = generateState();
+        const authUrl = this.buildXaiAuthUrl(redirectUri, state, codeChallenge, authorizeUrl);
 
-      console.log("\nOpening browser for xAI authentication...");
-      console.log(`If browser doesn't open, visit:\n${authUrl}\n`);
-      await open(authUrl);
+        console.log("\nOpening browser for xAI authentication...");
+        console.log(`If browser doesn't open, visit:\n${authUrl}\n`);
+        await open(authUrl);
 
-      spinner.start("Waiting for xAI authorization...");
-      await new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => reject(new Error("Authentication timeout (5 minutes)")), 300000);
-        const iv = setInterval(() => {
-          if (callbackParams) {
-            clearInterval(iv);
-            clearTimeout(timeout);
-            resolve();
-          }
-        }, 100);
-      });
-      close();
+        spinner.start("Waiting for xAI authorization...");
+        await new Promise((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error("Authentication timeout (5 minutes)")), 300000);
+          const iv = setInterval(() => {
+            if (callbackParams) {
+              clearInterval(iv);
+              clearTimeout(timeout);
+              resolve();
+            }
+          }, 100);
+        });
 
-      if (callbackParams.error) {
-        throw new Error(callbackParams.error_description || callbackParams.error);
+        if (callbackParams.error) {
+          throw new Error(callbackParams.error_description || callbackParams.error);
+        }
+        if (!callbackParams.code) throw new Error("No authorization code received");
+        if (callbackParams.state !== state) throw new Error("Invalid state parameter");
+
+        spinner.start("Exchanging code for tokens...");
+        const tokens = await this.exchangeXaiCode({
+          tokenUrl,
+          code: callbackParams.code,
+          redirectUri,
+          codeVerifier,
+        });
+
+        const email = decodeIdTokenEmail(tokens.id_token);
+        spinner.succeed("xAI connected successfully!");
+        return { tokens, email };
+      } finally {
+        close();
       }
-      if (!callbackParams.code) throw new Error("No authorization code received");
-      if (callbackParams.state !== state) throw new Error("Invalid state parameter");
-
-      spinner.start("Exchanging code for tokens...");
-      const tokens = await this.exchangeXaiCode({
-        tokenUrl,
-        code: callbackParams.code,
-        redirectUri,
-        codeVerifier,
-      });
-
-      const email = decodeIdTokenEmail(tokens.id_token);
-      spinner.succeed("xAI connected successfully!");
-      return { tokens, email };
     } catch (error) {
       spinner.fail(`Failed: ${error.message}`);
       throw error;

--- a/src/lib/providers/xai/executor.js
+++ b/src/lib/providers/xai/executor.js
@@ -1,0 +1,330 @@
+/**
+ * xAI (Grok) Inference Executor
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/runtime/executor/xai_executor.go
+ *
+ * xAI's Responses endpoint is always-SSE: regardless of the inbound `stream`
+ * flag, xAI streams back `response.*` events. For non-stream callers we collect
+ * events and synthesize a `response.completed` payload by aggregating the
+ * `response.output_item.done` events plus final usage/metadata.
+ */
+
+import { XAI_CONFIG, XAI_API_BASE } from "../../oauth/constants/xai.js";
+import { XaiService } from "../../oauth/services/xai.js";
+
+const XAI_RESPONSES_URL = `${XAI_API_BASE}/responses`;
+
+/**
+ * Build the request headers for an xAI inference call.
+ *
+ * @param {object} ctx
+ * @param {string} ctx.token  Bearer secret (OAuth access_token OR API key)
+ * @param {string} [ctx.idempotencyKey] Forward incoming Idempotency-Key
+ */
+export function buildXaiHeaders({ token, idempotencyKey } = {}) {
+  const headers = {
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (idempotencyKey) headers["Idempotency-Key"] = idempotencyKey;
+  return headers;
+}
+
+/**
+ * Parse a single SSE chunk string into discrete events.
+ * Returns an array of { event, data } where data is the raw JSON string
+ * (caller decides whether to JSON.parse based on event type).
+ *
+ * SSE framing rules per https://html.spec.whatwg.org/#server-sent-events:
+ *   - Events are separated by a blank line (\n\n)
+ *   - Lines starting with "event:" set the event name (default "message")
+ *   - Lines starting with "data:" are concatenated with newlines
+ *   - Other fields (id, retry, comments) are ignored here
+ */
+export function parseSseBlock(block) {
+  const events = [];
+  if (!block) return events;
+  const frames = block.split(/\r?\n\r?\n/);
+  for (const frame of frames) {
+    if (!frame.trim()) continue;
+    let eventName = "message";
+    const dataLines = [];
+    for (const line of frame.split(/\r?\n/)) {
+      if (line.startsWith(":")) continue; // SSE comment
+      if (line.startsWith("event:")) {
+        eventName = line.slice(6).trim();
+      } else if (line.startsWith("data:")) {
+        dataLines.push(line.slice(5).replace(/^ /, ""));
+      }
+    }
+    if (dataLines.length === 0) continue;
+    events.push({ event: eventName, data: dataLines.join("\n") });
+  }
+  return events;
+}
+
+/**
+ * Async generator that decodes a fetch Response body into SSE events.
+ *
+ * Buffers across chunks because SSE frames can split mid-buffer.
+ *
+ * @param {ReadableStream<Uint8Array>} body
+ * @yields { event: string, data: string }
+ */
+export async function* iterateSseEvents(body) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      // Split off complete frames (terminated by \n\n)
+      let idx;
+      while ((idx = buffer.search(/\r?\n\r?\n/)) !== -1) {
+        const frame = buffer.slice(0, idx);
+        // Advance past the matched delimiter
+        const sep = buffer.slice(idx).match(/\r?\n\r?\n/)[0];
+        buffer = buffer.slice(idx + sep.length);
+        for (const ev of parseSseBlock(frame)) yield ev;
+      }
+    }
+    // Flush any trailing event (no terminating blank line)
+    if (buffer.trim()) {
+      for (const ev of parseSseBlock(buffer)) yield ev;
+    }
+  } finally {
+    try { reader.releaseLock(); } catch { /* noop */ }
+  }
+}
+
+/**
+ * Collect an xAI SSE stream into a synthesized `response.completed` payload.
+ *
+ * Tracks each `response.output_item.done` (final state of one output item)
+ * and any `response.completed` event from upstream. If upstream emits a
+ * native `response.completed`, we use it verbatim. Otherwise we synthesize:
+ *   {
+ *     id, object: "response", status: "completed",
+ *     output: [...output_items in arrival order],
+ *     usage: <last seen usage>, model, created_at,
+ *     ...metadata last seen in response.created
+ *   }
+ *
+ * @param {ReadableStream<Uint8Array>} body
+ * @returns {Promise<object>}
+ */
+export async function collectSseToCompleted(body) {
+  let nativeCompleted = null;
+  let header = null;          // from response.created / response.in_progress
+  const outputItems = [];     // in arrival order
+  let usage = null;
+  let lastError = null;
+
+  for await (const ev of iterateSseEvents(body)) {
+    if (!ev.data || ev.data === "[DONE]") continue;
+    let payload;
+    try {
+      payload = JSON.parse(ev.data);
+    } catch {
+      continue;
+    }
+
+    switch (ev.event) {
+      case "response.created":
+      case "response.in_progress":
+        if (payload?.response) header = payload.response;
+        break;
+      case "response.output_item.done":
+        if (payload?.item) outputItems.push(payload.item);
+        break;
+      case "response.completed":
+        nativeCompleted = payload?.response || payload;
+        if (payload?.response?.usage) usage = payload.response.usage;
+        break;
+      case "response.usage":
+        if (payload?.usage) usage = payload.usage;
+        break;
+      case "response.error":
+      case "error":
+        lastError = payload?.error || payload;
+        break;
+      default:
+        // ignore unknown events
+        break;
+    }
+  }
+
+  if (lastError) {
+    const err = new Error(lastError.message || "xAI stream error");
+    err.code = lastError.code || lastError.type;
+    err.status = lastError.status || 502;
+    err.details = lastError;
+    throw err;
+  }
+
+  if (nativeCompleted) {
+    if (!nativeCompleted.output && outputItems.length) {
+      nativeCompleted.output = outputItems;
+    }
+    if (!nativeCompleted.usage && usage) nativeCompleted.usage = usage;
+    return nativeCompleted;
+  }
+
+  // Synthesize
+  const synthesized = {
+    id: header?.id || null,
+    object: "response",
+    created_at: header?.created_at || Math.floor(Date.now() / 1000),
+    status: "completed",
+    model: header?.model || null,
+    output: outputItems,
+    usage: usage || null,
+  };
+  if (header?.metadata) synthesized.metadata = header.metadata;
+  if (header?.previous_response_id) synthesized.previous_response_id = header.previous_response_id;
+  if (header?.reasoning) synthesized.reasoning = header.reasoning;
+  return synthesized;
+}
+
+/**
+ * Resolve the Bearer token for an xAI account record.
+ * Mirrors CLIProxyAPI: OAuth uses access_token, API key uses the literal key
+ * — both are sent as `Authorization: Bearer <secret>`.
+ *
+ * @param {object} account  { authType, accessToken, refreshToken, apiKey, ... }
+ * @returns {string}
+ */
+export function resolveXaiBearer(account) {
+  if (!account) throw new Error("xAI account not provided");
+  if (account.authType === "apikey" || account.apiKey) {
+    return account.apiKey;
+  }
+  if (account.accessToken) return account.accessToken;
+  throw new Error("xAI account has no usable credential");
+}
+
+/**
+ * Perform a refresh-and-retry on a single 401 from xAI.
+ *
+ * Returns { account, refreshed } — the (possibly updated) account record
+ * plus a flag indicating whether a refresh actually happened. Callers should
+ * persist the new tokens via their connection store.
+ *
+ * @param {object} account
+ * @param {object} [opts]
+ * @param {(updated: object) => Promise<void>} [opts.persist]  Optional persistence hook
+ */
+export async function refreshXaiAccount(account, opts = {}) {
+  if (account?.authType === "apikey" || !account?.refreshToken) {
+    return { account, refreshed: false };
+  }
+  const svc = new XaiService();
+  const tokenEndpoint = account.providerSpecificData?.tokenEndpoint;
+  const tokens = await svc.refreshAccessToken(account.refreshToken, tokenEndpoint);
+  const providerSpecificData = {
+    ...(account.providerSpecificData || {}),
+    authKind: "oauth",
+    baseUrl: XAI_CONFIG.apiBaseUrl,
+    lastRefresh: new Date().toISOString(),
+  };
+  if (tokenEndpoint) providerSpecificData.tokenEndpoint = tokenEndpoint;
+  if (tokens.id_token) providerSpecificData.idToken = tokens.id_token;
+  const updated = {
+    ...account,
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token || account.refreshToken,
+    providerSpecificData,
+    expiresIn: tokens.expires_in,
+    expiresAt: tokens.expires_in
+      ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+      : account.expiresAt,
+  };
+  if (typeof opts.persist === "function") {
+    try { await opts.persist(updated); } catch { /* swallow — caller can retry */ }
+  }
+  return { account: updated, refreshed: true };
+}
+
+/**
+ * Internal: POST a body to /responses, with single 401→refresh→retry.
+ *
+ * Returns the raw fetch Response (caller chooses to stream-pipe or collect).
+ */
+async function postResponses({ body, account, signal, idempotencyKey, persist }) {
+  let active = account;
+  let bearer = resolveXaiBearer(active);
+  let res = await fetch(XAI_RESPONSES_URL, {
+    method: "POST",
+    headers: buildXaiHeaders({ token: bearer, idempotencyKey }),
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (res.status === 401 && active?.authType !== "apikey") {
+    try {
+      const { account: refreshed, refreshed: didRefresh } = await refreshXaiAccount(active, { persist });
+      if (didRefresh) {
+        active = refreshed;
+        bearer = resolveXaiBearer(active);
+        // Drain prior response body to free socket
+        try { await res.body?.cancel?.(); } catch { /* noop */ }
+        res = await fetch(XAI_RESPONSES_URL, {
+          method: "POST",
+          headers: buildXaiHeaders({ token: bearer, idempotencyKey }),
+          body: JSON.stringify(body),
+          signal,
+        });
+      }
+    } catch (err) {
+      // refresh failed — surface upstream 401 as needs_reauth
+      const e = new Error("xAI refresh failed: " + (err?.message || String(err)));
+      e.status = 401;
+      e.code = "needs_reauth";
+      throw e;
+    }
+  }
+
+  return { res, account: active };
+}
+
+export const __XAI_TEST__ = {
+  XAI_RESPONSES_URL,
+  postResponses,
+};
+
+/**
+ * Execute an xAI Responses request.
+ *
+ * @param {object} opts
+ * @param {object} opts.request   xAI Responses-shaped JSON body
+ * @param {object} opts.account   account record (OAuth or API key)
+ * @param {boolean} [opts.stream] whether the caller wants SSE pass-through
+ * @param {AbortSignal} [opts.signal]
+ * @param {string} [opts.idempotencyKey]
+ * @param {(updated: object) => Promise<void>} [opts.persist]
+ * @returns {Promise<{ stream?: ReadableStream<Uint8Array>, completed?: object, account: object, status: number }>}
+ */
+export async function executeResponses(opts) {
+  const { request, account, stream = false, signal, idempotencyKey, persist } = opts;
+  const { res, account: active } = await postResponses({
+    body: request, account, signal, idempotencyKey, persist,
+  });
+
+  if (!res.ok && res.status !== 200) {
+    const errBody = await res.text().catch(() => "");
+    const err = new Error(`xAI /responses failed: ${res.status} ${errBody.slice(0, 500)}`);
+    err.status = res.status;
+    err.body = errBody;
+    if (res.status === 401) err.code = "needs_reauth";
+    throw err;
+  }
+
+  if (stream) {
+    return { stream: res.body, account: active, status: res.status };
+  }
+  const completed = await collectSseToCompleted(res.body);
+  return { completed, account: active, status: res.status };
+}

--- a/src/lib/providers/xai/images.js
+++ b/src/lib/providers/xai/images.js
@@ -1,0 +1,126 @@
+/**
+ * xAI Image Endpoints
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/runtime/executor/xai_executor.go
+ * (image branches)
+ *
+ * - POST /v1/images/generations  (JSON)
+ * - POST /v1/images/edits        (multipart/form-data)
+ *
+ * Auth + 401 retry semantics mirror executor.js. Idempotency-Key is forwarded
+ * from the inbound request when present.
+ */
+
+import { XAI_API_BASE } from "../../oauth/constants/xai.js";
+import { resolveXaiBearer, refreshXaiAccount } from "./executor.js";
+
+const XAI_IMAGES_GEN_URL = `${XAI_API_BASE}/images/generations`;
+const XAI_IMAGES_EDIT_URL = `${XAI_API_BASE}/images/edits`;
+
+function buildBaseHeaders({ token, idempotencyKey, accept = "application/json" }) {
+  const headers = {
+    Accept: accept,
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (idempotencyKey) headers["Idempotency-Key"] = idempotencyKey;
+  return headers;
+}
+
+async function singleRetryOn401(doFetch, account, opts = {}) {
+  let active = account;
+  let res = await doFetch(resolveXaiBearer(active));
+  if (res.status === 401 && active?.authType !== "apikey") {
+    try {
+      const { account: refreshed, refreshed: didRefresh } = await refreshXaiAccount(active, { persist: opts.persist });
+      if (didRefresh) {
+        active = refreshed;
+        try { await res.body?.cancel?.(); } catch { /* noop */ }
+        res = await doFetch(resolveXaiBearer(active));
+      }
+    } catch (err) {
+      const e = new Error("xAI refresh failed: " + (err?.message || String(err)));
+      e.status = 401;
+      e.code = "needs_reauth";
+      throw e;
+    }
+  }
+  return { res, account: active };
+}
+
+/**
+ * POST /v1/images/generations on xAI.
+ *
+ * @param {object} opts
+ * @param {object} opts.request   OpenAI images.generations-shaped JSON
+ * @param {object} opts.account
+ * @param {AbortSignal} [opts.signal]
+ * @param {string} [opts.idempotencyKey]
+ * @param {(updated: object) => Promise<void>} [opts.persist]
+ * @returns {Promise<object>}  parsed JSON response
+ */
+export async function imagesGenerate({ request, account, signal, idempotencyKey, persist }) {
+  const doFetch = (token) =>
+    fetch(XAI_IMAGES_GEN_URL, {
+      method: "POST",
+      headers: { ...buildBaseHeaders({ token, idempotencyKey }), "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+      signal,
+    });
+
+  const { res } = await singleRetryOn401(doFetch, account, { persist });
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "");
+    const err = new Error(`xAI /images/generations failed: ${res.status} ${errBody.slice(0, 500)}`);
+    err.status = res.status;
+    if (res.status === 401) err.code = "needs_reauth";
+    throw err;
+  }
+  return await res.json();
+}
+
+/**
+ * POST /v1/images/edits on xAI (multipart).
+ *
+ * Accepts either:
+ *   - a pre-built FormData (preferred — caller streams from incoming request)
+ *   - a plain object that we convert into FormData
+ *
+ * Caller must NOT set Content-Type — fetch + FormData produces the correct
+ * multipart boundary automatically.
+ */
+export async function imagesEdit({ formData, account, signal, idempotencyKey, persist }) {
+  if (!(formData instanceof FormData)) {
+    throw new Error("imagesEdit requires FormData (use buildImagesEditForm helper)");
+  }
+  const doFetch = (token) =>
+    fetch(XAI_IMAGES_EDIT_URL, {
+      method: "POST",
+      headers: buildBaseHeaders({ token, idempotencyKey }),
+      body: formData,
+      signal,
+    });
+
+  const { res } = await singleRetryOn401(doFetch, account, { persist });
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "");
+    const err = new Error(`xAI /images/edits failed: ${res.status} ${errBody.slice(0, 500)}`);
+    err.status = res.status;
+    if (res.status === 401) err.code = "needs_reauth";
+    throw err;
+  }
+  return await res.json();
+}
+
+/**
+ * Helper: convert a plain object of fields into FormData, useful for tests
+ * and small server-side composing. Image and mask values must be Blobs.
+ */
+export function buildImagesEditForm(fields) {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields || {})) {
+    if (v == null) continue;
+    if (v instanceof Blob || v instanceof File) fd.append(k, v);
+    else fd.append(k, String(v));
+  }
+  return fd;
+}

--- a/src/lib/providers/xai/thinking.js
+++ b/src/lib/providers/xai/thinking.js
@@ -1,0 +1,90 @@
+/**
+ * xAI Reasoning / Thinking Patcher
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/thinking/provider/xai/apply.go
+ *
+ * Maps the various inbound reasoning/thinking spec shapes (OpenAI Chat,
+ * OpenAI Responses, Anthropic Messages, Gemini) onto the xAI Responses
+ * `reasoning` field. Single source of truth for budget mapping.
+ *
+ * Defaults policy mirrors CLIProxyAPI:
+ *   - never proactively enable reasoning when the caller omits it
+ *   - honor explicit caller intent verbatim
+ */
+
+const VALID_EFFORTS = new Set(["minimal", "low", "medium", "high"]);
+
+/**
+ * Map a numeric token budget to a discrete effort tier.
+ *   <=0       → undefined (disabled)
+ *   1..3999   → "low"
+ *   4000..15999 → "medium"
+ *   >=16000   → "high"
+ *
+ * @param {number} budget
+ * @returns {"low"|"medium"|"high"|undefined}
+ */
+export function budgetToEffort(budget) {
+  if (typeof budget !== "number" || !Number.isFinite(budget) || budget <= 0) return undefined;
+  if (budget >= 16000) return "high";
+  if (budget >= 4000) return "medium";
+  return "low";
+}
+
+/**
+ * Apply reasoning/thinking patch to an xAI request body.
+ *
+ * Returns a new object — caller's request is not mutated.
+ *
+ * Recognized inbound shapes:
+ *   - request.reasoning_effort: "minimal"|"low"|"medium"|"high"  (OpenAI Chat)
+ *   - request.reasoning: { effort: ... }                          (OpenAI Responses)
+ *   - request.thinking: { type: "enabled", budget_tokens: N }     (Anthropic)
+ *   - request.thinkingConfig: { thinkingBudget: N, includeThoughts } (Gemini)
+ *
+ * @param {object} request
+ * @param {object} [options]
+ * @returns {object}
+ */
+export function applyThinking(request, options = {}) {
+  if (!request || typeof request !== "object") return request;
+  const out = { ...request };
+
+  // 1) Already xAI-native? Honor and stop.
+  if (out.reasoning && typeof out.reasoning === "object") {
+    if (out.reasoning.effort && VALID_EFFORTS.has(out.reasoning.effort)) {
+      return out;
+    }
+  }
+
+  // 2) OpenAI Chat reasoning_effort
+  if (typeof out.reasoning_effort === "string" && VALID_EFFORTS.has(out.reasoning_effort)) {
+    out.reasoning = { effort: out.reasoning_effort };
+    delete out.reasoning_effort;
+    return out;
+  }
+
+  // 3) Anthropic-style thinking
+  if (out.thinking && typeof out.thinking === "object") {
+    if (out.thinking.type === "enabled") {
+      const eff = budgetToEffort(out.thinking.budget_tokens) || "medium";
+      out.reasoning = { effort: eff };
+    }
+    delete out.thinking;
+    return out;
+  }
+
+  // 4) Gemini-style thinkingConfig
+  if (out.thinkingConfig && typeof out.thinkingConfig === "object") {
+    const eff = budgetToEffort(out.thinkingConfig.thinkingBudget);
+    if (eff) out.reasoning = { effort: eff };
+    delete out.thinkingConfig;
+    return out;
+  }
+
+  // 5) Default — leave untouched
+  if (options.defaultEffort && VALID_EFFORTS.has(options.defaultEffort)) {
+    out.reasoning = { effort: options.defaultEffort };
+  }
+  return out;
+}

--- a/src/lib/providers/xai/translators/claude.js
+++ b/src/lib/providers/xai/translators/claude.js
@@ -1,0 +1,213 @@
+/**
+ * Claude (Anthropic Messages) ↔ xAI Responses translator
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/translator/claude/xai/*
+ *
+ * Inbound: Anthropic /v1/messages { model, system, messages, tools, ... }
+ * Outbound (to xAI): xAI Responses { model, input, instructions, tools, ... }
+ *
+ * Reverse direction:
+ *   - xAI completed → Anthropic Messages JSON (full message)
+ *   - per-event xAI SSE → Anthropic SSE frames:
+ *       message_start, content_block_start, content_block_delta,
+ *       content_block_stop, message_delta, message_stop
+ */
+
+function genId(prefix) {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}`;
+}
+
+/**
+ * Translate Anthropic content blocks into xAI input content blocks.
+ * Anthropic block types:
+ *   "text", "image", "tool_use", "tool_result", "thinking"
+ */
+function blocksToXai(blocks) {
+  if (typeof blocks === "string") return [{ type: "input_text", text: blocks }];
+  if (!Array.isArray(blocks)) return [];
+  const out = [];
+  for (const b of blocks) {
+    if (!b || typeof b !== "object") continue;
+    if (b.type === "text") out.push({ type: "input_text", text: b.text || "" });
+    else if (b.type === "image" && b.source) {
+      // Anthropic source { type: "base64"|"url", media_type, data | url }
+      if (b.source.type === "url") {
+        out.push({ type: "input_image", image_url: b.source.url });
+      } else {
+        const dataUrl = `data:${b.source.media_type || "image/png"};base64,${b.source.data || ""}`;
+        out.push({ type: "input_image", image_url: dataUrl });
+      }
+    } else if (b.type === "thinking") {
+      // dropped on the input side — xAI does not accept caller thinking blocks
+    } else {
+      out.push(b);
+    }
+  }
+  return out;
+}
+
+/**
+ * Translate Anthropic tools[] into xAI tools[].
+ * Anthropic uses { name, description, input_schema } — xAI uses
+ * function-tool shape { type: "function", function: { name, description, parameters } }.
+ */
+function toolsAnthropicToXai(tools) {
+  if (!Array.isArray(tools)) return undefined;
+  return tools.map((t) => {
+    if (!t || typeof t !== "object") return t;
+    if (t.type === "function" && t.function) return t;
+    return {
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.input_schema || t.parameters || { type: "object" },
+      },
+    };
+  });
+}
+
+/**
+ * Translate an Anthropic Messages request body into an xAI Responses body.
+ *
+ * @param {object} req
+ * @returns {object}
+ */
+export function claudeRequestToXaiResponses(req) {
+  if (!req || typeof req !== "object") return req;
+  const input = [];
+
+  for (const m of req.messages || []) {
+    if (!m) continue;
+    if (m.role === "user") {
+      // Detect tool_result blocks → emit as function_call_output items
+      const blocks = Array.isArray(m.content) ? m.content : [{ type: "text", text: m.content }];
+      const userBlocks = [];
+      for (const b of blocks) {
+        if (b?.type === "tool_result") {
+          input.push({
+            type: "function_call_output",
+            call_id: b.tool_use_id,
+            output: typeof b.content === "string" ? b.content : JSON.stringify(b.content ?? ""),
+          });
+        } else {
+          userBlocks.push(b);
+        }
+      }
+      if (userBlocks.length) input.push({ role: "user", content: blocksToXai(userBlocks) });
+      continue;
+    }
+    if (m.role === "assistant") {
+      const blocks = Array.isArray(m.content) ? m.content : [{ type: "text", text: m.content }];
+      const textBlocks = [];
+      for (const b of blocks) {
+        if (b?.type === "tool_use") {
+          if (textBlocks.length) {
+            input.push({ role: "assistant", content: blocksToXai(textBlocks.splice(0)) });
+          }
+          input.push({
+            type: "function_call",
+            call_id: b.id,
+            name: b.name,
+            arguments: typeof b.input === "string" ? b.input : JSON.stringify(b.input ?? {}),
+          });
+        } else {
+          textBlocks.push(b);
+        }
+      }
+      if (textBlocks.length) input.push({ role: "assistant", content: blocksToXai(textBlocks) });
+      continue;
+    }
+  }
+
+  const out = {
+    model: req.model,
+    input,
+  };
+
+  // System → instructions
+  if (req.system) {
+    if (typeof req.system === "string") out.instructions = req.system;
+    else if (Array.isArray(req.system)) {
+      out.instructions = req.system.map((b) => (typeof b === "string" ? b : b?.text || "")).filter(Boolean).join("\n\n");
+    }
+  }
+
+  if (req.temperature != null) out.temperature = req.temperature;
+  if (req.top_p != null) out.top_p = req.top_p;
+  if (req.max_tokens != null) out.max_output_tokens = req.max_tokens;
+  if (req.stop_sequences) out.stop = req.stop_sequences;
+  if (req.metadata) out.metadata = req.metadata;
+  if (req.tool_choice) out.tool_choice = req.tool_choice;
+  if (req.thinking) out.reasoning = mapClaudeThinking(req.thinking);
+
+  const tools = toolsAnthropicToXai(req.tools);
+  if (tools) out.tools = tools;
+  return out;
+}
+
+function mapClaudeThinking(thinking) {
+  if (!thinking || typeof thinking !== "object") return undefined;
+  if (thinking.type === "enabled") {
+    if (typeof thinking.budget_tokens === "number") {
+      // Map Anthropic budget_tokens → xAI reasoning.effort approximation
+      const b = thinking.budget_tokens;
+      if (b >= 16000) return { effort: "high" };
+      if (b >= 4000) return { effort: "medium" };
+      if (b > 0) return { effort: "low" };
+    }
+    return { effort: "medium" };
+  }
+  return undefined;
+}
+
+/**
+ * Convert an xAI completed response into an Anthropic Messages JSON.
+ * @param {object} completed
+ * @param {object} [origReq]
+ */
+export function xaiCompletedToClaudeJson(completed, origReq = null) {
+  const content = [];
+  let stopReason = "end_turn";
+  for (const item of completed?.output || []) {
+    if (!item) continue;
+    if (item.type === "message" && Array.isArray(item.content)) {
+      for (const c of item.content) {
+        if (c?.type === "output_text") content.push({ type: "text", text: c.text || "" });
+        if (c?.type === "refusal") content.push({ type: "text", text: c.refusal || "" });
+      }
+    } else if (item.type === "function_call") {
+      stopReason = "tool_use";
+      let inputObj = {};
+      try {
+        inputObj = item.arguments ? JSON.parse(item.arguments) : {};
+      } catch { inputObj = { _raw: item.arguments }; }
+      content.push({
+        type: "tool_use",
+        id: item.call_id || item.id || genId("toolu"),
+        name: item.name,
+        input: inputObj,
+      });
+    } else if (item.type === "reasoning" && Array.isArray(item.summary)) {
+      const text = item.summary.map((s) => s?.text || "").filter(Boolean).join("\n");
+      if (text) content.push({ type: "thinking", thinking: text });
+    }
+  }
+  const out = {
+    id: completed?.id || genId("msg"),
+    type: "message",
+    role: "assistant",
+    model: completed?.model || origReq?.model || null,
+    content,
+    stop_reason: stopReason,
+    stop_sequence: null,
+  };
+  if (completed?.usage) {
+    const u = completed.usage;
+    out.usage = {
+      input_tokens: u.input_tokens ?? u.prompt_tokens ?? 0,
+      output_tokens: u.output_tokens ?? u.completion_tokens ?? 0,
+    };
+  }
+  return out;
+}

--- a/src/lib/providers/xai/translators/gemini.js
+++ b/src/lib/providers/xai/translators/gemini.js
@@ -1,0 +1,198 @@
+/**
+ * Gemini ↔ xAI Responses translator
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/translator/gemini/xai/*
+ *
+ * Inbound: Google Gemini generateContent { contents, systemInstruction, tools, ... }
+ * Outbound (to xAI): xAI Responses { model, input, instructions, tools, ... }
+ *
+ * Reverse direction:
+ *   - xAI completed → Gemini generateContent JSON ({ candidates: [...] })
+ *   - per-event xAI SSE → Gemini streamGenerateContent chunks
+ */
+
+/**
+ * Convert Gemini parts[] into xAI input content blocks.
+ *
+ * Gemini part types:
+ *   text, inlineData (mime+data b64), fileData (uri),
+ *   functionCall (name, args), functionResponse (name, response)
+ */
+function partsToXaiBlocks(parts) {
+  if (!Array.isArray(parts)) return [];
+  const out = [];
+  for (const p of parts) {
+    if (!p || typeof p !== "object") continue;
+    if (typeof p.text === "string") {
+      out.push({ type: "input_text", text: p.text });
+    } else if (p.inlineData?.data) {
+      const mime = p.inlineData.mimeType || "image/png";
+      out.push({
+        type: "input_image",
+        image_url: `data:${mime};base64,${p.inlineData.data}`,
+      });
+    } else if (p.fileData?.fileUri) {
+      out.push({ type: "input_image", image_url: p.fileData.fileUri });
+    }
+    // functionCall / functionResponse handled at message level
+  }
+  return out;
+}
+
+/**
+ * Pull functionCall / functionResponse parts out of a Gemini message
+ * — these need to become standalone xAI input items, not nested content blocks.
+ */
+function extractFunctionItems(parts) {
+  const items = [];
+  if (!Array.isArray(parts)) return items;
+  for (const p of parts) {
+    if (p?.functionCall) {
+      items.push({
+        type: "function_call",
+        call_id: p.functionCall.id || p.functionCall.name,
+        name: p.functionCall.name,
+        arguments: typeof p.functionCall.args === "string"
+          ? p.functionCall.args
+          : JSON.stringify(p.functionCall.args || {}),
+      });
+    } else if (p?.functionResponse) {
+      items.push({
+        type: "function_call_output",
+        call_id: p.functionResponse.id || p.functionResponse.name,
+        output: typeof p.functionResponse.response === "string"
+          ? p.functionResponse.response
+          : JSON.stringify(p.functionResponse.response || {}),
+      });
+    }
+  }
+  return items;
+}
+
+/**
+ * Convert Gemini tools[] into xAI tools[].
+ * Gemini: [{ functionDeclarations: [{ name, description, parameters }] }, ...]
+ * xAI:    [{ type: "function", function: { name, description, parameters } }, ...]
+ */
+function toolsGeminiToXai(tools) {
+  if (!Array.isArray(tools)) return undefined;
+  const out = [];
+  for (const t of tools) {
+    if (!t) continue;
+    if (Array.isArray(t.functionDeclarations)) {
+      for (const fn of t.functionDeclarations) {
+        out.push({
+          type: "function",
+          function: {
+            name: fn.name,
+            description: fn.description,
+            parameters: fn.parameters || { type: "object" },
+          },
+        });
+      }
+    } else if (t.type === "function") {
+      out.push(t);
+    }
+  }
+  return out.length ? out : undefined;
+}
+
+/**
+ * Translate a Gemini generateContent request body into an xAI Responses body.
+ *
+ * @param {object} req
+ * @param {string} [model] — Gemini path-level model (Gemini puts model in URL)
+ * @returns {object}
+ */
+export function geminiRequestToXaiResponses(req, model = null) {
+  if (!req || typeof req !== "object") return req;
+  const input = [];
+  for (const c of req.contents || []) {
+    if (!c) continue;
+    const role = c.role === "model" ? "assistant" : (c.role || "user");
+    // Pull function items first (they become standalone)
+    const fnItems = extractFunctionItems(c.parts);
+    if (fnItems.length) {
+      for (const it of fnItems) input.push(it);
+      // Filter remaining text/image parts
+      const remaining = (c.parts || []).filter((p) => !p?.functionCall && !p?.functionResponse);
+      if (remaining.length) input.push({ role, content: partsToXaiBlocks(remaining) });
+    } else {
+      input.push({ role, content: partsToXaiBlocks(c.parts) });
+    }
+  }
+
+  const out = { model: model || req.model, input };
+
+  if (req.systemInstruction) {
+    const sys = req.systemInstruction;
+    if (typeof sys === "string") out.instructions = sys;
+    else if (sys.parts) {
+      out.instructions = sys.parts.map((p) => p?.text || "").filter(Boolean).join("\n\n");
+    }
+  }
+
+  const cfg = req.generationConfig || {};
+  if (cfg.temperature != null) out.temperature = cfg.temperature;
+  if (cfg.topP != null) out.top_p = cfg.topP;
+  if (cfg.maxOutputTokens != null) out.max_output_tokens = cfg.maxOutputTokens;
+  if (cfg.stopSequences) out.stop = cfg.stopSequences;
+  if (cfg.responseSchema) out.text = { format: { type: "json_schema", schema: cfg.responseSchema } };
+  if (cfg.thinkingConfig?.thinkingBudget != null) {
+    const b = cfg.thinkingConfig.thinkingBudget;
+    if (b >= 16000) out.reasoning = { effort: "high" };
+    else if (b >= 4000) out.reasoning = { effort: "medium" };
+    else if (b > 0) out.reasoning = { effort: "low" };
+  }
+
+  const tools = toolsGeminiToXai(req.tools);
+  if (tools) out.tools = tools;
+
+  if (req.toolConfig?.functionCallingConfig?.mode === "ANY") out.tool_choice = "required";
+  return out;
+}
+
+/**
+ * Convert an xAI completed response into a Gemini generateContent JSON.
+ * @param {object} completed
+ * @param {object} [origReq]
+ */
+export function xaiCompletedToGeminiJson(completed, origReq = null) {
+  const parts = [];
+  let finishReason = "STOP";
+  for (const item of completed?.output || []) {
+    if (!item) continue;
+    if (item.type === "message" && Array.isArray(item.content)) {
+      for (const c of item.content) {
+        if (c?.type === "output_text") parts.push({ text: c.text || "" });
+        if (c?.type === "refusal") parts.push({ text: c.refusal || "" });
+      }
+    } else if (item.type === "function_call") {
+      finishReason = "STOP"; // Gemini does not have a tool-call finish reason
+      let args = {};
+      try { args = item.arguments ? JSON.parse(item.arguments) : {}; }
+      catch { args = { _raw: item.arguments }; }
+      parts.push({
+        functionCall: { name: item.name, args },
+      });
+    }
+  }
+  const candidate = {
+    content: { role: "model", parts },
+    finishReason,
+    index: 0,
+  };
+  const out = {
+    candidates: [candidate],
+    modelVersion: completed?.model || origReq?.model || null,
+  };
+  if (completed?.usage) {
+    const u = completed.usage;
+    out.usageMetadata = {
+      promptTokenCount: u.input_tokens ?? u.prompt_tokens ?? 0,
+      candidatesTokenCount: u.output_tokens ?? u.completion_tokens ?? 0,
+      totalTokenCount: u.total_tokens ?? ((u.input_tokens || 0) + (u.output_tokens || 0)),
+    };
+  }
+  return out;
+}

--- a/src/lib/providers/xai/translators/openai-chat.js
+++ b/src/lib/providers/xai/translators/openai-chat.js
@@ -1,0 +1,180 @@
+/**
+ * OpenAI Chat Completions ↔ xAI Responses translator
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/translator/openai/xai/*
+ *
+ * Inbound: OpenAI Chat Completions { model, messages, tools, ... }
+ * Outbound (to xAI): xAI Responses { model, input, instructions, tools, ... }
+ *
+ * Reverse direction:
+ *   - aggregated xAI response.completed → OpenAI ChatCompletion JSON
+ *   - per-event xAI SSE → OpenAI ChatCompletion stream chunks
+ */
+
+function genId(prefix) {
+  return `${prefix}_${Math.random().toString(36).slice(2, 14)}`;
+}
+
+/**
+ * Convert OpenAI message content (string | array of parts) into xAI input
+ * content blocks. Mirrors CLIProxyAPI mapping:
+ *   "text"       → { type: "input_text", text }
+ *   "image_url"  → { type: "input_image", image_url }
+ *   "input_audio"→ { type: "input_audio", input_audio }
+ */
+function messageContentToXaiBlocks(content) {
+  if (typeof content === "string") {
+    return [{ type: "input_text", text: content }];
+  }
+  if (!Array.isArray(content)) return [];
+  return content.map((p) => {
+    if (!p || typeof p !== "object") return null;
+    if (p.type === "text") return { type: "input_text", text: p.text || "" };
+    if (p.type === "image_url") return { type: "input_image", image_url: p.image_url };
+    if (p.type === "input_audio") return { type: "input_audio", input_audio: p.input_audio };
+    return p; // passthrough unknown
+  }).filter(Boolean);
+}
+
+/**
+ * Convert OpenAI Chat tools[] (function-calling spec) into xAI tools[].
+ * xAI accepts the OpenAI function-tool shape verbatim, so passthrough.
+ */
+function toolsPassthrough(tools) {
+  if (!Array.isArray(tools)) return undefined;
+  return tools.map((t) => ({ ...t }));
+}
+
+/**
+ * Translate an inbound OpenAI Chat Completions request body into an xAI Responses body.
+ *
+ * @param {object} req
+ * @returns {object}
+ */
+export function chatRequestToXaiResponses(req) {
+  if (!req || typeof req !== "object") return req;
+  const messages = Array.isArray(req.messages) ? req.messages : [];
+  const instructionsParts = [];
+  const input = [];
+
+  for (const m of messages) {
+    if (!m) continue;
+    if (m.role === "system" || m.role === "developer") {
+      const txt = typeof m.content === "string"
+        ? m.content
+        : (Array.isArray(m.content) ? m.content.map((p) => p?.text || "").filter(Boolean).join("\n") : "");
+      if (txt) instructionsParts.push(txt);
+      continue;
+    }
+    if (m.role === "tool") {
+      input.push({
+        type: "function_call_output",
+        call_id: m.tool_call_id,
+        output: typeof m.content === "string" ? m.content : JSON.stringify(m.content ?? ""),
+      });
+      continue;
+    }
+    if (m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+      // Emit any pre-existing assistant text first
+      if (m.content) {
+        input.push({ role: "assistant", content: messageContentToXaiBlocks(m.content) });
+      }
+      for (const tc of m.tool_calls) {
+        if (tc.type !== "function" || !tc.function) continue;
+        input.push({
+          type: "function_call",
+          call_id: tc.id,
+          name: tc.function.name,
+          arguments: tc.function.arguments || "",
+        });
+      }
+      continue;
+    }
+    input.push({ role: m.role || "user", content: messageContentToXaiBlocks(m.content) });
+  }
+
+  const out = {
+    model: req.model,
+    input,
+  };
+  if (instructionsParts.length) out.instructions = instructionsParts.join("\n\n");
+
+  if (req.temperature != null) out.temperature = req.temperature;
+  if (req.top_p != null) out.top_p = req.top_p;
+  if (req.max_tokens != null) out.max_output_tokens = req.max_tokens;
+  if (req.max_output_tokens != null) out.max_output_tokens = req.max_output_tokens;
+  if (req.stop != null) out.stop = req.stop;
+  if (req.user) out.user = req.user;
+  if (req.metadata) out.metadata = req.metadata;
+  if (req.response_format) out.text = { format: req.response_format };
+  if (req.parallel_tool_calls != null) out.parallel_tool_calls = req.parallel_tool_calls;
+  if (req.seed != null) out.seed = req.seed;
+  if (req.reasoning_effort) out.reasoning = { effort: req.reasoning_effort };
+  if (req.reasoning) out.reasoning = req.reasoning;
+  if (req.tool_choice) out.tool_choice = req.tool_choice;
+
+  const tools = toolsPassthrough(req.tools);
+  if (tools) out.tools = tools;
+  return out;
+}
+
+/**
+ * Aggregate output_text content blocks from an xAI completed response.
+ */
+function extractAssistantTextAndCalls(completed) {
+  let text = "";
+  const toolCalls = [];
+  const refusal = [];
+  for (const item of completed?.output || []) {
+    if (!item) continue;
+    if (item.type === "message" && Array.isArray(item.content)) {
+      for (const c of item.content) {
+        if (c?.type === "output_text" && typeof c.text === "string") text += c.text;
+        if (c?.type === "refusal" && typeof c.refusal === "string") refusal.push(c.refusal);
+      }
+    } else if (item.type === "function_call") {
+      toolCalls.push({
+        id: item.call_id || item.id || genId("call"),
+        type: "function",
+        function: { name: item.name, arguments: item.arguments || "" },
+      });
+    }
+  }
+  return { text, toolCalls, refusal: refusal.join("\n") || undefined };
+}
+
+/**
+ * Convert an aggregated xAI completed response into an OpenAI ChatCompletion JSON.
+ *
+ * @param {object} completed
+ * @param {object} [origReq] original request (for model id fallback)
+ * @returns {object}
+ */
+export function xaiCompletedToChatJson(completed, origReq = null) {
+  const { text, toolCalls, refusal } = extractAssistantTextAndCalls(completed);
+  const finishReason = toolCalls.length ? "tool_calls" : "stop";
+
+  const message = {
+    role: "assistant",
+    content: text || (toolCalls.length ? null : ""),
+  };
+  if (toolCalls.length) message.tool_calls = toolCalls;
+  if (refusal) message.refusal = refusal;
+
+  const out = {
+    id: completed?.id || genId("chatcmpl"),
+    object: "chat.completion",
+    created: completed?.created_at || Math.floor(Date.now() / 1000),
+    model: completed?.model || origReq?.model || null,
+    choices: [{ index: 0, message, finish_reason: finishReason }],
+  };
+  if (completed?.usage) {
+    const u = completed.usage;
+    out.usage = {
+      prompt_tokens: u.input_tokens ?? u.prompt_tokens ?? 0,
+      completion_tokens: u.output_tokens ?? u.completion_tokens ?? 0,
+      total_tokens: u.total_tokens ?? ((u.input_tokens || 0) + (u.output_tokens || 0)),
+    };
+  }
+  return out;
+}

--- a/src/lib/providers/xai/translators/openai-responses.js
+++ b/src/lib/providers/xai/translators/openai-responses.js
@@ -1,0 +1,64 @@
+/**
+ * OpenAI Responses ↔ xAI Responses translator
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/translator/openai-responses/xai/*
+ *
+ * xAI's Responses API is shape-compatible with OpenAI Responses, so this is
+ * mostly a passthrough. Translator responsibilities:
+ *   - normalize response.id when synthesized
+ *   - reconcile a small set of unsupported fields (drop unknown vendor-only opts)
+ *   - apply the thinking patcher hook (delegated upstream)
+ */
+
+/**
+ * Translate an inbound OpenAI-Responses request body into an xAI request body.
+ *
+ * @param {object} req
+ * @returns {object}
+ */
+export function openaiResponsesRequestToXai(req) {
+  if (!req || typeof req !== "object") return req;
+  const out = { ...req };
+
+  // xAI does not currently honor `parallel_tool_calls: false` on every model;
+  // mirror CLIProxyAPI: leave the flag as caller specified.
+
+  // Drop OpenAI-specific service_tier hint that xAI rejects.
+  if ("service_tier" in out) delete out.service_tier;
+
+  // xAI expects `input` (Responses-style); if the caller passed `messages`
+  // instead, leave them — xAI also accepts messages, but warn via metadata.
+  return out;
+}
+
+/**
+ * Translate an xAI completed response (already aggregated by collectSseToCompleted)
+ * into the OpenAI Responses JSON shape that callers expect.
+ *
+ * @param {object} completed
+ * @returns {object}
+ */
+export function xaiCompletedToOpenaiResponses(completed) {
+  if (!completed || typeof completed !== "object") return completed;
+  return {
+    ...completed,
+    object: completed.object || "response",
+    status: completed.status || "completed",
+  };
+}
+
+/**
+ * Pass-through transform for SSE event objects { event, data } emitted by
+ * iterateSseEvents(). For OpenAI Responses callers we forward verbatim — only
+ * normalize event names that diverge.
+ *
+ * @param {{event: string, data: string}} ev
+ * @returns {{event: string, data: string} | null} null = drop event
+ */
+export function xaiSseEventToOpenaiResponses(ev) {
+  if (!ev || !ev.event) return ev;
+  // CLIProxyAPI drops xAI-internal `response.output_text.annotation.added`
+  // when the caller is OpenAI Responses, since OpenAI emits a different name.
+  if (ev.event === "response.output_text.annotation.added") return null;
+  return ev;
+}

--- a/src/lib/providers/xai/videos.js
+++ b/src/lib/providers/xai/videos.js
@@ -1,0 +1,128 @@
+/**
+ * xAI Video Endpoints
+ *
+ * Source of truth: router-for-me/CLIProxyAPI internal/runtime/executor/xai_executor.go
+ * (video branches)
+ *
+ * - POST /v1/videos/generations  (JSON, async job)
+ * - POST /v1/videos/edits        (multipart, async job)
+ * - POST /v1/videos/extensions   (multipart, async job)
+ * - GET  /v1/videos/{id}         (poll status)
+ *
+ * Auth + 401 retry semantics mirror executor.js. Idempotency-Key is forwarded
+ * on POSTs. CLIProxyAPI does NOT synthesize completion locally — caller polls
+ * GET /v1/videos/{id} until terminal state.
+ */
+
+import { XAI_API_BASE } from "../../oauth/constants/xai.js";
+import { resolveXaiBearer, refreshXaiAccount } from "./executor.js";
+
+const VIDEOS_BASE = `${XAI_API_BASE}/videos`;
+const VIDEOS_GEN_URL = `${VIDEOS_BASE}/generations`;
+const VIDEOS_EDIT_URL = `${VIDEOS_BASE}/edits`;
+const VIDEOS_EXTEND_URL = `${VIDEOS_BASE}/extensions`;
+
+function buildHeaders({ token, idempotencyKey, contentType }) {
+  const h = {
+    Accept: "application/json",
+  };
+  if (token) h.Authorization = `Bearer ${token}`;
+  if (idempotencyKey) h["Idempotency-Key"] = idempotencyKey;
+  if (contentType) h["Content-Type"] = contentType;
+  return h;
+}
+
+async function singleRetryOn401(doFetch, account, opts = {}) {
+  let active = account;
+  let res = await doFetch(resolveXaiBearer(active));
+  if (res.status === 401 && active?.authType !== "apikey") {
+    try {
+      const { account: refreshed, refreshed: didRefresh } =
+        await refreshXaiAccount(active, { persist: opts.persist });
+      if (didRefresh) {
+        active = refreshed;
+        try { await res.body?.cancel?.(); } catch { /* noop */ }
+        res = await doFetch(resolveXaiBearer(active));
+      }
+    } catch (err) {
+      const e = new Error("xAI refresh failed: " + (err?.message || String(err)));
+      e.status = 401;
+      e.code = "needs_reauth";
+      throw e;
+    }
+  }
+  return { res, account: active };
+}
+
+async function jsonOrThrow(res, label) {
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    const err = new Error(`xAI ${label} failed: ${res.status} ${body.slice(0, 500)}`);
+    err.status = res.status;
+    if (res.status === 401) err.code = "needs_reauth";
+    throw err;
+  }
+  return await res.json();
+}
+
+export async function videosGenerate({ request, account, signal, idempotencyKey, persist }) {
+  const doFetch = (token) =>
+    fetch(VIDEOS_GEN_URL, {
+      method: "POST",
+      headers: buildHeaders({ token, idempotencyKey, contentType: "application/json" }),
+      body: JSON.stringify(request),
+      signal,
+    });
+  const { res } = await singleRetryOn401(doFetch, account, { persist });
+  return await jsonOrThrow(res, "/videos/generations");
+}
+
+export async function videosEdit({ formData, account, signal, idempotencyKey, persist }) {
+  if (!(formData instanceof FormData)) {
+    throw new Error("videosEdit requires FormData");
+  }
+  const doFetch = (token) =>
+    fetch(VIDEOS_EDIT_URL, {
+      method: "POST",
+      headers: buildHeaders({ token, idempotencyKey }),
+      body: formData,
+      signal,
+    });
+  const { res } = await singleRetryOn401(doFetch, account, { persist });
+  return await jsonOrThrow(res, "/videos/edits");
+}
+
+export async function videosExtend({ formData, account, signal, idempotencyKey, persist }) {
+  if (!(formData instanceof FormData)) {
+    throw new Error("videosExtend requires FormData");
+  }
+  const doFetch = (token) =>
+    fetch(VIDEOS_EXTEND_URL, {
+      method: "POST",
+      headers: buildHeaders({ token, idempotencyKey }),
+      body: formData,
+      signal,
+    });
+  const { res } = await singleRetryOn401(doFetch, account, { persist });
+  return await jsonOrThrow(res, "/videos/extensions");
+}
+
+export async function videosGet({ id, account, signal, persist }) {
+  if (!id) throw new Error("videosGet requires an id");
+  const url = `${VIDEOS_BASE}/${encodeURIComponent(id)}`;
+  const doFetch = (token) =>
+    fetch(url, {
+      method: "GET",
+      headers: buildHeaders({ token }),
+      signal,
+    });
+  const { res } = await singleRetryOn401(doFetch, account, { persist });
+  return await jsonOrThrow(res, `GET /videos/${id}`);
+}
+
+export const __XAI_VIDEOS_TEST__ = {
+  VIDEOS_GEN_URL,
+  VIDEOS_EDIT_URL,
+  VIDEOS_EXTEND_URL,
+  VIDEOS_BASE,
+};

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -163,6 +163,7 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       apiKey: connection.apiKey,
       accessToken: connection.accessToken,
       refreshToken: connection.refreshToken,
+      expiresAt: connection.expiresAt,
       projectId: connection.projectId,
       connectionName: connection.displayName || connection.name || connection.email || connection.id,
       copilotToken: connection.providerSpecificData?.copilotToken,

--- a/tests/unit/xai-oauth-service.test.js
+++ b/tests/unit/xai-oauth-service.test.js
@@ -100,6 +100,8 @@ describe("xai/oauth service", () => {
           access_token: "access-token",
           refresh_token: "refresh-token",
           expires_in: 3600,
+          id_token: `h.${Buffer.from(JSON.stringify({ email: "grok@example.com", sub: "sub-1" })).toString("base64url")}.s`,
+          token_type: "Bearer",
         }),
       });
 
@@ -120,6 +122,18 @@ describe("xai/oauth service", () => {
       accessToken: "access-token",
       refreshToken: "refresh-token",
       expiresIn: 3600,
+      tokenType: "Bearer",
+      email: "grok@example.com",
+      providerSpecificData: {
+        idToken: expect.any(String),
+        sub: "sub-1",
+        redirectUri: "http://127.0.0.1:56121/callback",
+        tokenEndpoint: "https://auth.x.ai/oauth2/token-from-discovery",
+        baseUrl: "https://api.x.ai/v1",
+        authKind: "oauth",
+        lastRefresh: expect.any(String),
+      },
     });
+    expect(new Date(tokens.expiresAt).getTime()).toBeGreaterThan(Date.now());
   });
 });

--- a/tests/unit/xai-sse.test.js
+++ b/tests/unit/xai-sse.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSseBlock,
+  iterateSseEvents,
+  collectSseToCompleted,
+  buildXaiHeaders,
+  resolveXaiBearer,
+} from "../../src/lib/providers/xai/executor.js";
+
+function makeStream(chunks) {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+}
+
+describe("xai/executor parseSseBlock", () => {
+  it("parses a single named event with data", () => {
+    const block = "event: response.created\ndata: {\"a\":1}\n\nevent: response.completed\ndata: {\"b\":2}";
+    const events = parseSseBlock(block);
+    expect(events).toEqual([
+      { event: "response.created", data: '{"a":1}' },
+      { event: "response.completed", data: '{"b":2}' },
+    ]);
+  });
+  it("ignores comments and unknown fields", () => {
+    const block = ":comment\nevent: ping\nid: 7\ndata: hello";
+    const events = parseSseBlock(block);
+    expect(events).toEqual([{ event: "ping", data: "hello" }]);
+  });
+  it("concatenates multi-line data with newlines", () => {
+    const block = "event: x\ndata: line1\ndata: line2";
+    expect(parseSseBlock(block)).toEqual([{ event: "x", data: "line1\nline2" }]);
+  });
+});
+
+describe("xai/executor iterateSseEvents", () => {
+  it("yields events across chunk boundaries", async () => {
+    const stream = makeStream([
+      "event: a\ndata: 1\n\nevent: b\nda",
+      "ta: 2\n\n",
+      "event: c\ndata: 3\n\n",
+    ]);
+    const out = [];
+    for await (const ev of iterateSseEvents(stream)) out.push(ev);
+    expect(out).toEqual([
+      { event: "a", data: "1" },
+      { event: "b", data: "2" },
+      { event: "c", data: "3" },
+    ]);
+  });
+  it("flushes trailing event without blank line", async () => {
+    const stream = makeStream(["event: tail\ndata: bye"]);
+    const out = [];
+    for await (const ev of iterateSseEvents(stream)) out.push(ev);
+    expect(out).toEqual([{ event: "tail", data: "bye" }]);
+  });
+});

--- a/tests/unit/xai-thinking.test.js
+++ b/tests/unit/xai-thinking.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyThinking,
+  budgetToEffort,
+} from "../../src/lib/providers/xai/thinking.js";
+
+describe("xai/thinking budgetToEffort", () => {
+  it("maps 0 / negative to undefined", () => {
+    expect(budgetToEffort(0)).toBeUndefined();
+    expect(budgetToEffort(-100)).toBeUndefined();
+    expect(budgetToEffort(NaN)).toBeUndefined();
+  });
+  it("maps small budgets to low", () => {
+    expect(budgetToEffort(1)).toBe("low");
+    expect(budgetToEffort(3999)).toBe("low");
+  });
+  it("maps medium budgets to medium", () => {
+    expect(budgetToEffort(4000)).toBe("medium");
+    expect(budgetToEffort(15999)).toBe("medium");
+  });
+  it("maps large budgets to high", () => {
+    expect(budgetToEffort(16000)).toBe("high");
+    expect(budgetToEffort(64000)).toBe("high");
+  });
+});
+
+describe("xai/thinking applyThinking", () => {
+  it("returns input untouched when nothing matches", () => {
+    const req = { model: "grok-4", input: [] };
+    const out = applyThinking(req);
+    expect(out).toEqual(req);
+    expect(out).not.toBe(req); // cloned
+  });
+
+  it("honors xAI-native reasoning.effort verbatim", () => {
+    const req = { reasoning: { effort: "high" }, foo: 1 };
+    const out = applyThinking(req);
+    expect(out.reasoning).toEqual({ effort: "high" });
+    expect(out.foo).toBe(1);
+  });
+
+  it("rewrites OpenAI Chat reasoning_effort into reasoning.effort", () => {
+    const req = { reasoning_effort: "medium" };
+    const out = applyThinking(req);
+    expect(out.reasoning).toEqual({ effort: "medium" });
+    expect(out.reasoning_effort).toBeUndefined();
+  });
+
+  it("ignores invalid reasoning_effort values", () => {
+    const req = { reasoning_effort: "ultra" };
+    const out = applyThinking(req);
+    expect(out.reasoning).toBeUndefined();
+  });
+
+  it("maps Anthropic thinking enabled with budget_tokens", () => {
+    const req = { thinking: { type: "enabled", budget_tokens: 20000 } };
+    const out = applyThinking(req);
+    expect(out.reasoning).toEqual({ effort: "high" });
+    expect(out.thinking).toBeUndefined();
+  });
+
+  it("defaults Anthropic thinking enabled without budget_tokens to medium", () => {
+    const req = { thinking: { type: "enabled" } };
+    const out = applyThinking(req);
+    expect(out.reasoning).toEqual({ effort: "medium" });
+  });
+
+  it("strips Anthropic thinking type=disabled without setting reasoning", () => {
+    const req = { thinking: { type: "disabled" } };
+    const out = applyThinking(req);
+    expect(out.reasoning).toBeUndefined();
+    expect(out.thinking).toBeUndefined();
+  });
+
+  it("maps Gemini thinkingConfig.thinkingBudget", () => {
+    const req = { thinkingConfig: { thinkingBudget: 5000 } };
+    const out = applyThinking(req);
+    expect(out.reasoning).toEqual({ effort: "medium" });
+    expect(out.thinkingConfig).toBeUndefined();
+  });
+
+  it("strips Gemini thinkingConfig with budget=0 without setting reasoning", () => {
+    const req = { thinkingConfig: { thinkingBudget: 0 } };
+    const out = applyThinking(req);
+    expect(out.reasoning).toBeUndefined();
+    expect(out.thinkingConfig).toBeUndefined();
+  });
+
+  it("applies defaultEffort when nothing else is provided", () => {
+    const out = applyThinking({}, { defaultEffort: "low" });
+    expect(out.reasoning).toEqual({ effort: "low" });
+  });
+});

--- a/tests/unit/xai-tokenRefresh.test.js
+++ b/tests/unit/xai-tokenRefresh.test.js
@@ -11,14 +11,20 @@ describe("xai/token-refresh wrapper", () => {
     expect(typeof mod.formatProviderCredentials).toBe("function");
   });
 
-  it("formatProviderCredentials returns Bearer-shape for xai", async () => {
+  it("formatProviderCredentials preserves refresh metadata for xai", async () => {
     const mod = await import("../../open-sse/services/tokenRefresh.js");
     const out = mod.formatProviderCredentials(
       "xai",
-      { apiKey: "k", accessToken: "t", refreshToken: "r" },
+      { apiKey: "k", accessToken: "t", refreshToken: "r", expiresAt: "2030-01-01T00:00:00.000Z", providerSpecificData: { authKind: "oauth" } },
       null
     );
-    expect(out).toEqual({ apiKey: "k", accessToken: "t" });
+    expect(out).toEqual({
+      apiKey: "k",
+      accessToken: "t",
+      refreshToken: "r",
+      expiresAt: "2030-01-01T00:00:00.000Z",
+      providerSpecificData: { authKind: "oauth" },
+    });
   });
 
   it("refreshTokenByProvider returns null when refreshToken missing", async () => {
@@ -27,11 +33,14 @@ describe("xai/token-refresh wrapper", () => {
     expect(out).toBeNull();
   });
 
-  it("refreshTokenByProvider returns expiresIn for refreshed xai tokens", async () => {
+  it("refreshTokenByProvider returns expiry and metadata for refreshed xai tokens", async () => {
     vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-21T00:00:00.000Z"));
     vi.doMock("../../src/lib/oauth/services/xai.js", () => ({
       XaiService: class {
-        async refreshAccessToken(refreshToken) {
+        async refreshAccessToken(refreshToken, tokenEndpoint) {
+          expect(tokenEndpoint).toBe("https://auth.x.ai/oauth2/token-from-storage");
           return {
             access_token: "new-access",
             refresh_token: `${refreshToken}-rotated`,
@@ -45,7 +54,14 @@ describe("xai/token-refresh wrapper", () => {
     const mod = await import("../../open-sse/services/tokenRefresh.js");
     const out = await mod.refreshTokenByProvider(
       "xai",
-      { refreshToken: "old-refresh" },
+      {
+        refreshToken: "old-refresh",
+        providerSpecificData: {
+          redirectUri: "http://127.0.0.1:56121/callback",
+          tokenEndpoint: "https://auth.x.ai/oauth2/token-from-storage",
+          customField: "keep-me",
+        },
+      },
       null
     );
 
@@ -54,10 +70,20 @@ describe("xai/token-refresh wrapper", () => {
       refreshToken: "old-refresh-rotated",
       expiresIn: 900,
       idToken: "id-token",
+      providerSpecificData: {
+        redirectUri: "http://127.0.0.1:56121/callback",
+        tokenEndpoint: "https://auth.x.ai/oauth2/token-from-storage",
+        customField: "keep-me",
+        authKind: "oauth",
+        baseUrl: "https://api.x.ai/v1",
+        lastRefresh: "2026-05-21T00:00:00.000Z",
+        idToken: "id-token",
+      },
     });
     expect(out).not.toHaveProperty("expiresAt");
 
     vi.doUnmock("../../src/lib/oauth/services/xai.js");
+    vi.useRealTimers();
     vi.resetModules();
   });
 });

--- a/tests/unit/xai-video-account.test.js
+++ b/tests/unit/xai-video-account.test.js
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/sse/services/auth.js", () => ({
+  getProviderCredentials: vi.fn(),
+}));
+
+vi.mock("@/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(),
+  updateProviderCredentials: vi.fn(),
+}));
+
+const { getProviderCredentials } = await import("@/sse/services/auth.js");
+const { checkAndRefreshToken, updateProviderCredentials } = await import(
+  "@/sse/services/tokenRefresh.js"
+);
+const { persistXaiAccount, resolveXaiAccount } = await import(
+  "@/app/api/v1/videos/_xaiAccount.js"
+);
+
+describe("xAI video account helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the saved xAI connection instead of the gateway Authorization bearer", async () => {
+    const connection = {
+      connectionId: "conn-xai",
+      authType: "oauth",
+      accessToken: "stored-access",
+      refreshToken: "stored-refresh",
+      expiresAt: "2026-05-20T00:10:00.000Z",
+    };
+
+    getProviderCredentials.mockResolvedValue(connection);
+    checkAndRefreshToken.mockResolvedValue({
+      ...connection,
+      accessToken: "fresh-access",
+    });
+
+    const request = new Request("http://localhost:20128/v1/videos/generations", {
+      headers: {
+        Authorization: "Bearer gateway-api-key",
+        "x-connection-id": "conn-xai",
+      },
+    });
+
+    const account = await resolveXaiAccount(request);
+
+    expect(getProviderCredentials).toHaveBeenCalledWith("xai", null, null, {
+      preferredConnectionId: "conn-xai",
+    });
+    expect(checkAndRefreshToken).toHaveBeenCalledWith("xai", connection);
+    expect(account).toMatchObject({
+      authType: "oauth",
+      accessToken: "fresh-access",
+      refreshToken: "stored-refresh",
+      connectionId: "conn-xai",
+    });
+    expect(account.apiKey).toBeUndefined();
+  });
+
+  it("persists refreshed xAI video tokens with a relative expiry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T00:00:00.000Z"));
+
+    await persistXaiAccount({
+      connectionId: "conn-xai",
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresAt: "2026-05-20T00:10:00.000Z",
+    });
+
+    expect(updateProviderCredentials).toHaveBeenCalledWith("conn-xai", {
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      expiresIn: 600,
+    });
+  });
+});


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/625b96f0-7a71-467c-b847-2b209669c452



Adds xAI / Grok as a first-class provider

- OAuth 2.0 with PKCE on loopback port `56121`, plus API-key auth path
- Always-SSE Responses pipeline that synthesizes `response.completed` from `response.output_item.done` for non-stream callers
- Reasoning / thinking patcher for Grok thinking events
- Inbound translators: **OpenAI Chat Completions**, **OpenAI Responses**, **Anthropic Messages**, **Gemini** -> xAI Responses
- Image endpoints (`/v1/images/generations`, `/v1/images/edits`) and video endpoints (`/v1/videos/{generations,edits,extensions,{id}}`, multipart preserved)
- CLI `xai-login` command for the interactive OAuth flow

Closes #1285. Refs #1281.

## Follow-Up Updates

### Dashboard Install + Token Refresh Wiring

Commit `550ac80` completes the installable dashboard flow for xAI:

- Adds a fixed-port xAI OAuth proxy on `127.0.0.1:56121` in `src/lib/oauth/utils/server.js`, matching the Codex proxy shape.
- Extends `/api/oauth/[provider]/[action]` so `xai` supports `start-proxy`, `poll-status`, and `stop-proxy`.
- Updates `OAuthModal` so xAI uses the fixed loopback redirect URI and server-side proxy registration.
- Registers `xai` under `OAUTH_PROVIDERS`, so the dashboard can render the OAuth connection flow next to API-key support.
- Adds `case "xai"` to `_getAccessTokenInternal`, `refreshTokenByProvider`, and `formatProviderCredentials` in `open-sse/services/tokenRefresh.js`.
- Adds `tokenUrl`, `refreshUrl`, and `responsesUrl` to the `xai` entry in `open-sse/config/providers.js`.
- Replaces stub xAI video-route account resolution with `getProviderCredentials("xai", ...)` and `checkAndRefreshToken`.
- Adds token-refresh wrapper unit coverage.

### CLIProxyAPI Parity Follow-Ups

Commits `638dec8`, `cb1774d`, and `8dc34de` tighten OAuth parity with `router-for-me/CLIProxyAPI`:

- Adds xAI authorize URL extras from the Go reference: `nonce`, `plan=generic`, and `referrer=cli-proxy-api`.
- Uses `/oauth2/authorize`, matching xAI OIDC discovery, instead of the incorrect `/oauth2/auth` fallback.
- Validates discovered OAuth endpoints: HTTPS only, host `x.ai` or `*.x.ai`.
- Removes custom `User-Agent` headers from xAI discovery/token/refresh requests to match CLIProxyAPI token request behavior.
- Adds unit coverage for endpoint validation, discovery headers, and authorize URL query params.

### Manual OAuth Fallback

Commit `319a4ff` handles the Grok Build fallback page case:

- Accepts a raw copied xAI authorization code when Grok Build cannot redirect to `http://127.0.0.1:56121/callback`.
- Adds `POST /api/oauth/xai/manual-code`, using the registered server-side session, code verifier, and redirect URI.
- Fixes xAI server-side polling in `OAuthModal`.
- Cleans up the xAI proxy when the modal closes.

### Dashboard Auth Clarity

Commit `77be275` makes the xAI dashboard flow explicit and keeps the dashboard path aligned with CLIProxyAPI:

- Dashboard xAI auth generation now uses 96-byte PKCE verifier output and discovery-derived authorize/token endpoints.
- `/api/oauth/xai/*` awaits the async auth-data path.
- Provider detail UI separates **Grok Build OAuth** from **xAI API Key**.
- Connection rows display the saved auth type (`OAuth`, `API Key`, or `Cookie`) instead of treating all xAI rows as OAuth.
- API-key modal copy clarifies that direct xAI API keys from `console.x.ai` are separate from Grok Build OAuth.
- `getProviderCredentials()` returns `authType`, so downstream xAI routes preserve OAuth vs API-key behavior.

## CLIProxyAPI Cross-Check

Verified against `router-for-me/CLIProxyAPI` source:

- `internal/auth/xai/types.go`
- `internal/auth/xai/xai.go`
- `internal/auth/xai/pkce.go`
- `internal/auth/xai/token.go`
- `sdk/auth/xai.go`
- `internal/cmd/xai_login.go`

| Topic | Verdict |
|---|---|
| Loopback port `127.0.0.1:56121` + `/callback` | MATCH |
| PKCE 96-byte verifier + S256 | MATCH |
| Scope `openid profile email offline_access grok-cli:access api:access` | MATCH |
| Token refresh form (`grant_type=refresh_token`, `client_id`, `refresh_token`, no `scope`) | MATCH |
| Code exchange form (form-urlencoded, `code_verifier`) | MATCH |
| OIDC discovery endpoint | MATCH |
| Refresh lead time = 300s | MATCH |
| `id_token` decode (base64url, no signature verify, `email`/`sub`) | MATCH |
| Public PKCE `client_id` `b1a00492-073a-47ea-816f-4c329264a828` | MATCH |
| Token endpoint `https://auth.x.ai/oauth2/token` | MATCH |
| API base `https://api.x.ai/v1` | MATCH |
| Disconnect = local delete (no revoke endpoint) | MATCH |
| Authorize URL extras (`nonce`, `plan=generic`, `referrer=cli-proxy-api`) | MATCH |
| Token request custom User-Agent | MATCH: no custom override |

## File Inventory

### Created

- `src/lib/oauth/constants/xai.js` - endpoint, scope, port, redirect URI, PKCE bytes
- `src/lib/oauth/services/xai.js` - discovery, code exchange, refresh, id_token email decode
- `src/lib/providers/xai/executor.js` - chat / responses executor, always-SSE pipeline
- `src/lib/providers/xai/thinking.js` - reasoning/thinking patcher
- `src/lib/providers/xai/images.js` - image generation + edits
- `src/lib/providers/xai/videos.js` - video generation, edits, extensions, retrieval
- `src/lib/providers/xai/translators/openai-chat.js`
- `src/lib/providers/xai/translators/openai-responses.js`
- `src/lib/providers/xai/translators/claude.js`
- `src/lib/providers/xai/translators/gemini.js`
- `src/app/api/v1/videos/generations/route.js`
- `src/app/api/v1/videos/edits/route.js`
- `src/app/api/v1/videos/extensions/route.js`
- `src/app/api/v1/videos/[id]/route.js`
- `cli/commands/xai-login.js` - interactive OAuth login
- `tests/unit/xai-thinking.test.js`
- `tests/unit/xai-sse.test.js`

### Modified

- `src/lib/oauth/providers.js` - register `xai`, discovery-backed auth data, 96-byte PKCE
- `src/lib/oauth/utils/pkce.js` - configurable PKCE verifier byte size
- `src/lib/providerNormalization.js` - `xai` branch (base URL, Bearer auth, `grok-*` passthrough)
- `src/shared/constants/providers.js` - `xai` in OAuth/API-key registries
- `src/lib/oauth/utils/server.js` - xAI fixed-port proxy
- `src/app/api/oauth/[provider]/[action]/route.js` - xAI proxy, manual-code fallback, async auth data
- `src/shared/components/OAuthModal.js` - xAI fixed-port flow, polling, manual code fallback, clearer copy
- `src/app/(dashboard)/dashboard/providers/[id]/page.js` - separate Grok Build OAuth and xAI API-key actions
- `src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js` - direct xAI API-key copy
- `src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js` - per-connection auth type display
- `src/sse/services/auth.js` - return `authType` with resolved credentials
- `open-sse/services/tokenRefresh.js` - xAI refresh branches
- `open-sse/config/providers.js` - xAI token/refresh/responses URLs
- `tests/unit/xai-oauth-service.test.js` - OAuth service/dashboard auth-data coverage
- `tests/unit/xai-tokenRefresh.test.js` - token-refresh wrapper coverage

## Testing

Initial provider primitives:

```bash
cd tests && ./node_modules/.bin/vitest run unit/xai-thinking.test.js unit/xai-sse.test.js

Test Files  2 passed (2)
Tests       19 passed (19)
```

Latest focused verification:

```bash
cd tests && /tmp/node_modules/.bin/vitest run unit/xai-oauth-service.test.js unit/xai-tokenRefresh.test.js unit/xai-thinking.test.js unit/xai-sse.test.js

Test Files  4 passed (4)
Tests       27 passed (27)
```

Additional checks:

```bash
git diff --check
npm run build
```

Both passed locally. The first build attempt inside the sandbox failed because `next/font` could not reach `fonts.googleapis.com`; rerunning with network access passed.

## Out of Scope

Wiring xAI **OAuth** into the existing chat handler remains intentionally separate from the provider primitives and dashboard auth clarity work. The API-key flow continues through the existing `open-sse/config` xAI entry, while OAuth-specific runtime calls use the xAI executor paths added in this PR.

## Constants Used

| Name | Value |
|---|---|
| `clientId` | `b1a00492-073a-47ea-816f-4c329264a828` |
| `issuer` | `https://auth.x.ai` |
| `scope` | `openid profile email offline_access grok-cli:access api:access` |
| `apiBaseURL` | `https://api.x.ai/v1` |
| `loopbackPort` | `56121` |
| `redirectURI` | `http://127.0.0.1:56121/callback` |
| `pkceVerifierBytes` | `96` |
| `refreshLeadTime` | `5 * 60s` |

