### PR TITLE
fix(claude): normalize anthropic-version header

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -6,6 +6,19 @@ import { getCachedClaudeHeaders } from "../utils/claudeHeaderCache.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 
+function ensureSingleHeader(headers, name, fallbackValue) {
+  const lowerName = name.toLowerCase();
+  let value = headers[name];
+
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() !== lowerName) continue;
+    if (value === undefined) value = headers[key];
+    if (key !== name) delete headers[key];
+  }
+
+  headers[name] = value ?? fallbackValue;
+}
+
 export class DefaultExecutor extends BaseExecutor {
   constructor(provider) {
     super(provider, PROVIDERS[provider] || PROVIDERS.openai);
@@ -110,9 +123,7 @@ export class DefaultExecutor extends BaseExecutor {
           } else if (credentials.accessToken) {
             headers["Authorization"] = `Bearer ${credentials.accessToken}`;
           }
-          if (!headers["anthropic-version"]) {
-            headers["anthropic-version"] = "2023-06-01";
-          }
+          ensureSingleHeader(headers, "anthropic-version", "2023-06-01");
         } else if (this.provider === "gitlab") {
           // GitLab Duo uses Bearer token (PAT with ai_features scope, or OAuth access token)
           headers["Authorization"] = `Bearer ${credentials.apiKey || credentials.accessToken}`;
@@ -128,7 +139,7 @@ export class DefaultExecutor extends BaseExecutor {
         } else if (this.config?.format === "claude") {
           // Generic claude-format provider (e.g. agentrouter): x-api-key + anthropic-version
           headers["x-api-key"] = credentials.apiKey || credentials.accessToken;
-          if (!headers["anthropic-version"]) headers["anthropic-version"] = "2023-06-01";
+          ensureSingleHeader(headers, "anthropic-version", "2023-06-01");
         } else {
           headers["Authorization"] = `Bearer ${credentials.apiKey || credentials.accessToken}`;
         }

--- a/tests/unit/claude-header-forwarding.test.js
+++ b/tests/unit/claude-header-forwarding.test.js
@@ -228,6 +228,45 @@ describe("DefaultExecutor.buildHeaders() — claude provider cold start (no cach
   });
 });
 
+describe("DefaultExecutor.buildHeaders() — claude-format header casing", () => {
+  let DefaultExecutor;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("open-sse/executors/default.js");
+    DefaultExecutor = mod.DefaultExecutor || mod.default;
+  });
+
+  it("does not send duplicate anthropic-version headers for generic claude providers", () => {
+    const executor = new DefaultExecutor("agentrouter");
+    const headers = executor.buildHeaders({ apiKey: "key" }, false);
+    const versionKeys = Object.keys(headers).filter(
+      (key) => key.toLowerCase() === "anthropic-version",
+    );
+
+    expect(versionKeys).toEqual(["anthropic-version"]);
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+  });
+
+  it("normalizes static Title-Case version headers for anthropic-compatible providers", () => {
+    const executor = new DefaultExecutor("anthropic-compatible-custom");
+    executor.config.headers = { "Anthropic-Version": "2023-06-01" };
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "key",
+        providerSpecificData: { baseUrl: "https://api.anthropic.com/v1" },
+      },
+      false,
+    );
+    const versionKeys = Object.keys(headers).filter(
+      (key) => key.toLowerCase() === "anthropic-version",
+    );
+
+    expect(versionKeys).toEqual(["anthropic-version"]);
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+  });
+});
+
 // ─── anthropic-compatible header stripping ────────────────────────────────────
 
 describe("DefaultExecutor.buildHeaders() — anthropic-compatible stripping", () => {


### PR DESCRIPTION
## Summary
- normalize anthropic-version case before adding the default version
- prevent Title-Case + lowercase duplicates from becoming "2023-06-01, 2023-06-01"
- add regression coverage for generic claude-format and anthropic-compatible headers

Fixes #1227.

## Tests
- cd tests && ./node_modules/.bin/vitest run unit/claude-header-forwarding.test.js -t "claude-format header casing" --reporter=verbose
- node --check open-sse/executors/default.js
- node --check tests/unit/claude-header-forwarding.test.js
- git diff --check

Note: running the entire claude-header-forwarding file locally still hits the existing proxyAwareFetch/got-scraping mock expectation in this environment; the new header-casing regression tests pass.