### PR TITLE
fix(tts): expose minimax/minimax-cn voices in public audio API

### DIFF
--- a/src/app/api/v1/audio/voices/route.js
+++ b/src/app/api/v1/audio/voices/route.js
@@ -5,6 +5,8 @@ const PROVIDER_API = {
   elevenlabs: (origin) => `${origin}/api/media-providers/tts/elevenlabs/voices`,
   deepgram: (origin) => `${origin}/api/media-providers/tts/deepgram/voices`,
   inworld: (origin) => `${origin}/api/media-providers/tts/inworld/voices`,
+  minimax: (origin) => `${origin}/api/media-providers/tts/minimax/voices`,
+  "minimax-cn": (origin) => `${origin}/api/media-providers/tts/minimax/voices?provider=minimax-cn`,
   "edge-tts": (origin) => `${origin}/api/media-providers/tts/voices?provider=edge-tts`,
   "local-device": (origin) => `${origin}/api/media-providers/tts/voices?provider=local-device`,
 };

--- a/src/app/api/v1/models/info/route.js
+++ b/src/app/api/v1/models/info/route.js
@@ -13,7 +13,7 @@ const KIND_ENDPOINT = {
   webFetch: "/v1/fetch",
 };
 
-const TTS_VOICES_API = new Set(["elevenlabs", "edge-tts", "deepgram", "inworld", "local-device"]);
+const TTS_VOICES_API = new Set(["elevenlabs", "edge-tts", "deepgram", "inworld", "local-device", "minimax", "minimax-cn"]);
 
 function buildInfo({ alias, providerId, model, kind, providerInfo }) {
   const out = {


### PR DESCRIPTION
## Vấn đề

`minimax` + `minimax-cn` đã có route voices chạy tốt (`/api/media-providers/tts/minimax/voices`) và được dashboard tích hợp đầy đủ, nhưng bị **bỏ sót ở 2 điểm expose public API**:

- `PROVIDER_API` trong `src/app/api/v1/audio/voices/route.js` → `GET /v1/audio/voices?provider=minimax` trả **400** (`provider must be one of: ...`).
- `TTS_VOICES_API` trong `src/app/api/v1/models/info/route.js` → các model TTS của minimax **không có `voicesUrl`**.

→ Desync giữa list endpoint và route đã tồn tại (cùng class với bug gemini TTS gần đây).

## Fix

Thêm `minimax` + `minimax-cn` vào cả hai set. `minimax-cn` dùng chung route với `?provider=minimax-cn` (đúng convention sẵn có trong `ttsProviders.js`).

3 dòng, không đụng logic. Alias provider trùng providerId (`minimax`/`minimax-cn`) nên `/v1/audio/voices` map đúng.

## Phạm vi đã kiểm

- 5 route voices trong `src/app/api/media-providers/tts/` (shared, deepgram, elevenlabs, inworld, minimax) — soi kỹ, **không có lỗi code**.
- Registry `ttsConfig`: phần lớn cảnh báo "missing models/defaultModel" là báo động giả vì synthesize generic đọc `PROVIDER_MODELS` (top-level) + handler có fallback; special adapter openai/openrouter đọc `ttsConfig.defaultModel` (đều đã khai). gemini là bug thật duy nhất, đã xử lý ở PR #1986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)