### PR TITLE
fix: show llm combos on dashboard

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -37,8 +37,8 @@ export default function CombosPage() {
       const providersData = await providersRes.json();
       const settingsData = settingsRes.ok ? await settingsRes.json() : {};
       
-      // Only LLM combos here — webSearch/webFetch combos belong to media-providers/web
-      if (combosRes.ok) setCombos((combosData.combos || []).filter(c => !c.kind));
+      // Only LLM combos here - webSearch/webFetch combos belong to media-providers/web
+      if (combosRes.ok) setCombos((combosData.combos || []).filter(c => !c.kind || c.kind === "llm"));
       if (providersRes.ok) {
         setActiveProviders(providersData.connections || []);
       }


### PR DESCRIPTION
## Description

LLM combos created with `kind: "llm"` are hidden from the Dashboard Combos page because the page only lists combos without a `kind` value.

Web Search/Web Fetch combos are intentionally managed from the media providers page, but LLM combos should remain visible on `/dashboard/combos`.

## Changes

- Keep existing no-kind combos visible for backward compatibility.
- Include explicit `kind: "llm"` combos on the Dashboard Combos page.
- Continue filtering out non-LLM combos such as media provider combos.

## Verification

- `npm run build`
- `git diff --check`

Closes #1682