### PR TITLE
fix(mitm): update Kiro API endpoint to runtime.us-east-1.kiro.dev

### DIFF
--- a/src/lib/dataDir.js
+++ b/src/lib/dataDir.js
@@ -14,6 +14,14 @@ function defaultDir() {
 export function getDataDir() {
   const configured = process.env.DATA_DIR;
   if (!configured) return defaultDir();
+
+  // On Windows, ignore Unix-style absolute paths (e.g. /var/lib/...) that come
+  // from a Linux-targeted .env or Docker config — they are not valid here.
+  if (process.platform === "win32" && /^\//.test(configured)) {
+    console.warn(`[DATA_DIR] '${configured}' is a Unix path on Windows → fallback to default`);
+    return defaultDir();
+  }
+
   try {
     fs.mkdirSync(configured, { recursive: true });
     return configured;

--- a/src/mitm/config.js
+++ b/src/mitm/config.js
@@ -18,6 +18,8 @@ const TARGET_HOSTS = [
   "cloudcode-pa.googleapis.com",
   "api.individual.githubcopilot.com",
   "q.us-east-1.amazonaws.com",
+  "codewhisperer.us-east-1.amazonaws.com",
+  "runtime.us-east-1.kiro.dev",
   "api2.cursor.sh",
 ];
 
@@ -79,7 +81,7 @@ function getToolForHost(host) {
   const h = (host || "").split(":")[0];
   if (h === "api.individual.githubcopilot.com") return "copilot";
   if (h === "daily-cloudcode-pa.googleapis.com" || h === "cloudcode-pa.googleapis.com") return "antigravity";
-  if (h === "q.us-east-1.amazonaws.com") return "kiro";
+  if (h === "q.us-east-1.amazonaws.com" || h === "codewhisperer.us-east-1.amazonaws.com" || h === "runtime.us-east-1.kiro.dev") return "kiro";
   if (h === "api2.cursor.sh") return "cursor";
   return null;
 }

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -49,7 +49,7 @@ export const MITM_TOOLS = {
     color: "#FF6B00",
     description: "Kiro IDE with MITM",
     configType: "mitm",
-    mitmDomain: "q.us-east-1.amazonaws.com",
+    mitmDomain: "runtime.us-east-1.kiro.dev",
     defaultModels: [
       // Kiro's agent/"vibe" mode sends modelId "auto" for the main turn and "simple-task"
       // for background sub-tasks (verified via MITM request dump of generateAssistantResponse).

--- a/src/shared/constants/mitmToolHosts.js
+++ b/src/shared/constants/mitmToolHosts.js
@@ -5,7 +5,7 @@
 const TOOL_HOSTS = {
   antigravity: ["daily-cloudcode-pa.googleapis.com", "cloudcode-pa.googleapis.com"],
   copilot: ["api.individual.githubcopilot.com"],
-  kiro: ["q.us-east-1.amazonaws.com", "codewhisperer.us-east-1.amazonaws.com"],
+  kiro: ["runtime.us-east-1.kiro.dev", "q.us-east-1.amazonaws.com", "codewhisperer.us-east-1.amazonaws.com"],
   cursor: ["api2.cursor.sh"],
 };
 


### PR DESCRIPTION
Kiro IDE changed its API endpoint from q.us-east-1.amazonaws.com to runtime.us-east-1.kiro.dev. The old domain is kept as fallback.

- Add runtime.us-east-1.kiro.dev to TARGET_HOSTS and getToolForHost()
- Update mitmDomain in cliTools.js
- Add new domain to mitmToolHosts.js (keep old domains for compatibility)