### PR TITLE
feat(config): make upstream timeouts configurable via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ CLOUD_URL=https://9router.com
 NEXT_PUBLIC_BASE_URL=http://localhost:20128
 NEXT_PUBLIC_CLOUD_URL=https://9router.com
 
+# Optional upstream timeout tuning (milliseconds)
+# Raise these for slow or long-thinking providers that exceed the defaults.
+# STREAM_STALL_TIMEOUT_MS=30000
+# FETCH_CONNECT_TIMEOUT_MS=20000
+
 # Optional outbound proxy variables for upstream provider calls
 # Lowercase variants are also supported: http_proxy, https_proxy, all_proxy, no_proxy
 # HTTP_PROXY=http://127.0.0.1:7890

--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,8 @@ docker pull decolua/9router:latest   # update to latest
 | `AUTH_COOKIE_SECURE` | `false` | Force `Secure` auth cookie (set `true` behind HTTPS reverse proxy) |
 | `REQUIRE_API_KEY` | `false` | Enforce Bearer API key on `/v1/*` routes (recommended for internet-exposed deploys) |
 | `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY` | empty | Optional outbound proxy for upstream provider calls |
+| `STREAM_STALL_TIMEOUT_MS` | `30000` | Abort an upstream stream if no chunk is received within this many milliseconds (raise for slow/long-thinking providers) |
+| `FETCH_CONNECT_TIMEOUT_MS` | `20000` | Abort an upstream request if it does not return response headers within this many milliseconds |
 
 Notes:
 - Lowercase proxy variables are also supported: `http_proxy`, `https_proxy`, `all_proxy`, `no_proxy`.

--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -31,11 +31,13 @@ export const MEMORY_CONFIG = {
   proxyDispatchersMaxSize: 20,
 };
 
-// Stream stall timeout: abort if no chunk received within this duration
-export const STREAM_STALL_TIMEOUT_MS = 30 * 1000;
+// Stream stall timeout: abort if no chunk received within this duration.
+// Override via STREAM_STALL_TIMEOUT_MS env var (milliseconds).
+export const STREAM_STALL_TIMEOUT_MS = parseInt(process.env.STREAM_STALL_TIMEOUT_MS || "30000", 10);
 
-// Fetch connect timeout: abort if upstream doesn't return response headers within this duration
-export const FETCH_CONNECT_TIMEOUT_MS = 20 * 1000;
+// Fetch connect timeout: abort if upstream doesn't return response headers within this duration.
+// Override via FETCH_CONNECT_TIMEOUT_MS env var (milliseconds).
+export const FETCH_CONNECT_TIMEOUT_MS = parseInt(process.env.FETCH_CONNECT_TIMEOUT_MS || "20000", 10);
 
 // Default token limits
 export const DEFAULT_MAX_TOKENS = 64000;

--- a/tests/unit/runtime-timeout-env.test.js
+++ b/tests/unit/runtime-timeout-env.test.js
@@ -1,0 +1,33 @@
+// Tests for configurable upstream timeouts via env vars
+// Covers STREAM_STALL_TIMEOUT_MS and FETCH_CONNECT_TIMEOUT_MS in runtimeConfig.js
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const CONFIG_PATH = "../../open-sse/config/runtimeConfig.js";
+
+describe("runtimeConfig upstream timeout env overrides", () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.STREAM_STALL_TIMEOUT_MS;
+    delete process.env.FETCH_CONNECT_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it("falls back to defaults when env vars are unset", async () => {
+    const cfg = await import(CONFIG_PATH);
+    expect(cfg.STREAM_STALL_TIMEOUT_MS).toBe(30000);
+    expect(cfg.FETCH_CONNECT_TIMEOUT_MS).toBe(20000);
+  });
+
+  it("reads overrides from env vars", async () => {
+    process.env.STREAM_STALL_TIMEOUT_MS = "120000";
+    process.env.FETCH_CONNECT_TIMEOUT_MS = "60000";
+    const cfg = await import(CONFIG_PATH);
+    expect(cfg.STREAM_STALL_TIMEOUT_MS).toBe(120000);
+    expect(cfg.FETCH_CONNECT_TIMEOUT_MS).toBe(60000);
+  });
+});


### PR DESCRIPTION
## Problem

`STREAM_STALL_TIMEOUT_MS` (30s) and `FETCH_CONNECT_TIMEOUT_MS` (20s) in `open-sse/config/runtimeConfig.js` are hardcoded. Slow or long-thinking upstream providers can exceed these, which surfaces as:

```
[RETRY] network "fetch connect timeout" retry 1/3 after 3s
[ERROR] [502]: fetch connect timeout
```

and as prematurely aborted streams on long reasoning/agentic responses. There is currently no way to tune these without rebuilding the image.

## Fix

Read both values from environment variables, keeping the existing values as defaults so behavior is unchanged when the vars are unset:

```js
export const STREAM_STALL_TIMEOUT_MS = parseInt(process.env.STREAM_STALL_TIMEOUT_MS || "30000", 10);
export const FETCH_CONNECT_TIMEOUT_MS = parseInt(process.env.FETCH_CONNECT_TIMEOUT_MS || "20000", 10);
```

This matches the existing `parseInt(process.env.X || "default", 10)` convention already used elsewhere (e.g. `src/lib/updater/updater.js`).

Also documents both vars in `README.md` (Environment Variables table) and `.env.example`.

## Tests

Adds `tests/unit/runtime-timeout-env.test.js` (vitest):
- falls back to `30000` / `20000` when the env vars are unset
- reads overrides from the env vars

Both pass locally.