### PR TITLE
Default Codex reasoning to medium

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -39,6 +39,11 @@ export const PROVIDER_MODELS = {
   ],
   cx: withCodexReviewModels([  // OpenAI Codex
     { id: "gpt-5.5", name: "GPT 5.5" },
+    { id: "gpt-5.5-xhigh", name: "GPT 5.5 (xHigh)" },
+    { id: "gpt-5.5-high", name: "GPT 5.5 (High)" },
+    { id: "gpt-5.5-medium", name: "GPT 5.5 (Medium)" },
+    { id: "gpt-5.5-low", name: "GPT 5.5 (Low)" },
+    { id: "gpt-5.5-none", name: "GPT 5.5 (None)" },
     { id: "gpt-5.4", name: "GPT 5.4" },
     { id: "gpt-5.4-mini", name: "GPT 5.4 Mini" },
     // GPT 5.3 Codex - all thinking levels

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -19,6 +19,7 @@ const CODEX_SSE_PEEK_BYTES = 4096;
 
 // In-memory map: hash(machineId + first assistant content) → { sessionId, lastUsed }
 const SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CODEX_DEFAULT_REASONING_EFFORT = "medium";
 const assistantSessionMap = new Map();
 
 // Server-generated item id prefixes that Codex /responses cannot resolve when store=false
@@ -428,7 +429,9 @@ export class CodexExecutor extends BaseExecutor {
 
     // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (medium)
     if (!body.reasoning) {
-      const effort = body.reasoning_effort || modelEffort || 'low';
+      // #1417: Claude Code does not always send reasoning_effort, so keep
+      // Codex requests at the documented medium default unless configured.
+      const effort = body.reasoning_effort || modelEffort || CODEX_DEFAULT_REASONING_EFFORT;
       body.reasoning = { effort, summary: "auto" };
     } else if (!body.reasoning.summary) {
       body.reasoning.summary = "auto";

--- a/tests/unit/codex-reasoning.test.js
+++ b/tests/unit/codex-reasoning.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+import { PROVIDER_MODELS } from "../../open-sse/config/providerModels.js";
+
+function transformCodex(model, body = {}) {
+  const executor = new CodexExecutor();
+  return executor.transformRequest(model, { input: "hello", ...body }, true, {});
+}
+
+describe("CodexExecutor reasoning effort", () => {
+  it("defaults missing reasoning effort to medium", () => {
+    const body = transformCodex("gpt-5.5");
+
+    expect(body.model).toBe("gpt-5.5");
+    expect(body.reasoning).toEqual({ effort: "medium", summary: "auto" });
+    expect(body.include).toEqual(["reasoning.encrypted_content"]);
+  });
+
+  it("uses model suffixes as reasoning effort selectors", () => {
+    const body = transformCodex("gpt-5.5-high");
+
+    expect(body.model).toBe("gpt-5.5");
+    expect(body.reasoning).toEqual({ effort: "high", summary: "auto" });
+    expect(body.include).toEqual(["reasoning.encrypted_content"]);
+  });
+
+  it("lets request reasoning_effort override model suffixes", () => {
+    const body = transformCodex("gpt-5.5-high", { reasoning_effort: "low" });
+
+    expect(body.model).toBe("gpt-5.5");
+    expect(body.reasoning).toEqual({ effort: "low", summary: "auto" });
+  });
+
+  it("preserves explicit reasoning objects", () => {
+    const body = transformCodex("gpt-5.5-high", {
+      reasoning: { effort: "none" },
+      reasoning_effort: "low",
+    });
+
+    expect(body.model).toBe("gpt-5.5");
+    expect(body.reasoning).toEqual({ effort: "none", summary: "auto" });
+    expect(body.include).toBeUndefined();
+  });
+
+  it("lists GPT 5.5 effort variants for clients that configure by model id", () => {
+    const modelIds = PROVIDER_MODELS.cx.map((model) => model.id);
+
+    expect(modelIds).toContain("gpt-5.5-xhigh");
+    expect(modelIds).toContain("gpt-5.5-high");
+    expect(modelIds).toContain("gpt-5.5-medium");
+    expect(modelIds).toContain("gpt-5.5-low");
+    expect(modelIds).toContain("gpt-5.5-none");
+  });
+});


### PR DESCRIPTION
## Summary
- default Codex requests without reasoning_effort to medium instead of low
- expose GPT 5.5 reasoning-effort model variants for clients that configure effort via model id
- add focused regression coverage for Codex reasoning precedence

Fixes #1417

## Tests
- npx vitest run --config tests/vitest.config.js tests/unit/codex-reasoning.test.js --reporter=verbose
- npx vitest run --config tests/vitest.config.js tests/unit/codex-reasoning.test.js tests/unit/codex-image-fetch.test.js --reporter=verbose
- node --check open-sse\\executors\\codex.js
- node --check open-sse\\config\\providerModels.js
- node --check tests\\unit\\codex-reasoning.test.js
- git diff --cached --check