### PR TITLE
fix: mask request debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new models: Claude Opus 4.8 (Claude Code), GPT 5.4 Mini (Codex)
 
 ## Fixes
+- Request debug logs: mask sensitive headers (authorization, API keys, cookies, tokens, secrets) before writing opt-in request/response log files.
 - DeepSeek thinking mode: echo `reasoning_content` back on follow-up/tool-call turns so OpenCode-free and custom providers no longer 400 with "reasoning_content must be passed back" (#1543)
 - Reasoning injector: match deepseek/kimi model ids case-insensitively (covers custom providers using capitalized model names)
 - OpenCode suggested-models: include free models without the `-free` suffix, e.g. `big-pickle` (#1535)

--- a/open-sse/utils/requestLogger.js
+++ b/open-sse/utils/requestLogger.js
@@ -69,25 +69,52 @@ function writeJsonFile(sessionPath, filename, data) {
   }
 }
 
-// Mask sensitive data in headers (DISABLED - keep full token for testing)
-function maskSensitiveHeaders(headers) {
+const SENSITIVE_HEADER_PATTERNS = [
+  "authorization",
+  "proxy-authorization",
+  "api-key",
+  "apikey",
+  "x-api-key",
+  "x-key",
+  "cookie",
+  "set-cookie",
+  "token",
+  "secret",
+  "password",
+  "credential"
+];
+
+function maskHeaderValue(value) {
+  if (Array.isArray(value)) return value.map(maskHeaderValue);
+  if (value === undefined || value === null) return value;
+  const text = String(value);
+  if (!text) return text;
+
+  const bearerMatch = text.match(/^(Bearer|Token|Basic)\s+(.+)$/i);
+  if (bearerMatch) return `${bearerMatch[1]} ${maskToken(bearerMatch[2])}`;
+  return maskToken(text);
+}
+
+function maskToken(text) {
+  if (text.length <= 8) return "[REDACTED]";
+  if (text.length <= 20) return `${text.slice(0, 4)}...[REDACTED]`;
+  return `${text.slice(0, 8)}...[REDACTED]...${text.slice(-4)}`;
+}
+
+// Debug request logs are opt-in, but they must never persist live secrets.
+export function maskSensitiveHeaders(headers) {
   if (!headers) return {};
-  return { ...headers };
-  
-  // Old masking code (disabled):
-  // const masked = { ...headers };
-  // const sensitiveKeys = ["authorization", "x-api-key", "cookie", "token"];
-  // 
-  // for (const key of Object.keys(masked)) {
-  //   const lowerKey = key.toLowerCase();
-  //   if (sensitiveKeys.some(sk => lowerKey.includes(sk))) {
-  //     const value = masked[key];
-  //     if (value && value.length > 20) {
-  //       masked[key] = value.slice(0, 10) + "..." + value.slice(-5);
-  //     }
-  //   }
-  // }
-  // return masked;
+  const source = typeof headers.entries === "function" ? Object.fromEntries(headers.entries()) : headers;
+  const masked = { ...source };
+
+  for (const key of Object.keys(masked)) {
+    const lowerKey = key.toLowerCase();
+    if (SENSITIVE_HEADER_PATTERNS.some(pattern => lowerKey.includes(pattern))) {
+      masked[key] = maskHeaderValue(masked[key]);
+    }
+  }
+
+  return masked;
 }
 
 // No-op logger when logging is disabled
@@ -170,7 +197,7 @@ export async function createRequestLogger(sourceFormat, targetFormat, model) {
         timestamp: new Date().toISOString(),
         status,
         statusText,
-        headers: headers ? (typeof headers.entries === "function" ? Object.fromEntries(headers.entries()) : headers) : {},
+        headers: maskSensitiveHeaders(headers),
         body
       });
     },

--- a/tests/unit/requestLogger.test.js
+++ b/tests/unit/requestLogger.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { maskSensitiveHeaders } from "../../open-sse/utils/requestLogger.js";
+
+describe("requestLogger", () => {
+  it("masks sensitive request headers without mutating non-sensitive headers", () => {
+    const headers = {
+      Authorization: "Bearer sk-test-1234567890abcdef",
+      "x-api-key": "abc123456789xyz",
+      Cookie: "sid=session-secret; theme=dark",
+      Accept: "application/json",
+      "User-Agent": "official-client/1.2.3"
+    };
+
+    const masked = maskSensitiveHeaders(headers);
+
+    expect(masked.Authorization).toBe("Bearer sk-test-...[REDACTED]...cdef");
+    expect(masked["x-api-key"]).toBe("abc1...[REDACTED]");
+    expect(masked.Cookie).toContain("[REDACTED]");
+    expect(masked.Accept).toBe("application/json");
+    expect(masked["User-Agent"]).toBe("official-client/1.2.3");
+    expect(headers.Authorization).toBe("Bearer sk-test-1234567890abcdef");
+  });
+
+  it("supports Headers objects and masks provider response secrets", () => {
+    const headers = new Headers({
+      "set-cookie": "token=secret-cookie-value",
+      "x-ratelimit-remaining": "42"
+    });
+
+    const masked = maskSensitiveHeaders(headers);
+
+    expect(masked["set-cookie"]).toContain("[REDACTED]");
+    expect(masked["x-ratelimit-remaining"]).toBe("42");
+  });
+});


### PR DESCRIPTION
@
Masks sensitive headers before opt-in request/response logs are written, so Authorization/API-key/Cookie/Token/Secret values do not persist in local debug artifacts.

On `master`, `maskSensitiveHeaders()` in `open-sse/utils/requestLogger.js` is currently disabled (`return { ...headers }`, comment "keep full token for testing"), so secrets land in plaintext in debug request logs. This re-enables masking with a configurable pattern list (authorization, proxy-authorization, api-key, x-api-key, cookie, token, secret, password, credential, ...) and a `maskToken` helper that keeps a short prefix/suffix for debugging while redacting the middle.

Verification:
- npx vitest run tests/unit/requestLogger.test.js --config tests/vitest.config.js
- node --check open-sse/utils/requestLogger.js
- npm run build

Note: re-submission of previously closed #1604 (same branch/content).
@