### PR TITLE
[codex] Fix Perplexity models endpoint

### DIFF
--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -226,7 +226,7 @@ const PROVIDER_MODELS_CONFIG = {
   groq: createOpenAIModelsConfig("https://api.groq.com/openai/v1/models"),
   xai: createOpenAIModelsConfig("https://api.x.ai/v1/models"),
   mistral: createOpenAIModelsConfig("https://api.mistral.ai/v1/models"),
-  perplexity: createOpenAIModelsConfig("https://api.perplexity.ai/models"),
+  perplexity: createOpenAIModelsConfig("https://api.perplexity.ai/v1/models"),
   together: createOpenAIModelsConfig("https://api.together.xyz/v1/models"),
   fireworks: createOpenAIModelsConfig("https://api.fireworks.ai/inference/v1/models"),
   cerebras: createOpenAIModelsConfig("https://api.cerebras.ai/v1/models"),

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -502,7 +502,7 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
       }
       case "perplexity": {
-        const res = await fetchWithConnectionProxy("https://api.perplexity.ai/models", { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy);
+        const res = await fetchWithConnectionProxy("https://api.perplexity.ai/v1/models", { headers: { Authorization: `Bearer ${connection.apiKey}` } }, effectiveProxy);
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
       }
       case "together": {


### PR DESCRIPTION
## Summary

Updates Perplexity model-list validation endpoints from the deprecated `/models` path to the current `/v1/models` path.

## Root Cause

Perplexity API keys are valid against `https://api.perplexity.ai/v1/models`, while `https://api.perplexity.ai/models` now returns `404`. The stale endpoint can make valid Perplexity API keys appear invalid in provider testing and model listing.

## Changes

- Update Perplexity provider connection test endpoint to `https://api.perplexity.ai/v1/models`
- Update Perplexity models route endpoint to `https://api.perplexity.ai/v1/models`

## Validation

- Verified a local endpoint string check passes for both changed files.
- Verified in a live `9router@0.5.4` deployment that:
  - `GET https://api.perplexity.ai/models` returns `404`
  - `GET https://api.perplexity.ai/v1/models` returns `200`
  - `POST /v1/search` with provider `perplexity` returns `200` after the endpoint fix

Fixes #1894
