### PR TITLE
feat(dashboard): show API key for each recent request

### DIFF
--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -18,12 +18,14 @@ if (!global._statsEmitter) {
 if (!global._pendingTimers) global._pendingTimers = {};
 if (!global._recentRing) global._recentRing = { items: [], initialized: false };
 if (!global._connectionMapCache) global._connectionMapCache = { map: {}, ts: 0 };
+if (!global._apiKeyMapCache) global._apiKeyMapCache = { map: {}, ts: 0 };
 
 const pendingRequests = global._pendingRequests;
 const lastErrorProvider = global._lastErrorProvider;
 const pendingTimers = global._pendingTimers;
 const recentRing = global._recentRing;
 const connCache = global._connectionMapCache;
+const apiKeyCache = global._apiKeyMapCache;
 
 export const statsEmitter = global._statsEmitter;
 
@@ -94,6 +96,25 @@ async function getConnectionMapCached() {
     connCache.ts = Date.now();
   } catch {}
   return connCache.map;
+}
+
+async function getApiKeyMapCached() {
+  if (Date.now() - apiKeyCache.ts < CONN_CACHE_TTL_MS) return apiKeyCache.map;
+  try {
+    const { getApiKeys } = await import("./apiKeysRepo.js");
+    const all = await getApiKeys();
+    const map = {};
+    for (const k of all) map[k.key] = { name: k.name, id: k.id, createdAt: k.createdAt };
+    apiKeyCache.map = map;
+    apiKeyCache.ts = Date.now();
+  } catch {}
+  return apiKeyCache.map;
+}
+
+function resolveKeyName(apiKey, apiKeyMap) {
+  if (!apiKey || typeof apiKey !== "string") return "Local";
+  const info = apiKeyMap[apiKey];
+  return info?.name || apiKey.slice(0, 8) + "...";
 }
 
 async function ensureRingInitialized() {
@@ -214,6 +235,7 @@ export async function getActiveRequests() {
   }
 
   await ensureRingInitialized();
+  const apiKeyMap = await getApiKeyMapCached();
   const seen = new Set();
   const recentRequests = [...recentRing.items]
     .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
@@ -221,6 +243,8 @@ export async function getActiveRequests() {
       const t = e.tokens || {};
       return {
         timestamp: e.timestamp, model: e.model, provider: e.provider || "",
+        apiKey: e.apiKey || null,
+        keyName: resolveKeyName(e.apiKey, apiKeyMap),
         promptTokens: t.prompt_tokens || t.input_tokens || 0,
         completionTokens: t.completion_tokens || t.output_tokens || 0,
         status: e.status || "ok",
@@ -229,7 +253,7 @@ export async function getActiveRequests() {
     .filter((e) => {
       if (e.promptTokens === 0 && e.completionTokens === 0) return false;
       const minute = e.timestamp ? e.timestamp.slice(0, 16) : "";
-      const key = `${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}`;
+      const key = `${e.model}|${e.provider}|${e.apiKey || ""}|${e.promptTokens}|${e.completionTokens}|${minute}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
@@ -342,13 +366,15 @@ export async function getUsageStats(period = "all") {
   for (const k of allApiKeys) apiKeyMap[k.key] = { name: k.name, id: k.id, createdAt: k.createdAt };
 
   // recentRequests from live history (last 100 entries enough for 20 deduped)
-  const recentRows = db.all(`SELECT timestamp, provider, model, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
+  const recentRows = db.all(`SELECT timestamp, provider, model, apiKey, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
   const seen = new Set();
   const recentRequests = recentRows
     .map((r) => {
       const t = parseJson(r.tokens, {}) || {};
       return {
         timestamp: r.timestamp, model: r.model, provider: r.provider || "",
+        apiKey: r.apiKey || null,
+        keyName: resolveKeyName(r.apiKey, apiKeyMap),
         promptTokens: t.prompt_tokens || t.input_tokens || 0,
         completionTokens: t.completion_tokens || t.output_tokens || 0,
         status: r.status || "ok",
@@ -357,7 +383,7 @@ export async function getUsageStats(period = "all") {
     .filter((e) => {
       if (e.promptTokens === 0 && e.completionTokens === 0) return false;
       const minute = e.timestamp ? e.timestamp.slice(0, 16) : "";
-      const key = `${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}`;
+      const key = `${e.model}|${e.provider}|${e.apiKey || ""}|${e.promptTokens}|${e.completionTokens}|${minute}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -54,6 +54,7 @@ function RecentRequests({ requests = [] }) {
               <tr className="border-b border-border">
                 <th className="py-1.5 text-left font-semibold text-text-muted w-2"></th>
                 <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
+                <th className="py-1.5 text-left font-semibold text-text-muted">API Key</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted">When</th>
               </tr>
@@ -61,12 +62,14 @@ function RecentRequests({ requests = [] }) {
             <tbody className="divide-y divide-border/50">
               {requests.map((r, i) => {
                 const ok = !r.status || r.status === "ok" || r.status === "success";
+                const keyLabel = r.keyName || (r.apiKey ? r.apiKey.slice(0, 8) + "..." : "Local");
                 return (
                   <tr key={i} className="hover:bg-bg-subtle transition-colors">
                     <td className="py-1.5">
                       <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} />
                     </td>
                     <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
+                    <td className="py-1.5 truncate max-w-[100px] text-text-muted" title={keyLabel}>{keyLabel}</td>
                     <td className="py-1.5 text-right whitespace-nowrap">
                       <span className="text-primary">{fmt(r.promptTokens)}↑</span>
                       {" "}


### PR DESCRIPTION
## Summary

Resolves #1258.

The Recent Requests table on the dashboard now shows which API key was used for each request — useful for debugging which CLI/integration sent a request, auditing per-key usage, and spotting a leaked or misbehaving key.

- `src/lib/db/repos/usageRepo.js`: include `apiKey` and resolved `keyName` in the `recentRequests` objects returned by `getActiveRequests()` and `getUsageStats()`.
- Added a 30s in-memory cache for the api-key map (mirrors the existing `getConnectionMapCached` pattern) so `getActiveRequests()` doesn't hit the DB on every SSE tick.
- Added `apiKey` to the recent-request dedup key, so two requests with identical model/tokens within the same minute but from different keys don't collapse into one row.
- `src/shared/components/UsageStats.js`: new **API Key** column in the Recent Requests table — shows the key's friendly name, falls back to a truncated key string, or "Local" when no key was used.

## Test plan

- [ ] With multiple API keys configured, send requests via each; confirm the dashboard's Recent Requests table shows the correct key name per row.
- [ ] Send a request with no API key (local); confirm the row shows "Local".
- [ ] Confirm the row's `In / Out` and `When` columns are unchanged.
- [ ] Confirm SSE updates still stream live without regressions.