### PR TITLE
fix: sanitize system role in passthrough mode for Claude provider

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -17,6 +17,7 @@ import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
+import { sanitizeSystemRole } from "../translator/helpers/claudeHelper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
 
@@ -90,6 +91,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (passthrough) {
     log?.debug?.("PASSTHROUGH", `${clientTool} → ${provider} | native lossless`);
     translatedBody = { ...body, model };
+    // Sanitize system role: Anthropic no longer accepts role:'system' in messages[]
+    if (provider === "claude" || provider?.startsWith("anthropic-compatible")) {
+      translatedBody = sanitizeSystemRole(translatedBody);
+    }
   } else {
     translatedBody = translateRequest(sourceFormat, targetFormat, model, body, stream, credentials, provider, reqLogger, stripList, connectionId, clientTool);
     if (!translatedBody) {

--- a/open-sse/translator/helpers/claudeHelper.js
+++ b/open-sse/translator/helpers/claudeHelper.js
@@ -4,6 +4,44 @@ import { adjustMaxTokens } from "./maxTokensHelper.js";
 import { applyCloaking } from "../../utils/claudeCloaking.js";
 import { deriveSessionId } from "../../utils/sessionManager.js";
 
+/**
+ * Sanitize system role from messages[] for Claude API.
+ * Anthropic no longer accepts role:'system' inside the messages array.
+ * This moves any system messages into the top-level `system` field.
+ */
+export function sanitizeSystemRole(body) {
+  if (!body.messages || !Array.isArray(body.messages)) return body;
+
+  const systemMessages = body.messages.filter(m => m.role === "system");
+  if (systemMessages.length === 0) return body;
+
+  const systemTexts = systemMessages.map(m =>
+    typeof m.content === "string"
+      ? m.content
+      : Array.isArray(m.content)
+        ? m.content.filter(b => b.type === "text").map(b => b.text).join("\n")
+        : ""
+  ).filter(Boolean);
+
+  const existingSystem = body.system
+    ? (Array.isArray(body.system)
+        ? body.system.map(b => b.text || "").join("\n")
+        : body.system)
+    : "";
+
+  const allSystemText = [existingSystem, ...systemTexts].filter(Boolean).join("\n");
+
+  const newSystem = allSystemText
+    ? [{ type: "text", text: allSystemText, cache_control: { type: "ephemeral", ttl: "1h" } }]
+    : body.system;
+
+  return {
+    ...body,
+    system: newSystem,
+    messages: body.messages.filter(m => m.role !== "system")
+  };
+}
+
 // Check if message has valid non-empty content
 export function hasValidContent(msg) {
   if (typeof msg.content === "string" && msg.content.trim()) return true;


### PR DESCRIPTION
Anthropic API no longer accepts role:'system' inside messages[]. In passthrough mode (Claude Code → claude provider), requests were forwarded as-is without sanitizing system messages.

Added sanitizeSystemRole() in claudeHelper.js that moves system messages from messages[] to the top-level system field before dispatch.