### PR TITLE
fix: increase default connect timeout to 60s and support config.timeoutMs override

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -35,7 +35,8 @@ export const MEMORY_CONFIG = {
 export const STREAM_STALL_TIMEOUT_MS = 30 * 1000;
 
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
-export const FETCH_CONNECT_TIMEOUT_MS = 60 * 1000;
+const envFetchTimeout = process.env.FETCH_CONNECT_TIMEOUT_MS ? parseInt(process.env.FETCH_CONNECT_TIMEOUT_MS, 10) : NaN;
+export const FETCH_CONNECT_TIMEOUT_MS = !isNaN(envFetchTimeout) && envFetchTimeout > 0 ? envFetchTimeout : 60 * 1000;
 
 
 // Default token limits

--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -35,7 +35,8 @@ export const MEMORY_CONFIG = {
 export const STREAM_STALL_TIMEOUT_MS = 30 * 1000;
 
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
-export const FETCH_CONNECT_TIMEOUT_MS = 20 * 1000;
+export const FETCH_CONNECT_TIMEOUT_MS = 60 * 1000;
+
 
 // Default token limits
 export const DEFAULT_MAX_TOKENS = 64000;

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -122,15 +122,16 @@ export class BaseExecutor {
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
 
-      // Abort if upstream doesn't return response headers within FETCH_CONNECT_TIMEOUT_MS
+      // Abort if upstream doesn't return response headers within connection timeout
       const connectCtrl = new AbortController();
-      const connectTimer = setTimeout(() => connectCtrl.abort(new Error("fetch connect timeout")), FETCH_CONNECT_TIMEOUT_MS);
+      const timeoutMs = this.config?.timeoutMs || FETCH_CONNECT_TIMEOUT_MS;
+      const connectTimer = setTimeout(() => connectCtrl.abort(new Error("fetch connect timeout")), timeoutMs);
       const mergedSignal = signal ? AbortSignal.any([signal, connectCtrl.signal]) : connectCtrl.signal;
 
       try {
         const bodyStr = JSON.stringify(transformedBody);
         const fetchT0 = Date.now();
-        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${FETCH_CONNECT_TIMEOUT_MS}ms`);
+        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${timeoutMs}ms`);
         const response = await proxyAwareFetch(url, {
           method: "POST",
           headers,


### PR DESCRIPTION
This PR increases the default connection timeout from 20s to 60s to prevent timeouts on slow upstream models/providers (like Mimo or reasoning models) for large prompts. It also adds support for overriding this timeout on a per-provider basis using `config.timeoutMs`.