### PR TITLE
fix(codex): abort stalled initial upstream responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ DATA_DIR=/var/lib/9router
 # Recommended runtime variables
 PORT=20128
 NODE_ENV=production
+# Initial Codex upstream response deadline in milliseconds (0 disables timeout)
+CODEX_INITIAL_RESPONSE_TIMEOUT_MS=7000
 
 # Recommended security and ops variables
 API_KEY_SECRET=endpoint-proxy-api-key-secret

--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,7 @@ docker pull decolua/9router:latest   # update to latest
 | `PORT` | framework default | Service port (`20128` in examples) |
 | `HOSTNAME` | framework default | Bind host (Docker defaults to `0.0.0.0`) |
 | `NODE_ENV` | runtime default | Set `production` for deploy |
+| `CODEX_INITIAL_RESPONSE_TIMEOUT_MS` | `7000` | Abort a Codex request that has not returned an initial upstream response within this time; set `0` to disable |
 | `BASE_URL` | `http://localhost:20128` | Server-side internal base URL used by cloud sync jobs |
 | `CLOUD_URL` | `https://9router.com` | Server-side cloud sync endpoint base URL |
 | `NEXT_PUBLIC_BASE_URL` | `http://localhost:3000` | Backward-compatible/public base URL (prefer `BASE_URL` for server runtime) |

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -10,6 +10,10 @@ import { getConsistentMachineId } from "../../src/shared/utils/machineId.js";
 // In-memory map: hash(machineId + first assistant content) → { sessionId, lastUsed }
 const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
 const assistantSessionMap = new Map();
+const configuredInitialResponseTimeoutMs = Number(process.env.CODEX_INITIAL_RESPONSE_TIMEOUT_MS);
+const CODEX_INITIAL_RESPONSE_TIMEOUT_MS = Number.isFinite(configuredInitialResponseTimeoutMs) && configuredInitialResponseTimeoutMs >= 0
+  ? configuredInitialResponseTimeoutMs
+  : 7 * 1000;
 
 // Cache machine ID at module level (resolved once)
 let cachedMachineId = null;
