### PR TITLE
improve(antigravity): harden client fingerprint to match real Antigravity/Electron

### DIFF
--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -127,9 +127,22 @@ export const AG_DEFAULT_TOOLS = new Set([
   "write_to_file"
 ]);
 
+// Antigravity version fingerprint — match real Antigravity/Electron client headers
+export const ANTIGRAVITY_VERSION = "4.2.5";
+const ANTIGRAVITY_CHROME = "132.0.6834.160";
+const ANTIGRAVITY_ELECTRON = "39.2.3";
+
+function antigravityPlatformInfo() {
+  switch (platform()) {
+    case "darwin": return "Macintosh; Intel Mac OS X 10_15_7";
+    case "win32": return "Windows NT 10.0; Win64; x64";
+    default: return "X11; Linux x86_64";
+  }
+}
+
 // Antigravity chat/stream headers
 export const ANTIGRAVITY_HEADERS = {
-  "User-Agent": `antigravity/1.107.0 ${platform()}/${arch()}`
+  "User-Agent": `Antigravity/${ANTIGRAVITY_VERSION} (${antigravityPlatformInfo()}) Chrome/${ANTIGRAVITY_CHROME} Electron/${ANTIGRAVITY_ELECTRON}`
 };
 
 // Cloud Code Assist API

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
-import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, INTERNAL_REQUEST_HEADER, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX } from "../config/appConstants.js";
+import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, ANTIGRAVITY_VERSION, INTERNAL_REQUEST_HEADER, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX } from "../config/appConstants.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
@@ -17,6 +17,9 @@ function sanitizeFunctionName(name) {
 
 const MAX_RETRY_AFTER_MS = 10000;
 const MAX_ANTIGRAVITY_OUTPUT_TOKENS = 16384;
+
+// Stable per-process session ID (matches AG Manager's SESSION_ID = one UUID per app launch)
+const ANTIGRAVITY_SESSION_ID = crypto.randomUUID();
 
 // Fields Google generateContent rejects (Claude/OpenAI/Qwen thinking fields set at body root by thinkingUnified.js)
 const ANTIGRAVITY_REQUEST_BLACKLIST = [
@@ -91,6 +94,10 @@ export class AntigravityExecutor extends BaseExecutor {
       "Authorization": `Bearer ${credentials.accessToken}`,
       "User-Agent": this.config.headers?.["User-Agent"] || ANTIGRAVITY_HEADERS["User-Agent"],
       [INTERNAL_REQUEST_HEADER.name]: INTERNAL_REQUEST_HEADER.value,
+      // Identity headers matching real Antigravity client fingerprint
+      "x-client-name": "antigravity",
+      "x-client-version": ANTIGRAVITY_VERSION,
+      "x-vscode-sessionid": ANTIGRAVITY_SESSION_ID,
       ...(sid && { "X-Machine-Session-Id": sid }),
       "Accept": stream ? "text/event-stream" : "application/json"
     };

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -21,13 +21,12 @@ export default {
   serviceKinds: ["llm", "image"],
   transport: {
     baseUrls: [
-      "https://daily-cloudcode-pa.googleapis.com",
       "https://daily-cloudcode-pa.sandbox.googleapis.com",
+      "https://daily-cloudcode-pa.googleapis.com",
+      "https://cloudcode-pa.googleapis.com",
     ],
     format: "antigravity",
-    headers: {
-      "User-Agent": "antigravity/1.107.0 darwin/arm64",
-    },
+    headers: {},
     retry: {
       "429": {
         attempts: 3,


### PR DESCRIPTION
## Summary

Hardens the Antigravity provider's client fingerprint to match what a real Antigravity/Electron desktop client sends, reducing detection risk without adding any new dependencies or changing architecture.

## Changes (3 files, ~25 lines)

### 1. User-Agent format fix (ppConstants.js)

**Before:** `antigravity/1.107.0 linux/x64`
**After:** `Antigravity/4.2.5 (Windows NT 10.0; Win64; x64) Chrome/132.0.6834.160 Electron/39.2.3`

- Matches real Antigravity client format with Chrome/Electron versions
- Platform-aware: detects darwin/win32/linux and uses matching platform string

### 2. Identity headers (executors/antigravity.js)

Added headers that real Antigravity clients send on every request:
- `x-client-name: antigravity`
- `x-client-version: 4.2.5`
- `x-vscode-sessionid: <stable UUID>`

Also generates a **stable per-process session ID** (one UUID per server launch) instead of changing per-request — matching real client behavior.

### 3. Endpoint fallback order (egistry/antigravity.js)

- Reordered: **Sandbox → Daily → Prod** (matching upstream priority)
- Added Prod (`cloudcode-pa.googleapis.com`) as last-resort fallback
- Removed hardcoded `darwin/arm64` User-Agent from registry (now dynamically generated)

## Testing

All verified locally:
- ✅ LLM streaming (Flash) — 200, SSE chunks
- ✅ LLM streaming (Pro) — 200, SSE chunks  
- ✅ Image generation — 200, base64 image data
- ✅ Build passes with no errors