### PR TITLE
fix: handle Cloudflare AI param support rule

### DIFF
--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -16,6 +16,7 @@ const STRIP_RULES = [
 
 // Test a rule's match (regex or predicate) against the model id.
 function matches(rule, model) {
+  if (!rule.match) return true;
   return typeof rule.match === "function" ? rule.match(model) : rule.match.test(model);
 }
 
@@ -25,7 +26,7 @@ export function stripUnsupportedParams(provider, model, body) {
   for (const rule of STRIP_RULES) {
     if (rule.provider && rule.provider !== provider) continue;
     if (!matches(rule, model)) continue;
-    for (const key of rule.drop) {
+    for (const key of rule.drop || []) {
       if (body[key] !== undefined) delete body[key];
     }
     // CF Workers AI oneOf root schema only accepts content as plain string (#1926)

--- a/tests/unit/param-support.test.js
+++ b/tests/unit/param-support.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+
+import { stripUnsupportedParams } from "../../open-sse/translator/concerns/paramSupport.js";
+
+describe("stripUnsupportedParams", () => {
+  it("flattens Cloudflare AI OpenAI content-part arrays", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hello " },
+            { type: "image_url", image_url: { url: "data:image/png;base64,xx" } },
+            { type: "text", text: "world" },
+          ],
+        },
+      ],
+    };
+
+    expect(() => stripUnsupportedParams("cloudflare-ai", "@cf/meta/llama-3.1-8b-instruct", body)).not.toThrow();
+    expect(body.messages[0].content).toBe("hello world");
+  });
+
+  it("still drops unsupported GitHub model params", () => {
+    const body = { temperature: 0.7, top_p: 1 };
+
+    stripUnsupportedParams("github", "gpt-5.4", body);
+
+    expect(body).toEqual({ top_p: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a crash when testing/using Cloudflare Workers AI models through the OpenAI-compatible path.

The Cloudflare-specific strip rule sets `flattenContent: true` but does not need a `match` predicate or `drop` list. The shared param-support loop assumed both existed, so the Cloudflare rule crashed with:

```text
Cannot read properties of undefined (reading 'test')
```

## Changes
- Treat strip rules without `match` as provider-wide rules
- Treat missing `drop` as an empty list
- Add a focused unit test for Cloudflare content-part flattening
- Keep an existing drop-rule regression test for GitHub params

## Verification
- Watched the new Cloudflare unit test fail first with the reported `reading 'test'` error
- `NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run --reporter=verbose tests/unit/param-support.test.js` — 2 passed
- `npm run build` — compiled successfully and generated 123 static pages

Fixes #1960