### PR TITLE
fix(antigravity): sanitize thinking level and map Claude models under antigravity to gemini-level

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -98,6 +98,12 @@ export const captureThinking = extractThinking;
 
 // Resolve thinking format: provider override > capability > derive(targetFormat).
 function resolveFormat(targetFormat, model, provider) {
+  if (provider === "antigravity" || targetFormat === "antigravity") {
+    const caps = getCapabilitiesForModel(provider, model);
+    if (caps.reasoning) {
+      return caps.thinkingFormat === "gemini-budget" ? "gemini-budget" : "gemini-level";
+    }
+  }
   const providerFmt = provider ? PROVIDERS[provider]?.thinkingFormat : null;
   if (providerFmt) return providerFmt;
   const caps = getCapabilitiesForModel(provider, model);
@@ -162,13 +168,15 @@ function applyFormat(fmt, body, cfg, caps) {
   switch (fmt) {
     case "openai": {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
-      const level = toLevel(eff);
+      let level = toLevel(eff);
+      if (level === "auto") level = "high";
       if (level) body.reasoning_effort = level === "xhigh" || level === "max" ? "high" : level;
       break;
     }
     case "claude-adaptive": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
-      const level = toLevel(eff);
+      let level = toLevel(eff);
+      if (level === "auto") level = "high";
       body.output_config = { effort: level === "xhigh" ? "high" : level };
       break;
     }
@@ -179,7 +187,13 @@ function applyFormat(fmt, body, cfg, caps) {
       break;
     }
     case "gemini-level": {
-      const level = none ? "minimal" : (toLevel(eff) || "high");
+      let level = none ? "minimal" : (toLevel(eff) || "high");
+      if (level === "xhigh" || level === "max" || level === "auto") {
+        level = "high";
+      }
+      if (!["minimal", "low", "medium", "high"].includes(level)) {
+        level = "high";
+      }
       setGeminiThinking(body, { thinkingLevel: level, includeThoughts: level !== "minimal" });
       break;
     }
@@ -212,7 +226,8 @@ function applyFormat(fmt, body, cfg, caps) {
     }
     case "kimi": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
-      const level = toLevel(eff);
+      let level = toLevel(eff);
+      if (level === "auto" || level === "xhigh") level = "high";
       if (level) body.reasoning_effort = level === "max" ? "high" : level;
       break;
     }
@@ -229,7 +244,8 @@ function applyFormat(fmt, body, cfg, caps) {
     }
     case "step": {
       if (none && canDisable) break;
-      const level = toLevel(eff);
+      let level = toLevel(eff);
+      if (level === "auto") level = "high";
       if (level) body.reasoning_effort = level === "xhigh" || level === "max" ? "high" : level;
       break;
     }

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -67,6 +67,22 @@ describe("applyThinking per provider format", () => {
   it("gemini-3 → thinkingLevel", () => {
     const out = apply("gemini", "gemini-3-pro", { reasoning_effort: "medium" }, "gemini");
     expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("medium");
+
+    const outXHigh = apply("gemini", "gemini-3-pro", { reasoning_effort: "xhigh" }, "gemini");
+    expect(outXHigh.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
+
+    const outMax = apply("gemini", "gemini-3-pro", { reasoning_effort: "max" }, "gemini");
+    expect(outMax.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
+
+    const outAuto = apply("gemini", "gemini-3-pro", { reasoning_effort: "auto" }, "gemini");
+    expect(outAuto.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
+  });
+  it("claude under antigravity provider → gemini-level thinkingLevel", () => {
+    const out = apply("antigravity", "claude-sonnet-4-6", { reasoning_effort: "medium" }, "antigravity");
+    expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("medium");
+
+    const outXHigh = apply("antigravity", "claude-sonnet-4-6", { reasoning_effort: "xhigh" }, "antigravity");
+    expect(outXHigh.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
   });
   it("gemini-2.5 → thinkingBudget", () => {
     const out = apply("gemini", "gemini-2.5-flash", { reasoning_effort: "high" }, "gemini");


### PR DESCRIPTION
Fixes 400 Bad Request errors on Gemini thinkingLevel by mapping xhigh, max, and auto effort levels to high. Also ensures Claude models under antigravity are correctly converted to gemini-level format on Google's backend.