### PR TITLE
feat(i18n): auto-detect browser language on first visit

### DIFF
--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -85,6 +85,9 @@ export async function getUsageForProvider(connection, proxyOptions = null) {
     case "minimax":
     case "minimax-cn":
       return await getMiniMaxUsage(apiKey, provider, proxyOptions);
+    case "alicode":
+    case "alicode-intl":
+      return await getDashscopeUsage(apiKey, provider, proxyOptions);
     default:
       return { message: `Usage API not implemented for ${provider}` };
   }
@@ -961,7 +964,162 @@ async function getGlmUsage(apiKey, provider, proxyOptions = null) {
   }
 }
 
-// ── MiniMax helpers ──────────────────────────────────────────────────────
+// DashScope (Alibaba Cloud / 百炼) config
+const DASHSCOPE_CONFIG = {
+  alicode: "https://dashscope.aliyuncs.com",
+  "alicode-intl": "https://dashscope-intl.aliyuncs.com",
+};
+
+// ── alicode / DashScope ─────────────────────────────────────────────
+/**
+ * DashScope (百炼) usage via balance + token statistics API.
+ * Returns monthly balance info (free-tier token cap vs used) when available.
+ */
+async function getDashscopeUsage(apiKey, provider, proxyOptions = null) {
+  if (!apiKey) {
+    return { message: "DashScope API key not available." };
+  }
+
+  const base = DASHSCOPE_CONFIG[provider] || DASHSCOPE_CONFIG.alicode;
+  const quotas = {};
+
+  // 1) Try balance endpoint — returns account balance + package info
+  try {
+    const balanceResp = await proxyAwareFetch(
+      `${base}/api/v1/users/balance`,
+      {
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "X-DashScope-AuthMode": "api",
+        },
+      },
+      proxyOptions
+    );
+
+    if (balanceResp.ok) {
+      const bd = await balanceResp.json();
+      const pkg = bd.package_balance ?? bd.packageBalance ?? null;
+      if (pkg && typeof pkg === "object") {
+        const total = Number(pkg.total_count ?? pkg.totalCount ?? 0);
+        const used = Number(pkg.used_count ?? pkg.usedCount ?? 0);
+        if (total > 0) {
+          const remaining = Math.max(0, total - used);
+          quotas["token_package"] = {
+            used,
+            total,
+            remaining,
+            remainingPercentage: (remaining / total) * 100,
+            unlimited: false,
+          };
+        }
+      }
+
+      // Also capture coupon / balance info
+      const bal = Number(bd.balance ?? pkg?.balance ?? 0);
+      if (bal > 0) {
+        quotas["paid_balance"] = {
+          used: 0,
+          total: bal,
+          remaining: bal,
+          remainingPercentage: 100,
+          unlimited: true,
+        };
+      }
+    }
+  } catch (e) {
+    // Balance endpoint may not be available for all keys — ignore
+  }
+
+  // 2) Try token statistics — monthly quota per model/resource
+  try {
+    const now = new Date();
+    const ymd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    const statsResp = await proxyAwareFetch(
+      `${base}/api/v1/financing/statistics?unit=token&billDate=${ymd}`,
+      {
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+          "X-DashScope-AuthMode": "api",
+        },
+      },
+      proxyOptions
+    );
+
+    if (statsResp.ok) {
+      const sd = await statsResp.json();
+      const statItems = sd.statistic_item_list ?? sd.statisticItem ?? sd.statistics ?? [];
+      const dailyTotal = sd.daily_total_amount ?? sd.dailyTotal ?? 0;
+      if (dailyTotal) {
+        const usedVal = Number(dailyTotal) || 0;
+        // Token consumption today
+        quotas["today_tokens"] = {
+          used: usedVal,
+          total: usedVal, // daily consumption, no upper bound from this API
+          remaining: 0,
+          unlimited: true,
+          label: `Today's usage: ${usedVal.toLocaleString()} tokens`,
+        };
+      }
+      if (Array.isArray(statItems) && statItems.length) {
+        const modelUsage = {};
+        for (const item of statItems) {
+          const mid = item.model_id ?? item.modelId ?? "unknown";
+          const consumed = Number(item.consumption ?? item.amount ?? 0);
+          if (consumed > 0) {
+            modelUsage[mid] = (modelUsage[mid] || 0) + consumed;
+          }
+        }
+        if (Object.keys(modelUsage).length) {
+          for (const [mid, amt] of Object.entries(modelUsage)) {
+            quotas[`model_${mid}`] = {
+              used: amt,
+              total: amt,
+              remaining: 0,
+              unlimited: true,
+              label: `${mid}: ${amt.toLocaleString()} tokens today`,
+            };
+          }
+        }
+      }
+    }
+  } catch (e) {
+    // Stats endpoint may not be available
+  }
+
+  // 3) Fallback: try free-tier token inquiry
+  if (Object.keys(quotas).length === 0) {
+    try {
+      const inquiryResp = await proxyAwareFetch(
+        `${base}/api/v1/inquiries/usage`,
+        {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+            "X-DashScope-AuthMode": "api",
+          },
+          body: JSON.stringify({}),
+        },
+        proxyOptions
+      );
+      if (inquiryResp.ok) {
+        const id = await inquiryResp.json();
+        return {
+          plan: `${provider === "alicode-intl" ? "Intl" : "CN"} Free Tier`,
+          quotas: {},
+          message: `DashScope connected. Usage inquiry submitted (${id.task_id ?? id}).`,
+        };
+      }
+    } catch (e) { /* ignore */ }
+  }
+
+  return {
+    plan: `${provider === "alicode-intl" ? "Intl" : "CN"} Free Tier`,
+    quotas,
+    ...(Object.keys(quotas).length === 0 ? { message: "DashScope connected. Usage tracked per request." } : {}),
+  };
+}
 function getMiniMaxField(model, snakeKey, camelKey) {
   if (!model || typeof model !== "object") return null;
   return model[snakeKey] ?? model[camelKey] ?? null;

--- a/public/i18n/literals/zh-CN.json
+++ b/public/i18n/literals/zh-CN.json
@@ -764,5 +764,14 @@
   "Click to add, click again to remove. Changes are saved automatically.": "点击添加，再次点击删除。更改将自动保存。",
   "Close": "关闭",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ 风险提示：此提供商使用的订阅/OAuth 会话未获官方授权用于代理/路由器使用。账户可能被限制或封禁。使用风险自负。",
-  "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM 通过本地 CA 拦截 IDE 工具（Antigravity、GitHub Copilot、Kiro）的 HTTPS 流量，将请求重定向到您的提供商。可能违反 ToS → 账户封禁风险。使用风险自负。"
+  "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM 通过本地 CA 拦截 IDE 工具（Antigravity、GitHub Copilot、Kiro）的 HTTPS 流量，将请求重定向到您的提供商。可能违反 ToS → 账户封禁风险。使用风险自负。",
+  "Quota Guard": "配额守护",
+  "Enable Quota Guard": "启用配额守护",
+  "Automatically skip accounts that exceed the quota threshold (e.g., 95%) to avoid unexpected charges": "自动跳过超过配额阈值的账号（例如95%），避免意外扣费",
+  "Threshold (%)": "阈值 (%)",
+  "Block an account when its remaining quota drops below this value": "当剩余配额低于此值时阻止该账号",
+  "Enters exact percentage (1-99)": "精确输入百分比 (1-99)",
+  "% threshold": "% 阈值",
+  "Accounts will be excluded when usage reaches the threshold. Quota data cached 5 min/account.": "当使用量达到阈值时将排除该账号。配额数据每账号缓存 5 分钟。",
+  "Disabled — all active accounts routed normally regardless of quota usage.": "已禁用 — 所有活跃账号正常路由，不受配额使用量影响。"
 }

