### PR TITLE
fix: add opencode-go and xiaomi-tokenplan cases to connection test route

### DIFF
--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -608,6 +608,23 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         const valid = !!(data && data.user);
         return { valid, error: valid ? null : "Session expired — re-paste cookie" };
       }
+      case "opencode-go": {
+        const res = await fetchWithConnectionProxy("https://opencode.ai/zen/go/v1/chat/completions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${connection.apiKey}` },
+          body: JSON.stringify({ model: getDefaultModel("opencode-go"), messages: [{ role: "user", content: "ping" }], max_tokens: 1, stream: false }),
+        }, effectiveProxy);
+        const valid = res.status !== 401 && res.status !== 403;
+        return { valid, error: valid ? null : "Invalid API key" };
+      }
+      case "xiaomi-mimo":
+      case "xiaomi-tokenplan": {
+        const baseUrls = { "xiaomi-mimo": "https://api.xiaomimimo.com/v1", "xiaomi-tokenplan": "https://token-plan-sgp.xiaomimimo.com/v1" };
+        const res = await fetchWithConnectionProxy(`${baseUrls[connection.provider]}/models`, {
+          headers: { Authorization: `Bearer ${connection.apiKey}` },
+        }, effectiveProxy);
+        return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
+      }
       default:
         return { valid: false, error: "Provider test not supported" };
     }


### PR DESCRIPTION
## Description

The `/api/providers/[id]/test` endpoint (used when testing a saved provider connection) returns `{"valid":false,"error":"Provider test not supported"}` for **opencode-go**, **xiaomi-mimo**, and **xiaomi-tokenplan** because the switch statement in `testApiKeyConnection()` is missing cases for these providers.

The `/api/providers/validate` endpoint already handles these providers correctly.

## Changes

Added cases for:
- **opencode-go** — tests via `https://opencode.ai/zen/go/v1/chat/completions` with the default model
- **xiaomi-mimo / xiaomi-tokenplan** — tests via their respective `/models` endpoints

## Files changed

`src/app/api/providers/[id]/test/testUtils.js` — added 3 cases before `default:` in the `testApiKeyConnection()` switch statement.

Closes #1575