### PR TITLE
Vertex AI ADC credential support

### DIFF
--- a/open-sse/executors/vertex.js
+++ b/open-sse/executors/vertex.js
@@ -1,10 +1,32 @@
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
-import { parseVertexSaJson, refreshVertexToken } from "../services/tokenRefresh.js";
+import { parseVertexSaJson, refreshVertexToken, refreshGoogleToken } from "../services/tokenRefresh.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 
 // Cache project IDs resolved from raw API keys { apiKey → projectId }
 const projectIdCache = new Map();
+
+/**
+ * Parse Google ADC user credential JSON from apiKey string.
+ * This is the format produced by `gcloud auth application-default login`.
+ */
+function parseVertexAdcJson(apiKey) {
+  if (typeof apiKey !== "string") return null;
+  try {
+    const parsed = JSON.parse(apiKey);
+    if (
+      parsed.type === "authorized_user" &&
+      parsed.client_id &&
+      parsed.client_secret &&
+      parsed.refresh_token
+    ) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Resolve GCP project ID from a raw Vertex API key.
@@ -43,8 +65,13 @@ export class VertexExecutor extends BaseExecutor {
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {
     const saJson = parseVertexSaJson(credentials?.apiKey);
-    const rawKey = !saJson ? credentials?.apiKey : null;
-    const projectId = saJson?.project_id || credentials?.providerSpecificData?.projectId;
+    const adcJson = parseVertexAdcJson(credentials?.apiKey);
+    const usesOAuth = !!saJson || !!adcJson || !!credentials?.accessToken;
+    const rawKey = !usesOAuth ? credentials?.apiKey : null;
+    const projectId =
+      saJson?.project_id ||
+      adcJson?.quota_project_id ||
+      credentials?.providerSpecificData?.projectId;
 
     if (this.provider === "vertex-partner") {
       // Partner models require project_id in path regardless of auth method
@@ -56,8 +83,14 @@ export class VertexExecutor extends BaseExecutor {
     // Gemini on Vertex
     const action = stream ? "streamGenerateContent" : "generateContent";
 
-    if (saJson) {
-      // SA JSON + Bearer token: must use project-scoped path to avoid RESOURCE_PROJECT_INVALID
+    if (usesOAuth) {
+      // SA JSON / ADC / pre-set accessToken: must use project-scoped path to avoid RESOURCE_PROJECT_INVALID
+      if (!projectId) {
+        throw new Error(
+          "Vertex OAuth/ADC requires a project_id. " +
+          "Add quota_project_id to your ADC JSON or set providerSpecificData.projectId."
+        );
+      }
       const location = credentials?.providerSpecificData?.location || "us-central1";
       let url = `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/publishers/google/models/${model}:${action}`;
       if (stream) url += "?alt=sse";
@@ -97,16 +130,29 @@ export class VertexExecutor extends BaseExecutor {
 
   async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
     const saJson = parseVertexSaJson(credentials?.apiKey);
+    const adcJson = parseVertexAdcJson(credentials?.apiKey);
 
-    // SA JSON flow: mint Bearer token (cached)
+    // SA JSON flow: mint Bearer token via JWT assertion (cached)
     if (saJson) {
       const result = await refreshVertexToken(saJson, log);
       if (!result?.accessToken) throw new Error("Vertex: failed to mint access token from Service Account JSON");
       credentials.accessToken = result.accessToken;
     }
 
+    // ADC user credential flow: refresh Bearer token via Google OAuth2 token endpoint
+    if (adcJson) {
+      const result = await refreshGoogleToken(
+        adcJson.refresh_token,
+        adcJson.client_id,
+        adcJson.client_secret,
+        log
+      );
+      if (!result?.accessToken) throw new Error("Vertex: failed to refresh access token from ADC JSON (authorized_user)");
+      credentials.accessToken = result.accessToken;
+    }
+
     // vertex-partner with raw key: auto-resolve project_id if not provided
-    if (this.provider === "vertex-partner" && !saJson && !credentials?.providerSpecificData?.projectId) {
+    if (this.provider === "vertex-partner" && !saJson && !adcJson && !credentials?.providerSpecificData?.projectId) {
       const projectId = await resolveProjectId(credentials.apiKey);
       if (!projectId) throw new Error("Vertex: could not resolve project_id from API key. Please add it manually in provider settings.");
       log?.debug?.("VERTEX", `Resolved project_id: ${projectId}`);


### PR DESCRIPTION
### Problem

Many GCP organizations enforce `iam.disableServiceAccountKeyCreation` 
org policy, blocking creation of Service Account JSON keys. Users with 
Vertex AI credit in these organizations have no way to authenticate 
through 9router.

### Solution

Accept **Google Application Default Credentials** (`authorized_user` type) 
as an alternative to Service Account JSON in the Vertex provider's `apiKey` 
field.

The ADC file is produced by:
```bash
gcloud auth application-default login
```

The file lives at `%APPDATA%\gcloud\application_default_credentials.json` 
(Windows) or `~/.config/gcloud/application_default_credentials.json` (Linux/Mac).

### How to use

1. Run `gcloud auth application-default login`
2. Copy the contents of `application_default_credentials.json` (minified)
3. Paste it as the **API Key** in Vertex AI provider settings
4. Set `quota_project_id` in the JSON **or** set `projectId` in 
   `providerSpecificData` — required to route the request to the correct project

### Changes

**`open-sse/executors/vertex.js`**
- `parseVertexAdcJson()` — detects `authorized_user` JSON in `apiKey`
- `buildUrl()` — unified `usesOAuth` flag covers SA JSON, ADC, and pre-set `accessToken`
- `execute()` — calls existing `refreshGoogleToken()` to exchange the ADC `refresh_token` for a Bearer token before each request

**No changes to `tokenRefresh.js`** — `refreshGoogleToken` already exists and handles this flow correctly.

### Backward compatibility

- Existing SA JSON flow: unchanged
- Raw API key flow: unchanged  
- ADC flow: opt-in, only activates when `apiKey` parses as `{ type: "authorized_user" }`