### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Seamless translation between formats:
 | | GitHub Copilot | $10-19/mo | Monthly | GitHub users |
 | | Cursor IDE | $20/mo | Monthly | Cursor users |
 | **💰 CHEAP** | GLM-5.1 / GLM-4.7 | $0.6/1M | Daily 10AM | Budget backup |
-| | MiniMax M2.7 | $0.2/1M | 5-hour rolling | Cheapest option |
+| | MiniMax M3 | $0.2/1M | 5-hour rolling | Cheapest option |
 | | Kimi K2.5 | $9/mo flat | 10M tokens/mo | Predictable cost |
 | **🆓 FREE** | Kiro AI | $0 | Unlimited | Claude 4.5 + GLM-5 + MiniMax free |
 | | OpenCode Free | $0 | Unlimited | No auth, auto-fetch models |
@@ -615,7 +615,7 @@ Combo: "always-on"
   1. cc/claude-opus-4-7        (best quality)
   2. cx/gpt-5.5                (second subscription)
   3. glm/glm-5.1               (cheap, resets daily)
-  4. minimax/MiniMax-M2.7      (cheapest, 5h reset)
+  4. minimax/MiniMax-M3        (cheapest, 5h reset)
   5. kr/claude-sonnet-4.5      (free unlimited)
 
 Result: 5 layers of fallback = zero downtime
@@ -818,13 +818,13 @@ Models:
 
 **Pro Tip:** Coding Plan offers 3× quota at 1/7 cost! Reset daily 10:00 AM.
 
