### PR TITLE
Fix OpenAI-compatible token parameter handling

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -14,6 +14,7 @@ let fsPromises = null;
 let cacheFilePath = null;
 let paramCacheSaveTimer = null;
 let paramCacheSaveInFlight = false;
+let paramCacheSavePromise = null;
 let paramCacheSaveDirty = false;
 const PARAM_CACHE_SAVE_DELAY_MS = 250;
 const DEFAULT_MAX_AUTO_FIX_ATTEMPTS = 3;
@@ -85,17 +86,21 @@ async function flushParamCacheSave() {
 
   paramCacheSaveDirty = false;
   paramCacheSaveInFlight = true;
+  paramCacheSavePromise = (async () => {
+    try {
+      const data = Object.fromEntries(paramFixCache.entries());
+      await writeJsonFileAtomically(fsPromises, cacheFilePath, data);
+    } catch (error) {
+      paramCacheSaveDirty = true;
+      dbg("CACHE", `Failed to save param cache: ${error.message}`);
+    } finally {
+      paramCacheSaveInFlight = false;
+      paramCacheSavePromise = null;
+      if (paramCacheSaveDirty && !paramCacheSaveTimer) scheduleParamCacheSave();
+    }
+  })();
 
-  try {
-    const data = Object.fromEntries(paramFixCache.entries());
-    await writeJsonFileAtomically(fsPromises, cacheFilePath, data);
-  } catch (error) {
-    paramCacheSaveDirty = true;
-    dbg("CACHE", `Failed to save param cache: ${error.message}`);
-  } finally {
-    paramCacheSaveInFlight = false;
-    if (paramCacheSaveDirty && !paramCacheSaveTimer) scheduleParamCacheSave();
-  }
+  await paramCacheSavePromise;
 }
 
 const paramCacheReady = initParamCache();
