### PR TITLE
feat(codebuddy-cn): add API key auth + credit quota tracker

### DIFF
--- a/open-sse/providers/registry/codebuddy-cn.js
+++ b/open-sse/providers/registry/codebuddy-cn.js
@@ -12,6 +12,8 @@ export default {
     },
   },
   category: "oauth",
+  authModes: ["oauth", "apikey"],
+  hasOAuth: true,
   transport: {
     baseUrl: "https://copilot.tencent.com/v2/chat/completions",
     forceStream: true,

--- a/open-sse/providers/registry/codebuddy-cn.js
+++ b/open-sse/providers/registry/codebuddy-cn.js
@@ -34,6 +34,11 @@ export default {
       header: "Authorization",
       scheme: "bearer",
     },
+    // Quota endpoint differs from the chat gateway: POST returns nested Tencent
+    // billing payload (data.Response.Data.Accounts[]). See services/usage/codebuddy.js.
+    usage: {
+      url: "https://copilot.tencent.com/v2/billing/meter/get-user-resource",
+    },
   },
   models: [
     { id: "glm-5.2", name: "GLM-5.2" },
@@ -60,5 +65,9 @@ export default {
     userAgent: "CLI/2.63.2 CodeBuddy/2.63.2",
     platform: "CLI",
     pollInterval: 5000,
+  },
+  features: {
+    usage: true,
+    usageApikey: true,
   },
 };

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -10,6 +10,7 @@ import { getCodexUsage, consumeCodexRateLimitResetCredit } from "./usage/codex.j
 export { consumeCodexRateLimitResetCredit };
 import { getKiroUsage } from "./usage/kiro.js";
 import { getMiniMaxUsage } from "./usage/minimax.js";
