### PR TITLE
fix(test): use POST /v1/messages to validate anthropic-compatible connections

### DIFF
--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -354,11 +354,14 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
     if (!modelsBase) return { valid: false, error: "Missing base URL" };
     try {
       modelsBase = modelsBase.replace(/\/$/, "");
-      if (modelsBase.endsWith("/messages")) modelsBase = modelsBase.slice(0, -9);
-      const res = await fetchWithConnectionProxy(`${modelsBase}/models`, {
-        headers: { "x-api-key": connection.apiKey, "anthropic-version": "2023-06-01", "Authorization": `Bearer ${connection.apiKey}` },
+      const testModel = connection.defaultModel || "claude-3-haiku-20240307";
+      const res = await fetchWithConnectionProxy(`${modelsBase}/v1/messages`, {
+        method: "POST",
+        headers: { "x-api-key": connection.apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },
+        body: JSON.stringify({ model: testModel, max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
       }, effectiveProxy);
-      return { valid: res.ok, error: res.ok ? null : "Invalid API key or base URL" };
+      const valid = res.status !== 401 && res.status !== 403;
+      return { valid, error: valid ? null : "Invalid API key or base URL" };
     } catch (err) {
       return { valid: false, error: err.message };
     }


### PR DESCRIPTION
## Problem

The connection test for `anthropic-compatible` providers uses `GET /models` to validate API keys:

```js
const res = await fetchWithConnectionProxy(`${modelsBase}/models`, {
  headers: { "x-api-key": connection.apiKey, ... },
});
return { valid: res.ok, ... };
```

`GET /models` is not part of the Anthropic API spec. Many compatible proxies don't implement it, so it returns a 404 — causing the dashboard indicator to always show red even when the key and endpoint are valid.

## Fix

Switch to `POST /v1/messages` with `max_tokens: 1`, matching what the built-in `anthropic` provider already does for its own connection test. Treat any response that isn't 401 or 403 as valid — a 400 or 529 still confirms the key was accepted.

Also uses `connection.defaultModel` when set, so the test respects the configured model instead of always hardcoding `claude-3-haiku-20240307`.

## Relation to #1892

PR #1892 fixes the same issue for the built-in `anthropic` provider (adding `baseUrl` override support). This PR fixes the parallel `anthropic-compatible` branch which was missed.

## Test

Tested against a self-hosted Anthropic-compatible proxy — connection test now returns green with a valid key.