### PR TITLE
fix CEREBRAS & MISTRAL ERROR: strip unsupported client_metadata from downstream requests

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -13,6 +13,11 @@ export class DefaultExecutor extends BaseExecutor {
 
   transformRequest(model, body) {
     const transformed = this.applyJsonSchemaFallback(body);
+
+    if (this.provider === "cerebras" && transformed && typeof transformed === "object") {
+      delete transformed.client_metadata;
+    }
+
     return injectReasoningContent({ provider: this.provider, model, body: transformed });
   }
 

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -14,8 +14,10 @@ export class DefaultExecutor extends BaseExecutor {
   transformRequest(model, body) {
     const transformed = this.applyJsonSchemaFallback(body);
 
-    if (this.provider === "cerebras" && transformed && typeof transformed === "object") {
-      delete transformed.client_metadata;
+    if (transformed && typeof transformed === "object") {
+      if (this.provider === "cerebras" || this.provider === "mistral") {
+        delete transformed.client_metadata;
+      }
     }
 
     return injectReasoningContent({ provider: this.provider, model, body: transformed });


### PR DESCRIPTION
Fix outbound request handling for `cerebras` and `mistral` by stripping unsupported `client_metadata` before sending downstream.

Error details

Cerebras:
```
Model metadata for cerebras not found. Defaulting to fallback metadata; this can degrade performance and cause issues.

{"error":{"message":"[cerebras/zai-glm-4.7] [400]: {\"message\":\"client_metadata: property 'client_metadata' is unsupported\",\"type\":\"invalid_request_error\",\"param\":\"validation_error\",\"code\":\"wrong_api_format\"} (reset after 30s)"}}
```

Mistral:
```
Model metadata for `Mistral` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.

■ unexpected status 422 Unprocessable Entity: [mistral/mistral-medium-latest] [422]: {"object":"error","message":{"detail":[{"type":"extra_forbidden","loc":["body","client_metadata"]}]}}
```

What changed

- Remove `client_metadata` from outbound requests when provider is `cerebras`
- Remove `client_metadata` from outbound requests when provider is `mistral`
- Implemented in `open-sse/executors/default.js` before the request payload is forwarded downstream

Notes

- This is a provider-specific fix for `cerebras` and `mistral`
- No behavior change for other OpenAI-compatible providers
