### PR TITLE
feat: OpenCode context window and reasoning controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ source/*
 .cursor/*
 docs/*
 !docs/ARCHITECTURE.md
+!docs/opencode-setup-metadata.md
 test/*
 open-sse/test/*
 RM.vn.md
@@ -75,3 +76,9 @@ gitbook/README.md
 
 # Refactor backup reference (do not bundle/lint)
 open-sse.old/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/proxieddb/

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ source/*
 docs/*
 !docs/ARCHITECTURE.md
 !docs/opencode-setup-metadata.md
+!docs/runtime-reasoning.md
 test/*
 open-sse/test/*
 RM.vn.md

--- a/docs/opencode-setup-metadata.md
+++ b/docs/opencode-setup-metadata.md
@@ -86,6 +86,60 @@ Variants use the OpenCode/AI SDK-compatible `reasoningEffort` key.  The
 runtime translator (Epic 3) maps these to provider-native formats at
 request time.  No variant globally forces high/max thinking by default.
 
+## Metadata Overrides (Epic 2)
+
+Users can override per-model metadata via the dashboard or API.  Overrides
+are stored in the `modelOverrides` KV scope in SQLite and take precedence
+over hardcoded capabilities.
+
+### Precedence chain (highest priority wins)
+
+1. **Manual override** — user-set via dashboard or `PUT /api/models/overrides`
+2. **Hardcoded capabilities** — source-of-truth in `open-sse/providers/capabilities.js`
+
+### Affected consumers
+
+- **`/v1/models`** — each model entry now includes a `metadata` field with
+  resolved capabilities (contextWindow, maxOutput, reasoning, tools, vision,
+  etc.).  Manual overrides are reflected.
+- **`POST /api/cli-tools/opencode-settings`** — setup route uses the resolver
+  to produce enriched model configs.  Re-running setup picks up overrides.
+- **`resolveModelMetadata(provider, model)`** — the central resolver function.
+  All consumers should use this for consistent precedence.
+
+### API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/models/overrides?provider=<alias>` | List all overrides for a provider |
+| `PUT` | `/api/models/overrides` | Set/update an override (body: `{ provider, model, override }`) |
+| `DELETE` | `/api/models/overrides?provider=<alias>&model=<id>` | Delete override (reverts to defaults) |
+
+### Valid override fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `contextWindow` | `integer ≥ 0` | Total token context window |
+| `maxOutput` | `integer ≥ 0` | Max completion tokens |
+| `reasoning` | `boolean` | Model supports reasoning/chain-of-thought |
+| `tools` | `boolean` | Model supports tool/function calling |
+| `vision` | `boolean` | Model accepts image input |
+| `pdf` | `boolean` | Model accepts PDF input |
+| `audioInput` | `boolean` | Model accepts audio input |
+| `videoInput` | `boolean` | Model accepts video input |
+| `imageOutput` | `boolean` | Model can generate images |
+| `audioOutput` | `boolean` | Model can generate audio |
+| `search` | `boolean` | Model supports web search |
+| `thinkingFormat` | `string \| null` | Thinking format (e.g., "x-internal") |
+| `thinkingCanDisable` | `boolean` | User can disable thinking |
+| `thinkingRange` | `{ min?, max? } \| null` | Thinking token bounds |
+
+### Reset to defaults
+
+Deleting an override via `DELETE /api/models/overrides` or clicking
+"Reset to Default" in the dashboard reverts the model to its hardcoded
+capabilities.
+
 ## Unknown Models
 
 Models not found in the capability resolver receive safe defaults:
@@ -105,17 +159,30 @@ Setup does not crash for unknown models.
 cd tests && npx vitest run \
   unit/opencode-converter.test.js \
   unit/opencode-setup-characterization.test.js \
+  unit/model-metadata-resolver.test.js \
+  unit/v1-models-metadata.test.js \
+  unit/e2e-metadata-override-flow.test.js \
   --reporter=verbose
 ```
 
-All 21 tests pass (6 converter + 7 merge + 5 variants + 3 route characterization).
+All 41 tests pass (6 converter + 7 merge + 5 variants + 3 route characterization + 10 resolver + 5 API metadata + 5 e2e override flow).
 
-## Files Changed (Epic 1)
+## Files Changed (Epic 1 + Epic 2)
 
 | File | Change |
 |---|---|
 | `src/app/api/cli-tools/opencode-settings/converter.js` | New — `buildOpenCodeModelConfig`, `mergeOpenCodeModelConfig`, `buildOpenCodeReasoningVariants` |
 | `src/app/api/cli-tools/opencode-settings/route.js` | Wired converter + merge into POST handler |
-| `tests/unit/opencode-converter.test.js` | New — 18 tests (converter + merge + variants) |
-| `tests/unit/opencode-setup-characterization.test.js` | New — 3 route-level characterization tests |
+| `src/lib/db/repos/modelOverridesRepo.js` | New — KV-based CRUD for model metadata overrides |
+| `src/sse/services/modelMetadataResolver.js` | New — resolver with override > hardcoded precedence |
+| `src/app/api/models/overrides/route.js` | New — API route for GET/PUT/DELETE overrides |
+| `src/app/api/v1/models/route.js` | Added `metadata` field to each model entry |
+| `src/app/(dashboard)/dashboard/providers/[id]/ModelMetadataEditor.js` | New — dashboard UI for editing overrides |
+| `src/app/(dashboard)/dashboard/providers/[id]/page.js` | Integrated `ModelMetadataEditor` |
+| `src/shared/utils/modelOverridesApi.js` | New — fetch helpers for override API |
+| `tests/unit/opencode-converter.test.js` | 18 tests (converter + merge + variants) |
+| `tests/unit/opencode-setup-characterization.test.js` | 3 route-level characterization tests |
+| `tests/unit/model-metadata-resolver.test.js` | 10 resolver tests |
+| `tests/unit/v1-models-metadata.test.js` | 5 API metadata tests |
+| `tests/unit/e2e-metadata-override-flow.test.js` | 5 e2e override flow tests |
 | `docs/opencode-setup-metadata.md` | This file |

--- a/docs/opencode-setup-metadata.md
+++ b/docs/opencode-setup-metadata.md
@@ -1,0 +1,121 @@
+# OpenCode Setup Metadata Enrichment
+
+> Bead: 9r-ocmr.e1.05 — PRD: REQ-001..005, VAL-001..005, DOC-001
+
+## Overview
+
+When 9router configures OpenCode as an `@ai-sdk/openai-compatible` provider,
+the setup route (`POST /api/cli-tools/opencode-settings`) now writes enriched
+model metadata including context limits, capability flags, and reasoning
+variants.  Re-running setup preserves user-edited fields via controlled merge
+(ADR-001).
+
+## Before / After
+
+### Before (pre-e1)
+
+```json
+{
+  "name": "claude-opus-4.6",
+  "modalities": { "input": ["text", "image"], "output": ["text"] }
+}
+```
+
+Missing: `limit`, `reasoning`, `tool_call`, `attachment`, `variants`.
+Existing user fields lost on re-run.
+
+### After (post-e1)
+
+```json
+{
+  "name": "claude-opus-4.6",
+  "modalities": { "input": ["text", "image"], "output": ["text"] },
+  "reasoning": true,
+  "tool_call": true,
+  "attachment": true,
+  "limit": { "context": 1000000, "input": 1000000, "output": 128000 },
+  "variants": {
+    "low":    { "reasoningEffort": "low" },
+    "medium": { "reasoningEffort": "medium" },
+    "high":   { "reasoningEffort": "high" },
+    "max":    { "reasoningEffort": "max" }
+  }
+}
+```
+
+## Field Meanings
+
+| Field | Source | Description |
+|---|---|---|
+| `name` | Request | Model identifier as sent by the client. |
+| `modalities.input` | Capability resolver | `"text"`, `"image"`, `"pdf"`, `"audio"`, `"video"` |
+| `modalities.output` | Capability resolver | `"text"`, `"image"`, `"audio"` |
+| `reasoning` | Capability resolver | `true` if model supports thinking/reasoning. |
+| `tool_call` | Capability resolver | `true` if model supports function/tool calling (default: `true`). |
+| `attachment` | Capability resolver | `true` if any non-text input modality is present. |
+| `limit.context` | Capability resolver | Context window in tokens. |
+| `limit.input` | Capability resolver | Input token limit (falls back to `context` when unknown). |
+| `limit.output` | Capability resolver | Max output tokens. |
+| `variants` | Reasoning variants | Selectable reasoning levels (only for `reasoning: true` models). |
+
+## Merge Behavior (ADR-001)
+
+When setup is re-run, existing user config is preserved via controlled merge:
+
+- **Scalars** (`name`, `reasoning`, `tool_call`, `attachment`): existing wins.
+- **Objects** (`limit`, `options`, `headers`, `variants`): merged, existing keys win on conflict, generated fills blanks.
+- **`modalities`**: existing wins if present; otherwise generated.
+- **Unknown fields**: preserved as-is.
+
+Example: if a user manually set `limit.context: 500000`, re-running setup
+keeps that value while filling in `limit.input` and `limit.output` from
+the resolver.
+
+## Reasoning Variants (ADR-003)
+
+Models with `reasoning: true` receive four selectable variants:
+
+| Level | `reasoningEffort` | Behavior |
+|---|---|---|
+| `low` | `"low"` | Minimal reasoning effort. |
+| `medium` | `"medium"` | Moderate reasoning. |
+| `high` | `"high"` | Heavy reasoning. |
+| `max` | `"max"` | Maximum reasoning effort. |
+
+Variants use the OpenCode/AI SDK-compatible `reasoningEffort` key.  The
+runtime translator (Epic 3) maps these to provider-native formats at
+request time.  No variant globally forces high/max thinking by default.
+
+## Unknown Models
+
+Models not found in the capability resolver receive safe defaults:
+
+```
+contextWindow: 200000
+maxOutput: 64000
+reasoning: false
+tools: true (tool_call: true)
+```
+
+Setup does not crash for unknown models.
+
+## Test Commands
+
+```bash
+cd tests && npx vitest run \
+  unit/opencode-converter.test.js \
+  unit/opencode-setup-characterization.test.js \
+  --reporter=verbose
+```
+
+All 21 tests pass (6 converter + 7 merge + 5 variants + 3 route characterization).
+
+## Files Changed (Epic 1)
+
+| File | Change |
+|---|---|
+| `src/app/api/cli-tools/opencode-settings/converter.js` | New — `buildOpenCodeModelConfig`, `mergeOpenCodeModelConfig`, `buildOpenCodeReasoningVariants` |
+| `src/app/api/cli-tools/opencode-settings/route.js` | Wired converter + merge into POST handler |
+| `tests/unit/opencode-converter.test.js` | New — 18 tests (converter + merge + variants) |
+| `tests/unit/opencode-setup-characterization.test.js` | New — 3 route-level characterization tests |
+| `docs/opencode-setup-metadata.md` | This file |

--- a/docs/runtime-reasoning.md
+++ b/docs/runtime-reasoning.md
@@ -1,0 +1,111 @@
+# Runtime Reasoning Request Shapes and Forwarding
+
+> Bead: 9r-ocmr.e3.05 — PRD: REQ-010..015, VAL-010..016
+
+## Overview
+
+9router normalizes reasoning/thinking parameters from multiple client formats into provider-native formats. The normalizer lives in `open-sse/translator/concerns/thinkingUnified.js`.
+
+## Accepted Request Shapes
+
+### OpenAI (snake_case)
+
+```json
+{ "reasoning_effort": "high" }
+{ "reasoning": { "effort": "medium" } }
+```
+
+### OpenAI / AI SDK (camelCase)
+
+```json
+{ "reasoningEffort": "high" }
+```
+
+### Claude
+
+```json
+{ "thinking": { "type": "enabled", "budget_tokens": 8192 } }
+{ "thinking": { "type": "disabled" } }
+{ "output_config": { "effort": "high" } }
+```
+
+### Gemini
+
+```json
+{ "thinkingConfig": { "thinkingBudget": 8192 } }
+{ "thinkingConfig": { "thinkingLevel": "high" } }
+```
+
+### Qwen
+
+```json
+{ "enable_thinking": true, "thinking_budget": 8192 }
+{ "enable_thinking": false }
+```
+
+## Model-Name Suffix Override
+
+Append a suffix to the model name to override thinking intent:
+
+| Syntax | Effect |
+|--------|--------|
+| `gpt-5(high)` | Level override → high |
+| `gpt-5(8192)` | Budget override → 8192 tokens |
+| `gpt-5(auto)` | Auto mode |
+| `gpt-5(none)` | No thinking |
+
+## Provider Output Mapping
+
+| Provider | Input | Output |
+|----------|-------|--------|
+| OpenAI | `reasoningEffort: "high"` | `reasoning_effort: "high"` |
+| OpenAI | `reasoningEffort: "xhigh"` | `reasoning_effort: "high"` (clamped) |
+| Claude (adaptive) | `reasoningEffort: "high"` | `output_config.effort: "high"` |
+| Claude (budget) | `reasoningEffort: "high"` | `thinking.type: "enabled", budget_tokens: 24576` |
+| Gemini (level) | `reasoningEffort: "medium"` | `thinkingConfig.thinkingLevel: "medium"` |
+| Gemini (budget) | `reasoningEffort: "high"` | `thinkingConfig.thinkingBudget: 24576` |
+| Qwen | `reasoningEffort: "medium"` | `enable_thinking: true, thinking_budget: 8192` |
+| DeepSeek | `reasoningEffort: "high"` | `thinking.type: "enabled", reasoning_effort: "high"` |
+| Kimi | `reasoningEffort: "high"` | `reasoning_effort: "high"` |
+| MiniMax | `reasoningEffort: "high"` | `thinking.type: "adaptive"` |
+
+## Precedence Rules
+
+1. **Model-name suffix** (highest) — `gpt-5(high)`
+2. **Provider-native shape** — Claude `thinking`, Gemini `thinkingConfig`
+3. **OpenAI camelCase** — `reasoningEffort`
+4. **OpenAI snake_case** — `reasoning_effort`
+5. **No thinking intent** → no change
+
+## Budget Clamping
+
+Budgets are clamped to respect model metadata:
+
+- **thinkingRange.min/max** — explicit bounds from model capabilities
+- **maxOutput reserve** — budget cannot exceed 80% of `maxOutput` (leaves room for response)
+
+Example: a model with `maxOutput: 16000` clamps `budget_tokens: 20000` to `12800`.
+
+## Non-Disableable Thinking
+
+Models with `thinkingCanDisable: false` in their capabilities cannot fully disable thinking. When "none"/"off" is requested, the normalizer clamps to "minimal" effort instead.
+
+Known non-disableable models: MiniMax M2.x.
+
+## Non-Reasoning Models
+
+Models with `reasoning: false` in their capabilities have **all** thinking fields stripped from the request body, regardless of input. This prevents sending unsupported parameters to providers.
+
+## Limitations
+
+- Not every provider supports every option
+- Some providers have limited level mappings (e.g., DeepSeek only has low→high, xhigh→max)
+- Budget values are approximate; providers may round to their own granularity
+- Gemini-3 cannot fully disable thinking (maps "none" to "minimal")
+
+## Cross-References
+
+- Setup metadata: [opencode-setup-metadata.md](./opencode-setup-metadata.md)
+- Capability resolver: `open-sse/providers/capabilities.js`
+- Thinking normalizer: `open-sse/translator/concerns/thinkingUnified.js`
+- Level-to-budget maps: `open-sse/translator/concerns/thinking.js`

--- a/open-sse/translator/concerns/thinking.js
+++ b/open-sse/translator/concerns/thinking.js
@@ -51,3 +51,35 @@ export function budgetToEffort(budget) {
   if (budget <= 16384) return "medium";
   return "high";
 }
+
+// Clamp a thinking budget to respect model metadata constraints.
+//
+// Considers:
+//   - thinkingRange.min/max — explicit bounds from model capabilities
+//   - maxOutput — reserves space for the actual response (budget ≤ 80% of maxOutput)
+//
+// @param {number} budget - raw budget_tokens
+// @param {object} caps - full capabilities object from getCapabilitiesForModel
+// @returns {number} clamped budget
+export function clampThinkingBudget(budget, caps) {
+  if (!Number.isFinite(budget) || budget <= 0) return budget;
+
+  let clamped = budget;
+
+  // Apply explicit thinking range bounds
+  const range = caps?.thinkingRange;
+  if (range) {
+    if (range.min != null && clamped < range.min) clamped = range.min;
+    if (range.max != null && clamped > range.max) clamped = range.max;
+  }
+
+  // Reserve output space: budget must not consume all of maxOutput.
+  // Leave at least 20% of maxOutput for the actual response.
+  const maxOutput = caps?.maxOutput;
+  if (maxOutput && maxOutput > 0) {
+    const maxBudget = Math.floor(maxOutput * 0.8);
+    if (clamped > maxBudget) clamped = maxBudget;
+  }
+
+  return clamped;
+}

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -4,7 +4,7 @@
 
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { PROVIDERS } from "../../providers/index.js";
-import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget } from "./thinking.js";
+import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, clampThinkingBudget } from "./thinking.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
 const FORMAT_TO_NATIVE = {
@@ -60,8 +60,8 @@ export function extractThinking(body) {
     }
   }
 
-  // OpenAI chat / Responses shape
-  const effort = body.reasoning_effort ?? (typeof body.reasoning === "object" ? body.reasoning?.effort : null);
+  // OpenAI chat / Responses shape (camelCase alias takes precedence over snake_case)
+  const effort = body.reasoningEffort ?? body.reasoning_effort ?? (typeof body.reasoning === "object" ? body.reasoning?.effort : null);
   if (typeof effort === "string" && effort) {
     const e = effort.toLowerCase();
     if (e === "none" || e === "off") return { mode: "none" };
@@ -106,17 +106,14 @@ function resolveFormat(targetFormat, model, provider) {
 }
 
 // Convert unified config to a budget number (for budget-based formats).
-function toBudget(cfg, range) {
+// Uses clampThinkingBudget to respect thinkingRange and maxOutput reserves.
+function toBudget(cfg, caps) {
   let budget;
   if (cfg.mode === "budget") budget = cfg.budget;
   else if (cfg.mode === "level") budget = effortToBudget(cfg.level);
   else if (cfg.mode === "auto") return -1;
   if (!Number.isFinite(budget)) return undefined;
-  if (range) {
-    if (range.min != null && budget < range.min) budget = range.min;
-    if (range.max != null && budget > range.max) budget = range.max;
-  }
-  return budget;
+  return clampThinkingBudget(budget, caps);
 }
 
 // Convert unified config to a discrete level string.
@@ -174,7 +171,7 @@ function applyFormat(fmt, body, cfg, caps) {
     }
     case "claude-budget": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
-      const budget = toBudget(eff, caps.thinkingRange);
+      const budget = toBudget(eff, caps);
       body.thinking = budget === -1 ? { type: "enabled" } : { type: "enabled", budget_tokens: budget || 8192 };
       break;
     }
@@ -185,7 +182,7 @@ function applyFormat(fmt, body, cfg, caps) {
     }
     case "gemini-budget": {
       if (none && canDisable) { setGeminiThinking(body, { thinkingBudget: 0, includeThoughts: false }); break; }
-      const budget = toBudget(eff, caps.thinkingRange);
+      const budget = toBudget(eff, caps);
       setGeminiThinking(body, { thinkingBudget: budget ?? -1, includeThoughts: true });
       break;
     }
@@ -198,7 +195,7 @@ function applyFormat(fmt, body, cfg, caps) {
     case "qwen": {
       if (none && canDisable) { body.enable_thinking = false; break; }
       body.enable_thinking = true;
-      const budget = toBudget(eff, caps.thinkingRange);
+      const budget = toBudget(eff, caps);
       if (Number.isFinite(budget) && budget > 0) body.thinking_budget = budget;
       break;
     }
@@ -223,7 +220,7 @@ function applyFormat(fmt, body, cfg, caps) {
     }
     case "hunyuan": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
-      const budget = toBudget(eff, caps.thinkingRange);
+      const budget = toBudget(eff, caps);
       body.thinking = budget === -1 ? { type: "enabled" } : { type: "enabled", budget_tokens: budget || 8192 };
       break;
     }

--- a/src/app/(dashboard)/dashboard/providers/[id]/ModelMetadataEditor.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ModelMetadataEditor.js
@@ -29,6 +29,13 @@ const BOOLEAN_FIELDS = [
   { key: "thinkingCanDisable", label: "Thinking Can Disable" },
 ];
 
+/* ── thinking constants ────────────────────────────────────────────── */
+
+const THINKING_LEVELS = ["none", "low", "medium", "high", "xhigh", "max"];
+
+const LEVEL_FORMATS = ["openai", "claude-adaptive", "gemini-level", "deepseek", "kimi", "minimax"];
+const BUDGET_FORMATS = ["claude-budget", "gemini-budget", "qwen"];
+
 /* ── small helpers ─────────────────────────────────────────────────── */
 
 function formatNum(n) {
@@ -112,6 +119,84 @@ function BooleanField({ field, value, defaultValue, onChange }) {
   );
 }
 
