### PR TITLE
fix: add Codex subagent role description

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
@@ -58,7 +58,7 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
       if (modelMatch) setSelectedModel(modelMatch[1]);
 
       // Parse subagent settings
-      const subagentModelMatch = codexStatus.config.match(/\[agents\.subagent\]\s*\n\s*model\s*=\s*"([^"]+)"/m);
+      const subagentModelMatch = codexStatus.config.match(/\[agents\.subagent\][\s\S]*?^model\s*=\s*"([^"]+)"/m);
       if (subagentModelMatch) setSubagentModel(subagentModelMatch[1]);
     }
   }, [codexStatus]);
@@ -174,6 +174,7 @@ base_url = "${getEffectiveBaseUrl()}"
 wire_api = "responses"
 
 [agents.subagent]
+description = "Fast subagent for codebase exploration"
 model = "${effectiveSubagentModel}"
 `;
 

--- a/src/app/api/cli-tools/codex-settings/config.js
+++ b/src/app/api/cli-tools/codex-settings/config.js
@@ -1,0 +1,6 @@
+export const CODEX_SUBAGENT_DESCRIPTION = "Fast subagent for codebase exploration";
+
+export const buildCodexSubagentRole = (model) => ({
+  description: CODEX_SUBAGENT_DESCRIPTION,
+  model,
+});

--- a/src/app/api/cli-tools/codex-settings/route.js
+++ b/src/app/api/cli-tools/codex-settings/route.js
@@ -7,6 +7,7 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import { parseTOML, stringifyTOML } from "confbox";
+import { buildCodexSubagentRole } from "./config.js";
 
 const execAsync = promisify(exec);
 
@@ -143,9 +144,7 @@ export async function POST(request) {
 
     // Add subagent configuration
     const effectiveSubagentModel = subagentModel || model;
-    setNestedSection(parsed, "agents.subagent", {
-      model: effectiveSubagentModel,
-    });
+    setNestedSection(parsed, "agents.subagent", buildCodexSubagentRole(effectiveSubagentModel));
 
     // Write merged config
     const configContent = stringifyTOML(parsed);

--- a/tests/unit/codex-settings.test.js
+++ b/tests/unit/codex-settings.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCodexSubagentRole } from "../../src/app/api/cli-tools/codex-settings/config.js";
+
+describe("Codex CLI settings", () => {
+  it("writes a valid subagent role with required description", () => {
+    expect(buildCodexSubagentRole("cx/gpt-5.5")).toEqual({
+      description: "Fast subagent for codebase exploration",
+      model: "cx/gpt-5.5",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the required Codex CLI agent role description for agents.subagent
- reuse that role shape in the Codex settings generator
- update the dashboard manual config preview and parser to handle the new description line

## Tests
- ./node_modules/.bin/vitest run --reporter=verbose --config ./tests/vitest.config.js tests/unit/codex-settings.test.js
- npm run build