### PR TITLE
Silence repetitive DATA_DIR fallback warnings

### DIFF
--- a/src/lib/dataDir.js
+++ b/src/lib/dataDir.js
@@ -18,7 +18,6 @@ export function getDataDir() {
   // On Windows, ignore Unix-style absolute paths (e.g. /var/lib/...) that come
   // from a Linux-targeted .env or Docker config — they are not valid here.
   if (process.platform === "win32" && /^\//.test(configured)) {
-    console.warn(`[DATA_DIR] '${configured}' is a Unix path on Windows → fallback to default`);
     return defaultDir();
   }
 
@@ -27,7 +26,6 @@ export function getDataDir() {
     return configured;
   } catch (e) {
     if (e?.code === "EACCES" || e?.code === "EPERM") {
-      console.warn(`[DATA_DIR] '${configured}' not writable → fallback ~/.${APP_NAME}`);
       return defaultDir();
     }
     throw e;

--- a/src/mitm/paths.js
+++ b/src/mitm/paths.js
@@ -19,7 +19,6 @@ function getDataDir() {
     return configured;
   } catch (e) {
     if (e?.code === "EACCES" || e?.code === "EPERM") {
-      console.warn(`[DATA_DIR] '${configured}' not writable → fallback ~/.${APP_NAME}`);
       return defaultDir();
     }
     throw e;


### PR DESCRIPTION
The warning '[DATA_DIR] ... not writable → fallback ~/.9router' fires on every module import during build (Next.js workers, page renders, etc.), producing 15+ noisy lines. The fallback is expected behavior — remove the console.warn entirely.