### PR TITLE
feat(provider): add CodeBuddy international provider (www.codebuddy.ai)

### DIFF
--- a/open-sse/executors/codebuddy.js
+++ b/open-sse/executors/codebuddy.js
@@ -1,0 +1,53 @@
+/**
+ * CodeBuddyExecutor — thin shim over DefaultExecutor for www.codebuddy.ai.
+ *
+ * CodeBuddy's /v2/chat/completions is OpenAI-compatible SSE with two constraints:
+ *   1. A `system` message must be present (server returns 11101 without it).
+ *   2. `stream: true` is required (non-stream not supported).
+ *
+ * Constraint #2 is handled by `forceStream: true` in the registry entry.
+ * This executor handles #1 by injecting an empty system message when absent.
+ *
+ * Auth: Bearer ck_* API key (same token also sent as X-API-Key for redundancy,
+ * matching the CLI's dual-header pattern).
+ */
+import { DefaultExecutor } from "./default.js";
+import { PROVIDERS } from "../config/providers.js";
+
+const CODEBUDDY_DEFAULT_SYSTEM = {
+  role: "system",
+  content: "You are a helpful assistant.",
+};
+
+function ensureSystemMessage(body) {
+  if (!body || typeof body !== "object") return body;
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return body;
+  const hasSystem = messages.some((m) => m.role === "system");
+  if (hasSystem) return body;
+  return { ...body, messages: [CODEBUDDY_DEFAULT_SYSTEM, ...messages] };
+}
+
+export class CodeBuddyExecutor extends DefaultExecutor {
+  constructor() {
+    super("codebuddy");
+  }
+
+  transformRequest(model, body, stream, credentials) {
+    // Delegate to base transform (json_schema fallback, reasoning injection, etc.)
+    const transformed = super.transformRequest(model, body, stream, credentials);
+    return ensureSystemMessage(transformed);
+  }
+
+  buildHeaders(credentials, stream = true) {
+    const headers = super.buildHeaders(credentials, stream);
+    // Match CLI dual-header pattern: Authorization + X-API-Key with the same token.
+    // From spike: only Authorization is strictly required, but sending both matches
+    // the CLI fingerprint and avoids potential future auth changes.
+    const token = credentials?.apiKey || credentials?.accessToken || "";
+    if (token && !headers["X-API-Key"]) {
+      headers["X-API-Key"] = token;
+    }
+    return headers;
+  }
+}

--- a/open-sse/executors/index.js
+++ b/open-sse/executors/index.js
@@ -17,6 +17,7 @@ import { OllamaLocalExecutor } from "./ollama-local.js";
 import { CommandCodeExecutor } from "./commandcode.js";
 import { XiaomiTokenplanExecutor } from "./xiaomi-tokenplan.js";
 import { MimoFreeExecutor } from "./mimo-free.js";
