### PR TITLE
feat: per-key token quota + request attribution for shared gateways

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -187,7 +187,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     trackPendingRequest(model, provider, connectionId, false, true);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${error.name === "AbortError" ? 499 : HTTP_STATUS.BAD_GATEWAY}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
-      provider, model, connectionId,
+      provider, model, connectionId, apiKey,
       latency: { ttft: 0, total: Date.now() - requestStartTime },
       tokens: { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),
@@ -233,7 +233,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     const { statusCode, message, resetsAtMs } = await parseUpstreamError(providerResponse, executor);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${statusCode}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
-      provider, model, connectionId,
+      provider, model, connectionId, apiKey,
       latency: { ttft: 0, total: Date.now() - requestStartTime },
       tokens: { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -201,7 +201,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   const totalLatency = Date.now() - requestStartTime;
   saveRequestDetail(buildRequestDetail({
-    provider, model, connectionId,
+    provider, model, connectionId, apiKey,
     latency: { ttft: totalLatency, total: totalLatency },
     tokens: usage || { prompt_tokens: 0, completion_tokens: 0 },
     request: extractRequestConfig(body, stream),

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -159,7 +159,8 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
-  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+  // Only write for this request → canonical quota row
+  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, countsTowardQuota: true });
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
     ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat)

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -73,7 +73,9 @@ export function buildRequestDetail(base, overrides = {}) {
   };
 }
 
-export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE" }) {
+// countsTowardQuota: set true at the single canonical write of a request (quota accounting);
+// the streaming duplicate (onStreamComplete) leaves it false
+export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE", countsTowardQuota = false }) {
   if (!tokens || typeof tokens !== "object") return;
 
   const inTokens = tokens.input_tokens ?? tokens.prompt_tokens ?? 0;
@@ -98,6 +100,7 @@ export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, 
     timestamp: new Date().toISOString(),
     connectionId: connectionId || undefined,
     apiKey: apiKey || undefined,
-    endpoint: endpoint || null
+    endpoint: endpoint || null,
+    countsTowardQuota
   }).catch(() => {});
 }

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -60,6 +60,7 @@ export function buildRequestDetail(base, overrides = {}) {
     provider: base.provider || "unknown",
     model: base.model || "unknown",
     connectionId: base.connectionId || undefined,
+    apiKey: base.apiKey || null,
     timestamp: new Date().toISOString(),
     latency: base.latency || { ttft: 0, total: 0 },
     tokens: base.tokens || { prompt_tokens: 0, completion_tokens: 0 },

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -106,7 +106,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
   trackDone();
 
   const ctx = {
-    provider, model, connectionId,
+    provider, model, connectionId, apiKey,
     request: extractRequestConfig(body, stream),
     providerRequest: finalBody || translatedBody || null
   };

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -120,7 +120,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
       const usage = jsonResponse.usage || {};
       appendLog({ tokens: usage, status: "200 OK" });
-      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+      // Only write for this request → canonical quota row
+      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, countsTowardQuota: true });
 
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
       const totalLatency = Date.now() - requestStartTime;
