### PR TITLE
fix: preserve tool context in combo and Kiro routing

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -106,8 +106,17 @@ export function getComboModelsFromData(modelStr, combosData) {
  * @returns {Promise<Response>}
  */
 export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1 }) {
-  // Apply rotation strategy if enabled
-  const rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
+  // Coding agents send tools and need stable priority order. Keep the original
+  // combo strategy for normal chat, but try tool-capable requests top-to-bottom
+  // while preserving the exact same body (messages/tools/tool_choice/context).
+  const hasTools = Array.isArray(body?.tools) && body.tools.length > 0;
+  const rotatedModels = hasTools
+    ? models
+    : getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
+
+  if (hasTools) {
+    log.info("COMBO", `Tool request: ordered fallback ${comboName || ""} (${rotatedModels.length} models), tools/context preserved`);
+  }
   
   let lastError = null;
   let earliestRetryAfter = null;

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -161,9 +161,15 @@ function convertMessages(messages, tools, model) {
         }
       }
       
-      // Handle tool role (from normalized)
+      // Handle tool role (from normalized). OpenAI-compatible coding agents may
+      // send tool content as an array of text blocks; preserve it instead of
+      // silently converting it to an empty Kiro tool result.
       if (msg.role === "tool") {
-        const toolContent = typeof msg.content === "string" ? msg.content : "";
+        const toolContent = typeof msg.content === "string"
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content.map(c => typeof c === "string" ? c : (c?.text || c?.content || "")).join("\n")
+            : (msg.content ? JSON.stringify(msg.content) : "");
         pendingToolResults.push({
           toolUseId: msg.tool_call_id,
           status: "success",

--- a/tests/unit/combo-routing.test.js
+++ b/tests/unit/combo-routing.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { getRotatedModels, resetComboRotation } from "../../open-sse/services/combo.js";
+import { getRotatedModels, resetComboRotation, handleComboChat } from "../../open-sse/services/combo.js";
 
 describe("combo round-robin routing", () => {
   beforeEach(() => {
@@ -54,5 +54,67 @@ describe("combo round-robin routing", () => {
 
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
     expect(getRotatedModels(models, "code-xhigh", "fallback", 2)).toEqual(models);
+  });
+
+  it("keeps tool requests in priority order even for round-robin combos", async () => {
+    const models = ["provider/model-a", "provider/model-b"];
+    const tried = [];
+
+    const result = await handleComboChat({
+      body: { tools: [{ type: "function", function: { name: "read" } }] },
+      models,
+      comboName: "code-xhigh",
+      comboStrategy: "round-robin",
+      comboStickyLimit: 1,
+      log: { info() {}, warn() {} },
+      handleSingleModel: async (_body, model) => {
+        tried.push(model);
+        return new Response("ok", { status: 200 });
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(tried).toEqual(["provider/model-a"]);
+
+    const secondTried = [];
+    await handleComboChat({
+      body: { tools: [{ type: "function", function: { name: "read" } }] },
+      models,
+      comboName: "code-xhigh",
+      comboStrategy: "round-robin",
+      comboStickyLimit: 1,
+      log: { info() {}, warn() {} },
+      handleSingleModel: async (_body, model) => {
+        secondTried.push(model);
+        return new Response("ok", { status: 200 });
+      },
+    });
+
+    expect(secondTried).toEqual(["provider/model-a"]);
+  });
+
+  it("falls back through tool requests with the same request body", async () => {
+    const body = { tools: [{ type: "function", function: { name: "read" } }], messages: [{ role: "user", content: "hi" }] };
+    const bodies = [];
+    const tried = [];
+
+    const result = await handleComboChat({
+      body,
+      models: ["provider/dead", "provider/live"],
+      comboName: "code-xhigh",
+      comboStrategy: "round-robin",
+      log: { info() {}, warn() {} },
+      handleSingleModel: async (passedBody, model) => {
+        bodies.push(passedBody);
+        tried.push(model);
+        return model.endsWith("dead")
+          ? new Response(JSON.stringify({ error: { message: "rate limit" } }), { status: 429, headers: { "content-type": "application/json" } })
+          : new Response("ok", { status: 200 });
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(tried).toEqual(["provider/dead", "provider/live"]);
+    expect(bodies).toEqual([body, body]);
   });
 });

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -143,4 +143,33 @@ describe("buildKiroPayload", () => {
       expect(currentMsg.userInputMessage.content).toContain("[Image: https://example.com/photo.jpg]");
     });
   });
+
+  describe("tool results", () => {
+    it("should preserve OpenAI tool message array content", () => {
+      const body = {
+        messages: [
+          { role: "user", content: "Run tool" },
+          {
+            role: "assistant",
+            content: [],
+            tool_calls: [{ id: "call_1", type: "function", function: { name: "echo", arguments: "{}" } }]
+          },
+          {
+            role: "tool",
+            tool_call_id: "call_1",
+            content: [{ type: "text", text: "TOOL_ARRAY_OUTPUT" }]
+          },
+          { role: "user", content: "What was output?" }
+        ],
+        tools: [{ type: "function", function: { name: "echo", description: "echo", parameters: { type: "object", properties: {} } } }]
+      };
+
+      const result = buildKiroPayload("claude-sonnet-4.6", body, true, {});
+      const toolResults = result.conversationState.currentMessage.userInputMessage.userInputMessageContext.toolResults;
+
+      expect(toolResults).toHaveLength(1);
+      expect(toolResults[0].toolUseId).toBe("call_1");
+      expect(toolResults[0].content[0].text).toBe("TOOL_ARRAY_OUTPUT");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Keep combo requests that include tools in priority order instead of round-robin rotation.
- Preserve the original request body across combo fallback so messages/tools/tool_choice stay intact.
- Preserve OpenAI-compatible tool message content arrays when translating tool results to Kiro.

## Test Plan
- `NODE_PATH=/root/src/9router-src/node_modules:/root/src/9router-src/tests/node_modules /root/src/9router-src/tests/node_modules/.bin/vitest run --reporter=verbose tests/unit/openai-to-kiro.test.js tests/unit/combo-routing.test.js`
- Result: 2 files passed, 14 tests passed