+import { CodeBuddyExecutor } from "./codebuddy.js";
 import { DefaultExecutor } from "./default.js";
 
 const executors = {
@@ -42,6 +43,7 @@ const executors = {
   "xiaomi-tokenplan": new XiaomiTokenplanExecutor(),
   "mimo-free": new MimoFreeExecutor(),
   mmf: new MimoFreeExecutor(), // Alias for mimo-free
+  codebuddy: new CodeBuddyExecutor(),
 };
 
 const defaultCache = new Map();
@@ -77,3 +79,4 @@ export { OllamaLocalExecutor } from "./ollama-local.js";
 export { CommandCodeExecutor } from "./commandcode.js";
 export { XiaomiTokenplanExecutor } from "./xiaomi-tokenplan.js";
 export { MimoFreeExecutor } from "./mimo-free.js";
+export { CodeBuddyExecutor } from "./codebuddy.js";

--- a/open-sse/providers/registry/codebuddy.js
+++ b/open-sse/providers/registry/codebuddy.js
@@ -1,32 +1,60 @@
+/**
+ * CodeBuddy — Tencent AI coding assistant (international + China).
+ *
+ * API: POST /v2/chat/completions (OpenAI-compatible SSE).
+ * Auth: Bearer ck_<id>.<secret> (API key from dashboard).
+ * Constraints: system message required; stream:true required.
+ * Models: gpt-5.5, gpt-5.4, claude-sonnet-4.6, gemini-3.1-pro, etc.
+ */
 export default {
   id: "codebuddy",
-  hidden: true,
   priority: 90,
+  category: "apikey",
+  authType: "apikey",
+  authModes: ["apikey", "oauth"],
+
   display: {
     name: "CodeBuddy",
     icon: "smart_toy",
     color: "#006EFF",
-    website: "https://copilot.tencent.com",
+    textIcon: "CB",
+    website: "https://www.codebuddy.ai",
     notice: {
-      signupUrl: "https://copilot.tencent.com",
+      apiKeyUrl: "https://www.codebuddy.ai/console/api-keys",
+      signupUrl: "https://www.codebuddy.ai",
     },
   },
-  category: "oauth",
+
   transport: {
-    baseUrl: "https://copilot.tencent.com/v1/chat/completions",
+    baseUrl: "https://www.codebuddy.ai/v2/chat/completions",
+    format: "openai",
+    forceStream: true,
+    executor: "codebuddy",
     auth: {
       combined: true,
       header: "Authorization",
       scheme: "bearer",
     },
+    headers: {
+      "User-Agent": "CLI/2.106.3 CodeBuddy/2.106.3",
+      "x-codebuddy-request": "1",
+    },
   },
+
   oauth: {
-    baseUrl: "https://copilot.tencent.com",
-    stateUrl: "https://copilot.tencent.com/v2/plugin/auth/state",
-    tokenUrl: "https://copilot.tencent.com/v2/plugin/auth/token",
-    refreshUrl: "https://copilot.tencent.com/v2/plugin/auth/token/refresh",
-    userAgent: "CLI/2.63.2 CodeBuddy/2.63.2",
+    baseUrl: "https://www.codebuddy.ai",
+    stateUrl: "https://www.codebuddy.ai/v2/plugin/auth/state",
+    tokenUrl: "https://www.codebuddy.ai/v2/plugin/auth/token",
+    refreshUrl: "https://www.codebuddy.ai/v2/plugin/auth/token/refresh",
+    userAgent: "CLI/2.106.3 CodeBuddy/2.106.3",
     platform: "CLI",
     pollInterval: 5000,
   },
+
+  models: [
+    { id: "gpt-5.5", name: "GPT-5.5", contextWindow: 128000 },
+    { id: "gpt-5.4", name: "GPT-5.4", contextWindow: 128000 },
+    { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6", contextWindow: 200000 },
+    { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro", contextWindow: 1000000 },
+  ],
 };


### PR DESCRIPTION
## Summary

Adds CodeBuddy (www.codebuddy.ai) as a fully functional provider with API key authentication, enabling users to access GPT-5.5, GPT-5.4, Claude Sonnet 4.6, and Gemini 3.1 Pro through their CodeBuddy subscriptions.

The existing `codebuddy.js` registry entry was `hidden: true` and pointed to `copilot.tencent.com` (China-only). This PR switches it to the international domain, adds models, and exposes it to users.

## Changes

### 1. Registry (`providers/registry/codebuddy.js`)
- Switch baseUrl from `copilot.tencent.com` to `www.codebuddy.ai/v2/chat/completions`
- Change category from `oauth` to `apikey` (API key is the primary auth method)
- Add `forceStream: true` (server requires streaming — rejects non-stream with error 11101)
- Add 4 confirmed-working models: `gpt-5.5`, `gpt-5.4`, `claude-sonnet-4.6`, `gemini-3.1-pro`
- Set `hidden: false` to expose to users
- Keep OAuth config for future device flow support

### 2. Executor (`executors/codebuddy.js`)
Lightweight shim over `DefaultExecutor` (~53 LOC). Two responsibilities:
- **System message injection**: CodeBuddy's API requires a `system` message in the messages array (returns `11101:invalid request` without one). Injects `You are a helpful assistant.` when absent.
- **Dual-header auth**: Sends both `Authorization: Bearer` and `X-API-Key` with the same token, matching the CLI's fingerprint.

### 3. Executor registration (`executors/index.js`)
Import and register `CodeBuddyExecutor` in the executor map.

## API Wire Format

Captured via mitmproxy interception of `codebuddy -p` CLI v2.106.3:

**Request:**
```
POST https://www.codebuddy.ai/v2/chat/completions
Authorization: Bearer ck_<id>.<secret>
Content-Type: application/json

{
  "model": "gpt-5.5",
  "messages": [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Hello"}
  ],
  "stream": true
}
```

**Response (SSE):**
```
data: {"id":"resp_...","model":"gpt-5.5","object":"response","choices":[{"delta":{"content":"Hi"}}]}

data: {"id":"resp_...","choices":[{"delta":{"content":""},"finish_reason":"stop"}],"usage":{"total_tokens":42}}

data: [DONE]
```

## Testing

- ✅ Syntax validation (Node.js ESM import check)
- ✅ Unit tests: system message injection (4/4 pass — inject, no-duplicate, empty-messages, headers)
- ✅ Live smoke test: real API call through executor → HTTP 200 → reconstructed "PONG"
- ✅ Verified with `ck_*` API key from active CodeBuddy account

## API Key Setup

Users obtain API keys from: https://www.codebuddy.ai/console/api-keys

Key format: `ck_<id>.<secret>`

Add as API key connection in 9router dashboard → Providers → CodeBuddy.

## Constraints (documented in executor JSDoc)

1. **System message required**: Server returns `{"code":11101,"msg":"Parse message failed: 11101:invalid request"}` without it. Handled by `ensureSystemMessage()` in the executor.
2. **Stream-only**: `stream: false` returns `{"code":11101,"msg":"Non-stream chat request is currently not supported"}`. Handled by `forceStream: true` in registry.

## Not in scope (future PRs)
- Device flow OAuth (`/v2/plugin/auth/state` + `/v2/plugin/auth/token`)
- Live model discovery via dashboard API
- Tool calling validation (presumably zero-effort since OpenAI format, not yet tested)
- Vision/image input support

---

*Closes #<issue if exists>*