### PR TITLE
Send account context for Codex usage

### DIFF
--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -74,7 +74,7 @@ export async function getUsageForProvider(connection, proxyOptions = null) {
     case "claude":
       return await getClaudeUsage(accessToken, proxyOptions);
     case "codex":
-      return await getCodexUsage(accessToken, proxyOptions);
+      return await getCodexUsage(accessToken, providerSpecificData, proxyOptions);
     case "kiro":
       return await getKiroUsage(accessToken, providerSpecificData, proxyOptions);
     case "qoder":
@@ -629,13 +629,28 @@ function getCodexRateLimitBody(snapshot) {
     : snapshot;
 }
 
+function parseCodexResetTime(window) {
+  const absoluteReset = window?.reset_at ?? window?.resets_at ?? window?.resetAt ?? null;
+  const parsedAbsolute = parseResetTime(absoluteReset);
+  if (parsedAbsolute) return parsedAbsolute;
+
+  const relativeSeconds = toFiniteNumber(
+    window?.reset_after_seconds ?? window?.resets_in_seconds ?? window?.resetAfterSeconds,
+    null
+  );
+  if (typeof relativeSeconds === "number" && relativeSeconds > 0) {
+    return new Date(Date.now() + relativeSeconds * 1000).toISOString();
+  }
+  return null;
+}
+
 function formatCodexWindow(window) {
   const used = Math.max(0, Math.min(100, toFiniteNumber(window?.used_percent ?? window?.percent_used, 0)));
   return {
     used,
     total: 100,
     remaining: Math.max(0, 100 - used),
-    resetAt: parseResetTime(window?.reset_at ?? window?.resets_at ?? window?.resetAt ?? null),
+    resetAt: parseCodexResetTime(window),
     unlimited: false,
   };
 }
@@ -677,14 +692,21 @@ function getCodexReviewRateLimit(data) {
   }) || null;
 }
 
-async function getCodexUsage(accessToken, proxyOptions = null) {
+async function getCodexUsage(accessToken, providerSpecificData = {}, proxyOptions = null) {
   try {
+    const headers = {
+      "Authorization": `Bearer ${accessToken}`,
+      "Accept": "application/json",
+    };
+    const accountId = providerSpecificData?.chatgptAccountId || providerSpecificData?.accountId;
+    if (accountId) {
+      // #1407: /wham/usage can be account-scoped for ChatGPT Plus/Pro users.
+      headers["ChatGPT-Account-Id"] = accountId;
+    }
+
     const response = await proxyAwareFetch(CODEX_CONFIG.usageUrl, {
       method: "GET",
-      headers: {
-        "Authorization": `Bearer ${accessToken}`,
-        "Accept": "application/json",
-      },
+      headers,
     }, proxyOptions);
 
     if (!response.ok) {
@@ -700,10 +722,13 @@ async function getCodexUsage(accessToken, proxyOptions = null) {
     appendCodexQuotaWindows(quotas, "review", reviewRateLimit);
 
     return {
-      plan: data.plan_type || data.summary?.plan || "unknown",
+      plan: data.plan_type || data.summary?.plan || providerSpecificData?.chatgptPlanType || "unknown",
       limitReached: getCodexRateLimitBody(normalRateLimit)?.limit_reached || false,
       reviewLimitReached: getCodexRateLimitBody(reviewRateLimit)?.limit_reached || false,
       quotas,
+      ...(Object.keys(quotas).length === 0
+        ? { message: "Codex connected. Usage API returned no quota windows." }
+        : {}),
     };
   } catch (error) {
     throw new Error(`Failed to fetch Codex usage: ${error.message}`);

--- a/tests/unit/codex-usage.test.js
+++ b/tests/unit/codex-usage.test.js
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Codex usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends the ChatGPT account id and parses Plus quota windows", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({
+      plan_type: "plus",
+      rate_limit: {
+        limit_reached: false,
+        primary_window: {
+          used_percent: 25,
+          reset_after_seconds: 3600,
+        },
+        secondary_window: {
+          used_percent: 60,
+          reset_at: 1770000000,
+        },
+      },
+    }));
+
+    const usage = await getUsageForProvider({
+      provider: "codex",
+      accessToken: "token",
+      providerSpecificData: {
+        chatgptAccountId: "acct_123",
+        chatgptPlanType: "plus",
+      },
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledWith(
+      "https://chatgpt.com/backend-api/wham/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token",
+          "ChatGPT-Account-Id": "acct_123",
+        }),
+      }),
+      null
+    );
+    expect(usage.plan).toBe("plus");
+    expect(usage.quotas.session).toMatchObject({
+      used: 25,
+      remaining: 75,
+      resetAt: "2026-05-25T13:00:00.000Z",
+    });
+    expect(usage.quotas.weekly).toMatchObject({
+      used: 60,
+      remaining: 40,
+      resetAt: "2026-02-02T02:40:00.000Z",
+    });
+  });
+
+  it("falls back to stored plan info and explains empty quota responses", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({}));
+
+    const usage = await getUsageForProvider({
+      provider: "codex",
+      accessToken: "token",
+      providerSpecificData: { chatgptPlanType: "plus" },
+    });
+
+    expect(usage.plan).toBe("plus");
+    expect(usage.quotas).toEqual({});
+    expect(usage.message).toBe("Codex connected. Usage API returned no quota windows.");
+  });
+});


### PR DESCRIPTION
## Summary
- send stored ChatGPT account id when fetching Codex /wham/usage
- parse relative Codex reset fields into resetAt
- show an explicit connected/no quota-window message instead of returning a blank usage payload

Fixes #1407

## Tests
- npx vitest run --config tests/vitest.config.js tests/unit/codex-usage.test.js --reporter=verbose
- npx vitest run --config tests/vitest.config.js tests/unit/codex-usage.test.js tests/unit/minimax-usage.test.js --reporter=verbose
- node --check open-sse\\services\\usage.js
- node --check tests\\unit\\codex-usage.test.js
- git diff --check