### PR TITLE
fix(commandcode): force stream=true in transformRequest

### DIFF
--- a/open-sse/executors/commandcode.js
+++ b/open-sse/executors/commandcode.js
@@ -19,6 +19,11 @@ export class CommandCodeExecutor extends BaseExecutor {
     super("commandcode", PROVIDERS.commandcode);
   }
 
+  transformRequest(model, body, stream, credentials) {
+    body.stream = true;
+    return body;
+  }
+
   buildHeaders(credentials, stream = true) {
     const headers = {
       "Content-Type": "application/json",


### PR DESCRIPTION
CommandCode API requires \stream=true\ for every \/alpha/generate\ request. Without it, the API returns \400: expected true at params.stream\.

This PR adds a \	ransformRequest\ override to \CommandCodeExecutor\ that enforces \stream=true\ in the request body before sending to upstream, preventing the 400 error.