### PR TITLE
fix: avoid exposing api keys in logs and usage history

### DIFF
--- a/src/lib/db/helpers/apiKeyUsageId.js
+++ b/src/lib/db/helpers/apiKeyUsageId.js
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+
+const API_KEY_USAGE_ID_RE = /^sha256:[0-9a-f]{16}$/i;
+
+export function isApiKeyUsageId(value) {
+  return typeof value === "string" && API_KEY_USAGE_ID_RE.test(value);
+}
+
+export function createApiKeyUsageId(apiKey) {
+  if (!apiKey || typeof apiKey !== "string") return null;
+  return `sha256:${createHash("sha256").update(apiKey).digest("hex").slice(0, 16)}`;
+}
+
+export function normalizeApiKeyUsageId(value) {
+  if (!value || typeof value !== "string") return null;
+  if (isApiKeyUsageId(value)) return value.toLowerCase();
+  return createApiKeyUsageId(value);
+}
+
+export function normalizeUsageDailySummary(day) {
+  if (!day || typeof day !== "object" || !day.byApiKey || typeof day.byApiKey !== "object") return day;
+
+  const normalized = {};
+  for (const [legacyKey, value] of Object.entries(day.byApiKey)) {
+    const entry = value && typeof value === "object" ? { ...value } : {};
+    const parts = String(legacyKey).split("|");
+    const legacyApiKey = parts[0] && parts[0] !== "local-no-key" ? parts[0] : null;
+    const rawModel = entry.rawModel || parts[1] || "";
+    const provider = entry.provider || parts[2] || "unknown";
+    const apiKeyId = normalizeApiKeyUsageId(entry.apiKey) || normalizeApiKeyUsageId(legacyApiKey);
+    const apiKeyKey = apiKeyId || "local-no-key";
+    const normalizedKey = `${apiKeyKey}|${rawModel}|${provider || "unknown"}`;
+
+    const next = { ...entry, rawModel, provider, apiKey: apiKeyId };
+    if (!normalized[normalizedKey]) {
+      normalized[normalizedKey] = next;
+      continue;
+    }
+
+    normalized[normalizedKey].requests = (normalized[normalizedKey].requests || 0) + (next.requests || 0);
+    normalized[normalizedKey].promptTokens = (normalized[normalizedKey].promptTokens || 0) + (next.promptTokens || 0);
+    normalized[normalizedKey].completionTokens = (normalized[normalizedKey].completionTokens || 0) + (next.completionTokens || 0);
+    normalized[normalizedKey].cost = (normalized[normalizedKey].cost || 0) + (next.cost || 0);
+  }
+
+  return { ...day, byApiKey: normalized };
+}

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { LEGACY_FILES, DB_DIR, DATA_FILE } from "./paths.js";
+import { normalizeApiKeyUsageId, normalizeUsageDailySummary } from "./helpers/apiKeyUsageId.js";
 import { TABLES, buildCreateTableSql } from "./schema.js";
 import { MIGRATIONS, latestVersion } from "./migrations/index.js";
 import { getMetaSync, setMetaSync } from "./helpers/metaStore.js";
