### PR TITLE
Fix Claude Office gateway CORS preflight

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -34,6 +34,12 @@ const PUBLIC_API_PATHS = [
 // Public top-level prefixes (LLM API endpoints with their own API key auth).
 const PUBLIC_PREFIXES = ["/v1", "/v1beta", "/api/v1", "/api/v1beta"];
 
+const LLM_API_CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+};
+
 // Always require JWT token regardless of requireLogin setting
 const ALWAYS_PROTECTED = [
   "/api/shutdown",
@@ -123,6 +129,20 @@ async function canAccessPublicLlmApi(request) {
   return await hasValidApiKey(request);
 }
 
+function llmApiCorsPreflight() {
+  return new Response(null, {
+    status: 204,
+    headers: LLM_API_CORS_HEADERS,
+  });
+}
+
+function publicLlmApiAuthError() {
+  return NextResponse.json(
+    { error: "API key required for remote API access" },
+    { status: 401, headers: LLM_API_CORS_HEADERS },
+  );
+}
+
 async function canAccessLocalOnlyRoute(request) {
   if (await hasValidCliToken(request)) return true;
   // Browser on host: loopback Host + Origin (blocks tunnel/CSRF) + JWT cookie (blocks unauth raw clients)
@@ -182,8 +202,9 @@ export async function proxy(request) {
   }
 
   if (isPublicLlmApi(pathname)) {
+    if (request.method === "OPTIONS") return llmApiCorsPreflight();
     if (await canAccessPublicLlmApi(request)) return NextResponse.next();
-    return NextResponse.json({ error: "API key required for remote API access" }, { status: 401 });
+    return publicLlmApiAuthError();
   }
 
   // Deny-by-default for /api/* — public allow-list bypasses, everything else requires auth.

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   jsonResponse: vi.fn((body, init) => ({
     status: init?.status || 200,
     body,
+    headers: new Headers(init?.headers),
   })),
   getSettings: vi.fn(),
   validateApiKey: vi.fn(),
@@ -35,10 +36,11 @@ vi.mock("@/lib/auth/dashboardSession", () => ({
 
 const { proxy, __test__ } = await import("../../src/dashboardGuard.js");
 
-function request(pathname, headers = {}) {
+function request(pathname, headers = {}, method = "GET") {
   const normalizedHeaders = new Headers(headers);
   return {
     nextUrl: { pathname },
+    method,
     headers: normalizedHeaders,
     cookies: { get: vi.fn(() => undefined) },
     url: `http://localhost${pathname}`,
@@ -66,6 +68,22 @@ describe("dashboard guard public LLM API access", () => {
 
     expect(response.status).toBe(401);
     expect(response.body.error).toBe("API key required for remote API access");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  it("allows remote public LLM API CORS preflight without API key", async () => {
+    const response = await proxy(request("/v1/messages", {
+      host: "localhost:20128",
+      origin: "https://pivot.claude.ai",
+      "access-control-request-method": "POST",
+      "access-control-request-headers": "authorization,anthropic-version,content-type",
+    }, "OPTIONS"));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+    expect(response.headers.get("Access-Control-Allow-Headers")).toBe("*");
+    expect(mocks.validateApiKey).not.toHaveBeenCalled();
   });
 
   it("allows loopback rewritten public LLM API without API key", async () => {


### PR DESCRIPTION
﻿## Summary

Fixes Claude for Office gateway connections failing before authentication when the Office task pane calls 9Router from `https://pivot.claude.ai`.

## Root cause

`dashboardGuard` classified public LLM API requests with a non-loopback `Origin` as remote and required an API key before routing. Browser CORS preflight requests do not include the gateway token, so `OPTIONS /v1/models` and `OPTIONS /v1/messages` returned `401` without CORS headers. Claude for Office surfaced that as `Failed to fetch` / `Could not reach gateway`.

## Changes

- Add shared CORS headers for public LLM API guard responses.
- Allow unauthenticated `OPTIONS` preflight for `/v1`, `/v1beta`, `/api/v1`, and `/api/v1beta`.
- Include CORS headers on remote public LLM API auth errors so clients can read the actual auth failure.
- Add a unit test for the Claude Office `https://pivot.claude.ai` preflight case.

Fixes #1279

## Validation

- `npx --prefix tests vitest run tests/unit/dashboard-guard.test.js --config tests/vitest.config.js --reporter=verbose`
- Manually reproduced on Windows with global 9Router v0.4.55: before the fix, `OPTIONS` from `https://pivot.claude.ai` returned `401`; after applying the same middleware change, it returned `204` with CORS headers and `GET /v1/models` with the stored `x-api-key` returned `200`.