@@ -104,12 +109,17 @@ export async function flushParamCacheSaveForTests(maxPasses = 5) {
   await paramCacheReady;
 
   for (let pass = 0; pass < maxPasses; pass++) {
+    if (paramCacheSaveInFlight) {
+      await paramCacheSavePromise;
+      continue;
+    }
+
     if (paramCacheSaveTimer) {
       clearTimeout(paramCacheSaveTimer);
       paramCacheSaveTimer = null;
     }
 
-    if (!paramCacheSaveDirty || paramCacheSaveInFlight) return;
+    if (!paramCacheSaveDirty) return;
     await flushParamCacheSave();
   }
 }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -79,12 +79,23 @@ async function flushParamCacheSave() {
 
   try {
     const data = Object.fromEntries(paramFixCache.entries());
-    await fsPromises.writeFile(cacheFilePath, JSON.stringify(data, null, 2));
+    await writeJsonFileAtomically(cacheFilePath, data);
   } catch (error) {
     dbg("CACHE", `Failed to save param cache: ${error.message}`);
   } finally {
     paramCacheSaveInFlight = false;
     if (paramCacheSaveDirty && !paramCacheSaveTimer) scheduleParamCacheSave();
+  }
+}
+
+async function writeJsonFileAtomically(filePath, data) {
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    await fsPromises.writeFile(tempPath, JSON.stringify(data, null, 2));
+    await fsPromises.rename(tempPath, filePath);
+  } catch (error) {
+    if (fsPromises.rm) await fsPromises.rm(tempPath, { force: true }).catch(() => {});
+    throw error;
   }
 }
 

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -1,6 +1,71 @@
-import { HTTP_STATUS, RETRY_CONFIG, DEFAULT_RETRY_CONFIG, resolveRetryEntry, FETCH_CONNECT_TIMEOUT_MS } from "../config/runtimeConfig.js";
+import { HTTP_STATUS, DEFAULT_RETRY_CONFIG, resolveRetryEntry, FETCH_CONNECT_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
+
+const isNode = typeof process !== "undefined" && process.versions?.node && typeof window === "undefined";
+const isNextBuildPhase = isNode && (
+  process.env.NEXT_PHASE === "phase-production-build" ||
+  process.env.NEXT_PHASE === "phase-export" ||
+  process.env.NEXT_PHASE === "phase-static"
+);
+let fs = null;
+let cacheFilePath = null;
+
+// Cache learned unsupported parameter fixes.
+// Format: "provider:model" -> { "max_tokens": "max_completion_tokens", "temperature": null }
+const paramFixCache = new Map();
+
+async function initParamCache() {
+  if (!isNode || isNextBuildPhase || fs) return;
+
+  try {
+    fs = await import("fs");
+
+    const dataDir = process.env.DATA_DIR || (
+      process.platform === "win32"
+        ? joinPath(process.env.APPDATA || process.env.USERPROFILE || process.cwd(), "9router")
+        : joinPath(process.env.HOME || process.cwd(), ".9router")
+    );
+
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    cacheFilePath = joinPath(dataDir, "param_fixes.json");
+
+    if (fs.existsSync(cacheFilePath)) {
+      const data = JSON.parse(fs.readFileSync(cacheFilePath, "utf8"));
+      for (const [key, value] of Object.entries(data)) {
+        paramFixCache.set(key, value);
+      }
+      dbg("CACHE", `Loaded ${paramFixCache.size} param fixes from disk`);
+    }
+  } catch (error) {
+    dbg("CACHE", `Failed to load param cache: ${error.message}`);
+  }
+}
+
+function joinPath(...parts) {
+  const separator = process.platform === "win32" ? "\\" : "/";
+  return parts
+    .filter(Boolean)
+    .map((part, index) => {
+      const normalized = String(part);
+      if (index === 0) return normalized.replace(/[\\/]+$/, "");
+      return normalized.replace(/^[\\/]+|[\\/]+$/g, "");
+    })
+    .join(separator);
+}
+
+function saveParamCache() {
+  if (!fs || !cacheFilePath) return;
+
+  try {
+    const data = Object.fromEntries(paramFixCache.entries());
+    fs.writeFileSync(cacheFilePath, JSON.stringify(data, null, 2));
+  } catch (error) {
+    dbg("CACHE", `Failed to save param cache: ${error.message}`);
+  }
+}
+
+const paramCacheReady = initParamCache();
 
 /**
  * BaseExecutor - Base class for provider executors
@@ -96,13 +161,101 @@ export class BaseExecutor {
     return { status: response.status, message: bodyText || `HTTP ${response.status}` };
   }
 
+  applyCachedParamFixes(cacheKey, body, transformedBody) {
+    const fixes = paramFixCache.get(cacheKey);
+    if (!fixes) return;
+
+    for (const [badParam, goodParam] of Object.entries(fixes)) {
+      if (body[badParam] !== undefined) {
+        if (goodParam) body[goodParam] = body[badParam];
+        delete body[badParam];
+      }
+
+      if (transformedBody && transformedBody[badParam] !== undefined) {
+        if (goodParam) transformedBody[goodParam] = transformedBody[badParam];
+        delete transformedBody[badParam];
+      }
+    }
+  }
+
+  learnUnsupportedParamFix(cacheKey, param, msg, body, transformedBody, log) {
+    if (!paramFixCache.has(cacheKey)) paramFixCache.set(cacheKey, {});
+    const modelFixes = paramFixCache.get(cacheKey);
+
+    if (param === "max_tokens" && msg.includes("max_completion_tokens") && transformedBody.max_tokens !== undefined) {
+      log?.debug?.("RETRY", "400 unsupported max_tokens, caching and retrying with max_completion_tokens");
+      modelFixes.max_tokens = "max_completion_tokens";
+      body.max_completion_tokens = body.max_tokens ?? transformedBody.max_tokens;
+      delete body.max_tokens;
+      saveParamCache();
+      return true;
+    }
+
+    if (param === "max_completion_tokens" && msg.includes("max_tokens") && transformedBody.max_completion_tokens !== undefined) {
+      log?.debug?.("RETRY", "400 unsupported max_completion_tokens, caching and retrying with max_tokens");
+      modelFixes.max_completion_tokens = "max_tokens";
+      body.max_tokens = body.max_completion_tokens ?? transformedBody.max_completion_tokens;
+      delete body.max_completion_tokens;
+      saveParamCache();
+      return true;
+    }
+
+    if (transformedBody[param] !== undefined) {
+      log?.debug?.("RETRY", `400 unsupported ${param}, caching and retrying without it`);
+      modelFixes[param] = null;
+      delete body[param];
+      saveParamCache();
+      return true;
+    }
+
+    return false;
+  }
+
+  async tryAutoFixBadRequest(response, cacheKey, body, transformedBody, autoFixedParams, log) {
+    if (response.status !== HTTP_STATUS.BAD_REQUEST || !transformedBody || typeof transformedBody !== "object") {
+      return false;
+    }
+
+    try {
+      const errBody = await response.clone().json();
+      const err = errBody?.error || {};
+      const msg = (err.message || "").toLowerCase();
+      const errCode = err.code;
+      let param = err.param;
+
+      if (!param) {
+        const match = msg.match(/(?:unsupported|unrecognized|unknown).*?(?:parameter|argument).*?['"]?([a-zA-Z0-9_]+)['"]?/i);
+        if (match) param = match[1];
+      }
+
+      const isUnsupported =
+        errCode === "unsupported_parameter" ||
+        errCode === "unrecognized_request_argument" ||
+        msg.includes("unsupported") ||
+        msg.includes("unrecognized") ||
+        msg.includes("not supported");
+
+      if (!isUnsupported || !param || typeof param !== "string" || autoFixedParams.has(param)) {
+        return false;
+      }
+
+      autoFixedParams.add(param);
+      return this.learnUnsupportedParamFix(cacheKey, param, msg, body, transformedBody, log);
+    } catch {
+      return false;
+    }
+  }
+
   async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+    await paramCacheReady;
+
     const fallbackCount = this.getFallbackCount();
     let lastError = null;
     let lastStatus = 0;
     const retryAttemptsByUrl = {};
 
-    // Merge default retry config with provider-specific config
+    const cacheKey = `${this.provider}:${model}`;
+    const autoFixedParams = new Set();
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
 
     // Schedule retry via retryConfig[statusKey]. Returns true when caller should `urlIndex--; continue`
@@ -118,6 +271,7 @@ export class BaseExecutor {
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
       const transformedBody = this.transformRequest(model, body, stream, credentials);
+      this.applyCachedParamFixes(cacheKey, body, transformedBody);
       const headers = this.buildHeaders(credentials, stream);
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
@@ -130,7 +284,7 @@ export class BaseExecutor {
       try {
         const bodyStr = JSON.stringify(transformedBody);
         const fetchT0 = Date.now();
-        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${FETCH_CONNECT_TIMEOUT_MS}ms`);
+        dbg("FETCH", `${this.provider.toUpperCase()} -> ${url} | body=${bodyStr.length}B | connectTimeout=${FETCH_CONNECT_TIMEOUT_MS}ms`);
         const response = await proxyAwareFetch(url, {
           method: "POST",
           headers,
@@ -140,7 +294,12 @@ export class BaseExecutor {
         clearTimeout(connectTimer);
         const ct = response.headers?.get?.("content-type") || "";
         const cl = response.headers?.get?.("content-length") || "?";
-        dbg("FETCH", `${this.provider.toUpperCase()} ← ${response.status} | ttft=${Date.now() - fetchT0}ms | ct=${ct} | cl=${cl}`);
+        dbg("FETCH", `${this.provider.toUpperCase()} <- ${response.status} | ttft=${Date.now() - fetchT0}ms | ct=${ct} | cl=${cl}`);
+
+        if (await this.tryAutoFixBadRequest(response, cacheKey, body, transformedBody, autoFixedParams, log)) {
+          urlIndex--;
+          continue;
+        }
 
         if (await tryRetry(urlIndex, response.status, `status ${response.status}`)) { urlIndex--; continue; }
 
@@ -155,7 +314,7 @@ export class BaseExecutor {
         clearTimeout(connectTimer);
         lastError = error;
         const isConnectTimeout = connectCtrl.signal.aborted && error.name === "AbortError";
-        dbg("FETCH", `${this.provider.toUpperCase()} ✖ ${error.name}: ${error.message}${isConnectTimeout ? " (connect timeout)" : ""}`);
+        dbg("FETCH", `${this.provider.toUpperCase()} x ${error.name}: ${error.message}${isConnectTimeout ? " (connect timeout)" : ""}`);
         // Connect timeout is internal — convert to retryable network error, don't propagate AbortError
         if (error.name === "AbortError" && !isConnectTimeout) throw error;
 

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -289,6 +289,7 @@ export class BaseExecutor {
 
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
+      this.applyCachedParamFixes(cacheKey, workingBody);
       const transformedBody = this.transformRequest(model, workingBody, stream, credentials);
       this.applyCachedParamFixes(cacheKey, workingBody, transformedBody);
       const headers = this.buildHeaders(credentials, stream);

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -88,6 +88,36 @@ async function flushParamCacheSave() {
   }
 }
 
+function parseErrorPayload(text) {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function extractUnsupportedParam(response) {
+  const responseText = await response.clone().text().catch(() => "");
+  const data = parseErrorPayload(responseText);
+  const err = data?.error || {};
+  const msg = String(err.message || data?.message || responseText || "").toLowerCase();
+  let param = err.param;
+
+  if (!param) {
+    const match = msg.match(/(?:unsupported|unrecognized|unknown).*?(?:parameter|argument).*?['"]?([a-zA-Z0-9_]+)['"]?/i);
+    if (match) param = match[1];
+  }
+
+  const isUnsupported =
+    err.code === "unsupported_parameter" ||
+    err.code === "unrecognized_request_argument" ||
+    msg.includes("unsupported") ||
+    msg.includes("unrecognized") ||
+    msg.includes("not supported");
+
+  return isUnsupported ? { param, msg } : null;
+}
+
 const paramCacheReady = initParamCache();
 
 /**
@@ -240,30 +270,13 @@ export class BaseExecutor {
     }
 
     try {
-      const errBody = await response.clone().json();
-      const err = errBody?.error || {};
-      const msg = (err.message || "").toLowerCase();
-      const errCode = err.code;
-      let param = err.param;
-
-      if (!param) {
-        const match = msg.match(/(?:unsupported|unrecognized|unknown).*?(?:parameter|argument).*?['"]?([a-zA-Z0-9_]+)['"]?/i);
-        if (match) param = match[1];
-      }
-
-      const isUnsupported =
-        errCode === "unsupported_parameter" ||
-        errCode === "unrecognized_request_argument" ||
-        msg.includes("unsupported") ||
-        msg.includes("unrecognized") ||
-        msg.includes("not supported");
-
-      if (!isUnsupported || !param || typeof param !== "string" || autoFixedParams.has(param)) {
+      const unsupported = await extractUnsupportedParam(response);
+      if (!unsupported || !unsupported.param || typeof unsupported.param !== "string" || autoFixedParams.has(unsupported.param)) {
         return false;
       }
 
-      autoFixedParams.add(param);
-      return this.learnUnsupportedParamFix(cacheKey, param, msg, body, transformedBody, log);
+      autoFixedParams.add(unsupported.param);
+      return this.learnUnsupportedParamFix(cacheKey, unsupported.param, unsupported.msg, body, transformedBody, log);
     } catch {
       return false;
     }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -9,7 +9,12 @@ const isNextBuildPhase = isNode && (
   process.env.NEXT_PHASE === "phase-static"
 );
 let fs = null;
+let fsPromises = null;
 let cacheFilePath = null;
+let paramCacheSaveTimer = null;
+let paramCacheSaveInFlight = false;
+let paramCacheSaveDirty = false;
+const PARAM_CACHE_SAVE_DELAY_MS = 250;
 
 // Cache learned unsupported parameter fixes.
 // Format: "provider:model" -> { "max_tokens": "max_completion_tokens", "temperature": null }
@@ -20,6 +25,7 @@ async function initParamCache() {
 
   try {
     fs = await import("fs");
+    fsPromises = await import("fs/promises");
 
     const dataDir = process.env.DATA_DIR || (
       process.platform === "win32"
@@ -54,14 +60,31 @@ function joinPath(...parts) {
     .join(separator);
 }
 
-function saveParamCache() {
-  if (!fs || !cacheFilePath) return;
+function scheduleParamCacheSave() {
+  if (!fsPromises || !cacheFilePath) return;
+
+  paramCacheSaveDirty = true;
+  if (paramCacheSaveTimer || paramCacheSaveInFlight) return;
+
+  paramCacheSaveTimer = setTimeout(flushParamCacheSave, PARAM_CACHE_SAVE_DELAY_MS);
+  paramCacheSaveTimer.unref?.();
+}
+
+async function flushParamCacheSave() {
+  paramCacheSaveTimer = null;
+  if (!fsPromises || !cacheFilePath || !paramCacheSaveDirty) return;
+
+  paramCacheSaveDirty = false;
+  paramCacheSaveInFlight = true;
 
   try {
     const data = Object.fromEntries(paramFixCache.entries());
-    fs.writeFileSync(cacheFilePath, JSON.stringify(data, null, 2));
+    await fsPromises.writeFile(cacheFilePath, JSON.stringify(data, null, 2));
   } catch (error) {
     dbg("CACHE", `Failed to save param cache: ${error.message}`);
+  } finally {
+    paramCacheSaveInFlight = false;
+    if (paramCacheSaveDirty && !paramCacheSaveTimer) scheduleParamCacheSave();
   }
 }
 
@@ -187,7 +210,7 @@ export class BaseExecutor {
       modelFixes.max_tokens = "max_completion_tokens";
       body.max_completion_tokens = body.max_tokens ?? transformedBody.max_tokens;
       delete body.max_tokens;
-      saveParamCache();
+      scheduleParamCacheSave();
       return true;
     }
 
@@ -196,7 +219,7 @@ export class BaseExecutor {
       modelFixes.max_completion_tokens = "max_tokens";
       body.max_tokens = body.max_completion_tokens ?? transformedBody.max_completion_tokens;
       delete body.max_completion_tokens;
-      saveParamCache();
+      scheduleParamCacheSave();
       return true;
     }
 
@@ -204,7 +227,7 @@ export class BaseExecutor {
       log?.debug?.("RETRY", `400 unsupported ${param}, caching and retrying without it`);
       modelFixes[param] = null;
       delete body[param];
-      saveParamCache();
+      scheduleParamCacheSave();
       return true;
     }
 

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -17,6 +17,7 @@ let paramCacheSaveTimer = null;
 let paramCacheSaveInFlight = false;
 let paramCacheSaveDirty = false;
 const PARAM_CACHE_SAVE_DELAY_MS = 250;
+const DEFAULT_MAX_AUTO_FIX_ATTEMPTS = 3;
 
 // Cache learned unsupported parameter fixes.
 // Format: "provider:model" -> { "max_tokens": "max_completion_tokens", "temperature": null }
@@ -60,6 +61,12 @@ function joinPath(...parts) {
       return normalized.replace(/^[\\/]+|[\\/]+$/g, "");
     })
     .join(separator);
+}
+
+function resolveMaxAutoFixAttempts(value) {
+  if (value == null) return DEFAULT_MAX_AUTO_FIX_ATTEMPTS;
+  const attempts = Number(value);
+  return Number.isFinite(attempts) ? Math.max(0, Math.floor(attempts)) : DEFAULT_MAX_AUTO_FIX_ATTEMPTS;
 }
 
 function scheduleParamCacheSave() {
@@ -265,6 +272,8 @@ export class BaseExecutor {
 
     const cacheKey = `${this.provider}:${model}`;
     const autoFixedParams = new Set();
+    const maxAutoFixAttempts = resolveMaxAutoFixAttempts(this.config.maxAutoFixAttempts);
+    let autoFixAttempts = 0;
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
     const workingBody = body && typeof body === "object" ? { ...body } : body;
 
@@ -307,7 +316,10 @@ export class BaseExecutor {
         const cl = response.headers?.get?.("content-length") || "?";
         dbg("FETCH", `${this.provider.toUpperCase()} <- ${response.status} | ttft=${Date.now() - fetchT0}ms | ct=${ct} | cl=${cl}`);
 
-        if (await this.tryAutoFixBadRequest(response, cacheKey, workingBody, transformedBody, autoFixedParams, log)) {
+        if (response.status === HTTP_STATUS.BAD_REQUEST && autoFixAttempts >= maxAutoFixAttempts) {
+          log?.debug?.("RETRY", `400 auto-fix limit reached (${autoFixAttempts}/${maxAutoFixAttempts})`);
+        } else if (await this.tryAutoFixBadRequest(response, cacheKey, workingBody, transformedBody, autoFixedParams, log)) {
+          autoFixAttempts++;
           urlIndex--;
           continue;
         }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -70,6 +70,19 @@ function resolveMaxAutoFixAttempts(value) {
   return Number.isFinite(attempts) ? Math.max(0, Math.floor(attempts)) : DEFAULT_MAX_AUTO_FIX_ATTEMPTS;
 }
 
+async function discardResponseBody(response) {
+  if (!response?.body) return;
+
+  if (typeof response.body.cancel === "function") {
+    await response.body.cancel().catch(() => {});
+    return;
+  }
+
+  if (!response.bodyUsed && typeof response.arrayBuffer === "function") {
+    await response.arrayBuffer().catch(() => {});
+  }
+}
+
 function scheduleParamCacheSave() {
   if (!fsPromises || !cacheFilePath) return;
 
@@ -344,6 +357,7 @@ export class BaseExecutor {
           log?.debug?.("RETRY", `400 auto-fix limit reached (${autoFixAttempts}/${maxAutoFixAttempts})`);
         } else if (await this.tryAutoFixBadRequest(response, cacheKey, workingBody, transformedBody, autoFixedParams, log)) {
           autoFixAttempts++;
+          await discardResponseBody(response);
           urlIndex--;
           continue;
         }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -2,6 +2,7 @@ import { HTTP_STATUS, DEFAULT_RETRY_CONFIG, resolveRetryEntry, FETCH_CONNECT_TIM
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
 import { extractUnsupportedParamFromResponse } from "../utils/unsupportedParam.js";
+import { writeJsonFileAtomically } from "../utils/atomicWrite.js";
 
 const isNode = typeof process !== "undefined" && process.versions?.node && typeof window === "undefined";
 const isNextBuildPhase = isNode && (
@@ -80,23 +81,12 @@ async function flushParamCacheSave() {
 
   try {
     const data = Object.fromEntries(paramFixCache.entries());
-    await writeJsonFileAtomically(cacheFilePath, data);
+    await writeJsonFileAtomically(fsPromises, cacheFilePath, data);
   } catch (error) {
     dbg("CACHE", `Failed to save param cache: ${error.message}`);
   } finally {
     paramCacheSaveInFlight = false;
     if (paramCacheSaveDirty && !paramCacheSaveTimer) scheduleParamCacheSave();
-  }
-}
-
-async function writeJsonFileAtomically(filePath, data) {
-  const tempPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
-  try {
-    await fsPromises.writeFile(tempPath, JSON.stringify(data, null, 2));
-    await fsPromises.rename(tempPath, filePath);
-  } catch (error) {
-    if (fsPromises.rm) await fsPromises.rm(tempPath, { force: true }).catch(() => {});
-    throw error;
   }
 }
 

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -83,6 +83,7 @@ async function flushParamCacheSave() {
     const data = Object.fromEntries(paramFixCache.entries());
     await writeJsonFileAtomically(fsPromises, cacheFilePath, data);
   } catch (error) {
+    paramCacheSaveDirty = true;
     dbg("CACHE", `Failed to save param cache: ${error.message}`);
   } finally {
     paramCacheSaveInFlight = false;

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -293,6 +293,7 @@ export class BaseExecutor {
     const cacheKey = `${this.provider}:${model}`;
     const autoFixedParams = new Set();
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
+    const workingBody = body && typeof body === "object" ? { ...body } : body;
 
     // Schedule retry via retryConfig[statusKey]. Returns true when caller should `urlIndex--; continue`
     const tryRetry = async (urlIndex, statusKey, reason) => {
@@ -306,8 +307,8 @@ export class BaseExecutor {
 
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
-      const transformedBody = this.transformRequest(model, body, stream, credentials);
-      this.applyCachedParamFixes(cacheKey, body, transformedBody);
+      const transformedBody = this.transformRequest(model, workingBody, stream, credentials);
+      this.applyCachedParamFixes(cacheKey, workingBody, transformedBody);
       const headers = this.buildHeaders(credentials, stream);
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
@@ -332,7 +333,7 @@ export class BaseExecutor {
         const cl = response.headers?.get?.("content-length") || "?";
         dbg("FETCH", `${this.provider.toUpperCase()} <- ${response.status} | ttft=${Date.now() - fetchT0}ms | ct=${ct} | cl=${cl}`);
 
-        if (await this.tryAutoFixBadRequest(response, cacheKey, body, transformedBody, autoFixedParams, log)) {
+        if (await this.tryAutoFixBadRequest(response, cacheKey, workingBody, transformedBody, autoFixedParams, log)) {
           urlIndex--;
           continue;
         }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -100,6 +100,20 @@ async function flushParamCacheSave() {
 
 const paramCacheReady = initParamCache();
 
+export async function flushParamCacheSaveForTests(maxPasses = 5) {
+  await paramCacheReady;
+
+  for (let pass = 0; pass < maxPasses; pass++) {
+    if (paramCacheSaveTimer) {
+      clearTimeout(paramCacheSaveTimer);
+      paramCacheSaveTimer = null;
+    }
+
+    if (!paramCacheSaveDirty || paramCacheSaveInFlight) return;
+    await flushParamCacheSave();
+  }
+}
+
 /**
  * BaseExecutor - Base class for provider executors
  */

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -190,12 +190,12 @@ export class BaseExecutor {
 
     for (const [badParam, goodParam] of Object.entries(fixes)) {
       if (body[badParam] !== undefined) {
-        if (goodParam) body[goodParam] = body[badParam];
+        if (goodParam && body[goodParam] === undefined) body[goodParam] = body[badParam];
         delete body[badParam];
       }
 
       if (transformedBody && transformedBody[badParam] !== undefined) {
-        if (goodParam) transformedBody[goodParam] = transformedBody[badParam];
+        if (goodParam && transformedBody[goodParam] === undefined) transformedBody[goodParam] = transformedBody[badParam];
         delete transformedBody[badParam];
       }
     }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -10,7 +10,6 @@ const isNextBuildPhase = isNode && (
   process.env.NEXT_PHASE === "phase-export" ||
   process.env.NEXT_PHASE === "phase-static"
 );
-let fs = null;
 let fsPromises = null;
 let cacheFilePath = null;
 let paramCacheSaveTimer = null;
@@ -24,10 +23,9 @@ const DEFAULT_MAX_AUTO_FIX_ATTEMPTS = 3;
 const paramFixCache = new Map();
 
 async function initParamCache() {
-  if (!isNode || isNextBuildPhase || fs) return;
+  if (!isNode || isNextBuildPhase || fsPromises) return;
 
   try {
-    fs = await import("fs");
     fsPromises = await import("fs/promises");
 
     const dataDir = process.env.DATA_DIR || (
@@ -36,15 +34,17 @@ async function initParamCache() {
         : joinPath(process.env.HOME || process.cwd(), ".9router")
     );
 
-    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    await fsPromises.mkdir(dataDir, { recursive: true });
     cacheFilePath = joinPath(dataDir, "param_fixes.json");
 
-    if (fs.existsSync(cacheFilePath)) {
-      const data = JSON.parse(fs.readFileSync(cacheFilePath, "utf8"));
+    try {
+      const data = JSON.parse(await fsPromises.readFile(cacheFilePath, "utf8"));
       for (const [key, value] of Object.entries(data)) {
         paramFixCache.set(key, value);
       }
       dbg("CACHE", `Loaded ${paramFixCache.size} param fixes from disk`);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
     }
   } catch (error) {
     dbg("CACHE", `Failed to load param cache: ${error.message}`);

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -1,6 +1,7 @@
 import { HTTP_STATUS, DEFAULT_RETRY_CONFIG, resolveRetryEntry, FETCH_CONNECT_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
+import { extractUnsupportedParamFromResponse } from "../utils/unsupportedParam.js";
 
 const isNode = typeof process !== "undefined" && process.versions?.node && typeof window === "undefined";
 const isNextBuildPhase = isNode && (
@@ -97,36 +98,6 @@ async function writeJsonFileAtomically(filePath, data) {
     if (fsPromises.rm) await fsPromises.rm(tempPath, { force: true }).catch(() => {});
     throw error;
   }
-}
-
-function parseErrorPayload(text) {
-  try {
-    return text ? JSON.parse(text) : null;
-  } catch {
-    return null;
-  }
-}
-
-async function extractUnsupportedParam(response) {
-  const responseText = await response.clone().text().catch(() => "");
-  const data = parseErrorPayload(responseText);
-  const err = data?.error || {};
-  const msg = String(err.message || data?.message || responseText || "").toLowerCase();
-  let param = err.param;
-
-  if (!param) {
-    const match = msg.match(/(?:unsupported|unrecognized|unknown).*?(?:parameter|argument).*?['"]?([a-zA-Z0-9_]+)['"]?/i);
-    if (match) param = match[1];
-  }
-
-  const isUnsupported =
-    err.code === "unsupported_parameter" ||
-    err.code === "unrecognized_request_argument" ||
-    msg.includes("unsupported") ||
-    msg.includes("unrecognized") ||
-    msg.includes("not supported");
-
-  return isUnsupported ? { param, msg } : null;
 }
 
 const paramCacheReady = initParamCache();
@@ -281,7 +252,7 @@ export class BaseExecutor {
     }
 
     try {
-      const unsupported = await extractUnsupportedParam(response);
+      const unsupported = await extractUnsupportedParamFromResponse(response);
       if (!unsupported || !unsupported.param || typeof unsupported.param !== "string" || autoFixedParams.has(unsupported.param)) {
         return false;
       }

--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -106,6 +106,11 @@ export class GithubExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     const transformed = { ...body };
 
+    // Do not reintroduce proactive model-name regex fixes here (for example,
+    // gpt-* token renames or Claude/GPT field stripping). GitHub Copilot model
+    // compatibility changes often enough that those rules go stale; the
+    // intentional tradeoff is one bounded 400 retry on a cold provider/model,
+    // then BaseExecutor learns and caches the exact upstream-supported fix.
     // "none" means the client asks to disable thinking. Many APIs reject this
     // string flag, so strip it and let BaseExecutor learn other unsupported params.
     if (transformed.reasoning_effort === "none") {

--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -103,57 +103,12 @@ export class GithubExecutor extends BaseExecutor {
     return sanitized;
   }
 
-  // Newer OpenAI models (gpt-5+, o1, o3, o4) require max_completion_tokens instead of max_tokens
-  requiresMaxCompletionTokens(model) {
-    return /gpt-5|o[134]-/i.test(model);
-  }
-
-  // Some models (like gpt-5.4) don't support the temperature parameter
-  supportsTemperature(model) {
-    // gpt-5.4 and similar newer models don't support temperature
-    return !/gpt-5\.4/i.test(model);
-  }
-
-  // GitHub Copilot /chat/completions rejects Claude-style thinking payloads
-  // (OpenClaw sends thinking: { type: "enabled" } → upstream 400).
-  // GPT-5 family on Copilot DOES honor reasoning_effort, so only strip for Claude. (#713)
-  supportsThinking(model) {
-    return !/claude/i.test(model);
-  }
-
-  // reasoning_effort works for GPT-5 family AND Claude Opus 4.6 / Sonnet 4.6
-  // on GitHub Copilot. Only strip for models that don't support it:
-  // Claude Haiku 4.5, Claude Opus 4.7 (rejected upstream).
-  supportsReasoningEffort(model) {
-    const m = model.toLowerCase();
-    // Claude models that DO support reasoning_effort
-    if (/claude.*opus.*4\.6/i.test(m) || /claude.*sonnet.*4\.6/i.test(m)) return true;
-    // All other Claude models: strip
-    if (/claude/i.test(model)) return false;
-    // GPT-5 family, Gemini, etc.: keep
-    return true;
-  }
-
   transformRequest(model, body, stream, credentials) {
     const transformed = { ...body };
-    if (this.requiresMaxCompletionTokens(model) && transformed.max_tokens !== undefined) {
-      transformed.max_completion_tokens = transformed.max_tokens;
-      delete transformed.max_tokens;
-    }
-    // Strip temperature for models that don't support it
-    if (!this.supportsTemperature(model) && transformed.temperature !== undefined) {
-      delete transformed.temperature;
-    }
-    // Always strip Claude-style thinking payload (Copilot doesn't understand it)
-    if (!this.supportsThinking(model)) {
-      delete transformed.thinking;
-    }
-    // "none" means no thinking — strip it so models that don't support "none" don't 400
+
+    // "none" means the client asks to disable thinking. Many APIs reject this
+    // string flag, so strip it and let BaseExecutor learn other unsupported params.
     if (transformed.reasoning_effort === "none") {
-      delete transformed.reasoning_effort;
-    }
-    // Strip reasoning_effort only for models that reject it
-    if (!this.supportsReasoningEffort(model) && transformed.reasoning_effort !== undefined) {
       delete transformed.reasoning_effort;
     }
     return transformed;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -256,6 +256,15 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (!clientRequestedStreaming && providerRequiresStreaming) {
     const result = await handleForcedSSEToJson({ ...sharedCtx, providerResponse, sourceFormat, trackDone, appendLog });
     if (result) { streamController.handleComplete(); return result; }
+
+    // Some providers in this bucket can still return ordinary JSON when the
+    // translated payload contains stream:false. Do not pass JSON through the
+    // SSE streaming pipeline, or model tests see a 200 with no emitted chunks.
+    if (!providerResponse.bodyUsed) {
+      const jsonResult = await handleNonStreamingResponse({ ...sharedCtx, stream: false, providerResponse, sourceFormat, targetFormat, reqLogger, toolNameMap, trackDone, appendLog });
+      streamController.handleComplete();
+      return jsonResult;
+    }
   }
 
   // True non-streaming response

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -7,7 +7,6 @@ import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
 import { getModelTargetFormat, getModelStrip, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
-import { isJsonContentType } from "../utils/contentType.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
@@ -259,14 +258,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     if (result) { streamController.handleComplete(); return result; }
 
     // Some providers in this bucket can still return ordinary JSON when the
-    // translated payload contains stream:false. bodyUsed only tells us whether
-    // a reader was acquired, so use content-type to avoid treating SSE as JSON.
-    const providerContentType = providerResponse.headers.get("content-type") || "";
-    if (isJsonContentType(providerContentType)) {
-      const jsonResult = await handleNonStreamingResponse({ ...sharedCtx, stream: false, providerResponse, sourceFormat, targetFormat, reqLogger, toolNameMap, trackDone, appendLog });
-      streamController.handleComplete();
-      return jsonResult;
-    }
+    // translated payload contains stream:false, even with missing or incorrect
+    // Content-Type. handleNonStreamingResponse still treats explicit SSE as SSE
+    // and otherwise safely attempts JSON parsing with its own error handling.
+    const jsonResult = await handleNonStreamingResponse({ ...sharedCtx, stream: false, providerResponse, sourceFormat, targetFormat, reqLogger, toolNameMap, trackDone, appendLog });
+    streamController.handleComplete();
+    return jsonResult;
   }
 
   // True non-streaming response

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -7,6 +7,7 @@ import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
 import { getModelTargetFormat, getModelStrip, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
+import { isJsonContentType } from "../utils/contentType.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
@@ -258,9 +259,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     if (result) { streamController.handleComplete(); return result; }
 
     // Some providers in this bucket can still return ordinary JSON when the
-    // translated payload contains stream:false. Do not pass JSON through the
-    // SSE streaming pipeline, or model tests see a 200 with no emitted chunks.
-    if (!providerResponse.bodyUsed) {
+    // translated payload contains stream:false. bodyUsed only tells us whether
+    // a reader was acquired, so use content-type to avoid treating SSE as JSON.
+    const providerContentType = providerResponse.headers.get("content-type") || "";
+    if (isJsonContentType(providerContentType)) {
       const jsonResult = await handleNonStreamingResponse({ ...sharedCtx, stream: false, providerResponse, sourceFormat, targetFormat, reqLogger, toolNameMap, trackDone, appendLog });
       streamController.handleComplete();
       return jsonResult;

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -3,6 +3,7 @@ import { needsTranslation } from "../../translator/index.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
+import { isEventStreamContentType } from "../../utils/contentType.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./requestDetail.js";
@@ -133,7 +134,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   const contentType = providerResponse.headers.get("content-type") || "";
   let responseBody;
 
-  if (contentType.includes("text/event-stream")) {
+  if (isEventStreamContentType(contentType)) {
     const sseText = await providerResponse.text();
     const parsed = parseSSEToOpenAIResponse(sseText, model);
     if (!parsed) {

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -2,6 +2,7 @@ import { convertResponsesStreamToJson } from "../../transformer/streamToJsonConv
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
+import { isEventStreamContentType } from "../../utils/contentType.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats } from "./requestDetail.js";
 import { saveRequestDetail, appendRequestLog } from "@/lib/usageDb.js";
 
@@ -100,7 +101,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
  */
 export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog }) {
   const contentType = providerResponse.headers.get("content-type") || "";
-  const isSSE = contentType.includes("text/event-stream") || (contentType === "" && provider === "codex");
+  const isSSE = isEventStreamContentType(contentType) || (contentType.trim() === "" && provider === "codex");
   if (!isSSE) return null; // not handled here
 
   trackDone();

--- a/open-sse/translator/helpers/maxTokensHelper.js
+++ b/open-sse/translator/helpers/maxTokensHelper.js
@@ -1,12 +1,17 @@
 import { DEFAULT_MAX_TOKENS, DEFAULT_MIN_TOKENS } from "../../config/runtimeConfig.js";
 
+export function getTokenLimit(body, fallback = undefined) {
+  return body.max_completion_tokens ?? body.max_tokens ?? fallback;
+}
+
 /**
- * Adjust max_tokens based on request context
+ * Adjust max_tokens based on request context.
+ * OpenAI-style token limit precedence is max_completion_tokens, then max_tokens.
  * @param {object} body - Request body
  * @returns {number} Adjusted max_tokens
  */
 export function adjustMaxTokens(body) {
-  let maxTokens = body.max_tokens ?? body.max_completion_tokens ?? DEFAULT_MAX_TOKENS;
+  let maxTokens = getTokenLimit(body, DEFAULT_MAX_TOKENS);
 
   // Auto-increase for tool calling to prevent truncated arguments
   if (body.tools && Array.isArray(body.tools) && body.tools.length > 0) {

--- a/open-sse/translator/helpers/maxTokensHelper.js
+++ b/open-sse/translator/helpers/maxTokensHelper.js
@@ -6,7 +6,7 @@ import { DEFAULT_MAX_TOKENS, DEFAULT_MIN_TOKENS } from "../../config/runtimeConf
  * @returns {number} Adjusted max_tokens
  */
 export function adjustMaxTokens(body) {
-  let maxTokens = body.max_tokens || DEFAULT_MAX_TOKENS;
+  let maxTokens = body.max_tokens ?? body.max_completion_tokens ?? DEFAULT_MAX_TOKENS;
 
   // Auto-increase for tool calling to prevent truncated arguments
   if (body.tools && Array.isArray(body.tools) && body.tools.length > 0) {

--- a/open-sse/translator/helpers/maxTokensHelper.js
+++ b/open-sse/translator/helpers/maxTokensHelper.js
@@ -1,7 +1,13 @@
 import { DEFAULT_MAX_TOKENS, DEFAULT_MIN_TOKENS } from "../../config/runtimeConfig.js";
 
 export function getTokenLimit(body, fallback = undefined) {
-  return body.max_completion_tokens ?? body.max_tokens ?? fallback;
+  if (Number.isFinite(body.max_completion_tokens) && body.max_completion_tokens > 0) {
+    return body.max_completion_tokens;
+  }
+  if (Number.isFinite(body.max_tokens) && body.max_tokens > 0) {
+    return body.max_tokens;
+  }
+  return fallback;
 }
 
 /**

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -308,6 +308,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   // Pass through other relevant fields
   if (body.temperature !== undefined) result.temperature = body.temperature;
   if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
+  if (body.max_completion_tokens !== undefined) result.max_completion_tokens = body.max_completion_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
 
   return result;

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -307,8 +307,9 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
 
   // Pass through other relevant fields
   if (body.temperature !== undefined) result.temperature = body.temperature;
-  if (body.max_completion_tokens !== undefined) result.max_completion_tokens = body.max_completion_tokens;
-  else if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
+  if (body.max_output_tokens !== undefined) result.max_output_tokens = body.max_output_tokens;
+  else if (body.max_completion_tokens !== undefined) result.max_output_tokens = body.max_completion_tokens;
+  else if (body.max_tokens !== undefined) result.max_output_tokens = body.max_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
 
   return result;

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -307,8 +307,8 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
 
   // Pass through other relevant fields
   if (body.temperature !== undefined) result.temperature = body.temperature;
-  if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
   if (body.max_completion_tokens !== undefined) result.max_completion_tokens = body.max_completion_tokens;
+  else if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
 
   return result;

--- a/open-sse/translator/request/openai-to-commandcode.js
+++ b/open-sse/translator/request/openai-to-commandcode.js
@@ -137,7 +137,7 @@ export function openaiToCommandCode(model, body, stream /* , credentials */) {
     model,
     messages,
     stream: stream !== false,
-    max_tokens: body.max_tokens ?? body.max_output_tokens ?? 64000,
+    max_tokens: body.max_tokens ?? body.max_completion_tokens ?? body.max_output_tokens ?? 64000,
     temperature: body.temperature ?? 0.3,
   };
 

--- a/open-sse/translator/request/openai-to-commandcode.js
+++ b/open-sse/translator/request/openai-to-commandcode.js
@@ -11,6 +11,7 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
+import { getTokenLimit } from "../helpers/maxTokensHelper.js";
 import { randomUUID } from "crypto";
 
 function flattenText(content) {
@@ -137,7 +138,7 @@ export function openaiToCommandCode(model, body, stream /* , credentials */) {
     model,
     messages,
     stream: stream !== false,
-    max_tokens: body.max_tokens ?? body.max_completion_tokens ?? body.max_output_tokens ?? 64000,
+    max_tokens: getTokenLimit(body, body.max_output_tokens ?? 64000),
     temperature: body.temperature ?? 0.3,
   };
 

--- a/open-sse/translator/request/openai-to-cursor.js
+++ b/open-sse/translator/request/openai-to-cursor.js
@@ -8,6 +8,7 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
+import { getTokenLimit } from "../helpers/maxTokensHelper.js";
 
 function extractContent(content) {
   if (typeof content === "string") return content;
@@ -172,7 +173,7 @@ export function buildCursorRequest(model, body, stream, credentials) {
 
   // Strip fields irrelevant to Cursor (OpenAI/Anthropic-specific)
   const { user, metadata, tool_choice, stream_options, system, max_tokens, max_completion_tokens, ...rest } = body;
-  const maxTokens = max_tokens ?? max_completion_tokens ?? 32000;
+  const maxTokens = getTokenLimit({ max_tokens, max_completion_tokens }, 32000);
 
   return {
     ...rest,

--- a/open-sse/translator/request/openai-to-cursor.js
+++ b/open-sse/translator/request/openai-to-cursor.js
@@ -171,12 +171,13 @@ export function buildCursorRequest(model, body, stream, credentials) {
   const messages = convertMessages(body.messages || []);
 
   // Strip fields irrelevant to Cursor (OpenAI/Anthropic-specific)
-  const { user, metadata, tool_choice, stream_options, system, ...rest } = body;
+  const { user, metadata, tool_choice, stream_options, system, max_tokens, max_completion_tokens, ...rest } = body;
+  const maxTokens = max_tokens ?? max_completion_tokens ?? 32000;
 
   return {
     ...rest,
     messages,
-    max_tokens: 32000
+    max_tokens: maxTokens
   };
 }
 

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -3,6 +3,7 @@ import { FORMATS } from "../formats.js";
 import { DEFAULT_THINKING_AG_SIGNATURE, DEFAULT_THINKING_GEMINI_CLI_SIGNATURE } from "../../config/defaultThinkingSignature.js";
 import { ANTIGRAVITY_DEFAULT_SYSTEM } from "../../config/appConstants.js";
 import { openaiToClaudeRequestForAntigravity } from "./openai-to-claude.js";
+import { getTokenLimit } from "../helpers/maxTokensHelper.js";
 
 function generateUUID() {
   return crypto.randomUUID();
@@ -54,7 +55,7 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
   if (body.top_k !== undefined) {
     result.generationConfig.topK = body.top_k;
   }
-  const maxTokens = body.max_tokens ?? body.max_completion_tokens;
+  const maxTokens = getTokenLimit(body);
   if (maxTokens !== undefined) {
     result.generationConfig.maxOutputTokens = maxTokens;
   }

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -54,8 +54,9 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
   if (body.top_k !== undefined) {
     result.generationConfig.topK = body.top_k;
   }
-  if (body.max_tokens !== undefined) {
-    result.generationConfig.maxOutputTokens = body.max_tokens;
+  const maxTokens = body.max_tokens ?? body.max_completion_tokens;
+  if (maxTokens !== undefined) {
+    result.generationConfig.maxOutputTokens = maxTokens;
   }
 
   // Build tool_call_id -> name map

--- a/open-sse/translator/request/openai-to-ollama.js
+++ b/open-sse/translator/request/openai-to-ollama.js
@@ -1,5 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
+import { getTokenLimit } from "../helpers/maxTokensHelper.js";
 
 /**
  * Convert OpenAI request to Ollama format
@@ -29,7 +30,7 @@ export function openaiToOllamaRequest(model, body, stream) {
   }
 
   // Max tokens (Ollama uses num_predict)
-  const maxTokens = body.max_tokens ?? body.max_completion_tokens;
+  const maxTokens = getTokenLimit(body);
   if (maxTokens !== undefined) {
     result.options = result.options || {};
     result.options.num_predict = maxTokens;

--- a/open-sse/translator/request/openai-to-ollama.js
+++ b/open-sse/translator/request/openai-to-ollama.js
@@ -29,9 +29,10 @@ export function openaiToOllamaRequest(model, body, stream) {
   }
 
   // Max tokens (Ollama uses num_predict)
-  if (body.max_tokens !== undefined) {
+  const maxTokens = body.max_tokens ?? body.max_completion_tokens;
+  if (maxTokens !== undefined) {
     result.options = result.options || {};
-    result.options.num_predict = body.max_tokens;
+    result.options.num_predict = maxTokens;
   }
 
   // Top_p

--- a/open-sse/utils/atomicWrite.js
+++ b/open-sse/utils/atomicWrite.js
@@ -1,0 +1,50 @@
+function isWindowsReplaceError(error, platform) {
+  return platform === "win32" && ["EEXIST", "EPERM", "EACCES"].includes(error?.code);
+}
+
+export async function writeJsonFileAtomically(fsApi, filePath, data, options = {}) {
+  const platform = options.platform || (typeof process !== "undefined" ? process.platform : undefined);
+  const pid = options.pid || (typeof process !== "undefined" ? process.pid : "pid");
+  const now = options.now || Date.now;
+  const random = options.random || Math.random;
+  const suffix = `${pid}.${now()}.${random().toString(36).slice(2)}`;
+  const tempPath = `${filePath}.${suffix}.tmp`;
+  const backupPath = `${filePath}.${suffix}.bak`;
+
+  try {
+    await fsApi.writeFile(tempPath, JSON.stringify(data, null, 2));
+    await renameReplacingFile(fsApi, tempPath, filePath, backupPath, platform);
+  } catch (error) {
+    if (fsApi.rm) {
+      await fsApi.rm(tempPath, { force: true }).catch(() => {});
+      await fsApi.rm(backupPath, { force: true }).catch(() => {});
+    }
+    throw error;
+  }
+}
+
+async function renameReplacingFile(fsApi, tempPath, filePath, backupPath, platform) {
+  try {
+    await fsApi.rename(tempPath, filePath);
+    return;
+  } catch (error) {
+    if (!isWindowsReplaceError(error, platform)) throw error;
+  }
+
+  let hasBackup = false;
+  try {
+    await fsApi.rename(filePath, backupPath);
+    hasBackup = true;
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  try {
+    await fsApi.rename(tempPath, filePath);
+  } catch (error) {
+    if (hasBackup) await fsApi.rename(backupPath, filePath).catch(() => {});
+    throw error;
+  } finally {
+    if (hasBackup && fsApi.rm) await fsApi.rm(backupPath, { force: true }).catch(() => {});
+  }
+}

--- a/open-sse/utils/contentType.js
+++ b/open-sse/utils/contentType.js
@@ -1,0 +1,12 @@
+export function getMediaType(contentType) {
+  return String(contentType || "").split(";")[0].trim().toLowerCase();
+}
+
+export function isEventStreamContentType(contentType) {
+  return getMediaType(contentType) === "text/event-stream";
+}
+
+export function isJsonContentType(contentType) {
+  const mediaType = getMediaType(contentType);
+  return mediaType === "application/json" || mediaType.endsWith("+json");
+}

--- a/open-sse/utils/unsupportedParam.js
+++ b/open-sse/utils/unsupportedParam.js
@@ -1,0 +1,33 @@
+export function parseErrorPayload(text) {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function extractUnsupportedParamFromText(responseText) {
+  const data = parseErrorPayload(responseText);
+  const err = data?.error || {};
+  const msg = String(err.message || data?.message || responseText || "").toLowerCase();
+  let param = err.param;
+
+  if (!param) {
+    const match = msg.match(/(?:unsupported|unrecognized|unknown).*?(?:parameter|argument).*?['"]?([a-zA-Z0-9_]+)['"]?/i);
+    if (match) param = match[1];
+  }
+
+  const isUnsupported =
+    err.code === "unsupported_parameter" ||
+    err.code === "unrecognized_request_argument" ||
+    msg.includes("unsupported") ||
+    msg.includes("unrecognized") ||
+    msg.includes("not supported");
+
+  return isUnsupported ? { param, msg } : null;
+}
+
+export async function extractUnsupportedParamFromResponse(response) {
+  const responseText = await response.clone().text().catch(() => "");
+  return extractUnsupportedParamFromText(responseText);
+}

--- a/open-sse/utils/unsupportedParam.js
+++ b/open-sse/utils/unsupportedParam.js
@@ -17,14 +17,12 @@ export function extractUnsupportedParamFromText(responseText) {
     if (match) param = match[1];
   }
 
-  const isUnsupported =
+  const hasRecognizedUnsupportedParamCode =
     err.code === "unsupported_parameter" ||
-    err.code === "unrecognized_request_argument" ||
-    msg.includes("unsupported") ||
-    msg.includes("unrecognized") ||
-    msg.includes("not supported");
+    err.code === "unrecognized_request_argument";
+  const hasParam = typeof param === "string" && param.length > 0;
 
-  return isUnsupported ? { param, msg } : null;
+  return hasRecognizedUnsupportedParamCode || hasParam ? { param, msg } : null;
 }
 
 export async function extractUnsupportedParamFromResponse(response) {

--- a/src/app/api/models/test/route.js
+++ b/src/app/api/models/test/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getApiKeys } from "@/lib/localDb";
+import { OPENAI_STYLE_PROBE_MAX_TOKENS } from "@/lib/openaiParamFallback";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 
@@ -20,7 +21,7 @@ export async function POST(request) {
       apiKey = keys.find((k) => k.isActive !== false)?.key || null;
     } catch {}
 
-    const headers = { "Content-Type": "application/json" };
+    const headers = { "Content-Type": "application/json", "Accept": "application/json" };
     if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
     // Bypass dashboardGuard for internal self-call via CLI token (machineId-based)
     headers["x-9r-cli-token"] = await getConsistentMachineId(CLI_TOKEN_SALT);
@@ -57,7 +58,7 @@ export async function POST(request) {
       headers,
       body: JSON.stringify({
         model,
-        max_tokens: 1,
+        max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
         stream: false,
         messages: [{ role: "user", content: "hi" }],
       }),

--- a/src/app/api/provider-nodes/validate/route.js
+++ b/src/app/api/provider-nodes/validate/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { OPENAI_STYLE_PROBE_MAX_TOKENS, fetchOpenAIStyleWithTokenFallback } from "@/lib/openaiParamFallback";
 
 // Fetch with timeout wrapper
 const fetchWithTimeout = (url, options, timeout = 10000) => {
@@ -120,19 +121,18 @@ export async function POST(request) {
 
       // Fallback: try chat/completions if modelId provided
       if (modelId) {
-        const chatRes = await fetchWithTimeout(`${normalizedBase}/chat/completions`, {
+        const chatRes = await fetchOpenAIStyleWithTokenFallback(fetchWithTimeout, `${normalizedBase}/chat/completions`, {
           method: "POST",
           headers: {
             "Authorization": `Bearer ${apiKey}`,
             "Content-Type": "application/json",
             "x-api-key": apiKey,
             "anthropic-version": "2023-06-01"
-          },
-          body: JSON.stringify({
-            model: modelId,
-            messages: [{ role: "user", content: "ping" }],
-            max_tokens: 1
-          })
+          }
+        }, {
+          model: modelId,
+          messages: [{ role: "user", content: "ping" }],
+          max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS
         });
         if (chatRes.ok) {
           return NextResponse.json({ valid: true, method: "chat" });
@@ -162,17 +162,16 @@ export async function POST(request) {
 
     // Fallback: try chat/completions if modelId provided
     if (modelId) {
-      const chatRes = await fetchWithTimeout(`${baseUrl.replace(/\/$/, "")}/chat/completions`, {
+      const chatRes = await fetchOpenAIStyleWithTokenFallback(fetchWithTimeout, `${baseUrl.replace(/\/$/, "")}/chat/completions`, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${apiKey}`,
           "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-          model: modelId,
-          messages: [{ role: "user", content: "ping" }],
-          max_tokens: 1
-        })
+        }
+      }, {
+        model: modelId,
+        messages: [{ role: "user", content: "ping" }],
+        max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS
       });
       if (chatRes.ok) {
         return NextResponse.json({ valid: true, method: "chat" });

--- a/src/app/api/providers/[id]/test-models/route.js
+++ b/src/app/api/providers/[id]/test-models/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getProviderConnectionById, getApiKeys } from "@/lib/localDb";
+import { OPENAI_STYLE_PROBE_MAX_TOKENS } from "@/lib/openaiParamFallback";
 import { getProviderModels, PROVIDER_ID_TO_ALIAS } from "open-sse/config/providerModels.js";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
@@ -22,7 +23,7 @@ async function getInternalApiKey() {
 async function pingModel(modelId, baseUrl, apiKey, cliToken) {
   const start = Date.now();
   try {
-    const headers = { "Content-Type": "application/json" };
+    const headers = { "Content-Type": "application/json", "Accept": "application/json" };
     if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
     if (cliToken) headers["x-9r-cli-token"] = cliToken;
     const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
@@ -30,7 +31,7 @@ async function pingModel(modelId, baseUrl, apiKey, cliToken) {
       headers,
       body: JSON.stringify({
         model: modelId,
-        max_tokens: 1,
+        max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
         stream: false,
         messages: [{ role: "user", content: "hi" }],
       }),

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -5,6 +5,7 @@ import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/sha
 import { PROVIDER_ENDPOINTS } from "@/shared/constants/config";
 import { getDefaultModel } from "open-sse/config/providerModels.js";
 import { resolveOllamaLocalHost } from "open-sse/config/providers.js";
+import { OPENAI_STYLE_PROBE_MAX_TOKENS, fetchOpenAIStyleWithTokenFallback } from "@/lib/openaiParamFallback";
 import {
   GEMINI_CONFIG,
   ANTIGRAVITY_CONFIG,
@@ -347,6 +348,15 @@ async function fetchWithConnectionProxy(url, options = {}, effectiveProxy = null
   });
 }
 
+async function fetchOpenAIProbeWithConnectionProxy(url, options, payload, effectiveProxy = null) {
+  return fetchOpenAIStyleWithTokenFallback(
+    (targetUrl, targetOptions) => fetchWithConnectionProxy(targetUrl, targetOptions, effectiveProxy),
+    url,
+    options,
+    payload
+  );
+}
+
 async function testApiKeyConnection(connection, effectiveProxy = null) {
   if (isOpenAICompatibleProvider(connection.provider)) {
     const modelsBase = connection.providerSpecificData?.baseUrl;
@@ -383,11 +393,10 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         const accountId = psd.accountId;
         if (!accountId) return { valid: false, error: "Missing Account ID" };
         const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1/chat/completions`;
-        const res = await fetchWithConnectionProxy(url, {
+        const res = await fetchOpenAIProbeWithConnectionProxy(url, {
           method: "POST",
           headers: { "Authorization": `Bearer ${connection.apiKey}`, "Content-Type": "application/json" },
-          body: JSON.stringify({ model: getDefaultModel("cloudflare-ai"), messages: [{ role: "user", content: "test" }], max_tokens: 1 }),
-        }, effectiveProxy);
+        }, { model: getDefaultModel("cloudflare-ai"), messages: [{ role: "user", content: "test" }], max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403 && res.status !== 404;
         return { valid, error: valid ? null : "Invalid API token or Account ID" };
       }
@@ -399,10 +408,9 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`;
         const headers = { "api-key": connection.apiKey, "Content-Type": "application/json" };
         if (psd.organization) headers["OpenAI-Organization"] = psd.organization;
-        const res = await fetchWithConnectionProxy(url, {
+        const res = await fetchOpenAIProbeWithConnectionProxy(url, {
           method: "POST", headers,
-          body: JSON.stringify({ messages: [{ role: "user", content: "test" }], max_completion_tokens: 1 }),
-        }, effectiveProxy);
+        }, { messages: [{ role: "user", content: "test" }], max_completion_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
         return { valid, error: valid ? null : "Invalid API key or Azure configuration" };
       }
@@ -441,11 +449,10 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         return { valid, error: valid ? null : "Invalid API key" };
       }
       case "glm-cn": {
-        const res = await fetchWithConnectionProxy("https://open.bigmodel.cn/api/coding/paas/v4/chat/completions", {
+        const res = await fetchOpenAIProbeWithConnectionProxy("https://open.bigmodel.cn/api/coding/paas/v4/chat/completions", {
           method: "POST",
           headers: { "Authorization": `Bearer ${connection.apiKey}`, "content-type": "application/json" },
-          body: JSON.stringify({ model: "glm-4.7", max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
-        }, effectiveProxy);
+        }, { model: "glm-4.7", max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS, messages: [{ role: "user", content: "test" }] }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
         return { valid, error: valid ? null : "Invalid API key" };
       }
@@ -475,21 +482,19 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         const aliBaseUrl = connection.provider === "alicode-intl"
           ? "https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions"
           : "https://coding.dashscope.aliyuncs.com/v1/chat/completions";
-        const res = await fetchWithConnectionProxy(aliBaseUrl, {
+        const res = await fetchOpenAIProbeWithConnectionProxy(aliBaseUrl, {
           method: "POST",
           headers: { "Authorization": `Bearer ${connection.apiKey}`, "content-type": "application/json" },
-          body: JSON.stringify({ model: getDefaultModel(connection.provider), max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
-        }, effectiveProxy);
+        }, { model: getDefaultModel(connection.provider), max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS, messages: [{ role: "user", content: "test" }] }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
         return { valid, error: valid ? null : "Invalid API key" };
       }
       case "volcengine-ark":
       case "byteplus": {
-        const res = await fetchWithConnectionProxy(PROVIDER_ENDPOINTS[connection.provider], {
+        const res = await fetchOpenAIProbeWithConnectionProxy(PROVIDER_ENDPOINTS[connection.provider], {
           method: "POST",
           headers: { "Authorization": `Bearer ${connection.apiKey}`, "content-type": "application/json" },
-          body: JSON.stringify({ model: getDefaultModel(connection.provider), max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
-        }, effectiveProxy);
+        }, { model: getDefaultModel(connection.provider), max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS, messages: [{ role: "user", content: "test" }] }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
         return { valid, error: valid ? null : "Invalid API key" };
       }
@@ -609,11 +614,10 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         return { valid, error: valid ? null : "Session expired — re-paste cookie" };
       }
       case "opencode-go": {
-        const res = await fetchWithConnectionProxy("https://opencode.ai/zen/go/v1/chat/completions", {
+        const res = await fetchOpenAIProbeWithConnectionProxy("https://opencode.ai/zen/go/v1/chat/completions", {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: `Bearer ${connection.apiKey}` },
-          body: JSON.stringify({ model: getDefaultModel("opencode-go"), messages: [{ role: "user", content: "ping" }], max_tokens: 1, stream: false }),
-        }, effectiveProxy);
+        }, { model: getDefaultModel("opencode-go"), messages: [{ role: "user", content: "ping" }], max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS, stream: false }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
         return { valid, error: valid ? null : "Invalid API key" };
       }

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -6,6 +6,7 @@ import { resolveOllamaLocalHost, resolveXiaomiTokenplanBaseUrl, PROVIDERS } from
 import { openaiToCommandCode } from "open-sse/translator/request/openai-to-commandcode.js";
 import { PROVIDER_ENDPOINTS } from "@/shared/constants/config";
 import { normalizeProviderId } from "@/lib/providerNormalization";
+import { OPENAI_STYLE_PROBE_MAX_TOKENS, fetchOpenAIStyleWithTokenFallback } from "@/lib/openaiParamFallback";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
@@ -180,14 +181,13 @@ export async function POST(request) {
           return NextResponse.json({ valid: false, error: "Missing Account ID" });
         }
         const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1/chat/completions`;
-        const cfRes = await fetch(url, {
+        const cfRes = await fetchOpenAIStyleWithTokenFallback(fetch, url, {
           method: "POST",
           headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
-          body: JSON.stringify({
-            model: getDefaultModel("cloudflare-ai"),
-            messages: [{ role: "user", content: "test" }],
-            max_tokens: 1,
-          }),
+        }, {
+          model: getDefaultModel("cloudflare-ai"),
+          messages: [{ role: "user", content: "test" }],
+          max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
         });
         isValid = cfRes.status !== 401 && cfRes.status !== 403 && cfRes.status !== 404;
         return NextResponse.json({
@@ -210,13 +210,12 @@ export async function POST(request) {
         };
         if (organization) headers["OpenAI-Organization"] = organization;
 
-        const azureRes = await fetch(url, {
+        const azureRes = await fetchOpenAIStyleWithTokenFallback(fetch, url, {
           method: "POST",
           headers,
-          body: JSON.stringify({
-            messages: [{ role: "user", content: "test" }],
-            max_tokens: 1,
-          }),
+        }, {
+          messages: [{ role: "user", content: "test" }],
+          max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
         });
         isValid = azureRes.status !== 401 && azureRes.status !== 403;
         return NextResponse.json({
@@ -301,11 +300,10 @@ export async function POST(request) {
 
           if (isOpenAiFormat) {
             const testModel = getDefaultModel(provider);
-            const res = await fetch(cfg.baseUrl, {
+            const res = await fetchOpenAIStyleWithTokenFallback(fetch, cfg.baseUrl, {
               method: "POST",
               headers: { "Authorization": `Bearer ${apiKey}`, "content-type": "application/json" },
-              body: JSON.stringify({ model: testModel, max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
-            });
+            }, { model: testModel, max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS, messages: [{ role: "user", content: "test" }] });
             isValid = res.status !== 401 && res.status !== 403;
           } else {
             const testModel = getDefaultModel(provider) || "claude-sonnet-4-20250514";
@@ -326,17 +324,16 @@ export async function POST(request) {
         }
         case "volcengine-ark":
         case "byteplus": {
-          const res = await fetch(PROVIDER_ENDPOINTS[provider], {
+          const res = await fetchOpenAIStyleWithTokenFallback(fetch, PROVIDER_ENDPOINTS[provider], {
             method: "POST",
             headers: {
               "Authorization": `Bearer ${apiKey}`,
               "content-type": "application/json",
             },
-            body: JSON.stringify({
-              model: getDefaultModel(provider),
-              max_tokens: 1,
-              messages: [{ role: "user", content: "test" }],
-            }),
+          }, {
+            model: getDefaultModel(provider),
+            max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
+            messages: [{ role: "user", content: "test" }],
           });
           isValid = res.status !== 401 && res.status !== 403;
           break;
@@ -397,15 +394,14 @@ export async function POST(request) {
         }
 
         case "opencode-go": {
-          const res = await fetch("https://opencode.ai/zen/go/v1/chat/completions", {
+          const res = await fetchOpenAIStyleWithTokenFallback(fetch, "https://opencode.ai/zen/go/v1/chat/completions", {
             method: "POST",
             headers: { "Content-Type": "application/json", "Authorization": `Bearer ${apiKey}` },
-            body: JSON.stringify({
-              model: getDefaultModel("opencode-go"),
-              messages: [{ role: "user", content: "ping" }],
-              max_tokens: 1,
-              stream: false,
-            }),
+          }, {
+            model: getDefaultModel("opencode-go"),
+            messages: [{ role: "user", content: "ping" }],
+            max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
+            stream: false,
           });
           isValid = res.status !== 401 && res.status !== 403;
           break;
@@ -416,7 +412,7 @@ export async function POST(request) {
           const model = getDefaultModel("commandcode");
           const payload = openaiToCommandCode(model, {
             messages: [{ role: "user", content: "ping" }],
-            max_tokens: 1,
+            max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
             stream: false,
           }, false);
           const res = await fetch(cfg.baseUrl, {
@@ -442,17 +438,16 @@ export async function POST(request) {
         }
 
         case "blackbox": {
-          const res = await fetch("https://api.blackbox.ai/chat/completions", {
+          const res = await fetchOpenAIStyleWithTokenFallback(fetch, "https://api.blackbox.ai/chat/completions", {
             method: "POST",
             headers: {
               "Authorization": `Bearer ${apiKey}`,
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({
-              model: "gpt-4o",
-              messages: [{ role: "user", content: "test" }],
-              max_tokens: 10,
-            }),
+          }, {
+            model: "gpt-4o",
+            messages: [{ role: "user", content: "test" }],
+            max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS,
           });
           // Returns 401 for invalid key, 200 for valid, 400 for malformed
           isValid = res.status === 200 || res.status === 400;
@@ -611,12 +606,11 @@ export async function POST(request) {
           }
           // Fallback: minimal chat probe
           const defaultModel = getDefaultModel(provider) || "test";
-          const chatRes = await fetch(cfg.baseUrl, {
+          const chatRes = await fetchOpenAIStyleWithTokenFallback(fetch, cfg.baseUrl, {
             method: "POST",
             headers,
-            body: JSON.stringify({ model: defaultModel, messages: [{ role: "user", content: "ping" }], max_tokens: 1 }),
             signal: AbortSignal.timeout(10000),
-          });
+          }, { model: defaultModel, messages: [{ role: "user", content: "ping" }], max_tokens: OPENAI_STYLE_PROBE_MAX_TOKENS });
           isValid = chatRes.status !== 401 && chatRes.status !== 403;
           break;
         }

--- a/src/lib/openaiParamFallback.js
+++ b/src/lib/openaiParamFallback.js
@@ -1,0 +1,71 @@
+export const OPENAI_STYLE_PROBE_MAX_TOKENS = 64;
+
+function parseErrorPayload(text) {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractUnsupportedParam(responseText) {
+  const data = parseErrorPayload(responseText);
+  const err = data?.error || {};
+  const msg = String(err.message || data?.message || responseText || "").toLowerCase();
+  let param = err.param;
+
+  if (!param) {
+    const match = msg.match(/(?:unsupported|unrecognized|unknown).*?(?:parameter|argument).*?['"]?([a-zA-Z0-9_]+)['"]?/i);
+    if (match) param = match[1];
+  }
+
+  const isUnsupported =
+    err.code === "unsupported_parameter" ||
+    err.code === "unrecognized_request_argument" ||
+    msg.includes("unsupported") ||
+    msg.includes("unrecognized") ||
+    msg.includes("not supported");
+
+  return isUnsupported ? { param, msg } : null;
+}
+
+async function getTokenFallbackPayload(response, payload) {
+  if (response.status !== 400 || !payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const responseText = await response.clone().text().catch(() => "");
+  const unsupported = extractUnsupportedParam(responseText);
+  if (!unsupported) return null;
+
+  const { param, msg } = unsupported;
+  const hasMaxTokens = payload.max_tokens !== undefined;
+  const hasMaxCompletionTokens = payload.max_completion_tokens !== undefined;
+
+  if (hasMaxTokens && !hasMaxCompletionTokens && (param === "max_tokens" || msg.includes("max_completion_tokens"))) {
+    const nextPayload = { ...payload, max_completion_tokens: payload.max_tokens };
+    delete nextPayload.max_tokens;
+    return nextPayload;
+  }
+
+  if (hasMaxCompletionTokens && !hasMaxTokens && (param === "max_completion_tokens" || msg.includes("max_tokens"))) {
+    const nextPayload = { ...payload, max_tokens: payload.max_completion_tokens };
+    delete nextPayload.max_completion_tokens;
+    return nextPayload;
+  }
+
+  return null;
+}
+
+export async function fetchOpenAIStyleWithTokenFallback(fetcher, url, options = {}, payload) {
+  const buildOptions = (body) => ({
+    ...options,
+    body: JSON.stringify(body)
+  });
+
+  const firstResponse = await fetcher(url, buildOptions(payload));
+  const fallbackPayload = await getTokenFallbackPayload(firstResponse, payload);
+  if (!fallbackPayload) return firstResponse;
+
+  return fetcher(url, buildOptions(fallbackPayload));
+}

--- a/src/lib/openaiParamFallback.js
+++ b/src/lib/openaiParamFallback.js
@@ -33,6 +33,19 @@ async function getTokenFallbackPayload(response, payload) {
   return null;
 }
 
+async function discardResponseBody(response) {
+  if (!response?.body) return;
+
+  if (typeof response.body.cancel === "function") {
+    await response.body.cancel().catch(() => {});
+    return;
+  }
+
+  if (!response.bodyUsed && typeof response.arrayBuffer === "function") {
+    await response.arrayBuffer().catch(() => {});
+  }
+}
+
 export async function fetchOpenAIStyleWithTokenFallback(fetcher, url, options = {}, payload) {
   const buildOptions = (body) => ({
     ...options,
@@ -43,5 +56,6 @@ export async function fetchOpenAIStyleWithTokenFallback(fetcher, url, options = 
   const fallbackPayload = await getTokenFallbackPayload(firstResponse, payload);
   if (!fallbackPayload) return firstResponse;
 
+  await discardResponseBody(firstResponse);
   return fetcher(url, buildOptions(fallbackPayload));
 }

--- a/src/lib/openaiParamFallback.js
+++ b/src/lib/openaiParamFallback.js
@@ -1,33 +1,6 @@
+import { extractUnsupportedParamFromText } from "../../open-sse/utils/unsupportedParam.js";
+
 export const OPENAI_STYLE_PROBE_MAX_TOKENS = 64;
-
-function parseErrorPayload(text) {
-  try {
-    return text ? JSON.parse(text) : null;
-  } catch {
-    return null;
-  }
-}
-
-function extractUnsupportedParam(responseText) {
-  const data = parseErrorPayload(responseText);
-  const err = data?.error || {};
-  const msg = String(err.message || data?.message || responseText || "").toLowerCase();
-  let param = err.param;
-
-  if (!param) {
-    const match = msg.match(/(?:unsupported|unrecognized|unknown).*?(?:parameter|argument).*?['"]?([a-zA-Z0-9_]+)['"]?/i);
-    if (match) param = match[1];
-  }
-
-  const isUnsupported =
-    err.code === "unsupported_parameter" ||
-    err.code === "unrecognized_request_argument" ||
-    msg.includes("unsupported") ||
-    msg.includes("unrecognized") ||
-    msg.includes("not supported");
-
-  return isUnsupported ? { param, msg } : null;
-}
 
 async function getTokenFallbackPayload(response, payload) {
   if (response.status !== 400 || !payload || typeof payload !== "object") {
@@ -35,7 +8,7 @@ async function getTokenFallbackPayload(response, payload) {
   }
 
   const responseText = await response.clone().text().catch(() => "");
-  const unsupported = extractUnsupportedParam(responseText);
+  const unsupported = extractUnsupportedParamFromText(responseText);
   if (!unsupported) return null;
 
   const { param, msg } = unsupported;

--- a/src/lib/openaiParamFallback.js
+++ b/src/lib/openaiParamFallback.js
@@ -1,6 +1,8 @@
 import { extractUnsupportedParamFromText } from "../../open-sse/utils/unsupportedParam.js";
 
-export const OPENAI_STYLE_PROBE_MAX_TOKENS = 64;
+// Validation probes only need to prove the endpoint accepts the token-limit field.
+// Keep this minimal to limit worst-case spend/latency if a provider ignores the prompt.
+export const OPENAI_STYLE_PROBE_MAX_TOKENS = 1;
 
 async function getTokenFallbackPayload(response, payload) {
   if (response.status !== 400 || !payload || typeof payload !== "object") {

--- a/src/lib/openaiParamFallback.js
+++ b/src/lib/openaiParamFallback.js
@@ -1,8 +1,9 @@
 import { extractUnsupportedParamFromText } from "../../open-sse/utils/unsupportedParam.js";
 
-// Validation probes only need to prove the endpoint accepts the token-limit field.
-// Keep this minimal to limit worst-case spend/latency if a provider ignores the prompt.
-export const OPENAI_STYLE_PROBE_MAX_TOKENS = 1;
+// Validation probes need enough output budget to avoid false 400s from models
+// that reject too-small caps as "max_tokens or model output limit was reached".
+// Keep this bounded, but do not lower to 1 without rechecking OpenAI/gpt-5.x.
+export const OPENAI_STYLE_PROBE_MAX_TOKENS = 64;
 
 async function getTokenFallbackPayload(response, payload) {
   if (response.status !== 400 || !payload || typeof payload !== "object") {

--- a/tests/unit/atomic-write.test.js
+++ b/tests/unit/atomic-write.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { writeJsonFileAtomically } from "../../open-sse/utils/atomicWrite.js";
+
+function enoent(path) {
+  const error = new Error(`ENOENT: ${path}`);
+  error.code = "ENOENT";
+  return error;
+}
+
+describe("writeJsonFileAtomically", () => {
+  it("falls back to backup replace when Windows rename cannot overwrite an existing file", async () => {
+    const target = "C:\\cache\\param_fixes.json";
+    const files = new Map([[target, "{\"old\":true}"]]);
+    const renameCalls = [];
+
+    const fsApi = {
+      writeFile: vi.fn(async (path, content) => {
+        files.set(path, content);
+      }),
+      rename: vi.fn(async (from, to) => {
+        renameCalls.push([from, to]);
+        if (from.endsWith(".tmp") && to === target && files.has(target)) {
+          const error = new Error("destination exists");
+          error.code = "EEXIST";
+          throw error;
+        }
+        if (!files.has(from)) throw enoent(from);
+        files.set(to, files.get(from));
+        files.delete(from);
+      }),
+      rm: vi.fn(async (path) => {
+        files.delete(path);
+      })
+    };
+
+    await writeJsonFileAtomically(fsApi, target, { next: true }, {
+      platform: "win32",
+      pid: 123,
+      now: () => 456,
+      random: () => 0.5
+    });
+
+    expect(JSON.parse(files.get(target))).toEqual({ next: true });
+    expect([...files.keys()]).toEqual([target]);
+    expect(renameCalls).toEqual([
+      [`${target}.123.456.i.tmp`, target],
+      [target, `${target}.123.456.i.bak`],
+      [`${target}.123.456.i.tmp`, target]
+    ]);
+  });
+});

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -13,6 +13,7 @@ describe("BaseExecutor parameter cache persistence", () => {
   let previousDataDir;
 
   afterEach(async () => {
+    vi.useRealTimers();
     vi.doUnmock("../../open-sse/utils/proxyFetch.js");
     vi.doUnmock("../../open-sse/utils/atomicWrite.js");
     vi.resetModules();
@@ -121,6 +122,75 @@ describe("BaseExecutor parameter cache persistence", () => {
       max_tokens: "max_completion_tokens"
     });
     expect(writeJsonFileAtomically).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for an already in-flight param cache save before returning", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+
+    const proxyAwareFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: {
+          code: "unsupported_parameter",
+          param: "max_tokens",
+          message: "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+        }
+      }), { status: 400, headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }));
+    let releaseWrite;
+    const writeCanFinish = new Promise(resolve => {
+      releaseWrite = resolve;
+    });
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+    vi.doMock("../../open-sse/utils/atomicWrite.js", async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        writeJsonFileAtomically: vi.fn(async (...args) => {
+          await writeCanFinish;
+          return actual.writeJsonFileAtomically(...args);
+        })
+      };
+    });
+
+    vi.useFakeTimers();
+    const { BaseExecutor, flushParamCacheSaveForTests } = await import("../../open-sse/executors/base.js");
+    const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+
+    const result = await executor.execute({
+      model: "model-a",
+      body: { messages: [], max_tokens: 5 },
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(result.response.status).toBe(200);
+
+    vi.advanceTimersByTime(250);
+    const flushPromise = flushParamCacheSaveForTests();
+    let flushReturned = false;
+    flushPromise.then(() => {
+      flushReturned = true;
+    });
+
+    vi.advanceTimersByTime(0);
+    expect(flushReturned).toBe(false);
+
+    releaseWrite();
+    await flushPromise;
+    vi.useRealTimers();
+
+    const cache = await readParamCache(dataDir);
+    expect(cache["openai-compatible-test:model-a"]).toEqual({
+      max_tokens: "max_completion_tokens"
+    });
   });
 
   it("learns replacement token params from plain-text unsupported-parameter errors", async () => {

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -62,6 +62,41 @@ describe("BaseExecutor parameter cache persistence", () => {
     const cache = JSON.parse(await readFile(join(dataDir, "param_fixes.json"), "utf8"));
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       max_tokens: "max_completion_tokens"
+    });
+  });
+
+  it("preserves an already-present replacement param when applying cached fixes", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+    await writeFile(join(dataDir, "param_fixes.json"), JSON.stringify({
+      "openai-compatible-test:model-a": {
+        max_tokens: "max_completion_tokens"
+      }
+    }));
+
+    const proxyAwareFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    }));
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+
+    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+
+    await executor.execute({
+      model: "model-a",
+      body: { messages: [], max_tokens: 5, max_completion_tokens: 11 },
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(proxyAwareFetch.mock.calls[0][1].body)).toEqual({
+      messages: [],
+      max_completion_tokens: 11
     });
   });
 });

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -3,26 +3,9 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-const PARAM_CACHE_TIMEOUT_MS = 2000;
-const PARAM_CACHE_POLL_MS = 25;
-
-async function readParamCacheUntil(dataDir, key, expectedValue) {
+async function readParamCache(dataDir) {
   const filePath = join(dataDir, "param_fixes.json");
-  const deadline = Date.now() + PARAM_CACHE_TIMEOUT_MS;
-  let lastError;
-
-  while (Date.now() < deadline) {
-    try {
-      const cache = JSON.parse(await readFile(filePath, "utf8"));
-      if (JSON.stringify(cache[key]) === JSON.stringify(expectedValue)) return cache;
-    } catch (error) {
-      lastError = error;
-    }
-    await sleep(PARAM_CACHE_POLL_MS);
-  }
-
-  throw new Error(`Timed out waiting for ${key} in param_fixes.json${lastError ? `: ${lastError.message}` : ""}`);
+  return JSON.parse(await readFile(filePath, "utf8"));
 }
 
 describe("BaseExecutor parameter cache persistence", () => {
@@ -60,7 +43,7 @@ describe("BaseExecutor parameter cache persistence", () => {
 
     vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
 
-    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const { BaseExecutor, flushParamCacheSaveForTests } = await import("../../open-sse/executors/base.js");
     const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
     const body = { messages: [], max_tokens: 5 };
 
@@ -80,9 +63,8 @@ describe("BaseExecutor parameter cache persistence", () => {
     });
     expect(body).toEqual({ messages: [], max_tokens: 5 });
 
-    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
-      max_tokens: "max_completion_tokens"
-    });
+    await flushParamCacheSaveForTests();
+    const cache = await readParamCache(dataDir);
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       max_tokens: "max_completion_tokens"
     });
@@ -119,7 +101,7 @@ describe("BaseExecutor parameter cache persistence", () => {
       };
     });
 
-    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const { BaseExecutor, flushParamCacheSaveForTests } = await import("../../open-sse/executors/base.js");
     const { writeJsonFileAtomically } = await import("../../open-sse/utils/atomicWrite.js");
     const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
 
@@ -133,9 +115,8 @@ describe("BaseExecutor parameter cache persistence", () => {
 
     expect(result.response.status).toBe(200);
 
-    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
-      max_tokens: "max_completion_tokens"
-    });
+    await flushParamCacheSaveForTests();
+    const cache = await readParamCache(dataDir);
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       max_tokens: "max_completion_tokens"
     });
@@ -160,7 +141,7 @@ describe("BaseExecutor parameter cache persistence", () => {
 
     vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
 
-    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const { BaseExecutor, flushParamCacheSaveForTests } = await import("../../open-sse/executors/base.js");
     const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
 
     const result = await executor.execute({
@@ -178,9 +159,8 @@ describe("BaseExecutor parameter cache persistence", () => {
       max_completion_tokens: 5
     });
 
-    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
-      max_tokens: "max_completion_tokens"
-    });
+    await flushParamCacheSaveForTests();
+    const cache = await readParamCache(dataDir);
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       max_tokens: "max_completion_tokens"
     });
@@ -206,7 +186,7 @@ describe("BaseExecutor parameter cache persistence", () => {
 
     vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
 
-    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const { BaseExecutor, flushParamCacheSaveForTests } = await import("../../open-sse/executors/base.js");
     const executor = new BaseExecutor("openai-compatible-test", {
       baseUrl: "https://example.test/v1",
       maxAutoFixAttempts: 2
@@ -238,10 +218,8 @@ describe("BaseExecutor parameter cache persistence", () => {
       param_c: "c"
     });
 
-    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
-      param_a: null,
-      param_b: null
-    });
+    await flushParamCacheSaveForTests();
+    const cache = await readParamCache(dataDir);
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       param_a: null,
       param_b: null

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -72,6 +72,57 @@ describe("BaseExecutor parameter cache persistence", () => {
     expect((await readdir(dataDir)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
   });
 
+  it("cancels the original 400 response body before auto-fix retrying", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const firstResponse = {
+      status: 400,
+      headers: {
+        get: (name) => name.toLowerCase() === "content-type" ? "application/json" : null
+      },
+      body: { cancel },
+      bodyUsed: false,
+      clone: () => ({
+        text: () => Promise.resolve(JSON.stringify({
+          error: {
+            code: "unsupported_parameter",
+            param: "max_tokens",
+            message: "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+          }
+        }))
+      })
+    };
+    const proxyAwareFetch = vi
+      .fn()
+      .mockResolvedValueOnce(firstResponse)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }));
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+
+    const { BaseExecutor, flushParamCacheSaveForTests } = await import("../../open-sse/executors/base.js");
+    const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+
+    const result = await executor.execute({
+      model: "model-a",
+      body: { messages: [], max_tokens: 5 },
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel.mock.invocationCallOrder[0]).toBeLessThan(proxyAwareFetch.mock.invocationCallOrder[1]);
+    await flushParamCacheSaveForTests();
+  });
+
   it("retries pending param cache saves after transient write failures", async () => {
     previousDataDir = process.env.DATA_DIR;
     dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -31,6 +31,7 @@ describe("BaseExecutor parameter cache persistence", () => {
 
   afterEach(async () => {
     vi.doUnmock("../../open-sse/utils/proxyFetch.js");
+    vi.doUnmock("../../open-sse/utils/atomicWrite.js");
     vi.resetModules();
     if (previousDataDir === undefined) delete process.env.DATA_DIR;
     else process.env.DATA_DIR = previousDataDir;
@@ -86,6 +87,59 @@ describe("BaseExecutor parameter cache persistence", () => {
       max_tokens: "max_completion_tokens"
     });
     expect((await readdir(dataDir)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("retries pending param cache saves after transient write failures", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+
+    const proxyAwareFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: {
+          code: "unsupported_parameter",
+          param: "max_tokens",
+          message: "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+        }
+      }), { status: 400, headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }));
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+    vi.doMock("../../open-sse/utils/atomicWrite.js", async (importOriginal) => {
+      const actual = await importOriginal();
+      return {
+        ...actual,
+        writeJsonFileAtomically: vi.fn()
+          .mockRejectedValueOnce(new Error("temporary write failure"))
+          .mockImplementation((...args) => actual.writeJsonFileAtomically(...args))
+      };
+    });
+
+    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const { writeJsonFileAtomically } = await import("../../open-sse/utils/atomicWrite.js");
+    const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+
+    const result = await executor.execute({
+      model: "model-a",
+      body: { messages: [], max_tokens: 5 },
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(result.response.status).toBe(200);
+
+    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
+      max_tokens: "max_completion_tokens"
+    });
+    expect(cache["openai-compatible-test:model-a"]).toEqual({
+      max_tokens: "max_completion_tokens"
+    });
+    expect(writeJsonFileAtomically).toHaveBeenCalledTimes(2);
   });
 
   it("learns replacement token params from plain-text unsupported-parameter errors", async () => {

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -3,7 +3,27 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const PARAM_CACHE_TIMEOUT_MS = 2000;
+const PARAM_CACHE_POLL_MS = 25;
+
+async function readParamCacheUntil(dataDir, key, expectedValue) {
+  const filePath = join(dataDir, "param_fixes.json");
+  const deadline = Date.now() + PARAM_CACHE_TIMEOUT_MS;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      const cache = JSON.parse(await readFile(filePath, "utf8"));
+      if (JSON.stringify(cache[key]) === JSON.stringify(expectedValue)) return cache;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(PARAM_CACHE_POLL_MS);
+  }
+
+  throw new Error(`Timed out waiting for ${key} in param_fixes.json${lastError ? `: ${lastError.message}` : ""}`);
+}
 
 describe("BaseExecutor parameter cache persistence", () => {
   let dataDir;
@@ -59,8 +79,9 @@ describe("BaseExecutor parameter cache persistence", () => {
     });
     expect(body).toEqual({ messages: [], max_tokens: 5 });
 
-    await wait(400);
-    const cache = JSON.parse(await readFile(join(dataDir, "param_fixes.json"), "utf8"));
+    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
+      max_tokens: "max_completion_tokens"
+    });
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       max_tokens: "max_completion_tokens"
     });
@@ -103,8 +124,9 @@ describe("BaseExecutor parameter cache persistence", () => {
       max_completion_tokens: 5
     });
 
-    await wait(400);
-    const cache = JSON.parse(await readFile(join(dataDir, "param_fixes.json"), "utf8"));
+    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
+      max_tokens: "max_completion_tokens"
+    });
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       max_tokens: "max_completion_tokens"
     });

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -64,6 +64,7 @@ describe("BaseExecutor parameter cache persistence", () => {
     expect(cache["openai-compatible-test:model-a"]).toEqual({
       max_tokens: "max_completion_tokens"
     });
+    expect((await readdir(dataDir)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
   });
 
   it("learns replacement token params from plain-text unsupported-parameter errors", async () => {

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -186,6 +186,68 @@ describe("BaseExecutor parameter cache persistence", () => {
     });
   });
 
+  it("bounds chained auto-fix retries with maxAutoFixAttempts", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+
+    const unsupportedParamResponse = (param) => new Response(JSON.stringify({
+      error: {
+        code: "unsupported_parameter",
+        param,
+        message: `Unsupported parameter: ${param}.`
+      }
+    }), { status: 400, headers: { "Content-Type": "application/json" } });
+    const proxyAwareFetch = vi
+      .fn()
+      .mockResolvedValueOnce(unsupportedParamResponse("param_a"))
+      .mockResolvedValueOnce(unsupportedParamResponse("param_b"))
+      .mockResolvedValueOnce(unsupportedParamResponse("param_c"));
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+
+    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const executor = new BaseExecutor("openai-compatible-test", {
+      baseUrl: "https://example.test/v1",
+      maxAutoFixAttempts: 2
+    });
+
+    const result = await executor.execute({
+      model: "model-a",
+      body: { messages: [], param_a: "a", param_b: "b", param_c: "c" },
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(result.response.status).toBe(400);
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(proxyAwareFetch.mock.calls[0][1].body)).toEqual({
+      messages: [],
+      param_a: "a",
+      param_b: "b",
+      param_c: "c"
+    });
+    expect(JSON.parse(proxyAwareFetch.mock.calls[1][1].body)).toEqual({
+      messages: [],
+      param_b: "b",
+      param_c: "c"
+    });
+    expect(JSON.parse(proxyAwareFetch.mock.calls[2][1].body)).toEqual({
+      messages: [],
+      param_c: "c"
+    });
+
+    const cache = await readParamCacheUntil(dataDir, "openai-compatible-test:model-a", {
+      param_a: null,
+      param_b: null
+    });
+    expect(cache["openai-compatible-test:model-a"]).toEqual({
+      param_a: null,
+      param_b: null
+    });
+  });
+
   it("preserves an already-present replacement param when applying cached fixes", async () => {
     previousDataDir = process.env.DATA_DIR;
     dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -65,6 +65,49 @@ describe("BaseExecutor parameter cache persistence", () => {
     });
   });
 
+  it("learns replacement token params from plain-text unsupported-parameter errors", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+
+    const proxyAwareFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(
+        "Unsupported parameter: max_tokens. Use max_completion_tokens instead.",
+        { status: 400, headers: { "Content-Type": "text/plain" } }
+      ))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }));
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+
+    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+
+    const result = await executor.execute({
+      model: "model-a",
+      body: { messages: [], max_tokens: 5 },
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(proxyAwareFetch.mock.calls[1][1].body)).toEqual({
+      messages: [],
+      max_completion_tokens: 5
+    });
+
+    await wait(400);
+    const cache = JSON.parse(await readFile(join(dataDir, "param_fixes.json"), "utf8"));
+    expect(cache["openai-compatible-test:model-a"]).toEqual({
+      max_tokens: "max_completion_tokens"
+    });
+  });
+
   it("preserves an already-present replacement param when applying cached fixes", async () => {
     previousDataDir = process.env.DATA_DIR;
     dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -57,6 +57,7 @@ describe("BaseExecutor parameter cache persistence", () => {
       messages: [],
       max_completion_tokens: 5
     });
+    expect(body).toEqual({ messages: [], max_tokens: 5 });
 
     await wait(400);
     const cache = JSON.parse(await readFile(join(dataDir, "param_fixes.json"), "utf8"));
@@ -127,10 +128,11 @@ describe("BaseExecutor parameter cache persistence", () => {
 
     const { BaseExecutor } = await import("../../open-sse/executors/base.js");
     const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+    const body = { messages: [], max_tokens: 5, max_completion_tokens: 11 };
 
     await executor.execute({
       model: "model-a",
-      body: { messages: [], max_tokens: 5, max_completion_tokens: 11 },
+      body,
       stream: false,
       credentials: { apiKey: "test-key" },
       log: null
@@ -141,5 +143,6 @@ describe("BaseExecutor parameter cache persistence", () => {
       messages: [],
       max_completion_tokens: 11
     });
+    expect(body).toEqual({ messages: [], max_tokens: 5, max_completion_tokens: 11 });
   });
 });

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -1,0 +1,67 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("BaseExecutor parameter cache persistence", () => {
+  let dataDir;
+  let previousDataDir;
+
+  afterEach(async () => {
+    vi.doUnmock("../../open-sse/utils/proxyFetch.js");
+    vi.resetModules();
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    if (dataDir) await rm(dataDir, { recursive: true, force: true });
+    dataDir = null;
+  });
+
+  it("persists learned fixes asynchronously after retrying with replacement token param", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+
+    const proxyAwareFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: {
+          code: "unsupported_parameter",
+          param: "max_tokens",
+          message: "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+        }
+      }), { status: 400, headers: { "Content-Type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }));
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+
+    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    const executor = new BaseExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+    const body = { messages: [], max_tokens: 5 };
+
+    const result = await executor.execute({
+      model: "model-a",
+      body,
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(proxyAwareFetch.mock.calls[1][1].body)).toEqual({
+      messages: [],
+      max_completion_tokens: 5
+    });
+
+    await wait(400);
+    const cache = JSON.parse(await readFile(join(dataDir, "param_fixes.json"), "utf8"));
+    expect(cache["openai-compatible-test:model-a"]).toEqual({
+      max_tokens: "max_completion_tokens"
+    });
+  });
+});

--- a/tests/unit/base-executor-param-cache.test.js
+++ b/tests/unit/base-executor-param-cache.test.js
@@ -168,4 +168,49 @@ describe("BaseExecutor parameter cache persistence", () => {
     });
     expect(body).toEqual({ messages: [], max_tokens: 5, max_completion_tokens: 11 });
   });
+
+  it("applies cached fixes before transformRequest derives provider-specific fields", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-param-cache-"));
+    process.env.DATA_DIR = dataDir;
+    await writeFile(join(dataDir, "param_fixes.json"), JSON.stringify({
+      "openai-compatible-test:model-a": {
+        max_tokens: "max_completion_tokens"
+      }
+    }));
+
+    const proxyAwareFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    }));
+
+    vi.doMock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+
+    const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+    class DerivedParamExecutor extends BaseExecutor {
+      transformRequest(model, body) {
+        if (body.max_tokens !== undefined) {
+          return { providerParams: { unsupportedMaxTokens: body.max_tokens } };
+        }
+        return { providerParams: { supportedMaxCompletionTokens: body.max_completion_tokens } };
+      }
+    }
+
+    const executor = new DerivedParamExecutor("openai-compatible-test", { baseUrl: "https://example.test/v1" });
+    const body = { messages: [], max_tokens: 5 };
+
+    await executor.execute({
+      model: "model-a",
+      body,
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      log: null
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(proxyAwareFetch.mock.calls[0][1].body)).toEqual({
+      providerParams: { supportedMaxCompletionTokens: 5 }
+    });
+    expect(body).toEqual({ messages: [], max_tokens: 5 });
+  });
 });

--- a/tests/unit/chat-core-forced-json.test.js
+++ b/tests/unit/chat-core-forced-json.test.js
@@ -1,0 +1,83 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("handleChatCore forced-stream JSON fallback", () => {
+  let dataDir;
+  let previousDataDir;
+
+  afterEach(async () => {
+    vi.doUnmock("@/lib/usageDb.js");
+    vi.doUnmock("../../open-sse/executors/index.js");
+    vi.resetModules();
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    if (dataDir) await rm(dataDir, { recursive: true, force: true });
+    dataDir = null;
+    previousDataDir = undefined;
+  });
+
+  it("parses ordinary JSON from forced-stream providers even with a non-JSON content-type", async () => {
+    previousDataDir = process.env.DATA_DIR;
+    dataDir = await mkdtemp(join(tmpdir(), "9router-chat-core-"));
+    process.env.DATA_DIR = dataDir;
+
+    const execute = vi.fn().mockResolvedValue({
+      response: new Response(JSON.stringify({
+        id: "chatcmpl-test",
+        choices: [{
+          index: 0,
+          message: { role: "assistant", content: "pong" },
+          finish_reason: "stop"
+        }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+      }), {
+        status: 200,
+        headers: { "Content-Type": "text/plain" }
+      }),
+      url: "https://example.test/v1/chat/completions",
+      headers: { "Content-Type": "application/json" },
+      transformedBody: { model: "gpt-test", messages: [], stream: false }
+    });
+
+    vi.doMock("@/lib/usageDb.js", () => ({
+      trackPendingRequest: vi.fn(),
+      appendRequestLog: vi.fn().mockResolvedValue(undefined),
+      saveRequestDetail: vi.fn().mockResolvedValue(undefined),
+      saveRequestUsage: vi.fn().mockResolvedValue(undefined)
+    }));
+    vi.doMock("../../open-sse/executors/index.js", () => ({
+      getExecutor: () => ({
+        noAuth: true,
+        execute
+      })
+    }));
+
+    const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
+
+    const result = await handleChatCore({
+      body: {
+        model: "gpt-test",
+        messages: [{ role: "user", content: "ping" }],
+        stream: false
+      },
+      modelInfo: { provider: "openai", model: "gpt-test" },
+      credentials: { apiKey: "test-key" },
+      log: null,
+      connectionId: "conn-test",
+      apiKey: "router-key"
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0][0].stream).toBe(true);
+    expect(result.success).toBe(true);
+    expect(result.response.headers.get("content-type")).toContain("application/json");
+    await expect(result.response.json()).resolves.toMatchObject({
+      choices: [{
+        message: { role: "assistant", content: "pong" },
+        finish_reason: "stop"
+      }]
+    });
+  });
+});

--- a/tests/unit/content-type.test.js
+++ b/tests/unit/content-type.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMediaType,
+  isEventStreamContentType,
+  isJsonContentType
+} from "../../open-sse/utils/contentType.js";
+
+describe("content type helpers", () => {
+  it("normalizes media types with parameters", () => {
+    expect(getMediaType("Application/JSON; charset=utf-8")).toBe("application/json");
+    expect(getMediaType(" text/event-stream ; charset=utf-8")).toBe("text/event-stream");
+  });
+
+  it("detects event-stream without treating it as JSON", () => {
+    const response = new Response("data: {}\n\n", {
+      headers: { "Content-Type": "text/event-stream; charset=utf-8" }
+    });
+
+    expect(response.bodyUsed).toBe(false);
+    expect(isEventStreamContentType(response.headers.get("content-type"))).toBe(true);
+    expect(isJsonContentType(response.headers.get("content-type"))).toBe(false);
+  });
+
+  it("accepts JSON and structured JSON media types only", () => {
+    expect(isJsonContentType("application/json; charset=utf-8")).toBe(true);
+    expect(isJsonContentType("application/problem+json")).toBe(true);
+    expect(isJsonContentType("text/plain")).toBe(false);
+    expect(isJsonContentType("")).toBe(false);
+  });
+});

--- a/tests/unit/openai-param-fallback.test.js
+++ b/tests/unit/openai-param-fallback.test.js
@@ -105,4 +105,27 @@ describe("fetchOpenAIStyleWithTokenFallback", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(cancel).not.toHaveBeenCalled();
   });
+
+  it("does not retry token fallback for unrelated unsupported model errors", async () => {
+    const firstResponse = new Response(JSON.stringify({
+      error: {
+        message: "This model is not supported for max_tokens or output limits."
+      }
+    }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" }
+    });
+    const fetcher = vi.fn().mockResolvedValueOnce(firstResponse);
+
+    const response = await fetchOpenAIStyleWithTokenFallback(fetcher, "https://example.test/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" }
+    }, {
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 64
+    });
+
+    expect(response).toBe(firstResponse);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/openai-param-fallback.test.js
+++ b/tests/unit/openai-param-fallback.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchOpenAIStyleWithTokenFallback } from "../../src/lib/openaiParamFallback.js";
+
+describe("fetchOpenAIStyleWithTokenFallback", () => {
+  it("uses the shared unsupported-param parser for plain-text fallback errors", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(
+        "Unsupported parameter: max_tokens. Use max_completion_tokens instead.",
+        { status: 400, headers: { "Content-Type": "text/plain" } }
+      ))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }));
+
+    const response = await fetchOpenAIStyleWithTokenFallback(fetcher, "https://example.test/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" }
+    }, {
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 64
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fetcher.mock.calls[1][1].body)).toEqual({
+      messages: [{ role: "user", content: "ping" }],
+      max_completion_tokens: 64
+    });
+  });
+});

--- a/tests/unit/openai-param-fallback.test.js
+++ b/tests/unit/openai-param-fallback.test.js
@@ -36,4 +36,73 @@ describe("fetchOpenAIStyleWithTokenFallback", () => {
       max_completion_tokens: 64
     });
   });
+
+  it("cancels the first response body before retrying with fallback payload", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const firstResponse = {
+      status: 400,
+      body: { cancel },
+      bodyUsed: false,
+      clone: () => ({
+        text: () => Promise.resolve(JSON.stringify({
+          error: {
+            code: "unsupported_parameter",
+            param: "max_tokens",
+            message: "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+          }
+        }))
+      })
+    };
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(firstResponse)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }));
+
+    const response = await fetchOpenAIStyleWithTokenFallback(fetcher, "https://example.test/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" }
+    }, {
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 64
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel.mock.invocationCallOrder[0]).toBeLessThan(fetcher.mock.invocationCallOrder[1]);
+  });
+
+  it("returns the first response untouched when no fallback is needed", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const firstResponse = {
+      status: 400,
+      body: { cancel },
+      bodyUsed: false,
+      clone: () => ({
+        text: () => Promise.resolve(JSON.stringify({
+          error: {
+            code: "unsupported_parameter",
+            param: "temperature",
+            message: "Unsupported parameter: temperature."
+          }
+        }))
+      })
+    };
+    const fetcher = vi.fn().mockResolvedValueOnce(firstResponse);
+
+    const response = await fetchOpenAIStyleWithTokenFallback(fetcher, "https://example.test/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" }
+    }, {
+      messages: [{ role: "user", content: "ping" }],
+      max_tokens: 64
+    });
+
+    expect(response).toBe(firstResponse);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(cancel).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/openai-param-fallback.test.js
+++ b/tests/unit/openai-param-fallback.test.js
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import { fetchOpenAIStyleWithTokenFallback } from "../../src/lib/openaiParamFallback.js";
+import {
+  OPENAI_STYLE_PROBE_MAX_TOKENS,
+  fetchOpenAIStyleWithTokenFallback
+} from "../../src/lib/openaiParamFallback.js";
 
 describe("fetchOpenAIStyleWithTokenFallback", () => {
+  it("keeps validation probes capped to the smallest useful completion", () => {
+    expect(OPENAI_STYLE_PROBE_MAX_TOKENS).toBe(1);
+  });
+
   it("uses the shared unsupported-param parser for plain-text fallback errors", async () => {
     const fetcher = vi
       .fn()

--- a/tests/unit/openai-param-fallback.test.js
+++ b/tests/unit/openai-param-fallback.test.js
@@ -5,8 +5,8 @@ import {
 } from "../../src/lib/openaiParamFallback.js";
 
 describe("fetchOpenAIStyleWithTokenFallback", () => {
-  it("keeps validation probes capped to the smallest useful completion", () => {
-    expect(OPENAI_STYLE_PROBE_MAX_TOKENS).toBe(1);
+  it("keeps validation probes high enough to avoid output-limit false negatives", () => {
+    expect(OPENAI_STYLE_PROBE_MAX_TOKENS).toBe(64);
   });
 
   it("uses the shared unsupported-param parser for plain-text fallback errors", async () => {

--- a/tests/unit/openai-responses-token-normalization.test.js
+++ b/tests/unit/openai-responses-token-normalization.test.js
@@ -6,34 +6,39 @@ const baseBody = {
 };
 
 describe("openaiToOpenAIResponsesRequest token limit normalization", () => {
-  it("prefers max_completion_tokens when both token limit fields are present", () => {
+  it("prefers max_output_tokens when token limit fields are present", () => {
+    const result = openaiToOpenAIResponsesRequest("gpt-5", {
+      ...baseBody,
+      max_tokens: 5,
+      max_completion_tokens: 11,
+      max_output_tokens: 17
+    }, false);
+
+    expect(result.max_output_tokens).toBe(17);
+    expect(result.max_completion_tokens).toBeUndefined();
+    expect(result.max_tokens).toBeUndefined();
+  });
+
+  it("maps max_completion_tokens to max_output_tokens before max_tokens", () => {
     const result = openaiToOpenAIResponsesRequest("gpt-5", {
       ...baseBody,
       max_tokens: 5,
       max_completion_tokens: 11
     }, false);
 
-    expect(result.max_completion_tokens).toBe(11);
+    expect(result.max_output_tokens).toBe(11);
+    expect(result.max_completion_tokens).toBeUndefined();
     expect(result.max_tokens).toBeUndefined();
   });
 
-  it("passes through max_tokens when max_completion_tokens is absent", () => {
+  it("maps max_tokens to max_output_tokens when other token limits are absent", () => {
     const result = openaiToOpenAIResponsesRequest("gpt-5", {
       ...baseBody,
       max_tokens: 5
     }, false);
 
-    expect(result.max_tokens).toBe(5);
+    expect(result.max_output_tokens).toBe(5);
     expect(result.max_completion_tokens).toBeUndefined();
-  });
-
-  it("passes through max_completion_tokens when it is the only token limit", () => {
-    const result = openaiToOpenAIResponsesRequest("gpt-5", {
-      ...baseBody,
-      max_completion_tokens: 11
-    }, false);
-
-    expect(result.max_completion_tokens).toBe(11);
     expect(result.max_tokens).toBeUndefined();
   });
 });

--- a/tests/unit/openai-responses-token-normalization.test.js
+++ b/tests/unit/openai-responses-token-normalization.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { openaiToOpenAIResponsesRequest } from "../../open-sse/translator/request/openai-responses.js";
+
+const baseBody = {
+  messages: [{ role: "user", content: "hello" }]
+};
+
+describe("openaiToOpenAIResponsesRequest token limit normalization", () => {
+  it("prefers max_completion_tokens when both token limit fields are present", () => {
+    const result = openaiToOpenAIResponsesRequest("gpt-5", {
+      ...baseBody,
+      max_tokens: 5,
+      max_completion_tokens: 11
+    }, false);
+
+    expect(result.max_completion_tokens).toBe(11);
+    expect(result.max_tokens).toBeUndefined();
+  });
+
+  it("passes through max_tokens when max_completion_tokens is absent", () => {
+    const result = openaiToOpenAIResponsesRequest("gpt-5", {
+      ...baseBody,
+      max_tokens: 5
+    }, false);
+
+    expect(result.max_tokens).toBe(5);
+    expect(result.max_completion_tokens).toBeUndefined();
+  });
+
+  it("passes through max_completion_tokens when it is the only token limit", () => {
+    const result = openaiToOpenAIResponsesRequest("gpt-5", {
+      ...baseBody,
+      max_completion_tokens: 11
+    }, false);
+
+    expect(result.max_completion_tokens).toBe(11);
+    expect(result.max_tokens).toBeUndefined();
+  });
+});

--- a/tests/unit/token-limit-precedence.test.js
+++ b/tests/unit/token-limit-precedence.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { adjustMaxTokens, getTokenLimit } from "../../open-sse/translator/helpers/maxTokensHelper.js";
+import { DEFAULT_MAX_TOKENS } from "../../open-sse/config/runtimeConfig.js";
 import { openaiToCommandCode } from "../../open-sse/translator/request/openai-to-commandcode.js";
 import { buildCursorRequest } from "../../open-sse/translator/request/openai-to-cursor.js";
 import { openaiToGeminiRequest } from "../../open-sse/translator/request/openai-to-gemini.js";
@@ -15,6 +16,13 @@ describe("OpenAI token-limit precedence", () => {
   it("prefers max_completion_tokens in the shared helpers", () => {
     expect(getTokenLimit(bodyWithBothLimits)).toBe(222);
     expect(adjustMaxTokens(bodyWithBothLimits)).toBe(222);
+  });
+
+  it("ignores non-positive token limits before falling back", () => {
+    expect(getTokenLimit({ max_completion_tokens: 0, max_tokens: 111 })).toBe(111);
+    expect(getTokenLimit({ max_completion_tokens: -1, max_tokens: 111 })).toBe(111);
+    expect(getTokenLimit({ max_completion_tokens: 0, max_tokens: 0 }, 333)).toBe(333);
+    expect(adjustMaxTokens({ max_tokens: 0 })).toBe(DEFAULT_MAX_TOKENS);
   });
 
   it("uses the same precedence for Gemini maxOutputTokens", () => {

--- a/tests/unit/token-limit-precedence.test.js
+++ b/tests/unit/token-limit-precedence.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { adjustMaxTokens, getTokenLimit } from "../../open-sse/translator/helpers/maxTokensHelper.js";
+import { openaiToCommandCode } from "../../open-sse/translator/request/openai-to-commandcode.js";
+import { buildCursorRequest } from "../../open-sse/translator/request/openai-to-cursor.js";
+import { openaiToGeminiRequest } from "../../open-sse/translator/request/openai-to-gemini.js";
+import { openaiToOllamaRequest } from "../../open-sse/translator/request/openai-to-ollama.js";
+
+const bodyWithBothLimits = {
+  messages: [{ role: "user", content: "hello" }],
+  max_tokens: 111,
+  max_completion_tokens: 222
+};
+
+describe("OpenAI token-limit precedence", () => {
+  it("prefers max_completion_tokens in the shared helpers", () => {
+    expect(getTokenLimit(bodyWithBothLimits)).toBe(222);
+    expect(adjustMaxTokens(bodyWithBothLimits)).toBe(222);
+  });
+
+  it("uses the same precedence for Gemini maxOutputTokens", () => {
+    const result = openaiToGeminiRequest("gemini-test", bodyWithBothLimits, false);
+    expect(result.generationConfig.maxOutputTokens).toBe(222);
+  });
+
+  it("uses the same precedence for Ollama num_predict", () => {
+    const result = openaiToOllamaRequest("ollama-test", bodyWithBothLimits, false);
+    expect(result.options.num_predict).toBe(222);
+  });
+
+  it("uses the same precedence for Cursor max_tokens", () => {
+    const result = buildCursorRequest("cursor-test", bodyWithBothLimits, false);
+    expect(result.max_tokens).toBe(222);
+  });
+
+  it("uses the same precedence for CommandCode max_tokens", () => {
+    const result = openaiToCommandCode("commandcode-test", bodyWithBothLimits, false);
+    expect(result.params.max_tokens).toBe(222);
+  });
+});

--- a/tests/unit/unsupported-param-parser.test.js
+++ b/tests/unit/unsupported-param-parser.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractUnsupportedParamFromResponse,
+  extractUnsupportedParamFromText,
+  parseErrorPayload
+} from "../../open-sse/utils/unsupportedParam.js";
+
+describe("unsupported parameter parser", () => {
+  it("parses JSON error payloads", () => {
+    const parsed = extractUnsupportedParamFromText(JSON.stringify({
+      error: {
+        code: "unsupported_parameter",
+        param: "max_tokens",
+        message: "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+      }
+    }));
+
+    expect(parsed).toEqual({
+      param: "max_tokens",
+      msg: "unsupported parameter: max_tokens. use max_completion_tokens instead."
+    });
+  });
+
+  it("extracts params from plain-text unsupported errors", () => {
+    const parsed = extractUnsupportedParamFromText(
+      "Unsupported parameter: 'max_tokens'. Use max_completion_tokens instead."
+    );
+
+    expect(parsed).toEqual({
+      param: "max_tokens",
+      msg: "unsupported parameter: 'max_tokens'. use max_completion_tokens instead."
+    });
+  });
+
+  it("returns null for non-JSON unrelated errors", () => {
+    expect(extractUnsupportedParamFromText("request failed")).toBeNull();
+    expect(parseErrorPayload("not-json")).toBeNull();
+  });
+
+  it("reads response text before applying the shared parser", async () => {
+    const response = new Response("Unrecognized argument max_tokens", {
+      status: 400,
+      headers: { "Content-Type": "text/plain" }
+    });
+
+    expect(await extractUnsupportedParamFromResponse(response)).toEqual({
+      param: "max_tokens",
+      msg: "unrecognized argument max_tokens"
+    });
+  });
+});

--- a/tests/unit/unsupported-param-parser.test.js
+++ b/tests/unit/unsupported-param-parser.test.js
@@ -37,6 +37,30 @@ describe("unsupported parameter parser", () => {
     expect(parseErrorPayload("not-json")).toBeNull();
   });
 
+  it("ignores broad unsupported errors when no parameter name is present", () => {
+    expect(extractUnsupportedParamFromText(JSON.stringify({
+      error: {
+        message: "This model is not supported for max_tokens or output limits."
+      }
+    }))).toBeNull();
+
+    expect(extractUnsupportedParamFromText(
+      "Unsupported feature for this model. Try a different model."
+    )).toBeNull();
+  });
+
+  it("accepts recognized unsupported-param codes even without an extracted parameter", () => {
+    expect(extractUnsupportedParamFromText(JSON.stringify({
+      error: {
+        code: "unsupported_parameter",
+        message: "Unsupported parameter."
+      }
+    }))).toEqual({
+      param: undefined,
+      msg: "unsupported parameter."
+    });
+  });
+
   it("reads response text before applying the shared parser", async () => {
     const response = new Response("Unrecognized argument max_tokens", {
       status: 400,


### PR DESCRIPTION
## Summary

This PR replaces brittle model-name based parameter compatibility logic with a shared auto-learning fallback mechanism.

Instead of hardcoding provider/model regex rules such as `gpt-*` token renames or model-specific field stripping, the router now  learns unsupported-parameter fixes from upstream `400` responses, retries the request with a corrected body, and persists the learned fix per provider/model for future requests.

## Main Idea

Provider compatibility changes frequently, especially for GitHub Copilot and OpenAI-compatible upstreams. Hardcoded model regexes quickly become stale and require code changes for every new model variant.

This PR intentionally trades one bounded cold `400 + retry` for a learned, cached fix that works for newly-added models without shipping new model-specific rules.

It also makes future cleanup easier. If older models that still accept `max_tokens` eventually disappear and `max_completion_tokens` becomes the only supported token-limit field, the codebase will be easier to simplify because compatibility behavior is now centralized in shared helpers and the BaseExecutor fallback/cache path, instead of being spread across provider-specific model regex branches.

  ## What Changed

  - Added shared unsupported-parameter parsing for JSON and plain-text upstream errors.
  - Added BaseExecutor auto-fix learning for unsupported request params.
  - Cached learned fixes per `provider:model` and applied them before request transformation.
  - Kept caller request bodies immutable by applying fixes to a per-execution working copy.
  - Added bounded auto-fix retries to avoid unbounded retry loops.
  - Persisted learned fixes asynchronously with debounced, atomic writes.
  - Made cache writes safer across transient write failures and Windows replace behavior.
  - Added deterministic test hooks for flushing pending cache writes.
  - Standardized token-limit precedence: `max_completion_tokens` first, then `max_tokens`.
  - Normalized non-positive token limits so `0` does not get sent as a real limit.
  - Improved validation fallback behavior for providers returning plain-text or malformed content-types.
  - Ensured discarded retry responses are cancelled/drained before issuing the next request.
  - Documented why GitHub Copilot no longer uses proactive model-name regex fixes.

  ## Why This Helps

  - New provider/model incompatibilities can be handled without adding new model-name regexes.
  - Known fixes are persisted after the first successful learning retry.
  - Retry behavior is bounded, so bad upstream responses cannot create long auto-fix loops.
  - Request mutation side effects are avoided by using per-execution working copies.
  - The codebase becomes easier to migrate away from legacy fields like `max_tokens` in the future.

  ## Tests

  Added and updated unit coverage for:

  - unsupported-param parsing
  - plain-text error fallback learning
  - cached param fix application
  - immutable request body behavior
  - token-limit precedence and non-positive limits
  - bounded auto-fix retries
  - async/atomic param cache persistence
  - retry response body cleanup
  - forced-stream JSON fallback handling

<img width="1280" height="509" alt="image" src="https://github.com/user-attachments/assets/c6b88c04-905c-4413-9bb0-9af15d288907" />

<img width="1280" height="505" alt="image" src="https://github.com/user-attachments/assets/c33092f2-3932-4210-a8cc-0bcf2b44c09d" />

<img width="1280" height="534" alt="image" src="https://github.com/user-attachments/assets/35a2ee7b-166d-4d7f-8e53-428fbac9c194" />

