### PR TITLE
fix(codex): preserve custom tools during request normalization

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -26,6 +26,9 @@ const CODEX_HOSTED_TOOL_TYPES = new Set([
   "tool_search"
 ]);
 
+// Responses-native freeform tools carry a name plus format payload and must pass through intact.
+const CODEX_PASSTHROUGH_TOOL_TYPES = new Set(["custom"]);
+
 // Allowlist of fields accepted by Codex Responses API — anything else is stripped
 const RESPONSES_API_ALLOWLIST = new Set([
   "model", "input", "instructions", "tools", "tool_choice", "stream", "store",
@@ -72,6 +75,7 @@ function normalizeCodexTools(body) {
       return true;
     }
     if (type !== "function") {
+      if (CODEX_PASSTHROUGH_TOOL_TYPES.has(type)) return true;
       if (!type || tool.function || typeof tool.name === "string") return false;
       return CODEX_HOSTED_TOOL_TYPES.has(type);
     }

--- a/tests/unit/codex-tool-normalization.test.js
+++ b/tests/unit/codex-tool-normalization.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+function normalizeTools(tools) {
+  const executor = new CodexExecutor();
+  const body = {
+    model: "gpt-5.5",
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "probe" }] }],
+    tools,
+    stream: true,
+  };
+
+  executor.transformRequest("gpt-5.5", body, true, {
+    connectionId: "test-codex-tools",
+    providerSpecificData: {},
+  });
+
+  return body.tools;
+}
+
+describe("CodexExecutor tool normalization", () => {
+  it("preserves Responses-native tool_search tools", () => {
+    const tools = normalizeTools([
+      {
+        type: "tool_search",
+        execution: "sync",
+        description: "Discover deferred tools",
+        parameters: { type: "object", properties: {} },
+      },
+      {
+        type: "namespace",
+        name: "codex_app",
+        description: "app tools",
+        tools: [
+          {
+            type: "function",
+            name: "automation_update",
+            description: "automation",
+            parameters: { type: "object", properties: {} },
+            defer_loading: true,
+          },
+        ],
+      },
+      {
+        type: "function",
+        name: "plain_fn",
+        description: "plain",
+        parameters: { type: "object", properties: {} },
+      },
+    ]);
+
+    expect(tools.map((tool) => `${tool.type}:${tool.name || ""}`)).toEqual([
+      "tool_search:",
+      "namespace:codex_app",
+      "function:plain_fn",
+    ]);
+  });
+
+  it("preserves hosted Responses tools", () => {
+    const tools = normalizeTools([
+      { type: "web_search", search_context_size: "medium" },
+      { type: "image_generation", size: "1024x1024" },
+      { type: "mcp", server_label: "docs", server_url: "https://example.com/mcp" },
+      { type: "local_shell" },
+      { type: "code_interpreter", container: { type: "auto" } },
+      { type: "computer", display_width: 1024, display_height: 768, environment: "browser" },
+    ]);
+
+    expect(tools.map((tool) => tool.type)).toEqual([
+      "web_search",
+      "image_generation",
+      "mcp",
+      "local_shell",
+      "code_interpreter",
+      "computer",
+    ]);
+  });
+
+  it("preserves custom freeform tools with format payloads", () => {
+    const tools = normalizeTools([
+      {
+        type: "custom",
+        name: "apply_patch",
+        description: "patch",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      },
+    ]);
+
+    expect(tools).toEqual([
+      {
+        type: "custom",
+        name: "apply_patch",
+        description: "patch",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR tightens Codex Responses request normalization so Responses-native tools are not accidentally dropped before the request is forwarded upstream.

The original #1907 report focused on `tool_search` being filtered out, which breaks deferred tool discovery in Codex Desktop. On current `master`, `tool_search` is already included in `CODEX_HOSTED_TOOL_TYPES`, so that part of the repro is now covered before this PR. This PR addresses the remaining related gap from the same normalization path: `custom` / freeform tools were still filtered out because they have a `name` field but are not `function`, `namespace`, or hosted tools.

## What changed

- Preserves Responses-native `custom` tools during `normalizeCodexTools(body)`.
- Keeps the full `custom` tool payload intact, including `name`, `description`, and `format` grammar fields.
- Adds regression coverage showing these tools survive Codex request normalization:
  - `tool_search` deferred-tool discovery
  - `namespace` tools
  - normal `function` tools
  - hosted Responses tools (`web_search`, `image_generation`, `mcp`, `local_shell`, `code_interpreter`, `computer`)
  - `custom` freeform tools such as grammar-backed `apply_patch`

## Why

Codex clients use Responses-native tools for capabilities that are not plain function tools. If request normalization removes those tool entries, Codex Desktop can lose access to deferred tool discovery or freeform tool calls, making tools appear missing even though the model/provider is capable.

This covers the `custom` / freeform-tool observation in #1907:

```js
{ type: 'custom', name: 'apply_patch', description: 'patch', format: { type: 'grammar', syntax: 'lark', definition: 'start: /.+/' } }
```

## Related issues

- Related to #1371, but this PR targets the request-time filtering path in `open-sse/executors/codex.js`; #1371 tracks response translation for `custom_tool_call` output.
- Related to broader Codex tool/subagent compatibility work in #1873 and #1758, but this PR is intentionally scoped to request normalization.

## Verification

```bash
./node_modules/.bin/vitest run tests/unit/codex-tool-normalization.test.js --reporter=verbose
```

Result:

```text
Test Files  1 passed (1)
Tests       3 passed (3)
EXIT:0
```

Refs #1907