+/* ── thinking section ──────────────────────────────────────────────── */
+
+function ThinkingSection({ defaults, draft, setField }) {
+  const format = draft.thinkingFormat ?? defaults.thinkingFormat ?? null;
+  const isLevel = LEVEL_FORMATS.includes(format);
+  const isBudget = BUDGET_FORMATS.includes(format);
+  const range = defaults.thinkingRange;
+
+  return (
+    <div className="mb-3">
+      <p className="mb-1.5 text-[10px] uppercase tracking-wider text-text-muted/50">Thinking</p>
+      <div className="flex flex-wrap items-end gap-x-5 gap-y-2">
+        {/* Format badge */}
+        {format && (
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-text-muted">Format</label>
+            <span className="inline-block w-fit rounded bg-background px-1.5 py-0.5 font-mono text-[11px] text-text-muted/70 border border-border">
+              {format}
+            </span>
+          </div>
+        )}
+
+        {/* Level selector */}
+        {isLevel && (
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-text-muted">
+              Level
+              <span className="ml-1 font-normal text-text-muted/60">(default: —)</span>
+            </label>
+            <select
+              value={draft.thinkingLevel ?? ""}
+              onChange={(e) => setField("thinkingLevel", e.target.value || null)}
+              className="rounded border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:border-primary"
+            >
+              <option value="">—</option>
+              {THINKING_LEVELS.map((l) => (
+                <option key={l} value={l}>{l}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Budget input */}
+        {isBudget && (
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-text-muted">
+              Budget Tokens
+              {range?.min != null && range?.max != null && (
+                <span className="ml-1 font-normal text-text-muted/60">
+                  ({formatNum(range.min)}–{formatNum(range.max)})
+                </span>
+              )}
+              {range?.min != null && range?.max == null && (
+                <span className="ml-1 font-normal text-text-muted/60">(min: {formatNum(range.min)})</span>
+              )}
+              {range?.min == null && range?.max != null && (
+                <span className="ml-1 font-normal text-text-muted/60">(max: {formatNum(range.max)})</span>
+              )}
+            </label>
+            <input
+              type="number"
+              min={0}
+              step={1}
+              value={draft.thinkingBudget ?? ""}
+              onChange={(e) => {
+                const v = e.target.value;
+                setField("thinkingBudget", v === "" ? null : Number(v));
+              }}
+              placeholder="—"
+              className="w-full max-w-[180px] rounded border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:border-primary"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 /* ── per-model card ────────────────────────────────────────────────── */
 
 function ModelOverrideCard({ modelId, fullModel, providerAlias, override, defaults, onSave, onDelete }) {
@@ -168,21 +253,19 @@ function ModelOverrideCard({ modelId, fullModel, providerAlias, override, defaul
   const hasOverride = override && Object.keys(override).length > 0;
 
   return (
-    <div className="rounded-lg border border-border p-3">
+    <div className="rounded-lg border border-border bg-sidebar p-3">
       <div className="mb-2 flex items-center justify-between gap-2">
         <code className="truncate rounded bg-sidebar px-1.5 py-0.5 font-mono text-xs text-text-muted">
           {fullModel}
         </code>
-        {hasOverride && (
-          <button
-            onClick={handleDelete}
-            disabled={saving}
-            className="shrink-0 rounded px-2 py-0.5 text-[11px] text-text-muted transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:opacity-50"
-            title="Reset to defaults"
-          >
-            Reset to Default
-          </button>
-        )}
+        <button
+          onClick={handleDelete}
+          disabled={saving || !hasOverride}
+          className="shrink-0 rounded px-2 py-0.5 text-[11px] text-text-muted transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:opacity-30 disabled:cursor-not-allowed"
+          title="Reset to defaults"
+        >
+          Reset to Default
+        </button>
       </div>
 
       {/* Limits */}
@@ -216,6 +299,11 @@ function ModelOverrideCard({ modelId, fullModel, providerAlias, override, defaul
           ))}
         </div>
       </div>
+
+      {/* Thinking */}
+      {defaults.reasoning && (
+        <ThinkingSection defaults={defaults} draft={draft} setField={setField} />
+      )}
 
       {/* Actions */}
       {dirty && (
@@ -334,6 +422,8 @@ export default function ModelMetadataEditor({ providerAlias, models }) {
                   audioOutput: caps.audioOutput,
                   search: caps.search,
                   thinkingCanDisable: caps.thinkingCanDisable,
+                  thinkingFormat: caps.thinkingFormat,
+                  thinkingRange: caps.thinkingRange,
                 };
                 return (
                   <ModelOverrideCard

--- a/src/app/(dashboard)/dashboard/providers/[id]/ModelMetadataEditor.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ModelMetadataEditor.js
@@ -1,0 +1,364 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import PropTypes from "prop-types";
+import {
+  fetchModelOverrides,
+  setModelOverride,
+  deleteModelOverride,
+} from "@/shared/utils/modelOverridesApi";
+import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+
+/* ── field definitions ─────────────────────────────────────────────── */
+
+const NUMERIC_FIELDS = [
+  { key: "contextWindow", label: "Context Window", hint: "Total token context" },
+  { key: "maxOutput", label: "Max Output", hint: "Max completion tokens" },
+];
+
+const BOOLEAN_FIELDS = [
+  { key: "reasoning", label: "Reasoning" },
+  { key: "tools", label: "Tool Use" },
+  { key: "vision", label: "Vision" },
+  { key: "pdf", label: "PDF" },
+  { key: "audioInput", label: "Audio Input" },
+  { key: "videoInput", label: "Video Input" },
+  { key: "imageOutput", label: "Image Output" },
+  { key: "audioOutput", label: "Audio Output" },
+  { key: "search", label: "Search" },
+  { key: "thinkingCanDisable", label: "Thinking Can Disable" },
+];
+
+/* ── small helpers ─────────────────────────────────────────────────── */
+
+function formatNum(n) {
+  if (n == null) return "—";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+  return String(n);
+}
+
+/* ── sub-components ────────────────────────────────────────────────── */
+
+function NumericField({ field, value, defaultValue, onChange }) {
+  const [local, setLocal] = useState(value ?? "");
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLocal(value ?? "");
+    setError(null);
+  }, [value]);
+
+  const commit = () => {
+    if (local === "" || local === null) {
+      // empty → remove field from override
+      onChange(null);
+      setError(null);
+      return;
+    }
+    const n = Number(local);
+    if (!Number.isInteger(n) || n < 0) {
+      setError("Must be a non-negative integer");
+      return;
+    }
+    setError(null);
+    onChange(n);
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs font-medium text-text-muted">
+        {field.label}
+        {defaultValue != null && (
+          <span className="ml-1 font-normal text-text-muted/60">
+            (default: {formatNum(defaultValue)})
+          </span>
+        )}
+      </label>
+      <input
+        type="number"
+        min={0}
+        step={1}
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => e.key === "Enter" && commit()}
+        placeholder={defaultValue != null ? String(defaultValue) : "—"}
+        className="w-full max-w-[180px] rounded border border-border bg-background px-2 py-1 text-sm focus:outline-none focus:border-primary"
+      />
+      {error && <span className="text-[11px] text-red-500">{error}</span>}
+    </div>
+  );
+}
+
+function BooleanField({ field, value, defaultValue, onChange }) {
+  return (
+    <label className="flex items-center gap-2 cursor-pointer select-none">
+      <input
+        type="checkbox"
+        checked={!!value}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-4 w-4 rounded border-border accent-primary"
+      />
+      <span className="text-xs font-medium text-text-muted">
+        {field.label}
+        {defaultValue != null && (
+          <span className="ml-1 font-normal text-text-muted/60">
+            (default: {defaultValue ? "on" : "off"})
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}
+
+/* ── per-model card ────────────────────────────────────────────────── */
+
+function ModelOverrideCard({ modelId, fullModel, providerAlias, override, defaults, onSave, onDelete }) {
+  const [draft, setDraft] = useState(() => ({ ...override }));
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Sync when override prop changes (e.g. after delete)
+  useEffect(() => {
+    setDraft({ ...override });
+    setDirty(false);
+    setError(null);
+  }, [override]);
+
+  const setField = (key, val) => {
+    setDraft((prev) => {
+      const next = { ...prev };
+      if (val === null || val === undefined) {
+        delete next[key]; // remove from override → reverts to default
+      } else {
+        next[key] = val;
+      }
+      return next;
+    });
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(modelId, draft);
+      setDirty(false);
+    } catch (err) {
+      setError(err.message || "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onDelete(modelId);
+    } catch (err) {
+      setError(err.message || "Reset failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasOverride = override && Object.keys(override).length > 0;
+
+  return (
+    <div className="rounded-lg border border-border p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <code className="truncate rounded bg-sidebar px-1.5 py-0.5 font-mono text-xs text-text-muted">
+          {fullModel}
+        </code>
+        {hasOverride && (
+          <button
+            onClick={handleDelete}
+            disabled={saving}
+            className="shrink-0 rounded px-2 py-0.5 text-[11px] text-text-muted transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:opacity-50"
+            title="Reset to defaults"
+          >
+            Reset to Default
+          </button>
+        )}
+      </div>
+
+      {/* Limits */}
+      <div className="mb-3">
+        <p className="mb-1.5 text-[10px] uppercase tracking-wider text-text-muted/50">Limits</p>
+        <div className="flex flex-wrap gap-x-5 gap-y-2">
+          {NUMERIC_FIELDS.map((f) => (
+            <NumericField
+              key={f.key}
+              field={f}
+              value={draft[f.key]}
+              defaultValue={defaults[f.key]}
+              onChange={(v) => setField(f.key, v)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Capabilities */}
+      <div className="mb-3">
+        <p className="mb-1.5 text-[10px] uppercase tracking-wider text-text-muted/50">Capabilities</p>
+        <div className="flex flex-wrap gap-x-5 gap-y-1.5">
+          {BOOLEAN_FIELDS.map((f) => (
+            <BooleanField
+              key={f.key}
+              field={f}
+              value={draft[f.key]}
+              defaultValue={defaults[f.key]}
+              onChange={(v) => setField(f.key, v)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Actions */}
+      {dirty && (
+        <div className="flex items-center gap-2 mt-2">
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="rounded bg-primary px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+          {error && <span className="text-[11px] text-red-500">{error}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+ModelOverrideCard.propTypes = {
+  modelId: PropTypes.string.isRequired,
+  fullModel: PropTypes.string.isRequired,
+  providerAlias: PropTypes.string.isRequired,
+  override: PropTypes.object,
+  defaults: PropTypes.object,
+  onSave: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+/* ── main component ────────────────────────────────────────────────── */
+
+export default function ModelMetadataEditor({ providerAlias, models }) {
+  const [open, setOpen] = useState(false);
+  const [overrides, setOverrides] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchModelOverrides(providerAlias);
+      setOverrides(data);
+    } catch {
+      // silently ignore — UI stays usable with empty overrides
+    } finally {
+      setLoading(false);
+    }
+  }, [providerAlias]);
+
+  // Fetch on mount and when provider changes
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSave = async (modelId, draft) => {
+    const saved = await setModelOverride(providerAlias, modelId, draft);
+    setOverrides((prev) => ({ ...prev, [modelId]: saved }));
+  };
+
+  const handleDelete = async (modelId) => {
+    await deleteModelOverride(providerAlias, modelId);
+    setOverrides((prev) => {
+      const next = { ...prev };
+      delete next[modelId];
+      return next;
+    });
+  };
+
+  const activeCount = Object.keys(overrides).length;
+
+  return (
+    <div className="rounded-lg border border-border">
+      {/* Header / toggle */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-sidebar/50"
+      >
+        <div className="flex items-center gap-2">
+          <span className="material-symbols-outlined text-base text-text-muted">
+            tune
+          </span>
+          <span className="text-sm font-medium">Model Metadata</span>
+          {activeCount > 0 && (
+            <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+              {activeCount} override{activeCount !== 1 && "s"}
+            </span>
+          )}
+        </div>
+        <span className="material-symbols-outlined text-base text-text-muted transition-transform" style={{ transform: open ? "rotate(180deg)" : undefined }}>
+          expand_more
+        </span>
+      </button>
+
+      {/* Body */}
+      {open && (
+        <div className="border-t border-border px-4 py-3">
+          {loading ? (
+            <p className="text-xs text-text-muted">Loading overrides…</p>
+          ) : models.length === 0 ? (
+            <p className="text-xs text-text-muted">No models to configure.</p>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {models.map((m) => {
+                const modelId = m.id;
+                const fullModel = `${providerAlias}/${modelId}`;
+                // Compute defaults from hardcoded capabilities
+                const caps = getCapabilitiesForModel(providerAlias, modelId);
+                const defaults = {
+                  contextWindow: caps.contextWindow,
+                  maxOutput: caps.maxOutput,
+                  reasoning: caps.reasoning,
+                  tools: caps.tools,
+                  vision: caps.vision,
+                  pdf: caps.pdf,
+                  audioInput: caps.audioInput,
+                  videoInput: caps.videoInput,
+                  imageOutput: caps.imageOutput,
+                  audioOutput: caps.audioOutput,
+                  search: caps.search,
+                  thinkingCanDisable: caps.thinkingCanDisable,
+                };
+                return (
+                  <ModelOverrideCard
+                    key={modelId}
+                    modelId={modelId}
+                    fullModel={fullModel}
+                    providerAlias={providerAlias}
+                    override={overrides[modelId] || {}}
+                    defaults={defaults}
+                    onSave={handleSave}
+                    onDelete={handleDelete}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+ModelMetadataEditor.propTypes = {
+  providerAlias: PropTypes.string.isRequired,
+  models: PropTypes.arrayOf(
+    PropTypes.shape({ id: PropTypes.string.isRequired })
+  ).isRequired,
+};

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -19,6 +19,7 @@ import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
 import BulkImportCodexModal from "./BulkImportCodexModal";
+import ModelMetadataEditor from "./ModelMetadataEditor";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
@@ -1500,6 +1501,19 @@ export default function ProviderDetailPage() {
         )}
         {renderModelsSection()}
       </Card>
+
+      {/* Model Metadata Editor */}
+      <ModelMetadataEditor
+        providerAlias={providerStorageAlias}
+        models={[
+          ...models,
+          ...kiloFreeModels.filter((fm) => !models.some((m) => m.id === fm.id)),
+          ...Object.entries(modelAliases)
+            .filter(([, fm]) => fm.startsWith(`${providerStorageAlias}/`))
+            .map(([, fm]) => ({ id: fm.slice(`${providerStorageAlias}/`.length) }))
+            .filter((m) => !models.some((x) => x.id === m.id) && !kiloFreeModels.some((x) => x.id === m.id)),
+        ]}
+      />
 
       {bulkActionModal}
 

--- a/src/app/api/cli-tools/opencode-settings/converter.js
+++ b/src/app/api/cli-tools/opencode-settings/converter.js
@@ -1,0 +1,121 @@
+/**
+ * Converter: 9router capability resolver → OpenCode model config.
+ *
+ * Bead: 9r-ocmr.e1.02, e1.03, e1.04
+ * PRD:  ADR-002, ADR-003, IFACE-001, IFACE-002, REQ-001–005
+ *
+ * Maps resolved model capabilities into the OpenCode-supported model-config
+ * shape: `{ name, modalities, reasoning, tool_call, attachment, limit,
+ *          variants? }`.
+ *
+ * Deterministic and side-effect free.  Does not write credentials,
+ * headers, or unsafe options.
+ */
+
+import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+
+/**
+ * Build reasoning variants for an OpenCode model entry.
+ *
+ * Bead: 9r-ocmr.e1.04
+ * PRD:  ADR-003, REQ-005, VAL-005
+ *
+ * Returns `undefined` for non-reasoning models.  Each variant uses the
+ * OpenCode/AI SDK-compatible `reasoningEffort` key so that variant
+ * selection in OpenCode maps cleanly through 9router's runtime translator
+ * to any upstream format.
+ *
+ * @param {object} caps — Capabilities object from getCapabilitiesForModel.
+ * @returns {Record<string, { reasoningEffort: string }> | undefined}
+ */
+export function buildOpenCodeReasoningVariants(caps) {
+  if (!caps.reasoning) return undefined;
+  return {
+    low:    { reasoningEffort: "low" },
+    medium: { reasoningEffort: "medium" },
+    high:   { reasoningEffort: "high" },
+    max:    { reasoningEffort: "max" },
+  };
+}
+
+/**
+ * Build an OpenCode model config entry from resolved capabilities.
+ *
+ * @param {string|null} provider — Provider ID (optional; used for
+ *   provider-specific overrides.  Pass null when the provider is unknown.)
+ * @param {string} modelId — Model identifier (may include vendor prefix).
+ * @returns {{
+ *   name: string,
+ *   modalities: { input: string[], output: string[] },
+ *   reasoning: boolean,
+ *   tool_call: boolean,
+ *   attachment: boolean,
+ *   limit: { context: number, input: number, output: number },
+ *   variants?: Record<string, { reasoningEffort: string }>,
+ * }}
+ */
+export function buildOpenCodeModelConfig(provider, modelId) {
+  const caps = getCapabilitiesForModel(provider, modelId);
+
+  // ── Input modalities ──────────────────────────────────────────
+  const input = ["text"];
+  if (caps.vision) input.push("image");
+  if (caps.pdf) input.push("pdf");
+  if (caps.audioInput) input.push("audio");
+  if (caps.videoInput) input.push("video");
+
+  // ── Output modalities ─────────────────────────────────────────
+  const output = ["text"];
+  if (caps.imageOutput) output.push("image");
+  if (caps.audioOutput) output.push("audio");
+
+  const config = {
+    name: modelId,
+    modalities: { input, output },
+    reasoning: Boolean(caps.reasoning),
+    tool_call: Boolean(caps.tools),
+    attachment: Boolean(
+      caps.vision || caps.pdf || caps.audioInput || caps.videoInput,
+    ),
+    limit: {
+      context: caps.contextWindow,
+      input: caps.inputLimit ?? caps.contextWindow,
+      output: caps.maxOutput,
+    },
+  };
+
+  // Attach reasoning variants only for reasoning-capable models (ADR-003).
+  const variants = buildOpenCodeReasoningVariants(caps);
+  if (variants) config.variants = variants;
+
+  return config;
+}
+
+/**
+ * Controlled merge of generated and existing OpenCode model config.
+ *
+ * Bead: 9r-ocmr.e1.03
+ * PRD:  ADR-001, REQ-003, VAL-003
+ *
+ * Merge rules (ADR-001):
+ *   - Existing top-level scalar wins over generated.
+ *   - `limit`:          generated defaults + existing overrides.
+ *   - `options/headers/variants`: generated defaults + existing overrides.
+ *   - `modalities`:     existing wins if present; otherwise generated.
+ *   - Unknown existing fields are preserved.
+ *
+ * @param {object} generated - Output of buildOpenCodeModelConfig.
+ * @param {object} [existing] - Existing user-edited model entry (may be empty).
+ * @returns {object} Merged model config safe to persist.
+ */
+export function mergeOpenCodeModelConfig(generated, existing = {}) {
+  return {
+    ...generated,
+    ...existing,
+    modalities: existing.modalities ?? generated.modalities,
+    limit: { ...generated.limit, ...(existing.limit ?? {}) },
+    options: { ...(generated.options ?? {}), ...(existing.options ?? {}) },
+    headers: { ...(generated.headers ?? {}), ...(existing.headers ?? {}) },
+    variants: { ...(generated.variants ?? {}), ...(existing.variants ?? {}) },
+  };
+}

--- a/src/app/api/cli-tools/opencode-settings/converter.js
+++ b/src/app/api/cli-tools/opencode-settings/converter.js
@@ -12,7 +12,7 @@
  * headers, or unsafe options.
  */
 
-import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { resolveModelMetadata } from "@/sse/services/modelMetadataResolver.js";
 
 /**
  * Build reasoning variants for an OpenCode model entry.
@@ -54,8 +54,8 @@ export function buildOpenCodeReasoningVariants(caps) {
  *   variants?: Record<string, { reasoningEffort: string }>,
  * }}
  */
-export function buildOpenCodeModelConfig(provider, modelId) {
-  const caps = getCapabilitiesForModel(provider, modelId);
+export async function buildOpenCodeModelConfig(provider, modelId) {
+  const caps = await resolveModelMetadata(provider, modelId);
 
   // ── Input modalities ──────────────────────────────────────────
   const input = ["text"];

--- a/src/app/api/cli-tools/opencode-settings/route.js
+++ b/src/app/api/cli-tools/opencode-settings/route.js
@@ -6,6 +6,7 @@ import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
+import { buildOpenCodeModelConfig, mergeOpenCodeModelConfig } from "./converter.js";
 
 const execAsync = promisify(exec);
 
@@ -125,10 +126,12 @@ export async function POST(request) {
     // Ensure models map exists
     existingProvider.models = existingProvider.models || {};
 
-    // Add or update entries for all requested models
+    // Add or update entries for all requested models (converter + merge)
     for (const m of modelsArray) {
       if (!m || typeof m !== "string") continue;
-      existingProvider.models[m] = { name: m, modalities: { input: ["text", "image"], output: ["text"] } };
+      const generated = buildOpenCodeModelConfig(null, m);
+      const existing = existingProvider.models[m] || {};
+      existingProvider.models[m] = mergeOpenCodeModelConfig(generated, existing);
     }
 
     // Save merged provider back

--- a/src/app/api/cli-tools/opencode-settings/route.js
+++ b/src/app/api/cli-tools/opencode-settings/route.js
@@ -129,7 +129,7 @@ export async function POST(request) {
     // Add or update entries for all requested models (converter + merge)
     for (const m of modelsArray) {
       if (!m || typeof m !== "string") continue;
-      const generated = buildOpenCodeModelConfig(null, m);
+      const generated = await buildOpenCodeModelConfig(null, m);
       const existing = existingProvider.models[m] || {};
       existingProvider.models[m] = mergeOpenCodeModelConfig(generated, existing);
     }

--- a/src/app/api/models/overrides/route.js
+++ b/src/app/api/models/overrides/route.js
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import {
+  getModelOverride,
+  getModelOverrides,
+  setModelOverride,
+  deleteModelOverride,
+} from "@/lib/db/repos/modelOverridesRepo.js";
+
+// Valid metadata fields that can be overridden
+const VALID_FIELDS = [
+  "contextWindow",
+  "maxOutput",
+  "reasoning",
+  "tools",
+  "vision",
+  "pdf",
+  "audioInput",
+  "videoInput",
+  "imageOutput",
+  "audioOutput",
+  "search",
+  "thinkingFormat",
+  "thinkingCanDisable",
+  "thinkingRange",
+];
+
+// Validate override values
+function validateOverride(override) {
+  const errors = [];
+  for (const [key, value] of Object.entries(override)) {
+    if (!VALID_FIELDS.includes(key)) {
+      errors.push(`Unknown field: ${key}`);
+      continue;
+    }
+    if (["contextWindow", "maxOutput"].includes(key)) {
+      if (typeof value !== "number" || value < 0 || !Number.isInteger(value)) {
+        errors.push(`${key} must be a non-negative integer`);
+      }
+    }
+    if (["reasoning", "tools", "vision", "pdf", "audioInput", "videoInput", "imageOutput", "audioOutput", "search", "thinkingCanDisable"].includes(key)) {
+      if (typeof value !== "boolean") {
+        errors.push(`${key} must be a boolean`);
+      }
+    }
+    if (key === "thinkingFormat" && value !== null && typeof value !== "string") {
+      errors.push(`${key} must be a string or null`);
+    }
+    if (key === "thinkingRange") {
+      if (value !== null && (typeof value !== "object" || Array.isArray(value))) {
+        errors.push(`${key} must be an object or null`);
+      } else if (value !== null) {
+        if (value.min !== undefined && (typeof value.min !== "number" || value.min < 0)) {
+          errors.push("thinkingRange.min must be a non-negative number");
+        }
+        if (value.max !== undefined && (typeof value.max !== "number" || value.max < 0)) {
+          errors.push("thinkingRange.max must be a non-negative number");
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+// GET /api/models/overrides?provider=<alias> — list overrides
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const provider = searchParams.get("provider") || undefined;
+    const overrides = await getModelOverrides(provider);
+    return NextResponse.json({ overrides });
+  } catch (error) {
+    console.log("Error fetching model overrides:", error);
+    return NextResponse.json({ error: "Failed to fetch overrides" }, { status: 500 });
+  }
+}
+
+// PUT /api/models/overrides — set/update override
+export async function PUT(request) {
+  try {
+    const { provider, model, override } = await request.json();
+
+    if (!provider || !model) {
+      return NextResponse.json({ error: "provider and model are required" }, { status: 400 });
+    }
+    if (!override || typeof override !== "object") {
+      return NextResponse.json({ error: "override must be an object" }, { status: 400 });
+    }
+
+    const errors = validateOverride(override);
+    if (errors.length > 0) {
+      return NextResponse.json({ error: "Validation failed", details: errors }, { status: 400 });
+    }
+
+    await setModelOverride(provider, model, override);
+    const saved = await getModelOverride(provider, model);
+    return NextResponse.json({ success: true, override: saved });
+  } catch (error) {
+    console.log("Error setting model override:", error);
+    return NextResponse.json({ error: "Failed to set override" }, { status: 500 });
+  }
+}
+
+// DELETE /api/models/overrides?provider=<alias>&model=<id> — delete override
+export async function DELETE(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const provider = searchParams.get("provider");
+    const model = searchParams.get("model");
+
+    if (!provider || !model) {
+      return NextResponse.json({ error: "provider and model are required" }, { status: 400 });
+    }
+
+    await deleteModelOverride(provider, model);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.log("Error deleting model override:", error);
+    return NextResponse.json({ error: "Failed to delete override" }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -9,7 +9,8 @@ import { getProviderConnections, getCombos, getCustomModels, getModelAliases } f
 import { getDisabledModels } from "@/lib/disabledModelsDb";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
-import { capabilitiesFromServiceKind } from "open-sse/providers/capabilities.js";
+import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { getModelOverrides } from "@/lib/db/repos/modelOverridesRepo.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -358,6 +359,12 @@ export async function buildModelsList(kindFilter) {
 
       const mergedModelIds = Array.from(new Set([...modelIds, ...customModelIds, ...aliasModelIds]));
 
+      // Pre-fetch manual overrides for this provider (single DB call per provider)
+      let providerOverrides = {};
+      try {
+        providerOverrides = await getModelOverrides(outputAlias);
+      } catch { /* DB unavailable — proceed without overrides */ }
+
       for (const modelId of mergedModelIds) {
         // Resolve kind: prefer static/custom metadata, otherwise infer from ID heuristics
         const customKind = customModelKindById.get(modelId);
@@ -374,6 +381,25 @@ export async function buildModelsList(kindFilter) {
         };
         const caps = capabilitiesFromServiceKind(customKind);
         if (caps) model.capabilities = caps;
+
+        // Enrich with resolved metadata (manual override > hardcoded fallback)
+        try {
+          const base = getCapabilitiesForModel(outputAlias, modelId);
+          const overrideKey = `${outputAlias}|${modelId}`;
+          const override = providerOverrides[overrideKey];
+          const resolved = override ? { ...base, ...override } : base;
+          model.metadata = {
+            contextWindow: resolved.contextWindow,
+            maxOutput: resolved.maxOutput,
+            reasoning: resolved.reasoning,
+            tools: resolved.tools,
+            vision: resolved.vision,
+            thinkingFormat: resolved.thinkingFormat,
+            thinkingCanDisable: resolved.thinkingCanDisable,
+            thinkingRange: resolved.thinkingRange,
+          };
+        } catch { /* resolver error — skip metadata */ }
+
         models.push(model);
       }
 

--- a/src/lib/db/repos/modelOverridesRepo.js
+++ b/src/lib/db/repos/modelOverridesRepo.js
@@ -1,0 +1,51 @@
+import { makeKv } from "../helpers/kvStore.js";
+
+const overridesKv = makeKv("modelOverrides");
+
+// Key format: `${providerAlias}|${modelId}`
+function overrideKey(providerAlias, modelId) {
+  return `${providerAlias}|${modelId}`;
+}
+
+/**
+ * Get a single model's metadata override.
+ * @param {string} providerAlias
+ * @param {string} modelId
+ * @returns {Promise<object|null>}
+ */
+export async function getModelOverride(providerAlias, modelId) {
+  return await overridesKv.get(overrideKey(providerAlias, modelId));
+}
+
+/**
+ * Get all model overrides, optionally filtered by provider.
+ * @param {string} [providerAlias]
+ * @returns {Promise<Record<string,object>>}
+ */
+export async function getModelOverrides(providerAlias) {
+  const all = await overridesKv.getAll();
+  if (!providerAlias) return all;
+  return Object.fromEntries(
+    Object.entries(all).filter(([k]) => k.startsWith(`${providerAlias}|`))
+  );
+}
+
+/**
+ * Set a model metadata override (shallow merge with existing).
+ * @param {string} providerAlias
+ * @param {string} modelId
+ * @param {object} override - fields to override (contextWindow, maxOutput, reasoning, etc.)
+ */
+export async function setModelOverride(providerAlias, modelId, override) {
+  const existing = await getModelOverride(providerAlias, modelId);
+  await overridesKv.set(overrideKey(providerAlias, modelId), { ...existing, ...override });
+}
+
+/**
+ * Delete a model metadata override.
+ * @param {string} providerAlias
+ * @param {string} modelId
+ */
+export async function deleteModelOverride(providerAlias, modelId) {
+  await overridesKv.remove(overrideKey(providerAlias, modelId));
+}

--- a/src/shared/utils/modelOverridesApi.js
+++ b/src/shared/utils/modelOverridesApi.js
@@ -1,0 +1,60 @@
+/**
+ * API helpers for model metadata overrides.
+ *
+ * Endpoints:
+ *   GET    /api/models/overrides?provider=<alias>  → { overrides: { "alias|model": {...} } }
+ *   PUT    /api/models/overrides                   → body: { provider, model, override }
+ *   DELETE /api/models/overrides?provider=<alias>&model=<id>
+ */
+
+/**
+ * Fetch all overrides for a provider.
+ * @param {string} provider - provider alias
+ * @returns {Promise<Record<string, object>>} map of "model" → override object
+ */
+export async function fetchModelOverrides(provider) {
+  const res = await fetch(
+    `/api/models/overrides?provider=${encodeURIComponent(provider)}`,
+    { cache: "no-store" }
+  );
+  if (!res.ok) throw new Error("Failed to fetch model overrides");
+  const data = await res.json();
+  return data.overrides || {};
+}
+
+/**
+ * Set (upsert) a metadata override for one model.
+ * @param {string} provider - provider alias
+ * @param {string} model    - model ID
+ * @param {object} override - partial override fields
+ * @returns {Promise<object>} saved override
+ */
+export async function setModelOverride(provider, model, override) {
+  const res = await fetch("/api/models/overrides", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider, model, override }),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    const msg = data.details
+      ? data.details.join("; ")
+      : data.error || "Failed to save override";
+    throw new Error(msg);
+  }
+  return data.override;
+}
+
+/**
+ * Delete the override for one model (reverts to defaults).
+ * @param {string} provider - provider alias
+ * @param {string} model    - model ID
+ * @returns {Promise<void>}
+ */
+export async function deleteModelOverride(provider, model) {
+  const res = await fetch(
+    `/api/models/overrides?provider=${encodeURIComponent(provider)}&model=${encodeURIComponent(model)}`,
+    { method: "DELETE" }
+  );
+  if (!res.ok) throw new Error("Failed to delete override");
+}

--- a/src/sse/services/modelMetadataResolver.js
+++ b/src/sse/services/modelMetadataResolver.js
@@ -1,0 +1,27 @@
+import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { getModelOverride } from "../../lib/db/repos/modelOverridesRepo.js";
+
+/**
+ * Resolve model capabilities with manual override precedence.
+ *
+ * Fallback chain (highest priority wins):
+ *   1. Manual override (DB) — user/dashboard edits
+ *   2. Hardcoded provider/exact/pattern/default — source code
+ *
+ * @param {string} provider - 9router provider alias
+ * @param {string} model - model ID
+ * @returns {Promise<object>} full capabilities object (always complete, never null)
+ */
+export async function resolveModelMetadata(provider, model) {
+  const base = getCapabilitiesForModel(provider, model);
+
+  try {
+    const override = await getModelOverride(provider, model);
+    if (!override) return base;
+
+    return { ...base, ...override };
+  } catch {
+    // DB unavailable — fall back to hardcoded capabilities
+    return base;
+  }
+}

--- a/tests/unit/e2e-metadata-override-flow.test.js
+++ b/tests/unit/e2e-metadata-override-flow.test.js
@@ -1,0 +1,165 @@
+/**
+ * Integration test: full metadata override flow (9r-ocmr.e2.05)
+ *
+ * Verifies end-to-end: set override → resolver reads it → setup/API output uses it.
+ *
+ * Bead: 9r-ocmr.e2.05
+ * PRD:  VAL-006..009
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+// Mock fs/promises for setup route (it writes to a temp dir)
+vi.mock("fs/promises", async () => {
+  const actual = await vi.importActual("fs/promises");
+  return {
+    ...actual,
+    mkdir: vi.fn(actual.mkdir),
+    writeFile: vi.fn(actual.writeFile),
+    readFile: vi.fn(actual.readFile),
+    access: vi.fn(actual.access),
+  };
+});
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+      headers: new Map(),
+    }),
+  },
+}));
+
+// Mock DB modules to return provider connections
+vi.mock("../../src/lib/localDb.js", () => ({
+  getProviderConnections: vi.fn().mockResolvedValue([
+    {
+      provider: "openai",
+      isActive: true,
+      apiKey: "test-key",
+      providerSpecificData: {},
+    },
+  ]),
+  getCombos: vi.fn().mockResolvedValue([]),
+  getCustomModels: vi.fn().mockResolvedValue([]),
+  getModelAliases: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../src/lib/disabledModelsDb.js", () => ({
+  getDisabledModels: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../src/lib/db/repos/modelOverridesRepo.js", () => ({
+  getModelOverrides: vi.fn().mockResolvedValue({}),
+  getModelOverride: vi.fn().mockResolvedValue(null),
+  setModelOverride: vi.fn().mockImplementation(async (provider, model, override) => {
+    const key = `${provider}|${model}`;
+    globalThis.__mockOverrides = globalThis.__mockOverrides || {};
+    globalThis.__mockOverrides[key] = { ...override };
+    return { key, ...override };
+  }),
+  deleteModelOverride: vi.fn().mockImplementation(async (provider, model) => {
+    const key = `${provider}|${model}`;
+    globalThis.__mockOverrides = globalThis.__mockOverrides || {};
+    delete globalThis.__mockOverrides[key];
+  }),
+}));
+
+import { buildModelsList } from "../../src/app/api/v1/models/route.js";
+import { getModelOverrides, getModelOverride } from "../../src/lib/db/repos/modelOverridesRepo.js";
+import { resolveModelMetadata } from "../../src/sse/services/modelMetadataResolver.js";
+
+describe("Full metadata override flow (9r-ocmr.e2.05)", () => {
+  beforeEach(() => {
+    globalThis.__mockOverrides = {};
+    vi.clearAllMocks();
+    getModelOverrides.mockResolvedValue({});
+    getModelOverride.mockResolvedValue(null);
+  });
+
+  it("override precedence: DB > hardcoded", async () => {
+    // Mock getModelOverride (singular) to return an override
+    getModelOverride.mockImplementation(async (provider, model) => {
+      const key = `${provider}|${model}`;
+      return globalThis.__mockOverrides[key] || null;
+    });
+
+    // Simulate an override set
+    globalThis.__mockOverrides = {
+      "openai|gpt-5": { contextWindow: 123_456, maxOutput: 99_999 },
+    };
+
+    // Verify resolver picks up the override
+    const meta = await resolveModelMetadata("openai", "gpt-5");
+    expect(meta.contextWindow).toBe(123_456);
+    expect(meta.maxOutput).toBe(99_999);
+  });
+
+  it("no override: resolver returns hardcoded defaults", async () => {
+    getModelOverride.mockResolvedValue(null);
+    const meta = await resolveModelMetadata("openai", "gpt-5");
+    // gpt-5 should have a reasonable contextWindow from hardcoded caps
+    expect(meta.contextWindow).toBeGreaterThan(0);
+    expect(meta.maxOutput).toBeGreaterThan(0);
+    expect(typeof meta.reasoning).toBe("boolean");
+  });
+
+  it("/v1/models metadata field reflects override", async () => {
+    // The route uses getModelOverrides (plural) which returns a map keyed by "alias|model"
+    getModelOverrides.mockResolvedValue({
+      "openai|gpt-5": { contextWindow: 999_999 },
+    });
+    getModelOverride.mockImplementation(async (provider, model) => {
+      const key = `${provider}|${model}`;
+      const allOverrides = await getModelOverrides();
+      return allOverrides[key] || null;
+    });
+
+    const models = await buildModelsList(["llm"]);
+    const gpt5 = models.find((m) => m.id === "openai/gpt-5");
+    expect(gpt5).toBeDefined();
+    expect(gpt5.metadata.contextWindow).toBe(999_999);
+  });
+
+  it("setup converter uses resolver for metadata", async () => {
+    // Mock getModelOverride to return known values
+    getModelOverride.mockResolvedValue({
+      contextWindow: 500_000,
+      maxOutput: 200_000,
+      reasoning: true,
+      tools: true,
+      vision: true,
+    });
+
+    const { buildOpenCodeModelConfig } = await import(
+      "../../src/app/api/cli-tools/opencode-settings/converter.js"
+    );
+
+    // buildOpenCodeModelConfig is async — it calls resolveModelMetadata
+    const config = await buildOpenCodeModelConfig("openai", "gpt-5", "test-key");
+    expect(config.limit.context).toBe(500_000);
+    expect(config.limit.output).toBe(200_000);
+    expect(config.reasoning).toBe(true);
+    expect(config.tool_call).toBe(true);
+  });
+
+  it("credentials never leak in metadata or API responses", async () => {
+    getModelOverride.mockImplementation(async (provider, model) => {
+      const key = `${provider}|${model}`;
+      return globalThis.__mockOverrides[key] || null;
+    });
+    globalThis.__mockOverrides = {
+      "openai|gpt-5": { contextWindow: 100_000 },
+    };
+
+    const models = await buildModelsList(["llm"]);
+    const modelStr = JSON.stringify(models);
+    expect(modelStr).not.toContain("test-key");
+    expect(modelStr).not.toContain("apiKey");
+    expect(modelStr).not.toContain("Authorization");
+  });
+});

--- a/tests/unit/model-metadata-resolver.test.js
+++ b/tests/unit/model-metadata-resolver.test.js
@@ -1,0 +1,160 @@
+/**
+ * Tests for the model metadata resolver.
+ *
+ * Bead: 9r-ocmr.e2.02
+ * PRD:  REQ-006, REQ-008, VAL-006, VAL-008
+ *
+ * Validates that resolveModelMetadata() applies manual overrides with
+ * correct precedence and gracefully falls back on DB errors.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock the KV store ──────────────────────────────────────────────
+// We intercept getModelOverride to control what the DB returns.
+
+vi.mock("../../src/lib/db/repos/modelOverridesRepo.js", () => ({
+  getModelOverride: vi.fn().mockResolvedValue(null),
+  getModelOverrides: vi.fn().mockResolvedValue({}),
+  setModelOverride: vi.fn().mockResolvedValue(undefined),
+  deleteModelOverride: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { getModelOverride } from "../../src/lib/db/repos/modelOverridesRepo.js";
+import { resolveModelMetadata } from "../../src/sse/services/modelMetadataResolver.js";
+
+describe("resolveModelMetadata (9r-ocmr.e2.02)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no override in DB
+    getModelOverride.mockResolvedValue(null);
+  });
+
+  // ── Known model returns hardcoded caps when no override ───────────
+
+  it("returns hardcoded caps for known model when no override exists", async () => {
+    const caps = await resolveModelMetadata(null, "claude-opus-4.6");
+
+    expect(caps.reasoning).toBe(true);
+    expect(caps.contextWindow).toBe(1_000_000);
+    expect(caps.maxOutput).toBe(128_000);
+    expect(caps.vision).toBe(true);
+    expect(getModelOverride).toHaveBeenCalledWith(null, "claude-opus-4.6");
+  });
+
+  // ── Unknown model returns safe defaults ───────────────────────────
+
+  it("returns safe defaults for unknown model when no override exists", async () => {
+    const caps = await resolveModelMetadata(null, "unknown-xyz-model");
+
+    expect(caps.contextWindow).toBe(200_000);
+    expect(caps.maxOutput).toBe(64_000);
+    expect(caps.reasoning).toBe(false);
+    expect(caps.tools).toBe(true);
+  });
+
+  // ── Manual override wins over hardcoded (REQ-008) ────────────────
+
+  it("manual override wins over hardcoded caps", async () => {
+    getModelOverride.mockResolvedValue({
+      contextWindow: 500_000,
+      maxOutput: 32_000,
+    });
+
+    const caps = await resolveModelMetadata(null, "claude-opus-4.6");
+
+    // Override fields replace base
+    expect(caps.contextWindow).toBe(500_000);
+    expect(caps.maxOutput).toBe(32_000);
+    // Non-overridden fields remain from base
+    expect(caps.reasoning).toBe(true);
+    expect(caps.vision).toBe(true);
+    expect(caps.thinkingFormat).toBe("claude-adaptive");
+  });
+
+  // ── Partial override merges correctly ─────────────────────────────
+
+  it("partial override merges with base — override fields win, rest from base", async () => {
+    getModelOverride.mockResolvedValue({ contextWindow: 999 });
+
+    const caps = await resolveModelMetadata(null, "claude-opus-4.6");
+
+    expect(caps.contextWindow).toBe(999);       // overridden
+    expect(caps.maxOutput).toBe(128_000);        // from base
+    expect(caps.reasoning).toBe(true);           // from base
+    expect(caps.tools).toBe(true);               // from base
+    expect(caps.thinkingFormat).toBe("claude-adaptive"); // from base
+  });
+
+  // ── Override can add new fields ───────────────────────────────────
+
+  it("override can add fields not present in base", async () => {
+    getModelOverride.mockResolvedValue({ reasoning: false, customField: "test" });
+
+    const caps = await resolveModelMetadata(null, "claude-opus-4.6");
+
+    expect(caps.reasoning).toBe(false);  // overridden from true to false
+    expect(caps.customField).toBe("test"); // new field
+  });
+
+  // ── DB error gracefully falls back to hardcoded ───────────────────
+
+  it("gracefully falls back to hardcoded caps when DB errors", async () => {
+    getModelOverride.mockRejectedValue(new Error("DB unavailable"));
+
+    const caps = await resolveModelMetadata(null, "claude-opus-4.6");
+
+    // Should still return valid caps (from hardcoded)
+    expect(caps.contextWindow).toBe(1_000_000);
+    expect(caps.reasoning).toBe(true);
+    expect(caps.vision).toBe(true);
+  });
+
+  // ── DB returns null (no override) ─────────────────────────────────
+
+  it("returns base caps when DB returns null override", async () => {
+    getModelOverride.mockResolvedValue(null);
+
+    const caps = await resolveModelMetadata("openai", "gpt-5");
+
+    expect(caps.contextWindow).toBe(400_000);
+    expect(caps.reasoning).toBe(true);
+    expect(caps.thinkingFormat).toBe("openai");
+  });
+
+  // ── Provider argument forwarded to DB ─────────────────────────────
+
+  it("forwards provider alias to DB lookup", async () => {
+    getModelOverride.mockResolvedValue(null);
+
+    await resolveModelMetadata("anthropic", "claude-opus-4.6");
+
+    expect(getModelOverride).toHaveBeenCalledWith("anthropic", "claude-opus-4.6");
+  });
+
+  // ── Non-reasoning model override can enable reasoning ─────────────
+
+  it("override can enable reasoning on a non-reasoning model", async () => {
+    getModelOverride.mockResolvedValue({ reasoning: true, thinkingFormat: "openai" });
+
+    const caps = await resolveModelMetadata(null, "gpt-4o");
+
+    expect(caps.reasoning).toBe(true);
+    expect(caps.thinkingFormat).toBe("openai");
+    // Base vision stays
+    expect(caps.vision).toBe(true);
+  });
+
+  // ── Unknown model with override returns override + defaults ───────
+
+  it("unknown model with override returns override fields plus safe defaults", async () => {
+    getModelOverride.mockResolvedValue({ contextWindow: 100_000 });
+
+    const caps = await resolveModelMetadata(null, "custom-unknown-model");
+
+    expect(caps.contextWindow).toBe(100_000);  // override
+    expect(caps.maxOutput).toBe(64_000);        // default
+    expect(caps.reasoning).toBe(false);         // default
+    expect(caps.tools).toBe(true);              // default
+  });
+});

--- a/tests/unit/opencode-converter.test.js
+++ b/tests/unit/opencode-converter.test.js
@@ -11,8 +11,8 @@ import { buildOpenCodeModelConfig, buildOpenCodeReasoningVariants, mergeOpenCode
 describe("buildOpenCodeModelConfig (9r-ocmr.e1.02)", () => {
   // ── Known reasoning + vision model ──────────────────────────────
 
-  it("returns correct limits and flags for claude-opus-4.6", () => {
-    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+  it("returns correct limits and flags for claude-opus-4.6", async () => {
+    const config = await buildOpenCodeModelConfig(null, "claude-opus-4.6");
 
     expect(config.name).toBe("claude-opus-4.6");
     expect(config.limit.context).toBeGreaterThan(0);
@@ -32,8 +32,8 @@ describe("buildOpenCodeModelConfig (9r-ocmr.e1.02)", () => {
 
   // ── Unknown model falls back safely (REQ-002 / VAL-002) ────────
 
-  it("falls back to defaults for unknown model without crashing", () => {
-    const config = buildOpenCodeModelConfig(null, "unknown-model-xyz");
+  it("falls back to defaults for unknown model without crashing", async () => {
+    const config = await buildOpenCodeModelConfig(null, "unknown-model-xyz");
 
     expect(config.name).toBe("unknown-model-xyz");
     // Default contextWindow: 200_000, maxOutput: 64_000
@@ -51,8 +51,8 @@ describe("buildOpenCodeModelConfig (9r-ocmr.e1.02)", () => {
 
   // ── Non-reasoning model with smaller context (gpt-3.5) ─────────
 
-  it("returns reasoning:false and smaller limits for gpt-3.5-turbo", () => {
-    const config = buildOpenCodeModelConfig(null, "gpt-3.5-turbo");
+  it("returns reasoning:false and smaller limits for gpt-3.5-turbo", async () => {
+    const config = await buildOpenCodeModelConfig(null, "gpt-3.5-turbo");
 
     expect(config.reasoning).toBe(false);
     expect(config.limit.context).toBe(16_385);
@@ -61,8 +61,8 @@ describe("buildOpenCodeModelConfig (9r-ocmr.e1.02)", () => {
 
   // ── Image output model with tools disabled (gpt-image-1) ───────
 
-  it("maps imageOutput and tools:false for gpt-image-1", () => {
-    const config = buildOpenCodeModelConfig(null, "gpt-image-1");
+  it("maps imageOutput and tools:false for gpt-image-1", async () => {
+    const config = await buildOpenCodeModelConfig(null, "gpt-image-1");
 
     expect(config.modalities.output).toContain("image");
     expect(config.tool_call).toBe(false);
@@ -72,8 +72,8 @@ describe("buildOpenCodeModelConfig (9r-ocmr.e1.02)", () => {
 
   // ── Vendor prefix stripping (anthropic/claude-opus-4.6) ────────
 
-  it("strips vendor prefix when resolving capabilities", () => {
-    const config = buildOpenCodeModelConfig(null, "anthropic/claude-opus-4.6");
+  it("strips vendor prefix when resolving capabilities", async () => {
+    const config = await buildOpenCodeModelConfig(null, "anthropic/claude-opus-4.6");
 
     expect(config.name).toBe("anthropic/claude-opus-4.6");
     expect(config.limit.context).toBe(1_000_000);
@@ -82,8 +82,8 @@ describe("buildOpenCodeModelConfig (9r-ocmr.e1.02)", () => {
 
   // ── No credentials or unsafe options (security) ────────────────
 
-  it("does not include credentials, headers, or arbitrary options", () => {
-    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+  it("does not include credentials, headers, or arbitrary options", async () => {
+    const config = await buildOpenCodeModelConfig(null, "claude-opus-4.6");
 
     const keys = Object.keys(config).sort();
     expect(keys).toEqual(
@@ -115,8 +115,8 @@ describe("buildOpenCodeReasoningVariants (9r-ocmr.e1.04)", () => {
     expect(buildOpenCodeReasoningVariants(caps)).toBeUndefined();
   });
 
-  it("does not globally force high/max in any variant", () => {
-    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+  it("does not globally force high/max in any variant", async () => {
+    const config = await buildOpenCodeModelConfig(null, "claude-opus-4.6");
     expect(config.variants).toBeDefined();
     // Each variant has exactly one key: reasoningEffort
     for (const [level, variant] of Object.entries(config.variants)) {
@@ -125,13 +125,13 @@ describe("buildOpenCodeReasoningVariants (9r-ocmr.e1.04)", () => {
     }
   });
 
-  it("non-reasoning model has no variants key", () => {
-    const config = buildOpenCodeModelConfig(null, "gpt-3.5-turbo");
+  it("non-reasoning model has no variants key", async () => {
+    const config = await buildOpenCodeModelConfig(null, "gpt-3.5-turbo");
     expect(config).not.toHaveProperty("variants");
   });
 
-  it("reasoning flag is present in setup output for reasoning model", () => {
-    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+  it("reasoning flag is present in setup output for reasoning model", async () => {
+    const config = await buildOpenCodeModelConfig(null, "claude-opus-4.6");
     expect(config.reasoning).toBe(true);
   });
 });

--- a/tests/unit/opencode-converter.test.js
+++ b/tests/unit/opencode-converter.test.js
@@ -1,0 +1,212 @@
+/**
+ * Tests for the OpenCode model config converter.
+ *
+ * Bead: 9r-ocmr.e1.02
+ * PRD:  REQ-001, REQ-002, REQ-004, VAL-001, VAL-002, VAL-004
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildOpenCodeModelConfig, buildOpenCodeReasoningVariants, mergeOpenCodeModelConfig } from "@/app/api/cli-tools/opencode-settings/converter.js";
+
+describe("buildOpenCodeModelConfig (9r-ocmr.e1.02)", () => {
+  // ── Known reasoning + vision model ──────────────────────────────
+
+  it("returns correct limits and flags for claude-opus-4.6", () => {
+    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+
+    expect(config.name).toBe("claude-opus-4.6");
+    expect(config.limit.context).toBeGreaterThan(0);
+    expect(config.limit.input).toBeGreaterThan(0);
+    expect(config.limit.output).toBeGreaterThan(0);
+    // Claude opus 4.6 pattern: contextWindow 1_000_000, maxOutput 128_000
+    expect(config.limit.context).toBe(1_000_000);
+    expect(config.limit.output).toBe(128_000);
+    // Reasoning + vision + tools
+    expect(config.reasoning).toBe(true);
+    expect(config.tool_call).toBe(true);
+    expect(config.attachment).toBe(true);
+    // Vision → image in input
+    expect(config.modalities.input).toContain("image");
+    expect(config.modalities.output).toContain("text");
+  });
+
+  // ── Unknown model falls back safely (REQ-002 / VAL-002) ────────
+
+  it("falls back to defaults for unknown model without crashing", () => {
+    const config = buildOpenCodeModelConfig(null, "unknown-model-xyz");
+
+    expect(config.name).toBe("unknown-model-xyz");
+    // Default contextWindow: 200_000, maxOutput: 64_000
+    expect(config.limit.context).toBe(200_000);
+    expect(config.limit.input).toBe(200_000);
+    expect(config.limit.output).toBe(64_000);
+    // Defaults: reasoning false, tools true
+    expect(config.reasoning).toBe(false);
+    expect(config.tool_call).toBe(true);
+    expect(config.attachment).toBe(false);
+    // Only text modalities
+    expect(config.modalities.input).toEqual(["text"]);
+    expect(config.modalities.output).toEqual(["text"]);
+  });
+
+  // ── Non-reasoning model with smaller context (gpt-3.5) ─────────
+
+  it("returns reasoning:false and smaller limits for gpt-3.5-turbo", () => {
+    const config = buildOpenCodeModelConfig(null, "gpt-3.5-turbo");
+
+    expect(config.reasoning).toBe(false);
+    expect(config.limit.context).toBe(16_385);
+    expect(config.limit.output).toBe(4_096);
+  });
+
+  // ── Image output model with tools disabled (gpt-image-1) ───────
+
+  it("maps imageOutput and tools:false for gpt-image-1", () => {
+    const config = buildOpenCodeModelConfig(null, "gpt-image-1");
+
+    expect(config.modalities.output).toContain("image");
+    expect(config.tool_call).toBe(false);
+    // No vision/pdf/audio/video → no attachment
+    expect(config.attachment).toBe(false);
+  });
+
+  // ── Vendor prefix stripping (anthropic/claude-opus-4.6) ────────
+
+  it("strips vendor prefix when resolving capabilities", () => {
+    const config = buildOpenCodeModelConfig(null, "anthropic/claude-opus-4.6");
+
+    expect(config.name).toBe("anthropic/claude-opus-4.6");
+    expect(config.limit.context).toBe(1_000_000);
+    expect(config.reasoning).toBe(true);
+  });
+
+  // ── No credentials or unsafe options (security) ────────────────
+
+  it("does not include credentials, headers, or arbitrary options", () => {
+    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+
+    const keys = Object.keys(config).sort();
+    expect(keys).toEqual(
+      ["attachment", "limit", "modalities", "name", "reasoning", "tool_call", "variants"],
+    );
+    // No apiKey, headers, options, baseURL, or other provider fields
+    expect(config).not.toHaveProperty("apiKey");
+    expect(config).not.toHaveProperty("headers");
+    expect(config).not.toHaveProperty("options");
+    expect(config).not.toHaveProperty("baseURL");
+  });
+});
+
+describe("buildOpenCodeReasoningVariants (9r-ocmr.e1.04)", () => {
+  it("returns variants with reasoningEffort for reasoning-capable models", () => {
+    const caps = { reasoning: true };
+    const variants = buildOpenCodeReasoningVariants(caps);
+
+    expect(variants).toBeDefined();
+    expect(Object.keys(variants).sort()).toEqual(["high", "low", "max", "medium"]);
+    expect(variants.low).toEqual({ reasoningEffort: "low" });
+    expect(variants.medium).toEqual({ reasoningEffort: "medium" });
+    expect(variants.high).toEqual({ reasoningEffort: "high" });
+    expect(variants.max).toEqual({ reasoningEffort: "max" });
+  });
+
+  it("returns undefined for non-reasoning models", () => {
+    const caps = { reasoning: false };
+    expect(buildOpenCodeReasoningVariants(caps)).toBeUndefined();
+  });
+
+  it("does not globally force high/max in any variant", () => {
+    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+    expect(config.variants).toBeDefined();
+    // Each variant has exactly one key: reasoningEffort
+    for (const [level, variant] of Object.entries(config.variants)) {
+      expect(Object.keys(variant)).toEqual(["reasoningEffort"]);
+      expect(variant.reasoningEffort).toBe(level);
+    }
+  });
+
+  it("non-reasoning model has no variants key", () => {
+    const config = buildOpenCodeModelConfig(null, "gpt-3.5-turbo");
+    expect(config).not.toHaveProperty("variants");
+  });
+
+  it("reasoning flag is present in setup output for reasoning model", () => {
+    const config = buildOpenCodeModelConfig(null, "claude-opus-4.6");
+    expect(config.reasoning).toBe(true);
+  });
+});
+
+describe("mergeOpenCodeModelConfig (9r-ocmr.e1.03)", () => {
+  const generated = {
+    name: "claude-opus-4.6",
+    modalities: { input: ["text", "image"], output: ["text"] },
+    reasoning: true,
+    tool_call: true,
+    attachment: true,
+    limit: { context: 1_000_000, input: 1_000_000, output: 128_000 },
+  };
+
+  it("returns generated config when no existing entry", () => {
+    const result = mergeOpenCodeModelConfig(generated);
+    expect(result.name).toBe(generated.name);
+    expect(result.modalities).toEqual(generated.modalities);
+    expect(result.reasoning).toBe(generated.reasoning);
+    expect(result.tool_call).toBe(generated.tool_call);
+    expect(result.attachment).toBe(generated.attachment);
+    expect(result.limit).toEqual(generated.limit);
+    // Merge always materializes options/headers/variants (harmless empty objects)
+    expect(result.options).toEqual({});
+    expect(result.headers).toEqual({});
+    expect(result.variants).toEqual({});
+  });
+
+  it("existing limit overrides generated limit fields", () => {
+    const existing = { limit: { context: 500_000 } };
+    const result = mergeOpenCodeModelConfig(generated, existing);
+    expect(result.limit).toEqual({ context: 500_000, input: 1_000_000, output: 128_000 });
+  });
+
+  it("existing options/headers/variants are preserved and merged", () => {
+    const existing = {
+      options: { temperature: 0.5 },
+      headers: { "X-Custom": "value" },
+      variants: { low: { reasoningEffort: "low" } },
+    };
+    const result = mergeOpenCodeModelConfig(generated, existing);
+    expect(result.options).toEqual({ temperature: 0.5 });
+    expect(result.headers).toEqual({ "X-Custom": "value" });
+    expect(result.variants).toEqual({ low: { reasoningEffort: "low" } });
+  });
+
+  it("existing modalities win over generated", () => {
+    const existing = { modalities: { input: ["text"], output: ["text"] } };
+    const result = mergeOpenCodeModelConfig(generated, existing);
+    expect(result.modalities).toEqual({ input: ["text"], output: ["text"] });
+  });
+
+  it("unknown custom top-level fields survive merge", () => {
+    const existing = { customField: "should-survive", anotherKey: 42 };
+    const result = mergeOpenCodeModelConfig(generated, existing);
+    expect(result.customField).toBe("should-survive");
+    expect(result.anotherKey).toBe(42);
+  });
+
+  it("generated flags fill blanks when absent from existing", () => {
+    const existing = { limit: { context: 500_000 } };
+    const result = mergeOpenCodeModelConfig(generated, existing);
+    expect(result.reasoning).toBe(true);
+    expect(result.tool_call).toBe(true);
+    expect(result.attachment).toBe(true);
+  });
+
+  it("idempotent: merging same config twice produces same result", () => {
+    const existing = {
+      limit: { context: 500_000 },
+      options: { temperature: 0.5 },
+      customField: "keep",
+    };
+    const first = mergeOpenCodeModelConfig(generated, existing);
+    const second = mergeOpenCodeModelConfig(first, existing);
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/unit/opencode-setup-characterization.test.js
+++ b/tests/unit/opencode-setup-characterization.test.js
@@ -1,0 +1,150 @@
+/**
+ * Characterization tests for the OpenCode setup route.
+ *
+ * Bead: 9r-ocmr.e1.01
+ * PRD:  REQ-001, REQ-003, VAL-001, VAL-003
+ *
+ * These tests assert the DESIRED behavior (limits present, user fields
+ * preserved).  They fail against the current code, which writes only
+ * { name, modalities } and overwrites existing model entries.
+ *
+ * The tests will turn green once e1.02 (converter) and e1.03 (controlled
+ * merge) are implemented.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+// The route imports `fs` as a default import from "fs/promises".
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+    access: vi.fn(),
+  },
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data, init) => ({ _data: data, _status: init?.status ?? 200 }),
+  },
+}));
+
+import fs from "fs/promises";
+import { POST } from "@/app/api/cli-tools/opencode-settings/route.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function mockRequest(body) {
+  return { json: () => Promise.resolve(body) };
+}
+
+/** Extract the config object that was passed to fs.writeFile. */
+function getWrittenConfig() {
+  const call = fs.writeFile.mock.calls[0];
+  if (!call) throw new Error("fs.writeFile was not called");
+  return JSON.parse(call[1]); // [path, content]
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("OpenCode setup route — characterization (9r-ocmr.e1.01)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.mkdir.mockResolvedValue(undefined);
+    // Default: no existing config on disk
+    fs.readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+  });
+
+  // ── REQ-001 / VAL-001: limit metadata ───────────────────────────
+
+  it("should write limit.context/input/output for known models", async () => {
+    await POST(
+      mockRequest({
+        baseUrl: "http://localhost:20128",
+        apiKey: "sk_test",
+        models: ["claude-opus-4.6"],
+      }),
+    );
+
+    const config = getWrittenConfig();
+    const modelEntry = config.provider?.["9router"]?.models?.["claude-opus-4.6"];
+
+    expect(modelEntry).toBeDefined();
+    // Current code omits `limit` entirely — this captures the gap.
+    expect(modelEntry.limit).toBeDefined();
+    expect(modelEntry.limit.context).toBeGreaterThan(0);
+    expect(modelEntry.limit.input).toBeGreaterThan(0);
+    expect(modelEntry.limit.output).toBeGreaterThan(0);
+  });
+
+  // ── REQ-003 / VAL-003: field preservation on re-run ────────────
+
+  it("should preserve existing user limit, options, headers, variants, and unknown fields", async () => {
+    const existingConfig = {
+      provider: {
+        "9router": {
+          npm: "@ai-sdk/openai-compatible",
+          options: { baseURL: "http://old:20128/v1", apiKey: "sk_old" },
+          models: {
+            "claude-opus-4.6": {
+              name: "claude-opus-4.6",
+              modalities: { input: ["text", "image"], output: ["text"] },
+              limit: { context: 500000, input: 500000, output: 64000 },
+              options: { temperature: 0.5 },
+              headers: { "X-Custom": "value" },
+              variants: { low: { reasoningEffort: "low", customSetting: "keep" } },
+              customField: "should-survive",
+            },
+          },
+        },
+      },
+    };
+    fs.readFile.mockResolvedValue(JSON.stringify(existingConfig));
+
+    await POST(
+      mockRequest({
+        baseUrl: "http://localhost:20128",
+        apiKey: "sk_new",
+        models: ["claude-opus-4.6"],
+      }),
+    );
+
+    const config = getWrittenConfig();
+    const modelEntry = config.provider?.["9router"]?.models?.["claude-opus-4.6"];
+
+    expect(modelEntry).toBeDefined();
+    // Current code overwrites the entire model entry — these capture the gap.
+    expect(modelEntry.limit).toEqual({ context: 500000, input: 500000, output: 64000 });
+    expect(modelEntry.options).toEqual({ temperature: 0.5 });
+    expect(modelEntry.headers).toEqual({ "X-Custom": "value" });
+    // Variants merge: existing wins on key conflict, generated fills blanks.
+    expect(modelEntry.variants.low).toEqual({ reasoningEffort: "low", customSetting: "keep" });
+    expect(modelEntry.variants.medium).toEqual({ reasoningEffort: "medium" });
+    expect(modelEntry.variants.high).toEqual({ reasoningEffort: "high" });
+    expect(modelEntry.variants.max).toEqual({ reasoningEffort: "max" });
+    expect(modelEntry.customField).toBe("should-survive");
+  });
+
+  // ── REQ-004 / VAL-004: capability flags (forward-looking) ──────
+
+  it("should derive reasoning/tool_call/attachment from resolved capabilities", async () => {
+    await POST(
+      mockRequest({
+        baseUrl: "http://localhost:20128",
+        apiKey: "sk_test",
+        models: ["claude-opus-4.6"],
+      }),
+    );
+
+    const config = getWrittenConfig();
+    const modelEntry = config.provider?.["9router"]?.models?.["claude-opus-4.6"];
+
+    expect(modelEntry).toBeDefined();
+    // claude-opus-4.6 is reasoning-capable per the resolver.
+    expect(modelEntry.reasoning).toBe(true);
+    // tools defaults to true.
+    expect(modelEntry.tool_call).toBe(true);
+  });
+});

--- a/tests/unit/thinking-alias-characterization.test.js
+++ b/tests/unit/thinking-alias-characterization.test.js
@@ -1,0 +1,163 @@
+/**
+ * Characterization tests for runtime reasoning alias normalization.
+ *
+ * Bead: 9r-ocmr.e3.01
+ * PRD:  REQ-010..012, VAL-010..012
+ *
+ * These tests document the CURRENT behavior (snake_case extraction) and
+ * define the TARGET behavior (camelCase alias support) for the thinking
+ * normalizer in open-sse/translator/concerns/thinkingUnified.js.
+ *
+ * Red-green workflow:
+ *   - "CURRENT" tests should PASS before implementation
+ *   - "TARGET" tests should FAIL before implementation (red)
+ *   - After implementation, all tests should PASS (green)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  extractThinking,
+  applyThinking,
+} from "../../open-sse/translator/concerns/thinkingUnified.js";
+
+// Helper: apply thinking with body clone
+const apply = (targetFormat, model, body, provider) => {
+  const b = JSON.parse(JSON.stringify(body));
+  applyThinking(targetFormat, model, b, provider);
+  return b;
+};
+
+// ─── CURRENT BEHAVIOR: snake_case extraction ─────────────────────────
+
+describe("extractThinking — CURRENT: snake_case provider-native shapes", () => {
+  it("extracts reasoning_effort (OpenAI snake_case)", () => {
+    expect(extractThinking({ reasoning_effort: "high" })).toEqual({
+      mode: "level",
+      level: "high",
+    });
+  });
+
+  it("extracts reasoning.effort (OpenAI nested)", () => {
+    expect(extractThinking({ reasoning: { effort: "medium" } })).toEqual({
+      mode: "level",
+      level: "medium",
+    });
+  });
+
+  it("extracts thinking (Claude shape)", () => {
+    expect(extractThinking({ thinking: { type: "enabled", budget_tokens: 4096 } })).toEqual({
+      mode: "budget",
+      budget: 4096,
+    });
+  });
+
+  it("extracts output_config.effort (Claude adaptive)", () => {
+    expect(extractThinking({ output_config: { effort: "high" } })).toEqual({
+      mode: "level",
+      level: "high",
+    });
+  });
+
+  it("extracts thinkingConfig (Gemini)", () => {
+    expect(extractThinking({ thinkingConfig: { thinkingBudget: 8192 } })).toEqual({
+      mode: "budget",
+      budget: 8192,
+    });
+  });
+
+  it("extracts enable_thinking (Qwen snake_case)", () => {
+    expect(extractThinking({ enable_thinking: true, thinking_budget: 1024 })).toEqual({
+      mode: "budget",
+      budget: 1024,
+    });
+  });
+
+  it("returns null when no thinking intent present", () => {
+    expect(extractThinking({ messages: [{ role: "user", content: "hi" }] })).toBeNull();
+  });
+});
+
+// ─── TARGET BEHAVIOR: camelCase alias extraction ─────────────────────
+
+describe("extractThinking — TARGET: camelCase aliases (OpenCode SDK)", () => {
+  it("extracts reasoningEffort (camelCase alias for reasoning_effort)", () => {
+    // TARGET: OpenCode sends reasoningEffort (camelCase)
+    const result = extractThinking({ reasoningEffort: "high" });
+    expect(result).toEqual({ mode: "level", level: "high" });
+  });
+
+  it("camelCase reasoningEffort takes precedence over snake_case reasoning_effort", () => {
+    // When both are present, camelCase (OpenCode) should win
+    const result = extractThinking({
+      reasoningEffort: "low",
+      reasoning_effort: "high",
+    });
+    expect(result).toEqual({ mode: "level", level: "low" });
+  });
+
+  it("camelCase reasoningEffort with none/off value", () => {
+    const result = extractThinking({ reasoningEffort: "none" });
+    expect(result).toEqual({ mode: "none" });
+  });
+
+  it("camelCase reasoningEffort with auto value", () => {
+    const result = extractThinking({ reasoningEffort: "auto" });
+    expect(result).toEqual({ mode: "auto" });
+  });
+
+  it("camelCase reasoningEffort is case-insensitive", () => {
+    expect(extractThinking({ reasoningEffort: "High" })).toEqual({
+      mode: "level",
+      level: "high",
+    });
+  });
+
+  it("Claude thinking shape takes precedence over camelCase reasoningEffort", () => {
+    // Provider-native shapes are more specific than generic aliases.
+    // When both are present, the provider-native shape wins.
+    const result = extractThinking({
+      reasoningEffort: "medium",
+      thinking: { type: "enabled", budget_tokens: 8192 },
+    });
+    expect(result).toEqual({ mode: "budget", budget: 8192 });
+  });
+
+  it("camelCase reasoningEffort overrides Gemini shape", () => {
+    const result = extractThinking({
+      reasoningEffort: "low",
+      thinkingConfig: { thinkingBudget: 24576 },
+    });
+    expect(result).toEqual({ mode: "level", level: "low" });
+  });
+});
+
+// ─── TARGET BEHAVIOR: applyThinking with camelCase input ─────────────
+
+describe("applyThinking — TARGET: camelCase input flows through correctly", () => {
+  it("OpenAI format: reasoningEffort → reasoning_effort", () => {
+    const out = apply("openai", "gpt-5", { reasoningEffort: "high" }, "openai");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("Claude adaptive: reasoningEffort → output_config.effort", () => {
+    const out = apply("claude", "claude-opus-4.7", { reasoningEffort: "high" }, "claude");
+    expect(out.output_config).toEqual({ effort: "high" });
+  });
+
+  it("Gemini budget: reasoningEffort → thinkingConfig.thinkingBudget", () => {
+    const out = apply("gemini", "gemini-2.5-flash", { reasoningEffort: "high" }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingBudget).toBe(24576);
+  });
+
+  it("Qwen: reasoningEffort → enable_thinking + thinking_budget", () => {
+    const out = apply("openai", "qwen3-max", { reasoningEffort: "medium" }, "qwen");
+    expect(out.enable_thinking).toBe(true);
+    expect(out.thinking_budget).toBe(8192);
+  });
+
+  it("DeepSeek: reasoningEffort → thinking + reasoning_effort", () => {
+    const out = apply("openai", "deepseek-v4-pro", { reasoningEffort: "high" }, "deepseek");
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("high");
+  });
+});

--- a/tests/unit/thinking-clamp.test.js
+++ b/tests/unit/thinking-clamp.test.js
@@ -1,0 +1,90 @@
+/**
+ * Tests for thinking budget clamping (9r-ocmr.e3.03).
+ *
+ * Validates:
+ * - Over-max numeric budget is clamped to thinkingRange.max
+ * - Budget cannot consume all visible output (maxOutput reserve)
+ * - Non-disableable thinking metadata is respected
+ * - Missing metadata fallback works correctly
+ */
+
+import { describe, it, expect } from "vitest";
+import { clampThinkingBudget } from "../../open-sse/translator/concerns/thinking.js";
+import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
+
+const apply = (targetFormat, model, body, provider) => {
+  const b = JSON.parse(JSON.stringify(body));
+  applyThinking(targetFormat, model, b, provider);
+  return b;
+};
+
+describe("clampThinkingBudget", () => {
+  it("clamps to thinkingRange.max when budget exceeds it", () => {
+    const caps = { thinkingRange: { max: 16384 } };
+    expect(clampThinkingBudget(32768, caps)).toBe(16384);
+  });
+
+  it("clamps to thinkingRange.min when budget is below it", () => {
+    const caps = { thinkingRange: { min: 1024 } };
+    expect(clampThinkingBudget(512, caps)).toBe(1024);
+  });
+
+  it("clamps to 80% of maxOutput when budget exceeds it", () => {
+    const caps = { maxOutput: 16000 };
+    // 80% of 16000 = 12800
+    expect(clampThinkingBudget(15000, caps)).toBe(12800);
+  });
+
+  it("applies both thinkingRange.max and maxOutput reserve (stricter wins)", () => {
+    const caps = { thinkingRange: { max: 50000 }, maxOutput: 20000 };
+    // thinkingRange.max = 50000, 80% of maxOutput = 16000 → 16000 wins
+    expect(clampThinkingBudget(50000, caps)).toBe(16000);
+  });
+
+  it("does not clamp when budget is within all bounds", () => {
+    const caps = { thinkingRange: { max: 50000 }, maxOutput: 50000 };
+    expect(clampThinkingBudget(8192, caps)).toBe(8192);
+  });
+
+  it("passes through non-finite values", () => {
+    expect(clampThinkingBudget(NaN, {})).toBe(NaN);
+    expect(clampThinkingBudget(Infinity, {})).toBe(Infinity);
+  });
+
+  it("passes through zero and negative (handled elsewhere)", () => {
+    expect(clampThinkingBudget(0, {})).toBe(0);
+    expect(clampThinkingBudget(-1, {})).toBe(-1);
+  });
+
+  it("works with missing/empty caps", () => {
+    expect(clampThinkingBudget(8192, null)).toBe(8192);
+    expect(clampThinkingBudget(8192, undefined)).toBe(8192);
+    expect(clampThinkingBudget(8192, {})).toBe(8192);
+  });
+});
+
+describe("applyThinking — budget clamping integration", () => {
+  it("claude-budget: over-max budget is clamped", () => {
+    const out = apply("claude", "claude-haiku-4.5", { thinking: { type: "enabled", budget_tokens: 200000 } }, "claude");
+    // Claude haiku has thinkingRange.max, budget should be clamped
+    expect(out.thinking.budget_tokens).toBeLessThanOrEqual(200000);
+  });
+
+  it("gemini-budget: budget respects maxOutput reserve", () => {
+    const out = apply("gemini", "gemini-2.5-flash", { reasoningEffort: "high" }, "gemini");
+    // Should have a thinkingBudget that doesn't consume all output
+    expect(out.generationConfig.thinkingConfig.thinkingBudget).toBeGreaterThan(0);
+  });
+
+  it("non-reasoning model still strips thinking regardless of budget", () => {
+    const out = apply("openai", "gpt-4o", { reasoningEffort: "high" }, "openai");
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.thinking).toBeUndefined();
+  });
+
+  it("non-disableable model clamps none to minimal", () => {
+    // MiniMax M2.x cannot disable thinking (thinkingCanDisable: false)
+    const out = apply("claude", "MiniMax-M2.7", { thinking: { type: "disabled" } }, "minimax");
+    expect(out.thinking.type).toBe("adaptive");
+  });
+});

--- a/tests/unit/thinking-regression-matrix.test.js
+++ b/tests/unit/thinking-regression-matrix.test.js
@@ -1,0 +1,246 @@
+/**
+ * Provider-format reasoning regression matrix (9r-ocmr.e3.04).
+ *
+ * Comprehensive pipeline tests: input (snake_case + camelCase) → extractThinking → applyThinking → provider output.
+ * Covers all provider formats, level variants, budget inputs, and negative controls.
+ */
+
+import { describe, it, expect } from "vitest";
+import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
+
+const apply = (targetFormat, model, body, provider) => {
+  const b = JSON.parse(JSON.stringify(body));
+  applyThinking(targetFormat, model, b, provider);
+  return b;
+};
+
+// ─── Negative controls: non-reasoning models ─────────────────────────
+
+describe("Regression: non-reasoning model strips all thinking", () => {
+  it("openai gpt-4o strips reasoning_effort", () => {
+    const out = apply("openai", "gpt-4o", { reasoning_effort: "high" }, "openai");
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.thinking).toBeUndefined();
+    expect(out.output_config).toBeUndefined();
+  });
+
+  it("openai gpt-4o strips reasoningEffort (camelCase)", () => {
+    const out = apply("openai", "gpt-4o", { reasoningEffort: "high" }, "openai");
+    expect(out.reasoning_effort).toBeUndefined();
+  });
+
+  it("claude gpt-4o strips thinking shape", () => {
+    const out = apply("claude", "gpt-4o", { thinking: { type: "enabled", budget_tokens: 4096 } }, "openai");
+    expect(out.thinking).toBeUndefined();
+  });
+});
+
+// ─── OpenAI format ───────────────────────────────────────────────────
+
+describe("Regression: openai format", () => {
+  it("snake_case reasoning_effort 'high'", () => {
+    const out = apply("openai", "gpt-5", { reasoning_effort: "high" }, "openai");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("camelCase reasoningEffort 'high'", () => {
+    const out = apply("openai", "gpt-5", { reasoningEffort: "high" }, "openai");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("nested reasoning.effort 'medium'", () => {
+    const out = apply("openai", "gpt-5", { reasoning: { effort: "medium" } }, "openai");
+    expect(out.reasoning_effort).toBe("medium");
+  });
+
+  it("level 'none' → reasoning_effort 'none'", () => {
+    const out = apply("openai", "gpt-5", { reasoningEffort: "none" }, "openai");
+    expect(out.reasoning_effort).toBe("none");
+  });
+
+  it("level 'xhigh' clamps to 'high'", () => {
+    const out = apply("openai", "gpt-5", { reasoningEffort: "xhigh" }, "openai");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("level 'max' clamps to 'high'", () => {
+    const out = apply("openai", "gpt-5", { reasoningEffort: "max" }, "openai");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("model suffix overrides body", () => {
+    const out = apply("openai", "gpt-5(low)", { reasoningEffort: "high" }, "openai");
+    expect(out.reasoning_effort).toBe("low");
+  });
+});
+
+// ─── Claude adaptive format ──────────────────────────────────────────
+
+describe("Regression: claude-adaptive format", () => {
+  it("snake_case → output_config.effort", () => {
+    const out = apply("claude", "claude-opus-4.7", { reasoning_effort: "high" }, "claude");
+    expect(out.output_config).toEqual({ effort: "high" });
+  });
+
+  it("camelCase → output_config.effort", () => {
+    const out = apply("claude", "claude-opus-4.7", { reasoningEffort: "high" }, "claude");
+    expect(out.output_config).toEqual({ effort: "high" });
+  });
+
+  it("level 'none' → thinking.type disabled (canDisable)", () => {
+    const out = apply("claude", "claude-opus-4.7", { reasoningEffort: "none" }, "claude");
+    expect(out.thinking).toEqual({ type: "disabled" });
+    expect(out.output_config).toBeUndefined();
+  });
+
+  it("existing Claude thinking shape still works", () => {
+    const out = apply("claude", "claude-opus-4.7", { thinking: { type: "disabled" } }, "claude");
+    expect(out.thinking).toEqual({ type: "disabled" });
+  });
+});
+
+// ─── Claude budget format ────────────────────────────────────────────
+
+describe("Regression: claude-budget format", () => {
+  it("level 'high' → budget 24576", () => {
+    const out = apply("claude", "claude-haiku-4.5", { reasoningEffort: "high" }, "claude");
+    expect(out.thinking).toEqual({ type: "enabled", budget_tokens: 24576 });
+  });
+
+  it("level 'medium' → budget 8192", () => {
+    const out = apply("claude", "claude-haiku-4.5", { reasoningEffort: "medium" }, "claude");
+    expect(out.thinking).toEqual({ type: "enabled", budget_tokens: 8192 });
+  });
+
+  it("direct budget input preserved", () => {
+    const out = apply("claude", "claude-haiku-4.5", { thinking: { type: "enabled", budget_tokens: 4096 } }, "claude");
+    expect(out.thinking).toEqual({ type: "enabled", budget_tokens: 4096 });
+  });
+});
+
+// ─── Gemini level format ─────────────────────────────────────────────
+
+describe("Regression: gemini-level format", () => {
+  it("level 'medium' → thinkingLevel 'medium'", () => {
+    const out = apply("gemini", "gemini-3-pro", { reasoningEffort: "medium" }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("medium");
+  });
+
+  it("level 'high' → thinkingLevel 'high'", () => {
+    const out = apply("gemini", "gemini-3-pro", { reasoningEffort: "high" }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
+  });
+
+  it("level 'none' → thinkingLevel 'minimal' (gemini-3 cannot fully disable)", () => {
+    const out = apply("gemini", "gemini-3-pro", { reasoningEffort: "none" }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("minimal");
+  });
+});
+
+// ─── Gemini budget format ────────────────────────────────────────────
+
+describe("Regression: gemini-budget format", () => {
+  it("level 'high' → thinkingBudget 24576", () => {
+    const out = apply("gemini", "gemini-2.5-flash", { reasoningEffort: "high" }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingBudget).toBe(24576);
+  });
+
+  it("direct thinkingConfig preserved", () => {
+    const out = apply("gemini", "gemini-2.5-flash", { thinkingConfig: { thinkingBudget: 8192 } }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingBudget).toBe(8192);
+  });
+
+  it("level 'none' → thinkingBudget 0", () => {
+    const out = apply("gemini", "gemini-2.5-flash", { reasoningEffort: "none" }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingBudget).toBe(0);
+  });
+});
+
+// ─── Qwen format ─────────────────────────────────────────────────────
+
+describe("Regression: qwen format", () => {
+  it("level 'medium' → enable_thinking + thinking_budget 8192", () => {
+    const out = apply("openai", "qwen3-max", { reasoningEffort: "medium" }, "qwen");
+    expect(out.enable_thinking).toBe(true);
+    expect(out.thinking_budget).toBe(8192);
+  });
+
+  it("level 'none' → enable_thinking false", () => {
+    const out = apply("openai", "qwen3-max", { reasoningEffort: "none" }, "qwen");
+    expect(out.enable_thinking).toBe(false);
+  });
+
+  it("QwQ cannot disable → clamp minimal", () => {
+    const out = apply("openai", "qwq-32b", { reasoningEffort: "none" }, "qwen");
+    expect(out.enable_thinking).toBe(true);
+  });
+});
+
+// ─── DeepSeek format ─────────────────────────────────────────────────
+
+describe("Regression: deepseek format", () => {
+  it("level 'high' → thinking enabled + reasoning_effort high", () => {
+    const out = apply("openai", "deepseek-v4-pro", { reasoningEffort: "high" }, "deepseek");
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("level 'low' → reasoning_effort high (low/medium→high)", () => {
+    const out = apply("openai", "deepseek-v4-pro", { reasoningEffort: "low" }, "deepseek");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("level 'xhigh' → reasoning_effort max", () => {
+    const out = apply("openai", "deepseek-v4-pro", { reasoningEffort: "xhigh" }, "deepseek");
+    expect(out.reasoning_effort).toBe("max");
+  });
+});
+
+// ─── Kimi format ─────────────────────────────────────────────────────
+
+describe("Regression: kimi format", () => {
+  it("level 'high' → reasoning_effort high", () => {
+    const out = apply("openai", "kimi-k2.6", { reasoningEffort: "high" }, "kimi");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("level 'max' → reasoning_effort high (max clamped)", () => {
+    const out = apply("openai", "kimi-k2.6", { reasoningEffort: "max" }, "kimi");
+    expect(out.reasoning_effort).toBe("high");
+  });
+});
+
+// ─── MiniMax format ──────────────────────────────────────────────────
+
+describe("Regression: minimax format", () => {
+  it("any effort → thinking.type adaptive", () => {
+    const out = apply("claude", "MiniMax-M3", { reasoningEffort: "high" }, "minimax");
+    expect(out.thinking).toEqual({ type: "adaptive" });
+  });
+
+  it("non-disableable model (M2.7) → adaptive even when disabled", () => {
+    const out = apply("claude", "MiniMax-M2.7", { thinking: { type: "disabled" } }, "minimax");
+    expect(out.thinking.type).toBe("adaptive");
+  });
+});
+
+// ─── camelCase vs snake_case equivalence ─────────────────────────────
+
+describe("Regression: camelCase and snake_case produce identical output fields", () => {
+  const cases = [
+    { model: "gpt-5", target: "openai", prov: "openai", field: "reasoning_effort" },
+    { model: "claude-opus-4.7", target: "claude", prov: "claude", field: "output_config" },
+    { model: "gemini-3-pro", target: "gemini", prov: "gemini", field: "generationConfig" },
+    { model: "deepseek-v4-pro", target: "openai", prov: "deepseek", field: "thinking" },
+    { model: "kimi-k2.6", target: "openai", prov: "kimi", field: "reasoning_effort" },
+  ];
+
+  for (const { model, target, prov, field } of cases) {
+    it(`${prov}/${model}: camelCase ≡ snake_case (provider output)`, () => {
+      const snake = apply(target, model, { reasoning_effort: "high" }, prov);
+      const camel = apply(target, model, { reasoningEffort: "high" }, prov);
+      // Compare only the provider-specific output field (original input field is preserved)
+      expect(camel[field]).toEqual(snake[field]);
+    });
+  }
+});

--- a/tests/unit/v1-models-metadata.test.js
+++ b/tests/unit/v1-models-metadata.test.js
@@ -1,0 +1,178 @@
+/**
+ * Tests for the /v1/models metadata enrichment.
+ *
+ * Bead: 9r-ocmr.e2.03
+ * PRD:  REQ-009, VAL-009
+ *
+ * Validates that:
+ * - /v1/models response includes metadata for each model
+ * - Baseline OpenAI-compatible fields remain present
+ * - Credentials and headers are not exposed
+ * - Metadata fields include limits, reasoning, tools, modalities
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the DB modules
+vi.mock("../../src/lib/localDb.js", () => ({
+  getProviderConnections: vi.fn().mockResolvedValue([]),
+  getCombos: vi.fn().mockResolvedValue([]),
+  getCustomModels: vi.fn().mockResolvedValue([]),
+  getModelAliases: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../src/lib/disabledModelsDb.js", () => ({
+  getDisabledModels: vi.fn().mockResolvedValue({}),
+}));
+
+// Use @/ alias to match the route's import path
+vi.mock("@/lib/db/repos/modelOverridesRepo.js", () => ({
+  getModelOverrides: vi.fn().mockResolvedValue({}),
+}));
+
+import { buildModelsList } from "../../src/app/api/v1/models/route.js";
+import { getModelOverrides } from "../../src/lib/db/repos/modelOverridesRepo.js";
+
+describe("/v1/models metadata enrichment (9r-ocmr.e2.03)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getModelOverrides.mockResolvedValue({});
+  });
+
+  it("returns metadata field for models when connections exist", async () => {
+    // Mock a provider connection
+    const { getProviderConnections } = await import("../../src/lib/localDb.js");
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        apiKey: "test-key",
+        providerSpecificData: {},
+      },
+    ]);
+
+    const models = await buildModelsList(["llm"]);
+
+    // Should have at least one model
+    expect(models.length).toBeGreaterThan(0);
+
+    // Each model should have the standard OpenAI fields
+    for (const model of models) {
+      expect(model.id).toBeDefined();
+      expect(model.object).toBe("model");
+      expect(model.owned_by).toBeDefined();
+      // Should NOT contain credentials
+      expect(model).not.toHaveProperty("apiKey");
+      expect(model).not.toHaveProperty("headers");
+      expect(model).not.toHaveProperty("baseURL");
+    }
+  });
+
+  it("includes metadata with contextWindow and maxOutput", async () => {
+    const { getProviderConnections } = await import("../../src/lib/localDb.js");
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        apiKey: "test-key",
+        providerSpecificData: {},
+      },
+    ]);
+
+    const models = await buildModelsList(["llm"]);
+
+    // Find a known model (gpt-5 should be in the list)
+    const gpt5 = models.find((m) => m.id?.includes("gpt-5"));
+    if (gpt5) {
+      expect(gpt5.metadata).toBeDefined();
+      expect(gpt5.metadata.contextWindow).toBeGreaterThan(0);
+      expect(gpt5.metadata.maxOutput).toBeGreaterThan(0);
+      expect(typeof gpt5.metadata.reasoning).toBe("boolean");
+      expect(typeof gpt5.metadata.tools).toBe("boolean");
+    }
+  });
+
+  it("metadata reflects manual overrides from DB", async () => {
+    // We need to know what outputAlias resolves to for openai.
+    // Instead, we test with a provider/connection that gives us a known alias.
+    const { getProviderConnections } = await import("../../src/lib/localDb.js");
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        apiKey: "test-key",
+        providerSpecificData: { prefix: "openai" },
+      },
+    ]);
+
+    // First, get the model list to find exact IDs
+    const models = await buildModelsList(["llm"]);
+    const gpt5 = models.find((m) => m.id?.includes("gpt-5"));
+    
+    if (gpt5) {
+      // Extract the exact alias and modelId from the model ID
+      const [alias, modelId] = gpt5.id.split("/");
+      
+      // Set override with the exact key format
+      getModelOverrides.mockResolvedValue({
+        [`${alias}|${modelId}`]: {
+          contextWindow: 999_999,
+          maxOutput: 123_456,
+        },
+      });
+
+      // Re-run to pick up the override
+      const models2 = await buildModelsList(["llm"]);
+      const gpt5v2 = models2.find((m) => m.id?.includes("gpt-5"));
+      
+      if (gpt5v2) {
+        expect(gpt5v2.metadata).toBeDefined();
+        expect(gpt5v2.metadata.contextWindow).toBe(999_999);
+        expect(gpt5v2.metadata.maxOutput).toBe(123_456);
+      }
+    }
+  });
+
+  it("does not expose credentials or auth headers in metadata", async () => {
+    const { getProviderConnections } = await import("../../src/lib/localDb.js");
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        apiKey: "sk-secret-key-12345",
+        providerSpecificData: { baseUrl: "https://api.openai.com/v1" },
+      },
+    ]);
+
+    const models = await buildModelsList(["llm"]);
+
+    for (const model of models) {
+      const modelStr = JSON.stringify(model);
+      expect(modelStr).not.toContain("sk-secret-key-12345");
+      expect(modelStr).not.toContain("api.openai.com");
+      expect(model).not.toHaveProperty("apiKey");
+      expect(model).not.toHaveProperty("headers");
+    }
+  });
+
+  it("baseline OpenAI-compatible fields are preserved", async () => {
+    const { getProviderConnections } = await import("../../src/lib/localDb.js");
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        apiKey: "test-key",
+        providerSpecificData: {},
+      },
+    ]);
+
+    const models = await buildModelsList(["llm"]);
+
+    for (const model of models) {
+      // Required OpenAI fields
+      expect(model.id).toMatch(/^[^/]+\/.+$/); // format: "alias/modelId"
+      expect(model.object).toBe("model");
+      expect(typeof model.owned_by).toBe("string");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements OpenCode metadata enrichment, model metadata overrides, and runtime reasoning normalization for the 9router project.
You can set context window size, max output tokens and for some models also reasoning level. These settings will be applied if you use 9router CLI setup page.
This way you don't have to manually edit context window size in opencode settings, and those manual edits don't get overwritten if you change 9router setup.

`http://localhost:20128/dashboard/providers/opencode`

<img width="784" height="683" alt="image" src="https://github.com/user-attachments/assets/904fea91-ecf8-44e6-9fe8-7701703b01f3" />


### Epic 1: OpenCode Setup Metadata Enrichment
- Enriches OpenCode setup route with model limits, capabilities, and reasoning variants
- Proper merging of generated and existing config (no destructive overwrites)
- 21 tests (converter, merge, variants, characterization)

### Epic 2: Model Metadata Overrides
- New `modelOverrides` KV store for per-model metadata
- `modelMetadataResolver` with DB > hardcoded precedence chain
- `PUT/GET/DELETE /api/models/overrides` API endpoints
- `/v1/models` enriched with additive metadata field
- Dashboard UI: ModelMetadataEditor with level selectors, budget inputs, reset buttons
- 20 tests (resolver, API, e2e flow)

### Epic 3: Runtime Reasoning Normalization
- `extractThinking` supports camelCase `reasoningEffort` alias (AI SDK compat)
- `clampThinkingBudget` enforces `thinkingRange.min/max` and 80% maxOutput reserve
- Regression matrix: 38 tests covering all provider formats (OpenAI, Claude, Gemini, Qwen, DeepSeek, Kimi, MiniMax)
- `docs/runtime-reasoning.md` documentation

## Files Changed

| Category | Files |
|----------|-------|
| Core | `thinkingUnified.js`, `thinking.js`, `converter.js`, `route.js` (setup) |
| New | `modelOverridesRepo.js`, `modelMetadataResolver.js`, `overrides/route.js`, `ModelMetadataEditor.js`, `modelOverridesApi.js` |
| Modified | `/v1/models/route.js`, provider detail `page.js` |
| Tests | 9 test files, 138 tests passing |
| Docs | `opencode-setup-metadata.md`, `runtime-reasoning.md` |

## Test Results

```
9 test files passed
138 tests passed
Duration: 1.52s
```

## Validation

- [x] All 138 tests pass
- [x] `next build` succeeds
- [x] No credentials or auth headers exposed
- [x] Docs consistent with implementation

---

**Branch:** `feat/opencode-metadata-reasoning`
**Base:** `master`