### PR TITLE
feat: per-key cost quota + request attribution for shared gateways

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -187,7 +187,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     trackPendingRequest(model, provider, connectionId, false, true);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${error.name === "AbortError" ? 499 : HTTP_STATUS.BAD_GATEWAY}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
-      provider, model, connectionId,
+      provider, model, connectionId, apiKey,
       latency: { ttft: 0, total: Date.now() - requestStartTime },
       tokens: { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),
@@ -233,7 +233,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     const { statusCode, message, resetsAtMs } = await parseUpstreamError(providerResponse, executor);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${statusCode}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
-      provider, model, connectionId,
+      provider, model, connectionId, apiKey,
       latency: { ttft: 0, total: Date.now() - requestStartTime },
       tokens: { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -159,7 +159,8 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
-  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+  // Only write for this request → canonical quota row
+  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, countsTowardQuota: true });
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
     ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat)
@@ -201,7 +202,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   const totalLatency = Date.now() - requestStartTime;
   saveRequestDetail(buildRequestDetail({
-    provider, model, connectionId,
+    provider, model, connectionId, apiKey,
     latency: { ttft: totalLatency, total: totalLatency },
     tokens: usage || { prompt_tokens: 0, completion_tokens: 0 },
     request: extractRequestConfig(body, stream),

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -60,6 +60,7 @@ export function buildRequestDetail(base, overrides = {}) {
     provider: base.provider || "unknown",
     model: base.model || "unknown",
     connectionId: base.connectionId || undefined,
+    apiKey: base.apiKey || null,
     timestamp: new Date().toISOString(),
     latency: base.latency || { ttft: 0, total: 0 },
     tokens: base.tokens || { prompt_tokens: 0, completion_tokens: 0 },
@@ -72,7 +73,9 @@ export function buildRequestDetail(base, overrides = {}) {
   };
 }
 
-export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE" }) {
+// countsTowardQuota: set true at the single canonical write of a request (quota accounting);
+// the streaming duplicate (onStreamComplete) leaves it false
+export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE", countsTowardQuota = false }) {
   if (!tokens || typeof tokens !== "object") return;
 
   const inTokens = tokens.input_tokens ?? tokens.prompt_tokens ?? 0;
@@ -97,6 +100,7 @@ export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, 
     timestamp: new Date().toISOString(),
     connectionId: connectionId || undefined,
     apiKey: apiKey || undefined,
-    endpoint: endpoint || null
+    endpoint: endpoint || null,
+    countsTowardQuota
   }).catch(() => {});
 }

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -106,7 +106,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
   trackDone();
 
   const ctx = {
-    provider, model, connectionId,
+    provider, model, connectionId, apiKey,
     request: extractRequestConfig(body, stream),
     providerRequest: finalBody || translatedBody || null
   };
@@ -120,7 +120,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
       const usage = jsonResponse.usage || {};
       appendLog({ tokens: usage, status: "200 OK" });
-      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+      // Only write for this request → canonical quota row
+      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, countsTowardQuota: true });
 
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
       const totalLatency = Date.now() - requestStartTime;