@@ -177,7 +178,7 @@ function importLegacyUsage(adapter, data) {
       `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         e.timestamp || new Date().toISOString(),
-        e.provider || null, e.model || null, e.connectionId || null, e.apiKey || null, e.endpoint || null,
+        e.provider || null, e.model || null, e.connectionId || null, normalizeApiKeyUsageId(e.apiKey), e.endpoint || null,
         t.prompt_tokens || t.input_tokens || 0,
         t.completion_tokens || t.output_tokens || 0,
         e.cost || 0,
@@ -188,7 +189,7 @@ function importLegacyUsage(adapter, data) {
     );
   }
   for (const [dateKey, day] of Object.entries(data.dailySummary || {})) {
-    adapter.run(`INSERT OR REPLACE INTO usageDaily(dateKey, data) VALUES(?, ?)`, [dateKey, stringifyJson(day)]);
+    adapter.run(`INSERT OR REPLACE INTO usageDaily(dateKey, data) VALUES(?, ?)`, [dateKey, stringifyJson(normalizeUsageDailySummary(day))]);
   }
   if (typeof data.totalRequestsLifetime === "number") {
     setMetaSync(adapter, "totalRequestsLifetime", data.totalRequestsLifetime);

--- a/src/lib/db/migrations/002-normalize-usage-api-keys.js
+++ b/src/lib/db/migrations/002-normalize-usage-api-keys.js
@@ -1,0 +1,26 @@
+import { normalizeApiKeyUsageId, normalizeUsageDailySummary } from "../helpers/apiKeyUsageId.js";
+
+export default {
+  version: 2,
+  name: "normalize usage api keys",
+  up(db) {
+    const historyRows = db.all(`SELECT id, apiKey FROM usageHistory WHERE apiKey IS NOT NULL AND apiKey != ''`);
+    for (const row of historyRows) {
+      const normalized = normalizeApiKeyUsageId(row.apiKey);
+      if (normalized && normalized !== row.apiKey) {
+        db.run(`UPDATE usageHistory SET apiKey = ? WHERE id = ?`, [normalized, row.id]);
+      }
+    }
+
+    const dailyRows = db.all(`SELECT dateKey, data FROM usageDaily`);
+    for (const row of dailyRows) {
+      let day;
+      try { day = JSON.parse(row.data || "{}"); } catch { continue; }
+      const next = normalizeUsageDailySummary(day);
+      const serialized = JSON.stringify(next);
+      if (serialized !== row.data) {
+        db.run(`UPDATE usageDaily SET data = ? WHERE dateKey = ?`, [serialized, row.dateKey]);
+      }
+    }
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-normalize-usage-api-keys.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events";
 import { getAdapter } from "../driver.js";
+import { createApiKeyUsageId, normalizeApiKeyUsageId } from "../helpers/apiKeyUsageId.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 import { getMeta, setMeta } from "../helpers/metaStore.js";
 
@@ -26,6 +27,14 @@ const recentRing = global._recentRing;
 const connCache = global._connectionMapCache;
 
 export const statsEmitter = global._statsEmitter;
+
+function getApiKeyDisplayName(apiKeyId, apiKeyMap = {}) {
+  if (!apiKeyId) return "Local (No API Key)";
+  const keyInfo = apiKeyMap[apiKeyId];
+  if (keyInfo?.name) return keyInfo.name;
+  if (apiKeyId.startsWith("sha256:")) return `API Key ${apiKeyId.slice(7, 15)}`;
+  return "API Key";
+}
 
 function getLocalDateKey(timestamp) {
   const d = timestamp ? new Date(timestamp) : new Date();
@@ -67,9 +76,9 @@ function aggregateEntryToDay(day, entry) {
     addToCounter(day.byAccount, entry.connectionId, { ...vals, meta: { rawModel: entry.model, provider: entry.provider } });
   }
 
-  const apiKeyVal = entry.apiKey && typeof entry.apiKey === "string" ? entry.apiKey : "local-no-key";
+  const apiKeyVal = normalizeApiKeyUsageId(entry.apiKey) || "local-no-key";
   const akModelKey = `${apiKeyVal}|${entry.model}|${entry.provider || "unknown"}`;
-  addToCounter(day.byApiKey, akModelKey, { ...vals, meta: { rawModel: entry.model, provider: entry.provider, apiKey: entry.apiKey || null } });
+  addToCounter(day.byApiKey, akModelKey, { ...vals, meta: { rawModel: entry.model, provider: entry.provider, apiKey: normalizeApiKeyUsageId(entry.apiKey) } });
 
   const endpoint = entry.endpoint || "Unknown";
   const epKey = `${endpoint}|${entry.model}|${entry.provider || "unknown"}`;
@@ -104,7 +113,7 @@ async function ensureRingInitialized() {
     const rows = db.all(`SELECT timestamp, provider, model, connectionId, apiKey, endpoint, cost, status, tokens FROM usageHistory ORDER BY id DESC LIMIT ?`, [RING_CAP]);
     recentRing.items = rows.reverse().map((r) => ({
       timestamp: r.timestamp, provider: r.provider, model: r.model, connectionId: r.connectionId,
-      apiKey: r.apiKey, endpoint: r.endpoint, cost: r.cost, status: r.status,
+      apiKey: normalizeApiKeyUsageId(r.apiKey), endpoint: r.endpoint, cost: r.cost, status: r.status,
       tokens: parseJson(r.tokens, {}),
     }));
   } catch {}
@@ -250,6 +259,8 @@ export async function saveRequestUsage(entry) {
     const tokens = entry.tokens || {};
     const promptTokens = tokens.prompt_tokens || tokens.input_tokens || 0;
     const completionTokens = tokens.completion_tokens || tokens.output_tokens || 0;
+    const storedApiKey = createApiKeyUsageId(entry.apiKey);
+    const usageEntry = { ...entry, apiKey: storedApiKey };
 
     // All 3 writes (history insert, daily upsert, lifetime counter) in ONE transaction.
     // better-sqlite3 is sync → no JS yield mid-transaction → no race in same process.
@@ -258,7 +269,7 @@ export async function saveRequestUsage(entry) {
         `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           entry.timestamp, entry.provider || null, entry.model || null,
-          entry.connectionId || null, entry.apiKey || null, entry.endpoint || null,
+          entry.connectionId || null, storedApiKey, entry.endpoint || null,
           promptTokens, completionTokens, entry.cost || 0, entry.status || "ok",
           stringifyJson(tokens), stringifyJson({}),
         ]
