### PR TITLE
fix(models): persist custom model token limits

### DIFF
--- a/src/app/api/models/custom/route.js
+++ b/src/app/api/models/custom/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCustomModels, addCustomModel, deleteCustomModel } from "@/models";
+import { normalizeModelTokenLimits } from "@/shared/utils/modelTokenLimits";
 
 export const dynamic = "force-dynamic";
 
@@ -17,11 +18,18 @@ export async function GET() {
 // POST /api/models/custom - Add custom model
 export async function POST(request) {
   try {
-    const { providerAlias, id, type, name } = await request.json();
+    const body = await request.json();
+    const { providerAlias, id, type, name } = body;
     if (!providerAlias || !id) {
       return NextResponse.json({ error: "providerAlias and id required" }, { status: 400 });
     }
-    const added = await addCustomModel({ providerAlias, id, type: type || "llm", name });
+    const added = await addCustomModel({
+      providerAlias,
+      id,
+      type: type || "llm",
+      name,
+      ...normalizeModelTokenLimits(body),
+    });
     return NextResponse.json({ success: true, added });
   } catch (error) {
     console.log("Error adding custom model:", error);

--- a/src/app/api/v1/models/info/route.js
+++ b/src/app/api/v1/models/info/route.js
@@ -1,5 +1,7 @@
 import { PROVIDER_MODELS } from "open-sse/config/providerModels.js";
 import { AI_PROVIDERS, ALIAS_TO_ID } from "@/shared/constants/providers";
+import { getCustomModels } from "@/lib/localDb";
+import { withModelTokenLimits } from "@/shared/utils/modelTokenLimits";
 
 const KIND_ENDPOINT = {
   llm: "/v1/chat/completions",
@@ -36,11 +38,11 @@ function buildInfo({ alias, providerId, model, kind, providerInfo }) {
     if (cfg.maxMaxResults) out.maxResults = cfg.maxMaxResults;
     if (cfg.requiredOptions) out.required = cfg.requiredOptions;
   }
-  return out;
+  return withModelTokenLimits(out, model);
 }
 
 // id format: "{alias}/{modelId}" - alias may also be providerId
-function lookup(fullId) {
+async function lookup(fullId) {
   if (!fullId || !fullId.includes("/")) return null;
   const slash = fullId.indexOf("/");
   const alias = fullId.slice(0, slash);
@@ -80,6 +82,27 @@ function lookup(fullId) {
       model: { id: "fetch", name: `${providerInfo.name} Fetch`, params: ["url", "format", "max_characters"] },
     });
   }
+
+  let customModels = [];
+  try {
+    customModels = await getCustomModels();
+  } catch (e) {
+    console.log("Could not fetch custom models");
+  }
+
+  const customModel = customModels.find((x) => {
+    if (!x?.id) return false;
+    const customAlias = x.providerAlias;
+    return (
+      String(x.id).trim() === modelId &&
+      (customAlias === alias || customAlias === providerId)
+    );
+  });
+  if (customModel) {
+    const kind = customModel.type || "llm";
+    return buildInfo({ alias, providerId, model: customModel, kind, providerInfo });
+  }
+
   return null;
 }
 
@@ -99,7 +122,7 @@ export async function GET(request) {
       { status: 400, headers: { "Access-Control-Allow-Origin": "*" } },
     );
   }
-  const info = lookup(id);
+  const info = await lookup(id);
   if (!info) {
     return Response.json(
       { error: { message: `Model not found: ${id}`, type: "not_found" } },

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -8,6 +8,7 @@ import {
 import { getProviderConnections, getCombos, getCustomModels, getModelAliases } from "@/lib/localDb";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
+import { withModelTokenLimits } from "@/shared/utils/modelTokenLimits";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -133,6 +134,14 @@ function comboMatchesKinds(combo, kindFilter) {
   return kindFilter.includes(kind);
 }
 
+function modelListEntry(alias, modelId, metadata = {}) {
+  return withModelTokenLimits({
+    id: `${alias}/${modelId}`,
+    object: "model",
+    owned_by: alias,
+  }, metadata);
+}
+
 /**
  * Build OpenAI-format models list filtered by service kinds.
  * @param {string[]} kindFilter - List of service kinds to include (e.g. ["llm"], ["webSearch","webFetch"]).
@@ -209,11 +218,7 @@ export async function buildModelsList(kindFilter) {
       for (const model of providerModels) {
         if (!kindFilter.includes(modelKind(model))) continue;
         if (isDisabled(alias, model.id)) continue;
-        models.push({
-          id: `${alias}/${model.id}`,
-          object: "model",
-          owned_by: alias,
-        });
+        models.push(modelListEntry(alias, model.id, model));
       }
     }
 
@@ -227,11 +232,7 @@ export async function buildModelsList(kindFilter) {
       const modelId = String(customModel.id).trim();
       if (!modelId) continue;
 
-      models.push({
-        id: `${providerAlias}/${modelId}`,
-        object: "model",
-        owned_by: providerAlias,
-      });
+      models.push(modelListEntry(providerAlias, modelId, customModel));
     }
   } else {
     for (const [providerId, conn] of activeConnectionByProvider.entries()) {
@@ -251,9 +252,7 @@ export async function buildModelsList(kindFilter) {
         isOpenAICompatibleProvider(providerId) || isAnthropicCompatibleProvider(providerId);
 
       // Build kind lookup for static models so we can filter even when only IDs are exposed
-      const staticModelKindById = new Map(
-        providerModels.map((m) => [m.id, modelKind(m)])
-      );
+      const staticModelById = new Map(providerModels.map((m) => [m.id, m]));
 
       let rawModelIds = hasExplicitEnabledModels
         ? Array.from(
@@ -299,14 +298,16 @@ export async function buildModelsList(kindFilter) {
         })
         .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
 
-      const customModelIds = customModels
-        .filter((m) => {
-          if (!m?.id || (m.type && m.type !== "llm")) return false;
-          const alias = m.providerAlias;
-          return alias === staticAlias || alias === outputAlias || alias === providerId;
-        })
-        .map((m) => String(m.id).trim())
-        .filter((modelId) => modelId !== "");
+      const customModelById = new Map();
+      for (const customModel of customModels) {
+        if (!customModel?.id || (customModel.type && customModel.type !== "llm")) continue;
+        const alias = customModel.providerAlias;
+        if (!(alias === staticAlias || alias === outputAlias || alias === providerId)) continue;
+        const modelId = String(customModel.id).trim();
+        if (modelId) customModelById.set(modelId, customModel);
+      }
+
+      const customModelIds = Array.from(customModelById.keys());
 
       const aliasModelIds = Object.values(modelAliases || {})
         .filter((fullModel) => {
@@ -335,15 +336,12 @@ export async function buildModelsList(kindFilter) {
 
       for (const modelId of mergedModelIds) {
         // Resolve kind: prefer static metadata, otherwise infer from ID heuristics
-        const kind = staticModelKindById.get(modelId) || inferKindFromUnknownModelId(modelId);
+        const staticModel = staticModelById.get(modelId);
+        const kind = staticModel ? modelKind(staticModel) : inferKindFromUnknownModelId(modelId);
         if (!kindFilter.includes(kind)) continue;
         if (isDisabled(outputAlias, modelId) || isDisabled(staticAlias, modelId)) continue;
 
-        models.push({
-          id: `${outputAlias}/${modelId}`,
-          object: "model",
-          owned_by: outputAlias,
-        });
+        models.push(modelListEntry(outputAlias, modelId, customModelById.get(modelId) || staticModel));
       }
 
       // Merge sub-config models (TTS / embedding) that live on AI_PROVIDERS, not PROVIDER_MODELS

--- a/src/lib/db/repos/aliasRepo.js
+++ b/src/lib/db/repos/aliasRepo.js
@@ -30,14 +30,15 @@ export async function getCustomModels() {
 }
 
 // Atomic check-then-insert inside transaction to prevent duplicate races
-export async function addCustomModel({ providerAlias, id, type = "llm", name }) {
+export async function addCustomModel(model) {
+  const { providerAlias, id, type = "llm", name, ...metadata } = model || {};
   const k = customKey(providerAlias, id, type);
   const db = await getAdapter();
   let added = false;
   db.transaction(() => {
     const row = db.get(`SELECT 1 FROM kv WHERE scope = 'customModels' AND key = ?`, [k]);
     if (row) return;
-    const value = stringifyJson({ providerAlias, id, type, name: name || id });
+    const value = stringifyJson({ providerAlias, id, type, name: name || id, ...metadata });
     db.run(`INSERT INTO kv(scope, key, value) VALUES('customModels', ?, ?)`, [k, value]);
     added = true;
   });

--- a/src/shared/utils/modelTokenLimits.js
+++ b/src/shared/utils/modelTokenLimits.js
@@ -1,0 +1,33 @@
+function positiveInteger(value) {
+  if (value === null || value === undefined || value === "") return undefined;
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) return undefined;
+  return Math.floor(number);
+}
+
+export function normalizeModelTokenLimits(input = {}) {
+  const maxInputTokens = positiveInteger(
+    input.max_input_tokens
+      ?? input.maxInputTokens
+      ?? input.context_length
+      ?? input.contextLength
+      ?? input.contextWindow
+  );
+  const maxOutputTokens = positiveInteger(input.max_output_tokens ?? input.maxOutputTokens);
+
+  const limits = {};
+  if (maxInputTokens !== undefined) {
+    limits.max_input_tokens = maxInputTokens;
+    limits.context_length = maxInputTokens;
+  }
+  if (maxOutputTokens !== undefined) {
+    limits.max_output_tokens = maxOutputTokens;
+  }
+  return limits;
+}
+
+export function withModelTokenLimits(entry, model = {}) {
+  if (!entry || typeof entry !== "object") return entry;
+  const limits = normalizeModelTokenLimits(model);
+  return Object.keys(limits).length > 0 ? { ...entry, ...limits } : entry;
+}

--- a/tests/unit/model-token-limits.test.js
+++ b/tests/unit/model-token-limits.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeModelTokenLimits,
+  withModelTokenLimits,
+} from "../../src/shared/utils/modelTokenLimits.js";
+
+describe("model token limit metadata", () => {
+  it("normalizes OpenAI-style custom model limits", () => {
+    expect(normalizeModelTokenLimits({
+      max_input_tokens: 131072,
+      max_output_tokens: "8192",
+    })).toEqual({
+      max_input_tokens: 131072,
+      context_length: 131072,
+      max_output_tokens: 8192,
+    });
+  });
+
+  it("accepts existing context window aliases", () => {
+    expect(normalizeModelTokenLimits({ contextWindow: 200000 })).toEqual({
+      max_input_tokens: 200000,
+      context_length: 200000,
+    });
+  });
+
+  it("does not emit invalid limits", () => {
+    expect(normalizeModelTokenLimits({
+      max_input_tokens: 0,
+      max_output_tokens: -1,
+      context_length: "nope",
+    })).toEqual({});
+  });
+
+  it("adds known limits to OpenAI model list entries", () => {
+    expect(withModelTokenLimits(
+      { id: "custom/model", object: "model", owned_by: "custom" },
+      { max_input_tokens: 1000, max_output_tokens: 250 },
+    )).toEqual({
+      id: "custom/model",
+      object: "model",
+      owned_by: "custom",
+      max_input_tokens: 1000,
+      context_length: 1000,
+      max_output_tokens: 250,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- persist custom model token limit metadata from POST /api/models/custom
- include max_input_tokens, context_length, and max_output_tokens in /v1/models entries
- resolve custom models in /v1/models/info and include the same metadata

Addresses the custom-model metadata portion of #1294.

## Tests
- cd tests && ./node_modules/.bin/vitest run unit/model-token-limits.test.js --reporter=verbose
- node --check src/shared/utils/modelTokenLimits.js
- node --check src/lib/db/repos/aliasRepo.js
- node --check src/app/api/models/custom/route.js
- node --check src/app/api/v1/models/route.js
- node --check src/app/api/v1/models/info/route.js
- node --check tests/unit/model-token-limits.test.js
- git diff --check