### PR TITLE
fix(kiro): add mappable "auto" model slot for Kiro agent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Add new models: Claude Opus 4.8 (Claude Code), GPT 5.4 Mini (Codex)
 
 ## Fixes
+- Kiro MITM: route Kiro's agent/"vibe" turns to the configured model provider instead of leaking them back to AWS. Kiro's current client sends modelId `auto` for the main turn (and `simple-task` for background sub-tasks), for which there was no mappable slot — `getMappedModel` returned null, so the `/generateAssistantResponse` call was passed through to AWS/CodeWhisperer instead of the provider you configured. (The eventual "monthly usage limit" was only the downstream symptom once the AWS quota was gone.)
 - DeepSeek thinking mode: echo `reasoning_content` back on follow-up/tool-call turns so OpenCode-free and custom providers no longer 400 with "reasoning_content must be passed back" (#1543)
 - Reasoning injector: match deepseek/kimi model ids case-insensitively (covers custom providers using capitalized model names)
 - OpenCode suggested-models: include free models without the `-free` suffix, e.g. `big-pickle` (#1535)

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -56,6 +56,15 @@ export const MITM_TOOLS = {
     configType: "mitm",
     mitmDomain: "q.us-east-1.amazonaws.com",
     defaultModels: [
+      // Kiro's agent/"vibe" mode sends modelId "auto" for the main turn ("simple-task",
+      // below, covers the background sub-tasks). Evidence: MITM request dump of
+      // /generateAssistantResponse captured 2026-06-02 showed `conversationState.modelId
+      // = "auto"`. Unlike Copilot's "auto" (a client-side dispatch label that resolves to
+      // concrete wire ids — separately confirmed by live capture 2026-06-03, see the
+      // github block above), Kiro's "auto" is a real wire id: without a mappable slot
+      // getMappedModel returns null and the main turn is passed through to AWS instead of
+      // the configured provider. Re-verify the wire id if Kiro's client changes.
+      { id: "auto", name: "Auto (Kiro Agent)", alias: "auto" },
       { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5", alias: "claude-sonnet-4.5" },
       { id: "claude-sonnet-4", name: "Claude Sonnet 4", alias: "claude-sonnet-4" },
       { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", alias: "claude-haiku-4.5" },

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -56,14 +56,11 @@ export const MITM_TOOLS = {
     configType: "mitm",
     mitmDomain: "q.us-east-1.amazonaws.com",
     defaultModels: [
-      // Kiro's agent/"vibe" mode sends modelId "auto" for the main turn ("simple-task",
-      // below, covers the background sub-tasks). Evidence: MITM request dump of
-      // /generateAssistantResponse captured 2026-06-02 showed `conversationState.modelId
-      // = "auto"`. Unlike Copilot's "auto" (a client-side dispatch label that resolves to
-      // concrete wire ids — separately confirmed by live capture 2026-06-03, see the
-      // github block above), Kiro's "auto" is a real wire id: without a mappable slot
-      // getMappedModel returns null and the main turn is passed through to AWS instead of
-      // the configured provider. Re-verify the wire id if Kiro's client changes.
+      // Kiro's agent mode sends modelId "auto" for the main turn and "simple-task"
+      // for background sub-tasks. Without a matching slot getMappedModel returns null
+      // and the turn is passed through to the Kiro upstream instead of the configured
+      // provider. Wire ids seen in MITM captures of /generateAssistantResponse
+      // (runtime.us-east-1.kiro.dev), 2026-06-02 and 2026-06-14.
       { id: "auto", name: "Auto (Kiro Agent)", alias: "auto" },
       { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5", alias: "claude-sonnet-4.5" },
       { id: "claude-sonnet-4", name: "Claude Sonnet 4", alias: "claude-sonnet-4" },


### PR DESCRIPTION
Kiro's current client sends modelId `auto` for the main agent/"vibe" turn (and `simple-task` for background sub-tasks), but `cliTools` `defaultModels` only listed `claude-*` / `deepseek` / `minimax` / `simple-task` — there was no `auto` slot.

With no mapping for `auto`, `getMappedModel` returns `null` and the MITM passes the `/generateAssistantResponse` call through to AWS instead of routing it to the user's chosen provider. That surfaces as Kiro's "monthly usage limit" once the AWS quota is gone — but the real defect is the misrouting, not the quota.

This adds an `auto` slot so users can map Kiro's default agent model. Verified against a captured MITM request dump (`conversationState.modelId = "auto"`). Includes a guard test (`tests/unit/kiro-model-slots.test.js`).

Re-verified on a fresh MITM capture (2026-06-14, `runtime.us-east-1.kiro.dev/generateAssistantResponse`): the main agent turn sends `modelId="auto"`, logged by `extractModel` before routing — without a slot it falls through to passthrough.
