### PR TITLE
fix: implement json_schema fallback for OpenAI-compatible providers (#1343)

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -12,7 +12,33 @@ export class DefaultExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body) {
-    return injectReasoningContent({ provider: this.provider, model, body });
+    let transformedBody = { ...body };
+
+    // Handle json_schema response_format fallback for OpenAI-compatible providers
+    // (Models that don't natively support Structured Output will fail if passed json_schema)
+    if (transformedBody.response_format?.type === "json_schema" && transformedBody.response_format.json_schema?.schema) {
+      const schemaJson = JSON.stringify(transformedBody.response_format.json_schema.schema, null, 2);
+      const schemaPrompt = `You must respond with valid JSON that strictly follows this JSON schema:\n\`\`\`json\n${schemaJson}\n\`\`\`\nRespond ONLY with the JSON object, no other text.`;
+
+      transformedBody.messages = Array.isArray(transformedBody.messages)
+        ? [...transformedBody.messages.map(m => ({ ...m }))]
+        : [];
+
+      const systemMessage = transformedBody.messages.find(m => m.role === "system");
+      if (systemMessage) {
+        if (typeof systemMessage.content === "string") {
+          systemMessage.content += `\n\n${schemaPrompt}`;
+        } else if (Array.isArray(systemMessage.content)) {
+          systemMessage.content.push({ type: "text", text: `\n\n${schemaPrompt}` });
+        }
+      } else {
+        transformedBody.messages.unshift({ role: "system", content: schemaPrompt });
+      }
+
+      transformedBody.response_format = { type: "json_object" };
+    }
+
+    return injectReasoningContent({ provider: this.provider, model, body: transformedBody });
   }
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {

--- a/tests/unit/default-executor.test.js
+++ b/tests/unit/default-executor.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DefaultExecutor } from '../../open-sse/executors/default.js';
+
+// Mocking dependencies if necessary
+vi.mock('../../src/shared/utils/clineAuth.js', () => ({
+  buildClineHeaders: vi.fn(() => ({})),
+}));
+
+describe('DefaultExecutor', () => {
+  it('should fallback json_schema to json_object and inject prompt', () => {
+    const executor = new DefaultExecutor('openai');
+    const body = {
+      model: 'gpt-4o',
+      messages: [
+        { role: 'user', content: 'Extract name from: My name is John' }
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Name',
+          schema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' }
+            },
+            required: ['name']
+          }
+        }
+      }
+    };
+
+    const transformed = executor.transformRequest('gpt-4o', body);
+
+    expect(transformed.response_format.type).toBe('json_object');
+    expect(transformed.messages[0].role).toBe('system');
+    expect(transformed.messages[0].content).toContain('You must respond with valid JSON that strictly follows this JSON schema');
+    expect(transformed.messages[0].content).toContain('"name": {');
+    expect(transformed.messages[1].content).toBe('Extract name from: My name is John');
+  });
+
+  it('should append to existing system message', () => {
+    const executor = new DefaultExecutor('openai');
+    const body = {
+      model: 'gpt-4o',
+      messages: [
+        { role: 'system', content: 'Be concise.' },
+        { role: 'user', content: 'Extract name from: My name is John' }
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Name',
+          schema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' }
+            },
+            required: ['name']
+          }
+        }
+      }
+    };
+
+    const transformed = executor.transformRequest('gpt-4o', body);
+
+    expect(transformed.response_format.type).toBe('json_object');
+    expect(transformed.messages[0].role).toBe('system');
+    expect(transformed.messages[0].content).toContain('Be concise.');
+    expect(transformed.messages[0].content).toContain('You must respond with valid JSON');
+  });
+
+  it('should not modify body if no json_schema is present', () => {
+    const executor = new DefaultExecutor('openai');
+    const body = {
+      model: 'gpt-4o',
+      messages: [
+        { role: 'user', content: 'Hello' }
+      ]
+    };
+
+    const transformed = executor.transformRequest('gpt-4o', body);
+
+    expect(transformed.response_format).toBeUndefined();
+    expect(transformed.messages.length).toBe(1);
+    expect(transformed.messages[0].content).toBe('Hello');
+  });
+});


### PR DESCRIPTION
This PR addresses Issue #1343 by adding a fallback mechanism for json_schema in the DefaultExecutor.

### Problem
When json_schema response format is sent to models that do not natively support Structured Output (e.g., DeepSeek via Ollama), they often return empty or malformed content.

### Solution
Inspired by the Claude translator, this PR:
1. Detects esponse_format.type === 'json_schema'.
2. Injects the JSON schema into the system prompt.
3. Downgrades the esponse_format to json_object.

This ensures Structured Output works transparently across all OpenAI-compatible providers.

### Changes
- Modified open-sse/executors/default.js to handle the transformation.
- Added unit tests in 	ests/unit/default-executor.test.js to verify the logic.

Verified with itest.