### PR TITLE
fix(github): resolve 401 error on models discovery by proactively checking/refreshing copilot token

### DIFF
--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -220,6 +220,9 @@ export async function updateProviderCredentials(connectionId, newCredentials) {
  */
 export async function checkAndRefreshToken(provider, credentials) {
   let creds = { ...credentials };
+  if (!creds.connectionId && creds.id) {
+    creds.connectionId = creds.id;
+  }
 
   // ── 1. Regular access-token expiry ────────────────────────────────────────
   if (_shouldRefreshCredentials(provider, creds)) {
@@ -261,23 +264,26 @@ export async function checkAndRefreshToken(provider, credentials) {
   }
 
   // ── 2. GitHub Copilot token expiry ────────────────────────────────────────
-  if (provider === "github" && creds.providerSpecificData?.copilotTokenExpiresAt) {
-    const copilotExpiresAt = creds.providerSpecificData.copilotTokenExpiresAt * 1000;
+  if (provider === "github") {
+    const copilotToken = creds.providerSpecificData?.copilotToken;
+    const copilotExpiresAt = creds.providerSpecificData?.copilotTokenExpiresAt
+      ? creds.providerSpecificData.copilotTokenExpiresAt * 1000
+      : 0;
     const now              = Date.now();
     const remaining        = copilotExpiresAt - now;
 
-    if (remaining < TOKEN_EXPIRY_BUFFER_MS) {
-      log.info("TOKEN_REFRESH", "Copilot token expiring soon, refreshing proactively", {
+    if (!copilotToken || remaining < TOKEN_EXPIRY_BUFFER_MS) {
+      log.info("TOKEN_REFRESH", "Copilot token expiring soon or missing, refreshing proactively", {
         provider,
-        expiresIn: Math.round(remaining / 1000),
+        expiresIn: copilotToken ? Math.round(remaining / 1000) : "missing",
       });
 
-      const copilotToken = await refreshCopilotToken(creds.accessToken);
-      if (copilotToken) {
+      const copilotTokenResult = await refreshCopilotToken(creds.accessToken);
+      if (copilotTokenResult) {
         const updatedSpecific = {
           ...creds.providerSpecificData,
-          copilotToken:          copilotToken.token,
-          copilotTokenExpiresAt: copilotToken.expiresAt,
+          copilotToken:          copilotTokenResult.token,
+          copilotTokenExpiresAt: copilotTokenResult.expiresAt,
         };
 
         await updateProviderCredentials(creds.connectionId, {
@@ -285,7 +291,7 @@ export async function checkAndRefreshToken(provider, credentials) {
         });
 
         creds.providerSpecificData = updatedSpecific;
-        creds.copilotToken = copilotToken.token;
+        creds.copilotToken = copilotTokenResult.token;
       }
     }
   }


### PR DESCRIPTION
### Description
This PR resolves the 401 Unauthorized errors encountered when fetching models from the GitHub Copilot provider. The root cause was that Copilot tokens expire every 25-30 minutes, and the models endpoint was reading the cached token without proactively checking for expiration or missing values.

### Key Changes
- **Proactive Token Refresh**: Integrated `checkAndRefreshToken` at the entry point of the `/api/providers/[id]/models` route handler for `github`.
- **Enhanced Expiration Guard**: Updated `checkAndRefreshToken` in `tokenRefresh.js` to proactively fetch a new token if the cached `copilotToken` or `copilotTokenExpiresAt` is missing entirely (not just soon-to-expire).
- **ID Normalization**: Standardized ID mappings (`creds.connectionId = creds.id`) inside the credentials object to prevent database update failures during refresh persistence.

### Verification
- Verified that the backend successfully refreshes the Copilot token whenever it expires.
- Ran Next.js production build (`npm run build`) successfully with no compilation errors.
- Ran all unit tests in `tests/unit/github-adaptive-routing.test.js` and confirmed they pass.