### PR TITLE
feat(providers): Add bulk disable for failed provider models

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -10,6 +10,7 @@ import { getModelsByProviderId } from "@/shared/constants/models";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { translate } from "@/i18n/runtime";
 import { fetchSuggestedModels } from "@/shared/utils/providerModelsFetcher";
+import { collectBulkTestModelIds } from "@/shared/utils/providerModelBulkActions";
 import ModelRow from "./ModelRow";
 import PassthroughModelsSection from "./PassthroughModelsSection";
 import CompatibleModelsSection from "./CompatibleModelsSection";
@@ -19,6 +20,7 @@ import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
+const BULK_MODEL_TEST_DELAY_MS = 250;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -44,7 +46,9 @@ export default function ProviderDetailPage() {
   const [headerImgError, setHeaderImgError] = useState(false);
   const [modelTestResults, setModelTestResults] = useState({});
   const [modelsTestError, setModelsTestError] = useState("");
+  const [modelsTestMessage, setModelsTestMessage] = useState("");
   const [testingModelId, setTestingModelId] = useState(null);
+  const [bulkTestingModels, setBulkTestingModels] = useState(false);
   const [showAddCustomModel, setShowAddCustomModel] = useState(false);
   const [selectedConnectionIds, setSelectedConnectionIds] = useState([]);
   const [bulkProxyPoolId, setBulkProxyPoolId] = useState("__none__");
@@ -871,9 +875,7 @@ export default function ProviderDetailPage() {
     </Modal>
   );
 
-  const handleTestModel = async (modelId) => {
-    if (testingModelId) return;
-    setTestingModelId(modelId);
+  const runModelTest = async (modelId) => {
     try {
       const res = await fetch("/api/models/test", {
         method: "POST",
@@ -881,13 +883,67 @@ export default function ProviderDetailPage() {
         body: JSON.stringify({ model: `${providerStorageAlias}/${modelId}` }),
       });
       const data = await res.json();
-      setModelTestResults((prev) => ({ ...prev, [modelId]: data.ok ? "ok" : "error" }));
-      setModelsTestError(data.ok ? "" : (data.error || "Model not reachable"));
+      const ok = !!data.ok;
+      setModelTestResults((prev) => ({ ...prev, [modelId]: ok ? "ok" : "error" }));
+      return { modelId, ok, error: ok ? "" : (data.error || "Model not reachable") };
     } catch {
       setModelTestResults((prev) => ({ ...prev, [modelId]: "error" }));
-      setModelsTestError("Network error");
+      return { modelId, ok: false, error: "Network error" };
+    }
+  };
+
+  const handleTestModel = async (modelId) => {
+    if (testingModelId || bulkTestingModels) return;
+    setTestingModelId(modelId);
+    setModelsTestMessage("");
+    try {
+      const result = await runModelTest(modelId);
+      setModelsTestError(result.ok ? "" : result.error);
     } finally {
       setTestingModelId(null);
+    }
+  };
+
+  const handleDisableErrorModels = async (modelIds) => {
+    if (bulkTestingModels || testingModelId || modelIds.length === 0) return;
+    setBulkTestingModels(true);
+    setModelsTestError("");
+    setModelsTestMessage("");
+
+    const errorIds = [];
+    try {
+      for (let index = 0; index < modelIds.length; index += 1) {
+        const modelId = modelIds[index];
+        setTestingModelId(modelId);
+        const result = await runModelTest(modelId);
+        if (!result.ok) errorIds.push(modelId);
+        if (index < modelIds.length - 1) await sleep(BULK_MODEL_TEST_DELAY_MS);
+      }
+
+      if (errorIds.length === 0) {
+        setModelsTestMessage("No error models found.");
+        return;
+      }
+
+      const res = await fetch("/api/models/disabled", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerAlias: providerStorageAlias, ids: errorIds }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setModelsTestError(data.error || "Failed to disable error models");
+        return;
+      }
+
+      await fetchDisabledModels();
+      setModelsTestMessage(`Disabled ${errorIds.length} error model${errorIds.length === 1 ? "" : "s"}.`);
+    } catch (error) {
+      setModelsTestError(error.message || "Failed to disable error models");
+    } finally {
+      setTestingModelId(null);
+      setBulkTestingModels(false);
     }
   };
 
@@ -922,6 +978,7 @@ export default function ProviderDetailPage() {
         const prefix = `${providerStorageAlias}/`;
         if (!fullModel.startsWith(prefix)) return false;
         const modelId = fullModel.slice(prefix.length);
+        if (disabledSet.has(modelId)) return false;
         // Only show if not already in hardcoded list
         // For passthroughModels, include all aliases (model IDs may contain slashes like "anthropic/claude-3")
         if (providerInfo.passthroughModels) return !models.some((m) => m.id === modelId);
@@ -1427,20 +1484,36 @@ export default function ProviderDetailPage() {
             {"Available Models"}
           </h2>
           {!isCompatible && (() => {
-            const allIds = [
-              ...models,
-              ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
-            ].filter((m) => !m.type || m.type === "llm").map((m) => m.id);
+            const allIds = collectBulkTestModelIds({
+              models,
+              kiloFreeModels,
+              modelAliases,
+              providerStorageAlias,
+              providerInfo,
+              disabledModelIds: [],
+            });
             const activeIds = allIds.filter((id) => !disabledModelIds.includes(id));
+            const canTestModels = connections.length > 0 || isFreeNoAuth;
             return (
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 {disabledModelIds.length > 0 && (
-                  <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll}>
+                  <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll} disabled={bulkTestingModels}>
                     Active All
                   </Button>
                 )}
                 {activeIds.length > 0 && (
-                  <Button size="sm" variant="secondary" icon="block" onClick={() => handleDisableAll(activeIds)}>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    icon={bulkTestingModels ? "progress_activity" : "science"}
+                    onClick={() => handleDisableErrorModels(activeIds)}
+                    disabled={!canTestModels || bulkTestingModels || !!testingModelId}
+                  >
+                    {bulkTestingModels ? "Testing Models..." : "Test & Disable Failed Models"}
+                  </Button>
+                )}
+                {activeIds.length > 0 && (
+                  <Button size="sm" variant="secondary" icon="block" onClick={() => handleDisableAll(activeIds)} disabled={bulkTestingModels}>
                     Disable All
                   </Button>
                 )}
@@ -1450,6 +1523,9 @@ export default function ProviderDetailPage() {
         </div>
         {!!modelsTestError && (
           <p className="text-xs text-red-500 mb-3 break-words">{modelsTestError}</p>
+        )}
+        {!!modelsTestMessage && (
+          <p className="text-xs text-green-600 dark:text-green-400 mb-3 break-words">{modelsTestMessage}</p>
         )}
         {renderModelsSection()}
       </Card>

--- a/src/shared/utils/providerModelBulkActions.js
+++ b/src/shared/utils/providerModelBulkActions.js
@@ -1,0 +1,40 @@
+export function collectBulkTestModelIds({
+  models = [],
+  kiloFreeModels = [],
+  modelAliases = {},
+  providerStorageAlias,
+  providerInfo = {},
+  disabledModelIds = [],
+}) {
+  const disabledSet = new Set(disabledModelIds);
+  const ids = [];
+  const seen = new Set();
+
+  const addId = (id) => {
+    if (!id || seen.has(id) || disabledSet.has(id)) return;
+    seen.add(id);
+    ids.push(id);
+  };
+
+  const builtInModels = [
+    ...models,
+    ...kiloFreeModels.filter((freeModel) => !models.some((model) => model.id === freeModel.id)),
+  ].filter((model) => !model.type || model.type === "llm");
+
+  builtInModels.forEach((model) => addId(model.id));
+
+  const prefix = `${providerStorageAlias}/`;
+  Object.entries(modelAliases).forEach(([alias, fullModel]) => {
+    if (!fullModel?.startsWith(prefix)) return;
+    const modelId = fullModel.slice(prefix.length);
+    if (providerInfo.passthroughModels) {
+      if (!models.some((model) => model.id === modelId)) addId(modelId);
+      return;
+    }
+    if (!models.some((model) => model.id === modelId) && alias === modelId) {
+      addId(modelId);
+    }
+  });
+
+  return ids;
+}

--- a/tests/unit/provider-model-bulk-actions.test.js
+++ b/tests/unit/provider-model-bulk-actions.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { collectBulkTestModelIds } from "../../src/shared/utils/providerModelBulkActions.js";
+
+describe("provider model bulk actions", () => {
+  it("collects built-in, kilo, and custom model ids for bulk testing", () => {
+    const ids = collectBulkTestModelIds({
+      models: [
+        { id: "gemini-2.5-pro" },
+        { id: "gemini-embedding", type: "embedding" },
+      ],
+      kiloFreeModels: [
+        { id: "gemini-2.5-pro" },
+        { id: "gemini-2.5-flash" },
+      ],
+      modelAliases: {
+        "gemini-custom": "gc/gemini-custom",
+        "other-provider-model": "xx/other-provider-model",
+      },
+      providerStorageAlias: "gc",
+      providerInfo: {},
+      disabledModelIds: [],
+    });
+
+    expect(ids).toEqual(["gemini-2.5-pro", "gemini-2.5-flash", "gemini-custom"]);
+  });
+
+  it("excludes disabled ids and keeps passthrough custom ids with slashes", () => {
+    const ids = collectBulkTestModelIds({
+      models: [{ id: "openai/gpt-4.1" }],
+      kiloFreeModels: [],
+      modelAliases: {
+        "claude-3": "or/anthropic/claude-3",
+        "gpt-4.1": "or/openai/gpt-4.1",
+      },
+      providerStorageAlias: "or",
+      providerInfo: { passthroughModels: true },
+      disabledModelIds: ["openai/gpt-4.1"],
+    });
+
+    expect(ids).toEqual(["anthropic/claude-3"]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a bulk action for provider model management: **Test & Disable Failed Models**.

When clicked, the dashboard tests all currently active models for a provider, including custom alias models, and automatically disables only the models that fail the test. Models that pass remain active.

## Changes

- Added a new **Test & Disable Failed Models** button in the provider detail page.
- Reused the existing `/api/models/test` endpoint for per-model validation.
- Added sequential bulk testing to avoid firing all model checks at once.
- Added success/error status updates per model during testing.
- Automatically disables failed models through `/api/models/disabled`.
- Added `collectBulkTestModelIds` helper to gather built-in, Kilo free, and custom alias models.
- Added unit tests for bulk model collection behavior.

## Testing

```bash
cd tests
./node_modules/.bin/vitest run unit/provider-model-bulk-actions.test.js --config vitest.config.js