### PR TITLE
fix: distinguish dashboard-session 401 from upstream auth error (#1160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.4.63 (2026-05-26)
 
 ## Fixes
+- Dashboard: distinguish an expired dashboard session from an upstream provider auth failure instead of showing a bare "HTTP 401: Unauthorized" in the provider model list / quota panels (#1160)
 - proxyFetch: restore missing `Readable` import causing runtime `ReferenceError` in DNS-bypass fetch path
 
 ## Improvements

--- a/src/app/(dashboard)/dashboard/providers/[id]/CompatibleModelsSection.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/CompatibleModelsSection.js
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
 import { Button } from "@/shared/components";
+import { describeFetchError } from "@/shared/utils/fetchError";
 function CompatibleModelRow({ modelId, fullModel, copied, onCopy, onDeleteAlias, onTest, testStatus, isTesting }) {
   const borderColor = testStatus === "ok"
     ? "border-green-500/40"
@@ -149,9 +150,10 @@ export default function CompatibleModelsSection({ providerStorageAlias, provider
     setImporting(true);
     try {
       const res = await fetch(`/api/providers/${activeConnection.id}/models`);
-      const data = await res.json();
+      const data = await res.json().catch(() => ({}));
       if (!res.ok) {
-        alert(data.error || "Failed to import models");
+        // Session-401 vs upstream/provider error are now distinguished (#1160).
+        alert(describeFetchError(res.status, res.statusText, data.error));
         return;
       }
       const models = data.models || [];

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -8,6 +8,7 @@ import { parseQuotaData, calculatePercentage } from "./utils";
 import Card from "@/shared/components/Card";
 import { EditConnectionModal } from "@/shared/components";
 import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
+import { describeFetchError } from "@/shared/utils/fetchError";
 
 function getConnectionLabel(connection) {
   const isEmail = (value) =>
@@ -317,7 +318,8 @@ export default function ProviderLimits() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        const errorMsg = errorData.error || response.statusText;
+        // Distinguish a dashboard-session 401 from an upstream/provider error (#1160).
+        const errorMsg = describeFetchError(response.status, response.statusText, errorData.error);
 
         // Handle different error types gracefully
         if (response.status === 404) {

--- a/src/shared/utils/fetchError.js
+++ b/src/shared/utils/fetchError.js
@@ -1,0 +1,31 @@
+// Human-readable message for a failed dashboard fetch.
+//
+// Fixes #1160: dashboard panels (provider model list, quota/limits) used to render
+// a bare `HTTP 401: Unauthorized` for two very different failures:
+//   1. the browser's dashboard session expired (middleware rejects the request to
+//      our own /api/* route before it runs — body has no JSON `error` field), and
+//   2. the upstream provider rejected the token (our API route returns an explicit
+//      `{ error: "Failed to fetch models: 401" }`).
+// Users mistook (1) for a provider-token problem. Distinguish them so a session
+// expiry points the user at re-login instead of looking like an upstream auth error.
+//
+// @param {number} status        HTTP status of the response
+// @param {string} [statusText]  response.statusText (fallback only)
+// @param {string} [dataError]   parsed `error` field from our API JSON body, if any
+// @returns {string} message to display
+export function describeFetchError(status, statusText = "", dataError = "") {
+  // Our API routes always attach a descriptive `error` (e.g. "Failed to fetch
+  // models: 401"); when present it already identifies the real cause, so prefer it.
+  if (dataError) return dataError;
+
+  // No JSON body → the request was blocked before reaching our route, i.e. the
+  // dashboard session/auth, not the provider.
+  if (status === 401) {
+    return "Dashboard session expired or not authenticated — reload the page or log in again.";
+  }
+  if (status === 403) {
+    return "Dashboard access denied — reload the page or log in again.";
+  }
+
+  return `HTTP ${status}${statusText ? `: ${statusText}` : ""}`;
+}

--- a/tests/unit/fetch-error.test.js
+++ b/tests/unit/fetch-error.test.js
@@ -1,0 +1,38 @@
+/**
+ * Regression test for #1160:
+ * Dashboard fetch errors must distinguish a dashboard-session 401 (no JSON
+ * error body) from an upstream/provider error (explicit `error` from our API).
+ */
+
+import { describe, it, expect } from "vitest";
+import { describeFetchError } from "../../src/shared/utils/fetchError.js";
+
+describe("describeFetchError", () => {
+  it("prefers an explicit API error message (upstream failure)", () => {
+    expect(describeFetchError(401, "Unauthorized", "Failed to fetch models: 401")).toBe(
+      "Failed to fetch models: 401"
+    );
+  });
+
+  it("treats a bodyless 401 as a dashboard-session expiry, not a provider error", () => {
+    const msg = describeFetchError(401, "Unauthorized");
+    expect(msg).toMatch(/session expired|log in again/i);
+    expect(msg).not.toBe("HTTP 401: Unauthorized");
+    expect(msg).not.toContain("Unauthorized");
+  });
+
+  it("treats a bodyless 403 as a dashboard access problem", () => {
+    expect(describeFetchError(403, "Forbidden")).toMatch(/access denied|log in again/i);
+  });
+
+  it("falls back to HTTP status for other errors", () => {
+    expect(describeFetchError(500, "Internal Server Error")).toBe("HTTP 500: Internal Server Error");
+    expect(describeFetchError(502)).toBe("HTTP 502");
+  });
+
+  it("still prefers the API error for non-auth statuses", () => {
+    expect(describeFetchError(500, "Internal Server Error", "Failed to fetch models")).toBe(
+      "Failed to fetch models"
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The dashboard's provider detail page and quota panel show **"HTTP 401: Unauthorized"** for OAuth providers (Codex, Kilo Code) even when the upstream API returns 200 with the same token.

Root cause: a `401` was rendered identically for two different failures:
1. **Dashboard session expired** — the middleware rejects the browser's request to our own `/api/...` route before it runs (no JSON `error` body).
2. **Upstream provider auth failure** — our API route returns an explicit `{ error: "Failed to fetch models: 401" }`.

Both surfaced as a bare `HTTP 401: Unauthorized`, so users blamed their provider token.

## Fix

Add `describeFetchError(status, statusText, dataError)` (`src/shared/utils/fetchError.js`):
- prefer our API's explicit `error` message (already identifies an upstream failure);
- otherwise treat a bodyless `401`/`403` as a **dashboard session/auth** issue and tell the user to reload / log in again.

Applied at the two fetch-error sites that produced the bare message:
- `ProviderLimits/index.js` (quota fetch)
- `CompatibleModelsSection.js` (model import from `/models`)

## Tests

Adds `tests/unit/fetch-error.test.js` (5 tests, all passing) covering: explicit upstream error preferred, bodyless 401 → session message (no longer "Unauthorized"), bodyless 403, and HTTP fallback.

Fixes #1160
