### PR TITLE
fix(openai): fallback to responses for gpt-5/codex

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -5,6 +5,10 @@ import { buildClineHeaders } from "../../src/shared/utils/clineAuth.js";
 import { getCachedClaudeHeaders } from "../utils/claudeHeaderCache.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
+import { openaiToOpenAIResponsesRequest } from "../translator/request/openai-responses.js";
+import { openaiResponsesToOpenAIResponse } from "../translator/response/openai-responses.js";
+import { initState } from "../translator/index.js";
+import { parseSSELine, formatSSE } from "../utils/streamHelpers.js";
 
 export class DefaultExecutor extends BaseExecutor {
   constructor(provider) {
@@ -12,8 +16,177 @@ export class DefaultExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body) {
-    const transformed = this.applyJsonSchemaFallback(body);
+    let transformed = this.applyJsonSchemaFallback(body);
+    transformed = this.rewriteMaxTokensParam(model, transformed);
     return injectReasoningContent({ provider: this.provider, model, body: transformed });
+  }
+
+  requiresMaxCompletionTokens(model) {
+    return /gpt-5|o[134]-/i.test(String(model || ""));
+  }
+
+  rewriteMaxTokensParam(model, body) {
+    if (!body || typeof body !== "object") return body;
+    if (body.max_completion_tokens !== undefined || body.max_tokens === undefined) return body;
+    if (!this.requiresMaxCompletionTokens(model)) return body;
+
+    const transformed = { ...body, max_completion_tokens: body.max_tokens };
+    delete transformed.max_tokens;
+    return transformed;
+  }
+
+  isUnsupportedMaxTokensError(payload) {
+    const err = payload?.error;
+    if (!err || typeof err !== "object") return false;
+    const code = String(err.code || "").toLowerCase();
+    const param = String(err.param || "").toLowerCase();
+    const message = String(err.message || "").toLowerCase();
+    return (
+      ((code.includes("unsupported_parameter") || code.includes("unknown_parameter")) && param === "max_tokens")
+      || (message.includes("unknown parameter") && message.includes("max_tokens"))
+      || (message.includes("max_tokens") && message.includes("max_completion_tokens"))
+    );
+  }
+
+  isChatCompletionsUnsupportedModelError(payload) {
+    const message = String(payload?.error?.message || "").toLowerCase();
+    return (
+      message.includes("not a chat model")
+      && message.includes("/chat/completions")
+    );
+  }
+
+  isResponsesRequiredForChatError(payload) {
+    const message = String(payload?.error?.message || "").toLowerCase();
+    return (
+      message.includes("/chat/completions")
+      && message.includes("/v1/responses")
+      && message.includes("instead")
+    );
+  }
+
+  buildResponsesUrl(chatCompletionsUrl) {
+    return String(chatCompletionsUrl || "").replace(/\/chat\/completions(\?.*)?$/i, "/responses$1");
+  }
+
+  async executeWithResponsesFallback(options, priorResult) {
+    const { model, body, stream, credentials, signal, proxyOptions = null } = options;
+    const url = this.buildResponsesUrl(priorResult.url);
+    const headers = this.buildHeaders(credentials, stream);
+    const transformedBody = openaiToOpenAIResponsesRequest(model, body, stream, credentials);
+
+    const response = await proxyAwareFetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(transformedBody),
+      signal
+    }, proxyOptions);
+
+    if (!response.ok || !stream) {
+      return { response, url, headers, transformedBody };
+    }
+
+    const state = initState("openai-responses");
+    state.model = model;
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    const transformStream = new TransformStream({
+      transform(chunk, controller) {
+        buffer += decoder.decode(chunk, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+
+          const parsed = parseSSELine(trimmed);
+          if (!parsed) continue;
+
+          if (parsed.done) {
+            controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+            continue;
+          }
+
+          const converted = openaiResponsesToOpenAIResponse(parsed, state);
+          if (converted) {
+            controller.enqueue(new TextEncoder().encode(formatSSE(converted, "openai")));
+          }
+        }
+      },
+      flush(controller) {
+        if (buffer.trim()) {
+          const parsed = parseSSELine(buffer.trim());
+          if (parsed && !parsed.done) {
+            const converted = openaiResponsesToOpenAIResponse(parsed, state);
+            if (converted) {
+              controller.enqueue(new TextEncoder().encode(formatSSE(converted, "openai")));
+            }
+          }
+        }
+
+        const finalChunk = openaiResponsesToOpenAIResponse(null, state);
+        if (finalChunk) {
+          controller.enqueue(new TextEncoder().encode(formatSSE(finalChunk, "openai")));
+        }
+      }
+    });
+
+    const convertedStream = response.body.pipeThrough(transformStream);
+    const convertedHeaders = new Headers(response.headers);
+    convertedHeaders.set("content-type", "text/event-stream");
+    const convertedResponse = new Response(convertedStream, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: convertedHeaders
+    });
+
+    return { response: convertedResponse, url, headers, transformedBody };
+  }
+
+  async execute(options) {
+    let currentResult = await super.execute({ ...options, proxyOptions: options.proxyOptions || null });
+
+    if (currentResult.response.status === 400 && options?.body && options.body.max_tokens !== undefined) {
+      let payload;
+      try {
+        payload = await currentResult.response.clone().json();
+      } catch {
+        return currentResult;
+      }
+      if (this.isUnsupportedMaxTokensError(payload)) {
+        const retryMax = currentResult.transformedBody?.max_tokens ?? options.body.max_tokens;
+        if (retryMax === undefined) return currentResult;
+
+        const retryBody = { ...currentResult.transformedBody, max_completion_tokens: retryMax };
+        delete retryBody.max_tokens;
+
+        const retryResponse = await proxyAwareFetch(currentResult.url, {
+          method: "POST",
+          headers: currentResult.headers,
+          body: JSON.stringify(retryBody),
+          signal: options.signal
+        }, options.proxyOptions || null);
+
+        currentResult = { ...currentResult, response: retryResponse, transformedBody: retryBody };
+      }
+    }
+
+    if (this.provider !== "openai" || !options?.body) return currentResult;
+    if (currentResult.response.status !== 404 && currentResult.response.status !== 400) return currentResult;
+
+    let payload;
+    try {
+      payload = await currentResult.response.clone().json();
+    } catch {
+      return currentResult;
+    }
+    const shouldFallbackToResponses = this.isChatCompletionsUnsupportedModelError(payload) || this.isResponsesRequiredForChatError(payload);
+    if (!shouldFallbackToResponses) return currentResult;
+
+    return this.executeWithResponsesFallback(options, currentResult);
   }
 
   // Fallback json_schema → json_object for openai-compatible providers without native Structured Output.

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -307,7 +307,9 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
 
   // Pass through other relevant fields
   if (body.temperature !== undefined) result.temperature = body.temperature;
