### PR TITLE
fix(tunnel): resolve unix redirection error in tailscale status checks on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,8 @@ ecosystem.config.*
 scripts/agSniffer/*
 gitbooks/*
 gitbook/README.md
+
+.claude/
+plans/
+.repomixignore
+CLAUDE.md

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -33,8 +33,8 @@ const nextConfig = {
         path: false,
       };
     }
-    // Exclude logs, .next, gitbook subapp from watcher
-    config.watchOptions = { ...config.watchOptions, ignored: /[\\/](logs|\.next|gitbook|cli)[\\/]/ };
+    // Exclude logs, .next, gitbook subapp, data dir from watcher
+    config.watchOptions = { ...config.watchOptions, ignored: /[\\/](logs|\.next|gitbook|cli|data)[\\/]/ };
     return config;
   },
   async rewrites() {

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -113,10 +113,20 @@ export function createDisconnectAwareStream(transformStream, streamController) {
         }
         controller.enqueue(value);
       } catch (error) {
+        const wasConnected = streamController.isConnected();
         streamController.handleError(error);
         reader.cancel().catch(() => {});
         writer.abort().catch(() => {});
-        controller.error(error);
+        
+        if (!wasConnected || error.name === "AbortError" || error.message?.includes("aborted")) {
+          try {
+            controller.close();
+          } catch (e) {
+            // Stream might already be closed or cancelled
+          }
+        } else {
+          controller.error(error);
+        }
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "9Router web dashboard",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack --port 20128",
+    "dev": "next dev --webpack --port 20127",
     "build": "next build --webpack",
     "start": "next start",
     "dev:bun": "bun --bun next dev --webpack --port 20128",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "9Router web dashboard",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack --port 20127",
+    "dev": "next dev --webpack --port 20128",
     "build": "next build --webpack",
     "start": "next start",
     "dev:bun": "bun --bun next dev --webpack --port 20128",

--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import { Badge, Toggle } from "@/shared/components";
 import CooldownTimer from "./CooldownTimer";
 
-export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete }) {
+export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null }) {
   const [showProxyDropdown, setShowProxyDropdown] = useState(false);
   const [updatingProxy, setUpdatingProxy] = useState(false);
   const proxyDropdownRef = useRef(null);
@@ -109,6 +109,23 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
     return "default";
   };
 
+  const getOneByOneVariant = () => {
+    if (!oneByOneStatus) return "default";
+    if (oneByOneStatus.state === "success") return "success";
+    if (oneByOneStatus.state === "failed") return "error";
+    if (oneByOneStatus.state === "testing") return "primary";
+    return "default";
+  };
+
+  const getOneByOneLabel = () => {
+    if (!oneByOneStatus) return null;
+    if (oneByOneStatus.state === "queued") return "queued";
+    if (oneByOneStatus.state === "testing") return "testing";
+    if (oneByOneStatus.state === "success") return "success";
+    if (oneByOneStatus.state === "failed") return oneByOneStatus.error ? `failed: ${oneByOneStatus.error}` : "failed";
+    return null;
+  };
+
   return (
     <div className={`group flex min-w-0 flex-col gap-3 rounded-lg p-2 transition-colors hover:bg-black/[0.02] dark:hover:bg-white/[0.02] sm:flex-row sm:items-center sm:justify-between ${connection.isActive === false ? "opacity-60" : ""}`}>
       <div className="flex min-w-0 flex-1 items-start gap-2 sm:items-center sm:gap-3">
@@ -152,6 +169,11 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
             <span className="text-xs text-text-muted">#{connection.priority}</span>
             {connection.globalPriority && (
               <span className="text-xs text-text-muted">Auto: {connection.globalPriority}</span>
+            )}
+            {getOneByOneLabel() && (
+              <Badge variant={getOneByOneVariant()} size="sm">
+                {getOneByOneLabel()}
+              </Badge>
             )}
           </div>
           {hasAnyProxy && (
@@ -258,5 +280,9 @@ ConnectionRow.propTypes = {
   onUpdateProxy: PropTypes.func,
   onEdit: PropTypes.func.isRequired,
   onDelete: PropTypes.func.isRequired,
+  oneByOneStatus: PropTypes.shape({
+    state: PropTypes.string,
+    error: PropTypes.string,
+  }),
 };
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -16,6 +16,12 @@ import ConnectionRow from "./ConnectionRow";
 import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
+
+const ONE_BY_ONE_DELAY_MS = 1000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export default function ProviderDetailPage() {
   const params = useParams();
@@ -50,6 +56,12 @@ export default function ProviderDetailPage() {
   const [disabledModelIds, setDisabledModelIds] = useState([]);
   const [confirmState, setConfirmState] = useState(null);
   const [showAgRiskModal, setShowAgRiskModal] = useState(false);
+  const [oneByOneRunning, setOneByOneRunning] = useState(false);
+  const [oneByOneStopping, setOneByOneStopping] = useState(false);
+  const [oneByOneCurrentConnectionId, setOneByOneCurrentConnectionId] = useState(null);
+  const [oneByOneResults, setOneByOneResults] = useState({});
+  const [oneByOneSummary, setOneByOneSummary] = useState(null);
+  const stopOneByOneRef = useRef(false);
   const { copied, copy } = useCopyToClipboard();
 
   const AG_RISK_STORAGE_KEY = "ag_risk_confirmed";
@@ -376,6 +388,98 @@ export default function ProviderDetailPage() {
     }
   };
 
+  const handleRunOneByOneTest = async () => {
+    if (oneByOneRunning || connections.length === 0) return;
+
+    const queuedState = Object.fromEntries(
+      connections.map((connection) => [connection.id, { state: "queued", error: null }]),
+    );
+
+    stopOneByOneRef.current = false;
+    setOneByOneRunning(true);
+    setOneByOneStopping(false);
+    setOneByOneCurrentConnectionId(null);
+    setOneByOneResults(queuedState);
+    setOneByOneSummary({ total: connections.length, completed: 0, passed: 0, failed: 0, stopped: false });
+
+    let passed = 0;
+    let failed = 0;
+
+    try {
+      for (let index = 0; index < connections.length; index += 1) {
+        if (stopOneByOneRef.current) {
+          setOneByOneSummary({
+            total: connections.length,
+            completed: index,
+            passed,
+            failed,
+            stopped: true,
+          });
+          break;
+        }
+
+        const connection = connections[index];
+        setOneByOneCurrentConnectionId(connection.id);
+        setOneByOneResults((prev) => ({
+          ...prev,
+          [connection.id]: { state: "testing", error: null },
+        }));
+
+        try {
+          const res = await fetch(`/api/providers/${connection.id}/test`, { method: "POST" });
+          const data = await res.json();
+          const valid = !!data.valid;
+
+          if (valid) {
+            passed += 1;
+          } else {
+            failed += 1;
+          }
+
+          setOneByOneResults((prev) => ({
+            ...prev,
+            [connection.id]: {
+              state: valid ? "success" : "failed",
+              error: valid ? null : (data.error || null),
+            },
+          }));
+        } catch (error) {
+          failed += 1;
+          setOneByOneResults((prev) => ({
+            ...prev,
+            [connection.id]: {
+              state: "failed",
+              error: error.message || "Test failed",
+            },
+          }));
+        }
+
+        setOneByOneSummary({
+          total: connections.length,
+          completed: index + 1,
+          passed,
+          failed,
+          stopped: false,
+        });
+
+        if (index < connections.length - 1) {
+          await sleep(ONE_BY_ONE_DELAY_MS);
+        }
+      }
+    } finally {
+      setOneByOneCurrentConnectionId(null);
+      setOneByOneRunning(false);
+      setOneByOneStopping(false);
+      stopOneByOneRef.current = false;
+    }
+  };
+
+  const handleStopOneByOneTest = () => {
+    if (!oneByOneRunning) return;
+    stopOneByOneRef.current = true;
+    setOneByOneStopping(true);
+  };
+
   const handleDelete = async (id) => {
     setConfirmState({
       title: "Delete Connection",
@@ -625,6 +729,7 @@ export default function ProviderDetailPage() {
                   setShowEditModal(true);
                 }}
                 onDelete={() => handleDelete(conn.id)}
+                oneByOneStatus={oneByOneResults[conn.id] || null}
               />
             </div>
           </div>
@@ -1042,6 +1147,30 @@ export default function ProviderDetailPage() {
                   Apply Proxy
                 </Button>
               )}
+              {connections.length > 0 && (
+                <>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    icon="sync"
+                    onClick={handleRunOneByOneTest}
+                    disabled={oneByOneRunning}
+                  >
+                    {oneByOneRunning ? "Testing Connection One-by-One..." : "Test Connection One-by-One"}
+                  </Button>
+                  {oneByOneRunning && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      icon="stop"
+                      onClick={handleStopOneByOneTest}
+                      disabled={oneByOneStopping}
+                    >
+                      {oneByOneStopping ? "Stopping..." : "Stop"}
+                    </Button>
+                  )}
+                </>
+              )}
               {/* Thinking config */}
               {/* {thinkingConfig && (
                 <div className="flex items-center gap-2">
@@ -1106,6 +1235,22 @@ export default function ProviderDetailPage() {
             </div>
           ) : (
             <>
+              {oneByOneSummary && (
+                <div className="mb-4 rounded-lg border border-black/10 bg-black/[0.02] px-3 py-2 text-xs text-text-muted dark:border-white/10 dark:bg-white/[0.03]">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span>Total: {oneByOneSummary.total}</span>
+                    <span>Completed: {oneByOneSummary.completed}</span>
+                    <span>Passed: {oneByOneSummary.passed}</span>
+                    <span>Failed: {oneByOneSummary.failed}</span>
+                    {oneByOneSummary.stopped && (
+                      <span className="text-amber-600 dark:text-amber-400">Stopped</span>
+                    )}
+                    {oneByOneRunning && oneByOneCurrentConnectionId && (
+                      <span>Running: {connections.find((conn) => conn.id === oneByOneCurrentConnectionId)?.name || oneByOneCurrentConnectionId}</span>
+                    )}
+                  </div>
+                </div>
+              )}
               {connectionsList}
               {!isCompatible && (
                 <div className="mt-4 grid grid-cols-1 gap-2 sm:flex">

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
@@ -88,6 +88,7 @@ export default function QuotaTable({
   quotas = [],
   compact = false,
   sortMode = "default",
+  showSortLabel = false,
 }) {
   const [page, setPage] = useState(1);
 
@@ -130,12 +131,7 @@ export default function QuotaTable({
   const nameText = compact ? "text-[11px]" : "text-sm";
   const resetPrimary = compact ? "text-[11px]" : "text-sm";
   const resetSecondary = compact ? "text-[10px] leading-tight" : "text-xs";
-  const sortLabel =
-    sortMode === "remaining-asc"
-      ? "% quota: low to high"
-      : sortMode === "remaining-desc"
-        ? "% quota: high to low"
-        : "Default quota order";
+  const sortLabel = "Sorted by account remaining";
 
   return (
     <div className="space-y-2">
@@ -143,9 +139,11 @@ export default function QuotaTable({
         <div className="text-[10px] text-text-muted">
           {sortedQuotas.length} quota{sortedQuotas.length > 1 ? "s" : ""}
         </div>
-        <div className="rounded-md border border-black/10 bg-black/[0.02] px-2 py-1 text-[10px] text-text-muted dark:border-white/10 dark:bg-white/[0.03]">
-          {sortLabel}
-        </div>
+        {showSortLabel && (
+          <div className="rounded-md border border-black/10 bg-black/[0.02] px-2 py-1 text-[10px] text-text-muted dark:border-white/10 dark:bg-white/[0.03]">
+            {sortLabel}
+          </div>
+        )}
       </div>
 
       <div className="overflow-x-auto">

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
@@ -1,20 +1,23 @@
 "use client";
 
-import { formatResetTime, calculatePercentage } from "./utils";
+import { useEffect, useMemo, useState } from "react";
+import { formatResetTime, getRemainingPercentage } from "./utils";
+
+const PAGE_SIZE = 10;
 
 /**
  * Format reset time display (Today, 12:00 PM)
  */
 function formatResetTimeDisplay(resetTime) {
   if (!resetTime) return null;
-  
+
   try {
     const date = new Date(resetTime);
     const now = new Date();
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
-    
+
     let dayStr = "";
     if (date >= today && date < tomorrow) {
       dayStr = "Today";
@@ -23,13 +26,13 @@ function formatResetTimeDisplay(resetTime) {
     } else {
       dayStr = date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
     }
-    
-    const timeStr = date.toLocaleTimeString("en-US", { 
-      hour: "numeric", 
+
+    const timeStr = date.toLocaleTimeString("en-US", {
+      hour: "numeric",
       minute: "2-digit",
-      hour12: true 
+      hour12: true,
     });
-    
+
     return `${dayStr}, ${timeStr}`;
   } catch {
     return null;
@@ -45,127 +48,214 @@ function getColorClasses(remainingPercentage) {
       text: "text-green-600 dark:text-green-400",
       bg: "bg-green-500",
       bgLight: "bg-green-500/10",
-      emoji: "🟢"
+      emoji: "🟢",
     };
   }
-  
+
   if (remainingPercentage >= 30) {
     return {
       text: "text-yellow-600 dark:text-yellow-400",
       bg: "bg-yellow-500",
       bgLight: "bg-yellow-500/10",
-      emoji: "🟡"
+      emoji: "🟡",
     };
   }
-  
-  // 0-29% including 0% (out of quota) - show red
+
   return {
     text: "text-red-600 dark:text-red-400",
     bg: "bg-red-500",
     bgLight: "bg-red-500/10",
-    emoji: "🔴"
+    emoji: "🔴",
   };
+}
+
+function sortQuotas(quotas, sortMode) {
+  if (sortMode === "remaining-asc") {
+    return [...quotas].sort((a, b) => a.remaining - b.remaining || a.name.localeCompare(b.name));
+  }
+
+  if (sortMode === "remaining-desc") {
+    return [...quotas].sort((a, b) => b.remaining - a.remaining || a.name.localeCompare(b.name));
+  }
+
+  return quotas;
 }
 
 /**
  * Quota Table Component - Table-based display for quota data
  */
-export default function QuotaTable({ quotas = [], compact = false }) {
+export default function QuotaTable({
+  quotas = [],
+  compact = false,
+  sortMode = "default",
+}) {
+  const [page, setPage] = useState(1);
+
+  const normalizedQuotas = useMemo(
+    () => quotas.map((quota, index) => ({
+      ...quota,
+      index,
+      remaining: getRemainingPercentage(quota),
+    })),
+    [quotas],
+  );
+
+  const sortedQuotas = useMemo(
+    () => sortQuotas(normalizedQuotas, sortMode),
+    [normalizedQuotas, sortMode],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(sortedQuotas.length / PAGE_SIZE));
+
+  useEffect(() => {
+    setPage(1);
+  }, [sortMode, quotas]);
+
+  useEffect(() => {
+    setPage((currentPage) => Math.min(currentPage, totalPages));
+  }, [totalPages]);
+
   if (!quotas || quotas.length === 0) {
     return null;
   }
+
+  const currentPageRows = sortedQuotas.slice(
+    (page - 1) * PAGE_SIZE,
+    page * PAGE_SIZE,
+  );
+  const pageStart = sortedQuotas.length === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const pageEnd = Math.min(page * PAGE_SIZE, sortedQuotas.length);
 
   const cellPad = compact ? "py-1 px-1.5" : "py-2 px-3";
   const nameText = compact ? "text-[11px]" : "text-sm";
   const resetPrimary = compact ? "text-[11px]" : "text-sm";
   const resetSecondary = compact ? "text-[10px] leading-tight" : "text-xs";
+  const sortLabel =
+    sortMode === "remaining-asc"
+      ? "% quota: low to high"
+      : sortMode === "remaining-desc"
+        ? "% quota: high to low"
+        : "Default quota order";
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full table-fixed text-left">
-        <tbody>
-          {quotas.map((quota, index) => {
-            const remaining = quota.remainingPercentage !== undefined
-              ? Math.round(quota.remainingPercentage)
-              : calculatePercentage(quota.used, quota.total);
-            
-            const colors = getColorClasses(remaining);
-            const countdown = formatResetTime(quota.resetAt);
-            const resetDisplay = formatResetTimeDisplay(quota.resetAt);
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[10px] text-text-muted">
+          {sortedQuotas.length} quota{sortedQuotas.length > 1 ? "s" : ""}
+        </div>
+        <div className="rounded-md border border-black/10 bg-black/[0.02] px-2 py-1 text-[10px] text-text-muted dark:border-white/10 dark:bg-white/[0.03]">
+          {sortLabel}
+        </div>
+      </div>
 
-            return (
-              <tr 
-                key={index}
-                className="border-b border-black/5 dark:border-white/5 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
-              >
-                {/* Model Name with Status Emoji */}
-                <td className={`${cellPad} w-[30%]`}>
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    <span className="text-[10px] shrink-0">{colors.emoji}</span>
-                    <span className={`${nameText} font-medium text-text-primary truncate`}>
-                      {quota.name}
-                    </span>
-                  </div>
-                </td>
+      <div className="overflow-x-auto">
+        <table className="w-full table-fixed text-left">
+          <tbody>
+            {currentPageRows.map((quota) => {
+              const colors = getColorClasses(quota.remaining);
+              const countdown = formatResetTime(quota.resetAt);
+              const resetDisplay = formatResetTimeDisplay(quota.resetAt);
 
-                {/* Limit (Progress + Numbers) */}
-                <td className={`${cellPad} w-[45%]`}>
-                  <div className={compact ? "space-y-1" : "space-y-1.5"}>
-                    {/* Progress bar - always show with border for visibility */}
-                    <div className={`${compact ? "h-1" : "h-1.5"} rounded-full overflow-hidden border ${colors.bgLight} ${
-                      remaining === 0 ? 'border-black/10 dark:border-white/10' : 'border-transparent'
-                    }`}>
-                      <div
-                        className={`h-full transition-all duration-300 ${colors.bg}`}
-                        style={{ width: `${Math.min(remaining, 100)}%` }}
-                      />
-                    </div>
-                    
-                    {/* Numbers */}
-                    <div className={`flex items-center justify-between ${compact ? "text-[10px]" : "text-xs"}`}>
-                      <span className="text-text-muted">
-                        {quota.used.toLocaleString()} / {quota.total > 0 ? quota.total.toLocaleString() : "∞"}
-                      </span>
-                      <span className={`font-medium ${colors.text}`}>
-                        {remaining}%
+              return (
+                <tr
+                  key={`${quota.name}-${quota.index}`}
+                  className="border-b border-black/5 dark:border-white/5 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
+                >
+                  <td className={`${cellPad} w-[30%]`}>
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span className="text-[10px] shrink-0">{colors.emoji}</span>
+                      <span className={`${nameText} font-medium text-text-primary truncate`}>
+                        {quota.name}
                       </span>
                     </div>
-                  </div>
-                </td>
+                  </td>
 
-                {/* Reset Time */}
-                <td className={`${cellPad} w-[25%]`}>
-                  {countdown !== "-" || resetDisplay ? (
-                    compact ? (
-                      <div
-                        className={`${resetPrimary} text-text-primary font-medium truncate`}
-                        title={resetDisplay || ""}
-                      >
-                        {countdown !== "-" ? `in ${countdown}` : resetDisplay}
+                  <td className={`${cellPad} w-[45%]`}>
+                    <div className={compact ? "space-y-1" : "space-y-1.5"}>
+                      <div className={`${compact ? "h-1" : "h-1.5"} rounded-full overflow-hidden border ${colors.bgLight} ${
+                        quota.remaining === 0 ? "border-black/10 dark:border-white/10" : "border-transparent"
+                      }`}>
+                        <div
+                          className={`h-full transition-all duration-300 ${colors.bg}`}
+                          style={{ width: `${Math.min(quota.remaining, 100)}%` }}
+                        />
                       </div>
+
+                      <div className={`flex items-center justify-between ${compact ? "text-[10px]" : "text-xs"}`}>
+                        <span className="text-text-muted">
+                          {quota.used.toLocaleString()} / {quota.total > 0 ? quota.total.toLocaleString() : "∞"}
+                        </span>
+                        <span className={`font-medium ${colors.text}`}>
+                          {quota.remaining}%
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+
+                  <td className={`${cellPad} w-[25%]`}>
+                    {countdown !== "-" || resetDisplay ? (
+                      compact ? (
+                        <div
+                          className={`${resetPrimary} text-text-primary font-medium truncate`}
+                          title={resetDisplay || ""}
+                        >
+                          {countdown !== "-" ? `in ${countdown}` : resetDisplay}
+                        </div>
+                      ) : (
+                        <div className="space-y-0.5">
+                          {countdown !== "-" && (
+                            <div className={`${resetPrimary} text-text-primary font-medium`}>
+                              in {countdown}
+                            </div>
+                          )}
+                          {resetDisplay && (
+                            <div className={`${resetSecondary} text-text-muted`}>
+                              {resetDisplay}
+                            </div>
+                          )}
+                        </div>
+                      )
                     ) : (
-                      <div className="space-y-0.5">
-                        {countdown !== "-" && (
-                          <div className={`${resetPrimary} text-text-primary font-medium`}>
-                            in {countdown}
-                          </div>
-                        )}
-                        {resetDisplay && (
-                          <div className={`${resetSecondary} text-text-muted`}>
-                            {resetDisplay}
-                          </div>
-                        )}
-                      </div>
-                    )
-                  ) : (
-                    <div className={`${resetPrimary} text-text-muted italic`}>N/A</div>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                      <div className={`${resetPrimary} text-text-muted italic`}>N/A</div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="rounded-md border border-black/10 bg-black/[0.02] px-2 py-1.5 dark:border-white/10 dark:bg-white/[0.03]">
+          <div className="flex items-center justify-between gap-2 text-[10px] text-text-muted">
+            <span>
+              Showing {pageStart}-{pageEnd} of {sortedQuotas.length}
+            </span>
+            <span>
+              Page {page} / {totalPages}
+            </span>
+          </div>
+          <div className="mt-1.5 flex items-center justify-end gap-1">
+            <button
+              type="button"
+              onClick={() => setPage((currentPage) => Math.max(1, currentPage - 1))}
+              disabled={page === 1}
+              className="flex h-6 items-center rounded-md border border-black/10 px-2 text-[10px] text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
+            >
+              Prev
+            </button>
+            <button
+              type="button"
+              onClick={() => setPage((currentPage) => Math.min(totalPages, currentPage + 1))}
+              disabled={page === totalPages}
+              className="flex h-6 items-center rounded-md border border-black/10 px-2 text-[10px] text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -1,34 +1,147 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import QuotaTable from "./QuotaTable";
 import Toggle from "@/shared/components/Toggle";
 import { parseQuotaData, calculatePercentage } from "./utils";
 import Card from "@/shared/components/Card";
 import { EditConnectionModal } from "@/shared/components";
-import { USAGE_SUPPORTED_PROVIDERS, USAGE_APIKEY_PROVIDERS } from "@/shared/constants/providers";
 
-// Connection is eligible for the quota page when it uses OAuth or is an apikey provider whitelisted for quota
-const isUsageEligible = (conn) =>
-  USAGE_SUPPORTED_PROVIDERS.includes(conn.provider) &&
-  (conn.authType === "oauth" || USAGE_APIKEY_PROVIDERS.includes(conn.provider));
+function getConnectionLabel(connection) {
+  const isEmail = (value) => typeof value === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  if (isEmail(connection.email)) return connection.email;
+  if (isEmail(connection.name)) return connection.name;
+  return connection.name;
+}
+
+function sortVisibleConnections(connections, quotaData, expiringFirst) {
+  if (!expiringFirst) return connections;
+
+  const getEarliestResetTime = (connection) => {
+    const resetTimes = (quotaData[connection.id]?.quotas || [])
+      .map((quota) => (quota.resetAt ? new Date(quota.resetAt).getTime() : Number.POSITIVE_INFINITY))
+      .filter((time) => Number.isFinite(time));
+    return resetTimes.length > 0 ? Math.min(...resetTimes) : Number.POSITIVE_INFINITY;
+  };
+
+  return [...connections].sort((a, b) => {
+    const expiryDiff = getEarliestResetTime(a) - getEarliestResetTime(b);
+    if (expiryDiff !== 0) return expiryDiff;
+    return (a.provider || "").localeCompare(b.provider || "") || (getConnectionLabel(a) || "").localeCompare(getConnectionLabel(b) || "");
+  });
+}
+
+function buildLoadingState(connections) {
+  const nextLoadingState = {};
+  connections.forEach((connection) => {
+    nextLoadingState[connection.id] = true;
+  });
+  return nextLoadingState;
+}
+
+function filterQuotaStateByConnections(state, connections) {
+  const visibleIds = new Set(connections.map((connection) => connection.id));
+  return Object.fromEntries(Object.entries(state).filter(([id]) => visibleIds.has(id)));
+}
+
+function getConnectionsPageRange(pagination) {
+  if (!pagination.total) {
+    return { start: 0, end: 0 };
+  }
+
+  const start = (pagination.page - 1) * pagination.pageSize + 1;
+  const end = Math.min(pagination.page * pagination.pageSize, pagination.total);
+  return { start, end };
+}
+
+function getConnectionsEmptyMessage(totals, providerFilter, accountFilter) {
+  if (!totals.eligibleConnections) {
+    return {
+      icon: "cloud_off",
+      title: "No Providers Connected",
+      description: "Connect to providers with OAuth to track your API quota limits and usage.",
+    };
+  }
+
+  if (!totals.providerFilteredConnections) {
+    return {
+      icon: "filter_alt_off",
+      title: "No Accounts Match Current Filters",
+      description: providerFilter === "all"
+        ? "Try changing the account status filter to see more quota trackers."
+        : `No ${accountFilter === "inactive" ? "turned off" : accountFilter === "active" ? "active" : "matching"} accounts found for ${providerFilter}.`,
+    };
+  }
+
+  return {
+    icon: "filter_alt_off",
+    title: "No Accounts On This Page",
+    description: "Try moving to another page or refreshing the current filters.",
+  };
+}
+
+function sortRequestFromExpiringFirst(expiringFirst) {
+  return expiringFirst ? "expiring" : "priority";
+}
+
+function getPageSizeLabel(pageSize) {
+  return `${pageSize} / page`;
+}
+
+function getConnectionsPaginationSummary(pagination) {
+  const { start, end } = getConnectionsPageRange(pagination);
+  return `Showing ${start}-${end} of ${pagination.total}`;
+}
+
+function getSafePagination(pagination, fallbackPageSize) {
+  return pagination || { page: 1, pageSize: fallbackPageSize, total: 0, totalPages: 1 };
+}
+
+function getSafeTotals(totals, fallbackTotal = 0) {
+  return totals || { eligibleConnections: fallbackTotal, providerFilteredConnections: fallbackTotal };
+}
+
+function shouldResetPage(previousValue, nextValue) {
+  return previousValue !== nextValue;
+}
+
+function getPaginationPageValue(dataPagination, fallbackPage) {
+  return dataPagination?.page || fallbackPage;
+}
+
+function getProviderOptions(dataProviderOptions) {
+  return dataProviderOptions || [];
+}
+
+async function reconcileConnectionsPage(fetchConnections, targetPage) {
+  const nextConnections = await fetchConnections(targetPage);
+  return nextConnections;
+}
 
 const REFRESH_INTERVAL_MS = 60000; // 60 seconds
 const DEPLETED_QUOTA_THRESHOLD = 5; // percent
 const AUTO_REFRESH_STORAGE_KEY = "quotaAutoRefresh";
+const ACCOUNT_FILTER_OPTIONS = [
+  { value: "all", label: "All accounts" },
+  { value: "active", label: "Active" },
+  { value: "inactive", label: "Turned off" },
+];
+const QUOTA_SORT_OPTIONS = [
+  { value: "default", label: "Default quota order" },
+  { value: "remaining-asc", label: "% quota: low to high" },
+  { value: "remaining-desc", label: "% quota: high to low" },
+];
+const CONNECTIONS_PAGE_SIZE = 20;
 
 export default function ProviderLimits() {
   const [connections, setConnections] = useState([]);
   const [quotaData, setQuotaData] = useState({});
   const [loading, setLoading] = useState({});
   const [errors, setErrors] = useState({});
-  const [autoRefresh, setAutoRefresh] = useState(() => {
-    if (typeof window === "undefined") return true;
-    const stored = window.localStorage.getItem(AUTO_REFRESH_STORAGE_KEY);
-    return stored === null ? true : stored === "true";
-  });
+  const [autoRefresh, setAutoRefresh] = useState(true);
   const [lastUpdated, setLastUpdated] = useState(null);
+  const [hasHydratedAutoRefresh, setHasHydratedAutoRefresh] = useState(false);
   const [refreshingAll, setRefreshingAll] = useState(false);
   const [countdown, setCountdown] = useState(60);
   const [connectionsLoading, setConnectionsLoading] = useState(true);
@@ -38,29 +151,56 @@ export default function ProviderLimits() {
   const [selectedConnection, setSelectedConnection] = useState(null);
   const [proxyPools, setProxyPools] = useState([]);
   const [providerFilter, setProviderFilter] = useState("all");
+  const [providerOptions, setProviderOptions] = useState([]);
+  const [accountFilter, setAccountFilter] = useState("all");
+  const [quotaSortMode, setQuotaSortMode] = useState("default");
   const [expiringFirst, setExpiringFirst] = useState(false);
   const [providerMenuOpen, setProviderMenuOpen] = useState(false);
   const [bulkToggling, setBulkToggling] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(CONNECTIONS_PAGE_SIZE);
+  const [pagination, setPagination] = useState({ page: 1, pageSize: CONNECTIONS_PAGE_SIZE, total: 0, totalPages: 1 });
+  const [totals, setTotals] = useState({ eligibleConnections: 0, providerFilteredConnections: 0 });
 
   const intervalRef = useRef(null);
   const countdownRef = useRef(null);
 
-  // Fetch all provider connections
-  const fetchConnections = useCallback(async () => {
+  const fetchConnections = useCallback(async (targetPage = page) => {
     try {
-      const response = await fetch("/api/providers/client");
+      const params = new URLSearchParams({
+        page: String(targetPage),
+        pageSize: String(pageSize),
+        accountStatus: accountFilter,
+        sort: "priority",
+      });
+
+      if (providerFilter !== "all") {
+        params.set("provider", providerFilter);
+      }
+
+      const response = await fetch(`/api/providers/client?${params.toString()}`);
       if (!response.ok) throw new Error("Failed to fetch connections");
 
       const data = await response.json();
       const connectionList = data.connections || [];
+      const nextPagination = getSafePagination(data.pagination, pageSize);
+      const nextTotals = getSafeTotals(data.totals, connectionList.length);
+
       setConnections(connectionList);
+      setProviderOptions(getProviderOptions(data.providerOptions));
+      setPagination(nextPagination);
+      setTotals(nextTotals);
+      setPage(getPaginationPageValue(data.pagination, targetPage));
       return connectionList;
     } catch (error) {
       console.error("Error fetching connections:", error);
       setConnections([]);
+      setProviderOptions([]);
+      setPagination({ page: 1, pageSize, total: 0, totalPages: 1 });
+      setTotals({ eligibleConnections: 0, providerFilteredConnections: 0 });
       return [];
     }
-  }, []);
+  }, [accountFilter, expiringFirst, page, pageSize, providerFilter]);
 
   // Fetch quota for a specific connection
   const fetchQuota = useCallback(async (connectionId, provider) => {
@@ -149,7 +289,6 @@ export default function ProviderLimits() {
     try {
       const res = await fetch(`/api/providers/${id}`, { method: "DELETE" });
       if (res.ok) {
-        setConnections((prev) => prev.filter((c) => c.id !== id));
         setQuotaData((prev) => {
           const next = { ...prev };
           delete next[id];
@@ -165,13 +304,14 @@ export default function ProviderLimits() {
           delete next[id];
           return next;
         });
+        await reconcileConnectionsPage(fetchConnections, page);
       }
     } catch (error) {
       console.error("Error deleting connection:", error);
     } finally {
       setDeletingId(null);
     }
-  }, []);
+  }, [fetchConnections, page]);
 
   const handleToggleConnectionActive = useCallback(async (id, isActive) => {
     setTogglingId(id);
@@ -182,16 +322,18 @@ export default function ProviderLimits() {
         body: JSON.stringify({ isActive }),
       });
       if (res.ok) {
-        setConnections((prev) =>
-          prev.map((c) => (c.id === id ? { ...c, isActive } : c)),
-        );
+        setQuotaData((prev) => {
+          const next = { ...prev };
+          return next;
+        });
+        await reconcileConnectionsPage(fetchConnections, page);
       }
     } catch (error) {
       console.error("Error updating connection status:", error);
     } finally {
       setTogglingId(null);
     }
-  }, []);
+  }, [fetchConnections, page]);
 
   const handleUpdateConnection = useCallback(
     async (formData) => {
@@ -234,7 +376,6 @@ export default function ProviderLimits() {
     };
   }, []);
 
-  // Refresh all providers
   const refreshAll = useCallback(async () => {
     if (refreshingAll) return;
 
@@ -242,13 +383,14 @@ export default function ProviderLimits() {
     setCountdown(60);
 
     try {
-      const conns = await fetchConnections();
+      const visibleConnections = await fetchConnections(page);
 
-      // Filter eligible connections (OAuth + whitelisted apikey)
-      const eligibleConnections = conns.filter(isUsageEligible);
+      setLoading(buildLoadingState(visibleConnections));
+      setErrors((prev) => filterQuotaStateByConnections(prev, visibleConnections));
+      setQuotaData((prev) => filterQuotaStateByConnections(prev, visibleConnections));
 
       await Promise.all(
-        eligibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
+        visibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
       );
 
       setLastUpdated(new Date());
@@ -257,42 +399,43 @@ export default function ProviderLimits() {
     } finally {
       setRefreshingAll(false);
     }
-  }, [refreshingAll, fetchConnections, fetchQuota]);
+  }, [refreshingAll, fetchConnections, fetchQuota, page]);
 
-  // Initial load: fetch connections first so cards render immediately, then fetch quotas
   useEffect(() => {
     const initializeData = async () => {
       setConnectionsLoading(true);
-      const conns = await fetchConnections();
+      const visibleConnections = await fetchConnections(page);
       setConnectionsLoading(false);
 
-      const eligibleConnections = conns.filter(isUsageEligible);
-
-      // Mark all as loading before fetching
-      const loadingState = {};
-      eligibleConnections.forEach((conn) => {
-        loadingState[conn.id] = true;
-      });
-      setLoading(loadingState);
+      setLoading(buildLoadingState(visibleConnections));
+      setErrors((prev) => filterQuotaStateByConnections(prev, visibleConnections));
+      setQuotaData((prev) => filterQuotaStateByConnections(prev, visibleConnections));
 
       await Promise.all(
-        eligibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
+        visibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
       );
       setLastUpdated(new Date());
     };
 
     initializeData();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [fetchConnections, fetchQuota, page]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(AUTO_REFRESH_STORAGE_KEY);
+    setAutoRefresh(stored === null ? true : stored === "true");
+    setHasHydratedAutoRefresh(true);
+  }, []);
 
   // Persist auto-refresh preference
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined" || !hasHydratedAutoRefresh) return;
     window.localStorage.setItem(AUTO_REFRESH_STORAGE_KEY, String(autoRefresh));
-  }, [autoRefresh]);
+  }, [autoRefresh, hasHydratedAutoRefresh]);
 
   // Auto-refresh interval
   useEffect(() => {
-    if (!autoRefresh) {
+    if (!hasHydratedAutoRefresh || !autoRefresh) {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
@@ -321,7 +464,7 @@ export default function ProviderLimits() {
       if (intervalRef.current) clearInterval(intervalRef.current);
       if (countdownRef.current) clearInterval(countdownRef.current);
     };
-  }, [autoRefresh, refreshAll]);
+  }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
 
   // Pause auto-refresh when tab is hidden (Page Visibility API)
   useEffect(() => {
@@ -335,7 +478,7 @@ export default function ProviderLimits() {
           clearInterval(countdownRef.current);
           countdownRef.current = null;
         }
-      } else if (autoRefresh) {
+      } else if (autoRefresh && hasHydratedAutoRefresh) {
         // Resume auto-refresh when tab becomes visible
         intervalRef.current = setInterval(refreshAll, REFRESH_INTERVAL_MS);
         countdownRef.current = setInterval(() => {
@@ -348,34 +491,12 @@ export default function ProviderLimits() {
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [autoRefresh, refreshAll]);
+  }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
 
-  // Filter eligible connections (OAuth + whitelisted apikey)
-  const filteredConnections = connections.filter(isUsageEligible);
-
-  const providerFilteredConnections = filteredConnections.filter(
-    (conn) => providerFilter === "all" || conn.provider === providerFilter,
+  const sortedConnections = useMemo(
+    () => sortVisibleConnections(connections, quotaData, expiringFirst),
+    [connections, quotaData, expiringFirst],
   );
-
-  const getEarliestResetTime = (conn) => {
-    const resetTimes = (quotaData[conn.id]?.quotas || [])
-      .map((quota) => quota.resetAt ? new Date(quota.resetAt).getTime() : Number.POSITIVE_INFINITY)
-      .filter((time) => Number.isFinite(time));
-    return resetTimes.length > 0 ? Math.min(...resetTimes) : Number.POSITIVE_INFINITY;
-  };
-
-  // Sort providers by USAGE_SUPPORTED_PROVIDERS order, then alphabetically.
-  // Optionally surface accounts with quotas expiring soonest first.
-  const sortedConnections = [...providerFilteredConnections].sort((a, b) => {
-    if (expiringFirst) {
-      const expiryDiff = getEarliestResetTime(a) - getEarliestResetTime(b);
-      if (expiryDiff !== 0) return expiryDiff;
-    }
-    const orderA = USAGE_SUPPORTED_PROVIDERS.indexOf(a.provider);
-    const orderB = USAGE_SUPPORTED_PROVIDERS.indexOf(b.provider);
-    if (orderA !== orderB) return orderA - orderB;
-    return a.provider.localeCompare(b.provider);
-  });
 
   // Connection is depleted when any quota entry hit the threshold
   const isConnectionDepleted = (conn) => {
@@ -401,16 +522,14 @@ export default function ProviderLimits() {
             }),
           ),
         );
-        setConnections((prev) =>
-          prev.map((c) => (targetIds.includes(c.id) ? { ...c, isActive } : c)),
-        );
+        await reconcileConnectionsPage(fetchConnections, page);
       } catch (error) {
         console.error("Error bulk toggling connections:", error);
       } finally {
         setBulkToggling(false);
       }
     },
-    [bulkToggling],
+    [bulkToggling, fetchConnections, page],
   );
 
   const handleDisableDepleted = () => {
@@ -427,29 +546,14 @@ export default function ProviderLimits() {
     bulkSetActive(ids, true);
   };
 
-  const providerOptions = Array.from(new Set(filteredConnections.map((conn) => conn.provider))).sort();
   const selectedProviderLabel = providerFilter === "all" ? "All providers" : providerFilter;
+  const hasEligibleConnections = totals.eligibleConnections > 0;
+  const hasVisibleConnections = sortedConnections.length > 0;
+  const emptyState = getConnectionsEmptyMessage(totals, providerFilter, accountFilter);
+  const connectionsPageSummary = getConnectionsPaginationSummary(pagination);
+  const pageSizeLabel = getPageSizeLabel(pageSize);
 
-  // Calculate summary stats
-  const totalProviders = sortedConnections.length;
-  const activeWithLimits = Object.values(quotaData).filter(
-    (data) => data?.quotas?.length > 0,
-  ).length;
-
-  // Count low quotas (remaining < 30%)
-  const lowQuotasCount = Object.values(quotaData).reduce((count, data) => {
-    if (!data?.quotas) return count;
-
-    const hasLowQuota = data.quotas.some((quota) => {
-      const percentage = calculatePercentage(quota.used, quota.total);
-      return percentage < 30 && quota.total > 0;
-    });
-
-    return count + (hasLowQuota ? 1 : 0);
-  }, 0);
-
-  // Empty state
-  if (!connectionsLoading && sortedConnections.length === 0) {
+  if (!connectionsLoading && !hasEligibleConnections) {
     return (
       <Card padding="lg">
         <div className="text-center py-12">
@@ -462,6 +566,24 @@ export default function ProviderLimits() {
           <p className="mt-2 text-sm text-text-muted max-w-md mx-auto">
             Connect to providers with OAuth to track your API quota limits and
             usage.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  if (!connectionsLoading && !hasVisibleConnections) {
+    return (
+      <Card padding="lg">
+        <div className="text-center py-12">
+          <span className="material-symbols-outlined text-[64px] text-text-muted opacity-20">
+            {emptyState.icon}
+          </span>
+          <h3 className="mt-4 text-lg font-semibold text-text-primary">
+            {emptyState.title}
+          </h3>
+          <p className="mt-2 text-sm text-text-muted max-w-md mx-auto">
+            {emptyState.description}
           </p>
         </div>
       </Card>
@@ -516,7 +638,13 @@ export default function ProviderLimits() {
                 <div className="absolute left-0 z-40 mt-2 w-64 overflow-hidden rounded-2xl border border-black/10 bg-surface/95 p-1.5 shadow-xl shadow-black/10 backdrop-blur dark:border-white/10 dark:bg-surface/95 sm:w-72">
                   <button
                     type="button"
-                    onClick={() => { setProviderFilter("all"); setProviderMenuOpen(false); }}
+                    onClick={() => {
+                      if (shouldResetPage(providerFilter, "all")) {
+                        setPage(1);
+                      }
+                      setProviderFilter("all");
+                      setProviderMenuOpen(false);
+                    }}
                     className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors ${providerFilter === "all" ? "bg-primary/10 text-primary" : "text-text-primary hover:bg-black/5 dark:hover:bg-white/10"}`}
                   >
                     <span className="material-symbols-outlined text-[22px]">apps</span>
@@ -529,7 +657,13 @@ export default function ProviderLimits() {
                       <button
                         key={provider}
                         type="button"
-                        onClick={() => { setProviderFilter(provider); setProviderMenuOpen(false); }}
+                        onClick={() => {
+                          if (shouldResetPage(providerFilter, provider)) {
+                            setPage(1);
+                          }
+                          setProviderFilter(provider);
+                          setProviderMenuOpen(false);
+                        }}
                         className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors ${providerFilter === provider ? "bg-primary/10 text-primary" : "text-text-primary hover:bg-black/5 dark:hover:bg-white/10"}`}
                       >
                         <ProviderIcon
@@ -548,9 +682,42 @@ export default function ProviderLimits() {
               </>
             )}
           </div>
+          <select
+            value={accountFilter}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              if (shouldResetPage(accountFilter, nextValue)) {
+                setPage(1);
+              }
+              setAccountFilter(nextValue);
+            }}
+            className="h-8 rounded-lg border border-black/10 bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-black/5 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10"
+            aria-label="Filter accounts by status"
+          >
+            {ACCOUNT_FILTER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={quotaSortMode}
+            onChange={(event) => setQuotaSortMode(event.target.value)}
+            className="h-8 rounded-lg border border-black/10 bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-black/5 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10"
+            aria-label="Sort quota rows"
+          >
+            {QUOTA_SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+
           <button
             type="button"
             onClick={() => setExpiringFirst((prev) => !prev)}
+            aria-pressed={expiringFirst}
             className={`flex h-8 shrink-0 items-center gap-1 rounded-lg border px-2 text-xs transition-colors ${expiringFirst ? "border-amber-500/40 bg-amber-500/10 text-amber-500" : "border-black/10 text-text-primary hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5"}`}
             title="Sort accounts by earliest quota reset time"
           >
@@ -564,7 +731,7 @@ export default function ProviderLimits() {
             onClick={handleDisableDepleted}
             disabled={bulkToggling}
             className="flex h-8 shrink-0 items-center gap-1 rounded-lg border border-red-500/30 px-2 text-xs text-red-500 transition-colors hover:bg-red-500/10 disabled:opacity-50"
-            title="Disable connections with depleted quota (within current filter)"
+            title="Disable connections with depleted quota on the current page"
           >
             <span className="material-symbols-outlined text-[14px]">block</span>
             <span className="hidden sm:inline">Turn off Empty</span>
@@ -576,7 +743,7 @@ export default function ProviderLimits() {
             onClick={handleEnableAvailable}
             disabled={bulkToggling}
             className="flex h-8 shrink-0 items-center gap-1 rounded-lg border border-emerald-500/30 px-2 text-xs text-emerald-500 transition-colors hover:bg-emerald-500/10 disabled:opacity-50"
-            title="Enable connections that still have quota (within current filter)"
+            title="Enable connections that still have quota on the current page"
           >
             <span className="material-symbols-outlined text-[14px]">check_circle</span>
             <span className="hidden sm:inline">Turn on Available</span>
@@ -615,6 +782,12 @@ export default function ProviderLimits() {
       </div>
 
       {/* Provider cards: 2 columns, compact */}
+      {expiringFirst && (
+        <div className="rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          Expiring-first currently reorders accounts inside the current page. Cross-page ordering still follows backend pagination.
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {sortedConnections.map((conn) => {
           const quota = quotaData[conn.id];
@@ -649,13 +822,9 @@ export default function ProviderLimits() {
                       <h3 className="text-sm font-semibold text-text-primary capitalize truncate">
                         {conn.provider}
                       </h3>
-                      {(() => {
-                        const isEmail = (v) => typeof v === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
-                        const label = isEmail(conn.email) ? conn.email : (isEmail(conn.name) ? conn.name : conn.name);
-                        return label ? (
-                          <p className="text-xs text-text-muted truncate">{label}</p>
-                        ) : null;
-                      })()}
+                      {getConnectionLabel(conn) ? (
+                        <p className="text-xs text-text-muted truncate">{getConnectionLabel(conn)}</p>
+                      ) : null}
                     </div>
                   </div>
 
@@ -664,6 +833,7 @@ export default function ProviderLimits() {
                       type="button"
                       onClick={() => refreshProvider(conn.id, conn.provider)}
                       disabled={isLoading || rowBusy}
+                      aria-label="Refresh quota"
                       className="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 transition-colors disabled:opacity-50"
                       title="Refresh quota"
                     >
@@ -680,6 +850,7 @@ export default function ProviderLimits() {
                         setShowEditModal(true);
                       }}
                       disabled={rowBusy}
+                      aria-label="Edit connection"
                       className="p-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-primary transition-colors disabled:opacity-50"
                       title="Edit connection"
                     >
@@ -691,6 +862,7 @@ export default function ProviderLimits() {
                       type="button"
                       onClick={() => handleDeleteConnection(conn.id)}
                       disabled={rowBusy}
+                      aria-label="Delete connection"
                       className="p-1.5 rounded-lg hover:bg-red-500/10 text-red-500 transition-colors disabled:opacity-50"
                       title="Delete connection"
                     >
@@ -740,13 +912,48 @@ export default function ProviderLimits() {
                     <p className="text-xs text-text-muted">{quota.message}</p>
                   </div>
                 ) : (
-                  <QuotaTable quotas={quota?.quotas} compact />
+                  <QuotaTable
+                    quotas={quota?.quotas}
+                    compact
+                    sortMode={quotaSortMode}
+                  />
                 )}
               </div>
             </Card>
           );
         })}
       </div>
+
+      {pagination.totalPages > 1 && (
+        <div className="rounded-xl border border-black/10 bg-black/[0.02] px-3 py-2 dark:border-white/10 dark:bg-white/[0.03]">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-xs text-text-muted">
+              {connectionsPageSummary} · {pageSizeLabel}
+            </div>
+            <div className="flex items-center justify-end gap-1.5">
+              <button
+                type="button"
+                onClick={() => setPage((currentPage) => Math.max(1, currentPage - 1))}
+                disabled={pagination.page <= 1 || connectionsLoading || refreshingAll}
+                className="flex h-8 items-center rounded-lg border border-black/10 px-3 text-xs text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
+              >
+                Prev accounts
+              </button>
+              <div className="text-xs text-text-muted">
+                Page {pagination.page} / {pagination.totalPages}
+              </div>
+              <button
+                type="button"
+                onClick={() => setPage((currentPage) => Math.min(pagination.totalPages, currentPage + 1))}
+                disabled={pagination.page >= pagination.totalPages || connectionsLoading || refreshingAll}
+                className="flex h-8 items-center rounded-lg border border-black/10 px-3 text-xs text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
+              >
+                Next accounts
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <EditConnectionModal
         isOpen={showEditModal}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -7,6 +7,7 @@ import Toggle from "@/shared/components/Toggle";
 import { parseQuotaData, calculatePercentage } from "./utils";
 import Card from "@/shared/components/Card";
 import { EditConnectionModal } from "@/shared/components";
+import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
 
 function getConnectionLabel(connection) {
   const isEmail = (value) =>
@@ -175,6 +176,33 @@ async function reconcileConnectionsPage(fetchConnections, targetPage) {
   return nextConnections;
 }
 
+const QUOTA_CACHE_KEY = "quotaCacheData";
+
+function getQuotaCache() {
+  if (typeof window === "undefined") return {};
+  try {
+    const cached = window.localStorage.getItem(QUOTA_CACHE_KEY);
+    return cached ? JSON.parse(cached) : {};
+  } catch (error) {
+    console.error("Error reading quota cache:", error);
+    return {};
+  }
+}
+
+function setQuotaCache(connectionId, quotaEntry) {
+  if (typeof window === "undefined") return;
+  try {
+    const cache = getQuotaCache();
+    cache[connectionId] = {
+      ...quotaEntry,
+      cachedAt: new Date().toISOString(),
+    };
+    window.localStorage.setItem(QUOTA_CACHE_KEY, JSON.stringify(cache));
+  } catch (error) {
+    console.error("Error writing quota cache:", error);
+  }
+}
+
 const REFRESH_INTERVAL_MS = 60000; // 60 seconds
 const DEPLETED_QUOTA_THRESHOLD = 5; // percent
 const AUTO_REFRESH_STORAGE_KEY = "quotaAutoRefresh";
@@ -217,7 +245,9 @@ export default function ProviderLimits() {
   const [bulkToggling, setBulkToggling] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(CONNECTIONS_PAGE_SIZE);
-  const [customPageSizeInput, setCustomPageSizeInput] = useState(String(CONNECTIONS_PAGE_SIZE));
+  const [customPageSizeInput, setCustomPageSizeInput] = useState(
+    String(CONNECTIONS_PAGE_SIZE),
+  );
   const [pagination, setPagination] = useState({
     page: 1,
     pageSize: CONNECTIONS_PAGE_SIZE,
@@ -304,13 +334,15 @@ export default function ProviderLimits() {
             `[ProviderLimits] Auth error for ${provider}:`,
             errorMsg,
           );
+          const quotaEntry = {
+            quotas: [],
+            message: errorMsg,
+          };
           setQuotaData((prev) => ({
             ...prev,
-            [connectionId]: {
-              quotas: [],
-              message: errorMsg,
-            },
+            [connectionId]: quotaEntry,
           }));
+          setQuotaCache(connectionId, quotaEntry);
           return;
         }
 
@@ -323,15 +355,18 @@ export default function ProviderLimits() {
       // Parse quota data using provider-specific parser
       const parsedQuotas = parseQuotaData(provider, data);
 
+      const quotaEntry = {
+        quotas: parsedQuotas,
+        plan: data.plan || null,
+        message: data.message || null,
+        raw: data,
+      };
+
       setQuotaData((prev) => ({
         ...prev,
-        [connectionId]: {
-          quotas: parsedQuotas,
-          plan: data.plan || null,
-          message: data.message || null,
-          raw: data,
-        },
+        [connectionId]: quotaEntry,
       }));
+      setQuotaCache(connectionId, quotaEntry);
     } catch (error) {
       console.error(
         `[ProviderLimits] Error fetching quota for ${provider} (${connectionId}):`,
@@ -377,6 +412,22 @@ export default function ProviderLimits() {
             delete next[id];
             return next;
           });
+
+          if (typeof window !== "undefined") {
+            try {
+              const cache = getQuotaCache();
+              if (cache[id]) {
+                delete cache[id];
+                window.localStorage.setItem(
+                  QUOTA_CACHE_KEY,
+                  JSON.stringify(cache),
+                );
+              }
+            } catch (e) {
+              console.error("Error deleting cache entry:", e);
+            }
+          }
+
           await reconcileConnectionsPage(fetchConnections, page);
         }
       } catch (error) {
@@ -489,18 +540,62 @@ export default function ProviderLimits() {
       const visibleConnections = await fetchConnections(page);
       setConnectionsLoading(false);
 
-      setLoading(buildLoadingState(visibleConnections));
-      setErrors((prev) =>
-        filterQuotaStateByConnections(prev, visibleConnections),
-      );
-      setQuotaData((prev) =>
-        filterQuotaStateByConnections(prev, visibleConnections),
-      );
+      const cache = getQuotaCache();
+      const nextLoading = {};
+      const cachedQuotas = {};
+      const connectionsToFetch = [];
+      let latestCachedAt = null;
 
-      await Promise.all(
-        visibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
-      );
-      setLastUpdated(new Date());
+      visibleConnections.forEach((conn) => {
+        const cachedEntry = cache[conn.id];
+        if (cachedEntry) {
+          nextLoading[conn.id] = false;
+          cachedQuotas[conn.id] = {
+            quotas: cachedEntry.quotas,
+            plan: cachedEntry.plan,
+            message: cachedEntry.message,
+            raw: cachedEntry.raw,
+          };
+          if (cachedEntry.cachedAt) {
+            const cachedTime = new Date(cachedEntry.cachedAt);
+            if (!latestCachedAt || cachedTime > latestCachedAt) {
+              latestCachedAt = cachedTime;
+            }
+          }
+        } else {
+          nextLoading[conn.id] = true;
+          connectionsToFetch.push(conn);
+        }
+      });
+
+      setLoading(nextLoading);
+      setErrors((prev) => {
+        const nextErrors = filterQuotaStateByConnections(
+          prev,
+          visibleConnections,
+        );
+        visibleConnections.forEach((conn) => {
+          if (cache[conn.id]) {
+            nextErrors[conn.id] = null;
+          }
+        });
+        return nextErrors;
+      });
+      setQuotaData((prev) => ({
+        ...filterQuotaStateByConnections(prev, visibleConnections),
+        ...cachedQuotas,
+      }));
+
+      if (latestCachedAt) {
+        setLastUpdated(latestCachedAt);
+      }
+
+      if (connectionsToFetch.length > 0) {
+        await Promise.all(
+          connectionsToFetch.map((conn) => fetchQuota(conn.id, conn.provider)),
+        );
+        setLastUpdated(new Date());
+      }
     };
 
     initializeData();
@@ -697,6 +792,11 @@ export default function ProviderLimits() {
           <h2 className="text-xl font-semibold text-text-primary">
             Provider Limits
           </h2>
+          {lastUpdated && (
+            <span className="text-xs text-text-muted bg-black/5 dark:bg-white/5 px-2 py-0.5 rounded-full font-medium">
+              Last updated: {new Date(lastUpdated).toLocaleTimeString()}
+            </span>
+          )}
         </div>
 
         <div className="flex flex-wrap items-center gap-1.5">
@@ -1156,7 +1256,9 @@ export default function ProviderLimits() {
                 className="flex h-8 w-8 items-center justify-center rounded-lg border border-black/10 text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
                 aria-label="Previous accounts page"
               >
-                <span className="material-symbols-outlined text-[16px]">chevron_left</span>
+                <span className="material-symbols-outlined text-[16px]">
+                  chevron_left
+                </span>
               </button>
               <div className="text-xs text-text-muted">
                 Page {pagination.page} / {pagination.totalPages}
@@ -1176,13 +1278,17 @@ export default function ProviderLimits() {
                 className="flex h-8 w-8 items-center justify-center rounded-lg border border-black/10 text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
                 aria-label="Next accounts page"
               >
-                <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+                <span className="material-symbols-outlined text-[16px]">
+                  chevron_right
+                </span>
               </button>
               <button
                 type="button"
                 onClick={() => setPage(pagination.totalPages)}
                 disabled={
-                  pagination.page >= pagination.totalPages || connectionsLoading || refreshingAll
+                  pagination.page >= pagination.totalPages ||
+                  connectionsLoading ||
+                  refreshingAll
                 }
                 className="flex h-8 items-center rounded-lg border border-black/10 px-3 text-xs text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
               >

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -9,7 +9,8 @@ import Card from "@/shared/components/Card";
 import { EditConnectionModal } from "@/shared/components";
 
 function getConnectionLabel(connection) {
-  const isEmail = (value) => typeof value === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  const isEmail = (value) =>
+    typeof value === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
   if (isEmail(connection.email)) return connection.email;
   if (isEmail(connection.name)) return connection.name;
   return connection.name;
@@ -22,17 +23,26 @@ function getConnectionQuotaRemaining(connection, quotaData) {
   return Number.POSITIVE_INFINITY;
 }
 
-function sortVisibleConnections(connections, quotaData, expiringFirst, providerFilter, quotaSortMode) {
+function sortVisibleConnections(
+  connections,
+  quotaData,
+  expiringFirst,
+  providerFilter,
+  quotaSortMode,
+) {
   if (providerFilter === "codex" && quotaSortMode !== "default") {
     return [...connections].sort((a, b) => {
       const remainingA = getConnectionQuotaRemaining(a, quotaData);
       const remainingB = getConnectionQuotaRemaining(b, quotaData);
-      const remainingDiff = quotaSortMode === "remaining-asc"
-        ? remainingA - remainingB
-        : remainingB - remainingA;
+      const remainingDiff =
+        quotaSortMode === "remaining-asc"
+          ? remainingA - remainingB
+          : remainingB - remainingA;
 
       if (remainingDiff !== 0) return remainingDiff;
-      return (getConnectionLabel(a) || "").localeCompare(getConnectionLabel(b) || "");
+      return (getConnectionLabel(a) || "").localeCompare(
+        getConnectionLabel(b) || "",
+      );
     });
   }
 
@@ -40,15 +50,24 @@ function sortVisibleConnections(connections, quotaData, expiringFirst, providerF
 
   const getEarliestResetTime = (connection) => {
     const resetTimes = (quotaData[connection.id]?.quotas || [])
-      .map((quota) => (quota.resetAt ? new Date(quota.resetAt).getTime() : Number.POSITIVE_INFINITY))
+      .map((quota) =>
+        quota.resetAt
+          ? new Date(quota.resetAt).getTime()
+          : Number.POSITIVE_INFINITY,
+      )
       .filter((time) => Number.isFinite(time));
-    return resetTimes.length > 0 ? Math.min(...resetTimes) : Number.POSITIVE_INFINITY;
+    return resetTimes.length > 0
+      ? Math.min(...resetTimes)
+      : Number.POSITIVE_INFINITY;
   };
 
   return [...connections].sort((a, b) => {
     const expiryDiff = getEarliestResetTime(a) - getEarliestResetTime(b);
     if (expiryDiff !== 0) return expiryDiff;
-    return (a.provider || "").localeCompare(b.provider || "") || (getConnectionLabel(a) || "").localeCompare(getConnectionLabel(b) || "");
+    return (
+      (a.provider || "").localeCompare(b.provider || "") ||
+      (getConnectionLabel(a) || "").localeCompare(getConnectionLabel(b) || "")
+    );
   });
 }
 
@@ -62,7 +81,9 @@ function buildLoadingState(connections) {
 
 function filterQuotaStateByConnections(state, connections) {
   const visibleIds = new Set(connections.map((connection) => connection.id));
-  return Object.fromEntries(Object.entries(state).filter(([id]) => visibleIds.has(id)));
+  return Object.fromEntries(
+    Object.entries(state).filter(([id]) => visibleIds.has(id)),
+  );
 }
 
 function getConnectionsPageRange(pagination) {
@@ -80,7 +101,8 @@ function getConnectionsEmptyMessage(totals, providerFilter, accountFilter) {
     return {
       icon: "cloud_off",
       title: "No Providers Connected",
-      description: "Connect to providers with OAuth to track your API quota limits and usage.",
+      description:
+        "Connect to providers with OAuth to track your API quota limits and usage.",
     };
   }
 
@@ -88,16 +110,18 @@ function getConnectionsEmptyMessage(totals, providerFilter, accountFilter) {
     return {
       icon: "filter_alt_off",
       title: "No Accounts Match Current Filters",
-      description: providerFilter === "all"
-        ? "Try changing the account status filter to see more quota trackers."
-        : `No ${accountFilter === "inactive" ? "turned off" : accountFilter === "active" ? "active" : "matching"} accounts found for ${providerFilter}.`,
+      description:
+        providerFilter === "all"
+          ? "Try changing the account status filter to see more quota trackers."
+          : `No ${accountFilter === "inactive" ? "turned off" : accountFilter === "active" ? "active" : "matching"} accounts found for ${providerFilter}.`,
     };
   }
 
   return {
     icon: "filter_alt_off",
     title: "No Accounts On This Page",
-    description: "Try moving to another page or refreshing the current filters.",
+    description:
+      "Try moving to another page or refreshing the current filters.",
   };
 }
 
@@ -105,8 +129,8 @@ function sortRequestFromExpiringFirst(expiringFirst) {
   return expiringFirst ? "expiring" : "priority";
 }
 
-function getPageSizeLabel(pageSize) {
-  return `${pageSize} / page`;
+function getPageSizeLabel(pageSize, isCustomPageSize) {
+  return isCustomPageSize ? `Custom: ${pageSize} / page` : `${pageSize} / page`;
 }
 
 function getConnectionsPaginationSummary(pagination) {
@@ -115,11 +139,23 @@ function getConnectionsPaginationSummary(pagination) {
 }
 
 function getSafePagination(pagination, fallbackPageSize) {
-  return pagination || { page: 1, pageSize: fallbackPageSize, total: 0, totalPages: 1 };
+  return (
+    pagination || {
+      page: 1,
+      pageSize: fallbackPageSize,
+      total: 0,
+      totalPages: 1,
+    }
+  );
 }
 
 function getSafeTotals(totals, fallbackTotal = 0) {
-  return totals || { eligibleConnections: fallbackTotal, providerFilteredConnections: fallbackTotal };
+  return (
+    totals || {
+      eligibleConnections: fallbackTotal,
+      providerFilteredConnections: fallbackTotal,
+    }
+  );
 }
 
 function shouldResetPage(previousValue, nextValue) {
@@ -153,6 +189,8 @@ const QUOTA_SORT_OPTIONS = [
   { value: "remaining-desc", label: "% quota: high to low" },
 ];
 const CONNECTIONS_PAGE_SIZE = 20;
+const ACCOUNT_PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+const ACCOUNT_PAGE_SIZE_MAX = 500;
 
 export default function ProviderLimits() {
   const [connections, setConnections] = useState([]);
@@ -178,49 +216,63 @@ export default function ProviderLimits() {
   const [providerMenuOpen, setProviderMenuOpen] = useState(false);
   const [bulkToggling, setBulkToggling] = useState(false);
   const [page, setPage] = useState(1);
-  const [pageSize] = useState(CONNECTIONS_PAGE_SIZE);
-  const [pagination, setPagination] = useState({ page: 1, pageSize: CONNECTIONS_PAGE_SIZE, total: 0, totalPages: 1 });
-  const [totals, setTotals] = useState({ eligibleConnections: 0, providerFilteredConnections: 0 });
+  const [pageSize, setPageSize] = useState(CONNECTIONS_PAGE_SIZE);
+  const [customPageSizeInput, setCustomPageSizeInput] = useState(String(CONNECTIONS_PAGE_SIZE));
+  const [pagination, setPagination] = useState({
+    page: 1,
+    pageSize: CONNECTIONS_PAGE_SIZE,
+    total: 0,
+    totalPages: 1,
+  });
+  const [totals, setTotals] = useState({
+    eligibleConnections: 0,
+    providerFilteredConnections: 0,
+  });
 
   const intervalRef = useRef(null);
   const countdownRef = useRef(null);
 
-  const fetchConnections = useCallback(async (targetPage = page) => {
-    try {
-      const params = new URLSearchParams({
-        page: String(targetPage),
-        pageSize: String(pageSize),
-        accountStatus: accountFilter,
-        sort: "priority",
-      });
+  const fetchConnections = useCallback(
+    async (targetPage = page) => {
+      try {
+        const params = new URLSearchParams({
+          page: String(targetPage),
+          pageSize: String(pageSize),
+          accountStatus: accountFilter,
+          sort: "priority",
+        });
 
-      if (providerFilter !== "all") {
-        params.set("provider", providerFilter);
+        if (providerFilter !== "all") {
+          params.set("provider", providerFilter);
+        }
+
+        const response = await fetch(
+          `/api/providers/client?${params.toString()}`,
+        );
+        if (!response.ok) throw new Error("Failed to fetch connections");
+
+        const data = await response.json();
+        const connectionList = data.connections || [];
+        const nextPagination = getSafePagination(data.pagination, pageSize);
+        const nextTotals = getSafeTotals(data.totals, connectionList.length);
+
+        setConnections(connectionList);
+        setProviderOptions(getProviderOptions(data.providerOptions));
+        setPagination(nextPagination);
+        setTotals(nextTotals);
+        setPage(getPaginationPageValue(data.pagination, targetPage));
+        return connectionList;
+      } catch (error) {
+        console.error("Error fetching connections:", error);
+        setConnections([]);
+        setProviderOptions([]);
+        setPagination({ page: 1, pageSize, total: 0, totalPages: 1 });
+        setTotals({ eligibleConnections: 0, providerFilteredConnections: 0 });
+        return [];
       }
-
-      const response = await fetch(`/api/providers/client?${params.toString()}`);
-      if (!response.ok) throw new Error("Failed to fetch connections");
-
-      const data = await response.json();
-      const connectionList = data.connections || [];
-      const nextPagination = getSafePagination(data.pagination, pageSize);
-      const nextTotals = getSafeTotals(data.totals, connectionList.length);
-
-      setConnections(connectionList);
-      setProviderOptions(getProviderOptions(data.providerOptions));
-      setPagination(nextPagination);
-      setTotals(nextTotals);
-      setPage(getPaginationPageValue(data.pagination, targetPage));
-      return connectionList;
-    } catch (error) {
-      console.error("Error fetching connections:", error);
-      setConnections([]);
-      setProviderOptions([]);
-      setPagination({ page: 1, pageSize, total: 0, totalPages: 1 });
-      setTotals({ eligibleConnections: 0, providerFilteredConnections: 0 });
-      return [];
-    }
-  }, [accountFilter, expiringFirst, page, pageSize, providerFilter]);
+    },
+    [accountFilter, expiringFirst, page, pageSize, providerFilter],
+  );
 
   // Fetch quota for a specific connection
   const fetchQuota = useCallback(async (connectionId, provider) => {
@@ -303,57 +355,63 @@ export default function ProviderLimits() {
     [fetchQuota],
   );
 
-  const handleDeleteConnection = useCallback(async (id) => {
-    if (!confirm("Delete this connection?")) return;
-    setDeletingId(id);
-    try {
-      const res = await fetch(`/api/providers/${id}`, { method: "DELETE" });
-      if (res.ok) {
-        setQuotaData((prev) => {
-          const next = { ...prev };
-          delete next[id];
-          return next;
-        });
-        setLoading((prev) => {
-          const next = { ...prev };
-          delete next[id];
-          return next;
-        });
-        setErrors((prev) => {
-          const next = { ...prev };
-          delete next[id];
-          return next;
-        });
-        await reconcileConnectionsPage(fetchConnections, page);
+  const handleDeleteConnection = useCallback(
+    async (id) => {
+      if (!confirm("Delete this connection?")) return;
+      setDeletingId(id);
+      try {
+        const res = await fetch(`/api/providers/${id}`, { method: "DELETE" });
+        if (res.ok) {
+          setQuotaData((prev) => {
+            const next = { ...prev };
+            delete next[id];
+            return next;
+          });
+          setLoading((prev) => {
+            const next = { ...prev };
+            delete next[id];
+            return next;
+          });
+          setErrors((prev) => {
+            const next = { ...prev };
+            delete next[id];
+            return next;
+          });
+          await reconcileConnectionsPage(fetchConnections, page);
+        }
+      } catch (error) {
+        console.error("Error deleting connection:", error);
+      } finally {
+        setDeletingId(null);
       }
-    } catch (error) {
-      console.error("Error deleting connection:", error);
-    } finally {
-      setDeletingId(null);
-    }
-  }, [fetchConnections, page]);
+    },
+    [fetchConnections, page],
+  );
 
-  const handleToggleConnectionActive = useCallback(async (id, isActive) => {
-    setTogglingId(id);
-    try {
-      const res = await fetch(`/api/providers/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ isActive }),
-      });
-      if (res.ok) {
-        setQuotaData((prev) => {
-          const next = { ...prev };
-          return next;
+  const handleToggleConnectionActive = useCallback(
+    async (id, isActive) => {
+      setTogglingId(id);
+      try {
+        const res = await fetch(`/api/providers/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isActive }),
         });
-        await reconcileConnectionsPage(fetchConnections, page);
+        if (res.ok) {
+          setQuotaData((prev) => {
+            const next = { ...prev };
+            return next;
+          });
+          await reconcileConnectionsPage(fetchConnections, page);
+        }
+      } catch (error) {
+        console.error("Error updating connection status:", error);
+      } finally {
+        setTogglingId(null);
       }
-    } catch (error) {
-      console.error("Error updating connection status:", error);
-    } finally {
-      setTogglingId(null);
-    }
-  }, [fetchConnections, page]);
+    },
+    [fetchConnections, page],
+  );
 
   const handleUpdateConnection = useCallback(
     async (formData) => {
@@ -406,8 +464,12 @@ export default function ProviderLimits() {
       const visibleConnections = await fetchConnections(page);
 
       setLoading(buildLoadingState(visibleConnections));
-      setErrors((prev) => filterQuotaStateByConnections(prev, visibleConnections));
-      setQuotaData((prev) => filterQuotaStateByConnections(prev, visibleConnections));
+      setErrors((prev) =>
+        filterQuotaStateByConnections(prev, visibleConnections),
+      );
+      setQuotaData((prev) =>
+        filterQuotaStateByConnections(prev, visibleConnections),
+      );
 
       await Promise.all(
         visibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
@@ -428,8 +490,12 @@ export default function ProviderLimits() {
       setConnectionsLoading(false);
 
       setLoading(buildLoadingState(visibleConnections));
-      setErrors((prev) => filterQuotaStateByConnections(prev, visibleConnections));
-      setQuotaData((prev) => filterQuotaStateByConnections(prev, visibleConnections));
+      setErrors((prev) =>
+        filterQuotaStateByConnections(prev, visibleConnections),
+      );
+      setQuotaData((prev) =>
+        filterQuotaStateByConnections(prev, visibleConnections),
+      );
 
       await Promise.all(
         visibleConnections.map((conn) => fetchQuota(conn.id, conn.provider)),
@@ -514,7 +580,14 @@ export default function ProviderLimits() {
   }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
 
   const sortedConnections = useMemo(
-    () => sortVisibleConnections(connections, quotaData, expiringFirst, providerFilter, quotaSortMode),
+    () =>
+      sortVisibleConnections(
+        connections,
+        quotaData,
+        expiringFirst,
+        providerFilter,
+        quotaSortMode,
+      ),
     [connections, quotaData, expiringFirst, providerFilter, quotaSortMode],
   );
 
@@ -566,12 +639,18 @@ export default function ProviderLimits() {
     bulkSetActive(ids, true);
   };
 
-  const selectedProviderLabel = providerFilter === "all" ? "All providers" : providerFilter;
+  const selectedProviderLabel =
+    providerFilter === "all" ? "All providers" : providerFilter;
   const hasEligibleConnections = totals.eligibleConnections > 0;
   const hasVisibleConnections = sortedConnections.length > 0;
-  const emptyState = getConnectionsEmptyMessage(totals, providerFilter, accountFilter);
+  const emptyState = getConnectionsEmptyMessage(
+    totals,
+    providerFilter,
+    accountFilter,
+  );
   const connectionsPageSummary = getConnectionsPaginationSummary(pagination);
-  const pageSizeLabel = getPageSizeLabel(pageSize);
+  const isCustomPageSize = !ACCOUNT_PAGE_SIZE_OPTIONS.includes(pageSize);
+  const pageSizeLabel = getPageSizeLabel(pageSize, isCustomPageSize);
 
   if (!connectionsLoading && !hasEligibleConnections) {
     return (
@@ -632,7 +711,9 @@ export default function ProviderLimits() {
             >
               <span className="flex min-w-0 items-center gap-1.5">
                 {providerFilter === "all" ? (
-                  <span className="material-symbols-outlined text-[14px] text-text-muted">apps</span>
+                  <span className="material-symbols-outlined text-[14px] text-text-muted">
+                    apps
+                  </span>
                 ) : (
                   <ProviderIcon
                     src={`/providers/${providerFilter}.png`}
@@ -642,9 +723,13 @@ export default function ProviderLimits() {
                     fallbackText={providerFilter.slice(0, 2).toUpperCase()}
                   />
                 )}
-                <span className="truncate capitalize hidden lg:inline">{selectedProviderLabel}</span>
+                <span className="truncate capitalize hidden lg:inline">
+                  {selectedProviderLabel}
+                </span>
               </span>
-              <span className="material-symbols-outlined text-[14px] text-text-muted">expand_more</span>
+              <span className="material-symbols-outlined text-[14px] text-text-muted">
+                expand_more
+              </span>
             </button>
 
             {providerMenuOpen && (
@@ -667,9 +752,15 @@ export default function ProviderLimits() {
                     }}
                     className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition-colors ${providerFilter === "all" ? "bg-primary/10 text-primary" : "text-text-primary hover:bg-black/5 dark:hover:bg-white/10"}`}
                   >
-                    <span className="material-symbols-outlined text-[22px]">apps</span>
+                    <span className="material-symbols-outlined text-[22px]">
+                      apps
+                    </span>
                     <span className="font-medium">All providers</span>
-                    {providerFilter === "all" && <span className="material-symbols-outlined ml-auto text-[20px]">check</span>}
+                    {providerFilter === "all" && (
+                      <span className="material-symbols-outlined ml-auto text-[20px]">
+                        check
+                      </span>
+                    )}
                   </button>
                   <div className="my-1 h-px bg-black/10 dark:bg-white/10" />
                   <div className="max-h-72 overflow-y-auto pr-1">
@@ -693,8 +784,14 @@ export default function ProviderLimits() {
                           className="size-6 rounded-md object-contain"
                           fallbackText={provider.slice(0, 2).toUpperCase()}
                         />
-                        <span className="font-medium capitalize">{provider}</span>
-                        {providerFilter === provider && <span className="material-symbols-outlined ml-auto text-[20px]">check</span>}
+                        <span className="font-medium capitalize">
+                          {provider}
+                        </span>
+                        {providerFilter === provider && (
+                          <span className="material-symbols-outlined ml-auto text-[20px]">
+                            check
+                          </span>
+                        )}
                       </button>
                     ))}
                   </div>
@@ -743,7 +840,9 @@ export default function ProviderLimits() {
             className={`flex h-8 shrink-0 items-center gap-1 rounded-lg border px-2 text-xs transition-colors ${expiringFirst ? "border-amber-500/40 bg-amber-500/10 text-amber-500" : "border-black/10 text-text-primary hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5"}`}
             title="Sort accounts by earliest quota reset time"
           >
-            <span className="material-symbols-outlined text-[14px]">hourglass_top</span>
+            <span className="material-symbols-outlined text-[14px]">
+              hourglass_top
+            </span>
             <span className="hidden sm:inline">Expiring first</span>
           </button>
 
@@ -767,9 +866,78 @@ export default function ProviderLimits() {
             className="flex h-8 shrink-0 items-center gap-1 rounded-lg border border-emerald-500/30 px-2 text-xs text-emerald-500 transition-colors hover:bg-emerald-500/10 disabled:opacity-50"
             title="Enable connections that still have quota on the current page"
           >
-            <span className="material-symbols-outlined text-[14px]">check_circle</span>
+            <span className="material-symbols-outlined text-[14px]">
+              check_circle
+            </span>
             <span className="hidden sm:inline">Turn on Available</span>
           </button>
+
+          <div className="flex items-center gap-1.5">
+            <select
+              value={isCustomPageSize ? "custom" : String(pageSize)}
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                if (nextValue === "custom") {
+                  return;
+                }
+                const nextPageSize = Number.parseInt(nextValue, 10);
+                if (Number.isFinite(nextPageSize)) {
+                  setPage(1);
+                  setPageSize(nextPageSize);
+                  setCustomPageSizeInput(String(nextPageSize));
+                }
+              }}
+              className="h-8 rounded-lg border border-black/10 bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-black/5 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10"
+              aria-label="Accounts per page"
+            >
+              {ACCOUNT_PAGE_SIZE_OPTIONS.map((option) => (
+                <option key={option} value={String(option)}>
+                  {option} / page
+                </option>
+              ))}
+              <option value="custom">Custom</option>
+            </select>
+            <input
+              type="number"
+              min="1"
+              max={String(ACCOUNT_PAGE_SIZE_MAX)}
+              inputMode="numeric"
+              value={customPageSizeInput}
+              onChange={(event) => setCustomPageSizeInput(event.target.value)}
+              onBlur={() => {
+                const parsedValue = Number.parseInt(customPageSizeInput, 10);
+                if (!Number.isFinite(parsedValue)) {
+                  setCustomPageSizeInput(String(pageSize));
+                  return;
+                }
+                const nextPageSize = Math.min(
+                  ACCOUNT_PAGE_SIZE_MAX,
+                  Math.max(1, parsedValue),
+                );
+                setPage(1);
+                setPageSize(nextPageSize);
+                setCustomPageSizeInput(String(nextPageSize));
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter") return;
+                const parsedValue = Number.parseInt(customPageSizeInput, 10);
+                if (!Number.isFinite(parsedValue)) {
+                  setCustomPageSizeInput(String(pageSize));
+                  return;
+                }
+                const nextPageSize = Math.min(
+                  ACCOUNT_PAGE_SIZE_MAX,
+                  Math.max(1, parsedValue),
+                );
+                setPage(1);
+                setPageSize(nextPageSize);
+                setCustomPageSizeInput(String(nextPageSize));
+              }}
+              className="h-8 w-20 rounded-lg border border-black/10 bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-black/5 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10"
+              aria-label="Custom accounts per page"
+              placeholder="Custom"
+            />
+          </div>
 
           {/* Auto-refresh toggle */}
           <button
@@ -784,9 +952,13 @@ export default function ProviderLimits() {
             >
               {autoRefresh ? "toggle_on" : "toggle_off"}
             </span>
-            <span className="hidden text-text-primary sm:inline">Auto-refresh</span>
+            <span className="hidden text-text-primary sm:inline">
+              Auto-refresh
+            </span>
             {autoRefresh && (
-              <span className="text-[10px] text-text-muted tabular-nums">({countdown}s)</span>
+              <span className="text-[10px] text-text-muted tabular-nums">
+                ({countdown}s)
+              </span>
             )}
           </button>
 
@@ -798,7 +970,11 @@ export default function ProviderLimits() {
             className="flex h-8 shrink-0 items-center gap-1 rounded-lg border border-black/10 px-2 text-xs text-text-primary transition-colors hover:bg-black/5 dark:border-white/10 dark:hover:bg-white/5 disabled:opacity-50"
             title="Refresh all"
           >
-            <span className={`material-symbols-outlined text-[14px] ${refreshingAll ? "animate-spin" : ""}`}>refresh</span>
+            <span
+              className={`material-symbols-outlined text-[14px] ${refreshingAll ? "animate-spin" : ""}`}
+            >
+              refresh
+            </span>
           </button>
         </div>
       </div>
@@ -806,7 +982,8 @@ export default function ProviderLimits() {
       {/* Provider cards: 2 columns, compact */}
       {expiringFirst && (
         <div className="rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
-          Expiring-first currently reorders accounts inside the current page. Cross-page ordering still follows backend pagination.
+          Expiring-first currently reorders accounts inside the current page.
+          Cross-page ordering still follows backend pagination.
         </div>
       )}
 
@@ -845,7 +1022,9 @@ export default function ProviderLimits() {
                         {conn.provider}
                       </h3>
                       {getConnectionLabel(conn) ? (
-                        <p className="text-xs text-text-muted truncate">{getConnectionLabel(conn)}</p>
+                        <p className="text-xs text-text-muted truncate">
+                          {getConnectionLabel(conn)}
+                        </p>
                       ) : null}
                     </div>
                   </div>
@@ -938,7 +1117,9 @@ export default function ProviderLimits() {
                     quotas={quota?.quotas}
                     compact
                     sortMode="default"
-                    showSortLabel={conn.provider === "codex" && quotaSortMode !== "default"}
+                    showSortLabel={
+                      conn.provider === "codex" && quotaSortMode !== "default"
+                    }
                   />
                 )}
               </div>
@@ -956,22 +1137,56 @@ export default function ProviderLimits() {
             <div className="flex items-center justify-end gap-1.5">
               <button
                 type="button"
-                onClick={() => setPage((currentPage) => Math.max(1, currentPage - 1))}
-                disabled={pagination.page <= 1 || connectionsLoading || refreshingAll}
+                onClick={() => setPage(1)}
+                disabled={
+                  pagination.page <= 1 || connectionsLoading || refreshingAll
+                }
                 className="flex h-8 items-center rounded-lg border border-black/10 px-3 text-xs text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
               >
-                Prev accounts
+                First Page
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  setPage((currentPage) => Math.max(1, currentPage - 1))
+                }
+                disabled={
+                  pagination.page <= 1 || connectionsLoading || refreshingAll
+                }
+                className="flex h-8 w-8 items-center justify-center rounded-lg border border-black/10 text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
+                aria-label="Previous accounts page"
+              >
+                <span className="material-symbols-outlined text-[16px]">chevron_left</span>
               </button>
               <div className="text-xs text-text-muted">
                 Page {pagination.page} / {pagination.totalPages}
               </div>
               <button
                 type="button"
-                onClick={() => setPage((currentPage) => Math.min(pagination.totalPages, currentPage + 1))}
-                disabled={pagination.page >= pagination.totalPages || connectionsLoading || refreshingAll}
+                onClick={() =>
+                  setPage((currentPage) =>
+                    Math.min(pagination.totalPages, currentPage + 1),
+                  )
+                }
+                disabled={
+                  pagination.page >= pagination.totalPages ||
+                  connectionsLoading ||
+                  refreshingAll
+                }
+                className="flex h-8 w-8 items-center justify-center rounded-lg border border-black/10 text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
+                aria-label="Next accounts page"
+              >
+                <span className="material-symbols-outlined text-[16px]">chevron_right</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setPage(pagination.totalPages)}
+                disabled={
+                  pagination.page >= pagination.totalPages || connectionsLoading || refreshingAll
+                }
                 className="flex h-8 items-center rounded-lg border border-black/10 px-3 text-xs text-text-primary transition-colors hover:bg-black/5 disabled:cursor-not-allowed disabled:opacity-40 dark:border-white/10 dark:hover:bg-white/5"
               >
-                Next accounts
+                Last Page
               </button>
             </div>
           </div>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -15,7 +15,27 @@ function getConnectionLabel(connection) {
   return connection.name;
 }
 
-function sortVisibleConnections(connections, quotaData, expiringFirst) {
+function getConnectionQuotaRemaining(connection, quotaData) {
+  const quota = quotaData[connection.id]?.quotas?.[0];
+  if (!quota) return Number.POSITIVE_INFINITY;
+  if (typeof quota.remaining === "number") return quota.remaining;
+  return Number.POSITIVE_INFINITY;
+}
+
+function sortVisibleConnections(connections, quotaData, expiringFirst, providerFilter, quotaSortMode) {
+  if (providerFilter === "codex" && quotaSortMode !== "default") {
+    return [...connections].sort((a, b) => {
+      const remainingA = getConnectionQuotaRemaining(a, quotaData);
+      const remainingB = getConnectionQuotaRemaining(b, quotaData);
+      const remainingDiff = quotaSortMode === "remaining-asc"
+        ? remainingA - remainingB
+        : remainingB - remainingA;
+
+      if (remainingDiff !== 0) return remainingDiff;
+      return (getConnectionLabel(a) || "").localeCompare(getConnectionLabel(b) || "");
+    });
+  }
+
   if (!expiringFirst) return connections;
 
   const getEarliestResetTime = (connection) => {
@@ -494,8 +514,8 @@ export default function ProviderLimits() {
   }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
 
   const sortedConnections = useMemo(
-    () => sortVisibleConnections(connections, quotaData, expiringFirst),
-    [connections, quotaData, expiringFirst],
+    () => sortVisibleConnections(connections, quotaData, expiringFirst, providerFilter, quotaSortMode),
+    [connections, quotaData, expiringFirst, providerFilter, quotaSortMode],
   );
 
   // Connection is depleted when any quota entry hit the threshold
@@ -701,18 +721,20 @@ export default function ProviderLimits() {
             ))}
           </select>
 
-          <select
-            value={quotaSortMode}
-            onChange={(event) => setQuotaSortMode(event.target.value)}
-            className="h-8 rounded-lg border border-black/10 bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-black/5 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10"
-            aria-label="Sort quota rows"
-          >
-            {QUOTA_SORT_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          {providerFilter === "codex" && (
+            <select
+              value={quotaSortMode}
+              onChange={(event) => setQuotaSortMode(event.target.value)}
+              className="h-8 rounded-lg border border-black/10 bg-black/[0.02] px-2 text-xs text-text-primary outline-none transition-colors hover:bg-black/5 dark:border-white/10 dark:bg-white/[0.03] dark:hover:bg-white/10"
+              aria-label="Sort Codex quotas by remaining"
+            >
+              {QUOTA_SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          )}
 
           <button
             type="button"
@@ -915,7 +937,8 @@ export default function ProviderLimits() {
                   <QuotaTable
                     quotas={quota?.quotas}
                     compact
-                    sortMode={quotaSortMode}
+                    sortMode="default"
+                    showSortLabel={conn.provider === "codex" && quotaSortMode !== "default"}
                   />
                 )}
               </div>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -81,6 +81,10 @@ export function calculatePercentage(used, total) {
  * @returns {number} Remaining percentage (0-100)
  */
 export function getRemainingPercentage(quota) {
+  if (quota?.remaining !== undefined) {
+    return Math.max(0, Math.round(quota.remaining));
+  }
+
   if (quota?.remainingPercentage !== undefined) {
     return Math.round(quota.remainingPercentage);
   }
@@ -136,6 +140,7 @@ export function parseQuotaData(provider, data) {
               name: quotaType,
               used: quota.used || 0,
               total: quota.total || 0,
+              remaining: quota.remaining,
               resetAt: quota.resetAt || null,
             });
           });

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -76,6 +76,19 @@ export function calculatePercentage(used, total) {
 }
 
 /**
+ * Get remaining percentage from a normalized quota row
+ * @param {Object} quota - Normalized quota object
+ * @returns {number} Remaining percentage (0-100)
+ */
+export function getRemainingPercentage(quota) {
+  if (quota?.remainingPercentage !== undefined) {
+    return Math.round(quota.remainingPercentage);
+  }
+
+  return calculatePercentage(quota?.used, quota?.total);
+}
+
+/**
  * Parse provider-specific quota structures into normalized array
  * @param {string} provider - Provider name (github, antigravity, codex, kiro, claude)
  * @param {Object} data - Raw quota data from provider

--- a/src/app/api/providers/client/route.js
+++ b/src/app/api/providers/client/route.js
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { getProviderConnections } from "@/lib/localDb";
 import { backfillCodexEmails } from "@/lib/oauth/providers";
+import { USAGE_APIKEY_PROVIDERS, USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
 
-// Whitelist: only safe metadata fields exposed to UI
 const SAFE_FIELDS = [
   "id", "provider", "authType", "name", "email", "displayName",
   "priority", "globalPriority", "isActive", "defaultModel",
@@ -11,7 +11,6 @@ const SAFE_FIELDS = [
   "createdAt", "updatedAt",
 ];
 
-// providerSpecificData fields safe to expose (non-secret config only)
 const SAFE_PSD_FIELDS = [
   "baseUrl", "azureEndpoint", "deployment", "apiVersion", "accountId",
   "region", "projectId", "resourceUrl", "proxyPoolId",
@@ -20,9 +19,11 @@ const SAFE_PSD_FIELDS = [
   "username", "firstName", "lastName", "authMethod", "authKind",
 ];
 
+const DEFAULT_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 100;
+
 function maskName(name) {
   if (typeof name !== "string" || name.length <= 16) return name;
-  // Names like "hahask-uDUOg90..." may embed API keys — mask if looks like key
   if (/[a-zA-Z0-9_-]{32,}/.test(name)) return `${name.slice(0, 8)}***`;
   return name;
 }
@@ -41,12 +42,83 @@ function sanitize(c) {
   return safe;
 }
 
-// GET /api/providers/client - List connections for dashboard UI (whitelist only)
-export async function GET() {
+function isUsageEligible(connection) {
+  return USAGE_SUPPORTED_PROVIDERS.includes(connection.provider) && (
+    connection.authType === "oauth" || USAGE_APIKEY_PROVIDERS.includes(connection.provider)
+  );
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sortConnections(connections, sort) {
+  const list = [...connections];
+
+  if (sort === "provider") {
+    return list.sort((a, b) => {
+      const orderA = USAGE_SUPPORTED_PROVIDERS.indexOf(a.provider);
+      const orderB = USAGE_SUPPORTED_PROVIDERS.indexOf(b.provider);
+      if (orderA !== orderB) return orderA - orderB;
+      return a.provider.localeCompare(b.provider);
+    });
+  }
+
+  return list.sort((a, b) => {
+    const priorityA = a.priority ?? Number.MAX_SAFE_INTEGER;
+    const priorityB = b.priority ?? Number.MAX_SAFE_INTEGER;
+    if (priorityA !== priorityB) return priorityA - priorityB;
+    return (a.provider || "").localeCompare(b.provider || "");
+  });
+}
+
+export async function GET(request) {
   try {
     await backfillCodexEmails();
-    const connections = await getProviderConnections();
-    return NextResponse.json({ connections: connections.map(sanitize) });
+
+    const { searchParams } = new URL(request.url);
+    const provider = searchParams.get("provider") || "all";
+    const accountStatus = searchParams.get("accountStatus") || "all";
+    const sort = searchParams.get("sort") || "priority";
+    const page = parsePositiveInt(searchParams.get("page"), 1);
+    const pageSize = Math.min(parsePositiveInt(searchParams.get("pageSize"), DEFAULT_PAGE_SIZE), MAX_PAGE_SIZE);
+
+    const allConnections = await getProviderConnections();
+    const eligibleConnections = allConnections.filter(isUsageEligible);
+    const providerOptions = Array.from(new Set(eligibleConnections.map((conn) => conn.provider))).sort();
+
+    const providerFilteredConnections = eligibleConnections.filter((conn) => (
+      provider === "all" || conn.provider === provider
+    ));
+
+    const accountFilteredConnections = providerFilteredConnections.filter((conn) => {
+      if (accountStatus === "active") return conn.isActive ?? true;
+      if (accountStatus === "inactive") return !(conn.isActive ?? true);
+      return true;
+    });
+
+    const sortedConnections = sortConnections(accountFilteredConnections, sort);
+    const total = sortedConnections.length;
+    const totalPages = Math.max(1, Math.ceil(total / pageSize));
+    const currentPage = Math.min(page, totalPages);
+    const offset = (currentPage - 1) * pageSize;
+    const pageConnections = sortedConnections.slice(offset, offset + pageSize).map(sanitize);
+
+    return NextResponse.json({
+      connections: pageConnections,
+      providerOptions,
+      pagination: {
+        page: currentPage,
+        pageSize,
+        total,
+        totalPages,
+      },
+      totals: {
+        eligibleConnections: eligibleConnections.length,
+        providerFilteredConnections: providerFilteredConnections.length,
+      },
+    });
   } catch (error) {
     console.log("Error fetching providers for client:", error);
     return NextResponse.json({ error: "Failed to fetch providers" }, { status: 500 });

--- a/src/app/api/providers/client/route.js
+++ b/src/app/api/providers/client/route.js
@@ -20,7 +20,7 @@ const SAFE_PSD_FIELDS = [
 ];
 
 const DEFAULT_PAGE_SIZE = 20;
-const MAX_PAGE_SIZE = 100;
+const MAX_PAGE_SIZE = 500;
 
 function maskName(name) {
   if (typeof name !== "string" || name.length <= 16) return name;

--- a/src/lib/tunnel/tailscale.js
+++ b/src/lib/tunnel/tailscale.js
@@ -49,7 +49,8 @@ function fallbackBin() {
 function bgRefreshBin() {
   if (binCache.refreshing) return;
   binCache.refreshing = true;
-  execAsync("which tailscale 2>/dev/null || where tailscale 2>nul", { windowsHide: true, timeout: PROBE_TIMEOUT_MS })
+  const cmd = IS_WINDOWS ? "where tailscale 2>nul" : "which tailscale 2>/dev/null";
+  execAsync(cmd, { windowsHide: true, timeout: PROBE_TIMEOUT_MS })
     .then(({ stdout }) => {
       const sys = stdout.trim();
       binCache.value = sys || fallbackBin();
@@ -138,9 +139,10 @@ export function isTailscaleRunningStrict() {
   const bin = getTailscaleBin();
   if (!bin) return false;
   try {
-    const out = execSync(`"${bin}" ${SOCKET_FLAG.join(" ")} funnel status --json 2>/dev/null`, {
+    const out = execSync(`"${bin}" ${SOCKET_FLAG.join(" ")} funnel status --json`, {
       encoding: "utf8",
       windowsHide: true,
+      stdio: ["ignore", "pipe", "ignore"],
       timeout: PROBE_TIMEOUT_MS,
     });
     const json = JSON.parse(out);


### PR DESCRIPTION
## Summary
Resolves the issue where Tailscale connection fails on Windows platforms due to Unix-specific shell redirection syntax (`2>/dev/null`) inside node's execution context.

## Root Cause
- The strict status probe command `tailscale funnel status --json 2>/dev/null` uses Unix redirection. 
- On Windows, this shell syntax throws a `"The system cannot find the path specified"` exception, causing the status helper function `isTailscaleRunningStrict()` to catch the error and prematurely return `false`.
- This causes the frontend/backend connection flow to wrongly assume Tailscale is not connected or logged in.

## Changes
- Removed shell redirection (`2>/dev/null` and `||`) from Tailscale probing commands.
- Configured Node's native subprocess runner options `{ stdio: ["ignore", "pipe", "ignore"] }` to drop stderr silently in a cross-platform manner.
- Made binary detection (`bgRefreshBin`) platform-aware: uses `where` command on Windows and `which` on Unix-like operating systems.

## Test Plan
- Manually verified Tailscale login and funnel checks on Windows machine:
  - Both `getTailscaleBin()` and `isTailscaleRunningStrict()` successfully locate the binary and parse the funnel status JSON without raising system exceptions.