--- a/public/i18n/literals/zh-TW.json
+++ b/public/i18n/literals/zh-TW.json
@@ -190,5 +190,14 @@
   "Sudo Password": "Sudo 密碼",
   "Click to add, click again to remove. Changes are saved automatically.": "點擊新增，再次點擊移除。變更將自動儲存。",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ 風險提示：此提供商使用的訂閱/OAuth 工作階段未獲官方授權用於代理/路由器使用。帳戶可能被限制或封禁。使用風險自負。",
-  "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM 透過本地 CA 攔截 IDE 工具（Antigravity、GitHub Copilot、Kiro）的 HTTPS 流量，將請求重新導向到您的提供商。可能違反 ToS → 帳戶封禁風險。使用風險自負。"
+  "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM 透過本地 CA 攔截 IDE 工具（Antigravity、GitHub Copilot、Kiro）的 HTTPS 流量，將請求重新導向到您的提供商。可能違反 ToS → 帳戶封禁風險。使用風險自負。",
+  "Quota Guard": "配額守護",
+  "Enable Quota Guard": "啟用配額守護",
+  "Automatically skip accounts that exceed the quota threshold (e.g., 95%) to avoid unexpected charges": "自動跳過超過配額閾值的帳號（例如95%），避免意外扣費",
+  "Threshold (%)": "閾值 (%)",
+  "Block an account when its remaining quota drops below this value": "當剩餘配額低於此值時阻止該帳號",
+  "Enters exact percentage (1-99)": "精確輸入百分比 (1-99)",
+  "% threshold": "% 閾值",
+  "Accounts will be excluded when usage reaches the threshold. Quota data cached 5 min/account.": "當使用量達到閾值時將排除該帳號。配額數據每帳號快取 5 分鐘。",
+  "Disabled — all active accounts routed normally regardless of quota usage.": "已禁用 — 所有活躍帳號正常路由，不受配額使用量影響。"
 }

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -270,6 +270,22 @@ export default function ProfilePage() {
     }
   };
 
