### PR TITLE
Allow Windows MITM elevation on startup

### DIFF
--- a/src/app/api/cli-tools/antigravity-mitm/route.js
+++ b/src/app/api/cli-tools/antigravity-mitm/route.js
@@ -59,7 +59,7 @@ function checkIsAdmin() {
 
 function checkPrivilege(pwd) {
   if (checkIsAdmin()) return true;
-  if (isWin) return false;
+  if (isWin) return true;
   if (!isSudoPasswordRequired()) return true;
   return !!pwd;
 }

--- a/src/mitm/dns/dnsConfig.js
+++ b/src/mitm/dns/dnsConfig.js
@@ -4,31 +4,78 @@ const path = require("path");
 const os = require("os");
 const { log, err } = require("../logger");
 const { TOOL_HOSTS } = require("../../shared/constants/mitmToolHosts.js");
-const { runElevatedPowerShell, isAdmin } = require("../winElevated.js");
+const { runElevatedPowerShell, quotePs } = require("../winElevated.js");
 
-/**
- * Atomic-ish write for Windows hosts file with rollback on failure.
- * Strategy: write `.new` sibling → rename current to `.bak` → rename `.new` to target.
- * If anything fails mid-way, restore from `.bak`. Same-volume renames are atomic on NTFS.
- */
-function atomicWriteHostsWin(target, originalContent, newContent) {
-  const tmpNew = `${target}.9router.new`;
-  const tmpBak = `${target}.9router.bak`;
-  try {
-    fs.writeFileSync(tmpNew, newContent, "utf8");
-    try { fs.unlinkSync(tmpBak); } catch { /* none */ }
-    fs.renameSync(target, tmpBak);
-    try {
-      fs.renameSync(tmpNew, target);
-    } catch (e) {
-      // Rollback: restore original
-      try { fs.renameSync(tmpBak, target); } catch { fs.writeFileSync(target, originalContent, "utf8"); }
-      throw e;
+function psArray(values) {
+  return values.map(quotePs).join(", ");
+}
+
+function buildAddHostsScript(hosts) {
+  return `
+    $hostsPath = ${quotePs(HOSTS_FILE)}
+    $hostsToAdd = @(${psArray(hosts)})
+    $content = if (Test-Path -LiteralPath $hostsPath) { Get-Content -LiteralPath $hostsPath -Raw } else { "" }
+    $lines = if ($content) { $content -split "\\r?\\n" } else { @() }
+    $next = New-Object System.Collections.Generic.List[string]
+    foreach ($line in $lines) {
+      $trimmedRight = $line.TrimEnd()
+      if ($trimmedRight.Trim().Length -gt 0) { [void]$next.Add($trimmedRight) }
     }
-    try { fs.unlinkSync(tmpBak); } catch { /* best effort */ }
-  } finally {
-    try { fs.unlinkSync(tmpNew); } catch { /* already moved or never created */ }
-  }
+    foreach ($hostName in $hostsToAdd) {
+      $exists = $false
+      foreach ($line in $next) {
+        if ($line -match ("(^|\\s)" + [regex]::Escape($hostName) + "(\\s|$)")) { $exists = $true; break }
+      }
+      if (-not $exists) { [void]$next.Add("127.0.0.1 $hostName") }
+    }
+    $newContent = ($next -join [Environment]::NewLine) + [Environment]::NewLine
+    $tmpNew = "$hostsPath.9router.new"
+    $tmpBak = "$hostsPath.9router.bak"
+    Set-Content -LiteralPath $tmpNew -Value $newContent -NoNewline -Encoding utf8
+    Remove-Item -LiteralPath $tmpBak -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $hostsPath) { Rename-Item -LiteralPath $hostsPath -NewName ([System.IO.Path]::GetFileName($tmpBak)) -Force }
+    try {
+      Rename-Item -LiteralPath $tmpNew -NewName ([System.IO.Path]::GetFileName($hostsPath)) -Force
+      Remove-Item -LiteralPath $tmpBak -ErrorAction SilentlyContinue
+    } catch {
+      if (Test-Path -LiteralPath $tmpBak) { Rename-Item -LiteralPath $tmpBak -NewName ([System.IO.Path]::GetFileName($hostsPath)) -Force }
+      throw
+    }
+    ipconfig /flushdns | Out-Null
+  `;
+}
+
+function buildRemoveHostsScript(hosts) {
+  return `
+    $hostsPath = ${quotePs(HOSTS_FILE)}
+    $hostsToRemove = @(${psArray(hosts)})
+    if (-not (Test-Path -LiteralPath $hostsPath)) { exit 0 }
+    $content = Get-Content -LiteralPath $hostsPath -Raw
+    $lines = if ($content) { $content -split "\\r?\\n" } else { @() }
+    $next = New-Object System.Collections.Generic.List[string]
+    foreach ($line in $lines) {
+      $remove = $false
+      foreach ($hostName in $hostsToRemove) {
+        if ($line -match ("(^|\\s)" + [regex]::Escape($hostName) + "(\\s|$)")) { $remove = $true; break }
+      }
+      $trimmedRight = $line.TrimEnd()
+      if (-not $remove -and $trimmedRight.Trim().Length -gt 0) { [void]$next.Add($trimmedRight) }
+    }
+    $newContent = ($next -join [Environment]::NewLine) + [Environment]::NewLine
+    $tmpNew = "$hostsPath.9router.new"
+    $tmpBak = "$hostsPath.9router.bak"
+    Set-Content -LiteralPath $tmpNew -Value $newContent -NoNewline -Encoding utf8
+    Remove-Item -LiteralPath $tmpBak -ErrorAction SilentlyContinue
+    Rename-Item -LiteralPath $hostsPath -NewName ([System.IO.Path]::GetFileName($tmpBak)) -Force
+    try {
+      Rename-Item -LiteralPath $tmpNew -NewName ([System.IO.Path]::GetFileName($hostsPath)) -Force
+      Remove-Item -LiteralPath $tmpBak -ErrorAction SilentlyContinue
+    } catch {
+      if (Test-Path -LiteralPath $tmpBak) { Rename-Item -LiteralPath $tmpBak -NewName ([System.IO.Path]::GetFileName($hostsPath)) -Force }
+      throw
+    }
+    ipconfig /flushdns | Out-Null
+  `;
 }
 
 const IS_WIN = process.platform === "win32";
@@ -155,13 +202,7 @@ async function addDNSEntry(tool, sudoPassword) {
 
   try {
     if (IS_WIN) {
-      // Read → trim → append → atomic write (Node-side, no CLI size limit)
-      const current = fs.readFileSync(HOSTS_FILE, "utf8");
-      const trimmed = current.replace(/[\r\n\s]+$/g, "");
-      const toAppend = entriesToAdd.map(h => `127.0.0.1 ${h}`).join("\r\n");
-      const next = `${trimmed}\r\n${toAppend}\r\n`;
-      atomicWriteHostsWin(HOSTS_FILE, current, next);
-      await runElevatedPowerShell("ipconfig /flushdns | Out-Null");
+      await runElevatedPowerShell(buildAddHostsScript(entriesToAdd));
     } else {
       const current = fs.readFileSync(HOSTS_FILE, "utf8");
       const trimmed = current.replace(/[\r\n\s]+$/g, "");
@@ -194,11 +235,7 @@ async function removeDNSEntry(tool, sudoPassword) {
 
   try {
     if (IS_WIN) {
-      const current = fs.readFileSync(HOSTS_FILE, "utf8");
-      const filtered = current.split(/\r?\n/).filter(l => !entriesToRemove.some(h => l.includes(h))).join("\r\n");
-      const next = filtered.replace(/[\r\n\s]+$/g, "") + "\r\n";
-      atomicWriteHostsWin(HOSTS_FILE, current, next);
-      await runElevatedPowerShell("ipconfig /flushdns | Out-Null");
+      await runElevatedPowerShell(buildRemoveHostsScript(entriesToRemove));
     } else {
       const current = fs.readFileSync(HOSTS_FILE, "utf8");
       const filtered = current.split(/\r?\n/).filter(l => !entriesToRemove.some(h => l.includes(h))).join("\n");

--- a/tests/unit/mitm-windows-elevation.test.js
+++ b/tests/unit/mitm-windows-elevation.test.js
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execSync: vi.fn(),
+  getMitmStatus: vi.fn(),
+  startServer: vi.fn(),
+  stopServer: vi.fn(),
+  enableToolDNS: vi.fn(),
+  disableToolDNS: vi.fn(),
+  trustCert: vi.fn(),
+  getCachedPassword: vi.fn(),
+  setCachedPassword: vi.fn(),
+  loadEncryptedPassword: vi.fn(),
+  isSudoPasswordRequired: vi.fn(),
+  initDbHooks: vi.fn(),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  jsonResponse: vi.fn((body, init) => ({
+    status: init?.status || 200,
+    body,
+  })),
+}));
+
+vi.mock("child_process", () => ({
+  execSync: mocks.execSync,
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: mocks.jsonResponse,
+  },
+}));
+
+vi.mock("@/mitm/manager", () => ({
+  getMitmStatus: mocks.getMitmStatus,
+  startServer: mocks.startServer,
+  stopServer: mocks.stopServer,
+  enableToolDNS: mocks.enableToolDNS,
+  disableToolDNS: mocks.disableToolDNS,
+  trustCert: mocks.trustCert,
+  getCachedPassword: mocks.getCachedPassword,
+  setCachedPassword: mocks.setCachedPassword,
+  loadEncryptedPassword: mocks.loadEncryptedPassword,
+  isSudoPasswordRequired: mocks.isSudoPasswordRequired,
+  initDbHooks: mocks.initDbHooks,
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+  updateSettings: mocks.updateSettings,
+}));
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(value) {
+  Object.defineProperty(process, "platform", { value });
+}
+
+function requestJson(body) {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+  };
+}
+
+describe("MITM Windows elevation route handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    setPlatform("win32");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("not elevated");
+    });
+    mocks.getCachedPassword.mockReturnValue(null);
+    mocks.loadEncryptedPassword.mockResolvedValue("");
+    mocks.startServer.mockResolvedValue({ running: true, pid: 1234 });
+  });
+
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+  });
+
+  it("does not reject Windows MITM start before UAC-capable helpers can run", async () => {
+    const { POST } = await import("../../src/app/api/cli-tools/antigravity-mitm/route.js");
+
+    const response = await POST(requestJson({ apiKey: "sk-test" }));
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true, running: true, pid: 1234 });
+    expect(mocks.startServer).toHaveBeenCalledWith("sk-test", "", false);
+  });
+});


### PR DESCRIPTION
# Allow Windows MITM startup to use elevated helpers

Fixes #1312.

## Summary

- Stops rejecting Windows MITM startup only because the main 9Router process is not already elevated.
- Routes Windows hosts-file add/remove operations through the existing UAC-capable PowerShell helper path.
- Keeps non-Windows hosts-file behavior unchanged.

## Validation

```text
npx vitest run --config ./vitest.config.js --reporter=verbose mitm-windows-elevation.test.js
-> 1 passed

git diff --check origin/master..HEAD
-> passed

npm run build
-> passed
```

## Notes

This PR is intentionally scoped to Windows MITM startup/elevation handling and its regression test.

