### PR TITLE
feat(providers/codex): bulk add accounts via JSON

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/BulkImportCodexModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/BulkImportCodexModal.js
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { Button, Modal } from "@/shared/components";
+import { translate } from "@/i18n/runtime";
+
+const PLACEHOLDER = `[
+  {
+    "accessToken": "eyJhbGc...",
+    "refreshToken": "rt_...",
+    "idToken": "eyJhbGc...",
+    "email": "user@example.com"
+  }
+]`;
+
+function normalizeToArray(parsed) {
+  if (Array.isArray(parsed)) return parsed;
+  if (parsed && typeof parsed === "object") {
+    if (Array.isArray(parsed.accounts)) return parsed.accounts;
+    return [parsed];
+  }
+  return null;
+}
+
+export default function BulkImportCodexModal({ isOpen, onClose, onSuccess }) {
+  const [jsonText, setJsonText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [parseError, setParseError] = useState("");
+  const [result, setResult] = useState(null);
+
+  const handleClose = () => {
+    if (submitting) return;
+    setJsonText("");
+    setParseError("");
+    setResult(null);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    setParseError("");
+    setResult(null);
+
+    const trimmed = jsonText.trim();
+    if (!trimmed) return;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      setParseError(`${translate("Invalid JSON")}: ${err.message}`);
+      return;
+    }
+
+    const accounts = normalizeToArray(parsed);
+    if (!accounts || accounts.length === 0) {
+      setParseError(translate("No accounts found in input"));
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/oauth/codex/bulk-import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ accounts }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setParseError(data?.error || `Request failed: ${res.status}`);
+        return;
+      }
+      setResult(data);
+      if (data.success > 0 && typeof onSuccess === "function") {
+        onSuccess();
+      }
+    } catch (err) {
+      setParseError(err.message || translate("Request failed"));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const failedItems = result?.results?.filter((r) => !r.ok) || [];
+
+  return (
+    <Modal isOpen={isOpen} title={translate("Bulk Add Codex Accounts")} onClose={handleClose}>
+      <div className="flex flex-col gap-4">
+        <p className="text-xs text-text-muted">
+          {translate(
+            "Paste an array of codex account JSON objects. Each must include accessToken (and ideally refreshToken, idToken)."
+          )}
+        </p>
+
+        <textarea
+          className="w-full rounded border border-accent/30 bg-sidebar p-2 text-sm font-mono resize-y min-h-[240px] focus:outline-none focus:ring-1 focus:ring-primary"
+          placeholder={PLACEHOLDER}
+          value={jsonText}
+          onChange={(e) => setJsonText(e.target.value)}
+          disabled={submitting}
+        />
+
+        {parseError && (
+          <p className="text-xs text-red-500 break-words">{parseError}</p>
+        )}
+
+        {result && (
+          <div className="flex flex-col gap-2">
+            <div
+              className={`text-sm font-medium ${
+                result.failed > 0 ? "text-yellow-400" : "text-green-400"
+              }`}
+            >
+              ✓ {result.success} {translate("added")}
+              {result.failed > 0 ? `, ✗ ${result.failed} ${translate("failed")}` : ""}
+            </div>
+            {failedItems.length > 0 && (
+              <ul className="rounded border border-accent/20 bg-sidebar/50 p-2 text-xs font-mono max-h-40 overflow-y-auto">
+                {failedItems.map((item) => (
+                  <li key={item.index} className="text-red-400">
+                    [{item.index}] {item.error}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <Button
+            onClick={handleSubmit}
+            fullWidth
+            disabled={submitting || !jsonText.trim()}
+          >
+            {submitting ? translate("Importing...") : translate("Import All")}
+          </Button>
+          <Button onClick={handleClose} variant="ghost" fullWidth disabled={submitting}>
+            {translate("Close")}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+BulkImportCodexModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func,
+};

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -17,6 +17,7 @@ import ConnectionRow from "./ConnectionRow";
 import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
+import BulkImportCodexModal from "./BulkImportCodexModal";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
@@ -36,6 +37,7 @@ export default function ProviderDetailPage() {
   const [showIFlowCookieModal, setShowIFlowCookieModal] = useState(false);
   const [showAddApiKeyModal, setShowAddApiKeyModal] = useState(false);
   const [addConnectionError, setAddConnectionError] = useState("");
+  const [showBulkImportCodex, setShowBulkImportCodex] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showEditNodeModal, setShowEditNodeModal] = useState(false);
   const [showBulkProxyModal, setShowBulkProxyModal] = useState(false);
@@ -1339,6 +1341,11 @@ export default function ProviderDetailPage() {
                         Cookie
                       </Button>
                     )}
+                    {providerId === "codex" && (
+                      <Button size="sm" icon="playlist_add" variant="secondary" onClick={() => setShowBulkImportCodex(true)}>
+                        {translate("Bulk Add")}
+                      </Button>
+                    )}
                     <Button
                       size="sm"
                       icon="add"
@@ -1381,6 +1388,18 @@ export default function ProviderDetailPage() {
                       className="w-full sm:w-auto"
                     >
                       Cookie
+                    </Button>
+                  )}
+                  {providerId === "codex" && (
+                    <Button
+                      size="sm"
+                      icon="playlist_add"
+                      variant="secondary"
+                      onClick={() => setShowBulkImportCodex(true)}
+                      title={translate("Bulk import codex accounts from JSON")}
+                      className="w-full sm:w-auto"
+                    >
+                      {translate("Bulk Add")}
                     </Button>
                   )}
                   {hasDualAuthModes ? (
@@ -1541,6 +1560,14 @@ export default function ProviderDetailPage() {
             setShowAddCustomModel(false);
           }}
           onClose={() => setShowAddCustomModel(false)}
+        />
+      )}
+
+      {providerId === "codex" && (
+        <BulkImportCodexModal
+          isOpen={showBulkImportCodex}
+          onClose={() => setShowBulkImportCodex(false)}
+          onSuccess={fetchConnections}
         />
       )}
 

--- a/src/app/api/oauth/codex/bulk-import/route.js
+++ b/src/app/api/oauth/codex/bulk-import/route.js
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import { createProviderConnection } from "@/models";
+import { extractCodexAccountInfo } from "@/lib/oauth/providers";
+
+/**
+ * POST /api/oauth/codex/bulk-import
+ * Bulk import multiple codex (OAuth) account JSON objects in one call.
+ *
+ * Body accepts any of:
+ *   - Array:    [{...}, {...}]
+ *   - Single:   {...}
+ *   - Wrapped:  { accounts: [{...}, ...] }
+ *
+ * Each item must contain at least `accessToken`. Missing email / chatgpt
+ * account info is best-effort backfilled from the JWT (idToken or accessToken).
+ *
+ * Tokens are NEVER echoed back in the response.
+ */
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Invalid JSON body: ${err.message}` },
+      { status: 400 }
+    );
+  }
+
+  // Normalize to array
+  let accounts;
+  if (Array.isArray(body)) {
+    accounts = body;
+  } else if (body && typeof body === "object" && Array.isArray(body.accounts)) {
+    accounts = body.accounts;
+  } else if (body && typeof body === "object") {
+    accounts = [body];
+  } else {
+    accounts = null;
+  }
+
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    return NextResponse.json(
+      { error: "No accounts provided" },
+      { status: 400 }
+    );
+  }
+
+  const results = [];
+  let success = 0;
+  let failed = 0;
+
+  // SERIAL loop — createProviderConnection reads max(priority) and reorders
+  // inside a transaction. Parallel calls would race on priority assignment.
+  for (let i = 0; i < accounts.length; i++) {
+    const raw = accounts[i];
+    try {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        throw new Error("Item is not an object");
+      }
+
+      // Strip server-controlled fields
+      const {
+        id: _id,
+        provider: _provider,
+        authType: _authType,
+        createdAt: _createdAt,
+        updatedAt: _updatedAt,
+        ...item
+      } = raw;
+
+      if (!item.accessToken || typeof item.accessToken !== "string") {
+        throw new Error("Missing accessToken");
+      }
+
+      // Backfill missing identity fields from JWT claims
+      const psd = item.providerSpecificData || {};
+      const needsEmail = !item.email;
+      const needsAccountId = !psd.chatgptAccountId;
+      const needsPlanType = !psd.chatgptPlanType;
+
+      if (needsEmail || needsAccountId || needsPlanType) {
+        const info = extractCodexAccountInfo(item.idToken || item.accessToken) || {};
+        if (needsEmail && info.email) item.email = info.email;
+        if (needsAccountId && info.chatgptAccountId) {
+          psd.chatgptAccountId = info.chatgptAccountId;
+        }
+        if (needsPlanType && info.chatgptPlanType) {
+          psd.chatgptPlanType = info.chatgptPlanType;
+        }
+      }
+      if (Object.keys(psd).length > 0) {
+        item.providerSpecificData = psd;
+      }
+
+      // Compute expiresAt from expiresIn if absent
+      if (!item.expiresAt && typeof item.expiresIn === "number" && item.expiresIn > 0) {
+        item.expiresAt = new Date(Date.now() + item.expiresIn * 1000).toISOString();
+      }
+
+      // Defaults aligned with OAuth-completed flow
+      if (item.testStatus === undefined) item.testStatus = "active";
+      if (item.isActive === undefined) item.isActive = true;
+      if (!item.lastRefreshAt) item.lastRefreshAt = new Date().toISOString();
+
+      const created = await createProviderConnection({
+        provider: "codex",
+        authType: "oauth",
+        ...item,
+      });
+
+      results.push({ index: i, ok: true, id: created.id });
+      success++;
+    } catch (e) {
+      results.push({ index: i, ok: false, error: e.message || "Unknown error" });
+      failed++;
+    }
+  }
+
+  return NextResponse.json({ success, failed, results });
+}

--- a/src/lib/db/repos/connectionsRepo.js
+++ b/src/lib/db/repos/connectionsRepo.js
@@ -7,7 +7,7 @@ const OPTIONAL_FIELDS = [
   "accessToken", "refreshToken", "expiresAt", "tokenType",
   "scope", "projectId", "apiKey", "testStatus",
   "lastTested", "lastError", "lastErrorAt", "rateLimitedUntil", "expiresIn", "errorCode",
-  "consecutiveUseCount",
+  "consecutiveUseCount", "idToken", "lastRefreshAt",
 ];
 
 function rowToConn(row) {


### PR DESCRIPTION
## Summary

Add a "Bulk Add" button on `/dashboard/providers/codex` that lets users import multiple codex (OAuth) accounts at once by pasting a JSON payload. Reduces manual one-by-one OAuth flow when migrating or seeding many accounts.

## Motivation

The codex provider currently only supports one OAuth account per flow. Operators with many accounts (migrating from another tool, restoring a backup, seeding a fresh deployment) have to repeat the OAuth dance N times. This PR adds a JSON-based bulk import path, scoped strictly to codex.

## What's changed

### UI

- New `BulkImportCodexModal` component with a JSON textarea, parse-error feedback, and a per-item success/failure summary.
- "Bulk Add" button rendered only when `providerId === "codex"`, in both the empty-state and populated-state of the Connections card.
- All other providers and the existing OAuth / API-key flows are untouched.

<img width="3252" height="1974" alt="CleanShot 2026-06-07 at 12 55 45@2x" src="https://github.com/user-attachments/assets/239a9df7-35df-46b9-9f25-af1621fab37c" />

### API

- New `POST /api/oauth/codex/bulk-import`. Accepts three input shapes (normalized to an array on both client and server):
  - `[{...}, {...}]`
  - `{...}` (single object)
  - `{ accounts: [...] }`
- Per-item processing:
  - Strips server-controlled fields (`id`, `provider`, `authType`, `createdAt`, `updatedAt`).
  - Validates `accessToken`.
  - Backfills `email` / `chatgptAccountId` / `chatgptPlanType` from the JWT via `extractCodexAccountInfo` when missing.
  - Derives `expiresAt` from `expiresIn` when missing.
  - Sets sane defaults: `testStatus = "active"`, `isActive = true`, `lastRefreshAt = now`.
- Loop is **serial** (`for ... await`) to avoid races on `max(priority)` and `reorderInTx`.
- Tokens (`accessToken`, `refreshToken`, `idToken`) are **not** echoed in the response.

### DB / repo

- `OPTIONAL_FIELDS` in `src/lib/db/repos/connectionsRepo.js` now includes `idToken` and `lastRefreshAt`. The existing OAuth flow worked because dedup-merge uses a full-merge path; new bulk inserts go through the create path, where these two fields were previously dropped.

## Files

- `src/app/api/oauth/codex/bulk-import/route.js` (new)
- `src/app/(dashboard)/dashboard/providers/[id]/BulkImportCodexModal.js` (new)
- `src/app/(dashboard)/dashboard/providers/[id]/page.js` (button + state + modal wire-up)
- `src/lib/db/repos/connectionsRepo.js` (whitelist `idToken`, `lastRefreshAt`)

## How to test

1. Run the app and open `/dashboard/providers/codex`.
2. Click "Bulk Add".
3. Paste a JSON payload of codex account objects, each with at least `accessToken`. Submit.
4. Verify:
   - Banner shows `✓ N added, ✗ M failed`.
   - Connections list refreshes.
   - Tokens are not visible in the network response payload.
5. Edge cases:
   - Single object instead of array: still works.
   - `{ accounts: [...] }` wrapper: still works.
   - One item missing `accessToken`: that index reports failure, others succeed.
   - Invalid JSON: modal shows a parse error, no API call is made.
6. Open `/dashboard/providers/<other>`: confirm "Bulk Add" button does not appear.

## Behavioral notes

- Dedup is preserved: if two input items resolve to the same `(email, chatgptAccountId)` as an existing row, the existing row is updated (full merge), not duplicated.
- `priority` is auto-assigned with `max(existing) + 1` and a re-pack pass per insert; fine for tens of accounts. Very large batches (hundreds+) are out of scope.
- The endpoint sits next to the other `/api/oauth/codex/*` routes and inherits the same middleware / auth posture; no new exposure surface.

## Out of scope

- Other OAuth providers. The button and modal are explicitly hardcoded to `codex`.
- Bulk export. This PR is import-only.
- Background revalidation of imported tokens. Existing `testStatus` and refresh logic apply unchanged.

## Risks

- If a user imports already-expired tokens, the row is created but fails on first use. This matches existing OAuth behavior.
- Sensitive payloads: the response shape avoids echoing tokens; logs do not print tokens.
