### PR TITLE
fix: strip Claude context management for compatible providers

### DIFF
--- a/open-sse/translator/helpers/claudeHelper.js
+++ b/open-sse/translator/helpers/claudeHelper.js
@@ -85,6 +85,12 @@ const CLAUDE_FORMAT_PROVIDERS_WITHOUT_OUTPUT_CONFIG = new Set(["minimax", "minim
 // - Fix tool_use/tool_result ordering
 // - Apply cloaking (billing header + fake user ID) for OAuth tokens
 export function prepareClaudeRequest(body, provider = null, apiKey = null, connectionId = null) {
+  if (provider?.startsWith("anthropic-compatible")) {
+    // Fixes #1468: Claude Code may send Anthropic-only context_management, but
+    // most anthropic-compatible gateways reject unknown top-level fields.
+    delete body.context_management;
+  }
+
   // MiniMax exposes a Claude-compatible endpoint but rejects Anthropic's extended
   // structured output parameter with a generic 400 "invalid params" response.
   if (CLAUDE_FORMAT_PROVIDERS_WITHOUT_OUTPUT_CONFIG.has(provider)) {

--- a/tests/unit/claude-context-management.test.js
+++ b/tests/unit/claude-context-management.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { prepareClaudeRequest } from "../../open-sse/translator/helpers/claudeHelper.js";
+
+describe("prepareClaudeRequest context_management compatibility", () => {
+  it("strips Claude Code context_management for anthropic-compatible providers", () => {
+    const body = {
+      model: "claude-compatible",
+      max_tokens: 100,
+      context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }]
+    };
+
+    const result = prepareClaudeRequest(body, "anthropic-compatible-custom");
+
+    expect(result.context_management).toBeUndefined();
+    expect(result.messages[0].content[0].text).toBe("hi");
+  });
+
+  it("keeps context_management for the first-party Claude provider", () => {
+    const body = {
+      model: "claude-sonnet",
+      max_tokens: 100,
+      context_management: { edits: [{ type: "clear_tool_uses_20250919" }] },
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }]
+    };
+
+    const result = prepareClaudeRequest(body, "claude");
+
+    expect(result.context_management).toEqual({ edits: [{ type: "clear_tool_uses_20250919" }] });
+  });
+});


### PR DESCRIPTION
## Summary
- strip Claude Code context_management before forwarding requests to anthropic-compatible providers
- keep context_management intact for the first-party Claude provider
- add focused regression coverage for the compatibility behavior

Fixes #1468.

## Validation
- node --check open-sse/translator/helpers/claudeHelper.js
- npx vitest run --config ./tests/vitest.config.js tests/unit/claude-context-management.test.js
- git diff --check
- npm run build