### PR TITLE
feat(cli): add headless mode and usage commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ NODE_ENV=production
 # Recommended security and ops variables
 API_KEY_SECRET=endpoint-proxy-api-key-secret
 MACHINE_ID_SALT=endpoint-proxy-salt
+HEADLESS_DASHBOARD=0
 ENABLE_REQUEST_LOGS=false
 OBSERVABILITY_ENABLED=true
 AUTH_COOKIE_SECURE=false

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ npm install -g 9router
 9router
 ```
 
+Headless (no dashboard/UI, endpoint + CLI only):
+
+```bash
+9router --headless
+# or
+HEADLESS_DASHBOARD=1 9router
+```
+
 🎉 Dashboard opens at `http://localhost:20128`
 
 **2. Connect a FREE provider (no signup needed):**

--- a/cli/CLI_HEADLESS.md
+++ b/cli/CLI_HEADLESS.md
@@ -1,0 +1,69 @@
+# 9Router Headless CLI Guide (Command Mode)
+
+Use this when dashboard is not needed (CI, script, or remote automation).
+
+## 1) Run server without UI
+
+```bash
+9router --headless --port 20128
+```
+
+Then in another terminal, run non-interactive commands against the same API endpoint.
+
+## 2) API Key management
+
+```bash
+9router api-keys list
+9router api-keys create "ci-key"
+9router api-keys usage <key_id> --period 7d
+9router api-keys delete <key_id>
+
+# aliases
+9router keys list
+9router k list
+```
+
+Supported usage periods: `today`, `24h`, `7d`, `30d`, `60d`, `all`.
+
+## 3) Provider management
+
+```bash
+9router providers list
+9router providers add openrouter <provider_api_key> --name openrouter-free --default-model nvidia/nemotron-3.5-content-safety:free
+9router providers test <connection_id>
+9router providers models <connection_id>
+9router providers delete <connection_id>
+
+9router prov list
+9router p list
+```
+
+`provider add` uses `/api/providers` and creates an API-key type connection.
+
+## 4) Usage lookup
+
+```bash
+9router usage key <key_id> --period 30d
+9router usage connection <provider_connection_id>
+
+9router u key <key_id> --period 30d
+9router usg connection <provider_connection_id>
+```
+
+`usage key` calls `/api/usage/keys/:id`.
+`usage connection` calls `/api/usage/:connectionId`.
+
+## 5) Endpoint mode flags
+
+```bash
+9router --host 127.0.0.1 --port 20128 providers list
+9router --port 20128 api-keys list
+```
+
+## 6) Related endpoints (REST)
+
+- `GET /api/keys`, `POST /api/keys`, `DELETE /api/keys/:id`
+- `GET /api/usage/keys/:id?period=...`
+- `GET /api/providers`, `POST /api/providers`, `DELETE /api/providers/:id`
+- `POST /api/providers/:id/test`, `GET /api/providers/:id/models`
+- `GET /api/usage/:connectionId`

--- a/cli/README.md
+++ b/cli/README.md
@@ -82,11 +82,48 @@ That's it! Start coding with FREE AI models.
 9router                    # Start with default settings
 9router --port 8080        # Custom port
 9router --no-browser       # Don't open browser
+9router --headless          # API/CLI only, no dashboard terminal UI
 9router --skip-update      # Skip auto-update check
 9router --help             # Show all options
 ```
 
 **Dashboard**: `http://localhost:20128/dashboard`
+
+## 🧩 Headless/CLI API Commands
+
+`9router` now supports direct non-interactive commands for automation:
+
+```bash
+9router --headless                   # Run server in API-only mode (no dashboard / terminal UI)
+9router api-keys list                # List all router API keys
+9router api-keys create "ci-token"    # Create API key
+9router api-keys usage <id> --period 7d
+9router api-keys delete <id>          # Delete API key
+
+# aliases
+9router keys list
+9router k list
+
+9router providers list                 # List provider connections
+9router providers add openrouter <key> # Add API-key provider
+9router providers test <id>            # Test provider connection
+9router providers models <id>          # Show available models for connection
+9router providers delete <id>          # Delete provider connection
+
+9router prov list
+9router p list
+
+9router usage key <key_id> --period 30d         # Usage by API key
+9router usage connection <provider_connection_id> # Usage from provider connection
+
+9router usage key <key_id>                 # alias command variant
+9router u key <key_id>
+9router usg connection <provider_connection_id>
+```
+
+All commands use the same runtime config as the running server (`--port` / `--host` flags can be passed).
+
+Detailed examples and quick scripts are available in [CLI Headless API Guide](CLI_HEADLESS.md).
 
 ---
 

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -89,6 +89,242 @@ let noBrowser = false;
 let skipUpdate = false;
 let showLog = false;
 let trayMode = false;
