### PR TITLE
Fallback on empty tool-heavy combo streams

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -5,6 +5,8 @@
 import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 
+const EMPTY_TOOL_STREAM_STATUS = 502;
+
 /**
  * Track rotation state per combo (for round-robin strategy)
  * @type {Map<string, { index: number, consecutiveUseCount: number }>}
@@ -93,6 +95,108 @@ export function getComboModelsFromData(modelStr, combosData) {
   return null;
 }
 
+function requestHasTools(body) {
+  return Array.isArray(body?.tools) && body.tools.length > 0;
+}
+
+function isInspectableSseResponse(response) {
+  const contentType = response?.headers?.get?.("content-type") || "";
+  return response?.ok && response?.body && typeof response.clone === "function" && contentType.includes("text/event-stream");
+}
+
+function parseSsePayloads(text) {
+  const messages = String(text || "").split(/\r?\n\r?\n/);
+  const payloads = [];
+
+  for (const msg of messages) {
+    if (!msg.trim()) continue;
+    const eventMatch = msg.match(/^event:\s*(.+)$/m);
+    const dataMatch = msg.match(/^data:\s*(.+)$/m);
+    if (!dataMatch) continue;
+
+    const data = dataMatch[1].trim();
+    if (!data || data === "[DONE]") continue;
+
+    try {
+      payloads.push({ event: eventMatch?.[1]?.trim() || "", data: JSON.parse(data) });
+    } catch {
+      payloads.push({ event: eventMatch?.[1]?.trim() || "", malformed: true });
+    }
+  }
+
+  return payloads;
+}
+
+function payloadHasVisibleOutput({ event, data }) {
+  if (!data || typeof data !== "object") return false;
+
+  const choice = data.choices?.[0];
+  const delta = choice?.delta;
+  if (delta?.content || delta?.reasoning_content) return true;
+  if (Array.isArray(delta?.tool_calls) && delta.tool_calls.length > 0) return true;
+  if (choice?.message?.content) return true;
+  if (Array.isArray(choice?.message?.tool_calls) && choice.message.tool_calls.length > 0) return true;
+
+  if (data.type === "content_block_start" && data.content_block?.type === "tool_use") return true;
+  if (data.type === "content_block_delta" && (data.delta?.text || data.delta?.partial_json || data.delta?.thinking)) return true;
+  if (event === "response.output_text.delta" && data.delta) return true;
+  if (event === "response.reasoning_summary_text.delta" && data.delta) return true;
+  if (event === "response.output_item.added" && (data.item?.type === "function_call" || data.item?.type === "custom_tool_call")) return true;
+  if ((event === "response.function_call_arguments.delta" || event === "response.custom_tool_call_input.delta") && data.delta) return true;
+
+  return false;
+}
+
+async function inspectToolStreamForFallback(response) {
+  if (!isInspectableSseResponse(response)) return null;
+
+  const clone = response.clone();
+  const reader = clone.body?.getReader?.();
+  if (!reader) return null;
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let sawMalformedPayload = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split(/\r?\n\r?\n/);
+      buffer = parts.pop() || "";
+
+      for (const payload of parseSsePayloads(parts.join("\n\n"))) {
+        if (payload.malformed) sawMalformedPayload = true;
+        if (payloadHasVisibleOutput(payload)) {
+          reader.cancel().catch(() => { });
+          return null;
+        }
+      }
+    }
+  } catch (error) {
+    return { shouldFallback: false, reason: `stream inspection failed: ${error.message || String(error)}` };
+  }
+
+  const remaining = buffer + decoder.decode();
+  const payloads = parseSsePayloads(remaining);
+  const hasVisibleOutput = payloads.some(payloadHasVisibleOutput);
+  const hasMalformedPayload = sawMalformedPayload || payloads.some(p => p.malformed);
+
+  // #1382: Some OpenAI-compatible backends return HTTP 200 SSE streams for
+  // tool-heavy Claude requests but emit no client-visible text/tool calls. Treat
+  // those as transient upstream failures so combos can try the next model.
+  if (!hasVisibleOutput) {
+    return {
+      shouldFallback: true,
+      reason: hasMalformedPayload ? "malformed tool stream with no visible output" : "empty tool stream with no visible output"
+    };
+  }
+
+  return null;
+}
+
 /**
  * Handle combo chat with fallback
  * @param {Object} options
@@ -122,6 +226,15 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       
       // Success (2xx) - return response
       if (result.ok) {
+        if (requestHasTools(body)) {
+          const streamIssue = await inspectToolStreamForFallback(result);
+          if (streamIssue?.shouldFallback) {
+            lastError = streamIssue.reason;
+            if (!lastStatus) lastStatus = EMPTY_TOOL_STREAM_STATUS;
+            log.warn("COMBO", `Model ${modelStr} returned empty tool stream, trying next`, { status: EMPTY_TOOL_STREAM_STATUS });
+            continue;
+          }
+        }
         log.info("COMBO", `Model ${modelStr} succeeded`);
         return result;
       }

--- a/tests/unit/combo-routing.test.js
+++ b/tests/unit/combo-routing.test.js
@@ -1,6 +1,18 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { getRotatedModels, resetComboRotation } from "../../open-sse/services/combo.js";
+import { getRotatedModels, handleComboChat, resetComboRotation } from "../../open-sse/services/combo.js";
+
+const log = {
+  info() {},
+  warn() {},
+};
+
+function sseResponse(events) {
+  return new Response(events.join("\n\n"), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
 
 describe("combo round-robin routing", () => {
   beforeEach(() => {
@@ -54,5 +66,73 @@ describe("combo round-robin routing", () => {
 
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
+  });
+
+  it("falls through when a tool-heavy SSE response has no visible output", async () => {
+    const tried = [];
+    const result = await handleComboChat({
+      body: {
+        messages: [{ role: "user", content: "echo ok" }],
+        tools: [{ name: "Read", input_schema: { type: "object", properties: {} } }],
+      },
+      models: ["ds/deepseek-v4-pro-max", "minimax/MiniMax-M2.7"],
+      log,
+      handleSingleModel: async (_body, model) => {
+        tried.push(model);
+        if (model.startsWith("ds/")) {
+          return sseResponse([
+            'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[]}}',
+            'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+            'event: message_stop\ndata: {"type":"message_stop"}',
+            "data: [DONE]",
+          ]);
+        }
+        return sseResponse([
+          'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ok"}}',
+          "data: [DONE]",
+        ]);
+      },
+    });
+
+    expect(tried).toEqual(["ds/deepseek-v4-pro-max", "minimax/MiniMax-M2.7"]);
+    expect(await result.text()).toContain("ok");
+  });
+
+  it("does not inspect or fallback empty streams when the request has no tools", async () => {
+    const tried = [];
+    const result = await handleComboChat({
+      body: { messages: [{ role: "user", content: "ping" }] },
+      models: ["provider/model-a", "provider/model-b"],
+      log,
+      handleSingleModel: async (_body, model) => {
+        tried.push(model);
+        return sseResponse(["event: message_stop\ndata: {\"type\":\"message_stop\"}", "data: [DONE]"]);
+      },
+    });
+
+    expect(tried).toEqual(["provider/model-a"]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("keeps tool streams that emit tool calls", async () => {
+    const tried = [];
+    const result = await handleComboChat({
+      body: {
+        messages: [{ role: "user", content: "read" }],
+        tools: [{ name: "Read", input_schema: { type: "object", properties: {} } }],
+      },
+      models: ["provider/model-a", "provider/model-b"],
+      log,
+      handleSingleModel: async (_body, model) => {
+        tried.push(model);
+        return sseResponse([
+          'event: content_block_start\ndata: {"type":"content_block_start","content_block":{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}}',
+          "data: [DONE]",
+        ]);
+      },
+    });
+
+    expect(tried).toEqual(["provider/model-a"]);
+    expect(await result.text()).toContain("tool_use");
   });
 });


### PR DESCRIPTION
## Summary
- inspect successful combo SSE responses only when the original request contains tools
- fall through to the next combo model when a 200 SSE stream has no client-visible text, reasoning, or tool-call output
- keep normal no-tool streams untouched and keep tool streams that emit tool calls

Fixes #1382.

## Validation
- `node --check open-sse/services/combo.js`
- `npx vitest run --config ./tests/vitest.config.js --reporter=verbose tests/unit/combo-routing.test.js` (7 passed)
- `npm run build`
- `git diff --check`

## Notes
- Scope is intentionally limited to combo fallback. Direct single-model requests still return the provider response; this avoids buffering every streaming request globally.
- The stream inspector reads only until the first visible output/tool-call, then releases the cloned stream. It reads to the end only for streams that are actually empty/malformed.