### PR TITLE
feat(codebuddy-cn): add short model prefix alias "cbcn"

### DIFF
--- a/open-sse/providers/registry/codebuddy-cn.js
+++ b/open-sse/providers/registry/codebuddy-cn.js
@@ -1,5 +1,9 @@
 export default {
   id: "codebuddy-cn",
+  // Short model prefix (cbcn/glm-5.2). "cbcn" = CodeBuddy CN; reserve "cbai"
+  // for a future codebuddy-ai (intl) provider. The full id still resolves.
+  alias: "cbcn",
+  uiAlias: "cbcn",
   hidden: false,
   priority: 90,
   display: {


### PR DESCRIPTION
## CodeBuddy CN: short model prefix `cbcn`

Follow-up to #1889. The `codebuddy-cn` provider shipped without a short alias, so its model prefix uses the full id (`codebuddy-cn/glm-5.2`) — the longest of any provider. Every other provider defines a short `alias`/`uiAlias` (qoder `qd`, kiro `kr`, codex `cx`, …).

### What's included

**Short alias** — `open-sse/providers/registry/codebuddy-cn.js`
- Add `alias: "cbcn"` + `uiAlias: "cbcn"` → the model prefix becomes `cbcn/glm-5.2`.
- `cbcn` = CodeBuddy **CN**, reserving `cbai` for a future `codebuddy-ai` (intl) provider — consistent with the CN/AI split designed in #1889.
- **Backward-compatible:** the full id `codebuddy-cn/...` still resolves (the resolver matches both id and alias), so existing model references keep working.

### Testing

- Registry loads; the provider entry exposes `alias`/`uiAlias` = `cbcn`. Verified no alias collision against all registry entries (`cb`, `cbcn`, `cbn`, `cdb` were all free). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
