### PR TITLE
fix(codex): migrate deprecated hooks config

### DIFF
--- a/src/app/api/cli-tools/codex-settings/route.js
+++ b/src/app/api/cli-tools/codex-settings/route.js
@@ -7,6 +7,7 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import { parseTOML, stringifyTOML } from "confbox";
+import { migrateCodexFeatureFlags } from "@/shared/utils/codexConfig";
 
 const execAsync = promisify(exec);
 
@@ -126,6 +127,7 @@ export async function POST(request) {
     try {
       const existingConfig = await fs.readFile(configPath, "utf-8");
       parsed = parsedToWritable(parseTOML(existingConfig));
+      migrateCodexFeatureFlags(parsed);
     } catch { /* No existing config */ }
 
     // Update only 9Router related fields (api_key goes to auth.json, not config.toml)
@@ -185,6 +187,7 @@ export async function DELETE() {
     try {
       const existingConfig = await fs.readFile(configPath, "utf-8");
       parsed = parsedToWritable(parseTOML(existingConfig));
+      migrateCodexFeatureFlags(parsed);
     } catch (error) {
       if (error.code === "ENOENT") {
         return NextResponse.json({

--- a/src/shared/utils/codexConfig.js
+++ b/src/shared/utils/codexConfig.js
@@ -1,0 +1,14 @@
+export function migrateCodexFeatureFlags(config) {
+  if (!config || typeof config !== "object") return config;
+
+  const features = config.features;
+  if (!features || typeof features !== "object") return config;
+  if (!Object.prototype.hasOwnProperty.call(features, "codex_hooks")) return config;
+
+  if (!Object.prototype.hasOwnProperty.call(features, "hooks")) {
+    features.hooks = features.codex_hooks;
+  }
+  delete features.codex_hooks;
+
+  return config;
+}

--- a/tests/unit/codex-config.test.js
+++ b/tests/unit/codex-config.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { migrateCodexFeatureFlags } from "../../src/shared/utils/codexConfig.js";
+
+describe("Codex config migration", () => {
+  it("renames deprecated codex_hooks feature flag to hooks", () => {
+    const config = {
+      model: "cx/gpt-5.3-codex",
+      features: {
+        codex_hooks: true,
+      },
+    };
+
+    migrateCodexFeatureFlags(config);
+
+    expect(config.features).toEqual({ hooks: true });
+  });
+
+  it("keeps an existing hooks value and removes the deprecated key", () => {
+    const config = {
+      features: {
+        codex_hooks: true,
+        hooks: false,
+      },
+    };
+
+    migrateCodexFeatureFlags(config);
+
+    expect(config.features).toEqual({ hooks: false });
+  });
+
+  it("leaves configs without deprecated feature flags untouched", () => {
+    const config = {
+      model_provider: "9router",
+      features: {
+        hooks: true,
+      },
+    };
+
+    const result = migrateCodexFeatureFlags(config);
+
+    expect(result).toBe(config);
+    expect(config.features).toEqual({ hooks: true });
+  });
+});


### PR DESCRIPTION
## Summary
- migrate deprecated `features.codex_hooks` to `features.hooks` when applying or resetting Codex CLI settings
- preserve an existing `features.hooks` value if users already moved to the new key
- add focused regression coverage for the config migration helper

Fixes #1327.

## Test plan
- `cd tests && ./node_modules/.bin/vitest run unit/codex-config.test.js --reporter=verbose`
- `node --check src/app/api/cli-tools/codex-settings/route.js`
- `node --check tests/../src/shared/utils/codexConfig.js`
- `git diff --check`