### PR TITLE
fix: update codex integration to 1.136-compatible headers and response events

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -71,8 +71,8 @@ export const PROVIDERS = {
     baseUrl: "https://chatgpt.com/backend-api/codex/responses",
     format: "openai-responses",
     headers: {
-      "originator": "codex-cli",
-      "User-Agent": "codex-cli/1.0.18 (macOS; arm64)"
+      "originator": "codex_cli_rs",
+      "User-Agent": "codex_cli_rs/0.136.0"
     },
     clientId: "app_EMoamEEZ73f0CkXaXp7hrann",
     tokenUrl: "https://auth.openai.com/oauth/token"

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -167,7 +167,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       } else {
         const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
         if (hasToolCalls) message.tool_calls = toolCalls;
-        const finishReason = hasToolCalls ? "tool_calls" : (jsonResponse.status === "completed" ? "stop" : (jsonResponse.status || "stop"));
+        const responseDone = jsonResponse.status === "completed" || jsonResponse.status === "done";
+        const finishReason = hasToolCalls ? "tool_calls" : (responseDone ? "stop" : (jsonResponse.status || "stop"));
         finalResp = {
           id: jsonResponse.id || `chatcmpl-${Date.now()}`,
           object: "chat.completion",

--- a/open-sse/handlers/imageProviders/codex.js
+++ b/open-sse/handlers/imageProviders/codex.js
@@ -3,8 +3,8 @@ import { randomUUID } from "node:crypto";
 import { nowSec } from "./_base.js";
 
 const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
-const CODEX_USER_AGENT = "codex-imagen/0.2.6";
-const CODEX_VERSION = "0.129.0";
+const CODEX_USER_AGENT = "codex_cli_rs/0.136.0";
+const CODEX_VERSION = "0.136.0";
 const CODEX_ORIGINATOR = "codex_cli_rs";
 const CODEX_MODEL_SUFFIX = "-image";
 const CODEX_REF_DETAIL = "high";

--- a/open-sse/transformer/streamToJsonConverter.js
+++ b/open-sse/transformer/streamToJsonConverter.js
@@ -27,7 +27,7 @@ function processSSEMessage(msg, state) {
     state.created = parsed.response?.created_at || state.created;
   } else if (eventType === "response.output_item.done") {
     state.items.set(parsed.output_index ?? 0, parsed.item);
-  } else if (eventType === "response.completed") {
+  } else if (eventType === "response.completed" || eventType === "response.done") {
     state.status = "completed";
     if (parsed.response?.usage) {
       state.usage.input_tokens = parsed.response.usage.input_tokens || 0;

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -490,7 +490,7 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
   }
 
   // Response completed
-  if (eventType === "response.completed") {
+  if (eventType === "response.completed" || eventType === "response.done") {
     // Extract usage from response.completed event
     const responseUsage = data.response?.usage;
     if (responseUsage && typeof responseUsage === "object") {

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -25,7 +25,7 @@ const OAUTH_TEST_CONFIG = {
     method: "POST",
     authHeader: "Authorization",
     authPrefix: "Bearer ",
-    extraHeaders: { "Content-Type": "application/json", "originator": "codex-cli", "User-Agent": "codex-cli/1.0.18 (macOS; arm64)" },
+    extraHeaders: { "Content-Type": "application/json", "originator": "codex_cli_rs", "User-Agent": "codex_cli_rs/0.136.0" },
     // Minimal invalid body — triggers fast 400 without consuming quota
     body: JSON.stringify({ model: "gpt-5.3-codex", input: [], stream: false, store: false }),
     // 400 (bad request) means auth succeeded; only 401/403 means token is bad

--- a/tests/unit/image-generation.test.js
+++ b/tests/unit/image-generation.test.js
@@ -319,7 +319,7 @@ describe("handleImageGenerationCore", () => {
         headers: expect.objectContaining({
           authorization: "Bearer codex-token",
           "chatgpt-account-id": "account-123",
-          version: "0.129.0",
+          version: "0.136.0",
         }),
       })
     );


### PR DESCRIPTION
## Why this change
This is a compatibility-hardening patch for Codex integration paths in 9router, aligned with upstream Codex client conventions.

## External evidence from upstream Codex source (openai/codex)

- Upstream sets the default originator to `codex_cli_rs` in the HTTP client defaults:
  - `codex-rs/login/src/auth/default_client.rs:36` (`DEFAULT_ORIGINATOR: "codex_cli_rs"`)
  - `codex-rs/login/src/auth/default_client.rs:232-247` (default headers include `originator` and default `User-Agent`)
- Upstream `User-Agent` construction is built from originator + version:
  - `codex-rs/login/src/auth/default_client.rs:133-145` (`get_codex_user_agent`), with tests confirming it starts with `{originator}/`:
    - `codex-rs/login/src/auth/default_client_tests.rs:7-12`
- Upstream tests explicitly verify default header behavior:
  - `codex-rs/login/src/auth/default_client_tests.rs:71-83` (created client must send `originator` and `user-agent` headers matching above defaults)
- Upstream protocol includes `response.done` as a first-class event type in protocol mapping/parsing:
  - `codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_v2.rs:70`
  - `codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs:1312-1323` (test for `parse_realtime_v2_response_done_event`)
- Upstream codex tooling also emits `response.done` in mock response streams:
  - `scripts/mock_responses_websocket_server.py:42-50`
- Upstream /models flow includes `client_version` query handling for model refresh:
  - `codex-rs/core/tests/suite/models_etag_responses.rs:149-156` (assert `client_version` query exists)
  - `codex-rs/model-provider/src/models_endpoint.rs:81-105` (passes `client_version` arg into client request)

## What this PR changes in 9router

- Sync Codex identity headers with upstream shape:
  - `open-sse/config/providers.js:74-76`
  - `open-sse/handlers/imageProviders/codex.js:5-8`
  - `src/app/api/providers/[id]/test/testUtils.js:28`
- Handle both `response.completed` and `response.done` across Codex stream conversion paths:
  - `open-sse/transformer/streamToJsonConverter.js:30`
  - `open-sse/translator/response/openai-responses.js:493`
  - `open-sse/handlers/chatCore/sseToJsonHandler.js:170-171`
- Keep unit test expectation aligned:
  - `tests/unit/image-generation.test.js:319-323`

## Note on version value
- Upstream `User-Agent` and model client versions are programmatically built (`{originator}/{VERSION}` pattern in upstream code); this PR uses the practical runtime target `0.136.0` in 9router where the integration compatibility is currently tuned.
