### PR TITLE
fix: send Bearer auth for third-party anthropic-compatible gateways

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -157,6 +157,12 @@ export class DefaultExecutor extends BaseExecutor {
       const baseUrl = credentials?.providerSpecificData?.baseUrl || "";
       const isOfficialAnthropic = baseUrl === "" || baseUrl.includes("api.anthropic.com");
       if (!isOfficialAnthropic) {
+        // Some third-party Anthropic-compatible gateways require Bearer auth in
+        // addition to x-api-key. Send both (x-api-key already set above) so
+        // gateways that read either header succeed.
+        if (credentials.apiKey && !headers["Authorization"]) {
+          headers["Authorization"] = `Bearer ${credentials.apiKey}`;
+        }
         delete headers["anthropic-dangerous-direct-browser-access"];
         delete headers["Anthropic-Dangerous-Direct-Browser-Access"];
         delete headers["x-app"];


### PR DESCRIPTION
## Summary

Third-party Anthropic-compatible gateways that require `Authorization: Bearer`
(in addition to `x-api-key`) were returning **401 `missing_api_key`** when used
as a Custom Provider. The forward path in `DefaultExecutor.buildHeaders()` only
set `x-api-key` for `anthropic-compatible-*` providers, so gateways reading the
Bearer header rejected the request.

This change also explains why the **connection test / model import succeeded but
live forwarding failed**: the test/validate paths already sent both headers,
while the forward path did not — a header divergence.

## Fix

For **non-official** Anthropic upstreams (i.e. baseUrl is not empty and not
`api.anthropic.com`), also send `Authorization: Bearer <apiKey>` alongside the
existing `x-api-key`. Official `api.anthropic.com` behavior is unchanged.

```js
if (!isOfficialAnthropic) {
  // Some third-party Anthropic-compatible gateways require Bearer auth in
  // addition to x-api-key. Send both (x-api-key already set above) so
  // gateways that read either header succeed.
  if (credentials.apiKey && !headers["Authorization"]) {
    headers["Authorization"] = `Bearer ${credentials.apiKey}`;
  }
  ...
}
```

- Scope is limited to the existing `!isOfficialAnthropic` block, so official
  Anthropic and any gateway already setting `Authorization` are untouched.
- 6 lines added, 1 file changed.

## Test plan

- [x] Configure an Anthropic-compatible Custom Provider pointing at a gateway
      that requires Bearer auth (baseUrl ending in `/v1`).
- [x] Send a real request through 9router (`POST /v1/messages`).
- [x] Before fix: `401 missing_api_key`. After fix: **HTTP 200** with a valid
      assistant message (`"pong"`).
- [x] Verified official `api.anthropic.com` path is not affected (gated by
      `isOfficialAnthropic`).