### PR TITLE
fix: include free OpenCode models without -free suffix in suggested models (#1535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.4.63 (2026-05-26)
 
 ## Fixes
+- Suggested models: include free OpenCode models without a `-free` suffix (e.g. `big-pickle`) so they show up for import (#1535)
 - proxyFetch: restore missing `Readable` import causing runtime `ReferenceError` in DNS-bypass fetch path
 
 ## Improvements

--- a/src/app/api/providers/suggested-models/filters.js
+++ b/src/app/api/providers/suggested-models/filters.js
@@ -1,0 +1,27 @@
+// Suggested-model filters for the "Import suggested models" dashboard flow.
+// Extracted from route.js so the filter logic is unit-testable (#1535).
+
+// Free OpenCode models that are routable but do NOT use the conventional
+// "-free" suffix, so the suffix-only filter would hide them. `big-pickle` is
+// such a model — it's handled in open-sse/executors/opencode.js
+// (MESSAGES_MODELS) yet never appeared in the suggested-models UI. See #1535.
+export const KNOWN_FREE_OPENCODE_MODELS = new Set(["big-pickle"]);
+
+export const SUGGESTED_MODEL_FILTERS = {
+  "openrouter-free": (models) =>
+    models
+      .filter(
+        (m) =>
+          m.pricing?.prompt === "0" &&
+          m.pricing?.completion === "0" &&
+          m.context_length >= 200000
+      )
+      .map((m) => ({ id: m.id, name: m.name, contextLength: m.context_length }))
+      .sort((a, b) => b.contextLength - a.contextLength),
+
+  "opencode-free": (models) =>
+    models
+      // Include conventional "-free" models plus known free models that lack the suffix (#1535).
+      .filter((m) => m.id?.endsWith("-free") || KNOWN_FREE_OPENCODE_MODELS.has(m.id))
+      .map((m) => ({ id: m.id, name: m.id })),
+};

--- a/src/app/api/providers/suggested-models/route.js
+++ b/src/app/api/providers/suggested-models/route.js
@@ -1,24 +1,7 @@
 import { NextResponse } from "next/server";
+import { SUGGESTED_MODEL_FILTERS as FILTERS } from "./filters";
 
 export const dynamic = "force-dynamic";
-
-const FILTERS = {
-  "openrouter-free": (models) =>
-    models
-      .filter(
-        (m) =>
-          m.pricing?.prompt === "0" &&
-          m.pricing?.completion === "0" &&
-          m.context_length >= 200000
-      )
-      .map((m) => ({ id: m.id, name: m.name, contextLength: m.context_length }))
-      .sort((a, b) => b.contextLength - a.contextLength),
-
-  "opencode-free": (models) =>
-    models
-      .filter((m) => m.id?.endsWith("-free"))
-      .map((m) => ({ id: m.id, name: m.id })),
-};
 
 export async function GET(request) {
   const { searchParams } = new URL(request.url);

--- a/tests/unit/suggested-models-filters.test.js
+++ b/tests/unit/suggested-models-filters.test.js
@@ -1,0 +1,46 @@
+/**
+ * Regression test for #1535:
+ * The "opencode-free" suggested-models filter only kept models whose id ends
+ * in "-free", which hid free-but-unsuffixed models like `big-pickle`.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  SUGGESTED_MODEL_FILTERS,
+  KNOWN_FREE_OPENCODE_MODELS,
+} from "../../src/app/api/providers/suggested-models/filters.js";
+
+const opencodeFree = SUGGESTED_MODEL_FILTERS["opencode-free"];
+
+describe("opencode-free filter (#1535)", () => {
+  it("includes free models that lack the -free suffix (big-pickle)", () => {
+    const models = [
+      { id: "some-model-free" },
+      { id: "big-pickle" },
+      { id: "paid-model" },
+    ];
+    const ids = opencodeFree(models).map((m) => m.id);
+    expect(ids).toContain("big-pickle");
+    expect(ids).toContain("some-model-free");
+    expect(ids).not.toContain("paid-model");
+  });
+
+  it("still includes conventional -free models", () => {
+    const ids = opencodeFree([{ id: "x-free" }, { id: "y-free" }]).map((m) => m.id);
+    expect(ids).toEqual(["x-free", "y-free"]);
+  });
+
+  it("maps to { id, name } with id as name", () => {
+    expect(opencodeFree([{ id: "big-pickle" }])).toEqual([
+      { id: "big-pickle", name: "big-pickle" },
+    ]);
+  });
+
+  it("is null-safe for entries without an id", () => {
+    expect(opencodeFree([{}, { id: "big-pickle" }]).map((m) => m.id)).toEqual(["big-pickle"]);
+  });
+
+  it("exposes big-pickle as a known free model", () => {
+    expect(KNOWN_FREE_OPENCODE_MODELS.has("big-pickle")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The `opencode-free` suggested-models filter (`src/app/api/providers/suggested-models/route.js`) only kept models whose id ends in `-free`:

```js
.filter((m) => m.id?.endsWith("-free"))
```

`big-pickle` is a free OpenCode model that does **not** use that suffix — it's already routed in `open-sse/executors/opencode.js` (`MESSAGES_MODELS`). As a result it never showed up in the suggested-models import UI.

## Fix

- Extract the filters into `src/app/api/providers/suggested-models/filters.js` so they are unit-testable.
- Add a `KNOWN_FREE_OPENCODE_MODELS` allowlist (`big-pickle`) and include it alongside the `-free` suffix check.

Future free-but-unsuffixed OpenCode models can be added to the same allowlist.

## Tests

Adds `tests/unit/suggested-models-filters.test.js` (5 tests, all passing): `big-pickle` inclusion, `-free` models still included, paid models excluded, `{ id, name }` shape, and null-safety.

Fixes #1535
