### PR TITLE
fix(sse): prevent false stall aborts on large-context reasoning streams

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -31,11 +31,23 @@ export const MEMORY_CONFIG = {
   proxyDispatchersMaxSize: 20,
 };
 
-// Stream stall timeout: abort if no chunk received within this duration
-export const STREAM_STALL_TIMEOUT_MS = 30 * 1000;
+// Parse a positive integer env override, falling back to a default.
+function envMs(name, def) {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return def;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+// Inter-chunk stall timeout (once tokens are flowing). Generous headroom so
+// slow reasoning models aren't aborted mid-stream. Env: STREAM_STALL_TIMEOUT_MS.
+export const STREAM_STALL_TIMEOUT_MS = envMs("STREAM_STALL_TIMEOUT_MS", 180 * 1000);
+
+// Time-to-first-token timeout (prompt prefill). Env: STREAM_FIRST_CHUNK_TIMEOUT_MS.
+export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_MS", 120 * 1000);
 
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
-export const FETCH_CONNECT_TIMEOUT_MS = 20 * 1000;
+export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 20 * 1000);
 
 // Default token limits
 export const DEFAULT_MAX_TOKENS = 64000;

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -95,6 +95,8 @@ export class KiroExecutor extends BaseExecutor {
 
     const transformStream = new TransformStream({
       async transform(chunk, controller) {
+        // Track output so we can emit a keepalive if this frame yields no chunk.
+        const enqueueCountBefore = chunkIndex;
         // Append to buffer
         const newBuffer = new Uint8Array(buffer.length + chunk.length);
         newBuffer.set(buffer);
@@ -372,6 +374,12 @@ export class KiroExecutor extends BaseExecutor {
 
         if (iterations >= maxIterations) {
           console.warn("[Kiro] Max iterations reached in event parsing");
+        }
+
+        // No client chunk produced this frame — emit an SSE comment keepalive
+        // so the stall watchdog sees upstream activity (ignored by parser/client).
+        if (chunkIndex === enqueueCountBefore && !state.finishEmitted) {
+          controller.enqueue(new TextEncoder().encode(": ka\n\n"));
         }
       },
 

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -1,5 +1,5 @@
 // Stream handler with disconnect detection - shared for all providers
-import { STREAM_STALL_TIMEOUT_MS } from "../config/runtimeConfig.js";
+import { STREAM_STALL_TIMEOUT_MS, STREAM_FIRST_CHUNK_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 // Get HH:MM:SS timestamp
@@ -183,14 +183,17 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
   const clearStall = () => {
     if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
   };
+  // Generous TTFT timeout while the prompt prefills, then the stall timeout.
   const armStall = () => {
     clearStall();
+    const timeout = chunkCount === 0 ? STREAM_FIRST_CHUNK_TIMEOUT_MS : STREAM_STALL_TIMEOUT_MS;
     stallTimer = setTimeout(() => {
       stallTimer = null;
-      dbg(tag, `STALL TIMEOUT ${STREAM_STALL_TIMEOUT_MS}ms | chunks=${chunkCount} | bytes=${totalBytes} | sinceLast=${Date.now() - lastChunkAt}ms`);
-      streamController.handleError?.(new Error("stream stall timeout"));
+      const phase = chunkCount === 0 ? "first-chunk timeout" : "stall timeout";
+      dbg(tag, `STALL ${phase} ${timeout}ms | chunks=${chunkCount} | bytes=${totalBytes} | sinceLast=${Date.now() - lastChunkAt}ms`);
+      streamController.handleError?.(new Error(chunkCount === 0 ? "stream first-chunk timeout" : "stream stall timeout"));
       streamController.abort?.();
-    }, STREAM_STALL_TIMEOUT_MS);
+    }, timeout);
   };
 
   // Wrap controller so every termination path clears the stall timer.
@@ -207,7 +210,7 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
   };
 
   armStall();
-  dbg(tag, `pipe start | stallTimeout=${STREAM_STALL_TIMEOUT_MS}ms`);
+  dbg(tag, `pipe start | firstChunkTimeout=${STREAM_FIRST_CHUNK_TIMEOUT_MS}ms | stallTimeout=${STREAM_STALL_TIMEOUT_MS}ms`);
 
   const upstreamTap = new TransformStream({
     transform(chunk, controller) {


### PR DESCRIPTION
## Problem

Large-context requests to Kiro (e.g. Claude Opus thinking, 100+ msgs / many tools / 40k+ input tokens) intermittently fail with:

> API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request

The proxy returns `200 OK` + SSE headers but an empty body. Logs show:

```
🌊 [STREAM] KIRO | claude-opus-4.8 | first chunk | ttft=3ms
🌊 [STREAM] KIRO | claude-opus-4.8 | ABORT stall timeout | budget=30000ms | chunks=54 | bytes=11730 | sinceLast=30001ms
🌊 [STREAM] KIRO | claude-opus-4.8 | error: stream stall timeout
```

## Root cause

Two issues compounded:

1. **One watchdog gating two very different phases.** The single `STREAM_STALL_TIMEOUT_MS` covered both time-to-first-token (prompt prefill, can be long for big contexts) and the inter-chunk gap. A long prefill, or a mid-stream reasoning pause, both tripped the same short timer.
2. **The stall default was too aggressive.** It had been lowered to 30s "for faster hang detection", which regressed reasoning models that legitimately go silent 60s+ between tokens on large contexts (observed real pause: `sinceLast=60002ms`).

For Kiro specifically, the AWS EventStream→SSE transform runs inside the executor, so the downstream stall watchdog only sees *enqueued client chunks* — frames that produce no chunk (partial-frame buffering, metering/context events, reasoning pauses) look like silence even though raw upstream bytes are still arriving.

## Fix

- **Split the watchdog into two phases** — `STREAM_FIRST_CHUNK_TIMEOUT_MS` (120s) covers prefill until the first byte; `STREAM_STALL_TIMEOUT_MS` (restored to 180s) covers inter-chunk gaps once tokens flow.
- **Kiro keepalive** — emit an SSE comment (`: ka`) when an upstream frame yields no client chunk, so the watchdog reflects genuine upstream activity. Comment lines are ignored by the downstream SSE parser and clients.
- **Env-overridable** — all three timeouts (`STREAM_STALL_TIMEOUT_MS`, `STREAM_FIRST_CHUNK_TIMEOUT_MS`, `FETCH_CONNECT_TIMEOUT_MS`) now read from env with positive-integer validation.

## Testing

Built the Docker image and ran it in production mode (`NODE_ENV=production`). Confirmed via live logs that large-context Kiro/Opus requests that previously aborted with `stream stall timeout` now stream to completion. No behavior change for fast requests.