### PR TITLE
fix: replay reasoning content for thinking tool calls

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -8,6 +8,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { shouldPreserveReasoningContent } from "../../utils/reasoningContentInjector.js";
 
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
@@ -189,11 +190,14 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     translatedResponse.usage = filterUsageForFormat(addBufferToUsage(translatedResponse.usage), sourceFormat);
   }
 
-  // Strip reasoning_content — some clients (e.g. Firecrawl AI SDK) have JSON parsers that
-  // break on this non-standard field, even though OpenAI allows it in extensions.
+  // Strip reasoning_content except on DeepSeek tool-call turns. DeepSeek thinking
+  // mode requires those assistant messages to be replayed with reasoning_content.
+  // Other providers/models keep the old behavior for client compatibility.
   if (translatedResponse?.choices) {
     for (const choice of translatedResponse.choices) {
-      if (choice?.message) delete choice.message.reasoning_content;
+      const message = choice?.message;
+      const shouldPreserve = shouldPreserveReasoningContent({ provider, model, message });
+      if (message && !shouldPreserve) delete message.reasoning_content;
     }
   }
 

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -4,6 +4,7 @@ import { prepareClaudeRequest } from "./helpers/claudeHelper.js";
 import { cloakClaudeTools } from "../utils/claudeCloaking.js";
 import { filterToOpenAIFormat } from "./helpers/openaiHelper.js";
 import { normalizeThinkingConfig } from "../services/provider.js";
+import { needsReasoningContentReplay } from "../utils/reasoningContentInjector.js";
 import { AntigravityExecutor } from "../executors/antigravity.js";
 
 // Registry for translators
@@ -71,10 +72,54 @@ function stripContentTypes(body, stripList = []) {
   }
 }
 