+let headlessMode = false;
+let commandArgs = null;
+
+function isTruthyEnvFlag(value) {
+  return value === "1" || value === "true";
+}
+
+headlessMode = isTruthyEnvFlag(process.env.HEADLESS_DASHBOARD)
+  || isTruthyEnvFlag(process.env.HEADLESS_MODE)
+  || isTruthyEnvFlag(process.env.HEADLESS);
+
+function printHeadlessCommandHelp() {
+  console.log(`
+Usage:
+  ${APP_NAME} [global options]
+  ${APP_NAME} <resource> <action> [arguments...]
+
+Global options:
+  -p, --port <port>   Port for API endpoint (default: ${DEFAULT_PORT})
+  -H, --host <host>   Host for API endpoint (default: ${DEFAULT_HOST})
+  -n, --no-browser    Don't open browser automatically
+  --headless           Run server without dashboard/terminal UI
+  -l, --log           Show server logs (default: hidden)
+  -t, --tray          Run in system tray mode (background)
+  --skip-update       Skip auto-update check
+  -h, --help           Show startup + command help
+  -v, --version        Show version
+
+Resource/action examples (headless/non-interactive mode):
+  ${APP_NAME} api-keys list
+  ${APP_NAME} api-keys create <name>
+  ${APP_NAME} api-keys usage <key_id> [--period today|24h|7d|30d|60d|all]
+  ${APP_NAME} api-keys delete <key_id>
+  ${APP_NAME} providers list
+  ${APP_NAME} providers add <provider> <api_key> [--name <name>] [--priority <n>] [--default-model <model>]
+  ${APP_NAME} providers test <connection_id>
+  ${APP_NAME} providers models <connection_id>
+  ${APP_NAME} providers delete <connection_id>
+  ${APP_NAME} usage key <key_id> [--period today|24h|7d|30d|60d|all]
+  ${APP_NAME} usage connection <connection_id>
+
+Aliases:
+  keys   -> api-keys
+  k      -> api-keys (shortcut)
+  prov   -> providers
+  p      -> providers
+  usg    -> usage
+  u      -> usage
+
+Examples:
+  ${APP_NAME} --port 20128 api-keys list
+  ${APP_NAME} --port 20128 providers add openrouter sk-or-xxx
+  ${APP_NAME} --port 20128 providers test cmpl_xxx
+  ${APP_NAME} --port 20128 api-keys usage kidxxx --period 30d
+`);
+}
+
+function parseCliOptions(argv) {
+  const options = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--host" || token === "-H") {
+      options.host = argv[i + 1] || DEFAULT_HOST;
+      i++;
+    } else if (token === "--port" || token === "-p") {
+      options.port = parseInt(argv[i + 1], 10) || DEFAULT_PORT;
+      i++;
+    } else if (token === "--period") {
+      options.period = (argv[i + 1] || "7d").toLowerCase();
+      i++;
+    } else if (token === "--name") {
+      options.name = argv[i + 1] || "";
+      i++;
+    } else if (token === "--priority") {
+      options.priority = parseInt(argv[i + 1], 10);
+      i++;
+    } else if (token === "--global-priority") {
+      options.globalPriority = parseInt(argv[i + 1], 10);
+      i++;
+    } else if (token === "--default-model") {
+      options.defaultModel = argv[i + 1] || "";
+      i++;
+    } else if (token.startsWith("-")) {
+      throw new Error(`Unknown option: ${token}`);
+    } else {
+      positional.push(token);
+    }
+  }
+  return { options, positional };
+}
+
+function printResultOrFail(action, result) {
+  if (!result || !result.success) {
+    const status = result?.statusCode ? ` (HTTP ${result.statusCode})` : "";
+    console.error(`${action} failed${status}: ${result?.error || "Unknown error"}`);
+    return 1;
+  }
+  console.log(JSON.stringify(result.data, null, 2));
+  return 0;
+}
+
+async function runHeadlessCommand() {
+  const api = require("./src/cli/api/client");
+
+  const parsed = parseCliOptions(commandArgs);
+  const effectiveHost = parsed.options.host || host;
+  const effectivePort = parsed.options.port || port;
+  const positional = parsed.positional;
+  const options = parsed.options;
+  let resource = (positional[0] || "").toLowerCase();
+  const action = (positional[1] || "").toLowerCase();
+  const normalizedResource = resource;
+  if (resource === "k" || resource === "keys") resource = "api-keys";
+  if (resource === "prov" || resource === "p") resource = "providers";
+  if (resource === "usg" || resource === "u") resource = "usage";
+  if (resource === "key" && normalizedResource === "key") {
+    if (action === "create" || action === "list" || action === "usage" || action === "delete") {
+      resource = "api-keys";
+    }
+  }
+  const args = positional.slice(2);
+
+  if (!resource || !action) {
+    printHeadlessCommandHelp();
+    return 1;
+  }
+
+  if (resource === "api-keys" || resource === "apikeys") {
+    if (action === "list") {
+      return printResultOrFail("List API keys", await api.getApiKeys());
+    }
+    if (action === "create") {
+      const name = args[0];
+      if (!name) {
+        console.error("API key name is required.");
+        return 1;
+      }
+      return printResultOrFail("Create API key", await api.createApiKey(name));
+    }
+    if (action === "usage") {
+      const id = args[0];
+      if (!id) {
+        console.error("API key id is required.");
+        return 1;
+      }
+      const period = options.period || "7d";
+      return printResultOrFail("Get API key usage", await api.getApiKeyUsageSummary(id, period));
+    }
+    if (action === "delete") {
+      const id = args[0];
+      if (!id) {
+        console.error("API key id is required.");
+        return 1;
+      }
+      return printResultOrFail("Delete API key", await api.deleteApiKey(id));
+    }
+    console.error(`Unsupported api-keys action: ${action}`);
+    return 1;
+  }
+
+  if (resource === "providers") {
+    if (action === "list") {
+      return printResultOrFail("List providers", await api.getProviders());
+    }
+    if (action === "add") {
+      const provider = args[0];
+      const apiKey = args[1];
+      if (!provider || !apiKey) {
+        console.error("Provider and api key are required.");
+        return 1;
+      }
+      const body = {
+        provider,
+        apiKey,
+        name: options.name,
+        priority: Number.isInteger(options.priority) ? options.priority : undefined,
+        globalPriority: Number.isInteger(options.globalPriority) ? options.globalPriority : undefined,
+        defaultModel: options.defaultModel || undefined,
+      };
+      Object.keys(body).forEach((k) => body[k] === undefined && delete body[k]);
+      return printResultOrFail("Add provider", await api.createApiKeyProvider(body));
+    }
+    if (action === "test") {
+      const id = args[0];
+      if (!id) {
+        console.error("Provider connection id is required.");
+        return 1;
+      }
+      return printResultOrFail("Test provider", await api.testProvider(id));
+    }
+    if (action === "models") {
+      const id = args[0];
+      if (!id) {
+        console.error("Provider connection id is required.");
+        return 1;
+      }
+      return printResultOrFail("List provider models", await api.getProviderModels(id));
+    }
+    if (action === "delete") {
+      const id = args[0];
+      if (!id) {
+        console.error("Provider connection id is required.");
+        return 1;
+      }
+      return printResultOrFail("Delete provider", await api.deleteProvider(id));
+    }
+    console.error(`Unsupported providers action: ${action}`);
+    return 1;
+  }
+
+  if (resource === "usage") {
+    if (action === "key") {
+      const id = args[0];
+      if (!id) {
+        console.error("API key id is required.");
+        return 1;
+      }
+      const period = options.period || "7d";
+      return printResultOrFail("Get API key usage", await api.getApiKeyUsageSummary(id, period));
+    }
+    if (action === "connection") {
+      const id = args[0];
+      if (!id) {
+        console.error("Connection id is required.");
+        return 1;
+      }
+      return printResultOrFail("Get connection usage", await api.getConnectionUsage(id));
+    }
+    console.error(`Unsupported usage action: ${action}`);
+    return 1;
+  }
+
+  console.error(`Unknown resource: ${resource}`);
+  return 1;
+}
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "--port" || args[i] === "-p") {
@@ -101,29 +337,26 @@ for (let i = 0; i < args.length; i++) {
     noBrowser = true;
   } else if (args[i] === "--log" || args[i] === "-l") {
     showLog = true;
+  } else if (args[i] === "--headless") {
+    headlessMode = true;
   } else if (args[i] === "--skip-update") {
     skipUpdate = true;
   } else if (args[i] === "--tray" || args[i] === "-t") {
     trayMode = true;
     process.env.TRAY_MODE = "1";
   } else if (args[i] === "--help" || args[i] === "-h") {
-    console.log(`
-Usage: ${APP_NAME} [options]
-
-Options:
-  -p, --port <port>   Port to run the server (default: ${DEFAULT_PORT})
-  -H, --host <host>   Host to bind (default: ${DEFAULT_HOST})
-  -n, --no-browser    Don't open browser automatically
-  -l, --log           Show server logs (default: hidden)
-  -t, --tray          Run in system tray mode (background)
-  --skip-update       Skip auto-update check
-  -h, --help          Show this help message
-  -v, --version       Show version
-`);
+    printHeadlessCommandHelp();
     process.exit(0);
   } else if (args[i] === "--version" || args[i] === "-v") {
     console.log(pkg.version);
     process.exit(0);
+  } else if (args[i].startsWith("-")) {
+    console.error(`Unknown option: ${args[i]}`);
+    printHeadlessCommandHelp();
+    process.exit(1);
+  } else {
+    commandArgs = args.slice(i);
+    break;
   }
 }
 
