### PR TITLE
fix(model-test): route image and STT probes to their real endpoints

### DIFF
--- a/open-sse/services/model.js
+++ b/open-sse/services/model.js
@@ -29,6 +29,8 @@ const ALIAS_TO_PROVIDER_ID = {
   kimi: "kimi",
   minimax: "minimax",
   "minimax-cn": "minimax-cn",
+  hf: "huggingface",
+  huggingface: "huggingface",
   ds: "deepseek",
   deepseek: "deepseek",
   cmc: "commandcode",

--- a/src/app/api/models/test/ping.js
+++ b/src/app/api/models/test/ping.js
@@ -1,0 +1,129 @@
+import { getApiKeys } from "@/lib/localDb";
+import { UPDATER_CONFIG } from "@/shared/constants/config";
+import { getConsistentMachineId } from "@/shared/utils/machineId";
+
+const CLI_TOKEN_SALT = "9r-cli-auth";
+
+async function getInternalHeaders() {
+  let apiKey = null;
+  try {
+    const keys = await getApiKeys();
+    apiKey = keys.find((k) => k.isActive !== false)?.key || null;
+  } catch {}
+
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+  headers["x-9r-cli-token"] = await getConsistentMachineId(CLI_TOKEN_SALT);
+  return headers;
+}
+
+export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:${process.env.PORT || UPDATER_CONFIG.appPort}`) {
+  const headers = await getInternalHeaders();
+  const start = Date.now();
+
+  if (kind === "embedding") {
+    const res = await fetch(`${baseUrl}/api/v1/embeddings`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ model, input: "test" }),
+      signal: AbortSignal.timeout(15000),
+    });
+    const latencyMs = Date.now() - start;
+    const rawText = await res.text().catch(() => "");
+    let parsed = null;
+    try { parsed = rawText ? JSON.parse(rawText) : null; } catch {}
+
+    if (!res.ok) {
+      const detail = parsed?.error?.message || parsed?.error || rawText;
+      return { ok: false, latencyMs, error: `HTTP ${res.status}${detail ? `: ${String(detail).slice(0, 240)}` : ""}`, status: res.status };
+    }
+    const hasEmbedding = Array.isArray(parsed?.data) && parsed.data.length > 0 && Array.isArray(parsed.data[0]?.embedding);
+    if (!hasEmbedding) {
+      return { ok: false, latencyMs, status: res.status, error: "Provider returned no embedding data" };
+    }
+    return { ok: true, latencyMs, error: null, status: res.status };
+  }
+
+  if (kind === "image") {
+    const res = await fetch(`${baseUrl}/api/v1/images/generations`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ model, prompt: "test" }),
+      signal: AbortSignal.timeout(15000),
+    });
+    const latencyMs = Date.now() - start;
+    const rawText = await res.text().catch(() => "");
+    let parsed = null;
+    try { parsed = rawText ? JSON.parse(rawText) : null; } catch {}
+
+    if (!res.ok) {
+      const detail = parsed?.error?.message || parsed?.msg || parsed?.message || parsed?.error || rawText;
+      return { ok: false, latencyMs, error: `HTTP ${res.status}${detail ? `: ${String(detail).slice(0, 240)}` : ""}`, status: res.status };
+    }
+
+    const hasImages = Array.isArray(parsed?.data) && parsed.data.length > 0;
+    if (!hasImages) {
+      return { ok: false, latencyMs, status: res.status, error: "Provider returned no image data for this model" };
+    }
+    return { ok: true, latencyMs, error: null, status: res.status };
+  }
+
+  const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      max_tokens: 1,
+      stream: false,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+    signal: AbortSignal.timeout(15000),
+  });
+  const latencyMs = Date.now() - start;
+
+  const rawText = await res.text().catch(() => "");
+  let parsed = null;
+  try { parsed = rawText ? JSON.parse(rawText) : null; } catch {}
+
+  if (!res.ok) {
+    const detail = parsed?.error?.message || parsed?.msg || parsed?.message || parsed?.error || rawText;
+    return { ok: false, latencyMs, error: `HTTP ${res.status}${detail ? `: ${String(detail).slice(0, 240)}` : ""}`, status: res.status };
+  }
+
+  const providerStatus = parsed?.status;
+  const providerMsg = parsed?.msg || parsed?.message;
+  const hasProviderErrorStatus = providerStatus !== undefined
+    && providerStatus !== null
+    && String(providerStatus) !== "200"
+    && String(providerStatus) !== "0";
+  if (hasProviderErrorStatus && providerMsg) {
+    return {
+      ok: false,
+      latencyMs,
+      status: res.status,
+      error: `Provider status ${providerStatus}: ${String(providerMsg).slice(0, 240)}`,
+    };
+  }
+
+  if (parsed?.error) {
+    const providerError = parsed?.error?.message || parsed?.error || "Provider returned an error";
+    return {
+      ok: false,
+      latencyMs,
+      status: res.status,
+      error: String(providerError).slice(0, 240),
+    };
+  }
+
+  const hasChoices = Array.isArray(parsed?.choices) && parsed.choices.length > 0;
+  if (!hasChoices) {
+    return {
+      ok: false,
+      latencyMs,
+      status: res.status,
+      error: "Provider returned no completion choices for this model",
+    };
+  }
+
+  return { ok: true, latencyMs, error: null, status: res.status };
+}

--- a/src/app/api/models/test/ping.js
+++ b/src/app/api/models/test/ping.js
@@ -34,7 +34,7 @@ function createSilentWavFile() {
   writeAscii(36, "data");
   view.setUint32(40, dataSize, true);
 
-  return new File([buffer], "test.wav", { type: "audio/wav" });
+  return new Blob([buffer], { type: "audio/wav" });
 }
 
 async function getInternalHeaders() {
@@ -104,7 +104,7 @@ export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:$
   if (kind === "stt") {
     const form = new FormData();
     const sampleAudio = createSilentWavFile();
-    form.append("file", sampleAudio);
+    form.append("file", sampleAudio, "test.wav");
     form.append("model", model);
 
     const res = await fetch(`${baseUrl}/api/v1/audio/transcriptions`, {

--- a/src/app/api/models/test/ping.js
+++ b/src/app/api/models/test/ping.js
@@ -68,6 +68,35 @@ export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:$
     return { ok: true, latencyMs, error: null, status: res.status };
   }
 
+  if (kind === "stt") {
+    const form = new FormData();
+    const sampleAudio = new File([new Uint8Array([82, 73, 70, 70, 36, 0, 0, 0, 87, 65, 86, 69, 102, 109, 116, 32, 16, 0, 0, 0, 1, 0, 1, 0, 64, 31, 0, 0, 128, 62, 0, 0, 2, 0, 16, 0, 100, 97, 116, 97, 0, 0, 0, 0])], "test.wav", { type: "audio/wav" });
+    form.append("file", sampleAudio);
+    form.append("model", model);
+
+    const res = await fetch(`${baseUrl}/api/v1/audio/transcriptions`, {
+      method: "POST",
+      headers: Object.fromEntries(Object.entries(headers).filter(([key]) => key.toLowerCase() !== "content-type")),
+      body: form,
+      signal: AbortSignal.timeout(15000),
+    });
+    const latencyMs = Date.now() - start;
+    const rawText = await res.text().catch(() => "");
+    let parsed = null;
+    try { parsed = rawText ? JSON.parse(rawText) : null; } catch {}
+
+    if (!res.ok) {
+      const detail = parsed?.error?.message || parsed?.msg || parsed?.message || parsed?.error || rawText;
+      return { ok: false, latencyMs, error: `HTTP ${res.status}${detail ? `: ${String(detail).slice(0, 240)}` : ""}`, status: res.status };
+    }
+
+    const text = typeof parsed?.text === "string" ? parsed.text : "";
+    if (!text.trim()) {
+      return { ok: false, latencyMs, status: res.status, error: "Provider returned no transcription text for this model" };
+    }
+    return { ok: true, latencyMs, error: null, status: res.status };
+  }
+
   const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
     method: "POST",
     headers,

--- a/src/app/api/models/test/ping.js
+++ b/src/app/api/models/test/ping.js
@@ -4,6 +4,39 @@ import { getConsistentMachineId } from "@/shared/utils/machineId";
 
 const CLI_TOKEN_SALT = "9r-cli-auth";
 
+function createSilentWavFile() {
+  const sampleRate = 16000;
+  const channels = 1;
+  const bitsPerSample = 16;
+  const durationMs = 250;
+  const sampleCount = Math.max(1, Math.floor((sampleRate * durationMs) / 1000));
+  const dataSize = sampleCount * channels * (bitsPerSample / 8);
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  const writeAscii = (offset, value) => {
+    for (let i = 0; i < value.length; i += 1) {
+      view.setUint8(offset + i, value.charCodeAt(i));
+    }
+  };
+
+  writeAscii(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(8, "WAVE");
+  writeAscii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * channels * (bitsPerSample / 8), true);
+  view.setUint16(32, channels * (bitsPerSample / 8), true);
+  view.setUint16(34, bitsPerSample, true);
+  writeAscii(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  return new File([buffer], "test.wav", { type: "audio/wav" });
+}
+
 async function getInternalHeaders() {
   let apiKey = null;
   try {
@@ -70,7 +103,7 @@ export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:$
 
   if (kind === "stt") {
     const form = new FormData();
-    const sampleAudio = new File([new Uint8Array([82, 73, 70, 70, 36, 0, 0, 0, 87, 65, 86, 69, 102, 109, 116, 32, 16, 0, 0, 0, 1, 0, 1, 0, 64, 31, 0, 0, 128, 62, 0, 0, 2, 0, 16, 0, 100, 97, 116, 97, 0, 0, 0, 0])], "test.wav", { type: "audio/wav" });
+    const sampleAudio = createSilentWavFile();
     form.append("file", sampleAudio);
     form.append("model", model);
 

--- a/src/app/api/models/test/route.js
+++ b/src/app/api/models/test/route.js
@@ -1,119 +1,13 @@
 import { NextResponse } from "next/server";
-import { getApiKeys } from "@/lib/localDb";
-import { UPDATER_CONFIG } from "@/shared/constants/config";
-import { getConsistentMachineId } from "@/shared/utils/machineId";
-
-const CLI_TOKEN_SALT = "9r-cli-auth";
+import { pingModelByKind } from "./ping";
 
 // POST /api/models/test - Ping a single model via internal completions or embeddings
 export async function POST(request) {
   try {
     const { model, kind } = await request.json();
     if (!model) return NextResponse.json({ error: "Model required" }, { status: 400 });
-
-    const baseUrl = `http://127.0.0.1:${process.env.PORT || UPDATER_CONFIG.appPort}`;
-
-    // Get an active internal API key for auth (if requireApiKey is enabled)
-    let apiKey = null;
-    try {
-      const keys = await getApiKeys();
-      apiKey = keys.find((k) => k.isActive !== false)?.key || null;
-    } catch {}
-
-    const headers = { "Content-Type": "application/json" };
-    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-    // Bypass dashboardGuard for internal self-call via CLI token (machineId-based)
-    headers["x-9r-cli-token"] = await getConsistentMachineId(CLI_TOKEN_SALT);
-
-    const start = Date.now();
-
-    // Route to appropriate endpoint based on kind
-    if (kind === "embedding") {
-      const res = await fetch(`${baseUrl}/api/v1/embeddings`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ model, input: "test" }),
-        signal: AbortSignal.timeout(15000),
-      });
-      const latencyMs = Date.now() - start;
-      const rawText = await res.text().catch(() => "");
-      let parsed = null;
-      try { parsed = rawText ? JSON.parse(rawText) : null; } catch {}
-
-      if (!res.ok) {
-        const detail = parsed?.error?.message || parsed?.error || rawText;
-        return NextResponse.json({ ok: false, latencyMs, error: `HTTP ${res.status}${detail ? `: ${String(detail).slice(0, 240)}` : ""}`, status: res.status });
-      }
-      const hasEmbedding = Array.isArray(parsed?.data) && parsed.data.length > 0 && Array.isArray(parsed.data[0]?.embedding);
-      if (!hasEmbedding) {
-        return NextResponse.json({ ok: false, latencyMs, status: res.status, error: "Provider returned no embedding data" });
-      }
-      return NextResponse.json({ ok: true, latencyMs, error: null, status: res.status });
-    }
-
-    // Default: chat completions
-    const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        model,
-        max_tokens: 1,
-        stream: false,
-        messages: [{ role: "user", content: "hi" }],
-      }),
-      signal: AbortSignal.timeout(15000),
-    });
-    const latencyMs = Date.now() - start;
-
-    const rawText = await res.text().catch(() => "");
-    let parsed = null;
-    try {
-      parsed = rawText ? JSON.parse(rawText) : null;
-    } catch {}
-
-    if (!res.ok) {
-      const detail = parsed?.error?.message || parsed?.msg || parsed?.message || parsed?.error || rawText;
-      const error = `HTTP ${res.status}${detail ? `: ${String(detail).slice(0, 240)}` : ""}`;
-      return NextResponse.json({ ok: false, latencyMs, error, status: res.status });
-    }
-
-    // Some providers may return HTTP 200 but not a real completion for invalid models.
-    const providerStatus = parsed?.status;
-    const providerMsg = parsed?.msg || parsed?.message;
-    const hasProviderErrorStatus = providerStatus !== undefined
-      && providerStatus !== null
-      && String(providerStatus) !== "200"
-      && String(providerStatus) !== "0";
-    if (hasProviderErrorStatus && providerMsg) {
-      return NextResponse.json({
-        ok: false,
-        latencyMs,
-        status: res.status,
-        error: `Provider status ${providerStatus}: ${String(providerMsg).slice(0, 240)}`,
-      });
-    }
-
-    if (parsed?.error) {
-      const providerError = parsed?.error?.message || parsed?.error || "Provider returned an error";
-      return NextResponse.json({
-        ok: false,
-        latencyMs,
-        status: res.status,
-        error: String(providerError).slice(0, 240),
-      });
-    }
-
-    const hasChoices = Array.isArray(parsed?.choices) && parsed.choices.length > 0;
-    if (!hasChoices) {
-      return NextResponse.json({
-        ok: false,
-        latencyMs,
-        status: res.status,
-        error: "Provider returned no completion choices for this model",
-      });
-    }
-
-    return NextResponse.json({ ok: true, latencyMs, error: null, status: res.status });
+    const result = await pingModelByKind(model, kind || "llm");
+    return NextResponse.json(result);
   } catch (err) {
     return NextResponse.json({ ok: false, error: err.message }, { status: 500 });
   }

