### PR TITLE
fix(cursor): strip Composer <｜final｜> sentinel markers leaking after #1310

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -51,7 +51,23 @@ function visibleComposerContentFromThinking(thinking) {
   const endTag = "</think>";
   const endIdx = thinking.lastIndexOf(endTag);
   if (endIdx < 0) return "";
-  return thinking.slice(endIdx + endTag.length).trimStart();
+  let visible = thinking.slice(endIdx + endTag.length).trimStart();
+  // Strip Composer protocol markers that wrap the final visible answer.
+  // Cursor's Composer protobuf sometimes prefixes the visible suffix with
+  // sentinel tags like `<｜final｜>` (full-width pipes) or `<|final|>` (ASCII)
+  // and may close them with a matching `<｜/final｜>` / `<|/final|>`.
+  // These are protocol-internal and must not leak to OpenAI-compatible clients.
+  const openMarker = /^\s*<[｜|]\s*final\s*[｜|]>\s*/i;
+  const closeMarker = /\s*<[｜|]\s*\/\s*final\s*[｜|]>\s*$/i;
+  if (openMarker.test(visible)) {
+    visible = visible.replace(openMarker, "");
+  } else if (/^\s*<(?![｜|/])/.test(visible) || /^\s*<[｜|][^>]*$/.test(visible)) {
+    // A streaming chunk delivered a partial opening marker like `<` or `<｜fin`.
+    // Wait for more data before emitting anything to avoid leaking the marker.
+    return "";
+  }
+  visible = visible.replace(closeMarker, "").trim();
+  return visible;
 }
 
 function decompressPayload(payload, flags) {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "vitest": "^4.1.7"
   }
 }

--- a/tests/unit/cursor-composer-thinking.test.js
+++ b/tests/unit/cursor-composer-thinking.test.js
@@ -83,4 +83,54 @@ describe("CursorExecutor Composer thinking-field responses", () => {
     expect(payload.choices[0].message.content).toBeNull();
     expect(JSON.stringify(payload)).not.toContain("SHOULD_NOT_APPEAR");
   });
+
+  it("strips Composer `<｜final｜>` sentinel markers from non-streaming output", async () => {
+    const executor = new CursorExecutor();
+    const buffer = cursorResponseFrame({
+      thinking: "reasoning</think><｜final｜>OK_PR1310<｜/final｜>",
+    });
+
+    const response = executor.transformProtobufToJSON(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "reply OK" }],
+    });
+    const payload = await response.json();
+
+    expect(payload.choices[0].message.content).toBe("OK_PR1310");
+    expect(payload.choices[0].message.content).not.toMatch(/final/i);
+  });
+
+  it("strips ASCII `<|final|>` sentinel markers from non-streaming output", async () => {
+    const executor = new CursorExecutor();
+    const buffer = cursorResponseFrame({
+      thinking: "reasoning</think><|final|>HELLO<|/final|>",
+    });
+
+    const response = executor.transformProtobufToJSON(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const payload = await response.json();
+
+    expect(payload.choices[0].message.content).toBe("HELLO");
+  });
+
+  it("does not leak partial `<｜final｜>` marker across streamed Composer chunks", async () => {
+    const executor = new CursorExecutor();
+    const buffer = Buffer.concat([
+      cursorResponseFrame({ thinking: "reasoning</think><｜fina" }),
+      cursorResponseFrame({ thinking: "l｜>OK_S" }),
+      cursorResponseFrame({ thinking: "TREAM" }),
+    ]);
+
+    const response = executor.transformProtobufToSSE(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "reply" }],
+    });
+    const events = parseSSE(await response.text());
+    const content = events
+      .map((event) => event.choices?.[0]?.delta?.content || "")
+      .join("");
+
+    expect(content).toBe("OK_STREAM");
+    expect(JSON.stringify(events)).not.toContain("final");
+    expect(JSON.stringify(events)).not.toContain("｜");
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1310. That PR correctly decodes Cursor Composer's visible answer from protobuf thinking field #25 by slicing after the last `</think>`, but the slice still includes a Composer-internal sentinel marker, which leaks verbatim to OpenAI-compatible clients:

```text
CONTENT: '<｜final｜>OK_PR1310'
```

In practice Cursor Composer wraps its visible suffix in protocol-internal tags:

- `<｜final｜>...<｜/final｜>` (full-width pipes, what Composer sends in the wild today)
- `<|final|>...<|/final|>` (ASCII variant, defensive)

This patch strips both opening and closing markers in `visibleComposerContentFromThinking`, and also handles the streaming case where the opening marker straddles a Connect-RPC frame boundary (e.g. one frame ends with `<｜fina` and the next starts with `l｜>`) — in that case the executor now buffers instead of emitting a partial marker as visible content.

## Reproduction (before this patch)

Real Cursor account, `cu/composer-2.5`, 9router master:

```text
--- NON-STREAM ---
CONTENT: '<｜final｜>OK_PR1310'

--- STREAM ---
CONTENT: '<｜final｜>STREAM_OK_PR1310'
```

## After this patch

Same request, 9router built from this branch:

```text
--- NON-STREAM ---
CONTENT: 'NONSTREAM_FIXED'
USAGE: {'prompt_tokens': 4034, 'completion_tokens': 3, 'total_tokens': 4037}

--- STREAM ---
CONTENT: 'STREAM_FIXED'
```

## Tests

Adds 3 vitest cases on top of the 3 added in #1310:

- `strips Composer <｜final｜> sentinel markers from non-streaming output`
- `strips ASCII <|final|> sentinel markers from non-streaming output`
- `does not leak partial <｜final｜> marker across streamed Composer chunks`

```text
✓ tests/unit/cursor-composer-thinking.test.js (6 tests) 23ms
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Also declares `vitest` as a `devDependency`. #1310 added a vitest test file but did not add the package, so `npx vitest` on a fresh `npm install` fails with `Cannot find package 'vitest'`. With this PR a fresh checkout can run the suite directly.

## Verification commands

```bash
npm install
npx vitest run tests/unit/cursor-composer-thinking.test.js --config tests/vitest.config.js
npm run build
```

## Scope

- `open-sse/executors/cursor.js` — extend `visibleComposerContentFromThinking` with marker stripping and partial-marker buffering. Non-Composer models are unaffected (gated by `isComposerModel(model)` at both call sites, unchanged from #1310).
- `tests/unit/cursor-composer-thinking.test.js` — three new cases.
- `package.json` — add `vitest` to `devDependencies`.

No runtime dependencies added.
