### PR TITLE
feat(config): make stream and fetch timeouts configurable via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,13 @@ DATA_DIR=/var/lib/9router
 PORT=20128
 NODE_ENV=production
 
+# Stream & fetch timeouts (milliseconds). Override to accommodate slow
+# upstreams or deep-reasoning models. Both default to safe values that
+# match the original hardcoded constants; raise them only if you see
+# "stream stall timeout" errors in the logs.
+# NINE_ROUTER_STREAM_STALL_TIMEOUT_MS=30000
+# NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS=20000
+
 # Recommended security and ops variables
 API_KEY_SECRET=endpoint-proxy-api-key-secret
 MACHINE_ID_SALT=endpoint-proxy-salt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Features
+- Make `STREAM_STALL_TIMEOUT_MS` and `FETCH_CONNECT_TIMEOUT_MS` configurable via `NINE_ROUTER_STREAM_STALL_TIMEOUT_MS` and `NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS` environment variables. Backward compatible — defaults unchanged.
+
 # v0.4.66 (2026-05-29)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-### Features
+## Features
 - Make `STREAM_STALL_TIMEOUT_MS` and `FETCH_CONNECT_TIMEOUT_MS` configurable via `NINE_ROUTER_STREAM_STALL_TIMEOUT_MS` and `NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS` environment variables. Backward compatible — defaults unchanged.
 
 # v0.4.66 (2026-05-29)

--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,8 @@ docker pull decolua/9router:latest   # update to latest
 | `ENABLE_REQUEST_LOGS` | `false` | Enables request/response logs under `logs/` |
 | `AUTH_COOKIE_SECURE` | `false` | Force `Secure` auth cookie (set `true` behind HTTPS reverse proxy) |
 | `REQUIRE_API_KEY` | `false` | Enforce Bearer API key on `/v1/*` routes (recommended for internet-exposed deploys) |
+| `NINE_ROUTER_STREAM_STALL_TIMEOUT_MS` | `30000` | Stream stall abort timeout in ms. Raise for slow reasoning models (Xiaomi mimo, zai/glm, etc.). |
+| `NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS` | `20000` | Upstream fetch connect timeout in ms. Raise if specific providers hang on connect. |
 | `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY` | empty | Optional outbound proxy for upstream provider calls |
 
 Notes:

--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -1,3 +1,20 @@
+// Read a timeout (in milliseconds) from an env var, falling back to a default.
+// Logs a warning and falls back if the value is not a positive integer.
+// Reading happens once at module load — set the env var before importing.
+function _parseTimeoutMs(envName, defaultMs) {
+  const raw = process.env[envName];
+  if (raw == null || raw === "") return defaultMs;
+  const trimmed = raw.trim();
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || String(parsed) !== trimmed) {
+    console.warn(
+      `[runtimeConfig] Invalid ${envName}=${JSON.stringify(raw)}; using default ${defaultMs}ms. Expected positive integer in milliseconds.`
+    );
+    return defaultMs;
+  }
+  return parsed;
+}
+
 // HTTP status codes
 export const HTTP_STATUS = {
   BAD_REQUEST: 400,
@@ -31,11 +48,22 @@ export const MEMORY_CONFIG = {
   proxyDispatchersMaxSize: 20,
 };
 
-// Stream stall timeout: abort if no chunk received within this duration
-export const STREAM_STALL_TIMEOUT_MS = 30 * 1000;
+// Stream stall timeout: abort if no chunk received within this duration.
+// Override at runtime via env var NINE_ROUTER_STREAM_STALL_TIMEOUT_MS (milliseconds).
+const _stallTimeoutMs = _parseTimeoutMs(
+  "NINE_ROUTER_STREAM_STALL_TIMEOUT_MS",
+  30 * 1000
+);
+export const STREAM_STALL_TIMEOUT_MS = _stallTimeoutMs;
 
-// Fetch connect timeout: abort if upstream doesn't return response headers within this duration
-export const FETCH_CONNECT_TIMEOUT_MS = 20 * 1000;
+// Fetch connect timeout: abort if upstream doesn't return response headers
+// within this duration. Override at runtime via env var
+// NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS (milliseconds).
+const _fetchConnectTimeoutMs = _parseTimeoutMs(
+  "NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS",
+  20 * 1000
+);
+export const FETCH_CONNECT_TIMEOUT_MS = _fetchConnectTimeoutMs;
 
 // Default token limits
 export const DEFAULT_MAX_TOKENS = 64000;

--- a/tests/unit/runtimeConfig.test.js
+++ b/tests/unit/runtimeConfig.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const STALL_ENV = "NINE_ROUTER_STREAM_STALL_TIMEOUT_MS";
+const FETCH_ENV = "NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS";
+
+const importFresh = async () => {
+  vi.resetModules();
+  return import("../../open-sse/config/runtimeConfig.js");
+};
+
+describe("runtimeConfig env overrides", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("uses the env value when NINE_ROUTER_STREAM_STALL_TIMEOUT_MS is set", async () => {
+    vi.stubEnv(STALL_ENV, "60000");
+    const mod = await importFresh();
+    expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(60000);
+  });
+});

--- a/tests/unit/runtimeConfig.test.js
+++ b/tests/unit/runtimeConfig.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
 const STALL_ENV = "NINE_ROUTER_STREAM_STALL_TIMEOUT_MS";
 const FETCH_ENV = "NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS";
