### PR TITLE
fix(antigravity): preserve inlineData parts for image-to-image editing

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -105,13 +105,13 @@ export class AntigravityExecutor extends BaseExecutor {
       // Strip model name suffixes for the actual API model name
       const cleanModel = model.replace(/-(\d+)x(\d+)$/, "");
 
-      // Build simplified contents — text-only, merge all user messages
+      // Build simplified contents — text and image parts, merge all user messages
       const contents = [];
       const srcContents = body.request?.contents || body.contents || [];
       for (const c of srcContents) {
-        const textParts = (c.parts || []).filter(p => p.text !== undefined).map(p => ({ text: p.text }));
-        if (textParts.length > 0) {
-          contents.push({ role: c.role || "user", parts: textParts });
+        const validParts = (c.parts || []).filter(p => p.text !== undefined || p.inlineData !== undefined);
+        if (validParts.length > 0) {
+          contents.push({ role: c.role || "user", parts: validParts });
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes the image-to-image (editing) functionality for the Antigravity image generation provider.

Previously, `AntigravityExecutor.transformRequest` filtered out all non-text parts from the `contents` array when building image generation requests. This caused any input image (passed as an `inlineData` part by the adapter) to be silently stripped before reaching Google's API, making the model generate a completely new image from the text prompt alone instead of editing the provided source image.

## Problem

```js
// Before: only text parts survived
const textParts = (c.parts || []).filter(p => p.text !== undefined).map(p => ({ text: p.text }));
```

When a user sent an image with a prompt like "put a santa hat on this person", the image was discarded and the model generated a random person with a santa hat.

## Fix

```js
// After: preserve both text and inlineData (image) parts
const validParts = (c.parts || []).filter(p => p.text !== undefined || p.inlineData !== undefined);
```

Now the source image is correctly forwarded to the Gemini API, enabling true image editing workflows.

## Testing

Tested locally with `POST /v1/images/generations` using `body.image` (data URI) — the model correctly reads and modifies the input image instead of generating a new one.
