### PR TITLE
Fix Xiaomi reasoning content echo

### DIFF
--- a/open-sse/utils/reasoningContentInjector.js
+++ b/open-sse/utils/reasoningContentInjector.js
@@ -8,7 +8,9 @@ const PLACEHOLDER = " ";
 const PROVIDER_RULES = {
   deepseek: { scope: "all" },
   minimax: { scope: "all" },
-  "minimax-cn": { scope: "all" }
+  "minimax-cn": { scope: "all" },
+  "xiaomi-mimo": { scope: "all" },
+  "xiaomi-tokenplan": { scope: "all" }
 };
 
 // Model-level rules: matched by predicate against model id

--- a/tests/unit/reasoning-content-injector.test.js
+++ b/tests/unit/reasoning-content-injector.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { injectReasoningContent } from "../../open-sse/utils/reasoningContentInjector.js";
+
+describe("reasoning content injector", () => {
+  it("echoes placeholder reasoning_content for Xiaomi thinking models with tool calls", () => {
+    const body = {
+      model: "mimo-v2.5-pro",
+      messages: [
+        { role: "user", content: "call a tool" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: { name: "read_file", arguments: "{}" },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call-1", content: "ok" },
+      ],
+    };
+
+    const result = injectReasoningContent({
+      provider: "xiaomi-tokenplan",
+      model: "mimo-v2.5-pro",
+      body,
+    });
+
+    expect(result.messages[1].reasoning_content).toBe(" ");
+    expect(body.messages[1]).not.toHaveProperty("reasoning_content");
+  });
+
+  it("echoes placeholder reasoning_content for Xiaomi plain assistant messages", () => {
+    const body = {
+      model: "mimo-v2.5-pro",
+      messages: [
+        { role: "assistant", content: "plain text" },
+      ],
+    };
+
+    const result = injectReasoningContent({
+      provider: "xiaomi-tokenplan",
+      model: "mimo-v2.5-pro",
+      body,
+    });
+
+    expect(result.messages[0].reasoning_content).toBe(" ");
+  });
+
+  it("preserves existing reasoning_content values", () => {
+    const body = {
+      model: "mimo-v2.5-pro",
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          reasoning_content: "actual reasoning",
+          tool_calls: [{ id: "call-1", type: "function", function: { name: "x", arguments: "{}" } }],
+        },
+      ],
+    };
+
+    const result = injectReasoningContent({
+      provider: "xiaomi-tokenplan",
+      model: "mimo-v2.5-pro",
+      body,
+    });
+
+    expect(result.messages[0].reasoning_content).toBe("actual reasoning");
+  });
+});


### PR DESCRIPTION
# Fix Xiaomi reasoning content echo for thinking models

Fixes #1321.

## Summary

- Adds Xiaomi thinking providers to the reasoning-content echo rules.
- Ensures assistant messages sent back to Xiaomi thinking models carry placeholder `reasoning_content` when the previous assistant turn omitted it.
- Preserves existing non-empty `reasoning_content` values.

## Validation

```text
npx vitest run --config ./vitest.config.js --reporter=verbose reasoning-content-injector.test.js
-> 3 passed

git diff --check origin/master..HEAD
-> passed

npm run build
-> passed
```

## Notes

This PR is intentionally scoped to the reasoning-content injector and its regression coverage.