+  const patchGenericSettings = async (patch) => {
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSettings(prev => ({ ...prev, ...data }));
+      }
+    } catch (err) {
+      console.error("Failed to update settings:", err);
+    }
+  };
+
   const updateRequireLogin = async (requireLogin) => {
     try {
       const res = await fetch("/api/settings", {
@@ -925,6 +941,66 @@ export default function ProfilePage() {
               {settings.comboStrategy === "round-robin"
                 ? ` Combos rotate after ${settings.comboStickyRoundRobinLimit || 1} call${(settings.comboStickyRoundRobinLimit || 1) === 1 ? "" : "s"} per model.`
                 : " Combos always start with their first model."}
+            </p>
+          </div>
+        </Card>
+
+        {/* Quota Guard */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-amber-500/10 text-amber-500 shrink-0">
+              <span className="material-symbols-outlined text-[20px]">shield</span>
+            </div>
+            <h3 className="text-base sm:text-lg font-semibold">Quota Guard</h3>
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start sm:items-center justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm sm:text-base">Enable Quota Guard</p>
+                <p className="text-xs sm:text-sm text-text-muted">
+                  Automatically skip accounts that exceed the quota threshold (e.g., 95%) to avoid unexpected charges
+                </p>
+              </div>
+              <Toggle
+                checked={settings.quotaGuardEnabled === true}
+                onChange={() => {
+                  const next = settings.quotaGuardEnabled !== true;
+                  patchGenericSettings({ quotaGuardEnabled: next });
+                }}
+                disabled={loading}
+              />
+            </div>
+
+            {settings.quotaGuardEnabled === true && (
+              <div className="flex items-start sm:items-center justify-between gap-4 pt-2 border-t border-border/50">
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm sm:text-base">Threshold (%)</p>
+                  <p className="text-xs sm:text-sm text-text-muted">
+                    Block an account when its remaining quota drops below this value
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  <Input
+                    type="range"
+                    min="1"
+                    max="99"
+                    value={settings.quotaGuardThreshold ?? 95}
+                    onChange={(e) => {
+                      const val = Math.max(1, Math.min(99, Number(e.target.value) || 95));
+                      patchGenericSettings({ quotaGuardThreshold: val });
+                    }}
+                    disabled={loading}
+                    className="w-24 sm:w-32"
+                  />
+                  <span className="text-sm font-mono w-10 text-right">{settings.quotaGuardThreshold ?? 95}%</span>
+                </div>
+              </div>
+            )}
+
+            <p className="text-xs text-text-muted italic pt-2 border-t border-border/50">
+              {settings.quotaGuardEnabled === true
+                ? `Accounts will be excluded from routing when usage reaches ${settings.quotaGuardThreshold ?? 95}%. Quota data is cached for 5 minutes per account.`
+                : "Disabled — all active accounts will be routed normally regardless of quota usage."}
             </p>
           </div>
         </Card>

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -979,28 +979,44 @@ export default function ProfilePage() {
                     Block an account when its remaining quota drops below this value
                   </p>
                 </div>
-                <div className="flex items-center gap-3 shrink-0">
-                  <Input
-                    type="range"
-                    min="1"
-                    max="99"
-                    value={settings.quotaGuardThreshold ?? 95}
-                    onChange={(e) => {
-                      const val = Math.max(1, Math.min(99, Number(e.target.value) || 95));
-                      patchGenericSettings({ quotaGuardThreshold: val });
-                    }}
-                    disabled={loading}
-                    className="w-24 sm:w-32"
-                  />
-                  <span className="text-sm font-mono w-10 text-right">{settings.quotaGuardThreshold ?? 95}%</span>
+                <div className="flex flex-col items-end gap-2 shrink-0">
+                  <div className="flex items-center gap-2">
+                    <Input
+                      type="number"
+                      min="1"
+                      max="99"
+                      value={settings.quotaGuardThreshold ?? 95}
+                      onChange={(e) => {
+                        const v = Number(e.target.value);
+                        if (v >= 1 && v <= 99) patchGenericSettings({ quotaGuardThreshold: v });
+                      }}
+                      disabled={loading}
+                      className="w-16 text-center"
+                    />
+                    <span className="text-sm font-mono">%</span>
+                  </div>
+                  <div className="flex items-center gap-2 w-full">
+                    <Input
+                      type="range"
+                      min="1"
+                      max="99"
+                      value={settings.quotaGuardThreshold ?? 95}
+                      onChange={(e) => {
+                        const val = Math.max(1, Math.min(99, Number(e.target.value) || 95));
+                        patchGenericSettings({ quotaGuardThreshold: val });
+                      }}
+                      disabled={loading}
+                      className="w-full"
+                    />
+                  </div>
                 </div>
               </div>
             )}
 
             <p className="text-xs text-text-muted italic pt-2 border-t border-border/50">
               {settings.quotaGuardEnabled === true
-                ? `Accounts will be excluded from routing when usage reaches ${settings.quotaGuardThreshold ?? 95}%. Quota data is cached for 5 minutes per account.`
-                : "Disabled — all active accounts will be routed normally regardless of quota usage."}
+                ? "Accounts will be excluded when usage reaches the threshold. Quota data cached 5 min/account."
+                : "Disabled — all active accounts routed normally regardless of quota usage."}
             </p>
           </div>
         </Card>

--- a/src/i18n/runtime.js
+++ b/src/i18n/runtime.js
@@ -1,12 +1,89 @@
 "use client";
 
-import { DEFAULT_LOCALE, LOCALE_COOKIE, normalizeLocale } from "./config";
+import { DEFAULT_LOCALE, LOCALE_COOKIE, normalizeLocale, LOCALES } from "./config";
 
 let translationMap = {};
 let currentLocale = DEFAULT_LOCALE;
 let reloadCallbacks = [];
 
-// Read locale from cookie
+// Detect browser language and map to a supported locale.
+// Tries exact match first, then prefix (e.g. "en-GB" → "en"), falls back to "en".
+function detectBrowserLocale() {
+  if (typeof navigator === "undefined") return null;
+
+  // navigator.language is the primary preference (e.g. "zh-CN", "en-US")
+  const langs = [navigator.language];
+
+  // navigator.languages lists all preferences in order (Chrome/Firefox)
+  if (Array.isArray(navigator.languages) && navigator.languages.length) {
+    langs.push(...navigator.languages);
+  }
+
+  for (const lang of [...new Set(langs)]) {
+    const lower = lang.toLowerCase();
+
+    // Exact match (case-insensitive)
+    const matched = LOCALES.find(
+      (l) => l.toLowerCase() === lower
+    );
+    if (matched) return matched;
+
+    // zh-HK → zh-TW (Traditional Chinese)
+    if (lower === "zh-hk" || lower === "zh-mo") return "zh-TW";
+
+    // Prefix match: "en-GB" → "en", "fr-CA" → "fr"
+    // Skip when prefix alone is "zh" (handled above for HK/MO)
+    const prefix = lower.split("-")[0];
+    if (prefix === "zh") continue;
+    const prefixMatched = LOCALES.find(
+      (l) => l.toLowerCase().split("-")[0] === prefix
+    );
+    if (prefixMatched) return prefixMatched;
+  }
+
+  return null;
+}
+
+// Set locale cookie via the existing /api/locale POST endpoint.
+async function setLocaleCookie(locale) {
+  if (typeof fetch === "undefined") return;
+  try {
+    await fetch("/api/locale", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ locale }),
+      credentials: "same-origin",
+    });
+  } catch {
+    // Silently fail — translations still work in-memory for this session.
+  }
+}
+
+// Read locale from cookie. If no cookie exists, auto-detect from browser language.
+async function getLocaleAsync() {
+  if (typeof document === "undefined") return DEFAULT_LOCALE;
+
+  const cookie = document.cookie
+    .split(";")
+    .find((c) => c.trim().startsWith(`${LOCALE_COOKIE}=`));
+
+  if (cookie) {
+    const value = decodeURIComponent(cookie.split("=")[1]);
+    return normalizeLocale(value);
+  }
+
+  // No cookie — detect from browser
+  const detected = detectBrowserLocale();
+  if (detected) {
+    await setLocaleCookie(detected);
+    return detected;
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+// Sync version (for modules that can't await, e.g. translate() calls).
+// Still used as fallback; initRuntimeI18n is the true entry point.
 function getLocaleFromCookie() {
   if (typeof document === "undefined") return DEFAULT_LOCALE;
   const cookie = document.cookie
@@ -121,10 +198,19 @@ function processElement(element) {
 }
 
 // Initialize runtime i18n
+// On first load (no cookie) this auto-detects browser language and sets the locale cookie.
 export async function initRuntimeI18n() {
   if (typeof window === "undefined") return;
-  
-  currentLocale = getLocaleFromCookie();
+
+  // Auto-detect locale if no cookie exists (first visit)
+  const hasCookie = typeof document !== "undefined" &&
+    document.cookie.split(";").some((c) => c.trim().startsWith(`${LOCALE_COOKIE}=`));
+
+  if (hasCookie) {
+    currentLocale = getLocaleFromCookie();
+  } else {
+    currentLocale = await getLocaleAsync();
+  }
   await loadTranslations(currentLocale);
   
   // Process existing DOM

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -36,6 +36,8 @@ const DEFAULT_SETTINGS = {
   rtkEnabled: true,
   cavemanEnabled: false,
   cavemanLevel: "full",
+  quotaGuardEnabled: false,
+  quotaGuardThreshold: 95,
 };
 
 async function readRaw() {

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -276,6 +276,8 @@ export const USAGE_SUPPORTED_PROVIDERS = [
   "glm-cn",
   "minimax",
   "minimax-cn",
+  "alicode",
+  "alicode-intl",
 ];
 
 // Subset that uses apikey auth (still surfaced on quota page)
@@ -284,4 +286,6 @@ export const USAGE_APIKEY_PROVIDERS = [
   "glm-cn",
   "minimax",
   "minimax-cn",
+  "alicode",
+  "alicode-intl",
 ];

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -2,11 +2,90 @@ import { getProviderConnections, validateApiKey, updateProviderConnection, getSe
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
-import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
+import { resolveProviderId, FREE_PROVIDERS, USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers.js";
+import { getUsageForProvider } from "open-sse/services/usage.js";
 import * as log from "../utils/logger.js";
 
 // Mutex to prevent race conditions during account selection
 let selectionMutex = Promise.resolve();
+
+// ── Quota Guard (pre-request usage threshold check) ──────────
+// In-memory cache: connectionId → { used, total, timestamp }
+const quotaCache = new Map();
+const QUOTA_CACHE_TTL_MS = 5 * 60 * 1000; // 5 min
+
+function getQuotaThreshold(connection) {
+  // Per-connection override via providerSpecificData, then global connection-level data
+  return (connection.providerSpecificData?.quotaThreshold ??
+          connection.quotaThreshold ??
+          null);
+}
+
+async function getCachedQuotaPercent(connectionId, connection, proxyOptions) {
+  const cached = quotaCache.get(connectionId);
+  if (cached && Date.now() - cached.timestamp < QUOTA_CACHE_TTL_MS) {
+    return cached.percent;
+  }
+
+  // Fetch from provider API
+  try {
+    const usageResult = await getUsageForProvider(connection, proxyOptions);
+    if (usageResult.quotas && typeof usageResult.quotas === "object" && !Array.isArray(usageResult.quotas)) {
+      const percent = computeQuotaPercent(usageResult.quotas);
+      quotaCache.set(connectionId, { percent, timestamp: Date.now() });
+      return percent;
+    }
+  } catch (e) {
+    log.warn("QUOTA", `Failed to fetch quota for ${connection.provider} (${connectionId?.slice(0, 8)}): ${e.message}`);
+  }
+  return -1; // unknown
+}
+
+function computeQuotaPercent(quotas) {
+  if (!quotas || typeof quotas !== "object") return -1;
+  let minPercent = 100;
+  let found = false;
+
+  for (const entry of Object.values(quotas)) {
+    if (!entry || typeof entry !== "object") continue;
+    if (entry.unlimited) continue;
+
+    let pct = -1;
+    if (typeof entry.remainingPercentage === "number" && entry.remainingPercentage >= 0) {
+      pct = 100 - entry.remainingPercentage;
+    } else if (typeof entry.total === "number" && entry.total > 0 && typeof entry.used === "number") {
+      pct = (entry.used / entry.total) * 100;
+    }
+
+    if (pct >= 0) {
+      minPercent = Math.min(minPercent, pct);
+      found = true;
+    }
+  }
+
+  return found ? minPercent : -1;
+}
+
+async function isConnectionQuotaExceeded(connection, settings, proxyOptions) {
+  // Check global enable
+  if (!settings.quotaGuardEnabled) return false;
+
+  // Per-connection threshold > 0, otherwise use global
+  const thresh = getQuotaThreshold(connection) ?? settings.quotaGuardThreshold ?? 95;
+  if (thresh <= 0 || thresh >= 100) return false;
+
+  // Only supported providers
+  if (!USAGE_SUPPORTED_PROVIDERS.includes(connection.provider)) return false;
+
+  const pct = await getCachedQuotaPercent(connection.id, connection, proxyOptions);
+  if (pct < 0) return false;
+
+  if (pct >= thresh) {
+    log.info("QUOTA", `${connection.provider} | conn ${connection.id?.slice(0, 8)} at ${pct.toFixed(1)}% >= ${thresh}% — excluded`);
+    return true;
+  }
+  return false;
+}
 
 /**
  * Get provider credentials from localDb
@@ -60,14 +139,18 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       return null;
     }
 
-    // Filter out model-locked and excluded connections
-    const availableConnections = connections.filter(c => {
-      if (excludeSet.has(c.id)) return false;
-      if (isModelLockActive(c, model)) return false;
-      return true;
-    });
+    // Filter out model-locked, excluded, and quota-exceeded connections
+    const availableConnections = await Promise.all(connections.map(async (c) => {
+      if (excludeSet.has(c.id)) return null;
+      if (isModelLockActive(c, model)) return null;
+      // Quota threshold guard (only for supported providers, cached to avoid API overhead)
+      const settings = await getSettings();
+      if (await isConnectionQuotaExceeded(c, settings, null)) return null;
+      return c;
+    }));
+    const filtered = availableConnections.filter(Boolean);
 
-    log.debug("AUTH", `${provider} | available: ${availableConnections.length}/${connections.length}`);
+    log.debug("AUTH", `${provider} | available: ${filtered.length}/${connections.length}`);
     connections.forEach(c => {
       const excluded = excludeSet.has(c.id);
       const locked = isModelLockActive(c, model);
@@ -77,7 +160,7 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       }
     });
 
-    if (availableConnections.length === 0) {
+    if (filtered.length === 0) {
       // Find earliest lock expiry across all connections for retry timing
       const lockedConns = connections.filter(c => isModelLockActive(c, model));
       const expiries = lockedConns.map(c => getEarliestModelLockUntil(c)).filter(Boolean);
@@ -105,7 +188,7 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
     let connection;
     // Pin to preferred connection if specified and available
     if (preferredConnectionId) {
-      connection = availableConnections.find((c) => c.id === preferredConnectionId);
+      connection = filtered.find((c) => c.id === preferredConnectionId);
       if (connection) {
         log.info("AUTH", `${provider} | pinned to ${connection.id?.slice(0, 8)} (${connection.name || connection.email || "unnamed"})`);
       }
@@ -116,7 +199,7 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       const stickyLimit = providerOverride.stickyRoundRobinLimit || settings.stickyRoundRobinLimit || 3;
 
       // Sort by lastUsed (most recent first) to find current candidate
-      const byRecency = [...availableConnections].sort((a, b) => {
+      const byRecency = [...filtered].sort((a, b) => {
         if (!a.lastUsedAt && !b.lastUsedAt) return (a.priority || 999) - (b.priority || 999);
         if (!a.lastUsedAt) return 1;
         if (!b.lastUsedAt) return -1;
@@ -136,7 +219,7 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
         });
       } else {
         // Pick the least recently used (excluding current if possible)
-        const sortedByOldest = [...availableConnections].sort((a, b) => {
+        const sortedByOldest = [...filtered].sort((a, b) => {
           if (!a.lastUsedAt && !b.lastUsedAt) return (a.priority || 999) - (b.priority || 999);
           if (!a.lastUsedAt) return -1;
           if (!b.lastUsedAt) return 1;
@@ -153,7 +236,7 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       }
     } else {
       // Default: fill-first (already sorted by priority in getProviderConnections)
-      connection = availableConnections[0];
+      connection = filtered[0];
     }
 
     const resolvedProxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});


### PR DESCRIPTION
When no locale cookie exists, detect the user's browser language (navigator.language) and automatically set the matching locale.

- Exact match: zh-CN, ja-JP, pt-BR, etc.
- Prefix match: en-US → en, fr-CA → fr, de-DE → de
- zh-HK/zh-MO → zh-TW (Traditional Chinese)
- Falls back to English if no match found
- Auto-sets locale cookie so user doesn't need to switch manually
- Subsequent visits and manual overrides still use cookie as before