### PR TITLE
fix: enable vision capability for MiniMax-M3/M2.7 family

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -176,11 +176,11 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*deepseek-chat*", caps: { contextWindow: 128000 } },
   { pattern: "*deepseek*",      caps: { reasoning: true, thinkingFormat: "deepseek", contextWindow: 128000 } },
 
-  // ── MiniMax (M3 = adaptive; M2.x cannot disable) ─────────────────
+  // ── MiniMax (M3 = adaptive + vision; M2.x cannot disable) ─────────
   { pattern: "*minimax*image*", caps: { imageOutput: true } },
-  { pattern: "*minimax-m3*",    caps: { reasoning: true, thinkingFormat: "minimax", contextWindow: 1048576, maxOutput: 512000 } },
-  { pattern: "*minimax-m2.7*",  caps: { reasoning: true, thinkingFormat: "minimax", thinkingCanDisable: false, contextWindow: 204800, maxOutput: 131072 } },
-  { pattern: "*minimax*",       caps: { reasoning: true, thinkingFormat: "minimax", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 131072 } },
+  { pattern: "*minimax-m3*",    caps: { vision: true, reasoning: true, thinkingFormat: "minimax", contextWindow: 1048576, maxOutput: 512000 } },
+  { pattern: "*minimax-m2.7*",  caps: { vision: true, reasoning: true, thinkingFormat: "minimax", thinkingCanDisable: false, contextWindow: 204800, maxOutput: 131072 } },
+  { pattern: "*minimax*",       caps: { vision: true, reasoning: true, thinkingFormat: "minimax", thinkingCanDisable: false, contextWindow: 200000, maxOutput: 131072 } },
 
   // ── Xiaomi MiMo (vision, 1M / 262K ctx) ──────────────────────────
   { pattern: "*mimo*v2.5*",     caps: { vision: true, contextWindow: 1048576, maxOutput: 131072 } },


### PR DESCRIPTION
## Bug

The pattern matcher in `open-sse/providers/capabilities.js` marks all `minimax-*` models as `vision: false`. This causes 9Router to strip image attachments from requests before forwarding to upstream, breaking vision flows for Claude Code / Cursor / Cline / etc. when routing through minimax models.

## Repro

```bash
curl -s http://localhost:20128/v1/chat/completions   -H "Content-Type: application/json"   -d '{"model":"MiniMax-M3","messages":[{"role":"user","content":[{"type":"text","text":"Do you see an image?"},{"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}]}]}'
# Before fix: model responds "NO_IMAGE"
# After fix: model responds "Yes, I see an image"
```

## Root cause

`stripUnsupportedModalities()` in `open-sse/translator/concerns/modality.js` removes image blocks when `caps.vision === false`. The `PATTERN_CAPABILITIES` for `*minimax-m3*`, `*minimax-m2.7*`, and `*minimax*` did not set `vision: true`, so DEFAULT (`vision: false`) applied, causing all MiniMax model requests to have images stripped.

## Fix

Add `vision: true` to the 3 affected minimax patterns (M3, M2.7, catch-all). These models support image input.

## Tested

Patched `app/.next-cli-build/server/chunks/6306.js`, `412.js`, and `static/chunks/5497-*.js` with this one-line change per pattern. Verified via curl: MiniMax-M3 now correctly receives image content instead of stripped placeholder.