### PR TITLE
feat(glm): add configurable OpenAI-compatible output format for GLM Coding

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -130,6 +130,7 @@ export const PROVIDERS = {
   },
   glm: {
     baseUrl: "https://api.z.ai/api/anthropic/v1/messages",
+    openaiBaseUrl: "https://api.z.ai/api/coding/paas/v4/chat/completions",
     format: "claude",
     headers: { ...CLAUDE_API_HEADERS }
   },

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -50,7 +50,14 @@ export class DefaultExecutor extends BaseExecutor {
     }
     switch (this.provider) {
       case "claude":
-      case "glm":
+        return `${this.config.baseUrl}?beta=true`;
+      case "glm": {
+        const glmOutputFormat = credentials?.providerSpecificData?.outputFormat;
+        if (glmOutputFormat === "openai") {
+          return this.config.openaiBaseUrl || this.config.baseUrl;
+        }
+        return `${this.config.baseUrl}?beta=true`;
+      }
       case "kimi":
       case "minimax":
       case "minimax-cn":
@@ -113,7 +120,17 @@ export class DefaultExecutor extends BaseExecutor {
           : (headers["Authorization"] = `Bearer ${credentials.accessToken}`);
         break;
       }
-      case "glm":
+      case "glm": {
+        const glmOutputFormat = credentials?.providerSpecificData?.outputFormat;
+        if (glmOutputFormat === "openai") {
+          delete headers["Anthropic-Version"];
+          delete headers["Anthropic-Beta"];
+          headers["Authorization"] = `Bearer ${credentials.apiKey || credentials.accessToken}`;
+        } else {
+          headers["x-api-key"] = credentials.apiKey || credentials.accessToken;
+        }
+        break;
+      }
       case "kimi":
       case "minimax":
       case "minimax-cn":

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -39,7 +39,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);
-  const targetFormat = modelTargetFormat || getTargetFormat(provider);
+  const targetFormat = modelTargetFormat || getTargetFormat(provider, credentials);
   const stripList = getModelStrip(alias, model);
   const upstreamModel = getModelUpstreamId(alias, model);
 

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -197,7 +197,13 @@ export function buildProviderUrl(provider, model, stream = true, options = {}) {
     case "github":
       return config.baseUrl;
 
-    case "glm":
+    case "glm": {
+      const glmOutputFormat = options?.providerSpecificData?.outputFormat;
+      if (glmOutputFormat === "openai") {
+        return config.openaiBaseUrl || config.baseUrl;
+      }
+      return `${config.baseUrl}?beta=true`;
+    }
     case "kimi":
     case "minimax":
       // Claude-compatible providers
@@ -292,7 +298,17 @@ export function buildProviderHeaders(provider, credentials, stream = true, body 
         Object.assign(headers, buildClineHeaders(credentials.apiKey || credentials.accessToken));
         break;
   
-      case "glm":
+      case "glm": {
+        const glmOutputFormat = credentials?.providerSpecificData?.outputFormat;
+        if (glmOutputFormat === "openai") {
+          delete headers["Anthropic-Version"];
+          delete headers["Anthropic-Beta"];
+          headers["Authorization"] = `Bearer ${credentials.apiKey || credentials.accessToken}`;
+        } else {
+          headers["x-api-key"] = credentials.apiKey;
+        }
+        break;
+      }
       case "kimi":
       case "minimax":
         // Claude-compatible API providers use x-api-key
@@ -319,8 +335,10 @@ export function buildProviderHeaders(provider, credentials, stream = true, body 
   return headers;
 }
 
-// Get target format for provider
-export function getTargetFormat(provider) {
+// Get target format for provider, optionally overriding via connection-level outputFormat
+export function getTargetFormat(provider, credentials = null) {
+  const outputFormat = credentials?.providerSpecificData?.outputFormat;
+  if (outputFormat === "openai" && provider === "glm") return "openai";
   if (isOpenAICompatible(provider)) {
     return getOpenAICompatibleType(provider) === "responses" ? "openai-responses" : "openai";
   }

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -421,6 +421,16 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
       }
       case "glm": {
+        const glmOutputFormat = connection.providerSpecificData?.outputFormat;
+        if (glmOutputFormat === "openai") {
+          const res = await fetchWithConnectionProxy("https://api.z.ai/api/coding/paas/v4/chat/completions", {
+            method: "POST",
+            headers: { "Authorization": `Bearer ${connection.apiKey}`, "content-type": "application/json" },
+            body: JSON.stringify({ model: "glm-4.7", max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
+          }, effectiveProxy);
+          const valid = res.status !== 401 && res.status !== 403;
+          return { valid, error: valid ? null : "Invalid API key" };
+        }
         const res = await fetchWithConnectionProxy("https://api.z.ai/api/anthropic/v1/messages", {
           method: "POST",
           headers: { "x-api-key": connection.apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -297,11 +297,13 @@ export async function POST(request) {
         case "agentrouter": {
           // Use baseUrl from PROVIDERS (DRY); separate openai-format vs claude-format flow
           const cfg = PROVIDERS[provider];
-          const isOpenAiFormat = provider === "glm-cn" || provider === "alicode" || provider === "alicode-intl";
+          const glmOutputFormat = providerSpecificData?.outputFormat;
+          const isOpenAiFormat = provider === "glm-cn" || provider === "alicode" || provider === "alicode-intl" || (provider === "glm" && glmOutputFormat === "openai");
 
           if (isOpenAiFormat) {
             const testModel = getDefaultModel(provider);
-            const res = await fetch(cfg.baseUrl, {
+            const url = provider === "glm" ? cfg.openaiBaseUrl : cfg.baseUrl;
+            const res = await fetch(url, {
               method: "POST",
               headers: { "Authorization": `Bearer ${apiKey}`, "content-type": "application/json" },
               body: JSON.stringify({ model: testModel, max_tokens: 1, messages: [{ role: "user", content: "test" }] }),

--- a/src/app/api/translator/translate/route.js
+++ b/src/app/api/translator/translate/route.js
@@ -49,12 +49,7 @@ export async function POST(request) {
           return NextResponse.json({ success: false, error: "provider and model required" }, { status: 400 });
         }
 
-        const targetFormat = getTargetFormat(provider);
         const stream = openaiBody.stream !== false;
-
-        // translateRequest(OPENAI, target) = second half of pipeline
-        const translated = translateRequest(FORMATS.OPENAI, targetFormat, model, openaiBody, stream, null, provider);
-        delete translated._toolNameMap;
 
         // Build URL + headers via executor (same as chatCore → executor.execute)
         const connections = await getProviderConnections({ provider });
@@ -71,6 +66,12 @@ export async function POST(request) {
           projectId: connection.projectId,
           providerSpecificData: connection.providerSpecificData
         };
+
+        const targetFormat = getTargetFormat(provider, credentials);
+
+        // translateRequest(OPENAI, target) = second half of pipeline
+        const translated = translateRequest(FORMATS.OPENAI, targetFormat, model, openaiBody, stream, null, provider);
+        delete translated._toolNameMap;
 
         const executor = getExecutor(provider);
         const url = executor.buildUrl(model, stream, 0, credentials);

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -21,6 +21,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
     organization: "",
   });
   const [cloudflareData, setCloudflareData] = useState({ accountId: "" });
+  const [glmOutputFormat, setGlmOutputFormat] = useState("claude");
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [validating, setValidating] = useState(false);
@@ -46,6 +47,9 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       if (connection.provider === "cloudflare-ai" && connection.providerSpecificData) {
         setCloudflareData({ accountId: connection.providerSpecificData.accountId || "" });
       }
+      if (connection.provider === "glm" && connection.providerSpecificData) {
+        setGlmOutputFormat(connection.providerSpecificData.outputFormat || "claude");
+      }
       setTestResult(null);
       setValidationResult(null);
     }
@@ -54,6 +58,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
   const isOAuth = connection?.authType === "oauth";
   const isAzure = connection?.provider === "azure";
   const isCloudflareAi = connection?.provider === "cloudflare-ai";
+  const isGlm = connection?.provider === "glm";
   const isCompatible = connection
     ? (isOpenAICompatibleProvider(connection.provider) || isAnthropicCompatibleProvider(connection.provider))
     : false;
@@ -86,6 +91,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
           apiKey: formData.apiKey,
           ...(isAzure ? { providerSpecificData: azureData } : {}),
           ...(isCloudflareAi ? { providerSpecificData: cloudflareData } : {}),
+          ...(isGlm ? { providerSpecificData: { outputFormat: glmOutputFormat } } : {}),
         }),
       });
       const data = await res.json();
@@ -120,6 +126,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
                 apiKey: formData.apiKey,
                 ...(isAzure ? { providerSpecificData: azureData } : {}),
                 ...(isCloudflareAi ? { providerSpecificData: cloudflareData } : {}),
+                ...(isGlm ? { providerSpecificData: { outputFormat: glmOutputFormat } } : {}),
               }),
             });
             const data = await res.json();
@@ -149,6 +156,9 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       }
       if (isCloudflareAi) {
         updates.providerSpecificData = { accountId: cloudflareData.accountId };
+      }
+      if (isGlm) {
+        updates.providerSpecificData = { ...(connection.providerSpecificData || {}), outputFormat: glmOutputFormat };
       }
       
       await onSave(updates);
@@ -243,7 +253,29 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
           </div>
         )}
 
-        {!isCompatible && !isAzure && !isCloudflareAi && (
+        {isGlm && (
+          <div className="bg-sidebar/50 p-4 rounded-lg border border-accent/20">
+            <h3 className="font-semibold mb-3 text-sm">GLM Configuration</h3>
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium text-text-muted">Output Format</label>
+                <select
+                  value={glmOutputFormat}
+                  onChange={(e) => setGlmOutputFormat(e.target.value)}
+                  className="w-full px-3 py-2 bg-background border border-accent/20 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-accent/40"
+                >
+                  <option value="claude">Claude (Anthropic) — Default</option>
+                  <option value="openai">OpenAI Compatible</option>
+                </select>
+                <p className="text-xs text-text-muted">
+                  Choose the API protocol. Claude format uses the Anthropic Messages endpoint. OpenAI format uses the Chat Completions endpoint.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!isCompatible && !isAzure && !isCloudflareAi && !isGlm && (
           <div className="flex items-center gap-3">
             <Button onClick={handleTest} variant="secondary" disabled={testing}>
               {testing ? "Testing..." : "Test Connection"}

--- a/src/shared/constants/config.js
+++ b/src/shared/constants/config.js
@@ -65,7 +65,7 @@ export const CLIENT_STORE_TTL_MS = 60000;
 // Provider API endpoints (for display only)
 export const PROVIDER_ENDPOINTS = {
   openrouter: "https://openrouter.ai/api/v1/chat/completions",
-  glm: "https://api.z.ai/api/anthropic/v1/messages",
+  glm: "Claude: https://api.z.ai/api/anthropic/v1/messages | OpenAI: https://api.z.ai/api/coding/paas/v4/chat/completions",
   "glm-cn": "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions",
   kimi: "https://api.kimi.com/coding/v1/messages",
   minimax: "https://api.minimax.io/anthropic/v1/messages",

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -68,7 +68,7 @@ export const OAUTH_PROVIDERS = {
 };
 
 export const APIKEY_PROVIDERS = {
-  glm: { id: "glm", alias: "glm", name: "GLM Coding", icon: "code", color: "#2563EB", textIcon: "GL", website: "https://open.bigmodel.cn", notice: { apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys" } },
+  glm: { id: "glm", alias: "glm", name: "GLM Coding", icon: "code", color: "#2563EB", textIcon: "GL", website: "https://open.bigmodel.cn", notice: { apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys" }, hasProviderSpecificData: true },
   "glm-cn": { id: "glm-cn", alias: "glm-cn", name: "GLM (China)", icon: "code", color: "#DC2626", textIcon: "GC", website: "https://open.bigmodel.cn", notice: { apiKeyUrl: "https://open.bigmodel.cn/usercenter/apikeys" } },
   kimi: { id: "kimi", alias: "kimi", name: "Kimi", icon: "psychology", color: "#1E3A8A", textIcon: "KM", website: "https://kimi.moonshot.cn", notice: { apiKeyUrl: "https://platform.moonshot.ai/console/api-keys" }, serviceKinds: ["llm", "webSearch"], searchViaChat: { defaultModel: "kimi-k2.5", pricingUrl: "https://platform.moonshot.ai/docs/pricing/chat" } },
   minimax: { id: "minimax", alias: "minimax", name: "Minimax Coding", icon: "memory", color: "#7C3AED", textIcon: "MM", website: "https://www.minimaxi.com", notice: { apiKeyUrl: "https://platform.minimaxi.com/user-center/basic-information/interface-key" }, serviceKinds: ["llm", "image", "imageToText", "webSearch", "tts"], searchViaChat: { defaultModel: "MiniMax-M2.7", pricingUrl: "https://www.minimaxi.com/document/price" }, ttsConfig: { baseUrl: "https://api.minimax.io/v1/t2a_v2", authType: "apikey", authHeader: "bearer", format: "minimax-tts", models: MINIMAX_TTS_MODELS } },


### PR DESCRIPTION
## Summary

GLM Coding provider currently only outputs in Claude (Anthropic Messages) format. This PR makes the OpenAI Chat Completions endpoint (api.z.ai/api/coding/paas/v4/chat/completions) selectable per-connection from the UI.

## Changes

- Add `openaiBaseUrl` to GLM provider config
- Store `outputFormat` in `providerSpecificData`, defaults to `"claude"` (backward compatible)
- Update `getTargetFormat()`, `buildProviderUrl()`, `buildProviderHeaders()` to respect connection-level override
- Update `DefaultExecutor` buildUrl/buildHeaders for GLM openai mode, strips Anthropic headers
- Update validate and test routes for GLM openai format
- Add Output Format dropdown in EditConnectionModal
- Add `hasProviderSpecificData: true` to GLM provider

## Test plan

-[x] Existing GLM connections continue working (default is claude format)
-[x] Unit tests pass (573 passed, no regressions)
-[ ] Manual: create GLM connection, switch to OpenAI format, verify chat completions work