### PR TITLE
Fix provider client priority sorting

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -269,7 +269,7 @@ export default function ProviderLimits() {
           page: String(targetPage),
           pageSize: String(pageSize),
           accountStatus: accountFilter,
-          sort: "priority",
+          sort: sortRequestFromExpiringFirst(expiringFirst),
         });
 
         if (providerFilter !== "all") {
@@ -1004,8 +1004,8 @@ export default function ProviderLimits() {
       {/* Provider cards: 2 columns, compact */}
       {expiringFirst && (
         <div className="rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
-          Expiring-first currently reorders accounts inside the current page.
-          Cross-page ordering still follows backend pagination.
+          Expiring-first uses saved token expiry and rate-limit times across
+          pages. Live quota-reset ordering requires a deeper quota refresh pass.
         </div>
       )}
 

--- a/src/app/api/providers/client/route.js
+++ b/src/app/api/providers/client/route.js
@@ -28,14 +28,20 @@ function maskName(name) {
   return name;
 }
 
+function toJsonSafe(value) {
+  if (typeof value !== "bigint") return value;
+  const asNumber = Number(value);
+  return Number.isSafeInteger(asNumber) ? asNumber : value.toString();
+}
+
 function sanitize(c) {
   const safe = {};
-  for (const f of SAFE_FIELDS) if (c[f] !== undefined) safe[f] = c[f];
+  for (const f of SAFE_FIELDS) if (c[f] !== undefined) safe[f] = toJsonSafe(c[f]);
   if (safe.name) safe.name = maskName(safe.name);
   if (c.providerSpecificData) {
     const psd = {};
     for (const f of SAFE_PSD_FIELDS) {
-      if (c.providerSpecificData[f] !== undefined) psd[f] = c.providerSpecificData[f];
+      if (c.providerSpecificData[f] !== undefined) psd[f] = toJsonSafe(c.providerSpecificData[f]);
     }
     safe.providerSpecificData = psd;
   }
@@ -53,6 +59,16 @@ function parsePositiveInt(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function sortablePriority(value) {
+  if (value === null || value === undefined || value === "") return Number.MAX_SAFE_INTEGER;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : Number.MAX_SAFE_INTEGER;
+}
+
+function sortableText(value) {
+  return value == null ? "" : String(value);
+}
+
 function sortConnections(connections, sort) {
   const list = [...connections];
 
@@ -61,15 +77,15 @@ function sortConnections(connections, sort) {
       const orderA = USAGE_SUPPORTED_PROVIDERS.indexOf(a.provider);
       const orderB = USAGE_SUPPORTED_PROVIDERS.indexOf(b.provider);
       if (orderA !== orderB) return orderA - orderB;
-      return a.provider.localeCompare(b.provider);
+      return sortableText(a.provider).localeCompare(sortableText(b.provider));
     });
   }
 
   return list.sort((a, b) => {
-    const priorityA = a.priority ?? Number.MAX_SAFE_INTEGER;
-    const priorityB = b.priority ?? Number.MAX_SAFE_INTEGER;
+    const priorityA = sortablePriority(a.priority);
+    const priorityB = sortablePriority(b.priority);
     if (priorityA !== priorityB) return priorityA - priorityB;
-    return (a.provider || "").localeCompare(b.provider || "");
+    return sortableText(a.provider).localeCompare(sortableText(b.provider));
   });
 }
 

--- a/src/app/api/providers/client/route.js
+++ b/src/app/api/providers/client/route.js
@@ -7,7 +7,7 @@ const SAFE_FIELDS = [
   "id", "provider", "authType", "name", "email", "displayName",
   "priority", "globalPriority", "isActive", "defaultModel",
   "testStatus", "lastError", "lastErrorAt", "errorCode",
-  "expiresAt", "lastUsedAt", "consecutiveUseCount",
+  "expiresAt", "rateLimitedUntil", "lastUsedAt", "consecutiveUseCount",
   "createdAt", "updatedAt",
 ];
 
@@ -69,6 +69,11 @@ function sortableText(value) {
   return value == null ? "" : String(value);
 }
 
+function sortableExpiryTime(connection) {
+  const timestamp = new Date(connection.expiresAt || connection.rateLimitedUntil || 0).getTime();
+  return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : Number.POSITIVE_INFINITY;
+}
+
 function sortConnections(connections, sort) {
   const list = [...connections];
 
@@ -77,6 +82,20 @@ function sortConnections(connections, sort) {
       const orderA = USAGE_SUPPORTED_PROVIDERS.indexOf(a.provider);
       const orderB = USAGE_SUPPORTED_PROVIDERS.indexOf(b.provider);
       if (orderA !== orderB) return orderA - orderB;
+      return sortableText(a.provider).localeCompare(sortableText(b.provider));
+    });
+  }
+
+  if (sort === "expiring") {
+    return list.sort((a, b) => {
+      // PR #1338 follow-up: this is connection-level expiry sorting. Full quota reset
+      // sorting would need provider quota fetches before pagination, which is broader.
+      const timeA = sortableExpiryTime(a);
+      const timeB = sortableExpiryTime(b);
+      if (timeA !== timeB) return timeA - timeB;
+      const priorityA = sortablePriority(a.priority);
+      const priorityB = sortablePriority(b.priority);
+      if (priorityA !== priorityB) return priorityA - priorityB;
       return sortableText(a.provider).localeCompare(sortableText(b.provider));
     });
   }
@@ -136,7 +155,10 @@ export async function GET(request) {
       },
     });
   } catch (error) {
-    console.log("Error fetching providers for client:", error);
-    return NextResponse.json({ error: "Failed to fetch providers" }, { status: 500 });
+    console.error("Error fetching providers for client:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch providers", details: error.message },
+      { status: 500 },
+    );
   }
 }

