### PR TITLE
Fix /v1/messages non-streaming JSON mode

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -20,6 +20,43 @@ import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
 
+function getHeaderValue(headers, name) {
+  if (!headers) return "";
+  if (typeof headers.get === "function") return headers.get(name) || "";
+  const lowerName = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lowerName) return String(value || "");
+  }
+  return "";
+}
+
+export function resolveChatStreamMode({ body = {}, sourceFormat, provider, clientHeaders = {}, clientTool = null }) {
+  const acceptHeader = getHeaderValue(clientHeaders, "accept").toLowerCase();
+  const clientPrefersJson = acceptHeader.includes("application/json");
+  const clientPrefersSSE = acceptHeader.includes("text/event-stream");
+  const formatAlwaysStreams = sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
+  const clientRequestedStreaming = body.stream === true || (body.stream !== false && clientPrefersSSE) || formatAlwaysStreams;
+  const providerRequiresStreaming = provider === "openai" || provider === "codex" || provider === "commandcode";
+  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+
+  // #1396: Anthropic /v1/messages defaults to JSON; only stream when the client asks.
+  if (sourceFormat === FORMATS.CLAUDE && !clientRequestedStreaming) {
+    stream = false;
+  }
+
+  // DeepSeek-TUI: interactive TUI panel sends stream:true and needs SSE.
+  // Non-interactive mode (-p flag) sends without stream and can't parse SSE.
+  // Only force non-streaming when client didn't explicitly request it.
+  if (clientTool === "deepseek-tui" && body.stream !== true) stream = false;
+
+  // AI SDK and browser clients often advertise JSON instead of setting stream:false.
+  if (clientPrefersJson && !clientPrefersSSE && body.stream !== true) {
+    stream = false;
+  }
+
+  return { stream, clientRequestedStreaming, providerRequiresStreaming };
+}
+
 /**
  * Core chat handler - shared between SSE and Worker
  * @param {object} options.body - Request body
@@ -57,24 +94,14 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     }
   }
 
-  const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
-  const providerRequiresStreaming = provider === "openai" || provider === "codex" || provider === "commandcode";
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
-
-  // DeepSeek-TUI: interactive TUI panel sends stream:true and needs SSE.
-  // Non-interactive mode (-p flag) sends without stream and can't parse SSE.
-  // Only force non-streaming when client didn't explicitly request it.
-  const detectedTool = detectClientTool(clientRawRequest?.headers || {}, body);
-  if (detectedTool === "deepseek-tui" && body.stream !== true) stream = false;
-
-  // Check client Accept header preference for non-streaming requests
-  // This fixes AI SDK compatibility where clients send Accept: application/json
-  const acceptHeader = clientRawRequest?.headers?.accept || "";
-  const clientPrefersJson = acceptHeader.includes("application/json");
-  const clientPrefersSSE = acceptHeader.includes("text/event-stream");
-  if (clientPrefersJson && !clientPrefersSSE && body.stream !== true) {
-    stream = false;
-  }
+  const clientTool = detectClientTool(clientRawRequest?.headers || {}, body);
+  const { stream, clientRequestedStreaming, providerRequiresStreaming } = resolveChatStreamMode({
+    body,
+    sourceFormat,
+    provider,
+    clientHeaders: clientRawRequest?.headers || {},
+    clientTool
+  });
 
   const reqLogger = await createRequestLogger(sourceFormat, targetFormat, model);
   if (clientRawRequest) reqLogger.logClientRawRequest(clientRawRequest.endpoint, clientRawRequest.body, clientRawRequest.headers);
@@ -83,7 +110,6 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Native passthrough: CLI tool and provider are the same ecosystem
   // Skip all translation/normalization — only model and Bearer are swapped
-  const clientTool = detectClientTool(clientRawRequest?.headers || {}, body);
   const passthrough = isNativePassthrough(clientTool, provider);
 
   let translatedBody;

--- a/tests/unit/chat-stream-mode.test.js
+++ b/tests/unit/chat-stream-mode.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveChatStreamMode } from "../../open-sse/handlers/chatCore.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("chat stream mode", () => {
+  it("keeps Claude /v1/messages JSON by default (#1396)", () => {
+    const mode = resolveChatStreamMode({
+      body: { model: "opus", messages: [{ role: "user", content: "say hi" }] },
+      sourceFormat: FORMATS.CLAUDE,
+      provider: "glm",
+      clientHeaders: { "content-type": "application/json" },
+    });
+
+    expect(mode.stream).toBe(false);
+    expect(mode.clientRequestedStreaming).toBe(false);
+  });
+
+  it("streams Claude /v1/messages when the body explicitly asks for it", () => {
+    const mode = resolveChatStreamMode({
+      body: { stream: true, messages: [{ role: "user", content: "say hi" }] },
+      sourceFormat: FORMATS.CLAUDE,
+      provider: "glm",
+    });
+
+    expect(mode.stream).toBe(true);
+    expect(mode.clientRequestedStreaming).toBe(true);
+  });
+
+  it("streams Claude /v1/messages when the client accepts SSE", () => {
+    const mode = resolveChatStreamMode({
+      body: { messages: [{ role: "user", content: "say hi" }] },
+      sourceFormat: FORMATS.CLAUDE,
+      provider: "glm",
+      clientHeaders: { Accept: "text/event-stream" },
+    });
+
+    expect(mode.stream).toBe(true);
+    expect(mode.clientRequestedStreaming).toBe(true);
+  });
+
+  it("uses a non-streaming provider request when JSON is explicitly preferred", () => {
+    const mode = resolveChatStreamMode({
+      body: { messages: [{ role: "user", content: "say hi" }] },
+      sourceFormat: FORMATS.OPENAI,
+      provider: "openai",
+      clientHeaders: { Accept: "application/json" },
+    });
+
+    expect(mode.stream).toBe(false);
+    expect(mode.clientRequestedStreaming).toBe(false);
+    expect(mode.providerRequiresStreaming).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- keep Claude-format /v1/messages non-streaming by default unless the client explicitly requests SSE
- preserve existing explicit stream:true and Accept: text/event-stream behavior
- add focused stream-mode regression coverage for #1396

Fixes #1396

## Tests
- npx vitest run --config ./tests/vitest.config.js tests/unit/chat-stream-mode.test.js
- node --check open-sse/handlers/chatCore.js
- git diff --check
- npm run build