### PR TITLE
feat(kiro): enable multi-endpoint failover for GenerateAssistantResponse

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -192,7 +192,19 @@ export const PROVIDERS = {
     clientId: "Iv1.b507a08c87ecfe98"
   },
   kiro: {
-    baseUrl: "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse",
+    // All three hosts resolve to the same regional CodeWhisperer streaming service
+    // (GenerateAssistantResponse). They are alternate DNS surfaces, NOT separate quota
+    // buckets — AWS throttles per authenticated identity (token + profileArn), not per
+    // hostname. Listing them enables edge-level failover (5xx / connect timeout / a
+    // degraded surface); it does NOT multiply 429 headroom. To actually spread 429 load,
+    // add multiple Kiro accounts — account rotation in sse/handlers/chat.js handles that.
+    // Order: newest Kiro IDE endpoint first, legacy AWS domains as fallback.
+    baseUrl: "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
+    baseUrls: [
+      "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
+      "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse",
+      "https://q.us-east-1.amazonaws.com/generateAssistantResponse",
+    ],
     format: "kiro",
     retry: { 429: 2 },
     headers: {

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -2,8 +2,6 @@ import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
 import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.js";
-import { proxyAwareFetch } from "../utils/proxyFetch.js";
-import { HTTP_STATUS, RETRY_CONFIG, DEFAULT_RETRY_CONFIG, resolveRetryEntry } from "../config/runtimeConfig.js";
 
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
@@ -33,45 +31,25 @@ export class KiroExecutor extends BaseExecutor {
   }
 
   /**
-   * Custom execute for Kiro - handles AWS EventStream binary response with retry support
+   * Kiro execute — delegate to BaseExecutor for endpoint fallback + retry, then
+   * transform the binary AWS EventStream into OpenAI-shaped SSE on success.
+   *
+   * BaseExecutor.execute() walks config.baseUrls (runtime.us-east-1.kiro.dev →
+   * codewhisperer → q) advancing to the next host on 429 (shouldRetry) and on
+   * network/5xx errors, while tryRetry handles in-place retries per `retry: {429: 2}`.
+   * Note: the baseUrls are alternate surfaces of one regional service, so rotation
+   * is edge-level failover — it does not grant fresh 429 quota. Per-account 429
+   * spreading is handled upstream by account rotation in sse/handlers/chat.js.
+   *
+   * Errors are returned untransformed so the upstream handler can read the body,
+   * classify the status, and trigger account fallback/cooldown.
    */
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
-    const url = this.buildUrl(model, stream, 0);
-    const transformedBody = this.transformRequest(model, body, stream, credentials);
-    
-    // Merge default retry config with provider-specific config
-    const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
-    let retryAttempts = 0;
-
-    while (true) {
-      const headers = this.buildHeaders(credentials, stream);
-      
-      const response = await proxyAwareFetch(url, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(transformedBody),
-        signal
-      }, proxyOptions);
-
-      // Check if should retry based on status code
-      const { attempts: maxRetries, delayMs } = resolveRetryEntry(retryConfig[response.status]);
-      if (!response.ok && maxRetries > 0 && retryAttempts < maxRetries) {
-        retryAttempts++;
-        log?.debug?.("RETRY", `${response.status} retry ${retryAttempts}/${maxRetries} after ${delayMs / 1000}s`);
-        await new Promise(resolve => setTimeout(resolve, delayMs));
-        continue;
-      }
-
-      if (!response.ok) {
-        return { response, url, headers, transformedBody };
-      }
-
-      // Success - transform and return
-      // For Kiro, we need to transform the binary EventStream to SSE
-      // Create a TransformStream to convert binary to SSE text
-      const transformedResponse = this.transformEventStreamToSSE(response, model);
-      return { response: transformedResponse, url, headers, transformedBody };
+  async execute(args) {
+    const result = await super.execute(args);
+    if (result?.response?.ok) {
+      result.response = this.transformEventStreamToSSE(result.response, args.model);
     }
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Summary

Enables multi-endpoint failover for the Kiro provider's `GenerateAssistantResponse` calls by wiring `KiroExecutor` into the `BaseExecutor` `baseUrls` fallback mechanism that already exists for other providers.

A Kiro request now advances across the three CodeWhisperer surfaces on `429` and on network/`5xx` errors:

1. `runtime.us-east-1.kiro.dev` (current Kiro IDE endpoint)
2. `codewhisperer.us-east-1.amazonaws.com` (legacy)
3. `q.us-east-1.amazonaws.com` (legacy)

## Changes

- **`open-sse/config/providers.js`** — add `baseUrls[]` to the kiro config (newest endpoint first); keep `baseUrl` as the single-value default for backward compat.
- **`open-sse/executors/kiro.js`** — replace the hand-rolled single-endpoint loop with `super.execute()` delegation (inherits endpoint rotation + retry + connect-timeout), transforming the binary AWS EventStream → SSE only on `response.ok`. Matches the `super.execute()`+post-process idiom already used in `codex.js` / `github.js`. Removes two now-unused imports.

## Important caveat on 429s

The three hosts are **alternate DNS surfaces of one regional service**, not separate quota buckets. AWS throttles per authenticated identity (access token + `profileArn`), **not** per hostname — so this is **edge-level failover** (degraded surface / 5xx / connect timeout), and does **not** multiply 429 headroom for a single account.

To actually spread 429 load, add multiple Kiro accounts: per-account rotation already exists generically in `src/sse/handlers/chat.js` (retry with next account on fallback-worthy error) backed by `src/sse/services/auth.js` (selection + per-model cooldown locks with exponential backoff).

The headers `X-Amz-Target`, `User-Agent`, `X-Amz-User-Agent` do **not** affect rate limiting — `X-Amz-Target` is AWS operation routing (required for correctness), the UA strings are client identifiers AWS may check for request acceptance but not for quota bucketing.

## Testing

- `node --check` passes on both edited files.
- Verified the delegation pattern matches existing executors (`codex.js:268`, `github.js:189`) and that both `chatCore.js` call sites pass the full args object the new `execute(args)` expects.
- Not exercised against a live Kiro account in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)