--- a/tests/unit/providers-client-route.test.js
+++ b/tests/unit/providers-client-route.test.js
@@ -90,4 +90,93 @@ describe("providers client route", () => {
     expect(response.status).toBe(200);
     expect(response.body.connections.map((conn) => conn.id)).toEqual(["valid", "invalid"]);
   });
+
+  it("sorts expiring results by connection expiry before paginating", async () => {
+    mocks.getProviderConnections.mockResolvedValue([
+      {
+        id: "third",
+        provider: "codex",
+        authType: "oauth",
+        name: "Third",
+        priority: 1,
+        expiresAt: "2026-05-25T10:00:00.000Z",
+        isActive: true,
+      },
+      {
+        id: "first",
+        provider: "claude",
+        authType: "oauth",
+        name: "First",
+        priority: 3,
+        rateLimitedUntil: "2026-05-24T10:00:00.000Z",
+        isActive: true,
+      },
+      {
+        id: "second",
+        provider: "github",
+        authType: "oauth",
+        name: "Second",
+        priority: 2,
+        expiresAt: "2026-05-24T12:00:00.000Z",
+        isActive: true,
+      },
+      {
+        id: "undated",
+        provider: "codex",
+        authType: "oauth",
+        name: "Undated",
+        priority: 0,
+        isActive: true,
+      },
+    ]);
+
+    const response = await GET(request("/api/providers/client?sort=expiring&page=1&pageSize=2"));
+
+    expect(response.status).toBe(200);
+    expect(response.body.connections.map((conn) => conn.id)).toEqual(["first", "second"]);
+    expect(response.body.pagination).toMatchObject({
+      page: 1,
+      pageSize: 2,
+      total: 4,
+      totalPages: 2,
+    });
+  });
+
+  it("falls back to priority when expiring results have no expiry time", async () => {
+    mocks.getProviderConnections.mockResolvedValue([
+      {
+        id: "second",
+        provider: "codex",
+        authType: "oauth",
+        name: "Second",
+        priority: 2,
+        isActive: true,
+      },
+      {
+        id: "first",
+        provider: "claude",
+        authType: "oauth",
+        name: "First",
+        priority: 1,
+        isActive: true,
+      },
+    ]);
+
+    const response = await GET(request("/api/providers/client?sort=expiring"));
+
+    expect(response.status).toBe(200);
+    expect(response.body.connections.map((conn) => conn.id)).toEqual(["first", "second"]);
+  });
+
+  it("includes error details when provider client fetch fails", async () => {
+    mocks.getProviderConnections.mockRejectedValue(new Error("database unavailable"));
+
+    const response = await GET(request("/api/providers/client"));
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      error: "Failed to fetch providers",
+      details: "database unavailable",
+    });
+  });
 });

