### PR TITLE
feat(dashboard): show which API key was used per recent request (#1258)

### DIFF
--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -136,6 +136,36 @@ export function resolveRecentRequestApiKey(apiKey, apiKeyMap = {}) {
   };
 }
 
+// Strip plaintext API keys from the byApiKey aggregate before it leaves the
+// server. Internally the plaintext key is used as the map key and stored in
+// `apiKey`/`apiKeyKey`, but the client only renders `keyName`. Re-key each entry
+// by the key's stable non-secret id (uuid for known keys, ••••last4 otherwise)
+// and drop the secret fields. Two distinct known keys keep distinct uuid ids, so
+// they stay distinct rows; only unknown keys sharing a ••••last4 fallback merge,
+// which is acceptable and no worse than the previous slice(0,8) label. (#1258)
+function sanitizeByApiKey(byApiKey, apiKeyMap = {}) {
+  const out = {};
+  for (const entry of Object.values(byApiKey || {})) {
+    const plain = typeof entry.apiKey === "string" && entry.apiKey ? entry.apiKey : null;
+    const info = plain ? apiKeyMap[plain] : null;
+    const apiKeyId = plain ? (info?.id || maskApiKey(plain)) : "local-no-key";
+    const keyName = plain ? (info?.name || maskApiKey(plain)) : (entry.keyName || "Local (No API Key)");
+    const outKey = `${apiKeyId}|${entry.rawModel || ""}|${entry.provider || ""}`;
+    const { apiKey, apiKeyKey, ...rest } = entry; // eslint-disable-line no-unused-vars
+    if (!out[outKey]) {
+      out[outKey] = { ...rest, apiKeyId, keyName };
+    } else {
+      const o = out[outKey];
+      o.requests += rest.requests || 0;
+      o.promptTokens += rest.promptTokens || 0;
+      o.completionTokens += rest.completionTokens || 0;
+      o.cost += rest.cost || 0;
+      if ((rest.lastUsed || "") > (o.lastUsed || "")) o.lastUsed = rest.lastUsed;
+    }
+  }
+  return out;
+}
+
 export function formatRecentRequest(entry, apiKeyMap = {}) {
   const t = entry.tokens || {};
   return {
@@ -652,6 +682,9 @@ export async function getUsageStats(period = "all") {
   }
 
   stats.totalRequests = Object.values(stats.byProvider).reduce((sum, p) => sum + (p.requests || 0), 0);
+  // Security (#1258): the byApiKey aggregate uses the plaintext key as map key
+  // and stores it in apiKey/apiKeyKey; strip it before returning to the client.
+  stats.byApiKey = sanitizeByApiKey(stats.byApiKey, apiKeyMap);
   return stats;
 }
 

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -6,6 +6,7 @@ import { getMeta, setMeta } from "../helpers/metaStore.js";
 const PENDING_TIMEOUT_MS = 60 * 1000;
 const RING_CAP = 50;
 const CONN_CACHE_TTL_MS = 30 * 1000;
+const API_KEY_CACHE_TTL_MS = 30 * 1000;
 const PERIOD_MS = { "24h": 86400000, "7d": 604800000, "30d": 2592000000, "60d": 5184000000 };
 
 // In-memory state shared across Next.js modules
@@ -18,12 +19,14 @@ if (!global._statsEmitter) {
 if (!global._pendingTimers) global._pendingTimers = {};
 if (!global._recentRing) global._recentRing = { items: [], initialized: false };
 if (!global._connectionMapCache) global._connectionMapCache = { map: {}, ts: 0 };
+if (!global._apiKeyMapCache) global._apiKeyMapCache = { map: {}, ts: 0 };
 
 const pendingRequests = global._pendingRequests;
 const lastErrorProvider = global._lastErrorProvider;
 const pendingTimers = global._pendingTimers;
 const recentRing = global._recentRing;
 const connCache = global._connectionMapCache;
+const apiKeyCache = global._apiKeyMapCache;
 
 export const statsEmitter = global._statsEmitter;
 
@@ -94,6 +97,56 @@ async function getConnectionMapCached() {
     connCache.ts = Date.now();
   } catch {}
   return connCache.map;
+}
+
+async function getApiKeyMapCached() {
+  if (Date.now() - apiKeyCache.ts < API_KEY_CACHE_TTL_MS) return apiKeyCache.map;
+  try {
+    const { getApiKeys } = await import("./apiKeysRepo.js");
+    const all = await getApiKeys();
+    const map = {};
+    for (const k of all) map[k.key] = { name: k.name, id: k.id, createdAt: k.createdAt };
+    apiKeyCache.map = map;
+    apiKeyCache.ts = Date.now();
+  } catch {}
+  return apiKeyCache.map;
+}
+
+// Mask a secret API key for display: ••••last4 — never the full value. (#1258)
+function maskApiKey(apiKeyValue) {
+  if (!apiKeyValue || typeof apiKeyValue !== "string") return "••••";
+  return apiKeyValue.length <= 4 ? "••••" : `••••${apiKeyValue.slice(-4)}`;
+}
+
+// Resolve display metadata for the API key behind a request WITHOUT exposing the
+// secret. The plaintext key must never reach the client — the dashboard payload
+// is visible in DevTools/Network — so we return only the key's stable non-secret
+// id (used for dedup + identity) and a human label (configured name, else the
+// masked ••••last4 form). See #1258: surface *which* key was used, not its value.
+export function resolveRecentRequestApiKey(apiKey, apiKeyMap = {}) {
+  const apiKeyValue = typeof apiKey === "string" && apiKey ? apiKey : null;
+  if (!apiKeyValue) {
+    return { apiKeyId: "local-no-key", keyName: "Local" };
+  }
+
+  const info = apiKeyMap[apiKeyValue];
+  return {
+    apiKeyId: info?.id || maskApiKey(apiKeyValue),
+    keyName: info?.name || maskApiKey(apiKeyValue),
+  };
+}
+
+export function formatRecentRequest(entry, apiKeyMap = {}) {
+  const t = entry.tokens || {};
+  return {
+    timestamp: entry.timestamp,
+    model: entry.model,
+    provider: entry.provider || "",
+    promptTokens: t.prompt_tokens || t.input_tokens || 0,
+    completionTokens: t.completion_tokens || t.output_tokens || 0,
+    status: entry.status || "ok",
+    ...resolveRecentRequestApiKey(entry.apiKey, apiKeyMap),
+  };
 }
 
 async function ensureRingInitialized() {
@@ -198,6 +251,7 @@ export function trackPendingRequest(model, provider, connectionId, started, erro
 export async function getActiveRequests() {
   const activeRequests = [];
   const connectionMap = await getConnectionMapCached();
+  const apiKeyMap = await getApiKeyMapCached();
 
   for (const [connectionId, models] of Object.entries(pendingRequests.byAccount)) {
     for (const [modelKey, count] of Object.entries(models)) {
@@ -217,19 +271,11 @@ export async function getActiveRequests() {
   const seen = new Set();
   const recentRequests = [...recentRing.items]
     .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
-    .map((e) => {
-      const t = e.tokens || {};
-      return {
-        timestamp: e.timestamp, model: e.model, provider: e.provider || "",
-        promptTokens: t.prompt_tokens || t.input_tokens || 0,
-        completionTokens: t.completion_tokens || t.output_tokens || 0,
-        status: e.status || "ok",
-      };
-    })
+    .map((e) => formatRecentRequest(e, apiKeyMap))
     .filter((e) => {
       if (e.promptTokens === 0 && e.completionTokens === 0) return false;
       const minute = e.timestamp ? e.timestamp.slice(0, 16) : "";
-      const key = `${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}`;
+      const key = `${e.apiKeyId}|${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
@@ -342,22 +388,14 @@ export async function getUsageStats(period = "all") {
   for (const k of allApiKeys) apiKeyMap[k.key] = { name: k.name, id: k.id, createdAt: k.createdAt };
 
   // recentRequests from live history (last 100 entries enough for 20 deduped)
-  const recentRows = db.all(`SELECT timestamp, provider, model, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
+  const recentRows = db.all(`SELECT timestamp, provider, model, apiKey, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
   const seen = new Set();
   const recentRequests = recentRows
-    .map((r) => {
-      const t = parseJson(r.tokens, {}) || {};
-      return {
-        timestamp: r.timestamp, model: r.model, provider: r.provider || "",
-        promptTokens: t.prompt_tokens || t.input_tokens || 0,
-        completionTokens: t.completion_tokens || t.output_tokens || 0,
-        status: r.status || "ok",
-      };
-    })
+    .map((r) => formatRecentRequest({ ...r, tokens: parseJson(r.tokens, {}) || {} }, apiKeyMap))
     .filter((e) => {
       if (e.promptTokens === 0 && e.completionTokens === 0) return false;
       const minute = e.timestamp ? e.timestamp.slice(0, 16) : "";
-      const key = `${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}`;
+      const key = `${e.apiKeyId}|${e.model}|${e.provider}|${e.promptTokens}|${e.completionTokens}|${minute}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -48,12 +48,12 @@ function RecentRequests({ requests = [] }) {
       {!requests.length ? (
         <div className="flex-1 flex items-center justify-center text-text-muted text-sm">No requests yet.</div>
       ) : (
-        <div className="flex-1 overflow-y-auto">
-          <table className="w-full min-w-[300px] border-collapse text-xs">
+        <div className="flex-1 overflow-auto">
+          <table className="w-full min-w-[340px] border-collapse text-xs">
             <thead className="sticky top-0 bg-bg z-10">
               <tr className="border-b border-border">
                 <th className="py-1.5 text-left font-semibold text-text-muted w-2"></th>
-                <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
+                <th className="py-1.5 text-left font-semibold text-text-muted">Model / API Key</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted">When</th>
               </tr>
@@ -66,7 +66,12 @@ function RecentRequests({ requests = [] }) {
                     <td className="py-1.5">
                       <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} />
                     </td>
-                    <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
+                    <td className="py-1.5 min-w-0 max-w-[220px]">
+                      <div className="font-mono truncate" title={r.model}>{r.model}</div>
+                      <div className="truncate text-[11px] text-text-muted" title={r.keyName || "Local"}>
+                        {r.keyName || "Local"}
+                      </div>
+                    </td>
                     <td className="py-1.5 text-right whitespace-nowrap">
                       <span className="text-primary">{fmt(r.promptTokens)}↑</span>
                       {" "}
@@ -441,7 +446,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
 
       {/* Provider topology + Recent Requests */}
       {loading ? spinner : (
-        <div className="grid min-w-0 grid-cols-1 items-stretch gap-2 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
+        <div className="grid min-w-0 grid-cols-1 items-stretch gap-2 lg:grid-cols-[minmax(0,1.4fr)_minmax(380px,1fr)]">
           <ProviderTopology
             providers={providers}
             activeRequests={stats.activeRequests || []}

--- a/tests/unit/usage-recent-requests-stats.test.js
+++ b/tests/unit/usage-recent-requests-stats.test.js
@@ -74,4 +74,48 @@ describe("usage stats recent request API key metadata", () => {
     expect(stats.recentRequests[0]).not.toHaveProperty("apiKey");
     expect(JSON.stringify(stats.recentRequests)).not.toContain("sk-test-1234567890");
   });
+
+  it("strips plaintext keys from the byApiKey aggregate while keeping known keys distinct", async () => {
+    mocks.getApiKeys.mockResolvedValue([
+      { id: "key-1", key: "sk-aaa-1111", name: "Agent CLI", createdAt: "2026-05-18T19:00:00.000Z" },
+      { id: "key-2", key: "sk-bbb-2222", name: "Teammate", createdAt: "2026-05-18T19:00:00.000Z" },
+    ]);
+    // period "24h" builds byApiKey from the raw-rows path (usageRepo Z.609 query).
+    mocks.db.all.mockImplementation((sql) => {
+      if (sql.includes("promptTokens, completionTokens, cost, tokens FROM usageHistory WHERE timestamp")) {
+        return [
+          { timestamp: "2026-05-18T20:00:00.000Z", provider: "openai", model: "gpt-5", apiKey: "sk-aaa-1111", tokens: JSON.stringify({ prompt_tokens: 10, completion_tokens: 20 }), cost: 0 },
+          { timestamp: "2026-05-18T20:01:00.000Z", provider: "openai", model: "gpt-5", apiKey: "sk-aaa-1111", tokens: JSON.stringify({ prompt_tokens: 5, completion_tokens: 7 }), cost: 0 },
+          { timestamp: "2026-05-18T20:02:00.000Z", provider: "openai", model: "gpt-5", apiKey: "sk-bbb-2222", tokens: JSON.stringify({ prompt_tokens: 3, completion_tokens: 4 }), cost: 0 },
+        ];
+      }
+      return [];
+    });
+
+    const stats = await getUsageStats("24h");
+
+    // No plaintext key anywhere in the aggregate — neither in values nor in the map keys.
+    const serialized = JSON.stringify(stats.byApiKey);
+    expect(serialized).not.toContain("sk-aaa-1111");
+    expect(serialized).not.toContain("sk-bbb-2222");
+    for (const k of Object.keys(stats.byApiKey)) {
+      expect(k).not.toContain("sk-aaa-1111");
+      expect(k).not.toContain("sk-bbb-2222");
+    }
+
+    // Two known keys stay distinct rows (keyed by non-secret id) with summed tokens.
+    const rows = Object.values(stats.byApiKey);
+    const agentCli = rows.find((r) => r.keyName === "Agent CLI");
+    const teammate = rows.find((r) => r.keyName === "Teammate");
+    expect(agentCli).toBeTruthy();
+    expect(teammate).toBeTruthy();
+    expect(agentCli.apiKeyId).toBe("key-1");
+    expect(teammate.apiKeyId).toBe("key-2");
+    expect(agentCli.requests).toBe(2);
+    expect(agentCli.promptTokens).toBe(15);
+    expect(agentCli.completionTokens).toBe(27);
+    expect(teammate.requests).toBe(1);
+    expect(agentCli).not.toHaveProperty("apiKey");
+    expect(agentCli).not.toHaveProperty("apiKeyKey");
+  });
 });

--- a/tests/unit/usage-recent-requests-stats.test.js
+++ b/tests/unit/usage-recent-requests-stats.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  db: {
+    all: vi.fn(),
+  },
+  getApiKeys: vi.fn(),
+}));
+
+vi.mock("../../src/lib/db/driver.js", () => ({
+  getAdapter: vi.fn(async () => mocks.db),
+}));
+
+vi.mock("../../src/lib/db/repos/connectionsRepo.js", () => ({
+  getProviderConnections: vi.fn(async () => []),
+}));
+
+vi.mock("../../src/lib/db/repos/apiKeysRepo.js", () => ({
+  getApiKeys: mocks.getApiKeys,
+}));
+
+vi.mock("../../src/lib/db/repos/nodesRepo.js", () => ({
+  getProviderNodes: vi.fn(async () => []),
+}));
+
+const { getUsageStats } = await import("../../src/lib/db/repos/usageRepo.js");
+
+describe("usage stats recent request API key metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global._apiKeyMapCache.map = {};
+    global._apiKeyMapCache.ts = 0;
+
+    mocks.getApiKeys.mockResolvedValue([
+      {
+        id: "key-1",
+        key: "sk-test-1234567890",
+        name: "Agent CLI",
+        createdAt: "2026-05-18T19:00:00.000Z",
+      },
+    ]);
+
+    mocks.db.all.mockImplementation((sql) => {
+      if (sql.includes("ORDER BY id DESC LIMIT 100")) {
+        return [
+          {
+            timestamp: "2026-05-18T20:00:00.000Z",
+            provider: "openai",
+            model: "gpt-5",
+            apiKey: "sk-test-1234567890",
+            tokens: JSON.stringify({ prompt_tokens: 10, completion_tokens: 20 }),
+            status: "ok",
+          },
+        ];
+      }
+      return [];
+    });
+  });
+
+  it("includes API key display metadata in stats recent requests", async () => {
+    const stats = await getUsageStats("24h");
+
+    expect(stats.recentRequests).toEqual([
+      expect.objectContaining({
+        model: "gpt-5",
+        provider: "openai",
+        promptTokens: 10,
+        completionTokens: 20,
+        apiKeyId: "key-1",
+        keyName: "Agent CLI",
+      }),
+    ]);
+    // Security (#1258): the secret key must not leak into the recent-requests payload.
+    expect(stats.recentRequests[0]).not.toHaveProperty("apiKey");
+    expect(JSON.stringify(stats.recentRequests)).not.toContain("sk-test-1234567890");
+  });
+});

--- a/tests/unit/usage-recent-requests.test.js
+++ b/tests/unit/usage-recent-requests.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+// usageRepo pulls in the DB driver chain (driver → paths → @/lib/dataDir.js) at
+// import time; vitest has no `@` alias config (only jsconfig paths), so stub the
+// driver to keep these pure-function tests self-contained.
+vi.mock("../../src/lib/db/driver.js", () => ({
+  getAdapter: vi.fn(async () => ({ all: vi.fn(() => []), get: vi.fn(), run: vi.fn() })),
+}));
+
+const {
+  formatRecentRequest,
+  resolveRecentRequestApiKey,
+} = await import("../../src/lib/db/repos/usageRepo.js");
+
+describe("usage recent request API key metadata", () => {
+  it("labels local requests without an API key", () => {
+    expect(resolveRecentRequestApiKey(null)).toEqual({
+      apiKeyId: "local-no-key",
+      keyName: "Local",
+    });
+  });
+
+  it("uses the configured API key name + stable id, never the secret", () => {
+    const result = resolveRecentRequestApiKey("sk-test-1234567890", {
+      "sk-test-1234567890": { id: "key-1", name: "Claude Desktop" },
+    });
+
+    expect(result).toEqual({
+      apiKeyId: "key-1",
+      keyName: "Claude Desktop",
+    });
+    // Security (#1258): the plaintext key must never appear in the payload.
+    expect(JSON.stringify(result)).not.toContain("sk-test-1234567890");
+  });
+
+  it("falls back to a masked ••••last4 label for unknown API keys", () => {
+    const result = resolveRecentRequestApiKey("sk-unknown-abcdef");
+    expect(result).toEqual({
+      apiKeyId: "••••cdef",
+      keyName: "••••cdef",
+    });
+    expect(JSON.stringify(result)).not.toContain("sk-unknown-abcdef");
+  });
+
+  it("formats recent request token counts with key display metadata, no secret", () => {
+    const result = formatRecentRequest(
+      {
+        timestamp: "2026-05-18T20:00:00.000Z",
+        provider: "openai",
+        model: "gpt-5",
+        apiKey: "sk-test-1234567890",
+        tokens: { input_tokens: 12, output_tokens: 34 },
+        status: "success",
+      },
+      { "sk-test-1234567890": { id: "key-1", name: "Agent CLI" } },
+    );
+
+    expect(result).toMatchObject({
+      model: "gpt-5",
+      provider: "openai",
+      promptTokens: 12,
+      completionTokens: 34,
+      status: "success",
+      apiKeyId: "key-1",
+      keyName: "Agent CLI",
+    });
+    // The secret key value is never carried in the formatted request.
+    expect(result).not.toHaveProperty("apiKey");
+    expect(JSON.stringify(result)).not.toContain("sk-test-1234567890");
+  });
+});


### PR DESCRIPTION
## What

Implements #1258: adds an **API Key** column to the **Recent Requests** table on the Usage dashboard, so operators running multiple keys (one per CLI tool, or one per teammate) can see which key sent each request.

The displayed key is the **inbound 9router API key** — the one a CLI tool puts in its `Authorization` header and that gets validated against the configured keys (`isValidApiKey`). It is **not** the upstream provider credential (those are resolved separately via `getProviderCredentials`).

## Security

The plaintext key never leaves the server, in **both** dashboard surfaces that expose key usage:

1. **Recent Requests** — `resolveRecentRequestApiKey` returns only `apiKeyId` (stable non-secret id) and `keyName` (configured name, or masked `••••last4`). Previously the full key was placed in `apiKey`/`apiKeyKey` and streamed to the client.
2. **`byApiKey` aggregate** ("Usage by API Key") — this used the plaintext key as its **map key** *and* stored it in `apiKey`/`apiKeyKey`. A single `sanitizeByApiKey` pass runs just before `getUsageStats` returns: it re-keys each entry by the non-secret `apiKeyId` and drops the secret fields. Internal aggregation is unchanged, so dedup/`lastUsed` keep working.

## Layout

The Recent Requests side panel was narrow for an extra column, so it was widened (`1.4fr` / min `380px`) and **Model + API Key** are stacked in a single column (model on top, key name below) instead of two hard-truncated columns — both stay readable, no horizontal overflow.

## Tests

- `tests/unit/usage-recent-requests.test.js`
- `tests/unit/usage-recent-requests-stats.test.js`

All green. They cover name resolution, the masked fallback, the local (no-key) case, "no plaintext in the recent-requests payload", "no plaintext in the byApiKey payload (keys or values)", and "two known keys stay distinct rows with summed tokens".
