### PR TITLE
fix: strip claude billing header from openai requests

### DIFF
--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -2,6 +2,11 @@ import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.js";
 
+function stripAnthropicBillingHeader(text) {
+  if (typeof text !== "string") return "";
+  return text.replace(/^x-anthropic-billing-header:[^\n]*(?:\r?\n)?/i, "");
+}
+
 // Convert Claude request to OpenAI format
 export function claudeToOpenAIRequest(model, body, stream) {
   const result = {
@@ -23,8 +28,8 @@ export function claudeToOpenAIRequest(model, body, stream) {
   // System message
   if (body.system) {
     const systemContent = Array.isArray(body.system)
-      ? body.system.map(s => s.text || "").join("\n")
-      : body.system;
+      ? body.system.map(s => stripAnthropicBillingHeader(s.text || "")).filter(Boolean).join("\n")
+      : stripAnthropicBillingHeader(body.system);
     
     if (systemContent) {
       result.messages.push({
@@ -229,4 +234,3 @@ function convertToolChoice(choice) {
 
 // Register
 register(FORMATS.CLAUDE, FORMATS.OPENAI, claudeToOpenAIRequest, null);
-

--- a/tests/unit/claude-to-openai-billing-header.test.js
+++ b/tests/unit/claude-to-openai-billing-header.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { claudeToOpenAIRequest } from "../../open-sse/translator/request/claude-to-openai.js";
+
+describe("claudeToOpenAIRequest billing header handling", () => {
+  it("strips Anthropic billing header from system text for OpenAI targets", () => {
+    const result = claudeToOpenAIRequest("gpt-5.5", {
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.156.e2c; cc_entrypoint=sdk-cli; cch=4a0f6;\nYou are helpful.",
+        },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    }, true);
+
+    expect(result.messages[0]).toEqual({
+      role: "system",
+      content: "You are helpful.",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- strip the Anthropic `x-anthropic-billing-header` from Claude system prompts when translating requests to OpenAI format
- preserve the remaining system prompt content
- add unit coverage for the header stripping behavior

## Why
Claude clients may include a dynamic Anthropic billing header in the system prompt. When forwarded to OpenAI-compatible providers, this metadata is not useful and can change the prompt prefix, reducing prompt cache hits for routed models.

## Tests
- `npx eslint "open-sse/translator/request/claude-to-openai.js" "tests/unit/claude-to-openai-billing-header.test.js"`
- `npx vitest run "tests/unit/claude-to-openai-billing-header.test.js"`