@@ -119,7 +123,40 @@ export class CodexExecutor extends BaseExecutor {
   async execute(args) {
     // Fetch remote images before the synchronous transform/execute pipeline
     await this.prefetchImages(args.body);
-    return super.execute(args);
+
+    if (CODEX_INITIAL_RESPONSE_TIMEOUT_MS === 0) {
+      return super.execute(args);
+    }
+
+    const upstreamController = new AbortController();
+    let initialResponseTimedOut = false;
+    const abortFromClient = () => upstreamController.abort(args.signal?.reason);
+
+    if (args.signal?.aborted) {
+      abortFromClient();
+    } else {
+      args.signal?.addEventListener("abort", abortFromClient, { once: true });
+    }
+
+    const timeout = setTimeout(() => {
+      initialResponseTimedOut = true;
+      upstreamController.abort();
+    }, CODEX_INITIAL_RESPONSE_TIMEOUT_MS);
+
+    try {
+      return await super.execute({ ...args, signal: upstreamController.signal });
+    } catch (error) {
+      if (initialResponseTimedOut) {
+        const timeoutError = new Error(`Codex initial response timeout after ${CODEX_INITIAL_RESPONSE_TIMEOUT_MS}ms`);
+        timeoutError.name = "UpstreamResponseTimeoutError";
+        timeoutError.status = 504;
+        throw timeoutError;
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      args.signal?.removeEventListener("abort", abortFromClient);
+    }
   }
 
   // Parse Codex usage_limit_reached to extract precise resetsAtMs; fallback to default otherwise

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -184,25 +184,30 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     finalBody = result.transformedBody;
     reqLogger.logTargetRequest(providerUrl, providerHeaders, finalBody);
   } catch (error) {
+    const isClientAbort = error.name === "AbortError";
+    const errorStatus = error.status === HTTP_STATUS.GATEWAY_TIMEOUT
+      ? HTTP_STATUS.GATEWAY_TIMEOUT
+      : (isClientAbort ? 499 : HTTP_STATUS.BAD_GATEWAY);
+
     trackPendingRequest(model, provider, connectionId, false, true);
-    appendRequestLog({ model, provider, connectionId, status: `FAILED ${error.name === "AbortError" ? 499 : HTTP_STATUS.BAD_GATEWAY}` }).catch(() => { });
+    appendRequestLog({ model, provider, connectionId, status: `FAILED ${errorStatus}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
       latency: { ttft: 0, total: Date.now() - requestStartTime },
       tokens: { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),
       providerRequest: translatedBody || null,
-      response: { error: error.message || String(error), status: error.name === "AbortError" ? 499 : 502, thinking: null },
+      response: { error: error.message || String(error), status: errorStatus, thinking: null },
       status: "error"
     })).catch(() => { });
 
-    if (error.name === "AbortError") {
+    if (isClientAbort) {
       streamController.handleError(error);
       return createErrorResult(499, "Request aborted");
     }
-    const errMsg = formatProviderError(error, provider, model, HTTP_STATUS.BAD_GATEWAY);
+    const errMsg = formatProviderError(error, provider, model, errorStatus);
     console.log(`${COLORS.red}[ERROR] ${errMsg}${COLORS.reset}`);
-    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg);
+    return createErrorResult(errorStatus, errMsg);
   }
 
   // Handle 401/403 - try token refresh (skip for noAuth providers)

--- a/tests/unit/codex-image-fetch.test.js
+++ b/tests/unit/codex-image-fetch.test.js
@@ -142,4 +142,64 @@ describe("CodexExecutor image handling", () => {
     const imgBlock = parsed.input[0].content.find((c) => c.type === "input_image");
     expect(imgBlock.image_url.startsWith("data:image/jpeg;base64,")).toBe(true);
   });
+
+  it("aborts a request that receives no initial upstream response within 7 seconds", async () => {
+    vi.useFakeTimers();
+
+    vi.spyOn(proxyFetchModule, "proxyAwareFetch").mockImplementation((_url, init) => (
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        }, { once: true });
+      })
+    ));
+
+    const executor = new CodexExecutor();
+    const pending = executor.execute({
+      model: "gpt-5.5",
+      body: { input: [{ role: "user", content: [{ type: "input_text", text: "ping" }] }] },
+      stream: true,
+      credentials: { accessToken: "test" },
+    });
+    const assertion = expect(pending).rejects.toMatchObject({
+      name: "UpstreamResponseTimeoutError",
+      status: 504,
+    });
+
+    await vi.advanceTimersByTimeAsync(7000);
+    await assertion;
+    vi.useRealTimers();
+  });
+
+  it("preserves a caller abort as AbortError rather than an upstream timeout", async () => {
+    vi.spyOn(proxyFetchModule, "proxyAwareFetch").mockImplementation((_url, init) => (
+      new Promise((_resolve, reject) => {
+        const rejectAbort = () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        };
+        if (init.signal.aborted) {
+          rejectAbort();
+        } else {
+          init.signal.addEventListener("abort", rejectAbort, { once: true });
+        }
+      })
+    ));
+
+    const controller = new AbortController();
+    const executor = new CodexExecutor();
+    const pending = executor.execute({
+      model: "gpt-5.5",
+      body: { input: [{ role: "user", content: [{ type: "input_text", text: "ping" }] }] },
+      stream: true,
+      credentials: { accessToken: "test" },
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
 });


### PR DESCRIPTION
## Summary
- add a Codex-specific initial upstream response deadline while `executor.execute()` is still waiting for `fetch()` to return
- default the deadline to 7 seconds, with `CODEX_INITIAL_RESPONSE_TIMEOUT_MS=0` available to disable it
- return this deadline as HTTP 504 so the existing account and combo fallback paths rotate away from a stalled Codex request
- document the environment setting and add executor regression coverage for deadline aborts and caller abort preservation

## Why this is separate from #576
PR #576 applies a TTFT deadline after `providerResponse` exists and races the first stream chunk. This PR covers the earlier failure mode where the Codex upstream request has not returned an initial response at all, so there is no response body to race yet.

This behavior was observed while investigating #1408: Codex calls could remain pending before an initial upstream response, keeping the account selected rather than allowing fallback to proceed.

## Verification
- `./node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/codex-image-fetch.test.js tests/unit/combo-routing.test.js --reporter=verbose`
- local runtime validation with an intentionally shortened timeout: two stalled Codex accounts returned 504 and an existing combo proceeded to its next provider, which returned HTTP 200
- local usage validation with the 7000 ms default: two stalled Codex attempts were aborted at 7022 ms and 7133 ms; the subsequent attempts on alternate Codex connections completed in 3218 ms and 3402 ms

Related to #1408. Complementary to #576.
