### PR TITLE
fix(kiro): emit valid concatenable tool_calls.arguments deltas

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -5,6 +5,45 @@ import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { HTTP_STATUS, RETRY_CONFIG, DEFAULT_RETRY_CONFIG, resolveRetryEntry } from "../config/runtimeConfig.js";
 
+// Flush buffered tool arguments at finish boundaries.
+// Kiro/CodeWhisperer streams toolUseEvent.input as PARTIAL OBJECTS that grow over
+// time (e.g. {command:"cat /home"} then {command:"cat /home/wxsys"}). Re-stringifying
+// each one and emitting it as an OpenAI argument delta produces overlapping prefixes
+// that concatenate into unparseable garbage downstream (Unterminated string).
+//
+// Fix: defer object-form payloads into state.toolArgsBuffered keyed by toolCallId,
+// keep only the latest canonical, and emit ONCE here as the complete arguments
+// string (the final object is the source of truth — intermediate states are noise).
+// String-form payloads are already concatenable deltas and emitted incrementally.
+export function flushBufferedToolArgs(state, controller, ctx) {
+  if (!state.toolArgsBuffered || state.toolArgsBuffered.size === 0) return;
+  const { responseId, created, model } = ctx;
+  for (const [toolCallId, info] of state.toolArgsBuffered) {
+    const alreadyEmitted = state.toolArgsEmitted.get(toolCallId) || "";
+    if (info.canonical && info.canonical !== alreadyEmitted) {
+      const argsChunk = {
+        id: responseId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: info.toolIndex,
+              function: { arguments: info.canonical }
+            }]
+          },
+          finish_reason: null
+        }]
+      };
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+      state.toolArgsEmitted.set(toolCallId, info.canonical);
+    }
+  }
+  state.toolArgsBuffered.clear();
+}
+
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
  * Uses AWS CodeWhisperer streaming API with AWS EventStream binary format
