### PR TITLE
fix: resolve nested standalone build path

### DIFF
--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -82,6 +82,29 @@ function copyRecursive(src, dest) {
   }
 }
 
+function findStandaloneApp(standaloneRootToUse) {
+  const rootServer = path.join(standaloneRootToUse, "server.js");
+  if (fs.existsSync(rootServer)) {
+    return standaloneRootToUse;
+  }
+
+  const appDir = path.join(standaloneRootToUse, "app");
+  if (fs.existsSync(path.join(appDir, "server.js"))) {
+    return appDir;
+  }
+
+  if (!fs.existsSync(standaloneRootToUse)) {
+    return null;
+  }
+
+  const nestedApp = fs.readdirSync(standaloneRootToUse, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => path.join(standaloneRootToUse, entry.name))
+    .find(dir => fs.existsSync(path.join(dir, "server.js")));
+
+  return nestedApp || (fs.existsSync(appDir) ? appDir : null);
+}
+
 console.log("📦 Building 9Router CLI package with Next.js...\n");
 
 fs.mkdirSync(buildHomeDir, { recursive: true });
@@ -137,12 +160,10 @@ console.log("3️⃣  Copying Next.js standalone build to app/cli/app...");
 const standaloneRoot = path.join(appDir, ".next", "standalone");
 const standaloneRootResolved = path.join(buildDistDir, "standalone");
 const standaloneRootToUse = fs.existsSync(standaloneRootResolved) ? standaloneRootResolved : standaloneRoot;
-const standaloneApp = fs.existsSync(path.join(standaloneRootToUse, "server.js"))
-  ? standaloneRootToUse
-  : path.join(standaloneRootToUse, "app");
-if (!fs.existsSync(standaloneApp)) {
+const standaloneApp = findStandaloneApp(standaloneRootToUse);
+if (!standaloneApp || !fs.existsSync(standaloneApp)) {
   console.error("❌ Next.js standalone build not found under .next/standalone");
-  console.error("Expected either .next/standalone/server.js or .next/standalone/app/");
+  console.error("Expected .next/standalone/server.js, .next/standalone/app/, or a nested standalone app with server.js");
   process.exit(1);
 }
 copyRecursive(standaloneApp, cliAppDir);


### PR DESCRIPTION
Description

Next.js standalone output can place server.js under a project-named subdirectory such as .next/standalone/9router/server.js. The CLI build script only checked .next/standalone/server.js and .next/standalone/app/, so it could fail even when a valid standalone server exists.

Changes

- Resolve the standalone app directory through a small helper.
- Keep the existing root and app/ layouts supported.
- Fall back to the first nested directory that contains server.js, covering project-named output folders.
- Improve the missing-standalone error message.

Verification

- node --check cli/scripts/build-cli.js
- git diff --check
- Fixture check for root, app, legacy app, nested 9router, app+nested, and missing layouts.

Closes #1632