### PR TITLE
fix(db,sse): bound usageHistory growth and clean up usage SSE listeners (#1245)

### DIFF
--- a/src/app/api/usage/stream/route.js
+++ b/src/app/api/usage/stream/route.js
@@ -2,9 +2,29 @@ import { getUsageStats, statsEmitter, getActiveRequests } from "@/lib/usageDb";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request) {
   const encoder = new TextEncoder();
   const state = { closed: false, keepalive: null, send: null, sendPending: null, cachedStats: null };
+
+  // Idempotent cleanup — releases EventEmitter listeners + interval so they
+  // don't accumulate when the SSE connection ends. ReadableStream.cancel() is
+  // not always invoked in Next.js, which previously caused statsEmitter
+  // listeners (each holding a full `cachedStats` object in closure) to leak.
+  // Mirrors the fix in /api/translator/console-logs/stream/route.js (#1245).
+  const cleanup = () => {
+    if (state.closed) return;
+    state.closed = true;
+    if (state.send) statsEmitter.off("update", state.send);
+    if (state.sendPending) statsEmitter.off("pending", state.sendPending);
+    if (state.keepalive) clearInterval(state.keepalive);
+    // Drop cached stats so a leaked closure (if any) cannot pin the full
+    // stats object in memory.
+    state.cachedStats = null;
+  };
+
+  // request.signal.abort fires reliably on client disconnect — the canonical
+  // cleanup trigger in Next.js. cancel() is kept as a belt-and-suspenders.
+  request.signal.addEventListener("abort", cleanup, { once: true });
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -23,10 +43,7 @@ export async function GET() {
           state.cachedStats = stats;
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
         } catch {
-          state.closed = true;
-          statsEmitter.off("update", state.send);
-          statsEmitter.off("pending", state.sendPending);
-          clearInterval(state.keepalive);
+          cleanup();
         }
       };
 
@@ -38,10 +55,7 @@ export async function GET() {
           const stats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider };
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
         } catch {
-          state.closed = true;
-          statsEmitter.off("update", state.send);
-          statsEmitter.off("pending", state.sendPending);
-          clearInterval(state.keepalive);
+          cleanup();
         }
       };
 
@@ -55,17 +69,13 @@ export async function GET() {
         try {
           controller.enqueue(encoder.encode(": ping\n\n"));
         } catch {
-          state.closed = true;
-          clearInterval(state.keepalive);
+          cleanup();
         }
       }, 25000);
     },
 
     cancel() {
-      state.closed = true;
-      statsEmitter.off("update", state.send);
-      statsEmitter.off("pending", state.sendPending);
-      clearInterval(state.keepalive);
+      cleanup();
     },
   });
 

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -8,6 +8,20 @@ const RING_CAP = 50;
 const CONN_CACHE_TTL_MS = 30 * 1000;
 const PERIOD_MS = { "24h": 86400000, "7d": 604800000, "30d": 2592000000, "60d": 5184000000 };
 
+// Cap usageHistory row count to bound DB / WASM heap growth (#1245).
+// usageDaily already holds rolled-up aggregates, so trimming oldest raw rows
+// only loses sub-day precision for periods older than the retained window.
+const DEFAULT_USAGE_HISTORY_MAX_ROWS = 10000;
+const USAGE_HISTORY_MAX_ROWS = (() => {
+  const v = parseInt(process.env.USAGE_HISTORY_MAX_ROWS || "", 10);
+  if (Number.isFinite(v) && v >= 100) return v;
+  return DEFAULT_USAGE_HISTORY_MAX_ROWS;
+})();
+// Prune check is cheap (COUNT + conditional DELETE) but we throttle it so the
+// transaction stays small under high request rates.
+const PRUNE_CHECK_EVERY = 50;
+let writesSincePrune = 0;
+
 // In-memory state shared across Next.js modules
 if (!global._pendingRequests) global._pendingRequests = { byModel: {}, byAccount: {} };
 if (!global._lastErrorProvider) global._lastErrorProvider = { provider: "", ts: 0 };
@@ -277,6 +291,22 @@ export async function saveRequestUsage(entry) {
       const cur = db.get(`SELECT value FROM _meta WHERE key = 'totalRequestsLifetime'`);
       const next = (cur ? parseInt(cur.value, 10) : 0) + 1;
       db.run(`INSERT INTO _meta(key, value) VALUES('totalRequestsLifetime', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`, [String(next)]);
+
+      // Prune oldest usageHistory rows above the configured cap (#1245).
+      // Throttled to every PRUNE_CHECK_EVERY writes — daily aggregates in
+      // usageDaily retain the long-term stats.
+      writesSincePrune++;
+      if (writesSincePrune >= PRUNE_CHECK_EVERY) {
+        writesSincePrune = 0;
+        const cnt = db.get(`SELECT COUNT(*) as c FROM usageHistory`);
+        const total = cnt ? cnt.c : 0;
+        if (total > USAGE_HISTORY_MAX_ROWS) {
+          db.run(
+            `DELETE FROM usageHistory WHERE id IN (SELECT id FROM usageHistory ORDER BY id ASC LIMIT ?)`,
+            [total - USAGE_HISTORY_MAX_ROWS]
+          );
+        }
+      }
     });
 
     pushToRing(entry);

