### PR TITLE
fix: show provider node name instead of connection name for custom providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ ecosystem.config.*
 scripts/agSniffer/*
 gitbooks/*
 gitbook/README.md
+
+# Local agent knowledge files
+AGENTS.md
+**/AGENTS.md

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
@@ -149,7 +149,7 @@ function buildLayout(providers, activeSet, lastSet, errorSet) {
     const error = !active && errorSet.has(p.provider?.toLowerCase());
     const nodeId = `provider-${p.provider}`;
     const data = {
-      label: (config.name !== p.provider ? config.name : null) || p.name || p.provider,
+      label: (config.name !== p.provider ? config.name : null) || p.nodeName || p.name || p.provider,
       color: config.color || "#6b7280",
       imageUrl: getProviderImageUrl(p.provider),
       textIcon: config.textIcon || (p.provider || "?").slice(0, 2).toUpperCase(),

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -208,7 +208,7 @@ export default function ModelSelectModal({
         // Find connection object to get prefix synchronously without waiting for providerNodes fetch
         const connection = activeProviders.find(p => p.provider === providerId);
         const matchedNode = providerNodes.find(node => node.id === providerId);
-        const displayName = connection?.name || matchedNode?.name || providerInfo.name;
+        const displayName = matchedNode?.name || connection?.name || providerInfo.name;
         const nodePrefix = connection?.providerSpecificData?.prefix || matchedNode?.prefix || providerId;
 
         // Aliases are stored using the raw providerId as key (e.g. "openai-compatible-chat-<uuid>/glm-4.7"),

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -209,9 +209,16 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
   // Fetch connected providers once, deduplicate by provider type
   // Always include noAuth free providers (e.g. opencode) regardless of connections
   useEffect(() => {
-    fetch("/api/providers")
-      .then((r) => r.ok ? r.json() : null)
-      .then((d) => {
+    Promise.all([
+      fetch("/api/providers").then((r) => r.ok ? r.json() : null),
+      fetch("/api/provider-nodes").then((r) => r.ok ? r.json() : null),
+    ])
+      .then(([d, nodesData]) => {
+        // Build node name lookup for custom providers
+        const nodeNameMap = {};
+        for (const node of (nodesData?.nodes || [])) {
+          nodeNameMap[node.id] = node.name;
+        }
         const seen = new Set();
         const unique = (d?.connections || []).filter((c) => {
           if (c.isActive === false) return false;
@@ -219,7 +226,10 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
           if (seen.has(c.provider)) return false;
           seen.add(c.provider);
           return true;
-        });
+        }).map((c) => ({
+          ...c,
+          nodeName: nodeNameMap[c.provider] || null,
+        }));
         const noAuthProviders = Object.values(FREE_PROVIDERS)
           .filter((p) => p.noAuth && !seen.has(p.id) && isLLMProvider(p.id))
           .map((p) => ({ provider: p.id, name: p.name }));


### PR DESCRIPTION
## Summary

Fixes custom providers displaying the connection record name instead of the provider node name in:

- **Usage page** — React Flow topology nodes
- **Add Model to Combos** — group header labels

When two custom providers have different endpoints but share the same connection name, they now correctly show their distinct provider node names instead of appearing identical.

## Changes

| File | Change |
|------|--------|
| `ModelSelectModal.js` | Swap displayName priority: `matchedNode?.name` first, then `connection?.name` |
| `UsageStats.js` | Fetch `/api/provider-nodes` in parallel with `/api/providers`, merge `nodeName` into providers array |
| `ProviderTopology.js` | Prefer `p.nodeName` before `p.name` in label logic |

## Root Cause

For custom providers (openai-compatible, anthropic-compatible), `AI_PROVIDERS` has no static entry. The label/displayName resolution chain fell through to `connection.name` (the API-key entry name) instead of the provider node name (the user-assigned endpoint name).

## Testing

- [ ] Create two custom providers with different node names but same connection name
- [ ] Verify Usage topology shows distinct node names
- [ ] Verify Add Model to Combos shows distinct node names
- [ ] Verify known providers (OpenAI, Anthropic, etc.) still display correctly

Closes #1769