@@ -195,7 +196,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
     const usage = parsed.usage || {};
     appendLog({ tokens: usage, status: "200 OK" });
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
+    // Only write for this request → canonical quota row
+    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, countsTowardQuota: true });
 
     const totalLatency = Date.now() - requestStartTime;
     saveRequestDetail(buildRequestDetail({

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -47,7 +47,7 @@ export function handleStreamingResponse({ providerResponse, provider, model, sou
 
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
   saveRequestDetail(buildRequestDetail({
-    provider, model, connectionId,
+    provider, model, connectionId, apiKey,
     latency: { ttft: 0, total: Date.now() - requestStartTime },
     tokens: { prompt_tokens: 0, completion_tokens: 0 },
     request: extractRequestConfig(body, stream),
@@ -80,7 +80,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     const safeThinking = contentObj?.thinking || null;
 
     saveRequestDetail(buildRequestDetail({
-      provider, model, connectionId,
+      provider, model, connectionId, apiKey,
       latency,
       tokens: usage || { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),
@@ -92,6 +92,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
 
+    // Duplicate stats row — logUsage in stream.js already wrote the canonical quota row
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE" });
   };
 

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -342,6 +342,7 @@ export function logUsage(provider, usage, model = null, connectionId = null, api
     cache_creation_input_tokens: cacheCreation || 0,
     reasoning_tokens: reasoning || 0
   };
-  saveRequestUsage({ model, provider, connectionId, tokens, apiKey: apiKey || undefined }).catch(() => { });
+  // Canonical quota row for the streaming path (onStreamComplete writes a second, unflagged stats row)
+  saveRequestUsage({ model, provider, connectionId, tokens, apiKey: apiKey || undefined, countsTowardQuota: true }).catch(() => { });
   appendRequestLog({ model, provider, connectionId, tokens, status: "200 OK" }).catch(() => { });
 }

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -21,7 +21,7 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { isActive } = body;
+    const { isActive, costBudget5h } = body;
 
     const existing = await getApiKeyById(id);
     if (!existing) {
@@ -30,6 +30,13 @@ export async function PUT(request, { params }) {
 
     const updateData = {};
     if (isActive !== undefined) updateData.isActive = isActive;
+    if (costBudget5h !== undefined) {
+      // null = clear override (use global default); otherwise a positive number (USD-equivalent)
+      if (costBudget5h !== null && (typeof costBudget5h !== "number" || !Number.isFinite(costBudget5h) || costBudget5h <= 0)) {
+        return NextResponse.json({ error: "costBudget5h must be null or a positive number" }, { status: 400 });
+      }
+      updateData.costBudget5h = costBudget5h;
+    }
 
     const updated = await updateApiKey(id, updateData);
 

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -10,6 +10,8 @@ function rowToKey(row) {
     machineId: row.machineId,
     isActive: row.isActive === 1 || row.isActive === true,
     createdAt: row.createdAt,
+    // Cost budget (USD-equivalent) per 5h window; null = use the global default
+    costBudget5h: row.costBudget5h ?? null,
   };
 }
 
@@ -53,8 +55,8 @@ export async function updateApiKey(id, data) {
     if (!row) return;
     const merged = { ...rowToKey(row), ...data };
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ? WHERE id = ?`,
-      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, id]
+      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, costBudget5h = ? WHERE id = ?`,
+      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, merged.costBudget5h ?? null, id]
     );
     result = merged;
   });

--- a/src/lib/db/repos/requestDetailsRepo.js
+++ b/src/lib/db/repos/requestDetailsRepo.js
@@ -90,6 +90,7 @@ async function flushToDatabase() {
             provider: item.provider || null,
             model: item.model || null,
             connectionId: item.connectionId || null,
+            apiKey: item.apiKey || null,
             timestamp: item.timestamp,
             status: item.status || null,
             latency: item.latency || {},
@@ -101,8 +102,8 @@ async function flushToDatabase() {
           };
 
           db.run(
-            `INSERT INTO requestDetails(id, timestamp, provider, model, connectionId, status, data) VALUES(?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET timestamp = excluded.timestamp, provider = excluded.provider, model = excluded.model, connectionId = excluded.connectionId, status = excluded.status, data = excluded.data`,
-            [record.id, record.timestamp, record.provider, record.model, record.connectionId, record.status, stringifyJson(record)]
+            `INSERT INTO requestDetails(id, timestamp, provider, model, connectionId, apiKey, status, data) VALUES(?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET timestamp = excluded.timestamp, provider = excluded.provider, model = excluded.model, connectionId = excluded.connectionId, apiKey = excluded.apiKey, status = excluded.status, data = excluded.data`,
+            [record.id, record.timestamp, record.provider, record.model, record.connectionId, record.apiKey, record.status, stringifyJson(record)]
           );
         }
 

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -255,12 +255,12 @@ export async function saveRequestUsage(entry) {
     // better-sqlite3 is sync → no JS yield mid-transaction → no race in same process.
     db.transaction(() => {
       db.run(
-        `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta, countsTowardQuota) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           entry.timestamp, entry.provider || null, entry.model || null,
           entry.connectionId || null, entry.apiKey || null, entry.endpoint || null,
           promptTokens, completionTokens, entry.cost || 0, entry.status || "ok",
-          stringifyJson(tokens), stringifyJson({}),
+          stringifyJson(tokens), stringifyJson({}), entry.countsTowardQuota ? 1 : 0,
         ]
       );
 
@@ -728,4 +728,98 @@ export async function getRecentLogs(limit = 200) {
     console.error("[usageRepo] getRecentLogs failed:", e.message);
     return [];
   }
+}
+
+// ─── Per-user cost quota (prevent one user from draining the shared pool) ───
+const QUOTA_WINDOW_MS = 5 * 60 * 60 * 1000; // 5h
+const DEFAULT_USER_COST_BUDGET_5H = 50; // USD-equivalent per 5h window
+
+/**
+ * Check a user's (apiKey) usage cost within a fixed 5h window anchored to the
+ * window's first request (not rolling — matches codex's reset behavior).
+ *
+ * Cost budget (USD-equivalent): sums the cost column of rows flagged
+ * countsTowardQuota = 1 — each request writes exactly one such row regardless of
+ * streaming/non-streaming (streaming also writes a second stats row which stays
+ * unflagged). cost is computed by calculateCost with per-model pricing, weighting
+ * non-cached input, cached input and output separately — mirroring how upstream
+ * (codex credits, Claude limits) actually accounts usage. Models without pricing
+ * data have cost 0 and are intentionally not charged (no token fallback).
+ *
+ * Eventually consistent by design: usage rows are written async after the response
+ * completes, so concurrent requests can all pass the check before any row lands and
+ * the budget may be overshot during a burst. Acceptable for a soft quota.
+ *
+ * @returns {{allowed:boolean, used?:number, budget?:number, windowStart?:string,
+ *            retryAfterIso?:string, retryAfterSec?:number, disabled?:boolean}}
+ */
+export async function checkUserQuota(apiKey) {
+  if (!apiKey) return { allowed: true };
+  const db = await getAdapter();
+
+  // Enabled flag & default budget resolve as: DB setting > env > built-in default.
+  // - userQuotaEnabled: DB boolean if set, else env USER_QUOTA_ENABLED === "true" (disabled by default)
+  // - userCostBudget5hDefault: DB number if set, else env USER_COST_BUDGET_5H, else constant
+  let budget = DEFAULT_USER_COST_BUDGET_5H;
+  try {
+    const { getSettings } = await import("./settingsRepo.js");
+    const settings = await getSettings();
+    const enabled = typeof settings.userQuotaEnabled === "boolean"
+      ? settings.userQuotaEnabled
+      : process.env.USER_QUOTA_ENABLED === "true";
+    if (!enabled) return { allowed: true, disabled: true };
+    budget = settings.userCostBudget5hDefault
+      || parseFloat(process.env.USER_COST_BUDGET_5H || String(DEFAULT_USER_COST_BUDGET_5H));
+  } catch { /* fall back to default if settings cannot be read */ }
+  try {
+    const keyRow = db.get(`SELECT costBudget5h FROM apiKeys WHERE key = ?`, [apiKey]);
+    if (keyRow && keyRow.costBudget5h != null) budget = keyRow.costBudget5h;
+  } catch { /* ignore, keep current budget */ }
+
+  const now = Date.now();
+  let windowStartIso;
+  const wrow = db.get(`SELECT windowStart FROM userQuotaWindow WHERE apiKey = ?`, [apiKey]);
+  if (!wrow || (now - new Date(wrow.windowStart).getTime()) >= QUOTA_WINDOW_MS) {
+    // Open a new window: this request is the window's first request
+    windowStartIso = new Date(now).toISOString();
+    db.run(
+      `INSERT INTO userQuotaWindow(apiKey, windowStart) VALUES(?, ?) ON CONFLICT(apiKey) DO UPDATE SET windowStart = excluded.windowStart`,
+      [apiKey, windowStartIso]
+    );
+  } else {
+    windowStartIso = wrow.windowStart;
+  }
+
+  const row = db.get(
+    `SELECT COALESCE(SUM(cost), 0) AS used FROM usageHistory
+     WHERE apiKey = ? AND countsTowardQuota = 1 AND timestamp >= ?`,
+    [apiKey, windowStartIso]
+  );
+  const used = row?.used || 0;
+  const resetMs = new Date(windowStartIso).getTime() + QUOTA_WINDOW_MS;
+  const retryAfterSec = Math.max(Math.ceil((resetMs - now) / 1000), 1);
+
+  // Reset time in the server's local timezone, formatted HH:MM DD/MM (UTC±H[:MM]).
+  // The explicit offset avoids confusion when the server runs in a container (usually UTC).
+  const d = new Date(resetMs);
+  const pad = (n) => String(n).padStart(2, "0");
+  const offMin = -d.getTimezoneOffset();
+  const offSign = offMin >= 0 ? "+" : "-";
+  const offAbs = Math.abs(offMin);
+  const tzLabel = `UTC${offSign}${Math.floor(offAbs / 60)}${offAbs % 60 ? `:${pad(offAbs % 60)}` : ""}`;
+  const resetAtLocal = `${pad(d.getHours())}:${pad(d.getMinutes())} ${pad(d.getDate())}/${pad(d.getMonth() + 1)} (${tzLabel})`;
+  const h = Math.floor(retryAfterSec / 3600);
+  const m = Math.ceil((retryAfterSec % 3600) / 60);
+  const retryAfterHuman = h > 0 ? `${h}h${m}m` : `${m}m`;
+
+  return {
+    allowed: used < budget,
+    used,
+    budget,
+    windowStart: windowStartIso,
+    retryAfterIso: new Date(resetMs).toISOString(),
+    retryAfterSec,
+    resetAtLocal,
+    retryAfterHuman,
+  };
 }

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -79,6 +79,8 @@ export const TABLES = {
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
       createdAt: "TEXT NOT NULL",
+      // Per-key cost budget (USD-equivalent) per 5h; null = use the global default
+      costBudget5h: "REAL",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],
   },
@@ -117,12 +119,17 @@ export const TABLES = {
       status: "TEXT",
       tokens: "TEXT",
       meta: "TEXT",
+      // 1 = canonical row for per-key quota accounting (each request has exactly one);
+      // streaming writes a second stats row (endpoint set) which stays 0
+      countsTowardQuota: "INTEGER DEFAULT 0",
     },
     indexes: [
       "CREATE INDEX IF NOT EXISTS idx_uh_ts ON usageHistory(timestamp DESC)",
       "CREATE INDEX IF NOT EXISTS idx_uh_provider ON usageHistory(provider)",
       "CREATE INDEX IF NOT EXISTS idx_uh_model ON usageHistory(model)",
       "CREATE INDEX IF NOT EXISTS idx_uh_conn ON usageHistory(connectionId)",
+      // Speeds up the per-user token sum within the quota window
+      "CREATE INDEX IF NOT EXISTS idx_uh_apikey_ts ON usageHistory(apiKey, timestamp)",
     ],
   },
   usageDaily: {
@@ -138,6 +145,7 @@ export const TABLES = {
       provider: "TEXT",
       model: "TEXT",
       connectionId: "TEXT",
+      apiKey: "TEXT",
       status: "TEXT",
       data: "TEXT NOT NULL",
     },
@@ -146,7 +154,16 @@ export const TABLES = {
       "CREATE INDEX IF NOT EXISTS idx_rd_provider ON requestDetails(provider)",
       "CREATE INDEX IF NOT EXISTS idx_rd_model ON requestDetails(model)",
       "CREATE INDEX IF NOT EXISTS idx_rd_conn ON requestDetails(connectionId)",
+      "CREATE INDEX IF NOT EXISTS idx_rd_apikey ON requestDetails(apiKey)",
     ],
+  },
+  // Start of each user's (apiKey) current 5h quota window.
+  // windowStart = first request of the current window; a new window opens after 5h.
+  userQuotaWindow: {
+    columns: {
+      apiKey: "TEXT PRIMARY KEY",
+      windowStart: "TEXT NOT NULL",
+    },
   },
 };
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -9,6 +9,7 @@ import {
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
 import { getSettings } from "@/lib/localDb";
+import { checkUserQuota } from "@/lib/db/repos/usageRepo.js";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -76,6 +77,21 @@ export async function handleChat(request, clientRawRequest = null) {
     if (!valid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    }
+  }
+
+  // Per-user 5h cost quota: prevent one user from draining the shared pool.
+  // Placed before combo/non-combo branching to cover all paths.
+  if (apiKey) {
+    const quota = await checkUserQuota(apiKey);
+    if (quota && quota.allowed === false) {
+      log.warn("QUOTA", `[${log.maskKey(apiKey)}] exceeded 5h cost quota ($${quota.used.toFixed(2)}/$${quota.budget.toFixed(2)}), resets at ${quota.resetAtLocal}, in ${quota.retryAfterHuman}`);
+      return unavailableResponse(
+        429,
+        `[quota] Usage quota exceeded`,
+        quota.retryAfterIso,
+        `Resets at ${quota.resetAtLocal}, in ${quota.retryAfterHuman}`
+      );
     }
   }
 

--- a/tests/unit/user-quota.test.js
+++ b/tests/unit/user-quota.test.js
@@ -1,0 +1,207 @@
+// Per-key cost quota — window math, budget resolution, and accounting dedupe.
+// Quota sums the cost column (per-model pricing: non-cached input / cached input /
+// output weighted separately) of rows flagged countsTowardQuota = 1, so both
+// streaming and non-streaming are charged exactly once. Models without pricing
+// have cost 0 and are intentionally not charged (no token fallback).
+//
+// Built-in gpt-4 pricing used below (USD per 1M tokens):
+//   input 2.50 | cached 1.25 | output 10.00
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+const QUOTA_WINDOW_MS = 5 * 60 * 60 * 1000;
+
+const originalDataDir = process.env.DATA_DIR;
+let tempDir;
+let db;
+let usageRepo;
+let adapter;
+
+beforeAll(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-quota-"));
+  process.env.DATA_DIR = tempDir;
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+  usageRepo = await import("@/lib/db/repos/usageRepo.js");
+  const driver = await import("@/lib/db/driver.js");
+  adapter = await driver.getAdapter();
+});
+
+afterAll(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+// Ghi 1 row usage canonical (countsTowardQuota = 1) cho apiKey, model gpt-4
+async function writeCanonical(apiKey, tokens, extra = {}) {
+  await usageRepo.saveRequestUsage({
+    provider: "openai", model: "gpt-4", connectionId: "c1",
+    apiKey, tokens, countsTowardQuota: true, ...extra,
+  });
+}
+
+describe("checkUserQuota — enabled resolution", () => {
+  it("disabled by default → always allowed", async () => {
+    const res = await usageRepo.checkUserQuota("sk-default-off");
+    expect(res.allowed).toBe(true);
+    expect(res.disabled).toBe(true);
+  });
+
+  it("no apiKey → allowed", async () => {
+    const res = await usageRepo.checkUserQuota(null);
+    expect(res.allowed).toBe(true);
+  });
+});
+
+describe("checkUserQuota — cost accounting (countsTowardQuota marker)", () => {
+  beforeAll(async () => {
+    await db.updateSettings({ userQuotaEnabled: true, userCostBudget5hDefault: 2.0 });
+  });
+
+  it("streaming dual-write counts exactly once", async () => {
+    const key = "sk-stream";
+    await usageRepo.checkUserQuota(key); // mở window trước (giống handleChat: check rồi mới ghi usage)
+    // Row canonical (logUsage: endpoint null, flagged) — 400k input → $1.00
+    await writeCanonical(key, { prompt_tokens: 400_000, completion_tokens: 0 });
+    // Row duplicate (onStreamComplete: endpoint set, KHÔNG flag)
+    await usageRepo.saveRequestUsage({
+      provider: "openai", model: "gpt-4", connectionId: "c1",
+      apiKey: key, tokens: { prompt_tokens: 400_000, completion_tokens: 0 },
+      endpoint: "/v1/chat/completions",
+    });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBeCloseTo(1.0, 6); // không phải 2.0
+    expect(res.allowed).toBe(true);
+  });
+
+  it("non-streaming single write (endpoint set + flagged) is charged", async () => {
+    const key = "sk-nonstream";
+    await usageRepo.checkUserQuota(key); // mở window trước
+    await writeCanonical(key, { prompt_tokens: 200_000, completion_tokens: 0 }, { endpoint: "/v1/chat/completions" });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBeCloseTo(0.5, 6);
+  });
+
+  it("output tokens are weighted (4x input for gpt-4)", async () => {
+    const key = "sk-output";
+    await usageRepo.checkUserQuota(key);
+    // 100k input ($0.25) + 100k output ($1.00) = $1.25
+    await writeCanonical(key, { prompt_tokens: 100_000, completion_tokens: 100_000 });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBeCloseTo(1.25, 6);
+  });
+
+  it("cached input is discounted (0.5x input for gpt-4)", async () => {
+    const key = "sk-cached";
+    await usageRepo.checkUserQuota(key);
+    // 1M input trong đó 900k cached: 100k×2.5 + 900k×1.25 = $1.375
+    await writeCanonical(key, { prompt_tokens: 1_000_000, completion_tokens: 0, cached_tokens: 900_000 });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBeCloseTo(1.375, 6);
+  });
+
+  it("model without pricing → cost 0, intentionally not charged", async () => {
+    const key = "sk-nopricing";
+    await usageRepo.checkUserQuota(key);
+    await usageRepo.saveRequestUsage({
+      provider: "nopricing", model: "model-without-pricing", connectionId: "c1",
+      apiKey: key, tokens: { prompt_tokens: 99_000_000, completion_tokens: 1_000_000 },
+      countsTowardQuota: true,
+    });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBe(0);
+    expect(res.allowed).toBe(true);
+  });
+
+  it("over budget → blocked with retry info", async () => {
+    const key = "sk-over";
+    await usageRepo.checkUserQuota(key); // mở window trước
+    await writeCanonical(key, { prompt_tokens: 600_000, completion_tokens: 0 }); // $1.50
+    await writeCanonical(key, { prompt_tokens: 600_000, completion_tokens: 0 }); // $1.50
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.used).toBeCloseTo(3.0, 6);
+    expect(res.budget).toBe(2.0);
+    expect(res.allowed).toBe(false);
+    expect(res.retryAfterSec).toBeGreaterThan(0);
+    expect(res.retryAfterSec).toBeLessThanOrEqual(QUOTA_WINDOW_MS / 1000);
+    expect(res.resetAtLocal).toContain("UTC"); // offset tường minh
+    expect(new Date(res.retryAfterIso).getTime()).toBe(
+      new Date(res.windowStart).getTime() + QUOTA_WINDOW_MS
+    );
+  });
+});
+
+describe("checkUserQuota — window math", () => {
+  it("first request anchors the window", async () => {
+    const key = "sk-window";
+    const before = Date.now();
+    const res = await usageRepo.checkUserQuota(key);
+    const start = new Date(res.windowStart).getTime();
+    expect(start).toBeGreaterThanOrEqual(before);
+    expect(start).toBeLessThanOrEqual(Date.now());
+
+    // Lần check tiếp theo trong cùng window → giữ nguyên anchor
+    const res2 = await usageRepo.checkUserQuota(key);
+    expect(res2.windowStart).toBe(res.windowStart);
+  });
+
+  it("expired window (>5h) → new window opens and usage resets", async () => {
+    const key = "sk-expired";
+    const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString();
+
+    // Window cũ đã hết hạn, usage cũ nằm trong window cũ
+    adapter.run(
+      `INSERT INTO userQuotaWindow(apiKey, windowStart) VALUES(?, ?)`,
+      [key, sixHoursAgo]
+    );
+    await writeCanonical(key, { prompt_tokens: 5_000_000, completion_tokens: 0 }, { timestamp: sixHoursAgo });
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(new Date(res.windowStart).getTime()).toBeGreaterThan(new Date(sixHoursAgo).getTime());
+    expect(res.used).toBe(0); // usage của window cũ không tính sang window mới
+    expect(res.allowed).toBe(true);
+  });
+});
+
+describe("checkUserQuota — per-key budget override", () => {
+  it("apiKeys.costBudget5h overrides the global default", async () => {
+    const key = "sk-override";
+    adapter.run(
+      `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt, costBudget5h) VALUES(?, ?, ?, ?, 1, ?, ?)`,
+      ["id-override", key, "override", "m1", new Date().toISOString(), 0.3]
+    );
+    await usageRepo.checkUserQuota(key); // mở window trước
+    await writeCanonical(key, { prompt_tokens: 200_000, completion_tokens: 0 }); // $0.50
+
+    const res = await usageRepo.checkUserQuota(key);
+    expect(res.budget).toBe(0.3);
+    expect(res.allowed).toBe(false);
+  });
+
+  it("updateApiKey persists costBudget5h and rowToKey exposes it", async () => {
+    const keysRepo = await import("@/lib/db/repos/apiKeysRepo.js");
+    adapter.run(
+      `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, 1, ?)`,
+      ["id-crud", "sk-crud", "crud", "m1", new Date().toISOString()]
+    );
+
+    const updated = await keysRepo.updateApiKey("id-crud", { costBudget5h: 1.5 });
+    expect(updated.costBudget5h).toBe(1.5);
+
+    const fetched = await keysRepo.getApiKeyById("id-crud");
+    expect(fetched.costBudget5h).toBe(1.5);
+
+    // Clear override → quay về default toàn cục
+    const cleared = await keysRepo.updateApiKey("id-crud", { costBudget5h: null });
+    expect(cleared.costBudget5h).toBe(null);
+  });
+});


### PR DESCRIPTION
## Why

9Router is often used as a **single gateway feeding many AI tools** — Claude Code, Codex CLI, Cursor, Cline, Copilot, etc. — all sharing one upstream account pool, with **one API key per tool**. At that scale two gaps show up:

1. **One heavy tool can drain the shared pool.** When a single tool's key burns through the pool's quota, every other tool starts getting `429`s through no fault of its own. There is no way to bound a single key's consumption.
2. **You can't tell which tool used what.** `requestDetails` stores `connectionId` (the upstream account) but not the **API key** that made the call, so usage can't be attributed back to the tool that issued it.

This PR adds two small, **opt-in** governance features to close those gaps — without changing default behavior for anyone who doesn't turn them on.

> Supersedes #1569 — consolidates the original feature plus all fixes from the review there (thanks @muhfauziazhar) into a single clean commit.

## What

### 1. Per-key cost quota (disabled by default)

- **Fixed 5h window anchored to the key's first request** (`userQuotaWindow` table) — mirrors upstream reset semantics, not a rolling window. Enforced in `handleChat` **before** combo/non-combo routing so every path is covered.
- **Cost-based accounting, not raw tokens.** The budget is `SUM(cost)` (USD-equivalent), where `cost` is already computed per row by `calculateCost` with per-model pricing — weighting **non-cached input, cached input and output separately**. This mirrors how upstream actually accounts usage (codex credits: input 1×, cached ~0.1×, output ~6×; Claude weights similarly). A prompt-token budget would overcharge cache reads ~10× and ignore output entirely.
  - Models without pricing data have `cost = 0` and are **intentionally not charged** (no token fallback).
- **Each request charged exactly once** via an explicit `usageHistory.countsTowardQuota` marker, set at the single canonical write of each path:
  - streaming → `logUsage()` (the `onStreamComplete` duplicate stats row stays unflagged)
  - non-streaming → `nonStreamingHandler`
  - forced SSE→JSON → both branches of `sseToJsonHandler`
- Over budget → **`429` + `Retry-After`** with a human-readable reset time incl. explicit UTC offset (e.g. `14:30 05/06 (UTC+7)`).
- **Budget resolution:** `apiKeys.costBudget5h` (per-key, set via `PUT /api/keys/[id]`; `null` clears) → `userCostBudget5hDefault` DB setting → `USER_COST_BUDGET_5H` env → built-in default (`50`).
- **Eventually consistent by design:** usage rows land async after the response completes, so a burst can overshoot the soft budget. Documented in the code.

### 2. Per-key request attribution

Persists `apiKey` on every `requestDetails` and `usageHistory` row (previously `connectionId` only), so usage and tool calls can be traced back to the specific tool/key.

## Safe by design

- **Opt-in, off by default** — `userQuotaEnabled` resolves `DB setting > env > built-in default (false)`. Existing deployments behave exactly as before until explicitly enabled.
- **Additive schema only** — applied automatically by `syncSchemaFromTables`: `apiKeys.costBudget5h`, `requestDetails.apiKey`, `usageHistory.apiKey/endpoint/countsTowardQuota`, `userQuotaWindow` table, supporting indexes (`idx_uh_apikey_ts`, `idx_rd_apikey`). No migration file, no destructive change.
- **Backward compatible** — attribution columns are nullable; pre-upgrade rows simply have `apiKey = null` / `countsTowardQuota = 0`.

## Testing

`tests/unit/user-quota.test.js` — 12 cases:
- accounting dedupe: streaming dual-write charged exactly once; non-streaming charged
- weighting: output and cached-input weighted per pricing; model without pricing charged 0 (documented no-fallback)
- over-budget blocking with correct `Retry-After`/reset info
- window math: anchor on first request, reset after 5h
- enabled-flag resolution; per-key override and its CRUD path

Also verified end-to-end on a live instance: `429` with correct reset time when over budget, normal service under budget, `apiKey` recorded on `requestDetails`.

## How to enable

```yaml
environment:
  - USER_QUOTA_ENABLED=true
  - USER_COST_BUDGET_5H=50   # USD-equivalent per 5h per key, optional
```

Or via DB settings (`userQuotaEnabled`, `userCostBudget5hDefault`); per-key limit via `PUT /api/keys/[id]` with `{"costBudget5h": 20}`.

## Follow-ups (out of scope)

- Dashboard UI surface for `costBudget5h` (API is in place)
- Broader per-key governance tracked in #1677
