### PR TITLE
Ensure correct setting of anthropic-version header for variations

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -110,7 +110,7 @@ export class DefaultExecutor extends BaseExecutor {
           } else if (credentials.accessToken) {
             headers["Authorization"] = `Bearer ${credentials.accessToken}`;
           }
-          if (!headers["anthropic-version"]) {
+          if (!headers["anthropic-version"] && !headers["Anthropic-Version"]) {
             headers["anthropic-version"] = "2023-06-01";
           }
         } else if (this.provider === "gitlab") {
@@ -128,7 +128,7 @@ export class DefaultExecutor extends BaseExecutor {
         } else if (this.config?.format === "claude") {
           // Generic claude-format provider (e.g. agentrouter): x-api-key + anthropic-version
           headers["x-api-key"] = credentials.apiKey || credentials.accessToken;
-          if (!headers["anthropic-version"]) headers["anthropic-version"] = "2023-06-01";
+          if (!headers["anthropic-version"] && !headers["Anthropic-Version"]) headers["anthropic-version"] = "2023-06-01";
         } else {
           headers["Authorization"] = `Bearer ${credentials.apiKey || credentials.accessToken}`;
         }


### PR DESCRIPTION
This pull request updates how the default executor sets the `anthropic-version` header to ensure compatibility with providers that may use either lowercase or capitalized header names. The logic now checks for both `anthropic-version` and `Anthropic-Version` before setting the default value, preventing duplicate or conflicting headers.

Header handling improvements:

* Updated the header-setting logic in `DefaultExecutor` (`open-sse/executors/default.js`) to check for both `anthropic-version` and `Anthropic-Version` headers before assigning the default value, ensuring compatibility with varying header casing conventions. [[1]](diffhunk://#diff-c7727c2dffb667b0cbc632b5e43c22f70f7843abd6f58aae46050f0dbd099103L113-R113) [[2]](diffhunk://#diff-c7727c2dffb667b0cbc632b5e43c22f70f7843abd6f58aae46050f0dbd099103L131-R131)…ions