### PR TITLE
feat: add param compatibility adaptation for upstream API

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -96,7 +96,7 @@ export class BaseExecutor {
     return { status: response.status, message: bodyText || `HTTP ${response.status}` };
   }
 
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null, adaptTransformedBody = null }) {
     const fallbackCount = this.getFallbackCount();
     let lastError = null;
     let lastStatus = 0;
@@ -118,6 +118,9 @@ export class BaseExecutor {
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
       const transformedBody = this.transformRequest(model, body, stream, credentials);
+      const finalBody = adaptTransformedBody
+        ? await adaptTransformedBody(transformedBody)
+        : transformedBody;
       const headers = this.buildHeaders(credentials, stream);
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
@@ -128,7 +131,7 @@ export class BaseExecutor {
       const mergedSignal = signal ? AbortSignal.any([signal, connectCtrl.signal]) : connectCtrl.signal;
 
       try {
-        const bodyStr = JSON.stringify(transformedBody);
+        const bodyStr = JSON.stringify(finalBody);
         const fetchT0 = Date.now();
         dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${FETCH_CONNECT_TIMEOUT_MS}ms`);
         const response = await proxyAwareFetch(url, {
@@ -150,7 +153,7 @@ export class BaseExecutor {
           continue;
         }
 
-        return { response, url, headers, transformedBody };
+        return { response, url, headers, transformedBody: finalBody };
       } catch (error) {
         clearTimeout(connectTimer);
         lastError = error;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -177,7 +177,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Execute request
   let providerResponse, providerUrl, providerHeaders, finalBody;
   try {
-    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+    // Wrap executor.execute with param adaptation and retry
+    const { wrapExecute } = await import("../../src/lib/paramAdapter.js");
+    const result = await wrapExecute(executor, { model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, connectionId });
     providerResponse = result.response;
     providerUrl = result.url;
     providerHeaders = result.headers;
@@ -216,8 +218,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
           try { await onCredentialsRefreshed(newCredentials); } catch (e) { log?.warn?.("TOKEN", `onCredentialsRefreshed failed: ${e.message}`); }
         }
         try {
-          const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
-          if (retryResult.response.ok) { providerResponse = retryResult.response; providerUrl = retryResult.url; }
+          const { wrapExecute } = await import("../../src/lib/paramAdapter.js");
+          const retryResult = await wrapExecute(executor, { model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, connectionId });
+          if (retryResult.response.ok) { providerResponse = retryResult.response; providerUrl = retryResult.url; providerHeaders = retryResult.headers; finalBody = retryResult.transformedBody; }
         } catch { log?.warn?.("TOKEN", `${provider.toUpperCase()} | retry after refresh failed`); }
       } else {
         log?.warn?.("TOKEN", `${provider.toUpperCase()} | refresh failed`);

--- a/open-sse/services/paramProbe.js
+++ b/open-sse/services/paramProbe.js
@@ -1,0 +1,282 @@
+/**
+ * Parameter Probe Service
+ * 
+ * Probes upstream API to detect parameter compatibility per model.
+ * Runs asynchronously after request failures to build paramSupport cache.
+ */
+
+import { proxyAwareFetch } from "../utils/proxyFetch.js";
+
+// Parameters to probe - no model pattern filtering, probe all models for all params
+// If a param doesn't apply to a model, upstream will reject it and we'll mark as unsupported
+const PROBE_PARAMS = [
+  { name: "max_completion_tokens", probeBody: { max_completion_tokens: 1 } },
+  { name: "reasoning_effort", probeBody: { reasoning_effort: "low" } },
+  { name: "thinking", probeBody: { thinking: { type: "enabled", budget_tokens: 100 } } },
+  { name: "stream_options", probeBody: { stream: true, stream_options: { include_usage: true } }, streamingOnly: true },
+  { name: "response_format.json_schema", probeBody: { response_format: { type: "json_schema", json_schema: { name: "test", schema: { type: "object" } } } } },
+  { name: "temperature", probeBody: { temperature: 0.7 } },
+  { name: "logprobs", probeBody: { logprobs: true, top_logprobs: 5 } },
+  { name: "frequency_penalty", probeBody: { frequency_penalty: 0.5 } },
+  { name: "presence_penalty", probeBody: { presence_penalty: 0.5 } },
+];
+
+// Probe queue for async processing
+const probeQueue = [];
+const queuedModels = new Set(); // Track models already queued or running (for dedup)
+let probeRunning = false;
+
+/**
+ * Queue an async probe task for a model
+ * @param {object} options - { connectionId, model, credentials, proxyOptions }
+ */
+export async function queueProbeTask(options) {
+  // Skip if missing required fields
+  if (!options?.connectionId || !options?.model || !options?.credentials) {
+    console.log(`[ParamProbe] Skipping probe task: missing required fields`);
+    return;
+  }
+  
+  const { connectionId, model } = options;
+  const queueKey = `${connectionId}:${model}`;
+  
+  // Dedup: skip if already queued
+  if (queuedModels.has(queueKey)) {
+    console.log(`[ParamProbe] Skipping probe for ${model}: already queued`);
+    return;
+  }
+  
+  // Check cooldown: skip if recently probed
+  const { shouldProbe } = await import("../../src/lib/paramSupportCache.js");
+  if (!await shouldProbe(connectionId, model)) {
+    console.log(`[ParamProbe] Skipping probe for ${model}: recently probed (cooldown)`);
+    return;
+  }
+  
+  queuedModels.add(queueKey);
+  probeQueue.push({
+    ...options,
+    queuedAt: Date.now(),
+    queueKey
+  });
+  
+  // Start processing if not already running
+  if (!probeRunning) {
+    processProbeQueue();
+  }
+}
+
+/**
+ * Process probe queue asynchronously
+ */
+async function processProbeQueue() {
+  probeRunning = true;
+  
+  while (probeQueue.length > 0) {
+    const task = probeQueue.shift();
+
+    try {
+      await probeModelParams(task);
+    } catch (err) {
+      console.log(`[ParamProbe] Probe failed for ${task.model}: ${err.message}`);
+    } finally {
+      queuedModels.delete(task.queueKey);
+    }
+    
+    // Small delay between probes to avoid rate limiting
+    await new Promise(r => setTimeout(r, 500));
+  }
+  
+  probeRunning = false;
+}
+
+/**
+ * Probe all parameters for a specific model
+ * @param {object} options - { connectionId, model, credentials, proxyOptions }
+ * @returns {object} - { param: boolean } results
+ */
+export async function probeModelParams(options) {
+  const { connectionId, model, credentials, proxyOptions } = options;
+  
+  // Extract baseUrl and apiKey from credentials
+  const baseUrl = credentials?.providerSpecificData?.baseUrl;
+  const apiKey = credentials?.apiKey || credentials?.accessToken;
+  
+  // Skip if no baseUrl (can't send probe requests)
+  if (!baseUrl) {
+    console.log(`[ParamProbe] Skipping probe for ${model}: no baseUrl in credentials`);
+    return null;
+  }
+  
+  // Pre-detect which token parameter this model supports
+  // Some models reject max_tokens and require max_completion_tokens
+  let supportedTokenParam = "max_tokens"; // default
+  let maxTokensSupport = null;
+  const tokenTestBody = { model, messages: [{ role: "user", content: "hi" }], max_tokens: 1, stream: false };
+  try {
+    const tokenTestResponse = await sendProbeRequest(baseUrl, apiKey, tokenTestBody, proxyOptions);
+    if (!tokenTestResponse.ok && tokenTestResponse.status === 400) {
+      const errorText = await tokenTestResponse.text();
+      if (errorText.toLowerCase().includes("max_tokens") &&
+          (errorText.toLowerCase().includes("unsupported") || errorText.toLowerCase().includes("not supported"))) {
+        maxTokensSupport = false;
+        // max_tokens not supported, try max_completion_tokens
+        const altTestBody = { model, messages: [{ role: "user", content: "hi" }], max_completion_tokens: 1, stream: false };
+        const altTestResponse = await sendProbeRequest(baseUrl, apiKey, altTestBody, proxyOptions);
+        const altErrorText = altTestResponse.status === 400 ? await altTestResponse.text() : "";
+        if (altTestResponse.ok || altTestResponse.status !== 400 ||
+            !altErrorText.toLowerCase().includes("max_completion_tokens")) {
+          supportedTokenParam = "max_completion_tokens";
+          console.log(`[ParamProbe] ${model}: uses max_completion_tokens instead of max_tokens`);
+        }
+        if (altTestResponse.status !== 400) await cancelResponseBody(altTestResponse);
+      }
+    } else if (tokenTestResponse.ok) {
+      maxTokensSupport = true;
+      await cancelResponseBody(tokenTestResponse);
+    } else {
+      await cancelResponseBody(tokenTestResponse);
+    }
+  } catch (err) {
+    console.log(`[ParamProbe] Token pre-detect failed: ${err.message}, using max_tokens`);
+  }
+  
+  const results = {};
+  const baseBody = {
+    model,
+    messages: [{ role: "user", content: "hi" }],
+    stream: false
+  };
+  if (maxTokensSupport !== null) {
+    results.max_tokens = maxTokensSupport;
+  }
+
+  for (const paramConfig of PROBE_PARAMS) {
+    // Skip streaming-only params for non-streaming probe context
+    // (streaming params will be detected when actual streaming request fails)
+    if (paramConfig.streamingOnly) {
+      results[paramConfig.name] = null;
+      continue;
+    }
+
+    // Build probe body, handling conflicting params
+    let probeBody = { ...baseBody, ...paramConfig.probeBody };    
+    // max_completion_tokens and max_tokens shouldn't coexist
+    if (paramConfig.name === "max_completion_tokens") {
+      probeBody.max_completion_tokens = probeBody.max_tokens || 1;
+      delete probeBody.max_tokens;
+    } else {
+      // Use the pre-detected supported token param
+      if (!probeBody.max_tokens && !probeBody.max_completion_tokens) {
+        probeBody[supportedTokenParam] = 1;
+      }
+    }
+    
+    try {
+      const response = await sendProbeRequest(baseUrl, apiKey, probeBody, proxyOptions);
+      
+      if (response.ok) {
+        results[paramConfig.name] = true;
+        await cancelResponseBody(response);
+      } else if (response.status === 400) {
+        const errorBody = await response.text();
+        // Check if the error is specifically about this parameter
+        const isParamError = isParamUnsupported(errorBody, paramConfig.name);
+        results[paramConfig.name] = !isParamError;
+      } else {
+        // Other errors (401, 403, 429, 5xx) - upstream issue, abort entire probe
+        console.log(`[ParamProbe] Aborting probe for ${model}: non-400 error ${response.status}`);
+        // Mark remaining params as unknown
+        for (const remaining of PROBE_PARAMS) {
+          if (results[remaining.name] === undefined) {
+            results[remaining.name] = null;
+          }
+        }
+        await cancelResponseBody(response);
+        break; // Exit loop
+      }
+    } catch (err) {
+      // Network error - can't determine
+      console.log(`[ParamProbe] Probe ${paramConfig.name} failed: ${err.message}`);
+      results[paramConfig.name] = null;
+    }
+  }
+
+  // Import cache module dynamically to update results
+  const { batchSetParamSupport } = await import("../../src/lib/paramSupportCache.js");
+  await batchSetParamSupport(connectionId, model, results);
+
+  console.log(`[ParamProbe] Results for ${model}: ${JSON.stringify(results)}`);
+  
+  return results;
+}
+
+/**
+ * Send a probe request
+ */
+async function sendProbeRequest(baseUrl, apiKey, body, proxyOptions) {
+  const url = `${baseUrl.replace(/\/$/, "")}/chat/completions`;
+  const headers = {
+    "Content-Type": "application/json",
+    ...(apiKey && { "Authorization": `Bearer ${apiKey}` })
+  };
+
+  return proxyAwareFetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(15000)
+  }, proxyOptions || null);
+}
+
+async function cancelResponseBody(response) {
+  try {
+    await response?.body?.cancel?.();
+  } catch {
+    // Ignore cleanup failures; probes use status/error text only.
+  }
+}
+
+/**
+ * Check if error body indicates a specific parameter is unsupported
+ */
+function isParamUnsupported(errorBody, paramName) {
+  const lower = errorBody.toLowerCase();
+  const paramLower = paramName.toLowerCase();
+  
+  // Check for parameter name in error
+  if (!lower.includes(paramLower) &&
+      !lower.includes(paramLower.replace("_", "")) &&
+      !lower.includes(paramLower.replace(".", "_"))) {
+    return false;
+  }
+  
+  // Check for VALUE errors first (parameter IS supported, value is wrong)
+  const valueErrorKeywords = ["invalid value", "out of range", "must be between", "must be", "value should", "minimum", "maximum", "too small", "too large"];
+  if (valueErrorKeywords.some(e => lower.includes(e))) {
+    // This is a value problem, parameter IS supported
+    return false;
+  }
+  
+  // Check for "unsupported parameter" keywords
+  return lower.includes("unknown") ||
+         lower.includes("unsupported") ||
+         lower.includes("not supported") ||
+         lower.includes("unexpected") ||
+         lower.includes("unrecognized");
+}
+
+/**
+ * Get current queue length (for monitoring)
+ */
+export function getProbeQueueLength() {
+  return probeQueue.length;
+}
+
+/**
+ * Clear queue (for testing)
+ */
+export function clearProbeQueue() {
+  probeQueue.length = 0;
+  queuedModels.clear();
+}

--- a/src/lib/paramAdapter.js
+++ b/src/lib/paramAdapter.js
@@ -1,0 +1,189 @@
+/**
+ * Parameter Adapter
+ *
+ * Wraps executor.execute with parameter adaptation, error detection, and retry.
+ * Minimal changes to existing code - just replace executor.execute with wrapExecute.
+ */
+
+import { setParamSupport, detectUnsupportedParam, getAllParamSupport } from "./paramSupportCache.js";
+
+/**
+ * Wrap executor.execute with param adaptation and retry logic
+ *
+ * Usage: Replace `executor.execute(...)` with `wrapExecute(executor, ...)`
+ *
+ * @returns {object} - { response, url, headers, transformedBody, paramErrorHandled? }
+ */
+export async function wrapExecute(executor, { model, body, stream, credentials, signal, log, proxyOptions, connectionId }) {
+  // Step 1: Adapt params based on cached support info
+  let adaptedBody = body;
+  if (connectionId) {
+    adaptedBody = await adaptParams(connectionId, model, body);
+  }
+
+  // Helper: execute with post-transform adaptation
+  const executeWithAdaptation = async (requestBody) => executor.execute({
+    model,
+    body: requestBody,
+    stream,
+    credentials,
+    signal,
+    log,
+    proxyOptions,
+    adaptTransformedBody: connectionId
+      ? transformed => adaptParams(connectionId, model, transformed)
+      : null
+  });
+
+  // Step 2: Execute request
+  const result = await executeWithAdaptation(adaptedBody);
+  
+  const MAX_RETRIES = 3;
+  let currentResult = result;
+  let retryCount = 0;
+  const detectedParams = new Set(); // Track params detected in this loop
+  
+  // Loop to handle multiple unsupported params (one per 400 response)
+  while (!currentResult.response.ok && currentResult.response.status === 400 && connectionId && retryCount < MAX_RETRIES) {
+    // Clone response to read error text without consuming original body
+    const clonedResponse = currentResult.response.clone();
+    const errorText = await clonedResponse.text();
+    const unsupportedParam = detectUnsupportedParam(errorText);
+    
+    if (!unsupportedParam) {
+      // Not a param-related error, stop retrying
+      break;
+    }
+    
+    // Check if we've already detected this param (body unchanged, stop retrying)
+    if (detectedParams.has(unsupportedParam)) {
+      log?.warn?.("PARAMPROBE", `${model}: ${unsupportedParam} detected again, body unchanged, stopping retry`);
+      break;
+    }
+    detectedParams.add(unsupportedParam);
+    
+    log?.info?.("PARAMPROBE", `${model}: detected unsupported param ${unsupportedParam} (retry ${retryCount + 1}/${MAX_RETRIES})`);
+    
+    await cancelResponseBody(currentResult.response);
+
+    // Mark param as unsupported
+    await setParamSupport(connectionId, model, unsupportedParam, false);
+    
+    // Re-adapt params with updated cache (applied to original body)
+    const retryBody = await adaptParams(connectionId, model, body);
+    
+    // Retry with post-transform adaptation
+    currentResult = await executeWithAdaptation(retryBody);
+    retryCount++;
+  }
+  
+  // Queue async probe for other params (after all retries, success or fail)
+  if (retryCount > 0 && connectionId) {
+    const { queueProbeTask } = await import("../../open-sse/services/paramProbe.js");
+    queueProbeTask({ connectionId, model, credentials, proxyOptions });
+  }
+  
+  if (currentResult.response.ok && retryCount > 0) {
+    log?.info?.("PARAMPROBE", `${model}: retry succeeded after ${retryCount} attempts`);
+    return { ...currentResult, paramErrorHandled: true, retriesUsed: retryCount };  
+  }
+  
+  if (retryCount > 0) {
+    log?.warn?.("PARAMPROBE", `${model}: retry failed after ${retryCount} attempts`);
+    return { ...currentResult, paramErrorHandled: false, retriesUsed: retryCount };
+  }
+  
+  return result;
+}
+
+async function cancelResponseBody(response) {
+  try {
+    await response?.body?.cancel?.();
+  } catch {
+    // Ignore cleanup failures; retry handling should continue.
+  }
+}
+
+/**
+ * Adapt request body parameters based on cached support info
+ * Optimized: fetch all param support at once, then apply adaptations
+ *
+ * @param {string} connectionId - Provider connection ID
+ * @param {string} modelId - Model ID
+ * @param {object} body - Request body to adapt
+ * @returns {object} - Adapted request body
+ */
+export async function adaptParams(connectionId, modelId, body) {
+  if (!connectionId || !modelId || !body) return body;
+
+  // Fetch all cached param support at once (more efficient than 7 separate DB reads)
+  const cached = await getAllParamSupport(connectionId, modelId);
+  if (!cached) return body; // No cache data, can't adapt
+
+  const adapted = { ...body };
+
+  // max_tokens -> max_completion_tokens
+  if (adapted.max_tokens !== undefined && cached.max_tokens === false) {
+    console.log(`[ParamAdapter] ${modelId}: max_tokens -> max_completion_tokens`);
+    adapted.max_completion_tokens = adapted.max_tokens;
+    delete adapted.max_tokens;
+  }
+
+  // max_completion_tokens → max_tokens
+  if (adapted.max_completion_tokens !== undefined && cached.max_completion_tokens === false) {
+    console.log(`[ParamAdapter] ${modelId}: max_completion_tokens -> max_tokens`);
+    adapted.max_tokens = adapted.max_completion_tokens;
+    delete adapted.max_completion_tokens;
+  }
+
+  // reasoning_effort → delete
+  if (adapted.reasoning_effort !== undefined && cached.reasoning_effort === false) {
+    console.log(`[ParamAdapter] ${modelId}: removing reasoning_effort`);
+    delete adapted.reasoning_effort;
+  }
+
+  // thinking → delete
+  if (adapted.thinking !== undefined && cached.thinking === false) {
+    console.log(`[ParamAdapter] ${modelId}: removing thinking`);
+    delete adapted.thinking;
+  }
+
+  // stream_options → delete
+  if (adapted.stream_options !== undefined && cached.stream_options === false) {
+    console.log(`[ParamAdapter] ${modelId}: removing stream_options`);
+    delete adapted.stream_options;
+  }
+
+  // temperature → delete
+  if (adapted.temperature !== undefined && cached.temperature === false) {
+    console.log(`[ParamAdapter] ${modelId}: removing temperature`);
+    delete adapted.temperature;
+  }
+
+  // response_format.json_schema → json_object
+  if (adapted.response_format?.type === "json_schema" && cached["response_format.json_schema"] === false) {
+    console.log(`[ParamAdapter] ${modelId}: json_schema → json_object`);
+    adapted.response_format = { type: "json_object" };
+  }
+
+  // logprobs/top_logprobs → delete
+  if ((adapted.logprobs !== undefined || adapted.top_logprobs !== undefined) && cached.logprobs === false) {
+    console.log(`[ParamAdapter] ${modelId}: removing logprobs/top_logprobs`);
+    delete adapted.logprobs;
+    delete adapted.top_logprobs;
+  }
+
+  // frequency_penalty → delete
+  if (adapted.frequency_penalty !== undefined && cached.frequency_penalty === false) {
+    console.log(`[ParamAdapter] ${modelId}: removing frequency_penalty`);
+    delete adapted.frequency_penalty;
+  }
+
+  // presence_penalty → delete
+  if (adapted.presence_penalty !== undefined && cached.presence_penalty === false) {
+    console.log(`[ParamAdapter] ${modelId}: removing presence_penalty`);
+    delete adapted.presence_penalty;
+  }
+
+  return adapted;
+}

--- a/src/lib/paramAdapter.js
+++ b/src/lib/paramAdapter.js
@@ -136,6 +136,13 @@ export async function adaptParams(connectionId, modelId, body) {
     delete adapted.max_completion_tokens;
   }
 
+  // max_completion_token -> max_tokens (tolerate singular client/upstream variants)
+  if (adapted.max_completion_token !== undefined && cached.max_completion_tokens === false) {
+    console.log(`[ParamAdapter] ${modelId}: max_completion_token -> max_tokens`);
+    adapted.max_tokens = adapted.max_completion_token;
+    delete adapted.max_completion_token;
+  }
+
   // reasoning_effort → delete
   if (adapted.reasoning_effort !== undefined && cached.reasoning_effort === false) {
     console.log(`[ParamAdapter] ${modelId}: removing reasoning_effort`);

--- a/src/lib/paramSupportCache.js
+++ b/src/lib/paramSupportCache.js
@@ -1,0 +1,194 @@
+/**
+ * Parameter Support Cache
+ * 
+ * Stores per-provider, per-model parameter compatibility results.
+ * Currently uses in-memory cache only (no DB persistence).
+ * 
+ * TODO: Add DB persistence for param support data
+ * - Store in providerSpecificData.paramSupport.models[modelId]
+ * - Need to evaluate DB schema compatibility impact
+ * - See discussion in PR review about JSON field safety
+ */
+
+// In-memory cache: Map<connectionId:modelId:param, { value, timestamp }>
+const memoryCache = new Map();
+
+// Memory cache - no TTL (param support is stable, only clears on restart)
+// If you want TTL, set it to a long duration like 24 hours
+const MEMORY_CACHE_TTL_MS = 0; // 0 = no expiry
+
+// Probe cooldown period - don't probe again within this time (10 minutes)
+const PROBE_COOLDOWN_MS = 10 * 60 * 1000;
+
+// Track when models were probed (for cooldown)
+const probeTimestamps = new Map(); // Map<connectionId:modelId, timestamp>
+
+/**
+ * Check if we should probe this model (hasn't been probed recently)
+ */
+export async function shouldProbe(connectionId, modelId) {
+  const key = `${connectionId}:${modelId}`;
+  const lastProbed = probeTimestamps.get(key);
+  if (!lastProbed) return true;
+  
+  const elapsed = Date.now() - lastProbed;
+  return elapsed > PROBE_COOLDOWN_MS;
+}
+
+/**
+ * Get parameter support status for a specific model
+ * @returns {boolean|null} - true=supported, false=not supported, null=unknown
+ */
+export async function getParamSupport(connectionId, modelId, param) {
+  const cacheKey = `${connectionId}:${modelId}:${param}`;
+  const cached = memoryCache.get(cacheKey);
+  
+  if (cached !== undefined) {
+    // Check TTL only if set (0 = no expiry)
+    if (MEMORY_CACHE_TTL_MS > 0 && Date.now() - cached.timestamp > MEMORY_CACHE_TTL_MS) {
+      memoryCache.delete(cacheKey);
+      return null;
+    }
+    return cached.value;
+  }
+  
+  return null;
+}
+
+/**
+ * Get all parameter support info for a model
+ * @returns {object|null} - { param: boolean } or null if not cached
+ */
+export async function getAllParamSupport(connectionId, modelId) {
+  const results = {};
+  const prefix = `${connectionId}:${modelId}:`;
+  
+  for (const [key, entry] of memoryCache.entries()) {
+    if (key.startsWith(prefix)) {
+      // Check TTL only if set (0 = no expiry)
+      if (MEMORY_CACHE_TTL_MS > 0 && Date.now() - entry.timestamp > MEMORY_CACHE_TTL_MS) {
+        continue;
+      }
+      const param = key.slice(prefix.length);
+      if (!param.startsWith("_")) {
+        results[param] = entry.value;
+      }
+    }
+  }
+  
+  return Object.keys(results).length > 0 ? results : null;
+}
+
+/**
+ * Mark a parameter as supported/unsupported for a specific model
+ */
+export async function setParamSupport(connectionId, modelId, param, supported) {
+  const cacheKey = `${connectionId}:${modelId}:${param}`;
+  memoryCache.set(cacheKey, { value: supported, timestamp: Date.now() });
+  
+  // TODO: Add DB persistence
+  // await updateProviderConnection(connectionId, {
+  //   providerSpecificData: {
+  //     ...current,
+  //     paramSupport: {
+  //       models: {
+  //         ...models,
+  //         [modelId]: {
+  //           ...models[modelId],
+  //           [param]: supported,
+  //           _updatedAt: new Date().toISOString()
+  //         }
+  //       }
+  //     }
+  //   }
+  // });
+}
+
+/**
+ * Batch set parameter support for a model (called after full probe)
+ */
+export async function batchSetParamSupport(connectionId, modelId, params) {
+  const now = Date.now();
+  
+  for (const [param, supported] of Object.entries(params)) {
+    if (param.startsWith("_")) continue; // Skip metadata
+    if (supported === null) continue; // Skip unknown results
+    const cacheKey = `${connectionId}:${modelId}:${param}`;
+    memoryCache.set(cacheKey, { value: supported, timestamp: now });
+  }
+  
+  // Mark as probed for cooldown
+  const probeKey = `${connectionId}:${modelId}`;
+  probeTimestamps.set(probeKey, now);
+  
+  // TODO: Add DB persistence
+  // await updateProviderConnection(connectionId, {
+  //   providerSpecificData: {
+  //     ...current,
+  //     paramSupport: {
+  //       models: {
+  //         ...models,
+  //         [modelId]: {
+  //           ...models[modelId],
+  //           ...params,
+  //           _probedAt: new Date().toISOString()
+  //         }
+  //       }
+  //     }
+  //   }
+  // });
+}
+
+/**
+ * Clear memory cache (for testing)
+ */
+export function clearMemoryCache() {
+  memoryCache.clear();
+  probeTimestamps.clear();
+}
+
+/**
+ * Parse error response to detect which parameter caused the error
+ * @returns {string|null} - Parameter name that caused the error, or null
+ */
+export function detectUnsupportedParam(errorBody) {
+  const lower = errorBody.toLowerCase();
+  
+  const patterns = [
+    { param: "max_tokens", keywords: ["max_tokens"] },
+    { param: "max_completion_tokens", keywords: ["max_completion_tokens", "max_completion"] },
+    { param: "reasoning_effort", keywords: ["reasoning_effort", "reasoningeffort"] },
+    { param: "thinking", keywords: ["thinking", "budget_tokens"] },
+    { param: "response_format.json_schema", keywords: ["json_schema", "structured output"] },
+    { param: "stream_options", keywords: ["stream_options", "include_usage"] },
+    { param: "temperature", keywords: ["temperature"] },
+    { param: "logprobs", keywords: ["logprobs", "top_logprobs"] },
+    { param: "frequency_penalty", keywords: ["frequency_penalty"] },
+    { param: "presence_penalty", keywords: ["presence_penalty"] },
+  ];
+
+  // Error keywords that indicate parameter is NOT SUPPORTED (not just invalid value)
+  // "invalid" alone can mean "invalid value" (range/type issue), not "parameter unsupported"
+  const unsupportedKeywords = ["unknown", "unsupported", "not supported", "unexpected", "unrecognized", "does not support", "unsupported parameter"];
+  
+  // Keywords that indicate VALUE is invalid (parameter IS supported, value is wrong)
+  const valueErrorKeywords = ["invalid value", "out of range", "must be between", "must be", "value should", "range", "minimum", "maximum"];
+
+  for (const { param, keywords } of patterns) {
+    for (const kw of keywords) {
+      if (lower.includes(kw.toLowerCase())) {
+        // First check if it's a VALUE error (parameter IS supported)
+        if (valueErrorKeywords.some(e => lower.includes(e))) {
+          // This is a value problem, not unsupported parameter
+          return null;
+        }
+        // Check if it's an error indicating parameter is NOT SUPPORTED
+        if (unsupportedKeywords.some(e => lower.includes(e))) {
+          return param;
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/lib/paramSupportCache.js
+++ b/src/lib/paramSupportCache.js
@@ -156,7 +156,7 @@ export function detectUnsupportedParam(errorBody) {
   
   const patterns = [
     { param: "max_tokens", keywords: ["max_tokens"] },
-    { param: "max_completion_tokens", keywords: ["max_completion_tokens", "max_completion"] },
+    { param: "max_completion_tokens", keywords: ["max_completion_tokens", "max_completion_token", "max_completion"] },
     { param: "reasoning_effort", keywords: ["reasoning_effort", "reasoningeffort"] },
     { param: "thinking", keywords: ["thinking", "budget_tokens"] },
     { param: "response_format.json_schema", keywords: ["json_schema", "structured output"] },
@@ -169,7 +169,7 @@ export function detectUnsupportedParam(errorBody) {
 
   // Error keywords that indicate parameter is NOT SUPPORTED (not just invalid value)
   // "invalid" alone can mean "invalid value" (range/type issue), not "parameter unsupported"
-  const unsupportedKeywords = ["unknown", "unsupported", "not supported", "unexpected", "unrecognized", "does not support", "unsupported parameter"];
+  const unsupportedKeywords = ["unknown", "unsupported", "not supported", "unexpected", "unrecognized", "does not support", "unsupported parameter", "invalid_parameter_error", "invalid parameter"];
   
   // Keywords that indicate VALUE is invalid (parameter IS supported, value is wrong)
   const valueErrorKeywords = ["invalid value", "out of range", "must be between", "must be", "value should", "range", "minimum", "maximum"];

--- a/tests/unit/paramAdapter.test.js
+++ b/tests/unit/paramAdapter.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { adaptParams } from "../../src/lib/paramAdapter.js";
+import { clearMemoryCache, detectUnsupportedParam, setParamSupport } from "../../src/lib/paramSupportCache.js";
+
+describe("param adapter", () => {
+  beforeEach(() => {
+    clearMemoryCache();
+  });
+
+  it("detects max_tokens unsupported errors", () => {
+    const errorBody = JSON.stringify({
+      error: {
+        message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+      },
+    });
+
+    expect(detectUnsupportedParam(errorBody)).toBe("max_tokens");
+  });
+
+  it("adapts max_tokens to max_completion_tokens when max_tokens is unsupported", async () => {
+    await setParamSupport("conn-1", "o3-test", "max_tokens", false);
+
+    const adapted = await adaptParams("conn-1", "o3-test", {
+      model: "o3-test",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 12,
+    });
+
+    expect(adapted).toMatchObject({ max_completion_tokens: 12 });
+    expect(adapted.max_tokens).toBeUndefined();
+  });
+
+  it("keeps the existing max_completion_tokens fallback for providers that reject it", async () => {
+    await setParamSupport("conn-1", "legacy-test", "max_completion_tokens", false);
+
+    const adapted = await adaptParams("conn-1", "legacy-test", {
+      model: "legacy-test",
+      messages: [{ role: "user", content: "hi" }],
+      max_completion_tokens: 8,
+    });
+
+    expect(adapted).toMatchObject({ max_tokens: 8 });
+    expect(adapted.max_completion_tokens).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Third-party providers often don't support new OpenAI parameters (e.g., max_completion_tokens, reasoning_effort, thinking), causing requests to fail with 400 errors and poor user experience.

## Solution

Automatically detect unsupported parameter 400 errors, cache results, adapt parameters, and retry requests.

- **Transparent to users**: Auto-fix without manual troubleshooting
- **Smart caching**: Learn parameter support, faster subsequent requests
- **Minimal changes**: Only 9 lines in chatCore.js
- **Backward compatible**: No side effects for non-OpenAI protocols

## Flow

Request → 400 param error → Detect → Cache → Adapt → Retry (max 3) → Success

## Supported Parameters

- max_completion_tokens ↔ max_tokens
- reasoning_effort
- thinking / budget_tokens
- stream_options
- response_format.json_schema
- temperature
- logprobs
- frequency_penalty
- presence_penalty

## Scope

OpenAI-compatible protocols. Non-OpenAI protocols unaffected (parameter name mismatch → no cache → normal error return).

## Files Changed

- `open-sse/executors/base.js` - 9 lines (added adaptTransformedBody hook)
- `open-sse/handlers/chatCore.js` - 9 lines
- `open-sse/services/paramProbe.js` - 282 lines (async probe service)
- `src/lib/paramAdapter.js` - 189 lines (adaptation logic)
- `src/lib/paramSupportCache.js` - 194 lines (cache service)
- `tests/unit/paramAdapter.test.js` - 46 lines (unit tests)

## Note

Executors overriding execute without calling super.execute may need similar post-transform adaptation (antigravity, cursor, kiro, etc.). Can be addressed in follow-up PR if needed.