### PR TITLE
fix(docker): include MITM runtime files missing from Next standalone output + document /etc/hosts mount modes

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -64,6 +64,63 @@ docker run -d \
   decolua/9router:latest
 ```
 
+## MITM proxy & `/etc/hosts`
+
+The MITM proxy feature redirects traffic from certain CLI/IDE tools (Antigravity, GitHub Copilot, Kiro, …) to 9Router by mapping their API hostnames to `127.0.0.1` in your host's `/etc/hosts`. To make this work from inside the container, you need to mount `/etc/hosts` from the host.
+
+Two modes are supported, with different security trade-offs.
+
+### Mode 1 — Manual hosts management (recommended) 🔒
+
+Mount `/etc/hosts` **read-only**. The container can read entries but cannot modify the host file.
+
+````bash
+docker run -d \
+  -p 20128:20128 \
+  -v "$HOME/.9router:/app/data" \
+  -v "/etc/hosts:/etc/hosts:ro" \
+  -e DATA_DIR=/app/data \
+  --name 9router \
+  decolua/9router:latest
+````
+
+The in-app DNS toggle on the **MITM Proxy** page cannot rewrite `/etc/hosts` in this mode. Instead, the UI displays the exact entries to add. Append them on your host manually, for example:
+
+````text
+127.0.0.1 daily-cloudcode-pa.googleapis.com
+127.0.0.1 cloudcode-pa.googleapis.com
+# … plus any other entries shown in the UI for the tools you use
+````
+
+No elevated access is granted to the container; the host's `/etc/hosts` cannot be altered unexpectedly. One-time manual edit per tool.
+
+### Mode 2 — Automatic hosts management ⚠️
+
+Mount `/etc/hosts` **read-write**. The in-app DNS toggle adds and removes entries automatically when you enable/disable a tool.
+
+````bash
+docker run -d \
+  -p 20128:20128 \
+  -v "$HOME/.9router:/app/data" \
+  -v "/etc/hosts:/etc/hosts" \
+  -e DATA_DIR=/app/data \
+  --name 9router \
+  decolua/9router:latest
+````
+
+> ⚠️ **Security note:** this gives the container write access to your host's `/etc/hosts`. Only use it if you trust the image and accept the trade-off. Not recommended for shared or multi-user machines.
+
+### Which mode should I pick?
+
+| Use case                                  | Recommended mode |
+| ----------------------------------------- | ---------------- |
+| Personal dev machine, security-conscious  | Mode 1 (`:ro`)   |
+| Quick local experimentation               | Mode 2 (rw)      |
+| Shared / production-ish host              | Mode 1 (`:ro`)   |
+| CI / ephemeral environments               | Mode 1 (`:ro`)   |
+
+If you don't need the MITM feature at all, simply omit the `/etc/hosts` mount — 9Router still works as a regular router/proxy for the providers you configure.
+
 ## Optional Headroom sidecar
 
 The 9Router image does not bundle Python or Headroom. To use Headroom in Docker, run it as a separate service and point 9Router at that proxy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=builder /app/custom-server.js ./custom-server.js
 COPY --from=builder /app/open-sse ./open-sse
 # Next file tracing can omit sibling files; MITM runs server.js as a separate process.
 COPY --from=builder /app/src/mitm ./src/mitm
+COPY --from=builder /app/src/shared ./src/shared
 # Standalone node_modules may omit deps only required by the MITM child process.
 COPY --from=builder /app/node_modules/node-forge ./node_modules/node-forge
 # Ensure `next` is available at runtime in case tracing did not include it.


### PR DESCRIPTION
Fixes #1256
Refs #1101

> **Root cause:** Next.js standalone trace misses files that are
> `require()`-d at runtime by the MITM child process but never
> statically imported by a Next.js route:
> - `src/mitm/**`
> - `src/shared/**`  ← e.g. `mitmToolHosts.js` (exact error in #1256)
> - `node_modules/node-forge`
> - `next` CLI binary
>
> Same family as the npm CLI tracing bug fixed in #1101 / commit a8100e9,
> but on the Docker side.
>
> **Fix:** copy the missing files explicitly in the runner stage of the
> Dockerfile.
>
> **Docs:** document `/etc/hosts` mount modes (read-only vs read-write)
> for the MITM proxy in `DOCKER.md`.
>
> Happy to split into two PRs if maintainers prefer.


## Summary

The Docker image currently fails to start because several runtime files are missing from the final `runner` stage. The container crashes on boot with:
`Error: Cannot find module '/app/src/shared/constants/mitmToolHosts'`

## Root cause

Next.js' `output: 'standalone'` file tracing only includes files reachable from the Next.js entry points. It does **not** trace:

- `src/mitm/**` and `src/shared/**`, because the MITM server is spawned as a **separate Node.js child process** from `server.js` (not imported through the Next.js graph).
- Some runtime dependencies (`node-forge`, `next`) that are required at runtime by this child process but aren't picked up by the tracer in this context.

As a result, the standalone build is incomplete for this project's runtime topology.

## Fix

Explicitly copy the missing files into the `runner` stage of the Dockerfile:

```dockerfile
COPY --from=builder /app/src/mitm ./src/mitm
COPY --from=builder /app/src/shared ./src/shared
COPY --from=builder /app/node_modules/node-forge ./node_modules/node-forge
COPY --from=builder /app/node_modules/next ./node_modules/next
```
This is intentionally minimal and only copies what's actually needed by the MITM child process.

## Alternative considered

A cleaner long-term fix would be to declare these paths via experimental.outputFileTracingIncludes in next.config.js, so the Next.js tracer includes them in .next/standalone natively. I kept the change scoped to the Dockerfile here to avoid touching application config in a hotfix, but I'm happy to follow up with a separate PR if maintainers prefer that approach.

## Verification

Built and ran the image locally:
```
docker build -t 9router-fix .

# Files are present in the final image
docker run --rm 9router-fix ls /app/src/shared/constants/mitmToolHosts.js
docker run --rm 9router-fix ls /app/node_modules/node-forge/package.json
docker run --rm 9router-fix ls /app/node_modules/next/package.json

# Container boots cleanly
docker run -d -p 20128:20128 \
  -v "$HOME/.9router:/app/data:rw" \
  -v "/etc/hosts:/etc/hosts:ro" \
  -e DATA_DIR=/app/data \
  --name 9router 9router-fix:latest
```

The web UI loads correctly and the MITM Proxy page shows Server: Running.

## Documentation changes (`DOCKER.md`)

Added a new **MITM proxy & `/etc/hosts`** section under the "For Users" part, between "Optional env vars" and "Update to latest". It documents:

- **Mode 1 — `:ro`** (recommended): the container can't write to the host file; users add redirect entries manually. The UI already lists the exact entries needed.
- **Mode 2 — `rw`**: convenient, but grants the container write access to `/etc/hosts`. Documented with an explicit security warning.

A small decision matrix helps users pick the right mode based on their context (personal dev machine, shared host, CI, etc.).

This complements the fix above: now that the image boots, users hit the `/etc/hosts` question immediately, and the docs should answer it explicitly rather than leaving the choice implicit.

## Checklist

- [x] Image builds successfully
- [x] Container starts without errors
- [x] MITM server reports Running in the UI
- [x] No unrelated changes
