### PR TITLE
fix(kiro): honor thinking effort budgets

### DIFF
--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -14,6 +14,7 @@
  * Kiro upstream does not advertise `-agentic` model IDs; they are a 9router
  * fiction. The suffix is stripped before the request leaves this process.
  */
+import { effortToBudget } from "../translator/concerns/thinking.js";
 
 export const KIRO_AGENTIC_SUFFIX = "-agentic";
 export const KIRO_THINKING_SUFFIX = "-thinking";
@@ -89,13 +90,52 @@ REMEMBER: When in doubt, write LESS per operation. Multiple small operations > o
 `.trim();
 
 /**
+ * Resolve the Kiro thinking budget requested by a client.
+ *
+ * Explicit disable (`none` / `off` / disabled / non-positive budget) wins over
+ * model suffixes and other implicit triggers. Explicit effort levels reuse the
+ * shared 9router budget map; buildThinkingSystemPrefix performs Kiro's final
+ * 1..32000 clamp.
+ *
+ * @param {object} body OpenAI/Claude-shaped request body
+ * @param {object} [headers] Original inbound HTTP headers (case-insensitive)
+ * @param {string} [model] Model id the caller asked for
+ * @returns {number|null} budget to inject, or null when thinking is disabled
+ */
+export function resolveKiroThinkingBudget(body, headers, model) {
+  const explicit = resolveExplicitKiroThinkingBudget(body);
+  if (explicit === null) return null;
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+
+  if (headers) {
+    const beta = pickHeader(headers, "anthropic-beta");
+    if (typeof beta === "string" && beta.toLowerCase().includes("interleaved-thinking")) {
+      return KIRO_THINKING_BUDGET_DEFAULT;
+    }
+  }
+
+  if (containsThinkingModeTag(body)) {
+    return KIRO_THINKING_BUDGET_DEFAULT;
+  }
+
+  if (typeof model === "string" && model) {
+    const m = model.toLowerCase();
+    if (m.includes("thinking") || m.includes("-reason")) {
+      return KIRO_THINKING_BUDGET_DEFAULT;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Detect whether an inbound request is asking for reasoning / thinking output.
  *
  * Sources of intent (any one is enough):
  *   - HTTP header `Anthropic-Beta: ...interleaved-thinking...`
- *   - JSON `thinking.type === "enabled"` (Claude Messages API)
- *   - JSON `reasoning_effort` in {low, medium, high, auto} (OpenAI o1/o3)
- *   - JSON `reasoning.effort` in {low, medium, high, auto} (OpenAI Responses)
+ *   - JSON `output_config.effort` / `thinking` (Claude Messages API)
+ *   - JSON `reasoning_effort` (OpenAI Chat)
+ *   - JSON `reasoning.effort` (OpenAI Responses)
  *   - System prompt contains `<thinking_mode>enabled</thinking_mode>` or
  *     `<thinking_mode>interleaved</thinking_mode>` (AMP / Cursor)
  *   - Model name contains `thinking` or `-reason`
@@ -106,44 +146,40 @@ REMEMBER: When in doubt, write LESS per operation. Multiple small operations > o
  * @returns {boolean}
  */
 export function isThinkingEnabled(body, headers, model) {
-  if (headers) {
-    const beta = pickHeader(headers, "anthropic-beta");
-    if (typeof beta === "string" && beta.toLowerCase().includes("interleaved-thinking")) {
-      return true;
-    }
-  }
+  return resolveKiroThinkingBudget(body, headers, model) !== null;
+}
 
-  if (body && typeof body === "object") {
-    const thinking = body.thinking;
-    if (thinking && typeof thinking === "object" && thinking.type === "enabled") {
+function resolveExplicitKiroThinkingBudget(body) {
+  if (!body || typeof body !== "object") return undefined;
+
+  const outputConfigEffort = body.output_config?.effort;
+  const outputConfigBudget = resolveEffortBudget(outputConfigEffort);
+  if (outputConfigBudget !== undefined) return outputConfigBudget;
+
+  const thinking = body.thinking;
+  if (thinking && typeof thinking === "object") {
+    if (thinking.type === "disabled") return null;
+    if (thinking.type === "enabled" || thinking.type === "adaptive") {
       const budget = Number(thinking.budget_tokens);
-      if (!Number.isFinite(budget) || budget > 0) {
-        return true;
+      if (Number.isFinite(budget)) {
+        return budget > 0 ? budget : null;
       }
-    }
-
-    const effort = body.reasoning_effort
-      ?? (body.reasoning && typeof body.reasoning === "object" ? body.reasoning.effort : null);
-    if (typeof effort === "string") {
-      const v = effort.toLowerCase();
-      if (v && v !== "none" && (v === "low" || v === "medium" || v === "high" || v === "auto")) {
-        return true;
-      }
-    }
-
-    if (containsThinkingModeTag(body)) {
-      return true;
+      return KIRO_THINKING_BUDGET_DEFAULT;
     }
   }
 
-  if (typeof model === "string" && model) {
-    const m = model.toLowerCase();
-    if (m.includes("thinking") || m.includes("-reason")) {
-      return true;
-    }
-  }
+  const effort = body.reasoning_effort
+    ?? (body.reasoning && typeof body.reasoning === "object" ? body.reasoning.effort : null);
+  return resolveEffortBudget(effort);
+}
 
-  return false;
+function resolveEffortBudget(effort) {
+  if (typeof effort !== "string") return undefined;
+  const normalized = effort.toLowerCase().trim();
+  if (!normalized) return undefined;
+  if (normalized === "none" || normalized === "off") return null;
+  if (normalized === "auto") return KIRO_THINKING_BUDGET_DEFAULT;
+  return effortToBudget(normalized);
 }
 
 /**

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -27,7 +27,7 @@ import { FORMATS } from "../formats.js";
 import { v4 as uuidv4 } from "uuid";
 import {
   resolveKiroModel,
-  isThinkingEnabled,
+  resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
 } from "../../config/kiroConstants.js";
@@ -376,10 +376,8 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   const {
     upstream: upstreamModel,
     agentic,
-    thinking: modelImpliesThinking,
   } = resolveKiroModel(model);
-  const thinkingEnabled =
-    modelImpliesThinking || isThinkingEnabled(body, null, model);
+  const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
 
   // Guard 1: no client tools → flatten all tool interactions to text.
   if (!clientProvidedTools) {
@@ -415,7 +413,7 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   // Prefix order: thinking_mode tag, timestamp marker, then agentic prompt.
   const timestamp = new Date().toISOString();
   const prefixParts = [];
-  if (thinkingEnabled) prefixParts.push(buildThinkingSystemPrefix());
+  if (thinkingBudget !== null) prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
   finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -8,7 +8,7 @@ import { v4 as uuidv4 } from "uuid";
 import { resolveSessionId } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
-  isThinkingEnabled,
+  resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn
@@ -519,8 +519,8 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   const temperature = body.temperature;
   const topP = body.top_p;
 
-  const { upstream: upstreamModel, agentic, thinking: modelImpliesThinking } = resolveKiroModel(model);
-  const thinkingEnabled = modelImpliesThinking || isThinkingEnabled(body, null, model);
+  const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
+  const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
 
   const { history, currentMessage } = convertMessages(messages, tools, upstreamModel);
 
@@ -543,8 +543,8 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   // Order: thinking_mode tag first (so Kiro sees it before any user text),
   // then context/timestamp marker, then optional agentic chunked-write prompt.
   const prefixParts = [];
-  if (thinkingEnabled) {
-    prefixParts.push(buildThinkingSystemPrefix());
+  if (thinkingBudget !== null) {
+    prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
   }
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) {

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -64,6 +64,17 @@ describe("Claude → Kiro (direct route)", () => {
       "<thinking_mode>enabled</thinking_mode>"
     );
   });
+
+  it("maps output_config.effort high to Kiro max_thinking_length 24576", () => {
+    const out = C2K({
+      output_config: { effort: "high" },
+      messages: [{ role: "user", content: "think with adaptive effort" }],
+    });
+
+    expect(out.conversationState.currentMessage.userInputMessage.content).toContain(
+      "<max_thinking_length>24576</max_thinking_length>"
+    );
+  });
 });
 
 describe("Kiro → Claude (direct route, OpenAI-shaped chunks from executor)", () => {

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -9,6 +9,9 @@
 import { describe, it, expect } from "vitest";
 import { openaiToKiroRequest } from "../../open-sse/translator/request/openai-to-kiro.js";
 
+const contentOf = (result) =>
+  result.conversationState.currentMessage.userInputMessage.content;
+
 describe("openaiToKiroRequest", () => {
   describe("basic message conversion", () => {
     it("should convert a simple text message", () => {
@@ -278,6 +281,85 @@ describe("openaiToKiroRequest", () => {
       expect(allJson).not.toContain("orphan_call");
       // ...but the content is preserved as salvaged text, not discarded.
       expect(allJson).toContain("[Tool result: important orphaned output]");
+    });
+  });
+
+  describe("thinking budget", () => {
+    it("maps reasoning_effort low to max_thinking_length 1024", () => {
+      const body = {
+        reasoning_effort: "low",
+        messages: [{ role: "user", content: "Think lightly" }]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
+
+      expect(contentOf(result)).toContain("<max_thinking_length>1024</max_thinking_length>");
+    });
+
+    it("maps reasoning_effort high to max_thinking_length 24576", () => {
+      const body = {
+        reasoning_effort: "high",
+        messages: [{ role: "user", content: "Think deeply" }]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
+
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+    });
+
+    it("clamps reasoning_effort max to Kiro max_thinking_length 32000", () => {
+      const body = {
+        reasoning_effort: "max",
+        messages: [{ role: "user", content: "Think as much as possible" }]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
+
+      expect(contentOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
+    });
+
+    it("clamps OpenAI Responses reasoning.effort xhigh to max_thinking_length 32000", () => {
+      const body = {
+        reasoning: { effort: "xhigh" },
+        messages: [{ role: "user", content: "Think extra deeply" }]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
+
+      expect(contentOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
+    });
+
+    it("uses Claude thinking.budget_tokens as max_thinking_length", () => {
+      const body = {
+        thinking: { type: "enabled", budget_tokens: 4096 },
+        messages: [{ role: "user", content: "Use a fixed budget" }]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
+
+      expect(contentOf(result)).toContain("<max_thinking_length>4096</max_thinking_length>");
+    });
+
+    it("uses the default budget for synthetic -thinking models with no explicit config", () => {
+      const body = {
+        messages: [{ role: "user", content: "Think by model suffix" }]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.6-thinking", body, true, {});
+
+      expect(contentOf(result)).toContain("<max_thinking_length>16000</max_thinking_length>");
+    });
+
+    it("does not inject thinking prefix for reasoning_effort none", () => {
+      const body = {
+        reasoning_effort: "none",
+        messages: [{ role: "user", content: "Do not think" }]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
+
+      expect(contentOf(result)).not.toContain("<thinking_mode>enabled</thinking_mode>");
+      expect(contentOf(result)).not.toContain("<max_thinking_length>");
     });
   });
 });


### PR DESCRIPTION
## Summary
- resolve Kiro thinking budgets from OpenAI reasoning_effort, OpenAI Responses reasoning.effort, Claude output_config.effort, and Claude thinking.budget_tokens
- pass the resolved budget into the Kiro thinking system prefix while preserving the default budget for synthetic -thinking model aliases
- keep explicit none/off/disabled/non-positive thinking configs from injecting the Kiro thinking prefix

## Tests
- npx vitest run --reporter=verbose --config ./tests/vitest.config.js tests/unit/openai-to-kiro.test.js tests/translator/claude-kiro-direct.test.js
- npx vitest run --reporter=verbose --config ./tests/vitest.config.js tests/translator/thinking-unified.test.js
- npx eslint open-sse/config/kiroConstants.js open-sse/translator/request/openai-to-kiro.js open-sse/translator/request/claude-to-kiro.js tests/unit/openai-to-kiro.test.js tests/translator/claude-kiro-direct.test.js