### PR TITLE
feat(providers): model filter, bulk actions, and disabled-model selection

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/ModelBulkActions.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ModelBulkActions.js
@@ -1,0 +1,93 @@
+"use client";
+
+import PropTypes from "prop-types";
+
+/**
+ * ModelBulkActions - Bulk action bar for selected models
+ *
+ * @param {Object} props
+ * @param {number} props.selectedCount - Number of selected models
+ * @param {Function} props.onEnable - Called when "Enable" is clicked
+ * @param {Function} props.onDisable - Called when "Disable" is clicked
+ * @param {Function} props.onDelete - Called when "Delete" is clicked
+ * @param {Function} props.onClearSelection - Called to clear selection
+ * @param {boolean} props.hideEnable - Whether to hide the Enable button
+ * @param {boolean} props.isDisabled - Whether bulk actions are disabled (e.g., during operation)
+ * @param {boolean} props.hideDisable - Whether to hide the Disable button
+ * @param {boolean} props.hideDelete - Whether to hide the Delete button
+ */
+export default function ModelBulkActions({
+  selectedCount,
+  onEnable,
+  onDisable,
+  onDelete,
+  onClearSelection,
+  hideEnable = false,
+  isDisabled = false,
+  hideDisable = false,
+  hideDelete = false,
+}) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 bg-primary/5 border border-primary/20 rounded-lg">
+      <span className="text-sm font-medium text-primary mr-2">
+        {selectedCount} model{selectedCount !== 1 ? "s" : ""} selected
+      </span>
+
+      {!hideEnable && (
+        <button
+          onClick={onEnable}
+          disabled={isDisabled}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-500/10 hover:bg-green-100 dark:hover:bg-green-500/20 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <span className="material-symbols-outlined text-[16px]">check_circle</span>
+          Enable
+        </button>
+      )}
+
+      {!hideDisable && (
+        <button
+          onClick={onDisable}
+          disabled={isDisabled}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 hover:bg-yellow-100 dark:hover:bg-yellow-500/20 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <span className="material-symbols-outlined text-[16px]">block</span>
+          Disable
+        </button>
+      )}
+
+      {!hideDelete && (
+        <button
+          onClick={onDelete}
+          disabled={isDisabled}
+          className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-red-700 dark:text-red-400 bg-red-50 dark:bg-red-500/10 hover:bg-red-100 dark:hover:bg-red-500/20 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <span className="material-symbols-outlined text-[16px]">delete</span>
+          Delete
+        </button>
+      )}
+
+      <button
+        onClick={onClearSelection}
+        disabled={isDisabled}
+        className="ml-auto px-2 py-1.5 text-sm text-text-muted hover:text-text hover:bg-bg-hover rounded-md transition-colors"
+        title="Clear selection"
+      >
+        <span className="material-symbols-outlined text-[16px]">close</span>
+      </button>
+    </div>
+  );
+}
+
+ModelBulkActions.propTypes = {
+  selectedCount: PropTypes.number.isRequired,
+  onEnable: PropTypes.func.isRequired,
+  onDisable: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onClearSelection: PropTypes.func.isRequired,
+  hideEnable: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  hideDisable: PropTypes.bool,
+  hideDelete: PropTypes.bool,
+};