@@ -132,6 +365,8 @@ if (skipUpdate && !trayMode && !process.stdin.isTTY) {
   trayMode = true;
   process.env.TRAY_MODE = "1";
 }
+
+if (headlessMode) trayMode = false;
 
 // Always use Node.js runtime with absolute path
 const RUNTIME = process.execPath;
@@ -499,14 +734,27 @@ if (!fs.existsSync(serverPath)) {
   process.exit(1);
 }
 
-// Check for updates FIRST, then start server
-checkForUpdate().then((latestVersion) => {
-  killAllAppProcesses(port).then(() => {
-    return killProcessOnPort(port);
-  }).then(() => {
-    startServer(latestVersion);
+// Check for updates, then start server, unless running in headless command mode.
+(async () => {
+  if (commandArgs) {
+    try {
+      const exitCode = await runHeadlessCommand();
+      process.exit(exitCode);
+    } catch (error) {
+      console.error(error.message || String(error));
+      process.exit(1);
+    }
+    return;
+  }
+
+  checkForUpdate().then((latestVersion) => {
+    killAllAppProcesses(port).then(() => {
+      return killProcessOnPort(port);
+    }).then(() => {
+      startServer(latestVersion, headlessMode);
+    });
   });
-});
+})();
 
 // Show interface selection menu
 async function showInterfaceMenu(latestVersion) {
@@ -556,9 +804,10 @@ async function showInterfaceMenu(latestVersion) {
 const MAX_RESTARTS = 2;
 const RESTART_RESET_MS = 30000; // Reset counter if alive > 30s
 
-function startServer(latestVersion) {
+function startServer(latestVersion, headlessMode = false) {
   const displayHost = getDisplayHost();
-  const url = `http://${displayHost}:${port}/dashboard`;
+  const url = `http://${displayHost}:${port}`;
+  const dashboardUrl = `${url}/dashboard`;
   // Surface real network exposure when bound to all interfaces (default 0.0.0.0).
   if (host === DEFAULT_HOST) {
     const lanIp = getLanIp();
@@ -582,7 +831,8 @@ function startServer(latestVersion) {
       env: {
         ...buildEnvWithRuntime(process.env),
         PORT: port.toString(),
-        HOSTNAME: host
+        HOSTNAME: host,
+        HEADLESS_DASHBOARD: headlessMode ? "1" : "0"
       }
     });
     if (!showLog && child.stderr) {
@@ -649,6 +899,15 @@ function startServer(latestVersion) {
     setTimeout(() => process.exit(0), 100);
   });
 
+  if (headlessMode) {
+    console.log(`\n🚀 ${pkg.name} v${pkg.version} (headless)`);
+    console.log(`Server: ${url}`);
+    console.log(`LLM API: ${url}/v1`);
+    console.log(`Health:  ${url}/api/health`);
+    console.log("Mode:   API + CLI management only (dashboard disabled)\n");
+    return;
+  }
+
   // Initialize tray icon (runs alongside TUI)
   const initTrayIcon = () => {
     try {
@@ -661,7 +920,7 @@ function startServer(latestVersion) {
           cleanup();
           setTimeout(() => process.exit(0), 100);
         },
-        onOpenDashboard: () => openBrowser(url)
+        onOpenDashboard: () => openBrowser(dashboardUrl)
       });
     } catch (err) {
       // Tray not available - continue without it
@@ -708,7 +967,7 @@ function startServer(latestVersion) {
           setTimeout(() => process.exit(0), 200);
           return;
         } else if (choice === "web") {
-          openBrowser(url);
+          openBrowser(dashboardUrl);
           // Wait for user to come back
           const { pause } = require("./src/cli/utils/input");
           await pause("\nPress Enter to go back to menu...");

--- a/cli/src/cli/api/client.js
+++ b/cli/src/cli/api/client.js
@@ -300,6 +300,26 @@ async function createApiKey(name) {
 }
 
 /**
+ * Get usage summary for API key
+ * @param {string} id - API key ID
+ * @param {string} period - Period: today,24h,7d,30d,60d,all
+ * @returns {Promise<Object>} { success, data: { key, summary, topModels, period, startDate, endDate } }
+ */
+async function getApiKeyUsageSummary(id, period = "7d") {
+  const query = new URLSearchParams({ period });
+  return makeRequest("GET", `/api/usage/keys/${encodeURIComponent(id)}?${query}`);
+}
+
+/**
+ * Get usage by connection ID
+ * @param {string} id - Provider connection ID
+ * @returns {Promise<Object>} { success, data }
+ */
+async function getConnectionUsage(id) {
+  return makeRequest("GET", `/api/usage/${encodeURIComponent(id)}`);
+}
+
+/**
  * Delete API key
  * @param {string} id - Key ID
  * @returns {Promise<Object>} { success, data: { success } }
@@ -519,7 +539,9 @@ module.exports = {
   // API Keys
   getApiKeys,
   createApiKey,
+  getApiKeyUsageSummary,
   deleteApiKey,
+  getConnectionUsage,
   
   // Combos
   getCombos,

--- a/cli/src/cli/menus/apiKeys.js
+++ b/cli/src/cli/menus/apiKeys.js
@@ -1,10 +1,12 @@
 const api = require("../api/client");
 const { prompt, confirm, pause } = require("../utils/input");
-const { clearScreen, showStatus, showHeader } = require("../utils/display");
-const { maskKey, formatDate, getRelativeTime } = require("../utils/format");
+const { clearScreen, showStatus } = require("../utils/display");
+const { maskKey, formatDate, formatNumber, getRelativeTime } = require("../utils/format");
 const { showMenuWithBack } = require("../utils/menuHelper");
 const { copyToClipboard } = require("../utils/clipboard");
 const { getEndpoint } = require("../utils/endpoint");
+
+const VALID_USAGE_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "all"]);
 
 /**
  * Display API keys list with formatted output
@@ -129,6 +131,68 @@ async function handleCopyKey(key) {
   await pause();
 }
 
+function normalizeUsagePeriod(period) {
+  const candidate = (period || "").trim().toLowerCase();
+  return VALID_USAGE_PERIODS.has(candidate) ? candidate : "7d";
+}
+
+function formatUsageCost(cost) {
+  if (typeof cost !== "number" || Number.isNaN(cost)) return "0.000000";
+  return cost.toFixed(6);
+}
+
+/**
+ * Handle showing usage summary of a specific key
+ * @param {Object} key - API key object
+ */
+async function handleViewUsage(key) {
+  console.log("\n📈 Usage Summary");
+  console.log("─".repeat(30));
+  console.log(`Key: ${key.name}`);
+  
+  const rawPeriod = await prompt("Period [today|24h|7d|30d|60d|all] (default 7d): ");
+  const period = normalizeUsagePeriod(rawPeriod);
+
+  const result = await api.getApiKeyUsageSummary(key.id, period);
+
+  if (!result.success) {
+    showStatus(`Failed to fetch usage: ${result.error}`, "error");
+    await pause();
+    return;
+  }
+
+  const usage = result.data || {};
+  const summary = usage.summary || {};
+  const topModels = usage.topModels || [];
+
+  console.log(`\nPeriod: ${usage.period || period}`);
+  console.log(`From: ${usage.startDate ? formatDate(usage.startDate) : "All time"}`);
+  console.log(`To: ${usage.endDate ? formatDate(usage.endDate) : "Now"}`);
+  console.log(`Requests: ${formatNumber(summary.requests || 0)}`);
+  console.log(`Prompt tokens: ${formatNumber(summary.promptTokens || 0)}`);
+  console.log(`Completion tokens: ${formatNumber(summary.completionTokens || 0)}`);
+  console.log(`Total tokens: ${formatNumber(summary.totalTokens || 0)}`);
+  console.log(`Estimated cost: ${formatUsageCost(summary.cost)}`);
+  if (summary.lastUsed) {
+    console.log(`Last used: ${formatDate(summary.lastUsed)}`);
+  }
+
+  if (topModels.length === 0) {
+    console.log("\nNo request in this period.");
+  } else {
+    console.log("\nTop Models:");
+    topModels.forEach((model, index) => {
+      const totalTokens = formatNumber(model.totalTokens || 0);
+      const requestCount = formatNumber(model.requests || 0);
+      const providerLabel = model.provider && model.provider !== "unknown" ? ` (${model.provider})` : "";
+      console.log(`  ${index + 1}. ${model.model || "unknown"}${providerLabel}`);
+      console.log(`     Requests: ${requestCount} | Tokens: ${totalTokens} | Cost: ${formatUsageCost(model.cost)}`);
+    });
+  }
+
+  await pause();
+}
+
 /**
  * Handle deleting API key
  * @param {Object} key - API key object
@@ -178,6 +242,13 @@ async function showKeyActions(key, port, breadcrumb = []) {
         label: "Copy to Clipboard",
         action: async () => {
           await handleCopyKey(key);
+          return true;
+        }
+      },
+      {
+        label: "View Usage",
+        action: async () => {
+          await handleViewUsage(key);
           return true;
         }
       },

--- a/src/app/api/usage/keys/[id]/route.js
+++ b/src/app/api/usage/keys/[id]/route.js
@@ -1,0 +1,142 @@
+import { NextResponse } from "next/server";
+import { getApiKeyById } from "@/lib/localDb";
+import { getUsageHistory } from "@/lib/usageDb";
+
+const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "all"]);
+const PERIOD_MS = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+  "60d": 60 * 24 * 60 * 60 * 1000,
+};
+
+export const dynamic = "force-dynamic";
+
+function getPeriodRange(period) {
+  const now = new Date();
+  if (period === "all") {
+    return { startDate: null, endDate: now };
+  }
+
+  if (period === "today") {
+    const startDate = new Date();
+    startDate.setHours(0, 0, 0, 0);
+    return { startDate, endDate: now };
+  }
+
+  const ms = PERIOD_MS[period];
+  if (ms) {
+    return { startDate: new Date(now.getTime() - ms), endDate: now };
+  }
+
+  return { startDate: null, endDate: now };
+}
+
+function formatModelKey(model, provider) {
+  const normalizedModel = model || "unknown";
+  const normalizedProvider = provider || "unknown";
+  return `${normalizedModel} (${normalizedProvider})`;
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+export async function GET(request, { params }) {
+  try {
+    const { id } = await params;
+    const key = await getApiKeyById(id);
+    if (!key) {
+      return NextResponse.json({ error: "Key not found" }, { status: 404 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const period = searchParams.get("period") || "7d";
+
+    if (!VALID_PERIODS.has(period)) {
+      return NextResponse.json({ error: "Invalid period" }, { status: 400 });
+    }
+
+    const { startDate, endDate } = getPeriodRange(period);
+    const rows = await getUsageHistory({
+      startDate: startDate ? startDate.toISOString() : null,
+      endDate: endDate.toISOString(),
+      apiKey: key.key,
+    });
+
+    let totalRequests = 0;
+    let totalPromptTokens = 0;
+    let totalCompletionTokens = 0;
+    let totalCost = 0;
+    let lastUsed = null;
+    const modelMap = {};
+
+    for (const row of rows) {
+      totalRequests += 1;
+      const promptTokens = toNumber(row.promptTokens);
+      const completionTokens = toNumber(row.completionTokens);
+      const rowCost = toNumber(row.cost);
+
+      totalPromptTokens += promptTokens;
+      totalCompletionTokens += completionTokens;
+      totalCost += rowCost;
+
+      if (row.timestamp && (!lastUsed || row.timestamp > lastUsed)) {
+        lastUsed = row.timestamp;
+      }
+
+      const modelKey = formatModelKey(row.model, row.provider);
+      if (!modelMap[modelKey]) {
+        modelMap[modelKey] = {
+          model: row.model || "unknown",
+          provider: row.provider || "unknown",
+          requests: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+          cost: 0,
+          lastUsed: null,
+        };
+      }
+      const agg = modelMap[modelKey];
+      agg.requests += 1;
+      agg.promptTokens += promptTokens;
+      agg.completionTokens += completionTokens;
+      agg.cost += rowCost;
+      if (row.timestamp && (!agg.lastUsed || row.timestamp > agg.lastUsed)) {
+        agg.lastUsed = row.timestamp;
+      }
+    }
+
+    const topModels = Object.values(modelMap)
+      .map((m) => ({
+        ...m,
+        totalTokens: m.promptTokens + m.completionTokens,
+      }))
+      .sort((a, b) => b.requests - a.requests || b.totalTokens - a.totalTokens)
+      .slice(0, 5);
+
+    return NextResponse.json({
+      key: {
+        id: key.id,
+        name: key.name,
+        createdAt: key.createdAt,
+      },
+      period,
+      startDate: startDate ? startDate.toISOString() : null,
+      endDate: endDate.toISOString(),
+      summary: {
+        requests: totalRequests,
+        promptTokens: totalPromptTokens,
+        completionTokens: totalCompletionTokens,
+        totalTokens: totalPromptTokens + totalCompletionTokens,
+        cost: totalCost,
+        lastUsed,
+      },
+      topModels,
+    });
+  } catch (error) {
+    console.error("[API] Failed to get usage for API key:", error);
+    return NextResponse.json({ error: "Failed to fetch API key usage" }, { status: 500 });
+  }
+}

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -6,6 +6,14 @@ import { verifyDashboardAuthToken } from "@/lib/auth/dashboardSession";
 const CLI_TOKEN_HEADER = "x-9r-cli-token";
 const CLI_TOKEN_SALT = "9r-cli-auth";
 
+function isTruthy(value) {
+  return value === "1" || value === "true";
+}
+
+function isHeadlessMode() {
+  return isTruthy(process.env.HEADLESS_DASHBOARD) || isTruthy(process.env.HEADLESS_MODE) || isTruthy(process.env.HEADLESS);
+}
+
 let cachedCliToken = null;
 async function getCliToken() {
   if (!cachedCliToken) cachedCliToken = await getConsistentMachineId(CLI_TOKEN_SALT);
@@ -175,6 +183,16 @@ export const __test__ = {
 
 export async function proxy(request) {
   const { pathname } = request.nextUrl;
+
+  if (isHeadlessMode()) {
+    if (pathname === "/") {
+      return NextResponse.redirect(new URL("/api/health", request.url));
+    }
+
+    if (pathname === "/login" || pathname.startsWith("/dashboard")) {
+      return NextResponse.json({ error: "Dashboard is disabled in headless mode" }, { status: 404 });
+    }
+  }
 
   // Local-only gate for spawn-capable / host-secret routes.
   if (LOCAL_ONLY_PATHS.some((p) => pathname.startsWith(p))) {

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -295,6 +295,14 @@ export async function getUsageHistory(filter = {}) {
   if (filter.model) { conds.push("model = ?"); params.push(filter.model); }
   if (filter.startDate) { conds.push("timestamp >= ?"); params.push(new Date(filter.startDate).toISOString()); }
   if (filter.endDate) { conds.push("timestamp <= ?"); params.push(new Date(filter.endDate).toISOString()); }
+  if (filter.apiKey !== undefined) {
+    if (filter.apiKey === "local-no-key" || filter.apiKey === null) {
+      conds.push("apiKey IS NULL");
+    } else {
+      conds.push("apiKey = ?");
+      params.push(filter.apiKey);
+    }
+  }
 
   const where = conds.length ? `WHERE ${conds.join(" AND ")}` : "";
   const rows = db.all(`SELECT timestamp, provider, model, connectionId, apiKey, endpoint, cost, status, tokens FROM usageHistory ${where} ORDER BY id ASC`, params);


### PR DESCRIPTION
## Summary
- add non-interactive headless CLI commands for api key CRUD + usage and provider CRUD/test/models.
- add endpoint alias support for usage by key connection id and docs for headless mode.
- add endpoint for key-usage retrieval used by CLI.

## Testing
Not run in this session per request; please run smoke checks before merge.