### PR TITLE
Make proxy client body limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ DATA_DIR=/var/lib/9router
 # Recommended runtime variables
 PORT=20128
 NODE_ENV=production
+NEXT_PROXY_CLIENT_MAX_BODY_SIZE=268435456
 
 # Recommended security and ops variables
 API_KEY_SECRET=endpoint-proxy-api-key-secret

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -59,6 +59,7 @@ docker run -d \
   -e DATA_DIR=/app/data \
   -e PORT=20128 \
   -e HOSTNAME=0.0.0.0 \
+  -e NEXT_PROXY_CLIENT_MAX_BODY_SIZE=268435456 \
   -e DEBUG=true \
   --name 9router \
   decolua/9router:latest

--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,7 @@ docker pull decolua/9router:latest   # update to latest
 | `PORT` | framework default | Service port (`20128` in examples) |
 | `HOSTNAME` | framework default | Bind host (Docker defaults to `0.0.0.0`) |
 | `NODE_ENV` | runtime default | Set `production` for deploy |
+| `NEXT_PROXY_CLIENT_MAX_BODY_SIZE` | `268435456` | Max proxied request body size for `/v1/*` routes. Accepts bytes or Next.js size strings like `50mb` |
 | `BASE_URL` | `http://localhost:20128` | Server-side internal base URL used by cloud sync jobs |
 | `CLOUD_URL` | `https://9router.com` | Server-side cloud sync endpoint base URL |
 | `NEXT_PUBLIC_BASE_URL` | `http://localhost:3000` | Backward-compatible/public base URL (prefer `BASE_URL` for server runtime) |

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,19 @@ const tracingRoot = process.env.NEXT_TRACING_ROOT_MODE === "workspace"
   ? join(projectRoot, "..")
   : projectRoot;
 
+export const DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE = 256 * 1024 * 1024;
+
+export function resolveProxyClientMaxBodySize(value = process.env.NEXT_PROXY_CLIENT_MAX_BODY_SIZE) {
+  const raw = value == null ? "" : String(value).trim();
+  if (!raw) return DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE;
+
+  const numericValue = Number(raw);
+  if (Number.isFinite(numericValue) && numericValue > 0) return numericValue;
+
+  // Next.js accepts strings like "50mb" and validates them during startup.
+  return raw;
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   distDir: process.env.NEXT_DIST_DIR || ".next",
@@ -24,6 +37,9 @@ const nextConfig = {
     unoptimized: true
   },
   env: {},
+  experimental: {
+    proxyClientMaxBodySize: resolveProxyClientMaxBodySize()
+  },
   webpack: (config, { isServer }) => {
     // Ignore fs/path modules in browser bundle
     if (!isServer) {

--- a/tests/unit/proxy-body-limit.test.js
+++ b/tests/unit/proxy-body-limit.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE,
+  resolveProxyClientMaxBodySize,
+} from "../../next.config.mjs";
+
+describe("Next proxy client body size", () => {
+  it("defaults to 256 MB so Codex screenshot-heavy requests do not fail at 10 MB", () => {
+    expect(DEFAULT_PROXY_CLIENT_MAX_BODY_SIZE).toBe(256 * 1024 * 1024);
+    expect(resolveProxyClientMaxBodySize()).toBe(256 * 1024 * 1024);
+  });
+
+  it("accepts numeric byte overrides from NEXT_PROXY_CLIENT_MAX_BODY_SIZE", () => {
+    expect(resolveProxyClientMaxBodySize("52428800")).toBe(52428800);
+  });
+
+  it("passes Next.js size strings through for built-in validation", () => {
+    expect(resolveProxyClientMaxBodySize("50mb")).toBe("50mb");
+  });
+});


### PR DESCRIPTION
## Summary

- Raise the default Next proxy client body limit to 256 MB.
- Add NEXT_PROXY_CLIENT_MAX_BODY_SIZE so deployments can override the limit with bytes or Next.js size strings.
- Document the setting in the environment template, README, and Docker docs.

## Why

Screenshot-heavy Codex Responses requests can include inline base64 image data and exceed Next.js's default 10 MB proxy client body limit. When that happens, 9Router can reject the request body before the route handler reaches provider routing.

## Validation

- NODE_PATH=../node_modules:./node_modules ./node_modules/.bin/vitest run --reporter=verbose unit/proxy-body-limit.test.js unit/codex-image-fetch.test.js
- npm run build

## Notes

The full unit suite was also attempted from tests/ with the same local dependency path. It currently has unrelated failures in existing suites for missing optional test fixtures and assertions outside this change area.