--- a/src/app/(dashboard)/dashboard/providers/[id]/ModelFilterBar.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ModelFilterBar.js
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+
+const OPERATORS = [
+  { value: "contains", label: "Contains" },
+  { value: "notContains", label: "Does Not Contain" },
+  { value: "startsWith", label: "Starts With" },
+  { value: "endsWith", label: "Ends With" },
+  { value: "equals", label: "Equals" },
+];
+
+const SORT_OPTIONS = [
+  { value: "asc", label: "A → Z" },
+  { value: "desc", label: "Z → A" },
+];
+
+/**
+ * Apply Excel-style filter to a list of models
+ * @param {Array} models - Array of model objects with at least { id, name? }
+ * @param {Object} filter - { text: string, operator: string }
+ * @returns {Array} Filtered models
+ */
+export function applyModelFilter(models, filter) {
+  if (!filter || !filter.text || !filter.text.trim()) return models;
+
+  const text = filter.text.trim().toLowerCase();
+  const operator = filter.operator || "contains";
+
+  return models.filter((model) => {
+    const searchable = [
+      model.id,
+      model.name,
+      model.fullModel,
+      model.alias,
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+
+    switch (operator) {
+      case "contains":
+        return searchable.includes(text);
+      case "notContains":
+        return !searchable.includes(text);
+      case "startsWith":
+        return searchable.startsWith(text);
+      case "endsWith":
+        return searchable.endsWith(text);
+      case "equals":
+        return searchable === text;
+      default:
+        return searchable.includes(text);
+    }
+  });
+}
+
+/**
+ * Sort models by ID
+ * @param {Array} models - Array of model objects
+ * @param {string} sortOrder - "asc" or "desc"
+ * @returns {Array} Sorted models
+ */
+export function sortModels(models, sortOrder) {
+  if (!sortOrder) return models;
+  const sorted = [...models].sort((a, b) => {
+    const aId = (a.id || "").toLowerCase();
+    const bId = (b.id || "").toLowerCase();
+    return sortOrder === "asc" ? aId.localeCompare(bId) : bId.localeCompare(aId);
+  });
+  return sorted;
+}
+
+/**
+ * ModelFilterBar - Excel-style filter for model lists
+ *
+ * @param {Object} props
+ * @param {Function} props.onFilterChange - Called with { text, operator } when filter changes
+ * @param {Function} props.onSortChange - Called with sortOrder ("asc" / "desc" / null)
+ * @param {Function} props.onSelectAll - Called with true (select all) or false (deselect all)
+ * @param {boolean} props.allSelected - Whether all visible models are selected
+ * @param {number} props.selectedCount - Number of currently selected models
+ * @param {number} props.totalCount - Total number of models
+ * @param {string} props.currentSort - Current sort order ("asc" / "desc" / null)
+ * @param {Object} props.currentFilter - Current filter state { text, operator }
+ */
+export default function ModelFilterBar({
+  onFilterChange,
+  onSortChange,
+  onSelectAll,
+  allSelected,
+  selectedCount,
+  totalCount,
+  currentSort,
+  currentFilter,
+}) {
+  const [showFilterPanel, setShowFilterPanel] = useState(false);
+  const [showSortPanel, setShowSortPanel] = useState(false);
+  const filterPanelRef = useRef(null);
+  const sortPanelRef = useRef(null);
+
+  // Close panels on outside click
+  useEffect(() => {
+    function handleClickOutside(event) {
+      if (filterPanelRef.current && !filterPanelRef.current.contains(event.target)) {
+        setShowFilterPanel(false);
+      }
+      if (sortPanelRef.current && !sortPanelRef.current.contains(event.target)) {
+        setShowSortPanel(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleFilterTextChange = useCallback(
+    (text) => {
+      onFilterChange?.({ text, operator: currentFilter?.operator || "contains" });
+    },
+    [onFilterChange, currentFilter?.operator]
+  );
+
+  const handleOperatorChange = useCallback(
+    (operator) => {
+      onFilterChange?.({ text: currentFilter?.text || "", operator });
+    },
+    [onFilterChange, currentFilter?.text]
+  );
+
+  const clearFilter = useCallback(() => {
+    onFilterChange?.({ text: "", operator: "contains" });
+    setShowFilterPanel(false);
+  }, [onFilterChange]);
+
+  const hasActiveFilter = currentFilter?.text && currentFilter.text.trim();
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      {/* Filter input + button */}
+      <div className="relative" ref={filterPanelRef}>
+        <div className="flex items-center">
+          <div className="relative">
+            <input
+              type="text"
+              value={currentFilter?.text || ""}
+              onChange={(e) => handleFilterTextChange(e.target.value)}
+              placeholder="Filter models..."
+              className="w-48 sm:w-56 px-3 py-1.5 pr-8 text-sm border border-r-0 border-border rounded-l-lg bg-background focus:outline-none focus:border-primary"
+            />
+            {hasActiveFilter && (
+              <button
+                onClick={clearFilter}
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-text-muted hover:text-text hover:bg-bg-hover"
+                title="Clear filter"
+              >
+                <span className="material-symbols-outlined text-sm">close</span>
+              </button>
+            )}
+          </div>
+          <button
+            onClick={() => {
+              setShowFilterPanel(!showFilterPanel);
+              setShowSortPanel(false);
+            }}
+            className={`px-2 py-1.5 border border-border rounded-r-lg hover:bg-bg-hover transition-colors ${hasActiveFilter ? "bg-primary/10 text-primary" : "text-text-muted"}`}
+            title="Filter options"
+          >
+            <span className="material-symbols-outlined text-[18px]">filter_list</span>
+          </button>
+        </div>
+
+        {/* Filter operator dropdown */}
+        {showFilterPanel && (
+          <div className="absolute z-50 mt-1 w-56 bg-surface border border-border rounded-lg shadow-lg p-2">
+            <p className="text-xs font-semibold text-text-muted mb-2 uppercase tracking-wide">Operator</p>
+            {OPERATORS.map((op) => (
+              <button
+                key={op.value}
+                onClick={() => {
+                  handleOperatorChange(op.value);
+                  setShowFilterPanel(false);
+                }}
+                className={`w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors ${
+                  currentFilter?.operator === op.value
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-text-main hover:bg-bg-hover"
+                }`}
+              >
+                {op.label}
+              </button>
+            ))}
+            <div className="border-t border-border mt-2 pt-2">
+              <button
+                onClick={clearFilter}
+                className="w-full text-left px-3 py-1.5 text-sm text-text-muted hover:bg-bg-hover rounded-md transition-colors"
+              >
+                Clear Filter
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Sort button */}
+      <div className="relative" ref={sortPanelRef}>
+        <button
+          onClick={() => {
+            setShowSortPanel(!showSortPanel);
+            setShowFilterPanel(false);
+          }}
+          className={`px-2 py-1.5 border border-border rounded-lg hover:bg-bg-hover transition-colors ${currentSort ? "bg-primary/10 text-primary" : "text-text-muted"}`}
+          title="Sort models"
+        >
+          <span className="material-symbols-outlined text-[18px]">
+            {currentSort === "desc" ? "arrow_downward" : "sort"}
+          </span>
+        </button>
+
+        {showSortPanel && (
+          <div className="absolute z-50 mt-1 w-40 bg-surface border border-border rounded-lg shadow-lg p-2">
+            <p className="text-xs font-semibold text-text-muted mb-2 uppercase tracking-wide">Sort</p>
+            {SORT_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => {
+                  onSortChange?.(currentSort === opt.value ? null : opt.value);
+                  setShowSortPanel(false);
+                }}
+                className={`w-full text-left px-3 py-1.5 text-sm rounded-md transition-colors ${
+                  currentSort === opt.value
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-text-main hover:bg-bg-hover"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+            {currentSort && (
+              <button
+                onClick={() => {
+                  onSortChange?.(null);
+                  setShowSortPanel(false);
+                }}
+                className="w-full text-left px-3 py-1.5 text-sm text-text-muted hover:bg-bg-hover rounded-md transition-colors"
+              >
+                Clear Sort
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Select all checkbox */}
+      <div className="flex items-center gap-1.5 ml-2">
+        <input
+          type="checkbox"
+          checked={allSelected}
+          onChange={() => onSelectAll?.(!allSelected)}
+          className="size-4 rounded border-border text-primary focus:ring-primary/20 cursor-pointer"
+        />
+        <span className="text-xs text-text-muted">
+          {selectedCount > 0
+            ? `${selectedCount} / ${totalCount} selected`
+            : `${totalCount} models`}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+ModelFilterBar.propTypes = {
+  onFilterChange: PropTypes.func.isRequired,
+  onSortChange: PropTypes.func.isRequired,
+  onSelectAll: PropTypes.func.isRequired,
+  allSelected: PropTypes.bool.isRequired,
+  selectedCount: PropTypes.number.isRequired,
+  totalCount: PropTypes.number.isRequired,
+  currentSort: PropTypes.string,
+  currentFilter: PropTypes.shape({
+    text: PropTypes.string,
+    operator: PropTypes.string,
+  }),
+};

--- a/src/app/(dashboard)/dashboard/providers/[id]/ModelRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ModelRow.js
@@ -1,12 +1,16 @@
 import PropTypes from "prop-types";
 import { CapacityBadges } from "@/shared/components";
 
-export default function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCustom, isFree, onDeleteAlias, onTest, isTesting, onDisable, caps }) {
+export default function ModelRow({ model, fullModel, alias, copied, onCopy, testStatus, isCustom, isFree, onDeleteAlias, isDisabled, onTest, isTesting, onDisable, caps, selected, onToggleSelect }) {
   const borderColor = testStatus === "ok"
     ? "border-green-500/40"
     : testStatus === "error"
     ? "border-red-500/40"
-    : "border-border";
+    : selected
+    ? "border-primary/40"
+    : isDisabled
+    ? "border-text-muted/10"
+    : "border-success/15";
 
   const iconColor = testStatus === "ok"
     ? "#22c55e"
@@ -14,9 +18,23 @@ export default function ModelRow({ model, fullModel, alias, copied, onCopy, test
     ? "#ef4444"
     : undefined;
 
+  const rowBg = selected
+    ? "bg-primary/5"
+    : isDisabled
+    ? "bg-surface-2"
+    : "bg-success/[0.03] hover:bg-success/[0.06]";
+
   return (
-    <div className={`group min-w-0 max-w-full rounded-lg border px-3 py-2 ${borderColor} hover:bg-sidebar/50`}>
+    <div className={`group min-w-0 max-w-full rounded-lg border px-3 py-2 ${borderColor} ${rowBg}`}>
       <div className="flex min-w-0 items-start gap-2 sm:items-center">
+        {onToggleSelect && (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onToggleSelect(model.id)}
+            className="size-4 shrink-0 rounded border-border text-primary focus:ring-primary/20 cursor-pointer mt-0.5 sm:mt-0"
+          />
+        )}
         <span
           className="material-symbols-outlined shrink-0 text-base"
           style={iconColor ? { color: iconColor } : undefined}
@@ -91,10 +109,13 @@ ModelRow.propTypes = {
   onCopy: PropTypes.func.isRequired,
   testStatus: PropTypes.oneOf(["ok", "error"]),
   isCustom: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   isFree: PropTypes.bool,
   onDeleteAlias: PropTypes.func,
   onTest: PropTypes.func,
   isTesting: PropTypes.bool,
   onDisable: PropTypes.func,
   caps: PropTypes.object,
+  selected: PropTypes.bool,
+  onToggleSelect: PropTypes.func,
 };

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -1097,6 +1097,8 @@ export default function ProviderDetailPage() {
 
     const filteredDisplayModels = sortModels(applyModelFilter(displayModels, modelFilter), modelSort);
     const filteredActiveCustomModels = sortModels(applyModelFilter(activeCustomModels, modelFilter), modelSort);
+    const filteredDisabledDisplayModels = sortModels(applyModelFilter(disabledDisplayModels, modelFilter), modelSort);
+    const filteredDisabledCustomModels = sortModels(applyModelFilter(disabledCustomModels, modelFilter), modelSort);
     const allVisibleIds = [...filteredActiveCustomModels.map((m) => m.id), ...filteredDisplayModels.map((m) => m.id)];
     const allVisibleSelected = allVisibleIds.length > 0 && allVisibleIds.every((id) => selectedModelIds.includes(id));
 
@@ -1223,10 +1225,10 @@ export default function ProviderDetailPage() {
             );
           })()}
 
-          {(disabledDisplayModels.length + disabledCustomModels.length) > 0 && (
+          {(filteredDisabledDisplayModels.length + filteredDisabledCustomModels.length) > 0 && (
             <div className="w-full mt-2">
               <div className="flex items-center gap-2 mb-2">
-                <p className="text-xs text-text-muted">Disabled models ({disabledDisplayModels.length + disabledCustomModels.length}):</p>
+                <p className="text-xs text-text-muted">Disabled models ({filteredDisabledDisplayModels.length + filteredDisabledCustomModels.length}):</p>
                 <label className="flex items-center gap-1 cursor-pointer select-none">
                   <input
                     type="checkbox"
@@ -1241,10 +1243,10 @@ export default function ProviderDetailPage() {
                 </label>
                 {selectDisabledMode && (
                   <>
-                    {selectedDisabledModelIds.length < (disabledDisplayModels.length + disabledCustomModels.length) && (
+                    {selectedDisabledModelIds.length < (filteredDisabledDisplayModels.length + filteredDisabledCustomModels.length) && (
                       <button
                         onClick={() => {
-                          const allIds = [...disabledDisplayModels.map((m) => m.id), ...disabledCustomModels.map((m) => m.id)];
+                          const allIds = [...filteredDisabledDisplayModels.map((m) => m.id), ...filteredDisabledCustomModels.map((m) => m.id)];
                           setSelectedDisabledModelIds(allIds);
                         }}
                         className="text-[11px] text-text-muted/60 hover:text-primary underline"
@@ -1276,7 +1278,7 @@ export default function ProviderDetailPage() {
               )}
 
               <div className="flex flex-wrap gap-2">
-                {disabledDisplayModels.map((m) => (
+                {filteredDisabledDisplayModels.map((m) => (
                   <button
                     key={m.id}
                     onClick={() => {
@@ -1307,7 +1309,7 @@ export default function ProviderDetailPage() {
                     <span className={selectDisabledMode ? "text-xs" : ""}>{m.id}</span>
                   </button>
                 ))}
-                {disabledCustomModels.map((m) => (
+                {filteredDisabledCustomModels.map((m) => (
                   <button
                     key={m.id}
                     onClick={() => {

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -19,6 +19,8 @@ import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
 import BulkImportCodexModal from "./BulkImportCodexModal";
+import ModelFilterBar, { applyModelFilter, sortModels } from "./ModelFilterBar";
+import ModelBulkActions from "./ModelBulkActions";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
@@ -69,6 +71,11 @@ export default function ProviderDetailPage() {
   const [oneByOneSummary, setOneByOneSummary] = useState(null);
   const stopOneByOneRef = useRef(false);
   const [importingQoderModels, setImportingQoderModels] = useState(false);
+  const [modelFilter, setModelFilter] = useState({ text: "", operator: "contains" });
+  const [modelSort, setModelSort] = useState(null);
+  const [selectedModelIds, setSelectedModelIds] = useState([]);
+  const [selectDisabledMode, setSelectDisabledMode] = useState(false);
+  const [selectedDisabledModelIds, setSelectedDisabledModelIds] = useState([]);
   const { copied, copy } = useCopyToClipboard();
 
   const AG_RISK_STORAGE_KEY = "ag_risk_confirmed";
@@ -209,6 +216,136 @@ export default function ProviderDetailPage() {
     } catch (error) {
       console.log("Error enabling all models:", error);
     }
+  };
+
+  // Bulk model actions
+  const handleBulkEnable = async () => {
+    if (!selectedModelIds.length) return;
+    const idsToEnable = [...selectedModelIds];
+    setConfirmState({
+      title: "Enable Selected Models",
+      message: `Enable ${idsToEnable.length} model(s)?`,
+      onConfirm: async () => {
+        setConfirmState(null);
+        try {
+          let failed = 0;
+          for (const modelId of idsToEnable) {
+            const res = await fetch(`/api/models/disabled?providerAlias=${encodeURIComponent(providerStorageAlias)}&id=${encodeURIComponent(modelId)}`, { method: "DELETE" });
+            if (!res.ok) failed += 1;
+          }
+          await fetchDisabledModels();
+          if (failed > 0) alert(`Failed to enable ${failed} model(s).`);
+          setSelectedModelIds([]);
+        } catch (error) {
+          console.log("Error enabling selected models:", error);
+        }
+      }
+    });
+  };
+
+  const handleBulkDisable = async () => {
+    if (!selectedModelIds.length) return;
+    const idsToDisable = [...selectedModelIds];
+    setConfirmState({
+      title: "Disable Selected Models",
+      message: `Disable ${idsToDisable.length} model(s)?`,
+      onConfirm: async () => {
+        setConfirmState(null);
+        try {
+          const res = await fetch("/api/models/disabled", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ providerAlias: providerStorageAlias, ids: idsToDisable }),
+          });
+          if (res.ok) {
+            await fetchDisabledModels();
+            setSelectedModelIds([]);
+          } else {
+            const data = await res.json().catch(() => ({}));
+            alert(data.error || "Failed to disable models");
+          }
+        } catch (error) {
+          console.log("Error disabling selected models:", error);
+        }
+      }
+    });
+  };
+
+  const handleBulkDelete = async () => {
+    if (!selectedModelIds.length) return;
+    setConfirmState({
+      title: "Delete Selected Models",
+      message: `Permanently delete ${selectedModelIds.length} model(s)? This cannot be undone.`,
+      onConfirm: async () => {
+        setConfirmState(null);
+        try {
+          for (const modelId of selectedModelIds) {
+            const alias = Object.entries(modelAliases).find(([, m]) => m === `${providerStorageAlias}/${modelId}`)?.[0];
+            if (alias) {
+              await fetch(`/api/models/alias?alias=${encodeURIComponent(alias)}`, { method: "DELETE" });
+            }
+          }
+          await fetchAliases();
+          setSelectedModelIds([]);
+        } catch (error) {
+          console.log("Error deleting selected models:", error);
+        }
+      }
+    });
+  };
+
+  const handleBulkEnableDisabled = async () => {
+    if (!selectedDisabledModelIds.length) return;
+    const idsToEnable = [...selectedDisabledModelIds];
+    try {
+      let failed = 0;
+      for (const modelId of idsToEnable) {
+        const res = await fetch(`/api/models/disabled?providerAlias=${encodeURIComponent(providerStorageAlias)}&id=${encodeURIComponent(modelId)}`, { method: "DELETE" });
+        if (!res.ok) failed += 1;
+      }
+      await fetchDisabledModels();
+      if (failed > 0) alert(`Failed to enable ${failed} model(s).`);
+      setSelectedDisabledModelIds([]);
+    } catch (error) {
+      console.log("Error enabling disabled models:", error);
+    }
+  };
+
+  const handleBulkDeleteDisabled = async () => {
+    if (!selectedDisabledModelIds.length) return;
+    try {
+      for (const modelId of selectedDisabledModelIds) {
+        const alias = Object.entries(modelAliases).find(([, m]) => m === `${providerStorageAlias}/${modelId}`)?.[0];
+        if (alias) {
+          await fetch(`/api/models/alias?alias=${encodeURIComponent(alias)}`, { method: "DELETE" });
+        }
+      }
+      await fetchAliases();
+      setSelectedDisabledModelIds([]);
+    } catch (error) {
+      console.log("Error deleting disabled models:", error);
+    }
+  };
+
+  const toggleSelectModel = (modelId) => {
+    setSelectedModelIds((prev) =>
+      prev.includes(modelId) ? prev.filter((id) => id !== modelId) : [...prev, modelId]
+    );
+  };
+
+  const selectAllFilteredModels = (select, filteredIds) => {
+    setSelectedModelIds(select ? filteredIds : []);
+  };
+
+  const toggleSelectDisabledModel = (modelId) => {
+    setSelectedDisabledModelIds((prev) =>
+      prev.includes(modelId) ? prev.filter((id) => id !== modelId) : [...prev, modelId]
+    );
+  };
+
+  const selectAllDisabledModels = (select) => {
+    const allDisabledIds = [...disabledDisplayModels.map((m) => m.id), ...disabledCustomModels.map((m) => m.id)];
+    setSelectedDisabledModelIds(select ? allDisabledIds : []);
   };
 
   // Define callbacks BEFORE the useEffect that uses them
@@ -935,8 +1072,6 @@ export default function ProviderDetailPage() {
         />
       );
     }
-    // Combine hardcoded models with Kilo free models (deduplicated)
-    // Exclude non-llm models (embedding, tts, etc.) — they have dedicated pages under media-providers
     const allModels = [
       ...models,
       ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
@@ -944,14 +1079,11 @@ export default function ProviderDetailPage() {
     const disabledSet = new Set(disabledModelIds);
     const displayModels = allModels.filter((m) => !disabledSet.has(m.id));
     const disabledDisplayModels = allModels.filter((m) => disabledSet.has(m.id));
-    // Custom models added by user (stored as aliases: modelId → providerAlias/modelId)
     const customModels = Object.entries(modelAliases)
       .filter(([alias, fullModel]) => {
         const prefix = `${providerStorageAlias}/`;
         if (!fullModel.startsWith(prefix)) return false;
         const modelId = fullModel.slice(prefix.length);
-        // Only show if not already in hardcoded list
-        // For passthroughModels, include all aliases (model IDs may contain slashes like "anthropic/claude-3")
         if (providerInfo.passthroughModels) return !models.some((m) => m.id === modelId);
         return !models.some((m) => m.id === modelId) && alias === modelId;
       })
@@ -960,131 +1092,260 @@ export default function ProviderDetailPage() {
         alias,
         fullModel,
       }));
+    const activeCustomModels = customModels.filter((m) => !disabledSet.has(m.id));
+    const disabledCustomModels = customModels.filter((m) => disabledSet.has(m.id));
+
+    const filteredDisplayModels = sortModels(applyModelFilter(displayModels, modelFilter), modelSort);
+    const filteredActiveCustomModels = sortModels(applyModelFilter(activeCustomModels, modelFilter), modelSort);
+    const allVisibleIds = [...filteredActiveCustomModels.map((m) => m.id), ...filteredDisplayModels.map((m) => m.id)];
+    const allVisibleSelected = allVisibleIds.length > 0 && allVisibleIds.every((id) => selectedModelIds.includes(id));
 
     return (
-      <div className="flex flex-wrap gap-3">
-        {/* Custom models first */}
-        {customModels.map((model) => (
-          <ModelRow
-            key={model.id}
-            model={{ id: model.id }}
-            fullModel={`${providerDisplayAlias}/${model.id}`}
-            alias={model.alias}
-            copied={copied}
-            onCopy={copy}
-            onSetAlias={() => {}}
-            onDeleteAlias={() => handleDeleteAlias(model.alias)}
-            testStatus={modelTestResults[model.id]}
-            onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
-            isTesting={testingModelIds.has(model.id)}
-            isCustom
-            isFree={false}
-            caps={getCaps(`${providerId}/${model.id}`)}
-          />
-        ))}
+      <div className="flex flex-col gap-3">
+        <ModelFilterBar
+          onFilterChange={setModelFilter}
+          onSortChange={setModelSort}
+          onSelectAll={(select) => selectAllFilteredModels(select, allVisibleIds)}
+          allSelected={allVisibleSelected}
+          selectedCount={selectedModelIds.length}
+          totalCount={allVisibleIds.length}
+          currentSort={modelSort}
+          currentFilter={modelFilter}
+        />
 
-        {displayModels.map((model) => {
-          const fullModel = `${providerStorageAlias}/${model.id}`;
-          const oldFormatModel = `${providerId}/${model.id}`;
-          const existingAlias = Object.entries(modelAliases).find(
-            ([, m]) => m === fullModel || m === oldFormatModel
-          )?.[0];
-          return (
+        <ModelBulkActions
+          selectedCount={selectedModelIds.length}
+          onEnable={handleBulkEnable}
+          onDisable={handleBulkDisable}
+          onDelete={handleBulkDelete}
+          onClearSelection={() => setSelectedModelIds([])}
+          hideEnable
+        />
+
+        <div className="flex flex-wrap gap-3">
+          {filteredActiveCustomModels.map((model) => (
             <ModelRow
               key={model.id}
-              model={model}
+              model={{ id: model.id }}
               fullModel={`${providerDisplayAlias}/${model.id}`}
-              alias={existingAlias}
+              alias={model.alias}
               copied={copied}
               onCopy={copy}
-              onSetAlias={(alias) => handleSetAlias(model.id, alias, providerStorageAlias)}
-              onDeleteAlias={() => handleDeleteAlias(existingAlias)}
+              onSetAlias={() => {}}
+              onDeleteAlias={() => handleDeleteAlias(model.alias)}
               testStatus={modelTestResults[model.id]}
               onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
               isTesting={testingModelIds.has(model.id)}
-              isFree={model.isFree}
-              onDisable={() => handleDisableModel(model.id)}
+              isCustom
+              isFree={false}
               caps={getCaps(`${providerId}/${model.id}`)}
+              selected={selectedModelIds.includes(model.id)}
+              onToggleSelect={toggleSelectModel}
             />
-          );
-        })}
+          ))}
 
-        {/* Add model button — inline, same style as model chips */}
-        <button
-          onClick={() => setShowAddCustomModel(true)}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-primary/40 px-3 py-2 text-xs text-primary transition-colors hover:border-primary hover:bg-primary/5 sm:w-auto"
-        >
-          <span className="material-symbols-outlined text-sm">add</span>
-          Add Model
-        </button>
+          {filteredDisplayModels.map((model) => {
+            const fullModel = `${providerStorageAlias}/${model.id}`;
+            const oldFormatModel = `${providerId}/${model.id}`;
+            const existingAlias = Object.entries(modelAliases).find(
+              ([, m]) => m === fullModel || m === oldFormatModel
+            )?.[0];
+            return (
+              <ModelRow
+                key={model.id}
+                model={model}
+                fullModel={`${providerDisplayAlias}/${model.id}`}
+                alias={existingAlias}
+                copied={copied}
+                onCopy={copy}
+                onSetAlias={(alias) => handleSetAlias(model.id, alias, providerStorageAlias)}
+                onDeleteAlias={() => handleDeleteAlias(existingAlias)}
+                testStatus={modelTestResults[model.id]}
+                onTest={connections.length > 0 || isFreeNoAuth ? () => handleTestModel(model.id) : undefined}
+                isTesting={testingModelIds.has(model.id)}
+                isFree={model.isFree}
+                onDisable={() => handleDisableModel(model.id)}
+                caps={getCaps(`${providerId}/${model.id}`)}
+                selected={selectedModelIds.includes(model.id)}
+                onToggleSelect={toggleSelectModel}
+              />
+            );
+          })}
 
-        {/* Import Qoder models button — only show for qoder provider */}
-        {providerId === "qoder" && connections.some((conn) => conn.isActive !== false) && (
           <button
-            onClick={handleImportQoderModels}
-            disabled={importingQoderModels}
-            className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-blue-500/40 px-3 py-2 text-xs text-blue-600 dark:text-blue-400 transition-colors hover:border-blue-500 hover:bg-blue-500/5 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={() => setShowAddCustomModel(true)}
+            className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-primary/40 px-3 py-2 text-xs text-primary transition-colors hover:border-primary hover:bg-primary/5 sm:w-auto"
           >
-            <span className="material-symbols-outlined text-sm" style={importingQoderModels ? { animation: "spin 1s linear infinite" } : undefined}>
-              {importingQoderModels ? "progress_activity" : "download"}
-            </span>
-            {importingQoderModels ? translate("Fetching...") : translate("Fetch Qoder Models")}
+            <span className="material-symbols-outlined text-sm">add</span>
+            Add Model
           </button>
-        )}
 
-        {/* Suggested models from provider API — show only models not yet added */}
-        {suggestedModels.length > 0 && (() => {
-          const addedFullModels = new Set(Object.values(modelAliases));
-          const hardcodedIds = new Set(models.map((m) => m.id));
-          const notAdded = suggestedModels.filter(
-            (m) => !addedFullModels.has(`${providerStorageAlias}/${m.id}`) && !hardcodedIds.has(m.id)
-          );
-          if (notAdded.length === 0) return null;
-          return (
+          {providerId === "qoder" && connections.some((conn) => conn.isActive !== false) && (
+            <button
+              onClick={handleImportQoderModels}
+              disabled={importingQoderModels}
+              className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-blue-500/40 px-3 py-2 text-xs text-blue-600 dark:text-blue-400 transition-colors hover:border-blue-500 hover:bg-blue-500/5 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span className="material-symbols-outlined text-sm" style={importingQoderModels ? { animation: "spin 1s linear infinite" } : undefined}>
+                {importingQoderModels ? "progress_activity" : "download"}
+              </span>
+              {importingQoderModels ? translate("Fetching...") : translate("Fetch Qoder Models")}
+            </button>
+          )}
+
+          {suggestedModels.length > 0 && (() => {
+            const addedFullModels = new Set(Object.values(modelAliases));
+            const hardcodedIds = new Set(models.map((m) => m.id));
+            const notAdded = suggestedModels.filter(
+              (m) => !addedFullModels.has(`${providerStorageAlias}/${m.id}`) && !hardcodedIds.has(m.id)
+            );
+            if (notAdded.length === 0) return null;
+            return (
+              <div className="w-full mt-2">
+                <p className="text-xs text-text-muted mb-2">Suggested free models (≥200k context):</p>
+                <div className="flex flex-wrap gap-2">
+                  {notAdded.map((m) => (
+                    <button
+                      key={m.id}
+                      onClick={async () => {
+                        const alias = m.id.split("/").pop();
+                        await handleSetAlias(m.id, alias, providerStorageAlias);
+                      }}
+                      className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-black/10 dark:border-white/10 text-xs text-text-muted hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors"
+                      title={`${m.name} · ${(m.contextLength / 1000).toFixed(0)}k ctx`}
+                    >
+                      <span className="material-symbols-outlined text-[13px]">add</span>
+                      {m.id.split("/").pop()}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
+
+          {(disabledDisplayModels.length + disabledCustomModels.length) > 0 && (
             <div className="w-full mt-2">
-              <p className="text-xs text-text-muted mb-2">Suggested free models (≥200k context):</p>
+              <div className="flex items-center gap-2 mb-2">
+                <p className="text-xs text-text-muted">Disabled models ({disabledDisplayModels.length + disabledCustomModels.length}):</p>
+                <label className="flex items-center gap-1 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={selectDisabledMode}
+                    onChange={() => {
+                      setSelectDisabledMode((prev) => !prev);
+                      setSelectedDisabledModelIds([]);
+                    }}
+                    className="size-3.5 rounded border-border text-primary focus:ring-primary/20 cursor-pointer"
+                  />
+                  <span className="text-[11px] text-text-muted">{selectDisabledMode ? "Close" : "Select"}</span>
+                </label>
+                {selectDisabledMode && (
+                  <>
+                    {selectedDisabledModelIds.length < (disabledDisplayModels.length + disabledCustomModels.length) && (
+                      <button
+                        onClick={() => {
+                          const allIds = [...disabledDisplayModels.map((m) => m.id), ...disabledCustomModels.map((m) => m.id)];
+                          setSelectedDisabledModelIds(allIds);
+                        }}
+                        className="text-[11px] text-text-muted/60 hover:text-primary underline"
+                      >
+                        Select All
+                      </button>
+                    )}
+                    {selectedDisabledModelIds.length > 0 && (
+                      <button
+                        onClick={() => setSelectedDisabledModelIds([])}
+                        className="text-[11px] text-text-muted/60 hover:text-primary underline"
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {selectDisabledMode && selectedDisabledModelIds.length > 0 && (
+                <ModelBulkActions
+                  selectedCount={selectedDisabledModelIds.length}
+                  onEnable={handleBulkEnableDisabled}
+                  onDisable={() => {}}
+                  onDelete={handleBulkDeleteDisabled}
+                  onClearSelection={() => setSelectedDisabledModelIds([])}
+                  hideDisable
+                />
+              )}
+
               <div className="flex flex-wrap gap-2">
-                {notAdded.map((m) => (
+                {disabledDisplayModels.map((m) => (
                   <button
                     key={m.id}
-                    onClick={async () => {
-                      const alias = m.id.split("/").pop();
-                      await handleSetAlias(m.id, alias, providerStorageAlias);
+                    onClick={() => {
+                      if (selectDisabledMode) {
+                        toggleSelectDisabledModel(m.id);
+                      } else {
+                        handleEnableModel(m.id);
+                      }
                     }}
-                    className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-black/10 dark:border-white/10 text-xs text-text-muted hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors"
-                    title={`${m.name} · ${(m.contextLength / 1000).toFixed(0)}k ctx`}
+                    className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg border transition-colors ${
+                      selectDisabledMode && selectedDisabledModelIds.includes(m.id)
+                        ? "border-primary/40 bg-primary/10 text-primary"
+                        : "border border-dashed border-text-muted/20 bg-surface-2 text-xs text-text-muted/80 hover:text-primary hover:border-primary/40 hover:bg-primary/5"
+                    }`}
+                    title={selectDisabledMode ? "Toggle select" : "Restore model"}
                   >
-                    <span className="material-symbols-outlined text-[13px]">add</span>
-                    {m.id.split("/").pop()}
+                    {selectDisabledMode ? (
+                      <input
+                        type="checkbox"
+                        checked={selectedDisabledModelIds.includes(m.id)}
+                        onChange={() => toggleSelectDisabledModel(m.id)}
+                        className="size-3.5 rounded border-border text-primary focus:ring-primary/20 cursor-pointer"
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    ) : (
+                      <span className="material-symbols-outlined text-[13px]">add</span>
+                    )}
+                    <span className={selectDisabledMode ? "text-xs" : ""}>{m.id}</span>
+                  </button>
+                ))}
+                {disabledCustomModels.map((m) => (
+                  <button
+                    key={m.id}
+                    onClick={() => {
+                      if (selectDisabledMode) {
+                        toggleSelectDisabledModel(m.id);
+                      } else {
+                        handleEnableModel(m.id);
+                      }
+                    }}
+                    className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg border transition-colors ${
+                      selectDisabledMode && selectedDisabledModelIds.includes(m.id)
+                        ? "border-primary/40 bg-primary/10 text-primary"
+                        : "border border-dashed border-text-muted/20 bg-surface-2 text-xs text-text-muted/80 hover:text-primary hover:border-primary/40 hover:bg-primary/5"
+                    }`}
+                    title={selectDisabledMode ? "Toggle select" : "Restore custom model"}
+                  >
+                    {selectDisabledMode ? (
+                      <input
+                        type="checkbox"
+                        checked={selectedDisabledModelIds.includes(m.id)}
+                        onChange={() => toggleSelectDisabledModel(m.id)}
+                        className="size-3.5 rounded border-border text-primary focus:ring-primary/20 cursor-pointer"
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    ) : (
+                      <span className="material-symbols-outlined text-[13px]">add</span>
+                    )}
+                    <span className={selectDisabledMode ? "text-xs" : ""}>{m.id}</span>
                   </button>
                 ))}
               </div>
             </div>
-          );
-        })()}
-
-        {/* Disabled models — restorable */}
-        {disabledDisplayModels.length > 0 && (
-          <div className="w-full mt-2">
-            <p className="text-xs text-text-muted mb-2">Disabled models ({disabledDisplayModels.length}):</p>
-            <div className="flex flex-wrap gap-2">
-              {disabledDisplayModels.map((m) => (
-                <button
-                  key={m.id}
-                  onClick={() => handleEnableModel(m.id)}
-                  className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-dashed border-black/10 dark:border-white/10 text-xs text-text-muted hover:text-primary hover:border-primary/40 hover:bg-primary/5 transition-colors"
-                  title="Restore model"
-                >
-                  <span className="material-symbols-outlined text-[13px]">add</span>
-                  {m.id}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     );
   };
+;
 
   if (loading) {
     return (
@@ -1473,23 +1734,35 @@ export default function ProviderDetailPage() {
           <h2 className="text-lg font-semibold">
             {"Available Models"}
           </h2>
-          {!isCompatible && (() => {
+          {(() => {
             const allIds = [
-              ...models,
-              ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
-            ].filter((m) => { const k = getModelKind(m); return !k || k === "llm"; }).map((m) => m.id);
+              ...Object.values(modelAliases)
+                .filter((fm) => fm.startsWith(providerStorageAlias + "/"))
+                .map((fm) => fm.slice(providerStorageAlias.length + 1)),
+              ...(!isCompatible ? [
+                ...models,
+                ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
+              ].filter((m) => { const k = getModelKind(m); return !k || k === "llm"; }).map((m) => m.id) : []),
+            ].filter((id, i, arr) => arr.indexOf(id) === i);
             const activeIds = allIds.filter((id) => !disabledModelIds.includes(id));
+            if (allIds.length === 0) return null;
             return (
               <div className="flex gap-2">
-                {disabledModelIds.length > 0 && (
-                  <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll}>
-                    Active All
-                  </Button>
-                )}
+                <button
+                  onClick={handleEnableAll}
+                  className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-500/10 hover:bg-green-100 dark:hover:bg-green-500/20 rounded-md transition-colors"
+                >
+                  <span className="material-symbols-outlined text-[16px]">check_circle</span>
+                  Enable All
+                </button>
                 {activeIds.length > 0 && (
-                  <Button size="sm" variant="secondary" icon="block" onClick={() => handleDisableAll(activeIds)}>
+                  <button
+                    onClick={() => handleDisableAll(activeIds)}
+                    className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-500/10 hover:bg-yellow-100 dark:hover:bg-yellow-500/20 rounded-md transition-colors"
+                  >
+                    <span className="material-symbols-outlined text-[16px]">block</span>
                     Disable All
-                  </Button>
+                  </button>
                 )}
               </div>
             );


### PR DESCRIPTION
## Summary

Adds Excel-style keyword filtering, bulk operations, and visual improvements to the provider models page ().
Model name filtering:
<img width="776" height="174" alt="image" src="https://github.com/user-attachments/assets/fb9d4497-bae6-476e-b6d8-13235201b75f" />

Filter types:
<img width="757" height="278" alt="image" src="https://github.com/user-attachments/assets/fc83afca-b054-46cb-a1ac-6d1e07ef3ebc" />


Selecting multiple enabled models:
<img width="782" height="274" alt="image" src="https://github.com/user-attachments/assets/90d6a222-09a7-49d6-bb42-e32f2095a37f" />

Selecting multiple disabled models:

<img width="752" height="99" alt="image" src="https://github.com/user-attachments/assets/5592d956-e123-4edb-a931-135fe1f535d6" />


## Changes

### New Components

**ModelFilterBar** — keyword filter input with operator dropdown (Contains, Does Not Contain, Starts With, Ends With, Equals), sort toggle (A→Z / Z→A), select-all checkbox, and filter state display.

**ModelBulkActions** — action bar with Enable, Disable, Delete buttons and selection count. Supports , ,  props for context-specific rendering.

### Modified Components

**ModelRow** — green background tint for enabled models, muted background for disabled models (light + dark theme support via CSS variables).

**Provider models page** — integrated filter bar + bulk actions into the model grid. Added Enable All / Disable All toggle buttons. Disabled models section now has a separate checkbox-based selection mode showing Enable + Delete only (Disable is redundant for already-disabled models).

### Bug Fixes

- Alias-based custom models (e.g., opencode) now properly respect  — previously, enabling/disabling updated state but the visible rows never reflected changes
- Bulk actions work correctly for alias-based model IDs by resolving  format


Closes: provider models page usability improvements