### PR TITLE
feat(kiro): Add API-key auth for Kiro provider + quota dashboard display

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -21,7 +21,17 @@ export class KiroExecutor extends BaseExecutor {
       "Amz-Sdk-Invocation-Id": uuidv4()
     };
 
-    if (credentials.accessToken) {
+    // API-key auth: the key is stored as accessToken and sent as a bearer token
+    // exactly like an OAuth access token, but with an extra `tokentype: API_KEY`
+    // header so CodeWhisperer treats it as a long-lived API key rather than an
+    // OIDC/social access token. Mirrors the Kiro IDE headless-auth behavior.
+    const isApiKey = credentials?.providerSpecificData?.authMethod === "api_key";
+
+    const apiKey = credentials?.apiKey || (isApiKey ? credentials?.accessToken : null);
+    if (isApiKey && apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+      headers["tokentype"] = "API_KEY";
+    } else if (credentials.accessToken) {
       headers["Authorization"] = `Bearer ${credentials.accessToken}`;
     }
 

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -758,6 +758,13 @@ async function getKiroUsage(accessToken, providerSpecificData, proxyOptions = nu
   const profileArn = providerSpecificData?.profileArn || DEFAULT_PROFILE_ARN;
   const authMethod = providerSpecificData?.authMethod || "builder-id";
 
+  // API-key Kiro connections authenticate the quota API the same way the chat
+  // executor does: a bearer token plus a `tokentype: API_KEY` header so
+  // CodeWhisperer treats it as a long-lived API key rather than an OIDC token.
+  // Without this header the GetUsageLimits call is rejected (401/403).
+  const isApiKey = authMethod === "api_key";
+  const apiKeyHeaders = isApiKey ? { tokentype: "API_KEY" } : {};
+
   const getUsageParams = new URLSearchParams({
     isEmailRequired: "true",
     origin: "AI_EDITOR",
@@ -777,6 +784,7 @@ async function getKiroUsage(accessToken, providerSpecificData, proxyOptions = nu
             "Accept": "application/json",
             "x-amz-user-agent": "aws-sdk-js/1.0.0 KiroIDE",
             "user-agent": "aws-sdk-js/1.0.0 KiroIDE",
+            ...apiKeyHeaders,
           },
         },
         proxyOptions
@@ -791,6 +799,7 @@ async function getKiroUsage(accessToken, providerSpecificData, proxyOptions = nu
           "Content-Type": "application/x-amz-json-1.0",
           "x-amz-target": "AmazonCodeWhispererService.GetUsageLimits",
           "Accept": "application/json",
+          ...apiKeyHeaders,
         },
         body: JSON.stringify({
           origin: "AI_EDITOR",
@@ -812,6 +821,7 @@ async function getKiroUsage(accessToken, providerSpecificData, proxyOptions = nu
           headers: {
             "Authorization": `Bearer ${accessToken}`,
             "Accept": "application/json",
+            ...apiKeyHeaders,
           },
         }, proxyOptions);
       },

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -205,17 +205,15 @@ export default function ProvidersPage() {
     return { connected, error, total, errorCode, errorTime, allDisabled };
   };
 
-  // Toggle all connections for a provider on/off
+  // Toggle all connections for a provider on/off. authType may be a single
+  // string or an array (kiro counts oauth + api_key/apikey together).
   const handleToggleProvider = async (providerId, authType, newActive) => {
-    const providerConns = connections.filter(
-      (c) => c.provider === providerId && c.authType === authType,
-    );
+    const authTypes = Array.isArray(authType) ? authType : [authType];
+    const matches = (c) =>
+      c.provider === providerId && authTypes.includes(c.authType);
+    const providerConns = connections.filter(matches);
     setConnections((prev) =>
-      prev.map((c) =>
-        c.provider === providerId && c.authType === authType
-          ? { ...c, isActive: newActive }
-          : c,
-      ),
+      prev.map((c) => (matches(c) ? { ...c, isActive: newActive } : c)),
     );
     await Promise.allSettled(
       providerConns.map((c) =>
@@ -453,7 +451,10 @@ export default function ProvidersPage() {
           {freeEntries.map(([key, info]) => {
             // Kiro accepts both OAuth and api-key connections; count/toggle both
             // so the card total matches the provider detail page (#kiro-apikey).
-            const freeAuthTypes = key === "kiro" ? ["oauth", "apikey"] : "oauth";
+            // Kiro's headless api-key flow persists authType "api_key" (underscore),
+            // while generic apikey providers use "apikey" — include both spellings.
+            const freeAuthTypes =
+              key === "kiro" ? ["oauth", "apikey", "api_key"] : "oauth";
             return (
               <ProviderCard
                 key={key}

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -162,8 +162,9 @@ export default function ProvidersPage() {
   }, []);
 
   const getProviderStats = (providerId, authType) => {
+    const authTypes = Array.isArray(authType) ? authType : [authType];
     const providerConnections = connections.filter(
-      (c) => c.provider === providerId && c.authType === authType,
+      (c) => c.provider === providerId && authTypes.includes(c.authType),
     );
 
     const getEffectiveStatus = (conn) => {
@@ -449,16 +450,23 @@ export default function ProvidersPage() {
           </button>
         </div>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3 xl:grid-cols-4">
-          {freeEntries.map(([key, info]) => (
-            <ProviderCard
-              key={key}
-              providerId={key}
-              provider={info}
-              stats={getProviderStats(key, "oauth")}
-              authType="free"
-              onToggle={(active) => handleToggleProvider(key, "oauth", active)}
-            />
-          ))}
+          {freeEntries.map(([key, info]) => {
+            // Kiro accepts both OAuth and api-key connections; count/toggle both
+            // so the card total matches the provider detail page (#kiro-apikey).
+            const freeAuthTypes = key === "kiro" ? ["oauth", "apikey"] : "oauth";
+            return (
+              <ProviderCard
+                key={key}
+                providerId={key}
+                provider={info}
+                stats={getProviderStats(key, freeAuthTypes)}
+                authType="free"
+                onToggle={(active) =>
+                  handleToggleProvider(key, freeAuthTypes, active)
+                }
+              />
+            );
+          })}
           {freeTierEntries.map(([key, info]) => (
             <ApiKeyProviderCard
               key={key}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -8,6 +8,36 @@ import { parseQuotaData, calculatePercentage } from "./utils";
 import Card from "@/shared/components/Card";
 import { EditConnectionModal } from "@/shared/components";
 import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
+import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+
+// Maps the stored providerSpecificData.authMethod to a human label for Kiro.
+// Values come from the Kiro connect flows: builder-id/idc (device code),
+// google/github (social), imported (refresh-token paste), api_key (headless).
+const KIRO_METHOD_LABELS = {
+  "builder-id": "AWS Builder ID",
+  idc: "IAM Identity Center",
+  google: "Google",
+  github: "GitHub",
+  imported: "Imported Token",
+  api_key: "API Key",
+};
+
+function kiroMethodLabel(conn) {
+  const m = conn.providerSpecificData?.authMethod;
+  if (m && KIRO_METHOD_LABELS[m]) return KIRO_METHOD_LABELS[m];
+  return conn.authType === "api_key" ? "API Key" : "OAuth";
+}
+
+// Region is stored for builder-id/idc/api_key flows; social and imported flows
+// omit it, so fall back to the region segment of the profileArn
+// (arn:aws:codewhisperer:<region>:...).
+function kiroRegion(conn) {
+  const r = conn.providerSpecificData?.region;
+  if (r) return r;
+  const arn = conn.providerSpecificData?.profileArn;
+  const seg = typeof arn === "string" ? arn.split(":")[3] : "";
+  return seg || "";
+}
 
 function getConnectionLabel(connection) {
   const isEmail = (value) =>
@@ -221,6 +251,7 @@ const ACCOUNT_PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
 const ACCOUNT_PAGE_SIZE_MAX = 500;
 
 export default function ProviderLimits() {
+  const { copied, copy } = useCopyToClipboard();
   const [connections, setConnections] = useState([]);
   const [quotaData, setQuotaData] = useState({});
   const [loading, setLoading] = useState({});
@@ -1005,6 +1036,46 @@ export default function ProviderLimits() {
                           {getConnectionLabel(conn)}
                         </p>
                       ) : null}
+                      {conn.provider === "kiro" && (
+                        <div className="mt-1 flex flex-wrap items-center gap-1">
+                          <span className="rounded-full bg-brand-500/10 px-2 py-0.5 text-[10px] font-semibold text-brand-600 dark:text-brand-300">
+                            {kiroMethodLabel(conn)}
+                          </span>
+                          {kiroRegion(conn) && (
+                            <span className="rounded-full bg-blue-500/10 px-2 py-0.5 text-[10px] font-semibold text-blue-600 dark:text-blue-400">
+                              {kiroRegion(conn)}
+                            </span>
+                          )}
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                              isInactive
+                                ? "bg-surface-2 text-text-muted"
+                                : conn.testStatus === "active" || conn.testStatus === "success"
+                                  ? "bg-green-500/10 text-green-600 dark:text-green-400"
+                                  : conn.testStatus === "error" || conn.testStatus === "expired" || conn.testStatus === "unavailable"
+                                    ? "bg-red-500/10 text-red-600 dark:text-red-400"
+                                    : "bg-surface-2 text-text-muted"
+                            }`}
+                          >
+                            {isInactive ? "disabled" : conn.testStatus || "unknown"}
+                          </span>
+                          {conn.providerSpecificData?.profileArn && (
+                            <button
+                              type="button"
+                              onClick={() => copy(conn.providerSpecificData.profileArn, conn.id)}
+                              title={conn.providerSpecificData.profileArn}
+                              className="inline-flex max-w-full items-center gap-1 rounded-full border border-border-subtle px-2 py-0.5 text-[10px] text-text-muted transition-colors hover:text-primary"
+                            >
+                              <span className="material-symbols-outlined text-[12px]">
+                                {copied === conn.id ? "check" : "content_copy"}
+                              </span>
+                              <code className="truncate font-mono">
+                                {conn.providerSpecificData.profileArn}
+                              </code>
+                            </button>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </div>
 

--- a/src/app/api/oauth/kiro/api-key/route.js
+++ b/src/app/api/oauth/kiro/api-key/route.js
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { KiroService } from "@/lib/oauth/services/kiro";
+import { createProviderConnection } from "@/models";
+
+/**
+ * POST /api/oauth/kiro/api-key
+ * Import a Kiro API key (headless auth). The key is a long-lived bearer
+ * credential — there is no refresh token. It is validated by listing
+ * CodeWhisperer profiles, then stored with authMethod="api_key".
+ */
+export async function POST(request) {
+  try {
+    const { apiKey, region } = await request.json();
+
+    if (!apiKey || typeof apiKey !== "string" || !apiKey.trim()) {
+      return NextResponse.json(
+        { error: "API key is required" },
+        { status: 400 }
+      );
+    }
+
+    const kiroService = new KiroService();
+
+    // Validate the key and resolve its profileArn via ListAvailableProfiles
+    const credential = await kiroService.validateApiKey(
+      apiKey,
+      region || "us-east-1"
+    );
+
+    // Extract email from JWT if the key happens to be a JWT (optional display)
+    const email = kiroService.extractEmailFromJWT(credential.accessToken);
+
+    // API keys never expire on a fixed schedule; persist a long horizon so the
+    // proactive refresh path (which requires a refreshToken anyway) is skipped.
+    const connection = await createProviderConnection({
+      provider: "kiro",
+      authType: "api_key",
+      accessToken: credential.accessToken,
+      refreshToken: null,
+      expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString(),
+      email: email || null,
+      providerSpecificData: {
+        profileArn: credential.profileArn,
+        region: credential.region,
+        authMethod: "api_key",
+        provider: "API Key",
+      },
+      testStatus: "active",
+    });
+
+    return NextResponse.json({
+      success: true,
+      connection: {
+        id: connection.id,
+        provider: connection.provider,
+        email: connection.email,
+      },
+    });
+  } catch (error) {
+    console.log("Kiro API key import error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/src/app/api/providers/client/route.js
+++ b/src/app/api/providers/client/route.js
@@ -17,6 +17,7 @@ const SAFE_PSD_FIELDS = [
   "connectionProxyEnabled", "connectionProxyUrl", "connectionNoProxy",
   "githubLogin", "githubName", "githubEmail", "githubUserId",
   "username", "firstName", "lastName", "authMethod", "authKind",
+  "profileArn",
 ];
 
 const DEFAULT_PAGE_SIZE = 20;

--- a/src/app/api/usage/[connectionId]/route.js
+++ b/src/app/api/usage/[connectionId]/route.js
@@ -131,11 +131,14 @@ export async function GET(request, { params }) {
       return Response.json({ error: "Connection not found" }, { status: 404 });
     }
 
-    // Allow OAuth connections, plus whitelisted apikey providers (glm/minimax/...)
+    // Allow OAuth connections, plus whitelisted apikey providers (glm/minimax/kiro/...)
+    // Kiro's headless api-key flow persists authType "api_key" (underscore) while
+    // generic apikey providers persist "apikey" — accept both spellings here.
     const isOAuth = connection.authType === "oauth";
+    const isApikeyAuth =
+      connection.authType === "apikey" || connection.authType === "api_key";
     const isApikeyEligible =
-      connection.authType === "apikey" &&
-      USAGE_APIKEY_PROVIDERS.includes(connection.provider);
+      isApikeyAuth && USAGE_APIKEY_PROVIDERS.includes(connection.provider);
 
     if (!isOAuth && !isApikeyEligible) {
       return Response.json({ message: "Usage not available for this connection" });

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -970,7 +970,49 @@ const PROVIDERS = {
         },
       };
     },
-    mapTokens: (tokens) => {
+    // AWS SSO OIDC (Builder ID / IDC) only returns access/refresh tokens — no
+    // profileArn. The real profile lives in CodeWhisperer and must be fetched
+    // separately with the fresh access token via ListAvailableProfiles, exactly
+    // like the Kiro IDE does. Social/import flows already carry profileArn, so
+    // skip the call when one is present.
+    postExchange: async (tokens) => {
+      if (tokens?.profile_arn) return { profileArn: tokens.profile_arn };
+
+      const region = tokens._region || "us-east-1";
+      const endpoint = `https://codewhisperer.${region}.amazonaws.com`;
+      try {
+        const response = await fetch(endpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-amz-json-1.0",
+            "x-amz-target": "AmazonCodeWhispererService.ListAvailableProfiles",
+            Authorization: `Bearer ${tokens.access_token}`,
+            Accept: "application/json",
+          },
+          body: JSON.stringify({ maxResults: 10 }),
+        });
+
+        if (!response.ok) {
+          const error = await response.text();
+          console.log(`Kiro ListAvailableProfiles failed (${response.status}): ${error}`);
+          return { profileArn: null };
+        }
+
+        const data = await response.json();
+        const profiles = Array.isArray(data?.profiles) ? data.profiles : [];
+        // AWS field name varies by surface: the JSON-1.0 API returns `arn`,
+        // while some responses use `profileArn`. Accept either (the Kiro-Go
+        // reference fork reads `arn`).
+        const arnOf = (p) => p?.arn || p?.profileArn || null;
+        // Prefer a profile in the token's region, else fall back to the first.
+        const match = profiles.find((p) => arnOf(p)?.split(":")[3] === region) || profiles[0];
+        return { profileArn: arnOf(match) };
+      } catch (error) {
+        console.log(`Kiro ListAvailableProfiles error: ${error.message}`);
+        return { profileArn: null };
+      }
+    },
+    mapTokens: (tokens, extra) => {
       const email = extractEmailFromAccessToken(tokens.access_token);
       const mapped = {
         accessToken: tokens.access_token,
@@ -978,7 +1020,7 @@ const PROVIDERS = {
         expiresIn: tokens.expires_in,
         email,
         providerSpecificData: {
-          profileArn: tokens?.profile_arn || null,
+          profileArn: extra?.profileArn || tokens?.profile_arn || null,
           clientId: tokens._clientId,
           clientSecret: tokens._clientSecret,
           region: tokens._region || "us-east-1",

--- a/src/lib/oauth/services/kiro.js
+++ b/src/lib/oauth/services/kiro.js
@@ -254,6 +254,67 @@ export class KiroService {
   }
 
   /**
+   * List available CodeWhisperer profiles for a token (or API key) and return
+   * the best-matching profileArn. AWS SSO OIDC logins return no profileArn, so
+   * it must be fetched separately — the same call works for API-key auth.
+   * Accepts both `arn` and `profileArn` response field names (the API-key
+   * JSON-1.0 surface returns `arn`).
+   */
+  async listAvailableProfiles(accessToken, region = "us-east-1") {
+    const endpoint = `https://codewhisperer.${region}.amazonaws.com`;
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-amz-json-1.0",
+        "x-amz-target": "AmazonCodeWhispererService.ListAvailableProfiles",
+        "Authorization": `Bearer ${accessToken}`,
+        "Accept": "application/json",
+      },
+      body: JSON.stringify({ maxResults: 10 }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Failed to list profiles: ${error}`);
+    }
+
+    const data = await response.json();
+    const profiles = Array.isArray(data?.profiles) ? data.profiles : [];
+    const arnOf = (p) => p?.arn || p?.profileArn || null;
+    const match = profiles.find((p) => arnOf(p)?.split(":")[3] === region) || profiles[0];
+    return arnOf(match);
+  }
+
+  /**
+   * Validate an API-key credential by listing profiles with it. API keys are
+   * long-lived bearer tokens (no refresh), so the only way to validate one is
+   * to make an authenticated CodeWhisperer call. Returns a credential object
+   * ready to persist as a "kiro" connection with authMethod="api_key".
+   */
+  async validateApiKey(apiKey, region = "us-east-1") {
+    if (!apiKey || typeof apiKey !== "string" || !apiKey.trim()) {
+      throw new Error("API key is required");
+    }
+    const trimmed = apiKey.trim();
+
+    let profileArn = null;
+    try {
+      profileArn = await this.listAvailableProfiles(trimmed, region);
+    } catch (error) {
+      throw new Error(`API key validation failed: ${error.message}`);
+    }
+
+    return {
+      accessToken: trimmed,
+      refreshToken: null,
+      profileArn,
+      region,
+      authMethod: "api_key",
+    };
+  }
+
+  /**
    * List available models from CodeWhisperer API
    */
   async listAvailableModels(accessToken, profileArn) {

--- a/src/shared/components/KiroAuthModal.js
+++ b/src/shared/components/KiroAuthModal.js
@@ -13,6 +13,8 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
   const [idcStartUrl, setIdcStartUrl] = useState("");
   const [idcRegion, setIdcRegion] = useState("us-east-1");
   const [refreshToken, setRefreshToken] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [apiKeyRegion, setApiKeyRegion] = useState("us-east-1");
   const [error, setError] = useState(null);
   const [importing, setImporting] = useState(false);
   const [autoDetecting, setAutoDetecting] = useState(false);
@@ -96,6 +98,40 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
     onMethodSelect("idc", { startUrl: idcStartUrl.trim(), region: idcRegion });
   };
 
+  const handleApiKeyImport = async () => {
+    if (!apiKey.trim()) {
+      setError("Please enter an API key");
+      return;
+    }
+
+    setImporting(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/oauth/kiro/api-key", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          apiKey: apiKey.trim(),
+          region: apiKeyRegion.trim() || "us-east-1",
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || "Import failed");
+      }
+
+      // Success - notify parent to refresh connections
+      onMethodSelect("api-key");
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setImporting(false);
+    }
+  };
+
   const handleSocialLogin = (provider) => {
     onMethodSelect("social", { provider });
   };
@@ -137,6 +173,22 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
                   <h3 className="font-semibold mb-1">AWS IAM Identity Center</h3>
                   <p className="text-sm text-text-muted">
                     For enterprise users with custom AWS IAM Identity Center.
+                  </p>
+                </div>
+              </div>
+            </button>
+
+            {/* AWS API Key */}
+            <button
+              onClick={() => handleMethodSelect("api-key")}
+              className="w-full p-4 text-left border border-border rounded-lg hover:bg-sidebar transition-colors"
+            >
+              <div className="flex items-start gap-3">
+                <span className="material-symbols-outlined text-primary mt-0.5">key</span>
+                <div className="flex-1">
+                  <h3 className="font-semibold mb-1">API Key</h3>
+                  <p className="text-sm text-text-muted">
+                    Use a long-lived Kiro/CodeWhisperer API key (headless auth).
                   </p>
                 </div>
               </div>
@@ -232,6 +284,63 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
             <div className="flex gap-2">
               <Button onClick={handleIdcContinue} fullWidth>
                 Continue
+              </Button>
+              <Button onClick={handleBack} variant="ghost" fullWidth>
+                Back
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* API Key */}
+        {selectedMethod === "api-key" && (
+          <div className="space-y-4">
+            <div className="bg-blue-50 dark:bg-blue-900/20 p-3 rounded-lg border border-blue-200 dark:border-blue-800">
+              <div className="flex gap-2">
+                <span className="material-symbols-outlined text-blue-600 dark:text-blue-400">info</span>
+                <p className="text-sm text-blue-800 dark:text-blue-200">
+                  Paste a long-lived Kiro/CodeWhisperer API key. It is validated
+                  against AWS and stored directly as a bearer credential (no refresh).
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                API Key <span className="text-red-500">*</span>
+              </label>
+              <Input
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="Paste your Kiro API key..."
+                className="font-mono text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                AWS Region
+              </label>
+              <Input
+                value={apiKeyRegion}
+                onChange={(e) => setApiKeyRegion(e.target.value)}
+                placeholder="us-east-1"
+                className="font-mono text-sm"
+              />
+              <p className="text-xs text-text-muted mt-1">
+                AWS region for the key (default: us-east-1)
+              </p>
+            </div>
+
+            {error && (
+              <div className="bg-red-50 dark:bg-red-900/20 p-3 rounded-lg border border-red-200 dark:border-red-800">
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              <Button onClick={handleApiKeyImport} fullWidth disabled={importing || !apiKey.trim()}>
+                {importing ? "Validating..." : "Add API Key"}
               </Button>
               <Button onClick={handleBack} variant="ghost" fullWidth>
                 Back

--- a/src/shared/components/KiroOAuthWrapper.js
+++ b/src/shared/components/KiroOAuthWrapper.js
@@ -27,8 +27,8 @@ export default function KiroOAuthWrapper({ isOpen, providerInfo, onSuccess, onCl
       // Use social login with manual callback
       setAuthMethod("social");
       setSocialProvider(config.provider);
-    } else if (method === "import") {
-      // Import handled in KiroAuthModal, just close
+    } else if (method === "import" || method === "api-key") {
+      // Import / API-key handled in KiroAuthModal, just close
       onSuccess?.();
     }
   }, [onSuccess]);

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -281,6 +281,7 @@ export const USAGE_SUPPORTED_PROVIDERS = [
 
 // Subset that uses apikey auth (still surfaced on quota page)
 export const USAGE_APIKEY_PROVIDERS = [
+  "kiro",
   "glm",
   "glm-cn",
   "minimax",

--- a/tests/unit/kiro-profile-arn.test.js
+++ b/tests/unit/kiro-profile-arn.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getProvider } from "../../src/lib/oauth/providers.js";
+import { KiroService } from "../../src/lib/oauth/services/kiro.js";
+
+/**
+ * Regression tests for Kiro profileArn resolution + API-key auth.
+ *
+ * profileArn: AWS SSO OIDC (Builder ID / IDC) /token returns no profileArn, so
+ * the provider must fetch it from CodeWhisperer ListAvailableProfiles via
+ * postExchange and surface it through mapTokens. The response field name varies
+ * (`arn` vs `profileArn`) — both must be accepted.
+ *
+ * api-key: KiroService.validateApiKey resolves a profileArn with the key and
+ * returns a credential shaped for persistence with authMethod="api_key".
+ */
+describe("kiro provider profileArn resolution", () => {
+  const kiro = getProvider("kiro");
+
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("fetches profileArn via ListAvailableProfiles when SSO token has none", async () => {
+    const expectedArn = "arn:aws:codewhisperer:us-east-1:123456789012:profile/ABC";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ profileArn: expectedArn }] }),
+    });
+
+    const tokens = {
+      access_token: "aoaAAAA-access",
+      refresh_token: "aorAAAA-refresh",
+      expires_in: 3600,
+      profile_arn: null,
+      _region: "us-east-1",
+      _authMethod: "idc",
+      _clientId: "client-id",
+      _clientSecret: "client-secret",
+    };
+
+    const extra = await kiro.postExchange(tokens);
+    expect(extra.profileArn).toBe(expectedArn);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://codewhisperer.us-east-1.amazonaws.com");
+    expect(init.headers["x-amz-target"]).toBe(
+      "AmazonCodeWhispererService.ListAvailableProfiles"
+    );
+    expect(init.headers.Authorization).toBe("Bearer aoaAAAA-access");
+
+    const mapped = kiro.mapTokens(tokens, extra);
+    expect(mapped.providerSpecificData.profileArn).toBe(expectedArn);
+    expect(mapped.providerSpecificData.authMethod).toBe("idc");
+  });
+
+  it("accepts the `arn` response field name (Kiro-Go reference shape)", async () => {
+    const expectedArn = "arn:aws:codewhisperer:us-east-1:222:profile/ARNFIELD";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ arn: expectedArn }] }),
+    });
+
+    const extra = await kiro.postExchange({
+      access_token: "access",
+      _region: "us-east-1",
+    });
+    expect(extra.profileArn).toBe(expectedArn);
+  });
+
+  it("prefers a profile matching the token region", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        profiles: [
+          { profileArn: "arn:aws:codewhisperer:eu-west-1:111:profile/EU" },
+          { profileArn: "arn:aws:codewhisperer:us-east-1:111:profile/US" },
+        ],
+      }),
+    });
+
+    const extra = await kiro.postExchange({
+      access_token: "access",
+      _region: "us-east-1",
+    });
+    expect(extra.profileArn).toBe(
+      "arn:aws:codewhisperer:us-east-1:111:profile/US"
+    );
+  });
+
+  it("skips the network call when the token already carries a profileArn", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const extra = await kiro.postExchange({
+      access_token: "access",
+      profile_arn: "arn:aws:codewhisperer:us-east-1:333:profile/EXISTING",
+    });
+    expect(extra.profileArn).toBe(
+      "arn:aws:codewhisperer:us-east-1:333:profile/EXISTING"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null profileArn (non-fatal) when ListAvailableProfiles fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => "AccessDenied",
+    });
+    const extra = await kiro.postExchange({
+      access_token: "access",
+      _region: "us-east-1",
+    });
+    expect(extra.profileArn).toBeNull();
+  });
+});
+
+describe("kiro API-key auth (KiroService.validateApiKey)", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("validates an API key and resolves a credential with profileArn", async () => {
+    const expectedArn = "arn:aws:codewhisperer:us-east-1:444:profile/KEY";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ arn: expectedArn }] }),
+    });
+
+    const svc = new KiroService();
+    const cred = await svc.validateApiKey("  my-secret-key  ");
+
+    expect(cred).toEqual({
+      accessToken: "my-secret-key",
+      refreshToken: null,
+      profileArn: expectedArn,
+      region: "us-east-1",
+      authMethod: "api_key",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://codewhisperer.us-east-1.amazonaws.com");
+    expect(init.headers.Authorization).toBe("Bearer my-secret-key");
+    expect(init.headers["x-amz-target"]).toBe(
+      "AmazonCodeWhispererService.ListAvailableProfiles"
+    );
+  });
+
+  it("rejects an empty API key without a network call", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const svc = new KiroService();
+    await expect(svc.validateApiKey("   ")).rejects.toThrow("API key is required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a validation error when the key is rejected", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+    const svc = new KiroService();
+    await expect(svc.validateApiKey("bad-key")).rejects.toThrow(
+      /API key validation failed/
+    );
+  });
+});

--- a/tests/vitest.config.js
+++ b/tests/vitest.config.js
@@ -9,6 +9,10 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["**/*.test.js"],
+    // Don't scan into git worktrees nested under .claude/ — they carry their
+    // own copies of the test files but lack an installed node_modules (open-sse,
+    // etc.), which makes provider imports fail during collection.
+    exclude: ["**/node_modules/**", "**/.claude/**", "**/dist/**"],
     // Allow many it.concurrent cases (real provider smoke runs ~50 providers in parallel)
     maxConcurrency: 60,
     // Suppress noisy console output from handlers under test


### PR DESCRIPTION
## Summary

Adds an API-key authentication method for the Kiro provider and surfaces api-key Kiro connections in the quota usage dashboard.

## API-key authentication

- **Import route** (`src/app/api/oauth/kiro/api-key/route.js`): import a long-lived CodeWhisperer API key (no refresh token), resolve `profileArn` at import time, and persist `authMethod: "api_key"`.
- **OAuth providers/services** (`src/lib/oauth/providers.js`, `src/lib/oauth/services/kiro.js`): add `listAvailableProfiles()` + `validateApiKey()`, and a `postExchange` that resolves the profile ARN (accepts both `arn` and `profileArn` response fields).
- **Connect modal UI** (`src/shared/components/KiroAuthModal.js`, `KiroOAuthWrapper.js`): add the API-key entry path to the Kiro connect flow.
- **Executor** (`open-sse/executors/kiro.js`): send `Authorization: Bearer <key>` plus a `tokentype: API_KEY` header when `authMethod === "api_key"`.

## Quota usage dashboard

- **Quota Tracker** (`src/app/(dashboard)/.../usage/components/ProviderLimits/index.js`, `api/providers/client/route.js`): show per-account details on the Quota Tracker tab.
- **Usage service / route** (`open-sse/services/usage.js`, `api/usage/[connectionId]/route.js`): send the `tokentype: API_KEY` header on the usage calls and accept both `api_key` and `apikey` authType spellings in the eligibility check.
- **Providers page** (`src/app/(dashboard)/dashboard/providers/page.js`, `src/shared/constants/providers.js`): count and toggle both OAuth and api-key Kiro connections so the card total matches the detail page.

## Tests

`tests/unit/kiro-profile-arn.test.js` covers profileArn resolution (arn field, region preference, skip-when-present, non-fatal failure) and API-key validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)