### PR TITLE
fix: mask request debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new models: Claude Opus 4.8 (Claude Code), GPT 5.4 Mini (Codex)
 
 ## Fixes
+- Request debug logs: mask sensitive headers (authorization, API keys, cookies, tokens, secrets) before writing opt-in request/response log files.
 - DeepSeek thinking mode: echo `reasoning_content` back on follow-up/tool-call turns so OpenCode-free and custom providers no longer 400 with "reasoning_content must be passed back" (#1543)
 - Reasoning injector: match deepseek/kimi model ids case-insensitively (covers custom providers using capitalized model names)
 - OpenCode suggested-models: include free models without the `-free` suffix, e.g. `big-pickle` (#1535)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add new models: Claude Opus 4.8 (Claude Code), GPT 5.4 Mini (Codex)
 
 ## Fixes
+- MITM runtime copy: include the shared MITM host contract required by `dnsConfig.js` so the data-dir server can resolve `../../shared/constants/mitmToolHosts.js`. Self-heal a missing copy even when `server.js` is unchanged (older runtimes left it out, crashing the server with `MODULE_NOT_FOUND`).
+- MITM runtime process: preserve access to bundled `node_modules` for external dependencies such as `node-forge` when the server is launched from the data-dir runtime copy.
+- MITM standalone start: copy the full `src/mitm` tree into the runtime copy so `server.js` can still resolve local requires like `./logger`.
 - Request debug logs: mask sensitive headers (authorization, API keys, cookies, tokens, secrets) before writing opt-in request/response log files.
 - DeepSeek thinking mode: echo `reasoning_content` back on follow-up/tool-call turns so OpenCode-free and custom providers no longer 400 with "reasoning_content must be passed back" (#1543)
 - Reasoning injector: match deepseek/kimi model ids case-insensitively (covers custom providers using capitalized model names)

--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -2,7 +2,16 @@ import { platform, arch } from "os";
 
 // === Gemini CLI ===
 export const GEMINI_CLI_VERSION = "0.34.0";
+// Gemini CLI telemetry/debug logs currently show the Google client library
+// pair below together with the User-Agent surface tag handling.
 export const GEMINI_CLI_API_CLIENT = "google-genai-sdk/1.41.0 gl-node/v22.19.0";
+// Official Gemini CLI docs expose GEMINI_CLI_SURFACE as the supported
+// override for the trailing User-Agent surface tag.
+export const GEMINI_CLI_SURFACE = (process.env.GEMINI_CLI_SURFACE || "terminal").trim() || "terminal";
+
+// Match the installed Kiro desktop build observed in the local Kiro logs.
+// Keep this aligned with the actual app version instead of the old 1.0.0 placeholder.
+export const KIRO_IDE_VERSION = "0.12.263";
 
 // Map Node arch to Gemini CLI arch string (x64/x86/arm64/...)
 function geminiCLIArch() {
@@ -12,7 +21,9 @@ function geminiCLIArch() {
 }
 
 export function geminiCLIUserAgent(model = "unknown") {
-  return `GeminiCLI/${GEMINI_CLI_VERSION}/${model || "unknown"} (${platform()}; ${geminiCLIArch()}; terminal)`;
+  // Gemini CLI's official telemetry docs expose GEMINI_CLI_SURFACE for the
+  // trailing surface tag; default to "terminal" for standalone 9router runs.
+  return `GeminiCLI/${GEMINI_CLI_VERSION}/${model || "unknown"} (${platform()}; ${geminiCLIArch()}; ${GEMINI_CLI_SURFACE})`;
 }
 
 // === GitHub Copilot ===

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -1,4 +1,5 @@
 import { platform, arch } from "os";
+import { KIRO_IDE_VERSION } from "./appConstants.js";
 
 // === OS/Arch helpers ===
 function mapStainlessOs() {
@@ -27,11 +28,12 @@ const CLAUDE_API_HEADERS = {
 };
 
 // Full Claude CLI fingerprint — required by providers that gate on client identity (e.g. agentrouter)
+export const CLAUDE_CLI_VERSION = (process.env.CLAUDE_CLI_VERSION || "2.1.159").trim() || "2.1.159";
 const CLAUDE_CLI_SPOOF_HEADERS = {
   "Anthropic-Version": "2023-06-01",
   "Anthropic-Beta": "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advanced-tool-use-2025-11-20,effort-2025-11-24,structured-outputs-2025-12-15,fast-mode-2026-02-01,redact-thinking-2026-02-12,token-efficient-tools-2026-03-28",
   "Anthropic-Dangerous-Direct-Browser-Access": "true",
-  "User-Agent": "claude-cli/2.1.92 (external, sdk-cli)",
+  "User-Agent": `claude-cli/${CLAUDE_CLI_VERSION} (external, sdk-cli)`,
   "X-App": "cli",
   "X-Stainless-Helper-Method": "stream",
   "X-Stainless-Retry-Count": "0",
@@ -43,6 +45,13 @@ const CLAUDE_CLI_SPOOF_HEADERS = {
   "X-Stainless-Os": mapStainlessOs(),
   "X-Stainless-Timeout": "600"
 };
+
+// Codex uses the Rust CLI identity on the wire (`codex_cli_rs`), not the
+// older `codex-cli` placeholder. Keep the request headers aligned with the
+// current official CLI shape so backend allowlists and request captures match.
+export const CODEX_ORIGINATOR = "codex_cli_rs";
+export const CODEX_CLI_VERSION = (process.env.CODEX_CLI_VERSION || "0.135.0").trim() || "0.135.0";
+export const CODEX_USER_AGENT = `codex_cli_rs/${CODEX_CLI_VERSION} (${platform()}; ${arch()})`;
 
 // Shared baseUrls
 const KIMI_CODING_BASE_URL = "https://api.kimi.com/coding/v1/messages";
@@ -71,8 +80,8 @@ export const PROVIDERS = {
     baseUrl: "https://chatgpt.com/backend-api/codex/responses",
     format: "openai-responses",
     headers: {
-      "originator": "codex-cli",
-      "User-Agent": "codex-cli/1.0.18 (macOS; arm64)"
+      "originator": CODEX_ORIGINATOR,
+      "User-Agent": CODEX_USER_AGENT
     },
     clientId: "app_EMoamEEZ73f0CkXaXp7hrann",
     tokenUrl: "https://auth.openai.com/oauth/token"
@@ -199,8 +208,8 @@ export const PROVIDERS = {
       "Content-Type": "application/json",
       "Accept": "application/vnd.amazon.eventstream",
       "X-Amz-Target": "AmazonCodeWhispererStreamingService.GenerateAssistantResponse",
-      "User-Agent": "AWS-SDK-JS/3.0.0 kiro-ide/1.0.0",
-      "X-Amz-User-Agent": "aws-sdk-js/3.0.0 kiro-ide/1.0.0"
+      "User-Agent": `AWS-SDK-JS/3.0.0 kiro-ide/${KIRO_IDE_VERSION}`,
+      "X-Amz-User-Agent": `aws-sdk-js/3.0.0 kiro-ide/${KIRO_IDE_VERSION}`
     },
     tokenUrl: "https://prod.us-east-1.auth.desktop.kiro.dev/refreshToken",
     authUrl: "https://prod.us-east-1.auth.desktop.kiro.dev"

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { BaseExecutor } from "./base.js";
 import { CODEX_DEFAULT_INSTRUCTIONS } from "../config/codexInstructions.js";
-import { PROVIDERS } from "../config/providers.js";
+import { CODEX_ORIGINATOR, PROVIDERS } from "../config/providers.js";
 import { normalizeResponsesInput } from "../translator/helpers/responsesApiHelper.js";
 import { fetchImageAsBase64 } from "../translator/helpers/imageHelper.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
@@ -130,7 +130,10 @@ function normalizeSessionId(value) {
   return v;
 }
 
-// Resolve prompt-cache session id with priority: body → assistant-text-hash → workspaceId → machineId
+// Resolve prompt-cache session id with priority: body → assistant-text-hash → accountId → machineId.
+// Codex connections in this repo have historically stored the account binding as either
+// chatgptAccountId (current OAuth/import path) or workspaceId (older/local fallback), so
+// accept both without changing the visible request shape.
 function resolveCacheSessionId(body, credentials, machineId) {
   // 1. Client-provided session/conversation id (highest priority — stable per conversation)
   const fromBody =
@@ -164,9 +167,11 @@ function resolveCacheSessionId(body, credentials, machineId) {
     }
   }
 
-  // 3. Account-wide fallback (workspaceId from connection)
-  const workspaceId = normalizeSessionId(credentials?.providerSpecificData?.workspaceId);
-  if (workspaceId) return workspaceId;
+  // 3. Account-wide fallback (chatgptAccountId/workspaceId from connection)
+  const accountId =
+    normalizeSessionId(credentials?.providerSpecificData?.chatgptAccountId) ||
+    normalizeSessionId(credentials?.providerSpecificData?.workspaceId);
+  if (accountId) return accountId;
 
   // 4. Last resort — stable per-machine id
   return machineId ? `sess_${hashContent(machineId)}` : generateSessionId();
@@ -197,12 +202,14 @@ export class CodexExecutor extends BaseExecutor {
   buildHeaders(credentials, stream = true) {
     const headers = super.buildHeaders(credentials, stream);
     headers["session_id"] = this._currentSessionId || credentials?.connectionId || "default";
-    // Identify client type to Codex backend (matches official codex CLI)
-    if (!headers["originator"]) headers["originator"] = "codex_cli_rs";
+    // Identify client type to Codex backend (matches the official Rust CLI wire identity).
+    if (!headers["originator"]) headers["originator"] = CODEX_ORIGINATOR;
     // Workspace binding header — improves account scope + cache affinity
-    const workspaceId = credentials?.providerSpecificData?.workspaceId;
-    if (typeof workspaceId === "string" && workspaceId && !headers["chatgpt-account-id"]) {
-      headers["chatgpt-account-id"] = workspaceId;
+    const accountId =
+      credentials?.providerSpecificData?.chatgptAccountId ||
+      credentials?.providerSpecificData?.workspaceId;
+    if (typeof accountId === "string" && accountId && !headers["chatgpt-account-id"]) {
+      headers["chatgpt-account-id"] = accountId;
     }
     return headers;
   }

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -16,7 +16,8 @@ const SSE_HEADERS = {
  * Determine which SSE transform stream to use based on provider/format.
  */
 function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey }) {
-  const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
+  const lowerUserAgent = userAgent?.toLowerCase() || "";
+  const isDroidCLI = lowerUserAgent.includes("droid") || lowerUserAgent.includes("codex-cli") || lowerUserAgent.includes("codex_cli_rs");
   const needsCodexTranslation = provider === "codex" && targetFormat === FORMATS.OPENAI_RESPONSES && !isDroidCLI;
 
   if (needsCodexTranslation) {

--- a/open-sse/handlers/imageProviders/codex.js
+++ b/open-sse/handlers/imageProviders/codex.js
@@ -1,11 +1,11 @@
 // Codex (ChatGPT Plus/Pro) image generation via Responses API + SSE
 import { randomUUID } from "node:crypto";
 import { nowSec } from "./_base.js";
+import { CODEX_ORIGINATOR } from "../../config/providers.js";
 
 const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_USER_AGENT = "codex-imagen/0.2.6";
 const CODEX_VERSION = "0.129.0";
-const CODEX_ORIGINATOR = "codex_cli_rs";
 const CODEX_MODEL_SUFFIX = "-image";
 const CODEX_REF_DETAIL = "high";
 

--- a/open-sse/utils/claudeCloaking.js
+++ b/open-sse/utils/claudeCloaking.js
@@ -1,10 +1,10 @@
 import { createHash, randomBytes, randomUUID } from "crypto";
 import { CLAUDE_TOOL_SUFFIX, CC_DEFAULT_TOOLS } from "../config/appConstants.js";
 
-const CLAUDE_VERSION = "2.1.92";
+const CLAUDE_VERSION = (process.env.CLAUDE_CLI_VERSION || "2.1.159").trim() || "2.1.159";
 const CC_ENTRYPOINT = "sdk-cli";
 
-// Generate billing header matching real Claude Code 2.1.92+ format:
+// Generate billing header matching the current Claude Code format:
 // x-anthropic-billing-header: cc_version=<ver>.<build>; cc_entrypoint=sdk-cli; cch=<hash>;
 function generateBillingHeader(payload) {
   const content = JSON.stringify(payload);
@@ -13,7 +13,7 @@ function generateBillingHeader(payload) {
   return `x-anthropic-billing-header: cc_version=${CLAUDE_VERSION}.${buildHash}; cc_entrypoint=${CC_ENTRYPOINT}; cch=${cch};`;
 }
 
-// Generate fake user ID in Claude Code 2.1.92+ JSON format:
+// Generate fake user ID in the current Claude Code JSON format:
 // {"device_id":"<64hex>","account_uuid":"<uuid>","session_id":"<uuid>"}
 function generateFakeUserID(sessionId) {
   const deviceId = randomBytes(32).toString("hex");

--- a/open-sse/utils/clientDetector.js
+++ b/open-sse/utils/clientDetector.js
@@ -37,8 +37,9 @@ export function detectClientTool(headers = {}, body = {}) {
   // Gemini CLI
   if (ua.includes("gemini-cli")) return "gemini-cli";
 
-  // Codex CLI
-  if (ua.includes("codex-cli")) return "codex";
+  // Codex CLI/Rust CLI. The current official wire identity is codex_cli_rs,
+  // but keep the older codex-cli alias recognized for older local captures.
+  if (ua.includes("codex_cli_rs") || ua.includes("codex-cli")) return "codex";
 
   // DeepSeek TUI
   if (ua.includes("deepseek-tui")) return "deepseek-tui";

--- a/open-sse/utils/requestLogger.js
+++ b/open-sse/utils/requestLogger.js
@@ -69,25 +69,52 @@ function writeJsonFile(sessionPath, filename, data) {
   }
 }
 
-// Mask sensitive data in headers (DISABLED - keep full token for testing)
-function maskSensitiveHeaders(headers) {
+const SENSITIVE_HEADER_PATTERNS = [
+  "authorization",
+  "proxy-authorization",
+  "api-key",
+  "apikey",
+  "x-api-key",
+  "x-key",
+  "cookie",
+  "set-cookie",
+  "token",
+  "secret",
+  "password",
+  "credential"
+];
+
+function maskHeaderValue(value) {
+  if (Array.isArray(value)) return value.map(maskHeaderValue);
+  if (value === undefined || value === null) return value;
+  const text = String(value);
+  if (!text) return text;
+
+  const bearerMatch = text.match(/^(Bearer|Token|Basic)\s+(.+)$/i);
+  if (bearerMatch) return `${bearerMatch[1]} ${maskToken(bearerMatch[2])}`;
+  return maskToken(text);
+}
+
+function maskToken(text) {
+  if (text.length <= 8) return "[REDACTED]";
+  if (text.length <= 20) return `${text.slice(0, 4)}...[REDACTED]`;
+  return `${text.slice(0, 8)}...[REDACTED]...${text.slice(-4)}`;
+}
+
+// Debug request logs are opt-in, but they must never persist live secrets.
+export function maskSensitiveHeaders(headers) {
   if (!headers) return {};
-  return { ...headers };
-  
-  // Old masking code (disabled):
-  // const masked = { ...headers };
-  // const sensitiveKeys = ["authorization", "x-api-key", "cookie", "token"];
-  // 
-  // for (const key of Object.keys(masked)) {
-  //   const lowerKey = key.toLowerCase();
-  //   if (sensitiveKeys.some(sk => lowerKey.includes(sk))) {
-  //     const value = masked[key];
-  //     if (value && value.length > 20) {
-  //       masked[key] = value.slice(0, 10) + "..." + value.slice(-5);
-  //     }
-  //   }
-  // }
-  // return masked;
+  const source = typeof headers.entries === "function" ? Object.fromEntries(headers.entries()) : headers;
+  const masked = { ...source };
+
+  for (const key of Object.keys(masked)) {
+    const lowerKey = key.toLowerCase();
+    if (SENSITIVE_HEADER_PATTERNS.some(pattern => lowerKey.includes(pattern))) {
+      masked[key] = maskHeaderValue(masked[key]);
+    }
+  }
+
+  return masked;
 }
 
 // No-op logger when logging is disabled
@@ -170,7 +197,7 @@ export async function createRequestLogger(sourceFormat, targetFormat, model) {
         timestamp: new Date().toISOString(),
         status,
         statusText,
-        headers: headers ? (typeof headers.entries === "function" ? Object.fromEntries(headers.entries()) : headers) : {},
+        headers: maskSensitiveHeaders(headers),
         body
       });
     },

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -4,7 +4,7 @@ import { testProxyUrl } from "@/lib/network/proxyTest";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { PROVIDER_ENDPOINTS } from "@/shared/constants/config";
 import { getDefaultModel } from "open-sse/config/providerModels.js";
-import { resolveOllamaLocalHost } from "open-sse/config/providers.js";
+import { CODEX_ORIGINATOR, CODEX_USER_AGENT, resolveOllamaLocalHost } from "open-sse/config/providers.js";
 import {
   GEMINI_CONFIG,
   ANTIGRAVITY_CONFIG,
@@ -25,7 +25,7 @@ const OAUTH_TEST_CONFIG = {
     method: "POST",
     authHeader: "Authorization",
     authPrefix: "Bearer ",
-    extraHeaders: { "Content-Type": "application/json", "originator": "codex-cli", "User-Agent": "codex-cli/1.0.18 (macOS; arm64)" },
+    extraHeaders: { "Content-Type": "application/json", "originator": CODEX_ORIGINATOR, "User-Agent": CODEX_USER_AGENT },
     // Minimal invalid body — triggers fast 400 without consuming quota
     body: JSON.stringify({ model: "gpt-5.3-codex", input: [], stream: false, store: false }),
     // 400 (bad request) means auth succeeded; only 401/403 means token is bad

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -122,10 +122,17 @@ export async function POST(request) {
 
     let providerSpecificData = normalizeProviderSpecificData(provider, body, body.providerSpecificData);
 
+    // Compatible/embedding nodes allow exactly one connection each. These guards were
+    // dropped accidentally during the bun:sqlite refactor (v0.4.28); restored to honor
+    // the contract locked in by tests/unit/compatible-provider-connections.test.js (#925).
     if (isOpenAICompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);
       if (!node) {
         return NextResponse.json({ error: "OpenAI Compatible node not found" }, { status: 404 });
+      }
+      const existingConnections = await getProviderConnections({ provider });
+      if (existingConnections.length > 0) {
+        return NextResponse.json({ error: "Only one connection is allowed for this OpenAI Compatible node" }, { status: 400 });
       }
       providerSpecificData = {
         prefix: node.prefix,
@@ -138,6 +145,10 @@ export async function POST(request) {
       if (!node) {
         return NextResponse.json({ error: "Anthropic Compatible node not found" }, { status: 404 });
       }
+      const existingConnections = await getProviderConnections({ provider });
+      if (existingConnections.length > 0) {
+        return NextResponse.json({ error: "Only one connection is allowed for this Anthropic Compatible node" }, { status: 400 });
+      }
       providerSpecificData = {
         prefix: node.prefix,
         baseUrl: node.baseUrl,
@@ -147,6 +158,10 @@ export async function POST(request) {
       const node = await getProviderNodeById(provider);
       if (!node) {
         return NextResponse.json({ error: "Custom Embedding node not found" }, { status: 404 });
+      }
+      const existingConnections = await getProviderConnections({ provider });
+      if (existingConnections.length > 0) {
+        return NextResponse.json({ error: "Only one connection is allowed for this Custom Embedding node" }, { status: 400 });
       }
       providerSpecificData = {
         prefix: node.prefix,

--- a/src/lib/oauth/services/gemini.js
+++ b/src/lib/oauth/services/gemini.js
@@ -67,6 +67,8 @@ export class GeminiCLIService {
       {
         method: "POST",
         headers: {
+          // Keep the Cloud Code Assist request aligned with the current
+          // Gemini CLI telemetry surface and Google client headers.
           "Authorization": `Bearer ${accessToken}`,
           "Content-Type": "application/json",
           "User-Agent": "google-api-nodejs-client/9.15.1",

--- a/src/lib/qoder/constants.js
+++ b/src/lib/qoder/constants.js
@@ -28,6 +28,9 @@ export const QODER_MODEL_LIST_URL = `${QODER_CHAT_BASE}/algo/api/v2/model/list`;
 
 // COSY header constants. These are not arbitrary — the upstream signature
 // validation matches them against the values used at signing time.
+// Qoder 1.0 public docs/changelog still expose the 1.0 wire version, so
+// keep this aligned with the current CLI/IDE family rather than older v0.9
+// snapshots.
 export const QODER_IDE_VERSION = "1.0.0";
 export const QODER_CLIENT_TYPE = "5";
 export const QODER_DATA_POLICY = "disagree";
@@ -53,7 +56,7 @@ export const QODER_MODEL_MAP = {
   mmodel: "mmodel",
 };
 
-// RSA public key for COSY encryption (extracted from Qoder IDE v0.9).
+// RSA public key for COSY encryption (matches the current Qoder 1.0 family).
 // Matches the CLIProxyAPIPlus branch and live qodercli traffic.
 export const QODER_RSA_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDA8iMH5c02LilrsERw9t6Pv5Nc

--- a/src/mitm/dns/dnsConfig.js
+++ b/src/mitm/dns/dnsConfig.js
@@ -3,6 +3,11 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { log, err } = require("../logger");
+// GUARD: this is the only require from src/mitm that reaches OUTSIDE the mitm tree.
+// The MITM server runs from a loose-file copy under DATA_DIR/runtime (see manager.js),
+// so any such external require must be explicitly mirrored there by manager.js's copy
+// logic (resolveSharedMitmToolHostsPath/ensureRuntimeSharedHosts). Adding a new external
+// require without registering it will crash the runtime with MODULE_NOT_FOUND.
 const { TOOL_HOSTS } = require("../../shared/constants/mitmToolHosts.js");
 const { runElevatedPowerShell, isAdmin } = require("../winElevated.js");
 

--- a/src/mitm/manager.js
+++ b/src/mitm/manager.js
@@ -61,30 +61,131 @@ function resolveBundledServerPath() {
   return fromCwd;
 }
 
-// Copy bundled server.js into DATA_DIR so MITM doesn't lock node_modules
+function resolveMitmSourceDir(bundledPath) {
+  if (!bundledPath) return null;
+  const candidates = [
+    path.join(process.cwd(), "src", "mitm"),
+    path.join(process.cwd(), "..", "src", "mitm"),
+  ];
+  for (const candidate of candidates) {
+    const serverPath = path.join(candidate, "server.js");
+    if (fs.existsSync(serverPath)) return candidate;
+  }
+  const bundledDir = path.dirname(bundledPath);
+  if (fs.existsSync(path.join(bundledDir, "logger.js"))) return bundledDir;
+  return null;
+}
+
+function copyRecursive(srcDir, destDir) {
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const from = path.join(srcDir, entry.name);
+    const to = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      copyRecursive(from, to);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(from, to);
+    }
+  }
+}
+
+function copyFileIfExists(srcFile, destFile) {
+  if (!fs.existsSync(srcFile)) return false;
+  fs.mkdirSync(path.dirname(destFile), { recursive: true });
+  fs.copyFileSync(srcFile, destFile);
+  return true;
+}
+
+// Registry of src/mitm's external (outside-the-tree) require dependencies that must be
+// mirrored into the DATA_DIR runtime copy. Today that's only mitmToolHosts.js (kept in
+// src/shared because the dashboard UI consumes it too — see MitmToolCard.js). If a new
+// external require is ever added under src/mitm, register it here, or the runtime breaks
+// with MODULE_NOT_FOUND. See the matching GUARD note in dns/dnsConfig.js.
+function resolveSharedMitmToolHostsPath(sourceDir) {
+  const candidates = [
+    path.join(path.dirname(sourceDir || ""), "shared", "constants", "mitmToolHosts.js"),
+    path.join(process.cwd(), "src", "shared", "constants", "mitmToolHosts.js"),
+    path.join(process.cwd(), "..", "src", "shared", "constants", "mitmToolHosts.js"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) || null;
+}
+
+// dnsConfig requires ../../shared/constants/mitmToolHosts.js from runtime/mitm/dns,
+// so mirror that one shared contract beside the mitm tree. Kept independent of the
+// server.js size-skip below: an older runtime may have a same-size server.js but be
+// missing this file (it was only copied by newer builds), which crashed dnsConfig
+// with MODULE_NOT_FOUND. Always heal the shared file when it's absent.
+function ensureRuntimeSharedHosts(sourceDir, force = false, runtimeShared = path.join(DATA_DIR, "runtime", "shared", "constants", "mitmToolHosts.js")) {
+  if (!force && fs.existsSync(runtimeShared)) return;
+  const sharedHosts = resolveSharedMitmToolHostsPath(sourceDir);
+  if (sharedHosts) copyFileIfExists(sharedHosts, runtimeShared);
+}
+
+function findAncestorNodeModules(startPath) {
+  const found = [];
+  let dir = startPath && fs.existsSync(startPath) && fs.statSync(startPath).isDirectory()
+    ? startPath
+    : path.dirname(startPath || "");
+  while (dir && dir !== path.dirname(dir)) {
+    const candidate = path.join(dir, "node_modules");
+    if (fs.existsSync(candidate)) found.push(candidate);
+    dir = path.dirname(dir);
+  }
+  return found;
+}
+
+function buildMitmNodePath(bundledPath, existingNodePath = process.env.NODE_PATH || "") {
+  const parts = [];
+  for (const bundledNodeModules of findAncestorNodeModules(bundledPath)) {
+    if (!parts.includes(bundledNodeModules)) parts.push(bundledNodeModules);
+  }
+  for (const entry of String(existingNodePath).split(path.delimiter)) {
+    if (entry && !parts.includes(entry)) parts.push(entry);
+  }
+  return parts.join(path.delimiter);
+}
+
+function buildMitmChildEnv(apiKey, mitmRouterBase) {
+  const env = {
+    ...process.env,
+    ROUTER_API_KEY: apiKey,
+    NODE_ENV: "production",
+    MITM_ROUTER_BASE: mitmRouterBase,
+  };
+  const nodePath = buildMitmNodePath(BUNDLED_SERVER_PATH);
+  if (nodePath) {
+    // Runtime MITM lives under DATA_DIR to avoid update-time file locks, so
+    // external deps like node-forge must resolve from the original bundle.
+    env.NODE_PATH = nodePath;
+  }
+  return env;
+}
+
+// Copy MITM source tree into DATA_DIR so the spawned server keeps its local
+// relative requires (`./logger`, `./config`, etc.) intact even when Next.js
+// standalone only emits server.js.
 // (prevents EBUSY on `npm i -g 9router@latest` while MITM is running).
 function ensureRuntimeServer(bundledPath) {
   try {
     if (!bundledPath || !fs.existsSync(bundledPath)) return bundledPath;
-
-    // Dev mode: source file has relative requires (./logger, ./config...),
-    // only the bundled file inside node_modules is self-contained + safe to copy.
-    if (!bundledPath.includes(`${path.sep}node_modules${path.sep}`)) {
-      return bundledPath;
-    }
-
     const runtimeDir = path.join(DATA_DIR, "runtime", "mitm");
     const runtimeServer = path.join(runtimeDir, "server.js");
+    const sourceDir = resolveMitmSourceDir(bundledPath);
+    if (!sourceDir) return bundledPath;
 
-    // Skip copy if sizes match (bundle unchanged since last run)
+    // Skip copy if sizes match (bundle unchanged since last run), but still
+    // self-heal the shared hosts file — it may be absent from an older runtime.
     if (fs.existsSync(runtimeServer)) {
       try {
-        if (fs.statSync(bundledPath).size === fs.statSync(runtimeServer).size) return runtimeServer;
+        if (fs.statSync(bundledPath).size === fs.statSync(runtimeServer).size) {
+          ensureRuntimeSharedHosts(sourceDir);
+          return runtimeServer;
+        }
       } catch { /* recopy */ }
     }
 
-    fs.mkdirSync(runtimeDir, { recursive: true });
-    fs.copyFileSync(bundledPath, runtimeServer);
+    copyRecursive(sourceDir, runtimeDir);
+    ensureRuntimeSharedHosts(sourceDir, true);
     return runtimeServer;
   } catch (e) {
     try { log(`[MITM] runtime copy failed: ${e.message}`); } catch { /* ignore */ }
@@ -92,7 +193,8 @@ function ensureRuntimeServer(bundledPath) {
   }
 }
 
-const SERVER_PATH = ensureRuntimeServer(resolveBundledServerPath());
+const BUNDLED_SERVER_PATH = resolveBundledServerPath();
+const SERVER_PATH = ensureRuntimeServer(BUNDLED_SERVER_PATH);
 const ENCRYPT_ALGO = "aes-256-gcm";
 const ENCRYPT_SALT = "9router-mitm-pwd";
 
@@ -586,12 +688,7 @@ async function startServer(apiKey, sudoPassword, forceKillPort443 = false) {
         windowsHide: true,
         cwd: os.tmpdir(),
         stdio: ["ignore", "pipe", "pipe"],
-        env: {
-          ...process.env,
-          ROUTER_API_KEY: apiKey,
-          NODE_ENV: "production",
-          MITM_ROUTER_BASE: mitmRouterBase,
-        },
+        env: buildMitmChildEnv(apiKey, mitmRouterBase),
       }
     );
 
@@ -599,10 +696,12 @@ async function startServer(apiKey, sudoPassword, forceKillPort443 = false) {
   } else if (isSudoAvailable()) {
     // Pass HOME explicitly so os.homedir() resolves to the unprivileged user's home
     // instead of /root when sudo resets the environment.
+    const mitmNodePath = buildMitmNodePath(BUNDLED_SERVER_PATH);
     const inlineCmd = [
       `HOME=${shellQuoteSingle(os.homedir())}`,
       `ROUTER_API_KEY=${shellQuoteSingle(apiKey)}`,
       `MITM_ROUTER_BASE=${shellQuoteSingle(mitmRouterBase)}`,
+      ...(mitmNodePath ? [`NODE_PATH=${shellQuoteSingle(mitmNodePath)}`] : []),
       "NODE_ENV=production",
       shellQuoteSingle(process.execPath),
       shellQuoteSingle(effectiveServerPath),
@@ -620,12 +719,7 @@ async function startServer(apiKey, sudoPassword, forceKillPort443 = false) {
       windowsHide: true,
       cwd: os.tmpdir(),
       stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        ROUTER_API_KEY: apiKey,
-        NODE_ENV: "production",
-        MITM_ROUTER_BASE: mitmRouterBase,
-      },
+      env: buildMitmChildEnv(apiKey, mitmRouterBase),
     });
   }
 
@@ -848,4 +942,14 @@ module.exports = {
   restoreToolDNS,
   hasDnsPrivilege,
   removeAllDNSEntriesSync,
+  __test__: {
+    resolveMitmSourceDir,
+    copyRecursive,
+    copyFileIfExists,
+    resolveSharedMitmToolHostsPath,
+    ensureRuntimeSharedHosts,
+    ensureRuntimeServer,
+    findAncestorNodeModules,
+    buildMitmNodePath,
+  },
 };

--- a/tests/unit/claude-header-forwarding.test.js
+++ b/tests/unit/claude-header-forwarding.test.js
@@ -12,6 +12,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+const originalFetch = globalThis.fetch;
+
 // ─── claudeHeaderCache ────────────────────────────────────────────────────────
 
 describe("claudeHeaderCache", () => {
@@ -324,25 +326,23 @@ describe("DefaultExecutor.buildHeaders() — anthropic-compatible stripping", ()
 
 describe("proxyAwareFetch — api.anthropic.com routing", () => {
   afterEach(() => {
+    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 
-  it("routes api.anthropic.com to gotScraping (non-streaming) and returns ok response", async () => {
-    // Mock got-scraping before module load
-    vi.doMock("got-scraping", () => {
-      const mockGotScraping = vi.fn().mockResolvedValue({
-        statusCode: 200,
-        statusMessage: "OK",
-        headers: { "content-type": "application/json" },
-        rawBody: Buffer.from(JSON.stringify({ id: "msg_test" })),
-      });
-      mockGotScraping.stream = vi.fn();
-      return { gotScraping: mockGotScraping };
+  it("uses native fetch for api.anthropic.com when got-scraping is disabled", async () => {
+    const nativeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ "content-type": "application/json" }),
+      body: null,
+      text: async () => JSON.stringify({ id: "msg_test" }),
+      json: async () => ({ id: "msg_test" }),
     });
-
+    globalThis.fetch = nativeFetch;
     vi.resetModules();
     const { proxyAwareFetch } = await import("open-sse/utils/proxyFetch.js");
-    const { gotScraping } = await import("got-scraping");
 
     const res = await proxyAwareFetch("https://api.anthropic.com/v1/messages", {
       method: "POST",
@@ -351,22 +351,15 @@ describe("proxyAwareFetch — api.anthropic.com routing", () => {
       body: JSON.stringify({ model: "claude-3-5-sonnet-20241022", messages: [] }),
     });
 
-    expect(gotScraping).toHaveBeenCalledOnce();
+    expect(nativeFetch).toHaveBeenCalledOnce();
     expect(res.ok).toBe(true);
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.id).toBe("msg_test");
   });
 
-  it("falls back gracefully when got-scraping throws on non-streaming path", async () => {
-    vi.doMock("got-scraping", () => {
-      const fn = vi.fn().mockRejectedValue(new Error("TLS error"));
-      fn.stream = vi.fn();
-      return { gotScraping: fn };
-    });
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn().mockResolvedValue({
+  it("still uses native fetch for non-Anthropic hosts", async () => {
+    const nativeFetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
       statusText: "OK",
@@ -375,6 +368,7 @@ describe("proxyAwareFetch — api.anthropic.com routing", () => {
       text: async () => "{}",
       json: async () => ({}),
     });
+    globalThis.fetch = nativeFetch;
 
     vi.resetModules();
     const { proxyAwareFetch } = await import("open-sse/utils/proxyFetch.js");
@@ -386,14 +380,10 @@ describe("proxyAwareFetch — api.anthropic.com routing", () => {
     });
 
     expect(res.ok).toBe(true);
-    globalThis.fetch = originalFetch;
   });
 
-  it("does NOT route non-Anthropic hosts through gotScraping", async () => {
-    const gotScrapingMock = vi.fn();
-    vi.doMock("got-scraping", () => ({ gotScraping: gotScrapingMock }));
-
-    globalThis.fetch = vi.fn().mockResolvedValue({
+  it("does NOT alter non-Anthropic hosts", async () => {
+    const nativeFetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
       statusText: "OK",
@@ -402,6 +392,7 @@ describe("proxyAwareFetch — api.anthropic.com routing", () => {
       text: async () => "{}",
       json: async () => ({}),
     });
+    globalThis.fetch = nativeFetch;
 
     vi.resetModules();
     const { proxyAwareFetch } = await import("open-sse/utils/proxyFetch.js");
@@ -412,6 +403,6 @@ describe("proxyAwareFetch — api.anthropic.com routing", () => {
       body: "{}",
     });
 
-    expect(gotScrapingMock).not.toHaveBeenCalled();
+    expect(nativeFetch).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/clientDetector.test.js
+++ b/tests/unit/clientDetector.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { detectClientTool, isNativePassthrough } from "../../open-sse/utils/clientDetector.js";
+
+describe("clientDetector", () => {
+  it("recognizes both codex-cli and codex_cli_rs user agents as Codex", () => {
+    expect(detectClientTool({ "user-agent": "codex-cli/0.135.0 (macOS; arm64)" })).toBe("codex");
+    expect(detectClientTool({ "user-agent": "codex_cli_rs/0.135.0 (win32; x64)" })).toBe("codex");
+  });
+
+  it("keeps Codex as a native passthrough provider", () => {
+    expect(isNativePassthrough("codex", "codex")).toBe(true);
+    expect(isNativePassthrough("codex", "openai")).toBe(false);
+  });
+});

--- a/tests/unit/codex-refresh-token.test.js
+++ b/tests/unit/codex-refresh-token.test.js
@@ -14,6 +14,10 @@ const originalFetch = global.fetch;
 describe("Codex Refresh Token", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // tokenRefresh.js keeps a module-level dedup cache (keyed provider:oldToken, 10s TTL)
+    // to prevent refresh_token_reused. Reset modules so each case gets a fresh cache and
+    // reusing the same "old-refresh-token" across cases doesn't leak a prior result.
+    vi.resetModules();
   });
 
   afterEach(() => {

--- a/tests/unit/gemini-user-agent.test.js
+++ b/tests/unit/gemini-user-agent.test.js
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { arch, platform } from "os";
+
+function expectedSurface(surface) {
+  return `GeminiCLI/0.34.0/gemini-2.5-pro (${platform()}; ${arch() === "ia32" ? "x86" : arch()}; ${surface})`;
+}
+
+describe("geminiCLIUserAgent", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("defaults to the terminal surface", async () => {
+    const { geminiCLIUserAgent } = await import("../../open-sse/config/appConstants.js");
+    expect(geminiCLIUserAgent("gemini-2.5-pro")).toBe(expectedSurface("terminal"));
+  });
+
+  it("honors GEMINI_CLI_SURFACE for custom identification", async () => {
+    vi.stubEnv("GEMINI_CLI_SURFACE", "my-custom-tool");
+    const { geminiCLIUserAgent } = await import("../../open-sse/config/appConstants.js");
+    expect(geminiCLIUserAgent("gemini-2.5-pro")).toBe(expectedSurface("my-custom-tool"));
+  });
+});

--- a/tests/unit/image-generation.test.js
+++ b/tests/unit/image-generation.test.js
@@ -319,6 +319,7 @@ describe("handleImageGenerationCore", () => {
         headers: expect.objectContaining({
           authorization: "Bearer codex-token",
           "chatgpt-account-id": "account-123",
+          originator: "codex_cli_rs",
           version: "0.129.0",
         }),
       })

--- a/tests/unit/mitm-manager.test.js
+++ b/tests/unit/mitm-manager.test.js
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const tmpRoots = [];
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // best effort cleanup
+    }
+  }
+});
+
+describe("mitm manager helpers", () => {
+  it("resolves the source MITM directory when standalone only contains server.js", async () => {
+    const { __test__ } = await import("../../src/mitm/manager.js");
+    const bundledPath = path.join(process.cwd(), ".next", "standalone", "src", "mitm", "server.js");
+    const sourceDir = __test__.resolveMitmSourceDir(bundledPath);
+
+    expect(sourceDir).toBe(path.join(process.cwd(), "src", "mitm"));
+  });
+
+  it("copies the MITM tree recursively", async () => {
+    const { __test__ } = await import("../../src/mitm/manager.js");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "9router-mitm-"));
+    tmpRoots.push(root);
+
+    const srcDir = path.join(root, "src");
+    const nested = path.join(srcDir, "nested");
+    const destDir = path.join(root, "dest");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, "logger.js"), "module.exports = { ok: true };");
+    fs.writeFileSync(path.join(nested, "child.txt"), "child");
+
+    __test__.copyRecursive(srcDir, destDir);
+
+    expect(fs.readFileSync(path.join(destDir, "logger.js"), "utf8")).toContain("ok: true");
+    expect(fs.readFileSync(path.join(destDir, "nested", "child.txt"), "utf8")).toBe("child");
+  });
+
+  it("copies the shared MITM host contract beside the runtime tree", async () => {
+    const { __test__ } = await import("../../src/mitm/manager.js");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "9router-mitm-"));
+    tmpRoots.push(root);
+
+    const sourceDir = path.join(root, "src", "mitm");
+    const sharedDir = path.join(root, "src", "shared", "constants");
+    const destFile = path.join(root, "runtime", "shared", "constants", "mitmToolHosts.js");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.mkdirSync(sharedDir, { recursive: true });
+    fs.writeFileSync(path.join(sharedDir, "mitmToolHosts.js"), "module.exports = { TOOL_HOSTS: {} };");
+
+    const resolved = __test__.resolveSharedMitmToolHostsPath(sourceDir);
+    __test__.copyFileIfExists(resolved, destFile);
+
+    expect(resolved).toBe(path.join(sharedDir, "mitmToolHosts.js"));
+    expect(fs.readFileSync(destFile, "utf8")).toContain("TOOL_HOSTS");
+  });
+
+  it("self-heals a missing shared host file even when the server tree is untouched", async () => {
+    const { __test__ } = await import("../../src/mitm/manager.js");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "9router-mitm-"));
+    tmpRoots.push(root);
+
+    const sourceDir = path.join(root, "src", "mitm");
+    const sharedDir = path.join(root, "src", "shared", "constants");
+    const runtimeShared = path.join(root, "runtime", "shared", "constants", "mitmToolHosts.js");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.mkdirSync(sharedDir, { recursive: true });
+    fs.writeFileSync(path.join(sharedDir, "mitmToolHosts.js"), "module.exports = { TOOL_HOSTS: { a: [] } };");
+
+    // Runtime missing the shared file (older build that skipped it) → must be created.
+    __test__.ensureRuntimeSharedHosts(sourceDir, false, runtimeShared);
+    expect(fs.readFileSync(runtimeShared, "utf8")).toContain("a: []");
+
+    // Without force, an existing runtime file is left untouched (no needless rewrite).
+    fs.writeFileSync(runtimeShared, "STALE");
+    __test__.ensureRuntimeSharedHosts(sourceDir, false, runtimeShared);
+    expect(fs.readFileSync(runtimeShared, "utf8")).toBe("STALE");
+
+    // With force (fresh build copy), the file is refreshed from source.
+    __test__.ensureRuntimeSharedHosts(sourceDir, true, runtimeShared);
+    expect(fs.readFileSync(runtimeShared, "utf8")).toContain("a: []");
+  });
+
+  it("adds ancestor node_modules to the MITM child NODE_PATH", async () => {
+    const { __test__ } = await import("../../src/mitm/manager.js");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "9router-mitm-"));
+    tmpRoots.push(root);
+
+    const standaloneRoot = path.join(root, "standalone");
+    const bundledServer = path.join(standaloneRoot, "src", "mitm", "server.js");
+    const bundledNodeModules = path.join(standaloneRoot, "node_modules");
+    const packageNodeModules = path.join(root, "node_modules");
+    fs.mkdirSync(path.dirname(bundledServer), { recursive: true });
+    fs.mkdirSync(bundledNodeModules, { recursive: true });
+    fs.mkdirSync(packageNodeModules, { recursive: true });
+    fs.writeFileSync(bundledServer, "require('node-forge');");
+
+    const nodePath = __test__.buildMitmNodePath(bundledServer, path.join(root, "existing"));
+
+    expect(nodePath.split(path.delimiter)).toEqual([
+      bundledNodeModules,
+      packageNodeModules,
+      path.join(root, "existing"),
+    ]);
+  });
+});

--- a/tests/unit/mitm-runtime-copy.test.js
+++ b/tests/unit/mitm-runtime-copy.test.js
@@ -1,0 +1,71 @@
+import { afterAll, describe, expect, it } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// Integration test for ensureRuntimeServer's self-heal wiring. Redirect DATA_DIR to a
+// temp dir BEFORE manager.js is imported (paths.js reads process.env.DATA_DIR at load),
+// so the runtime copy lands in the sandbox and never touches the real AppData runtime.
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-data-"));
+process.env.DATA_DIR = dataDir;
+
+afterAll(() => {
+  delete process.env.DATA_DIR;
+  try {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  } catch {
+    // best effort cleanup
+  }
+});
+
+describe("ensureRuntimeServer self-heal wiring", () => {
+  // Reproduces the original bug class: an older runtime had a same-size server.js but was
+  // missing runtime/shared/constants/mitmToolHosts.js, so dnsConfig crashed with
+  // MODULE_NOT_FOUND. The size-skip path must still heal the shared contract.
+  it("recreates a missing shared host file even when server.js is unchanged (size-skip path)", async () => {
+    const { __test__ } = await import("../../src/mitm/manager.js");
+    const serverPath = path.join(process.cwd(), "src", "mitm", "server.js");
+    const runtimeServer = path.join(dataDir, "runtime", "mitm", "server.js");
+    const runtimeShared = path.join(dataDir, "runtime", "shared", "constants", "mitmToolHosts.js");
+
+    // Full copy on first run populates both the mitm tree and the shared contract.
+    __test__.ensureRuntimeServer(serverPath);
+    expect(fs.existsSync(runtimeServer)).toBe(true);
+    expect(fs.existsSync(runtimeShared)).toBe(true);
+
+    // Simulate the broken older runtime: shared file gone, server.js left untouched so the
+    // size-skip short-circuit fires (no full recopy).
+    fs.rmSync(runtimeShared, { force: true });
+    expect(fs.existsSync(runtimeShared)).toBe(false);
+
+    const before = fs.statSync(runtimeServer).mtimeMs;
+    const result = __test__.ensureRuntimeServer(serverPath);
+
+    // Shared file healed, and the untouched server.js was NOT recopied (size-skip held).
+    expect(result).toBe(runtimeServer);
+    expect(fs.existsSync(runtimeShared)).toBe(true);
+    expect(fs.readFileSync(runtimeShared, "utf8")).toContain("TOOL_HOSTS");
+    expect(fs.statSync(runtimeServer).mtimeMs).toBe(before);
+  });
+
+  it("refreshes the shared host file on a full recopy (server.js size changed)", async () => {
+    const { __test__ } = await import("../../src/mitm/manager.js");
+    const serverPath = path.join(process.cwd(), "src", "mitm", "server.js");
+    const runtimeServer = path.join(dataDir, "runtime", "mitm", "server.js");
+    const runtimeShared = path.join(dataDir, "runtime", "shared", "constants", "mitmToolHosts.js");
+
+    __test__.ensureRuntimeServer(serverPath);
+
+    // Make the runtime server.js a different size to force the full-copy branch, and write
+    // a stale shared file that must be overwritten from source.
+    fs.appendFileSync(runtimeServer, "\n// drift\n");
+    fs.writeFileSync(runtimeShared, "module.exports = { STALE: true };");
+
+    __test__.ensureRuntimeServer(serverPath);
+
+    // Full recopy restores server.js to the source size and refreshes the shared contract.
+    expect(fs.statSync(runtimeServer).size).toBe(fs.statSync(serverPath).size);
+    expect(fs.readFileSync(runtimeShared, "utf8")).toContain("TOOL_HOSTS");
+    expect(fs.readFileSync(runtimeShared, "utf8")).not.toContain("STALE");
+  });
+});

--- a/tests/unit/oauth-cursor-auto-import.test.js
+++ b/tests/unit/oauth-cursor-auto-import.test.js
@@ -1,99 +1,95 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import * as fsPromises from "fs/promises";
+import Database from "better-sqlite3";
+import fs from "fs";
+import os from "os";
+import path from "path";
 
-// Mock next/server
+// Aligned with the re-architected route (#368 drop sql.js, #411 better-sqlite3 → sqlite3
+// CLI → manual fallback). Deliberately-removed legacy behaviors are NOT tested anymore:
+// fuzzy LIKE key matching, "Please login to Cursor IDE first", "Unsupported platform" 400,
+// and the SQLITE_CANTOPEN "could not open it" message — the route no longer promises them.
+//
+// better-sqlite3 is a native module that Vitest externalizes, so `vi.mock("better-sqlite3")`
+// does NOT intercept the route's `require("better-sqlite3")` (this is why the previous mock
+// silently fell through). We therefore exercise the REAL better-sqlite3 against a REAL temp
+// SQLite db placed at the platform's candidate path under a mocked $HOME. Only os.homedir
+// and child_process (sqlite3 CLI / `which cursor`) are mocked.
+
+const hoisted = vi.hoisted(() => ({ home: "" }));
+
 vi.mock("next/server", () => ({
   NextResponse: {
-    json: vi.fn((body, init) => ({
-      status: init?.status || 200,
-      body,
-      json: async () => body,
-    })),
+    json: vi.fn((body, init) => ({ status: init?.status || 200, body })),
   },
 }));
 
-// Mock os
-vi.mock("os", () => ({
-  default: { homedir: vi.fn(() => "/mock/home") },
-  homedir: vi.fn(() => "/mock/home"),
+// Preserve the real os (tmpdir etc. are used by the test itself); only override homedir.
+vi.mock("os", async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    default: { ...actual.default, homedir: () => hoisted.home },
+    homedir: () => hoisted.home,
+  };
+});
+
+// No sqlite3 CLI and no `cursor` binary in the test env → reject so the route can't shell out.
+vi.mock("child_process", () => ({
+  execFile: vi.fn((...args) => {
+    const cb = args[args.length - 1];
+    if (typeof cb === "function") cb(new Error("mock: command unavailable"));
+  }),
 }));
 
-// Mock fs/promises
-vi.mock("fs/promises", () => ({
-  access: vi.fn(),
-  constants: { R_OK: 4 },
-}));
+/** Build the route's primary candidate db path for a platform under the mocked $HOME. */
+function candidateDbPath(home, platform) {
+  if (platform === "darwin") {
+    return path.join(home, "Library/Application Support/Cursor/User/globalStorage/state.vscdb");
+  }
+  // linux default
+  return path.join(home, ".config/Cursor/User/globalStorage/state.vscdb");
+}
 
-// Shared mock db instance
-const mockDbInstance = {
-  prepare: vi.fn(),
-  close: vi.fn(),
-  __throwOnConstruct: false,
-};
+/** Create a real SQLite state.vscdb with an itemTable holding the given key→value rows. */
+function writeCursorDb(dbPath, rows) {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE itemTable (key TEXT PRIMARY KEY, value TEXT)");
+  const insert = db.prepare("INSERT INTO itemTable (key, value) VALUES (?, ?)");
+  for (const [key, value] of Object.entries(rows)) insert.run(key, value);
+  db.close();
+}
 
-// Mock better-sqlite3 as a class so `new Database(...)` works
-vi.mock("better-sqlite3", () => ({
-  default: class MockDatabase {
-    constructor() {
-      if (mockDbInstance.__throwOnConstruct) {
-        throw new Error("SQLITE_CANTOPEN");
-      }
-      return mockDbInstance;
-    }
-  },
-}));
-
-// We need to dynamically import after mocks are registered
 let GET;
+const originalPlatform = process.platform;
+let tmpHome;
 
 describe("GET /api/oauth/cursor/auto-import", () => {
-  const originalPlatform = process.platform;
-
   beforeEach(async () => {
     vi.clearAllMocks();
-    mockDbInstance.__throwOnConstruct = false;
-    // Force darwin so macOS-specific logic is exercised
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "9router-cursor-"));
+    hoisted.home = tmpHome;
     Object.defineProperty(process, "platform", { value: "darwin", writable: true });
-    // Re-import to pick up fresh mocks each run
     const mod = await import("../../src/app/api/oauth/cursor/auto-import/route.js");
     GET = mod.GET;
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
-  // ── macOS path probing ────────────────────────────────────────────────
-
-  it("returns not-found when no macOS cursor db paths are accessible", async () => {
-    vi.mocked(fsPromises.access).mockRejectedValue(new Error("ENOENT"));
-
+  it("returns not-found listing checked locations when no db exists", async () => {
     const response = await GET();
 
     expect(response.body.found).toBe(false);
-    expect(response.body.error).toContain("Cursor database not found in known macOS locations");
+    expect(response.body.error).toContain("Cursor database not found. Checked locations:");
   });
 
-  it("returns descriptive error if macOS db file exists but cannot be opened", async () => {
-    vi.mocked(fsPromises.access).mockResolvedValue();
-    mockDbInstance.__throwOnConstruct = true;
-
-    const response = await GET();
-
-    expect(response.body.found).toBe(false);
-    expect(response.body.error).toContain("could not open it");
-    expect(response.body.error).toContain("SQLITE_CANTOPEN");
-  });
-
-  // ── Token extraction ──────────────────────────────────────────────────
-
-  it("extracts tokens using exact keys", async () => {
-    vi.mocked(fsPromises.access).mockResolvedValue();
-    mockDbInstance.prepare.mockReturnValue({
-      all: vi.fn().mockReturnValue([
-        { key: "cursorAuth/accessToken", value: "test-token" },
-        { key: "storage.serviceMachineId", value: "test-machine-id" },
-      ]),
+  it("extracts tokens from the Cursor SQLite db using exact keys", async () => {
+    writeCursorDb(candidateDbPath(tmpHome, "darwin"), {
+      "cursorAuth/accessToken": "test-token",
+      "storage.serviceMachineId": "test-machine-id",
     });
 
     const response = await GET();
@@ -101,16 +97,12 @@ describe("GET /api/oauth/cursor/auto-import", () => {
     expect(response.body.found).toBe(true);
     expect(response.body.accessToken).toBe("test-token");
     expect(response.body.machineId).toBe("test-machine-id");
-    expect(mockDbInstance.close).toHaveBeenCalled();
   });
 
   it("unwraps JSON-encoded string values", async () => {
-    vi.mocked(fsPromises.access).mockResolvedValue();
-    mockDbInstance.prepare.mockReturnValue({
-      all: vi.fn().mockReturnValue([
-        { key: "cursorAuth/accessToken", value: '"json-token"' },
-        { key: "storage.serviceMachineId", value: '"json-machine-id"' },
-      ]),
+    writeCursorDb(candidateDbPath(tmpHome, "darwin"), {
+      "cursorAuth/accessToken": '"json-token"',
+      "storage.serviceMachineId": '"json-machine-id"',
     });
 
     const response = await GET();
@@ -120,65 +112,29 @@ describe("GET /api/oauth/cursor/auto-import", () => {
     expect(response.body.machineId).toBe("json-machine-id");
   });
 
-  // ── Fuzzy fallback (macOS only) ───────────────────────────────────────
-
-  it("falls back to fuzzy key matching on macOS when exact keys are missing", async () => {
-    vi.mocked(fsPromises.access).mockResolvedValue();
-    mockDbInstance.prepare.mockImplementation((query) => {
-      if (query.includes("IN (")) {
-        return { all: vi.fn().mockReturnValue([]) };
-      }
-      // Fuzzy LIKE query
-      return {
-        all: vi.fn().mockReturnValue([
-          { key: "cursorAuth/someOtherAccessTokenKey", value: "fallback-token" },
-          { key: "storage.someMachineId", value: "fallback-machine" },
-        ]),
-      };
-    });
-
-    const response = await GET();
-
-    expect(response.body.found).toBe(true);
-    expect(response.body.accessToken).toBe("fallback-token");
-    expect(response.body.machineId).toBe("fallback-machine");
-  });
-
-  it("returns login-prompt error when tokens are missing even after fallback", async () => {
-    vi.mocked(fsPromises.access).mockResolvedValue();
-    mockDbInstance.prepare.mockReturnValue({
-      all: vi.fn().mockReturnValue([]),
-    });
+  it("falls through to manual paste when tokens are missing and CLI is unavailable", async () => {
+    // db exists but has no relevant keys → better-sqlite3 yields nulls, sqlite3 CLI mock rejects.
+    writeCursorDb(candidateDbPath(tmpHome, "darwin"), { "some/unrelated/key": "x" });
 
     const response = await GET();
 
     expect(response.body.found).toBe(false);
-    expect(response.body.error).toContain("Please login to Cursor IDE first");
+    expect(response.body.windowsManual).toBe(true);
+    expect(response.body.dbPath).toBeTruthy();
   });
 
-  // ── Backwards-compatible: linux/win32 keep original single-path logic ─
-
-  it("linux uses single hardcoded path and original error message", async () => {
+  it("linux: config db present but Cursor not installed → not-found", async () => {
     Object.defineProperty(process, "platform", { value: "linux", writable: true });
-    vi.mocked(fsPromises.access).mockRejectedValue(new Error("ENOENT"));
-    mockDbInstance.__throwOnConstruct = true;
+    // db present at the linux candidate, but `which cursor` (mocked reject) and the
+    // cursor.desktop marker (absent) both fail the install check.
+    writeCursorDb(candidateDbPath(tmpHome, "linux"), {
+      "cursorAuth/accessToken": "t",
+      "storage.serviceMachineId": "m",
+    });
 
     const response = await GET();
 
     expect(response.body.found).toBe(false);
-    expect(response.body.error).toBe(
-      "Cursor database not found. Make sure Cursor IDE is installed and you are logged in."
-    );
-    // fs/promises.access should NOT have been called (linux skips probing)
-    expect(fsPromises.access).not.toHaveBeenCalled();
-  });
-
-  it("unsupported platform returns 400", async () => {
-    Object.defineProperty(process, "platform", { value: "freebsd", writable: true });
-
-    const response = await GET();
-
-    expect(response.status).toBe(400);
-    expect(response.body.error).toBe("Unsupported platform");
+    expect(response.body.error).toContain("does not appear to be installed");
   });
 });

--- a/tests/unit/openai-to-claude.test.js
+++ b/tests/unit/openai-to-claude.test.js
@@ -126,8 +126,11 @@ describe("openaiToClaudeRequest", () => {
 
 describe("openaiToClaudeResponse", () => {
   it("omits empty Read pages tool argument before emitting Claude input deltas", () => {
+    // Since #1144 tool-call args are buffered and sanitized once at finish_reason
+    // (not per-chunk), so feed the args chunk then a finish chunk and assert on the
+    // single emitted input_json_delta.
     const state = { toolCalls: new Map() };
-    const chunk = {
+    const argsChunk = {
       id: "chatcmpl-test",
       model: "gpt-test",
       choices: [{
@@ -148,8 +151,14 @@ describe("openaiToClaudeResponse", () => {
         }
       }]
     };
+    const finishChunk = {
+      id: "chatcmpl-test",
+      model: "gpt-test",
+      choices: [{ delta: {}, finish_reason: "tool_calls" }]
+    };
 
-    const result = openaiToClaudeResponse(chunk, state);
+    openaiToClaudeResponse(argsChunk, state);
+    const result = openaiToClaudeResponse(finishChunk, state);
     const inputDelta = result.find(event => event.delta?.type === "input_json_delta");
 
     expect(inputDelta).toBeDefined();

--- a/tests/unit/provider-signatures.test.js
+++ b/tests/unit/provider-signatures.test.js
@@ -19,6 +19,7 @@ describe("provider signature/header matrix", () => {
 
   it("builds Codex identity headers with the connection-scoped session id", async () => {
     const { CodexExecutor } = await import("../../open-sse/executors/codex.js");
+    const { CODEX_ORIGINATOR, CODEX_USER_AGENT } = await import("../../open-sse/config/providers.js");
     const executor = new CodexExecutor();
     const headers = executor.buildHeaders(
       {
@@ -31,10 +32,40 @@ describe("provider signature/header matrix", () => {
 
     expect(headers.Authorization).toBe("Bearer codex-test-token");
     expect(headers["Content-Type"]).toBe("application/json");
-    expect(headers.originator).toBe("codex-cli");
+    expect(headers.originator).toBe(CODEX_ORIGINATOR);
     expect(headers.session_id).toBe("conn-123");
     expect(headers["chatgpt-account-id"]).toBe("workspace-abc");
+    expect(headers["User-Agent"]).toBe(CODEX_USER_AGENT);
     expect(headers.Accept).toBe("text/event-stream");
+  });
+
+  it("accepts chatgptAccountId as the Codex account binding fallback", async () => {
+    const { CodexExecutor } = await import("../../open-sse/executors/codex.js");
+    const { CODEX_ORIGINATOR } = await import("../../open-sse/config/providers.js");
+    const executor = new CodexExecutor();
+    const headers = executor.buildHeaders(
+      {
+        accessToken: "codex-test-token",
+        connectionId: "conn-456",
+        providerSpecificData: { chatgptAccountId: "account-xyz" }
+      },
+      true
+    );
+
+    expect(headers["chatgpt-account-id"]).toBe("account-xyz");
+    expect(headers.session_id).toBe("conn-456");
+    expect(headers.originator).toBe(CODEX_ORIGINATOR);
+  });
+
+  it("keeps the Claude cold-start spoof User-Agent aligned with the installed version", async () => {
+    const { DefaultExecutor } = await import("../../open-sse/executors/default.js");
+    const { CLAUDE_CLI_VERSION } = await import("../../open-sse/config/providers.js");
+    const executor = new DefaultExecutor("claude");
+    const headers = executor.buildHeaders({ apiKey: "claude-test-key" }, true);
+
+    expect(headers["User-Agent"]).toBe(`claude-cli/${CLAUDE_CLI_VERSION} (external, sdk-cli)`);
+    expect(headers["X-App"]).toBe("cli");
+    expect(headers["Anthropic-Beta"]).toContain("oauth-2025-04-20");
   });
 
   it("builds Gemini CLI request headers from the current model", async () => {
@@ -52,14 +83,15 @@ describe("provider signature/header matrix", () => {
 
   it("builds Kiro eventstream headers and preserves the AWS fingerprint shape", async () => {
     const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    const { KIRO_IDE_VERSION } = await import("../../open-sse/config/appConstants.js");
     const executor = new KiroExecutor();
     const headers = executor.buildHeaders({ accessToken: "kiro-test-token" }, true);
 
     expect(headers.Authorization).toBe("Bearer kiro-test-token");
     expect(headers["Content-Type"]).toBe("application/json");
     expect(headers.Accept).toBe("application/vnd.amazon.eventstream");
-    expect(headers["User-Agent"]).toBe("AWS-SDK-JS/3.0.0 kiro-ide/1.0.0");
-    expect(headers["X-Amz-User-Agent"]).toBe("aws-sdk-js/3.0.0 kiro-ide/1.0.0");
+    expect(headers["User-Agent"]).toBe(`AWS-SDK-JS/3.0.0 kiro-ide/${KIRO_IDE_VERSION}`);
+    expect(headers["X-Amz-User-Agent"]).toBe(`aws-sdk-js/3.0.0 kiro-ide/${KIRO_IDE_VERSION}`);
     expect(headers["Amz-Sdk-Request"]).toBe("attempt=1; max=3");
     expectUuidLike(headers["Amz-Sdk-Invocation-Id"]);
   });
@@ -92,5 +124,34 @@ describe("provider signature/header matrix", () => {
     expect(headers["Cosy-Bodyhash"]).toMatch(/^[0-9a-f]{32}$/);
     expect(headers["Login-Version"]).toBe("v2");
     expectUuidLike(headers["X-Request-Id"]);
+  });
+
+  it("keeps KiloCode on the generic OpenAI-compatible path", async () => {
+    const { DefaultExecutor } = await import("../../open-sse/executors/default.js");
+    const executor = new DefaultExecutor("kilocode");
+    const headers = executor.buildHeaders({ apiKey: "kilo-test-key" }, true);
+
+    // KiloCode has an official client fingerprint in its own repo/issues, but 9router
+    // currently routes it as a plain OpenAI-compatible backend and does not synthesize
+    // a KiloCode-specific UA/version header.
+    expect(headers.Authorization).toBe("Bearer kilo-test-key");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers.Accept).toBe("text/event-stream");
+    expect(headers["x-kilocode-version"]).toBeUndefined();
+    expect(headers["user-agent"]).toBeUndefined();
+  });
+
+  it("builds the current OpenCode local proxy headers", async () => {
+    const { OpenCodeExecutor } = await import("../../open-sse/executors/opencode.js");
+    const executor = new OpenCodeExecutor();
+    const headers = executor.buildHeaders();
+
+    // OpenCode's own issues mention webfetch/browser-like UA behavior, but the local
+    // 9router integration currently only marks the upstream as the desktop client.
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers.Authorization).toBe("Bearer public");
+    expect(headers["x-opencode-client"]).toBe("desktop");
+    expect(headers.Accept).toBe("text/event-stream");
+    expect(headers["user-agent"]).toBeUndefined();
   });
 });

--- a/tests/unit/provider-signatures.test.js
+++ b/tests/unit/provider-signatures.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+function expectUuidLike(value) {
+  expect(value).toMatch(/^[0-9a-f-]{36}$/i);
+}
+
+describe("provider signature/header matrix", () => {
+  it("builds the OpenRouter header shape without any live request", async () => {
+    const { DefaultExecutor } = await import("../../open-sse/executors/default.js");
+    const executor = new DefaultExecutor("openrouter");
+    const headers = executor.buildHeaders({ apiKey: "or-test-key" }, true);
+
+    expect(headers["HTTP-Referer"]).toBe("https://endpoint-proxy.local");
+    expect(headers["X-Title"]).toBe("Endpoint Proxy");
+    expect(headers.Authorization).toBe("Bearer or-test-key");
+    expect(headers.Accept).toBe("text/event-stream");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("builds Codex identity headers with the connection-scoped session id", async () => {
+    const { CodexExecutor } = await import("../../open-sse/executors/codex.js");
+    const executor = new CodexExecutor();
+    const headers = executor.buildHeaders(
+      {
+        accessToken: "codex-test-token",
+        connectionId: "conn-123",
+        providerSpecificData: { workspaceId: "workspace-abc" }
+      },
+      true
+    );
+
+    expect(headers.Authorization).toBe("Bearer codex-test-token");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers.originator).toBe("codex-cli");
+    expect(headers.session_id).toBe("conn-123");
+    expect(headers["chatgpt-account-id"]).toBe("workspace-abc");
+    expect(headers.Accept).toBe("text/event-stream");
+  });
+
+  it("builds Gemini CLI request headers from the current model", async () => {
+    const { GeminiCLIExecutor } = await import("../../open-sse/executors/gemini-cli.js");
+    const { geminiCLIUserAgent, GEMINI_CLI_API_CLIENT } = await import("../../open-sse/config/appConstants.js");
+    const executor = new GeminiCLIExecutor();
+    executor.transformRequest("gemini-2.5-pro", { contents: [] }, true, {});
+    const headers = executor.buildHeaders({ accessToken: "gemini-test-token" }, true);
+
+    expect(headers.Authorization).toBe("Bearer gemini-test-token");
+    expect(headers["User-Agent"]).toBe(geminiCLIUserAgent("gemini-2.5-pro"));
+    expect(headers["X-Goog-Api-Client"]).toBe(GEMINI_CLI_API_CLIENT);
+    expect(headers.Accept).toBe("text/event-stream");
+  });
+
+  it("builds Kiro eventstream headers and preserves the AWS fingerprint shape", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    const executor = new KiroExecutor();
+    const headers = executor.buildHeaders({ accessToken: "kiro-test-token" }, true);
+
+    expect(headers.Authorization).toBe("Bearer kiro-test-token");
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers.Accept).toBe("application/vnd.amazon.eventstream");
+    expect(headers["User-Agent"]).toBe("AWS-SDK-JS/3.0.0 kiro-ide/1.0.0");
+    expect(headers["X-Amz-User-Agent"]).toBe("aws-sdk-js/3.0.0 kiro-ide/1.0.0");
+    expect(headers["Amz-Sdk-Request"]).toBe("attempt=1; max=3");
+    expectUuidLike(headers["Amz-Sdk-Invocation-Id"]);
+  });
+
+  it("builds Qoder COSY signing headers locally without a network call", async () => {
+    const { buildCosyHeaders } = await import("../../src/lib/qoder/cosy.js");
+    const headers = buildCosyHeaders(
+      Buffer.from('{"messages":[{"role":"user","content":"ping"}]}'),
+      "https://api3.qoder.sh/algo/api/v2/service/pro/sse/agent_chat_generation?FetchKeys=llm_model_result&AgentId=agent_common",
+      {
+        userId: "user-123",
+        authToken: "dt-test-token",
+        machineId: "machine-abc",
+        email: "user@example.com",
+        name: "Test User"
+      }
+    );
+
+    expect(headers.Authorization).toMatch(/^Bearer COSY\./);
+    expect(headers["Cosy-Key"]).toBeTruthy();
+    expect(headers["Cosy-User"]).toBe("user-123");
+    expect(headers["Cosy-Machineid"]).toBe("machine-abc");
+    expect(headers["Cosy-Machinetoken"]).toBe("machine-abc");
+    expect(headers["Cosy-Machinetype"]).toBe("5");
+    expect(headers["Cosy-Machineos"]).toBe("x86_64_windows");
+    expect(headers["Cosy-Clienttype"]).toBe("5");
+    expect(headers["Cosy-Data-Policy"]).toBe("disagree");
+    expect(headers["Cosy-Sigpath"]).toBe("/api/v2/service/pro/sse/agent_chat_generation");
+    expect(headers["Cosy-Bodylength"]).toBe("47");
+    expect(headers["Cosy-Bodyhash"]).toMatch(/^[0-9a-f]{32}$/);
+    expect(headers["Login-Version"]).toBe("v2");
+    expectUuidLike(headers["X-Request-Id"]);
+  });
+});

--- a/tests/unit/requestLogger.test.js
+++ b/tests/unit/requestLogger.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { maskSensitiveHeaders } from "../../open-sse/utils/requestLogger.js";
+
+describe("requestLogger", () => {
+  it("masks sensitive request headers without mutating non-sensitive headers", () => {
+    const headers = {
+      Authorization: "Bearer sk-test-1234567890abcdef",
+      "x-api-key": "abc123456789xyz",
+      Cookie: "sid=session-secret; theme=dark",
+      Accept: "application/json",
+      "User-Agent": "official-client/1.2.3"
+    };
+
+    const masked = maskSensitiveHeaders(headers);
+
+    expect(masked.Authorization).toBe("Bearer sk-test-...[REDACTED]...cdef");
+    expect(masked["x-api-key"]).toBe("abc1...[REDACTED]");
+    expect(masked.Cookie).toContain("[REDACTED]");
+    expect(masked.Accept).toBe("application/json");
+    expect(masked["User-Agent"]).toBe("official-client/1.2.3");
+    expect(headers.Authorization).toBe("Bearer sk-test-1234567890abcdef");
+  });
+
+  it("supports Headers objects and masks provider response secrets", () => {
+    const headers = new Headers({
+      "set-cookie": "token=secret-cookie-value",
+      "x-ratelimit-remaining": "42"
+    });
+
+    const masked = maskSensitiveHeaders(headers);
+
+    expect(masked["set-cookie"]).toContain("[REDACTED]");
+    expect(masked["x-ratelimit-remaining"]).toBe("42");
+  });
+});

--- a/tests/unit/rtk.test.js
+++ b/tests/unit/rtk.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { compressMessages, setRtkEnabled, isRtkEnabled, formatRtkLog } from "../../open-sse/rtk/index.js";
+import { describe, it, expect } from "vitest";
+import { compressMessages, formatRtkLog } from "../../open-sse/rtk/index.js";
 import { gitDiff } from "../../open-sse/rtk/filters/gitDiff.js";
 import { gitStatus } from "../../open-sse/rtk/filters/gitStatus.js";
 import { grep } from "../../open-sse/rtk/filters/grep.js";
@@ -53,15 +53,8 @@ function makeFindOutput() {
   return lines.join("\n");
 }
 
-describe("RTK flag", () => {
-  it("default off, toggle works", () => {
-    setRtkEnabled(false);
-    expect(isRtkEnabled()).toBe(false);
-    setRtkEnabled(true);
-    expect(isRtkEnabled()).toBe(true);
-    setRtkEnabled(false);
-  });
-});
+// Note: the legacy global toggle (setRtkEnabled/isRtkEnabled) was removed; enablement is
+// now an explicit `enabled` argument to compressMessages — covered by the suites below.
 
 describe("RTK filters", () => {
   it("gitDiff truncates hunks beyond 100 lines and preserves file header", () => {
@@ -245,20 +238,17 @@ describe("safeApply", () => {
 });
 
 describe("compressMessages (disabled)", () => {
-  beforeEach(() => setRtkEnabled(false));
   it("returns null when disabled", () => {
     const body = { messages: [{ role: "tool", tool_call_id: "x", content: makeLongDiff() }] };
-    expect(compressMessages(body)).toBeNull();
+    expect(compressMessages(body, false)).toBeNull();
   });
 });
 
 describe("compressMessages (enabled)", () => {
-  beforeEach(() => setRtkEnabled(true));
-
   it("compresses OpenAI tool message (string content)", () => {
     const big = makeLongDiff();
     const body = { messages: [{ role: "tool", tool_call_id: "call_1", content: big }] };
-    const stats = compressMessages(body);
+    const stats = compressMessages(body, true);
     expect(stats.hits.length).toBeGreaterThan(0);
     expect(body.messages[0].content.length).toBeLessThan(big.length);
     expect(stats.bytesBefore).toBeGreaterThan(stats.bytesAfter);
@@ -272,7 +262,7 @@ describe("compressMessages (enabled)", () => {
         content: [{ type: "tool_result", tool_use_id: "toolu_1", content: big }]
       }]
     };
-    const stats = compressMessages(body);
+    const stats = compressMessages(body, true);
     expect(stats.hits.length).toBeGreaterThan(0);
     expect(body.messages[0].content[0].content.length).toBeLessThan(big.length);
   });
@@ -289,7 +279,7 @@ describe("compressMessages (enabled)", () => {
         }]
       }]
     };
-    const stats = compressMessages(body);
+    const stats = compressMessages(body, true);
     expect(stats.hits.length).toBeGreaterThan(0);
     expect(body.messages[0].content[0].content[0].text.length).toBeLessThan(big.length);
     // short part unchanged
@@ -304,7 +294,7 @@ describe("compressMessages (enabled)", () => {
         content: [{ type: "tool_result", tool_use_id: "toolu_1", content: big, is_error: true }]
       }]
     };
-    const stats = compressMessages(body);
+    const stats = compressMessages(body, true);
     expect(stats.hits.length).toBe(0);
     expect(body.messages[0].content[0].content).toBe(big);
   });
@@ -312,7 +302,7 @@ describe("compressMessages (enabled)", () => {
   it("skips below MIN_COMPRESS_SIZE (<500 bytes)", () => {
     const small = "diff --git a/x b/x\n@@ -1 +1 @@\n+a";
     const body = { messages: [{ role: "tool", tool_call_id: "x", content: small }] };
-    const stats = compressMessages(body);
+    const stats = compressMessages(body, true);
     expect(stats.hits.length).toBe(0);
     expect(body.messages[0].content).toBe(small);
   });
@@ -320,13 +310,13 @@ describe("compressMessages (enabled)", () => {
   it("never produces empty content (R14 guard)", () => {
     const input = "a".repeat(1000);
     const body = { messages: [{ role: "tool", tool_call_id: "x", content: input }] };
-    compressMessages(body);
+    compressMessages(body, true);
     expect(body.messages[0].content.length).toBeGreaterThan(0);
   });
 
   it("skips when body has no messages", () => {
-    expect(compressMessages({})).toBeNull();
-    expect(compressMessages({ messages: null })).toBeNull();
+    expect(compressMessages({}, true)).toBeNull();
+    expect(compressMessages({ messages: null }, true)).toBeNull();
   });
 
   it("handles mix of messages without crashing", () => {
@@ -339,7 +329,7 @@ describe("compressMessages (enabled)", () => {
         { role: "user", content: [{ type: "text", text: "next" }] }
       ]
     };
-    const stats = compressMessages(body);
+    const stats = compressMessages(body, true);
     expect(stats).not.toBeNull();
     expect(stats.hits.length).toBeGreaterThan(0);
   });


### PR DESCRIPTION
Masks sensitive headers before opt-in request/response logs are written, so Authorization/API-key/Cookie/Token/Secret values do not persist in local debug artifacts.\n\nVerification:\n- npx vitest run tests/unit/requestLogger.test.js --config tests/vitest.config.js\n- node --check open-sse/utils/requestLogger.js\n- npm run build