### PR TITLE
fix(codex): treat OpenAI 401/token_expired as permanent refresh failure (re-auth, not retry)

### DIFF
--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -288,12 +288,22 @@ export function classifyOAuthRefreshError(errorText = "", status = 0) {
   const code = parsed?.error?.code || parsed?.error || parsed?.error_code || "";
   const description = parsed?.error_description || parsed?.message || errorText || "";
   const combined = `${code} ${description}`.toLowerCase();
-  const permanent = [
+  const markerPermanent = [
     "refresh_token_expired",
     "refresh_token_reused",
     "refresh_token_invalidated",
     "invalid_grant",
+    // OpenAI's token endpoint returns HTTP 401
+    // {error:{code:"token_expired", type:"invalid_request_error"}} for a dead/invalid
+    // (rotated-away or expired) refresh token. None of the markers above match
+    // "token_expired", so it was classified as transient and retried instead of
+    // surfacing re-authentication.
+    "token_expired",
+    "could not validate your token",
   ].some((marker) => combined.includes(marker));
+  // A 401 from the OAuth token endpoint means the refresh credential itself was
+  // rejected -> re-authenticate, never retry. (429 / 5xx remain transient.)
+  const permanent = status === 401 || markerPermanent;
 
   return { status, code, description, permanent };
 }


### PR DESCRIPTION
## Problem

When a Codex (OpenAI) OAuth refresh token is dead/invalid (expired or rotated away), OpenAI's token endpoint responds:

```
HTTP 401
{ "error": { "message": "Could not validate your token. Please try signing in again.",
             "type": "invalid_request_error", "code": "token_expired" } }
```

`classifyOAuthRefreshError()` only treats these as permanent: `refresh_token_expired`, `refresh_token_reused`, `refresh_token_invalidated`, `invalid_grant`. None match OpenAI's actual `token_expired` code, so the failure is classified **transient**. `refreshCodexToken()` then returns `null` instead of `{ error: "unrecoverable_refresh_error" }`, so the caller **retries** the refresh (with backoff) instead of surfacing re-authentication — a retry loop that cannot succeed against a dead refresh token.

## Reproduction

POST an invalid/expired refresh token to `https://auth.openai.com/oauth/token` and observe the real `401 token_expired` payload above; running it through `classifyOAuthRefreshError` returns `permanent: false`.

## Fix

- Add `token_expired` (and the "could not validate your token" message) to the permanent markers.
- Treat **any 401 from the OAuth token endpoint as permanent** — a 401 there means the refresh credential itself was rejected, so re-auth is the only correct outcome. `429`/`5xx` remain transient.

Single-file change to `classifyOAuthRefreshError`; no behavior change for the existing markers. Verified the real OpenAI `401 token_expired` payload now classifies as permanent → `unrecoverable_refresh_error` (re-auth).
