### PR TITLE
fix: stop MITM restart loop when already running

### DIFF
--- a/src/mitm/manager.js
+++ b/src/mitm/manager.js
@@ -398,6 +398,31 @@ async function getMitmStatus() {
   return { running, pid, certExists, certTrusted, dnsStatus };
 }
 
+function isAlreadyRunningRestartRecovery(error, status) {
+  return error?.message === "MITM server is already running" && status?.running === true;
+}
+
+async function recoverAlreadyRunningRestart(error, sudoPassword) {
+  let status = null;
+  try {
+    status = await getMitmStatus();
+  } catch {
+    return false;
+  }
+
+  if (!isAlreadyRunningRestartRecovery(error, status)) return false;
+
+  // Fixes #1462: a crashed child can schedule a restart while manager state
+  // still points at a live MITM process. Treat that as recovered instead of
+  // recursively scheduling "already running" restart attempts.
+  log("MITM server already running; treating restart as recovered");
+  await saveMitmSettings(true, sudoPassword);
+  if (sudoPassword) setCachedPassword(sudoPassword);
+  mitmRestartCount = 0;
+  mitmIsRestarting = false;
+  return true;
+}
+
 async function scheduleMitmRestart(apiKey) {
   if (mitmIsRestarting) return;
 
@@ -417,6 +442,7 @@ async function scheduleMitmRestart(apiKey) {
   log(`Restarting in ${delay / 1000}s... (${mitmRestartCount}/${MITM_MAX_RESTARTS})`);
   await new Promise((r) => setTimeout(r, delay));
 
+  let password = null;
   try {
     const settings = _getSettings ? await _getSettings() : null;
     if (settings && !settings.mitmEnabled) {
@@ -424,7 +450,7 @@ async function scheduleMitmRestart(apiKey) {
       mitmIsRestarting = false;
       return;
     }
-    const password = getCachedPassword() || await loadEncryptedPassword();
+    password = getCachedPassword() || await loadEncryptedPassword();
     if (!password && !IS_WIN) {
       err("No cached password, cannot auto-restart");
       mitmIsRestarting = false;
@@ -435,6 +461,7 @@ async function scheduleMitmRestart(apiKey) {
     mitmRestartCount = 0;
     mitmIsRestarting = false;
   } catch (e) {
+    if (await recoverAlreadyRunningRestart(e, password)) return;
     err(`Restart attempt ${mitmRestartCount}/${MITM_MAX_RESTARTS} failed: ${e.message}`);
     mitmIsRestarting = false;
     // Schedule next retry
@@ -848,4 +875,7 @@ module.exports = {
   restoreToolDNS,
   hasDnsPrivilege,
   removeAllDNSEntriesSync,
+  __test__: {
+    isAlreadyRunningRestartRecovery,
+  },
 };

--- a/tests/unit/mitm-manager-restart.test.js
+++ b/tests/unit/mitm-manager-restart.test.js
@@ -1,0 +1,19 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { __test__ } = require("../../src/mitm/manager.js");
+
+describe("MITM manager restart recovery", () => {
+  it("treats an already-running MITM process as a recovered restart", () => {
+    const error = new Error("MITM server is already running");
+    const status = { running: true, pid: 1234 };
+
+    expect(__test__.isAlreadyRunningRestartRecovery(error, status)).toBe(true);
+  });
+
+  it("does not hide unrelated restart failures", () => {
+    expect(__test__.isAlreadyRunningRestartRecovery(new Error("port busy"), { running: true })).toBe(false);
+    expect(__test__.isAlreadyRunningRestartRecovery(new Error("MITM server is already running"), { running: false })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Treat MITM auto-restart as recovered when the manager discovers the server is already running
- Reset restart state instead of recursively scheduling more "MITM server is already running" attempts
- Add a focused unit test for the recovery guard and document the fix in the changelog

Fixes #1462.

Related: #1476 and #1470 report DNS/ALPN failures in nearby MITM/proxyFetch paths. This PR does not claim to fix those DNS timeout symptoms, but it prevents the restart-loop symptom seen in #1462 from compounding those failures.

## Validation
- node --check src/mitm/manager.js
- npx vitest run --config ./tests/vitest.config.js tests/unit/mitm-manager-restart.test.js
- git diff --check
- npm run build