--- a/tests/unit/providers-client-route.test.js
+++ b/tests/unit/providers-client-route.test.js
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  backfillCodexEmails: vi.fn(),
+  jsonResponse: vi.fn((body, init) => {
+    const serialized = JSON.stringify(body);
+    return {
+      status: init?.status || 200,
+      body: JSON.parse(serialized),
+    };
+  }),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: mocks.jsonResponse,
+  },
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+}));
+
+vi.mock("@/lib/oauth/providers", () => ({
+  backfillCodexEmails: mocks.backfillCodexEmails,
+}));
+
+const { GET } = await import("../../src/app/api/providers/client/route.js");
+
+function request(path) {
+  return { url: `http://localhost:20128${path}` };
+}
+
+describe("providers client route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.backfillCodexEmails.mockResolvedValue(undefined);
+  });
+
+  it("sorts priority results with BigInt priorities without returning 500", async () => {
+    mocks.getProviderConnections.mockResolvedValue([
+      {
+        id: "second",
+        provider: "codex",
+        authType: "oauth",
+        name: "Second",
+        priority: 2n,
+        isActive: true,
+      },
+      {
+        id: "first",
+        provider: "claude",
+        authType: "oauth",
+        name: "First",
+        priority: 1n,
+        isActive: true,
+      },
+    ]);
+
+    const response = await GET(request("/api/providers/client?page=1&pageSize=20&accountStatus=all&sort=priority"));
+
+    expect(response.status).toBe(200);
+    expect(response.body.connections.map((conn) => conn.id)).toEqual(["first", "second"]);
+    expect(response.body.connections.map((conn) => conn.priority)).toEqual([1, 2]);
+  });
+
+  it("places invalid priority values after valid numeric priorities", async () => {
+    mocks.getProviderConnections.mockResolvedValue([
+      {
+        id: "invalid",
+        provider: "codex",
+        authType: "oauth",
+        name: "Invalid",
+        priority: "not-a-number",
+        isActive: true,
+      },
+      {
+        id: "valid",
+        provider: "claude",
+        authType: "oauth",
+        name: "Valid",
+        priority: "1",
+        isActive: true,
+      },
+    ]);
+
+    const response = await GET(request("/api/providers/client?sort=priority"));
+
+    expect(response.status).toBe(200);
+    expect(response.body.connections.map((conn) => conn.id)).toEqual(["valid", "invalid"]);
+  });
+});


### PR DESCRIPTION
# Fix provider client priority sorting

Fixes #1323.

## Summary

- Normalizes provider connection priority values before sorting.
- Handles `BigInt`, numeric strings, invalid values, and nullish values without throwing.
- Converts returned provider client payloads through a JSON-safe path so `BigInt` values cannot break `Response.json()`.
- Adds server-side `sort=expiring` handling before pagination using connection-level `expiresAt` / `rateLimitedUntil`.
- Updates the quota page to send `sort=expiring` when the Expiring first toggle is active.
- Returns debuggable provider-client 500 responses with `details: error.message`.

## Scope Note

`sort=expiring` intentionally uses saved connection expiry/rate-limit fields. Full live quota-reset ordering would require fetching provider quota data for every filtered account before pagination, plus refresh/proxy/error handling, so that should be a larger follow-up.

## Validation

```text
npx vitest run --config ./tests/vitest.config.js --reporter=verbose tests/unit/providers-client-route.test.js
-> 5 passed

npm run build
-> passed

git diff --check
-> passed
```

## Reviewer Context

This PR now also addresses the review notes from https://github.com/decolua/9router/pull/1338#issuecomment-4526623356 while keeping the fix scoped to `/api/providers/client` and the quota page request wiring.