@@ -195,7 +196,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
     const usage = parsed.usage || {};
     appendLog({ tokens: usage, status: "200 OK" });
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+    // Only write for this request → canonical quota row
+    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, countsTowardQuota: true });
 
     const totalLatency = Date.now() - requestStartTime;
     saveRequestDetail(buildRequestDetail({

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -47,7 +47,7 @@ export function handleStreamingResponse({ providerResponse, provider, model, sou
 
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
   saveRequestDetail(buildRequestDetail({
-    provider, model, connectionId,
+    provider, model, connectionId, apiKey,
     latency: { ttft: 0, total: Date.now() - requestStartTime },
     tokens: { prompt_tokens: 0, completion_tokens: 0 },
     request: extractRequestConfig(body, stream),
@@ -80,7 +80,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     const safeThinking = contentObj?.thinking || null;
 
     saveRequestDetail(buildRequestDetail({
-      provider, model, connectionId,
+      provider, model, connectionId, apiKey,
       latency,
       tokens: usage || { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -92,6 +92,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
 
+    // Duplicate stats row — logUsage in stream.js already wrote the canonical quota row
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE" });
   };
 

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -342,6 +342,7 @@ export function logUsage(provider, usage, model = null, connectionId = null, api
     cache_creation_input_tokens: cacheCreation || 0,
     reasoning_tokens: reasoning || 0
   };
-  saveRequestUsage({ model, provider, connectionId, tokens, apiKey: apiKey || undefined }).catch(() => { });
+  // Canonical quota row for the streaming path (onStreamComplete writes a second, unflagged stats row)
+  saveRequestUsage({ model, provider, connectionId, tokens, apiKey: apiKey || undefined, countsTowardQuota: true }).catch(() => { });
   appendRequestLog({ model, provider, connectionId, tokens, status: "200 OK" }).catch(() => { });
 }

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -21,7 +21,7 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { isActive } = body;
+    const { isActive, tokenBudget5h } = body;
 
     const existing = await getApiKeyById(id);
     if (!existing) {
@@ -30,6 +30,13 @@ export async function PUT(request, { params }) {
 
     const updateData = {};
     if (isActive !== undefined) updateData.isActive = isActive;
+    if (tokenBudget5h !== undefined) {
+      // null = clear override (use global default); otherwise a positive integer
+      if (tokenBudget5h !== null && (!Number.isInteger(tokenBudget5h) || tokenBudget5h <= 0)) {
+        return NextResponse.json({ error: "tokenBudget5h must be null or a positive integer" }, { status: 400 });
+      }
+      updateData.tokenBudget5h = tokenBudget5h;
+    }
 
     const updated = await updateApiKey(id, updateData);
 

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -10,6 +10,8 @@ function rowToKey(row) {
     machineId: row.machineId,
     isActive: row.isActive === 1 || row.isActive === true,
     createdAt: row.createdAt,
+    // Token budget per 5h window; null = use the global default
+    tokenBudget5h: row.tokenBudget5h ?? null,
   };
 }
 
@@ -53,8 +55,8 @@ export async function updateApiKey(id, data) {
     if (!row) return;
     const merged = { ...rowToKey(row), ...data };
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ? WHERE id = ?`,
-      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, id]
+      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, tokenBudget5h = ? WHERE id = ?`,
+      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, merged.tokenBudget5h ?? null, id]
     );
     result = merged;
   });

--- a/src/lib/db/repos/requestDetailsRepo.js
+++ b/src/lib/db/repos/requestDetailsRepo.js
@@ -90,6 +90,7 @@ async function flushToDatabase() {
             provider: item.provider || null,
             model: item.model || null,
             connectionId: item.connectionId || null,
+            apiKey: item.apiKey || null,
             timestamp: item.timestamp,
             status: item.status || null,
             latency: item.latency || {},
@@ -101,8 +102,8 @@ async function flushToDatabase() {
           };
 
           db.run(
-            `INSERT INTO requestDetails(id, timestamp, provider, model, connectionId, status, data) VALUES(?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET timestamp = excluded.timestamp, provider = excluded.provider, model = excluded.model, connectionId = excluded.connectionId, status = excluded.status, data = excluded.data`,
-            [record.id, record.timestamp, record.provider, record.model, record.connectionId, record.status, stringifyJson(record)]
+            `INSERT INTO requestDetails(id, timestamp, provider, model, connectionId, apiKey, status, data) VALUES(?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET timestamp = excluded.timestamp, provider = excluded.provider, model = excluded.model, connectionId = excluded.connectionId, apiKey = excluded.apiKey, status = excluded.status, data = excluded.data`,
+            [record.id, record.timestamp, record.provider, record.model, record.connectionId, record.apiKey, record.status, stringifyJson(record)]
           );
         }
 

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -729,3 +729,83 @@ export async function getRecentLogs(limit = 200) {
     return [];
   }
 }
+
+// ─── Per-user token quota (prevent one user from draining the shared pool) ───
+const QUOTA_WINDOW_MS = 5 * 60 * 60 * 1000; // 5h
+const DEFAULT_USER_TOKEN_BUDGET_5H = 25_000_000;
+
+/**
+ * Check a user's (apiKey) token usage within a fixed 5h window anchored to the
+ * window's first request (not rolling — matches codex's reset behavior).
+ *
+ * Sums promptTokens (incl. cache_read) of rows with endpoint IS NULL to avoid
+ * double-write (each request is logged twice; only the null-endpoint row is correct).
+ *
+ * @returns {{allowed:boolean, used?:number, budget?:number, windowStart?:string,
+ *            retryAfterIso?:string, retryAfterSec?:number, disabled?:boolean}}
+ */
+export async function checkUserQuota(apiKey) {
+  if (!apiKey) return { allowed: true };
+  const db = await getAdapter();
+
+  // Enabled flag & default budget resolve as: DB setting > env > built-in default.
+  // - userQuotaEnabled: DB boolean if set, else env USER_QUOTA_ENABLED === "true" (disabled by default)
+  // - userTokenBudget5hDefault: DB number if set, else env USER_TOKEN_BUDGET_5H, else constant
+  let budget = DEFAULT_USER_TOKEN_BUDGET_5H;
+  try {
+    const { getSettings } = await import("./settingsRepo.js");
+    const settings = await getSettings();
+    const enabled = typeof settings.userQuotaEnabled === "boolean"
+      ? settings.userQuotaEnabled
+      : process.env.USER_QUOTA_ENABLED === "true";
+    if (!enabled) return { allowed: true, disabled: true };
+    budget = settings.userTokenBudget5hDefault
+      || parseInt(process.env.USER_TOKEN_BUDGET_5H || String(DEFAULT_USER_TOKEN_BUDGET_5H), 10);
+  } catch { /* fall back to default if settings cannot be read */ }
+  try {
+    const keyRow = db.get(`SELECT tokenBudget5h FROM apiKeys WHERE key = ?`, [apiKey]);
+    if (keyRow && keyRow.tokenBudget5h != null) budget = keyRow.tokenBudget5h;
+  } catch { /* ignore, keep current budget */ }
+
+  const now = Date.now();
+  let windowStartIso;
+  const wrow = db.get(`SELECT windowStart FROM userQuotaWindow WHERE apiKey = ?`, [apiKey]);
+  if (!wrow || (now - new Date(wrow.windowStart).getTime()) >= QUOTA_WINDOW_MS) {
+    // Open a new window: this request is the window's first request
+    windowStartIso = new Date(now).toISOString();
+    db.run(
+      `INSERT INTO userQuotaWindow(apiKey, windowStart) VALUES(?, ?) ON CONFLICT(apiKey) DO UPDATE SET windowStart = excluded.windowStart`,
+      [apiKey, windowStartIso]
+    );
+  } else {
+    windowStartIso = wrow.windowStart;
+  }
+
+  const row = db.get(
+    `SELECT COALESCE(SUM(promptTokens), 0) AS used FROM usageHistory
+     WHERE apiKey = ? AND endpoint IS NULL AND timestamp >= ?`,
+    [apiKey, windowStartIso]
+  );
+  const used = row?.used || 0;
+  const resetMs = new Date(windowStartIso).getTime() + QUOTA_WINDOW_MS;
+  const retryAfterSec = Math.max(Math.ceil((resetMs - now) / 1000), 1);
+
+  // Reset time in the server's local timezone, formatted HH:MM DD/MM
+  const d = new Date(resetMs);
+  const pad = (n) => String(n).padStart(2, "0");
+  const resetAtLocal = `${pad(d.getHours())}:${pad(d.getMinutes())} ${pad(d.getDate())}/${pad(d.getMonth() + 1)}`;
+  const h = Math.floor(retryAfterSec / 3600);
+  const m = Math.ceil((retryAfterSec % 3600) / 60);
+  const retryAfterHuman = h > 0 ? `${h}h${m}m` : `${m}m`;
+
+  return {
+    allowed: used < budget,
+    used,
+    budget,
+    windowStart: windowStartIso,
+    retryAfterIso: new Date(resetMs).toISOString(),
+    retryAfterSec,
+    resetAtLocal,
+    retryAfterHuman,
+  };
+}

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -255,12 +255,12 @@ export async function saveRequestUsage(entry) {
     // better-sqlite3 is sync → no JS yield mid-transaction → no race in same process.
     db.transaction(() => {
       db.run(
-        `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta, countsTowardQuota) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           entry.timestamp, entry.provider || null, entry.model || null,
           entry.connectionId || null, entry.apiKey || null, entry.endpoint || null,
           promptTokens, completionTokens, entry.cost || 0, entry.status || "ok",
-          stringifyJson(tokens), stringifyJson({}),
+          stringifyJson(tokens), stringifyJson({}), entry.countsTowardQuota ? 1 : 0,
         ]
       );
 
@@ -738,8 +738,14 @@ const DEFAULT_USER_TOKEN_BUDGET_5H = 25_000_000;
  * Check a user's (apiKey) token usage within a fixed 5h window anchored to the
  * window's first request (not rolling — matches codex's reset behavior).
  *
- * Sums promptTokens (incl. cache_read) of rows with endpoint IS NULL to avoid
- * double-write (each request is logged twice; only the null-endpoint row is correct).
+ * Prompt-token budget: sums promptTokens of rows flagged countsTowardQuota = 1 —
+ * each request writes exactly one such row regardless of streaming/non-streaming
+ * (streaming also writes a second stats row which stays unflagged). Completion
+ * tokens are intentionally excluded: input volume is what drains upstream pools.
+ *
+ * Eventually consistent by design: usage rows are written async after the response
+ * completes, so concurrent requests can all pass the check before any row lands and
+ * the budget may be overshot during a burst. Acceptable for a soft quota.
  *
  * @returns {{allowed:boolean, used?:number, budget?:number, windowStart?:string,
  *            retryAfterIso?:string, retryAfterSec?:number, disabled?:boolean}}
@@ -783,17 +789,22 @@ export async function checkUserQuota(apiKey) {
 
   const row = db.get(
     `SELECT COALESCE(SUM(promptTokens), 0) AS used FROM usageHistory
-     WHERE apiKey = ? AND endpoint IS NULL AND timestamp >= ?`,
+     WHERE apiKey = ? AND countsTowardQuota = 1 AND timestamp >= ?`,
     [apiKey, windowStartIso]
   );
   const used = row?.used || 0;
   const resetMs = new Date(windowStartIso).getTime() + QUOTA_WINDOW_MS;
   const retryAfterSec = Math.max(Math.ceil((resetMs - now) / 1000), 1);
 
-  // Reset time in the server's local timezone, formatted HH:MM DD/MM
+  // Reset time in the server's local timezone, formatted HH:MM DD/MM (UTC±H[:MM]).
+  // The explicit offset avoids confusion when the server runs in a container (usually UTC).
   const d = new Date(resetMs);
   const pad = (n) => String(n).padStart(2, "0");
-  const resetAtLocal = `${pad(d.getHours())}:${pad(d.getMinutes())} ${pad(d.getDate())}/${pad(d.getMonth() + 1)}`;
+  const offMin = -d.getTimezoneOffset();
+  const offSign = offMin >= 0 ? "+" : "-";
+  const offAbs = Math.abs(offMin);
+  const tzLabel = `UTC${offSign}${Math.floor(offAbs / 60)}${offAbs % 60 ? `:${pad(offAbs % 60)}` : ""}`;
+  const resetAtLocal = `${pad(d.getHours())}:${pad(d.getMinutes())} ${pad(d.getDate())}/${pad(d.getMonth() + 1)} (${tzLabel})`;
   const h = Math.floor(retryAfterSec / 3600);
   const m = Math.ceil((retryAfterSec % 3600) / 60);
   const retryAfterHuman = h > 0 ? `${h}h${m}m` : `${m}m`;

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -119,6 +119,9 @@ export const TABLES = {
       status: "TEXT",
       tokens: "TEXT",
       meta: "TEXT",
+      // 1 = canonical row for per-key quota accounting (each request has exactly one);
+      // streaming writes a second stats row (endpoint set) which stays 0
+      countsTowardQuota: "INTEGER DEFAULT 0",
     },
     indexes: [
       "CREATE INDEX IF NOT EXISTS idx_uh_ts ON usageHistory(timestamp DESC)",

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -79,6 +79,8 @@ export const TABLES = {
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
       createdAt: "TEXT NOT NULL",
+      // Per-key token budget per 5h; null = use the global default
+      tokenBudget5h: "INTEGER",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],
   },
@@ -123,6 +125,8 @@ export const TABLES = {
       "CREATE INDEX IF NOT EXISTS idx_uh_provider ON usageHistory(provider)",
       "CREATE INDEX IF NOT EXISTS idx_uh_model ON usageHistory(model)",
       "CREATE INDEX IF NOT EXISTS idx_uh_conn ON usageHistory(connectionId)",
+      // Speeds up the per-user token sum within the quota window
+      "CREATE INDEX IF NOT EXISTS idx_uh_apikey_ts ON usageHistory(apiKey, timestamp)",
     ],
   },
   usageDaily: {
@@ -138,6 +142,7 @@ export const TABLES = {
       provider: "TEXT",
       model: "TEXT",
       connectionId: "TEXT",
+      apiKey: "TEXT",
       status: "TEXT",
       data: "TEXT NOT NULL",
     },
@@ -146,7 +151,16 @@ export const TABLES = {
       "CREATE INDEX IF NOT EXISTS idx_rd_provider ON requestDetails(provider)",
       "CREATE INDEX IF NOT EXISTS idx_rd_model ON requestDetails(model)",
       "CREATE INDEX IF NOT EXISTS idx_rd_conn ON requestDetails(connectionId)",
+      "CREATE INDEX IF NOT EXISTS idx_rd_apikey ON requestDetails(apiKey)",
     ],
+  },
+  // Start of each user's (apiKey) current 5h quota window.
+  // windowStart = first request of the current window; a new window opens after 5h.
+  userQuotaWindow: {
+    columns: {
+      apiKey: "TEXT PRIMARY KEY",
+      windowStart: "TEXT NOT NULL",
+    },
   },
 };
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -9,6 +9,7 @@ import {
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
 import { getSettings } from "@/lib/localDb";
+import { checkUserQuota } from "@/lib/db/repos/usageRepo.js";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -76,6 +77,21 @@ export async function handleChat(request, clientRawRequest = null) {
     if (!valid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    }
+  }
+
+  // Per-user 5h token quota: prevent one user from draining the shared codex pool.
+  // Placed before combo/non-combo branching to cover all paths.
+  if (apiKey) {
+    const quota = await checkUserQuota(apiKey);
+    if (quota && quota.allowed === false) {
+      log.warn("QUOTA", `[${log.maskKey(apiKey)}] exceeded 5h token quota (${quota.used}/${quota.budget}), resets at ${quota.resetAtLocal}, in ${quota.retryAfterHuman}`);
+      return unavailableResponse(
+        429,
+        `[quota] Token quota exceeded`,
+        quota.retryAfterIso,
+        `Resets at ${quota.resetAtLocal}, in ${quota.retryAfterHuman}`
+      );
     }
   }
 

--- a/tests/unit/user-quota.test.js
+++ b/tests/unit/user-quota.test.js
@@ -1,0 +1,169 @@
+// Per-key token quota — window math, budget resolution, and accounting dedupe.
+// Covers the review findings on PR #1569: non-streaming requests must be charged
+// exactly once via the explicit countsTowardQuota marker (not endpoint IS NULL).
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+const QUOTA_WINDOW_MS = 5 * 60 * 60 * 1000;
+
+const originalDataDir = process.env.DATA_DIR;
+let tempDir;
+let db;
+let usageRepo;
+let adapter;
+
+beforeAll(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-quota-"));
+  process.env.DATA_DIR = tempDir;
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+  usageRepo = await import("@/lib/db/repos/usageRepo.js");
+  const driver = await import("@/lib/db/driver.js");
+  adapter = await driver.getAdapter();
+});
+
+afterAll(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+// Ghi 1 row usage canonical (countsTowardQuota = 1) cho apiKey
+async function writeCanonical(apiKey, promptTokens, extra = {}) {
+  await usageRepo.saveRequestUsage({
+    provider: "openai", model: "gpt-4", connectionId: "c1",
+    apiKey, tokens: { prompt_tokens: promptTokens, completion_tokens: 1 },
+    countsTowardQuota: true, ...extra,
+  });
+}
+
+describe("checkUserQuota — enabled resolution", () => {
+  it("disabled by default → always allowed", async () => {
+    const res = await usageRepo.checkUserQuota("sk-default-off");
+    expect(res.allowed).toBe(true);
+    expect(res.disabled).toBe(true);
+  });
+
+  it("no apiKey → allowed", async () => {
+    const res = await usageRepo.checkUserQuota(null);
+    expect(res.allowed).toBe(true);
+  });
+});
+
+describe("checkUserQuota — accounting (countsTowardQuota marker)", () => {
+  beforeAll(async () => {
+    await db.updateSettings({ userQuotaEnabled: true, userTokenBudget5hDefault: 1000 });
+  });
+
+  it("streaming dual-write counts exactly once", async () => {
+    const key = "sk-stream";
+    await usageRepo.checkUserQuota(key); // mở window trước (giống handleChat: check rồi mới ghi usage)
+    // Row canonical (logUsage: endpoint null, flagged)
+    await writeCanonical(key, 400);
+    // Row duplicate (onStreamComplete: endpoint set, KHÔNG flag)
+    await usageRepo.saveRequestUsage({
+      provider: "openai", model: "gpt-4", connectionId: "c1",
+      apiKey: key, tokens: { prompt_tokens: 400, completion_tokens: 1 },
+      endpoint: "/v1/chat/completions",
+    });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBe(400); // không phải 800
+    expect(res.allowed).toBe(true);
+  });
+
+  it("non-streaming single write (endpoint set + flagged) is charged", async () => {
+    const key = "sk-nonstream";
+    await usageRepo.checkUserQuota(key); // mở window trước
+    await writeCanonical(key, 300, { endpoint: "/v1/chat/completions" });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBe(300);
+  });
+
+  it("over budget → blocked with retry info", async () => {
+    const key = "sk-over";
+    await usageRepo.checkUserQuota(key); // mở window trước
+    await writeCanonical(key, 600);
+    await writeCanonical(key, 600);
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBe(1200);
+    expect(res.budget).toBe(1000);
+    expect(res.allowed).toBe(false);
+    expect(res.retryAfterSec).toBeGreaterThan(0);
+    expect(res.retryAfterSec).toBeLessThanOrEqual(QUOTA_WINDOW_MS / 1000);
+    expect(res.resetAtLocal).toContain("UTC"); // offset tường minh
+    expect(new Date(res.retryAfterIso).getTime()).toBe(
+      new Date(res.windowStart).getTime() + QUOTA_WINDOW_MS
+    );
+  });
+});
+
+describe("checkUserQuota — window math", () => {
+  it("first request anchors the window", async () => {
+    const key = "sk-window";
+    const before = Date.now();
+    const res = await usageRepo.checkUserQuota(key);
+    const start = new Date(res.windowStart).getTime();
+    expect(start).toBeGreaterThanOrEqual(before);
+    expect(start).toBeLessThanOrEqual(Date.now());
+
+    // Lần check tiếp theo trong cùng window → giữ nguyên anchor
+    const res2 = await usageRepo.checkUserQuota(key);
+    expect(res2.windowStart).toBe(res.windowStart);
+  });
+
+  it("expired window (>5h) → new window opens and usage resets", async () => {
+    const key = "sk-expired";
+    const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString();
+
+    // Window cũ đã hết hạn, usage cũ nằm trong window cũ
+    adapter.run(
+      `INSERT INTO userQuotaWindow(apiKey, windowStart) VALUES(?, ?)`,
+      [key, sixHoursAgo]
+    );
+    await writeCanonical(key, 5000, { timestamp: sixHoursAgo });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(new Date(res.windowStart).getTime()).toBeGreaterThan(new Date(sixHoursAgo).getTime());
+    expect(res.used).toBe(0); // usage của window cũ không tính sang window mới
+    expect(res.allowed).toBe(true);
+  });
+});
+
+describe("checkUserQuota — per-key budget override", () => {
+  it("apiKeys.tokenBudget5h overrides the global default", async () => {
+    const key = "sk-override";
+    adapter.run(
+      `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt, tokenBudget5h) VALUES(?, ?, ?, ?, 1, ?, ?)`,
+      ["id-override", key, "override", "m1", new Date().toISOString(), 200]
+    );
+    await usageRepo.checkUserQuota(key); // mở window trước
+    await writeCanonical(key, 250);
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.budget).toBe(200);
+    expect(res.allowed).toBe(false);
+  });
+
+  it("updateApiKey persists tokenBudget5h and rowToKey exposes it", async () => {
+    const keysRepo = await import("@/lib/db/repos/apiKeysRepo.js");
+    adapter.run(
+      `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, 1, ?)`,
+      ["id-crud", "sk-crud", "crud", "m1", new Date().toISOString()]
+    );
+
+    const updated = await keysRepo.updateApiKey("id-crud", { tokenBudget5h: 12345 });
+    expect(updated.tokenBudget5h).toBe(12345);
+
+    const fetched = await keysRepo.getApiKeyById("id-crud");
+    expect(fetched.tokenBudget5h).toBe(12345);
+
+    // Clear override → quay về default toàn cục
+    const cleared = await keysRepo.updateApiKey("id-crud", { tokenBudget5h: null });
+    expect(cleared.tokenBudget5h).toBe(null);
+  });
+});


### PR DESCRIPTION
## Why

9Router is often used as a **single gateway feeding many AI tools** — Claude Code, Codex, Cursor, Cline, Copilot, etc. — all sharing one upstream account pool, with **one API key per tool**. At that scale two gaps show up:

1. **One heavy tool can drain the shared pool.** When a single tool's API key burns through the pool's quota, *every other tool* starts getting `429`s through no fault of its own. There is currently no way to bound a single key's consumption.
2. **You can't tell which tool used what.** `requestDetails` stores `connectionId` (the upstream account) but not the **API key** that made the call, so usage/MCP/tooling can't be attributed back to the tool that issued it.

This PR adds two small, **opt-in** governance features to close those gaps — without changing default behavior for anyone who doesn't turn them on.

## What

### 1. Per-key token quota (disabled by default)
- A **fixed 5h window anchored to the key's first request** (mirrors upstream reset semantics — not a rolling window), enforced per API key in `handleChat` **before** combo/non-combo routing so every path is covered.
- Returns **`429` + `Retry-After`** with a human-readable reset time when the budget is exceeded.
- Per-key override via `apiKeys.tokenBudget5h` (e.g. a larger budget for your main coding tool, tighter for background agents); sensible global default otherwise.
- Counts `promptTokens` of the canonical (endpoint-null) usage rows only, so it stays correct alongside the existing dual-write.

### 2. Per-key request attribution
- Persists `apiKey` on every `requestDetails` row (previously `connectionId` only), so usage, MCP/tool calls and quota debugging can be traced back to the specific tool/key by an external process.

## Safe by design
- **Opt-in, off by default** — `userQuotaEnabled` resolves `DB setting > env > built-in default (false)`. Existing deployments behave exactly as before until explicitly enabled.
- **Additive schema only** — applied automatically by `syncSchemaFromTables` (`apiKeys.tokenBudget5h`, `requestDetails.apiKey`, `userQuotaWindow` table, supporting indexes). No migration file, no destructive change, no data loss.
- **Config follows existing conventions** — same `setting || env || default` resolution used by `observability*`; new env vars `USER_QUOTA_ENABLED`, `USER_TOKEN_BUDGET_5H`.
- **Backward compatible** — request attribution is a single nullable column; rows written before the upgrade simply have `apiKey = null`.

## Footprint
- 9 files, ~120 lines added. No new dependencies. Follows repo style (2-space, double quotes, `await getAdapter()`, dynamic repo imports, local-tz date formatting like `getLocalDateKey`). `eslint` clean.

## Testing
- Unit-level logic verified for the quota window (open/reset, under/over budget, per-key override, enabled resolution).
- Verified end-to-end on a live instance: `429` returned with correct `Retry-After`/reset time when a key is over budget, requests served normally when under budget, and `apiKey` correctly recorded on `requestDetails`.

## How to enable
```yaml
# docker-compose env
environment:
  - USER_QUOTA_ENABLED=true
  - USER_TOKEN_BUDGET_5H=25000000   # tokens per 5h per key, optional
```
Or via DB settings (`userQuotaEnabled`, `userTokenBudget5hDefault`); per-key limit via `apiKeys.tokenBudget5h`.
