### PR TITLE
fix(embeddings): add input_type param for nvidia nv-embedqa-e5-v5 model (closes #1378)

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -506,7 +506,7 @@ export const PROVIDER_MODELS = {
   nvidia: [
     { id: "minimaxai/minimax-m2.7", name: "Minimax M2.7" },
     { id: "z-ai/glm4.7", name: "GLM 4.7" },
-    { id: "nvidia/nv-embedqa-e5-v5", name: "NV EmbedQA E5 v5", type: "embedding" },
+    { id: "nvidia/nv-embedqa-e5-v5", name: "NV EmbedQA E5 v5", type: "embedding", params: { input_type: "query" } },
     // STT models
     { id: "nvidia/parakeet-ctc-1.1b-asr", name: "Parakeet CTC 1.1B", type: "stt", params: ["language"] },
   ],

--- a/open-sse/handlers/embeddingProviders/openai.js
+++ b/open-sse/handlers/embeddingProviders/openai.js
@@ -25,13 +25,16 @@ export default function createOpenAIEmbeddingAdapter(providerId) {
       }
       return headers;
     },
-    buildBody: (model, { input, encoding_format, dimensions }) => {
+    buildBody: (model, { input, encoding_format, dimensions }, modelInfo) => {
       const body = { model, input };
       if (encoding_format) body.encoding_format = encoding_format;
       if (dimensions != null && dimensions !== "") {
         const dim = Number(dimensions);
         if (Number.isFinite(dim) && dim > 0) body.dimensions = dim;
       }
+      // nv-embedqa-e5-v5 and other asymmetric embedding models require input_type="query"
+      // See: https://docs.api.nvidia.com/embeddings.html
+      if (modelInfo?.params?.input_type) body.input_type = modelInfo.params.input_type;
       return body;
     },
     normalize: (responseBody) => responseBody,

--- a/open-sse/handlers/embeddingsCore.js
+++ b/open-sse/handlers/embeddingsCore.js
@@ -44,7 +44,7 @@ export async function handleEmbeddingsCore({
     input,
     encoding_format: body.encoding_format || "float",
     dimensions: body.dimensions,
-  });
+  }, modelInfo);
 
   log?.debug?.("EMBEDDINGS", `${provider.toUpperCase()} | ${model} | input_type=${Array.isArray(input) ? `array[${input.length}]` : "string"}`);
 


### PR DESCRIPTION
## Summary

Fix #1378 — NVIDIA nv-embedqa-e5-v5 (an asymmetric embedding model) requires an input_type parameter set to "query".

Without it, requests return:
```
[nvidia/nvidia/nv-embedqa-e5-v5] [400]: 'input_type' parameter is required for asymmetric models
```

## Changes

- **open-sse/config/providerModels.js** — added `params: { input_type: "query" }` to the `nvidia/nv-embedqa-e5-v5` model entry
- **open-sse/handlers/embeddingProviders/openai.js** — extended `buildBody()` to accept `modelInfo` and forward `params.input_type` to the request body when present
- **open-sse/handlers/embeddingsCore.js** — passed `modelInfo` into `adapter.buildBody()`

## Notes

- The pattern is designed so other embedding models that need additional params (e.g., "passage" for symmetric/asymmetric pairs) can be configured by just adding to their `params` in providerModels.js
- STT params (`params: ["language"]`) and embedding params (`params: { input_type: "..." }`) are intentionally distinct shapes to avoid ambiguity

Closes #1378