### PR TITLE
fix(gemini-tts): resolve 502 models/undefined by adding ttsConfig.models

### DIFF
--- a/open-sse/providers/registry/gemini.js
+++ b/open-sse/providers/registry/gemini.js
@@ -54,6 +54,7 @@ export default {
     { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash", params: ["language","prompt"], kind: "stt" },
     { id: "gemini-2.5-flash-preview-tts", name: "Gemini 2.5 Flash TTS", kind: "tts" },
     { id: "gemini-2.5-pro-preview-tts", name: "Gemini 2.5 Pro TTS", kind: "tts" },
+    { id: "gemini-3.1-flash-tts-preview", name: "Gemini 3.1 Flash TTS", kind: "tts" },
     { id: "embedding-001", name: "Embedding 001", dimensions: 768, kind: "embedding" },
   ],
   serviceKinds: ["llm","embedding","image","imageToText","webSearch","tts","stt"],
@@ -62,6 +63,12 @@ export default {
     authType: "apikey",
     authHeader: "key",
     format: "gemini-tts",
+    defaultModel: "gemini-2.5-flash-preview-tts",
+    models: [
+      { id: "gemini-2.5-flash-preview-tts", name: "Gemini 2.5 Flash TTS" },
+      { id: "gemini-2.5-pro-preview-tts", name: "Gemini 2.5 Pro TTS" },
+      { id: "gemini-3.1-flash-tts-preview", name: "Gemini 3.1 Flash TTS" },
+    ],
   },
   sttConfig: {
     baseUrl: "https://generativelanguage.googleapis.com/v1beta/models",


### PR DESCRIPTION
## Bug

Mọi request `POST /v1/audio/speech` với provider `gemini` đều trả 502:

```
[gemini/gemini-2.5-flash-preview-tts/Zephyr] models/undefined is not found
for API version v1beta, or is not supported for generateContent.
```

## Root cause

`open-sse/handlers/ttsProviders/gemini.js` đọc default model từ `ttsConfig.models[0]`:

```js
const KNOWN_MODELS = (TTS_CFG.models || []).map((m) => m.id);
const DEFAULT_MODEL = KNOWN_MODELS[0];   // undefined
```

Nhưng `registry/gemini.js` không khai `models` trong `ttsConfig` → `DEFAULT_MODEL = undefined` → URL gọi Google thành `.../models/undefined:generateContent` → 502. Desync giữa endpoint list (`/v1/models/tts` vẫn list đúng vì model khai ở mảng `models` provider) và handler.

## Fix

Thêm `models` (+ `defaultModel`) vào `ttsConfig`, đúng convention của `elevenlabs`/`openai`. Kèm `gemini-3.1-flash-tts-preview` (đã verify HTTP 200 có audio).

Gọn 1 file `open-sse/providers/registry/gemini.js`, không đụng handler.

## Test

```bash
curl -X POST "http://localhost:20128/v1/audio/speech" \
  -H "Authorization: Bearer <KEY>" \
  -H "Content-Type: application/json" \
  -d '{"model":"gemini/gemini-2.5-flash-preview-tts/Zephyr","input":"Hello, this is a text to speech test."}' \
  --output speech.wav
```

Kỳ vọng: HTTP 200, output WAV PCM L16 24kHz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)