+function collectClaudeAssistantReasoningForToolCalls(body) {
+  if (!body?.messages || !Array.isArray(body.messages)) return [];
+  const entries = [];
+
+  for (const msg of body.messages) {
+    if (msg?.role !== "assistant" || !Array.isArray(msg.content)) continue;
+
+    const reasoning = msg.content
+      .filter(block => block?.type === "thinking" && typeof block.thinking === "string" && block.thinking.length > 0)
+      .map(block => block.thinking)
+      .join("");
+    if (!reasoning) continue;
+
+    const toolUseIds = msg.content
+      .filter(block => block?.type === "tool_use" && block.id)
+      .map(block => block.id);
+    if (toolUseIds.length === 0) continue;
+
+    entries.push({ reasoning, toolUseIds });
+  }
+
+  return entries;
+}
+
+function replayClaudeReasoningContent(sourceBody, openaiBody) {
+  const entries = collectClaudeAssistantReasoningForToolCalls(sourceBody);
+  if (entries.length === 0 || !Array.isArray(openaiBody?.messages)) return openaiBody;
+
+  const pending = [...entries];
+  for (const msg of openaiBody.messages) {
+    if (msg?.role !== "assistant" || !Array.isArray(msg.tool_calls)) continue;
+
+    const toolCallIds = new Set(msg.tool_calls.map(tc => tc.id).filter(Boolean));
+    const index = pending.findIndex(entry => entry.toolUseIds.some(id => toolCallIds.has(id)));
+    if (index === -1) continue;
+
+    msg.reasoning_content = pending[index].reasoning;
+    pending.splice(index, 1);
+  }
+
+  return openaiBody;
+}
+
 // Translate request: source -> openai -> target
 export function translateRequest(sourceFormat, targetFormat, model, body, stream = true, credentials = null, provider = null, reqLogger = null, stripList = [], connectionId = null, clientTool = null) {
   ensureInitialized();
   let result = body;
+  const originalBody = body;
 
   // Strip explicit content types (opt-in via strip[] in PROVIDER_MODELS entry)
   stripContentTypes(result, stripList);
@@ -95,6 +140,9 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
       const toOpenAI = requestRegistry.get(`${sourceFormat}:${FORMATS.OPENAI}`);
       if (toOpenAI) {
         result = toOpenAI(model, result, stream, credentials);
+        if (needsReasoningContentReplay({ provider, model }) && sourceFormat === FORMATS.CLAUDE && targetFormat === FORMATS.OPENAI) {
+          result = replayClaudeReasoningContent(originalBody, result);
+        }
         // Log OpenAI intermediate format
         reqLogger?.logOpenAIRequest?.(result);
       }

--- a/open-sse/utils/reasoningContentInjector.js
+++ b/open-sse/utils/reasoningContentInjector.js
@@ -15,6 +15,11 @@ const MODEL_RULES = [
   { match: m => m?.startsWith?.("deepseek-"), scope: "all" }
 ];
 
+const REASONING_REPLAY_RULES = [
+  { provider: "deepseek" },
+  { match: m => m?.startsWith?.("deepseek-") }
+];
+
 const DEEPSEEK_V4_PRO = "deepseek-v4-pro";
 const DEEPSEEK_V4_PRO_ALIASES = {
   [`${DEEPSEEK_V4_PRO}-max`]: {
@@ -74,4 +79,16 @@ export function injectReasoningContent({ provider, model, body }) {
   const rule = providerRule || modelRule;
   const nextBody = applyDeepSeekV4ProAlias({ provider, model, body });
   return applyRule(nextBody, rule);
+}
+
+export function needsReasoningContentReplay({ provider, model }) {
+  return REASONING_REPLAY_RULES.some(rule =>
+    (rule.provider && rule.provider === provider) || rule.match?.(model)
+  );
+}
+
+export function shouldPreserveReasoningContent({ provider, model, message }) {
+  return needsReasoningContentReplay({ provider, model })
+    && Array.isArray(message?.tool_calls)
+    && message.tool_calls.length > 0;
 }

--- a/tests/unit/translator-request-normalization.test.js
+++ b/tests/unit/translator-request-normalization.test.js
@@ -48,6 +48,113 @@ describe("request normalization", () => {
     expect(Array.isArray(result.messages[0].content)).toBe(true);
   });
 
+  it("translateRequest replays Claude thinking for providers that require reasoning_content", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Need to inspect the file first." },
+            {
+              type: "tool_use",
+              id: "toolu_01",
+              name: "Read",
+              input: { file_path: "/tmp/example.js" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_01",
+              content: "const value = 1;",
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.OPENAI,
+      "deepseek-v4-pro",
+      JSON.parse(JSON.stringify(body)),
+      true,
+      null,
+      "deepseek",
+    );
+    const assistantMessage = result.messages[0];
+
+    expect(assistantMessage.role).toBe("assistant");
+    expect(assistantMessage.reasoning_content).toBe("Need to inspect the file first.");
+    expect(assistantMessage.tool_calls[0].id).toBe("toolu_01");
+  });
+
+  it("translateRequest replays Claude thinking for matched models routed through another provider", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Need to inspect before calling Read." },
+            {
+              type: "tool_use",
+              id: "toolu_opencode",
+              name: "Read",
+              input: { file_path: "/tmp/example.js" },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.OPENAI,
+      "deepseek-v4-flash-free",
+      JSON.parse(JSON.stringify(body)),
+      true,
+      null,
+      "opencode",
+    );
+
+    expect(result.messages[0].reasoning_content).toBe("Need to inspect before calling Read.");
+    expect(result.messages[0].tool_calls[0].id).toBe("toolu_opencode");
+  });
+
+  it("translateRequest keeps original Claude thinking behavior when reasoning replay is not required", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Internal reasoning." },
+            {
+              type: "tool_use",
+              id: "toolu_01",
+              name: "Read",
+              input: { file_path: "/tmp/example.js" },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.OPENAI,
+      "gpt-4o",
+      JSON.parse(JSON.stringify(body)),
+      true,
+      null,
+      "openai",
+    );
+    expect(result.messages[0].reasoning_content).toBeUndefined();
+    expect(result.messages[0].tool_calls[0].id).toBe("toolu_01");
+  });
+
   it("filterToOpenAIFormat flattens text-only arrays to string", () => {
     const body = {
       messages: [


### PR DESCRIPTION
## Summary
- centralize reasoning-content replay/preserve capability checks in `reasoningContentInjector`
- replay Claude `thinking` blocks into OpenAI `reasoning_content` for providers/models that require it
- preserve `reasoning_content` on tool-call turns when replay is required
- add request normalization tests for direct provider, routed DeepSeek model, and non-replay model paths

## Why
Claude-format clients replay assistant tool-use turns with reasoning in `thinking` content blocks. The existing Claude -> OpenAI conversion drops those blocks, and placeholder injection is not enough for DeepSeek thinking-mode continuation. Routed DeepSeek models such as `opencode/deepseek-*` can still require the real `reasoning_content` to be passed back.

## Verification
- `node --check open-sse/utils/reasoningContentInjector.js`
- `node --check open-sse/translator/index.js`
- `node --check open-sse/handlers/chatCore/nonStreamingHandler.js`
- `git diff --check`
- local transform assertions for `opencode + deepseek-v4-flash-free`
- `npm run build`
- Claude CLI Task tool smoke test via `opencode/deepseek-v4-flash-free`