### PR TITLE
fix: prevent circular dependencies in model combos (#1235)

### DIFF
--- a/src/app/api/combos/[id]/route.js
+++ b/src/app/api/combos/[id]/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getComboById, updateCombo, deleteCombo, getComboByName } from "@/lib/localDb";
 import { resetComboRotation } from "open-sse/services/combo.js";
+import { hasCircularDependency } from "@/lib/comboValidation";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
@@ -38,6 +39,17 @@ export async function PUT(request, { params }) {
       const existing = await getComboByName(body.name);
       if (existing && existing.id !== id) {
         return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
+      }
+    }
+
+    // Check for circular dependencies if models are being updated
+    if (body.models) {
+      const prev = await getComboById(id);
+      if (!prev) return NextResponse.json({ error: "Combo not found" }, { status: 404 });
+      
+      const targetName = body.name || prev.name;
+      if (await hasCircularDependency(targetName, body.models, id)) {
+        return NextResponse.json({ error: "Circular dependency detected: Combo cannot include itself directly or indirectly." }, { status: 400 });
       }
     }
     

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCombos, createCombo, getComboByName } from "@/lib/localDb";
+import { hasCircularDependency } from "@/lib/comboValidation";
 
 export const dynamic = "force-dynamic";
 
@@ -36,6 +37,11 @@ export async function POST(request) {
     const existing = await getComboByName(name);
     if (existing) {
       return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
+    }
+
+    // Check for circular dependencies
+    if (await hasCircularDependency(name, models || [])) {
+      return NextResponse.json({ error: "Circular dependency detected: Combo cannot include itself directly or indirectly." }, { status: 400 });
     }
 
     const combo = await createCombo({ name, models: models || [], kind: kind || null });

--- a/src/lib/comboValidation.js
+++ b/src/lib/comboValidation.js
@@ -1,0 +1,52 @@
+import { getCombos } from "@/lib/localDb";
+
+/**
+ * Check for circular dependencies in model combos.
+ * A circular dependency occurs if combo A includes combo B, and combo B (directly or indirectly) includes combo A.
+ * 
+ * @param {string} targetName - The name of the combo being created or updated.
+ * @param {string[]} models - The list of model/combo names included in this combo.
+ * @param {string} [excludeId] - Optional ID to exclude from the existing combos (useful during updates).
+ * @returns {Promise<boolean>} True if a circular dependency is detected, false otherwise.
+ */
+export async function hasCircularDependency(targetName, models, excludeId = null) {
+  if (!models || !Array.isArray(models)) return false;
+
+  // 1. If the combo includes itself directly
+  if (models.includes(targetName)) return true;
+
+  // 2. Fetch all existing combos to build a map
+  const allCombos = await getCombos();
+  const comboMap = new Map();
+  
+  for (const combo of allCombos) {
+    // During update, skip the old version of the same combo
+    if (excludeId && combo.id === excludeId) continue;
+    // Map combo name to its model list
+    comboMap.set(combo.name, combo.models || []);
+  }
+
+  // 3. Use a stack for Depth-First Search (DFS) to find any path back to targetName
+  const stack = [...models];
+  const visited = new Set();
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+
+    // If we find a reference back to the target combo name
+    if (current === targetName) {
+      return true;
+    }
+
+    // If current is another combo and we haven't visited it yet
+    if (comboMap.has(current) && !visited.has(current)) {
+      visited.add(current);
+      const subModels = comboMap.get(current);
+      if (subModels && Array.isArray(subModels)) {
+        stack.push(...subModels);
+      }
+    }
+  }
+
+  return false;
+}

--- a/tests/unit/combo-circular-dependency.test.js
+++ b/tests/unit/combo-circular-dependency.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { hasCircularDependency } from '../../src/lib/comboValidation.js';
+import * as localDb from '../../src/lib/localDb';
+
+// Mock localDb
+vi.mock('../../src/lib/localDb', () => ({
+  getCombos: vi.fn(),
+}));
+
+describe('hasCircularDependency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should detect direct circular dependency (combo includes itself)', async () => {
+    const result = await hasCircularDependency('combo-a', ['model-1', 'combo-a']);
+    expect(result).toBe(true);
+  });
+
+  it('should detect indirect circular dependency (A -> B -> A)', async () => {
+    // Existing combos in DB
+    vi.mocked(localDb.getCombos).mockResolvedValue([
+      { id: '1', name: 'combo-b', models: ['model-2', 'combo-a'] }
+    ]);
+
+    const result = await hasCircularDependency('combo-a', ['model-1', 'combo-b']);
+    expect(result).toBe(true);
+  });
+
+  it('should detect deep circular dependency (A -> B -> C -> A)', async () => {
+    vi.mocked(localDb.getCombos).mockResolvedValue([
+      { id: '1', name: 'combo-b', models: ['combo-c'] },
+      { id: '2', name: 'combo-c', models: ['combo-a'] }
+    ]);
+
+    const result = await hasCircularDependency('combo-a', ['combo-b']);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for valid nested combos (A -> B -> model)', async () => {
+    vi.mocked(localDb.getCombos).mockResolvedValue([
+      { id: '1', name: 'combo-b', models: ['gpt-4o'] }
+    ]);
+
+    const result = await hasCircularDependency('combo-a', ['combo-b', 'claude-3-sonnet']);
+    expect(result).toBe(false);
+  });
+
+  it('should handle updates correctly (ignore own previous state)', async () => {
+    // When updating combo-a, it might already be in the DB with old models.
+    // We should ignore its OLD state and check the NEW models.
+    vi.mocked(localDb.getCombos).mockResolvedValue([
+      { id: 'uuid-a', name: 'combo-a', models: ['old-model'] },
+      { id: 'uuid-b', name: 'combo-b', models: ['combo-a'] }
+    ]);
+
+    // Update combo-a to include combo-b
+    const result = await hasCircularDependency('combo-a', ['combo-b'], 'uuid-a');
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR fixes Issue #1235 by preventing users from creating or updating model combos that contain circular references.

### Problem
Previously, a combo could include itself or another combo that eventually refers back to it, leading to infinite recursion and server crashes during request handling.

### Solution
- Implemented a DFS-based circular dependency check in \src/lib/comboValidation.js\.
- Integrated this check into \POST /api/combos\ and \PUT /api/combos/[id]\.
- Added comprehensive unit tests in \	ests/unit/combo-circular-dependency.test.js\.

Fixes #1235