--- a/src/app/api/providers/[id]/test-models/route.js
+++ b/src/app/api/providers/[id]/test-models/route.js
@@ -1,59 +1,14 @@
 import { NextResponse } from "next/server";
-import { getProviderConnectionById, getApiKeys } from "@/lib/localDb";
+import { getProviderConnectionById } from "@/lib/localDb";
 import { getProviderModels, PROVIDER_ID_TO_ALIAS } from "open-sse/config/providerModels.js";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
-import { getConsistentMachineId } from "@/shared/utils/machineId";
-
-const CLI_TOKEN_SALT = "9r-cli-auth";
-
-/**
- * Get an active API key to pass through auth when requireApiKey is enabled.
- */
-async function getInternalApiKey() {
-  const keys = await getApiKeys();
-  return keys.find((k) => k.isActive !== false)?.key || null;
-}
-
-/**
- * Ping a single model via internal completions endpoint (OpenAI format).
- * open-sse handles all provider translation automatically.
- */
-async function pingModel(modelId, baseUrl, apiKey, cliToken) {
-  const start = Date.now();
-  try {
-    const headers = { "Content-Type": "application/json" };
-    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-    if (cliToken) headers["x-9r-cli-token"] = cliToken;
-    const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        model: modelId,
-        max_tokens: 1,
-        stream: false,
-        messages: [{ role: "user", content: "hi" }],
-      }),
-      signal: AbortSignal.timeout(15000),
-    });
-    const latencyMs = Date.now() - start;
-    // 200 = working; 400 = bad request but auth passed (model reachable)
-    const ok = res.status === 200 || res.status === 400;
-    let error = null;
-    if (!ok) {
-      const text = await res.text().catch(() => "");
-      error = `HTTP ${res.status}${text ? `: ${text.slice(0, 120)}` : ""}`;
-    }
-    return { ok, latencyMs, error };
-  } catch (err) {
-    return { ok: false, latencyMs: Date.now() - start, error: err.message };
-  }
-}
+import { pingModelByKind } from "@/app/api/models/test/ping";
 
 /**
  * POST /api/providers/[id]/test-models
  * id = connectionId — used only to resolve provider + model list.
- * Actual requests go through /api/v1/chat/completions (open-sse handles everything).
+ * Actual requests go through the internal endpoint that matches each model kind.
  */
 export async function POST(request, { params }) {
   try {
@@ -86,20 +41,17 @@ export async function POST(request, { params }) {
       return NextResponse.json({ error: "No models configured for this provider" }, { status: 400 });
     }
 
-    const apiKey = await getInternalApiKey();
-    // Bypass dashboardGuard for internal self-call via CLI token (machineId-based)
-    const cliToken = await getConsistentMachineId(CLI_TOKEN_SALT);
-
     // Warm up with first model to trigger token refresh (if needed) before parallel calls.
     // This prevents race condition where multiple requests concurrently refresh the same token.
     const [first, ...rest] = models;
-    const firstResult = await pingModel(`${alias}/${first.id}`, baseUrl, apiKey, cliToken);
+    const firstKind = first.type || "llm";
+    const firstResult = await pingModelByKind(`${alias}/${first.id}`, firstKind, baseUrl);
     const results = [{ modelId: first.id, name: first.name || first.id, ...firstResult }];
 
     if (rest.length > 0) {
       const restResults = await Promise.all(
         rest.map(async (model) => {
-          const result = await pingModel(`${alias}/${model.id}`, baseUrl, apiKey, cliToken);
+          const result = await pingModelByKind(`${alias}/${model.id}`, model.type || "llm", baseUrl);
           return { modelId: model.id, name: model.name || model.id, ...result };
         })
       );

--- a/tests/unit/hf-model-routing.test.js
+++ b/tests/unit/hf-model-routing.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { parseModel } from "../../open-sse/services/model.js";
+
+describe("HuggingFace model alias parsing", () => {
+  it("resolves hf alias to huggingface provider", () => {
+    expect(parseModel("hf/black-forest-labs/FLUX.1-schnell")).toMatchObject({
+      provider: "huggingface",
+      model: "black-forest-labs/FLUX.1-schnell",
+      providerAlias: "hf",
+    });
+  });
+});

--- a/tests/unit/model-test-routing.test.js
+++ b/tests/unit/model-test-routing.test.js
@@ -71,4 +71,36 @@ describe("model test route kind routing", () => {
       })
     );
   });
