### PR TITLE
feat: support Antigravity 3.5 Flash variants

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,7 @@ const tracingRoot = process.env.NEXT_TRACING_ROOT_MODE === "workspace"
 const nextConfig = {
   distDir: process.env.NEXT_DIST_DIR || ".next",
   output: "standalone",
+  allowedDevOrigins: ["127.0.0.1"],
   serverExternalPackages: ["better-sqlite3", "sql.js", "node:sqlite", "bun:sqlite"],
   turbopack: {
     root: tracingRoot

--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -3,6 +3,7 @@ import { platform, arch } from "os";
 // === Gemini CLI ===
 export const GEMINI_CLI_VERSION = "0.34.0";
 export const GEMINI_CLI_API_CLIENT = "google-genai-sdk/1.41.0 gl-node/v22.19.0";
+export const ANTIGRAVITY_VERSION = "2.0.1";
 
 // Map Node arch to Gemini CLI arch string (x64/x86/arm64/...)
 function geminiCLIArch() {
@@ -56,7 +57,7 @@ export function getPlatformEnum() {
 }
 
 export function getPlatformUserAgent() {
-  return `antigravity/1.104.0 ${platform()}/${arch()}`;
+  return `antigravity/${ANTIGRAVITY_VERSION} ${platform()}/${arch()}`;
 }
 
 export const CLIENT_METADATA = {
@@ -126,7 +127,7 @@ export const AG_DEFAULT_TOOLS = new Set([
 
 // Antigravity chat/stream headers
 export const ANTIGRAVITY_HEADERS = {
-  "User-Agent": `antigravity/1.107.0 ${platform()}/${arch()}`
+  "User-Agent": `antigravity/${ANTIGRAVITY_VERSION} ${platform()}/${arch()}`
 };
 
 // Cloud Code Assist API

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -94,6 +94,9 @@ export const PROVIDER_MODELS = {
   ag: [  // Antigravity - special case: models call different backends
     { id: "gemini-3.1-pro-high", name: "Gemini 3 Pro High" },
     { id: "gemini-3.1-pro-low", name: "Gemini 3 Pro Low" },
+    { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash" },
+    { id: "gemini-3.5-flash-high", name: "Gemini 3.5 Flash (High)" },
+    { id: "gemini-3.5-flash-medium", name: "Gemini 3.5 Flash (Medium)" },
     { id: "gemini-3-flash", name: "Gemini 3 Flash", thinking: false }, // AG strips thinking for this model
     { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
     { id: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 Thinking" },

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -1,4 +1,5 @@
 import { platform, arch } from "os";
+import { ANTIGRAVITY_HEADERS } from "./appConstants.js";
 
 // === OS/Arch helpers ===
 function mapStainlessOs() {
@@ -105,10 +106,11 @@ export const PROVIDERS = {
   antigravity: {
     baseUrls: [
       "https://daily-cloudcode-pa.googleapis.com",
-      "https://daily-cloudcode-pa.sandbox.googleapis.com",
+      "https://autopush-cloudcode-pa.sandbox.googleapis.com",
+      "https://cloudcode-pa.googleapis.com",
     ],
     format: "antigravity",
-    headers: { "User-Agent": `antigravity/1.107.0 ${platform()}/${arch()}` },
+    headers: { ...ANTIGRAVITY_HEADERS },
     clientId: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
     clientSecret: "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"
   },

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -18,6 +18,78 @@ function sanitizeFunctionName(name) {
 const MAX_RETRY_AFTER_MS = 10000;
 const MAX_ANTIGRAVITY_OUTPUT_TOKENS = 16384;
 
+const ANTIGRAVITY_WIRE_MODEL_OVERRIDES = new Map([
+  ["gemini-3.5-flash-high", "gemini-3-flash-agent"],
+  ["gemini-3.5-flash", "gemini-3.5-flash-low"],
+  ["gemini-3.5-flash-medium", "gemini-3.5-flash-low"],
+  ["gemini-3-flash-high", "gemini-3-flash"],
+  ["gemini-3-flash-medium", "gemini-3-flash"],
+  ["gemini-3-flash-low", "gemini-3-flash"],
+]);
+
+function normalizeModelId(model) {
+  return String(model || "").trim().replace(/^models\//i, "").toLowerCase();
+}
+
+export function resolveAntigravityWireModel(model) {
+  return ANTIGRAVITY_WIRE_MODEL_OVERRIDES.get(normalizeModelId(model)) || model;
+}
+
+export function getAntigravityDefaultThinkingLevel(model) {
+  switch (normalizeModelId(model)) {
+    case "gemini-3.5-flash-high":
+      return "high";
+    case "gemini-3.5-flash-medium":
+      return "medium";
+    default:
+      return "";
+  }
+}
+
+function hasExplicitThinkingConfig(generationConfig) {
+  const thinkingConfig = generationConfig?.thinkingConfig;
+  if (!thinkingConfig || typeof thinkingConfig !== "object") return false;
+  return (
+    thinkingConfig.thinkingLevel != null ||
+    thinkingConfig.thinking_level != null ||
+    thinkingConfig.thinkingBudget != null ||
+    thinkingConfig.thinking_budget != null
+  );
+}
+
+function applyDefaultVariantThinkingConfig(generationConfig, model) {
+  const thinkingLevel = getAntigravityDefaultThinkingLevel(model);
+  if (!thinkingLevel || hasExplicitThinkingConfig(generationConfig)) {
+    return generationConfig;
+  }
+
+  return {
+    ...generationConfig,
+    thinkingConfig: {
+      ...(generationConfig.thinkingConfig || {}),
+      thinkingLevel,
+      includeThoughts: true,
+    },
+  };
+}
+
+export async function readAntigravityResponseBodyForRetry(response) {
+  const readableResponse = typeof response?.clone === "function" ? response.clone() : response;
+  return await readableResponse?.text?.().catch(() => "") || "";
+}
+
+export function shouldRetryAntigravityEndpointUnavailable(status, bodyText) {
+  if (status === HTTP_STATUS.NOT_FOUND) return true;
+  if (status !== HTTP_STATUS.FORBIDDEN || !bodyText) return false;
+
+  const message = String(bodyText).toLowerCase();
+  return (
+    message.includes("gemini for google cloud api (staging)") &&
+    message.includes("staging-cloudaicompanion.sandbox.googleapis.com") &&
+    message.includes("disabled")
+  );
+}
+
 export class AntigravityExecutor extends BaseExecutor {
   constructor() {
     super("antigravity", PROVIDERS.antigravity);
@@ -43,6 +115,7 @@ export class AntigravityExecutor extends BaseExecutor {
 
   transformRequest(model, body, stream, credentials) {
     const projectId = credentials?.projectId || this.generateProjectId();
+    const wireModel = resolveAntigravityWireModel(model);
 
     // Fix contents for Claude models via Antigravity
     const contents = body.request?.contents?.map(c => {
@@ -81,10 +154,11 @@ export class AntigravityExecutor extends BaseExecutor {
     }
 
     const { tools: _originalTools, toolConfig: _originalToolConfig, ...requestWithoutTools } = body.request || {};
-    const generationConfig = { ...(requestWithoutTools.generationConfig || {}) };
+    let generationConfig = { ...(requestWithoutTools.generationConfig || {}) };
     if (generationConfig.maxOutputTokens > MAX_ANTIGRAVITY_OUTPUT_TOKENS) {
       generationConfig.maxOutputTokens = MAX_ANTIGRAVITY_OUTPUT_TOKENS;
     }
+    generationConfig = applyDefaultVariantThinkingConfig(generationConfig, model);
 
     const transformedRequest = {
       ...requestWithoutTools,
@@ -99,7 +173,7 @@ export class AntigravityExecutor extends BaseExecutor {
     return {
       ...body,
       project: projectId,
-      model: model,
+      model: wireModel,
       userAgent: "antigravity",
       requestType: "agent",
       requestId: `agent-${crypto.randomUUID()}`,
@@ -226,6 +300,15 @@ export class AntigravityExecutor extends BaseExecutor {
           body: JSON.stringify(transformedBody),
           signal
         }, proxyOptions);
+
+        if ((response.status === HTTP_STATUS.NOT_FOUND || response.status === HTTP_STATUS.FORBIDDEN) && urlIndex + 1 < fallbackCount) {
+          const errorBody = await readAntigravityResponseBodyForRetry(response);
+          if (shouldRetryAntigravityEndpointUnavailable(response.status, errorBody)) {
+            log?.debug?.("RETRY", `${response.status} on ${url}, trying fallback ${urlIndex + 1}`);
+            lastStatus = response.status;
+            continue;
+          }
+        }
 
         if (response.status === HTTP_STATUS.RATE_LIMITED || response.status === HTTP_STATUS.SERVICE_UNAVAILABLE) {
           // Try to get retry time from headers first

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -9,11 +9,116 @@ import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, sav
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
 
+function convertFinishReasonToClaude(reason) {
+  switch (reason) {
+    case "length":
+      return "max_tokens";
+    case "tool_calls":
+      return "tool_use";
+    case "stop":
+    default:
+      return "end_turn";
+  }
+}
+
+function parseToolInput(args) {
+  if (!args) return {};
+  if (typeof args === "object") return args;
+  if (typeof args !== "string") return {};
+  try {
+    return JSON.parse(args);
+  } catch {
+    return {};
+  }
+}
+
+function openAIContentToText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part?.type === "text") return part.text || "";
+      if (typeof part?.text === "string") return part.text;
+      return "";
+    })
+    .join("");
+}
+
+function firstClaudeTextBlock(content) {
+  return Array.isArray(content)
+    ? content.find((block) => block?.type === "text")?.text
+    : null;
+}
+
+export function openAIChatCompletionToClaudeMessage(responseBody) {
+  if (responseBody?.type === "message" && Array.isArray(responseBody.content)) {
+    return responseBody;
+  }
+
+  const choice = responseBody?.choices?.[0] || {};
+  const message = choice.message || {};
+  const content = [];
+  const thinking = message.reasoning_content || message.reasoning;
+  const text = openAIContentToText(message.content);
+
+  if (thinking) content.push({ type: "thinking", thinking });
+  if (text) content.push({ type: "text", text });
+
+  if (Array.isArray(message.tool_calls)) {
+    for (const toolCall of message.tool_calls) {
+      const fn = toolCall?.function || {};
+      content.push({
+        type: "tool_use",
+        id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
+        name: fn.name || "tool",
+        input: parseToolInput(fn.arguments),
+      });
+    }
+  }
+
+  if (content.length === 0) content.push({ type: "text", text: "" });
+
+  const usage = responseBody?.usage || {};
+  const promptDetails = usage.prompt_tokens_details || {};
+  const cachedTokens = Number(promptDetails.cached_tokens || 0);
+  const cacheCreationTokens = Number(promptDetails.cache_creation_tokens || 0);
+  const inputTokens = Math.max(
+    0,
+    Number(usage.prompt_tokens || 0) - cachedTokens - cacheCreationTokens,
+  );
+  const claudeUsage = {
+    input_tokens: inputTokens,
+    output_tokens: Number(usage.completion_tokens || 0),
+  };
+  if (cachedTokens > 0) claudeUsage.cache_read_input_tokens = cachedTokens;
+  if (cacheCreationTokens > 0) claudeUsage.cache_creation_input_tokens = cacheCreationTokens;
+
+  const rawId = responseBody?.id ? String(responseBody.id) : `${Date.now()}`;
+  const id = rawId.startsWith("msg_") ? rawId : `msg_${rawId.replace(/^chatcmpl-/, "")}`;
+
+  return {
+    id,
+    type: "message",
+    role: "assistant",
+    model: responseBody?.model || "unknown",
+    content,
+    stop_reason: convertFinishReasonToClaude(choice.finish_reason),
+    stop_sequence: null,
+    usage: claudeUsage,
+  };
+}
+
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
  */
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat) {
-  if (targetFormat === sourceFormat || targetFormat === FORMATS.OPENAI) return responseBody;
+  if (targetFormat === sourceFormat) return responseBody;
+  if (targetFormat === FORMATS.OPENAI) {
+    return sourceFormat === FORMATS.CLAUDE
+      ? openAIChatCompletionToClaudeMessage(responseBody)
+      : responseBody;
+  }
 
   // Gemini / Antigravity
   if (targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.ANTIGRAVITY || targetFormat === FORMATS.GEMINI_CLI || targetFormat === FORMATS.VERTEX) {
@@ -67,7 +172,9 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
         result.usage.completion_tokens_details = { reasoning_tokens: usage.thoughtsTokenCount };
       }
     }
-    return result;
+    return sourceFormat === FORMATS.CLAUDE
+      ? openAIChatCompletionToClaudeMessage(result)
+      : result;
   }
 
   // Claude
@@ -114,7 +221,9 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
         total_tokens: (responseBody.usage.input_tokens || 0) + (responseBody.usage.output_tokens || 0)
       };
     }
-    return result;
+    return sourceFormat === FORMATS.CLAUDE
+      ? responseBody
+      : result;
   }
 
   // Ollama
@@ -175,14 +284,16 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     }
   }
 
-  // Ensure OpenAI-required fields
-  if (!translatedResponse.object) translatedResponse.object = "chat.completion";
-  if (!translatedResponse.created) translatedResponse.created = Math.floor(Date.now() / 1000);
+  if (sourceFormat !== FORMATS.CLAUDE) {
+    // Ensure OpenAI-required fields
+    if (!translatedResponse.object) translatedResponse.object = "chat.completion";
+    if (!translatedResponse.created) translatedResponse.created = Math.floor(Date.now() / 1000);
 
-  // Strip Azure-specific fields
-  delete translatedResponse.prompt_filter_results;
-  if (translatedResponse?.choices) {
-    for (const choice of translatedResponse.choices) delete choice.content_filter_results;
+    // Strip Azure-specific fields
+    delete translatedResponse.prompt_filter_results;
+    if (translatedResponse?.choices) {
+      for (const choice of translatedResponse.choices) delete choice.content_filter_results;
+    }
   }
 
   if (translatedResponse?.usage) {
@@ -191,7 +302,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   // Strip reasoning_content — some clients (e.g. Firecrawl AI SDK) have JSON parsers that
   // break on this non-standard field, even though OpenAI allows it in extensions.
-  if (translatedResponse?.choices) {
+  if (sourceFormat !== FORMATS.CLAUDE && translatedResponse?.choices) {
     for (const choice of translatedResponse.choices) {
       if (choice?.message) delete choice.message.reasoning_content;
     }
@@ -208,7 +319,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     providerRequest: finalBody || translatedBody || null,
     providerResponse: responseBody || null,
     response: {
-      content: translatedResponse?.choices?.[0]?.message?.content || translatedResponse?.content || null,
+      content: translatedResponse?.choices?.[0]?.message?.content || firstClaudeTextBlock(translatedResponse?.content) || translatedResponse?.content || null,
       thinking: translatedResponse?.choices?.[0]?.message?.reasoning_content || translatedResponse?.reasoning_content || null,
       finish_reason: translatedResponse?.choices?.[0]?.finish_reason || "unknown"
     },

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -2,7 +2,7 @@
  * Usage Fetcher - Get usage data from provider APIs
  */
 
-import { CLIENT_METADATA, getPlatformUserAgent } from "../config/appConstants.js";
+import { ANTIGRAVITY_VERSION, CLIENT_METADATA, getPlatformUserAgent } from "../config/appConstants.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 
 // GitHub API config
@@ -38,6 +38,65 @@ const ANTIGRAVITY_CONFIG = {
   clientSecret: "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",
   userAgent: getPlatformUserAgent(),
 };
+
+const ANTIGRAVITY_QUOTA_MODEL_ALIASES = {
+  "gemini-3-flash-agent": {
+    id: "gemini-3.5-flash-high",
+    displayName: "Gemini 3.5 Flash (High)",
+  },
+  "gemini-3.5-flash-low": {
+    id: "gemini-3.5-flash-medium",
+    displayName: "Gemini 3.5 Flash (Medium)",
+  },
+  "gemini-3.5-flash-high": {
+    id: "gemini-3.5-flash-high",
+    displayName: "Gemini 3.5 Flash (High)",
+  },
+  "gemini-3.5-flash-medium": {
+    id: "gemini-3.5-flash-medium",
+    displayName: "Gemini 3.5 Flash (Medium)",
+  },
+  "gemini-3.5-flash": {
+    id: "gemini-3.5-flash",
+    displayName: "Gemini 3.5 Flash",
+  },
+};
+
+const ANTIGRAVITY_IMPORTANT_MODELS = new Set([
+  "claude-opus-4-6-thinking",
+  "claude-sonnet-4-6",
+  "gemini-3.1-pro-high",
+  "gemini-3.1-pro-low",
+  "gemini-3-flash",
+  "gemini-3.5-flash",
+  "gemini-3.5-flash-high",
+  "gemini-3.5-flash-medium",
+  "gemini-3-flash-agent",
+  "gemini-3.5-flash-low",
+  "gpt-oss-120b-medium",
+]);
+
+export function normalizeAntigravityQuotaModel(modelKey, displayName = "") {
+  const rawKey = String(modelKey || "").trim();
+  const normalizedKey = rawKey.toLowerCase();
+  const rawDisplayName = String(displayName || "").trim();
+  const normalizedDisplayName = rawDisplayName.toLowerCase();
+
+  const alias = ANTIGRAVITY_QUOTA_MODEL_ALIASES[normalizedKey];
+  if (alias) return alias;
+
+  if (normalizedDisplayName.includes("gemini 3.5 flash (high)")) {
+    return ANTIGRAVITY_QUOTA_MODEL_ALIASES["gemini-3.5-flash-high"];
+  }
+  if (normalizedDisplayName.includes("gemini 3.5 flash (medium)")) {
+    return ANTIGRAVITY_QUOTA_MODEL_ALIASES["gemini-3.5-flash-medium"];
+  }
+
+  return {
+    id: rawKey,
+    displayName: rawDisplayName || rawKey,
+  };
+}
 
 // Codex (OpenAI) API config
 const CODEX_CONFIG = {
@@ -342,7 +401,7 @@ async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptio
           "User-Agent": ANTIGRAVITY_CONFIG.userAgent,
           "Content-Type": "application/json",
           "X-Client-Name": "antigravity",
-          "X-Client-Version": "1.107.0",
+          "X-Client-Version": ANTIGRAVITY_VERSION,
           "x-request-source": "local", // MITM bypass
         },
         body: JSON.stringify({
@@ -377,24 +436,16 @@ async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptio
 
     // Parse model quotas (inspired by vscode-antigravity-cockpit)
     if (data.models) {
-      // Filter only recommended/important models (must match PROVIDER_MODELS ag ids)
-      const importantModels = [
-        'claude-opus-4-6-thinking',
-        'claude-sonnet-4-6',
-        'gemini-3.1-pro-high',
-        'gemini-3.1-pro-low',
-        'gemini-3-flash',
-        'gpt-oss-120b-medium',
-      ];
-
       for (const [modelKey, info] of Object.entries(data.models)) {
         // Skip models without quota info
         if (!info.quotaInfo) {
           continue;
         }
 
+        const quotaModel = normalizeAntigravityQuotaModel(modelKey, info.displayName);
+
         // Skip internal models and non-important models
-        if (info.isInternal || !importantModels.includes(modelKey)) {
+        if (!ANTIGRAVITY_IMPORTANT_MODELS.has(quotaModel.id)) {
           continue;
         }
 
@@ -406,14 +457,14 @@ async function getAntigravityUsage(accessToken, providerSpecificData, proxyOptio
         const remaining = Math.round(total * remainingFraction);
         const used = total - remaining;
 
-        // Use modelKey as key (matches PROVIDER_MODELS id)
-        quotas[modelKey] = {
+        // Use normalized public key (matches PROVIDER_MODELS ag ids)
+        quotas[quotaModel.id] = {
           used,
           total,
           resetAt: parseResetTime(info.quotaInfo.resetTime),
           remainingPercentage,
           unlimited: false,
-          displayName: info.displayName || modelKey,
+          displayName: quotaModel.displayName || info.displayName || quotaModel.id,
         };
       }
     }

--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -9,6 +9,7 @@ const DNS_CACHE = new Map();
 const MITM_BYPASS_HOSTS = [
   "cloudcode-pa.googleapis.com",
   "daily-cloudcode-pa.googleapis.com",
+  "autopush-cloudcode-pa.sandbox.googleapis.com",
   "api.individual.githubcopilot.com",
   "q.us-east-1.amazonaws.com",
   "codewhisperer.us-east-1.amazonaws.com",

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -4,9 +4,11 @@ import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/sha
 import { GEMINI_CONFIG } from "@/lib/oauth/constants/oauth";
 import { refreshGoogleToken, updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveOllamaLocalHost } from "open-sse/config/providers.js";
+import { ANTIGRAVITY_VERSION, getPlatformUserAgent, INTERNAL_REQUEST_HEADER } from "open-sse/config/appConstants.js";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
+const ANTIGRAVITY_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
 const parseOpenAIStyleModels = (data) => {
   if (Array.isArray(data)) return data;
@@ -34,6 +36,82 @@ const parseGeminiCliModels = (data) => {
   }
 
   return [];
+};
+
+const ANTIGRAVITY_MODEL_ALIASES = {
+  "gemini-3-flash-agent": { id: "gemini-3.5-flash-high", name: "Gemini 3.5 Flash (High)" },
+  "gemini-3.5-flash-low": { id: "gemini-3.5-flash-medium", name: "Gemini 3.5 Flash (Medium)" },
+  "gemini-3.5-flash-high": { id: "gemini-3.5-flash-high", name: "Gemini 3.5 Flash (High)" },
+  "gemini-3.5-flash-medium": { id: "gemini-3.5-flash-medium", name: "Gemini 3.5 Flash (Medium)" },
+  "gemini-3.5-flash": { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash" },
+};
+
+const normalizeAntigravityModel = (id, name) => {
+  const rawId = String(id || "").trim();
+  const normalizedId = rawId.toLowerCase();
+  const rawName = String(name || "").trim();
+  const normalizedName = rawName.toLowerCase();
+
+  if (ANTIGRAVITY_MODEL_ALIASES[normalizedId]) {
+    return ANTIGRAVITY_MODEL_ALIASES[normalizedId];
+  }
+  if (normalizedName.includes("gemini 3.5 flash (high)")) {
+    return ANTIGRAVITY_MODEL_ALIASES["gemini-3.5-flash-high"];
+  }
+  if (normalizedName.includes("gemini 3.5 flash (medium)")) {
+    return ANTIGRAVITY_MODEL_ALIASES["gemini-3.5-flash-medium"];
+  }
+
+  return { id: rawId, name: rawName || rawId };
+};
+
+const isKnownAntigravityModel = (id, name) => {
+  const normalizedId = String(id || "").trim().toLowerCase();
+  const normalizedName = String(name || "").trim().toLowerCase();
+  return (
+    !!ANTIGRAVITY_MODEL_ALIASES[normalizedId] ||
+    normalizedName.includes("gemini 3.5 flash (high)") ||
+    normalizedName.includes("gemini 3.5 flash (medium)")
+  );
+};
+
+const parseAntigravityModels = (data) => {
+  const models = [];
+
+  if (Array.isArray(data?.models)) {
+    for (const item of data.models) {
+      const id = item?.id || item?.model || item?.name;
+      if (!id) continue;
+      models.push({
+        id,
+        name: item?.displayName || item?.name || id,
+        isInternal: item?.isInternal,
+      });
+    }
+  } else if (data?.models && typeof data.models === "object") {
+    for (const [id, info] of Object.entries(data.models)) {
+      models.push({
+        id,
+        name: info?.displayName || info?.name || id,
+        isInternal: info?.isInternal,
+      });
+    }
+  }
+
+  const byId = new Map();
+  for (const model of models) {
+    const normalized = normalizeAntigravityModel(model.id, model.name);
+    if (!normalized.id) continue;
+    if (model.isInternal && !isKnownAntigravityModel(model.id, model.name)) continue;
+    byId.set(normalized.id, { ...model, id: normalized.id, name: normalized.name });
+  }
+
+  return Array.from(byId.values());
+};
+
+const buildAntigravityModelsBody = (connection) => {
+  const projectId = connection?.projectId || connection?.providerSpecificData?.projectId;
+  return projectId ? { project: projectId } : {};
 };
 
 const appendCodexReviewModels = (models) => models.flatMap((model) => {
@@ -153,13 +231,19 @@ const PROVIDER_MODELS_CONFIG = {
     parseResponse: parseCodexModels
   },
   antigravity: {
-    url: "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:models",
+    url: ANTIGRAVITY_MODELS_URL,
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": getPlatformUserAgent(),
+      "X-Client-Name": "antigravity",
+      "X-Client-Version": ANTIGRAVITY_VERSION,
+      [INTERNAL_REQUEST_HEADER.name]: INTERNAL_REQUEST_HEADER.value,
+    },
     authHeader: "Authorization",
     authPrefix: "Bearer ",
-    body: {},
-    parseResponse: (data) => data.models || []
+    body: buildAntigravityModelsBody,
+    parseResponse: parseAntigravityModels
   },
   github: {
     url: "https://api.githubcopilot.com/models",
@@ -461,7 +545,8 @@ export async function GET(request, { params }) {
     };
 
     if (config.body && config.method === "POST") {
-      fetchOptions.body = JSON.stringify(config.body);
+      const requestBody = typeof config.body === "function" ? config.body(connection) : config.body;
+      fetchOptions.body = JSON.stringify(requestBody);
     }
 
     const response = await fetch(url, fetchOptions);

--- a/tests/unit/antigravity-35-models.test.js
+++ b/tests/unit/antigravity-35-models.test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { ANTIGRAVITY_VERSION, INTERNAL_REQUEST_HEADER } from "../../open-sse/config/appConstants.js";
+import { getModelsByProviderId } from "../../open-sse/config/providerModels.js";
+import { PROVIDERS } from "../../open-sse/config/providers.js";
+import {
+  AntigravityExecutor,
+  getAntigravityDefaultThinkingLevel,
+  readAntigravityResponseBodyForRetry,
+  resolveAntigravityWireModel,
+  shouldRetryAntigravityEndpointUnavailable,
+} from "../../open-sse/executors/antigravity.js";
+import { normalizeAntigravityQuotaModel } from "../../open-sse/services/usage.js";
+
+function baseBody(generationConfig = {}) {
+  return {
+    request: {
+      contents: [
+        { role: "user", parts: [{ text: "hello" }] },
+      ],
+      generationConfig,
+    },
+  };
+}
+
+describe("Antigravity Gemini 3.5 Flash variants", () => {
+  it("exposes public 3.5 model ids without backend wire ids", () => {
+    const ids = getModelsByProviderId("antigravity").map((model) => model.id);
+
+    expect(ids).toContain("gemini-3.5-flash");
+    expect(ids).toContain("gemini-3.5-flash-high");
+    expect(ids).toContain("gemini-3.5-flash-medium");
+    expect(ids).not.toContain("gemini-3-flash-agent");
+    expect(ids).not.toContain("gemini-3.5-flash-low");
+  });
+
+  it("uses Antigravity 2.x endpoint order and headers", () => {
+    const executor = new AntigravityExecutor();
+    const headers = executor.buildHeaders({ accessToken: "token" }, true, "session-1");
+
+    expect(PROVIDERS.antigravity.baseUrls).toEqual([
+      "https://daily-cloudcode-pa.googleapis.com",
+      "https://autopush-cloudcode-pa.sandbox.googleapis.com",
+      "https://cloudcode-pa.googleapis.com",
+    ]);
+    expect(headers["User-Agent"]).toMatch(new RegExp(`^antigravity/${ANTIGRAVITY_VERSION} `));
+    expect(headers[INTERNAL_REQUEST_HEADER.name]).toBe(INTERNAL_REQUEST_HEADER.value);
+    expect(headers["X-Machine-Session-Id"]).toBe("session-1");
+  });
+
+  it("maps public 3.5 ids to the real Antigravity wire model ids", () => {
+    expect(resolveAntigravityWireModel("gemini-3.5-flash-high")).toBe("gemini-3-flash-agent");
+    expect(resolveAntigravityWireModel("gemini-3.5-flash-medium")).toBe("gemini-3.5-flash-low");
+    expect(resolveAntigravityWireModel("gemini-3.5-flash")).toBe("gemini-3.5-flash-low");
+    expect(resolveAntigravityWireModel("gemini-3-flash-high")).toBe("gemini-3-flash");
+  });
+
+  it("keeps high and medium variant thinking distinct", () => {
+    const executor = new AntigravityExecutor();
+
+    const high = executor.transformRequest(
+      "gemini-3.5-flash-high",
+      baseBody({ maxOutputTokens: 64000 }),
+      false,
+      { projectId: "project-1", email: "test@example.com" },
+    );
+    const medium = executor.transformRequest(
+      "gemini-3.5-flash-medium",
+      baseBody(),
+      false,
+      { projectId: "project-1", email: "test@example.com" },
+    );
+
+    expect(high.model).toBe("gemini-3-flash-agent");
+    expect(high.request.generationConfig.maxOutputTokens).toBe(16384);
+    expect(high.request.generationConfig.thinkingConfig).toEqual({
+      thinkingLevel: "high",
+      includeThoughts: true,
+    });
+
+    expect(medium.model).toBe("gemini-3.5-flash-low");
+    expect(medium.request.generationConfig.thinkingConfig).toEqual({
+      thinkingLevel: "medium",
+      includeThoughts: true,
+    });
+    expect(getAntigravityDefaultThinkingLevel("gemini-3.5-flash")).toBe("");
+  });
+
+  it("does not overwrite explicit thinking config", () => {
+    const executor = new AntigravityExecutor();
+    const request = executor.transformRequest(
+      "gemini-3.5-flash-medium",
+      baseBody({ thinkingConfig: { thinkingBudget: 2048, include_thoughts: true } }),
+      false,
+      { projectId: "project-1", email: "test@example.com" },
+    );
+
+    expect(request.model).toBe("gemini-3.5-flash-low");
+    expect(request.request.generationConfig.thinkingConfig).toEqual({
+      thinkingBudget: 2048,
+      include_thoughts: true,
+    });
+  });
+
+  it("retries endpoint misses without treating staging 403 as account auth failure", () => {
+    const staging403 = JSON.stringify({
+      error: {
+        code: 403,
+        message: "Gemini for Google Cloud API (Staging) has not been used in project p before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/staging-cloudaicompanion.sandbox.googleapis.com/overview?project=p",
+      },
+    });
+
+    expect(shouldRetryAntigravityEndpointUnavailable(404, "")).toBe(true);
+    expect(shouldRetryAntigravityEndpointUnavailable(403, staging403)).toBe(true);
+    expect(shouldRetryAntigravityEndpointUnavailable(403, "generic permission denied")).toBe(false);
+  });
+
+  it("reads retry response bodies when DNS-bypass responses have no clone method", async () => {
+    await expect(readAntigravityResponseBodyForRetry({
+      text: async () => "not found",
+    })).resolves.toBe("not found");
+
+    await expect(readAntigravityResponseBodyForRetry({
+      clone: () => ({ text: async () => "cloned body" }),
+      text: async () => "original body",
+    })).resolves.toBe("cloned body");
+  });
+
+  it("normalizes quota-only backend 3.5 ids for usage display", () => {
+    expect(normalizeAntigravityQuotaModel("gemini-3-flash-agent")).toEqual({
+      id: "gemini-3.5-flash-high",
+      displayName: "Gemini 3.5 Flash (High)",
+    });
+    expect(normalizeAntigravityQuotaModel("gemini-3.5-flash-low")).toEqual({
+      id: "gemini-3.5-flash-medium",
+      displayName: "Gemini 3.5 Flash (Medium)",
+    });
+  });
+});

--- a/tests/unit/non-streaming-claude-response.test.js
+++ b/tests/unit/non-streaming-claude-response.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import {
+  openAIChatCompletionToClaudeMessage,
+  translateNonStreamingResponse,
+} from "../../open-sse/handlers/chatCore/nonStreamingHandler.js";
+
+describe("non-streaming Claude response formatting", () => {
+  it("converts OpenAI chat completions to Anthropic Messages shape", () => {
+    const result = openAIChatCompletionToClaudeMessage({
+      id: "chatcmpl-test",
+      model: "gemini-3.5-flash-low",
+      choices: [{
+        message: { role: "assistant", content: "ok" },
+        finish_reason: "stop",
+      }],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 3,
+        prompt_tokens_details: { cached_tokens: 2 },
+      },
+    });
+
+    expect(result).toMatchObject({
+      id: "msg_test",
+      type: "message",
+      role: "assistant",
+      model: "gemini-3.5-flash-low",
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 3,
+        cache_read_input_tokens: 2,
+      },
+    });
+    expect(result.object).toBeUndefined();
+    expect(result.choices).toBeUndefined();
+  });
+
+  it("converts Antigravity non-streaming responses to Anthropic Messages shape for /v1/messages", () => {
+    const result = translateNonStreamingResponse({
+      response: {
+        responseId: "ag-response",
+        modelVersion: "gemini-3-flash-b",
+        candidates: [{
+          finishReason: "STOP",
+          content: { parts: [{ text: "ok" }] },
+        }],
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 2,
+          totalTokenCount: 7,
+        },
+      },
+    }, FORMATS.ANTIGRAVITY, FORMATS.CLAUDE);
+
+    expect(result).toMatchObject({
+      id: "msg_ag-response",
+      type: "message",
+      role: "assistant",
+      model: "gemini-3-flash-b",
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 5,
+        output_tokens: 2,
+      },
+    });
+    expect(result.object).toBeUndefined();
+    expect(result.choices).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add Antigravity Gemini 3.5 Flash, High, and Medium public model IDs
- route 3.5 High/Medium to Antigravity backend wire model IDs instead of Gemini CLI aliases
- update Antigravity 2.x UA, endpoint fallback order, dynamic model fetch, and usage quota normalization

## Tests
- npx vitest run --config tests/vitest.config.js tests/unit/antigravity-35-models.test.js
- npm run build