### PR TITLE
fix: refresh Kiro model discovery on invalid bearer token

### DIFF
--- a/open-sse/services/kiroModels.js
+++ b/open-sse/services/kiroModels.js
@@ -156,6 +156,14 @@ function formatDisplayName(modelName, modelId, rateMultiplier) {
  * Fetch the raw model catalog from Kiro. Returns the array under `.models`
  * from the API response, or throws on network/HTTP error.
  */
+function isRefreshableAuthError(err) {
+  if (!err) return false;
+  if (err.status === 401) return true;
+  if (err.status !== 403) return false;
+  const body = String(err.body || err.message || "").toLowerCase();
+  return body.includes("bearer token") && body.includes("invalid");
+}
+
 async function fetchKiroCatalogRaw(credentials, signal) {
   const profileArn = credentials?.providerSpecificData?.profileArn || "";
   const region = regionFromProfileArn(profileArn);
@@ -252,8 +260,8 @@ export async function resolveKiroModels(credentials, options = {}) {
   try {
     raw = await fetchKiroCatalogRaw(credentials, options.signal);
   } catch (err) {
-    if (err && err.status === 401 && credentials.refreshToken) {
-      options.log?.info?.("KIRO_MODELS", "Got 401 from Kiro; refreshing token");
+    if (isRefreshableAuthError(err) && credentials.refreshToken) {
+      options.log?.info?.("KIRO_MODELS", `Got ${err.status} auth failure from Kiro; refreshing token`);
       const refreshed = await refreshKiroToken(
         credentials.refreshToken,
         credentials.providerSpecificData,

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -7,6 +7,7 @@ import {
 } from "@/shared/constants/providers";
 import { getProviderConnections, getCombos, getCustomModels, getModelAliases } from "@/lib/localDb";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
+import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 
@@ -19,7 +20,25 @@ const LIVE_MODEL_RESOLVERS = {
       accessToken: conn.accessToken,
       refreshToken: conn.refreshToken,
       providerSpecificData: conn.providerSpecificData || {}
-    }, { log: console });
+    }, {
+      log: console,
+      onCredentialsRefreshed: async (refreshed) => {
+        if (!refreshed?.accessToken || !conn.id) return;
+        await updateProviderCredentials(conn.id, {
+          ...refreshed,
+          existingProviderSpecificData: conn.providerSpecificData || {},
+          testStatus: "active",
+        });
+        conn.accessToken = refreshed.accessToken;
+        if (refreshed.refreshToken) conn.refreshToken = refreshed.refreshToken;
+        if (refreshed.providerSpecificData) {
+          conn.providerSpecificData = {
+            ...(conn.providerSpecificData || {}),
+            ...refreshed.providerSpecificData,
+          };
+        }
+      }
+    });
     return result?.models?.length ? { models: result.models } : null;
   },
   qoder: async (conn) => {


### PR DESCRIPTION
## Summary

- Treat Kiro `ListAvailableModels` 403 responses that say the bearer token is invalid as refreshable auth failures.
- Persist refreshed Kiro credentials from `/api/v1/models` live model discovery so subsequent model-list requests use the fresh token.

## Why

Kiro sometimes returns HTTP 403 with `The bearer token included in the request is invalid` instead of HTTP 401 when the access token has expired or is no longer accepted. The existing model discovery refresh path only handled 401, so `/api/v1/models` could keep logging the same failure and fall back to static models even when a refresh token was available.

## Testing

- `node --check open-sse/services/kiroModels.js`
- `node --check src/app/api/v1/models/route.js`
- `pnpm exec next build --webpack`

Opened as draft because this is a focused auth-refresh behavior change and may benefit from maintainer confirmation against a live Kiro account.
