### PR TITLE
fix(providers): restore one-connection guard for compatible/embedding nodes

### DIFF
--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -122,10 +122,17 @@ export async function POST(request) {
 
     let providerSpecificData = normalizeProviderSpecificData(provider, body, body.providerSpecificData);
 
+    // Compatible/embedding nodes allow exactly one connection each. These guards were
+    // dropped accidentally during the bun:sqlite refactor (v0.4.28); restored to honor
+    // the contract locked in by tests/unit/compatible-provider-connections.test.js (#925).
     if (isOpenAICompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);
       if (!node) {
         return NextResponse.json({ error: "OpenAI Compatible node not found" }, { status: 404 });
+      }
+      const existingConnections = await getProviderConnections({ provider });
+      if (existingConnections.length > 0) {
+        return NextResponse.json({ error: "Only one connection is allowed for this OpenAI Compatible node" }, { status: 400 });
       }
       providerSpecificData = {
         prefix: node.prefix,
@@ -138,6 +145,10 @@ export async function POST(request) {
       if (!node) {
         return NextResponse.json({ error: "Anthropic Compatible node not found" }, { status: 404 });
       }
+      const existingConnections = await getProviderConnections({ provider });
+      if (existingConnections.length > 0) {
+        return NextResponse.json({ error: "Only one connection is allowed for this Anthropic Compatible node" }, { status: 400 });
+      }
       providerSpecificData = {
         prefix: node.prefix,
         baseUrl: node.baseUrl,
@@ -147,6 +158,10 @@ export async function POST(request) {
       const node = await getProviderNodeById(provider);
       if (!node) {
         return NextResponse.json({ error: "Custom Embedding node not found" }, { status: 404 });
+      }
+      const existingConnections = await getProviderConnections({ provider });
+      if (existingConnections.length > 0) {
+        return NextResponse.json({ error: "Only one connection is allowed for this Custom Embedding node" }, { status: 400 });
       }
       providerSpecificData = {
         prefix: node.prefix,


### PR DESCRIPTION
## Problem
OpenAI-Compatible, Anthropic-Compatible and Custom-Embedding nodes are meant to allow **exactly one connection each**. The guards enforcing this were dropped accidentally during the bun:sqlite refactor in **v0.4.28** (`530dc9c`) — its diff removed the three `existing connections` checks from the `POST` handler of `src/app/api/providers/route.js`.

As a result, duplicate `POST /api/providers` requests for the same compatible/embedding node are silently accepted with `201 Created` instead of being rejected with `400`.

## Fix
Restore the per-node existing-connection check in the `POST` handler for all three node types (returns `400 "Only one connection is allowed for this … node"`).

## Test reference
This is covered by the existing test **`tests/unit/compatible-provider-connections.test.js`** (added in #925), specifically the case *"returns 400 for a duplicate connection on the same compatible node"*. That test has been **failing on `master` since v0.4.28** (duplicate returns `201` instead of `400`) and passes again with this change. No test changes are included here — the contract was already specified; only the route regressed.

```
npx vitest run --config tests/vitest.config.js tests/unit/compatible-provider-connections.test.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)