### PR TITLE
fix: show edited connection names in provider views

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -71,8 +71,11 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
   const authIcon = isCookieConnection ? "cookie" : isOAuthConnection ? "lock" : "key";
   const authLabel = isOAuthConnection ? "OAuth" : isCookieConnection ? "Cookie" : "API Key";
   const isEmail = (v) => typeof v === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+  const customName = [connection.name, connection.displayName]
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .find((value) => value && !isEmail(value));
   const displayName = isOAuthConnection
-    ? (isEmail(connection.email) ? connection.email : (isEmail(connection.name) ? connection.name : (connection.name || connection.email || connection.displayName || "OAuth Account")))
+    ? (customName || connection.email || connection.name || connection.displayName || "OAuth Account")
     : (connection.name || connection.email || connection.displayName || "API Key");
 
   // Use useState + useEffect for impure Date.now() to avoid calling during render

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -12,9 +12,10 @@ import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
 function getConnectionLabel(connection) {
   const isEmail = (value) =>
     typeof value === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-  if (isEmail(connection.email)) return connection.email;
-  if (isEmail(connection.name)) return connection.name;
-  return connection.name;
+  const customName = [connection.name, connection.displayName]
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .find((value) => value && !isEmail(value));
+  return customName || connection.email || connection.name || connection.displayName;
 }
 
 function getConnectionQuotaRemaining(connection, quotaData) {
@@ -997,14 +998,12 @@ export default function ProviderLimits() {
                       />
                     </div>
                     <div className="min-w-0">
-                      <h3 className="text-sm font-semibold text-text-primary capitalize truncate">
-                        {conn.provider}
+                      <h3 className="text-sm font-semibold text-text-primary truncate">
+                        {getConnectionLabel(conn) || conn.provider}
                       </h3>
-                      {getConnectionLabel(conn) ? (
-                        <p className="text-xs text-text-muted truncate">
-                          {getConnectionLabel(conn)}
-                        </p>
-                      ) : null}
+                      <p className="text-xs text-text-muted truncate capitalize">
+                        {conn.provider}
+                      </p>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Description
- Show edited account/provider names in Quota Tracker cards instead of always using the provider id.
- Prefer custom edited OAuth connection names in the Providers connection row before falling back to email/default labels.
- Keep the raw provider id visible as secondary context in Quota Tracker.

## Changes
- Update Quota Tracker connection label resolution to prefer non-email custom names from `name`/`displayName`.
- Update Providers connection row display name fallback order for OAuth accounts.

## Verification
- `npx eslint "src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js" "src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js"`
- `git diff --check`

Closes #1699
