### PR TITLE
fix: validate HuggingFace tokens via whoami

### DIFF
--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -17,6 +17,8 @@ import {
 } from "@/lib/oauth/constants/oauth";
 import { buildClineHeaders } from "@/shared/utils/clineAuth";
 
+const HUGGINGFACE_WHOAMI_URL = "https://huggingface.co/api/whoami-v2";
+
 // OAuth provider test endpoints
 const OAUTH_TEST_CONFIG = {
   claude: { checkExpiry: true, refreshable: true },
@@ -336,6 +338,19 @@ async function fetchWithConnectionProxy(url, options = {}, effectiveProxy = null
   });
 }
 
+async function testHuggingFaceToken(apiKey, effectiveProxy = null) {
+  const res = await fetchWithConnectionProxy(HUGGINGFACE_WHOAMI_URL, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  }, effectiveProxy);
+
+  if (res.ok) return { valid: true, error: null };
+  if (res.status === 401 || res.status === 403) return { valid: false, error: "Invalid API key" };
+
+  // HuggingFace fine-grained Inference Provider tokens can be valid even when
+  // task/model endpoints are unavailable. Only auth failures should invalidate.
+  return { valid: false, error: `HuggingFace token check returned ${res.status}` };
+}
+
 async function testApiKeyConnection(connection, effectiveProxy = null) {
   if (isOpenAICompatibleProvider(connection.provider)) {
     const modelsBase = connection.providerSpecificData?.baseUrl;
@@ -559,6 +574,9 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         const res = await fetchWithConnectionProxy("https://api.fal.ai/v1/models?limit=1", { headers: { Authorization: `Key ${connection.apiKey}` } }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
         return { valid, error: valid ? null : "Invalid API key" };
+      }
+      case "huggingface": {
+        return await testHuggingFaceToken(connection.apiKey, effectiveProxy);
       }
       case "chutes": {
         const res = await fetchWithConnectionProxy("https://llm.chutes.ai/v1/models", { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy);

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -7,6 +7,8 @@ import { openaiToCommandCode } from "open-sse/translator/request/openai-to-comma
 import { PROVIDER_ENDPOINTS } from "@/shared/constants/config";
 import { normalizeProviderId } from "@/lib/providerNormalization";
 
+const HUGGINGFACE_WHOAMI_URL = "https://huggingface.co/api/whoami-v2";
+
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
 async function probeWebProvider(provider, apiKey) {
@@ -42,6 +44,21 @@ async function probeWebProvider(provider, apiKey) {
   return res.status !== 401 && res.status !== 403;
 }
 
+async function probeHuggingFaceToken(apiKey) {
+  const res = await fetch(HUGGINGFACE_WHOAMI_URL, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(8000),
+  });
+
+  if (res.ok) return true;
+  if (res.status === 401 || res.status === 403) return false;
+
+  // HuggingFace model/task probes can reject valid fine-grained Inference
+  // Provider tokens. Use whoami-v2 strictly as an auth probe and surface
+  // transient upstream failures separately instead of calling the key invalid.
+  throw new Error(`HuggingFace token validation returned HTTP ${res.status}`);
+}
+
 // Probe a media provider (tts/embedding/stt/image/video) using *Config.
 // Returns true if API key is accepted; null to skip (let default handler decide).
 async function probeMediaProvider(provider, apiKey) {
@@ -51,6 +68,7 @@ async function probeMediaProvider(provider, apiKey) {
   const kinds = p.serviceKinds || ["llm"];
   const isMediaOnly = kinds.every((k) => MEDIA_KINDS.has(k));
   if (!isMediaOnly) return null;
+  if (provider === "huggingface") return await probeHuggingFaceToken(apiKey);
   const cfg = p.ttsConfig || p.sttConfig || p.embeddingConfig || p.imageConfig || p.videoConfig || p.musicConfig;
   // No probe config → best-effort accept (validate at usage time)
   if (!cfg) return true;


### PR DESCRIPTION
## Summary
- Validate HuggingFace API keys against https://huggingface.co/api/whoami-v2 instead of task/model media probes
- Apply the same auth-only check to the provider connection test path
- Avoid marking valid fine-grained Inference Provider tokens invalid when model/task endpoints are unavailable or incompatible

## Validation
- node --check src/app/api/providers/validate/route.js
- node --check src/app/api/providers/[id]/test/testUtils.js
- git diff --check

Notes: I did not find an existing HuggingFace validation issue or PR upstream before opening this.