### PR TITLE
Preserve Codex custom tool calls

### DIFF
--- a/open-sse/handlers/responsesHandler.js
+++ b/open-sse/handlers/responsesHandler.js
@@ -80,7 +80,7 @@ export async function handleResponsesCore({ body, modelInfo, credentials, log, o
 
   // Case 2: Client wants streaming, got SSE - transform it
   if (clientRequestedStreaming && contentType.includes("text/event-stream")) {
-    const transformStream = createResponsesApiTransformStream(null);
+    const transformStream = createResponsesApiTransformStream(null, body);
     const transformedBody = response.body.pipeThrough(transformStream);
 
     return {

--- a/open-sse/transformer/responsesTransformer.js
+++ b/open-sse/transformer/responsesTransformer.js
@@ -6,6 +6,13 @@
 
 import fs from "fs";
 import path from "path";
+import {
+  buildResponsesToolItem,
+  getResponsesCustomToolNames,
+  getResponsesToolInputEvent,
+  getResponsesToolItemIdPrefix,
+  getResponsesToolItemType
+} from "../translator/helpers/responsesCustomTools.js";
 
 // Create log directory for responses (Node.js only)
 export function createResponsesLogger(model, logsDir = null) {
@@ -51,7 +58,7 @@ export function createResponsesLogger(model, logsDir = null) {
  * @param {Object} logger - Optional logger instance
  * @returns {TransformStream}
  */
-export function createResponsesApiTransformStream(logger = null) {
+export function createResponsesApiTransformStream(logger = null, body = null) {
   const state = {
     seq: 0,
     responseId: `resp_${Date.now()}`,
@@ -70,8 +77,10 @@ export function createResponsesApiTransformStream(logger = null) {
     funcArgsBuf: {},
     funcNames: {},
     funcCallIds: {},
+    funcItemTypes: {},
     funcArgsDone: {},
     funcItemDone: {},
+    customToolNames: getResponsesCustomToolNames(body),
     buffer: "",
     completedSent: false
   };
@@ -196,25 +205,29 @@ export function createResponsesApiTransformStream(logger = null) {
   const closeToolCall = (controller, idx) => {
     const callId = state.funcCallIds[idx];
     if (callId && !state.funcItemDone[idx]) {
-      const args = state.funcArgsBuf[idx] || "{}";
+      const itemType = state.funcItemTypes?.[idx] || getResponsesToolItemType(state.funcNames[idx] || "", state.customToolNames);
+      const itemIdPrefix = getResponsesToolItemIdPrefix(itemType);
+      const doneEvent = getResponsesToolInputEvent(itemType, true);
+      const args = state.funcArgsBuf[idx] || (itemType === "custom_tool_call" ? "" : "{}");
       
-      emit(controller, "response.function_call_arguments.done", {
-        type: "response.function_call_arguments.done",
-        item_id: `fc_${callId}`,
+      emit(controller, doneEvent, {
+        type: doneEvent,
+        item_id: `${itemIdPrefix}_${callId}`,
         output_index: parseInt(idx),
-        arguments: args
+        name: state.funcNames[idx] || "",
+        ...(itemType === "custom_tool_call" ? { input: args } : { arguments: args })
       });
 
       emit(controller, "response.output_item.done", {
         type: "response.output_item.done",
         output_index: parseInt(idx),
-        item: {
-          id: `fc_${callId}`,
-          type: "function_call",
-          arguments: args,
-          call_id: callId,
-          name: state.funcNames[idx] || ""
-        }
+        item: buildResponsesToolItem({
+          itemType,
+          id: `${itemIdPrefix}_${callId}`,
+          callId,
+          name: state.funcNames[idx] || "",
+          value: args
+        })
       });
 
       state.funcItemDone[idx] = true;
@@ -380,20 +393,26 @@ export function createResponsesApiTransformStream(logger = null) {
             const funcName = tc.function?.name;
 
             if (funcName) state.funcNames[tcIdx] = funcName;
+            const toolName = state.funcNames[tcIdx] || "";
+            // #1371: preserve Codex freeform tools such as apply_patch as
+            // Responses custom_tool_call events instead of JSON function calls.
+            const itemType = getResponsesToolItemType(toolName, state.customToolNames);
+            const itemIdPrefix = getResponsesToolItemIdPrefix(itemType);
 
             if (!state.funcCallIds[tcIdx] && newCallId) {
               state.funcCallIds[tcIdx] = newCallId;
+              state.funcItemTypes[tcIdx] = itemType;
               
               emit(controller, "response.output_item.added", {
                 type: "response.output_item.added",
                 output_index: tcIdx,
-                item: {
-                  id: `fc_${newCallId}`,
-                  type: "function_call",
-                  arguments: "",
-                  call_id: newCallId,
-                  name: state.funcNames[tcIdx] || ""
-                }
+                item: buildResponsesToolItem({
+                  itemType,
+                  id: `${itemIdPrefix}_${newCallId}`,
+                  callId: newCallId,
+                  name: toolName,
+                  value: ""
+                })
               });
             }
 
@@ -401,10 +420,13 @@ export function createResponsesApiTransformStream(logger = null) {
 
             if (tc.function?.arguments) {
               const refCallId = state.funcCallIds[tcIdx] || newCallId;
+              const refItemType = state.funcItemTypes?.[tcIdx] || itemType;
+              const refItemIdPrefix = getResponsesToolItemIdPrefix(refItemType);
+              const deltaEvent = getResponsesToolInputEvent(refItemType);
               if (refCallId) {
-                emit(controller, "response.function_call_arguments.delta", {
-                  type: "response.function_call_arguments.delta",
-                  item_id: `fc_${refCallId}`,
+                emit(controller, deltaEvent, {
+                  type: deltaEvent,
+                  item_id: `${refItemIdPrefix}_${refCallId}`,
                   output_index: tcIdx,
                   delta: tc.function.arguments
                 });

--- a/open-sse/translator/helpers/responsesCustomTools.js
+++ b/open-sse/translator/helpers/responsesCustomTools.js
@@ -1,0 +1,70 @@
+const KNOWN_CUSTOM_TOOL_NAMES = new Set(["apply_patch"]);
+
+function getToolName(tool) {
+  return tool?.name || tool?.function?.name || "";
+}
+
+function isFreeformToolDefinition(tool) {
+  if (!tool || typeof tool !== "object") return false;
+  const type = tool.type || "";
+  const name = getToolName(tool);
+  return type === "custom" ||
+    type === "custom_tool" ||
+    tool.format?.type === "grammar" ||
+    tool.input_format?.type === "grammar" ||
+    KNOWN_CUSTOM_TOOL_NAMES.has(name);
+}
+
+export function getResponsesCustomToolNames(body) {
+  const names = new Set();
+  if (!Array.isArray(body?.tools)) return names;
+
+  for (const tool of body.tools) {
+    const name = getToolName(tool);
+    if (name && isFreeformToolDefinition(tool)) {
+      names.add(name);
+    }
+  }
+
+  return names;
+}
+
+export function isResponsesCustomToolName(name, customToolNames) {
+  if (!name) return false;
+  return customToolNames?.has?.(name) || KNOWN_CUSTOM_TOOL_NAMES.has(name);
+}
+
+export function getResponsesToolItemType(name, customToolNames) {
+  return isResponsesCustomToolName(name, customToolNames) ? "custom_tool_call" : "function_call";
+}
+
+export function getResponsesToolItemIdPrefix(itemType) {
+  return itemType === "custom_tool_call" ? "ctc" : "fc";
+}
+
+export function getResponsesToolInputEvent(itemType, done = false) {
+  if (itemType === "custom_tool_call") {
+    return done ? "response.custom_tool_call_input.done" : "response.custom_tool_call_input.delta";
+  }
+  return done ? "response.function_call_arguments.done" : "response.function_call_arguments.delta";
+}
+
+export function buildResponsesToolItem({ itemType, id, callId, name, value }) {
+  if (itemType === "custom_tool_call") {
+    return {
+      id,
+      type: itemType,
+      input: value,
+      call_id: callId,
+      name
+    };
+  }
+
+  return {
+    id,
+    type: itemType,
+    arguments: value,
+    call_id: callId,
+    name
+  };
+}

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -236,6 +236,7 @@ export function initState(sourceFormat) {
       funcArgsBuf: {},
       funcNames: {},
       funcCallIds: {},
+      funcItemTypes: {},
       funcArgsDone: {},
       funcItemDone: {},
       completedSent: false

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -86,7 +86,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
       pendingReasoning = "";
       result.messages.push(msg);
     }
-    else if (itemType === "function_call") {
+    else if (itemType === "function_call" || itemType === "custom_tool_call") {
       // Start or append to assistant message with tool_calls
       if (!currentAssistantMsg) {
         currentAssistantMsg = {
@@ -101,16 +101,18 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
       }
       // Skip items with empty/missing name — Codex/OpenAI reject nameless tool calls (#444)
       if (!item.name || typeof item.name !== "string" || item.name.trim() === "") continue;
+      // #1371: Responses custom_tool_call uses raw `input` instead of JSON
+      // `arguments`; preserve it while projecting history into Chat tool_calls.
       currentAssistantMsg.tool_calls.push({
         id: item.call_id,
         type: "function",
         function: {
           name: item.name,
-          arguments: item.arguments
+          arguments: itemType === "custom_tool_call" ? (item.input || "") : item.arguments
         }
       });
     }
-    else if (itemType === "function_call_output") {
+    else if (itemType === "function_call_output" || itemType === "custom_tool_call_output" || itemType === "apply_patch_call_output") {
       // Flush assistant message first if exists
       if (currentAssistantMsg) {
         result.messages.push(currentAssistantMsg);

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -4,6 +4,12 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
+import {
+  buildResponsesToolItem,
+  getResponsesToolInputEvent,
+  getResponsesToolItemIdPrefix,
+  getResponsesToolItemType
+} from "../helpers/responsesCustomTools.js";
 
 /**
  * Translate OpenAI chunk to Responses API events
@@ -258,20 +264,28 @@ function emitToolCall(state, emit, tc) {
   const funcName = tc.function?.name;
 
   if (funcName) state.funcNames[tcIdx] = funcName;
+  const toolName = state.funcNames[tcIdx] || "";
+  // #1371: Codex freeform tools such as apply_patch must stay Responses
+  // custom_tool_call items; downgrading them to JSON function_call args drops
+  // the raw patch input and makes Codex abort the edit.
+  const itemType = getResponsesToolItemType(toolName, state.customToolNames);
+  const itemIdPrefix = getResponsesToolItemIdPrefix(itemType);
 
   if (!state.funcCallIds[tcIdx] && newCallId) {
     state.funcCallIds[tcIdx] = newCallId;
+    state.funcItemTypes ??= {};
+    state.funcItemTypes[tcIdx] = itemType;
     
     emit("response.output_item.added", {
       type: "response.output_item.added",
       output_index: tcIdx,
-      item: {
-        id: `fc_${newCallId}`,
-        type: "function_call",
-        arguments: "",
-        call_id: newCallId,
-        name: state.funcNames[tcIdx] || ""
-      }
+      item: buildResponsesToolItem({
+        itemType,
+        id: `${itemIdPrefix}_${newCallId}`,
+        callId: newCallId,
+        name: toolName,
+        value: ""
+      })
     });
   }
 
@@ -279,10 +293,13 @@ function emitToolCall(state, emit, tc) {
 
   if (tc.function?.arguments) {
     const refCallId = state.funcCallIds[tcIdx] || newCallId;
+    const refItemType = state.funcItemTypes?.[tcIdx] || itemType;
+    const refItemIdPrefix = getResponsesToolItemIdPrefix(refItemType);
+    const deltaEvent = getResponsesToolInputEvent(refItemType);
     if (refCallId) {
-      emit("response.function_call_arguments.delta", {
-        type: "response.function_call_arguments.delta",
-        item_id: `fc_${refCallId}`,
+      emit(deltaEvent, {
+        type: deltaEvent,
+        item_id: `${refItemIdPrefix}_${refCallId}`,
         output_index: tcIdx,
         delta: tc.function.arguments
       });
@@ -294,25 +311,29 @@ function emitToolCall(state, emit, tc) {
 function closeToolCall(state, emit, idx) {
   const callId = state.funcCallIds[idx];
   if (callId && !state.funcItemDone[idx]) {
-    const args = state.funcArgsBuf[idx] || "{}";
+    const itemType = state.funcItemTypes?.[idx] || getResponsesToolItemType(state.funcNames[idx] || "", state.customToolNames);
+    const itemIdPrefix = getResponsesToolItemIdPrefix(itemType);
+    const doneEvent = getResponsesToolInputEvent(itemType, true);
+    const args = state.funcArgsBuf[idx] || (itemType === "custom_tool_call" ? "" : "{}");
     
-    emit("response.function_call_arguments.done", {
-      type: "response.function_call_arguments.done",
-      item_id: `fc_${callId}`,
+    emit(doneEvent, {
+      type: doneEvent,
+      item_id: `${itemIdPrefix}_${callId}`,
       output_index: parseInt(idx),
-      arguments: args
+      name: state.funcNames[idx] || "",
+      ...(itemType === "custom_tool_call" ? { input: args } : { arguments: args })
     });
 
     emit("response.output_item.done", {
       type: "response.output_item.done",
       output_index: parseInt(idx),
-      item: {
-        id: `fc_${callId}`,
-        type: "function_call",
-        arguments: args,
-        call_id: callId,
-        name: state.funcNames[idx] || ""
-      }
+      item: buildResponsesToolItem({
+        itemType,
+        id: `${itemIdPrefix}_${callId}`,
+        callId,
+        name: state.funcNames[idx] || "",
+        value: args
+      })
     });
 
     state.funcItemDone[idx] = true;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -1,5 +1,6 @@
 import { translateResponse, initState } from "../translator/index.js";
 import { FORMATS } from "../translator/formats.js";
+import { getResponsesCustomToolNames } from "../translator/helpers/responsesCustomTools.js";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
@@ -54,7 +55,9 @@ export function createSSEStream(options = {}) {
   // Per-stream decoder with stream:true to correctly handle multi-byte chars split across chunks
   const decoder = new TextDecoder("utf-8", { fatal: false });
 
-  const state = mode === STREAM_MODE.TRANSLATE ? { ...initState(sourceFormat), provider, toolNameMap, model } : null;
+  const state = mode === STREAM_MODE.TRANSLATE
+    ? { ...initState(sourceFormat), provider, toolNameMap, model, customToolNames: getResponsesCustomToolNames(body) }
+    : null;
 
   let totalContentLength = 0;
   let accumulatedContent = "";

--- a/tests/unit/openai-responses-custom-tools.test.js
+++ b/tests/unit/openai-responses-custom-tools.test.js
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { initState } from "../../open-sse/translator/index.js";
+import { openaiResponsesToOpenAIRequest } from "../../open-sse/translator/request/openai-responses.js";
+import { openaiToOpenAIResponsesResponse } from "../../open-sse/translator/response/openai-responses.js";
+import { getResponsesCustomToolNames } from "../../open-sse/translator/helpers/responsesCustomTools.js";
+import { createResponsesApiTransformStream } from "../../open-sse/transformer/responsesTransformer.js";
+
+function responsesState(body = {}) {
+  return {
+    ...initState(FORMATS.OPENAI_RESPONSES),
+    customToolNames: getResponsesCustomToolNames(body)
+  };
+}
+
+async function transformChatSSEToResponses(input, body) {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(input));
+      controller.close();
+    }
+  }).pipeThrough(createResponsesApiTransformStream(null, body));
+
+  const reader = stream.getReader();
+  let output = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+  output += decoder.decode();
+  return output;
+}
+
+describe("OpenAI Responses custom tool translation", () => {
+  it("emits Codex apply_patch as custom_tool_call with raw input", () => {
+    const patch = "*** Begin Patch\n*** Add File: demo.txt\n+hello\n*** End Patch\n";
+    const state = responsesState({
+      tools: [{ type: "custom", name: "apply_patch", description: "Apply patch" }]
+    });
+
+    const events = [
+      ...openaiToOpenAIResponsesResponse({
+        id: "chatcmpl_patch",
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: "call_patch",
+              type: "function",
+              function: { name: "apply_patch", arguments: patch }
+            }]
+          }
+        }]
+      }, state),
+      ...openaiToOpenAIResponsesResponse({
+        id: "chatcmpl_patch",
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }]
+      }, state)
+    ];
+
+    expect(events.find((event) => event.event === "response.output_item.added").data.item).toMatchObject({
+      type: "custom_tool_call",
+      call_id: "call_patch",
+      name: "apply_patch",
+      input: ""
+    });
+    expect(events.find((event) => event.event === "response.custom_tool_call_input.delta").data.delta).toBe(patch);
+    expect(events.find((event) => event.event === "response.custom_tool_call_input.done").data.input).toBe(patch);
+    expect(events.find((event) => event.event === "response.output_item.done").data.item).toMatchObject({
+      type: "custom_tool_call",
+      call_id: "call_patch",
+      name: "apply_patch",
+      input: patch
+    });
+    expect(events.some((event) => event.event === "response.function_call_arguments.delta")).toBe(false);
+  });
+
+  it("keeps normal tools as function_call arguments", () => {
+    const state = responsesState({
+      tools: [{
+        type: "function",
+        name: "read_file",
+        parameters: { type: "object", properties: { path: { type: "string" } } }
+      }]
+    });
+
+    const events = [
+      ...openaiToOpenAIResponsesResponse({
+        id: "chatcmpl_fn",
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: "call_read",
+              type: "function",
+              function: { name: "read_file", arguments: "{\"path\":\"demo.txt\"}" }
+            }]
+          }
+        }]
+      }, state),
+      ...openaiToOpenAIResponsesResponse({
+        id: "chatcmpl_fn",
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }]
+      }, state)
+    ];
+
+    expect(events.find((event) => event.event === "response.output_item.added").data.item.type).toBe("function_call");
+    expect(events.find((event) => event.event === "response.function_call_arguments.delta").data.delta).toBe("{\"path\":\"demo.txt\"}");
+    expect(events.some((event) => event.event === "response.custom_tool_call_input.delta")).toBe(false);
+  });
+
+  it("preserves custom_tool_call history and custom outputs in Responses requests", () => {
+    const result = openaiResponsesToOpenAIRequest("gpt-5.4", {
+      input: [
+        {
+          type: "custom_tool_call",
+          call_id: "call_patch",
+          name: "apply_patch",
+          input: "*** Begin Patch\n*** End Patch\n"
+        },
+        {
+          type: "custom_tool_call_output",
+          call_id: "call_patch",
+          output: "Done"
+        }
+      ]
+    }, true);
+
+    expect(result.messages).toEqual([
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{
+          id: "call_patch",
+          type: "function",
+          function: {
+            name: "apply_patch",
+            arguments: "*** Begin Patch\n*** End Patch\n"
+          }
+        }]
+      },
+      {
+        role: "tool",
+        tool_call_id: "call_patch",
+        content: "Done"
+      }
+    ]);
+  });
+
+  it("keeps the legacy Responses transform wrapper custom-tool aware", async () => {
+    const patch = "*** Begin Patch\n*** Add File: demo.txt\n+hello\n*** End Patch\n";
+    const body = { tools: [{ type: "custom", name: "apply_patch" }] };
+    const input = [
+      `data: ${JSON.stringify({
+        id: "chatcmpl_patch",
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: "call_patch",
+              type: "function",
+              function: { name: "apply_patch", arguments: patch }
+            }]
+          }
+        }]
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl_patch",
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }]
+      })}`,
+      "data: [DONE]"
+    ].join("\n\n");
+
+    const output = await transformChatSSEToResponses(input, body);
+
+    expect(output).toContain("response.custom_tool_call_input.delta");
+    expect(output).toContain("custom_tool_call");
+    expect(output).toContain("*** Begin Patch");
+    expect(output).not.toContain("response.function_call_arguments.delta");
+  });
+});


### PR DESCRIPTION
## Summary
- preserve Codex/Responses freeform tools such as `apply_patch` as `custom_tool_call` items with raw `input`
- keep normal JSON function tools on the existing `function_call` / `function_call_arguments` path
- preserve `custom_tool_call` history and custom/apply_patch outputs when projecting Responses requests into Chat Completions
- keep the legacy Responses stream wrapper custom-tool aware

Fixes #1371.

## Validation
- `node --check open-sse/translator/helpers/responsesCustomTools.js`
- `node --check open-sse/translator/response/openai-responses.js`
- `node --check open-sse/translator/request/openai-responses.js`
- `node --check open-sse/transformer/responsesTransformer.js`
- `node --check open-sse/handlers/responsesHandler.js`
- `npx vitest run --config ./tests/vitest.config.js --reporter=verbose tests/unit/openai-responses-custom-tools.test.js` (4 passed)
- `npm run build`
- `git diff --check`

## Notes
- `tests/unit/translator-request-normalization.test.js` still has pre-existing failures on this fresh `origin/master` branch around Claude/OpenAI text flattening and NDJSON parsing. Those failures are outside the Responses custom-tool path changed here.