### PR TITLE
Keep quota accounts active until all pools empty

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import QuotaTable from "./QuotaTable";
 import Toggle from "@/shared/components/Toggle";
-import { parseQuotaData, calculatePercentage } from "./utils";
+import { getBestQuotaRemaining, isQuotaCollectionDepleted, parseQuotaData } from "./utils";
 import Card from "@/shared/components/Card";
 import { EditConnectionModal } from "@/shared/components";
 import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
@@ -18,10 +18,7 @@ function getConnectionLabel(connection) {
 }
 
 function getConnectionQuotaRemaining(connection, quotaData) {
-  const quota = quotaData[connection.id]?.quotas?.[0];
-  if (!quota) return Number.POSITIVE_INFINITY;
-  if (typeof quota.remaining === "number") return quota.remaining;
-  return Number.POSITIVE_INFINITY;
+  return getBestQuotaRemaining(quotaData[connection.id]?.quotas);
 }
 
 function sortVisibleConnections(
@@ -643,14 +640,12 @@ export default function ProviderLimits() {
     [connections, quotaData, expiringFirst, providerFilter, quotaSortMode],
   );
 
-  // Connection is depleted when any quota entry hit the threshold
+  // Connection is depleted only when all usable quota entries hit the threshold.
   const isConnectionDepleted = (conn) => {
-    const quotas = quotaData[conn.id]?.quotas;
-    if (!quotas?.length) return false;
-    return quotas.some((q) => {
-      if (!q.total || q.total <= 0) return false;
-      return calculatePercentage(q.used, q.total) <= DEPLETED_QUOTA_THRESHOLD;
-    });
+    return isQuotaCollectionDepleted(
+      quotaData[conn.id]?.quotas,
+      DEPLETED_QUOTA_THRESHOLD,
+    );
   };
 
   const bulkSetActive = useCallback(

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -92,6 +92,26 @@ export function getRemainingPercentage(quota) {
   return calculatePercentage(quota?.used, quota?.total);
 }
 
+export function getBestQuotaRemaining(quotas = []) {
+  const remainingValues = quotas
+    .map((quota) => getRemainingPercentage(quota))
+    .filter((remaining) => Number.isFinite(remaining));
+
+  if (remainingValues.length === 0) return Number.POSITIVE_INFINITY;
+  return Math.max(...remainingValues);
+}
+
+export function isQuotaCollectionDepleted(quotas = [], threshold = 5) {
+  const remainingValues = quotas
+    .filter((quota) => quota?.total && quota.total > 0)
+    .map((quota) => getRemainingPercentage(quota))
+    .filter((remaining) => Number.isFinite(remaining));
+
+  // #1328: accounts can expose multiple pools (e.g. credit + credit_freetrial).
+  // Treat the account as empty only when every usable pool is depleted.
+  return remainingValues.length > 0 && remainingValues.every((remaining) => remaining <= threshold);
+}
+
 /**
  * Parse provider-specific quota structures into normalized array
  * @param {string} provider - Provider name (github, antigravity, codex, kiro, claude)

--- a/tests/unit/provider-limits-utils.test.js
+++ b/tests/unit/provider-limits-utils.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBestQuotaRemaining,
+  isQuotaCollectionDepleted,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+describe("ProviderLimits quota helpers", () => {
+  it("keeps an account available when a secondary quota pool still has capacity", () => {
+    const quotas = [
+      { name: "credit", used: 50, total: 50 },
+      { name: "credit_freetrial", used: 0, total: 500 },
+    ];
+
+    expect(isQuotaCollectionDepleted(quotas, 5)).toBe(false);
+    expect(getBestQuotaRemaining(quotas)).toBe(100);
+  });
+
+  it("marks an account depleted only when every usable pool is below the threshold", () => {
+    const quotas = [
+      { name: "credit", used: 50, total: 50 },
+      { name: "credit_freetrial", used: 495, total: 500 },
+    ];
+
+    expect(isQuotaCollectionDepleted(quotas, 5)).toBe(true);
+    expect(getBestQuotaRemaining(quotas)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- treat quota accounts as depleted only when every usable quota pool is below threshold
- use the best remaining quota pool for quota-sort account ordering
- add regression coverage for Kiro credit + credit_freetrial behavior

Fixes #1328

## Tests
- npx vitest run --config tests/vitest.config.js tests/unit/provider-limits-utils.test.js --reporter=verbose
- node --check tests\\unit\\provider-limits-utils.test.js
- node --check src\\app\\(dashboard)\\dashboard\\usage\\components\\ProviderLimits\\utils.js
- node --check src\\app\\(dashboard)\\dashboard\\usage\\components\\ProviderLimits\\index.js
- npm run build
- git diff --check