+
+  it("routes stt model tests to /api/v1/audio/transcriptions", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      text: "test",
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { POST } = await import("../../src/app/api/models/test/route.js");
+
+    const req = new Request("http://localhost/api/models/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "hf/openai/whisper-small",
+        kind: "stt",
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/audio/transcriptions"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(FormData),
+      })
+    );
+  });
 });

--- a/tests/unit/model-test-routing.test.js
+++ b/tests/unit/model-test-routing.test.js
@@ -72,6 +72,67 @@ describe("model test route kind routing", () => {
     );
   });
 
+  it("routes embedding model tests to /api/v1/embeddings", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: [{ embedding: [0.1, 0.2] }],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { POST } = await import("../../src/app/api/models/test/route.js");
+
+    const req = new Request("http://localhost/api/models/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "voyage/voyage-3-large",
+        kind: "embedding",
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/embeddings"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          model: "voyage/voyage-3-large",
+          input: "test",
+        }),
+      })
+    );
+  });
+
+  it("fails embedding model tests when provider returns no embedding data", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: [{ embedding: null }],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { POST } = await import("../../src/app/api/models/test/route.js");
+
+    const req = new Request("http://localhost/api/models/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "voyage/voyage-3-large",
+        kind: "embedding",
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("Provider returned no embedding data");
+  });
+
   it("routes stt model tests to /api/v1/audio/transcriptions", async () => {
     global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       text: "test",
@@ -102,5 +163,32 @@ describe("model test route kind routing", () => {
         body: expect.any(FormData),
       })
     );
+  });
+
+  it("returns formatted HTTP errors for non-2xx embedding responses", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: { message: "bad upstream" },
+    }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { POST } = await import("../../src/app/api/models/test/route.js");
+
+    const req = new Request("http://localhost/api/models/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "voyage/voyage-3-large",
+        kind: "embedding",
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(body.ok).toBe(false);
+    expect(body.status).toBe(502);
+    expect(body.error).toBe("HTTP 502: bad upstream");
   });
 });