@@ -270,7 +281,7 @@ export async function saveRequestUsage(entry) {
         requests: 0, promptTokens: 0, completionTokens: 0, cost: 0,
         byProvider: {}, byModel: {}, byAccount: {}, byApiKey: {}, byEndpoint: {},
       };
-      aggregateEntryToDay(day, entry);
+      aggregateEntryToDay(day, usageEntry);
       db.run(`INSERT INTO usageDaily(dateKey, data) VALUES(?, ?) ON CONFLICT(dateKey) DO UPDATE SET data = excluded.data`, [dateKey, stringifyJson(day)]);
 
       // Atomic counter increment in same transaction
@@ -279,7 +290,7 @@ export async function saveRequestUsage(entry) {
       db.run(`INSERT INTO _meta(key, value) VALUES('totalRequestsLifetime', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`, [String(next)]);
     });
 
-    pushToRing(entry);
+    pushToRing(usageEntry);
     statsEmitter.emit("update");
   } catch (e) {
     console.error("Failed to save usage stats:", e);
@@ -301,7 +312,7 @@ export async function getUsageHistory(filter = {}) {
 
   return rows.map((r) => ({
     timestamp: r.timestamp, provider: r.provider, model: r.model,
-    connectionId: r.connectionId, apiKey: r.apiKey, endpoint: r.endpoint,
+    connectionId: r.connectionId, apiKey: normalizeApiKeyUsageId(r.apiKey), endpoint: r.endpoint,
     cost: r.cost, status: r.status, tokens: parseJson(r.tokens, {}),
   }));
 }
@@ -339,7 +350,10 @@ export async function getUsageStats(period = "all") {
   let allApiKeys = [];
   try { allApiKeys = await getApiKeys(); } catch {}
   const apiKeyMap = {};
-  for (const k of allApiKeys) apiKeyMap[k.key] = { name: k.name, id: k.id, createdAt: k.createdAt };
+  for (const k of allApiKeys) {
+    const apiKeyId = createApiKeyUsageId(k.key);
+    if (apiKeyId) apiKeyMap[apiKeyId] = { name: k.name, id: k.id, createdAt: k.createdAt };
+  }
 
   // recentRequests from live history (last 100 entries enough for 20 deduped)
   const recentRows = db.all(`SELECT timestamp, provider, model, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
@@ -468,22 +482,22 @@ export async function getUsageStats(period = "all") {
         if (dateKey > (stats.byAccount[accountKey].lastUsed || "")) stats.byAccount[accountKey].lastUsed = dateKey;
       }
 
-      for (const [akKey, ak] of Object.entries(day.byApiKey || {})) {
+      for (const [, ak] of Object.entries(day.byApiKey || {})) {
         const rawModel = ak.rawModel || "";
         const provider = ak.provider || "";
         const providerDisplayName = providerNodeNameMap[provider] || provider;
-        const apiKeyVal = ak.apiKey;
-        const keyInfo = apiKeyVal ? apiKeyMap[apiKeyVal] : null;
-        const keyName = keyInfo?.name || (apiKeyVal ? apiKeyVal.slice(0, 8) + "..." : "Local (No API Key)");
+        const apiKeyVal = normalizeApiKeyUsageId(ak.apiKey);
+        const keyName = getApiKeyDisplayName(apiKeyVal, apiKeyMap);
         const apiKeyKey = apiKeyVal || "local-no-key";
-        if (!stats.byApiKey[akKey]) {
-          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKey: apiKeyVal, keyName, apiKeyKey, lastUsed: dateKey };
+        const normalizedAkKey = `${apiKeyKey}|${rawModel}|${provider || "unknown"}`;
+        if (!stats.byApiKey[normalizedAkKey]) {
+          stats.byApiKey[normalizedAkKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKey: apiKeyVal, keyName, apiKeyKey, lastUsed: dateKey };
         }
-        stats.byApiKey[akKey].requests += ak.requests || 0;
-        stats.byApiKey[akKey].promptTokens += ak.promptTokens || 0;
-        stats.byApiKey[akKey].completionTokens += ak.completionTokens || 0;
-        stats.byApiKey[akKey].cost += ak.cost || 0;
-        if (dateKey > (stats.byApiKey[akKey].lastUsed || "")) stats.byApiKey[akKey].lastUsed = dateKey;
+        stats.byApiKey[normalizedAkKey].requests += ak.requests || 0;
+        stats.byApiKey[normalizedAkKey].promptTokens += ak.promptTokens || 0;
+        stats.byApiKey[normalizedAkKey].completionTokens += ak.completionTokens || 0;
+        stats.byApiKey[normalizedAkKey].cost += ak.cost || 0;
+        if (dateKey > (stats.byApiKey[normalizedAkKey].lastUsed || "")) stats.byApiKey[normalizedAkKey].lastUsed = dateKey;
       }
 
       for (const [epKey, ep] of Object.entries(day.byEndpoint || {})) {
@@ -519,9 +533,10 @@ export async function getUsageStats(period = "all") {
         if (stats.byAccount[accountKey] && new Date(ts) > new Date(stats.byAccount[accountKey].lastUsed)) stats.byAccount[accountKey].lastUsed = ts;
       }
 
-      const apiKeyKey = (e.apiKey && typeof e.apiKey === "string")
-        ? `${e.apiKey}|${e.model}|${e.provider || "unknown"}`
-        : "local-no-key";
+      const historyApiKeyId = normalizeApiKeyUsageId(e.apiKey);
+      const apiKeyKey = historyApiKeyId
+        ? `${historyApiKeyId}|${e.model}|${e.provider || "unknown"}`
+        : `local-no-key|${e.model}|${e.provider || "unknown"}`;
       if (stats.byApiKey[apiKeyKey] && new Date(ts) > new Date(stats.byApiKey[apiKeyKey].lastUsed)) stats.byApiKey[apiKeyKey].lastUsed = ts;
 
       const endpoint = e.endpoint || "Unknown";
@@ -583,12 +598,12 @@ export async function getUsageStats(period = "all") {
         if (new Date(r.timestamp) > new Date(stats.byAccount[accountKey].lastUsed)) stats.byAccount[accountKey].lastUsed = r.timestamp;
       }
 
-      if (r.apiKey && typeof r.apiKey === "string") {
-        const keyInfo = apiKeyMap[r.apiKey];
-        const keyName = keyInfo?.name || r.apiKey.slice(0, 8) + "...";
-        const akKey = `${r.apiKey}|${r.model}|${r.provider || "unknown"}`;
+      const apiKeyId = normalizeApiKeyUsageId(r.apiKey);
+      if (apiKeyId) {
+        const keyName = getApiKeyDisplayName(apiKeyId, apiKeyMap);
+        const akKey = `${apiKeyId}|${r.model}|${r.provider || "unknown"}`;
         if (!stats.byApiKey[akKey]) {
-          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKey: r.apiKey, keyName, apiKeyKey: r.apiKey, lastUsed: r.timestamp };
+          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKey: apiKeyId, keyName, apiKeyKey: apiKeyId, lastUsed: r.timestamp };
         }
         const ake = stats.byApiKey[akKey];
         ake.requests++; ake.promptTokens += promptTokens; ake.completionTokens += completionTokens; ake.cost += entryCost;

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -55,12 +55,12 @@ export async function handleChat(request, clientRawRequest = null) {
   const effort = body.reasoning_effort || body.reasoning?.effort || null;
   log.request("POST", `${url.pathname} | ${modelStr} | ${msgCount} msgs${toolCount ? ` | ${toolCount} tools` : ""}${effort ? ` | effort=${effort}` : ""}`);
 
-  // Log API key (masked)
+  // Log API key presence only. Even prefix/last4 values can become
+  // sensitive when logs are copied into bug reports or support tickets.
   const authHeader = request.headers.get("Authorization");
   const apiKey = extractApiKey(request);
   if (authHeader && apiKey) {
-    const masked = log.maskKey(apiKey);
-    log.debug("AUTH", `API Key: ${masked}`);
+    log.debug("AUTH", "API key provided");
   } else {
     log.debug("AUTH", "No API key provided (local mode)");
   }

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -33,10 +33,11 @@ export async function handleEmbeddings(request) {
 
   log.request("POST", `${url.pathname} | ${modelStr}`);
 
-  // Log API key (masked)
+  // Log API key presence only. Even prefix/last4 values can become
+  // sensitive when logs are copied into bug reports or support tickets.
   const apiKey = extractApiKey(request);
   if (apiKey) {
-    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
+    log.debug("AUTH", "API key provided");
   } else {
     log.debug("AUTH", "No API key provided (local mode)");
   }

--- a/src/sse/handlers/fetch.js
+++ b/src/sse/handlers/fetch.js
@@ -38,10 +38,11 @@ export async function handleFetch(request) {
 
   log.request("POST", `${reqUrl.pathname} | ${providerInput}`);
 
-  // Log API key (masked)
+  // Log API key presence only. Even prefix/last4 values can become
+  // sensitive when logs are copied into bug reports or support tickets.
   const apiKey = extractApiKey(request);
   if (apiKey) {
-    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
+    log.debug("AUTH", "API key provided");
   } else {
     log.debug("AUTH", "No API key provided (local mode)");
   }

--- a/src/sse/handlers/search.js
+++ b/src/sse/handlers/search.js
@@ -36,10 +36,11 @@ export async function handleSearch(request) {
 
   log.request("POST", `${url.pathname} | ${providerInput}`);
 
-  // Log API key (masked)
+  // Log API key presence only. Even prefix/last4 values can become
+  // sensitive when logs are copied into bug reports or support tickets.
   const apiKey = extractApiKey(request);
   if (apiKey) {
-    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
+    log.debug("AUTH", "API key provided");
   } else {
     log.debug("AUTH", "No API key provided (local mode)");
   }

--- a/tests/unit/usage-api-key-hardening.test.js
+++ b/tests/unit/usage-api-key-hardening.test.js
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let tempDir;
+let dbApi;
+let driver;
+
+function usageId(value) {
+  return `sha256:${createHash("sha256").update(value).digest("hex").slice(0, 16)}`;
+}
+
+async function loadFreshDb() {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-usage-key-hardening-"));
+  process.env.DATA_DIR = tempDir;
+  delete global._dbAdapter;
+  delete global._recentRing;
+  vi.resetModules();
+  dbApi = await import("@/lib/db/index.js");
+  driver = await import("@/lib/db/driver.js");
+  await dbApi.initDb();
+}
+
+async function rawDb() {
+  return await driver.getAdapter();
+}
+
+beforeEach(async () => {
+  await loadFreshDb();
+});
+
+afterEach(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  delete process.env.DATA_DIR;
+  delete global._dbAdapter;
+  delete global._recentRing;
+});
+
+describe("usage API key hardening", () => {
+  it("stores only derived usage ids for new request usage", async () => {
+    const rawKey = "fixture-router-key-alpha";
+
+    await dbApi.saveRequestUsage({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      apiKey: rawKey,
+      tokens: { prompt_tokens: 12, completion_tokens: 4 },
+      endpoint: "/v1/chat/completions",
+      status: "ok",
+    });
+
+    const db = await rawDb();
+    const history = db.get(`SELECT apiKey FROM usageHistory ORDER BY id DESC LIMIT 1`);
+    expect(history.apiKey).toBe(usageId(rawKey));
+    expect(history.apiKey).not.toContain(rawKey);
+
+    const daily = db.get(`SELECT data FROM usageDaily ORDER BY dateKey DESC LIMIT 1`);
+    const serialized = daily.data;
+    expect(serialized).toContain(usageId(rawKey));
+    expect(serialized).not.toContain(rawKey);
+
+    const publicHistory = await dbApi.getUsageHistory({ provider: "openai" });
+    expect(publicHistory.at(-1).apiKey).toBe(usageId(rawKey));
+  });
+
+  it("hashes request-derived literal sha256-looking keys instead of trusting them", async () => {
+    const literalKey = "sha256:0123456789abcdef";
+
+    await dbApi.saveRequestUsage({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      apiKey: literalKey,
+      tokens: { prompt_tokens: 1, completion_tokens: 1 },
+      endpoint: "/v1/chat/completions",
+      status: "ok",
+    });
+
+    const db = await rawDb();
+    const history = db.get(`SELECT apiKey FROM usageHistory ORDER BY id DESC LIMIT 1`);
+    expect(history.apiKey).toBe(usageId(literalKey));
+    expect(history.apiKey).not.toBe(literalKey);
+  });
+
+  it("normalizes legacy raw history and daily summary values without public re-exposure", async () => {
+    const rawKey = "fixture-router-key-legacy";
+    const expected = usageId(rawKey);
+    const dateKey = "2026-06-12";
+    const db = await rawDb();
+
+    db.run(
+      `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        `${dateKey}T00:00:00.000Z`,
+        "openai",
+        "gpt-4o-mini",
+        null,
+        rawKey,
+        "/v1/chat/completions",
+        5,
+        6,
+        0,
+        "ok",
+        JSON.stringify({ prompt_tokens: 5, completion_tokens: 6 }),
+        JSON.stringify({}),
+      ]
+    );
+    db.run(
+      `INSERT OR REPLACE INTO usageDaily(dateKey, data) VALUES(?, ?)`,
+      [dateKey, JSON.stringify({
+        requests: 1,
+        promptTokens: 5,
+        completionTokens: 6,
+        cost: 0,
+        byApiKey: {
+          [`${rawKey}|gpt-4o-mini|openai`]: {
+            requests: 1,
+            promptTokens: 5,
+            completionTokens: 6,
+            cost: 0,
+            rawModel: "gpt-4o-mini",
+            provider: "openai",
+            apiKey: rawKey,
+          },
+        },
+      })]
+    );
+
+    const migration = await import("@/lib/db/migrations/002-normalize-usage-api-keys.js");
+    migration.default.up(db);
+
+    const storedHistory = db.get(`SELECT apiKey FROM usageHistory WHERE apiKey = ?`, [expected]);
+    expect(storedHistory.apiKey).toBe(expected);
+    expect(db.get(`SELECT apiKey FROM usageHistory WHERE apiKey = ?`, [rawKey])).toBeUndefined();
+
+    const storedDaily = db.get(`SELECT data FROM usageDaily WHERE dateKey = ?`, [dateKey]).data;
+    expect(storedDaily).toContain(expected);
+    expect(storedDaily).not.toContain(rawKey);
+
+    const stats = await dbApi.getUsageStats("all");
+    const serializedStats = JSON.stringify(stats.byApiKey);
+    expect(serializedStats).toContain(expected);
+    expect(serializedStats).not.toContain(rawKey);
+  });
+});


