### PR TITLE
fix(codex): preserve tool_search tools

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -22,7 +22,8 @@ const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
 // Hosted tool types that Codex/OpenAI Responses executes server-side
 const CODEX_HOSTED_TOOL_TYPES = new Set([
   "image_generation", "web_search", "web_search_preview", "file_search",
-  "computer", "computer_use_preview", "code_interpreter", "mcp", "local_shell"
+  "computer", "computer_use_preview", "code_interpreter", "mcp", "local_shell",
+  "tool_search"
 ]);
 
 // Allowlist of fields accepted by Codex Responses API — anything else is stripped

--- a/tests/unit/codex-tool-search.test.js
+++ b/tests/unit/codex-tool-search.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+describe("CodexExecutor tool normalization", () => {
+  it("preserves tool_search for deferred Codex tool discovery", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.5",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "probe" }],
+        },
+      ],
+      tools: [
+        {
+          type: "tool_search",
+          execution: "sync",
+          description: "Discover deferred tools",
+          parameters: { type: "object", properties: {} },
+        },
+        {
+          type: "namespace",
+          name: "codex_app",
+          description: "App tools",
+          tools: [
+            {
+              type: "function",
+              name: "automation_update",
+              description: "Update automation state",
+              parameters: { type: "object", properties: {} },
+              defer_loading: true,
+            },
+          ],
+        },
+        {
+          type: "function",
+          name: "plain_fn",
+          description: "plain",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    };
+
+    executor.transformRequest("gpt-5.5", body, true, {
+      connectionId: "codex-tool-search-test",
+      providerSpecificData: {},
+    });
+
+    expect(body.tools.map((tool) => tool.type)).toEqual([
+      "tool_search",
+      "namespace",
+      "function",
+    ]);
+    expect(body.tools[0]).toMatchObject({
+      type: "tool_search",
+      execution: "sync",
+      description: "Discover deferred tools",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve Responses `tool_search` tools in the Codex executor normalization allowlist.
- Add a regression test that exercises `CodexExecutor.transformRequest()` with `tool_search`, a deferred namespace tool, and a normal function tool.

## Why

Codex Desktop/App can expose deferred tools through `tool_search`. 9Router currently removes `tool_search` before forwarding the Responses request, so deferred app/thread/multi-agent tools cannot be discovered by the model.

## Test Plan

- PASS: `node --input-type=module` assertion against `CodexExecutor.transformRequest()` confirmed transformed tool types are `["tool_search", "namespace", "function"]`.
- NOT RUN: `npm exec --package vitest@4.1.9 -- vitest run tests/unit/codex-tool-search.test.js --config tests/vitest.config.js` could not load `tests/vitest.config.js` because this checkout does not declare a local `vitest` dependency, so `vitest/config` could not be resolved.