### PR TITLE
fix(cursor): resolve cu/default empty responses

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -7,6 +7,12 @@ import {
   extractTextFromResponse
 } from "../utils/cursorProtobuf.js";
 import { buildCursorHeaders } from "../utils/cursorChecksum.js";
+import {
+  normalizeCursorModelId,
+  resolveCursorUpstreamModel,
+  shouldPromoteThinkingToContent,
+  visibleContentFromThinking
+} from "../utils/cursorModel.js";
 import { estimateUsage } from "../utils/usageTracking.js";
 import { FORMATS } from "../translator/formats.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
@@ -40,19 +46,6 @@ const CURSOR_STREAM_DEBUG = process.env.CURSOR_STREAM_DEBUG === "1";
 const debugLog = (...args) => {
   if (CURSOR_STREAM_DEBUG) console.log(...args);
 };
-
-function isComposerModel(model) {
-  const modelId = String(model || "").split("/").pop();
-  return /^composer(?:-|$)/i.test(modelId);
-}
-
-function visibleComposerContentFromThinking(thinking) {
-  if (!thinking) return "";
-  const endTag = "</think>";
-  const endIdx = thinking.lastIndexOf(endTag);
-  if (endIdx < 0) return "";
-  return thinking.slice(endIdx + endTag.length).trimStart();
-}
 
 function decompressPayload(payload, flags) {
   // Check if payload is JSON error (starts with {"error")
@@ -118,6 +111,24 @@ function createErrorResponse(jsonError) {
   });
 }
 
