### PR TITLE
feat: add alitp provider for Aliyun Token Plan API

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -327,6 +327,29 @@ export const PROVIDER_MODELS = {
     { id: "qwen3-coder-plus", name: "Qwen3 Coder Plus" },
     { id: "glm-4.7", name: "GLM 4.7" },
   ],
+  "alitp": [
+    // 千问 (Qwen)
+    { id: "qwen3.7-max", name: "Qwen3.7 Max" },
+    { id: "qwen3.6-plus", name: "Qwen3.6 Plus" },
+    { id: "qwen3.6-flash", name: "Qwen3.6 Flash" },
+    { id: "qwen-image-2.0", name: "Qwen Image 2.0", type: "image" },
+    { id: "qwen-image-2.0-pro", name: "Qwen Image 2.0 Pro", type: "image" },
+    // 万相 (Wan)
+    { id: "wan2.7-image", name: "Wan2.7 Image", type: "image" },
+    { id: "wan2.7-image-pro", name: "Wan2.7 Image Pro", type: "image" },
+    // DeepSeek
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
+    { id: "deepseek-v3.2", name: "DeepSeek V3.2" },
+    // 月之暗面 (Moonshot)
+    { id: "kimi-k2.6", name: "Kimi K2.6" },
+    { id: "kimi-k2.5", name: "Kimi K2.5" },
+    // 智谱AI (GLM)
+    { id: "glm-5.1", name: "GLM 5.1" },
+    { id: "glm-5", name: "GLM 5" },
+    // MiniMax
+    { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
+  ],
   deepseek: [
     { id: "deepseek-chat", name: "DeepSeek V3.2 Chat" },
     { id: "deepseek-reasoner", name: "DeepSeek V3.2 Reasoner" },

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -156,6 +156,11 @@ export const PROVIDERS = {
     format: "openai",
     headers: {}
   },
+  "alitp": {
+    baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+    format: "openai",
+    headers: {}
+  },
   github: {
     baseUrl: "https://api.githubcopilot.com/chat/completions",
     responsesUrl: "https://api.githubcopilot.com/responses",

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -149,6 +149,14 @@ const PROVIDER_MODELS_CONFIG = {
     authPrefix: "Bearer ",
     parseResponse: (data) => data.data || []
   },
+  alitp: {
+    url: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/models",
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+    authHeader: "Authorization",
+    authPrefix: "Bearer ",
+    parseResponse: (data) => data.data || []
+  },
 
   // OpenAI-compatible API key providers
   deepseek: createOpenAIModelsConfig("https://api.deepseek.com/models"),

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -115,10 +115,11 @@ export async function POST(request) {
             "minimax-cn": "https://api.minimaxi.com/anthropic/v1/messages",
             alicode: "https://coding.dashscope.aliyuncs.com/v1/chat/completions",
             "alicode-intl": "https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions",
+            "alitp": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
           };
 
-          // glm-cn, alicode and alicode-intl use OpenAI format
-          if (provider === "glm-cn" || provider === "alicode" || provider === "alicode-intl") {
+          // glm-cn, alicode, alicode-intl and alicode-tp use OpenAI format
+          if (provider === "glm-cn" || provider === "alicode" || provider === "alicode-intl" || provider === "alitp") {
             const testModel = getDefaultModel(provider);
             const glmCnRes = await fetch(claudeBaseUrls[provider], {
               method: "POST",

--- a/src/shared/constants/config.js
+++ b/src/shared/constants/config.js
@@ -49,6 +49,7 @@ export const PROVIDER_ENDPOINTS = {
   "minimax-cn": "https://api.minimaxi.com/anthropic/v1/messages",
   alicode: "https://coding.dashscope.aliyuncs.com/v1/chat/completions",
   "alicode-intl": "https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions",
+  "alitp": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
   openai: "https://api.openai.com/v1/chat/completions",
   anthropic: "https://api.anthropic.com/v1/messages",
   gemini: "https://generativelanguage.googleapis.com/v1beta/models",


### PR DESCRIPTION
## Summary

Add new provider `alitp` for Aliyun MaaS Token Plan API endpoint.

## Changes

- Add `alitp` provider in `open-sse/config/providers.js`
- Add model list in `open-sse/config/providerModels.js`
- Add validation logic in `src/app/api/providers/validate/route.js`
- Add models fetch config in `src/app/api/providers/[id]/models/route.js`
- Add baseUrl in `src/shared/constants/config.js`

## Provider Details

| Property | Value |
|----------|-------|
| Name | `alitp` |
| Endpoint | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` |
| Format | OpenAI-compatible |
| Auth | Bearer Token (API Key) |

## Supported Models

**千问 (Qwen):**
- `qwen3.7-max` - 推理模型
- `qwen3.6-plus` - 推理/视觉/文本
- `qwen3.6-flash` - 推理/视觉/文本
- `qwen-image-2.0` / `qwen-image-2.0-pro` - 图片生成

**万相 (Wan):**
- `wan2.7-image` / `wan2.7-image-pro` - 图片生成

**DeepSeek:**
- `deepseek-v4-pro` / `deepseek-v4-flash` - 推理模型
- `deepseek-v3.2` - 推理/文本

**其他:**
- `kimi-k2.6` / `kimi-k2.5` (月之暗面)
- `glm-5.1` / `glm-5` (智谱AI)
- `MiniMax-M2.5`

## Testing

- ✅ Models list API verified
- ✅ Chat completion tested with `qwen3.7-max`