### PR TITLE
fix(antigravity): strip output_config from top-level body before sending to Google API

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -104,6 +104,10 @@ export class AntigravityExecutor extends BaseExecutor {
       ...(tools?.length > 0 && { toolConfig: { functionCallingConfig: { mode: "VALIDATED" } } })
     };
 
+    // Strip blacklisted fields from BOTH body.request (already done) AND the top-level body
+    // (e.g. output_config set by thinkingUnified.js for claude-adaptive format sits at body root, not body.request)
+    for (const key of ANTIGRAVITY_REQUEST_BLACKLIST) delete body[key];
+
     this._lastSessionId = transformedRequest.sessionId; // cached for buildHeaders (base.execute order)
 
     return {


### PR DESCRIPTION
## Fixes
Closes #1944
Closes #1870

## Root Cause

Since v0.5.4, Claude models (Sonnet, Opus) via the Antigravity provider
failed with:

400 INVALID_ARGUMENT: Invalid JSON payload received. Unknown name "output_config": Cannot find field.

Gemini models were unaffected. Postman (raw API calls) were unaffected.
Only IDE agentic usage (Claude Code, Copilot, etc.) triggered the bug.

**Why IDE only?** IDE clients send thinking/effort config, which causes
`thinkingUnified.js` to set `output_config` at the **top level** of the
request body (claude-adaptive format). The existing blacklist loop in
`AntigravityExecutor.transformRequest` only stripped it from `body.request`,
not from `body` root. The spread `...body` in the return object then leaked
`output_config` into the final payload sent to Google's API.

## Fix

One line in `AntigravityExecutor.transformRequest` — strip `ANTIGRAVITY_REQUEST_BLACKLIST`
fields from the top-level body **in addition to** `body.request`:

```js
// Before building return object
for (const key of ANTIGRAVITY_REQUEST_BLACKLIST) delete body[key];

Testing

Verified manually with Claude Sonnet 4.6 via Antigravity provider in
Claude Code — previously 400, now works correctly.
```