### PR TITLE
fix(antigravity): allow image inputs for image generation/editing

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -105,13 +105,13 @@ export class AntigravityExecutor extends BaseExecutor {
       // Strip model name suffixes for the actual API model name
       const cleanModel = model.replace(/-(\d+)x(\d+)$/, "");
 
-      // Build simplified contents — text-only, merge all user messages
+      // Build simplified contents — text and image parts, merge all user messages
       const contents = [];
       const srcContents = body.request?.contents || body.contents || [];
       for (const c of srcContents) {
-        const textParts = (c.parts || []).filter(p => p.text !== undefined).map(p => ({ text: p.text }));
-        if (textParts.length > 0) {
-          contents.push({ role: c.role || "user", parts: textParts });
+        const validParts = (c.parts || []).filter(p => p.text !== undefined || p.inlineData !== undefined);
+        if (validParts.length > 0) {
+          contents.push({ role: c.role || "user", parts: validParts });
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes the image-to-image (editing) functionality for the Antigravity provider. 

Previously, AntigravityExecutor.transformRequest filtered out all non-text parts from the contents array, causing any input image (passed as an inlineData part by the adapter) to be stripped before forwarding the request to Google's API. This caused the model to ignore the reference image completely and generate a completely new image from the prompt.

## Changes

- Updated the contents filter in AntigravityExecutor.transformRequest to preserve inlineData parts along with 	ext parts.
- Verified that the source image is correctly forwarded, allowing prompts like "put a santa hat on this man" to modify the input image instead of generating a new random portrait.