--- a/tests/unit/usage-history-prune.test.js
+++ b/tests/unit/usage-history-prune.test.js
@@ -1,0 +1,122 @@
+// Regression test for #1245 — usageHistory grows unboundedly without pruning,
+// causing severe memory leak (80MB → 4.8GB over 3 days) especially under the
+// sql.js fallback where the entire DB lives in WASM heap.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let tempDir;
+const originalDataDir = process.env.DATA_DIR;
+const originalMaxRows = process.env.USAGE_HISTORY_MAX_ROWS;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-usage-prune-"));
+  process.env.DATA_DIR = tempDir;
+  delete global._dbAdapter;
+  // Reset module-scope `writesSincePrune` counter by clearing the cache so the
+  // imported module gets a fresh closure with our env var applied.
+  vi.resetModules();
+});
+
+afterEach(() => {
+  try { global._dbAdapter?.instance?.close?.(); } catch {}
+  delete global._dbAdapter;
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+  if (originalMaxRows === undefined) delete process.env.USAGE_HISTORY_MAX_ROWS;
+  else process.env.USAGE_HISTORY_MAX_ROWS = originalMaxRows;
+});
+
+describe("usageHistory pruning (#1245)", () => {
+  it("trims oldest rows once total exceeds USAGE_HISTORY_MAX_ROWS", async () => {
+    // Small cap so the test runs fast — must be ≥100 (module clamps lower values).
+    process.env.USAGE_HISTORY_MAX_ROWS = "100";
+
+    const { saveRequestUsage } = await import("@/lib/db/repos/usageRepo.js");
+    const { getAdapter } = await import("@/lib/db/driver.js");
+    const db = await getAdapter();
+
+    // Insert enough entries to trip the prune check (every 50 writes) and
+    // overshoot the cap of 100 by a healthy margin.
+    const TOTAL_INSERTS = 250;
+    for (let i = 0; i < TOTAL_INSERTS; i++) {
+      await saveRequestUsage({
+        provider: "test",
+        model: `model-${i}`,
+        connectionId: "conn-1",
+        apiKey: "key-1",
+        endpoint: "/v1/chat/completions",
+        status: "ok",
+        tokens: { prompt_tokens: 10, completion_tokens: 20 },
+      });
+    }
+
+    const { c: rowCount } = db.get(`SELECT COUNT(*) as c FROM usageHistory`);
+    expect(rowCount).toBeLessThanOrEqual(100);
+    // Should be near the cap (within one prune-throttle window).
+    expect(rowCount).toBeGreaterThanOrEqual(50);
+
+    // Oldest rows (lowest ids) should be gone — the surviving rows should be
+    // the most-recently inserted ones.
+    const surviving = db.all(`SELECT model FROM usageHistory ORDER BY id ASC LIMIT 1`);
+    const oldestSurvivingIdx = parseInt(surviving[0].model.split("-")[1], 10);
+    expect(oldestSurvivingIdx).toBeGreaterThan(0);
+
+    const newest = db.all(`SELECT model FROM usageHistory ORDER BY id DESC LIMIT 1`);
+    expect(newest[0].model).toBe(`model-${TOTAL_INSERTS - 1}`);
+  });
+
+  it("usageDaily retains aggregates after history pruning", async () => {
+    process.env.USAGE_HISTORY_MAX_ROWS = "100";
+
+    const { saveRequestUsage } = await import("@/lib/db/repos/usageRepo.js");
+    const { getAdapter } = await import("@/lib/db/driver.js");
+    const db = await getAdapter();
+
+    for (let i = 0; i < 200; i++) {
+      await saveRequestUsage({
+        provider: "test",
+        model: "m",
+        tokens: { prompt_tokens: 5, completion_tokens: 7 },
+      });
+    }
+
+    const daily = db.all(`SELECT data FROM usageDaily`);
+    expect(daily.length).toBeGreaterThanOrEqual(1);
+    const day = JSON.parse(daily[0].data);
+    // All 200 requests should still be aggregated even though raw rows pruned.
+    expect(day.requests).toBe(200);
+    expect(day.promptTokens).toBe(200 * 5);
+    expect(day.completionTokens).toBe(200 * 7);
+  });
+
+  it("defaults to 10000 rows when env var unset", async () => {
+    delete process.env.USAGE_HISTORY_MAX_ROWS;
+    const mod = await import("@/lib/db/repos/usageRepo.js");
+    // Indirect check: insert a few rows, ensure none pruned (well below default 10k).
+    for (let i = 0; i < 10; i++) {
+      await mod.saveRequestUsage({ provider: "p", model: "m", tokens: { prompt_tokens: 1, completion_tokens: 1 } });
+    }
+    const { getAdapter } = await import("@/lib/db/driver.js");
+    const db = await getAdapter();
+    const { c } = db.get(`SELECT COUNT(*) as c FROM usageHistory`);
+    expect(c).toBe(10);
+  });
+
+  it("rejects env value below 100 and falls back to default", async () => {
+    process.env.USAGE_HISTORY_MAX_ROWS = "5";
+    await import("@/lib/db/repos/usageRepo.js");
+    // Module clamps via "v >= 100" — too low → 10000 default applies. Verifying
+    // by inserting 20 rows: with a real cap of 5 they'd be pruned, with 10k they survive.
+    const { saveRequestUsage } = await import("@/lib/db/repos/usageRepo.js");
+    for (let i = 0; i < 200; i++) {
+      await saveRequestUsage({ provider: "p", model: "m", tokens: { prompt_tokens: 1, completion_tokens: 1 } });
+    }
+    const { getAdapter } = await import("@/lib/db/driver.js");
+    const db = await getAdapter();
+    const { c } = db.get(`SELECT COUNT(*) as c FROM usageHistory`);
+    expect(c).toBe(200);
+  });
+});