@@ -9,7 +9,14 @@ const importFresh = async () => {
 };
 
 describe("runtimeConfig env overrides", () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
   afterEach(() => {
+    warnSpy.mockRestore();
     vi.unstubAllEnvs();
     vi.resetModules();
   });
@@ -18,5 +25,69 @@ describe("runtimeConfig env overrides", () => {
     vi.stubEnv(STALL_ENV, "60000");
     const mod = await importFresh();
     expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(60000);
+  });
+
+  it("uses the env value when NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS is set", async () => {
+    vi.stubEnv(FETCH_ENV, "45000");
+    const mod = await importFresh();
+    expect(mod.FETCH_CONNECT_TIMEOUT_MS).toBe(45000);
+  });
+
+  it("falls back to 30000ms for stream stall when no env is set", async () => {
+    const mod = await importFresh();
+    expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(30000);
+  });
+
+  it("falls back to 20000ms for fetch connect when no env is set", async () => {
+    const mod = await importFresh();
+    expect(mod.FETCH_CONNECT_TIMEOUT_MS).toBe(20000);
+  });
+
+  it("trims surrounding whitespace from a valid env value", async () => {
+    vi.stubEnv(STALL_ENV, "  90000  ");
+    const mod = await importFresh();
+    expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(90000);
+  });
+
+  it("warns and falls back when env value is non-numeric", async () => {
+    vi.stubEnv(STALL_ENV, "30s");
+    const mod = await importFresh();
+    expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(30000);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Invalid ${STALL_ENV}="30s"`)
+    );
+  });
+
+  it("warns and falls back when env value is zero", async () => {
+    vi.stubEnv(FETCH_ENV, "0");
+    const mod = await importFresh();
+    expect(mod.FETCH_CONNECT_TIMEOUT_MS).toBe(20000);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Invalid ${FETCH_ENV}="0"`)
+    );
+  });
+
+  it("warns and falls back when env value is negative", async () => {
+    vi.stubEnv(STALL_ENV, "-5");
+    const mod = await importFresh();
+    expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(30000);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Invalid ${STALL_ENV}="-5"`)
+    );
+  });
+
+  it("warns and falls back for partial-numeric values like '60abc'", async () => {
+    vi.stubEnv(STALL_ENV, "60abc");
+    const mod = await importFresh();
+    expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(30000);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Invalid ${STALL_ENV}="60abc"`)
+    );
+  });
+
+  it("does not warn when the env var is unset", async () => {
+    const mod = await importFresh();
+    expect(mod.STREAM_STALL_TIMEOUT_MS).toBe(30000);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Make `STREAM_STALL_TIMEOUT_MS` and `FETCH_CONNECT_TIMEOUT_MS` in `open-sse/config/runtimeConfig.js` overridable at runtime via `NINE_ROUTER_STREAM_STALL_TIMEOUT_MS` and `NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS` environment variables.

Operators proxying requests to slow / deep-reasoning models (Xiaomi mimo-v2.5, zai/glm-5.1, Claude thinking via Kiro, etc.) currently hit "stream stall timeout" mid-generation. This PR gives them a config knob to raise the timeouts without waiting for a 9router release.

**Addresses upstream issues:**
- #1621 — "[Bug] Frequent 'stream stall timeout' when proxying Claude Code CLI requests to Xiaomi mimo-v2.5 via 9router"
- #1557 — "Make STREAM_STALL_TIMEOUT_MS and FETCH_CONNECT_TIMEOUT_MS configurable via Env Vars"

**Backward compatible:** exported names, types, and defaults (30000ms / 20000ms) are unchanged. Existing deployments are unaffected unless they opt in by setting the env vars.

## Changes

- **`open-sse/config/runtimeConfig.js`** — added private `_parseTimeoutMs(envName, defaultMs)` helper that reads `process.env` once at module load, validates strictly (positive integer in ms, with trim), warns and falls back on invalid input. The two `export const` declarations are now thin wrappers.
- **`tests/unit/runtimeConfig.test.js`** *(new)* — 10 vitest cases covering defaults, valid overrides, whitespace trim, non-numeric (`"30s"`), zero, negative, partial-numeric (`"60abc"`), and "no warn when unset".
- **`.env.example`** — new section documenting both env vars with their defaults.
- **`README.md`** — two new rows in the Environment Variables table.
- **`CHANGELOG.md`** — new `## Unreleased` section under `## Features`.

No production dependencies, no breaking changes, no other files touched.

## Test Plan

- [x] All 10 new unit tests pass (`vitest run unit/runtimeConfig.test.js`)
- [x] All previously-passing tests still pass (411 passing on master; 26 pre-existing failures are unrelated — missing `lowdb`, missing `/cloud` handler, etc., none reference the timeout constants)
- [x] Default behavior verified end-to-end: `import { STREAM_STALL_TIMEOUT_MS, FETCH_CONNECT_TIMEOUT_MS }` returns `30000 20000` with no env set
- [x] Override behavior verified end-to-end: `NINE_ROUTER_STREAM_STALL_TIMEOUT_MS=120000 NINE_ROUTER_FETCH_CONNECT_TIMEOUT_MS=60000` returns `120000 60000`
- [x] Existing consumers (`open-sse/utils/streamHandler.js`, `open-sse/executors/base.js`) need zero changes
- [ ] Manual smoke test against a slow provider (e.g. Xiaomi mimo-v2.5) with `NINE_ROUTER_STREAM_STALL_TIMEOUT_MS=120000` to confirm the new value is used in logs

## Out of Scope (Follow-up Candidates)

These are intentionally NOT in this PR. Each is its own design discussion:

- Raising the default timeout values
- Per-provider timeout overrides (e.g. Xiaomi automatically gets 5 minutes)
- Adding `Connection: keep-alive` / `X-Accel-Buffering: no` headers to upstream requests
- Retry-on-stall logic (e.g. fallback to another provider)
- More granular logging fields
- Hot-reload of env var without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)