### PR TITLE
fix(usage): add missing await on getAdapter() in getRecentLogs

### DIFF
--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -700,7 +700,7 @@ export async function appendRequestLog() {}
 
 export async function getRecentLogs(limit = 200) {
   try {
-    const db = getAdapter();
+    const db = await getAdapter();
     const rows = db.all(
       `SELECT timestamp, provider, model, connectionId, promptTokens, completionTokens, status, tokens FROM usageHistory ORDER BY id DESC LIMIT ?`,
       [limit],


### PR DESCRIPTION
## Summary

`getAdapter()` is an async function. In `getRecentLogs`, it was called without `await`, making `db` a Promise. The subsequent `db.all(...)` call would throw (a Promise has no `.all` method). The outer try/catch silently swallowed the error, returning `[]` — meaning the usage logs endpoints (`/api/usage/logs`, `/api/usage/request-logs`) always returned empty data.

## Fix

Added missing `await` on line 703: `const db = await getAdapter();`

## Verification

- Every other call to `getAdapter()` across the codebase (47 occurrences in 11 files) uses `await`
- The `ensureRingInitialized()` function in the same file (line 103) correctly uses `await getAdapter()`
- SQLite adapter `.all()` methods are synchronous, so no additional `await` is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)