### PR TITLE
fix: harden Node.js built-in imports (Readable, Buffer) using node: prefix (#1469)

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -1,4 +1,5 @@
 import { BaseExecutor } from "./base.js";
+import { Buffer } from "node:buffer";
 import { PROVIDERS } from "../config/providers.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import {

--- a/open-sse/handlers/imageGenerationCore.js
+++ b/open-sse/handlers/imageGenerationCore.js
@@ -1,5 +1,6 @@
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
+import { Buffer } from "node:buffer";
 import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { getExecutor } from "../executors/index.js";
 import { getImageAdapter } from "./imageProviders/index.js";

--- a/open-sse/utils/cursorProtobuf.js
+++ b/open-sse/utils/cursorProtobuf.js
@@ -4,6 +4,7 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
+import { Buffer } from "node:buffer";
 import zlib from "zlib";
 
 const DEBUG = process.env.CURSOR_PROTOBUF_DEBUG === "1";

--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -1,4 +1,5 @@
-import { Readable } from "stream";
+import { Readable } from "node:stream";
+import { Buffer } from "node:buffer";
 import { MEMORY_CONFIG } from "../config/runtimeConfig.js";
 import { dbg } from "./debugLog.js";
 


### PR DESCRIPTION
This PR addresses Issue #1469 by hardening the imports of Node.js built-in modules.

### Problem
In Node.js v24+, some built-in globals or non-prefixed imports like \stream\ or \Buffer\ might cause \ReferenceError\ in certain ESM contexts, especially during stream fallback handling.

### Solution
- Updated \open-sse/utils/proxyFetch.js\ to use \
ode:stream\ and explicitly import \Buffer\ from \
ode:buffer\.
- Hardened imports in \open-sse/utils/cursorProtobuf.js\, \open-sse/executors/cursor.js\, and \open-sse/handlers/imageGenerationCore.js\ to use explicit \
ode:\ prefixed imports.

Verified locally with Node.js v24.12.0.

Fixes #1469