### PR TITLE
fix(cli): handle Next.js 16 nested standalone output path

### DIFF
--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -135,7 +135,15 @@ console.log("✅ Cleaned\n");
 console.log("3️⃣  Copying Next.js standalone build to app/cli/app...");
 const standaloneRoot = path.join(appDir, ".next", "standalone");
 const standaloneRootResolved = path.join(buildDistDir, "standalone");
-const standaloneRootToUse = fs.existsSync(standaloneRootResolved) ? standaloneRootResolved : standaloneRoot;
+let standaloneRootToUse = fs.existsSync(standaloneRootResolved) ? standaloneRootResolved : standaloneRoot;
+// Next.js 16 nests standalone output under the project name when NEXT_TRACING_ROOT_MODE=workspace
+// e.g. .next-cli-build/standalone/9router/server.js
+const pkgName = path.basename(appDir);
+const nestedRoot = path.join(standaloneRootToUse, pkgName);
+if (fs.existsSync(path.join(nestedRoot, "server.js")) && !fs.existsSync(path.join(standaloneRootToUse, "server.js"))) {
+  console.log(`ℹ️  Detected nested standalone output: ${pkgName}/`);
+  standaloneRootToUse = nestedRoot;
+}
 const standaloneApp = fs.existsSync(path.join(standaloneRootToUse, "server.js"))
   ? standaloneRootToUse
   : path.join(standaloneRootToUse, "app");


### PR DESCRIPTION
## Problem

The CLI build script (`cli/scripts/build-cli.js`) fails with Next.js 16 when using `NEXT_TRACING_ROOT_MODE=workspace`. The build expects `standalone/server.js` or `standalone/app/`, but Next.js 16 nests the standalone output under the project directory name (e.g. `standalone/9router/server.js`).

This affects both bun and npm users trying to build the CLI from source.

## Solution

Added detection for the nested standalone layout with backward-compatible fallback:

1. Check for existing `standalone/server.js` (current behavior)
2. If not found, check for nested path `standalone/<project-name>/server.js` (Next.js 16)
3. Fall back to `standalone/app/` if neither exists

The fix uses `path.basename(appDir)` to determine the project directory name, which is more reliable than parsing `package.json` name field.

## Testing

- Verified build succeeds with Next.js 16.2.9
- Backward compatible: existing `standalone/server.js` path still works for Next.js 15 and earlier
- Build output size unchanged (56M)

## Changes

- Modified `cli/scripts/build-cli.js` to detect and handle nested standalone output
- Added informative log message when nested layout is detected