### PR TITLE
Preserve reasoning effort for Codex translations

### DIFF
--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -70,6 +70,16 @@ export function claudeToOpenAIRequest(model, body, stream) {
     result.tool_choice = convertToolChoice(body.tool_choice);
   }
 
+  if (body.reasoning_effort !== undefined) {
+    result.reasoning_effort = body.reasoning_effort;
+  } else if (body.reasoning?.effort !== undefined) {
+    result.reasoning_effort = body.reasoning.effort;
+  }
+
+  if (body.reasoning !== undefined) {
+    result.reasoning = body.reasoning;
+  }
+
   return result;
 }
 

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -283,6 +283,8 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.temperature !== undefined) result.temperature = body.temperature;
   if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
+  if (body.reasoning !== undefined) result.reasoning = body.reasoning;
+  if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
 
   return result;
 }


### PR DESCRIPTION
## Summary
- Preserve explicit `reasoning_effort` / `reasoning.effort` when translating Claude-format requests into OpenAI Chat format.
- Map OpenAI Chat `reasoning_effort` into OpenAI Responses `reasoning.effort` so Codex receives the requested effort instead of falling back to its default.

Fixes #1459

## Test plan
- [x] Verified with a Node import smoke test that Claude `reasoning.effort: \"xhigh\"` becomes OpenAI Chat `reasoning_effort: \"xhigh\"` and then Responses `reasoning.effort: \"xhigh\"`.
- [x] Confirmed PR diff against upstream `master` only includes the translator fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)