### PR TITLE
feat: add optional Headroom token saver

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Default URLs:
 | Feature | What It Does | Why It Matters |
 |---------|--------------|----------------|
 | 🚀 **RTK Token Saver** ([RTK](https://github.com/rtk-ai/rtk) ⭐40K) | Compress tool outputs (`git diff`, `grep`, `ls`, `tree`...) before sending to LLM | Save **20-40% input tokens** per request |
+| 🧠 **Headroom Token Saver** ([Headroom](https://github.com/chopratejas/headroom)) | Optional external `/v1/compress` proxy before provider routing | Save more context tokens without changing clients |
 | 🪨 **Caveman Mode** ([Caveman](https://github.com/JuliusBrussee/caveman) ⭐52K) | Inject caveman-speak prompt → LLM replies terse, technical substance preserved | Save **up to 65% output tokens** |
 | 🎯 **Smart 3-Tier Fallback** | Auto-route: Subscription → Cheap → Free | Never stop coding, zero downtime |
 | 📊 **Real-Time Quota Tracking** | Live token count + reset countdown | Maximize subscription value |
@@ -436,6 +437,35 @@ Tool outputs (`git diff`, `grep`, `find`, `ls`, `tree`, log dumps...) often eat 
 Without RTK: 47K tokens sent to LLM
 With RTK:    28K tokens sent to LLM   (40% saved · same context · same answer)
 ```
+
+### 🧠 Headroom Token Saver
+
+Headroom is optional and runs separately. 9Router calls Headroom's local `/v1/compress` endpoint, then keeps normal routing, fallback, auth, and usage tracking:
+
+```
+Client → 9Router → Headroom /v1/compress → 9Router → provider
+```
+
+Local setup:
+
+```bash
+pip install "headroom-ai[proxy]"
+headroom proxy --port 8787
+```
+
+Enable in Dashboard → Endpoint → Token Saver → Headroom. Default URL: `http://localhost:8787`.
+
+Docker examples:
+
+```bash
+# Headroom service in same Docker network
+http://headroom:8787
+
+# Headroom running on host machine
+http://host.docker.internal:8787
+```
+
+If Headroom is down or returns an error, 9Router fails open and sends the original request.
 
 ### 🎯 Smart 3-Tier Fallback
 

--- a/cli/src/cli/menus/settings.js
+++ b/cli/src/cli/menus/settings.js
@@ -39,6 +39,8 @@ async function showSettingsMenu(breadcrumb = []) {
       // RTK section
       const rtkOn = data?.settings?.rtkEnabled !== false;
       lines.push(`  RTK:      ${rtkOn ? `${COLORS.green}ON${COLORS.reset}` : `${COLORS.red}OFF${COLORS.reset}`} ${COLORS.dim}(Token Saver)${COLORS.reset}`);
+      const headroomOn = data?.settings?.headroomEnabled === true;
+      lines.push(`  Headroom: ${headroomOn ? `${COLORS.green}ON${COLORS.reset}` : `${COLORS.red}OFF${COLORS.reset}`} ${COLORS.dim}(${data?.settings?.headroomUrl || "http://localhost:8787"})${COLORS.reset}`);
 
       // Auth mode section
       const authMode = data?.settings?.authMode || "password";
@@ -72,6 +74,13 @@ async function showSettingsMenu(breadcrumb = []) {
           return `Token Saver (RTK): ${on ? "ON" : "OFF"} → toggle`;
         },
         action: async (d) => { await toggleRtk(d?.settings?.rtkEnabled !== false); return true; }
+      },
+      {
+        label: (d) => {
+          const on = d?.settings?.headroomEnabled === true;
+          return `Token Saver (Headroom): ${on ? "ON" : "OFF"} → toggle`;
+        },
+        action: async (d) => { await toggleHeadroom(d?.settings?.headroomEnabled === true); return true; }
       },
       {
         label: "🔑 Reset Password to Default",
@@ -154,6 +163,17 @@ async function toggleRtk(currentlyOn) {
   const result = await api.updateSettings({ rtkEnabled: next });
   if (result.success) {
     showStatus(`Token Saver ${next ? "enabled" : "disabled"}`, "success");
+  } else {
+    showStatus(`Failed: ${result.error}`, "error");
+  }
+  await pause();
+}
+
+async function toggleHeadroom(currentlyOn) {
+  const next = !currentlyOn;
+  const result = await api.updateSettings({ headroomEnabled: next });
+  if (result.success) {
+    showStatus(`Headroom ${next ? "enabled" : "disabled"}`, "success");
   } else {
     showStatus(`Failed: ${result.error}`, "error");
   }

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -21,6 +21,7 @@ import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.j
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
+import { compressWithHeadroom, formatHeadroomLog } from "../rtk/headroom.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
@@ -32,7 +33,7 @@ import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, cavemanEnabled, cavemanLevel, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, cavemanEnabled, cavemanLevel, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -148,6 +149,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const rtkStats = compressMessages(translatedBody, rtkEnabled);
   const rtkLine = formatRtkLog(rtkStats);
   if (rtkLine) console.log(rtkLine);
+
+  // Headroom: optional external proxy compression; fail open if proxy is absent.
+  const headroomStats = await compressWithHeadroom(translatedBody, { enabled: headroomEnabled, url: headroomUrl, model: upstreamModel });
+  const headroomLine = formatHeadroomLog(headroomStats);
+  if (headroomLine) console.log(headroomLine);
 
   // Caveman: inject terse-style system prompt
   if (cavemanEnabled && cavemanLevel) {

--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -1,0 +1,38 @@
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export async function compressWithHeadroom(body, { enabled, url, model, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  if (!enabled || !url || !body) return null;
+
+  const key = Array.isArray(body.messages) ? "messages"
+    : Array.isArray(body.input) ? "input"
+    : null;
+  if (!key) return null;
+
+  const original = body[key];
+  try {
+    const endpoint = `${String(url).replace(/\/$/, "")}/v1/compress`;
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: original, model }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!Array.isArray(data?.messages)) return null;
+
+    body[key] = data.messages;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function formatHeadroomLog(stats) {
+  if (!stats || !stats.tokens_saved) return null;
+  const before = stats.tokens_before || 0;
+  const after = stats.tokens_after || 0;
+  const pct = before > 0 ? ((stats.tokens_saved / before) * 100).toFixed(1) : "0";
+  return `[Headroom] saved ${stats.tokens_saved} tokens / ${before} (${pct}%) ${after ? `after=${after}` : ""}`.trim();
+}

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -33,6 +33,8 @@ export default function APIPageClient({ machineId }) {
   const [hasPassword, setHasPassword] = useState(true);
   const [tunnelDashboardAccess, setTunnelDashboardAccess] = useState(false);
   const [rtkEnabled, setRtkEnabledState] = useState(true);
+  const [headroomEnabled, setHeadroomEnabled] = useState(false);
+  const [headroomUrl, setHeadroomUrl] = useState("http://localhost:8787");
   const [cavemanEnabled, setCavemanEnabled] = useState(false);
   const [cavemanLevel, setCavemanLevel] = useState("full");
   const [locale, setLocale] = useState("en");
@@ -232,6 +234,8 @@ export default function APIPageClient({ machineId }) {
         setHasPassword(data.hasPassword || false);
         setTunnelDashboardAccess(data.tunnelDashboardAccess || false);
         setRtkEnabledState(data.rtkEnabled !== false);
+        setHeadroomEnabled(!!data.headroomEnabled);
+        setHeadroomUrl(data.headroomUrl || "http://localhost:8787");
         setCavemanEnabled(!!data.cavemanEnabled);
         setCavemanLevel(data.cavemanLevel || "full");
       }
@@ -311,6 +315,19 @@ export default function APIPageClient({ machineId }) {
   const handleCavemanEnabled = (value) => {
     setCavemanEnabled(value);
     patchSetting({ cavemanEnabled: value });
+  };
+
+  const handleHeadroomEnabled = (value) => {
+    const nextUrl = headroomUrl.trim() || "http://localhost:8787";
+    setHeadroomUrl(nextUrl);
+    setHeadroomEnabled(value);
+    patchSetting({ headroomEnabled: value, headroomUrl: nextUrl });
+  };
+
+  const handleHeadroomUrlBlur = () => {
+    const next = headroomUrl.trim() || "http://localhost:8787";
+    setHeadroomUrl(next);
+    patchSetting({ headroomUrl: next });
   };
 
   const handleCavemanLevel = (level) => {
@@ -1041,6 +1058,37 @@ export default function APIPageClient({ machineId }) {
           <Toggle
             checked={rtkEnabled}
             onChange={() => handleRtkEnabled(!rtkEnabled)}
+          />
+        </div>
+        <div className="flex items-center justify-between py-4 border-b border-border gap-4 flex-wrap">
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">
+              Compress context{" "}
+              <a
+                href="https://github.com/chopratejas/headroom"
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs font-normal text-primary underline hover:opacity-80"
+              >
+                (Headroom)
+              </a>
+            </p>
+            <p className="text-sm text-text-muted">
+              Run Headroom separately → compress via /v1/compress before provider routing
+            </p>
+            {headroomEnabled && (
+              <Input
+                value={headroomUrl}
+                onChange={(e) => setHeadroomUrl(e.target.value)}
+                onBlur={handleHeadroomUrlBlur}
+                placeholder="http://localhost:8787"
+                className="mt-3 font-mono text-sm"
+              />
+            )}
+          </div>
+          <Toggle
+            checked={headroomEnabled}
+            onChange={() => handleHeadroomEnabled(!headroomEnabled)}
           />
         </div>
         <div className="flex items-center justify-between pt-4 gap-4 flex-wrap">

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -34,6 +34,8 @@ const DEFAULT_SETTINGS = {
   mitmRouterBaseUrl: DEFAULT_MITM_ROUTER_BASE,
   dnsToolEnabled: {},
   rtkEnabled: true,
+  headroomEnabled: false,
+  headroomUrl: "http://localhost:8787",
   cavemanEnabled: false,
   cavemanLevel: "full",
 };

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -251,6 +251,8 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       apiKey,
       ccFilterNaming: !!chatSettings.ccFilterNaming,
       rtkEnabled: !!chatSettings.rtkEnabled,
+      headroomEnabled: !!chatSettings.headroomEnabled,
+      headroomUrl: chatSettings.headroomUrl || "http://localhost:8787",
       cavemanEnabled: !!chatSettings.cavemanEnabled,
       cavemanLevel: chatSettings.cavemanLevel || "full",
       providerThinking,

--- a/tests/unit/headroom.test.js
+++ b/tests/unit/headroom.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { compressWithHeadroom, formatHeadroomLog } from "../../open-sse/rtk/headroom.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("compressWithHeadroom", () => {
+  it("no-ops when disabled", async () => {
+    global.fetch = vi.fn();
+    const body = { messages: [{ role: "user", content: "hello" }] };
+
+    const stats = await compressWithHeadroom(body, { enabled: false, url: "http://localhost:8787" });
+
+    expect(stats).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(body.messages[0].content).toBe("hello");
+  });
+
+  it("compresses messages in-place", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      messages: [{ role: "user", content: "short" }],
+      tokens_before: 100,
+      tokens_after: 20,
+      tokens_saved: 80,
+    }), { status: 200 }));
+    const body = { messages: [{ role: "user", content: "long" }] };
+
+    const stats = await compressWithHeadroom(body, { enabled: true, url: "http://headroom:8787/", model: "gpt-4o" });
+
+    expect(body.messages[0].content).toBe("short");
+    expect(stats.tokens_saved).toBe(80);
+    expect(global.fetch).toHaveBeenCalledWith("http://headroom:8787/v1/compress", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("compresses responses input in-place", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      messages: [{ role: "user", content: "short" }],
+    }), { status: 200 }));
+    const body = { input: [{ role: "user", content: "long" }] };
+
+    await compressWithHeadroom(body, { enabled: true, url: "http://localhost:8787" });
+
+    expect(body.input[0].content).toBe("short");
+  });
+
+  it("fails open on bad response", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({ error: "bad" }), { status: 500 }));
+    const body = { messages: [{ role: "user", content: "long" }] };
+
+    const stats = await compressWithHeadroom(body, { enabled: true, url: "http://localhost:8787" });
+
+    expect(stats).toBeNull();
+    expect(body.messages[0].content).toBe("long");
+  });
+
+  it("skips unknown shapes", async () => {
+    global.fetch = vi.fn();
+    const body = { contents: [{ parts: [{ text: "long" }] }] };
+
+    const stats = await compressWithHeadroom(body, { enabled: true, url: "http://localhost:8787" });
+
+    expect(stats).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatHeadroomLog", () => {
+  it("formats savings", () => {
+    expect(formatHeadroomLog({ tokens_before: 100, tokens_after: 25, tokens_saved: 75 }))
+      .toBe("[Headroom] saved 75 tokens / 100 (75.0%) after=25");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional Headroom compression via an external `/v1/compress` proxy before provider dispatch
- Adds dashboard and CLI toggles plus configurable Headroom proxy URL
- Documents local and Docker setup while keeping Headroom unbundled

## Why
Closes #1871.

This lets users run:

```
Client -> 9Router -> Headroom /v1/compress -> 9Router -> provider
```

9Router keeps routing, auth, fallback, usage logging, and provider translation. Headroom only handles context compression.

## Benefits
- Optional extra token savings on top of RTK
- No new runtime dependency or bundled Python process
- Docker-friendly via configurable URL, e.g. `http://headroom:8787` or `http://host.docker.internal:8787`
- Fail-open behavior: if Headroom is down or errors, the original request is sent unchanged

## Testing
- `NODE_PATH=tests/node_modules tests/node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/headroom.test.js --reporter=verbose` -> 6 passed
- `npm run build` -> TypeScript completed