### PR TITLE
feat(ag): add gemini-3.5-flash-high and gemini-3.5-flash-medium model aliases

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -85,6 +85,9 @@ export const PROVIDER_MODELS = {
     { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Extra Low)" },
     { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)" },
     { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium)" },
+    // Alias IDs requested by user
+    { id: "gemini-3.5-flash-high", name: "Gemini 3.5 Flash (High)", upstreamModelId: "gemini-3-flash-agent" },
+    { id: "gemini-3.5-flash-medium", name: "Gemini 3.5 Flash (Medium)", upstreamModelId: "gemini-3.5-flash-low" },
     { id: "gemini-pro-agent", name: "Gemini 3.1 Pro (High)" },
     { id: "gemini-3.1-pro-low", name: "Gemini 3.1 Pro (Low)" },
     { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Thinking)" },

--- a/src/mitm/config.js
+++ b/src/mitm/config.js
@@ -42,8 +42,10 @@ const MODEL_SYNONYMS = {
 // Order matters: more specific patterns first. Catches AG renamed variants (e.g. gemini-pro-agent)
 const MODEL_PATTERNS = {
   antigravity: [
-    { match: /flash.*low|low.*flash|flash.*medium|medium.*flash/i, alias: "gemini-3.5-flash-low" },
-    { match: /flash.*agent|agent.*flash|flash/i,                   alias: "gemini-3-flash-agent" },
+    { match: /flash.*high|high.*flash/i,                   alias: "gemini-3.5-flash-high" },
+    { match: /flash.*medium|medium.*flash/i,                alias: "gemini-3.5-flash-medium" },
+    { match: /flash.*low|low.*flash/i,                      alias: "gemini-3.5-flash-low" },
+    { match: /flash.*agent|agent.*flash|flash/i,             alias: "gemini-3-flash-agent" },
     { match: /pro.*low|low.*pro/i,                                 alias: "gemini-3.1-pro-low" },
     { match: /gemini.*pro|pro.*gemini/i,                           alias: "gemini-pro-agent" },
     { match: /opus/i,                                              alias: "claude-opus-4-6-thinking" },

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -8,7 +8,7 @@ export const MITM_TOOLS = {
     description: "Google Antigravity IDE with MITM",
     configType: "mitm",
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
-    modelAliases: ["gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
+    modelAliases: ["gemini-3.5-flash-low", "gemini-3.5-flash-medium", "gemini-3.5-flash-high", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
     defaultModels: [
       { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium) / Default", alias: "gemini-3.5-flash-low" },
       { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)", alias: "gemini-3-flash-agent" },


### PR DESCRIPTION
Adds two new model alias IDs for the Antigravity (ag) provider:

- ag/gemini-3.5-flash-high → maps to gemini-3-flash-agent (existing working model)
- ag/gemini-3.5-flash-medium → maps to gemini-3.5-flash-low (existing working model)

Changes:
1. Added upstreamModelId mappings in providerModels.js so the aliases resolve correctly
2. Updated MITM pattern matching in src/mitm/config.js to route the new IDs to the correct upstream models
3. Updated the modelAliases list in src/shared/constants/cliTools.js for completeness

These aliases allow users to request the more intuitive model IDs while 9Router routes them to working Gemini models via Antigravity.