### PR TITLE
fix: dedupe Anthropic version headers

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -3,6 +3,29 @@ import { shouldRefreshCredentials } from "../services/oauthCredentialManager.js"
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
 
+function uniqueCommaValues(values) {
+  return [...new Set(values
+    .filter(value => value !== undefined && value !== null && value !== "")
+    .flatMap(value => String(value).split(","))
+    .map(value => value.trim())
+    .filter(Boolean))];
+}
+
+function normalizeAnthropicHeaderVariants(headers) {
+  const versionValues = uniqueCommaValues([headers["anthropic-version"], headers["Anthropic-Version"]]);
+  delete headers["Anthropic-Version"];
+  delete headers["anthropic-version"];
+  if (versionValues.length > 0) {
+    // Fixes #1475 for executors using BaseExecutor directly.
+    headers["anthropic-version"] = versionValues[0];
+  }
+
+  const betaValues = uniqueCommaValues([headers["anthropic-beta"], headers["Anthropic-Beta"]]);
+  delete headers["Anthropic-Beta"];
+  delete headers["anthropic-beta"];
+  if (betaValues.length > 0) headers["anthropic-beta"] = betaValues.join(",");
+}
+
 /**
  * BaseExecutor - Base class for provider executors
  */
@@ -69,6 +92,8 @@ export class BaseExecutor {
     if (stream) {
       headers["Accept"] = "text/event-stream";
     }
+
+    normalizeAnthropicHeaderVariants(headers);
 
     return headers;
   }

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -6,6 +6,29 @@ import { getCachedClaudeHeaders } from "../utils/claudeHeaderCache.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 
+function uniqueCommaValues(values) {
+  return [...new Set(values
+    .filter(value => value !== undefined && value !== null && value !== "")
+    .flatMap(value => String(value).split(","))
+    .map(value => value.trim())
+    .filter(Boolean))];
+}
+
+function normalizeAnthropicHeaderVariants(headers) {
+  const versionValues = uniqueCommaValues([headers["anthropic-version"], headers["Anthropic-Version"]]);
+  delete headers["Anthropic-Version"];
+  delete headers["anthropic-version"];
+  if (versionValues.length > 0) {
+    // Fixes #1475: Node/fetch combines case variants into "v, v", which Anthropic rejects.
+    headers["anthropic-version"] = versionValues[0];
+  }
+
+  const betaValues = uniqueCommaValues([headers["anthropic-beta"], headers["Anthropic-Beta"]]);
+  delete headers["Anthropic-Beta"];
+  delete headers["anthropic-beta"];
+  if (betaValues.length > 0) headers["anthropic-beta"] = betaValues.join(",");
+}
+
 export class DefaultExecutor extends BaseExecutor {
   constructor(provider) {
     super(provider, PROVIDERS[provider] || PROVIDERS.openai);
@@ -178,6 +201,8 @@ export class DefaultExecutor extends BaseExecutor {
         }
       }
     }
+
+    normalizeAnthropicHeaderVariants(headers);
 
     if (stream) headers["Accept"] = "text/event-stream";
     return headers;

--- a/tests/unit/claude-header-forwarding.test.js
+++ b/tests/unit/claude-header-forwarding.test.js
@@ -228,6 +228,25 @@ describe("DefaultExecutor.buildHeaders() — claude provider cold start (no cach
   });
 });
 
+describe("DefaultExecutor.buildHeaders() — Anthropic header dedupe", () => {
+  let DefaultExecutor;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("open-sse/executors/default.js");
+    DefaultExecutor = mod.DefaultExecutor || mod.default;
+  });
+
+  it("does not send duplicate anthropic-version variants for the Anthropic provider", () => {
+    const executor = new DefaultExecutor("anthropic");
+    const headers = executor.buildHeaders({ apiKey: "sk-test" }, true);
+
+    expect(headers["Anthropic-Version"]).toBeUndefined();
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers["anthropic-version"]).not.toContain(",");
+  });
+});
+
 // ─── anthropic-compatible header stripping ────────────────────────────────────
 
 describe("DefaultExecutor.buildHeaders() — anthropic-compatible stripping", () => {


### PR DESCRIPTION
## Summary
- Normalize Anthropic header casing before requests leave executors
- Collapse `Anthropic-Version` / `anthropic-version` variants into one lowercase `anthropic-version`
- Merge beta header variants without duplicating comma-separated flags
- Add a regression test for the reported Anthropic provider path

Fixes #1475.

## Validation
- node --check open-sse/executors/default.js
- node --check open-sse/executors/base.js
- npx vitest run --config ./tests/vitest.config.js tests/unit/claude-header-forwarding.test.js -t "Anthropic header dedupe|cold start"
- git diff --check
- npm run build

Note: the full `tests/unit/claude-header-forwarding.test.js` file still has an unrelated existing `proxyAwareFetch`/got-scraping mock failure; the #1475-relevant header tests pass.
