### PR TITLE
Update Antigravity Gemini Flash model

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -64,6 +64,7 @@ export const PROVIDER_MODELS = {
     { id: "gpt-5.2-image", name: "GPT 5.2 Image", type: "image", capabilities: ["text2img", "edit"], params: ["size", "quality", "background", "image_detail", "output_format"] },
   ]),
   gc: [  // Gemini CLI
+    { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash" },
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
     { id: "gemini-3-pro-preview", name: "Gemini 3 Pro Preview" },
   ],
@@ -94,8 +95,11 @@ export const PROVIDER_MODELS = {
   ag: [  // Antigravity - special case: models call different backends
     { id: "gemini-3.1-pro-high", name: "Gemini 3 Pro High" },
     { id: "gemini-3.1-pro-low", name: "Gemini 3 Pro Low" },
-    { id: "gemini-3-flash", name: "Gemini 3 Flash", thinking: false }, // AG strips thinking for this model
+    { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash", thinking: false }, // AG strips thinking for this model
+    { id: "gemini-3-flash", name: "Gemini 3 Flash", thinking: false }, // Legacy AG flash alias
     { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    // TODO: Enable when Antigravity officially lists Claude Opus 4.7.
+    // { id: "claude-opus-4-7-thinking", name: "Claude Opus 4.7 Thinking" },
     { id: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 Thinking" },
     { id: "gpt-oss-120b-medium", name: "GPT OSS 120B Medium" },
   ],
@@ -121,6 +125,7 @@ export const PROVIDER_MODELS = {
     { id: "claude-opus-4.7", name: "Claude Opus 4.7" },
     // GitHub Copilot - Google models
     { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
+    { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash" },
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
     { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" },
     // GitHub Copilot - Other models

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -95,6 +95,8 @@ export const PROVIDER_MODELS = {
   ag: [  // Antigravity - special case: models call different backends
     { id: "gemini-3.1-pro-high", name: "Gemini 3 Pro High" },
     { id: "gemini-3.1-pro-low", name: "Gemini 3 Pro Low" },
+    { id: "gemini-3.5-flash-high", name: "Gemini 3.5 Flash High" },
+    { id: "gemini-3.5-flash-medium", name: "Gemini 3.5 Flash Medium" },
     { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash", thinking: false }, // AG strips thinking for this model
     { id: "gemini-3-flash", name: "Gemini 3 Flash", thinking: false }, // Legacy AG flash alias
     { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -383,6 +383,9 @@ async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptio
         'claude-sonnet-4-6',
         'gemini-3.1-pro-high',
         'gemini-3.1-pro-low',
+        'gemini-3.5-flash-high',
+        'gemini-3.5-flash-medium',
+        'gemini-3.5-flash',
         'gemini-3-flash',
         'gpt-oss-120b-medium',
       ];

--- a/src/mitm/config.js
+++ b/src/mitm/config.js
@@ -32,6 +32,8 @@ const URL_PATTERNS = {
 const MODEL_SYNONYMS = {
   antigravity: {
     "gemini-default": "gemini-3.5-flash",
+    "gemini-3.5-flash-high": "gemini-3.5-flash-high",
+    "gemini-3.5-flash-medium": "gemini-3.5-flash-medium",
     "gemini-3.5-flash": "gemini-3.5-flash",
     "gemini-3-flash": "gemini-3-flash",
     // TODO: Enable when Antigravity officially lists Claude Opus 4.7.
@@ -46,6 +48,8 @@ const MODEL_SYNONYMS = {
 // Order matters: more specific patterns first. Catches AG renamed variants (e.g. gemini-pro-agent)
 const MODEL_PATTERNS = {
   antigravity: [
+    { match: /flash.*high|high.*flash/i,  alias: "gemini-3.5-flash-high" },
+    { match: /flash.*medium|medium.*flash/i, alias: "gemini-3.5-flash-medium" },
     { match: /flash/i,                   alias: "gemini-3.5-flash" },
     { match: /pro.*low|low.*pro/i,       alias: "gemini-3.1-pro-low" },
     { match: /gemini.*pro|pro.*gemini/i, alias: "gemini-3.1-pro-high" },

--- a/src/mitm/config.js
+++ b/src/mitm/config.js
@@ -30,16 +30,27 @@ const URL_PATTERNS = {
 
 // Synonym map: rawModel from request → canonical alias key in mitmAlias DB
 const MODEL_SYNONYMS = {
-  antigravity: { "gemini-default": "gemini-3-flash" },
+  antigravity: {
+    "gemini-default": "gemini-3.5-flash",
+    "gemini-3.5-flash": "gemini-3.5-flash",
+    "gemini-3-flash": "gemini-3-flash",
+    // TODO: Enable when Antigravity officially lists Claude Opus 4.7.
+    // "claude-opus-4-7-thinking": "claude-opus-4-7-thinking",
+    // "claude-opus-4-7": "claude-opus-4-7-thinking",
+    "claude-opus-4-6-thinking": "claude-opus-4-6-thinking",
+    "claude-opus-4-6": "claude-opus-4-6-thinking",
+  },
 };
 
 // Pattern fallback: rawModel regex → canonical alias key (when exact + prefix match fail)
 // Order matters: more specific patterns first. Catches AG renamed variants (e.g. gemini-pro-agent)
 const MODEL_PATTERNS = {
   antigravity: [
-    { match: /flash/i,                   alias: "gemini-3-flash" },
+    { match: /flash/i,                   alias: "gemini-3.5-flash" },
     { match: /pro.*low|low.*pro/i,       alias: "gemini-3.1-pro-low" },
     { match: /gemini.*pro|pro.*gemini/i, alias: "gemini-3.1-pro-high" },
+    // TODO: Enable Opus 4.7 fallback when Antigravity officially lists it.
+    // { match: /opus.*4[.-]?7|4[.-]?7.*opus/i, alias: "claude-opus-4-7-thinking" },
     { match: /opus/i,                    alias: "claude-opus-4-6-thinking" },
     { match: /sonnet|claude/i,           alias: "claude-sonnet-4-6" },
     { match: /gpt.*oss|oss/i,            alias: "gpt-oss-120b-medium" },

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -106,7 +106,7 @@ function getMappedModel(tool, model) {
   try {
     const aliases = getMitmAlias(tool);
     if (!aliases) return null;
-    // Normalize via synonym map (e.g., gemini-default → gemini-3-flash)
+    // Normalize via synonym map (e.g., gemini-default → gemini-3.5-flash)
     const lookup = MODEL_SYNONYMS?.[tool]?.[model] || model;
     if (aliases[lookup]) return aliases[lookup];
     // Prefix match fallback

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -8,13 +8,17 @@ export const MITM_TOOLS = {
     description: "Google Antigravity IDE with MITM",
     configType: "mitm",
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
-    modelAliases: ["claude-opus-4-6-thinking", "claude-sonnet-4-6", "gemini-3-flash", "gpt-oss-120b-medium", "gemini-3-pro-high", "gemini-3-pro-low", "gemini-pro-agent"],
+    // TODO: Enable claude-opus-4-7-thinking when Antigravity officially lists Claude Opus 4.7.
+    modelAliases: ["claude-opus-4-6-thinking", "claude-sonnet-4-6", "gemini-3.5-flash", "gemini-3-flash", "gpt-oss-120b-medium", "gemini-3-pro-high", "gemini-3-pro-low", "gemini-pro-agent"],
     defaultModels: [
       { id: "gemini-pro-agent", name: "Gemini Pro Agent (AG v1.23+ Agent Mode)", alias: "gemini-pro-agent" },
       { id: "gemini-3.1-pro-high", name: "Gemini 3.1 Pro High", alias: "gemini-3.1-pro-high" },
       { id: "gemini-3.1-pro-low", name: "Gemini 3.1 Pro Low", alias: "gemini-3.1-pro-low" },
-      { id: "gemini-3-flash", name: "Gemini 3 Flash / Default", alias: "gemini-3-flash" },
+      { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash / Default", alias: "gemini-3.5-flash" },
+      { id: "gemini-3-flash", name: "Gemini 3 Flash (Legacy)", alias: "gemini-3-flash" },
       { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", alias: "claude-sonnet-4-6" },
+      // TODO: Enable when Antigravity officially lists Claude Opus 4.7.
+      // { id: "claude-opus-4-7-thinking", name: "Claude Opus 4.7 Thinking", alias: "claude-opus-4-7-thinking" },
       { id: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 Thinking", alias: "claude-opus-4-6-thinking" },
       { id: "gpt-oss-120b-medium", name: "GPT OSS 120B Medium", alias: "gpt-oss-120b-medium" },
     ],

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -9,11 +9,13 @@ export const MITM_TOOLS = {
     configType: "mitm",
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
     // TODO: Enable claude-opus-4-7-thinking when Antigravity officially lists Claude Opus 4.7.
-    modelAliases: ["claude-opus-4-6-thinking", "claude-sonnet-4-6", "gemini-3.5-flash", "gemini-3-flash", "gpt-oss-120b-medium", "gemini-3-pro-high", "gemini-3-pro-low", "gemini-pro-agent"],
+    modelAliases: ["claude-opus-4-6-thinking", "claude-sonnet-4-6", "gemini-3.5-flash-high", "gemini-3.5-flash-medium", "gemini-3.5-flash", "gemini-3-flash", "gpt-oss-120b-medium", "gemini-3-pro-high", "gemini-3-pro-low", "gemini-pro-agent"],
     defaultModels: [
       { id: "gemini-pro-agent", name: "Gemini Pro Agent (AG v1.23+ Agent Mode)", alias: "gemini-pro-agent" },
       { id: "gemini-3.1-pro-high", name: "Gemini 3.1 Pro High", alias: "gemini-3.1-pro-high" },
       { id: "gemini-3.1-pro-low", name: "Gemini 3.1 Pro Low", alias: "gemini-3.1-pro-low" },
+      { id: "gemini-3.5-flash-high", name: "Gemini 3.5 Flash High", alias: "gemini-3.5-flash-high" },
+      { id: "gemini-3.5-flash-medium", name: "Gemini 3.5 Flash Medium", alias: "gemini-3.5-flash-medium" },
       { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash / Default", alias: "gemini-3.5-flash" },
       { id: "gemini-3-flash", name: "Gemini 3 Flash (Legacy)", alias: "gemini-3-flash" },
       { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", alias: "claude-sonnet-4-6" },
@@ -382,4 +384,3 @@ export const getProviderModelsForMapping = (providers) => {
   });
   return result;
 };
-

--- a/src/shared/constants/pricing.js
+++ b/src/shared/constants/pricing.js
@@ -11,6 +11,7 @@
  */
 export const MODEL_PRICING = {
   // === Anthropic / Claude ===
+  "claude-opus-4-7":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 25.00,  cache_creation: 6.25  },
   "claude-opus-4-6":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 25.00,  cache_creation: 6.25  },
   "claude-opus-4-5-20251101":     { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 25.00,  cache_creation: 6.25  },
   "claude-sonnet-4-6":            { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 15.00,  cache_creation: 3.75  },
@@ -23,11 +24,14 @@ export const MODEL_PRICING = {
   "claude-opus-4.1":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
   "claude-opus-4.5":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
   "claude-opus-4.6":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
+  "claude-opus-4.7":              { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
   "claude-sonnet-4":              { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 22.50,  cache_creation: 3.00  },
   "claude-sonnet-4.5":            { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 22.50,  cache_creation: 3.00  },
   "claude-sonnet-4.6":            { input: 3.00,  output: 15.00, cached: 0.30,  reasoning: 22.50,  cache_creation: 3.00  },
   "claude-opus-4-5-thinking":     { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
   "claude-opus-4-6-thinking":     { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
+  // TODO: Enable when Antigravity officially lists Claude Opus 4.7.
+  // "claude-opus-4-7-thinking":     { input: 5.00,  output: 25.00, cached: 0.50,  reasoning: 37.50,  cache_creation: 5.00  },
 
   // === OpenAI / GPT ===
   "gpt-3.5-turbo":                { input: 0.50,  output: 1.50,  cached: 0.25,  reasoning: 2.25,   cache_creation: 0.50  },
@@ -56,6 +60,7 @@ export const MODEL_PRICING = {
   "o1-mini":                      { input: 3.00,  output: 12.00, cached: 1.50,  reasoning: 18.00,  cache_creation: 3.00  },
 
   // === Gemini ===
+  "gemini-3.5-flash":             { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
   "gemini-3-flash-preview":       { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
   "gemini-3-pro-preview":         { input: 2.00,  output: 12.00, cached: 0.25,  reasoning: 18.00,  cache_creation: 2.00  },
   "gemini-3.1-pro-low":           { input: 2.00,  output: 12.00, cached: 0.25,  reasoning: 18.00,  cache_creation: 2.00  },

--- a/src/shared/constants/pricing.js
+++ b/src/shared/constants/pricing.js
@@ -61,6 +61,8 @@ export const MODEL_PRICING = {
 
   // === Gemini ===
   "gemini-3.5-flash":             { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
+  "gemini-3.5-flash-high":        { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
+  "gemini-3.5-flash-medium":      { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
   "gemini-3-flash-preview":       { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
   "gemini-3-pro-preview":         { input: 2.00,  output: 12.00, cached: 0.25,  reasoning: 18.00,  cache_creation: 2.00  },
   "gemini-3.1-pro-low":           { input: 2.00,  output: 12.00, cached: 0.25,  reasoning: 18.00,  cache_creation: 2.00  },

--- a/tests/unit/antigravity-cache.test.js
+++ b/tests/unit/antigravity-cache.test.js
@@ -53,7 +53,7 @@ async function callAg({ accessToken, projectId, sessionId, longText, userText })
   const baseUrl = PROVIDERS.antigravity.baseUrls[0];
   const body = {
     project: projectId,
-    model: "gemini-3-flash",
+    model: "gemini-3.5-flash",
     userAgent: "antigravity",
     requestType: "agent",
     requestId: `agent-${crypto.randomUUID()}`,

--- a/tests/unit/mitm-config.test.js
+++ b/tests/unit/mitm-config.test.js
@@ -7,6 +7,8 @@ const { MODEL_SYNONYMS, MODEL_PATTERNS } = require("../../src/mitm/config.js");
 describe("Antigravity MITM model mappings", () => {
   it("maps explicit Antigravity aliases to current and legacy canonical models", () => {
     expect(MODEL_SYNONYMS.antigravity["gemini-default"]).toBe("gemini-3.5-flash");
+    expect(MODEL_SYNONYMS.antigravity["gemini-3.5-flash-high"]).toBe("gemini-3.5-flash-high");
+    expect(MODEL_SYNONYMS.antigravity["gemini-3.5-flash-medium"]).toBe("gemini-3.5-flash-medium");
     expect(MODEL_SYNONYMS.antigravity["gemini-3.5-flash"]).toBe("gemini-3.5-flash");
     expect(MODEL_SYNONYMS.antigravity["gemini-3-flash"]).toBe("gemini-3-flash");
     expect(MODEL_SYNONYMS.antigravity["claude-opus-4-7"]).toBeUndefined();
@@ -18,6 +20,8 @@ describe("Antigravity MITM model mappings", () => {
     const patternAliasFor = (rawModel) => MODEL_PATTERNS.antigravity.find(({ match }) => match.test(rawModel))?.alias;
 
     expect(patternAliasFor("Gemini Flash Default")).toBe("gemini-3.5-flash");
+    expect(patternAliasFor("Gemini Flash High")).toBe("gemini-3.5-flash-high");
+    expect(patternAliasFor("Gemini Medium Flash")).toBe("gemini-3.5-flash-medium");
     expect(patternAliasFor("Claude Opus")).toBe("claude-opus-4-6-thinking");
   });
 });

--- a/tests/unit/mitm-config.test.js
+++ b/tests/unit/mitm-config.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { MODEL_SYNONYMS, MODEL_PATTERNS } = require("../../src/mitm/config.js");
+
+describe("Antigravity MITM model mappings", () => {
+  it("maps explicit Antigravity aliases to current and legacy canonical models", () => {
+    expect(MODEL_SYNONYMS.antigravity["gemini-default"]).toBe("gemini-3.5-flash");
+    expect(MODEL_SYNONYMS.antigravity["gemini-3.5-flash"]).toBe("gemini-3.5-flash");
+    expect(MODEL_SYNONYMS.antigravity["gemini-3-flash"]).toBe("gemini-3-flash");
+    expect(MODEL_SYNONYMS.antigravity["claude-opus-4-7"]).toBeUndefined();
+    expect(MODEL_SYNONYMS.antigravity["claude-opus-4-7-thinking"]).toBeUndefined();
+    expect(MODEL_SYNONYMS.antigravity["claude-opus-4-6"]).toBe("claude-opus-4-6-thinking");
+  });
+
+  it("falls back to current Flash and Opus aliases for renamed raw models", () => {
+    const patternAliasFor = (rawModel) => MODEL_PATTERNS.antigravity.find(({ match }) => match.test(rawModel))?.alias;
+
+    expect(patternAliasFor("Gemini Flash Default")).toBe("gemini-3.5-flash");
+    expect(patternAliasFor("Claude Opus")).toBe("claude-opus-4-6-thinking");
+  });
+});

--- a/tests/unit/rtk.multi-provider.e2e.test.js
+++ b/tests/unit/rtk.multi-provider.e2e.test.js
@@ -97,7 +97,7 @@ function chatBodyWithDiff(model, diff) {
 const ROUTES = [
   { name: "claude (cc/* → openai→claude)",        model: "cc/claude-opus-4-7" },
   { name: "codex (cx/* → openai→openai-responses)", model: "cx/gpt-5.4" },
-  { name: "antigravity (ag/* → openai→antigravity)", model: "ag/gemini-3-flash" },
+  { name: "antigravity (ag/* → openai→antigravity)", model: "ag/gemini-3.5-flash" },
   { name: "cursor (cu/* → openai→cursor)",         model: "cu/claude-4.5-sonnet" },
   { name: "kiro (kr/* → openai→kiro)",             model: "kr/claude-sonnet-4.5" },
   { name: "gemini (gemini/* → openai→gemini)",     model: "gemini/gemini-2.5-flash" },


### PR DESCRIPTION
## Summary
- Add Gemini 3.5 Flash to Antigravity/Gemini-related model catalogs and MITM defaults.
- Keep Opus 4.7 commented/disabled for Antigravity until official Antigravity docs list it.
- Add MITM config tests and update targeted Antigravity model references.

## Tests
- `git diff --check`
- JS syntax checks for changed files
- Targeted Vitest tests were skipped in final pre-commit because dependencies were unavailable in the clean temp worktree.