### PR TITLE
fix: remove --webpack flag and make auth redirects basePath-aware

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "9Router web dashboard",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack --port 20128",
-    "build": "next build --webpack",
+    "dev": "next dev --port 20128",
+    "build": "next build",
     "start": "next start",
-    "dev:bun": "bun --bun next dev --webpack --port 20128",
-    "build:bun": "bun --bun next build --webpack",
+    "dev:bun": "bun --bun next dev --port 20128",
+    "build:bun": "bun --bun next build",
     "start:bun": "bun ./.next/standalone/server.js"
   },
   "dependencies": {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 
 export default function InitPage() {
-  redirect('/dashboard');
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+  redirect(`${basePath}/dashboard`);
 }

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -18,6 +18,23 @@ async function hasValidCliToken(request) {
   return token === await getCliToken();
 }
 
+// Detect basePath from reverse-proxy headers or environment variable.
+// The Zo reverse proxy sends x-forwarded-prefix; falls back to env var.
+function getBasePath(request) {
+  const forwarded = request.headers.get("x-forwarded-prefix");
+  if (forwarded) return forwarded.replace(/\/+$/, "");
+  return process.env.NEXT_PUBLIC_BASE_PATH || "";
+}
+
+// Strip basePath prefix from pathname so route matching still works
+// when the reverse proxy forwards the full prefixed path.
+function stripBasePath(pathname, basePath) {
+  if (basePath && pathname.startsWith(basePath)) {
+    return pathname.slice(basePath.length) || "/";
+  }
+  return pathname;
+}
+
 // Public API paths — no auth required (LLM API has its own key auth inside handler).
 const PUBLIC_API_PATHS = [
   "/api/health",
@@ -163,7 +180,12 @@ export const __test__ = {
 };
 
 export async function proxy(request) {
-  const { pathname } = request.nextUrl;
+  const rawPathname = request.nextUrl.pathname;
+  const basePath = getBasePath(request);
+  const pathname = stripBasePath(rawPathname, basePath);
+
+  // Helper: build a redirect URL that includes the basePath prefix
+  const redirectTo = (path) => new URL(`${basePath}${path}`, request.url);
 
   // Local-only gate for spawn-capable / host-secret routes.
   if (LOCAL_ONLY_PATHS.some((p) => pathname.startsWith(p))) {
@@ -209,7 +231,7 @@ export async function proxy(request) {
           const tunnelHost = settings.tunnelUrl ? new URL(settings.tunnelUrl).hostname.toLowerCase() : "";
           const tailscaleHost = settings.tailscaleUrl ? new URL(settings.tailscaleUrl).hostname.toLowerCase() : "";
           if ((tunnelHost && host === tunnelHost) || (tailscaleHost && host === tailscaleHost)) {
-            return NextResponse.redirect(new URL("/login", request.url));
+            return NextResponse.redirect(redirectTo("/login"));
           }
         }
       }
@@ -226,16 +248,16 @@ export async function proxy(request) {
       if (await verifyDashboardAuthToken(token)) {
         return NextResponse.next();
       } else {
-        return NextResponse.redirect(new URL("/login", request.url));
+        return NextResponse.redirect(redirectTo("/login"));
       }
     }
 
-    return NextResponse.redirect(new URL("/login", request.url));
+    return NextResponse.redirect(redirectTo("/login"));
   }
 
   // Redirect / to /dashboard if logged in, or /dashboard if it's the root
   if (pathname === "/") {
-    return NextResponse.redirect(new URL("/dashboard", request.url));
+    return NextResponse.redirect(redirectTo("/dashboard"));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Two root causes of white "Loading..." page through reverse proxy

### 1. `--webpack` flag silently prevents `proxy.js` middleware registration

In Next.js 16, `proxy.js` is the correct convention (not `middleware.js`). However, the `--webpack` flag in build/dev scripts causes the webpack bundler to silently fail to register `proxy.js` as middleware — it produces an empty `middleware-manifest.json` and the guard never runs.

**Fix:** Remove `--webpack` from all `package.json` scripts (`dev`, `build`, `dev:bun`, `build:bun`). Next.js 16 defaults to turbopack, which correctly recognizes `proxy.js`.

### 2. Auth redirects use hardcoded `/login` instead of basePath-aware URLs

`dashboardGuard.js` redirected to `new URL("/login", request.url)` and `new URL("/dashboard", request.url)`. Through the reverse proxy at `/9router/`, these produced redirects to the wrong origin path (e.g., `https://proxy/login` instead of `https://proxy/9router/login`).

**Fix:** Added `getBasePath()` helper that detects the basePath from:
- `x-forwarded-prefix` header (sent by reverse proxies)
- `NEXT_PUBLIC_BASE_PATH` env var (fallback)

All redirect URLs now use `redirectTo(path)` which prepends the detected basePath. Route matching also strips the basePath prefix so it works whether the proxy passes the full path or strips it.

Also fixed `src/app/page.js` root redirect to use the same basePath detection.

### Files changed
- `package.json` — Removed `--webpack` from 4 scripts
- `src/dashboardGuard.js` — Added basePath detection + `redirectTo()` helper; all 4 redirect calls updated
- `src/app/page.js` — Root redirect now uses `NEXT_PUBLIC_BASE_PATH`

### Remaining work (not in this PR)
Client-side `router.push("/login")` and `fetch("/api/auth/...")` calls in login page, Header, profile page, and landing page also use hardcoded paths. These would need `NEXT_PUBLIC_BASE_PATH` plumbing to work through the proxy.