--- a/tests/unit/usage-stream-cleanup.test.js
+++ b/tests/unit/usage-stream-cleanup.test.js
@@ -1,0 +1,86 @@
+// Regression test for #1245 — /api/usage/stream did not clean up statsEmitter
+// listeners on client disconnect, causing leaked closures (each holding the
+// full cachedStats object) to accumulate over days of dashboard use.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Stub out the heavy stats path before importing the route.
+vi.mock("@/lib/usageDb", () => {
+  const { EventEmitter } = require("events");
+  const statsEmitter = new EventEmitter();
+  statsEmitter.setMaxListeners(200);
+  return {
+    statsEmitter,
+    getUsageStats: vi.fn(async () => ({ totalRequests: 0, byProvider: {}, byModel: {} })),
+    getActiveRequests: vi.fn(async () => ({ activeRequests: [], recentRequests: [], errorProvider: "" })),
+  };
+});
+
+function makeAbortableRequest() {
+  const ctrl = new AbortController();
+  return {
+    signal: ctrl.signal,
+    abort: () => ctrl.abort(),
+  };
+}
+
+describe("/api/usage/stream listener cleanup (#1245)", () => {
+  let route;
+  let statsEmitter;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    route = await import("@/app/api/usage/stream/route.js");
+    ({ statsEmitter } = await import("@/lib/usageDb"));
+    statsEmitter.removeAllListeners();
+  });
+
+  it("removes statsEmitter listeners on request.signal abort", async () => {
+    const req = makeAbortableRequest();
+    const response = await route.GET(req);
+    // Wait one microtask tick so the start() callback registers listeners.
+    const reader = response.body.getReader();
+    // Pull one chunk to ensure start() ran fully.
+    await reader.read();
+
+    expect(statsEmitter.listenerCount("update")).toBe(1);
+    expect(statsEmitter.listenerCount("pending")).toBe(1);
+
+    req.abort();
+    // Yield so the abort handler runs.
+    await new Promise((r) => setImmediate(r));
+
+    expect(statsEmitter.listenerCount("update")).toBe(0);
+    expect(statsEmitter.listenerCount("pending")).toBe(0);
+
+    try { reader.cancel(); } catch {}
+  });
+
+  it("does not accumulate listeners across many short-lived connections", async () => {
+    const N = 25;
+    for (let i = 0; i < N; i++) {
+      const req = makeAbortableRequest();
+      const response = await route.GET(req);
+      const reader = response.body.getReader();
+      await reader.read();
+      req.abort();
+      await new Promise((r) => setImmediate(r));
+      try { reader.cancel(); } catch {}
+    }
+    expect(statsEmitter.listenerCount("update")).toBe(0);
+    expect(statsEmitter.listenerCount("pending")).toBe(0);
+  });
+
+  it("cleanup is idempotent (abort + cancel both safe)", async () => {
+    const req = makeAbortableRequest();
+    const response = await route.GET(req);
+    const reader = response.body.getReader();
+    await reader.read();
+
+    req.abort();
+    await new Promise((r) => setImmediate(r));
+    // Also trigger cancel() — must not throw, must keep listener count at 0.
+    try { await reader.cancel(); } catch {}
+    expect(statsEmitter.listenerCount("update")).toBe(0);
+    expect(statsEmitter.listenerCount("pending")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1245 — the reporter observed RSS climb from ~80 MB to ~4.8 GB over three days under normal load (linear, near-unbounded growth).

Two cooperating leaks were responsible.

### 1. `usageHistory` has no row cap

`requestDetails` already has a row-cap pruning pattern (default 200, env-tunable). `usageHistory` does not — every request inserts a row, nothing prunes them.

Under the **sql.js** driver (used when better-sqlite3 native bindings aren't available — common in Docker / Next.js standalone builds, and exactly the path #1390 also lives on) the entire database lives in WebAssembly heap. Unbounded inserts therefore translate directly to unbounded RSS growth. `PRAGMA mmap_size` / `cache_size` are no-ops under sql.js, so those limits don't protect that path.

### 2. `/api/usage/stream` only releases `statsEmitter` listeners in `ReadableStream.cancel()`

As the sibling `/api/translator/console-logs/stream` handler already documents, **Next.js does not reliably invoke `cancel()` on client disconnect** — it fires `request.signal.abort` instead. Every dashboard reload therefore leaked two `statsEmitter` listeners plus a 25 s keepalive interval. Each leaked listener held a `cachedStats` closure containing the full aggregated stats object, which compounded with leak #1 as `byProvider` / `byModel` / `byAccount` keyspaces grew.

## Changes

- **`src/lib/db/repos/usageRepo.js`** — cap `usageHistory` at `USAGE_HISTORY_MAX_ROWS` (default `10000`, env-tunable, floor 100). Prune is done inside the existing write transaction but throttled to every 50 inserts so the `COUNT` / `DELETE` isn't on the hot path of every request. `usageDaily` rollups are untouched, so long-term stats stay accurate after raw rows age out.
- **`src/app/api/usage/stream/route.js`** — idempotent `cleanup()` is now bound to `request.signal.abort` (the reliable Next.js signal), matching the pattern the console-logs handler adopted earlier. `cleanup()` also nulls `state.cachedStats` so any closure that somehow outlives the request cannot pin the stats object.

## Tests

Two new vitest suites:

- **`tests/unit/usage-history-prune.test.js`** (4 cases) — verifies pruning trims oldest rows once the cap is exceeded, the env override is honored, values below the floor fall back to the default, and `usageDaily` aggregates survive raw-row pruning.
- **`tests/unit/usage-stream-cleanup.test.js`** (3 cases) — verifies listeners are removed on `signal.abort`, do not accumulate across many short-lived connections, and that cleanup is idempotent (`abort` + `cancel` both safe).

Both suites pass locally. The remaining test failures in the repo are pre-existing (missing root deps like `open`, `uuid` in the standalone `tests/` package — not related to this change).

```
 ✓ unit/usage-history-prune.test.js (4 tests) 1639ms
 ✓ unit/usage-stream-cleanup.test.js (3 tests) 129ms
```

## Operator notes

- Existing installations with bloated `usageHistory` tables will prune lazily — the first ~50 writes after upgrade trigger the cap check and trim oldest rows down to `USAGE_HISTORY_MAX_ROWS`. No migration needed.
- High-volume users who want a different retention window can set `USAGE_HISTORY_MAX_ROWS` in the environment (e.g. `50000` for power users, `1000` for tight memory budgets).
- `usageDaily` is intentionally not pruned — daily rollups are tiny (one row per day) and feed the `/dashboard/usage` long-period charts.

## Not covered here

- The `getUsageStats()` overlay query (`usageRepo.js:508`) still scans the whole post-cutoff history range. With the row cap in place this is now bounded to ≤ 10 000 rows, so it's a much smaller concern, but a separate PR could swap that for an indexed range scan if it shows up in profiling.
- sql.js does not free WASM heap when rows are `DELETE`d without `VACUUM`. The cap keeps the working set small enough that this is acceptable, but adding a periodic `VACUUM` on shutdown or every N pruned rows would tighten it further. Out of scope here.

## Test plan

- [ ] Run 9router under steady traffic for an hour and confirm `usageHistory` row count plateaus at the cap.
- [ ] Open / close the dashboard `Usage` tab repeatedly and confirm `statsEmitter` listener count (visible via `setMaxListeners` warning, currently 50) does not climb.
- [ ] Verify the dashboard's 7-day / 30-day charts still render correctly after raw-row pruning (they read from `usageDaily`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)