### PR TITLE
fix(combo/fusion): strip tools and messages history in panel expert calls to prevent 503

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -468,8 +468,32 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
   // 1. Fan out to the panel in parallel: non-streaming, tools stripped (we want prose).
   const { tools, tool_choice, ...rest } = body;
   const panelBody = { ...rest, stream: false };
+
+  // Strip tool history from messages so models don't get tempted to emit tool_calls.
+  if (Array.isArray(panelBody.messages)) {
+    panelBody.messages = panelBody.messages
+      .filter((msg) => msg && msg.role !== "tool" && msg.role !== "function")
+      .map((msg) => {
+        if (msg.role === "assistant" && msg.tool_calls) {
+          const { tool_calls, ...cleanMsg } = msg;
+          return cleanMsg;
+        }
+        return msg;
+      });
+  } else if (Array.isArray(panelBody.input)) {
+    panelBody.input = panelBody.input
+      .filter((msg) => msg && msg.role !== "tool" && msg.role !== "function")
+      .map((msg) => {
+        if (msg.role === "assistant" && msg.tool_calls) {
+          const { tool_calls, ...cleanMsg } = msg;
+          return cleanMsg;
+        }
+        return msg;
+      });
+  }
+
   const t0 = Date.now();
-  const calls = panel.map((m) => withTimeout(handleSingleModel(panelBody, m), cfg.panelHardTimeoutMs));
+  const calls = panel.map((m) => withTimeout(handleSingleModel(panelBody, m, true), cfg.panelHardTimeoutMs));
   const settled = await collectPanel(calls, { ...cfg, minPanel });
   log.info("FUSION", `fan-out collected in ${Date.now() - t0}ms`);
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -102,7 +102,14 @@ export async function handleChat(request, clientRawRequest = null) {
       return handleFusionChat({
         body,
         models: comboModels,
-        handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
+        handleSingleModel: (b, m, isPanel) => {
+          let cleanRawReq = clientRawRequest;
+          if (isPanel && clientRawRequest) {
+            const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
+            cleanRawReq = { ...clientRawRequest, body: cleanBody };
+          }
+          return handleSingleModelChat(b, m, cleanRawReq, cleanRawReq ? null : request, apiKey);
+        },
         log,
         comboName: modelStr,
         judgeModel: comboStrategies[modelStr]?.judgeModel,
@@ -148,7 +155,14 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         return handleFusionChat({
           body,
           models: comboModels,
-          handleSingleModel: (b, m) => handleSingleModelChat(b, m, clientRawRequest, request, apiKey),
+          handleSingleModel: (b, m, isPanel) => {
+            let cleanRawReq = clientRawRequest;
+            if (isPanel && clientRawRequest) {
+              const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
+              cleanRawReq = { ...clientRawRequest, body: cleanBody };
+            }
+            return handleSingleModelChat(b, m, cleanRawReq, cleanRawReq ? null : request, apiKey);
+          },
           log,
           comboName: modelStr,
           judgeModel: comboStrategies[modelStr]?.judgeModel,

--- a/tests/unit/combo-fusion.test.js
+++ b/tests/unit/combo-fusion.test.js
@@ -32,7 +32,7 @@ describe("fusion combo", () => {
 
   it("fans out to the panel then routes a synthesis turn to the judge", async () => {
     const seen = [];
-    const handleSingleModel = vi.fn(async (body, model) => {
+    const handleSingleModel = vi.fn(async (body, model, isPanel) => {
       seen.push(model);
       if (model === "p/judge") return okResponse("FINAL");
       return okResponse(`ans-${model}`);
@@ -52,19 +52,21 @@ describe("fusion combo", () => {
     expect(seen[3]).toBe("p/judge");
 
     // Panel calls are non-streaming with tools stripped.
-    for (const [body, model] of handleSingleModel.mock.calls.filter(([, m]) => m !== "p/judge")) {
+    for (const [body, model, isPanel] of handleSingleModel.mock.calls.filter(([, m]) => m !== "p/judge")) {
       expect(body.stream).toBe(false);
       expect(body.tools).toBeUndefined();
+      expect(isPanel).toBe(true);
     }
 
     // Judge call carries every panel answer + keeps the client's stream flag.
-    const [judgeBody] = handleSingleModel.mock.calls.find(([, m]) => m === "p/judge");
+    const [judgeBody, , isPanel] = handleSingleModel.mock.calls.find(([, m]) => m === "p/judge");
     const judgeText = judgeBody.messages.at(-1).content;
     expect(judgeText).toContain("ans-p/a");
     expect(judgeText).toContain("ans-p/b");
     expect(judgeText).toContain("ans-p/c");
     expect(judgeText).toContain("Source 1");
     expect(judgeBody.stream).toBe(true);
+    expect(isPanel).toBeUndefined();
 
     expect(res.ok).toBe(true);
   });
@@ -138,5 +140,42 @@ describe("fusion combo", () => {
       tuning: { minPanel: 2, stragglerGraceMs: 50, panelHardTimeoutMs: 5000 },
     });
     expect(res.status).toBe(503);
+  });
+
+  it("strips previous tool history and assistant tool_calls from panel calls", async () => {
+    const handleSingleModel = vi.fn(async () => okResponse("ans"));
+    await handleFusionChat({
+      body: {
+        messages: [
+          { role: "user", content: "find files" },
+          { role: "assistant", content: "", tool_calls: [{ id: "c1", type: "function", function: { name: "find" } }] },
+          { role: "tool", tool_call_id: "c1", content: "['a.js']" },
+          { role: "user", content: "describe it" }
+        ],
+        tools: [{ type: "function" }]
+      },
+      models: ["p/a", "p/b"],
+      handleSingleModel,
+      log,
+      judgeModel: "p/judge"
+    });
+
+    // Verify panel calls have clean history by filtering for the third 'isPanel' argument
+    const panelCalls = handleSingleModel.mock.calls.filter(([,, isPanel]) => isPanel === true);
+    expect(panelCalls.length).toBe(2);
+    for (const [panelBody] of panelCalls) {
+      expect(panelBody.messages.length).toBe(3);
+      expect(panelBody.messages[0]).toEqual({ role: "user", content: "find files" });
+      expect(panelBody.messages[1]).toEqual({ role: "assistant", content: "" }); // tool_calls property is stripped!
+      expect(panelBody.messages[2]).toEqual({ role: "user", content: "describe it" });
+    }
+
+    // Verify judge call receives unmodified messages history + synthesis prompt
+    const judgeCall = handleSingleModel.mock.calls.find(([, m]) => m === "p/judge");
+    expect(judgeCall).toBeDefined();
+    const judgeBody = judgeCall[0];
+    expect(judgeBody.messages.length).toBe(5); // original 4 + judge prompt turn
+    expect(judgeBody.messages[1].tool_calls).toBeDefined();
+    expect(judgeBody.messages[2].role).toBe("tool");
   });
 });


### PR DESCRIPTION
Closes #1858

## Summary

When using the `fusion` strategy, the panel expert models must be executed in a prose-only sandbox. If the original request contains `tools` or previous `tool_calls` / `role: tool` messages in the history, agentic panel models (such as gemini-3.5-flash-agent, MiniMax-M3) keep executing tool loops and emit `tool_calls` instead of prose. `extractPanelText()` then returns an empty string for every panel answer and the engine falls into the 503 "All fusion panel models failed" branch.

## Changes

1. **`open-sse/services/combo.js`** — pass `isPanel = true` to `handleSingleModel` for fan-out calls and clean up `panelBody.messages` / `panelBody.input` before fanning out:
   - drop `role: "tool"` and `role: "function"` messages
   - drop the `tool_calls` property from assistant messages (keeping the turn so positional context is preserved)

2. **`src/sse/handlers/chat.js`** — when `isPanel` is true, build a sanitized clone of `clientRawRequest` with `tools` and `tool_choice` removed from `clientRawRequest.body` before forwarding to `handleSingleModelChat`. This prevents `handleChatCore` from re-attaching the original client tools during the translateRequest pass.

3. **`tests/unit/combo-fusion.test.js`** — new test `strips previous tool history and assistant tool_calls from panel calls` verifies both layers. The judge call still receives the unmodified history + the synthesis prompt.

All 7 unit tests pass.
