### PR TITLE
fix: use region-aware URL for xiaomi-tokenplan connection test

### DIFF
--- a/open-sse/providers/registry/xiaomi-tokenplan.js
+++ b/open-sse/providers/registry/xiaomi-tokenplan.js
@@ -22,6 +22,11 @@ export default {
   category: "apikey",
   hasProviderSpecificData: true,
   defaultRegion: "sgp",
+  regions: [
+    { id: "sgp", label: "Singapore" },
+    { id: "cn", label: "China" },
+    { id: "ams", label: "Europe" },
+  ],
   transport: {
     baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1/chat/completions",
     regions: {

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -622,7 +622,8 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
       }
       case "xiaomi-mimo":
       case "xiaomi-tokenplan": {
-        const baseUrls = { "xiaomi-mimo": "https://api.xiaomimimo.com/v1", "xiaomi-tokenplan": "https://token-plan-sgp.xiaomimimo.com/v1" };
+        const REGION_MAP = { cn: "https://token-plan-cn.xiaomimimo.com/v1", sgp: "https://token-plan-sgp.xiaomimimo.com/v1", ams: "https://token-plan-ams.xiaomimimo.com/v1" };
+        const baseUrls = { "xiaomi-mimo": "https://api.xiaomimimo.com/v1", "xiaomi-tokenplan": REGION_MAP[connection.providerSpecificData?.region] || REGION_MAP.sgp };
         const res = await fetchWithConnectionProxy(`${baseUrls[connection.provider]}/models`, {
           headers: { Authorization: `Bearer ${connection.apiKey}` },
         }, effectiveProxy);

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -3,7 +3,7 @@ import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { testProxyUrl } from "@/lib/network/proxyTest";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { getDefaultModel } from "open-sse/config/providerModels.js";
-import { resolveOllamaLocalHost, PROVIDERS } from "open-sse/config/providers.js";
+import { resolveOllamaLocalHost, PROVIDERS, resolveXiaomiTokenplanBaseUrl } from "open-sse/config/providers.js";
 import {
   refreshProviderCredentials,
   shouldRefreshCredentials,
@@ -622,8 +622,7 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
       }
       case "xiaomi-mimo":
       case "xiaomi-tokenplan": {
-        const REGION_MAP = { cn: "https://token-plan-cn.xiaomimimo.com/v1", sgp: "https://token-plan-sgp.xiaomimimo.com/v1", ams: "https://token-plan-ams.xiaomimimo.com/v1" };
-        const baseUrls = { "xiaomi-mimo": "https://api.xiaomimimo.com/v1", "xiaomi-tokenplan": REGION_MAP[connection.providerSpecificData?.region] || REGION_MAP.sgp };
+        const baseUrls = { "xiaomi-mimo": "https://api.xiaomimimo.com/v1", "xiaomi-tokenplan": resolveXiaomiTokenplanBaseUrl(connection) };
         const res = await fetchWithConnectionProxy(`${baseUrls[connection.provider]}/models`, {
           headers: { Authorization: `Bearer ${connection.apiKey}` },
         }, effectiveProxy);


### PR DESCRIPTION

## Problem

Two issues with xiaomi-tokenplan region handling:

1. **UI missing region selector** — the Add Connection dialog reads `Q2[provider].regions`, but the regions array is only inside `transport.regions` (URL map format). `buildProviderEntry` checks top-level `r.regions`, so the Q2 object never gets a `regions` property, and the dropdown never renders.

2. **Test endpoint duplicates URL map** — the test-connection handler hardcodes a `REGION_MAP` that duplicates the URLs already defined in `open-sse/config/providers.js`.

## Fix

### 1. `open-sse/providers/registry/xiaomi-tokenplan.js`
Add top-level `regions` array in `{id, label}` format — the format `buildProviderEntry` expects for the UI.

### 2. `src/app/api/providers/[id]/test/testUtils.js`
Replace hardcoded `REGION_MAP` with `resolveXiaomiTokenplanBaseUrl(connection)`, reusing the single-source utility from `open-sse/config/providers.js`.

Fixes #2026
