### PR TITLE
Route Codex auto-review to Codex provider

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -38,6 +38,7 @@ export const PROVIDER_MODELS = {
     { id: "claude-haiku-4-5-20251001", name: "Claude 4.5 Haiku" },
   ],
   cx: withCodexReviewModels([  // OpenAI Codex
+    { id: "codex-auto-review", name: "Codex Auto Review", quotaFamily: "review" },
     { id: "gpt-5.5", name: "GPT 5.5" },
     { id: "gpt-5.4", name: "GPT 5.4" },
     { id: "gpt-5.4-mini", name: "GPT 5.4 Mini" },

--- a/open-sse/services/model.js
+++ b/open-sse/services/model.js
@@ -248,6 +248,8 @@ export async function getModelInfoCore(modelStr, aliasesOrGetter) {
 function inferProviderFromModelName(modelName) {
   if (!modelName) return "openai";
   const m = modelName.toLowerCase();
+  // #1398: Codex CLI sends this bare virtual model for auto-review; keep it on OAuth Codex.
+  if (m === "codex-auto-review") return "codex";
   if (m.startsWith("claude-")) return "anthropic";
   if (m.startsWith("gemini-")) return "gemini";
   if (m.startsWith("gpt-")) return "openai";

--- a/tests/unit/model-routing.test.js
+++ b/tests/unit/model-routing.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { getProviderModels, getModelQuotaFamily } from "../../open-sse/config/providerModels.js";
+import { getModelInfoCore } from "../../open-sse/services/model.js";
+
+describe("model routing", () => {
+  it("routes bare Codex auto-review model to Codex OAuth (#1398)", async () => {
+    const modelInfo = await getModelInfoCore("codex-auto-review", {});
+
+    expect(modelInfo).toEqual({
+      provider: "codex",
+      model: "codex-auto-review",
+    });
+  });
+
+  it("exposes Codex auto-review as a review-quota Codex model", () => {
+    const models = getProviderModels("cx");
+    const autoReview = models.find((model) => model.id === "codex-auto-review");
+
+    expect(autoReview).toBeTruthy();
+    expect(autoReview.name).toBe("Codex Auto Review");
+    expect(getModelQuotaFamily("cx", "codex-auto-review")).toBe("review");
+  });
+});


### PR DESCRIPTION
## Summary
- register codex-auto-review as a Codex review-quota model
- route bare codex-auto-review requests to Codex OAuth instead of OpenAI API-key credentials
- add focused routing regression coverage for #1398

Fixes #1398

## Tests
- npx vitest run --config ./tests/vitest.config.js tests/unit/model-routing.test.js
- node --check open-sse/config/providerModels.js
- node --check open-sse/services/model.js
- git diff --check
- npm run build