-### MiniMax M2.7 (5h reset, $0.20/1M)
+### MiniMax M3 (5h reset, $0.20/1M)
 
 1. Sign up: [MiniMax](https://www.minimax.io/)
 2. Get API key
 3. Dashboard → Add API Key
 
-**Use:** `minimax/MiniMax-M2.7`, `minimax/MiniMax-M2.5`
+**Use:** `minimax/MiniMax-M3`, `minimax/MiniMax-M2.7`
 
 **Pro Tip:** Cheapest option for long context (1M tokens)!
 
@@ -905,7 +905,7 @@ Name: premium-coding
 Models:
   1. cc/claude-opus-4-7 (Subscription primary)
   2. glm/glm-5.1 (Cheap backup, $0.6/1M)
-  3. minimax/MiniMax-M2.7 (Cheapest fallback, $0.20/1M)
+  3. minimax/MiniMax-M3 (Cheapest fallback, $0.20/1M)
 
 Use in CLI: premium-coding
 
@@ -1168,8 +1168,8 @@ Notes:
 - `glm/glm-4.7`
 
 **MiniMax (`minimax/`)** - $0.2/1M:
+- `minimax/MiniMax-M3`
 - `minimax/MiniMax-M2.7`
-- `minimax/MiniMax-M2.5`
 
 **Kimi (`kimi/`)** - $9/mo flat:
 - `kimi/kimi-k2.5`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -525,7 +525,7 @@ PORT=20128 HOSTNAME=0.0.0.0 NEXT_PUBLIC_BASE_URL=http://localhost:20128 npm run 
 | | GitHub Copilot | $10-19/月 | 每月 | GitHub 用户 |
 | | Cursor IDE | $20/月 | 每月 | Cursor 用户 |
 | **💰 低价** | GLM-5.1 / GLM-4.7 | $0.6/1M | 每日 10AM | 预算备份 |
-| | MiniMax M2.7 | $0.2/1M | 5小时滚动 | 最便宜选项 |
+| | MiniMax M3 | $0.2/1M | 5小时滚动 | 最便宜选项 |
 | | Kimi K2.5 | $9/月固定 | 10M tokens/月 | 可预测成本 |
 | **🆓 免费** | Kiro AI | $0 | 无限量 | Claude 4.5 + GLM-5 + MiniMax 免费 |
 | | OpenCode Free | $0 | 无限量 | 无需认证，自动获取模型 |
@@ -612,7 +612,7 @@ PORT=20128 HOSTNAME=0.0.0.0 NEXT_PUBLIC_BASE_URL=http://localhost:20128 npm run 
   1. cc/claude-opus-4-7        （最佳质量）
   2. cx/gpt-5.5                （第二个订阅）
   3. glm/glm-5.1               （低价，每日重置）
-  4. minimax/MiniMax-M2.7      （最便宜，5小时重置）
+  4. minimax/MiniMax-M3        （最便宜，5小时重置）
   5. kr/claude-sonnet-4.5      （免费无限量）
 
 结果：5 层切换 = 零停机时间
@@ -815,13 +815,13 @@ PORT=20128 HOSTNAME=0.0.0.0 NEXT_PUBLIC_BASE_URL=http://localhost:20128 npm run 
 
 **专业提示：** 编程计划提供 3 倍配额，成本仅为 1/7！每日 10:00 AM 重置。
 
-### MiniMax M2.7（5小时重置，$0.20/1M）
+### MiniMax M3（5小时重置，$0.20/1M）
 
 1. 注册：[MiniMax](https://www.minimax.io/)
 2. 获取 API key
 3. 控制面板 → 添加 API Key
 
-**使用：** `minimax/MiniMax-M2.7`、`minimax/MiniMax-M2.5`
+**使用：** `minimax/MiniMax-M3`、`minimax/MiniMax-M2.7`
 
 **专业提示：** 长上下文（1M tokens）的最便宜选项！
 
@@ -902,7 +902,7 @@ Vertex 合作伙伴（通过 Vertex 提供 Anthropic / DeepSeek / GLM / Qwen）�
 模型：
   1. cc/claude-opus-4-7 (订阅主用)
   2. glm/glm-5.1 (低价备份，$0.6/1M)
-  3. minimax/MiniMax-M2.7 (最便宜的备选，$0.20/1M)
+  3. minimax/MiniMax-M3 (最便宜的备选，$0.20/1M)
 
 在 CLI 中使用：premium-coding
 
@@ -1161,8 +1161,8 @@ docker stop 9router && docker rm 9router
 - `glm/glm-4.7`
 
 **MiniMax（`minimax/`）** - $0.2/1M：
+- `minimax/MiniMax-M3`
 - `minimax/MiniMax-M2.7`
-- `minimax/MiniMax-M2.5`
 
 **Kimi（`kimi/`）** - $9/月固定：
 - `kimi/kimi-k2.5`

--- a/cli/src/cli/menus/providers.js
+++ b/cli/src/cli/menus/providers.js
@@ -109,7 +109,8 @@ const PROVIDER_MODELS = {
     { id: "kimi-latest" },
   ],
   minimax: [
-    { id: "MiniMax-M2.1" },
+    { id: "MiniMax-M3" },
+    { id: "MiniMax-M2.7" },
   ],
 };
 

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -337,9 +337,8 @@ export const PROVIDER_MODELS = {
     { id: "kimi-latest", name: "Kimi Latest" },
   ],
   minimax: [
+    { id: "MiniMax-M3", name: "MiniMax M3" },
     { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
-    { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
-    { id: "MiniMax-M2.1", name: "MiniMax M2.1" },
     // Image models
     { id: "minimax-image-01", name: "MiniMax Image 01", type: "image", params: ["n", "size", "response_format"] },
   ],
@@ -363,9 +362,8 @@ export const PROVIDER_MODELS = {
     { id: "qwen3-vl-plus", name: "Qwen3 VL Plus" },
   ],
   "minimax-cn": [
+    { id: "MiniMax-M3", name: "MiniMax M3" },
     { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
-    { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
-    { id: "MiniMax-M2.1", name: "MiniMax M2.1" },
   ],
   alicode: [
     { id: "qwen3.5-plus", name: "Qwen3.5 Plus" },

--- a/open-sse/handlers/search/chatSearch.js
+++ b/open-sse/handlers/search/chatSearch.js
@@ -196,7 +196,7 @@ const CHAT_SEARCH_CONFIG = {
 
   minimax: {
     endpoint: () => "https://api.minimaxi.com/v1/text/chatcompletion_v2",
-    defaultModel: "MiniMax-M2.7",
+    defaultModel: "MiniMax-M3",
     buildBody: (query, model) => ({
       model,
       messages: [{ role: "user", content: query }],

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -455,7 +455,7 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         const res = await fetchWithConnectionProxy(endpoints[connection.provider], {
           method: "POST",
           headers: { "x-api-key": connection.apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },
-          body: JSON.stringify({ model: "minimax-m2", max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
+          body: JSON.stringify({ model: "MiniMax-M3", max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
         }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
         return { valid, error: valid ? null : "Invalid API key" };

--- a/src/shared/constants/pricing.js
+++ b/src/shared/constants/pricing.js
@@ -95,6 +95,7 @@ export const MODEL_PRICING = {
   "glm-5":                        { input: 1.00,  output: 4.00,  cached: 0.50,  reasoning: 6.00,   cache_creation: 1.00  },
 
   // === MiniMax ===
+  "MiniMax-M3":                   { input: 0.50,  output: 2.00,  cached: 0.25,  reasoning: 3.00,   cache_creation: 0.50  },
   "MiniMax-M2.1":                 { input: 0.50,  output: 2.00,  cached: 0.25,  reasoning: 3.00,   cache_creation: 0.50  },
   "MiniMax-M2.5":                 { input: 0.50,  output: 2.00,  cached: 0.25,  reasoning: 3.00,   cache_creation: 0.50  },
   "MiniMax-M2.7":                 { input: 0.50,  output: 2.00,  cached: 0.25,  reasoning: 3.00,   cache_creation: 0.50  },


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M3 model as the default for the `minimax` (international) and `minimax-cn` (China) providers.

## Changes
- Add `MiniMax-M3` to the `minimax` / `minimax-cn` model lists in `open-sse/config/providerModels.js` and set it as the new default (listed first)
- Retain `MiniMax-M2.7` as an available alternative
- Remove deprecated older versions (`MiniMax-M2.5` / `MiniMax-M2.1`) from the minimax model lists
- Add `MiniMax-M3` pricing entry in `src/shared/constants/pricing.js`
- Update chat-search `defaultModel` to `MiniMax-M3`
- Update the minimax API key connection test to ping `MiniMax-M3`
- Update CLI provider menu (`cli/src/cli/menus/providers.js`)
- Update README (EN / zh-CN) examples to reference `MiniMax-M3`

Only the first-party `minimax` / `minimax-cn` provider configurations are touched; third-party providers that happen to re-list older MiniMax models (Kiro, OpenCode Go, alicode, volcengine-ark, commandcode, NVIDIA, Ollama, etc.) are left as-is to avoid asserting unverified support on those upstream services. TTS configuration and API URLs are unchanged.

## Why
MiniMax-M3 is the new flagship model from MiniMaxAI with 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces.

## Testing
- All modified `.js` files pass `node --check`
- `PROVIDER_MODELS.minimax` and `MODEL_PRICING['MiniMax-M3']` load cleanly via ESM import
- Existing unit test that pins `MiniMax-M2.7` (translator output_config stripping) continues to work because M2.7 is retained