### PR TITLE
fix: raise proxy body limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new models: Claude Opus 4.8 (Claude Code), GPT 5.4 Mini (Codex)
 
 ## Fixes
+- Raise the Next proxy client body limit to 128MB by default, configurable via `NINEROUTER_PROXY_CLIENT_MAX_BODY_SIZE`, so large `/v1/responses` and `/v1/chat/completions` payloads are not truncated at 10MB (#1529, #1572)
 - DeepSeek thinking mode: echo `reasoning_content` back on follow-up/tool-call turns so OpenCode-free and custom providers no longer 400 with "reasoning_content must be passed back" (#1543)
 - Reasoning injector: match deepseek/kimi model ids case-insensitively (covers custom providers using capitalized model names)
 - OpenCode suggested-models: include free models without the `-free` suffix, e.g. `big-pickle` (#1535)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const projectRoot = dirname(fileURLToPath(import.meta.url));
 const tracingRoot = process.env.NEXT_TRACING_ROOT_MODE === "workspace"
   ? join(projectRoot, "..")
   : projectRoot;
+const proxyClientMaxBodySize = process.env.NINEROUTER_PROXY_CLIENT_MAX_BODY_SIZE || "128mb";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -24,6 +25,10 @@ const nextConfig = {
     unoptimized: true
   },
   env: {},
+  experimental: {
+    // #1529/#1572: LLM clients can send long context or base64 image payloads through /v1 rewrites.
+    proxyClientMaxBodySize,
+  },
   webpack: (config, { isServer }) => {
     // Ignore fs/path modules in browser bundle
     if (!isServer) {


### PR DESCRIPTION
## Summary
- raise Next's proxy client body limit to 128MB by default
- allow overriding the limit with `NINEROUTER_PROXY_CLIENT_MAX_BODY_SIZE`
- document the fix in the changelog

## Root Cause
Next buffers/clones proxied request bodies for the `/v1` rewrites and defaults `proxyClientMaxBodySize` to 10MB. Large but valid LLM payloads were truncated before the route handler, so `request.json()` received partial JSON and returned `Invalid JSON body`.

Fixes #1529
Fixes #1572

## Validation
- reproduced before the fix: 9MiB valid JSON parsed to `Missing model`; just-over-10MiB valid JSON returned `Invalid JSON body` with `Request body exceeded 10MB` for `/v1/responses` and `/v1/chat/completions`
- verified after the fix: 9MiB and just-over-10MiB valid JSON all parse to `Missing model` for `/v1/responses` and `/v1/chat/completions`
- verified direct `/api/v1/responses` and `/api/v1/chat/completions` just-over-10MiB payloads parse to `Missing model`
- verified `NINEROUTER_PROXY_CLIENT_MAX_BODY_SIZE=64mb` is read by `next.config.mjs`
- `npm run build`