### PR TITLE
fix: preserve Antigravity tool property names

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.js
+++ b/open-sse/translator/helpers/geminiHelper.js
@@ -119,9 +119,12 @@ export function generateProjectId() {
   return `${adj}-${noun}-${crypto.randomUUID().slice(0, 5)}`;
 }
 
-// Helper: Remove unsupported keywords recursively from object/array
-// Also strips all vendor extension fields (x- prefixed) not supported by Gemini
-function removeUnsupportedKeywords(obj, keywords) {
+// Helper: Remove unsupported schema keywords recursively from object/array.
+// Keys inside a JSON Schema `properties` map are user-defined parameter names,
+// not schema keywords. Preserve them even when they are named `pattern`,
+// `default`, etc., and only clean the schema nested under each parameter.
+// Also strips all vendor extension fields (x- prefixed) not supported by Gemini.
+function removeUnsupportedKeywords(obj, keywords, context = {}) {
   if (!obj || typeof obj !== "object") return;
 
   if (Array.isArray(obj)) {
@@ -132,12 +135,25 @@ function removeUnsupportedKeywords(obj, keywords) {
   }
 
   for (const key of Object.keys(obj)) {
+    const value = obj[key];
+
+    if (context.inPropertiesMap) {
+      if (value && typeof value === "object") {
+        removeUnsupportedKeywords(value, keywords);
+      }
+      continue;
+    }
+
     if (keywords.includes(key) || key.startsWith("x-")) {
       delete obj[key];
       continue;
     }
 
-    const value = obj[key];
+    if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+      removeUnsupportedKeywords(value, keywords, { inPropertiesMap: true });
+      continue;
+    }
+
     if (value && typeof value === "object") {
       removeUnsupportedKeywords(value, keywords);
     }
@@ -369,4 +385,3 @@ export function cleanJSONSchemaForAntigravity(schema) {
 
   return cleaned;
 }
-

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -3,9 +3,52 @@ import { describe, it, expect } from "vitest";
 import "./registerAll.js";
 import { translateRequest } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
 
 const AG2O = (req) =>
   translateRequest(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, "m", { request: req }, true, null, null);
+
+const O2AG = (body) =>
+  translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.ANTIGRAVITY,
+    "gemini-3-flash",
+    body,
+    true,
+    { email: "test@example.com", connectionId: "test-conn" },
+    "antigravity"
+  );
+
+const opencodeGrepTool = () => ({
+  type: "function",
+  function: {
+    name: "grep",
+    description: "Search content",
+    parameters: {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        pattern: {
+          type: "string",
+          description: "The regex pattern to search for in file contents",
+        },
+        path: {
+          type: "string",
+          description: "The directory to search in",
+        },
+        include: {
+          type: "string",
+          description: "Optional file include pattern",
+          pattern: "\\\\.js$",
+        },
+      },
+      required: ["pattern"],
+    },
+  },
+});
+
+const firstFunctionParameters = (body) =>
+  body.request.tools[0].functionDeclarations[0].parameters;
 
 describe("Antigravity → OpenAI", () => {
   // antigravity-to-openai.js:177-189 — content with BOTH functionResponse and functionCall/text
@@ -50,5 +93,35 @@ describe("Antigravity → OpenAI", () => {
       ? content.some((c) => c.type === "text" && c.text === "")
       : content === "";
     expect(hasEmpty, "empty text part emitted").toBe(false);
+  });
+});
+
+describe("OpenAI → Antigravity", () => {
+  it("preserves OpenCode grep/glob parameter named pattern", () => {
+    const out = O2AG({
+      messages: [{ role: "user", content: "Search for TODO comments" }],
+      tools: [opencodeGrepTool()],
+    });
+    const parameters = firstFunctionParameters(out);
+
+    expect(parameters.properties.pattern?.type).toBe("string");
+    expect(parameters.required).toContain("pattern");
+    expect(parameters.properties.include?.pattern).toBeUndefined();
+  });
+
+  it("keeps required pattern after Antigravity executor sanitizes tools again", () => {
+    const translated = O2AG({
+      messages: [{ role: "user", content: "Search for TODO comments" }],
+      tools: [opencodeGrepTool()],
+    });
+    const executor = new AntigravityExecutor();
+    const finalBody = executor.transformRequest("gemini-3-flash", translated, true, {
+      email: "test@example.com",
+      connectionId: "test-conn",
+    });
+    const parameters = firstFunctionParameters(finalBody);
+
+    expect(parameters.properties.pattern?.type).toBe("string");
+    expect(parameters.required).toContain("pattern");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1368.

OpenCode sends tools such as `grep`/`glob` with a required parameter named `pattern`. The Antigravity schema cleaner treated every key named `pattern` as an unsupported JSON Schema keyword, including parameter names under `properties`, so it removed `properties.pattern`. The later required-field cleanup then removed `required: ["pattern"]` too.

This patch preserves user-defined parameter names inside JSON Schema `properties` maps while still removing unsupported schema constraints from each property's nested schema.

## What changed

- Preserve property names under `properties`, including `pattern`, `default`, or other names that can also be JSON Schema keywords.
- Continue removing unsupported constraints such as a nested string schema's regex `pattern`.
- Add regression coverage for the OpenCode `grep` shape through:
  - `OpenAI -> Antigravity` request translation
  - the Antigravity executor's second schema sanitization pass

## Relation to #1383

This is a smaller targeted fix for the OpenCode/Antigravity path in #1368. The important path for OpenCode using `ag/gemini-*` is `OpenAI -> Antigravity` plus the executor's final sanitization pass; this PR covers both with tests.

## Validation

```bash
npx vitest run --config tests/vitest.config.js tests/translator/bugs-antigravity.test.js
# Test Files 1 passed (1)
# Tests 3 passed | 2 expected fail (5)

npx vitest run --config tests/vitest.config.js tests/translator/
# Test Files 9 passed | 1 skipped (10)
# Tests 123 passed | 21 expected fail | 1 skipped (145)
```
