### PR TITLE
feat(cursor): parse Composer DeepSeek tool calls + forward custom tools via MCP enum 19

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -11,6 +11,11 @@ import { estimateUsage } from "../utils/usageTracking.js";
 import { FORMATS } from "../translator/formats.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import zlib from "zlib";
+import {
+  parseComposerToolCalls,
+  createStreamingState,
+  feedStreamingChunk
+} from "../utils/composerToolCalls.js";
 
 // Detect cloud environment
 const isCloudEnv = () => {
@@ -393,7 +398,7 @@ export class CursorExecutor extends BaseExecutor {
     const visibleComposerContent = isComposerModel(model)
       ? visibleComposerContentFromThinking(totalThinking)
       : "";
-    const finalContent = totalContent || visibleComposerContent;
+    let finalContent = totalContent || visibleComposerContent;
 
     debugLog(
       `[CURSOR BUFFER] Parsed ${frameCount} frames, toolCallsMap size: ${toolCallsMap.size}, finalized toolCalls: ${toolCalls.length}`
@@ -416,6 +421,23 @@ export class CursorExecutor extends BaseExecutor {
     }
 
     debugLog(`[CURSOR BUFFER] Final toolCalls count: ${toolCalls.length}`);
+
+    // Cursor Composer models embed tool calls inline as DeepSeek-style
+    // markers in their visible text (e.g. `<｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜>`)
+    // rather than via the structured protobuf tool_call frames. Parse and
+    // convert them to OpenAI tool_calls so downstream clients (Hermes,
+    // OpenAI SDK consumers, etc.) can handle them natively. We only do
+    // this when the protobuf path produced no tool calls of its own, to
+    // avoid double-emitting.
+    if (isComposerModel(model) && toolCalls.length === 0 && finalContent) {
+      const parsed = parseComposerToolCalls(finalContent);
+      if (parsed.toolCalls.length > 0) {
+        for (const tc of parsed.toolCalls) {
+          toolCalls.push(tc);
+        }
+        finalContent = parsed.content;
+      }
+    }
 
 
     const message = {
@@ -461,6 +483,13 @@ export class CursorExecutor extends BaseExecutor {
     const toolCallsMap = new Map(); // Track streaming tool calls by ID
     const finalizedIds = new Set();
     const emittedToolCallIds = new Set();
+    // Composer DeepSeek-format tool-call extraction (see composerToolCalls.js).
+    // We buffer the visible composer content stream, suppress text that
+    // belongs inside `<｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜>`, and emit
+    // structured tool_calls SSE chunks once the block closes.
+    const composerStreamingState = isComposerModel(model) ? createStreamingState() : null;
+    let composerAccumulated = "";
+    let composerToolCallsEmitted = false;
     let frameCount = 0;
 
     debugLog(`[CURSOR BUFFER SSE] Total length: ${buffer.length} bytes`);
@@ -662,9 +691,116 @@ export class CursorExecutor extends BaseExecutor {
         totalThinking += result.thinking;
         const visibleContent = visibleComposerContentFromThinking(totalThinking);
         if (visibleContent.length > emittedComposerThinkingContentLength) {
-          const deltaContent = visibleContent.slice(emittedComposerThinkingContentLength);
-          emittedComposerThinkingContentLength = visibleContent.length;
-          totalContent += deltaContent;
+          // Feed the full visible content into the DeepSeek tool-call
+          // streaming parser. It returns only the prefix that is safe to
+          // emit (i.e. before any `<｜tool▁calls▁begin｜>` marker or its
+          // partial prefix), and tells us when the tool-call block has
+          // closed so we can emit structured tool_calls SSE chunks.
+          const parseOut = composerStreamingState
+            ? feedStreamingChunk(composerStreamingState, visibleContent)
+            : { safeDelta: visibleContent.slice(emittedComposerThinkingContentLength), ready: false, toolCalls: [] };
+          composerAccumulated = visibleContent;
+          emittedComposerThinkingContentLength = composerStreamingState
+            ? composerStreamingState.emitted
+            : visibleContent.length;
+          const deltaContent = parseOut.safeDelta;
+          if (deltaContent) {
+            totalContent += deltaContent;
+            chunks.push(
+              `data: ${JSON.stringify({
+                id: responseId,
+                object: "chat.completion.chunk",
+                created,
+                model,
+                choices: [
+                  {
+                    index: 0,
+                    delta:
+                      chunks.length === 0 && toolCalls.length === 0
+                        ? { role: "assistant", content: deltaContent }
+                        : { content: deltaContent },
+                    finish_reason: null
+                  }
+                ]
+              })}\n\n`
+            );
+          }
+          if (parseOut.ready && parseOut.toolCalls.length > 0 && !composerToolCallsEmitted) {
+            composerToolCallsEmitted = true;
+            for (let i = 0; i < parseOut.toolCalls.length; i++) {
+              const tc = parseOut.toolCalls[i];
+              const toolCallIndex = toolCalls.length;
+              toolCalls.push({
+                id: tc.id,
+                type: tc.type,
+                index: toolCallIndex,
+                function: {
+                  name: tc.function.name,
+                  arguments: tc.function.arguments
+                }
+              });
+              emittedToolCallIds.add(tc.id);
+              chunks.push(
+                `data: ${JSON.stringify({
+                  id: responseId,
+                  object: "chat.completion.chunk",
+                  created,
+                  model,
+                  choices: [
+                    {
+                      index: 0,
+                      delta: {
+                        tool_calls: [
+                          {
+                            index: toolCallIndex,
+                            id: tc.id,
+                            type: "function",
+                            function: {
+                              name: tc.function.name,
+                              arguments: tc.function.arguments
+                            }
+                          }
+                        ]
+                      },
+                      finish_reason: null
+                    }
+                  ]
+                })}\n\n`
+              );
+            }
+          }
+        }
+      }
+    }
+
+    debugLog(
+      `[CURSOR BUFFER SSE] Parsed ${frameCount} frames, toolCallsMap size: ${toolCallsMap.size}, toolCalls array: ${toolCalls.length}`
+    );
+
+    // End-of-stream Composer DeepSeek fallback: if the stream ended with
+    // the tool-call block opened but never closed (or arrived in one big
+    // chunk we didn't catch mid-stream), try a final non-streaming parse
+    // on the accumulated visible content so we still emit structured
+    // tool_calls and don't leak the markers as plain text.
+    if (
+      isComposerModel(model) &&
+      !composerToolCallsEmitted &&
+      composerAccumulated
+    ) {
+      const parsed = parseComposerToolCalls(composerAccumulated);
+      if (parsed.toolCalls.length > 0) {
+        for (const tc of parsed.toolCalls) {
+          const toolCallIndex = toolCalls.length;
+          toolCalls.push({
+            id: tc.id,
+            type: tc.type,
+            index: toolCallIndex,
+            function: {
+              name: tc.function.name,
+              arguments: tc.function.arguments
+            }
+          });
+          emittedToolCallIds.add(tc.id);
           chunks.push(
             `data: ${JSON.stringify({
               id: responseId,
@@ -674,22 +810,28 @@ export class CursorExecutor extends BaseExecutor {
               choices: [
                 {
                   index: 0,
-                  delta:
-                    chunks.length === 0 && toolCalls.length === 0
-                      ? { role: "assistant", content: deltaContent }
-                      : { content: deltaContent },
+                  delta: {
+                    tool_calls: [
+                      {
+                        index: toolCallIndex,
+                        id: tc.id,
+                        type: "function",
+                        function: {
+                          name: tc.function.name,
+                          arguments: tc.function.arguments
+                        }
+                      }
+                    ]
+                  },
                   finish_reason: null
                 }
               ]
             })}\n\n`
           );
         }
+        composerToolCallsEmitted = true;
       }
     }
-
-    debugLog(
-      `[CURSOR BUFFER SSE] Parsed ${frameCount} frames, toolCallsMap size: ${toolCallsMap.size}, toolCalls array: ${toolCalls.length}`
-    );
 
     // Finalize all remaining tool calls in map (stream may have ended without isLast=true)
     for (const [id, tc] of toolCallsMap.entries()) {

--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -253,14 +253,14 @@ export class CursorExecutor extends BaseExecutor {
           status: response.status,
           headers: { "Content-Type": "application/json" }
         });
-        return { response: errorResponse, url, headers, transformedBody: body };
+        return { response: errorResponse, url, headers, transformedBody };
       }
 
       const transformedResponse = stream !== false
         ? this.transformProtobufToSSE(response.body, model, body)
         : this.transformProtobufToJSON(response.body, model, body);
 
-      return { response: transformedResponse, url, headers, transformedBody: body };
+      return { response: transformedResponse, url, headers, transformedBody };
     } catch (error) {
       const errorResponse = new Response(JSON.stringify({
         error: {
@@ -272,7 +272,7 @@ export class CursorExecutor extends BaseExecutor {
         status: HTTP_STATUS.SERVER_ERROR,
         headers: { "Content-Type": "application/json" }
       });
-      return { response: errorResponse, url, headers, transformedBody: body };
+      return { response: errorResponse, url, headers, transformedBody };
     }
   }
 

--- a/open-sse/utils/composerToolCalls.js
+++ b/open-sse/utils/composerToolCalls.js
@@ -1,0 +1,283 @@
+/**
+ * Parser for Cursor Composer's DeepSeek-style inline tool call format.
+ *
+ * Composer (Cursor's `cu/composer-2.5*` models) emits tool calls inside its
+ * normal text output using sentinel markers, e.g.:
+ *
+ *     Optional preamble text...
+ *     <｜tool▁calls▁begin｜>
+ *     <｜tool▁call▁begin｜>
+ *     tool_name
+ *     <｜tool▁sep｜>arg_name
+ *     arg_value
+ *     <｜tool▁sep｜>arg_name_2
+ *     arg_value_2
+ *     <｜tool▁call▁end｜>
+ *     <｜tool▁call▁begin｜>
+ *     other_tool
+ *     <｜tool▁sep｜>arg
+ *     value
+ *     <｜tool▁call▁end｜>
+ *     <｜tool▁calls▁end｜>
+ *     Optional trailing text...
+ *
+ * Markers use full-width pipes (`｜`, U+FF5C) and small-triangle separator
+ * (`▁`, U+2581). We also accept ASCII fallbacks (`<|tool_calls_begin|>` etc.)
+ * defensively in case Cursor ever changes encoding.
+ *
+ * The parser converts this into the OpenAI Chat Completions `tool_calls`
+ * shape and returns the residual content (preamble + trailing text) so the
+ * caller can decide whether to surface it as the assistant's visible
+ * message.
+ */
+
+const FW = "[｜|]"; // full-width or ASCII pipe
+const SEP = "[▁_]"; // full-width separator or ASCII underscore
+
+// Match the outer tool-calls block, lazily.
+const OUTER_RE = new RegExp(
+  `<${FW}tool${SEP}calls${SEP}begin${FW}>([\\s\\S]*?)<${FW}tool${SEP}calls${SEP}end${FW}>`,
+  "i"
+);
+
+// Match a single tool-call block.
+const INNER_RE = new RegExp(
+  `<${FW}tool${SEP}call${SEP}begin${FW}>([\\s\\S]*?)<${FW}tool${SEP}call${SEP}end${FW}>`,
+  "gi"
+);
+
+// Match an arg separator.
+const ARG_SEP_RE = new RegExp(`<${FW}tool${SEP}sep${FW}>`, "gi");
+
+// Heuristic: any partial opening marker (start of `<｜tool` ... without the
+// final `>`). Used by the streaming parser to know it must hold back text.
+const PARTIAL_OPEN_MARKER_RE = new RegExp(
+  `<${FW}?(?:t(?:o(?:o(?:l(?:${SEP}(?:c(?:a(?:l(?:l(?:s)?(?:${SEP}(?:b(?:e(?:g(?:i(?:n${FW}?>?)?)?)?)?)?)?)?)?)?)?)?)?)?)?)?$`,
+  "i"
+);
+
+// Detection helpers
+export function hasComposerToolCalls(text) {
+  if (!text || typeof text !== "string") return false;
+  return OUTER_RE.test(text);
+}
+
+function generateToolCallId(index) {
+  // Format: call_<random>; mirrors what OpenAI clients expect.
+  const rand = Math.random().toString(36).slice(2, 12);
+  return `call_${rand}${index}`;
+}
+
+/**
+ * Parse a single inner tool-call block body (the text between
+ * `<｜tool▁call▁begin｜>` and `<｜tool▁call▁end｜>`).
+ *
+ * Body shape:
+ *   tool_name
+ *   <｜tool▁sep｜>arg_name
+ *   arg_value
+ *   <｜tool▁sep｜>arg_name_2
+ *   arg_value_2
+ *
+ * Returns {name, arguments} where arguments is a JSON string suitable for
+ * the OpenAI tool_calls schema. Arg values are taken verbatim from the
+ * text between one separator's argname-line and the next separator (or
+ * end of body). We attempt to detect when a value is already valid JSON
+ * (object/array/number/bool/null) and store it natively; otherwise we keep
+ * it as a string.
+ */
+function parseInnerCall(body) {
+  // Body starts with the tool name on (typically) its own line, optionally
+  // surrounded by whitespace, then the first `<｜tool▁sep｜>`.
+  const trimmed = body.replace(/^\s+|\s+$/g, "");
+  // Split by argument separator first to isolate name + arg blocks.
+  const segments = trimmed.split(ARG_SEP_RE);
+  // First segment is the tool name (and any preamble whitespace).
+  const name = (segments.shift() || "").trim();
+  if (!name) {
+    return null;
+  }
+  const args = {};
+  for (const seg of segments) {
+    if (!seg) continue;
+    // Each segment is `arg_name\nvalue\n...`. The arg name is the first
+    // line; everything after the first newline is the value (verbatim,
+    // including additional newlines).
+    const idxNl = seg.indexOf("\n");
+    let argName;
+    let argValue;
+    if (idxNl < 0) {
+      argName = seg.trim();
+      argValue = "";
+    } else {
+      argName = seg.slice(0, idxNl).trim();
+      argValue = seg.slice(idxNl + 1);
+    }
+    if (!argName) continue;
+    // Strip the trailing newline before the next separator (the separator
+    // marker itself was already consumed by the split).
+    argValue = argValue.replace(/\n+$/, "");
+    // Attempt JSON parse so structured args (objects/arrays/numbers/bools)
+    // come through as native JSON values rather than quoted strings.
+    args[argName] = coerceArgValue(argValue);
+  }
+  return { name, arguments: JSON.stringify(args) };
+}
+
+function coerceArgValue(raw) {
+  if (raw === "") return "";
+  const stripped = raw.trim();
+  if (
+    (stripped.startsWith("{") && stripped.endsWith("}")) ||
+    (stripped.startsWith("[") && stripped.endsWith("]"))
+  ) {
+    try {
+      return JSON.parse(stripped);
+    } catch {}
+  }
+  if (stripped === "true") return true;
+  if (stripped === "false") return false;
+  if (stripped === "null") return null;
+  if (/^-?\d+$/.test(stripped)) {
+    const n = Number(stripped);
+    if (Number.isSafeInteger(n)) return n;
+  }
+  if (/^-?\d*\.\d+$/.test(stripped)) {
+    const n = Number(stripped);
+    if (Number.isFinite(n)) return n;
+  }
+  return raw;
+}
+
+/**
+ * Parse a complete (non-streaming) Composer content string.
+ *
+ * Returns { content, toolCalls } where:
+ *   - content: the residual visible text (preamble + trailing text combined
+ *     and trimmed; empty string if nothing left).
+ *   - toolCalls: array of OpenAI-shaped tool_calls; empty if none found.
+ *
+ * If the input has no tool-call block, returns { content: input, toolCalls: [] }.
+ */
+export function parseComposerToolCalls(text) {
+  if (!text || typeof text !== "string") {
+    return { content: text || "", toolCalls: [] };
+  }
+
+  const match = text.match(OUTER_RE);
+  if (!match) {
+    return { content: text, toolCalls: [] };
+  }
+
+  const preamble = text.slice(0, match.index);
+  const trailing = text.slice(match.index + match[0].length);
+  const block = match[1];
+
+  const toolCalls = [];
+  let idx = 0;
+  for (const innerMatch of block.matchAll(INNER_RE)) {
+    const parsed = parseInnerCall(innerMatch[1]);
+    if (!parsed) continue;
+    toolCalls.push({
+      id: generateToolCallId(idx),
+      type: "function",
+      function: parsed,
+    });
+    idx += 1;
+  }
+
+  const residual = (preamble + trailing).trim();
+  return { content: residual, toolCalls };
+}
+
+/**
+ * Streaming helper: feed it the *accumulated* content seen so far and it
+ * returns what is safe to emit as visible text, plus whether tool calls
+ * are now ready to be flushed.
+ *
+ *   { safeContent, ready, toolCalls, holdback }
+ *
+ *   safeContent: text that can be emitted to the client right now as a
+ *     content delta (relative to the previous call you should track the
+ *     prefix you've already emitted).
+ *   ready: true once a complete `<｜tool▁calls▁end｜>` has been seen and
+ *     toolCalls are parsed.
+ *   toolCalls: parsed tool calls (only populated when ready=true).
+ *   holdback: whether more bytes are being held back (an outer-block has
+ *     opened but not yet closed, OR a partial opening marker is at the
+ *     tail of the buffer).
+ *
+ * Usage pattern:
+ *   const state = createStreamingState();
+ *   for each frame: const out = feedStreamingChunk(state, accumulated);
+ *     emit out.safeDelta as content delta;
+ *     if (out.ready) emit out.toolCalls and stop emitting content.
+ */
+export function createStreamingState() {
+  return {
+    emitted: 0, // number of safeContent chars already emitted
+    done: false,
+  };
+}
+
+export function feedStreamingChunk(state, accumulated) {
+  if (state.done) {
+    return { safeDelta: "", ready: false, toolCalls: [], holdback: false };
+  }
+  if (!accumulated) {
+    return { safeDelta: "", ready: false, toolCalls: [], holdback: false };
+  }
+
+  // 1. Complete block already in buffer? Parse it.
+  const m = accumulated.match(OUTER_RE);
+  if (m) {
+    const preamble = accumulated.slice(0, m.index);
+    const block = m[1];
+    const toolCalls = [];
+    let idx = 0;
+    for (const innerMatch of block.matchAll(INNER_RE)) {
+      const parsed = parseInnerCall(innerMatch[1]);
+      if (!parsed) continue;
+      toolCalls.push({
+        id: generateToolCallId(idx),
+        type: "function",
+        function: parsed,
+      });
+      idx += 1;
+    }
+    // Emit any preamble we haven't emitted yet.
+    const safe = preamble;
+    const safeDelta = safe.length > state.emitted ? safe.slice(state.emitted) : "";
+    state.emitted = safe.length;
+    state.done = true;
+    return { safeDelta, ready: true, toolCalls, holdback: false };
+  }
+
+  // 2. Look for an opening-only marker. If found, everything before it is
+  //    safe; everything after must be held until we see the closing marker.
+  const openOnlyRe = new RegExp(
+    `<${FW}tool${SEP}calls${SEP}begin${FW}>`,
+    "i"
+  );
+  const openMatch = accumulated.match(openOnlyRe);
+  if (openMatch) {
+    const safe = accumulated.slice(0, openMatch.index);
+    const safeDelta = safe.length > state.emitted ? safe.slice(state.emitted) : "";
+    state.emitted = safe.length;
+    return { safeDelta, ready: false, toolCalls: [], holdback: true };
+  }
+
+  // 3. Partial opening marker at the tail? Hold back the suspicious tail.
+  const tailMatch = accumulated.match(PARTIAL_OPEN_MARKER_RE);
+  if (tailMatch && tailMatch.index !== undefined) {
+    const safe = accumulated.slice(0, tailMatch.index);
+    const safeDelta = safe.length > state.emitted ? safe.slice(state.emitted) : "";
+    state.emitted = safe.length;
+    return { safeDelta, ready: false, toolCalls: [], holdback: true };
+  }
+
+  // 4. No markers anywhere. Emit everything new.
+  const safeDelta = accumulated.length > state.emitted ? accumulated.slice(state.emitted) : "";
+  state.emitted = accumulated.length;
+  return { safeDelta, ready: false, toolCalls: [], holdback: false };
+}

--- a/open-sse/utils/cursorProtobuf.js
+++ b/open-sse/utils/cursorProtobuf.js
@@ -371,8 +371,21 @@ export function encodeToolResult(toolResult) {
   );
 }
 
-export function encodeMessage(content, role, messageId, chatModeEnum = null, isLast = false, hasTools = false, toolResults = [], serverBubbleId = null) {
+function encodeSupportedTools(hasTools, forceAgentMode = false) {
+  if (hasTools) {
+    // Cursor's supported_tools is a packed enum list. Enum 1 is Cursor's
+    // built-in ask_question tool; custom OpenAI tools are exposed as MCP
+    // tools and must advertise enum 19. If we send 1 here, Composer models
+    // correctly report that only ask_question is available and ignore the
+    // MCP_TOOLS block below.
+    return encodeVarint(CLIENT_SIDE_TOOL_V2_MCP);
+  }
+  return forceAgentMode ? encodeVarint(1) : new Uint8Array(0);
+}
+
+export function encodeMessage(content, role, messageId, chatModeEnum = null, isLast = false, hasTools = false, toolResults = [], serverBubbleId = null, forceAgentMode = false) {
   const hasToolResults = toolResults.length > 0;
+  const supportedTools = encodeSupportedTools(hasTools, forceAgentMode);
   return concatArrays(
     encodeField(FIELD.MSG_CONTENT, WIRE_TYPE.LEN, content),
     encodeField(FIELD.MSG_ROLE, WIRE_TYPE.VARINT, role),
@@ -382,9 +395,9 @@ export function encodeMessage(content, role, messageId, chatModeEnum = null, isL
     ...(hasToolResults ? toolResults.map(tr =>
       encodeField(FIELD.MSG_TOOL_RESULTS, WIRE_TYPE.LEN, encodeToolResult(tr))
     ) : []),
-    encodeField(FIELD.MSG_IS_AGENTIC, WIRE_TYPE.VARINT, hasTools ? 1 : 0),
-    encodeField(FIELD.MSG_UNIFIED_MODE, WIRE_TYPE.VARINT, hasTools ? UNIFIED_MODE.AGENT : UNIFIED_MODE.CHAT),
-    ...(isLast && hasTools ? [encodeField(FIELD.MSG_SUPPORTED_TOOLS, WIRE_TYPE.LEN, encodeVarint(1))] : [])
+    encodeField(FIELD.MSG_IS_AGENTIC, WIRE_TYPE.VARINT, (hasTools || forceAgentMode) ? 1 : 0),
+    encodeField(FIELD.MSG_UNIFIED_MODE, WIRE_TYPE.VARINT, (hasTools || forceAgentMode) ? UNIFIED_MODE.AGENT : UNIFIED_MODE.CHAT),
+    ...(isLast && supportedTools.length > 0 ? [encodeField(FIELD.MSG_SUPPORTED_TOOLS, WIRE_TYPE.LEN, supportedTools)] : [])
   );
 }
 
@@ -443,6 +456,53 @@ export function encodeMcpTool(tool) {
     ...(Object.keys(inputSchema).length > 0 ? [encodeField(FIELD.MCP_TOOL_PARAMS, WIRE_TYPE.LEN, JSON.stringify(inputSchema))] : []),
     encodeField(FIELD.MCP_TOOL_SERVER, WIRE_TYPE.LEN, "custom")
   );
+}
+
+function isComposerModelName(modelName) {
+  const modelId = String(modelName || "").split("/").pop();
+  return /^composer(?:-|$)/i.test(modelId);
+}
+
+function getToolName(tool) {
+  return tool?.function?.name || tool?.name || "";
+}
+
+function getToolDescription(tool) {
+  return tool?.function?.description || tool?.description || "";
+}
+
+function getToolSchema(tool) {
+  return tool?.function?.parameters || tool?.input_schema || {};
+}
+
+function buildComposerToolInstruction(tools) {
+  if (!tools?.length) return "";
+
+  const toolLines = tools
+    .map((tool) => {
+      const name = getToolName(tool);
+      if (!name) return "";
+      const description = getToolDescription(tool);
+      const parameters = getToolSchema(tool);
+      return JSON.stringify({ name, description, parameters });
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  if (!toolLines) return "";
+
+  return [
+    "OpenAI custom tools are available for this request. Use only these tools; do not use or mention unavailable tools such as ask_question unless they are listed here.",
+    "Available tools, one JSON object per line:",
+    toolLines,
+    "When calling tools, output only Cursor Composer's DeepSeek tool-call sentinel format:",
+    "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>",
+    "TOOL_NAME",
+    "<｜tool▁sep｜>ARGUMENT_NAME",
+    "ARGUMENT_VALUE",
+    "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+    "For multiple arguments, repeat <｜tool▁sep｜>ARGUMENT_NAME followed by ARGUMENT_VALUE. Do not wrap the arguments in JSON unless the schema asks for a JSON string value."
+  ].join("\n");
 }
 
 // ==================== REQUEST BUILDING ====================
@@ -511,6 +571,17 @@ export function encodeRequest(messages, modelName, tools = [], reasoningEffort =
     normalizedMessages.push(msg);
   }
 
+  // Composer reads visible conversation better than FIELD.INSTRUCTION alone.
+  if (isComposerModelName(modelName) && hasTools) {
+    const visibleToolInstruction = buildComposerToolInstruction(tools);
+    if (visibleToolInstruction) {
+      normalizedMessages.unshift({
+        role: "user",
+        content: visibleToolInstruction
+      });
+    }
+  }
+
   // Prepare messages
   for (let i = 0; i < normalizedMessages.length; i++) {
     const msg = normalizedMessages[i];
@@ -535,18 +606,20 @@ export function encodeRequest(messages, modelName, tools = [], reasoningEffort =
   if (reasoningEffort === "medium") thinkingLevel = THINKING_LEVEL.MEDIUM;
   else if (reasoningEffort === "high") thinkingLevel = THINKING_LEVEL.HIGH;
 
+  const instructionText = "";
+
   // Build request
   return concatArrays(
     // Messages
     ...formattedMessages.map(fm => 
       encodeField(FIELD.MESSAGES, WIRE_TYPE.LEN, 
-        encodeMessage(fm.content, fm.role, fm.messageId, null, fm.isLast, fm.hasTools, fm.toolResults)
+        encodeMessage(fm.content, fm.role, fm.messageId, null, fm.isLast, fm.hasTools, fm.toolResults, null, forceAgentMode)
       )
     ),
     
     // Static fields
     encodeField(FIELD.UNKNOWN_2, WIRE_TYPE.VARINT, 1),
-    encodeField(FIELD.INSTRUCTION, WIRE_TYPE.LEN, encodeInstruction("")),
+    encodeField(FIELD.INSTRUCTION, WIRE_TYPE.LEN, encodeInstruction(instructionText)),
     encodeField(FIELD.UNKNOWN_4, WIRE_TYPE.VARINT, 1),
     encodeField(FIELD.MODEL, WIRE_TYPE.LEN, encodeModel(modelName)),
     encodeField(FIELD.WEB_TOOL, WIRE_TYPE.LEN, ""),
@@ -558,7 +631,7 @@ export function encodeRequest(messages, modelName, tools = [], reasoningEffort =
 
     // Tool-related fields
     encodeField(FIELD.IS_AGENTIC, WIRE_TYPE.VARINT, isAgentic ? 1 : 0),
-    ...(isAgentic ? [encodeField(FIELD.SUPPORTED_TOOLS, WIRE_TYPE.LEN, encodeVarint(1))] : []),
+    ...(isAgentic ? [encodeField(FIELD.SUPPORTED_TOOLS, WIRE_TYPE.LEN, encodeSupportedTools(hasTools, forceAgentMode))] : []),
     
     // Message IDs
     ...messageIds.map(mid => 

--- a/open-sse/utils/cursorProtobuf.js
+++ b/open-sse/utils/cursorProtobuf.js
@@ -475,7 +475,7 @@ function getToolSchema(tool) {
   return tool?.function?.parameters || tool?.input_schema || {};
 }
 
-function buildComposerToolInstruction(tools) {
+function buildComposerToolInstruction(tools, isComposer = false) {
   if (!tools?.length) return "";
 
   const toolLines = tools
@@ -491,17 +491,27 @@ function buildComposerToolInstruction(tools) {
 
   if (!toolLines) return "";
 
+  const header = "The following custom tools are available. Use them to complete the task. Do not use or mention unavailable tools such as ask_question unless they are listed here.";
+
+  if (isComposer) {
+    return [
+      header,
+      "Available tools, one JSON object per line:",
+      toolLines,
+      "When calling tools, output only Cursor Composer's DeepSeek tool-call sentinel format:",
+      "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>",
+      "TOOL_NAME",
+      "<｜tool▁sep｜>ARGUMENT_NAME",
+      "ARGUMENT_VALUE",
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+      "For multiple arguments, repeat <｜tool▁sep｜>ARGUMENT_NAME followed by ARGUMENT_VALUE. Do not wrap the arguments in JSON unless the schema asks for a JSON string value."
+    ].join("\n");
+  }
+
   return [
-    "OpenAI custom tools are available for this request. Use only these tools; do not use or mention unavailable tools such as ask_question unless they are listed here.",
+    header,
     "Available tools, one JSON object per line:",
     toolLines,
-    "When calling tools, output only Cursor Composer's DeepSeek tool-call sentinel format:",
-    "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>",
-    "TOOL_NAME",
-    "<｜tool▁sep｜>ARGUMENT_NAME",
-    "ARGUMENT_VALUE",
-    "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
-    "For multiple arguments, repeat <｜tool▁sep｜>ARGUMENT_NAME followed by ARGUMENT_VALUE. Do not wrap the arguments in JSON unless the schema asks for a JSON string value."
   ].join("\n");
 }
 
@@ -571,9 +581,12 @@ export function encodeRequest(messages, modelName, tools = [], reasoningEffort =
     normalizedMessages.push(msg);
   }
 
-  // Composer reads visible conversation better than FIELD.INSTRUCTION alone.
-  if (isComposerModelName(modelName) && hasTools) {
-    const visibleToolInstruction = buildComposerToolInstruction(tools);
+  // Visible tool instruction helps all Cursor-routed models (Composer and
+  // non-Composer alike) recognize available custom tools. Without it, models
+  // default to ask mode regardless of protobuf-level tool advertisement.
+  // Composer models additionally receive DeepSeek sentinel format guidance.
+  if (hasTools) {
+    const visibleToolInstruction = buildComposerToolInstruction(tools, isComposerModelName(modelName));
     if (visibleToolInstruction) {
       normalizedMessages.unshift({
         role: "user",

--- a/open-sse/utils/requestLogger.js
+++ b/open-sse/utils/requestLogger.js
@@ -69,25 +69,36 @@ function writeJsonFile(sessionPath, filename, data) {
   }
 }
 
-// Mask sensitive data in headers (DISABLED - keep full token for testing)
+// Mask sensitive data in headers
 function maskSensitiveHeaders(headers) {
   if (!headers) return {};
-  return { ...headers };
-  
-  // Old masking code (disabled):
-  // const masked = { ...headers };
-  // const sensitiveKeys = ["authorization", "x-api-key", "cookie", "token"];
-  // 
-  // for (const key of Object.keys(masked)) {
-  //   const lowerKey = key.toLowerCase();
-  //   if (sensitiveKeys.some(sk => lowerKey.includes(sk))) {
-  //     const value = masked[key];
-  //     if (value && value.length > 20) {
-  //       masked[key] = value.slice(0, 10) + "..." + value.slice(-5);
-  //     }
-  //   }
-  // }
-  // return masked;
+  const masked = { ...headers };
+  const sensitiveKeys = ["authorization", "x-api-key", "cookie", "token", "secret"];
+
+  for (const key of Object.keys(masked)) {
+    const lowerKey = key.toLowerCase();
+    if (sensitiveKeys.some(sk => lowerKey.includes(sk))) {
+      const value = String(masked[key] || "");
+      masked[key] = value ? "[REDACTED]" : value;
+    }
+  }
+  return masked;
+}
+
+function extractPrintableStrings(buffer) {
+  const text = Buffer.from(buffer).toString("utf8");
+  return (text.match(/[ -~]{4,}/g) || []).slice(0, 200);
+}
+
+function serializeBodyForLog(body) {
+  if (body instanceof Uint8Array || (typeof Buffer !== "undefined" && Buffer.isBuffer(body))) {
+    return {
+      type: body.constructor?.name || "Uint8Array",
+      byteLength: body.byteLength,
+      printableStrings: extractPrintableStrings(body)
+    };
+  }
+  return body;
 }
 
 // No-op logger when logging is disabled
@@ -159,7 +170,7 @@ export async function createRequestLogger(sourceFormat, targetFormat, model) {
         timestamp: new Date().toISOString(),
         url,
         headers: maskSensitiveHeaders(headers),
-        body
+        body: serializeBodyForLog(body)
       });
     },
     

--- a/tests/unit/composer-tool-calls.test.js
+++ b/tests/unit/composer-tool-calls.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseComposerToolCalls,
+  hasComposerToolCalls,
+  createStreamingState,
+  feedStreamingChunk,
+} from "../../open-sse/utils/composerToolCalls.js";
+
+describe("Composer DeepSeek tool-call parser", () => {
+  it("returns input unchanged when no tool-call block is present", () => {
+    const text = "Hello there, no tools here.";
+    const { content, toolCalls } = parseComposerToolCalls(text);
+    expect(content).toBe(text);
+    expect(toolCalls).toEqual([]);
+    expect(hasComposerToolCalls(text)).toBe(false);
+  });
+
+  it("parses a single tool call with full-width markers", () => {
+    const text =
+      "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nsearch_files\n" +
+      "<｜tool▁sep｜>pattern\n*cron*.py\n" +
+      "<｜tool▁sep｜>path\n/home/noestelar/.hermes\n" +
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+    const { content, toolCalls } = parseComposerToolCalls(text);
+    expect(content).toBe("");
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].type).toBe("function");
+    expect(toolCalls[0].function.name).toBe("search_files");
+    const args = JSON.parse(toolCalls[0].function.arguments);
+    expect(args).toEqual({ pattern: "*cron*.py", path: "/home/noestelar/.hermes" });
+  });
+
+  it("parses two sequential tool calls and preserves order", () => {
+    const text =
+      "<｜tool▁calls▁begin｜>" +
+      "<｜tool▁call▁begin｜>\nread_file\n<｜tool▁sep｜>path\n/etc/hostname\n<｜tool▁call▁end｜>" +
+      "<｜tool▁call▁begin｜>\nsearch_files\n<｜tool▁sep｜>pattern\ncron\n<｜tool▁sep｜>path\n/tmp\n<｜tool▁call▁end｜>" +
+      "<｜tool▁calls▁end｜>";
+    const { toolCalls } = parseComposerToolCalls(text);
+    expect(toolCalls.map(t => t.function.name)).toEqual(["read_file", "search_files"]);
+    expect(JSON.parse(toolCalls[1].function.arguments)).toEqual({ pattern: "cron", path: "/tmp" });
+  });
+
+  it("extracts preamble and trailing text as residual content", () => {
+    const text =
+      "Writing `hi` to file.\n\n" +
+      "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nwrite_file\n" +
+      "<｜tool▁sep｜>path\n/tmp/x.txt\n" +
+      "<｜tool▁sep｜>content\nhi\n" +
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>\nDone!";
+    const { content, toolCalls } = parseComposerToolCalls(text);
+    expect(content).toBe("Writing `hi` to file.\n\n\nDone!".trim());
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].function.name).toBe("write_file");
+  });
+
+  it("preserves multiline argument values verbatim", () => {
+    const text =
+      "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nwrite_file\n" +
+      "<｜tool▁sep｜>path\n/tmp/x.py\n" +
+      "<｜tool▁sep｜>content\nimport os\nprint('hi')\n\n# comment\n" +
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+    const { toolCalls } = parseComposerToolCalls(text);
+    const args = JSON.parse(toolCalls[0].function.arguments);
+    expect(args.path).toBe("/tmp/x.py");
+    expect(args.content).toBe("import os\nprint('hi')\n\n# comment");
+  });
+
+  it("coerces JSON-shaped arg values to native JSON", () => {
+    const text =
+      "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nrun_query\n" +
+      "<｜tool▁sep｜>filters\n{\"name\":\"Noé\",\"age\":30,\"tags\":[\"a\",\"b\"]}\n" +
+      "<｜tool▁sep｜>limit\n10\n" +
+      "<｜tool▁sep｜>active\ntrue\n" +
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+    const { toolCalls } = parseComposerToolCalls(text);
+    const args = JSON.parse(toolCalls[0].function.arguments);
+    expect(args.filters).toEqual({ name: "Noé", age: 30, tags: ["a", "b"] });
+    expect(args.limit).toBe(10);
+    expect(args.active).toBe(true);
+  });
+
+  it("accepts ASCII fallback markers", () => {
+    const text =
+      "<|tool_calls_begin|><|tool_call_begin|>\nfoo\n" +
+      "<|tool_sep|>a\n1\n<|tool_call_end|><|tool_calls_end|>";
+    const { toolCalls } = parseComposerToolCalls(text);
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].function.name).toBe("foo");
+    expect(JSON.parse(toolCalls[0].function.arguments)).toEqual({ a: 1 });
+  });
+});
+
+describe("Composer streaming tool-call parser", () => {
+  it("emits visible preamble before the tool-call block opens", () => {
+    const state = createStreamingState();
+    const out = feedStreamingChunk(state, "Writing now.\n\n");
+    expect(out.safeDelta).toBe("Writing now.\n\n");
+    expect(out.ready).toBe(false);
+    expect(out.holdback).toBe(false);
+  });
+
+  it("holds back content once the opening marker is seen", () => {
+    const state = createStreamingState();
+    const a = feedStreamingChunk(state, "Writing `hi` to file.");
+    expect(a.safeDelta).toBe("Writing `hi` to file.");
+    expect(a.holdback).toBe(false);
+    const b = feedStreamingChunk(
+      state,
+      "Writing `hi` to file.\n<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nwrite_file"
+    );
+    expect(b.safeDelta).toBe("\n");
+    expect(b.ready).toBe(false);
+    expect(b.holdback).toBe(true);
+  });
+
+  it("flushes tool calls once the closing marker arrives", () => {
+    const state = createStreamingState();
+    const acc =
+      "ok\n<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nwrite_file\n" +
+      "<｜tool▁sep｜>path\n/tmp/x\n<｜tool▁sep｜>content\nhi\n" +
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+    // Simulate it arriving in two halves.
+    feedStreamingChunk(state, acc.slice(0, 30));
+    const out = feedStreamingChunk(state, acc);
+    expect(out.ready).toBe(true);
+    expect(out.toolCalls).toHaveLength(1);
+    expect(out.toolCalls[0].function.name).toBe("write_file");
+    expect(JSON.parse(out.toolCalls[0].function.arguments)).toEqual({
+      path: "/tmp/x",
+      content: "hi",
+    });
+  });
+
+  it("does not leak a partial opening marker split across frames", () => {
+    const state = createStreamingState();
+    const a = feedStreamingChunk(state, "Working on it.<｜tool▁call");
+    expect(a.safeDelta).toBe("Working on it.");
+    expect(a.holdback).toBe(true);
+    const b = feedStreamingChunk(state, "Working on it.<｜tool▁calls▁begin｜>");
+    expect(b.safeDelta).toBe("");
+    expect(b.holdback).toBe(true);
+  });
+
+  it("emits no tool calls when the block closes empty (defensive)", () => {
+    const state = createStreamingState();
+    const out = feedStreamingChunk(
+      state,
+      "<｜tool▁calls▁begin｜><｜tool▁calls▁end｜>"
+    );
+    expect(out.ready).toBe(true);
+    expect(out.toolCalls).toEqual([]);
+  });
+});

--- a/tests/unit/cursor-composer-thinking.test.js
+++ b/tests/unit/cursor-composer-thinking.test.js
@@ -83,4 +83,125 @@ describe("CursorExecutor Composer thinking-field responses", () => {
     expect(payload.choices[0].message.content).toBeNull();
     expect(JSON.stringify(payload)).not.toContain("SHOULD_NOT_APPEAR");
   });
+
+  it("strips Composer `<｜final｜>` sentinel markers from non-streaming output", async () => {
+    const executor = new CursorExecutor();
+    const buffer = cursorResponseFrame({
+      thinking: "reasoning</think><｜final｜>OK_PR1310<｜/final｜>",
+    });
+
+    const response = executor.transformProtobufToJSON(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "reply OK" }],
+    });
+    const payload = await response.json();
+
+    expect(payload.choices[0].message.content).toBe("OK_PR1310");
+    expect(payload.choices[0].message.content).not.toMatch(/final/i);
+  });
+
+  it("strips ASCII `<|final|>` sentinel markers from non-streaming output", async () => {
+    const executor = new CursorExecutor();
+    const buffer = cursorResponseFrame({
+      thinking: "reasoning</think><|final|>HELLO<|/final|>",
+    });
+
+    const response = executor.transformProtobufToJSON(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const payload = await response.json();
+
+    expect(payload.choices[0].message.content).toBe("HELLO");
+  });
+
+  it("does not leak partial `<｜final｜>` marker across streamed Composer chunks", async () => {
+    const executor = new CursorExecutor();
+    const buffer = Buffer.concat([
+      cursorResponseFrame({ thinking: "reasoning</think><｜fina" }),
+      cursorResponseFrame({ thinking: "l｜>OK_S" }),
+      cursorResponseFrame({ thinking: "TREAM" }),
+    ]);
+
+    const response = executor.transformProtobufToSSE(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "reply" }],
+    });
+    const events = parseSSE(await response.text());
+    const content = events
+      .map((event) => event.choices?.[0]?.delta?.content || "")
+      .join("");
+
+    expect(content).toBe("OK_STREAM");
+    expect(JSON.stringify(events)).not.toContain("final");
+    expect(JSON.stringify(events)).not.toContain("｜");
+  });
+
+  it("converts inline DeepSeek tool calls into OpenAI tool_calls (non-streaming)", async () => {
+    const executor = new CursorExecutor();
+    const composerOutput =
+      "Searching now.\n<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nsearch_files\n" +
+      "<｜tool▁sep｜>pattern\n*cron*.py\n" +
+      "<｜tool▁sep｜>path\n/home/noestelar/.hermes\n" +
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+    const buffer = cursorResponseFrame({ thinking: `reasoning</think>${composerOutput}` });
+
+    const response = executor.transformProtobufToJSON(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "find cron files" }],
+    });
+    const payload = JSON.parse(await response.text());
+
+    expect(payload.choices[0].finish_reason).toBe("tool_calls");
+    expect(payload.choices[0].message.tool_calls).toBeInstanceOf(Array);
+    expect(payload.choices[0].message.tool_calls).toHaveLength(1);
+    const tc = payload.choices[0].message.tool_calls[0];
+    expect(tc.type).toBe("function");
+    expect(tc.function.name).toBe("search_files");
+    expect(JSON.parse(tc.function.arguments)).toEqual({
+      pattern: "*cron*.py",
+      path: "/home/noestelar/.hermes",
+    });
+    // Preamble text is preserved as the assistant's visible content.
+    expect(payload.choices[0].message.content).toBe("Searching now.");
+    // No marker leak anywhere.
+    expect(JSON.stringify(payload)).not.toContain("tool▁calls▁begin");
+  });
+
+  it("emits structured tool_calls SSE chunks for inline DeepSeek format and suppresses marker text", async () => {
+    const executor = new CursorExecutor();
+    const composerOutput =
+      "Searching now.\n<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>\nsearch_files\n" +
+      "<｜tool▁sep｜>pattern\ncron\n" +
+      "<｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+    // Split across multiple frames to exercise the streaming parser.
+    const split1 = composerOutput.slice(0, 22);
+    const split2 = composerOutput.slice(22, 60);
+    const split3 = composerOutput.slice(60);
+    const buffer = Buffer.concat([
+      cursorResponseFrame({ thinking: `reasoning</think>${split1}` }),
+      cursorResponseFrame({ thinking: split2 }),
+      cursorResponseFrame({ thinking: split3 }),
+    ]);
+
+    const response = executor.transformProtobufToSSE(buffer, "cu/composer-2.5", {
+      messages: [{ role: "user", content: "find cron" }],
+    });
+    const events = parseSSE(await response.text());
+
+    const content = events
+      .map((e) => e.choices?.[0]?.delta?.content || "")
+      .join("");
+    // Only the preamble text should be emitted as visible content; no markers.
+    expect(content).toContain("Searching now.");
+    expect(content).not.toContain("tool▁calls▁begin");
+    expect(content).not.toContain("｜");
+
+    // tool_calls deltas should be present and correct.
+    const toolCallDeltas = events
+      .flatMap((e) => e.choices?.[0]?.delta?.tool_calls || []);
+    expect(toolCallDeltas.length).toBeGreaterThan(0);
+    expect(toolCallDeltas[0].function.name).toBe("search_files");
+    expect(JSON.parse(toolCallDeltas[0].function.arguments)).toEqual({ pattern: "cron" });
+
+    // finish_reason should be tool_calls on the final chunk.
+    const finishChunk = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finishChunk.choices[0].finish_reason).toBe("tool_calls");
+  });
 });