@@ -90,7 +129,9 @@ export class KiroExecutor extends BaseExecutor {
       hasReasoningContent: false,
       reasoningChunkCount: 0,
       toolCallIndex: 0,
-      seenToolIds: new Map()
+      seenToolIds: new Map(),
+      toolArgsEmitted: new Map(),
+      toolArgsBuffered: new Map()
     };
 
     const transformStream = new TransformStream({
@@ -244,42 +285,37 @@ export class KiroExecutor extends BaseExecutor {
               }
 
               if (toolInput !== undefined) {
-                let argumentsStr;
-
                 if (typeof toolInput === 'string') {
-                  argumentsStr = toolInput;
-                } else if (typeof toolInput === 'object') {
-                  argumentsStr = JSON.stringify(toolInput);
-                } else {
-                  continue;
-                }
+                  state.toolArgsEmitted.set(toolCallId, (state.toolArgsEmitted.get(toolCallId) || "") + toolInput);
 
-                const argsChunk = {
-                  id: responseId,
-                  object: "chat.completion.chunk",
-                  created,
-                  model,
-                  choices: [{
-                    index: 0,
-                    delta: {
-                      tool_calls: [{
-                        index: toolIndex,
-                        function: {
-                          arguments: argumentsStr
-                        }
-                      }]
-                    },
-                    finish_reason: null
-                  }]
-                };
-                chunkIndex++;
-                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+                  const argsChunk = {
+                    id: responseId,
+                    object: "chat.completion.chunk",
+                    created,
+                    model,
+                    choices: [{
+                      index: 0,
+                      delta: {
+                        tool_calls: [{
+                          index: toolIndex,
+                          function: { arguments: toolInput }
+                        }]
+                      },
+                      finish_reason: null
+                    }]
+                  };
+                  chunkIndex++;
+                  controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+                } else if (typeof toolInput === 'object') {
+                  state.toolArgsBuffered.set(toolCallId, { toolIndex, canonical: JSON.stringify(toolInput) });
+                }
               }
             }
           }
 
           // Handle messageStopEvent
           if (eventType === "messageStopEvent") {
+            flushBufferedToolArgs(state, controller, { responseId, created, model });
             const chunk = {
               id: responseId,
               object: "chat.completion.chunk",
@@ -328,6 +364,7 @@ export class KiroExecutor extends BaseExecutor {
           // Emit final chunk only after receiving BOTH meteringEvent AND contextUsageEvent
           if (state.hasMeteringEvent && state.hasContextUsage && !state.finishEmitted) {
             state.finishEmitted = true;
+            flushBufferedToolArgs(state, controller, { responseId, created, model });
             
             // Estimate tokens if not available from events
             if (!state.usage) {
@@ -379,6 +416,7 @@ export class KiroExecutor extends BaseExecutor {
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;
+          flushBufferedToolArgs(state, controller, { responseId, created, model });
           const finishChunk = {
             id: responseId,
             object: "chat.completion.chunk",

--- a/tests/unit/kiro-tool-args-streaming.test.js
+++ b/tests/unit/kiro-tool-args-streaming.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { flushBufferedToolArgs } from "../../open-sse/executors/kiro.js";
+
+function makeMockController() {
+  const enqueued = [];
+  return {
+    enqueued,
+    enqueue(bytes) {
+      enqueued.push(new TextDecoder().decode(bytes));
+    }
+  };
+}
+
+function parseSSEData(sseLines) {
+  return sseLines.map(line => {
+    const m = line.match(/^data: (.+)\n\n$/);
+    return m ? JSON.parse(m[1]) : null;
+  }).filter(Boolean);
+}
+
+function reconstructArguments(chunks) {
+  const perIndex = new Map();
+  for (const chunk of chunks) {
+    const tc = chunk.choices?.[0]?.delta?.tool_calls?.[0];
+    if (!tc) continue;
+    const idx = tc.index;
+    const args = tc.function?.arguments || "";
+    perIndex.set(idx, (perIndex.get(idx) || "") + args);
+  }
+  return perIndex;
+}
+
+describe("kiro tool args streaming — partial-object bug regression", () => {
+  it("flushes a single buffered tool call with valid concatenable JSON", () => {
+    const state = {
+      toolArgsEmitted: new Map(),
+      toolArgsBuffered: new Map([
+        ["tool_abc", { toolIndex: 0, canonical: '{"command":"cat /home/wxsys/Project/naskin/.impeccable.md"}' }]
+      ])
+    };
+    const controller = makeMockController();
+    flushBufferedToolArgs(state, controller, { responseId: "resp_test", created: 1, model: "kiro" });
+
+    const chunks = parseSSEData(controller.enqueued);
+    expect(chunks).toHaveLength(1);
+
+    const args = reconstructArguments(chunks);
+    const final = args.get(0);
+    expect(() => JSON.parse(final)).not.toThrow();
+    expect(JSON.parse(final)).toEqual({ command: "cat /home/wxsys/Project/naskin/.impeccable.md" });
+
+    expect(state.toolArgsBuffered.size).toBe(0);
+    expect(state.toolArgsEmitted.get("tool_abc")).toBe(final);
+  });
+
+  it("simulates the reported bug: 4 partial-object events produce 1 valid flush", () => {
+    const state = {
+      toolArgsEmitted: new Map(),
+      toolArgsBuffered: new Map()
+    };
+
+    const partialPayloads = [
+      { command: "cat /home" },
+      { command: "cat /home/wxsys" },
+      { command: "cat /home/wxsys/Project" },
+      { command: "cat /home/wxsys/Project/naskin/.impeccable.md" }
+    ];
+    for (const input of partialPayloads) {
+      state.toolArgsBuffered.set("tool_abc", { toolIndex: 0, canonical: JSON.stringify(input) });
+    }
+
+    const controller = makeMockController();
+    flushBufferedToolArgs(state, controller, { responseId: "resp_test", created: 1, model: "kiro" });
+
+    const chunks = parseSSEData(controller.enqueued);
+    expect(chunks).toHaveLength(1);
+
+    const args = reconstructArguments(chunks);
+    const final = args.get(0);
+    expect(() => JSON.parse(final)).not.toThrow();
+    expect(JSON.parse(final).command).toBe("cat /home/wxsys/Project/naskin/.impeccable.md");
+  });
+
+  it("flushes multiple concurrent tool calls preserving toolIndex", () => {
+    const state = {
+      toolArgsEmitted: new Map(),
+      toolArgsBuffered: new Map([
+        ["T1", { toolIndex: 0, canonical: '{"filePath":"/a/b/c.txt"}' }],
+        ["T2", { toolIndex: 1, canonical: '{"command":"ls"}' }]
+      ])
+    };
+    const controller = makeMockController();
+    flushBufferedToolArgs(state, controller, { responseId: "resp_test", created: 1, model: "kiro" });
+
+    const chunks = parseSSEData(controller.enqueued);
+    expect(chunks).toHaveLength(2);
+
+    const args = reconstructArguments(chunks);
+    expect(JSON.parse(args.get(0))).toEqual({ filePath: "/a/b/c.txt" });
+    expect(JSON.parse(args.get(1))).toEqual({ command: "ls" });
+  });
+
+  it("does not re-emit when canonical equals already-emitted (idempotent)", () => {
+    const state = {
+      toolArgsEmitted: new Map([["tool_abc", '{"command":"ls"}']]),
+      toolArgsBuffered: new Map([
+        ["tool_abc", { toolIndex: 0, canonical: '{"command":"ls"}' }]
+      ])
+    };
+    const controller = makeMockController();
+    flushBufferedToolArgs(state, controller, { responseId: "resp_test", created: 1, model: "kiro" });
+
+    expect(controller.enqueued).toHaveLength(0);
+    expect(state.toolArgsBuffered.size).toBe(0);
+  });
+
+  it("no-op when buffer is empty", () => {
+    const state = {
+      toolArgsEmitted: new Map(),
+      toolArgsBuffered: new Map()
+    };
+    const controller = makeMockController();
+    flushBufferedToolArgs(state, controller, { responseId: "resp_test", created: 1, model: "kiro" });
+
+    expect(controller.enqueued).toHaveLength(0);
+  });
+});
+
+describe("kiro tool args streaming — concatenation contract (regression)", () => {
+  it("OLD BUG: re-stringifying each partial object produces unparseable concat", () => {
+    const partials = [
+      { command: "cat /home" },
+      { command: "cat /home/wxsys" },
+      { command: "cat /home/wxsys/Project/naskin/.impeccable.md" }
+    ];
+    const buggyConcat = partials.map(p => JSON.stringify(p)).join("");
+
+    expect(() => JSON.parse(buggyConcat)).toThrow();
+  });
+
+  it("FIX: emitting only the final canonical produces parseable JSON", () => {
+    const partials = [
+      { command: "cat /home" },
+      { command: "cat /home/wxsys" },
+      { command: "cat /home/wxsys/Project/naskin/.impeccable.md" }
+    ];
+    const fixedConcat = JSON.stringify(partials[partials.length - 1]);
+
+    expect(() => JSON.parse(fixedConcat)).not.toThrow();
+    expect(JSON.parse(fixedConcat).command).toBe("cat /home/wxsys/Project/naskin/.impeccable.md");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a streaming protocol bug in the Kiro executor that caused random `Unterminated string` JSON parse errors in downstream consumers (opencode, claude-code, etc.) for tool calls with substantial argument content.

## Root cause

`open-sse/executors/kiro.js` reads `toolUseEvent.input` and emits its `JSON.stringify` as an OpenAI `tool_calls[].function.arguments` delta on **every** event. Kiro/AWS CodeWhisperer streams `input` as **partial objects that grow** across events:

```
event 1: { command: "cat /home" }
event 2: { command: "cat /home/wxsys" }
event 3: { command: "cat /home/wxsys/Project/naskin/.impeccable.md" }
```

Stringifying each one produces overlapping prefixes:

```
{"command":"cat /home"}
{"command":"cat /home/wxsys"}
{"command":"cat /home/wxsys/Project/naskin/.impeccable.md"}
```

The OpenAI streaming protocol requires `arguments` deltas to be **concatenable string fragments** that join into one valid JSON. Concatenating the three above produces:

```
{"command":"cat /home"}{"command":"cat /home/wxsys"}{"command":"cat /home/wxsys/Project/naskin/.impeccable.md"}
```

→ `JSON.parse` fails with `Unexpected non-whitespace character after JSON at position N` or `Unterminated string` depending on where the parser bails out.

The truncation position is **non-deterministic** because it tracks the prefix length of whichever partial object Kiro happened to send. This makes the bug present as random "the network truncated my tool call" failures — `{"comm`, `{"comman`, `{"command":` — when in fact the protocol contract was violated upstream.

## Reproduction

Any Kiro session that streams a tool whose arguments grow over multiple `toolUseEvent`s will hit this. Common triggers:
- File paths longer than a few words
- Multi-line `content` parameters in `write` tools
- Shell commands that get progressively expanded

I encountered it in opencode while writing a 1500-byte markdown file via the `write` tool routed through 9router → Kiro → Claude Opus 4.7. The `write` call failed with `Unterminated string` at variable byte offsets across retries.

## Fix

1. **String-form `input` payloads** are already concatenable deltas — emit them incrementally as before, tracking accumulated text per `toolCallId` in `state.toolArgsEmitted`.

2. **Object-form `input` payloads** are buffered into `state.toolArgsBuffered` keyed by `toolCallId`. The latest canonical (full JSON of the most recent partial object) overwrites earlier buffered values — earlier partials are noise once a more complete one arrives.

3. New helper `flushBufferedToolArgs()` is invoked at **all three** finish boundaries to emit each buffered canonical exactly once as a complete arguments string:
   - `messageStopEvent`
   - The dual-event finish path (`hasMeteringEvent && hasContextUsage`)
   - The TransformStream `flush()` callback

The result: downstream consumers receive arguments deltas that concatenate into valid JSON regardless of whether Kiro chose to send string fragments or growing partial objects.

## Tests

**New regression coverage** (`tests/unit/kiro-tool-args-streaming.test.js`, 7 tests):
- Single buffered tool call → valid flush
- 4-event partial-object stream (the exact reported repro) → 1 valid flush
- Multiple concurrent tool calls → indices preserved
- Idempotent flush (canonical equals already-emitted) → no re-emit
- Empty buffer → no-op
- Contract test: re-stringifying partials is unparseable
- Contract test: emitting once is parseable

**No regression**: all 14 existing kiro tests (`openai-to-kiro.test.js`, `rtkKiro.test.js`) continue to pass.

**End-to-end verified**: built the patched CLI tarball locally, reinstalled `9router@0.4.66`, restarted the proxy, and reproduced the original failure case (substantial `write` tool call ~1500 bytes) — now succeeds. Multiple test writes confirmed.

## Notes

- The fix is **executor-only** — `translator/response/kiro-to-openai.js` has the same shape of bug but is a separate (non-streaming-executor) code path. If this PR lands, that file deserves a follow-up; happy to include it here if preferred.
- `state` initialization adds two new Maps (`toolArgsEmitted`, `toolArgsBuffered`) — no change to existing field types.
- `flushBufferedToolArgs` is `export`ed so the unit tests can target it directly without standing up a full TransformStream pipeline.
