### PR TITLE
feat(antigravity): implement model grouping lock + fix resets-in quota parsing

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -82,15 +82,15 @@ export const PROVIDER_MODELS = {
     { id: "iflow-rome-30ba3b", name: "iFlow ROME" },
   ],
   ag: [  // Antigravity - special case: models call different backends
-    { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)" },
-    { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium)" },
-    { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)" },
-    { id: "gemini-pro-agent", name: "Gemini 3.1 Pro (High)" },
-    { id: "gemini-3.1-pro-low", name: "Gemini 3.1 Pro (Low)" },
-    { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Thinking)" },
-    { id: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 (Thinking)" },
-    { id: "gpt-oss-120b-medium", name: "GPT-OSS 120B (Medium)" },
-    { id: "gemini-3-flash", name: "Gemini 3 Flash", thinking: false }, // command model; AG strips thinking
+    { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)", quotaFamily: "ag-gemini" },
+    { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium)", quotaFamily: "ag-gemini" },
+    { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)", quotaFamily: "ag-gemini" },
+    { id: "gemini-pro-agent", name: "Gemini 3.1 Pro (High)", quotaFamily: "ag-gemini" },
+    { id: "gemini-3.1-pro-low", name: "Gemini 3.1 Pro (Low)", quotaFamily: "ag-gemini" },
+    { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Thinking)", quotaFamily: "ag-ex-gemini" },
+    { id: "claude-opus-4-6-thinking", name: "Claude Opus 4.6 (Thinking)", quotaFamily: "ag-ex-gemini" },
+    { id: "gpt-oss-120b-medium", name: "GPT-OSS 120B (Medium)", quotaFamily: "ag-ex-gemini" },
+    { id: "gemini-3-flash", name: "Gemini 3 Flash", thinking: false, quotaFamily: "ag-gemini" }, // command model; AG strips thinking
   ],
   gh: [  // GitHub Copilot - OpenAI models
     { id: "gpt-3.5-turbo", name: "GPT-3.5 Turbo" },

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -182,10 +182,11 @@ export class AntigravityExecutor extends BaseExecutor {
 
   // Parse retry time from Antigravity error message body
   // Format: "Your quota will reset after 2h7m23s" or "1h30m" or "45m" or "30s"
+  // Format 2: "Resets in 133h10m19s"
   parseRetryFromErrorMessage(errorMessage) {
     if (!errorMessage || typeof errorMessage !== "string") return null;
 
-    const match = errorMessage.match(/reset after (\d+h)?(\d+m)?(\d+s)?/i);
+    const match = errorMessage.match(/(?:reset after|resets in) (\d+h)?(\d+m)?(\d+s)?/i);
     if (!match) return null;
 
     let totalMs = 0;

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -133,7 +133,7 @@ export function getEarliestModelLockUntil(connection) {
   let earliest = null;
   const now = Date.now();
   for (const [key, val] of Object.entries(connection)) {
-    if (!key.startsWith(MODEL_LOCK_PREFIX) || !val) continue;
+    if ((!key.startsWith(MODEL_LOCK_PREFIX) && !key.startsWith(MODEL_GROUP_LOCK_PREFIX)) || !val) continue;
     const t = new Date(val).getTime();
     if (t <= now) continue;
     if (!earliest || t < earliest) earliest = t;
@@ -155,9 +155,59 @@ export function buildModelLockUpdate(model, cooldownMs) {
 export function buildClearModelLocksUpdate(connection) {
   const cleared = {};
   for (const key of Object.keys(connection)) {
-    if (key.startsWith(MODEL_LOCK_PREFIX)) cleared[key] = null;
+    if (key.startsWith(MODEL_LOCK_PREFIX) || key.startsWith(MODEL_GROUP_LOCK_PREFIX)) cleared[key] = null;
   }
   return cleared;
+}
+
+// ─── Group Lock (quota family) ────────────────────────────────────────────────
+// Prefix for model-group lock flat fields on connection record.
+// Only used for providers whose models declare quotaFamily (e.g. Antigravity).
+// Falls back gracefully: providers without quotaFamily never set/check this prefix.
+
+/** Prefix for group lock flat fields */
+export const MODEL_GROUP_LOCK_PREFIX = "modelGroupLock_";
+
+/** Build the flat field key for a group lock */
+export function getGroupLockKey(quotaFamily) {
+  return `${MODEL_GROUP_LOCK_PREFIX}${quotaFamily}`;
+}
+
+/**
+ * Check if a group lock on a connection is still active.
+ * Reads flat field `modelGroupLock_${quotaFamily}`.
+ * Returns false immediately if quotaFamily is falsy or "normal"
+ * (non-grouped models are never group-locked).
+ */
+export function isGroupLockActive(connection, quotaFamily) {
+  if (!quotaFamily || quotaFamily === "normal") return false;
+  const key = getGroupLockKey(quotaFamily);
+  const expiry = connection[key];
+  if (!expiry) return false;
+  return new Date(expiry).getTime() > Date.now();
+}
+
+/**
+ * Build update object to set a group lock on a connection.
+ * Returns empty object if quotaFamily is falsy or "normal"
+ * so it is always safe to spread into any update.
+ */
+export function buildGroupLockUpdate(quotaFamily, cooldownMs) {
+  if (!quotaFamily || quotaFamily === "normal") return {};
+  const key = getGroupLockKey(quotaFamily);
+  return { [key]: new Date(Date.now() + cooldownMs).toISOString() };
+}
+
+/**
+ * Collect all modelGroupLock_* keys from a connection that belong
+ * to the given quotaFamily and should be cleared on success.
+ * Returns an object { [key]: null } ready to spread into updateProviderConnection.
+ */
+export function buildClearGroupLockUpdate(connection, quotaFamily) {
+  if (!quotaFamily || quotaFamily === "normal") return {};
+  const key = getGroupLockKey(quotaFamily);
+  if (!(key in connection)) return {};
+  return { [key]: null };
 }
 
 /**

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,9 +1,23 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings } from "@/lib/localDb";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil, isGroupLockActive, buildGroupLockUpdate, buildClearGroupLockUpdate } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
+import { getModelQuotaFamily, PROVIDER_ID_TO_ALIAS } from "open-sse/config/providerModels.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
+
+/**
+ * Resolve the quota family for a given provider+model combination.
+ * Returns "normal" for providers/models without group definitions.
+ * @param {string} providerId - Resolved provider ID (e.g. "antigravity")
+ * @param {string|null} model - Model ID
+ * @returns {string} quotaFamily, e.g. "ag-gemini-flash" or "normal"
+ */
+function resolveQuotaFamily(providerId, model) {
+  if (!model || !providerId) return "normal";
+  const alias = PROVIDER_ID_TO_ALIAS[providerId] || providerId;
+  return getModelQuotaFamily(alias, model);
+}
 
 // Mutex to prevent race conditions during account selection
 let selectionMutex = Promise.resolve();
@@ -60,10 +74,12 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       return null;
     }
 
-    // Filter out model-locked and excluded connections
+    // Filter out model-locked, group-locked, and excluded connections
+    const quotaFamily = resolveQuotaFamily(providerId, model);
     const availableConnections = connections.filter(c => {
       if (excludeSet.has(c.id)) return false;
       if (isModelLockActive(c, model)) return false;
+      if (isGroupLockActive(c, quotaFamily)) return false;
       return true;
     });
 
@@ -219,9 +235,13 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
 
   const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
   const lockUpdate = buildModelLockUpdate(model, cooldownMs);
+  const providerId = resolveProviderId(provider);
+  const quotaFamily = resolveQuotaFamily(providerId, model);
+  const groupLockUpdate = buildGroupLockUpdate(quotaFamily, cooldownMs);
 
   await updateProviderConnection(connectionId, {
     ...lockUpdate,
+    ...groupLockUpdate,
     testStatus: "unavailable",
     lastError: reason,
     errorCode: status,
@@ -243,26 +263,46 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
 /**
  * Clear account error status on successful request.
  * - Clears modelLock_${model} (the model that just succeeded)
- * - Lazy-cleans any other expired modelLock_* keys
+ * - Clears modelGroupLock_${quotaFamily} (the quota family that just succeeded)
+ * - Lazy-cleans any other expired modelLock_* and modelGroupLock_* keys
  * - Resets error state only if no active locks remain
  * @param {string} connectionId
  * @param {object} currentConnection - credentials object (has _connection) or raw connection
  * @param {string|null} model - model that succeeded
+ * @param {string|null} provider - provider to resolve quota family
  */
-export async function clearAccountError(connectionId, currentConnection, model = null) {
+export async function clearAccountError(connectionId, currentConnection, model = null, provider = null) {
   if (!connectionId || connectionId === "noauth") return;
   const conn = currentConnection._connection || currentConnection;
   const now = Date.now();
-  const allLockKeys = Object.keys(conn).filter(k => k.startsWith("modelLock_"));
+
+  // Collect all model lock keys AND all group lock keys
+  const allModelLockKeys = Object.keys(conn).filter(k => k.startsWith("modelLock_"));
+  const allGroupLockKeys = Object.keys(conn).filter(k => k.startsWith("modelGroupLock_"));
+  const allLockKeys = [...allModelLockKeys, ...allGroupLockKeys];
 
   if (!conn.testStatus && !conn.lastError && allLockKeys.length === 0) return;
 
-  // Keys to clear: current model's lock + all expired locks
+  // Resolve quota family for the succeeded model
+  const providerId = provider ? resolveProviderId(provider) : null;
+  const quotaFamily = resolveQuotaFamily(providerId, model);
+
+  // Keys to clear: current model's lock + account-level lock + current group lock + all expired locks
   const keysToClear = allLockKeys.filter(k => {
-    if (model && k === `modelLock_${model}`) return true; // succeeded model
-    if (model && k === "modelLock___all") return true;    // account-level lock
-    const expiry = conn[k];
-    return expiry && new Date(expiry).getTime() <= now;   // expired
+    // Model locks
+    if (k.startsWith("modelLock_")) {
+      if (model && k === `modelLock_${model}`) return true; // succeeded model
+      if (model && k === "modelLock___all") return true;    // account-level lock
+      const expiry = conn[k];
+      return expiry && new Date(expiry).getTime() <= now;   // expired
+    }
+    // Group locks
+    if (k.startsWith("modelGroupLock_")) {
+      if (quotaFamily !== "normal" && k === `modelGroupLock_${quotaFamily}`) return true; // succeeded group
+      const expiry = conn[k];
+      return expiry && new Date(expiry).getTime() <= now;   // expired
+    }
+    return false;
   });
 
   if (keysToClear.length === 0 && conn.testStatus !== "unavailable" && !conn.lastError) return;


### PR DESCRIPTION
## Changes
### `open-sse/config/providerModels.js`
- Added `quotaFamily` properties to Antigravity (`ag`) models:
  - `ag-gemini`: For all native Google Gemini models.
  - `ag-ex-gemini`: For non-Gemini models (Claude Sonnet, Claude Opus, and GPT-OSS).

### `open-sse/services/accountFallback.js`
- Introduced `MODEL_GROUP_LOCK_PREFIX` (`modelGroupLock_`) flat-fields.
- Implemented `isGroupLockActive`, `buildGroupLockUpdate`, and `buildClearGroupLockUpdate` helpers (falsy or `"normal"` quota families are bypassed gracefully to maintain backward compatibility).
- Updated `getEarliestModelLockUntil` and `buildClearModelLocksUpdate` to handle group locks.

### `src/sse/services/auth.js`
- Integrated `isGroupLockActive` into connection availability filtering inside `getProviderCredentials`.
- Modified `markAccountUnavailable` to resolve the quota family and apply the group lock alongside the specific model lock in a single DB update.
- Updated `clearAccountError` to support clearing group locks on success while maintaining full backward compatibility for callers without a provider parameter.

### `src/sse/handlers/chat.js`
- Updated success callback invocation `clearAccountError` to pass `provider` as the fourth parameter.

### `open-sse/executors/antigravity.js`
- Updated the regex pattern in `parseRetryFromErrorMessage` to `/(?:reset after|resets in) (\d+h)?(\d+m)?(\d+s)?/i` to accurately capture the reset countdown (e.g., `Resets in 133h10m19s`), resulting in robust, multi-day model locks as dictated by the upstream provider.

## Verification
- verified parsing matches both formats: `"Your quota will reset after 2h"` and `"Resets in 133h10m19s"`.
- Verified lock filters block all models in `ag-gemini` once one Gemini model hits a 429/403 rate limit.
- Checked backward compatibility for `claude` (Claude Code) and other providers — they continue to resolve to `"normal"` quotaFamily with zero side-effects.
