### PR TITLE
fix(antigravity): passthrough tab-autocomplete + mark default agent slot mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new models: Claude Opus 4.8 (Claude Code), GPT 5.4 Mini (Codex)
 
 ## Fixes
+- Antigravity MITM: never re-route tab-autocomplete. Antigravity sends dedicated `tab_jump_flash_lite_preview` / `tab_flash_lite_preview` models for inline completion (no slot); the broad `flash` routing pattern was hijacking them onto the flash-agent mapping, so latency-critical autocomplete was being sent to a remote chat model. A `MODEL_NO_MAP` guard now passes these through natively. Also flags the out-of-box agent/Default model (`gemini-3.5-flash-low`) as mandatory in the dashboard. Verified via live MITM dump capture of `streamGenerateContent`.
 - DeepSeek thinking mode: echo `reasoning_content` back on follow-up/tool-call turns so OpenCode-free and custom providers no longer 400 with "reasoning_content must be passed back" (#1543)
 - Reasoning injector: match deepseek/kimi model ids case-insensitively (covers custom providers using capitalized model names)
 - OpenCode suggested-models: include free models without the `-free` suffix, e.g. `big-pickle` (#1535)

--- a/src/mitm/config.js
+++ b/src/mitm/config.js
@@ -52,6 +52,16 @@ const MODEL_PATTERNS = {
   ],
 };
 
+// Models that must NEVER be re-routed — always passthrough to the real upstream, even when
+// the tool's other models are mapped. Antigravity's tab-autocomplete (`tab_jump_flash_lite_preview`,
+// `tab_flash_lite_preview`, requestType tab/tab_jump) is latency-critical inline completion; routing
+// it through 9Router to an external chat model makes typing laggy and burns provider quota per
+// keystroke. Without this guard the broad `flash` pattern in MODEL_PATTERNS hijacks them onto the
+// flash-agent slot. Verified via MITM dump capture of streamGenerateContent (see AI_JOURNAL).
+const MODEL_NO_MAP = {
+  antigravity: [/^tab[_-]/i],
+};
+
 // URL substrings whose request/response should NOT be dumped to file (telemetry, polling, empty)
 const LOG_BLACKLIST_URL_PARTS = [
   "recordCodeAssistMetrics",
@@ -70,4 +80,4 @@ function getToolForHost(host) {
   return null;
 }
 
-module.exports = { IS_DEV, LSOF_BIN, TARGET_HOSTS, URL_PATTERNS, MODEL_SYNONYMS, MODEL_PATTERNS, LOG_BLACKLIST_URL_PARTS, getToolForHost };
+module.exports = { IS_DEV, LSOF_BIN, TARGET_HOSTS, URL_PATTERNS, MODEL_SYNONYMS, MODEL_PATTERNS, MODEL_NO_MAP, LOG_BLACKLIST_URL_PARTS, getToolForHost };

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -7,7 +7,7 @@ const dns = require("dns");
 const { promisify } = require("util");
 const { execSync } = require("child_process");
 const { log, err, dumpRequest, createResponseDumper, clearDumpDir } = require("./logger");
-const { IS_DEV, LSOF_BIN, TARGET_HOSTS, URL_PATTERNS, MODEL_SYNONYMS, MODEL_PATTERNS, getToolForHost } = require("./config");
+const { IS_DEV, LSOF_BIN, TARGET_HOSTS, URL_PATTERNS, MODEL_SYNONYMS, MODEL_PATTERNS, MODEL_NO_MAP, getToolForHost } = require("./config");
 const { DATA_DIR, MITM_DIR } = require("./paths");
 const { getCertForDomain } = require("./cert/generate");
 const { getMitmAlias } = require("./dbReader");
@@ -329,6 +329,14 @@ const server = https.createServer(sslOptions, async (req, res) => {
     }
 
     const model = extractModel(req.url, bodyBuffer);
+
+    // Intentional passthrough: some models must never be re-routed (e.g. Antigravity
+    // tab-autocomplete) so latency-critical inline completion stays native. Silent — this
+    // is by design, not a leak, and fires per keystroke. See MODEL_NO_MAP in config.js.
+    if (model && (MODEL_NO_MAP[tool] || []).some((re) => re.test(model))) {
+      return passthrough(req, res, bodyBuffer);
+    }
+
     const mappedModel = getMappedModel(tool, model);
     if (!mappedModel) {
       return passthrough(req, res, bodyBuffer);

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -10,7 +10,12 @@ export const MITM_TOOLS = {
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
     modelAliases: ["gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
     defaultModels: [
-      { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium) / Default", alias: "gemini-3.5-flash-low" },
+      // `mandatory: true` on the out-of-box agent/Default model — verified via MITM dump capture:
+      // Antigravity's agent loop sends `gemini-3.5-flash-low` (requestType agent/checkpoint) by
+      // default. The other slots only appear when the user explicitly picks that model, so they
+      // stay optional. (Tab-autocomplete uses `tab_*` models that are never re-routed — see
+      // MODEL_NO_MAP in src/mitm/config.js.)
+      { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium) / Default", alias: "gemini-3.5-flash-low", mandatory: true },
       { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)", alias: "gemini-3-flash-agent" },
       { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)", alias: "gemini-3.5-flash-extra-low" },
       { id: "gemini-3.1-pro-low", name: "Gemini 3.1 Pro (Low)", alias: "gemini-3.1-pro-low" },

--- a/tests/unit/antigravity-mitm.test.js
+++ b/tests/unit/antigravity-mitm.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "module";
+import { MITM_TOOLS } from "../../src/shared/constants/cliTools.js";
+
+// config.js is the CJS MITM bundle module (dependency-isolated for the runtime copy).
+const require = createRequire(import.meta.url);
+const { MODEL_NO_MAP } = require("../../src/mitm/config.js");
+
+// All assertions below are grounded in a live MITM dump capture of Antigravity's
+// streamGenerateContent requests (see AI_JOURNAL): the agent loop sends
+// `gemini-3.5-flash-low`, tab-autocomplete sends `tab_jump_flash_lite_preview` /
+// `tab_flash_lite_preview`.
+describe("Antigravity MITM model handling", () => {
+  const ag = MITM_TOOLS.antigravity;
+
+  it("flags the out-of-box agent/Default model mandatory", () => {
+    expect(ag.defaultModels.find((m) => m.id === "gemini-3.5-flash-low")?.mandatory).toBe(true);
+  });
+
+  it("leaves models not proven auto-sent optional", () => {
+    for (const id of ["gemini-3-flash-agent", "gemini-3.1-pro-low", "claude-sonnet-4-6", "gpt-oss-120b-medium"]) {
+      expect(ag.defaultModels.find((m) => m.id === id)?.mandatory).toBeFalsy();
+    }
+  });
+
+  // Tab-autocomplete is latency-critical inline completion — it must passthrough natively,
+  // never get re-routed onto a chat-model mapping by the broad `flash` pattern.
+  it.each(["tab_jump_flash_lite_preview", "tab_flash_lite_preview"])(
+    "excludes tab-autocomplete model '%s' from re-routing",
+    (id) => {
+      expect((MODEL_NO_MAP.antigravity || []).some((re) => re.test(id))).toBe(true);
+    }
+  );
+
+  it("does not exclude real agent models from re-routing", () => {
+    for (const id of ["gemini-3.5-flash-low", "gemini-3-flash-agent", "claude-sonnet-4-6"]) {
+      expect((MODEL_NO_MAP.antigravity || []).some((re) => re.test(id))).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
@
Two related Antigravity MITM fixes, both verified via live MITM dump capture of `streamGenerateContent`:

**1. Never re-route tab-autocomplete (MODEL_NO_MAP passthrough)**
Antigravity sends dedicated `tab_jump_flash_lite_preview` / `tab_flash_lite_preview` models for inline completion (these have no mappable slot). The broad `flash` routing pattern was hijacking them onto the flash-agent mapping, so latency-critical autocomplete was being sent to a remote chat model. A `MODEL_NO_MAP` guard in `src/mitm/config.js` now passes these through natively.

**2. Mark the out-of-box agent/Default model as mandatory**
The agent loop sends `gemini-3.5-flash-low` (requestType agent/checkpoint) by default; the other slots only appear when the user explicitly picks them, so they stay optional. The Default slot is now flagged `mandatory: true` in `src/shared/constants/cliTools.js` so the dashboard surfaces it as required.

Verification:
- npx vitest run tests/unit/antigravity-mitm.test.js --config tests/vitest.config.js  (5 passed)
- node --check src/mitm/config.js src/mitm/server.js src/shared/constants/cliTools.js
@