### PR TITLE
Fix sql.js WASM in standalone builds

### DIFF
--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -159,26 +159,49 @@ console.log("✅ Copied standalone build\n");
 // Windows EBUSY during global CLI updates. node:sqlite (Node ≥22.5) is also
 // available as a no-install middle tier.
 console.log("3️⃣ b Configuring SQLite drivers...");
-function ensureModuleInBundle(pkg) {
-  const dest = path.join(cliAppDir, "node_modules", pkg);
-  if (fs.existsSync(dest)) {
-    console.log(`✅ ${pkg} already bundled`);
-    return;
-  }
+function findLocalModule(pkg) {
   const candidates = [
     path.join(appDir, "node_modules", pkg),
     path.join(rootDir, "node_modules", pkg),
   ];
-  const src = candidates.find((p) => fs.existsSync(p));
+  return candidates.find((p) => fs.existsSync(p));
+}
+
+function ensureModuleInBundle(pkg) {
+  const dest = path.join(cliAppDir, "node_modules", pkg);
+  if (fs.existsSync(dest)) {
+    console.log(`✅ ${pkg} already bundled`);
+    return dest;
+  }
+  const src = findLocalModule(pkg);
   if (!src) {
     console.warn(`⚠️  ${pkg} not found locally — bundle will rely on node:sqlite or runtime install`);
-    return;
+    return null;
   }
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   copyRecursive(src, dest);
   console.log(`✅ Bundled ${pkg}`);
+  return dest;
+}
+
+function ensureBundledModuleFile(pkg, relativeFile) {
+  const destFile = path.join(cliAppDir, "node_modules", pkg, relativeFile);
+  if (fs.existsSync(destFile)) return;
+
+  const srcModule = findLocalModule(pkg);
+  const srcFile = srcModule ? path.join(srcModule, relativeFile) : null;
+  if (!srcFile || !fs.existsSync(srcFile)) {
+    console.warn(`⚠️  ${pkg}/${relativeFile} not found locally — sql.js fallback may be unavailable`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(destFile), { recursive: true });
+  fs.copyFileSync(srcFile, destFile);
+  console.log(`✅ Bundled ${pkg}/${relativeFile}`);
 }
 ensureModuleInBundle("sql.js");
+// #1390: Next traces sql-wasm.js but can omit the runtime WASM asset.
+ensureBundledModuleFile("sql.js", path.join("dist", "sql-wasm.wasm"));
 const betterDir = path.join(cliAppDir, "node_modules", "better-sqlite3");
 if (fs.existsSync(betterDir)) {
   fs.rmSync(betterDir, { recursive: true, force: true });

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,9 @@ const nextConfig = {
     root: tracingRoot
   },
   outputFileTracingRoot: tracingRoot,
+  outputFileTracingIncludes: {
+    "*": ["./node_modules/sql.js/dist/sql-wasm.wasm"]
+  },
   outputFileTracingExcludes: {
     "*": ["./gitbook/**/*"]
   },


### PR DESCRIPTION
## Summary

Fixes #1390.

- Adds `sql.js/dist/sql-wasm.wasm` to Next standalone output file tracing.
- Ensures the CLI packaging step copies the WASM asset even when Next only traces `sql-wasm.js` into `node_modules/sql.js`.
- Documents the fix in the changelog.

## Validation

```text
node --check cli/scripts/build-cli.js
-> passed

npm run build
-> passed

Get-Item .next/standalone/node_modules/sql.js/dist/sql-wasm.wasm
-> present, 659730 bytes

npx vitest run --config ./tests/vitest.config.js --reporter=verbose tests/unit/db-driver-chain.test.js
-> 3 passed, including sql.js fallback

git diff --check
-> passed
```

## Notes

I did not run the full CLI packaging script because it generates `cli/app`, which is not clearly ignored in this checkout. The underlying Next standalone trace was verified directly, and the CLI packager now has an explicit safety copy for the same missing WASM asset.