### PR TITLE
fix(responses): preserve Codex custom_tool_call shape through translator (#1371)

### DIFF
--- a/open-sse/handlers/responsesHandler.js
+++ b/open-sse/handlers/responsesHandler.js
@@ -22,6 +22,13 @@ import { convertResponsesStreamToJson } from "../transformer/streamToJsonConvert
  * @returns {Promise<{success: boolean, response?: Response, status?: number, error?: string}>}
  */
 export async function handleResponsesCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, connectionId }) {
+  // Capture freeform/custom tool names BEFORE conversion so the outbound
+  // transformer can re-emit them as `custom_tool_call` items instead of
+  // downgrading to `function_call` with empty JSON args (#1371).
+  const customToolNames = Array.isArray(body?.tools)
+    ? body.tools.filter(t => t && t.type === "custom" && typeof t.name === "string" && t.name).map(t => t.name)
+    : [];
+
   // Convert Responses API format to Chat Completions format
   const convertedBody = convertResponsesApiFormat(body);
 
@@ -80,7 +87,7 @@ export async function handleResponsesCore({ body, modelInfo, credentials, log, o
 
   // Case 2: Client wants streaming, got SSE - transform it
   if (clientRequestedStreaming && contentType.includes("text/event-stream")) {
-    const transformStream = createResponsesApiTransformStream(null);
+    const transformStream = createResponsesApiTransformStream(null, customToolNames);
     const transformedBody = response.body.pipeThrough(transformStream);
 
     return {

--- a/open-sse/transformer/responsesTransformer.js
+++ b/open-sse/transformer/responsesTransformer.js
@@ -51,7 +51,27 @@ export function createResponsesLogger(model, logsDir = null) {
  * @param {Object} logger - Optional logger instance
  * @returns {TransformStream}
  */
-export function createResponsesApiTransformStream(logger = null) {
+export function createResponsesApiTransformStream(logger = null, customTools = null) {
+  const customToolSet = customTools instanceof Set
+    ? customTools
+    : (Array.isArray(customTools) ? new Set(customTools) : new Set());
+  const isCustomToolName = (name) => !!(name && customToolSet.has(name));
+
+  const unwrapCustomInput = (rawArgs) => {
+    if (!rawArgs) return "";
+    try {
+      const parsed = JSON.parse(rawArgs);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        if (typeof parsed.input === "string") return parsed.input;
+        if (typeof parsed.patch === "string") return parsed.patch;
+      }
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // Not JSON — treat as raw text
+    }
+    return rawArgs;
+  };
+
   const state = {
     seq: 0,
     responseId: `resp_${Date.now()}`,
@@ -195,14 +215,49 @@ export function createResponsesApiTransformStream(logger = null) {
 
   const closeToolCall = (controller, idx) => {
     const callId = state.funcCallIds[idx];
-    if (callId && !state.funcItemDone[idx]) {
-      const args = state.funcArgsBuf[idx] || "{}";
-      
+    if (!callId || state.funcItemDone[idx]) return;
+
+    const name = state.funcNames[idx] || "";
+    const rawArgs = state.funcArgsBuf[idx] || "{}";
+
+    if (isCustomToolName(name)) {
+      // Codex freeform tools (apply_patch etc.) — emit custom_tool_call shape (#1371)
+      const input = unwrapCustomInput(rawArgs);
+      const itemId = `ctc_${callId}`;
+
+      if (input) {
+        emit(controller, "response.custom_tool_call_input.delta", {
+          type: "response.custom_tool_call_input.delta",
+          item_id: itemId,
+          output_index: parseInt(idx),
+          delta: input
+        });
+      }
+
+      emit(controller, "response.custom_tool_call_input.done", {
+        type: "response.custom_tool_call_input.done",
+        item_id: itemId,
+        output_index: parseInt(idx),
+        input
+      });
+
+      emit(controller, "response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: parseInt(idx),
+        item: {
+          id: itemId,
+          type: "custom_tool_call",
+          name,
+          call_id: callId,
+          input
+        }
+      });
+    } else {
       emit(controller, "response.function_call_arguments.done", {
         type: "response.function_call_arguments.done",
         item_id: `fc_${callId}`,
         output_index: parseInt(idx),
-        arguments: args
+        arguments: rawArgs
       });
 
       emit(controller, "response.output_item.done", {
@@ -211,15 +266,15 @@ export function createResponsesApiTransformStream(logger = null) {
         item: {
           id: `fc_${callId}`,
           type: "function_call",
-          arguments: args,
+          arguments: rawArgs,
           call_id: callId,
-          name: state.funcNames[idx] || ""
+          name
         }
       });
-
-      state.funcItemDone[idx] = true;
-      state.funcArgsDone[idx] = true;
     }
+
+    state.funcItemDone[idx] = true;
+    state.funcArgsDone[idx] = true;
   };
 
   const sendCompleted = (controller) => {
@@ -381,35 +436,56 @@ export function createResponsesApiTransformStream(logger = null) {
 
             if (funcName) state.funcNames[tcIdx] = funcName;
 
+            const custom = isCustomToolName(state.funcNames[tcIdx]);
+
             if (!state.funcCallIds[tcIdx] && newCallId) {
               state.funcCallIds[tcIdx] = newCallId;
-              
-              emit(controller, "response.output_item.added", {
-                type: "response.output_item.added",
-                output_index: tcIdx,
-                item: {
-                  id: `fc_${newCallId}`,
-                  type: "function_call",
-                  arguments: "",
-                  call_id: newCallId,
-                  name: state.funcNames[tcIdx] || ""
-                }
-              });
+
+              if (custom) {
+                emit(controller, "response.output_item.added", {
+                  type: "response.output_item.added",
+                  output_index: tcIdx,
+                  item: {
+                    id: `ctc_${newCallId}`,
+                    type: "custom_tool_call",
+                    name: state.funcNames[tcIdx] || "",
+                    call_id: newCallId,
+                    input: ""
+                  }
+                });
+              } else {
+                emit(controller, "response.output_item.added", {
+                  type: "response.output_item.added",
+                  output_index: tcIdx,
+                  item: {
+                    id: `fc_${newCallId}`,
+                    type: "function_call",
+                    arguments: "",
+                    call_id: newCallId,
+                    name: state.funcNames[tcIdx] || ""
+                  }
+                });
+              }
             }
 
             if (!state.funcArgsBuf[tcIdx]) state.funcArgsBuf[tcIdx] = "";
 
             if (tc.function?.arguments) {
-              const refCallId = state.funcCallIds[tcIdx] || newCallId;
-              if (refCallId) {
-                emit(controller, "response.function_call_arguments.delta", {
-                  type: "response.function_call_arguments.delta",
-                  item_id: `fc_${refCallId}`,
-                  output_index: tcIdx,
-                  delta: tc.function.arguments
-                });
-              }
               state.funcArgsBuf[tcIdx] += tc.function.arguments;
+
+              // For custom (freeform) tools, defer emission to closeToolCall so
+              // we can unwrap the JSON envelope back to a raw `input` string.
+              if (!custom) {
+                const refCallId = state.funcCallIds[tcIdx] || newCallId;
+                if (refCallId) {
+                  emit(controller, "response.function_call_arguments.delta", {
+                    type: "response.function_call_arguments.delta",
+                    item_id: `fc_${refCallId}`,
+                    output_index: tcIdx,
+                    delta: tc.function.arguments
+                  });
+                }
+              }
             }
           }
         }

--- a/open-sse/translator/helpers/responsesApiHelper.js
+++ b/open-sse/translator/helpers/responsesApiHelper.js
@@ -78,7 +78,7 @@ export function convertResponsesApiFormat(body) {
         : item.content;
       result.messages.push({ role: item.role, content });
     }
-    else if (itemType === "function_call") {
+    else if (itemType === "function_call" || itemType === "custom_tool_call") {
       // Start or append to assistant message with tool_calls
       if (!currentAssistantMsg) {
         currentAssistantMsg = {
@@ -89,16 +89,21 @@ export function convertResponsesApiFormat(body) {
       }
       // Skip items with empty/missing name — upstream APIs reject nameless tool calls (#444)
       if (!item.name || typeof item.name !== "string" || item.name.trim() === "") continue;
+      // custom_tool_call carries raw freeform `input` — wrap as `{ "input": ... }`
+      // so it round-trips through the synthesized function-tool schema (#1371).
+      const argsString = itemType === "custom_tool_call"
+        ? JSON.stringify({ input: typeof item.input === "string" ? item.input : (item.input ?? "") })
+        : (item.arguments ?? "{}");
       currentAssistantMsg.tool_calls.push({
         id: item.call_id,
         type: "function",
         function: {
           name: item.name,
-          arguments: item.arguments
+          arguments: argsString
         }
       });
     }
-    else if (itemType === "function_call_output") {
+    else if (itemType === "function_call_output" || itemType === "custom_tool_call_output") {
       // Flush assistant message first if exists
       if (currentAssistantMsg) {
         result.messages.push(currentAssistantMsg);
@@ -127,6 +132,12 @@ export function convertResponsesApiFormat(body) {
     }
   }
 
+  // Normalize tools so freeform `custom` tools survive downstream Chat Completions
+  // round-tripping (Codex `apply_patch` etc. — see #1371).
+  if (Array.isArray(result.tools)) {
+    result.tools = normalizeResponsesTools(result.tools);
+  }
+
   // Cleanup Responses API specific fields
   delete result.input;
   delete result.instructions;
@@ -136,4 +147,69 @@ export function convertResponsesApiFormat(body) {
   delete result.reasoning;
 
   return result;
+}
+
+/**
+ * Ensure object schema has properties (Chat Completions tool param requirement).
+ */
+function ensureObjectProperties(params) {
+  if (!params) return { type: "object", properties: {} };
+  if (params.type === "object" && !params.properties) return { ...params, properties: {} };
+  return params;
+}
+
+/**
+ * Convert a Responses API tools[] array to Chat Completions tools[]:
+ *   - Pass through tools that are already in Chat shape (`{ function: {...} }`)
+ *   - Drop hosted tools without a `name`
+ *   - Convert `{ type: "function", name, parameters, ... }` → Chat function tool
+ *   - Convert `{ type: "custom", name, format, ... }` (freeform / `apply_patch`)
+ *     into a function tool with a single string `input` parameter so downstream
+ *     models that don't support freeform tools still emit the raw payload as
+ *     `{"input":"<raw>"}`. The response translator unwraps it back to
+ *     `custom_tool_call_input` for the client (#1371).
+ */
+export function normalizeResponsesTools(tools) {
+  if (!Array.isArray(tools)) return tools;
+  return tools
+    .map(tool => {
+      if (!tool) return null;
+      if (tool.function) return tool;
+      const name = tool.name;
+      if (!name || typeof name !== "string" || name.trim() === "") return null;
+
+      if (tool.type === "custom") {
+        const baseDesc = String(tool.description || "");
+        return {
+          type: "function",
+          function: {
+            name,
+            description: baseDesc
+              ? `${baseDesc}\n\nCall this tool by passing the full raw payload as the string parameter "input".`
+              : `Call this tool by passing the full raw payload as the string parameter "input".`,
+            parameters: {
+              type: "object",
+              properties: {
+                input: {
+                  type: "string",
+                  description: "Raw text input passed verbatim to the tool."
+                }
+              },
+              required: ["input"]
+            }
+          }
+        };
+      }
+
+      return {
+        type: "function",
+        function: {
+          name,
+          description: String(tool.description || ""),
+          parameters: ensureObjectProperties(tool.parameters),
+          strict: tool.strict
+        }
+      };
+    })
+    .filter(Boolean);
 }

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -6,7 +6,7 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { normalizeResponsesInput } from "../helpers/responsesApiHelper.js";
+import { normalizeResponsesInput, normalizeResponsesTools } from "../helpers/responsesApiHelper.js";
 
 // Responses API enforces max 64 chars on call_id (#393)
 const MAX_CALL_ID_LEN = 64;
@@ -86,7 +86,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
       pendingReasoning = "";
       result.messages.push(msg);
     }
-    else if (itemType === "function_call") {
+    else if (itemType === "function_call" || itemType === "custom_tool_call") {
       // Start or append to assistant message with tool_calls
       if (!currentAssistantMsg) {
         currentAssistantMsg = {
@@ -101,16 +101,22 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
       }
       // Skip items with empty/missing name — Codex/OpenAI reject nameless tool calls (#444)
       if (!item.name || typeof item.name !== "string" || item.name.trim() === "") continue;
+      // custom_tool_call carries a raw freeform `input` string instead of JSON
+      // `arguments`. Re-wrap as `{ "input": "<raw>" }` so the synthesized
+      // function tool schema (see normalizeCustomToolToFunction) round-trips (#1371).
+      const argsString = itemType === "custom_tool_call"
+        ? JSON.stringify({ input: typeof item.input === "string" ? item.input : (item.input ?? "") })
+        : (item.arguments ?? "{}");
       currentAssistantMsg.tool_calls.push({
         id: item.call_id,
         type: "function",
         function: {
           name: item.name,
-          arguments: item.arguments
+          arguments: argsString
         }
       });
     }
-    else if (itemType === "function_call_output") {
+    else if (itemType === "function_call_output" || itemType === "custom_tool_call_output") {
       // Flush assistant message first if exists
       if (currentAssistantMsg) {
         result.messages.push(currentAssistantMsg);
@@ -148,31 +154,12 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
     }
   }
 
-  // Convert tools format.
-  // Responses API supports "hosted" tools (e.g. { type: "request_user_input" }) that carry no
-  // explicit `name` field and cannot be represented as Chat Completions function declarations.
-  // Filter them out to avoid sending nameless functionDeclarations to downstream providers
-  // such as Gemini, which strictly validates function names.
+  // Convert tools format (function + freeform custom tools, see #1371).
+  // Hosted tools without a `name` (e.g. `{ type: "request_user_input" }`) are
+  // dropped so downstream providers that strictly validate function names
+  // (Gemini etc.) don't see nameless function declarations.
   if (body.tools && Array.isArray(body.tools)) {
-    result.tools = body.tools
-      .map(tool => {
-        // Already in Chat Completions format: { type: "function", function: { name, ... } }
-        if (tool.function) return tool;
-        // Responses API function tool: { type: "function", name, description, parameters }
-        // Only convert when a non-empty name is present; skip hosted tools without one.
-        const name = tool.name;
-        if (!name || typeof name !== "string" || name.trim() === "") return null;
-        return {
-          type: "function",
-          function: {
-            name,
-            description: String(tool.description || ""),
-            parameters: normalizeToolParameters(tool.parameters),
-            strict: tool.strict
-          }
-        };
-      })
-      .filter(Boolean);
+    result.tools = normalizeResponsesTools(body.tools);
   }
 
   // Cleanup Responses API specific fields

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -252,6 +252,10 @@ function closeMessage(state, emit, idx) {
   }
 }
 
+function isCustomToolName(state, name) {
+  return !!(name && state.customTools && state.customTools.has(name));
+}
+
 function emitToolCall(state, emit, tc) {
   const tcIdx = tc.index ?? 0;
   const newCallId = tc.id;
@@ -259,48 +263,122 @@ function emitToolCall(state, emit, tc) {
 
   if (funcName) state.funcNames[tcIdx] = funcName;
 
+  const custom = isCustomToolName(state, state.funcNames[tcIdx]);
+
   if (!state.funcCallIds[tcIdx] && newCallId) {
     state.funcCallIds[tcIdx] = newCallId;
-    
-    emit("response.output_item.added", {
-      type: "response.output_item.added",
-      output_index: tcIdx,
-      item: {
-        id: `fc_${newCallId}`,
-        type: "function_call",
-        arguments: "",
-        call_id: newCallId,
-        name: state.funcNames[tcIdx] || ""
-      }
-    });
+
+    if (custom) {
+      // Codex `apply_patch` and similar freeform tools expect `custom_tool_call`
+      // items with a raw `input` string — not `function_call` with JSON args (#1371).
+      emit("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: tcIdx,
+        item: {
+          id: `ctc_${newCallId}`,
+          type: "custom_tool_call",
+          name: state.funcNames[tcIdx] || "",
+          call_id: newCallId,
+          input: ""
+        }
+      });
+    } else {
+      emit("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: tcIdx,
+        item: {
+          id: `fc_${newCallId}`,
+          type: "function_call",
+          arguments: "",
+          call_id: newCallId,
+          name: state.funcNames[tcIdx] || ""
+        }
+      });
+    }
   }
 
   if (!state.funcArgsBuf[tcIdx]) state.funcArgsBuf[tcIdx] = "";
 
   if (tc.function?.arguments) {
-    const refCallId = state.funcCallIds[tcIdx] || newCallId;
-    if (refCallId) {
-      emit("response.function_call_arguments.delta", {
-        type: "response.function_call_arguments.delta",
-        item_id: `fc_${refCallId}`,
-        output_index: tcIdx,
-        delta: tc.function.arguments
-      });
-    }
     state.funcArgsBuf[tcIdx] += tc.function.arguments;
+
+    if (!custom) {
+      const refCallId = state.funcCallIds[tcIdx] || newCallId;
+      if (refCallId) {
+        emit("response.function_call_arguments.delta", {
+          type: "response.function_call_arguments.delta",
+          item_id: `fc_${refCallId}`,
+          output_index: tcIdx,
+          delta: tc.function.arguments
+        });
+      }
+    }
+    // For custom tools we defer emission until close, because we must unwrap the
+    // downstream JSON envelope `{ "input": "<raw>" }` back to the raw string the
+    // Codex client expects in `custom_tool_call_input.delta`.
   }
+}
+
+function unwrapCustomInput(rawArgs) {
+  if (!rawArgs) return "";
+  try {
+    const parsed = JSON.parse(rawArgs);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      if (typeof parsed.input === "string") return parsed.input;
+      if (typeof parsed.patch === "string") return parsed.patch;
+    }
+    if (typeof parsed === "string") return parsed;
+  } catch {
+    // Not JSON — assume the upstream already sent raw text (e.g. Responses-native).
+  }
+  return rawArgs;
 }
 
 function closeToolCall(state, emit, idx) {
   const callId = state.funcCallIds[idx];
-  if (callId && !state.funcItemDone[idx]) {
-    const args = state.funcArgsBuf[idx] || "{}";
-    
+  if (!callId || state.funcItemDone[idx]) return;
+
+  const name = state.funcNames[idx] || "";
+  const rawArgs = state.funcArgsBuf[idx] || "{}";
+  const custom = isCustomToolName(state, name);
+
+  if (custom) {
+    const input = unwrapCustomInput(rawArgs);
+    const itemId = `ctc_${callId}`;
+
+    if (input) {
+      emit("response.custom_tool_call_input.delta", {
+        type: "response.custom_tool_call_input.delta",
+        item_id: itemId,
+        output_index: parseInt(idx),
+        delta: input
+      });
+    }
+
+    emit("response.custom_tool_call_input.done", {
+      type: "response.custom_tool_call_input.done",
+      item_id: itemId,
+      output_index: parseInt(idx),
+      input
+    });
+
+    emit("response.output_item.done", {
+      type: "response.output_item.done",
+      output_index: parseInt(idx),
+      item: {
+        id: itemId,
+        type: "custom_tool_call",
+        name,
+        call_id: callId,
+        input
+      }
+    });
+  } else {
     emit("response.function_call_arguments.done", {
       type: "response.function_call_arguments.done",
       item_id: `fc_${callId}`,
       output_index: parseInt(idx),
-      arguments: args
+      arguments: rawArgs
     });
 
     emit("response.output_item.done", {
@@ -309,15 +387,15 @@ function closeToolCall(state, emit, idx) {
       item: {
         id: `fc_${callId}`,
         type: "function_call",
-        arguments: args,
+        arguments: rawArgs,
         call_id: callId,
-        name: state.funcNames[idx] || ""
+        name
       }
     });
-
-    state.funcItemDone[idx] = true;
-    state.funcArgsDone[idx] = true;
   }
+
+  state.funcItemDone[idx] = true;
+  state.funcArgsDone[idx] = true;
 }
 
 function sendCompleted(state, emit) {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -52,7 +52,19 @@ export function createSSEStream(options = {}) {
   // Per-stream decoder with stream:true to correctly handle multi-byte chars split across chunks
   const decoder = new TextDecoder("utf-8", { fatal: false });
 
-  const state = mode === STREAM_MODE.TRANSLATE ? { ...initState(sourceFormat), provider, toolNameMap, model } : null;
+  // Capture freeform/custom tool names from the original client body so the
+  // response translator can re-emit them as Codex `custom_tool_call` items
+  // instead of downgrading to `function_call` with empty JSON args (#1371).
+  const customTools = new Set();
+  if (body?.tools && Array.isArray(body.tools)) {
+    for (const t of body.tools) {
+      if (t && t.type === "custom" && typeof t.name === "string" && t.name) {
+        customTools.add(t.name);
+      }
+    }
+  }
+
+  const state = mode === STREAM_MODE.TRANSLATE ? { ...initState(sourceFormat), provider, toolNameMap, model, customTools } : null;
 
   let totalContentLength = 0;
   let accumulatedContent = "";


### PR DESCRIPTION
## Summary

Fixes #1371 — Codex Desktop `apply_patch` was reaching the client as `function_call` with `arguments:"{}"` instead of `custom_tool_call` with the raw patch text in `input`, so edits were silently aborted.

Two layers were dropping the freeform shape:

1. **Request translator** collapsed `{ type: "custom", name, format }` tool definitions into a function tool with an empty parameter schema — the downstream model had nothing to fill and returned `{}`.
2. **Response translator** always emitted `function_call` items and `response.function_call_arguments.delta` events, even when the original tool was freeform.

## Changes

- **Shared `normalizeResponsesTools()` helper** (`open-sse/translator/helpers/responsesApiHelper.js`). Freeform `custom` tools are rewritten as function tools with a single required string parameter `input`, and the description nudges the model to put the raw payload there. Downstream models now emit `{"input":"<raw>"}`.
- **Request side** (`request/openai-responses.js`, `helpers/responsesApiHelper.js`): handle prior-turn `custom_tool_call` / `custom_tool_call_output` items by re-wrapping the raw `input` into the same `{"input": ...}` envelope so history round-trips cleanly.
- **Response side** (`response/openai-responses.js`, `utils/stream.js`): capture freeform tool names from the original client `body.tools` into `state.customTools`. When a tool call matches, buffer arguments until close, unwrap `{"input":"..."}` back to raw text, and emit `response.output_item.added` / `response.custom_tool_call_input.delta` / `.done` / `response.output_item.done` with `type: "custom_tool_call"`.
- **Worker path** (`transformer/responsesTransformer.js`, `handlers/responsesHandler.js`): mirror the same handling and thread custom tool names through the handler into the transformer.

Normal function tools are unchanged — still streamed as `function_call_arguments.delta` events with JSON arguments.

## Verification

Local smoke tests against the response translator:

- Custom tool path: input chunk `{ name: "apply_patch", arguments: '{"input":"*** Begin Patch\\n..."}' }` produces `response.output_item.added` with `type: "custom_tool_call"`, `response.custom_tool_call_input.delta` carrying the raw patch text, and `response.output_item.done` with `type: "custom_tool_call"`. ✅
- Function tool path: input chunks for a `shell` tool produce streamed `response.function_call_arguments.delta` events plus `function_call_arguments.done` and `output_item.done` with `type: "function_call"`. ✅
- Request translator round-trip: `custom_tool_call` history items re-wrap to `{"input": "..."}` and emerge as Chat Completions `tool_calls` correctly.

## Not covered in this PR

- Issue's secondary item — `cc/*` Claude first hop (`toolu_*` + empty args) — needs a separate fix in `response/claude-to-openai.js` to detect freeform tools when translating Claude `tool_use`.
- The combo-fallback gap (empty `apply_patch` args not triggering provider fallback) is also out of scope here.

## Test plan

- [ ] Codex Desktop with `wire_api = "responses"`, model `gpt-5.4` via oa-first combo → ask agent to edit a file, confirm rollout JSONL contains `custom_tool_call` + non-empty `input`.
- [ ] Verify chat-only turns still work end-to-end (no regression in `function_call` path).
- [ ] Verify `function_call_output` history (non-custom tools) still round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)