### PR TITLE
fix(runtime): save runtime deps so sibling install can't prune them

### DIFF
--- a/cli/hooks/sqliteRuntime.js
+++ b/cli/hooks/sqliteRuntime.js
@@ -89,7 +89,10 @@ function runNpmInstall({ cwd, pkgs, extraArgs = [], timeout = 180000 }) {
 
 function npmInstall(pkgs, opts = {}) {
   const cwd = ensureRuntimeDir();
-  const extra = opts.optional ? ["--no-save"] : [];
+  // Persist to the runtime package.json (exact version) so a later install of a
+  // sibling runtime dep (e.g. systray2 from trayRuntime.js) does not prune this
+  // package as "extraneous". `opts.optional` still keeps the install non-fatal.
+  const extra = ["--save-exact"];
   if (!opts.silent) console.log("⏳ Installing SQLite engine (first run)...");
   const res = runNpmInstall({ cwd, pkgs, extraArgs: extra, timeout: opts.timeout || 180000 });
   if (!res.ok && !opts.silent) {

--- a/cli/hooks/trayRuntime.js
+++ b/cli/hooks/trayRuntime.js
@@ -74,7 +74,10 @@ function ensureRuntimeDir() {
 function npmInstall(pkgs, { silent = false } = {}) {
   const cwd = ensureRuntimeDir();
   if (!silent) console.log("⏳ Installing system tray (first run)...");
-  const res = runNpmInstall({ cwd, pkgs, extraArgs: ["--no-save"], timeout: 120000 });
+  // Persist to the runtime package.json (exact version) so installing this does
+  // not prune a sibling runtime dep (e.g. better-sqlite3 from sqliteRuntime.js)
+  // as "extraneous", and so this survives a later sibling install.
+  const res = runNpmInstall({ cwd, pkgs, extraArgs: ["--save-exact"], timeout: 120000 });
   if (!res.ok && !silent) {
     const reason = summarizeNpmError(res.stderr);
     console.warn("⚠️  System tray install failed — tray disabled");

--- a/tests/unit/runtime-deps-no-prune.test.js
+++ b/tests/unit/runtime-deps-no-prune.test.js
@@ -1,0 +1,75 @@
+// Regression: the SQLite and tray runtime installers must persist their package
+// to ~/.9router/runtime/package.json instead of using `--no-save`. Both write to
+// the same runtime dir, so a `--no-save` install marks the other's package as
+// "extraneous" and npm prunes it — leaving "No SQLite driver available" after the
+// tray install removes the just-installed better-sqlite3. Saving keeps both.
+//
+// Instead of mocking child_process, we put a fake `npm` on PATH that records its
+// arguments. This exercises the real spawnSync code path with zero network use.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+let tempDir;
+let binDir;
+let logFile;
+const original = { DATA_DIR: process.env.DATA_DIR, PATH: process.env.PATH };
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-runtime-deps-"));
+  binDir = path.join(tempDir, "bin");
+  logFile = path.join(tempDir, "npm-calls.log");
+  fs.mkdirSync(binDir);
+  // Fake npm: append its args to the log and succeed without doing anything.
+  const npmStub = path.join(binDir, "npm");
+  fs.writeFileSync(npmStub, `#!/bin/sh\necho "$@" >> "${logFile}"\nexit 0\n`);
+  fs.chmodSync(npmStub, 0o755);
+
+  process.env.DATA_DIR = tempDir;
+  process.env.PATH = `${binDir}${path.delimiter}${original.PATH}`;
+});
+
+afterEach(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  for (const [k, v] of Object.entries(original)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+const installLineFor = (pkgPrefix) => {
+  if (!fs.existsSync(logFile)) return undefined;
+  return fs
+    .readFileSync(logFile, "utf8")
+    .split("\n")
+    .find((line) => line.includes("install") && line.includes(pkgPrefix));
+};
+
+describe("runtime dep installs are saved, not pruned", () => {
+  it.skipIf(process.platform === "win32")(
+    "ensureSqliteRuntime saves better-sqlite3 (never --no-save)",
+    async () => {
+      const { ensureSqliteRuntime } = await import("../../cli/hooks/sqliteRuntime.js");
+      ensureSqliteRuntime({ silent: true });
+
+      const line = installLineFor("better-sqlite3");
+      expect(line, "expected an npm install for better-sqlite3").toBeTruthy();
+      expect(line).not.toContain("--no-save");
+      expect(line).toContain("--save-exact");
+    }
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "ensureTrayRuntime saves systray2 (never --no-save)",
+    async () => {
+      const { ensureTrayRuntime } = await import("../../cli/hooks/trayRuntime.js");
+      ensureTrayRuntime({ silent: true });
+
+      const line = installLineFor("systray2");
+      expect(line, "expected an npm install for systray2").toBeTruthy();
+      expect(line).not.toContain("--no-save");
+      expect(line).toContain("--save-exact");
+    }
+  );
+});


### PR DESCRIPTION
## What

Persist runtime dependency installs (`better-sqlite3`, `systray2`) to `~/.9router/runtime/package.json` with `--save-exact` instead of `--no-save`.

Fixes #1605

## Why

`cli/hooks/postinstall.js` installs the SQLite engine and then the system tray into the **same** runtime dir. Both used `--no-save`, and `ensureRuntimeDir()` writes a `package.json` with no `dependencies`. So the second install (tray) sees the first install (`better-sqlite3`) as *extraneous* and npm prunes it. The runtime ends up with `systray2` but no `better-sqlite3`, and the app crashes at startup with:

```
[DB] No SQLite driver available (bun/better/node/sql.js all failed)
```

`--save-exact` writes the package into the runtime manifest (at the version already pinned in the install spec), so it is no longer extraneous and survives the next sibling install. No behavior change beyond the manifest now listing what was installed.

## Changes

- `cli/hooks/sqliteRuntime.js`: `npmInstall()` uses `--save-exact` (was `--no-save`).
- `cli/hooks/trayRuntime.js`: `npmInstall()` uses `--save-exact` (was `--no-save`).
- `tests/unit/runtime-deps-no-prune.test.js`: new regression test — puts a fake `npm` on `PATH` and asserts each installer saves its package and never passes `--no-save`. No network.

## Testing

```
$ cd tests && npm test
 ✓ ensureSqliteRuntime saves better-sqlite3 (never --no-save)
 ✓ ensureTrayRuntime saves systray2 (never --no-save)
```

The new test is red on the previous `--no-save` code (recorded command contains `--no-save`) and green after the change. Also verified by hand on macOS arm64 (Node 20): a fresh `~/.9router/runtime` retains both `better-sqlite3` and `systray2` after postinstall.

## Scope

This fixes the prune only. A first-run native build of `better-sqlite3` can still fail for environment reasons (e.g. broken local `node-gyp`/Python) — out of scope here; the existing `sql.js`/`node:sqlite` fallbacks cover that path.
