### PR TITLE
feat(cursor): identity backfill from Cursor state.vscdb

### DIFF
--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -137,12 +137,32 @@ console.log("3️⃣  Copying Next.js standalone build to app/cli/app...");
 const standaloneRoot = path.join(appDir, ".next", "standalone");
 const standaloneRootResolved = path.join(buildDistDir, "standalone");
 const standaloneRootToUse = fs.existsSync(standaloneRootResolved) ? standaloneRootResolved : standaloneRoot;
-const standaloneApp = fs.existsSync(path.join(standaloneRootToUse, "server.js"))
-  ? standaloneRootToUse
-  : path.join(standaloneRootToUse, "app");
-if (!fs.existsSync(standaloneApp)) {
+
+function resolveStandaloneApp(rootToUse) {
+  if (fs.existsSync(path.join(rootToUse, "server.js"))) {
+    return rootToUse;
+  }
+
+  const nestedApp = path.join(rootToUse, "app");
+  if (fs.existsSync(nestedApp)) {
+    return nestedApp;
+  }
+
+  for (const entry of fs.readdirSync(rootToUse, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = path.join(rootToUse, entry.name);
+    if (fs.existsSync(path.join(candidate, "server.js"))) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+const standaloneApp = resolveStandaloneApp(standaloneRootToUse);
+if (!standaloneApp) {
   console.error("❌ Next.js standalone build not found under .next/standalone");
-  console.error("Expected either .next/standalone/server.js or .next/standalone/app/");
+  console.error("Expected server.js under standalone root, app/, or a nested package dir");
   process.exit(1);
 }
 copyRecursive(standaloneApp, cliAppDir);

--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -4,8 +4,10 @@ import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import {
   generateCursorBody,
   parseConnectRPCFrame,
-  extractTextFromResponse
+  extractTextFromResponse,
+  parseNativeToolCallsFromText,
 } from "../utils/cursorProtobuf.js";
+import { shouldForceAgentMode } from "../utils/cursorToolMapping.js";
 import { buildCursorHeaders } from "../utils/cursorChecksum.js";
 import { estimateUsage } from "../utils/usageTracking.js";
 import { FORMATS } from "../translator/formats.js";
@@ -145,9 +147,8 @@ export class CursorExecutor extends BaseExecutor {
     const messages = body.messages || [];
     const tools = body.tools || [];
     const reasoningEffort = body.reasoning_effort || null;
-    // Detect Claude Code UA to force Agent mode (issue #643)
     const ua = credentials?.rawHeaders?.["user-agent"] || "";
-    const forceAgentMode = ua.includes("claude-cli") || ua.includes("claude-code") || ua.includes("Claude Code");
+    const forceAgentMode = shouldForceAgentMode(ua);
     return generateCursorBody(messages, model, tools, reasoningEffort, forceAgentMode);
   }
 
@@ -417,6 +418,13 @@ export class CursorExecutor extends BaseExecutor {
 
     debugLog(`[CURSOR BUFFER] Final toolCalls count: ${toolCalls.length}`);
 
+    if (toolCalls.length === 0 && finalContent) {
+      const parsedNative = parseNativeToolCallsFromText(finalContent);
+      if (parsedNative.length > 0) {
+        debugLog(`[CURSOR BUFFER] Parsed ${parsedNative.length} native text tool call(s)`);
+        toolCalls.push(...parsedNative);
+      }
+    }
 
     const message = {
       role: "assistant",

--- a/open-sse/utils/cursorProtobuf.js
+++ b/open-sse/utils/cursorProtobuf.js
@@ -5,6 +5,14 @@
 
 import { v4 as uuidv4 } from "uuid";
 import zlib from "zlib";
+import {
+  toCursorToolName,
+  fromCursorToolName,
+  toCursorToolArgs,
+  fromCursorToolArgs,
+  parseNativeToolCallsFromText,
+  getSupportedToolEnumsFromOpenAiTools,
+} from "./cursorToolMapping.js";
 
 const DEBUG = process.env.CURSOR_PROTOBUF_DEBUG === "1";
 const log = (tag, ...args) => DEBUG && console.log(`[PROTOBUF:${tag}]`, ...args);
@@ -347,8 +355,9 @@ function encodeClientSideToolV2Call(toolCallId, toolName, selectedTool, serverNa
  */
 export function encodeToolResult(toolResult) {
   const originalName = toolResult.tool_name || toolResult.name || "";
-  const toolName = formatToolName(originalName);
-  const rawArgs = toolResult.raw_args || "{}";
+  const cursorName = toCursorToolName(originalName);
+  const toolName = formatToolName(cursorName);
+  const rawArgs = toCursorToolArgs(originalName, toolResult.raw_args || "{}");
   const resultContent = toolResult.result_content || toolResult.result || "";
   const { toolCallId, modelCallId } = parseToolId(toolResult.tool_call_id || "");
   const toolIndex = toolResult.tool_index || toolResult.index || 1;
@@ -371,8 +380,11 @@ export function encodeToolResult(toolResult) {
   );
 }
 
-export function encodeMessage(content, role, messageId, chatModeEnum = null, isLast = false, hasTools = false, toolResults = [], serverBubbleId = null) {
+export function encodeMessage(content, role, messageId, chatModeEnum = null, isLast = false, hasTools = false, toolResults = [], serverBubbleId = null, supportedToolEnums = []) {
   const hasToolResults = toolResults.length > 0;
+  const msgSupportedTools = supportedToolEnums.length > 0
+    ? supportedToolEnums
+    : getSupportedToolEnumsFromOpenAiTools([]);
   return concatArrays(
     encodeField(FIELD.MSG_CONTENT, WIRE_TYPE.LEN, content),
     encodeField(FIELD.MSG_ROLE, WIRE_TYPE.VARINT, role),
@@ -384,7 +396,11 @@ export function encodeMessage(content, role, messageId, chatModeEnum = null, isL
     ) : []),
     encodeField(FIELD.MSG_IS_AGENTIC, WIRE_TYPE.VARINT, hasTools ? 1 : 0),
     encodeField(FIELD.MSG_UNIFIED_MODE, WIRE_TYPE.VARINT, hasTools ? UNIFIED_MODE.AGENT : UNIFIED_MODE.CHAT),
-    ...(isLast && hasTools ? [encodeField(FIELD.MSG_SUPPORTED_TOOLS, WIRE_TYPE.LEN, encodeVarint(1))] : [])
+    ...(isLast && hasTools
+      ? msgSupportedTools.map((toolEnum) =>
+          encodeField(FIELD.MSG_SUPPORTED_TOOLS, WIRE_TYPE.VARINT, toolEnum)
+        )
+      : [])
   );
 }
 
@@ -433,7 +449,8 @@ export function encodeMessageId(messageId, role, summaryId = null) {
 }
 
 export function encodeMcpTool(tool) {
-  const toolName = tool.function?.name || tool.name || "";
+  const rawToolName = tool.function?.name || tool.name || "";
+  const toolName = toCursorToolName(rawToolName);
   const toolDesc = tool.function?.description || tool.description || "";
   const inputSchema = tool.function?.parameters || tool.input_schema || {};
 
@@ -535,12 +552,14 @@ export function encodeRequest(messages, modelName, tools = [], reasoningEffort =
   if (reasoningEffort === "medium") thinkingLevel = THINKING_LEVEL.MEDIUM;
   else if (reasoningEffort === "high") thinkingLevel = THINKING_LEVEL.HIGH;
 
+  const supportedToolEnums = isAgentic ? getSupportedToolEnumsFromOpenAiTools(tools) : [];
+
   // Build request
   return concatArrays(
     // Messages
     ...formattedMessages.map(fm => 
       encodeField(FIELD.MESSAGES, WIRE_TYPE.LEN, 
-        encodeMessage(fm.content, fm.role, fm.messageId, null, fm.isLast, fm.hasTools, fm.toolResults)
+        encodeMessage(fm.content, fm.role, fm.messageId, null, fm.isLast, fm.hasTools, fm.toolResults, null, supportedToolEnums)
       )
     ),
     
@@ -558,7 +577,9 @@ export function encodeRequest(messages, modelName, tools = [], reasoningEffort =
 
     // Tool-related fields
     encodeField(FIELD.IS_AGENTIC, WIRE_TYPE.VARINT, isAgentic ? 1 : 0),
-    ...(isAgentic ? [encodeField(FIELD.SUPPORTED_TOOLS, WIRE_TYPE.LEN, encodeVarint(1))] : []),
+    ...supportedToolEnums.map((toolEnum) =>
+      encodeField(FIELD.SUPPORTED_TOOLS, WIRE_TYPE.VARINT, toolEnum)
+    ),
     
     // Message IDs
     ...messageIds.map(mid => 
@@ -602,11 +623,13 @@ export function buildToolResultRequest(toolResult) {
   // which is the name AFTER server prefix stripping (e.g. "custom_Write" -> name = "Write")
   // Actually cursor-api uses: name = tool_name.slice_unchecked(d+1..) → raw name without "custom_"
   // So selected_tool = raw tool name without any prefix
-  const selectedTool = rawName.startsWith("mcp_custom_")
-    ? rawName.slice("mcp_custom_".length)
-    : rawName.startsWith("mcp_")
-    ? rawName.slice(4)
-    : rawName;
+  const selectedTool = toCursorToolName(
+    rawName.startsWith("mcp_custom_")
+      ? rawName.slice("mcp_custom_".length)
+      : rawName.startsWith("mcp_")
+      ? rawName.slice(4)
+      : rawName
+  );
 
   // ClientSideToolV2Result per proto:
   //   field 1 (tool): varint = 19 (MCP)
@@ -802,12 +825,13 @@ function extractToolCall(toolCallData) {
   }
 
   if (toolCallId && toolName) {
+    const openAiName = fromCursorToolName(toolName);
     return {
       id: toolCallId,
       type: "function",
       function: {
-        name: toolName,
-        arguments: rawArgs || "{}"
+        name: openAiName,
+        arguments: fromCursorToolArgs(toolName, rawArgs || "{}")
       },
       isLast
     };
@@ -888,6 +912,10 @@ export function extractTextFromResponse(payload) {
 }
 
 // ==================== EXPORTS ====================
+
+export {
+  parseNativeToolCallsFromText,
+} from "./cursorToolMapping.js";
 
 export default {
   encodeVarint,

--- a/open-sse/utils/cursorToolMapping.js
+++ b/open-sse/utils/cursorToolMapping.js
@@ -1,0 +1,204 @@
+/**
+ * OpenCode / OpenAI-compatible tool name mapping for Cursor native tools.
+ *
+ * Cursor expects native tool names (shell, ls, read, write, grep).
+ * OpenCode sends OpenAI-style names (bash, list, glob, read, write, grep).
+ */
+
+const OPENAI_TO_CURSOR = {
+  bash: "shell",
+  shell: "shell",
+  run_terminal_cmd: "shell",
+  execute_command: "shell",
+  list: "ls",
+  glob: "grep",
+  read: "read",
+  write: "write",
+  grep: "grep",
+  edit: "write",
+  search: "grep",
+};
+
+const CURSOR_TO_OPENAI = {
+  shell: "bash",
+  run_terminal_cmd: "bash",
+  run_terminal_command: "bash",
+  run_terminal_command_v2: "bash",
+  execute_command: "bash",
+  ls: "list",
+  list_dir: "list",
+  list_dir_v2: "list",
+  read: "read",
+  read_file: "read",
+  read_file_v2: "read",
+  write: "write",
+  edit_file: "write",
+  edit_file_v2: "write",
+  grep: "grep",
+  ripgrep_search: "grep",
+  ripgrep_raw_search: "grep",
+  glob_file_search: "glob",
+};
+
+function normalizeName(name) {
+  return typeof name === "string" ? name.trim() : "";
+}
+
+export function toCursorToolName(name) {
+  const raw = normalizeName(name);
+  if (!raw) return "tool";
+  const mapped = OPENAI_TO_CURSOR[raw.toLowerCase()];
+  return mapped || raw;
+}
+
+export function fromCursorToolName(name) {
+  const raw = normalizeName(name);
+  if (!raw) return "tool";
+  const mapped = CURSOR_TO_OPENAI[raw.toLowerCase()];
+  return mapped || raw;
+}
+
+export function toCursorToolArgs(toolName, rawArgs) {
+  const args = typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs || {});
+  const cursorName = toCursorToolName(toolName).toLowerCase();
+
+  if (cursorName !== "shell") return args;
+
+  try {
+    const parsed = JSON.parse(args);
+    if (parsed && typeof parsed === "object" && !parsed.command) {
+      if (typeof parsed.cmd === "string") {
+        parsed.command = parsed.cmd;
+      } else if (typeof parsed.script === "string") {
+        parsed.command = parsed.script;
+      }
+    }
+    return JSON.stringify(parsed);
+  } catch {
+    return args;
+  }
+}
+
+export function fromCursorToolArgs(toolName, rawArgs) {
+  const openAiName = fromCursorToolName(toolName).toLowerCase();
+  const args = typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs || {});
+
+  if (openAiName !== "bash") return args;
+
+  try {
+    const parsed = JSON.parse(args);
+    if (parsed && typeof parsed === "object" && !parsed.command) {
+      if (typeof parsed.cmd === "string") {
+        parsed.command = parsed.cmd;
+      }
+    }
+    return JSON.stringify(parsed);
+  } catch {
+    return args;
+  }
+}
+
+export function isOpenCodeUserAgent(userAgent) {
+  return /opencode/i.test(userAgent || "");
+}
+
+export function shouldForceAgentMode(userAgent) {
+  const ua = userAgent || "";
+  return (
+    ua.includes("claude-cli") ||
+    ua.includes("claude-code") ||
+    ua.includes("Claude Code") ||
+    isOpenCodeUserAgent(ua)
+  );
+}
+
+/**
+ * Map OpenAI-style tool definitions to Cursor native ClientSideToolV2 enum ids.
+ * Enum values verified against cursor-api proto (RUN_TERMINAL_COMMAND_V2=15,
+ * EDIT_FILE_V2=38, LIST_DIR_V2=39, READ_FILE_V2=40, RIPGREP_RAW_SEARCH=41,
+ * GLOB_FILE_SEARCH=42).
+ *
+ * Note: arbitrary non-native tools (custom MCP server tools) are a separate,
+ * pre-existing limitation of the Cursor route and are not enabled here.
+ */
+export function getSupportedToolEnumsFromOpenAiTools(tools = []) {
+  const defaultSet = [
+    15, // RUN_TERMINAL_COMMAND_V2
+    40, // READ_FILE_V2
+    38, // EDIT_FILE_V2
+    39, // LIST_DIR_V2
+    41, // RIPGREP_RAW_SEARCH
+    42, // GLOB_FILE_SEARCH
+  ];
+
+  if (!Array.isArray(tools) || tools.length === 0) {
+    return defaultSet;
+  }
+
+  const mapping = {
+    bash: 15,
+    shell: 15,
+    run_terminal_cmd: 15,
+    execute_command: 15,
+    read: 40,
+    write: 38,
+    edit: 38,
+    list: 39,
+    ls: 39,
+    grep: 41,
+    glob: 42,
+  };
+
+  const enums = new Set();
+  for (const tool of tools) {
+    const name = String(tool?.function?.name || tool?.name || "").toLowerCase();
+    const enumVal = mapping[name];
+    if (enumVal) enums.add(enumVal);
+  }
+
+  return enums.size > 0 ? [...enums] : defaultSet;
+}
+
+/**
+ * Parse Cursor native tool-call text when protobuf frames are missing.
+ * Example: <|tool_calls_begin|>...run_terminal_cmd...{"command":"ls"}
+ */
+export function parseNativeToolCallsFromText(text) {
+  if (typeof text !== "string") return [];
+
+  // Only match Cursor's explicit native tool-call text delimiters.
+  // A broad `"name"/"arguments"` JSON regex was deliberately removed because it
+  // false-positives on ordinary assistant prose that happens to contain JSON.
+  const results = [];
+  const patterns = [
+    /(?:<\|[^|]*tool_call_begin[^|]*\|>\s*)?(run_terminal_cmd|execute_command|shell)\s*(\{[\s\S]*?\})/gi,
+    /(?:<\|tool_call_begin\|>\s*)([a-zA-Z0-9_\-]+)\s*([\s\S]*?)(?:<\|tool_call_end\|>)/g,
+  ];
+
+  for (const pattern of patterns) {
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+      const cursorName = match[1];
+      let rawArgs = (match[2] || "").trim();
+      if (!rawArgs.startsWith("{")) {
+        const jsonMatch = rawArgs.match(/\{[\s\S]*\}/);
+        rawArgs = jsonMatch ? jsonMatch[0] : "{}";
+      }
+
+      const openAiName = fromCursorToolName(cursorName);
+      const key = `${openAiName}:${rawArgs}`;
+      if (results.some((item) => `${item.function.name}:${item.function.arguments}` === key)) continue;
+
+      results.push({
+        id: `cursor-native-${results.length + 1}`,
+        type: "function",
+        function: {
+          name: openAiName,
+          arguments: fromCursorToolArgs(cursorName, rawArgs || "{}"),
+        },
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/lib/oauth/services/cursorLocalStore.js
+++ b/src/lib/oauth/services/cursorLocalStore.js
@@ -1,0 +1,138 @@
+import { access, constants } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+export const CURSOR_ACCESS_TOKEN_KEYS = ["cursorAuth/accessToken", "cursorAuth/token"];
+export const CURSOR_MACHINE_ID_KEYS = [
+  "storage.serviceMachineId",
+  "storage.machineId",
+  "telemetry.machineId",
+];
+export const CURSOR_CACHED_EMAIL_KEYS = ["cursorAuth/cachedEmail"];
+
+function normalizeStoredValue(value) {
+  if (typeof value !== "string") return value;
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === "string" ? parsed : value;
+  } catch {
+    return value;
+  }
+}
+
+/** Candidate state.vscdb paths by platform */
+export function getCursorDbCandidatePaths(platform = process.platform) {
+  const home = homedir();
+
+  if (platform === "darwin") {
+    return [
+      join(home, "Library/Application Support/Cursor/User/globalStorage/state.vscdb"),
+      join(home, "Library/Application Support/Cursor - Insiders/User/globalStorage/state.vscdb"),
+    ];
+  }
+
+  if (platform === "win32") {
+    const appData = process.env.APPDATA || join(home, "AppData", "Roaming");
+    const localAppData = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+    return [
+      join(appData, "Cursor", "User", "globalStorage", "state.vscdb"),
+      join(appData, "Cursor - Insiders", "User", "globalStorage", "state.vscdb"),
+      join(localAppData, "Cursor", "User", "globalStorage", "state.vscdb"),
+      join(localAppData, "Programs", "Cursor", "User", "globalStorage", "state.vscdb"),
+    ];
+  }
+
+  return [
+    join(home, ".config/Cursor/User/globalStorage/state.vscdb"),
+    join(home, ".config/cursor/User/globalStorage/state.vscdb"),
+  ];
+}
+
+function queryFirst(db, keys) {
+  for (const key of keys) {
+    const row = db.prepare("SELECT value FROM itemTable WHERE key=? LIMIT 1").get(key);
+    if (row?.value) return normalizeStoredValue(row.value);
+  }
+  return null;
+}
+
+/** Read Cursor auth fields from a known state.vscdb path (sync). */
+export function readCursorLocalAuthSync(dbPath) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Database = require("better-sqlite3");
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    return {
+      accessToken: queryFirst(db, CURSOR_ACCESS_TOKEN_KEYS),
+      machineId: queryFirst(db, CURSOR_MACHINE_ID_KEYS),
+      cachedEmail: queryFirst(db, CURSOR_CACHED_EMAIL_KEYS),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+/** Find the first readable Cursor state.vscdb and return stored auth fields. */
+export async function findAndReadCursorLocalAuth(platform = process.platform) {
+  for (const candidate of getCursorDbCandidatePaths(platform)) {
+    try {
+      await access(candidate, constants.R_OK);
+      return { dbPath: candidate, ...readCursorLocalAuthSync(candidate) };
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+function isCursorEmail(value) {
+  return typeof value === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function isAuth0Subject(value) {
+  return typeof value === "string" && /^auth0\|user_/i.test(value);
+}
+
+export function cursorConnectionNeedsIdentityBackfill(connection) {
+  if (connection?.provider !== "cursor") return false;
+  if (isCursorEmail(connection.providerSpecificData?.cachedEmail)) return false;
+  return isAuth0Subject(connection.email) || isAuth0Subject(connection.name);
+}
+
+export async function backfillCursorConnectionIdentity(connection, localAuth = null) {
+  if (!cursorConnectionNeedsIdentityBackfill(connection)) return connection;
+
+  const auth = localAuth || await findAndReadCursorLocalAuth();
+  if (!isCursorEmail(auth?.cachedEmail)) return connection;
+
+  const { updateProviderConnection } = await import("@/lib/localDb");
+  return await updateProviderConnection(connection.id, {
+    email: auth.cachedEmail,
+    name: auth.cachedEmail,
+    providerSpecificData: {
+      ...(connection.providerSpecificData || {}),
+      cachedEmail: auth.cachedEmail,
+    },
+  });
+}
+
+let cursorBackfillDone = false;
+
+export async function backfillCursorEmails() {
+  if (cursorBackfillDone) return;
+  cursorBackfillDone = true;
+  try {
+    const { getProviderConnections } = await import("@/lib/localDb");
+    const localAuth = await findAndReadCursorLocalAuth();
+    if (!isCursorEmail(localAuth?.cachedEmail)) return;
+
+    const connections = await getProviderConnections({ provider: "cursor" });
+    for (const conn of connections) {
+      if (!cursorConnectionNeedsIdentityBackfill(conn)) continue;
+      await backfillCursorConnectionIdentity(conn, localAuth);
+    }
+  } catch (err) {
+    cursorBackfillDone = false;
+    console.log("backfillCursorEmails failed:", err?.message || err);
+  }
+}

--- a/tests/unit/cursor-identity.test.js
+++ b/tests/unit/cursor-identity.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  CursorService,
+  isAuth0Subject,
+  isCursorEmail,
+} from "../../src/lib/oauth/services/cursor.js";
+
+describe("Cursor identity helpers", () => {
+  const service = new CursorService();
+
+  it("detects auth0 subjects and real emails", () => {
+    expect(isAuth0Subject("auth0|user_01KPAE2JJWEDFV9S93VS4M5S5Z")).toBe(true);
+    expect(isAuth0Subject("restacion@spscc.edu")).toBe(false);
+    expect(isCursorEmail("restacion@spscc.edu")).toBe(true);
+    expect(isCursorEmail("auth0|user_abc")).toBe(false);
+  });
+
+  it("does not treat auth0 sub as email from JWT", () => {
+    const payload = Buffer.from(
+      JSON.stringify({
+        sub: "auth0|user_01KPAE2JJWEDFV9S93VS4M5S5Z",
+      }),
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const token = `header.${payload}.sig`;
+    const info = service.extractUserInfo(token);
+    expect(info.email).toBeNull();
+    expect(info.userId).toBe("auth0|user_01KPAE2JJWEDFV9S93VS4M5S5Z");
+  });
+
+  it("prefers cachedEmail over auth0 subject", () => {
+    const payload = Buffer.from(
+      JSON.stringify({ sub: "auth0|user_01KPAE2JJWEDFV9S93VS4M5S5Z" }),
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const token = `header.${payload}.sig`;
+
+    const identity = service.resolveIdentity({
+      accessToken: token,
+      cachedEmail: "restacion@spscc.edu",
+    });
+
+    expect(identity.email).toBe("restacion@spscc.edu");
+    expect(identity.name).toBe("restacion@spscc.edu");
+    expect(identity.userId).toBe("auth0|user_01KPAE2JJWEDFV9S93VS4M5S5Z");
+  });
+});

--- a/tests/unit/cursor-tool-mapping.test.js
+++ b/tests/unit/cursor-tool-mapping.test.js
@@ -1,0 +1,42 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  toCursorToolName,
+  fromCursorToolName,
+  shouldForceAgentMode,
+  parseNativeToolCallsFromText,
+  getSupportedToolEnumsFromOpenAiTools,
+} from "../../open-sse/utils/cursorToolMapping.js";
+
+describe("cursorToolMapping", () => {
+  it("maps OpenCode bash to Cursor shell", () => {
+    assert.equal(toCursorToolName("bash"), "shell");
+    assert.equal(fromCursorToolName("shell"), "bash");
+  });
+
+  it("maps list/glob aliases", () => {
+    assert.equal(toCursorToolName("list"), "ls");
+    assert.equal(toCursorToolName("glob"), "grep");
+    assert.equal(fromCursorToolName("ls"), "list");
+  });
+
+  it("forces agent mode for OpenCode user agents", () => {
+    assert.equal(shouldForceAgentMode("opencode/1.16.2"), true);
+    assert.equal(shouldForceAgentMode("curl/8.0"), false);
+  });
+
+  it("maps native supported tool enums for bash", () => {
+    const enums = getSupportedToolEnumsFromOpenAiTools([
+      { type: "function", function: { name: "bash" } },
+    ]);
+    assert.equal(enums.includes(15), true);
+  });
+
+  it("parses native tool call text into OpenAI tool_calls", () => {
+    const text = '<|tool_call_begin|>run_terminal_cmd {"command":"ls /tmp"}<|tool_call_end|>';
+    const parsed = parseNativeToolCallsFromText(text);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].function.name, "bash");
+    assert.match(parsed[0].function.arguments, /ls \/tmp/);
+  });
+});

--- a/tests/unit/cursor-usage.test.js
+++ b/tests/unit/cursor-usage.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Cursor usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses GetCurrentPeriodUsage with all quota types", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          billingCycleEnd: "1771077734000",
+          planUsage: {
+            includedSpend: 23222,
+            limit: 40000,
+            autoPercentUsed: 12.5,
+            apiPercentUsed: 46.444,
+          },
+          spendLimitUsage: {
+            individualUsed: 500,
+            individualLimit: 10000,
+            pooledUsed: 0,
+            pooledLimit: 50000,
+          },
+          displayMessage: "You've used 46% of your usage limit",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          planInfo: { planName: "Ultra" },
+        }),
+      );
+
+    const usage = await getUsageForProvider({
+      provider: "cursor",
+      accessToken: "test-token",
+      providerSpecificData: { machineId: "machine-123" },
+    });
+
+    expect(usage.plan).toBe("Ultra");
+    expect(usage.quotas["Included spend"]).toMatchObject({
+      used: 232.22,
+      total: 400,
+      remaining: 42,
+    });
+    expect(usage.quotas["Auto mode"]).toMatchObject({
+      used: 12.5,
+      total: 100,
+      remaining: 87.5,
+    });
+    expect(usage.quotas["API usage"]).toMatchObject({
+      used: 46.444,
+      total: 100,
+    });
+    expect(usage.quotas["On-demand (individual)"]).toMatchObject({
+      used: 5,
+      total: 100,
+    });
+    expect(usage.quotas["On-demand (team pool)"]).toMatchObject({
+      used: 0,
+      total: 500,
+    });
+  });
+
+  it("omits on-demand rows when limits are zero", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          billingCycleEnd: "1771077734000",
+          planUsage: {
+            includedSpend: 1000,
+            limit: 40000,
+            autoPercentUsed: 0,
+            apiPercentUsed: 10,
+          },
+          spendLimitUsage: {
+            individualUsed: 0,
+            individualLimit: 0,
+            pooledUsed: 0,
+            pooledLimit: 0,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ planInfo: { planName: "Pro" } }));
+
+    const usage = await getUsageForProvider({
+      provider: "cursor",
+      accessToken: "test-token",
+      providerSpecificData: {},
+    });
+
+    expect(usage.quotas["On-demand (individual)"]).toBeUndefined();
+    expect(usage.quotas["On-demand (team pool)"]).toBeUndefined();
+    expect(usage.quotas["API usage"]).toBeDefined();
+  });
+
+  it("falls back to /auth/usage when dashboard returns empty planUsage", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({ billingCycleEnd: "1771077734000", planUsage: {} }))
+      .mockResolvedValueOnce(jsonResponse({ planInfo: { planName: "Enterprise" } }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          startOfMonth: "2026-03-01T00:00:00.000Z",
+          "gpt-4": { numRequests: 150, maxRequestUsage: 500 },
+        }),
+      );
+
+    const usage = await getUsageForProvider({
+      provider: "cursor",
+      accessToken: "test-token",
+      providerSpecificData: {},
+    });
+
+    expect(usage.plan).toBe("Enterprise");
+    expect(usage.quotas["gpt-4"]).toMatchObject({
+      used: 150,
+      total: 500,
+      remaining: 70,
+    });
+  });
+
+  it("returns auth message on 401", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401));
+
+    const usage = await getUsageForProvider({
+      provider: "cursor",
+      accessToken: "expired-token",
+      providerSpecificData: {},
+    });
+
+    expect(usage.message).toMatch(/expired or invalid/i);
+    expect(usage.quotas).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Backfill cachedEmail/machineId from Cursor IDE local DB (state.vscdb) on import and /api/providers/client.
Replaces auth0|user_* placeholders with real email (restacion@spscc.edu).
- src/lib/oauth/services/cursorLocalStore.js: readCursorLocalAuthSync, backfillCursorConnectionIdentity, startup sweep
- tests/unit/cursor-identity.test.js + cursor-usage.test.js
- Fixes display in quota dashboard and provider list.

Part of OpenCode + Cursor integration (PR supersedes #1732).
