### PR TITLE
fix(copilot): add mappable gpt-5-mini/gpt-5.4-nano slots for Copilot MITM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new models: Claude Opus 4.8 (Claude Code), GPT 5.4 Mini (Codex)
 
 ## Fixes
+- Copilot MITM: add mappable slots for `gpt-5-mini` and `gpt-5.4-nano` so GitHub Copilot turns route to the configured provider instead of leaking back to GitHub Copilot. The Copilot CLI's default model is `gpt-5-mini`, and its "Auto" mode also dispatches `gpt-5.4-nano` — neither had a slot, so `getMappedModel` returned null and the `/chat/completions` call was passed through to the real upstream (same class as the Kiro `auto` misrouting; confirmed via live MITM passthrough capture). `claude-haiku-4.5` already had a slot.
 - DeepSeek thinking mode: echo `reasoning_content` back on follow-up/tool-call turns so OpenCode-free and custom providers no longer 400 with "reasoning_content must be passed back" (#1543)
 - Reasoning injector: match deepseek/kimi model ids case-insensitively (covers custom providers using capitalized model names)
 - OpenCode suggested-models: include free models without the `-free` suffix, e.g. `big-pickle` (#1535)

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -29,11 +29,22 @@ export const MITM_TOOLS = {
     description: "GitHub Copilot IDE with MITM",
     configType: "mitm",
     mitmDomain: "api.individual.githubcopilot.com",
-    modelAliases: ["gpt-4o-mini", "claude-haiku-4.5", "gpt-4o", "gpt-5-mini"],
+    modelAliases: ["gpt-5-mini", "gpt-5.4-nano", "claude-haiku-4.5", "gpt-4o", "gpt-4.1"],
     defaultModels: [
+      // Verified via live MITM passthrough capture of the GitHub Copilot CLI: its model
+      // picker offers "GPT-5 mini" (default → wire id "gpt-5-mini"), "Claude Haiku 4.5"
+      // ("claude-haiku-4.5") and "Auto". "Auto" is NOT a wire id — Copilot dispatches
+      // concrete models dynamically (observed "gpt-5.4-nano" for light tasks and
+      // "claude-haiku-4.5"), so it needs no slot of its own. Without a slot for
+      // gpt-5-mini / gpt-5.4-nano, getMappedModel returns null and the /chat/completions
+      // call is passed through to GitHub Copilot instead of the configured provider —
+      // and gpt-5-mini is the CLI default, so the primary turn leaks (same class as the
+      // Kiro "auto" misrouting). gpt-4o / gpt-4.1 are kept for the VS Code Copilot Chat picker.
+      { id: "gpt-5-mini", name: "GPT-5 mini", alias: "gpt-5-mini" },
+      { id: "gpt-5.4-nano", name: "GPT-5.4 nano", alias: "gpt-5.4-nano" },
+      { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", alias: "claude-haiku-4.5" },
       { id: "gpt-4o", name: "GPT-4o", alias: "gpt-4o" },
       { id: "gpt-4.1", name: "GPT-4.1", alias: "gpt-4.1" },
-      { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", alias: "claude-haiku-4.5" },
     ],
   },
   kiro: {

--- a/tests/unit/copilot-model-slots.test.js
+++ b/tests/unit/copilot-model-slots.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { MITM_TOOLS } from "../../src/shared/constants/cliTools.js";
+
+// Guards the Copilot MITM slots. Verified via live MITM passthrough capture of the
+// GitHub Copilot CLI: it sends wire modelIds "gpt-5-mini" (default), "gpt-5.4-nano"
+// (Auto mode, light tasks) and "claude-haiku-4.5". Without a mappable slot,
+// getMappedModel (src/mitm/server.js) returns null and the /chat/completions call is
+// passed through to GitHub Copilot instead of the configured provider — and since
+// gpt-5-mini is the default, the primary turn leaks (same class as the Kiro "auto" bug).
+describe("Copilot MITM model slots", () => {
+  const copilot = MITM_TOOLS.copilot;
+
+  it("exposes the copilot mitm tool", () => {
+    expect(copilot).toBeTruthy();
+    expect(copilot.configType).toBe("mitm");
+    expect(Array.isArray(copilot.defaultModels)).toBe(true);
+  });
+
+  // Each modelId the Copilot CLI actually sends on the wire must have a mappable slot.
+  it.each(["gpt-5-mini", "gpt-5.4-nano", "claude-haiku-4.5"])(
+    "offers a mappable slot for wire modelId '%s'",
+    (id) => {
+      const slot = copilot.defaultModels.find((m) => m.id === id);
+      expect(slot).toBeTruthy();
+      expect(slot.alias).toBe(id);
+    }
+  );
+});


### PR DESCRIPTION
The GitHub Copilot client's model picker offers "GPT-5 mini" (default → wire id `gpt-5-mini`), "Claude Haiku 4.5" (`claude-haiku-4.5`, already had a slot) and "Auto". "Auto" is not a wire id — Copilot dispatches concrete models dynamically (observed `gpt-5.4-nano` for light tasks).

`gpt-5-mini` and `gpt-5.4-nano` had no `defaultModels` slot, so `getMappedModel` returned `null` and the `/chat/completions` call was passed through to GitHub Copilot instead of the configured provider. Since `gpt-5-mini` is the default, the primary turn leaked (same class as the Kiro `auto` misrouting).

Verified via a live MITM passthrough capture of the Copilot CLI. Includes a guard test (`tests/unit/copilot-model-slots.test.js`).