### PR TITLE
fix(commandcode): force params.stream=true for non-streaming requests

### DIFF
--- a/open-sse/executors/commandcode.js
+++ b/open-sse/executors/commandcode.js
@@ -20,7 +20,13 @@ export class CommandCodeExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body, stream, credentials) {
+    // CommandCode API requires stream=true unconditionally.
+    // Set both top-level (OpenAI-format bodies) and params.stream
+    // (CommandCode-native bodies) to cover all code paths.
     body.stream = true;
+    if (body.params) {
+      body.params.stream = true;
+    }
     return body;
   }
 


### PR DESCRIPTION
## Summary

Fixes #1840 — CommandCode handler fails on all non-streaming requests.

## Root Cause

The CommandCode `/alpha/generate` API requires `stream=true` unconditionally. When requests arrive with `stream: false`, the API returns HTTP 400 (`"expected true at params.stream"`) or ECONNRESET.

While `chatCore.js` already forces `stream=true` for the commandcode provider, the executor's `transformRequest` only set `body.stream = true` (top-level field). In already-translated CommandCode-native bodies, the stream flag lives at `body.params.stream`, which was left as `false`.

## Fix

Updated `transformRequest` in `CommandCodeExecutor` to also set `body.params.stream = true` when the body has a `params` wrapper — covering both OpenAI-format and CommandCode-format bodies.

## Testing

The fix is defensive: `params.stream` is set to `true` regardless of which body format arrives at the executor, ensuring the CommandCode API always receives `stream: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)