### PR TITLE
fix(codex): normalize max reasoning effort

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -116,6 +116,10 @@ function resolveCacheSessionId(body, credentials) {
   });
 }
 
+function normalizeReasoningEffort(value) {
+  return value === "max" ? "xhigh" : value;
+}
+
 /**
  * Codex Executor - handles OpenAI Codex API (Responses API format)
  * Automatically injects default instructions if missing
@@ -347,7 +351,7 @@ export class CodexExecutor extends BaseExecutor {
 
     // Extract thinking level from model name suffix
     // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → medium (default)
-    const effortLevels = ['none', 'low', 'medium', 'high', 'xhigh'];
+    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
     let modelEffort = null;
     for (const level of effortLevels) {
       if (body.model.endsWith(`-${level}`)) {
@@ -360,10 +364,11 @@ export class CodexExecutor extends BaseExecutor {
 
     // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (medium)
     if (!body.reasoning) {
-      const effort = body.reasoning_effort || modelEffort || 'low';
+      const effort = normalizeReasoningEffort(body.reasoning_effort || modelEffort || 'low');
       body.reasoning = { effort, summary: "auto" };
-    } else if (!body.reasoning.summary) {
-      body.reasoning.summary = "auto";
+    } else {
+      body.reasoning.effort = normalizeReasoningEffort(body.reasoning.effort);
+      if (!body.reasoning.summary) body.reasoning.summary = "auto";
     }
     delete body.reasoning_effort;
 

--- a/tests/unit/codex-reasoning-effort.test.mjs
+++ b/tests/unit/codex-reasoning-effort.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+const executor = new CodexExecutor();
+
+const topLevel = executor.transformRequest(
+  "gpt-5.5",
+  { model: "gpt-5.5", input: "hi", reasoning_effort: "max" },
+  true,
+  { connectionId: "conn_1", providerSpecificData: {} },
+);
+
+assert.equal(topLevel.reasoning.effort, "xhigh");
+
+const nested = executor.transformRequest(
+  "gpt-5.5",
+  { model: "gpt-5.5", input: "hi", reasoning: { effort: "max" } },
+  true,
+  { connectionId: "conn_1", providerSpecificData: {} },
+);
+
+assert.equal(nested.reasoning.effort, "xhigh");
+assert.equal(nested.reasoning.summary, "auto");
+console.log("codex-reasoning-effort ok");


### PR DESCRIPTION
## Summary
- maps Codex reasoning effort max to xhigh in the Codex executor only
- preserves nested reasoning.effort and adds missing summary auto
- leaves provider-native max support for other providers untouched

## Checks
- direct Codex transform assertion for top-level and nested max
- git diff --check