### PR TITLE
fix: count alternate usage token fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "postcss": "^8.5.6",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "vitest": "^4.1.8"
   }
 }

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -545,8 +545,8 @@ export async function getUsageStats(period = "all") {
 
     for (const r of filtered) {
       const tokens = parseJson(r.tokens, {}) || {};
-      const promptTokens = tokens.prompt_tokens || 0;
-      const completionTokens = tokens.completion_tokens || 0;
+      const promptTokens = tokens.prompt_tokens ?? tokens.input_tokens ?? r.promptTokens ?? 0;
+      const completionTokens = tokens.completion_tokens ?? tokens.output_tokens ?? r.completionTokens ?? 0;
       const entryCost = r.cost || 0;
       const providerDisplayName = providerNodeNameMap[r.provider] || r.provider;
 

--- a/tests/unit/usage-stats-token-fallback.test.js
+++ b/tests/unit/usage-stats-token-fallback.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../src/lib/db/repos/connectionsRepo.js", () => ({
+  getProviderConnections: vi.fn(() => []),
+}));
+
+vi.mock("../../src/lib/db/repos/apiKeysRepo.js", () => ({
+  getApiKeys: vi.fn(() => []),
+}));
+
+vi.mock("../../src/lib/db/repos/nodesRepo.js", () => ({
+  getProviderNodes: vi.fn(() => []),
+}));
+
+describe("usage stats token fallback", () => {
+  let dataDir;
+  let usageRepo;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    dataDir = mkdtempSync(path.join(os.tmpdir(), "9router-usage-stats-"));
+    process.env.DATA_DIR = dataDir;
+    delete global._dbAdapter;
+    delete global._pendingRequests;
+    delete global._lastErrorProvider;
+    delete global._statsEmitter;
+    delete global._pendingTimers;
+    delete global._recentRing;
+    delete global._connectionMapCache;
+
+    usageRepo = await import("../../src/lib/db/repos/usageRepo.js");
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("counts today usage rows stored with input_tokens/output_tokens", async () => {
+    await usageRepo.saveRequestUsage({
+      timestamp: new Date().toISOString(),
+      provider: "openai",
+      model: "gpt-5.5",
+      tokens: {
+        input_tokens: 123,
+        output_tokens: 45,
+      },
+    });
+
+    const stats = await usageRepo.getUsageStats("today");
+
+    expect(stats.totalRequests).toBe(1);
+    expect(stats.totalPromptTokens).toBe(123);
+    expect(stats.totalCompletionTokens).toBe(45);
+    expect(stats.byProvider.openai).toMatchObject({
+      requests: 1,
+      promptTokens: 123,
+      completionTokens: 45,
+    });
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(root, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Description
Addresses the Overview zero-token case reported in #1639.

Usage Overview can show `0` tokens even when Recent Requests contains non-zero usage rows. The today/24h aggregation only reads OpenAI-style `prompt_tokens` / `completion_tokens` from the stored token JSON, while some providers/store paths use `input_tokens` / `output_tokens`.

This PR focuses on the data aggregation path for Overview cards. It does not attempt to change the Overview / Details tab switching behavior.

## Changes
- Add `input_tokens` / `output_tokens` fallback support in `getUsageStats()` for today/24h aggregation.
- Fall back to normalized `usageHistory.promptTokens` / `usageHistory.completionTokens` columns when token JSON fields are missing.
- Add a focused unit test covering usage rows stored with `input_tokens` / `output_tokens`.
- Add `vitest` as a devDependency so existing Vitest unit tests can run from a fresh install.

## Verification
- `./node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/usage-stats-token-fallback.test.js`
- `./node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/dashboard-guard.test.js tests/unit/gemini-usage-projectid.test.js tests/unit/minimax-usage.test.js tests/unit/usage-stats-token-fallback.test.js`
- `npx eslint src/lib/db/repos/usageRepo.js tests/unit/usage-stats-token-fallback.test.js`
- `git diff --check`

## Note
`tests/unit/translator-request-normalization.test.js` currently fails in unrelated normalization / `parseSSELine` assertions, so it was excluded from the scoped verification for this Usage fix.

Refs #1639
