### PR TITLE
feat: add caveman wenyan mode with upstream parity

### DIFF
--- a/open-sse/rtk/cavemanPrompts.js
+++ b/open-sse/rtk/cavemanPrompts.js
@@ -5,31 +5,74 @@ export const CAVEMAN_LEVELS = {
   LITE: "lite",
   FULL: "full",
   ULTRA: "ultra",
+  WENYAN_LITE: "wenyan-lite",
+  WENYAN: "wenyan",
+  WENYAN_ULTRA: "wenyan-ultra",
 };
 
 const SHARED_BOUNDARIES = "Code blocks, file paths, commands, errors, URLs: keep exact. Security warnings, irreversible action confirmations, multi-step ordered sequences: write normal. Resume terse style after.";
+
+const SHARED_EXAMPLES = "Not: \"Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by...\" Yes: \"Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:\"";
+
+const SHARED_AUTO_CLARITY = "Auto-Clarity: drop caveman for security warnings, irreversible actions, multi-step sequences where fragment ambiguity risks misread, or when user repeats a question. Resume after the clear part.";
+
+const SHARED_PERSISTENCE = "ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.";
 
 export const CAVEMAN_PROMPTS = {
   [CAVEMAN_LEVELS.LITE]: [
     "Respond tersely. Keep grammar and full sentences but drop filler, hedging and pleasantries (just/really/basically/sure/of course/I'd be happy to).",
     "Pattern: state the thing, the action, the reason. Then next step.",
+    SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
-    "Active every response until user asks for normal mode.",
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
   ].join(" "),
 
   [CAVEMAN_LEVELS.FULL]: [
     "Respond like terse caveman. All technical substance stay exact, only fluff die.",
     "Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries, hedging. Fragments OK. Short synonyms (big not extensive, fix not implement a solution for).",
     "Pattern: [thing] [action] [reason]. [next step].",
+    SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
-    "Active every response until user asks for normal mode.",
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
   ].join(" "),
 
   [CAVEMAN_LEVELS.ULTRA]: [
     "Respond ultra-terse. Maximum compression. Telegraphic.",
     "Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, use arrows for causality (X → Y). One word when one word enough.",
     "Pattern: [thing] → [result]. [fix].",
+    SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
-    "Active every response until user asks for normal mode.",
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
+  ].join(" "),
+
+  [CAVEMAN_LEVELS.WENYAN_LITE]: [
+    "Respond semi-classical. Drop filler/hedging but keep grammar structure, classical register.",
+    "Use classical Chinese sentence patterns where natural. Keep English for technical terms.",
+    SHARED_EXAMPLES,
+    SHARED_BOUNDARIES,
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
+  ].join(" "),
+
+  [CAVEMAN_LEVELS.WENYAN]: [
+    "Respond classical Chinese (文言文). Maximum classical terseness. 80-90% character reduction.",
+    "Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其).",
+    "Keep English for code, commands, function names, API names, error strings.",
+    SHARED_EXAMPLES,
+    SHARED_BOUNDARIES,
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
+  ].join(" "),
+
+  [CAVEMAN_LEVELS.WENYAN_ULTRA]: [
+    "Respond extreme classical compression (文言文 ultra). Maximum compression, ultra terse.",
+    "Same classical rules as wenyan-full but even more compressed. One classical particle per clause.",
+    SHARED_EXAMPLES,
+    SHARED_BOUNDARIES,
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
   ].join(" "),
 };

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -53,6 +53,9 @@ const CAVEMAN_LEVELS = [
   { id: "lite", label: "Lite", desc: "Drop filler, keep grammar" },
   { id: "full", label: "Full", desc: "Drop articles, fragments OK" },
   { id: "ultra", label: "Ultra", desc: "Telegraphic, max compression" },
+  { id: "wenyan-lite", label: "文 Lite", desc: "Classical Chinese, light compression" },
+  { id: "wenyan", label: "文 Full", desc: "Maximum 文言文, 80-90% reduction" },
+  { id: "wenyan-ultra", label: "文 Ultra", desc: "Extreme classical compression" },
 ];
 export default function APIPageClient({ machineId }) {
   const [keys, setKeys] = useState([]);


### PR DESCRIPTION
Adds classical Chinese (文言文) caveman levels for maximum token compression (~80-90% reduction).

  ## What changed

  **Backend** (`open-sse/rtk/cavemanPrompts.js`):
  - Added 3 new levels: `wenyan-lite`, `wenyan`, `wenyan-ultra` to `CAVEMAN_LEVELS` enum
  - Synced all prompts with upstream caveman repo:
    - `SHARED_EXAMPLES` — Not/Yes response patterns
    - `SHARED_AUTO_CLARITY` — drops caveman for security warnings, irreversible actions, ambiguous fragments
    - `SHARED_PERSISTENCE` — "ACTIVE EVERY RESPONSE. No revert after many turns."

  **UI** (`EndpointPageClient.js`):
  - 3 new wenyan buttons with 文 prefix labels in endpoint settings

  ## Caveman levels (all 6 now supported)

  | Level | Style |
  |-------|-------|
  | `lite` | Drop filler, keep grammar |
  | `full` | Drop articles, fragments OK |
  | `ultra` | Telegraphic, abbreviations, arrows |
  | `wenyan-lite` | Classical Chinese, light compression |
  | `wenyan` | Maximum 文言文, 80-90% reduction |
  | `wenyan-ultra` | Extreme classical compression |

  ## Reference

  Adapted from [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)