### PR TITLE
fix: strip temperature for Anthropic models that reject it (claude-opus-4)

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -11,12 +11,25 @@ export class DefaultExecutor extends BaseExecutor {
     super(provider, PROVIDERS[provider] || PROVIDERS.openai);
   }
 
+  // Anthropic models that reject the deprecated `temperature` parameter
+  supportsTemperature(model) {
+    if (!model) return true;
+    // claude-opus-4 series: temperature is deprecated
+    if (/claude-opus-4/i.test(model)) return false;
+    return true;
+  }
+
   transformRequest(model, body) {
     const transformed = this.applyJsonSchemaFallback(body);
 
     if (transformed && typeof transformed === "object") {
       if (this.provider === "cerebras" || this.provider === "mistral") {
         delete transformed.client_metadata;
+      }
+
+      // Strip temperature for models that reject it (e.g. claude-opus-4)
+      if (!this.supportsTemperature(model) && transformed.temperature !== undefined) {
+        delete transformed.temperature;
       }
     }
 


### PR DESCRIPTION
@
## Summary

Fixes #1748 — the `temperature` parameter is deprecated for newer Anthropic models (`claude-opus-4`, `claude-opus-4-8`, etc.), causing HTTP 400:

```
"temperature is deprecated for this model."
```

## Fix

`DefaultExecutor` now strips `temperature` from the request body for `claude-opus-4` series models, following the same `supportsTemperature()` pattern already used in `GithubExecutor`.

Only `claude-opus-4*` models are affected. All other models continue to pass `temperature` as before.

## Files changed

- `open-sse/executors/default.js` — add `supportsTemperature()` + stripping in `transformRequest()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@