### PR TITLE
fix(opencode-go): strip Kimi temperature

### DIFF
--- a/open-sse/executors/opencode-go.js
+++ b/open-sse/executors/opencode-go.js
@@ -2,6 +2,7 @@ import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { ANTHROPIC_API_VERSION } from "../providers/shared.js";
+import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
 
 // Models that use /zen/go/v1/messages (Anthropic/Claude format + x-api-key auth)
 const MESSAGES_FORMAT_MODELS = new Set([
@@ -44,6 +45,7 @@ export class OpenCodeGoExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body) {
+    stripUnsupportedParams(this.provider, model, body);
     return injectReasoningContent({ provider: this.provider, model, body });
   }
 }

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -8,6 +8,8 @@ const STRIP_RULES = [
   { match: /claude-opus-4/i, drop: ["temperature"] },
   // GitHub Copilot gpt-5.4: temperature unsupported.
   { provider: "github", match: /gpt-5\.4/i, drop: ["temperature"] },
+  // OpenCode Go Kimi K2.7 Code rejects explicit temperature values.
+  { provider: "opencode-go", match: /^kimi-k2\.7-code$/i, drop: ["temperature"] },
   // GitHub Copilot Claude (except opus/sonnet 4.6): thinking + reasoning_effort rejected. #713
   { provider: "github", match: (m) => /claude/i.test(m) && !/claude.*(opus|sonnet).*4\.6/i.test(m), drop: ["thinking", "reasoning_effort"] },
 ];

--- a/tests/unit/opencode-go-models.test.js
+++ b/tests/unit/opencode-go-models.test.js
@@ -69,3 +69,30 @@ describe("OpenCode Go endpoint routing", () => {
     }
   });
 });
+
+describe("OpenCode Go request parameters", () => {
+  it("strips temperature for Kimi K2.7 Code because Moonshot only accepts its default", () => {
+    const executor = new OpenCodeGoExecutor();
+
+    const body = executor.transformRequest("kimi-k2.7-code", {
+      messages: [{ role: "user", content: "hello" }],
+      max_tokens: 8,
+      temperature: 0.7,
+    });
+
+    expect(body.temperature).toBeUndefined();
+    expect(body.max_tokens).toBe(8);
+  });
+
+  it("preserves temperature for other OpenCode Go chat models", () => {
+    const executor = new OpenCodeGoExecutor();
+
+    const body = executor.transformRequest("glm-5.2", {
+      messages: [{ role: "user", content: "hello" }],
+      max_tokens: 8,
+      temperature: 0.7,
+    });
+
+    expect(body.temperature).toBe(0.7);
+  });
+});


### PR DESCRIPTION
## Summary
- Strip explicit temperature for OpenCode Go kimi-k2.7-code before forwarding requests
- Reuse the existing provider/model param stripping rules instead of adding executor-specific delete logic
- Add regression coverage so Kimi drops temperature while other OpenCode Go chat models keep it

## Why
Moonshot/OpenCode Go rejects kimi-k2.7-code requests with explicit temperature values, returning: invalid temperature: only 1 is allowed for this model. Omitting temperature lets the provider use its required default.

## Verification
- npm --prefix tests test -- unit/opencode-go-models.test.js translator/coverage-all-models.test.js translator/thinking-unified.test.js
- npm run build