### PR TITLE
fix(kiro): inject agentic chunked-write prompt only on first turn (not every turn)

### DIFF
--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -413,11 +413,15 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   }
 
   // Prefix order: thinking_mode tag, timestamp marker, then agentic prompt.
+  // The agentic prompt is injected ONLY on the first turn (empty history): it
+  // is a one-time behavioural instruction, and re-prepending it to every user
+  // message made the model read it as fresh user-authored input each turn.
   const timestamp = new Date().toISOString();
+  const isFirstTurn = !Array.isArray(history) || history.length === 0;
   const prefixParts = [];
   if (thinkingEnabled) prefixParts.push(buildThinkingSystemPrefix());
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
-  if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
+  if (agentic && isFirstTurn) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
   finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
 
   const payload = {

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -539,15 +539,17 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
 
   const timestamp = new Date().toISOString();
 
-  // Build the system-prompt prefix that goes ABOVE the user message body.
-  // Order: thinking_mode tag first (so Kiro sees it before any user text),
-  // then context/timestamp marker, then optional agentic chunked-write prompt.
+  // Inject the agentic chunked-write prompt ONLY on the first turn (empty
+  // history). It is a one-time behavioural instruction; re-prepending it to
+  // every user message made the model read it as fresh user-authored input
+  // each turn. thinking_mode tag and timestamp stay per-turn by design.
+  const isFirstTurn = !Array.isArray(history) || history.length === 0;
   const prefixParts = [];
   if (thinkingEnabled) {
     prefixParts.push(buildThinkingSystemPrefix());
   }
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
-  if (agentic) {
+  if (agentic && isFirstTurn) {
     prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
   }
   finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;


### PR DESCRIPTION
## Problem

The synthetic `-agentic` model suffix injects the ~50-line `KIRO_AGENTIC_SYSTEM_PROMPT` (the **CHUNKED WRITE PROTOCOL**) into **every** user turn instead of once per conversation.

Kiro / CodeWhisperer has no `system` role — `open-sse/config/kiroConstants.js` documents this, and both translators glue all prefixes onto `currentMessage.userInputMessage.content`. So on each turn the model receives, as the *literal user message*:

```
<thinking_mode>enabled</thinking_mode>
<max_thinking_length>16000</max_thinking_length>

[Context: Current time is 2026-06-18T...]

# CRITICAL: CHUNKED WRITE PROTOCOL (MANDATORY)
... ~50 lines ...

<the user's actual text>
```

### Root cause

In `openai-to-kiro.js` (`openaiToKiroRequest`) and the direct `claude-to-kiro.js` (`claudeToKiroRequest`), the prefix builder unconditionally pushes the agentic prompt:

```js
prefixParts.push(`[Context: Current time is ${timestamp}]`);
if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);   // every turn
finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
```

`resolveKiroModel()` sets `agentic=true` for any `*-agentic` model (e.g. `kr/claude-opus-4.8-thinking-agentic`), so the protocol is re-prepended on every request for the whole session.

### Impact

- The model reads a behavioural system instruction as **fresh user-authored input on every turn**, so it keeps re-acknowledging / re-reasoning about the protocol instead of the user's request.
- In agent harnesses (Kiro, Claude Code, Cline, OpenCode) it looks like a **prompt injection on every turn**: the real user message is buried under the protocol, and assistants waste turns flagging or obeying it.
- Wastes input tokens (~50 lines × every turn) — directly counter to 9router's RTK token-saving goal.
- The protocol is a *one-time* behavioural instruction; repeating it adds zero value after turn 1.

## Fix

Inject `KIRO_AGENTIC_SYSTEM_PROMPT` **only on the first turn** (empty `history`) in both translators. The `history` array is already in scope at both call sites.

```js
const isFirstTurn = !Array.isArray(history) || history.length === 0;
...
if (agentic && isFirstTurn) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
```

- The model still sees the protocol **once** at conversation start (correct for a behavioural instruction).
- Turns 2+ stay clean — only the user's real content.
- `<thinking_mode>` tag and `[Context: Current time]` marker remain **per-turn by design** (reasoning must be re-enabled each request; timestamp is a fresh 1-line clock).

## Verification

- `lsp_diagnostics` clean on both changed files.
- `vitest run` on the kiro translator suites — **20 passed** (2 pre-existing `it.fails` markers unchanged):
  - `tests/unit/openai-to-kiro.test.js`
  - `tests/translator/claude-kiro-direct.test.js`
  - `tests/translator/bugs-kiro.test.js`

## Files

- `open-sse/translator/request/openai-to-kiro.js`
- `open-sse/translator/request/claude-to-kiro.js`
