### PR TITLE
fix(auth): preserve client IP behind local reverse proxy

### DIFF
--- a/custom-server.js
+++ b/custom-server.js
@@ -10,10 +10,15 @@ http.createServer = (...args) => {
   const rest = args.filter((a) => typeof a !== "function");
   if (!handler) return origCreate(...args);
   const wrapped = (req, res) => {
-    const ip = req.socket && req.socket.remoteAddress ? req.socket.remoteAddress : "";
-    // Forwarding headers present = request arrived via a reverse proxy; loopback
-    // socket is the proxy hop, not the end-user, so it must not be trusted as local.
-    const viaProxy = !!(req.headers["x-forwarded-for"] || req.headers["x-real-ip"]);
+    const socketIp = req.socket && req.socket.remoteAddress ? req.socket.remoteAddress : "";
+    const xff = req.headers["x-forwarded-for"];
+    const xRealIp = req.headers["x-real-ip"];
+    const viaProxy = !!(xff || xRealIp);
+    const isLoopbackProxy = socketIp === "127.0.0.1" || socketIp === "::1" || socketIp === "::ffff:127.0.0.1";
+    // Trust forwarding headers only when the TCP peer is a local reverse proxy.
+    // Direct/public sockets remain keyed by the unspoofable peer address.
+    const proxyIp = xRealIp || (xff ? String(xff).split(",")[0].trim() : "");
+    const ip = isLoopbackProxy && proxyIp ? proxyIp : socketIp;
     delete req.headers["x-9r-real-ip"];
     delete req.headers["x-forwarded-for"];
     delete req.headers["x-9r-via-proxy"];


### PR DESCRIPTION
## Description
Fix dashboard login lockout IP detection when 9Router runs behind a local reverse proxy such as nginx.

Previously, `custom-server.js` always keyed `x-9r-real-ip` from `req.socket.remoteAddress` and stripped forwarding headers. Behind a local proxy, the TCP peer is the proxy (`127.0.0.1` / `::1`), so all external clients can share the same login-rate-limit bucket and one client's failed login attempts can lock out others.

## Changes
- Detect local loopback reverse-proxy peers.
- Trust `X-Real-IP` / first `X-Forwarded-For` only when the TCP peer is local loopback.
- Keep direct/public sockets keyed by the unspoofable TCP peer address.

## Verification
- `node -c custom-server.js`
- `git diff --check`
- Validated on a v0.5.4 deployment behind nginx:
  - login page returns `200`
  - model list still works
  - limiter separation test: one simulated IP reaches `429` after 5 failures, another IP still receives `401` instead of inheriting the lockout

