### PR TITLE
Fix Gemini thought parts leaking into assistant content (issue: #1749)

### DIFF
--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -92,7 +92,10 @@ export function geminiToOpenAIResponse(chunk, state) {
         continue;
       }
 
-      // Text content (non-thinking)
+      // Text content. Gemini marks model-internal thinking with `thought: true`.
+      // Some responses include a thoughtSignature, but Google AI Studio/Gemini API
+      // can also stream thought parts without a signature; those must not be
+      // surfaced as normal assistant content in OpenAI-compatible clients.
       if (part.text !== undefined && part.text !== "") {
         results.push({
           id: `chatcmpl-${state.messageId}`,
@@ -101,7 +104,9 @@ export function geminiToOpenAIResponse(chunk, state) {
           model: state.model,
           choices: [{
             index: 0,
-            delta: { content: part.text },
+            delta: isThought
+              ? { reasoning_content: part.text }
+              : { content: part.text },
             finish_reason: null
           }]
         });

--- a/tests/unit/gemini-to-openai-thinking.test.js
+++ b/tests/unit/gemini-to-openai-thinking.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { geminiToOpenAIResponse } from "../../open-sse/translator/response/gemini-to-openai.js";
+
+function convert(parts) {
+  const state = { toolCalls: new Map() };
+  const chunks = geminiToOpenAIResponse({
+    responseId: "gemma-thinking-test",
+    modelVersion: "gemma-4-31b",
+    candidates: [{
+      content: { role: "model", parts },
+      finishReason: "STOP",
+    }],
+  }, state);
+  return chunks;
+}
+
+describe("gemini-to-openai thinking parts", () => {
+  it("maps thought text without thoughtSignature to reasoning_content, not content", () => {
+    const chunks = convert([
+      { thought: true, text: 'The user said "Hello World". Plan the greeting.' },
+      { text: "Hello! How can I help you today?" },
+    ]);
+
+    const deltas = chunks.map((chunk) => chunk.choices[0].delta);
+
+    expect(deltas).toContainEqual({ reasoning_content: 'The user said "Hello World". Plan the greeting.' });
+    expect(deltas).toContainEqual({ content: "Hello! How can I help you today?" });
+    expect(deltas.some((delta) => delta.content?.includes("Plan the greeting"))).toBe(false);
+  });
+
+  it("continues to map signed thought text to reasoning_content", () => {
+    const chunks = convert([
+      { thought: true, thoughtSignature: "sig", text: "internal plan" },
+      { thoughtSignature: "sig", text: "final answer" },
+    ]);
+
+    const deltas = chunks.map((chunk) => chunk.choices[0].delta);
+
+    expect(deltas).toContainEqual({ reasoning_content: "internal plan" });
+    expect(deltas).toContainEqual({ content: "final answer" });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes an issue where Gemini/Gemma streaming responses could expose model thinking text as normal assistant content in OpenAI-compatible clients.

This was observed with Gemma 4 from Google AI Studio when routed through 9router and displayed in clients such as OpenWebUI and Hermes Agent.

ISSUE: #1749 

## Problem

Gemini can stream model thinking as text parts marked with `thought: true`.

Previously, the Gemini-to-OpenAI streaming translator only separated thought content in cases where a thought signature was present. Some Google AI Studio / Gemini API responses can emit thought parts without a `thoughtSignature`, so those parts were treated as regular text and forwarded as `delta.content`.

As a result, OpenAI-compatible clients displayed the thinking text directly in the assistant message before the final answer.

## Changes

This PR updates the streaming Gemini-to-OpenAI conversion logic so that text parts marked as `thought: true` are no longer emitted as normal assistant content.

Instead:

* normal text parts are mapped to `delta.content`
* thought text parts are mapped to `delta.reasoning_content`

This keeps model reasoning/thinking separate from the final assistant response for clients that support reasoning fields, while preventing thinking text from leaking into normal chat content.

## Validation

I verified the fix with the following checks:

* Confirmed the fix is present in the latest HEAD
* Added/updated unit coverage for Gemini thinking conversion
* `gemini-to-openai-thinking.test.js` passes: 2/2 tests
* Confirmed the non-streaming handler already separates thought content into `reasoning_content`
* Built the project locally after the fix and confirmed the generated bundle includes the updated behavior

## Notes

The issue mainly affected streaming responses. Non-streaming conversion already handled thought separation correctly.