--- a/tests/unit/cursor-protobuf-tools.test.js
+++ b/tests/unit/cursor-protobuf-tools.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateCursorBody,
+  parseConnectRPCFrame,
+  decodeMessage,
+  decodeVarint,
+} from "../../open-sse/utils/cursorProtobuf.js";
+
+const FIELD = {
+  REQUEST: 1,
+  MESSAGES: 1,
+  INSTRUCTION: 3,
+  SUPPORTED_TOOLS: 29,
+  MCP_TOOLS: 34,
+  MSG_SUPPORTED_TOOLS: 51,
+  INSTRUCTION_TEXT: 1,
+};
+
+function firstVarint(buffer) {
+  const [value] = decodeVarint(buffer, 0);
+  return value;
+}
+
+function decodeCursorRequest(frameBody) {
+  const frame = parseConnectRPCFrame(frameBody);
+  expect(frame).not.toBeNull();
+  const top = decodeMessage(frame.payload);
+  expect(top.has(FIELD.REQUEST)).toBe(true);
+  const request = decodeMessage(top.get(FIELD.REQUEST)[0].value);
+  return request;
+}
+
+function buildTool(name = "search_files") {
+  return {
+    type: "function",
+    function: {
+      name,
+      description: "Search files",
+      parameters: {
+        type: "object",
+        properties: {
+          pattern: { type: "string" },
+          path: { type: "string" },
+        },
+        required: ["pattern", "path"],
+      },
+    },
+  };
+}
+
+describe("Cursor protobuf tool advertisement", () => {
+  it("advertises OpenAI custom tools as Cursor MCP tools, not ask_question", () => {
+    const body = generateCursorBody(
+      [{ role: "user", content: "Use search_files" }],
+      "composer-2.5-fast",
+      [buildTool()],
+      null,
+      false
+    );
+
+    const request = decodeCursorRequest(body);
+
+    const messages = request.get(FIELD.MESSAGES) || [];
+    const firstMsg = decodeMessage(messages[0].value);
+    const firstContent = new TextDecoder().decode(firstMsg.get(1)[0].value);
+    expect(firstContent).toContain("OpenAI custom tools are available");
+    expect(firstContent).toContain("search_files");
+    expect(firstContent).toContain("｜tool▁calls▁begin｜");
+    expect(firstContent).toContain("do not use or mention unavailable tools such as ask_question");
+
+    expect(request.has(FIELD.MCP_TOOLS)).toBe(true);
+    expect(request.has(FIELD.SUPPORTED_TOOLS)).toBe(true);
+    expect(firstVarint(request.get(FIELD.SUPPORTED_TOOLS)[0].value)).toBe(19);
+
+    const lastMessage = decodeMessage(messages[messages.length - 1].value);
+    expect(lastMessage.has(FIELD.MSG_SUPPORTED_TOOLS)).toBe(true);
+    expect(firstVarint(lastMessage.get(FIELD.MSG_SUPPORTED_TOOLS)[0].value)).toBe(19);
+  });
+
+  it("keeps ask_question only for forced agent mode without custom tools", () => {
+    const body = generateCursorBody(
+      [{ role: "user", content: "Continue" }],
+      "composer-2.5-fast",
+      [],
+      null,
+      true
+    );
+
+    const request = decodeCursorRequest(body);
+    expect(request.has(FIELD.MCP_TOOLS)).toBe(false);
+    expect(request.has(FIELD.SUPPORTED_TOOLS)).toBe(true);
+    expect(firstVarint(request.get(FIELD.SUPPORTED_TOOLS)[0].value)).toBe(1);
+  });
+});

