### PR TITLE
fix: reject unsupported Kiro 1m context suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 - proxyFetch: restore missing `Readable` import causing runtime `ReferenceError` in DNS-bypass fetch path
+- Kiro: reject unsupported `[1m]` context suffixes before forwarding malformed model IDs to AWS Bedrock (#1503)
 
 ## Improvements
 - Lower stream stall timeout from 60s → 35s for faster hang detection

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -17,6 +17,9 @@
 
 export const KIRO_AGENTIC_SUFFIX = "-agentic";
 export const KIRO_THINKING_SUFFIX = "-thinking";
+export const KIRO_UNSUPPORTED_CONTEXT_1M_SUFFIX = "[1m]";
+export const KIRO_UNSUPPORTED_CONTEXT_1M_MESSAGE =
+  "[kr/*] '[1m]' suffix is not supported by Kiro upstream. Kiro is AWS Bedrock-backed and does not honor Anthropic's context-1m beta. Use a direct-Anthropic provider for 1M-context routing.";
 
 export const KIRO_THINKING_BUDGET_DEFAULT = 16000;
 
@@ -180,6 +183,18 @@ export function stripThinkingSuffix(model) {
 }
 
 /**
+ * Kiro is AWS Bedrock-backed, so Anthropic's direct-provider `[1m]` context
+ * beta cannot be forwarded as part of a `kr/*` model id.
+ *
+ * @param {string} model
+ * @returns {boolean}
+ */
+export function hasUnsupportedKiroContextSuffix(model) {
+  return typeof model === "string"
+    && model.toLowerCase().includes(KIRO_UNSUPPORTED_CONTEXT_1M_SUFFIX);
+}
+
+/**
  * Resolve a 9router model id to the real upstream Kiro model id, plus flags
  * describing which behaviours the suffixes implied.
  *
@@ -194,8 +209,14 @@ export function stripThinkingSuffix(model) {
  *
  * @param {string} model
  * @returns {{ upstream: string, agentic: boolean, thinking: boolean }}
+ * @throws {Error} when the model requests an Anthropic-only context suffix Kiro cannot honor
  */
 export function resolveKiroModel(model) {
+  // Fixes #1503: forwarding `[1m]` to Kiro/Bedrock produces a malformed upstream model id.
+  if (hasUnsupportedKiroContextSuffix(model)) {
+    throw new Error(KIRO_UNSUPPORTED_CONTEXT_1M_MESSAGE);
+  }
+
   let upstream = model;
   let agentic = false;
   let thinking = false;

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -135,6 +135,8 @@ export const PROVIDER_MODELS = {
     { id: "text-embedding-3-large", name: "Text Embedding 3 Large (GitHub)", type: "embedding" },
   ],
   kr: [  // Kiro AI
+    // Kiro is AWS Bedrock-backed; Anthropic's `[1m]` context beta is
+    // intentionally rejected before upstream for kr/* routes (#1503).
     // --- Base Claude variants ---
     // { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
     { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -36,6 +36,17 @@ describe("buildKiroPayload", () => {
     });
   });
 
+  describe("model suffix handling", () => {
+    it("should reject Anthropic-only 1m context suffixes before Kiro upstream", () => {
+      const body = {
+        messages: [{ role: "user", content: "Hello" }]
+      };
+
+      expect(() => buildKiroPayload("claude-opus-4.7-thinking-agentic[1m]", body, true, {}))
+        .toThrow("[kr/*] '[1m]' suffix is not supported by Kiro upstream");
+    });
+  });
+
   describe("image forwarding", () => {
     it("should forward base64 image from image_url content part", () => {
       const fakeBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";


### PR DESCRIPTION
## Summary
- reject `kr/*` model IDs containing `[1m]` before building the Kiro/Bedrock payload
- document the Kiro namespace limitation near the provider model list
- add a regression test for the unsupported Kiro `[1m]` suffix

Fixes #1503.

## Validation
- `node --check open-sse/config/kiroConstants.js`
- `node --check open-sse/translator/request/openai-to-kiro.js`
- `node --check open-sse/config/providerModels.js`
- `git diff --check`
- `npx vitest run --config ./tests/vitest.config.js tests/unit/openai-to-kiro.test.js`
- `npm run build`
