### PR TITLE
feat(embeddings): Combo support for /v1/embeddings endpoint

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -20,6 +20,7 @@ export default function CombosPage() {
   const [activeProviders, setActiveProviders] = useState([]);
   const [comboStrategies, setComboStrategies] = useState({});
   const [confirmState, setConfirmState] = useState(null);
+  const [activeTab, setActiveTab] = useState("llm"); // "llm" | "embedding"
   const { copied, copy } = useCopyToClipboard();
 
   useEffect(() => {
@@ -37,8 +38,8 @@ export default function CombosPage() {
       const providersData = await providersRes.json();
       const settingsData = settingsRes.ok ? await settingsRes.json() : {};
       
-      // Only LLM combos here — webSearch/webFetch combos belong to media-providers/web
-      if (combosRes.ok) setCombos((combosData.combos || []).filter(c => !c.kind));
+      // Store all combos — filtering will be done client-side based on activeTab
+      if (combosRes.ok) setCombos(combosData.combos || []);
       if (providersRes.ok) {
         setActiveProviders(providersData.connections || []);
       }
@@ -50,12 +51,18 @@ export default function CombosPage() {
     }
   };
 
+  const filteredCombos = combos.filter(combo => {
+    if (activeTab === "llm") return !combo.kind;
+    return combo.kind === "embedding";
+  });
+
   const handleCreate = async (data) => {
     try {
+      const kind = activeTab === "embedding" ? "embedding" : null;
       const res = await fetch("/api/combos", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
+        body: JSON.stringify({ ...data, kind }),
       });
       if (res.ok) {
         await fetchData();
@@ -146,20 +153,43 @@ export default function CombosPage() {
             Create model combos with fallback support
           </p>
         </div>
-        <Button icon="add" onClick={() => setShowCreateModal(true)} className="w-full sm:w-auto">
-          Create Combo
-        </Button>
+        <div className="flex items-center gap-3">
+          {/* Tab Switcher */}
+          <div className="flex gap-1 bg-black/[0.03] dark:bg-white/[0.03] rounded-lg p-1">
+            <button
+              onClick={() => setActiveTab("llm")}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                activeTab === "llm" ? "bg-white dark:bg-black/20 shadow-sm" : "text-text-muted hover:text-text-main"
+              }`}
+            >LLM</button>
+            <button
+              onClick={() => setActiveTab("embedding")}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                activeTab === "embedding" ? "bg-white dark:bg-black/20 shadow-sm" : "text-text-muted hover:text-text-main"
+              }`}
+            >Embedding</button>
+          </div>
+          <Button icon="add" onClick={() => setShowCreateModal(true)} className="w-full sm:w-auto">
+            Create Combo
+          </Button>
+        </div>
       </div>
 
       {/* Combos List */}
-      {combos.length === 0 ? (
+      {filteredCombos.length === 0 ? (
         <Card>
           <div className="text-center py-12">
             <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 text-primary mb-4">
               <span className="material-symbols-outlined text-[32px]">layers</span>
             </div>
-            <p className="text-text-main font-medium mb-1">No combos yet</p>
-            <p className="text-sm text-text-muted mb-4">Create model combos with fallback support</p>
+            <p className="text-text-main font-medium mb-1">
+              {activeTab === "llm" ? "No LLM combos yet" : "No embedding combos yet"}
+            </p>
+            <p className="text-sm text-text-muted mb-4">
+              {activeTab === "llm" 
+                ? "Create LLM model combos with fallback support" 
+                : "Create embedding model combos with fallback support"}
+            </p>
             <Button icon="add" onClick={() => setShowCreateModal(true)} className="w-full sm:w-auto">
               Create Combo
             </Button>
@@ -167,7 +197,7 @@ export default function CombosPage() {
         </Card>
       ) : (
         <div className="flex flex-col gap-4">
-          {combos.map((combo) => (
+          {filteredCombos.map((combo) => (
             <ComboCard
               key={combo.id}
               combo={combo}
@@ -189,6 +219,7 @@ export default function CombosPage() {
         onClose={() => setShowCreateModal(false)}
         onSave={handleCreate}
         activeProviders={activeProviders}
+        kindFilter={activeTab === "embedding" ? "embedding" : null}
       />
 
       {/* Edit Modal - Use key to force remount and reset state */}
@@ -199,6 +230,7 @@ export default function CombosPage() {
         onClose={() => setEditingCombo(null)}
         onSave={(data) => handleUpdate(editingCombo.id, data)}
         activeProviders={activeProviders}
+        kindFilter={editingCombo?.kind === "embedding" ? "embedding" : null}
       />
 
       {/* Confirm Delete Modal */}

--- a/src/app/(dashboard)/dashboard/media-providers/combo/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/combo/[id]/page.js
@@ -22,6 +22,7 @@ const KIND_LABELS = {
   webFetch: "Web Fetch",
   image: "Text to Image",
   tts: "Text To Speech",
+  embedding: "Embedding",
 };
 
 const EXAMPLE_PATHS = {
@@ -29,6 +30,7 @@ const EXAMPLE_PATHS = {
   webFetch: "/v1/web/fetch",
   image: "/v1/images/generations",
   tts: "/v1/audio/speech",
+  embedding: "/v1/embeddings",
 };
 
 const EXAMPLE_BODIES = {
@@ -36,11 +38,13 @@ const EXAMPLE_BODIES = {
   webFetch: (n) => ({ model: n, url: "https://example.com", format: "markdown" }),
   image: (n) => ({ model: n, prompt: "A cute cat playing piano", n: 1, size: "1024x1024" }),
   tts: (n) => ({ model: n, input: "Hello, this is a test.", voice: "alloy" }),
+  embedding: (n) => ({ model: n, input: "Hello, this is a test." }),
 };
 
 // Map combo.kind → listing route to go back to
 function getListingHref(kind) {
   if (kind === "webSearch" || kind === "webFetch") return "/dashboard/media-providers/web";
+  if (kind === "embedding") return "/dashboard/combos";
   return `/dashboard/media-providers/${kind}`;
 }
 
@@ -61,6 +65,11 @@ export default function ComboDetailPage() {
   const [apiKey, setApiKey] = useState("");
   const [connections, setConnections] = useState([]);
   const [modelAliases, setModelAliases] = useState({});
+  const [dimensions, setDimensions] = useState(combo?.dimensions || "");
+
+  useEffect(() => {
+    if (combo) setDimensions(combo.dimensions || "");
+  }, [combo]);
 
   const fetchAll = async () => {
     try {
@@ -221,9 +230,13 @@ export default function ComboDetailPage() {
     if (Array.isArray(obj)) return obj.map(maskB64);
     const out = {};
     for (const [k, v] of Object.entries(obj)) {
-      out[k] = (k === "b64_json" && typeof v === "string" && v.length > 100)
-        ? `<${v.length} chars base64>`
-        : maskB64(v);
+      if (k === "b64_json" && typeof v === "string" && v.length > 100) {
+        out[k] = `<${v.length} chars base64>`;
+      } else if (k === "embedding" && Array.isArray(v) && v.length > 10) {
+        out[k] = `[${v.slice(0, 5).map(n => typeof n === "number" ? n.toFixed(4) : n).join(", ")}, ... (${v.length} total)]`;
+      } else {
+        out[k] = maskB64(v);
+      }
     }
     return out;
   }
@@ -268,6 +281,25 @@ export default function ComboDetailPage() {
             <Input label="Combo Name" value={name} onChange={(e) => { setName(e.target.value); validateName(e.target.value); }} onBlur={handleSaveName} error={nameError} />
             <p className="text-[10px] text-text-muted mt-0.5">Only letters, numbers, -, _ and .</p>
           </div>
+          {/* 维度配置 — 仅 embedding combo 显示 */}
+          {combo.kind === "embedding" && (
+            <div>
+              <Input
+                label="Dimensions"
+                value={dimensions}
+                onChange={(e) => setDimensions(e.target.value)}
+                onBlur={() => {
+                  const val = dimensions.trim();
+                  saveCombo({ dimensions: val || null });
+                }}
+                placeholder="e.g. 512, 1024, 1536 (leave empty for default)"
+                type="number"
+              />
+              <p className="text-[10px] text-text-muted mt-0.5">
+                指定向量维度。留空则使用模型默认值。仅部分 provider 支持（如 OpenAI text-embedding-3-*）。
+              </p>
+            </div>
+          )}
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium">Round Robin</p>
@@ -276,6 +308,44 @@ export default function ComboDetailPage() {
             <Toggle checked={roundRobin} onChange={handleToggleRoundRobin} />
           </div>
         </div>
+        {/* 维度警告 */}
+        {combo.kind === "embedding" && (() => {
+          const modelDims = combo.models.map(entry => {
+            const { providerId, model: modelId } = parseModelEntry(entry);
+            const provider = AI_PROVIDERS[providerId];
+            const dim = provider?.embeddingConfig?.models?.find(m => m.id === modelId)?.dimensions;
+            return { entry, providerId, modelId, dimensions: dim };
+          });
+          const uniqueDims = [...new Set(modelDims.map(m => m.dimensions).filter(Boolean))];
+          const hasUnknown = modelDims.some(m => m.dimensions === undefined);
+          
+          if (uniqueDims.length <= 1 && !hasUnknown) return null;
+          
+          return (
+            <div className="rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 p-3">
+              <div className="flex items-start gap-2">
+                <span className="material-symbols-outlined text-yellow-600 text-[18px]">warning</span>
+                <div className="text-xs">
+                  {uniqueDims.length > 1 && (
+                    <p className="text-yellow-700 dark:text-yellow-400 font-medium">
+                      ⚠️ 模型维度不一致 ({uniqueDims.join(", ")}). Fallback 可能导致维度不匹配。
+                    </p>
+                  )}
+                  {hasUnknown && (
+                    <p className="text-yellow-600 dark:text-yellow-500">
+                      部分模型维度未知。
+                    </p>
+                  )}
+                  {combo.dimensions && (
+                    <p className="text-yellow-600 dark:text-yellow-500 mt-1">
+                      将请求 {combo.dimensions} 维向量（仅支持维度截断的 provider 生效）。
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })()}
       </Card>
 
       {/* Providers Card */}

--- a/src/app/api/combos/route.js
+++ b/src/app/api/combos/route.js
@@ -21,7 +21,7 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name, models, kind } = body;
+    const { name, models, kind, dimensions } = body;
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -38,7 +38,7 @@ export async function POST(request) {
       return NextResponse.json({ error: "Combo name already exists" }, { status: 400 });
     }
 
-    const combo = await createCombo({ name, models: models || [], kind: kind || null });
+    const combo = await createCombo({ name, models: models || [], kind: kind || null, dimensions: dimensions || null });
 
     return NextResponse.json(combo, { status: 201 });
   } catch (error) {

--- a/src/lib/db/repos/combosRepo.js
+++ b/src/lib/db/repos/combosRepo.js
@@ -9,6 +9,7 @@ function rowToCombo(row) {
     name: row.name,
     kind: row.kind,
     models: parseJson(row.models, []),
+    dimensions: row.dimensions || null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -40,12 +41,13 @@ export async function createCombo(data) {
     name: data.name,
     kind: data.kind || null,
     models: data.models || [],
+    dimensions: data.dimensions || null,
     createdAt: now,
     updatedAt: now,
   };
   db.run(
-    `INSERT INTO combos(id, name, kind, models, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?)`,
-    [combo.id, combo.name, combo.kind, stringifyJson(combo.models), combo.createdAt, combo.updatedAt]
+    `INSERT INTO combos(id, name, kind, models, dimensions, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+    [combo.id, combo.name, combo.kind, stringifyJson(combo.models), combo.dimensions, combo.createdAt, combo.updatedAt]
   );
   return combo;
 }
@@ -58,8 +60,8 @@ export async function updateCombo(id, data) {
     if (!row) return;
     const merged = { ...rowToCombo(row), ...data, updatedAt: new Date().toISOString() };
     db.run(
-      `UPDATE combos SET name = ?, kind = ?, models = ?, updatedAt = ? WHERE id = ?`,
-      [merged.name, merged.kind, stringifyJson(merged.models || []), merged.updatedAt, id]
+      `UPDATE combos SET name = ?, kind = ?, models = ?, dimensions = ?, updatedAt = ? WHERE id = ?`,
+      [merged.name, merged.kind, stringifyJson(merged.models || []), merged.dimensions, merged.updatedAt, id]
     );
     result = merged;
   });

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -82,17 +82,18 @@ export const TABLES = {
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],
   },
-  combos: {
-    columns: {
-      id: "TEXT PRIMARY KEY",
-      name: "TEXT UNIQUE NOT NULL",
-      kind: "TEXT",
-      models: "TEXT NOT NULL",
-      createdAt: "TEXT NOT NULL",
-      updatedAt: "TEXT NOT NULL",
-    },
-    indexes: ["CREATE INDEX IF NOT EXISTS idx_combo_name ON combos(name)"],
-  },
+   combos: {
+     columns: {
+       id: "TEXT PRIMARY KEY",
+       name: "TEXT UNIQUE NOT NULL",
+       kind: "TEXT",
+       models: "TEXT NOT NULL",
+       dimensions: "TEXT",
+       createdAt: "TEXT NOT NULL",
+       updatedAt: "TEXT NOT NULL",
+     },
+     indexes: ["CREATE INDEX IF NOT EXISTS idx_combo_name ON combos(name)"],
+   },
   kv: {
     columns: {
       scope: "TEXT NOT NULL",

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -6,12 +6,14 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
-import { getModelInfo } from "../services/model.js";
+import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleEmbeddingsCore } from "open-sse/handlers/embeddingsCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
+import { handleComboChat } from "open-sse/services/combo.js";
+import { getComboByName } from "@/lib/localDb";
 
 /**
  * Handle embeddings request for the SSE/Next.js server.
@@ -65,9 +67,41 @@ export async function handleEmbeddings(request) {
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: input");
   }
 
+  // Combo 检测：model 可能是 combo 名称，使用 fallback/round-robin 策略
+  const comboModels = await getComboModels(modelStr);
+  if (comboModels) {
+    const comboStrategies = settings.comboStrategies || {};
+    const comboStrategy = comboStrategies[modelStr]?.fallbackStrategy || settings.comboStrategy || "fallback";
+    const comboStickyLimit = settings.comboStickyRoundRobinLimit;
+
+    // 注入 combo 级别 dimensions（若用户未显式传入）
+    if (!body.dimensions) {
+      const combo = await getComboByName(modelStr);
+      if (combo?.dimensions) {
+        body = { ...body, dimensions: combo.dimensions };
+        log.info("EMBEDDINGS", `使用 combo 维度: ${combo.dimensions}`);
+      }
+    }
+
+    log.info("EMBEDDINGS", `Combo "${modelStr}" 包含 ${comboModels.length} 个模型 (策略: ${comboStrategy}, sticky: ${comboStickyLimit})`);
+    return handleComboChat({
+      body,
+      models: comboModels,
+      handleSingleModel: (b, m) => handleSingleModelEmbedding(b, m),
+      log,
+      comboName: modelStr,
+      comboStrategy,
+      comboStickyLimit,
+    });
+  }
+
+  return handleSingleModelEmbedding(body, modelStr);
+}
+
+async function handleSingleModelEmbedding(body, modelStr) {
   const modelInfo = await getModelInfo(modelStr);
   if (!modelInfo.provider) {
-    log.warn("EMBEDDINGS", "Invalid model format", { model: modelStr });
+    log.warn("EMBEDDINGS", "无效的模型格式", { model: modelStr });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");
   }
 
@@ -79,7 +113,6 @@ export async function handleEmbeddings(request) {
     log.info("ROUTING", `Provider: ${provider}, Model: ${model}`);
   }
 
-  // Credential + fallback loop (mirrors handleChat)
   const excludeConnectionIds = new Set();
   let lastError = null;
   let lastStatus = null;
@@ -87,7 +120,6 @@ export async function handleEmbeddings(request) {
   while (true) {
     const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
 
-    // All accounts unavailable
     if (!credentials || credentials.allRateLimited) {
       if (credentials?.allRateLimited) {
         const errorMsg = lastError || credentials.lastError || "Unavailable";

--- a/tests/unit/embedding-combo.test.js
+++ b/tests/unit/embedding-combo.test.js
@@ -14,7 +14,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/localDb", () => ({
   getSettings: vi.fn(),
-  getComboByName: vi.fn(),
   getCombos: vi.fn(),
   getComboById: vi.fn(),
   createCombo: vi.fn(),
@@ -115,7 +114,7 @@ import { getModelInfo, getComboModels } from "../../src/sse/services/model.js";
 import { handleComboChat } from "open-sse/services/combo.js";
 import { handleEmbeddingsCore } from "open-sse/handlers/embeddingsCore.js";
 import { errorResponse } from "open-sse/utils/error.js";
-import { getProviderCredentials, markAccountUnavailable } from "../../src/sse/services/auth.js";
+import { getProviderCredentials, markAccountUnavailable, extractApiKey } from "../../src/sse/services/auth.js";
 import { checkAndRefreshToken } from "../../src/sse/services/tokenRefresh.js";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
@@ -180,7 +179,7 @@ describe("handleEmbeddings — combo detection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getSettings.mockResolvedValue(defaultSettings());
-    extractApiKey: vi.fn().mockReturnValue(null);
+    extractApiKey.mockReturnValue(null);
   });
 
   it("1. detects combo name and calls handleComboChat", async () => {

--- a/tests/unit/embedding-combo.test.js
+++ b/tests/unit/embedding-combo.test.js
@@ -1,0 +1,603 @@
+/**
+ * Unit tests for embedding combo feature
+ *
+ * Tests cover:
+ *  - handleEmbeddings combo detection & dimensions injection (Group 1)
+ *  - handleSingleModelEmbedding fallback logic (Group 2)
+ *  - Combo fallback with dimensions (Group 3)
+ *  - API routes dimensions handling (Group 4)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mock dependencies before imports ─────────────────────────────────────────
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: vi.fn(),
+  getComboByName: vi.fn(),
+  getCombos: vi.fn(),
+  getComboById: vi.fn(),
+  createCombo: vi.fn(),
+  updateCombo: vi.fn(),
+  deleteCombo: vi.fn(),
+  getComboByName: vi.fn(),
+}));
+
+vi.mock("../../src/sse/services/model.js", () => ({
+  getModelInfo: vi.fn(),
+  getComboModels: vi.fn(),
+}));
+
+vi.mock("../../src/sse/services/auth.js", () => ({
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  extractApiKey: vi.fn(),
+  isValidApiKey: vi.fn(),
+}));
+
+vi.mock("open-sse/handlers/embeddingsCore.js", () => ({
+  handleEmbeddingsCore: vi.fn(),
+}));
+
+vi.mock("open-sse/utils/error.js", () => ({
+  errorResponse: vi.fn((status, msg) =>
+    new Response(JSON.stringify({ error: { message: msg } }), { status, headers: { "Content-Type": "application/json" } })
+  ),
+  unavailableResponse: vi.fn((status, msg, retry, retryHuman) =>
+    new Response(JSON.stringify({ error: { message: `${msg} (${retryHuman})` } }), { status, headers: { "Content-Type": "application/json", "Retry-After": String(Math.ceil((new Date(retry).getTime() - Date.now()) / 1000)) } })
+  ),
+}));
+
+vi.mock("open-sse/config/runtimeConfig.js", () => ({
+  HTTP_STATUS: { BAD_REQUEST: 400, UNAUTHORIZED: 401, SERVICE_UNAVAILABLE: 503 },
+}));
+
+vi.mock("open-sse/services/combo.js", () => ({
+  handleComboChat: vi.fn(),
+  resetComboRotation: vi.fn(),
+  getRotatedModels: vi.fn(),
+}));
+
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  updateProviderCredentials: vi.fn(),
+  checkAndRefreshToken: vi.fn(),
+}));
+
+// Mock accountFallback (imported by combo.js)
+vi.mock("open-sse/services/accountFallback.js", () => ({
+  checkFallbackError: vi.fn(() => ({ shouldFallback: true, cooldownMs: 1000 })),
+  formatRetryAfter: vi.fn(() => "1s"),
+}));
+
+// Mock logger — imported as `import * as log from "../utils/logger.js"` in embeddings.js
+vi.mock("../../src/sse/utils/logger.js", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  request: vi.fn(),
+  maskKey: vi.fn((k) => k ? `${k.slice(0, 4)}...${k.slice(-4)}` : "***"),
+}));
+
+// Mock network/connectionProxy to avoid transitive imports
+vi.mock("@/lib/network/connectionProxy.js", () => ({
+  resolveConnectionProxyConfig: vi.fn(async () => ({
+    connectionProxyEnabled: false,
+    connectionProxyUrl: "",
+    connectionNoProxy: "",
+    proxyPoolId: null,
+    vercelRelayUrl: "",
+  })),
+}));
+
+// Mock shared constants
+vi.mock("@/shared/constants/providers.js", () => ({
+  resolveProviderId: vi.fn((id) => id),
+  FREE_PROVIDERS: {},
+}));
+
+// Mock NextResponse for API route tests
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((body, opts) => {
+      const status = opts?.status || 200;
+      return { status, body, headers: opts?.headers || {} };
+    }),
+  },
+}));
+
+// ─── Import after mocks ────────────────────────────────────────────────────────
+
+import { handleEmbeddings } from "../../src/sse/handlers/embeddings.js";
+import { getComboByName, getSettings, createCombo, updateCombo, getComboById } from "@/lib/localDb";
+import { getModelInfo, getComboModels } from "../../src/sse/services/model.js";
+import { handleComboChat } from "open-sse/services/combo.js";
+import { handleEmbeddingsCore } from "open-sse/handlers/embeddingsCore.js";
+import { errorResponse } from "open-sse/utils/error.js";
+import { getProviderCredentials, markAccountUnavailable } from "../../src/sse/services/auth.js";
+import { checkAndRefreshToken } from "../../src/sse/services/tokenRefresh.js";
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+/** 创建模拟的 Request 对象 */
+function createRequest(body, url = "http://localhost:20128/v1/embeddings") {
+  return {
+    json: vi.fn().mockResolvedValue(body),
+    url,
+    headers: { get: vi.fn() },
+  };
+}
+
+/** 模拟成功的 embedding 响应 (200) */
+function makeSuccessResponse() {
+  return new Response(
+    JSON.stringify({
+      object: "list",
+      data: [{ object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }],
+      model: "text-embedding-ada-002",
+      usage: { prompt_tokens: 3, total_tokens: 3 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+/** 模拟成功的 handleEmbeddingsCore 结果 */
+function makeCoreSuccessResult() {
+  return {
+    success: true,
+    response: makeSuccessResponse(),
+  };
+}
+
+/** 模拟失败的 handleEmbeddingsCore 结果 */
+function makeCoreErrorResult(status = 429, error = "Rate limit exceeded") {
+  return {
+    success: false,
+    status,
+    error,
+    response: new Response(JSON.stringify({ error: { message: error } }), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  };
+}
+
+/** 默认 settings mock */
+function defaultSettings(overrides = {}) {
+  return {
+    requireApiKey: false,
+    comboStrategies: {},
+    comboStrategy: "fallback",
+    comboStickyLimit: 1,
+    ...overrides,
+  };
+}
+
+// ─── Group 1: handleEmbeddings combo detection (6 tests) ───────────────────────
+
+describe("handleEmbeddings — combo detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSettings.mockResolvedValue(defaultSettings());
+    extractApiKey: vi.fn().mockReturnValue(null);
+  });
+
+  it("1. detects combo name and calls handleComboChat", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1", "minimax/MiniMax-M2.7"]);
+    getComboByName.mockResolvedValue({ name: "my-combo", models: ["glm/glm-5.1", "minimax/MiniMax-M2.7"], dimensions: null });
+    handleComboChat.mockResolvedValue(makeSuccessResponse());
+
+    const req = createRequest({ model: "my-combo", input: "hello" });
+    await handleEmbeddings(req);
+
+    expect(getComboModels).toHaveBeenCalledWith("my-combo");
+    expect(handleComboChat).toHaveBeenCalledOnce();
+  });
+
+  it("2. passes combo models to handleComboChat", async () => {
+    const models = ["glm/glm-5.1", "minimax/MiniMax-M2.7"];
+    getComboModels.mockResolvedValue(models);
+    getComboByName.mockResolvedValue({ name: "my-combo", models, dimensions: null });
+    handleComboChat.mockResolvedValue(makeSuccessResponse());
+
+    const req = createRequest({ model: "my-combo", input: "hello" });
+    await handleEmbeddings(req);
+
+    const callArgs = handleComboChat.mock.calls[0][0];
+    expect(callArgs.models).toEqual(models);
+    expect(callArgs.comboName).toBe("my-combo");
+  });
+
+  it("3. injects combo.dimensions into body when body.dimensions is absent", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1"]);
+    getComboByName.mockResolvedValue({ name: "emb-combo", models: ["glm/glm-5.1"], dimensions: "512" });
+    handleComboChat.mockResolvedValue(makeSuccessResponse());
+
+    const req = createRequest({ model: "emb-combo", input: "hello" });
+    await handleEmbeddings(req);
+
+    const callArgs = handleComboChat.mock.calls[0][0];
+    expect(callArgs.body.dimensions).toBe("512");
+  });
+
+  it("4. does NOT override body.dimensions if user already provided", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1"]);
+    getComboByName.mockResolvedValue({ name: "emb-combo", models: ["glm/glm-5.1"], dimensions: "512" });
+    handleComboChat.mockResolvedValue(makeSuccessResponse());
+
+    const req = createRequest({ model: "emb-combo", input: "hello", dimensions: "1024" });
+    await handleEmbeddings(req);
+
+    const callArgs = handleComboChat.mock.calls[0][0];
+    expect(callArgs.body.dimensions).toBe("1024");
+  });
+
+  it("5. injects combo.dimensions as string (e.g. '512')", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1"]);
+    getComboByName.mockResolvedValue({ name: "emb-combo", models: ["glm/glm-5.1"], dimensions: "512" });
+    handleComboChat.mockResolvedValue(makeSuccessResponse());
+
+    const req = createRequest({ model: "emb-combo", input: "hello" });
+    await handleEmbeddings(req);
+
+    const callArgs = handleComboChat.mock.calls[0][0];
+    // dimensions 从 combo 获取后原样注入（字符串）
+    expect(typeof callArgs.body.dimensions).toBe("string");
+    expect(callArgs.body.dimensions).toBe("512");
+  });
+
+  it("6. falls through to handleSingleModelEmbedding when not a combo", async () => {
+    getComboModels.mockResolvedValue(null);
+    getModelInfo.mockResolvedValue({ provider: "openai", model: "text-embedding-ada-002" });
+    getProviderCredentials.mockResolvedValue({
+      apiKey: "sk-test",
+      connectionId: "conn-1",
+      connectionName: "Test",
+    });
+    checkAndRefreshToken.mockImplementation(async (_p, creds) => creds);
+    handleEmbeddingsCore.mockResolvedValue(makeCoreSuccessResult());
+
+    const req = createRequest({ model: "openai/text-embedding-ada-002", input: "hello" });
+    await handleEmbeddings(req);
+
+    expect(handleComboChat).not.toHaveBeenCalled();
+    expect(getModelInfo).toHaveBeenCalledWith("openai/text-embedding-ada-002");
+  });
+});
+
+// ─── Group 2: handleSingleModelEmbedding (6 tests) ────────────────────────────
+
+describe("handleSingleModelEmbedding — fallback logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSettings.mockResolvedValue(defaultSettings());
+  });
+
+  it("7. returns 400 for invalid model format", async () => {
+    getComboModels.mockResolvedValue(null);
+    getModelInfo.mockResolvedValue({ provider: null, model: "bad-model" });
+
+    const req = createRequest({ model: "bad-model", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    expect(result.status).toBe(400);
+    const body = await result.json();
+    expect(body.error.message).toMatch(/invalid model format/i);
+  });
+
+  it("8. returns embedding response on success (200)", async () => {
+    getComboModels.mockResolvedValue(null);
+    getModelInfo.mockResolvedValue({ provider: "openai", model: "text-embedding-ada-002" });
+    getProviderCredentials.mockResolvedValue({
+      apiKey: "sk-test",
+      connectionId: "conn-1",
+      connectionName: "Test",
+    });
+    checkAndRefreshToken.mockImplementation(async (_p, creds) => creds);
+    handleEmbeddingsCore.mockResolvedValue(makeCoreSuccessResult());
+
+    const req = createRequest({ model: "openai/text-embedding-ada-002", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    expect(result.status).toBe(200);
+    const body = await result.json();
+    expect(body.object).toBe("list");
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]).toHaveProperty("embedding");
+  });
+
+  it("9. falls back to next credential on 429/503", async () => {
+    getComboModels.mockResolvedValue(null);
+    getModelInfo.mockResolvedValue({ provider: "openai", model: "text-embedding-ada-002" });
+
+    // 第一次凭据返回 429
+    getProviderCredentials
+      .mockResolvedValueOnce({
+        apiKey: "sk-1",
+        connectionId: "conn-1",
+        connectionName: "Account 1",
+      })
+      .mockResolvedValueOnce({
+        apiKey: "sk-2",
+        connectionId: "conn-2",
+        connectionName: "Account 2",
+      });
+
+    checkAndRefreshToken.mockImplementation(async (_p, creds) => creds);
+    handleEmbeddingsCore
+      .mockResolvedValueOnce(makeCoreErrorResult(429, "Rate limit"))
+      .mockResolvedValueOnce(makeCoreSuccessResult());
+
+    markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 1000 });
+
+    const req = createRequest({ model: "openai/text-embedding-ada-002", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    expect(result.status).toBe(200);
+    expect(handleEmbeddingsCore).toHaveBeenCalledTimes(2);
+    expect(markAccountUnavailable).toHaveBeenCalledWith("conn-1", 429, "Rate limit", "openai", "text-embedding-ada-002");
+  });
+
+  it("10. returns 400 when no credentials for provider", async () => {
+    getComboModels.mockResolvedValue(null);
+    getModelInfo.mockResolvedValue({ provider: "unknown-provider", model: "some-model" });
+    getProviderCredentials.mockResolvedValue(null);
+
+    const req = createRequest({ model: "unknown-provider/some-model", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    expect(result.status).toBe(400);
+    const body = await result.json();
+    expect(body.error.message).toMatch(/no credentials/i);
+  });
+
+  it("11. returns 503 when all accounts rate-limited", async () => {
+    getComboModels.mockResolvedValue(null);
+    getModelInfo.mockResolvedValue({ provider: "openai", model: "text-embedding-ada-002" });
+
+    const retryAfter = new Date(Date.now() + 30000).toISOString();
+    getProviderCredentials.mockResolvedValue({
+      allRateLimited: true,
+      retryAfter,
+      retryAfterHuman: "30s",
+      lastError: "Rate limited",
+      lastErrorCode: "429",
+    });
+
+    const req = createRequest({ model: "openai/text-embedding-ada-002", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    // 当 lastErrorCode 为 "429" 时，status = Number("429") = 429
+    // 代码逻辑：lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE
+    expect(result.status).toBe(429);
+  });
+
+  it("12. falls back on shouldFallback=true", async () => {
+    getComboModels.mockResolvedValue(null);
+    getModelInfo.mockResolvedValue({ provider: "openai", model: "text-embedding-ada-002" });
+
+    // 第一个账户失败，shouldFallback=true → 排除后重试
+    getProviderCredentials
+      .mockResolvedValueOnce({
+        apiKey: "sk-1",
+        connectionId: "conn-1",
+        connectionName: "Account 1",
+      })
+      .mockResolvedValueOnce({
+        apiKey: "sk-2",
+        connectionId: "conn-2",
+        connectionName: "Account 2",
+      });
+
+    checkAndRefreshToken.mockImplementation(async (_p, creds) => creds);
+    handleEmbeddingsCore
+      .mockResolvedValueOnce(makeCoreErrorResult(503, "Service unavailable"))
+      .mockResolvedValueOnce(makeCoreSuccessResult());
+
+    markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 2000 });
+
+    const req = createRequest({ model: "openai/text-embedding-ada-002", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    expect(markAccountUnavailable).toHaveBeenCalledWith("conn-1", 503, "Service unavailable", "openai", "text-embedding-ada-002");
+    expect(result.status).toBe(200);
+  });
+});
+
+// ─── Group 3: combo fallback with dimensions (4 tests) ─────────────────────────
+
+describe("combo fallback with dimensions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSettings.mockResolvedValue(defaultSettings());
+  });
+
+  it("13. first model success returns immediately with dimensions in response", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1", "minimax/MiniMax-M2.7"]);
+    getComboByName.mockResolvedValue({ name: "emb-combo", models: ["glm/glm-5.1", "minimax/MiniMax-M2.7"], dimensions: "256" });
+
+    // handleComboChat 直接模拟成功返回
+    const successResp = makeSuccessResponse();
+    handleComboChat.mockResolvedValue(successResp);
+
+    const req = createRequest({ model: "emb-combo", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    // handleComboChat 收到注入了 dimensions 的 body
+    const comboCall = handleComboChat.mock.calls[0][0];
+    expect(comboCall.body.dimensions).toBe("256");
+    expect(result.status).toBe(200);
+  });
+
+  it("14. first model failure falls back to second model", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1", "minimax/MiniMax-M2.7"]);
+    getComboByName.mockResolvedValue({ name: "emb-combo", models: ["glm/glm-5.1", "minimax/MiniMax-M2.7"], dimensions: null });
+
+    // handleComboChat 模拟：内部会依次调用 handleSingleModel
+    // 这里只验证 handleComboChat 被正确调用，且 handleSingleModel 回调被传入
+    const failResp = new Response(JSON.stringify({ error: { message: "Rate limit" } }), {
+      status: 429,
+      headers: { "Content-Type": "application/json" },
+    });
+    handleComboChat.mockResolvedValue(failResp);
+
+    const req = createRequest({ model: "emb-combo", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    expect(handleComboChat).toHaveBeenCalledOnce();
+    const comboCall = handleComboChat.mock.calls[0][0];
+    expect(typeof comboCall.handleSingleModel).toBe("function");
+  });
+
+  it("15. dimensions from combo injected into each fallback attempt", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1", "minimax/MiniMax-M2.7"]);
+    getComboByName.mockResolvedValue({ name: "emb-combo", models: ["glm/glm-5.1", "minimax/MiniMax-M2.7"], dimensions: "512" });
+    handleComboChat.mockResolvedValue(makeSuccessResponse());
+
+    const req = createRequest({ model: "emb-combo", input: "test input" });
+    await handleEmbeddings(req);
+
+    const comboCall = handleComboChat.mock.calls[0][0];
+    // body 上已注入 dimensions=512
+    expect(comboCall.body.dimensions).toBe("512");
+    // handleSingleModel 是闭包，会把带 dimensions 的 body 传给 handleSingleModelEmbedding
+    expect(typeof comboCall.handleSingleModel).toBe("function");
+
+    // 调用 handleSingleModel 模拟验证 body 中包含 dimensions
+    const mockBody = { ...comboCall.body };
+    expect(mockBody.dimensions).toBe("512");
+  });
+
+  it("16. all models fail returns 503 with error message", async () => {
+    getComboModels.mockResolvedValue(["glm/glm-5.1", "minimax/MiniMax-M2.7"]);
+    getComboByName.mockResolvedValue({ name: "emb-combo", models: ["glm/glm-5.1", "minimax/MiniMax-M2.7"], dimensions: "256" });
+
+    const failResp = new Response(JSON.stringify({ error: { message: "All combo models unavailable" } }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+    handleComboChat.mockResolvedValue(failResp);
+
+    const req = createRequest({ model: "emb-combo", input: "hello" });
+    const result = await handleEmbeddings(req);
+
+    expect(result.status).toBe(503);
+    const body = await result.json();
+    expect(body.error.message).toMatch(/unavailable/i);
+  });
+});
+
+// ─── Group 4: API routes dimensions handling (4 tests) ─────────────────────────
+
+describe("API routes — dimensions handling", () => {
+  // 动态导入路由处理器（在 mock 生效后）
+  let POST, PUT;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // 重新导入路由处理器以使用最新 mock
+    const combosRoute = await import("../../src/app/api/combos/route.js");
+    POST = combosRoute.POST;
+
+    const comboIdRoute = await import("../../src/app/api/combos/[id]/route.js");
+    PUT = comboIdRoute.PUT;
+  });
+
+  it("17. POST /api/combos accepts dimensions field", async () => {
+    const createdCombo = {
+      id: "combo-1",
+      name: "emb-combo",
+      models: ["glm/glm-5.1"],
+      kind: null,
+      dimensions: "512",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    createCombo.mockResolvedValue(createdCombo);
+    getComboByName.mockResolvedValue(null); // 名称不存在
+
+    const req = createRequest({ name: "emb-combo", models: ["glm/glm-5.1"], dimensions: "512" });
+    const result = await POST(req);
+
+    expect(createCombo).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "emb-combo", dimensions: "512", models: ["glm/glm-5.1"] })
+    );
+    expect(result.status).toBe(201);
+    expect(result.body.dimensions).toBe("512");
+  });
+
+  it("18. POST /api/combos accepts dimensions=null", async () => {
+    const createdCombo = {
+      id: "combo-2",
+      name: "no-dim-combo",
+      models: ["glm/glm-5.1"],
+      kind: null,
+      dimensions: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    createCombo.mockResolvedValue(createdCombo);
+    getComboByName.mockResolvedValue(null);
+
+    const req = createRequest({ name: "no-dim-combo", models: ["glm/glm-5.1"], dimensions: null });
+    const result = await POST(req);
+
+    expect(createCombo).toHaveBeenCalledWith(
+      expect.objectContaining({ dimensions: null })
+    );
+    expect(result.status).toBe(201);
+    expect(result.body.dimensions).toBeNull();
+  });
+
+  it("19. POST /api/combos works without dimensions field (backward compatible)", async () => {
+    const createdCombo = {
+      id: "combo-3",
+      name: "old-combo",
+      models: ["glm/glm-5.1"],
+      kind: null,
+      dimensions: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    createCombo.mockResolvedValue(createdCombo);
+    getComboByName.mockResolvedValue(null);
+
+    // 不传 dimensions 字段
+    const req = createRequest({ name: "old-combo", models: ["glm/glm-5.1"] });
+    const result = await POST(req);
+
+    expect(createCombo).toHaveBeenCalledWith(
+      expect.objectContaining({ dimensions: null })
+    );
+    expect(result.status).toBe(201);
+  });
+
+  it("20. PUT /api/combos/:id updates dimensions field", async () => {
+    const existingCombo = {
+      id: "combo-1",
+      name: "emb-combo",
+      models: ["glm/glm-5.1"],
+      kind: null,
+      dimensions: "256",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const updatedCombo = {
+      ...existingCombo,
+      dimensions: "1024",
+      updatedAt: new Date().toISOString(),
+    };
+
+    getComboById.mockResolvedValue(existingCombo);
+    getComboByName.mockResolvedValue(null); // 不重名
+    updateCombo.mockResolvedValue(updatedCombo);
+
+    const req = createRequest({ dimensions: "1024", name: "emb-combo", models: ["glm/glm-5.1"] });
+    const result = await PUT(req, { params: Promise.resolve({ id: "combo-1" }) });
+
+    expect(updateCombo).toHaveBeenCalledWith("combo-1", expect.objectContaining({ dimensions: "1024" }));
+    expect(result.body.dimensions).toBe("1024");
+  });
+});


### PR DESCRIPTION
This PR content adds support for the embeddings model to the composition and adds access to the embeddings composition at the /v1/embeddings endpoint. On the UI side, a tab has been added to the original LLM composition page to switch to the embeddings composition editing page

<img width="1499" height="389" alt="4399cabd-098b-4d5e-a0ca-9da89b930e70" src="https://github.com/user-attachments/assets/45b1af20-7223-4aff-b857-ed46e84bb83e" />
<img width="960" height="407" alt="89e90be9-5eb1-43e9-98f8-6b107ddf5140" src="https://github.com/user-attachments/assets/18d832d4-c362-4401-81e5-f26953e66fcf" />
