### PR TITLE
[AI-000] enable 1m context beta and strip unsupported effort for non-opus claude

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -29,7 +29,7 @@ const CLAUDE_API_HEADERS = {
 // Full Claude CLI fingerprint — required by providers that gate on client identity (e.g. agentrouter)
 const CLAUDE_CLI_SPOOF_HEADERS = {
   "Anthropic-Version": "2023-06-01",
-  "Anthropic-Beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,effort-2025-11-24,structured-outputs-2025-12-15,fast-mode-2026-02-01,redact-thinking-2026-02-12,token-efficient-tools-2026-03-28",
+  "Anthropic-Beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-1m-2025-08-07,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,effort-2025-11-24,structured-outputs-2025-12-15,fast-mode-2026-02-01,redact-thinking-2026-02-12,token-efficient-tools-2026-03-28",
   "Anthropic-Dangerous-Direct-Browser-Access": "true",
   "User-Agent": "claude-cli/2.1.92 (external, sdk-cli)",
   "X-App": "cli",

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -20,6 +20,10 @@ import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
 
+// Anthropic Messages top-level `effort` is Claude Opus 4.6+ only.
+// haiku/sonnet upstreams reject it with 400 invalid_request_error.
+const isEffortCapableClaude = (model = "") => /opus-4-(6|7|8)/.test(model);
+
 /**
  * Core chat handler - shared between SSE and Worker
  * @param {object} options.body - Request body
@@ -113,6 +117,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Token savers: applied at the final body just before dispatch
   // Covers both passthrough (source shape) and translated (target shape) flows
   const finalFormat = passthrough ? sourceFormat : targetFormat;
+
+  // Strip unsupported top-level `effort` for non-Opus claude upstreams (avoids 400)
+  if (finalFormat === "claude" && translatedBody.effort != null && !isEffortCapableClaude(model)) {
+    delete translatedBody.effort;
+    log?.debug?.("EFFORT", `stripped unsupported effort for ${model}`);
+  }
 
   // RTK: compress tool_result content
   const rtkStats = compressMessages(translatedBody, rtkEnabled);


### PR DESCRIPTION
## Summary
- Add `context-1m-2025-08-07` to the Anthropic-Beta header (`open-sse/config/providers.js`) to enable the 1M context window.
- Strip top-level `effort` from requests to non-Opus claude upstreams (`open-sse/handlers/chatCore.js`). haiku/sonnet upstreams reject `effort` with a 400 `invalid_request_error`; it is Opus 4.6+ only. Guarded by `finalFormat === "claude"` + `effort != null` so it only touches affected requests.

## Review
- `npm audit`: 0 HIGH/CRITICAL. 4 moderate, all transitive (dompurify via monaco-editor, postcss via next) — fixable only by breaking downgrades, out of scope.
- `node --check` passes on both changed files.
- Logic: `isEffortCapableClaude` regex `/opus-4-(6|7|8)/` matches opus-4-6/7/8, won't false-match `opus-4-10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)