### PR TITLE
fix(cli): auto-install sql.js when wasm binary missing

### DIFF
--- a/cli/hooks/sqliteRuntime.js
+++ b/cli/hooks/sqliteRuntime.js
@@ -101,21 +101,32 @@ function npmInstall(pkgs, opts = {}) {
   return res.ok;
 }
 
-// Public: ensure better-sqlite3 native module is installed in user-writable
-// runtime dir. sql.js is bundled in bin/app already; node:sqlite is built-in.
-// This is purely a *speed optimization* — app works without it via fallbacks.
+function isSqlJsWasmValid() {
+  const bundledWasm = path.join(__dirname, "..", "app", "node_modules", "sql.js", "dist", "sql-wasm.wasm");
+  if (fs.existsSync(bundledWasm)) return true;
+  const runtimeWasm = path.join(getRuntimeNodeModules(), "sql.js", "dist", "sql-wasm.wasm");
+  return fs.existsSync(runtimeWasm);
+}
+
 function ensureSqliteRuntime({ silent = false } = {}) {
   ensureRuntimeDir();
+
+  let sqlJsOk = isSqlJsWasmValid();
+  if (!sqlJsOk) {
+    sqlJsOk = npmInstall(["sql.js@1.14.1"], { silent });
+    if (sqlJsOk) sqlJsOk = isSqlJsWasmValid();
+  }
 
   const needBetterSqlite = !hasModule("better-sqlite3") || !isBetterSqliteBinaryValid();
   if (!needBetterSqlite) {
     if (!silent) console.log("✅ SQLite engine ready");
-    return { betterSqlite: true };
+    return { betterSqlite: true, sqlJs: sqlJsOk };
   }
 
   const ok = npmInstall([`better-sqlite3@${BETTER_SQLITE3_VERSION}`], { optional: true, silent });
   return {
     betterSqlite: ok && hasModule("better-sqlite3") && isBetterSqliteBinaryValid(),
+    sqlJs: sqlJsOk,
   };
 }
 


### PR DESCRIPTION
## Summary
- npm publish silently strips `.wasm` files from nested `node_modules/`, so `sql-wasm.wasm` is missing after `npm install -g 9router`
- On servers where `better-sqlite3` and `node:sqlite` also fail (e.g. Node 18 without build tools), all four SQLite drivers fail → app can't start
- `ensureSqliteRuntime()` now checks if `sql-wasm.wasm` exists, and if missing, installs `sql.js` into `~/.9router/runtime/node_modules/` (same approach as `better-sqlite3`)

## Test plan
- [ ] `npm pack` and verify `sql-wasm.wasm` still missing from tarball (confirms the bug exists)
- [ ] Install on Node 18 server without build tools → verify sql.js auto-installs to `~/.9router/runtime/`
- [ ] Verify `[DB] Driver: sql.js` or `better-sqlite3` in logs after startup
- [ ] Verify login page loads and DB operations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)