### PR TITLE
fix(open-sse): codex api compatibility and sse translation fixes

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -409,6 +409,48 @@ export class CodexExecutor extends BaseExecutor {
     // Ensure streaming is enabled (Codex API requires it)
     body.stream = true;
 
+    // Extract system messages from input[] and merge into instructions field
+    // Codex does not accept role=system in input[], only via the instructions field
+    if (Array.isArray(body.input)) {
+      const systemItems = body.input.filter(
+        (item) => item.role === "system"
+      );
+      if (systemItems.length > 0) {
+        body.input = body.input.filter(
+          (item) => item.role !== "system"
+        );
+        const systemText = systemItems
+          .map((item) => {
+            if (typeof item.content === "string")
+              return item.content;
+            if (Array.isArray(item.content))
+              return item.content
+                .map((c) => c.text || c.output || "")
+                .filter(Boolean)
+                .join("\n");
+            return "";
+          })
+          .filter(Boolean)
+          .join("\n\n");
+        // Prepend to existing instructions (if any), or set new
+        body.instructions = body.instructions
+          ? `${systemText}\n\n${body.instructions}`
+          : systemText;
+      }
+
+      // Normalize content type for assistant messages:
+      // Codex only accepts "output_text" (not "input_text") for role=assistant
+      for (const item of body.input) {
+        if (item.role === "assistant" && Array.isArray(item.content)) {
+          item.content = item.content.map((c) => {
+            if (c.type === "input_text")
+              return { ...c, type: "output_text" };
+            return c;
+          });
+        }
+      }
+    }
+
     // If no instructions provided, inject default Codex instructions
     if (!body.instructions || body.instructions.trim() === "") {
       body.instructions = CODEX_DEFAULT_INSTRUCTIONS;

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -414,6 +414,48 @@ export class CodexExecutor extends BaseExecutor {
     // Ensure streaming is enabled (Codex API requires it)
     body.stream = true;
 
+    // Extract system messages from input[] and merge into instructions field
+    // Codex does not accept role=system in input[], only via the instructions field
+    if (Array.isArray(body.input)) {
+      const systemItems = body.input.filter(
+        (item) => item.role === "system"
+      );
+      if (systemItems.length > 0) {
+        body.input = body.input.filter(
+          (item) => item.role !== "system"
+        );
+        const systemText = systemItems
+          .map((item) => {
+            if (typeof item.content === "string")
+              return item.content;
+            if (Array.isArray(item.content))
+              return item.content
+                .map((c) => c.text || c.output || "")
+                .filter(Boolean)
+                .join("\n");
+            return "";
+          })
+          .filter(Boolean)
+          .join("\n\n");
+        // Prepend to existing instructions (if any), or set new
+        body.instructions = body.instructions
+          ? `${systemText}\n\n${body.instructions}`
+          : systemText;
+      }
+
+      // Normalize content type for assistant messages:
+      // Codex only accepts "output_text" (not "input_text") for role=assistant
+      for (const item of body.input) {
+        if (item.role === "assistant" && Array.isArray(item.content)) {
+          item.content = item.content.map((c) => {
+            if (c.type === "input_text")
+              return { ...c, type: "output_text" };
+            return c;
+          });
+        }
+      }
+    }
+
     // If no instructions provided, inject default Codex instructions
     if (!body.instructions || body.instructions.trim() === "") {
       body.instructions = CODEX_DEFAULT_INSTRUCTIONS;

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -161,9 +161,9 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
 // Translate response chunk: target -> openai -> source
 export function translateResponse(targetFormat, sourceFormat, chunk, state) {
   ensureInitialized();
-  // If same format, return as-is
+  // If same format, return as-is (skip null flush chunks)
   if (sourceFormat === targetFormat) {
-    return [chunk];
+    return chunk != null ? [chunk] : [];
   }
 
   let results = [chunk];

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -446,6 +446,7 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     state.created = Math.floor(Date.now() / 1000);
     state.toolCallIndex = 0;
     state.currentToolCallId = null;
+    state.firstContentSent = false; // Track to send role: "assistant" in first delta chunk
   }
 
   // Text content delta
@@ -455,7 +456,10 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 
     return buildChunk(
       { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      { content: delta }
+      Object.assign(
+        !state.firstContentSent ? (state.firstContentSent = true, { role: "assistant" }) : {},
+        { content: delta }
+      )
     );
   }
 
@@ -471,14 +475,17 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 
     return buildChunk(
       { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      {
-        tool_calls: [{
-          index: state.toolCallIndex,
-          id: state.currentToolCallId,
-          type: OPENAI_BLOCK.FUNCTION,
-          function: { name: item.name || "", arguments: "" }
-        }]
-      }
+      Object.assign(
+        !state.firstContentSent ? (state.firstContentSent = true, { role: "assistant", content: null }) : {},
+        {
+          tool_calls: [{
+            index: state.toolCallIndex,
+            id: state.currentToolCallId,
+            type: OPENAI_BLOCK.FUNCTION,
+            function: { name: item.name || "", arguments: "" }
+          }]
+        }
+      )
     );
   }
 

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -407,6 +407,7 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
     state.created = Math.floor(Date.now() / 1000);
     state.toolCallIndex = 0;
     state.currentToolCallId = null;
+    state.firstContentSent = false; // Track to send role: "assistant" in first delta chunk
   }
 
   // Text content delta
@@ -416,7 +417,10 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 
     return buildChunk(
       { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      { content: delta }
+      Object.assign(
+        !state.firstContentSent ? (state.firstContentSent = true, { role: "assistant" }) : {},
+        { content: delta }
+      )
     );
   }
 
@@ -432,14 +436,17 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 
     return buildChunk(
       { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      {
-        tool_calls: [{
-          index: state.toolCallIndex,
-          id: state.currentToolCallId,
-          type: OPENAI_BLOCK.FUNCTION,
-          function: { name: item.name || "", arguments: "" }
-        }]
-      }
+      Object.assign(
+        !state.firstContentSent ? (state.firstContentSent = true, { role: "assistant", content: null }) : {},
+        {
+          tool_calls: [{
+            index: state.toolCallIndex,
+            id: state.currentToolCallId,
+            type: OPENAI_BLOCK.FUNCTION,
+            function: { name: item.name || "", arguments: "" }
+          }]
+        }
+      )
     );
   }
 

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -206,7 +206,18 @@ export function createSSEStream(options = {}) {
         }
 
         // Translate mode
-        if (!trimmed) continue;
+        // Responses API SSE: buffer "event:" lines (Codex uses multi-line format "event:\ndata:\n\n")
+        // parseSSELine only reads "data:" lines → "event:" lines get dropped → event type lost during translate
+        if (trimmed.startsWith("event:")) {
+          if (state) state._lastEventType = trimmed.slice(6).trim();
+          // When both formats are OPENAI_RESPONSES → forward event line as-is
+          if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+            const output = line + "\n";
+            reqLogger?.appendConvertedChunk?.(output);
+            controller.enqueue(sharedEncoder.encode(output));
+          }
+          continue;
+        }
 
         const parsed = parseSSELine(trimmed, targetFormat);
         if (!parsed) continue;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -203,7 +203,18 @@ export function createSSEStream(options = {}) {
         }
 
         // Translate mode
-        if (!trimmed) continue;
+        // Responses API SSE: buffer "event:" lines (Codex uses multi-line format "event:\ndata:\n\n")
+        // parseSSELine only reads "data:" lines → "event:" lines get dropped → event type lost during translate
+        if (trimmed.startsWith("event:")) {
+          if (state) state._lastEventType = trimmed.slice(6).trim();
+          // When both formats are OPENAI_RESPONSES → forward event line as-is
+          if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+            const output = line + "\n";
+            reqLogger?.appendConvertedChunk?.(output);
+            controller.enqueue(sharedEncoder.encode(output));
+          }
+          continue;
+        }
 
         const parsed = parseSSELine(trimmed, targetFormat);
         if (!parsed) continue;


### PR DESCRIPTION
- Codex: Extract system messages from input and merge into instructions field.
- Codex: Normalize assistant message content type from 'input_text' to 'output_text'.
- Translator: Add role 'assistant' in the first delta chunk when translating OpenAI Responses to OpenAI format.
- Translator: Skip null flush chunks in translateResponse when formats match.
- Stream: Buffer and preserve 'event:' lines in Responses API SSE translate mode.