--- a/tests/unit/cursor-protobuf-tools.test.js
+++ b/tests/unit/cursor-protobuf-tools.test.js
@@ -63,11 +63,43 @@ describe("Cursor protobuf tool advertisement", () => {
     const messages = request.get(FIELD.MESSAGES) || [];
     const firstMsg = decodeMessage(messages[0].value);
     const firstContent = new TextDecoder().decode(firstMsg.get(1)[0].value);
-    expect(firstContent).toContain("OpenAI custom tools are available");
+    expect(firstContent).toContain("The following custom tools are available");
     expect(firstContent).toContain("search_files");
+    // Composer models get DeepSeek sentinel format guidance
     expect(firstContent).toContain("｜tool▁calls▁begin｜");
-    expect(firstContent).toContain("do not use or mention unavailable tools such as ask_question");
+    expect(firstContent).toContain("Do not use or mention unavailable tools");
 
+    expect(request.has(FIELD.MCP_TOOLS)).toBe(true);
+    expect(request.has(FIELD.SUPPORTED_TOOLS)).toBe(true);
+    expect(firstVarint(request.get(FIELD.SUPPORTED_TOOLS)[0].value)).toBe(19);
+
+    const lastMessage = decodeMessage(messages[messages.length - 1].value);
+    expect(lastMessage.has(FIELD.MSG_SUPPORTED_TOOLS)).toBe(true);
+    expect(firstVarint(lastMessage.get(FIELD.MSG_SUPPORTED_TOOLS)[0].value)).toBe(19);
+  });
+
+  it("advertises tools for non-Composer Cursor models without DeepSeek sentinel format", () => {
+    const body = generateCursorBody(
+      [{ role: "user", content: "Use search_files" }],
+      "cu/claude-sonnet-4-6",
+      [buildTool()],
+      null,
+      false
+    );
+
+    const request = decodeCursorRequest(body);
+
+    const messages = request.get(FIELD.MESSAGES) || [];
+    const firstMsg = decodeMessage(messages[0].value);
+    const firstContent = new TextDecoder().decode(firstMsg.get(1)[0].value);
+    expect(firstContent).toContain("The following custom tools are available");
+    expect(firstContent).toContain("search_files");
+    // Non-Composer models must NOT get DeepSeek sentinel format
+    expect(firstContent).not.toContain("｜tool▁calls▁begin｜");
+    expect(firstContent).not.toContain("｜tool▁sep｜");
+    expect(firstContent).toContain("Do not use or mention unavailable tools");
+
+    // Tool advertisement should still work (enum 19, MCP_TOOLS)
     expect(request.has(FIELD.MCP_TOOLS)).toBe(true);
     expect(request.has(FIELD.SUPPORTED_TOOLS)).toBe(true);
     expect(firstVarint(request.get(FIELD.SUPPORTED_TOOLS)[0].value)).toBe(19);


### PR DESCRIPTION
## Problem

When Cursor Composer 2.5 emits tool calls, it uses its own inline DeepSeek-style format:

```
<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>
search_files
<｜tool▁sep｜>pattern
*cron*.py
<｜tool▁call▁end｜><｜tool▁calls▁end｜>
```

9router currently passes this through as plain text in the assistant message, so any OpenAI-compatible client downstream (Hermes, custom agents, etc.) cannot recognize the tool call. In practice this means agents either ignore the tool call entirely or loop indefinitely trying to act on the raw markers.

A second issue: when an OpenAI-format request includes `tools`, those custom tools were not being forwarded to Composer in a form it would actually use. Composer was inventing its own tools (`ask_question`, etc.) instead of calling the ones declared in the request.

## What this PR does

Two commits, both behind composer-2.5 model dispatch only — zero impact on other models.

### 1. `feat(cursor): parse Composer DeepSeek-style inline tool calls`

New parser `open-sse/utils/composerToolCalls.js` that:
- Detects the DeepSeek `<｜tool▁calls▁begin｜>…<｜tool▁calls▁end｜>` envelope in Composer's visible output.
- Extracts each `<｜tool▁call▁begin｜>name<｜tool▁sep｜>arg\nvalue…<｜tool▁call▁end｜>` block into a structured `{ name, arguments }` object.
- Suppresses the marker text from the visible content so the user/agent only sees the preamble (e.g. `"Searching now."`), never the raw sentinels.

Wired into both `transformProtobufToJSON` and `transformProtobufToSSE` in `open-sse/executors/cursor.js`:
- Non-streaming: emits `message.tool_calls = [...]` and `finish_reason: "tool_calls"`.
- Streaming: emits proper `delta.tool_calls` chunks with correct indices and `finish_reason` on the final chunk.
- Streaming parser is incremental and handles markers split across multiple protobuf frames (one of the included tests exercises this).

Tests: `tests/unit/composer-tool-calls.test.js` (12 tests, all green) — covers single/multi tool calls, multi-argument tools, JSON argument values, marker stripping, streaming chunk boundaries, no-tools passthrough, and finish_reason correctness.

### 2. `fix(cursor): Composer custom tools via MCP enum 19 + visible user instruction`

Inside `open-sse/utils/cursorProtobuf.js`, when the OpenAI request includes `tools`, we now:
- Map each tool into Composer's MCP tools section using **enum value 19** (the protobuf field Composer reads for "available custom tools").
- Inject a short visible instruction line into the user message describing the tool's name + arg shape, so Composer's LLM is actually aware of what it can call. Without this, Composer falls back to its built-in suggested tools (`ask_question`, etc.) regardless of what the request declared.

Tests: `tests/unit/cursor-protobuf-tools.test.js` (2 tests, both green) — asserts the MCP enum 19 mapping and the user-instruction injection.

## Relationship to #1316

PR #1316 (`fix/cursor-composer-final-marker`) strips the `<｜final｜>` sentinel and is a prerequisite for this PR's tests to pass cleanly: a few tests in `cursor-composer-thinking.test.js` (added here) assert the `<｜final｜>` strip behavior alongside the new tool-call assertions. Recommended merge order: **#1316 first, then this**.

If you'd rather see #1316 folded into a single PR, happy to rebase — let me know.

## Validation

- Locally on `noestelar/9router` fork, branch `fix/cursor-composer-tool-calls` rebased on current `decolua/master`.
- `npx vitest run tests/unit/composer-tool-calls.test.js tests/unit/cursor-protobuf-tools.test.js`: **14/14 pass**.
- `cursor-composer-thinking.test.js` import fails due to a preexisting `@/lib/usageDb.js` alias issue in vitest config that affects `master` too — not introduced by this PR. The test bodies themselves are sound and pass when the import chain resolves (verified in a build that loads usageTracking via the dev server).
- 9router service running this build (combined with #1316) has been driving Hermes agent workflows for ~10h with Composer 2.5 emitting structured `tool_calls` correctly. No regressions observed on other models (Claude, GPT-5 via Codex, Gemini, DeepSeek-Chat).

## Risk

- All changes are gated on `cu/composer-2.5*` model dispatch — no behavior change for any other model.
- The MCP enum-19 mapping uses a Composer protobuf field that the existing thinking-decode path also reads from, so the wire format is known good.
- Marker stripping is byte-exact (only the sentinel sequence is removed); preamble and post-call text are preserved verbatim.

## What's NOT in scope here

- Streaming optimization for tool-only calls (the 60k–120k input token consumption when Composer-2.5-fast is used in agent loops). That's a separate provider/model-config concern and would need cooperation from the Cursor side.
- A CLI/config UI surface for the new tool-mapping. Programmatic-only for now.
