### PR TITLE
Guard MCP routes to localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Fixes
+- MCP: enforce localhost-only access inside the SSE and message route handlers as defense in depth for local stdio plugins (#1114).
+
 # v0.4.59 (2026-05-21)
 
 ## Fixes

--- a/src/app/api/mcp/[plugin]/message/route.js
+++ b/src/app/api/mcp/[plugin]/message/route.js
@@ -1,10 +1,15 @@
 import { NextResponse } from "next/server";
 import { sendToChild, findPlugin } from "@/lib/mcp/stdioSseBridge";
+import { isLocalOnlyRequest, localOnlyJsonError } from "@/lib/security/localOnly";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(request, { params }) {
+  if (!isLocalOnlyRequest(request)) {
+    return localOnlyJsonError("Local only: MCP requires localhost access");
+  }
+
   const { plugin } = await params;
   if (!findPlugin(plugin)) {
     return NextResponse.json({ error: `Unknown plugin: ${plugin}` }, { status: 404 });

--- a/src/app/api/mcp/[plugin]/sse/route.js
+++ b/src/app/api/mcp/[plugin]/sse/route.js
@@ -1,9 +1,14 @@
 import { registerSession, unregisterSession, findPlugin } from "@/lib/mcp/stdioSseBridge";
+import { isLocalOnlyRequest, localOnlyJsonError } from "@/lib/security/localOnly";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(request, { params }) {
+  if (!isLocalOnlyRequest(request)) {
+    return localOnlyJsonError("Local only: MCP requires localhost access");
+  }
+
   const { plugin } = await params;
   if (!findPlugin(plugin)) {
     return new Response(`Unknown plugin: ${plugin}`, { status: 404 });

--- a/src/lib/security/localOnly.js
+++ b/src/lib/security/localOnly.js
@@ -1,0 +1,50 @@
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function normalizeHostname(value) {
+  const host = String(value || "").trim().toLowerCase();
+  if (!host) return null;
+
+  const bracketedIpv6 = host.match(/^\[([^\]]+)\](?::\d+)?$/);
+  if (bracketedIpv6) return bracketedIpv6[1];
+
+  if (host === "::1") return host;
+
+  const colonIndex = host.indexOf(":");
+  if (colonIndex === -1) return host;
+  if (host.indexOf(":", colonIndex + 1) !== -1) return null;
+  return host.slice(0, colonIndex);
+}
+
+function isLoopbackHostname(value) {
+  if (!value) return false;
+  const hostnames = String(value).split(",").map(normalizeHostname);
+  return hostnames.length > 0 && hostnames.every((hostname) => LOOPBACK_HOSTS.has(hostname));
+}
+
+function isLoopbackOrigin(value) {
+  if (!value) return true;
+  try {
+    return isLoopbackHostname(new URL(value).hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function isLocalOnlyRequest(request) {
+  const headers = request?.headers;
+  if (!headers?.get) return false;
+
+  // #1114: MCP route handlers spawn local stdio plugins, so they enforce
+  // loopback Host/Origin here even if middleware is bypassed or relaxed.
+  if (!isLoopbackHostname(headers.get("host"))) return false;
+  if (!isLoopbackOrigin(headers.get("origin"))) return false;
+
+  const forwardedHost = headers.get("x-forwarded-host");
+  if (forwardedHost && !isLoopbackHostname(forwardedHost)) return false;
+
+  return true;
+}
+
+export function localOnlyJsonError(message = "Local only: requires localhost access") {
+  return Response.json({ error: message }, { status: 403 });
+}

--- a/tests/unit/mcp-local-only.test.js
+++ b/tests/unit/mcp-local-only.test.js
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const bridge = vi.hoisted(() => ({
+  findPlugin: vi.fn(),
+  registerSession: vi.fn(),
+  unregisterSession: vi.fn(),
+  sendToChild: vi.fn(),
+}));
+
+vi.mock("@/lib/mcp/stdioSseBridge", () => bridge);
+
+const sseRoute = await import("../../src/app/api/mcp/[plugin]/sse/route.js");
+const messageRoute = await import("../../src/app/api/mcp/[plugin]/message/route.js");
+
+function request(url, init = {}) {
+  return new Request(url, init);
+}
+
+async function json(response) {
+  return await response.json();
+}
+
+describe("MCP route localhost guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridge.findPlugin.mockReturnValue({ name: "filesystem", command: "node", args: [] });
+    bridge.registerSession.mockReturnValue("session-1");
+  });
+
+  it("rejects remote SSE access before plugin lookup or process spawn", async () => {
+    const response = await sseRoute.GET(
+      request("https://router.example.com/api/mcp/filesystem/sse", {
+        headers: { host: "router.example.com", origin: "https://router.example.com" },
+      }),
+      { params: Promise.resolve({ plugin: "filesystem" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await json(response)).toEqual({ error: "Local only: MCP requires localhost access" });
+    expect(bridge.findPlugin).not.toHaveBeenCalled();
+    expect(bridge.registerSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects remote message access before writing to a child process", async () => {
+    const response = await messageRoute.POST(
+      request("https://router.example.com/api/mcp/filesystem/message", {
+        method: "POST",
+        headers: {
+          host: "router.example.com",
+          origin: "https://router.example.com",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+      { params: Promise.resolve({ plugin: "filesystem" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await json(response)).toEqual({ error: "Local only: MCP requires localhost access" });
+    expect(bridge.findPlugin).not.toHaveBeenCalled();
+    expect(bridge.sendToChild).not.toHaveBeenCalled();
+  });
+
+  it("rejects forwarded remote hosts even when Host is loopback", async () => {
+    const response = await messageRoute.POST(
+      request("http://localhost:20128/api/mcp/filesystem/message", {
+        method: "POST",
+        headers: {
+          host: "localhost:20128",
+          "x-forwarded-host": "router.example.com",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+      { params: Promise.resolve({ plugin: "filesystem" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(bridge.sendToChild).not.toHaveBeenCalled();
+  });
+
+  it("rejects forwarded host lists that include a remote host", async () => {
+    const response = await messageRoute.POST(
+      request("http://localhost:20128/api/mcp/filesystem/message", {
+        method: "POST",
+        headers: {
+          host: "localhost:20128",
+          "x-forwarded-host": "localhost:20128, router.example.com",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+      { params: Promise.resolve({ plugin: "filesystem" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(bridge.sendToChild).not.toHaveBeenCalled();
+  });
+
+  it("allows bracketed IPv6 loopback message access", async () => {
+    const response = await messageRoute.POST(
+      request("http://[::1]:20128/api/mcp/filesystem/message", {
+        method: "POST",
+        headers: {
+          host: "[::1]:20128",
+          origin: "http://[::1]:20128",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+      { params: Promise.resolve({ plugin: "filesystem" }) },
+    );
+
+    expect(response.status).toBe(202);
+    expect(bridge.findPlugin).toHaveBeenCalledWith("filesystem");
+    expect(bridge.sendToChild).toHaveBeenCalledWith("filesystem", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+  });
+
+  it("allows loopback message access to reach the bridge", async () => {
+    const response = await messageRoute.POST(
+      request("http://localhost:20128/api/mcp/filesystem/message", {
+        method: "POST",
+        headers: {
+          host: "localhost:20128",
+          origin: "http://localhost:20128",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+      { params: Promise.resolve({ plugin: "filesystem" }) },
+    );
+
+    expect(response.status).toBe(202);
+    expect(bridge.findPlugin).toHaveBeenCalledWith("filesystem");
+    expect(bridge.sendToChild).toHaveBeenCalledWith("filesystem", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- enforce localhost-only Host/Origin checks inside the MCP SSE and message route handlers
- reject forwarded remote hosts before plugin lookup, session registration, or child-process writes
- add route-level regression coverage alongside the existing dashboard guard tests

Fixes #1114

## Tests
- npx vitest run --config tests/vitest.config.js tests/unit/mcp-local-only.test.js tests/unit/dashboard-guard.test.js --reporter=verbose
- node --check src/lib/security/localOnly.js
- node --check tests/unit/mcp-local-only.test.js
- node --check src/app/api/mcp/[plugin]/sse/route.js
- node --check src/app/api/mcp/[plugin]/message/route.js
- git diff --check