### PR TITLE
fix: middleware detection + basePath-aware auth redirects

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,7 @@ const proxyClientMaxBodySize = process.env.NINEROUTER_PROXY_CLIENT_MAX_BODY_SIZE
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: process.env.NINEROUTER_BASE_PATH || "",
   distDir: process.env.NEXT_DIST_DIR || ".next",
   output: "standalone",
   serverExternalPackages: ["better-sqlite3", "sql.js", "node:sqlite", "bun:sqlite"],
@@ -24,7 +25,9 @@ const nextConfig = {
   images: {
     unoptimized: true
   },
-  env: {},
+  env: {
+    NEXT_PUBLIC_BASE_PATH: process.env.NINEROUTER_BASE_PATH || "",
+  },
   experimental: {
     // #1529/#1572: LLM clients can send long context or base64 image payloads through /v1 rewrites.
     proxyClientMaxBodySize,

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -154,6 +154,17 @@ function isPublicApi(pathname) {
   return PUBLIC_API_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 }
 
+// Build a basePath-aware URL for redirects (works behind reverse proxy at /9router).
+// request.nextUrl.basePath is populated when basePath is set in next.config.mjs;
+// falls back to env var for cases where basePath isn't configured yet.
+function basePathUrl(path, request) {
+  const bp = request.nextUrl?.basePath
+    || process.env.NINEROUTER_BASE_PATH
+    || process.env.NEXT_PUBLIC_BASE_PATH
+    || "";
+  return new URL(bp + path, request.url);
+}
+
 export const __test__ = {
   isLocalRequest,
   isPublicLlmApi,
@@ -209,7 +220,7 @@ export async function proxy(request) {
           const tunnelHost = settings.tunnelUrl ? new URL(settings.tunnelUrl).hostname.toLowerCase() : "";
           const tailscaleHost = settings.tailscaleUrl ? new URL(settings.tailscaleUrl).hostname.toLowerCase() : "";
           if ((tunnelHost && host === tunnelHost) || (tailscaleHost && host === tailscaleHost)) {
-            return NextResponse.redirect(new URL("/login", request.url));
+            return NextResponse.redirect(basePathUrl("/login", request));
           }
         }
       }
@@ -226,16 +237,16 @@ export async function proxy(request) {
       if (await verifyDashboardAuthToken(token)) {
         return NextResponse.next();
       } else {
-        return NextResponse.redirect(new URL("/login", request.url));
+        return NextResponse.redirect(basePathUrl("/login", request));
       }
     }
 
-    return NextResponse.redirect(new URL("/login", request.url));
+    return NextResponse.redirect(basePathUrl("/login", request));
   }
 
   // Redirect / to /dashboard if logged in, or /dashboard if it's the root
   if (pathname === "/") {
-    return NextResponse.redirect(new URL("/dashboard", request.url));
+    return NextResponse.redirect(basePathUrl("/dashboard", request));
   }
 
   return NextResponse.next();

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,4 +1,8 @@
-export { proxy } from "./dashboardGuard";
+import { proxy as dashboardProxy } from "./dashboardGuard";
+
+export default async function proxy(request) {
+  return dashboardProxy(request);
+}
 
 export const config = {
   matcher: ["/((?!_next/static|_next/image|favicon\\.ico).*)"],


### PR DESCRIPTION
## Problem

The 9router app shows a white "Loading..." page when accessed through the reverse proxy at `/9router/`. Two root causes:

1. **Middleware not detected by Next.js** — `src/proxy.js` uses `export { proxy }` (named re-export) instead of `export default`. Next.js 16 requires a default export to identify middleware, so the build produces an empty middleware manifest. The auth guard never runs, `/dashboard` requests aren't redirected to `/login`, and API paths bypass auth.

2. **Auth redirects lose the basePath** — All 4 redirect calls use `new URL("/login", request.url)` which resolves against the origin, stripping the `/9router` prefix. The browser navigates to `https://proxy/login` (404) instead of `https://proxy/9router/login`.

## Changes

### `src/proxy.js` — use `export default`
Changed from bare named re-export to `export default async function proxy()`. This is the convention Next.js 16 detects for middleware registration. Do **not** rename to `middleware.js` — that forces Edge Runtime which rejects the Node.js imports in `dashboardGuard.js`.

### `src/dashboardGuard.js` — basePath-aware redirects
Added `basePathUrl(path, request)` helper that reads basePath from `request.nextUrl.basePath` (populated by Next.js when `basePath` is configured) with env var fallbacks. All 4 hardcoded `new URL("/login", ...)` / `new URL("/dashboard", ...)` calls now use this helper.

### `next.config.mjs` — add `basePath` config
Added `basePath: process.env.NINEROUTER_BASE_PATH || ""` so Next.js knows about the prefix. This populates `request.nextUrl.basePath` in middleware and auto-prepends to `router.push()` / `<Link>` in client components. Also exposes `NEXT_PUBLIC_BASE_PATH` for client-side `fetch()` calls.

## Build & Deploy

```bash
NINEROUTER_BASE_PATH=/9router npm run build
NINEROUTER_BASE_PATH=/9router npm run start
```

When `NINEROUTER_BASE_PATH` is empty or unset, the app works exactly as before (no basePath, all redirects go to `/login`).