### PR TITLE
fix: bump better-sqlite3 to 12.10.1 for Node 26 compatibility

### DIFF
--- a/cli/hooks/sqliteRuntime.js
+++ b/cli/hooks/sqliteRuntime.js
@@ -6,7 +6,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
-const BETTER_SQLITE3_VERSION = "12.6.2";
+const BETTER_SQLITE3_VERSION = "12.10.1";
 
 function getDataDir() {
   if (process.env.DATA_DIR) return process.env.DATA_DIR;


### PR DESCRIPTION
@
## Summary

Fixes #1812 — `better-sqlite3@12.6.2` does not support Node 26.x, causing a server crash loop on startup.

## Problem

`better-sqlite3@12.6.2` `engines` field is `20.x || 22.x || 23.x || 24.x || 25.x`. On Node 26.x, the native binding fails to load:

```
[DB] better-sqlite3 unavailable: Could not locate the bindings file.
⚠️  Server exited (code=unknown). Restarting in 1s... (1/2)
```

## Fix

One-line change in `cli/hooks/sqliteRuntime.js`: bump `BETTER_SQLITE3_VERSION` from `12.6.2` to `12.10.1`, which adds prebuilt binaries for Node 26 (ABI 147).

## Verification

- `better-sqlite3@12.10.1` ships prebuilt binaries for Node 26
- The `package.json` optionalDependency range `^12.6.2` already covers `12.10.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@