### PR DESCRIPTION
## Summary

This hardens 9Router's router API-key handling so keys are not exposed through logs or usage history/statistics.

Changes include:
- remove API-key prefix/last4 logging from chat/search/fetch/embeddings handlers
- store non-secret derived usage IDs instead of raw router API keys
- normalize legacy `usageHistory.apiKey` and `usageDaily.data.byApiKey` values via migration
- normalize legacy JSON imports immediately
- preserve dashboard grouping with non-secret identifiers
- add regression coverage for new writes, sha256-looking literal request keys, and legacy normalization

## Test plan

Run locally:

- `npx vitest run --config tests/vitest.config.js tests/unit/usage-api-key-hardening.test.js`
  - PASS: 3/3
- `npx vitest run --config tests/vitest.config.js tests/unit/db-sqlite-vs-lowdb.test.js tests/unit/usage-api-key-hardening.test.js`
  - PASS: 22/22
- `npm run build`
  - PASS
- private/environment term diff scan
  - PASS: no hits
- active raw/prefix scan over touched DB/SSE code
  - PASS: no hits

## Review

Independent Robin review recorded PASS for commit `301b0fc`:

- lanes: Claude Code primary + Kimi second opinion
- verdict: PASS
- scope: full diff, 10 files

Review notes called out expected tradeoffs:
- existing rows remain raw until migration 002 runs, though read paths normalize/mask in interim
- usage IDs are truncated SHA256 identifiers intended for grouping, not cryptographic identity
- very large usage tables may make the migration take time at startup
- consumers expecting raw API keys in history/stats will intentionally no longer receive them
