### PR TITLE
fix: add Codex subagent description

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
@@ -174,6 +174,7 @@ base_url = "${getEffectiveBaseUrl()}"
 wire_api = "responses"
 
 [agents.subagent]
+description = "Fast subagent for delegated Codex tasks"
 model = "${effectiveSubagentModel}"
 `;
 

--- a/src/app/api/cli-tools/codex-settings/route.js
+++ b/src/app/api/cli-tools/codex-settings/route.js
@@ -144,6 +144,7 @@ export async function POST(request) {
     // Add subagent configuration
     const effectiveSubagentModel = subagentModel || model;
     setNestedSection(parsed, "agents.subagent", {
+      description: "Fast subagent for delegated Codex tasks",
       model: effectiveSubagentModel,
     });
 


### PR DESCRIPTION
## Summary
- Add the required `description` field to generated `[agents.subagent]` Codex config.
- Update the manual Codex config preview to match the applied config.
- Prevent Codex CLI from ignoring the generated subagent role as malformed.

Fixes #1454

## Test plan
- [x] Reproduced the warning with generated config lacking `description`.
- [x] Updated local `~/.codex/config.toml` and confirmed `codex --help` no longer emits the malformed `subagent` warning.
- [x] Ran `node --check src/app/api/cli-tools/codex-settings/route.js`.
- [x] Ran `node --check src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js`.
- [x] Ran `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)