### PR TITLE
fix: show custom models in LLM selector

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -51,6 +51,21 @@ export const DEFAULT_CAPABILITIES = {
   maxOutput: 64000,
 };
 
+// User-added model metadata can carry dashboard service kinds instead of the
+// runtime capability names used here. Map those typed model kinds into input /
+// output capabilities so custom vision models are not treated as text-only.
+const SERVICE_KIND_CAPABILITIES = {
+  imageToText: { vision: true },
+  image: { imageOutput: true },
+  stt: { audioInput: true },
+  tts: { audioOutput: true },
+  embedding: { tools: false },
+};
+
+export function capabilitiesFromServiceKind(kind) {
+  return SERVICE_KIND_CAPABILITIES[kind] || null;
+}
+
 /**
  * Canonical exact-id overrides — used for exceptions that patterns would
  * otherwise mis-match. Only declare deltas vs DEFAULT.

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -9,6 +9,7 @@ import { getProviderConnections, getCombos, getCustomModels, getModelAliases } f
 import { getDisabledModels } from "@/lib/disabledModelsDb";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
+import { capabilitiesFromServiceKind } from "open-sse/providers/capabilities.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -314,13 +315,22 @@ export async function buildModelsList(kindFilter) {
         })
         .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
 
+      const customModelKindById = new Map();
       const customModelIds = customModels
         .filter((m) => {
-          if (!m?.id || (getModelKind(m) && getModelKind(m) !== "llm")) return false;
+          if (!m?.id) return false;
+          const kind = getModelKind(m) || LLM_KIND;
+          // imageToText custom models are vision-capable chat models: expose them
+          // both in the default LLM list and in /v1/models/image-to-text.
+          if (!kindFilter.includes(kind) && !(kind === "imageToText" && kindFilter.includes(LLM_KIND))) return false;
           const alias = m.providerAlias;
           return alias === staticAlias || alias === outputAlias || alias === providerId;
         })
-        .map((m) => String(m.id).trim())
+        .map((m) => {
+          const modelId = String(m.id).trim();
+          if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
+          return modelId;
+        })
         .filter((modelId) => modelId !== "");
 
       const aliasModelIds = Object.values(modelAliases || {})
@@ -349,16 +359,20 @@ export async function buildModelsList(kindFilter) {
       const mergedModelIds = Array.from(new Set([...modelIds, ...customModelIds, ...aliasModelIds]));
 
       for (const modelId of mergedModelIds) {
-        // Resolve kind: prefer static metadata, otherwise infer from ID heuristics
-        const kind = staticModelKindById.get(modelId) || inferKindFromUnknownModelId(modelId);
+        // Resolve kind: prefer static/custom metadata, otherwise infer from ID heuristics
+        const customKind = customModelKindById.get(modelId);
+        const kind = staticModelKindById.get(modelId) || customKind || inferKindFromUnknownModelId(modelId);
         if (!kindFilter.includes(kind)) continue;
         if (isDisabled(outputAlias, modelId) || isDisabled(staticAlias, modelId)) continue;
 
-        models.push({
+        const model = {
           id: `${outputAlias}/${modelId}`,
           object: "model",
           owned_by: outputAlias,
-        });
+        };
+        const caps = capabilitiesFromServiceKind(customKind);
+        if (caps) model.capabilities = caps;
+        models.push(model);
       }
 
       // Web search/fetch — provider IS the model, expose as {alias}/search and/or {alias}/fetch with explicit kind

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -128,7 +128,10 @@ export default function ModelSelectModal({
 
     // Filter a models[] array by kindFilter (keep only matching kind)
     const filterByKind = (models) => {
-      if (!kindFilter) return models.filter((m) => m.isPlaceholder || !getModelKind(m) || getModelKind(m) === "llm");
+      // No kindFilter means the LLM selector. Keep custom models visible because
+      // user-added models may have typed capabilities (for example imageToText)
+      // while still being valid chat/combo targets.
+      if (!kindFilter) return models.filter((m) => m.isPlaceholder || m.isCustom || !getModelKind(m) || getModelKind(m) === "llm");
       if (!TYPED_KINDS.has(kindFilter)) return models;
       return models.filter((m) => m.isPlaceholder || getModelKind(m) === kindFilter);
     };

--- a/tests/unit/capabilities-service-kind.test.js
+++ b/tests/unit/capabilities-service-kind.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { capabilitiesFromServiceKind } from "../../open-sse/providers/capabilities.js";
+
+describe("capabilitiesFromServiceKind", () => {
+  it("maps imageToText custom models to vision-capable runtime models", () => {
+    expect(capabilitiesFromServiceKind("imageToText")).toMatchObject({ vision: true });
+  });
+
+  it("maps media output/input custom model kinds to runtime capabilities", () => {
+    expect(capabilitiesFromServiceKind("image")).toMatchObject({ imageOutput: true });
+    expect(capabilitiesFromServiceKind("stt")).toMatchObject({ audioInput: true });
+    expect(capabilitiesFromServiceKind("tts")).toMatchObject({ audioOutput: true });
+  });
+});


### PR DESCRIPTION
## Description
Fixes selector/model-list handling for user-added custom models, including vision-capable custom models typed as `imageToText`.

## Changes
- Keep custom user-added models visible in the default LLM selector/model list when appropriate.
- Expose custom `imageToText` models in the default `/v1/models` list because they are vision-capable chat models.
- Preserve typed filtering for `/v1/models/{kind}` (`image`, `tts`, `stt`, `embedding`, `image-to-text`, `web`).
- Map custom model service kinds to runtime capabilities, e.g. `imageToText` → `vision`.

## Verification
- `npx vitest run tests/unit/capabilities-service-kind.test.js`
- `npm run build`

Related to #1855

Note: the issue discussion also mentions image fallback for vision models not processing images. This PR improves selector/model-list/capability exposure for custom vision models, but does not claim to fully cover every runtime fallback/translator path.
