### PR TITLE
Fix npm audit transitive dependency advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
     "eslint-config-next": "16.1.6",
     "postcss": "^8.5.6",
     "tailwindcss": "^4"
+  },
+  "overrides": {
+    "dompurify": "^3.4.5",
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## Summary
- add npm overrides for transitive dompurify and postcss dependencies
- keep the direct postcss dependency range unchanged by referencing it from overrides
- resolve moderate npm audit advisories without changing runtime behavior

## Verification
- npm install
- npm audit --omit=dev --audit-level=moderate
- DATA_DIR=/tmp/9router-audit-test-data NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 npm run build