+function createEmptyCompletionError(model) {
+  return new Response(JSON.stringify({
+    error: {
+      message: `Cursor returned an empty completion for model ${model}`,
+      type: "api_error",
+      code: "empty_completion"
+    }
+  }), {
+    status: HTTP_STATUS.BAD_GATEWAY,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+function visibleThinkingContent(model, totalThinking) {
+  if (!shouldPromoteThinkingToContent(model)) return "";
+  return visibleContentFromThinking(totalThinking);
+}
+
 export class CursorExecutor extends BaseExecutor {
   constructor() {
     super("cursor", PROVIDERS.cursor);
@@ -145,10 +156,19 @@ export class CursorExecutor extends BaseExecutor {
     const messages = body.messages || [];
     const tools = body.tools || [];
     const reasoningEffort = body.reasoning_effort || null;
+    const modelId = normalizeCursorModelId(model);
+    const upstreamModel = resolveCursorUpstreamModel(model);
+    if (modelId === "default" || modelId === "auto") {
+      debugLog(`[CURSOR] Resolved ${modelId} → ${upstreamModel}`);
+    }
     // Detect Claude Code UA to force Agent mode (issue #643)
     const ua = credentials?.rawHeaders?.["user-agent"] || "";
-    const forceAgentMode = ua.includes("claude-cli") || ua.includes("claude-code") || ua.includes("Claude Code");
-    return generateCursorBody(messages, model, tools, reasoningEffort, forceAgentMode);
+    const forceAgentMode = ua.includes("claude-cli")
+      || ua.includes("claude-code")
+      || ua.includes("Claude Code")
+      || modelId === "default"
+      || modelId === "auto";
+    return generateCursorBody(messages, upstreamModel, tools, reasoningEffort, forceAgentMode);
   }
 
   async makeFetchRequest(url, headers, body, signal, proxyOptions = null) {
@@ -390,10 +410,8 @@ export class CursorExecutor extends BaseExecutor {
       if (result.thinking) totalThinking += result.thinking;
     }
 
-    const visibleComposerContent = isComposerModel(model)
-      ? visibleComposerContentFromThinking(totalThinking)
-      : "";
-    const finalContent = totalContent || visibleComposerContent;
+    const visibleThinking = visibleThinkingContent(model, totalThinking);
+    const finalContent = totalContent || visibleThinking;
 
     debugLog(
       `[CURSOR BUFFER] Parsed ${frameCount} frames, toolCallsMap size: ${toolCallsMap.size}, finalized toolCalls: ${toolCalls.length}`
@@ -417,6 +435,9 @@ export class CursorExecutor extends BaseExecutor {
 
     debugLog(`[CURSOR BUFFER] Final toolCalls count: ${toolCalls.length}`);
 
+    if (!finalContent && toolCalls.length === 0) {
+      return createEmptyCompletionError(model);
+    }
 
     const message = {
       role: "assistant",
@@ -658,9 +679,9 @@ export class CursorExecutor extends BaseExecutor {
         );
       }
 
-      if (isComposerModel(model) && result.thinking) {
+      if (shouldPromoteThinkingToContent(model) && result.thinking) {
         totalThinking += result.thinking;
-        const visibleContent = visibleComposerContentFromThinking(totalThinking);
+        const visibleContent = visibleContentFromThinking(totalThinking);
         if (visibleContent.length > emittedComposerThinkingContentLength) {
           const deltaContent = visibleContent.slice(emittedComposerThinkingContentLength);
           emittedComposerThinkingContentLength = visibleContent.length;
@@ -737,6 +758,10 @@ export class CursorExecutor extends BaseExecutor {
           );
         }
       }
+    }
+
+    if (!totalContent && toolCalls.length === 0) {
+      return createEmptyCompletionError(model);
     }
 
     if (chunks.length === 0 && toolCalls.length === 0) {

--- a/open-sse/services/model.js
+++ b/open-sse/services/model.js
@@ -244,6 +244,7 @@ export async function getModelInfoCore(modelStr, aliasesOrGetter) {
 function inferProviderFromModelName(modelName) {
   if (!modelName) return "openai";
   const m = modelName.toLowerCase();
+  if (m === "default" || m === "auto") return "cursor";
   if (m.startsWith("claude-")) return "anthropic";
   if (m.startsWith("gemini-")) return "gemini";
   if (m.startsWith("gpt-")) return "openai";

--- a/open-sse/utils/cursorModel.js
+++ b/open-sse/utils/cursorModel.js
@@ -1,0 +1,72 @@
+/**
+ * Cursor model normalization and upstream resolution helpers.
+ */
+
+const LEGACY_MODEL_MAP = {
+  "claude-3-5-sonnet": "claude-4.5-sonnet",
+  "claude-3-5-sonnet-20241022": "claude-4.5-sonnet",
+  "claude-3-5-sonnet-20240620": "claude-4.5-sonnet",
+  "claude-3-5-haiku": "claude-4.5-haiku",
+  "gpt-4o": "gpt-5.2",
+  "gpt-4o-mini": "gpt-5.2",
+};
+
+const DEFAULT_UPSTREAM_MODEL =
+  process.env.CURSOR_DEFAULT_UPSTREAM_MODEL || "claude-4.5-sonnet";
+
+/**
+ * Strip provider prefix and return bare Cursor model id.
+ * @param {string} model
+ * @returns {string}
+ */
+export function normalizeCursorModelId(model) {
+  const raw = String(model || "").split("/").pop() || "";
+  let id = raw;
+
+  // Drop Anthropic-style date suffixes (e.g. claude-3-5-sonnet-20240620)
+  const dateSuffix = id.match(/^(.+)-(\d{8})$/);
+  if (dateSuffix) {
+    id = dateSuffix[1];
+  }
+
+  return LEGACY_MODEL_MAP[id] || id;
+}
+
+/**
+ * Resolve model id sent to Cursor upstream protobuf.
+ * @param {string} model
+ * @returns {string}
+ */
+export function resolveCursorUpstreamModel(model) {
+  const id = normalizeCursorModelId(model);
+  if (id === "default" || id === "auto") {
+    return DEFAULT_UPSTREAM_MODEL;
+  }
+  return id;
+}
+
+/**
+ * Whether thinking protobuf content should be promoted to visible assistant text.
+ * @param {string} model
+ * @returns {boolean}
+ */
+export function shouldPromoteThinkingToContent(model) {
+  const id = normalizeCursorModelId(model);
+  if (id === "default" || id === "auto") return true;
+  if (/^composer(?:-|$)/i.test(id)) return true;
+  if (/-thinking/i.test(id)) return true;
+  return false;
+}
+
+/**
+ * Extract user-visible text after redacted thinking block (Composer-style).
+ * @param {string} thinking
+ * @returns {string}
+ */
+export function visibleContentFromThinking(thinking) {
+  if (!thinking) return "";
+  const endTag = "</think>";
+  const endIdx = thinking.lastIndexOf(endTag);
+  if (endIdx < 0) return "";
+  return thinking.slice(endIdx + endTag.length).trimStart();
+}

--- a/src/app/api/models/test/route.js
+++ b/src/app/api/models/test/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getApiKeys } from "@/lib/localDb";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
+import { parseSSEToOpenAIResponse } from "open-sse/handlers/chatCore/sseToJsonHandler.js";
 
 const CLI_TOKEN_SALT = "9r-cli-auth";
 
@@ -51,14 +52,15 @@ export async function POST(request) {
       return NextResponse.json({ ok: true, latencyMs, error: null, status: res.status });
     }
 
-    // Default: chat completions
+    // Default: chat completions (Cursor models require streaming upstream)
+    const isCursorModel = /^(cu|cursor)\//i.test(model);
     const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
       method: "POST",
       headers,
       body: JSON.stringify({
         model,
         max_tokens: 1,
-        stream: false,
+        stream: isCursorModel,
         messages: [{ role: "user", content: "hi" }],
       }),
       signal: AbortSignal.timeout(15000),
@@ -68,7 +70,11 @@ export async function POST(request) {
     const rawText = await res.text().catch(() => "");
     let parsed = null;
     try {
-      parsed = rawText ? JSON.parse(rawText) : null;
+      if (isCursorModel && res.ok) {
+        parsed = parseSSEToOpenAIResponse(rawText, model);
+      } else {
+        parsed = rawText ? JSON.parse(rawText) : null;
+      }
     } catch {}
 
     if (!res.ok) {
@@ -110,6 +116,18 @@ export async function POST(request) {
         latencyMs,
         status: res.status,
         error: "Provider returned no completion choices for this model",
+      });
+    }
+
+    const message = parsed.choices[0]?.message;
+    const hasContent = typeof message?.content === "string" && message.content.length > 0;
+    const hasToolCalls = Array.isArray(message?.tool_calls) && message.tool_calls.length > 0;
+    if (!hasContent && !hasToolCalls) {
+      return NextResponse.json({
+        ok: false,
+        latencyMs,
+        status: res.status,
+        error: "Provider returned an empty completion for this model",
       });
     }
 

--- a/tests/unit/cursor-composer-thinking.test.js
+++ b/tests/unit/cursor-composer-thinking.test.js
@@ -69,7 +69,7 @@ describe("CursorExecutor Composer thinking-field responses", () => {
     expect(events.at(-1).usage.completion_tokens).toBeGreaterThan(0);
   });
 
-  it("does not treat thinking as visible output for non-Composer models", async () => {
+  it("returns empty-completion error for thinking-only on non-promoted models", async () => {
     const executor = new CursorExecutor();
     const buffer = cursorResponseFrame({
       thinking: "private reasoning</think>SHOULD_NOT_APPEAR",
@@ -80,7 +80,8 @@ describe("CursorExecutor Composer thinking-field responses", () => {
     });
     const payload = await response.json();
 
-    expect(payload.choices[0].message.content).toBeNull();
+    expect(response.status).toBe(502);
+    expect(payload.error?.code).toBe("empty_completion");
     expect(JSON.stringify(payload)).not.toContain("SHOULD_NOT_APPEAR");
   });
 });

--- a/tests/unit/cursor-default.test.js
+++ b/tests/unit/cursor-default.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+
+import { CursorExecutor } from "../../open-sse/executors/cursor.js";
+import { encodeField, wrapConnectRPCFrame } from "../../open-sse/utils/cursorProtobuf.js";
+import {
+  normalizeCursorModelId,
+  resolveCursorUpstreamModel,
+  shouldPromoteThinkingToContent,
+} from "../../open-sse/utils/cursorModel.js";
+
+const LEN = 2;
+
+function cursorResponseFrame({ text = "", thinking = "" }) {
+  const responseFields = [];
+
+  if (text) {
+    responseFields.push(encodeField(1, LEN, text));
+  }
+
+  if (thinking) {
+    const thinkingMessage = encodeField(1, LEN, thinking);
+    responseFields.push(encodeField(25, LEN, thinkingMessage));
+  }
+
+  const response = Buffer.concat(responseFields.map((field) => Buffer.from(field)));
+  const envelope = encodeField(2, LEN, response);
+  return Buffer.from(wrapConnectRPCFrame(envelope));
+}
+
+describe("cursorModel helpers", () => {
+  it("normalizes legacy Claude model ids", () => {
+    expect(normalizeCursorModelId("cu/claude-3-5-sonnet-20240620")).toBe("claude-4.5-sonnet");
+  });
+
+  it("resolves default/auto to upstream fallback", () => {
+    expect(resolveCursorUpstreamModel("cu/default")).toBe("claude-4.5-sonnet");
+    expect(resolveCursorUpstreamModel("auto")).toBe("claude-4.5-sonnet");
+  });
+
+  it("promotes thinking for default and -thinking models", () => {
+    expect(shouldPromoteThinkingToContent("cu/default")).toBe(true);
+    expect(shouldPromoteThinkingToContent("claude-4.5-sonnet-thinking")).toBe(true);
+    expect(shouldPromoteThinkingToContent("gpt-5.3-codex")).toBe(false);
+  });
+});
+
+describe("CursorExecutor default model responses", () => {
+  it("uses visible content after </think> for default model", async () => {
+    const executor = new CursorExecutor();
+    const buffer = cursorResponseFrame({
+      thinking: "internal plan</think>Hello!",
+    });
+
+    const response = executor.transformProtobufToJSON(buffer, "cu/default", {
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.choices[0].message.content).toBe("Hello!");
+    expect(payload.usage.completion_tokens).toBeGreaterThan(0);
+  });
+
+  it("uses visible thinking for -thinking variant models", async () => {
+    const executor = new CursorExecutor();
+    const buffer = cursorResponseFrame({
+      thinking: "reasoning</think>Visible",
+    });
+
+    const response = executor.transformProtobufToJSON(buffer, "claude-4.5-sonnet-thinking", {
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const payload = await response.json();
+
+    expect(payload.choices[0].message.content).toBe("Visible");
+  });
+
+  it("returns error for empty completion with no tool calls", async () => {
+    const executor = new CursorExecutor();
+    const response = executor.transformProtobufToJSON(Buffer.alloc(0), "cu/default", {
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload.error?.code).toBe("empty_completion");
+  });
+
+  it("returns error for thinking-only on non-promoted models", async () => {
+    const executor = new CursorExecutor();
+    const buffer = cursorResponseFrame({
+      thinking: "private</think>hidden",
+    });
+
+    const response = executor.transformProtobufToJSON(buffer, "gpt-5.3-codex", {
+      messages: [{ role: "user", content: "hi" }],
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload.error?.code).toBe("empty_completion");
+  });
+});


### PR DESCRIPTION
Fixes #1077

## Summary

- Fix `cu/default` returning 0 output tokens by promoting visible text from thinking protobuf frames (not only Composer models).
- Resolve `default`/`auto` to a concrete Cursor upstream model (`claude-4.5-sonnet`, overridable via `CURSOR_DEFAULT_UPSTREAM_MODEL`).
- Force Agent mode for `default`/`auto` and map bare `default`/`auto` model aliases to the `cursor` provider.
- Return `502 empty_completion` when Cursor yields no text and no tool calls (instead of silent empty 200).
- Dashboard model ping: use `stream: true` for `cu/*` models and validate non-empty content.
- Add `cursorModel` helpers with legacy id normalization and unit tests.

## Root cause

Cursor Auto often responds with thinking-only frames. The executor only surfaced thinking text for Composer models, so clients (Claude Code, dashboard) saw empty completions with input tokens billed.

## Test plan

- [x] `tests/unit/cursor-default.test.js`
- [x] `tests/unit/cursor-composer-thinking.test.js`
- [ ] Dashboard: ping `cu/default` → non-zero output tokens
- [ ] `curl` / Claude Code: `claude --model cu/default "hi"` returns text
- [ ] `cu/kimi-k2.5` still works


Made with [Cursor](https://cursor.com)