### PR TITLE
fix(translators): support AI SDK image parts

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.js
+++ b/open-sse/translator/helpers/geminiHelper.js
@@ -1,4 +1,5 @@
 // Gemini helper functions for translator
+import { parseImageDataUrl } from "./imageHelper.js";
 
 // Unsupported JSON Schema constraints that should be removed for Antigravity
 export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
@@ -42,15 +43,17 @@ export function convertOpenAIContentToParts(content) {
       if (item.type === "text") {
         parts.push({ text: item.text });
       } else if (item.type === "image_url" && item.image_url?.url?.startsWith("data:")) {
-        const url = item.image_url.url;
-        const commaIndex = url.indexOf(",");
-        if (commaIndex !== -1) {
-          const mimePart = url.substring(5, commaIndex); // skip "data:"
-          const data = url.substring(commaIndex + 1);
-          const mimeType = mimePart.split(";")[0];
-
+        const image = parseImageDataUrl(item.image_url.url);
+        if (image) {
           parts.push({
-            inlineData: { mime_type: mimeType, data: data }
+            inlineData: { mime_type: image.mediaType, data: image.data }
+          });
+        }
+      } else if (item.type === "image" && item.image) {
+        const image = parseImageDataUrl(item.image);
+        if (image) {
+          parts.push({
+            inlineData: { mime_type: image.mediaType, data: image.data }
           });
         }
       } else if (item.type === "image_url" && item.image_url?.url && (item.image_url.url.startsWith("http://") || item.image_url.url.startsWith("https://"))) {
@@ -369,4 +372,3 @@ export function cleanJSONSchemaForAntigravity(schema) {
 
   return cleaned;
 }
-

--- a/open-sse/translator/helpers/imageHelper.js
+++ b/open-sse/translator/helpers/imageHelper.js
@@ -1,3 +1,16 @@
+export function parseImageDataUrl(value) {
+  if (typeof value !== "string") return null;
+  const match = value.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) return null;
+  const mediaType = match[1];
+  const data = match[2];
+  return {
+    mediaType,
+    data,
+    format: mediaType.split("/")[1] || mediaType
+  };
+}
+
 /**
  * Fetch a remote image URL and return it as a base64 data URI.
  * Used when upstream providers (Codex, etc.) require inline base64 images

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -7,6 +7,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { normalizeResponsesInput } from "../helpers/responsesApiHelper.js";
+import { parseImageDataUrl } from "../helpers/imageHelper.js";
 
 // Responses API enforces max 64 chars on call_id (#393)
 const MAX_CALL_ID_LEN = 64;
@@ -237,6 +238,9 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
             if (c.type === "image_url") {
               const url = typeof c.image_url === "string" ? c.image_url : c.image_url?.url;
               return { type: "input_image", image_url: url, detail: c.image_url?.detail || "auto" };
+            }
+            if (c.type === "image" && parseImageDataUrl(c.image)) {
+              return { type: "input_image", image_url: c.image, detail: c.detail || "auto" };
             }
             if (c.type === "input_image") return c;
             // Serialize any unknown type (tool_use, tool_result, thinking, etc.) as text

--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -1,5 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
+import { parseImageDataUrl } from "../helpers/imageHelper.js";
 import { CLAUDE_SYSTEM_PROMPT } from "../../config/appConstants.js";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.js";
 
@@ -234,16 +235,24 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map()) {
           });
         } else if (part.type === "image_url") {
           const url = part.image_url.url;
-          const match = url.match(/^data:([^;]+);base64,(.+)$/);
-          if (match) {
+          const image = parseImageDataUrl(url);
+          if (image) {
             blocks.push({
               type: "image",
-              source: { type: "base64", media_type: match[1], data: match[2] }
+              source: { type: "base64", media_type: image.mediaType, data: image.data }
             });
           } else if (url.startsWith("http://") || url.startsWith("https://")) {
             blocks.push({
               type: "image",
               source: { type: "url", url }
+            });
+          }
+        } else if (part.type === "image" && part.image) {
+          const image = parseImageDataUrl(part.image);
+          if (image) {
+            blocks.push({
+              type: "image",
+              source: { type: "base64", media_type: image.mediaType, data: image.data }
             });
           }
         } else if (part.type === "image" && part.source) {
@@ -378,4 +387,3 @@ export { openaiToClaudeRequestForAntigravity };
 
 // Register
 register(FORMATS.OPENAI, FORMATS.CLAUDE, openaiToClaudeRequest, null);
-

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -11,6 +11,7 @@ import {
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT
 } from "../../config/kiroConstants.js";
+import { parseImageDataUrl } from "../helpers/imageHelper.js";
 
 /**
  * Convert OpenAI messages to Kiro format
@@ -28,6 +29,13 @@ function convertMessages(messages, tools, model) {
 
   // Image support is pre-filtered by caps in translateRequest before reaching here
   const supportsImages = true;
+
+  const pushDataUrlImage = (dataUrl) => {
+    const image = parseImageDataUrl(dataUrl);
+    if (!image) return false;
+    pendingImages.push({ format: image.format, source: { bytes: image.data } });
+    return true;
+  };
 
   const flushPending = () => {
     if (currentRole === "user") {
@@ -124,16 +132,16 @@ function convertMessages(messages, tools, model) {
           } else if (supportsImages && c.type === "image_url") {
             // OpenAI format: image_url.url with data URI
             const url = c.image_url?.url || "";
-            const base64Match = url.match(/^data:([^;]+);base64,(.+)$/);
-            if (base64Match) {
-              const mediaType = base64Match[1];
-              const format = mediaType.split("/")[1] || mediaType;
-              pendingImages.push({ format, source: { bytes: base64Match[2] } });
-            } else if (url.startsWith("http://") || url.startsWith("https://")) {
+            if (!pushDataUrlImage(url) && (url.startsWith("http://") || url.startsWith("https://"))) {
               // Kiro only supports base64 — fallback to URL text
               textParts.push(`[Image: ${url}]`);
             }
           } else if (supportsImages && c.type === "image") {
+            // AI SDK format: image is a data URI string.
+            if (pushDataUrlImage(c.image)) {
+              continue;
+            }
+
             // Claude format: source.type = "base64", source.media_type, source.data
             if (c.source?.type === "base64" && c.source?.data) {
               const mediaType = c.source.media_type || "image/png";

--- a/open-sse/translator/request/openai-to-ollama.js
+++ b/open-sse/translator/request/openai-to-ollama.js
@@ -1,5 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
+import { parseImageDataUrl } from "../helpers/imageHelper.js";
 
 /**
  * Convert OpenAI request to Ollama format
@@ -164,8 +165,9 @@ function normalizeContent(content) {
 
 /**
  * Extract base64 images from OpenAI multimodal content blocks.
- * OpenAI image block format:
+ * Supported image block formats:
  *   { type: "image_url", image_url: { url: "data:image/png;base64,..." } }
+ *   { type: "image", image: "data:image/png;base64,..." }
  * Ollama expects raw base64 strings in message.images[].
  */
 function extractImagesFromContent(content) {
@@ -174,15 +176,16 @@ function extractImagesFromContent(content) {
   const images = [];
 
   for (const block of content) {
-    if (!block || block.type !== "image_url") continue;
+    if (!block) continue;
 
-    const url = typeof block.image_url === "string" ? block.image_url : block.image_url?.url;
-    if (typeof url !== "string" || !url) continue;
+    const url = block.type === "image_url"
+      ? (typeof block.image_url === "string" ? block.image_url : block.image_url?.url)
+      : (block.type === "image" ? block.image : null);
 
-    const m = url.match(/^data:[^;]+;base64,([\s\S]+)$/);
-    if (!m) continue;
+    const image = parseImageDataUrl(url);
+    if (!image) continue;
 
-    images.push(m[1]);
+    images.push(image.data);
   }
 
   return images;

--- a/tests/unit/openai-responses.test.js
+++ b/tests/unit/openai-responses.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { openaiToOpenAIResponsesRequest } from "../../open-sse/translator/request/openai-responses.js";
+
+describe("openaiToOpenAIResponsesRequest image forwarding", () => {
+  it("should convert AI SDK image content part to input_image", () => {
+    const imageUrl = "data:image/png;base64,iVBORw0KGgo=";
+    const result = openaiToOpenAIResponsesRequest("gpt-5.2", {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image" },
+          { type: "image", image: imageUrl, detail: "high" }
+        ]
+      }]
+    }, true, {});
+
+    expect(result.input[0].content).toEqual([
+      { type: "input_text", text: "Describe this image" },
+      { type: "input_image", image_url: imageUrl, detail: "high" }
+    ]);
+  });
+});

--- a/tests/unit/openai-to-claude.test.js
+++ b/tests/unit/openai-to-claude.test.js
@@ -10,6 +10,27 @@ import { describe, it, expect } from "vitest";
 import { openaiToClaudeRequest } from "../../open-sse/translator/request/openai-to-claude.js";
 
 describe("openaiToClaudeRequest", () => {
+  describe("image forwarding", () => {
+    it("should convert AI SDK image content part to Claude image block", () => {
+      const fakeBase64 = "iVBORw0KGgo=";
+      const result = openaiToClaudeRequest("claude-sonnet-4.5", {
+        messages: [{
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this image" },
+            { type: "image", image: `data:image/png;base64,${fakeBase64}` }
+          ]
+        }]
+      }, false);
+
+      expect(result.messages[0].content[0]).toEqual({ type: "text", text: "Describe this image" });
+      expect(result.messages[0].content[1]).toEqual({
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: fakeBase64 }
+      });
+    });
+  });
+
   describe("response_format handling", () => {
     it("should inject JSON schema instructions for json_schema type", () => {
       const body = {

--- a/tests/unit/openai-to-commandcode.test.js
+++ b/tests/unit/openai-to-commandcode.test.js
@@ -85,6 +85,23 @@ describe("openaiToCommandCode — content shape", () => {
     expect(Array.isArray(a.content)).toBe(true);
     expect(a.content[0]).toEqual({ type: "text", text: "b" });
   });
+
+  it("intentionally omits AI SDK image parts as text placeholders", () => {
+    const out = openaiToCommandCode(MODEL, {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "Describe" },
+          { type: "image", image: "data:image/png;base64,iVBORw0KGgo=" }
+        ]
+      }],
+    }, true);
+
+    expect(out.params.messages[0].content).toEqual([
+      { type: "text", text: "Describe" },
+      { type: "text", text: "[image omitted]" }
+    ]);
+  });
 });
 
 describe("openaiToCommandCode — tool role / tool-result (AI SDK)", () => {

--- a/tests/unit/openai-to-gemini.test.js
+++ b/tests/unit/openai-to-gemini.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { convertOpenAIContentToParts } from "../../open-sse/translator/helpers/geminiHelper.js";
+import { openaiToGeminiRequest } from "../../open-sse/translator/request/openai-to-gemini.js";
+
+describe("openaiToGeminiRequest image forwarding", () => {
+  it("should convert AI SDK image content part to Gemini inlineData", () => {
+    const fakeBase64 = "iVBORw0KGgo=";
+    const result = openaiToGeminiRequest("gemini-2.5-pro", {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image" },
+          { type: "image", image: `data:image/png;base64,${fakeBase64}` }
+        ]
+      }]
+    }, true);
+
+    expect(result.contents[0].parts).toEqual([
+      { text: "Describe this image" },
+      { inlineData: { mime_type: "image/png", data: fakeBase64 } }
+    ]);
+  });
+});
+
+describe("convertOpenAIContentToParts", () => {
+  it("should preserve existing image_url data URL handling", () => {
+    const fakeBase64 = "abc123";
+    const parts = convertOpenAIContentToParts([
+      { type: "image_url", image_url: { url: `data:image/jpeg;base64,${fakeBase64}` } }
+    ]);
+
+    expect(parts).toEqual([
+      { inlineData: { mime_type: "image/jpeg", data: fakeBase64 } }
+    ]);
+  });
+});

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -83,6 +83,28 @@ describe("buildKiroPayload", () => {
       expect(currentMsg.userInputMessage.images[1].format).toBe("png");
     });
 
