### PR TITLE
ci: add ESLint and test gate to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm install --ignore-scripts
+      - run: npx eslint .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm install --ignore-scripts
+      - run: |
+          if [ -d tests ]; then
+            cd tests && npm install && npm run test
+          else
+            echo "No tests directory found"
+          fi


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with lint and test jobs
- Lint job runs `npx eslint .` on every push/PR
- Test job runs `npm run test` in tests/ directory after lint passes
- Existing docker-publish workflow is unchanged

## Problem
CI currently has no lint gate and no test gate. The docker-publish workflow only triggers on tags. Commits can introduce ESLint regressions and failing tests without any CI failure. This leaves 135 ESLint errors and the test suite unchecked.

## Solution
Add a dedicated CI workflow (ci.yml) that runs on push to master and on all pull requests. The lint job catches code quality issues before merge, and the test job ensures the test suite passes before merge.

## Tests
`npx eslint .` — verify lint passes
`cd tests && npm install && npm run test` — verify tests pass

## Risk / Compatibility
- Risk: LOW
- Affects: CI configuration only
- No changes to application code, provider logic, or runtime behavior
- Docker publish workflow unchanged