### PR TITLE
fix(antigravity): strip Claude/OpenAI thinking fields from top-level request body

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -19,7 +19,8 @@ const MAX_RETRY_AFTER_MS = 10000;
 const MAX_ANTIGRAVITY_OUTPUT_TOKENS = 16384;
 
 // Fields Google generateContent rejects (e.g. Claude adaptive output_config) — stripped from antigravity request envelope
-const ANTIGRAVITY_REQUEST_BLACKLIST = ["output_config"];
+// Claude/OpenAI-native thinking fields that Google generateContent rejects at the top-level body
+const ANTIGRAVITY_REQUEST_BLACKLIST = ["output_config", "thinking", "reasoning_effort", "reasoning", "enable_thinking", "thinking_budget"];
 
 export class AntigravityExecutor extends BaseExecutor {
   constructor() {

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -104,6 +104,10 @@ export class AntigravityExecutor extends BaseExecutor {
       ...(tools?.length > 0 && { toolConfig: { functionCallingConfig: { mode: "VALIDATED" } } })
     };
 
+    // Strip blacklisted fields from BOTH body.request (already done) AND the top-level body
+    // (e.g. output_config set by thinkingUnified.js for claude-adaptive format sits at body root, not body.request)
+    for (const key of ANTIGRAVITY_REQUEST_BLACKLIST) delete body[key];
+
     this._lastSessionId = transformedRequest.sessionId; // cached for buildHeaders (base.execute order)
 
     return {


### PR DESCRIPTION
## Problem

`thinking` field from claude-budget/adaptive format leaked to Google API,
causing 400 on thinking models (e.g. `claude-opus-4-6-thinking`):

400 INVALID_ARGUMENT: Unknown name "thinking": Cannot find field.

## Change

Expanded `ANTIGRAVITY_REQUEST_BLACKLIST` to include all fields
`thinkingUnified.js` can set at body root:

`output_config`, `thinking`, `reasoning_effort`, `reasoning`, `enable_thinking`, `thinking_budget`

## Testing

- ✅ `claude-opus-4-6-thinking` via Antigravity — previously 400, now works