### PR TITLE
fix: strip optional from Antigravity tool schemas

### DIFF
--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -19,7 +19,7 @@ export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
   // Dependency keywords (not supported)
   "dependencies", "dependentSchemas", "dependentRequired",
   // Other unsupported keywords
-  "title", "if", "then", "else", "contentMediaType", "contentEncoding",
+  "title", "optional", "if", "then", "else", "contentMediaType", "contentEncoding",
   // UI/Styling properties (from Cursor tools - NOT JSON Schema standard)
   "cornerRadius", "fillColor", "fontFamily", "fontSize", "fontWeight",
   "gap", "padding", "strokeColor", "strokeThickness", "textColor"
@@ -375,4 +375,3 @@ export function cleanJSONSchemaForAntigravity(schema) {
 
   return cleaned;
 }
-

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -1,6 +1,7 @@
 // Real Antigravity-MITM requests (Gemini-internal: { request: { contents, ... } }) → OpenAI.
 import { describe, it, expect } from "vitest";
 import "./registerAll.js";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
 import { translateRequest } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 
@@ -50,5 +51,34 @@ describe("Antigravity → OpenAI", () => {
       ? content.some((c) => c.type === "text" && c.text === "")
       : content === "";
     expect(hasEmpty, "empty text part emitted").toBe(false);
+  });
+});
+
+describe("Antigravity executor", () => {
+  it("strips optional from nested tool schemas", () => {
+    const out = new AntigravityExecutor().transformRequest("gemini-2.5-pro", {
+      request: {
+        contents: [{ role: "user", parts: [{ text: "hi" }] }],
+        tools: [{
+          functionDeclarations: [{
+            name: "lookup",
+            description: "Lookup a value",
+            parameters: {
+              type: "object",
+              properties: {
+                query: {
+                  type: "string",
+                  description: "Search query",
+                  optional: true,
+                },
+              },
+            },
+          }],
+        }],
+      },
+    }, true, { projectId: "project-1", connectionId: "conn-1" });
+
+    const query = out.request.tools[0].functionDeclarations[0].parameters.properties.query;
+    expect(query).toEqual({ type: "string", description: "Search query" });
   });
 });


### PR DESCRIPTION
Fixes #1537.

## Summary

This removes the Antigravity-specific `optional` marker from nested tool schemas before forwarding requests to Gemini, matching the existing cleanup path for unsupported schema keywords.

## Tests

```bash
npx vitest run --config tests/vitest.config.js tests/translator/bugs-antigravity.test.js
```

Passed: 1 test file, 3 tests, 1 expected failure.