-  if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
+  if (body.max_output_tokens !== undefined) result.max_output_tokens = body.max_output_tokens;
+  else if (body.max_completion_tokens !== undefined) result.max_output_tokens = body.max_completion_tokens;
+  else if (body.max_tokens !== undefined) result.max_output_tokens = body.max_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
 
   return result;

--- a/tests/unit/default-openai-token-compat.test.js
+++ b/tests/unit/default-openai-token-compat.test.js
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("DefaultExecutor OpenAI token parameter compatibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps max_tokens to max_completion_tokens for GPT-5 family", () => {
+    const executor = new DefaultExecutor("openai");
+    const out = executor.transformRequest("gpt-5.4", {
+      model: "gpt-5.4",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 64,
+    });
+
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.max_completion_tokens).toBe(64);
+  });
+
+  it("keeps max_tokens for models that still support it", () => {
+    const executor = new DefaultExecutor("openai");
+    const out = executor.transformRequest("gpt-4.1", {
+      model: "gpt-4.1",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 32,
+    });
+
+    expect(out.max_tokens).toBe(32);
+    expect(out.max_completion_tokens).toBeUndefined();
+  });
+
+  it("retries once with max_completion_tokens after unsupported max_tokens 400", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({
+        error: {
+          message: "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+          type: "invalid_request_error",
+          param: "max_tokens",
+          code: "unsupported_parameter",
+        },
+      }, 400))
+      .mockResolvedValueOnce(jsonResponse({
+        id: "chatcmpl_test",
+        object: "chat.completion",
+      }, 200));
+
+    const executor = new DefaultExecutor("openai");
+    const result = await executor.execute({
+      model: "gpt-4.1",
+      body: {
+        model: "gpt-4.1",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 24,
+      },
+      stream: false,
+      credentials: { apiKey: "test-key" },
+      signal: undefined,
+      log: null,
+      proxyOptions: null,
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+
+    const secondCall = proxyAwareFetch.mock.calls[1];
+    const secondBody = JSON.parse(secondCall[1].body);
+    expect(secondBody.max_tokens).toBeUndefined();
+    expect(secondBody.max_completion_tokens).toBe(24);
+    expect(result.response.status).toBe(200);
+  });
+
+  it("falls back to /responses when model is not supported by /chat/completions", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({
+        error: {
+          message: "This is not a chat model and thus not supported in the v1/chat/completions endpoint.",
+          type: "invalid_request_error",
+          param: "model",
+          code: null,
+        },
+      }, 404))
+      .mockResolvedValueOnce(jsonResponse({
+        id: "resp_test",
+        object: "response",
+      }, 200));
+
+    const executor = new DefaultExecutor("openai");
+    const result = await executor.execute({
+      model: "gpt-5.3-codex",
+      body: {
+        model: "gpt-5.3-codex",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      stream: true,
+      credentials: { apiKey: "test-key" },
+      signal: undefined,
+      log: null,
+      proxyOptions: null,
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(proxyAwareFetch.mock.calls[1][0]).toContain("/responses");
+
+    const secondBody = JSON.parse(proxyAwareFetch.mock.calls[1][1].body);
+    expect(secondBody.input).toBeDefined();
+    expect(result.response.status).toBe(200);
+  });
+
+  it("handles gpt-5.3-codex sequence: unknown max_tokens then non-chat fallback", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({
+        error: {
+          message: "Unknown parameter: 'max_tokens'.",
+          type: "invalid_request_error",
+          param: "max_tokens",
+          code: "unknown_parameter",
+        },
+      }, 400))
+      .mockResolvedValueOnce(jsonResponse({
+        error: {
+          message: "This is not a chat model and thus not supported in the v1/chat/completions endpoint.",
+          type: "invalid_request_error",
+          param: "model",
+          code: null,
+        },
+      }, 404))
+      .mockResolvedValueOnce(jsonResponse({
+        id: "resp_codex",
+        object: "response",
+      }, 200));
+
+    const executor = new DefaultExecutor("openai");
+    const result = await executor.execute({
+      model: "gpt-5.3-codex",
+      body: {
+        model: "gpt-5.3-codex",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 16,
+      },
+      stream: true,
+      credentials: { apiKey: "test-key" },
+      signal: undefined,
+      log: null,
+      proxyOptions: null,
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(3);
+
+    const secondBody = JSON.parse(proxyAwareFetch.mock.calls[1][1].body);
+    expect(secondBody.max_tokens).toBeUndefined();
+    expect(secondBody.max_completion_tokens).toBe(16);
+
+    expect(proxyAwareFetch.mock.calls[2][0]).toContain("/responses");
+    const thirdBody = JSON.parse(proxyAwareFetch.mock.calls[2][1].body);
+    expect(thirdBody.max_tokens).toBeUndefined();
+    expect(thirdBody.max_output_tokens).toBe(16);
+    expect(result.response.status).toBe(200);
+  });
+
+  it("falls back to /responses when chat endpoint says use /v1/responses", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({
+        error: {
+          message: "Function tools with reasoning_effort are not supported for gpt-5.4 in /v1/chat/completions. Please use /v1/responses instead.",
+          type: "invalid_request_error",
+          param: "reasoning_effort",
+          code: null,
+        },
+      }, 400))
+      .mockResolvedValueOnce(jsonResponse({
+        id: "resp_gpt54",
+        object: "response",
+      }, 200));
+
+    const executor = new DefaultExecutor("openai");
+    const result = await executor.execute({
+      model: "gpt-5.4",
+      body: {
+        model: "gpt-5.4",
+        messages: [{ role: "user", content: "hi" }],
+        reasoning_effort: "medium",
+        tools: [{ type: "function", function: { name: "x", parameters: { type: "object", properties: {} } } }],
+      },
+      stream: true,
+      credentials: { apiKey: "test-key" },
+      signal: undefined,
+      log: null,
+      proxyOptions: null,
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(proxyAwareFetch.mock.calls[1][0]).toContain("/responses");
+    expect(result.response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add OpenAI executor compatibility rewrite from `max_tokens` to `max_completion_tokens` for gpt-5/o1/o3/o4 families
- retry once on both `unsupported_parameter` and `unknown_parameter` token errors
- add automatic fallback from `/v1/chat/completions` to `/v1/responses` when upstream indicates chat endpoint is unsupported or explicitly requests responses
- normalize responses request token limit to `max_output_tokens`

## Tests
- `npx vitest run unit/default-openai-token-compat.test.js --reporter=verbose`
- `npx vitest run unit/reasoningContentInjector.test.js --reporter=verbose`