+    it("should forward base64 image from AI SDK image content part", () => {
+      const fakeBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const body = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Describe this image" },
+              { type: "image", image: `data:image/png;base64,${fakeBase64}` }
+            ]
+          }
+        ]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+
+      const currentMsg = result.conversationState.currentMessage;
+      expect(currentMsg.userInputMessage.images).toHaveLength(1);
+      expect(currentMsg.userInputMessage.images[0].format).toBe("png");
+      expect(currentMsg.userInputMessage.images[0].source.bytes).toBe(fakeBase64);
+    });
+
     it("should not include images field when images array is empty", () => {
       const body = {
         messages: [

--- a/tests/unit/openai-to-ollama.test.js
+++ b/tests/unit/openai-to-ollama.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { openaiToOllamaRequest } from "../../open-sse/translator/request/openai-to-ollama.js";
+
+describe("openaiToOllamaRequest image forwarding", () => {
+  it("should extract raw base64 from AI SDK image content part", () => {
+    const fakeBase64 = "iVBORw0KGgo=";
+    const result = openaiToOllamaRequest("llava", {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image" },
+          { type: "image", image: `data:image/png;base64,${fakeBase64}` }
+        ]
+      }]
+    }, true);
+
+    expect(result.messages[0]).toEqual({
+      role: "user",
+      content: "Describe this image",
+      images: [fakeBase64]
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a shared `parseImageDataUrl()` helper for base64 `data:` image URLs.
- Support AI SDK-style image content parts shaped as `{ type: \"image\", image: \"data:image/...;base64,...\" }` across multimodal OpenAI-input translators.
- Preserve each provider's existing image output shape: Kiro `images[]`, Gemini/Antigravity `inlineData`, Claude `image.source`, Responses `input_image`, and Ollama raw `images[]` base64.
- Keep CommandCode behavior unchanged and add coverage documenting its intentional `[image omitted]` fallback.

Closes #1330.

## Context

#1026 fixed Kiro image forwarding for OpenAI `image_url` data URLs. Some OpenAI-compatible clients instead send AI SDK-style image parts, so the image bytes can still be present in the request while being ignored by translators that only understand `image_url`.

This PR treats that as a generic translator compatibility gap rather than a client-specific issue.

## Testing

- `node --input-type=module -e \"await import('./open-sse/translator/helpers/imageHelper.js'); await import('./open-sse/translator/helpers/geminiHelper.js'); await import('./open-sse/translator/request/openai-to-kiro.js'); await import('./open-sse/translator/request/openai-to-claude.js'); await import('./open-sse/translator/request/openai-responses.js'); await import('./open-sse/translator/request/openai-to-ollama.js'); console.log('imports ok')\"`
- `./tests/node_modules/.bin/vitest run tests/unit/openai-to-kiro.test.js tests/unit/openai-to-claude.test.js tests/unit/openai-to-gemini.test.js tests/unit/openai-responses.test.js tests/unit/openai-to-ollama.test.js tests/unit/openai-to-commandcode.test.js --reporter=verbose`