### PR TITLE
Prevent combo circular dependencies

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -25,6 +25,80 @@ function rotateModelsFromIndex(models, currentIndex) {
   return rotatedModels;
 }
 
+function normalizeCombosData(combosData) {
+  return Array.isArray(combosData) ? combosData : (combosData?.combos || []);
+}
+
+function buildComboMap(combosData) {
+  const comboMap = new Map();
+  for (const combo of normalizeCombosData(combosData)) {
+    if (combo?.name) comboMap.set(combo.name, combo);
+  }
+  return comboMap;
+}
+
+export function findComboCycle(combosData, startName = null) {
+  const comboMap = buildComboMap(combosData);
+  const visited = new Set();
+
+  const visit = (name, path) => {
+    const existingIndex = path.indexOf(name);
+    if (existingIndex !== -1) return [...path.slice(existingIndex), name];
+    if (visited.has(name)) return null;
+
+    const combo = comboMap.get(name);
+    if (!combo) return null;
+
+    const nextPath = [...path, name];
+    for (const model of Array.isArray(combo.models) ? combo.models : []) {
+      if (!comboMap.has(model)) continue;
+      const cycle = visit(model, nextPath);
+      if (cycle) return cycle;
+    }
+
+    visited.add(name);
+    return null;
+  };
+
+  if (startName) return visit(startName, []);
+
+  for (const name of comboMap.keys()) {
+    const cycle = visit(name, []);
+    if (cycle) return cycle;
+  }
+  return null;
+}
+
+export function validateComboAcyclic({ name, models = [], combosData = [], currentId = null } = {}) {
+  const comboName = typeof name === "string" ? name.trim() : "";
+  if (!comboName) return { valid: false, error: "Combo name is required" };
+
+  // #1235: validate the full combo graph before saving so a combo cannot
+  // directly or indirectly route back into itself at request time.
+  const candidate = {
+    id: currentId || "__pending_combo__",
+    name: comboName,
+    models: Array.isArray(models) ? models : [],
+  };
+  const nextCombos = normalizeCombosData(combosData)
+    .filter((combo) => {
+      if (!combo) return false;
+      if (currentId && combo.id === currentId) return false;
+      return combo.name !== comboName;
+    })
+    .concat(candidate);
+
+  const cycle = findComboCycle(nextCombos, comboName);
+  if (cycle) {
+    return {
+      valid: false,
+      error: `Combo circular dependency detected: ${cycle.join(" -> ")}`,
+    };
+  }
+
+  return { valid: true, error: null };
+}
+
 /**
  * Get rotated model list based on strategy
  * @param {string[]} models - Array of model strings
@@ -84,7 +158,7 @@ export function getComboModelsFromData(modelStr, combosData) {
   if (modelStr.includes("/")) return null;
   
   // Handle both array and object formats
-  const combos = Array.isArray(combosData) ? combosData : (combosData?.combos || []);
+  const combos = normalizeCombosData(combosData);
   
   const combo = combos.find(c => c.name === modelStr);
   if (combo && combo.models && combo.models.length > 0) {

--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
-import { resetComboRotation } from "open-sse/services/combo.js";
+import { getCombos, getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
+import { resetComboRotation, validateComboAcyclic } from "open-sse/services/combo.js";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
@@ -41,8 +41,22 @@ export async function PUT(request, { params }) {
       }
     }
     
-    // Capture previous name to invalidate rotation state on rename
     const prev = await getComboById(id);
+    if (!prev) {
+      return NextResponse.json({ error: "Combo not found" }, { status: 404 });
+    }
+
+    const validation = validateComboAcyclic({
+      name: body.name || prev.name,
+      models: body.models || prev.models || [],
+      combosData: await getCombos(),
+      currentId: id,
+    });
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    // Capture previous name to invalidate rotation state on rename
     const combo = await updateCombo(id, body);
     
     if (!combo) {

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
+import { validateComboAcyclic } from "open-sse/services/combo.js";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,12 @@ export async function POST(request) {
     const existing = await getComboByName(name);
     if (existing) {
       return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
+    }
+
+    const existingCombos = await getCombos();
+    const validation = validateComboAcyclic({ name, models, combosData: existingCombos });
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
     }
 
     const combo = await createCombo({ name, models: models || [], kind: kind || null });

--- a/tests/unit/combo-api-validation.test.js
+++ b/tests/unit/combo-api-validation.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const db = vi.hoisted(() => ({
+  getCombos: vi.fn(),
+  createCombo: vi.fn(),
+  getComboByName: vi.fn(),
+  getComboById: vi.fn(),
+  updateCombo: vi.fn(),
+  deleteCombo: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => db);
+
+const combosRoute = await import("../../src/app/api/combos/route.js");
+const comboByIdRoute = await import("../../src/app/api/combos/[id]/route.js");
+
+function request(body) {
+  return new Request("http://localhost/api/combos", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function json(response) {
+  return await response.json();
+}
+
+describe("combo API cycle validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.getCombos.mockResolvedValue([]);
+    db.getComboByName.mockResolvedValue(null);
+  });
+
+  it("rejects creating a combo that includes itself", async () => {
+    const response = await combosRoute.POST(request({
+      name: "my-combo",
+      models: ["my-combo"],
+    }));
+
+    expect(response.status).toBe(400);
+    expect(await json(response)).toEqual({
+      error: "Combo circular dependency detected: my-combo -> my-combo",
+    });
+    expect(db.createCombo).not.toHaveBeenCalled();
+  });
+
+  it("rejects updating a combo when the resulting graph would be cyclic", async () => {
+    db.getComboById.mockResolvedValue({ id: "a", name: "alpha", models: ["openai/gpt-5"] });
+    db.getCombos.mockResolvedValue([
+      { id: "a", name: "alpha", models: ["openai/gpt-5"] },
+      { id: "b", name: "beta", models: ["alpha"] },
+    ]);
+
+    const response = await comboByIdRoute.PUT(
+      request({ models: ["beta"] }),
+      { params: Promise.resolve({ id: "a" }) },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await json(response)).toEqual({
+      error: "Combo circular dependency detected: alpha -> beta -> alpha",
+    });
+    expect(db.updateCombo).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/combo-routing.test.js
+++ b/tests/unit/combo-routing.test.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { getRotatedModels, resetComboRotation } from "../../open-sse/services/combo.js";
+import {
+  findComboCycle,
+  getRotatedModels,
+  resetComboRotation,
+  validateComboAcyclic,
+} from "../../open-sse/services/combo.js";
 
 describe("combo round-robin routing", () => {
   beforeEach(() => {
@@ -54,5 +59,53 @@ describe("combo round-robin routing", () => {
 
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
+  });
+});
+
+describe("combo cycle validation", () => {
+  it("detects a direct self-reference", () => {
+    const validation = validateComboAcyclic({
+      name: "my-combo",
+      models: ["my-combo"],
+      combosData: [],
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toBe("Combo circular dependency detected: my-combo -> my-combo");
+  });
+
+  it("detects an indirect cycle through another combo", () => {
+    const validation = validateComboAcyclic({
+      name: "alpha",
+      models: ["beta"],
+      combosData: [
+        { id: "b", name: "beta", models: ["gamma"] },
+        { id: "g", name: "gamma", models: ["alpha"] },
+      ],
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toBe("Combo circular dependency detected: alpha -> beta -> gamma -> alpha");
+  });
+
+  it("allows provider models and non-cyclic combo chains", () => {
+    const validation = validateComboAcyclic({
+      name: "alpha",
+      models: ["beta", "openai/gpt-5"],
+      combosData: [
+        { id: "b", name: "beta", models: ["anthropic/claude-sonnet"] },
+      ],
+    });
+
+    expect(validation).toEqual({ valid: true, error: null });
+  });
+
+  it("can scan an existing combo graph", () => {
+    const cycle = findComboCycle([
+      { id: "a", name: "alpha", models: ["beta"] },
+      { id: "b", name: "beta", models: ["alpha"] },
+    ]);
+
+    expect(cycle).toEqual(["alpha", "beta", "alpha"]);
   });
 });


### PR DESCRIPTION
## Summary
- add combo graph validation that catches direct and indirect circular dependencies
- reject cyclic combo creates and updates before saving
- add regression coverage for direct self-reference, indirect cycles, valid chains, and API validation

Fixes #1235

## Tests
- npx vitest run --config tests/vitest.config.js tests/unit/combo-routing.test.js tests/unit/combo-api-validation.test.js --reporter=verbose
- node --check open-sse/services/combo.js
- node --check tests/unit/combo-api-validation.test.js
- node --check tests/unit/combo-routing.test.js
- git diff --check