### PR TITLE
fix(test): distinguish API-banned account from invalid token; preserve refreshed RT

### DIFF
--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -215,6 +215,21 @@ async function refreshOAuthToken(connection) {
   }
 }
 
+/**
+ * Read a short snippet of an error response body for diagnostics, without
+ * throwing if the body is not text. Truncates to 200 chars and collapses
+ * whitespace so it fits on one line in the lastError column.
+ */
+async function safeReadErrorDetail(res) {
+  try {
+    const text = await res.text();
+    if (!text) return "";
+    return text.slice(0, 200).replace(/\s+/g, " ").trim();
+  } catch {
+    return "";
+  }
+}
+
 function isTokenExpired(connection) {
   if (!connection.expiresAt) return false;
   const expiresAt = new Date(connection.expiresAt).getTime();
@@ -258,25 +273,52 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
     const tryProbe = async (token) => {
       const res = await probeClineAccessToken(token);
       if (res.ok) return { valid: true, error: null, refreshed, newTokens };
-      if (res.status === 401) return { valid: false, error: "Token invalid or revoked", refreshed };
-      if (res.status === 403) return { valid: false, error: "Access denied", refreshed };
-      return { valid: false, error: `API returned ${res.status}`, refreshed };
+      if (res.status === 401) {
+        const detail = await safeReadErrorDetail(res);
+        return { valid: false, error: `Token invalid or revoked${detail ? ": " + detail : ""}`, refreshed, status: res.status };
+      }
+      if (res.status === 403) {
+        const detail = await safeReadErrorDetail(res);
+        return { valid: false, error: `Access denied${detail ? ": " + detail : ""}`, refreshed, status: res.status };
+      }
+      return { valid: false, error: `API returned ${res.status}`, refreshed, status: res.status };
     };
 
     const initial = await tryProbe(accessToken);
-    if (initial.valid || initial.error !== "Token invalid or revoked" || !connection.refreshToken) {
-      return initial;
+    if (initial.valid || initial.status !== 401 || !connection.refreshToken) {
+      // Strip internal status marker before returning
+      const { status, ...rest } = initial;
+      return rest;
     }
 
     const tokens = await refreshOAuthToken(connection);
     if (!tokens?.accessToken) {
-      return { valid: false, error: "Token invalid or revoked", refreshed: false };
+      return { valid: false, error: "Token invalid or revoked (refresh failed)", refreshed: false };
     }
 
     refreshed = true;
     newTokens = tokens;
     accessToken = tokens.accessToken;
-    return await tryProbe(accessToken);
+    const retry = await tryProbe(accessToken);
+    if (retry.valid) {
+      const { status, ...rest } = retry;
+      return rest;
+    }
+    if (retry.status === 401) {
+      // Refresh worked but API still 401 → account-level rejection.
+      // Preserve newTokens so the caller persists the rotated refresh_token.
+      return {
+        valid: false,
+        error: retry.error.replace(
+          /^Token invalid or revoked/,
+          "Account access denied by API (401 after token refresh)",
+        ),
+        refreshed: true,
+        newTokens,
+      };
+    }
+    const { status, ...rest } = retry;
+    return rest;
   }
 
   try {
@@ -293,22 +335,47 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
 
     if (res.status === 401 && config.refreshable && !refreshed && connection.refreshToken) {
       const tokens = await refreshOAuthToken(connection);
-      if (tokens) {
-        const retryUrl = config.buildUrl ? config.buildUrl(tokens.accessToken) : testUrl;
-        const retryHeaders = config.noAuth
-          ? { ...config.extraHeaders }
-          : { [config.authHeader]: `${config.authPrefix}${tokens.accessToken}`, ...config.extraHeaders };
-        const retryOpts = { method: config.method, headers: retryHeaders };
-        if (config.body) retryOpts.body = config.body;
-        const retryRes = await fetchWithConnectionProxy(retryUrl, retryOpts, effectiveProxy);
-        const retryAccepted = retryRes.ok || (config.acceptStatuses && config.acceptStatuses.includes(retryRes.status));
-        if (retryAccepted) return { valid: true, error: null, refreshed: true, newTokens: tokens };
+      if (!tokens) {
+        // Refresh itself failed → the refresh_token is dead.
+        return { valid: false, error: "Token invalid or revoked (refresh failed)", refreshed: false };
       }
-      return { valid: false, error: "Token invalid or revoked", refreshed: false };
+      const retryUrl = config.buildUrl ? config.buildUrl(tokens.accessToken) : testUrl;
+      const retryHeaders = config.noAuth
+        ? { ...config.extraHeaders }
+        : { [config.authHeader]: `${config.authPrefix}${tokens.accessToken}`, ...config.extraHeaders };
+      const retryOpts = { method: config.method, headers: retryHeaders };
+      if (config.body) retryOpts.body = config.body;
+      const retryRes = await fetchWithConnectionProxy(retryUrl, retryOpts, effectiveProxy);
+      const retryAccepted = retryRes.ok || (config.acceptStatuses && config.acceptStatuses.includes(retryRes.status));
+      if (retryAccepted) return { valid: true, error: null, refreshed: true, newTokens: tokens };
+      // Refresh worked but API still rejects: account-level issue, not a token issue.
+      // Preserve `newTokens` so the caller persists the rotated refresh_token —
+      // otherwise the next test would burn another rotation cycle on a stale RT.
+      const detail = await safeReadErrorDetail(retryRes);
+      return {
+        valid: false,
+        error: `Account access denied by API (${retryRes.status} after token refresh)${detail ? ": " + detail : ""}`,
+        refreshed: true,
+        newTokens: tokens,
+      };
     }
 
-    if (res.status === 401) return { valid: false, error: "Token invalid or revoked", refreshed };
-    if (res.status === 403) return { valid: false, error: "Access denied", refreshed };
+    if (res.status === 401) {
+      const detail = await safeReadErrorDetail(res);
+      return {
+        valid: false,
+        error: `Token invalid or revoked${detail ? ": " + detail : ""}`,
+        refreshed,
+      };
+    }
+    if (res.status === 403) {
+      const detail = await safeReadErrorDetail(res);
+      return {
+        valid: false,
+        error: `Access denied${detail ? ": " + detail : ""}`,
+        refreshed,
+      };
+    }
     return { valid: false, error: `API returned ${res.status}`, refreshed };
   } catch (err) {
     return { valid: false, error: err.message, refreshed };


### PR DESCRIPTION
Fixes #1444

## Summary

`testOAuthConnection` in `src/app/api/providers/[id]/test/testUtils.js` had two collapsed bugs in the 401 retry path:

- **Wrong error label.** When `refreshOAuthToken` succeeded but the API retry still returned 401, the result was labeled `"Token invalid or revoked"` — misleading, because the refresh demonstrably worked. The actual cause in that branch is an **account-level rejection** (deactivation/ban/no-org/region restriction), not a token problem. Operators investigating get sent to debug the wrong layer.
- **Lost rotated refresh_token.** The same branch returned `refreshed: false, newTokens: undefined`, so `testSingleConnection` skipped the DB update. Each test advanced OpenAI's RT rotation counter without persisting the new RT — eventually triggering `refresh_token_reused`, which kills an otherwise recoverable account.

The fix splits the two outcomes apart and surfaces the API's own error-body snippet so the actual reason appears in `lastError`.

## Changes

- **`testOAuthConnection`** (generic path)
  - Refactor 401 retry: handle `refresh failed` and `refresh ok but retry still 401` as distinct outcomes.
  - On `refresh ok but retry 401`: return `{ valid: false, error: "Account access denied by API (<status> after token refresh): <body>", refreshed: true, newTokens: tokens }` — so the rotated tokens get persisted, and the error names the actual cause.
  - On `refresh failed`: return `"Token invalid or revoked (refresh failed)"`.
  - 401/403 paths now append a short response-body snippet via the new `safeReadErrorDetail` helper.
- **Cline branch**
  - Same treatment: distinguish refresh-failed from refresh-ok-but-401, preserve `newTokens` on the latter, include body snippet.
- **New helper `safeReadErrorDetail(res)`**
  - Reads up to 200 chars of the response body, collapses whitespace, swallows errors. Output suitable for the single-line `lastError` column.

## Why the label change matters

In production fleets of hundreds of Codex connections, the difference between *"OAuth alive, account banned — re-login WILL NOT fix this"* and *"OAuth dead — re-login WILL fix this"* completely changes the operator's recovery action. Today they look identical (`Token invalid or revoked`), so the operator either:

- wastes a re-login attempt on a banned/deactivated account (no effect, just burns CAPTCHA / SMS / mailtemp budget), or
- gives up on a recoverable account because the same error keeps showing.

After this fix the two cases produce visually distinct `lastError` strings:

- `Token invalid or revoked (refresh failed)` → re-login may help
- `Account access denied by API (401 after token refresh): {"error":{"message":"Your OpenAI account has been deactivated…","code":"account_deactivated"}}` → re-login will not help; investigate account state in the OpenAI dashboard / inbox.

## Why preserving `newTokens` matters

OpenAI rotates the refresh_token on every successful refresh and grants only a short grace period for the old RT. Currently every failed test of a banned-but-OAuth-healthy account silently burns one rotation cycle and then forgets the new RT. Eventually OpenAI invalidates the (still-stored) old RT and the connection becomes truly dead — even though it could have been left alone or de-listed cleanly.

## Compatibility

- Public function signatures unchanged.
- `result.error` string format changed for the affected 401 cases. Any code parsing `lastError` for the exact literal `"Token invalid or revoked"` should be updated, but the prefix is preserved for the `refresh-failed` case so a `startsWith("Token invalid or revoked")` check still works.
- All other status codes (200, 400 via `acceptStatuses`, 403, 500, network errors, …) take unchanged code paths.

## E2E verification

Verified on a production 9router install (v0.4.62) with a deactivated Codex account:

| Layer | Test | Result |
|---|---|---|
| **Reproduce** | Inspect DB after test endpoint runs against deactivated acc | `lastError` is exact `"Token invalid or revoked"`; `refreshToken` is unchanged from prior write, but a direct probe against `auth.openai.com/oauth/token` returns 200 — confirming Bug 1 (mislabel) and Bug 2 (lost RT) |
| **Real backend** | Patched logic against real OpenAI auth + real ChatGPT Codex API, using a deactivated account's RT | refresh returns 200 with rotated RT; retry returns 401 with body `{"error":{"message":"Your OpenAI account has been deactivated…","code":"account_deactivated"}}`; patched output is `valid:false`, `error:"Account access denied by API (401 after token refresh): {"error":{"message":"Your OpenAI account has been deactivated…"`, `refreshed:true`, `newTokens` populated with the rotated RT — exactly what we want |
| **Happy path** | Mocked refresh-OK + retry-OK | `valid:true, refreshed:true, newTokens` populated |
| **Refresh failed** | Mocked OpenAI refresh returns 4xx | `valid:false, error:"Token invalid or revoked (refresh failed)", refreshed:false`, no newTokens |
| **Non-refreshable 401** | Mocked GitHub-style provider returning 401 with body `{"message": "Bad credentials"}` | `valid:false`, `error:"Token invalid or revoked: {"message": "Bad credentials"}"` — body surfaced |
| **Build** | `npm install && npx next build --webpack` | clean exit; patched string `"Account access denied by API"` confirmed in production chunk `.next/server/chunks/7153.js` |
| **Regression** | Existing `tests/unit/` suite on master vs this branch | identical: `24 failed | 247 passed | 24 skipped` on both — failing tests are pre-existing and do not touch `testUtils.js` |

## Note on tests

Repository's existing `tests/unit/` suite does not cover `testUtils.js` (no test files reference `testUtils` or `testOAuthConnection`). Adding direct coverage requires mocking `@/lib/localDb`, the network proxy layer, and the per-provider OAuth refresh endpoints. The verification above is the strongest evidence available short of building that mocking infrastructure; I'd be happy to add it as a follow-up if a maintainer wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
