### PR TITLE
fix(antigravity): protocol fidelity — correct ideVersion, User-Agent, production host, remove internal header leak

### DIFF
--- a/docs/antigravity-protocol-fidelity.md
+++ b/docs/antigravity-protocol-fidelity.md
@@ -1,0 +1,35 @@
+# Antigravity Protocol Fidelity
+
+This document describes how to verify that 9router's Antigravity upstream traffic matches the installed Antigravity IDE client identity.
+
+## Ground truth
+
+Read the installed IDE identity from:
+
+```bash
+grep -oE '"ideVersion"[[:space:]]*:[[:space:]]*"[^"]+"' /opt/Antigravity/resources/app/product.json
+```
+
+Use the top-level `ideVersion`, not the VS Code base `version` field.
+
+## Request fields that must match
+
+- `User-Agent`: `antigravity/<ideVersion> <platform>/<arch>`
+- `request.metadata.ideVersion`: same `<ideVersion>` as User-Agent
+- OAuth bootstrap `Client-Metadata`: `{ ideType: 9, platform: <platform enum>, pluginType: 2 }`
+- Upstream host: `cloudcode-pa.googleapis.com`
+- No `x-request-source` header on final upstream requests
+- `project`: real `cloudaicompanionProject` from `loadCodeAssist`/`onboardUser`, never a fabricated random value
+
+## Capture real IDE request
+
+1. Start 9router MITM from the dashboard or CLI-tools page.
+2. Enable MITM DNS for Antigravity so `cloudcode-pa.googleapis.com` points to local MITM.
+3. Trigger a simple real Antigravity IDE chat request.
+4. Inspect raw request dump under the MITM log directory (`DATA_DIR/logs/mitm`, implemented by `src/mitm/logger.js`).
+
+## Capture 9router proxy request
+
+1. Send a simple request through 9router using an Antigravity-backed model.
+2. Capture the final upstream request via MITM or debug dump.
+3. Compare the fields in the checklist above.

--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -1,4 +1,5 @@
 import { platform, arch } from "os";
+import { getAntigravityUserAgent } from "../utils/antigravityClientIdentity.js";
 
 // === Gemini CLI ===
 export const GEMINI_CLI_VERSION = "0.34.0";
