### PR TITLE
fix: import Readable for proxy fetch DNS bypass

### DIFF
--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -1,4 +1,5 @@
-// import { Readable } from "stream"; // unused — re-enable with got-scraping block below
+// #1451: DNS-bypass response wrappers call Readable.toWeb; Node does not expose Readable globally.
+import { Readable } from "node:stream";
 import { MEMORY_CONFIG } from "../config/runtimeConfig.js";
 import { dbg } from "./debugLog.js";
 


### PR DESCRIPTION
## Summary
- Fixes #1451 by importing Readable from node:stream in proxyFetch
- Keeps a short issue note near the import because the DNS-bypass response wrapper calls Readable.toWeb at runtime

## Validation
- node --check open-sse/utils/proxyFetch.js
- git diff --check
- npx vitest run tests/unit/gemini-usage-projectid.test.js tests/unit/minimax-usage.test.js
- Live Kiro usage check returned KIRO FREE quota data instead of ReferenceError

Note: tests/unit/claude-header-forwarding.test.js was attempted but this checkout cannot resolve its bare open-sse/* imports under Vitest; the failure occurs before exercising this change.