### PR TITLE
fix: record CLI usage and clean responses fields

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -172,8 +172,9 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   // Decloak tool_use names once on raw Claude body, before any translation (INPUT side)
   responseBody = decloakToolNames(responseBody, toolNameMap);
 
-  const usage = extractUsageFromResponse(responseBody);
-  appendLog({ tokens: usage, status: "200 OK" });
+  const usage = extractUsageFromResponse(responseBody, { targetFormat, provider, requestBody: body });
+  appendLog({ status: "200 OK" });
+
   saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -1,5 +1,8 @@
 import { saveRequestUsage, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
+import { FORMATS } from "../../translator/formats.js";
+import { toOpenAIUsage } from "../../translator/concerns/usage.js";
 import { COLORS } from "../../utils/stream.js";
+import { estimateInputTokens } from "../../utils/usageTracking.js";
 
 const OPTIONAL_PARAMS = [
   "temperature", "top_p", "top_k",
@@ -20,36 +23,134 @@ export function extractRequestConfig(body, stream) {
   return config;
 }
 
-export function extractUsageFromResponse(responseBody) {
+function completeEstimatedPromptTokens(usage, requestBody) {
+  if (!usage || typeof usage !== "object") return usage;
+
+  const promptTokens = usage.prompt_tokens ?? usage.input_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? usage.output_tokens ?? 0;
+  if (promptTokens !== 0 || completionTokens === 0 || !requestBody) return usage;
+
+  const estimatedPromptTokens = estimateInputTokens(requestBody);
+  if (estimatedPromptTokens <= 0) return usage;
+
+  return {
+    ...usage,
+    prompt_tokens: estimatedPromptTokens,
+    total_tokens: estimatedPromptTokens + completionTokens,
+    estimated: true
+  };
+}
+
+function hasUsableTokenData(usage) {
+  if (!usage || typeof usage !== "object") return false;
+
+  const promptTokens = usage.prompt_tokens ?? usage.input_tokens ?? 0;
+  const completionTokens = usage.completion_tokens ?? usage.output_tokens ?? 0;
+  const totalTokens = usage.total_tokens ?? 0;
+
+  return promptTokens > 0 || completionTokens > 0 || totalTokens > 0;
+}
+
+function extractOpenAIResponsesUsage(usage) {
+  if (!usage || typeof usage !== "object") return null;
+
+  if (usage.input_tokens !== undefined || usage.output_tokens !== undefined) {
+    return {
+      prompt_tokens: usage.input_tokens || 0,
+      completion_tokens: usage.output_tokens || 0,
+      total_tokens: (usage.input_tokens || 0) + (usage.output_tokens || 0),
+      cached_tokens: usage.input_tokens_details?.cached_tokens,
+      reasoning_tokens: usage.output_tokens_details?.reasoning_tokens,
+      prompt_tokens_details: usage.input_tokens_details?.cached_tokens
+        ? { cached_tokens: usage.input_tokens_details.cached_tokens }
+        : undefined,
+      completion_tokens_details: usage.output_tokens_details
+    };
+  }
+
+  if (usage.prompt_tokens !== undefined) {
+    return {
+      prompt_tokens: usage.prompt_tokens || 0,
+      completion_tokens: usage.completion_tokens || 0,
+      total_tokens: usage.total_tokens,
+      cached_tokens: usage.prompt_tokens_details?.cached_tokens,
+      reasoning_tokens: usage.completion_tokens_details?.reasoning_tokens,
+      prompt_tokens_details: usage.prompt_tokens_details,
+      completion_tokens_details: usage.completion_tokens_details
+    };
+  }
+
+  return null;
+}
+
+function extractGeminiUsage(usageMetadata) {
+  if (!usageMetadata || typeof usageMetadata !== "object") return null;
+
+  return {
+    prompt_tokens: usageMetadata.promptTokenCount || 0,
+    completion_tokens: usageMetadata.candidatesTokenCount || 0,
+    total_tokens: usageMetadata.totalTokenCount,
+    cached_tokens: usageMetadata.cachedContentTokenCount,
+    reasoning_tokens: usageMetadata.thoughtsTokenCount
+  };
+}
+
+function providerUsageKind(targetFormat, provider) {
+  const providerName = String(provider || "").toLowerCase();
+
+  if (targetFormat === FORMATS.OLLAMA || providerName === "ollama" || providerName === "ollama-local") return "ollama";
+  if (targetFormat === FORMATS.KIRO || providerName === "kiro") return "kiro";
+  if (targetFormat === FORMATS.COMMANDCODE || providerName === "commandcode") return "commandcode";
+  if (targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.GEMINI_CLI || targetFormat === FORMATS.ANTIGRAVITY || targetFormat === FORMATS.VERTEX) return "gemini";
+  if (targetFormat === FORMATS.CLAUDE || providerName === "claude") return "claude";
+
+  return null;
+}
+
+export function extractUsageFromResponse(responseBody, { targetFormat, provider, requestBody } = {}) {
   if (!responseBody || typeof responseBody !== "object") return null;
 
   // Claude format
   if (responseBody.usage?.input_tokens !== undefined) {
-    return {
+    return completeEstimatedPromptTokens({
       prompt_tokens: responseBody.usage.input_tokens || 0,
       completion_tokens: responseBody.usage.output_tokens || 0,
+      total_tokens: (responseBody.usage.input_tokens || 0) + (responseBody.usage.output_tokens || 0),
       cache_read_input_tokens: responseBody.usage.cache_read_input_tokens,
       cache_creation_input_tokens: responseBody.usage.cache_creation_input_tokens
-    };
+    }, requestBody);
   }
 
   // OpenAI format
   if (responseBody.usage?.prompt_tokens !== undefined) {
-    return {
+    return completeEstimatedPromptTokens({
       prompt_tokens: responseBody.usage.prompt_tokens || 0,
       completion_tokens: responseBody.usage.completion_tokens || 0,
+      total_tokens: responseBody.usage.total_tokens,
       cached_tokens: responseBody.usage.prompt_tokens_details?.cached_tokens,
-      reasoning_tokens: responseBody.usage.completion_tokens_details?.reasoning_tokens
-    };
+      reasoning_tokens: responseBody.usage.completion_tokens_details?.reasoning_tokens,
+      prompt_tokens_details: responseBody.usage.prompt_tokens_details,
+      completion_tokens_details: responseBody.usage.completion_tokens_details
+    }, requestBody);
+  }
+
+  // OpenAI Responses API format nested under response
+  const responseUsage = extractOpenAIResponsesUsage(responseBody.response?.usage);
+  if (responseUsage) {
+    return completeEstimatedPromptTokens(responseUsage, requestBody);
   }
 
   // Gemini format
-  if (responseBody.usageMetadata) {
-    return {
-      prompt_tokens: responseBody.usageMetadata.promptTokenCount || 0,
-      completion_tokens: responseBody.usageMetadata.candidatesTokenCount || 0,
-      reasoning_tokens: responseBody.usageMetadata.thoughtsTokenCount
-    };
+  const geminiUsage = extractGeminiUsage(responseBody.usageMetadata || responseBody.response?.usageMetadata);
+  if (geminiUsage) {
+    return completeEstimatedPromptTokens(geminiUsage, requestBody);
+  }
+
+  const usageKind = providerUsageKind(targetFormat, provider);
+  if (usageKind) {
+    const mappedUsage = toOpenAIUsage(responseBody, usageKind);
+    const completedUsage = completeEstimatedPromptTokens(mappedUsage, requestBody);
+    return hasUsableTokenData(completedUsage) ? completedUsage : null;
   }
 
   return null;
@@ -87,7 +188,15 @@ export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, 
   // Normalize to OpenAI token shape for storage
   const normalized = {
     prompt_tokens: tokens.prompt_tokens ?? tokens.input_tokens ?? 0,
-    completion_tokens: tokens.completion_tokens ?? tokens.output_tokens ?? 0
+    completion_tokens: tokens.completion_tokens ?? tokens.output_tokens ?? 0,
+    total_tokens: tokens.total_tokens,
+    cache_read_input_tokens: tokens.cache_read_input_tokens,
+    cache_creation_input_tokens: tokens.cache_creation_input_tokens,
+    cached_tokens: tokens.cached_tokens ?? tokens.prompt_tokens_details?.cached_tokens,
+    reasoning_tokens: tokens.reasoning_tokens ?? tokens.completion_tokens_details?.reasoning_tokens,
+    prompt_tokens_details: tokens.prompt_tokens_details,
+    completion_tokens_details: tokens.completion_tokens_details,
+    estimated: tokens.estimated
   };
 
   saveRequestUsage({

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -123,7 +123,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       if (onRequestSuccess) await onRequestSuccess();
 
       const usage = jsonResponse.usage || {};
-      appendLog({ tokens: usage, status: "200 OK" });
+      appendLog({ status: "200 OK" });
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
 
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
@@ -199,7 +199,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
     if (onRequestSuccess) await onRequestSuccess();
 
     const usage = parsed.usage || {};
-    appendLog({ tokens: usage, status: "200 OK" });
+    appendLog({ status: "200 OK" });
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
 
     const totalLatency = Date.now() - requestStartTime;

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -5,7 +5,7 @@ import { pipeWithDisconnect } from "../../utils/streamHandler.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
 import { buildAbortedResponsesTerminalBytes } from "../../utils/responsesStreamHelpers.js";
-import { buildRequestDetail, extractRequestConfig, saveUsageStats } from "./requestDetail.js";
+import { buildRequestDetail, extractRequestConfig } from "./requestDetail.js";
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
 
@@ -100,8 +100,6 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     }, { id: streamDetailId })).catch(err => {
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
-
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE" });
   };
 
   return { onStreamComplete, streamDetailId };

--- a/open-sse/translator/formats/responsesApi.js
+++ b/open-sse/translator/formats/responsesApi.js
@@ -136,6 +136,8 @@ export function convertResponsesApiFormat(body) {
   delete result.prompt_cache_key;
   delete result.store;
   delete result.reasoning;
+  delete result.text;
+  delete result.client_metadata;
 
   return result;
 }

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -189,6 +189,8 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   delete result.prompt_cache_key;
   delete result.store;
   delete result.reasoning;
+  delete result.text;
+  delete result.client_metadata;
 
   return result;
 }

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -2,7 +2,7 @@
  * Token Usage Tracking - Extract, normalize, estimate and log token usage
  */
 
-import { saveRequestUsage, appendRequestLog } from "@/lib/usageDb.js";
+import { appendRequestLog } from "@/lib/usageDb.js";
 import { FORMATS } from "../translator/formats.js";
 
 // ANSI color codes
@@ -334,7 +334,8 @@ export function logUsage(provider, usage, model = null, connectionId = null, api
 
   console.log(msg);
 
-  // Save to usage DB
+  // Save to usage DB via the request-log path. 0/0 events are ignored there so
+  // Recent Requests remains clean.
   const tokens = {
     prompt_tokens: inTokens,
     completion_tokens: outTokens,
@@ -342,6 +343,5 @@ export function logUsage(provider, usage, model = null, connectionId = null, api
     cache_creation_input_tokens: cacheCreation || 0,
     reasoning_tokens: reasoning || 0
   };
-  saveRequestUsage({ model, provider, connectionId, tokens, apiKey: apiKey || undefined }).catch(() => { });
   appendRequestLog({ model, provider, connectionId, tokens, status: "200 OK" }).catch(() => { });
 }

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -695,8 +695,28 @@ function formatLogDate(date = new Date()) {
   return `${pad(date.getDate())}-${pad(date.getMonth() + 1)}-${date.getFullYear()} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 }
 
-// No-op: request log is now derived from usageHistory table on read.
-export async function appendRequestLog() {}
+function hasUsageTokens(tokens) {
+  if (!tokens || typeof tokens !== "object") return false;
+  const promptTokens = tokens.prompt_tokens ?? tokens.input_tokens ?? 0;
+  const completionTokens = tokens.completion_tokens ?? tokens.output_tokens ?? 0;
+  return promptTokens > 0 || completionTokens > 0;
+}
+
+// Request log is derived from usageHistory. Only token-bearing events are stored
+// here so Recent Requests stays clean and keeps filtering 0/0 rows.
+export async function appendRequestLog(entry = {}) {
+  if (!hasUsageTokens(entry.tokens)) return;
+  await saveRequestUsage({
+    provider: entry.provider || "unknown",
+    model: entry.model || "unknown",
+    connectionId: entry.connectionId || undefined,
+    apiKey: entry.apiKey || undefined,
+    endpoint: entry.endpoint || null,
+    tokens: entry.tokens,
+    timestamp: entry.timestamp || new Date().toISOString(),
+    status: entry.status || "ok",
+  });
+}
 
 export async function getRecentLogs(limit = 200) {
   try {

--- a/tests/unit/nonstream-usage-extraction.test.js
+++ b/tests/unit/nonstream-usage-extraction.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { extractUsageFromResponse } from "../../open-sse/handlers/chatCore/requestDetail.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("extractUsageFromResponse", () => {
+  it("extracts raw Ollama usage from non-streaming responses", () => {
+    const usage = extractUsageFromResponse(
+      { done: true, prompt_eval_count: 18, eval_count: 3 },
+      { targetFormat: FORMATS.OLLAMA, requestBody: { messages: [{ role: "user", content: "hello" }] } }
+    );
+
+    expect(usage).toMatchObject({
+      prompt_tokens: 18,
+      completion_tokens: 3,
+      total_tokens: 21
+    });
+    expect(usage.estimated).toBeUndefined();
+  });
+
+  it("estimates missing Ollama prompt tokens when output tokens are present", () => {
+    const usage = extractUsageFromResponse(
+      { done: true, eval_count: 1 },
+      { targetFormat: FORMATS.OLLAMA, requestBody: { messages: [{ role: "user", content: "hello world" }] } }
+    );
+
+    expect(usage.prompt_tokens).toBeGreaterThan(0);
+    expect(usage.completion_tokens).toBe(1);
+    expect(usage.total_tokens).toBe(usage.prompt_tokens + usage.completion_tokens);
+    expect(usage.estimated).toBe(true);
+  });
+
+  it("extracts nested OpenAI Responses API usage", () => {
+    const usage = extractUsageFromResponse({
+      response: {
+        usage: {
+          input_tokens: 10,
+          output_tokens: 4,
+          input_tokens_details: { cached_tokens: 2 },
+          output_tokens_details: { reasoning_tokens: 1 }
+        }
+      }
+    });
+
+    expect(usage).toMatchObject({
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      cached_tokens: 2,
+      reasoning_tokens: 1
+    });
+  });
+
+  it("extracts nested Gemini usage metadata", () => {
+    const usage = extractUsageFromResponse({
+      response: {
+        usageMetadata: {
+          promptTokenCount: 5,
+          candidatesTokenCount: 2,
+          thoughtsTokenCount: 1,
+          totalTokenCount: 8
+        }
+      }
+    });
+
+    expect(usage).toMatchObject({
+      prompt_tokens: 5,
+      completion_tokens: 2,
+      reasoning_tokens: 1,
+      total_tokens: 8
+    });
+  });
+
+  it("extracts Kiro and CommandCode raw non-stream usage fields", () => {
+    expect(extractUsageFromResponse({ inputTokens: 12, outputTokens: 3 }, { targetFormat: FORMATS.KIRO })).toMatchObject({
+      prompt_tokens: 12,
+      completion_tokens: 3,
+      total_tokens: 15
+    });
+
+    expect(extractUsageFromResponse({ inputTokens: 8, outputTokens: 2, totalTokens: 20 }, { targetFormat: FORMATS.COMMANDCODE })).toMatchObject({
+      prompt_tokens: 8,
+      completion_tokens: 2,
+      total_tokens: 20
+    });
+  });
+});

--- a/tests/unit/responses-api-cleanup.test.js
+++ b/tests/unit/responses-api-cleanup.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { convertResponsesApiFormat } from "../../open-sse/translator/formats/responsesApi.js";
+import { openaiResponsesToOpenAIRequest } from "../../open-sse/translator/request/openai-responses.js";
+
+const responsesBody = () => ({
+  model: "glm-5.2",
+  input: "hello",
+  text: { format: { type: "text" } },
+  client_metadata: { client: "codex-cli" },
+  max_output_tokens: 32,
+});
+
+describe("Responses API cleanup", () => {
+  it("does not leak Responses-only root fields from the direct converter", () => {
+    const converted = convertResponsesApiFormat(responsesBody());
+
+    expect(converted.messages).toHaveLength(1);
+    expect(converted).not.toHaveProperty("input");
+    expect(converted).not.toHaveProperty("text");
+    expect(converted).not.toHaveProperty("client_metadata");
+  });
+
+  it("does not leak Responses-only root fields through the registered translator", () => {
+    const converted = openaiResponsesToOpenAIRequest("glm-5.2", responsesBody(), false, null);
+
+    expect(converted.messages).toHaveLength(1);
+    expect(converted).not.toHaveProperty("input");
+    expect(converted).not.toHaveProperty("text");
+    expect(converted).not.toHaveProperty("client_metadata");
+    expect(converted.max_tokens).toBe(32);
+    expect(converted).not.toHaveProperty("max_output_tokens");
+  });
+});

--- a/tests/unit/usage-request-log.test.js
+++ b/tests/unit/usage-request-log.test.js
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const originalDataDir = process.env.DATA_DIR;
+let tempDir;
+let db;
+
+beforeAll(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-usage-log-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+});
+
+afterAll(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("appendRequestLog", () => {
+  it("records token-bearing CLI request events in usage history", async () => {
+    await db.appendRequestLog({
+      provider: "opencode-go",
+      model: "glm-5.2",
+      connectionId: "conn-1",
+      tokens: { prompt_tokens: 42, completion_tokens: 7 },
+      status: "200 OK",
+    });
+
+    const history = await db.getUsageHistory({ provider: "opencode-go" });
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatchObject({
+      provider: "opencode-go",
+      model: "glm-5.2",
+      connectionId: "conn-1",
+      status: "200 OK",
+    });
+    expect(history[0].tokens).toMatchObject({ prompt_tokens: 42, completion_tokens: 7 });
+
+    const stats = await db.getUsageStats("24h");
+    expect(stats.recentRequests[0]).toMatchObject({
+      provider: "opencode-go",
+      model: "glm-5.2",
+      promptTokens: 42,
+      completionTokens: 7,
+    });
+  });
+
+  it("does not add empty 0/0 request events to usage history", async () => {
+    await db.appendRequestLog({
+      provider: "opencode-go",
+      model: "qwen3.7-max",
+      connectionId: "conn-1",
+      tokens: { prompt_tokens: 0, completion_tokens: 0 },
+      status: "FAILED 502",
+    });
+
+    const history = await db.getUsageHistory({ provider: "opencode-go" });
+    expect(history).toHaveLength(1);
+    expect(history[0].model).toBe("glm-5.2");
+  });
+});


### PR DESCRIPTION
## Summary
- supersedes #1912 by carrying forward provider-native non-stream usage extraction and extending the usageHistory path used by Recent Requests
- record token-bearing CLI/stream usage through appendRequestLog while preserving the UI's existing 0/0 filtering behavior
- avoid duplicate streaming usage rows by keeping one usage write path
- strip Responses API-only text and client_metadata fields before forwarding converted chat-completions requests, fixing OpenCode Go GLM validation errors

## Tests
- /opt/9router/tests/node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/responses-api-cleanup.test.js tests/unit/usage-request-log.test.js
- /opt/9router/tests/node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/opencode-go-models.test.js tests/unit/nonstream-usage-extraction.test.js
- npm run build