### PR TITLE
Clean up provider model aliases on delete

### DIFF
--- a/src/lib/db/repos/nodesRepo.js
+++ b/src/lib/db/repos/nodesRepo.js
@@ -90,6 +90,17 @@ export async function deleteProviderNode(id) {
     if (!row) return;
     removed = rowToNode(row);
     db.run(`DELETE FROM providerNodes WHERE id = ?`, [id]);
+
+    // #1409: imported compatible-provider aliases store values as
+    // `${providerNodeId}/${model}`. Remove them with the node so stale aliases
+    // cannot block re-import after a provider is recreated with the same prefix.
+    const rows = db.all(`SELECT key, value FROM kv WHERE scope = 'modelAliases'`);
+    for (const alias of rows) {
+      const model = parseJson(alias.value, null);
+      if (typeof model === "string" && model.startsWith(`${id}/`)) {
+        db.run(`DELETE FROM kv WHERE scope = 'modelAliases' AND key = ?`, [alias.key]);
+      }
+    }
   });
   return removed;
 }

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -18,6 +18,9 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+  // Release SQLite file handles before removing the temp DATA_DIR on Windows.
+  try { global._dbAdapter?.instance?.close?.(); } catch {}
+  delete global._dbAdapter;
   if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
   if (originalDataDir === undefined) delete process.env.DATA_DIR;
   else process.env.DATA_DIR = originalDataDir;
@@ -102,7 +105,7 @@ describe("DB SQLite layer — public API parity", () => {
   });
 
   it("providerNodes: CRUD", async () => {
-    const n = await sqliteDb.createProviderNode({ type: "openai", name: "Test", baseUrl: "https://api.test", apiType: "openai" });
+    const n = await sqliteDb.createProviderNode({ id: "provider-alias-cleanup", type: "openai", name: "Test", baseUrl: "https://api.test", apiType: "openai" });
     expect(n.id).toBeDefined();
     expect(n.baseUrl).toBe("https://api.test");
 
@@ -113,8 +116,15 @@ describe("DB SQLite layer — public API parity", () => {
     const updated = await sqliteDb.getProviderNodeById(n.id);
     expect(updated.name).toBe("Test2");
 
+    await sqliteDb.setModelAlias("deleted-provider-model", `${n.id}/imported-model`);
+    await sqliteDb.setModelAlias("neighbor-provider-model", `${n.id}-neighbor/imported-model`);
+
     await sqliteDb.deleteProviderNode(n.id);
     expect(await sqliteDb.getProviderNodeById(n.id)).toBeNull();
+
+    const aliasesAfterDelete = await sqliteDb.getModelAliases();
+    expect(aliasesAfterDelete["deleted-provider-model"]).toBeUndefined();
+    expect(aliasesAfterDelete["neighbor-provider-model"]).toBe(`${n.id}-neighbor/imported-model`);
   });
 
   it("proxyPools: CRUD with sort by updatedAt desc", async () => {


### PR DESCRIPTION
## Summary
- delete imported model aliases whose value points at a provider node when that provider node is deleted
- keep aliases for similarly prefixed provider IDs intact
- document the fix for #1409 in the changelog

Fixes #1409

## Tests
- npx vitest run --config tests/vitest.config.js tests/unit/db-sqlite-vs-lowdb.test.js --reporter=verbose
- node --check src/lib/db/repos/nodesRepo.js
- node --check tests/unit/db-sqlite-vs-lowdb.test.js
- git diff --check