--- a/tests/unit/model-test-routing.test.js
+++ b/tests/unit/model-test-routing.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getApiKeys: vi.fn(),
+  getConsistentMachineId: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getApiKeys: mocks.getApiKeys,
+}));
+
+vi.mock("@/shared/utils/machineId", () => ({
+  getConsistentMachineId: mocks.getConsistentMachineId,
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json(body, init = {}) {
+      return new Response(JSON.stringify(body), {
+        status: init.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  },
+}));
+
+const originalFetch = global.fetch;
+
+describe("model test route kind routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getApiKeys.mockResolvedValue([{ key: "sk-internal", isActive: true }]);
+    mocks.getConsistentMachineId.mockResolvedValue("cli-token");
+    global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      created: 1,
+      data: [{ b64_json: "abc" }],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("routes image model tests to /api/v1/images/generations", async () => {
+    const { POST } = await import("../../src/app/api/models/test/route.js");
+
+    const req = new Request("http://localhost/api/models/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "hf/black-forest-labs/FLUX.1-schnell",
+        kind: "image",
+      }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/images/generations"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          model: "hf/black-forest-labs/FLUX.1-schnell",
+          prompt: "test",
+        }),
+      })
+    );
+  });
+});

--- a/tests/unit/provider-test-models-routing.test.js
+++ b/tests/unit/provider-test-models-routing.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnectionById: vi.fn(),
+  getApiKeys: vi.fn(),
+  getConsistentMachineId: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnectionById: mocks.getProviderConnectionById,
+  getApiKeys: mocks.getApiKeys,
+}));
+
+vi.mock("@/shared/utils/machineId", () => ({
+  getConsistentMachineId: mocks.getConsistentMachineId,
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json(body, init = {}) {
+      return new Response(JSON.stringify(body), {
+        status: init.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  },
+}));
+
+const originalFetch = global.fetch;
+
+describe("provider test-models route kind routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderConnectionById.mockResolvedValue({
+      id: "conn-hf",
+      provider: "huggingface",
+    });
+    mocks.getApiKeys.mockResolvedValue([{ key: "sk-internal", isActive: true }]);
+    mocks.getConsistentMachineId.mockResolvedValue("cli-token");
+    global.fetch = vi.fn((url) => {
+      if (String(url).includes("/api/v1/images/generations")) {
+        return Promise.resolve(new Response(JSON.stringify({
+          created: 1,
+          data: [{ b64_json: "abc" }],
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({
+        choices: [{ message: { role: "assistant", content: "ok" } }],
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("routes huggingface image models to /api/v1/images/generations", async () => {
+    const { POST } = await import("../../src/app/api/providers/[id]/test-models/route.js");
+
+    const req = new Request("http://localhost/api/providers/conn-hf/test-models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: "conn-hf" }) });
+    const body = await res.json();
+
+    expect(body.provider).toBe("huggingface");
+    expect(body.results.some((r) => r.modelId === "black-forest-labs/FLUX.1-schnell" && r.ok)).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/images/generations"),
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- route image model tests to `/api/v1/images/generations` instead of `/api/v1/chat/completions`
- route STT model tests to `/api/v1/audio/transcriptions`
- reuse the same kind-aware ping logic in `/api/providers/[id]/test-models`
- add server-side `hf -> huggingface` alias handling for the internal test path
- use a valid silent WAV sample for STT reachability checks

## Why
The dashboard model test path currently treats non-embedding models as chat models.
For media providers this can produce false failures:
- HuggingFace image models can be sent to the OpenAI chat executor and return `Incorrect API key provided`
- HuggingFace STT models can be sent to chat instead of transcription endpoints
- STT probes can also fail on malformed sample audio even when the routing is correct

This PR keeps the change scoped to dashboard/internal model testing. It does not change runtime inference routing.

## Validation
- `node --check src/app/api/models/test/ping.js`
- `node --check src/app/api/models/test/route.js`
- `node --check src/app/api/providers/[id]/test-models/route.js`
- `git diff --check`
- Targeted tests passed:
  - `./node_modules/.bin/vitest run --reporter=verbose unit/hf-model-routing.test.js unit/model-test-routing.test.js unit/provider-test-models-routing.test.js`

<img width="1309" height="646" alt="image" src="https://github.com/user-attachments/assets/9964972a-dceb-47bf-a2d5-0d8f6baa1fc4" />
<img width="1309" height="709" alt="image" src="https://github.com/user-attachments/assets/3e3676b2-8b1d-4e92-9c5a-7e6f75012d68" />