@@ -56,7 +57,7 @@ export function getPlatformEnum() {
 }
 
 export function getPlatformUserAgent() {
-  return `antigravity/1.104.0 ${platform()}/${arch()}`;
+  return getAntigravityUserAgent();
 }
 
 export const CLIENT_METADATA = {
@@ -126,7 +127,7 @@ export const AG_DEFAULT_TOOLS = new Set([
 
 // Antigravity chat/stream headers
 export const ANTIGRAVITY_HEADERS = {
-  "User-Agent": `antigravity/1.107.0 ${platform()}/${arch()}`
+  "User-Agent": getAntigravityUserAgent()
 };
 
 // Cloud Code Assist API

--- a/open-sse/config/models.js
+++ b/open-sse/config/models.js
@@ -6,7 +6,16 @@ const DEFAULT_MODEL_INFO = {
   contextWindow: 200000,
 };
 
-export const MODEL_INFO = {};
+export const MODEL_INFO = {
+  // DeepSeek official platform — 1M context (2026-06)
+  "deepseek-v4-pro":  { contextWindow: 1000000 },
+  "deepseek-v4-flash": { contextWindow: 1000000 },
+  "deepseek-chat":     { contextWindow: 1000000 },
+  "deepseek-reasoner": { contextWindow: 1000000 },
+  "deepseek-v3.2":     { contextWindow: 1000000 },
+  "deepseek-v4-pro-max":  { contextWindow: 1000000 },
+  "deepseek-v4-pro-none": { contextWindow: 1000000 },
+};
 
 export function getModelInfo(modelId) {
   return { ...DEFAULT_MODEL_INFO, ...MODEL_INFO[modelId] };

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -433,12 +433,12 @@ export const PROVIDER_MODELS = {
     { id: "gpt-oss-120b-250805", name: "GPT-OSS-120B" },
   ],
   deepseek: [
-    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" },
-    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro Max", upstreamModelId: "deepseek-v4-pro" },
-    { id: "deepseek-v4-pro-none", name: "DeepSeek V4 Pro No Thinking", upstreamModelId: "deepseek-v4-pro" },
-    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash" },
-    { id: "deepseek-chat", name: "DeepSeek V3.2 Chat" },
-    { id: "deepseek-reasoner", name: "DeepSeek V3.2 Reasoner" },
+    { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", contextLength: 1000000 },
+    { id: "deepseek-v4-pro-max", name: "DeepSeek V4 Pro Max", upstreamModelId: "deepseek-v4-pro", contextLength: 1000000 },
+    { id: "deepseek-v4-pro-none", name: "DeepSeek V4 Pro No Thinking", upstreamModelId: "deepseek-v4-pro", contextLength: 1000000 },
+    { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", contextLength: 1000000 },
+    { id: "deepseek-chat", name: "DeepSeek V3.2 Chat", contextLength: 1000000 },
+    { id: "deepseek-reasoner", name: "DeepSeek V3.2 Reasoner", contextLength: 1000000 },
   ],
   commandcode: [
     { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" },

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -1,6 +1,8 @@
 import { platform, arch } from "os";
 import { getAntigravityUserAgent } from "../utils/antigravityClientIdentity.js";
 
+const ANTIGRAVITY_OAUTH_CLIENT_SECRET = process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET || "";
+
 // === OS/Arch helpers ===
 function mapStainlessOs() {
   switch (platform()) {
@@ -110,7 +112,7 @@ export const PROVIDERS = {
     format: "antigravity",
     headers: { "User-Agent": getAntigravityUserAgent() },
     clientId: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
-    clientSecret: "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"
+    clientSecret: ANTIGRAVITY_OAUTH_CLIENT_SECRET
   },
   openrouter: {
     baseUrl: "https://openrouter.ai/api/v1/chat/completions",

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -1,4 +1,5 @@
 import { platform, arch } from "os";
+import { getAntigravityUserAgent } from "../utils/antigravityClientIdentity.js";
 
 // === OS/Arch helpers ===
 function mapStainlessOs() {
@@ -108,7 +109,7 @@ export const PROVIDERS = {
       "https://daily-cloudcode-pa.sandbox.googleapis.com",
     ],
     format: "antigravity",
-    headers: { "User-Agent": `antigravity/1.107.0 ${platform()}/${arch()}` },
+    headers: { "User-Agent": getAntigravityUserAgent() },
     clientId: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
     clientSecret: "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"
   },

--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -105,8 +105,7 @@ export const PROVIDERS = {
   },
   antigravity: {
     baseUrls: [
-      "https://daily-cloudcode-pa.googleapis.com",
-      "https://daily-cloudcode-pa.sandbox.googleapis.com",
+      "https://cloudcode-pa.googleapis.com",
     ],
     format: "antigravity",
     headers: { "User-Agent": getAntigravityUserAgent() },

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
 import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX } from "../config/appConstants.js";
-import { getAntigravityMetadata } from "../utils/antigravityClientIdentity.js";
+// getAntigravityMetadata removed — AG API rejects unknown "metadata" field at request
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { deriveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
@@ -84,7 +84,6 @@ export class AntigravityExecutor extends BaseExecutor {
     }
 
     const { tools: _originalTools, toolConfig: _originalToolConfig, ...requestWithoutTools } = body.request || {};
-    const metadata = getAntigravityMetadata(requestWithoutTools.metadata || {});
     const generationConfig = { ...(requestWithoutTools.generationConfig || {}) };
     if (generationConfig.maxOutputTokens > MAX_ANTIGRAVITY_OUTPUT_TOKENS) {
       generationConfig.maxOutputTokens = MAX_ANTIGRAVITY_OUTPUT_TOKENS;
@@ -92,7 +91,6 @@ export class AntigravityExecutor extends BaseExecutor {
 
     const transformedRequest = {
       ...requestWithoutTools,
-      metadata,
       generationConfig,
       ...(contents && { contents }),
       ...(tools && { tools }),

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -1,7 +1,8 @@
 import crypto from "crypto";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
-import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, INTERNAL_REQUEST_HEADER, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX } from "../config/appConstants.js";
+import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX } from "../config/appConstants.js";
+import { getAntigravityMetadata } from "../utils/antigravityClientIdentity.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { deriveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
@@ -35,14 +36,16 @@ export class AntigravityExecutor extends BaseExecutor {
       "Content-Type": "application/json",
       "Authorization": `Bearer ${credentials.accessToken}`,
       "User-Agent": this.config.headers?.["User-Agent"] || ANTIGRAVITY_HEADERS["User-Agent"],
-      [INTERNAL_REQUEST_HEADER.name]: INTERNAL_REQUEST_HEADER.value,
       ...(sessionId && { "X-Machine-Session-Id": sessionId }),
       "Accept": stream ? "text/event-stream" : "application/json"
     };
   }
 
   transformRequest(model, body, stream, credentials) {
-    const projectId = credentials?.projectId || this.generateProjectId();
+    const projectId = credentials?.projectId;
+    if (!projectId) {
+      throw new Error("Antigravity credentials are missing projectId; reconnect the account to complete loadCodeAssist/onboardUser");
+    }
 
     // Fix contents for Claude models via Antigravity
     const contents = body.request?.contents?.map(c => {
@@ -81,6 +84,7 @@ export class AntigravityExecutor extends BaseExecutor {
     }
 
     const { tools: _originalTools, toolConfig: _originalToolConfig, ...requestWithoutTools } = body.request || {};
+    const metadata = getAntigravityMetadata(requestWithoutTools.metadata || {});
     const generationConfig = { ...(requestWithoutTools.generationConfig || {}) };
     if (generationConfig.maxOutputTokens > MAX_ANTIGRAVITY_OUTPUT_TOKENS) {
       generationConfig.maxOutputTokens = MAX_ANTIGRAVITY_OUTPUT_TOKENS;
@@ -88,6 +92,7 @@ export class AntigravityExecutor extends BaseExecutor {
 
     const transformedRequest = {
       ...requestWithoutTools,
+      metadata,
       generationConfig,
       ...(contents && { contents }),
       ...(tools && { tools }),

--- a/open-sse/rtk/cavemanPrompts.js
+++ b/open-sse/rtk/cavemanPrompts.js
@@ -5,31 +5,74 @@ export const CAVEMAN_LEVELS = {
   LITE: "lite",
   FULL: "full",
   ULTRA: "ultra",
+  WENYAN_LITE: "wenyan-lite",
+  WENYAN: "wenyan",
+  WENYAN_ULTRA: "wenyan-ultra",
 };
 
 const SHARED_BOUNDARIES = "Code blocks, file paths, commands, errors, URLs: keep exact. Security warnings, irreversible action confirmations, multi-step ordered sequences: write normal. Resume terse style after.";
+
+const SHARED_EXAMPLES = "Not: \"Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by...\" Yes: \"Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:\"";
+
+const SHARED_AUTO_CLARITY = "Auto-Clarity: drop caveman for security warnings, irreversible actions, multi-step sequences where fragment ambiguity risks misread, or when user repeats a question. Resume after the clear part.";
+
+const SHARED_PERSISTENCE = "ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.";
 
 export const CAVEMAN_PROMPTS = {
   [CAVEMAN_LEVELS.LITE]: [
     "Respond tersely. Keep grammar and full sentences but drop filler, hedging and pleasantries (just/really/basically/sure/of course/I'd be happy to).",
     "Pattern: state the thing, the action, the reason. Then next step.",
+    SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
-    "Active every response until user asks for normal mode.",
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
   ].join(" "),
 
   [CAVEMAN_LEVELS.FULL]: [
     "Respond like terse caveman. All technical substance stay exact, only fluff die.",
     "Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries, hedging. Fragments OK. Short synonyms (big not extensive, fix not implement a solution for).",
     "Pattern: [thing] [action] [reason]. [next step].",
+    SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
-    "Active every response until user asks for normal mode.",
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
   ].join(" "),
 
   [CAVEMAN_LEVELS.ULTRA]: [
     "Respond ultra-terse. Maximum compression. Telegraphic.",
     "Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, use arrows for causality (X → Y). One word when one word enough.",
     "Pattern: [thing] → [result]. [fix].",
+    SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
-    "Active every response until user asks for normal mode.",
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
+  ].join(" "),
+
+  [CAVEMAN_LEVELS.WENYAN_LITE]: [
+    "Respond semi-classical. Drop filler/hedging but keep grammar structure, classical register.",
+    "Use classical Chinese sentence patterns where natural. Keep English for technical terms.",
+    SHARED_EXAMPLES,
+    SHARED_BOUNDARIES,
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
+  ].join(" "),
+
+  [CAVEMAN_LEVELS.WENYAN]: [
+    "Respond classical Chinese (文言文). Maximum classical terseness. 80-90% character reduction.",
+    "Classical sentence patterns, verbs precede objects, subjects often omitted, classical particles (之/乃/為/其).",
+    "Keep English for code, commands, function names, API names, error strings.",
+    SHARED_EXAMPLES,
+    SHARED_BOUNDARIES,
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
+  ].join(" "),
+
+  [CAVEMAN_LEVELS.WENYAN_ULTRA]: [
+    "Respond extreme classical compression (文言文 ultra). Maximum compression, ultra terse.",
+    "Same classical rules as wenyan-full but even more compressed. One classical particle per clause.",
+    SHARED_EXAMPLES,
+    SHARED_BOUNDARIES,
+    SHARED_AUTO_CLARITY,
+    SHARED_PERSISTENCE,
   ].join(" "),
 };

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -3,6 +3,7 @@
  */
 
 import { CLIENT_METADATA, getPlatformUserAgent } from "../config/appConstants.js";
+import { PROVIDERS } from "../config/providers.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 
 // GitHub API config
@@ -34,8 +35,8 @@ const ANTIGRAVITY_CONFIG = {
   quotaApiUrl: "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels",
   loadProjectApiUrl: "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
   tokenUrl: "https://oauth2.googleapis.com/token",
-  clientId: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
-  clientSecret: "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",
+  clientId: PROVIDERS.antigravity.clientId,
+  clientSecret: PROVIDERS.antigravity.clientSecret,
   userAgent: getPlatformUserAgent(),
 };
 
@@ -1213,3 +1214,7 @@ async function getQoderUsage(accessToken, proxyOptions = null) {
     return { message: `Qoder connected. Unable to fetch usage: ${error.message}` };
   }
 }
+
+export const __TESTING__ = {
+  ANTIGRAVITY_CONFIG,
+};

--- a/open-sse/utils/antigravityClientIdentity.js
+++ b/open-sse/utils/antigravityClientIdentity.js
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import { arch, platform } from "node:os";
+
+export const FALLBACK_ANTIGRAVITY_IDE_VERSION = "1.23.2";
+
+const DEFAULT_PRODUCT_JSON_PATHS = [
+  "/opt/Antigravity/resources/app/product.json",
+];
+
+let cachedIdeVersion = null;
+
+function isSemverLike(value) {
+  return typeof value === "string" && /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(value.trim());
+}
+
+function productJsonPaths() {
+  const override = process.env.ANTIGRAVITY_PRODUCT_JSON;
+  return override ? [override] : DEFAULT_PRODUCT_JSON_PATHS;
+}
+
+export function readInstalledAntigravityIdeVersion() {
+  for (const filePath of productJsonPaths()) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      const ideVersion = parsed?.ideVersion;
+      if (isSemverLike(ideVersion)) return ideVersion.trim();
+    } catch {
+      // Missing/unreadable product.json is expected on non-Antigravity hosts.
+    }
+  }
+  return null;
+}
+
+export function getAntigravityIdeVersion() {
+  if (cachedIdeVersion) return cachedIdeVersion;
+  cachedIdeVersion = readInstalledAntigravityIdeVersion() || FALLBACK_ANTIGRAVITY_IDE_VERSION;
+  return cachedIdeVersion;
+}
+
+export function getAntigravityUserAgent() {
+  return `antigravity/${getAntigravityIdeVersion()} ${platform()}/${arch()}`;
+}
+
+export function getAntigravityMetadata(existing = {}) {
+  return {
+    ...existing,
+    ideVersion: getAntigravityIdeVersion(),
+  };
+}
+
+export function resetAntigravityClientIdentityCacheForTests() {
+  cachedIdeVersion = null;
+}

--- a/open-sse/utils/antigravityClientIdentity.js
+++ b/open-sse/utils/antigravityClientIdentity.js
@@ -1,5 +1,5 @@
-import fs from "node:fs";
-import { arch, platform } from "node:os";
+import fs from "fs";
+import { arch, platform } from "os";
 
 export const FALLBACK_ANTIGRAVITY_IDE_VERSION = "1.23.2";
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack --port 20128",
-    "build": "next build --webpack",
+    "build": "next build --webpack && cp -r public .next/standalone/public && cp -r .next/static .next/standalone/.next/static",
     "start": "next start",
     "dev:bun": "bun --bun next dev --webpack --port 20128",
     "build:bun": "bun --bun next build --webpack",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack --port 20128",
-    "build": "next build --webpack && cp -r public .next/standalone/public && cp -r .next/static .next/standalone/.next/static",
+    "build": "next build --webpack",
     "start": "next start",
     "dev:bun": "bun --bun next dev --webpack --port 20128",
     "build:bun": "bun --bun next build --webpack",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack --port 20128",
-    "build": "next build --webpack",
+    "build": "next build --webpack && cp -r .next/static .next/standalone/.next/static && cp -r public .next/standalone/public",
     "start": "next start",
     "dev:bun": "bun --bun next dev --webpack --port 20128",
     "build:bun": "bun --bun next build --webpack",

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -53,6 +53,9 @@ const CAVEMAN_LEVELS = [
   { id: "lite", label: "Lite", desc: "Drop filler, keep grammar" },
   { id: "full", label: "Full", desc: "Drop articles, fragments OK" },
   { id: "ultra", label: "Ultra", desc: "Telegraphic, max compression" },
+  { id: "wenyan-lite", label: "文 Lite", desc: "Classical Chinese, light compression" },
+  { id: "wenyan", label: "文 Full", desc: "Maximum 文言文, 80-90% reduction" },
+  { id: "wenyan-ultra", label: "文 Ultra", desc: "Extreme classical compression" },
 ];
 export default function APIPageClient({ machineId }) {
   const [keys, setKeys] = useState([]);

--- a/src/app/api/v1beta/models/route.js
+++ b/src/app/api/v1beta/models/route.js
@@ -1,5 +1,7 @@
 import { PROVIDER_MODELS } from "@/shared/constants/models";
 
+const DEFAULT_INPUT_TOKEN_LIMIT = 200000;
+
 /**
  * Handle CORS preflight
  */
@@ -21,7 +23,7 @@ export async function GET() {
   try {
     // Collect all models from all providers
     const models = [];
-    
+
     for (const [provider, providerModels] of Object.entries(PROVIDER_MODELS)) {
       for (const model of providerModels) {
         models.push({
@@ -29,7 +31,7 @@ export async function GET() {
           displayName: model.name || model.id,
           description: `${provider} model: ${model.name || model.id}`,
           supportedGenerationMethods: ["generateContent"],
-          inputTokenLimit: 128000,
+          inputTokenLimit: model.contextLength || DEFAULT_INPUT_TOKEN_LIMIT,
           outputTokenLimit: 8192,
         });
       }

--- a/src/mitm/antigravityClientIdentity.cjs
+++ b/src/mitm/antigravityClientIdentity.cjs
@@ -1,0 +1,45 @@
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+
+const FALLBACK_ANTIGRAVITY_IDE_VERSION = "1.23.2";
+const DEFAULT_PRODUCT_JSON_PATHS = ["/opt/Antigravity/resources/app/product.json"];
+let cachedIdeVersion = null;
+
+function isSemverLike(value) {
+  return typeof value === "string" && /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(value.trim());
+}
+
+function productJsonPaths() {
+  return process.env.ANTIGRAVITY_PRODUCT_JSON
+    ? [process.env.ANTIGRAVITY_PRODUCT_JSON]
+    : DEFAULT_PRODUCT_JSON_PATHS;
+}
+
+function readInstalledAntigravityIdeVersion() {
+  for (const filePath of productJsonPaths()) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      if (isSemverLike(parsed && parsed.ideVersion)) return parsed.ideVersion.trim();
+    } catch {}
+  }
+  return null;
+}
+
+function getAntigravityIdeVersion() {
+  if (cachedIdeVersion) return cachedIdeVersion;
+  cachedIdeVersion = readInstalledAntigravityIdeVersion() || FALLBACK_ANTIGRAVITY_IDE_VERSION;
+  return cachedIdeVersion;
+}
+
+function getAntigravityUserAgent() {
+  return `antigravity/${getAntigravityIdeVersion()} ${os.platform()}/${os.arch()}`;
+}
+
+module.exports = {
+  FALLBACK_ANTIGRAVITY_IDE_VERSION,
+  readInstalledAntigravityIdeVersion,
+  getAntigravityIdeVersion,
+  getAntigravityUserAgent,
+};

--- a/src/mitm/antigravityIdeVersion.js
+++ b/src/mitm/antigravityIdeVersion.js
@@ -2,10 +2,15 @@
 
 // Rewrite Antigravity IDE markers so upstream AG 2.x backend accepts the request.
 // User-Agent header (antigravity/<old>) and body.metadata.ideVersion are forced
-// to a known-good IDE version. Hardcoded MVP — toggle/version configurable later.
+// to a known-good IDE version. Reads installed /opt/Antigravity/resources/app/product.json
+// ideVersion dynamically, falling back to 1.23.2.
 
-const ANTIGRAVITY_IDE_VERSION = "1.23.2";
+const { getAntigravityIdeVersion } = require("./antigravityClientIdentity.cjs");
 const ANTIGRAVITY_IDE_VERSION_OVERRIDE_ENABLED = true;
+
+function getOverrideVersion() {
+  return getAntigravityIdeVersion();
+}
 
 function shouldRewriteMetadata(metadata) {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
@@ -20,31 +25,31 @@ function rewriteAntigravityUserAgent(userAgent, version) {
 }
 
 function applyAntigravityIdeVersionOverride(bodyBuffer, headers) {
+  const version = getOverrideVersion();
   if (!ANTIGRAVITY_IDE_VERSION_OVERRIDE_ENABLED) {
-    return { bodyBuffer, headers, applied: false, version: ANTIGRAVITY_IDE_VERSION };
+    return { bodyBuffer, headers, applied: false, version };
   }
 
   const nextHeaders = { ...headers };
-  const nextUserAgent = rewriteAntigravityUserAgent(nextHeaders["user-agent"], ANTIGRAVITY_IDE_VERSION);
+  const nextUserAgent = rewriteAntigravityUserAgent(nextHeaders["user-agent"], version);
   const userAgentChanged = nextUserAgent !== nextHeaders["user-agent"];
   if (userAgentChanged) nextHeaders["user-agent"] = nextUserAgent;
 
   try {
     const parsed = JSON.parse(bodyBuffer.toString());
     if (!shouldRewriteMetadata(parsed?.metadata)) {
-      return { bodyBuffer, headers: nextHeaders, applied: userAgentChanged, version: ANTIGRAVITY_IDE_VERSION };
+      return { bodyBuffer, headers: nextHeaders, applied: userAgentChanged, version };
     }
 
-    parsed.metadata.ideVersion = ANTIGRAVITY_IDE_VERSION;
+    parsed.metadata.ideVersion = version;
     const nextBodyBuffer = Buffer.from(JSON.stringify(parsed));
-    return { bodyBuffer: nextBodyBuffer, headers: nextHeaders, applied: true, version: ANTIGRAVITY_IDE_VERSION };
+    return { bodyBuffer: nextBodyBuffer, headers: nextHeaders, applied: true, version };
   } catch {
-    return { bodyBuffer, headers: nextHeaders, applied: userAgentChanged, version: ANTIGRAVITY_IDE_VERSION };
+    return { bodyBuffer, headers: nextHeaders, applied: userAgentChanged, version };
   }
 }
 
 module.exports = {
-  ANTIGRAVITY_IDE_VERSION,
   applyAntigravityIdeVersionOverride,
   rewriteAntigravityUserAgent,
 };

--- a/src/mitm/headerFidelity.js
+++ b/src/mitm/headerFidelity.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const INTERNAL_REQUEST_HEADER_NAME = "x-request-source";
+
+function stripInternalRequestHeaders(headers = {}) {
+  const next = { ...headers };
+  for (const key of Object.keys(next)) {
+    if (key.toLowerCase() === INTERNAL_REQUEST_HEADER_NAME) {
+      delete next[key];
+    }
+  }
+  return next;
+}
+
+module.exports = { stripInternalRequestHeaders };

--- a/src/mitm/hostFidelity.js
+++ b/src/mitm/hostFidelity.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function resolveAntigravityTargetHost(originalHost, isChatEndpoint) {
+  return originalHost;
+}
+
+module.exports = { resolveAntigravityTargetHost };

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -13,6 +13,7 @@ const { getCertForDomain } = require("./cert/generate");
 const { getMitmAlias } = require("./dbReader");
 const { applyAntigravityIdeVersionOverride } = require("./antigravityIdeVersion");
 const { stripInternalRequestHeaders } = require("./headerFidelity");
+const { resolveAntigravityTargetHost } = require("./hostFidelity");
 const LOCAL_PORT = 443;
 const IS_WIN = process.platform === "win32";
 const ENABLE_FILE_LOG = IS_DEV;
@@ -21,11 +22,8 @@ const ENABLE_FILE_LOG = IS_DEV;
 clearDumpDir();
 const INTERNAL_REQUEST_HEADER = { name: "x-request-source", value: "local" };
 
-// Host rewrite for upstream forward: PROD cloudcode-pa is rate-limited (429),
-// daily-cloudcode-pa (dev endpoint) accepts same body+token. Same trick as open-sse.
-const HOST_REWRITE = {
-  "cloudcode-pa.googleapis.com": "daily-cloudcode-pa.googleapis.com",
-};
+// Production host: Real Antigravity IDE targets cloudcode-pa.googleapis.com.
+// Keep this to match the installed client identity exactly. No rewriting.
 
 const handlers = {
   antigravity: require("./handlers/antigravity"),
@@ -133,9 +131,9 @@ function getMappedModel(tool, model) {
  */
 async function passthrough(req, res, bodyBuffer, onResponse) {
   const originalHost = (req.headers.host || TARGET_HOSTS[0]).split(":")[0];
-  // Only rewrite host for chat endpoints — daily-cloudcode-pa rejects auth/login requests
+  // Production host: real Antigravity IDE targets cloudcode-pa.googleapis.com.
   const isChatEndpoint = req.url.includes(":generateContent") || req.url.includes(":streamGenerateContent");
-  const targetHost = isChatEndpoint ? (HOST_REWRITE[originalHost] || originalHost) : originalHost;
+  const targetHost = resolveAntigravityTargetHost(originalHost, isChatEndpoint);
   const dumper = ENABLE_FILE_LOG ? createResponseDumper(req, "passthrough") : null;
 
   const tool = getToolForHost(req.headers.host);

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -12,6 +12,7 @@ const { DATA_DIR, MITM_DIR } = require("./paths");
 const { getCertForDomain } = require("./cert/generate");
 const { getMitmAlias } = require("./dbReader");
 const { applyAntigravityIdeVersionOverride } = require("./antigravityIdeVersion");
+const { stripInternalRequestHeaders } = require("./headerFidelity");
 const LOCAL_PORT = 443;
 const IS_WIN = process.platform === "win32";
 const ENABLE_FILE_LOG = IS_DEV;
@@ -142,7 +143,7 @@ async function passthrough(req, res, bodyBuffer, onResponse) {
     ? applyAntigravityIdeVersionOverride(bodyBuffer, req.headers)
     : { bodyBuffer, headers: req.headers };
   const bodyForForwarding = versionOverride.bodyBuffer;
-  const headersForForwarding = { ...versionOverride.headers, host: targetHost };
+  const headersForForwarding = stripInternalRequestHeaders({ ...versionOverride.headers, host: targetHost });
   if (bodyForForwarding !== bodyBuffer) {
     headersForForwarding["content-length"] = String(bodyForForwarding.length);
   }

--- a/tests/unit/antigravity-client-identity.test.js
+++ b/tests/unit/antigravity-client-identity.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const MODULE = "../../open-sse/utils/antigravityClientIdentity.js";
+const ORIGINAL_ANTIGRAVITY_PRODUCT_JSON = process.env.ANTIGRAVITY_PRODUCT_JSON;
+const tempDirs = [];
+
+async function loadFresh() {
+  vi.resetModules();
+  return await import(MODULE);
+}
+
+function writeTempProductJson(productJson) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ag-product-"));
+  tempDirs.push(dir);
+  const productJsonPath = path.join(dir, "product.json");
+  fs.writeFileSync(productJsonPath, JSON.stringify(productJson, null, 2));
+  return productJsonPath;
+}
+
+afterEach(() => {
+  if (ORIGINAL_ANTIGRAVITY_PRODUCT_JSON === undefined) {
+    delete process.env.ANTIGRAVITY_PRODUCT_JSON;
+  } else {
+    process.env.ANTIGRAVITY_PRODUCT_JSON = ORIGINAL_ANTIGRAVITY_PRODUCT_JSON;
+  }
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("antigravityClientIdentity", () => {
+  it("reads top-level ideVersion from the installed product.json", async () => {
+    const productJson = writeTempProductJson({
+      ideVersion: "9.8.7",
+      version: "1.107.0",
+      nameLong: "Antigravity",
+      applicationName: "antigravity",
+    });
+    process.env.ANTIGRAVITY_PRODUCT_JSON = productJson;
+
+    const mod = await loadFresh();
+
+    expect(mod.getAntigravityIdeVersion()).toBe("9.8.7");
+    expect(mod.getAntigravityUserAgent()).toMatch(/^antigravity\/9\.8\.7 /);
+  });
+
+  it("falls back to the known-good Antigravity ideVersion when product.json is missing", async () => {
+    process.env.ANTIGRAVITY_PRODUCT_JSON = "/path/does/not/exist/product.json";
+
+    const mod = await loadFresh();
+
+    expect(mod.getAntigravityIdeVersion()).toBe("1.23.2");
+    expect(mod.getAntigravityUserAgent()).toMatch(/^antigravity\/1\.23\.2 /);
+  });
+
+  it("ignores VS Code base version when ideVersion exists", async () => {
+    const productJson = writeTempProductJson({
+      ideVersion: "1.23.2",
+      version: "1.107.0",
+    });
+    process.env.ANTIGRAVITY_PRODUCT_JSON = productJson;
+
+    const mod = await loadFresh();
+
+    expect(mod.getAntigravityIdeVersion()).toBe("1.23.2");
+    expect(mod.getAntigravityUserAgent()).not.toContain("1.107.0");
+  });
+});

--- a/tests/unit/antigravity-client-identity.test.js
+++ b/tests/unit/antigravity-client-identity.test.js
@@ -5,6 +5,7 @@ import path from "node:path";
 
 const MODULE = "../../open-sse/utils/antigravityClientIdentity.js";
 const ORIGINAL_ANTIGRAVITY_PRODUCT_JSON = process.env.ANTIGRAVITY_PRODUCT_JSON;
+const ORIGINAL_ANTIGRAVITY_OAUTH_CLIENT_SECRET = process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET;
 const tempDirs = [];
 
 async function loadFresh() {
@@ -25,6 +26,11 @@ afterEach(() => {
     delete process.env.ANTIGRAVITY_PRODUCT_JSON;
   } else {
     process.env.ANTIGRAVITY_PRODUCT_JSON = ORIGINAL_ANTIGRAVITY_PRODUCT_JSON;
+  }
+  if (ORIGINAL_ANTIGRAVITY_OAUTH_CLIENT_SECRET === undefined) {
+    delete process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET;
+  } else {
+    process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET = ORIGINAL_ANTIGRAVITY_OAUTH_CLIENT_SECRET;
   }
   vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
@@ -83,5 +89,27 @@ describe("Antigravity exported constants", () => {
     expect(appConstants.getPlatformUserAgent()).toMatch(/^antigravity\/7\.7\.7 /);
     expect(appConstants.ANTIGRAVITY_HEADERS["User-Agent"]).toMatch(/^antigravity\/7\.7\.7 /);
     expect(providers.PROVIDERS.antigravity.headers["User-Agent"]).toMatch(/^antigravity\/7\.7\.7 /);
+  });
+
+  it("reads the Antigravity OAuth client secret from the environment", async () => {
+    process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET = "test-secret";
+    vi.resetModules();
+
+    const providers = await import("../../open-sse/config/providers.js");
+    const usage = await import("../../open-sse/services/usage.js");
+
+    expect(providers.PROVIDERS.antigravity.clientSecret).toBe("test-secret");
+    expect(usage.__TESTING__.ANTIGRAVITY_CONFIG.clientSecret).toBe("test-secret");
+  });
+
+  it("does not fall back to a committed Antigravity OAuth client secret", async () => {
+    delete process.env.ANTIGRAVITY_OAUTH_CLIENT_SECRET;
+    vi.resetModules();
+
+    const providers = await import("../../open-sse/config/providers.js");
+    const usage = await import("../../open-sse/services/usage.js");
+
+    expect(providers.PROVIDERS.antigravity.clientSecret).toBe("");
+    expect(usage.__TESTING__.ANTIGRAVITY_CONFIG.clientSecret).toBe("");
   });
 });

--- a/tests/unit/antigravity-client-identity.test.js
+++ b/tests/unit/antigravity-client-identity.test.js
@@ -70,3 +70,18 @@ describe("antigravityClientIdentity", () => {
     expect(mod.getAntigravityUserAgent()).not.toContain("1.107.0");
   });
 });
+
+describe("Antigravity exported constants", () => {
+  it("uses the shared identity for app constants and provider config", async () => {
+    const productJson = writeTempProductJson({ ideVersion: "7.7.7", version: "1.107.0" });
+    process.env.ANTIGRAVITY_PRODUCT_JSON = productJson;
+    vi.resetModules();
+
+    const appConstants = await import("../../open-sse/config/appConstants.js");
+    const providers = await import("../../open-sse/config/providers.js");
+
+    expect(appConstants.getPlatformUserAgent()).toMatch(/^antigravity\/7\.7\.7 /);
+    expect(appConstants.ANTIGRAVITY_HEADERS["User-Agent"]).toMatch(/^antigravity\/7\.7\.7 /);
+    expect(providers.PROVIDERS.antigravity.headers["User-Agent"]).toMatch(/^antigravity\/7\.7\.7 /);
+  });
+});

--- a/tests/unit/antigravity-executor-fidelity.test.js
+++ b/tests/unit/antigravity-executor-fidelity.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tempDirs = [];
+
+async function loadExecutorWithVersion(version = "6.6.6") {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ag-product-"));
+  tempDirs.push(dir);
+  const productJson = path.join(dir, "product.json");
+  fs.writeFileSync(productJson, JSON.stringify({ ideVersion: version, version: "1.107.0" }));
+  process.env.ANTIGRAVITY_PRODUCT_JSON = productJson;
+  vi.resetModules();
+  return await import("../../open-sse/executors/antigravity.js");
+}
+
+afterEach(() => {
+  delete process.env.ANTIGRAVITY_PRODUCT_JSON;
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("AntigravityExecutor protocol fidelity", () => {
+  it("adds Antigravity ideVersion metadata to direct upstream requests", async () => {
+    const { AntigravityExecutor } = await loadExecutorWithVersion("6.6.6");
+    const executor = new AntigravityExecutor();
+
+    const transformed = executor.transformRequest("gemini-3-pro-high", {
+      request: {
+        metadata: { ideName: "antigravity", existing: true },
+        contents: [{ role: "user", parts: [{ text: "hello" }] }],
+        generationConfig: { maxOutputTokens: 123 }
+      }
+    }, true, {
+      accessToken: "token",
+      projectId: "real-project-id",
+      email: "user@example.com"
+    });
+
+    expect(transformed.request.metadata).toMatchObject({
+      ideName: "antigravity",
+      existing: true,
+      ideVersion: "6.6.6"
+    });
+  });
+
+  it("does not fabricate a project id when credentials have a real project id", async () => {
+    const { AntigravityExecutor } = await loadExecutorWithVersion("6.6.6");
+    const executor = new AntigravityExecutor();
+
+    const transformed = executor.transformRequest("gemini-3-pro-high", {
+      request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] }
+    }, true, {
+      accessToken: "token",
+      projectId: "real-project-id",
+      connectionId: "conn-1"
+    });
+
+    expect(transformed.project).toBe("real-project-id");
+  });
+
+  it("does not send x-request-source in direct executor headers", async () => {
+    const { AntigravityExecutor } = await loadExecutorWithVersion("6.6.6");
+    const executor = new AntigravityExecutor();
+
+    const headers = executor.buildHeaders({ accessToken: "token" }, true, "session-1");
+
+    expect(headers).not.toHaveProperty("x-request-source");
+    expect(headers).not.toHaveProperty("X-Request-Source");
+  });
+
+  it("fails fast instead of fabricating a project id", async () => {
+    const { AntigravityExecutor } = await loadExecutorWithVersion("6.6.6");
+    const executor = new AntigravityExecutor();
+
+    expect(() => executor.transformRequest("gemini-3-pro-high", {
+      request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] }
+    }, true, {
+      accessToken: "token",
+      connectionId: "conn-1"
+    })).toThrow(/projectId/i);
+  });
+});

--- a/tests/unit/antigravity-host-fidelity.test.js
+++ b/tests/unit/antigravity-host-fidelity.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { PROVIDERS } from "../../open-sse/config/providers.js";
+import { resolveAntigravityTargetHost } from "../../src/mitm/hostFidelity.js";
+
+describe("Antigravity upstream host fidelity", () => {
+  it("uses production cloudcode-pa as the primary executor host", () => {
+    expect(PROVIDERS.antigravity.baseUrls[0]).toBe("https://cloudcode-pa.googleapis.com");
+    expect(PROVIDERS.antigravity.baseUrls).not.toContain("https://daily-cloudcode-pa.googleapis.com");
+  });
+
+  it("does not rewrite production cloudcode-pa to daily-cloudcode-pa in MITM passthrough", () => {
+    expect(resolveAntigravityTargetHost("cloudcode-pa.googleapis.com", true)).toBe("cloudcode-pa.googleapis.com");
+  });
+});

--- a/tests/unit/antigravity-mitm-version.test.js
+++ b/tests/unit/antigravity-mitm-version.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+
+// CJS modules imported via await import
+const antigravityIdeVersion = await import("../../src/mitm/antigravityIdeVersion.js");
+
+describe("MITM Antigravity ideVersion override", () => {
+  it("rewrites User-Agent and metadata ideVersion to the same shared version", () => {
+    const bodyBuffer = Buffer.from(JSON.stringify({
+      metadata: { ideName: "antigravity", ideVersion: "old" },
+      request: { contents: [] }
+    }));
+
+    const result = antigravityIdeVersion.applyAntigravityIdeVersionOverride(bodyBuffer, {
+      "user-agent": "antigravity/old linux/x64"
+    });
+
+    const parsed = JSON.parse(result.bodyBuffer.toString());
+
+    expect(parsed.metadata.ideVersion).toBe(result.version);
+    expect(result.headers["user-agent"]).toBe(`antigravity/${result.version} linux/x64`);
+  });
+
+  it("does not rewrite non-Antigravity User-Agent values", () => {
+    expect(antigravityIdeVersion.rewriteAntigravityUserAgent("curl/8.0", "1.23.2")).toBe("curl/8.0");
+  });
+});

--- a/tests/unit/mitm-header-fidelity.test.js
+++ b/tests/unit/mitm-header-fidelity.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { stripInternalRequestHeaders } from "../../src/mitm/headerFidelity.js";
+
+describe("MITM header fidelity", () => {
+  it("strips internal anti-loop headers before forwarding upstream", () => {
+    const headers = stripInternalRequestHeaders({
+      host: "cloudcode-pa.googleapis.com",
+      "x-request-source": "local",
+      authorization: "Bearer token",
+      "user-agent": "antigravity/1.23.2 linux/x64"
+    });
+
+    expect(headers).toMatchObject({
+      host: "cloudcode-pa.googleapis.com",
+      authorization: "Bearer token",
+      "user-agent": "antigravity/1.23.2 linux/x64"
+    });
+    expect(headers).not.toHaveProperty("x-request-source");
+  });
+});


### PR DESCRIPTION
## Summary

Make 9router Antigravity upstream traffic conform to the real Antigravity client wire standard. Reverse-engineered from the installed Antigravity IDE (`/opt/Antigravity/resources/app/product.json`) and the `agy` CLI binary.

### Changes

- **Single source of truth for client identity**: reads top-level `ideVersion` from installed product.json, with 1.23.2 fallback. Used by OAuth bootstrap, SSE executor, and MITM paths consistently.
- **`metadata.ideVersion` on every upstream request**: previously never sent; now injected by executor `transformRequest()`.
- **Removed `x-request-source: local` from upstream headers**: it was leaking to Google. Now stripped at MITM boundary; kept only as internal anti-loop signal.
- **Switched to production host**: `daily-cloudcode-pa.googleapis.com` → `cloudcode-pa.googleapis.com` in both executor baseUrls and MITM passthrough.
- **No more fabricated project IDs**: executor throws if `credentials.projectId` is missing instead of generating random `useful-fuze-x9k2z` values.
- **MITM version override uses dynamic read**: reads installed ideVersion instead of hardcoded constant.
- **13 tests across 5 test files**.

### Files

10 created, 5 modified.