### PR TITLE
[AI-000] ignore local tool scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,11 @@ ecosystem.config.*
 scripts/agSniffer/*
 gitbooks/*
 gitbook/README.md
+
+# Claude Code local harness
+.claude/
+
+# Local tool scratch (codegraph index, codex pentest artifacts + reports — contain secrets)
+.codegraph/
+.codex-pentest/
+report/


### PR DESCRIPTION
## What

Add `.codegraph/`, `.codex-pentest/`, and `report/` to `.gitignore` — local tool scratch dirs that should never be committed.

## Why

- `.codegraph/codegraph.db` — 13.6 MB SQLite code index
- `.codex-pentest/live/cookies.txt` — contains a JWT `auth_token` (secret leak risk)
- `.codex-pentest/data/db/` — local SQLite + WAL
- `report/` — pentest security-assessment evidence output

None belong in version control; one carries a credential. Also added the `.claude/` local harness ignore (absent on this base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)