### PR TITLE
fix: never route GitHub Copilot Gemini/Claude models to /responses (#1062, #1119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.4.63 (2026-05-26)
 
 ## Fixes
+- GitHub Copilot: never route Gemini/Claude models to the `/responses` endpoint; prevents misleading "does not support Responses API" 400s (#1062)
 - proxyFetch: restore missing `Readable` import causing runtime `ReferenceError` in DNS-bypass fetch path
 
 ## Improvements

--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -159,11 +159,22 @@ export class GithubExecutor extends BaseExecutor {
     return transformed;
   }
 
+  // GitHub Copilot's /responses endpoint only serves OpenAI (gpt/codex) models.
+  // Gemini and Claude models are not available there and reject with a 400
+  // "does not support Responses API" (unsupported_api_for_model). They must
+  // therefore never be escalated to /responses, even if /chat/completions
+  // returned a "not supported" error for an unrelated reason. Fixes #1062.
+  supportsResponsesEndpoint(model) {
+    const m = (model || "").toLowerCase();
+    return !(m.includes("gemini") || m.includes("claude"));
+  }
+
   async execute(options) {
     const { model, log } = options;
 
     // Only use /responses for models that are explicitly known to need it (e.g. gpt codex models)
-    if (this.knownCodexModels.has(model)) {
+    // and that the /responses endpoint actually serves (excludes Gemini/Claude, see #1062).
+    if (this.knownCodexModels.has(model) && this.supportsResponsesEndpoint(model)) {
       log?.debug("GITHUB", `Using cached /responses route for ${model}`);
       return this.executeWithResponsesEndpoint(options);
     }
@@ -177,7 +188,10 @@ export class GithubExecutor extends BaseExecutor {
 
     const result = await super.execute({ ...sanitizedOptions, proxyOptions: options.proxyOptions || null });
 
-    if (result.response.status === HTTP_STATUS.BAD_REQUEST) {
+    // Only escalate to /responses for models that endpoint can actually serve.
+    // Gemini/Claude would otherwise loop into a misleading "does not support
+    // Responses API" 400 instead of surfacing the real /chat/completions error (#1062).
+    if (result.response.status === HTTP_STATUS.BAD_REQUEST && this.supportsResponsesEndpoint(model)) {
       const errorBody = await result.response.clone().text();
 
       if (errorBody.includes("not accessible via the /chat/completions endpoint") || errorBody.includes("The requested model is not supported")) {

--- a/tests/unit/github-responses-routing.test.js
+++ b/tests/unit/github-responses-routing.test.js
@@ -1,0 +1,56 @@
+/**
+ * Regression test for #1062:
+ * GitHub Copilot's /responses endpoint only serves OpenAI (gpt/codex) models.
+ * Gemini/Claude models must never be routed/escalated there, otherwise they
+ * fail with a misleading 400 "does not support Responses API".
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { GithubExecutor } from "../../open-sse/executors/github.js";
+
+describe("GithubExecutor.supportsResponsesEndpoint", () => {
+  const exec = new GithubExecutor();
+
+  it("excludes Gemini models from the /responses endpoint", () => {
+    expect(exec.supportsResponsesEndpoint("gemini-3.1-pro-preview")).toBe(false);
+    expect(exec.supportsResponsesEndpoint("gemini-3.1-pro-low")).toBe(false);
+  });
+
+  it("excludes Claude models from the /responses endpoint", () => {
+    expect(exec.supportsResponsesEndpoint("claude-sonnet-4.6")).toBe(false);
+    expect(exec.supportsResponsesEndpoint("claude-opus-4.7")).toBe(false);
+  });
+
+  it("allows OpenAI/codex models on the /responses endpoint", () => {
+    expect(exec.supportsResponsesEndpoint("gpt-5.5-codex")).toBe(true);
+    expect(exec.supportsResponsesEndpoint("o4-mini")).toBe(true);
+    expect(exec.supportsResponsesEndpoint("gpt-4.1")).toBe(true);
+  });
+
+  it("is null-safe", () => {
+    expect(exec.supportsResponsesEndpoint(undefined)).toBe(true);
+    expect(exec.supportsResponsesEndpoint("")).toBe(true);
+  });
+});
+
+describe("GithubExecutor.execute cached-route guard (#1062)", () => {
+  it("does NOT use /responses for a Gemini model even if it was wrongly cached as codex", async () => {
+    const exec = new GithubExecutor();
+    // Simulate a prior misclassification that cached the Gemini model.
+    exec.knownCodexModels.add("gemini-3.1-pro-preview");
+
+    const respSpy = vi
+      .spyOn(exec, "executeWithResponsesEndpoint")
+      .mockResolvedValue({ via: "responses" });
+    // Short-circuit the /chat/completions path (BaseExecutor.execute).
+    const baseSpy = vi
+      .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(exec)), "execute")
+      .mockResolvedValue({ response: { status: 200 }, via: "chat" });
+
+    const result = await exec.execute({ model: "gemini-3.1-pro-preview", body: { messages: [] }, log: null });
+
+    expect(respSpy).not.toHaveBeenCalled();
+    expect(baseSpy).toHaveBeenCalled();
+    expect(result.via).toBe("chat");
+  });
+});


### PR DESCRIPTION
## Problem

Gemini **and Claude** models on GitHub Copilot fail with:

```
[github/gemini-3.1-pro-preview] [400]: model gemini-3.1-pro-preview does not support Responses API.
[github/claude-sonnet-4.6]      [400]: model claude-sonnet-4.6 does not support Responses API.
(code: unsupported_api_for_model)
```

GitHub Copilot's `/responses` endpoint only serves OpenAI (gpt/codex) models. These models first hit `/chat/completions`, return a "not supported" error, get cached into `knownCodexModels`, and are then escalated to `/responses` — where they fail with the misleading error above.

## Fix

- Add `GithubExecutor.supportsResponsesEndpoint(model)` which excludes `gemini`/`claude` models.
- Gate **both** routing paths in `execute()` on it: the cached `/responses` route and the `400`-fallback escalation.

Result: Gemini/Claude models always stay on `/chat/completions`, and any real upstream error is surfaced instead of the misleading "does not support Responses API".

## Tests

Adds `tests/unit/github-responses-routing.test.js` (5 tests, all passing), covering both Gemini and Claude (sonnet-4.6, opus-4.7) exclusion, OpenAI/codex inclusion, null-safety, and a behavioral test that a wrongly-cached Gemini model is **not** routed to `/responses`.

Fixes #1062
Fixes #1119
