### PR TITLE
fix(claude-to-openai): handle OpenAI-format responses in non-streaming path

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -76,7 +76,12 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
     // missing/null (e.g. M3 with max_tokens:1 spends the budget on thinking
     // and returns `content: null`). Returning the raw body would leave the
     // OpenAI client without a `choices` array and surface as a UI test error.
-    if (responseBody.content && !Array.isArray(responseBody.content)) return responseBody;
+    // Early return if the response is already in OpenAI format (has choices array)
+    // or if it has content as a non-array value (likely a different non-Claude format).
+    // Some providers (e.g. xiaomi-tokenplan) return OpenAI-format responses even when
+    // the request was translated to Claude format — the targetFormat is Claude but the
+    // actual response is OpenAI-native and needs no further translation.
+    if (responseBody.choices || (responseBody.content && !Array.isArray(responseBody.content))) return responseBody;
 
     let textContent = "", thinkingContent = "";
     const toolCalls = [];
@@ -193,11 +198,14 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     translatedResponse.usage = filterUsageForFormat(addBufferToUsage(translatedResponse.usage), sourceFormat);
   }
 
-  // Strip reasoning_content — some clients (e.g. Firecrawl AI SDK) have JSON parsers that
-  // break on this non-standard field, even though OpenAI allows it in extensions.
+  // Strip reasoning_content only when content is non-empty.
+  // When content is empty (e.g. thinking models that used all tokens for reasoning),
+  // reasoning_content is the only useful output and must be preserved.
   if (translatedResponse?.choices) {
     for (const choice of translatedResponse.choices) {
-      if (choice?.message) delete choice.message.reasoning_content;
+      if (choice?.message?.reasoning_content && choice.message.content) {
+        delete choice.message.reasoning_content;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #1836 — Empty content when provider returns reasoning_content in non-streaming claude-to-openai conversion.

## Root Cause

When a provider (e.g. xiaomi-tokenplan with `-claude` suffix models) returns an OpenAI-format response even though the request was translated to Claude format, the non-streaming response handler failed to recognize it. The early-return check on line 79 only looked for `responseBody.content` as a non-array, missing the case where the response has `choices[0].message.content` (OpenAI format). The handler would then process it as a Claude body, iterating over `responseBody.content || []` (which is `[]`), producing empty content.

## Fixes

### 1. Early return for OpenAI-format responses
Added `responseBody.choices` check to the early-return condition. If the response already has a `choices` array, it's in OpenAI format and needs no further translation.

### 2. Conditional reasoning_content strip
Changed the unconditional `delete choice.message.reasoning_content` to only strip when `choice.message.content` is non-empty. This matches the existing behavior in `sseToJsonHandler.js` and preserves reasoning_content for thinking models where it may be the only output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)