### PR TITLE
fix(cli-tools): tolerate JSONC configs in CLI tool settings routes

### DIFF
--- a/src/app/api/cli-tools/claude-settings/route.js
+++ b/src/app/api/cli-tools/claude-settings/route.js
@@ -41,12 +41,12 @@ const readSettings = async () => {
   try {
     const settingsPath = getClaudeSettingsPath();
     const content = await fs.readFile(settingsPath, "utf-8");
-    return JSON.parse(content);
+    // Tolerate JSONC (trailing commas) and treat unparseable files as "no config"
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
   } catch (error) {
-    if (error.code === "ENOENT") {
-      return null;
-    }
-    throw error;
+    return null;
   }
 };
 

--- a/src/app/api/cli-tools/cline-settings/route.js
+++ b/src/app/api/cli-tools/cline-settings/route.js
@@ -35,10 +35,12 @@ const checkInstalled = async () => {
 const readJson = async (filePath) => {
   try {
     const content = await fs.readFile(filePath, "utf-8");
-    return JSON.parse(content);
+    // Tolerate JSONC (trailing commas) and treat unparseable files as "no config"
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
   } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
+    return null;
   }
 };
 

--- a/src/app/api/cli-tools/copilot-settings/route.js
+++ b/src/app/api/cli-tools/copilot-settings/route.js
@@ -21,10 +21,12 @@ const getConfigPath = () => {
 const readConfig = async () => {
   try {
     const content = await fs.readFile(getConfigPath(), "utf-8");
-    return JSON.parse(content);
+    // Tolerate JSONC (trailing commas) and treat unparseable files as "no config"
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
   } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
+    return null;
   }
 };
 

--- a/src/app/api/cli-tools/cowork-settings/route.js
+++ b/src/app/api/cli-tools/cowork-settings/route.js
@@ -116,10 +116,14 @@ const get1pRoot = () => {
 const get1pConfigPath = () => path.join(get1pRoot(), "claude_desktop_config.json");
 
 const read1pConfig = async () => {
-  try { return JSON.parse(await fs.readFile(get1pConfigPath(), "utf-8")) || {}; }
-  catch (error) {
-    if (error.code === "ENOENT") return {};
-    throw error;
+  try {
+    const content = await fs.readFile(get1pConfigPath(), "utf-8");
+    // Tolerate JSONC (trailing commas) and treat unparseable files as empty config
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped) || {};
+  } catch (error) {
+    return {};
   }
 };
 
@@ -193,10 +197,14 @@ const checkInstalled = async () => {
 };
 
 const readJson = async (filePath) => {
-  try { return JSON.parse(await fs.readFile(filePath, "utf-8")); }
-  catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    // Tolerate JSONC (trailing commas) and treat unparseable files as "no config"
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
+  } catch (error) {
+    return null;
   }
 };
 

--- a/src/app/api/cli-tools/droid-settings/route.js
+++ b/src/app/api/cli-tools/droid-settings/route.js
@@ -37,10 +37,12 @@ const readSettings = async () => {
   try {
     const settingsPath = getDroidSettingsPath();
     const content = await fs.readFile(settingsPath, "utf-8");
-    return JSON.parse(content);
+    // Tolerate JSONC (trailing commas) and treat unparseable files as "no config"
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
   } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
+    return null;
   }
 };
 

--- a/src/app/api/cli-tools/kilo-settings/route.js
+++ b/src/app/api/cli-tools/kilo-settings/route.js
@@ -35,10 +35,12 @@ const checkInstalled = async () => {
 const readJson = async (filePath) => {
   try {
     const content = await fs.readFile(filePath, "utf-8");
-    return JSON.parse(content);
+    // Tolerate JSONC (trailing commas) and treat unparseable files as "no config"
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
   } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
+    return null;
   }
 };
 

--- a/src/app/api/cli-tools/openclaw-settings/route.js
+++ b/src/app/api/cli-tools/openclaw-settings/route.js
@@ -47,10 +47,12 @@ const readSettings = async () => {
   try {
     const settingsPath = getOpenClawSettingsPath();
     const content = await fs.readFile(settingsPath, "utf-8");
-    return JSON.parse(content);
+    // Tolerate JSONC (trailing commas) and treat unparseable files as "no config"
+    // rather than throwing a 500 that the UI misreads as "tool not installed".
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
   } catch (error) {
-    if (error.code === "ENOENT") return null;
-    throw error;
+    return null;
   }
 };
 

--- a/src/app/api/cli-tools/opencode-settings/route.js
+++ b/src/app/api/cli-tools/opencode-settings/route.js
@@ -35,10 +35,16 @@ const checkOpenCodeInstalled = async () => {
 const readConfig = async () => {
   try {
     const content = await fs.readFile(getConfigPath(), "utf-8");
-    return JSON.parse(content);
+    // opencode config files may use JSONC format (trailing commas, comments).
+    // Strip trailing commas before parsing to avoid SyntaxError on valid JSONC.
+    const stripped = content.replace(/,(\s*[}\]])/g, "$1");
+    return JSON.parse(stripped);
   } catch (error) {
     if (error.code === "ENOENT") return null;
-    throw error;
+    // If the config file exists but is unparseable (corrupted, exotic JSONC),
+    // treat it as "no config" rather than throwing a 500 that the UI
+    // misinterprets as "opencode not installed".
+    return null;
   }
 };
 


### PR DESCRIPTION
## Summary

CLI tool detection fails when a tool's config file contains trailing commas (JSONC). The `readConfig`/`readSettings`/`readJson` functions used `JSON.parse()` but only caught `ENOENT` — a `SyntaxError` from trailing commas was re-thrown, causing the settings API to return HTTP 500. The UI interpreted the 500 response (missing `installed` field) as "tool not installed."

This affected 8 CLI tool routes: opencode, openclaw, kilo, droid, cowork, copilot, claude, and cline.

To explain it simply, if CLI .jsonc config file contains syntax that is invalid as per .json specs, 9router will end up saying thay the CLI is not installed.

## What changed

Each affected route's config-reading function now:

1. **Strips trailing commas** before parsing (`/,(\s*[}\]])/g` → `$1`), so JSONC-formatted configs parse without error.
2. **Returns `null` on any remaining parse error** instead of re-throwing, so the UI shows "installed but not configured" (accurate) rather than "not installed" (misleading).

The opencode fix also retains the explicit `ENOENT` check (for clarity), while the other 7 routes use a blanket `return null` in catch — both are functionally equivalent since `null` is already the ENOENT fallback.

## Verification
I removed trailing commas from my `opencode.jsonc` config file and 9router started detecting opencode as installed again.