+import { getCodeBuddyCnUsage } from "./usage/codebuddy-cn.js";
 import {
   getQwenUsage,
   getIflowUsage,
@@ -41,6 +42,7 @@ const USAGE_HANDLERS = {
   minimax: (c) => getMiniMaxUsage(c.apiKey, c.provider, c.proxyOptions),
   "minimax-cn": (c) => getMiniMaxUsage(c.apiKey, c.provider, c.proxyOptions),
   "vercel-ai-gateway": (c) => getVercelAiGatewayUsage(c.apiKey, c.proxyOptions),
+  "codebuddy-cn": (c) => getCodeBuddyCnUsage(c.accessToken, c.apiKey, c.providerSpecificData, c.proxyOptions),
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null) {

--- a/open-sse/services/usage/codebuddy-cn.js
+++ b/open-sse/services/usage/codebuddy-cn.js
@@ -1,0 +1,131 @@
+/**
+ * CodeBuddy CN usage handler
+ *
+ * Scoped to the "codebuddy-cn" provider specifically — a future "codebuddy-intl"
+ * variant would get its own handler/endpoint, so keep this CN-only.
+ *
+ * Quota lives behind a Tencent billing endpoint (POST, payload wrapped twice
+ * under data.Response.Data). It mixes two credit types that must NOT be merged:
+ *
+ *  - Refill / base ("基础体验包"): a recurring allowance whose cycle resets long
+ *    before the resource itself expires (CycleEndTime << DeductionEndTime). The
+ *    live numbers live in the *Cycle* fields (e.g. CycleCapacityUsed 6.54 / 500)
+ *    and resetAt is the next monthly refresh.
+ *  - Bonus ("活动赠送包"): one-shot credits that run a single cycle and then
+ *    expire for good (CycleEndTime == DeductionEndTime). Numbers live in the
+ *    plain Capacity fields.
+ *
+ * We surface one quota row per package — a cadence label (Monthly/Weekly/Daily)
+ * for refill packs, "Bonus Pack N" for bonus packs (soonest-expiring first).
+ */
+
+import { proxyAwareFetch } from "../../utils/proxyFetch.js";
+import { PROVIDERS } from "../../providers/index.js";
+import { U, parseResetTime } from "./shared.js";
+
+const PROVIDER_ID = "codebuddy-cn";
+
+// Prefer the *Precise string fields (exact), fall back to the numeric ones.
+function num(precise, plain) {
+  const n = Number(precise ?? plain);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// Label a refill pack by its cycle length (Monthly is the common CodeBuddy case).
+function refillCadence(acc) {
+  const start = parseResetTime(acc.CycleStartTime);
+  const end = parseResetTime(acc.CycleEndTime);
+  if (start && end) {
+    const days = (new Date(end).getTime() - new Date(start).getTime()) / 86400000;
+    if (days <= 1.5) return "Daily";
+    if (days <= 10) return "Weekly";
+  }
+  return "Monthly";
+}
+
+export async function getCodeBuddyCnUsage(accessToken, apiKey, providerSpecificData, proxyOptions = null) {
+  const token = accessToken || apiKey;
+  if (!token) {
+    return { message: "CodeBuddy CN credential not available." };
+  }
+
+  try {
+    const response = await proxyAwareFetch(U(PROVIDER_ID).url, {
+      method: "POST",
+      headers: {
+        ...(PROVIDERS[PROVIDER_ID]?.headers || {}),
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: "{}",
+    }, proxyOptions);
+
+    if (response.status === 401 || response.status === 403) {
+      return { message: "CodeBuddy CN credential invalid or expired." };
+    }
+    if (!response.ok) {
+      return { message: `CodeBuddy CN quota API error (${response.status}).` };
+    }
+
+    const json = await response.json();
+    if (json?.code !== 0) {
+      return { message: `CodeBuddy CN quota error: ${json?.msg || "unknown"}` };
+    }
+
+    const data = json?.data?.Response?.Data || {};
+    const accounts = Array.isArray(data.Accounts) ? data.Accounts : [];
+    if (accounts.length === 0) {
+      return { message: "CodeBuddy CN connected. No credit package found." };
+    }
+
+    const cycleEndMs = (acc) => {
+      const r = parseResetTime(acc.CycleEndTime);
+      return r ? new Date(r).getTime() : Number.POSITIVE_INFINITY;
+    };
+    // Refill packs roll into a new cycle before the resource expires; bonus packs
+    // end exactly at expiry. >2d gap between cycle end and validity end = refill.
+    const REFILL_GAP_MS = 2 * 24 * 60 * 60 * 1000;
+    const isRefill = (acc) => {
+      const ce = cycleEndMs(acc);
+      const de = Number(acc.DeductionEndTime);
+      return Number.isFinite(ce) && Number.isFinite(de) && de - ce > REFILL_GAP_MS;
+    };
+    const byExpiry = (a, b) => cycleEndMs(a) - cycleEndMs(b);
+
+    const refills = accounts.filter(isRefill).sort(byExpiry);
+    const bonuses = accounts.filter((a) => !isRefill(a)).sort(byExpiry);
+
+    const quotas = {};
+    // Refill packs first: cadence-labelled, using the *Cycle* balance and
+    // resetting at the next refresh.
+    const seenRefill = {};
+    refills.forEach((acc) => {
+      const base = refillCadence(acc);
+      seenRefill[base] = (seenRefill[base] || 0) + 1;
+      const name = seenRefill[base] > 1 ? `${base} ${seenRefill[base]}` : base;
+      quotas[name] = {
+        used: num(acc.CycleCapacityUsedPrecise, acc.CycleCapacityUsed),
+        total: num(acc.CycleCapacitySizePrecise, acc.CycleCapacitySize),
+        resetAt: parseResetTime(acc.CycleEndTime),
+        unlimited: false,
+      };
+    });
+    // Bonus packs: use the lifetime Capacity balance; resetAt is the expiry.
+    bonuses.forEach((acc, i) => {
+      quotas[`Bonus Pack ${i + 1}`] = {
+        used: num(acc.CapacityUsedPrecise, acc.CapacityUsed),
+        total: num(acc.CapacitySizePrecise, acc.CapacitySize),
+        resetAt: parseResetTime(acc.CycleEndTime),
+        unlimited: false,
+      };
+    });
+
+    const basePkg = refills[0] || accounts[0] || {};
+    const plan = basePkg.PackageName || basePkg.SubProductName || "CodeBuddy CN";
+
+    return { plan, quotas };
+  } catch (error) {
+    return { message: `CodeBuddy CN error: ${error.message}` };
+  }
+}

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -102,8 +102,12 @@ export async function POST(request) {
 
     // Validation
     const isWebCookieProvider = !!WEB_COOKIE_PROVIDERS[provider];
+    // Dual-auth providers (e.g. codebuddy-cn, xai) live under category "oauth" but also
+    // accept an API key via authModes — they aren't in APIKEY_PROVIDERS, so allow them here.
+    const supportsApiKeyMode = !!AI_PROVIDERS[provider]?.authModes?.includes("apikey");
     const isValidProvider = APIKEY_PROVIDERS[provider] ||
       FREE_TIER_PROVIDERS[provider] ||
+      supportsApiKeyMode ||
       isWebCookieProvider ||
       isOpenAICompatibleProvider(provider) ||
       isAnthropicCompatibleProvider(provider) ||


### PR DESCRIPTION
## CodeBuddy CN: API key auth + credit quota tracker

Follow-up to #1889 (the CodeBuddy CN OAuth provider, now merged). Two additions on top of the merged provider:

1. **Connect with a direct API key**, not only the OAuth browser flow.
2. **A usage-dashboard quota tracker** that surfaces CodeBuddy credit balances (refill + bonus) for both OAuth and API-key connections.

Both verified end-to-end against the live `copilot.tencent.com` backend with a real CN API key.

### What's included

**API key auth** — `open-sse/providers/registry/codebuddy-cn.js`, `src/app/api/providers/route.js`
- Registry: add `authModes: ["oauth", "apikey"]` + `hasOAuth: true` (still `category: "oauth"`). The dashboard already renders dual-auth providers with both an **OAuth** and an **API Key** button generically off `authModes`, so no UI change is needed.
- No executor change: the transport `auth` is already `combined` Bearer, so an API key is forwarded as `Authorization: Bearer <key>` exactly like an access token. Token refresh is a no-op for key connections (no refresh token), so they're skipped automatically.
- `POST /api/providers`: the create-connection validation only accepted providers in `APIKEY_PROVIDERS` (i.e. `category: "apikey"`), so dual-auth providers that live under `category: "oauth"` were rejected as **"Invalid provider"**. Widened to also accept any provider whose `authModes` includes `"apikey"`. This was a latent gap that also blocked `xai`'s API-key path; this fixes both.
- CodeBuddy also accepts an `X-API-Key` header, but `Authorization: Bearer` alone is sufficient, so no extra header is sent.

**Quota tracker** — `open-sse/providers/registry/codebuddy-cn.js`, `open-sse/services/usage/codebuddy-cn.js`, `open-sse/services/usage.js`
- Registry: add `transport.usage.url` (Tencent billing meter endpoint) + `features.usage` / `features.usageApikey` so the connection is quota-eligible for **both** OAuth and API-key auth.
- New CN-scoped handler `services/usage/codebuddy-cn.js`: `POST /v2/billing/meter/get-user-resource`, unwrapping the doubly-wrapped `data.Response.Data.Accounts[]`. The payload mixes two credit types that must **not** be merged:
  - **Refill / base** (`基础体验包`): a recurring allowance whose cycle resets long before the resource itself expires (`CycleEndTime` << `DeductionEndTime`). The live numbers live in the `*Cycle*` fields (e.g. `CycleCapacityUsed` 6.54 / 500); `resetAt` is the next refresh. Cadence-labelled (Monthly / Weekly / Daily).
  - **Bonus** (`活动赠送包`): one-shot credits that run a single cycle and expire for good at `CycleEndTime`. Reads the plain `Capacity` fields. Labelled `Bonus Pack N`.
  - One quota row per package, soonest-expiring first. Aggregating would mislabel every credit with the earliest package's expiry.
- Registered under `"codebuddy-cn"` in `USAGE_HANDLERS`. Named `codebuddy-cn` (not a generic `codebuddy`) to leave room for a future `codebuddy-ai` handler, consistent with the CN/AI split from #1889.
- No frontend change — `parseQuotaData`'s generic branch already renders the `{ quotas: { <name>: { used, total, resetAt } } }` shape.

### Testing

- **API key:** added a CodeBuddy CN connection via API key, confirmed inference works (Bearer auth) and the connection validates. OAuth connections continue to work unchanged.
- **Quota:** verified live against `copilot.tencent.com` with a real CN API key. The handler returns a `Monthly` refill row (e.g. `6.54 / 500`) plus `Bonus Pack 1/2` rows (e.g. `0 / 3000`, `0 / 1000`), matching CodeBuddy's own billing UI (`基础体验包` + `活动赠送包` breakdown). Refill-vs-bonus classification (`CycleEndTime` vs `DeductionEndTime`) confirmed against the live response.

### Notes for reviewers

- The providers **grid** (`src/app/(dashboard)/dashboard/providers/page.js`) has a pre-existing limitation for dual-auth providers: each card hardcodes `authType="oauth"` for its status badge and disable toggle, so an API-key connection isn't counted/toggled from the grid (the per-connection toggle on the provider **detail** page works correctly, and inference enforcement of `isActive` is correct). This affects `xai` too and is intentionally left out of this PR to keep its scope to API-key auth + quota; it can be addressed separately by passing `["oauth","apikey"]` for `authModes` providers (mirroring the existing Kiro handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
