### PR TITLE
fix(codex): normalize fast service tier

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -391,6 +391,9 @@ export class CodexExecutor extends BaseExecutor {
     delete body.safety_identifier; // Droid CLI sends this but Codex doesn't support it
     delete body.previous_response_id; // store=false → backend can't resolve previous resp; avoid 404
 
+    if (body.service_tier === "fast") body.service_tier = "priority";
+    if (body.service_tier && body.service_tier !== "priority") delete body.service_tier;
+
     // Final allowlist filter — strip any unknown field that could trigger upstream "routing_unsupported"
     for (const k of Object.keys(body)) {
       if (!RESPONSES_API_ALLOWLIST.has(k)) delete body[k];

--- a/tests/unit/codex-service-tier.test.mjs
+++ b/tests/unit/codex-service-tier.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+const executor = new CodexExecutor();
+const body = executor.transformRequest(
+  "gpt-5.5",
+  { model: "gpt-5.5", input: "hi", service_tier: "fast" },
+  true,
+  { connectionId: "conn_1", providerSpecificData: {} },
+);
+
+assert.equal(body.service_tier, "priority");
+
+const unsupported = executor.transformRequest(
+  "gpt-5.5",
+  { model: "gpt-5.5", input: "hi", service_tier: "flex" },
+  true,
+  { connectionId: "conn_1", providerSpecificData: {} },
+);
+
+assert.equal(unsupported.service_tier, undefined);
+console.log("codex-service-tier ok");


### PR DESCRIPTION
## Summary
- maps Codex service_tier fast to upstream priority
- strips unsupported Codex service_tier values before request forwarding

## Checks
- direct Codex transform assertion for fast and unsupported tiers
- git diff --check