### PR TITLE
Fix provider thinking, usage tracking, and smart routing

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -167,7 +167,13 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   }
 
   reqLogger.logProviderResponse(providerResponse.status, providerResponse.statusText, providerResponse.headers, responseBody);
-  if (onRequestSuccess) await onRequestSuccess();
+  if (onRequestSuccess) {
+    Promise.resolve()
+      .then(onRequestSuccess)
+      .catch(err => {
+        console.error("[ChatCore] onRequestSuccess failed:", err?.message || err);
+      });
+  }
 
   // Decloak tool_use names once on raw Claude body, before any translation (INPUT side)
   responseBody = decloakToolNames(responseBody, toolNameMap);

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -44,7 +44,13 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
 export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete }) {
-  if (onRequestSuccess) onRequestSuccess();
+  if (onRequestSuccess) {
+    Promise.resolve()
+      .then(onRequestSuccess)
+      .catch(err => {
+        console.error("[ChatCore] onRequestSuccess failed:", err?.message || err);
+      });
+  }
 
   const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey });
 

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -2,6 +2,7 @@
  * Shared combo (model combo) handling with fallback support
  */
 
+import { createHash } from "node:crypto";
 import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
@@ -75,10 +76,47 @@ export function reorderByCapabilities(models, required) {
   };
 
   // Stable sort by tier (Array.prototype.sort is stable in modern engines).
-  return models
+  const reordered = models
     .map((m, i) => ({ m, i, t: tierOf(m) }))
     .sort((a, b) => a.t - b.t || a.i - b.i)
     .map((x) => x.m);
+
+  return reordered.every((m, i) => m === models[i]) ? models : reordered;
+}
+
+const TASK_LEVEL_WEIGHT = {
+  light: 1,
+  standard: 2,
+  heavy: 3,
+  critical: 4,
+};
+
+const TASK_TARGET_POWER = {
+  light: 35,
+  standard: 65,
+  heavy: 95,
+  critical: 120,
+};
+
+const LIGHT_TASK_RE = /\b(hi|hello|thanks|thank you|ping|format|rewrite|grammar|translate|summari[sz]e|short|quick|one[- ]?liner|explain briefly)\b/i;
+const HEAVY_TASK_RE = /\b(debug|root cause|architecture|architectural|refactor|migrate|implementation|implement|design|analy[sz]e|investigate|compare|benchmark|whitebox|codebase|end[- ]?to[- ]?end|e2e)\b/i;
+const CRITICAL_TASK_RE = /\b(critical|security|vulnerability|exploit|rce|remote code execution|supply chain|account takeover|auth bypass|privilege escalation|tenant|cross[- ]tenant|sandbox escape|ssrf|deserialization|prod incident|data exfiltration|bug bounty)\b/i;
+
+function splitModelString(modelStr) {
+  const slash = typeof modelStr === "string" ? modelStr.indexOf("/") : -1;
+  return {
+    provider: slash > 0 ? modelStr.slice(0, slash) : "",
+    model: slash > 0 ? modelStr.slice(slash + 1) : String(modelStr || ""),
+  };
+}
+
+function getModelCapabilities(modelStr) {
+  const { provider, model } = splitModelString(modelStr);
+  return getCapabilitiesForModel(provider, model);
+}
+
+function taskWeight(level) {
+  return TASK_LEVEL_WEIGHT[level] || TASK_LEVEL_WEIGHT.standard;
 }
 
 /**
@@ -86,6 +124,15 @@ export function reorderByCapabilities(models, required) {
  * @type {Map<string, { index: number, consecutiveUseCount: number }>}
  */
 const comboRotationState = new Map();
+
+/**
+ * Keep chat-like traffic on the same first model so provider-side prompt caches
+ * keep hitting. New conversations still use round-robin for distribution.
+ * @type {Map<string, { index: number, lastUsed: number }>}
+ */
+const comboConversationAffinity = new Map();
+const CONVERSATION_AFFINITY_TTL_MS = 60 * 60 * 1000;
+const MAX_CONVERSATION_AFFINITY_ENTRIES = 1000;
 
 // Trailing run of items after the last assistant/model turn = the current user
 // turn. It may span several messages (e.g. text + image split across blocks),
@@ -127,7 +174,14 @@ export function detectRequiredCapabilities(body) {
   const contents = body.contents || body.request?.contents;                      // gemini / antigravity
   for (const c of trailingUserItems(contents)) scanContent(c.parts);
 
-  // search: temporarily disabled in auto-switch (feature not wired yet).
+  for (const tool of body.tools || []) {
+    const type = tool?.type || tool?.function?.name || tool?.name;
+    if (typeof type === "string" && /^web_search/.test(type)) required.add("search");
+  }
+
+  const effort = body.reasoning_effort || body.reasoning?.effort;
+  if (effort && String(effort).toLowerCase() !== "none") required.add("reasoning");
+  if (isHeavyRequest(body)) required.add("reasoning");
 
   return required;
 }
@@ -146,33 +200,19 @@ function rotateModelsFromIndex(models, currentIndex) {
   return rotatedModels;
 }
 
-/**
- * Get rotated model list based on strategy
- * @param {string[]} models - Array of model strings
- * @param {string} comboName - Name of the combo
- * @param {string} strategy - "fallback" or "round-robin"
- * @param {number|string} [stickyLimit=1] - Requests per combo model before switching
- * @returns {string[]} Rotated models array
- */
-export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
-  if (!models || models.length <= 1 || strategy !== "round-robin") {
-    return models;
-  }
-
-  const rotationKey = comboName || "__default__";
-  const normalizedStickyLimit = normalizeStickyLimit(stickyLimit);
+function getRotationState(rotationKey) {
   const existingState = comboRotationState.get(rotationKey);
-  const state = typeof existingState === "number"
+  return typeof existingState === "number"
     ? { index: existingState, consecutiveUseCount: 0 }
     : (existingState || { index: 0, consecutiveUseCount: 0 });
+}
 
-  const currentIndex = state.index % models.length;
-  const rotatedModels = rotateModelsFromIndex(models, currentIndex);
-  const nextUseCount = state.consecutiveUseCount + 1;
+function advanceRotationState(rotationKey, currentIndex, modelCount, normalizedStickyLimit, consecutiveUseCount) {
+  const nextUseCount = consecutiveUseCount + 1;
 
   if (nextUseCount >= normalizedStickyLimit) {
     comboRotationState.set(rotationKey, {
-      index: (currentIndex + 1) % models.length,
+      index: (currentIndex + 1) % modelCount,
       consecutiveUseCount: 0,
     });
   } else {
@@ -181,6 +221,356 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
       consecutiveUseCount: nextUseCount,
     });
   }
+}
+
+function pruneConversationAffinity(now = Date.now()) {
+  for (const [key, value] of comboConversationAffinity) {
+    if (!value || now - value.lastUsed > CONVERSATION_AFFINITY_TTL_MS) {
+      comboConversationAffinity.delete(key);
+    }
+  }
+
+  while (comboConversationAffinity.size > MAX_CONVERSATION_AFFINITY_ENTRIES) {
+    const oldestKey = comboConversationAffinity.keys().next().value;
+    comboConversationAffinity.delete(oldestKey);
+  }
+}
+
+function normalizeFingerprintText(value) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 12000);
+}
+
+function collectText(value, out = []) {
+  if (value == null) return out;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    out.push(String(value));
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectText(item, out);
+    return out;
+  }
+  if (typeof value !== "object") return out;
+
+  if (typeof value.text === "string") out.push(value.text);
+  if (typeof value.input_text === "string") out.push(value.input_text);
+  if (typeof value.output_text === "string") out.push(value.output_text);
+  if (typeof value.content === "string") out.push(value.content);
+  else if (Array.isArray(value.content)) collectText(value.content, out);
+  if (Array.isArray(value.parts)) collectText(value.parts, out);
+  if (typeof value.query === "string") out.push(value.query);
+  if (typeof value.url === "string") out.push(value.url);
+
+  return out;
+}
+
+function estimatePromptChars(body) {
+  const contents = body.contents || body.request?.contents;
+  const parts = [
+    body.system,
+    body.instructions,
+    body.messages,
+    body.input,
+    contents,
+    body.query,
+    body.url,
+  ];
+  return collectText(parts).join("\n").length;
+}
+
+function countMessages(body) {
+  return (Array.isArray(body.messages) ? body.messages.length : 0) +
+    (Array.isArray(body.input) ? body.input.length : 0) +
+    (Array.isArray(body.contents) ? body.contents.length : 0) +
+    (Array.isArray(body.request?.contents) ? body.request.contents.length : 0);
+}
+
+function maxRequestedOutput(body) {
+  const candidates = [
+    body.max_tokens,
+    body.max_output_tokens,
+    body.max_completion_tokens,
+    body.generationConfig?.maxOutputTokens,
+  ].map((v) => Number.parseInt(v, 10)).filter((v) => Number.isFinite(v));
+  return candidates.length > 0 ? Math.max(...candidates) : 0;
+}
+
+function getTaskText(body) {
+  const contents = body?.contents || body?.request?.contents;
+  return collectText([
+    body?.system,
+    body?.instructions,
+    body?.messages,
+    body?.input,
+    contents,
+    body?.query,
+    body?.url,
+  ]).join("\n");
+}
+
+function normalizeEffort(body) {
+  return String(body?.reasoning_effort || body?.reasoning?.effort || "").toLowerCase();
+}
+
+function getTaskSignals(body) {
+  const promptChars = estimatePromptChars(body || {});
+  const messageCount = countMessages(body || {});
+  const toolCount = Array.isArray(body?.tools) ? body.tools.length : 0;
+  const outputTokens = maxRequestedOutput(body || {});
+  const effort = normalizeEffort(body);
+  const text = getTaskText(body || {});
+
+  return {
+    promptChars,
+    messageCount,
+    toolCount,
+    outputTokens,
+    effort,
+    hasExplicitReasoning: Boolean(effort && effort !== "none" && effort !== "off" && effort !== "disabled"),
+    lightKeyword: LIGHT_TASK_RE.test(text),
+    heavyKeyword: HEAVY_TASK_RE.test(text),
+    criticalKeyword: CRITICAL_TASK_RE.test(text),
+  };
+}
+
+/**
+ * Classify request difficulty for smart combo routing.
+ *
+ * This deliberately uses cheap, local signals only. It is not a semantic judge;
+ * it is a routing hint so light requests stay on fast/cheap models while large,
+ * tool-heavy, security-sensitive, or reasoning-heavy requests try stronger
+ * models first. Fallback still tries every model.
+ */
+export function classifyTask(body) {
+  const s = getTaskSignals(body || {});
+  const reasons = [];
+  const add = (condition, reason) => {
+    if (condition) reasons.push(reason);
+    return condition;
+  };
+
+  const effortIsHigh = /^(high|xhigh|max|maximum|hard|deep)$/.test(s.effort);
+  const effortIsLight = !s.hasExplicitReasoning || /^(low|minimal|none|off|disabled)$/.test(s.effort);
+
+  const critical =
+    add(s.promptChars >= 100000, "huge-context") ||
+    add(s.outputTokens >= 32768, "huge-output") ||
+    add(s.toolCount >= 8 && s.promptChars >= 16000, "many-tools-large-context") ||
+    add(s.criticalKeyword && (effortIsHigh || s.toolCount >= 3 || s.promptChars >= 8000), "critical-domain");
+
+  if (critical) {
+    return { level: "critical", weight: taskWeight("critical"), ...s, reasons };
+  }
+
+  const heavySignalCount = [
+    add(s.promptChars >= 50000, "large-context"),
+    add(s.promptChars >= 24000, "medium-large-context"),
+    add(s.messageCount >= 16, "long-conversation"),
+    add(s.toolCount >= 4, "many-tools"),
+    add(s.outputTokens >= 8192, "large-output"),
+    add(effortIsHigh, "high-reasoning-effort"),
+    add(s.criticalKeyword, "security-sensitive"),
+    add(s.heavyKeyword && s.promptChars >= 4000, "complex-task"),
+  ].filter(Boolean).length;
+
+  if (heavySignalCount >= 2 || s.promptChars >= 50000 || effortIsHigh) {
+    return { level: "heavy", weight: taskWeight("heavy"), ...s, reasons };
+  }
+
+  const light =
+    s.promptChars <= 2000 &&
+    s.messageCount <= 3 &&
+    s.toolCount === 0 &&
+    s.outputTokens <= 1500 &&
+    effortIsLight &&
+    !s.criticalKeyword &&
+    !s.heavyKeyword;
+
+  if (light || (s.lightKeyword && s.promptChars <= 4000 && s.toolCount === 0 && effortIsLight && !s.criticalKeyword)) {
+    return { level: "light", weight: taskWeight("light"), ...s, reasons: reasons.length ? reasons : ["small-simple-request"] };
+  }
+
+  return { level: "standard", weight: taskWeight("standard"), ...s, reasons: reasons.length ? reasons : ["default"] };
+}
+
+function modelPowerScore(modelStr) {
+  const { model } = splitModelString(modelStr);
+  const id = `${modelStr || ""} ${model || ""}`.toLowerCase();
+  const caps = getModelCapabilities(modelStr);
+
+  let score = 35;
+  if (caps.reasoning) score += 18;
+  if (caps.search) score += 4;
+  if (caps.tools) score += 3;
+  if (caps.vision) score += 3;
+
+  if (caps.contextWindow >= 1000000) score += 22;
+  else if (caps.contextWindow >= 400000) score += 15;
+  else if (caps.contextWindow >= 200000) score += 9;
+  else if (caps.contextWindow <= 32000) score -= 10;
+
+  if (caps.maxOutput >= 128000) score += 12;
+  else if (caps.maxOutput >= 64000) score += 8;
+  else if (caps.maxOutput <= 8192) score -= 8;
+
+  if (/\b(opus|mythos|gpt-5|o3|o4|pro|max|ultra|deepseek-v4-pro|sonnet-4|glm-5|kimi-k2\.7|minimax-m3|reasoner)\b/i.test(id)) score += 28;
+  if (/\b(coder|code|coding)\b/i.test(id)) score += 8;
+  if (/\b(haiku|flash|mini|lite|small|nano|instant|fast|turbo|3\.5|8b|7b)\b/i.test(id)) score -= 24;
+
+  return Math.max(0, Math.min(150, score));
+}
+
+export function scoreModelForTask(modelStr, task = classifyTask({}), required = new Set()) {
+  const caps = getModelCapabilities(modelStr);
+  const target = TASK_TARGET_POWER[task.level] || TASK_TARGET_POWER.standard;
+  const power = modelPowerScore(modelStr);
+  let score = 100 - Math.abs(power - target);
+
+  const hard = [...(required || [])].filter((c) => HARD_CAPS.has(c));
+  if (!hard.every((c) => caps[c] === true)) score -= 10000;
+
+  if ((required?.has?.("reasoning") || task.weight >= TASK_LEVEL_WEIGHT.heavy) && !caps.reasoning) score -= 120;
+  if (required?.has?.("search") && !caps.search) score -= 30;
+
+  const estimatedPromptTokens = Math.ceil((task.promptChars || 0) / 4);
+  if (caps.contextWindow && estimatedPromptTokens > caps.contextWindow * 0.85) score -= 200;
+  if (caps.maxOutput && task.outputTokens && task.outputTokens > caps.maxOutput) score -= 80;
+
+  if (task.level === "light" && power > 95) score -= 35;
+  if (task.level === "standard" && power > 125) score -= 10;
+  if (task.level === "heavy" && power < 65) score -= 60;
+  if (task.level === "critical" && power < 85) score -= 100;
+
+  return score;
+}
+
+export function reorderByTaskWeight(models, task = classifyTask({}), required = new Set()) {
+  if (!Array.isArray(models) || models.length <= 1) return models;
+
+  const reordered = models
+    .map((m, i) => ({ m, i, score: scoreModelForTask(m, task, required) }))
+    .sort((a, b) => b.score - a.score || a.i - b.i)
+    .map((x) => x.m);
+
+  return reordered.every((m, i) => m === models[i]) ? models : reordered;
+}
+
+function isHeavyRequest(body) {
+  return classifyTask(body).weight >= TASK_LEVEL_WEIGHT.heavy;
+}
+
+function firstRoleText(items, roles, contentKey = "content") {
+  if (!Array.isArray(items)) return "";
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    if (!roles.has(item.role)) continue;
+    const content = contentKey === "parts" ? item.parts : item.content;
+    const text = normalizeFingerprintText(collectText(content).join("\n"));
+    if (text) return text;
+  }
+  return "";
+}
+
+function allRoleText(items, roles, contentKey = "content") {
+  if (!Array.isArray(items)) return "";
+  return normalizeFingerprintText(items
+    .filter((item) => item && typeof item === "object" && roles.has(item.role))
+    .map((item) => collectText(contentKey === "parts" ? item.parts : item.content).join("\n"))
+    .filter(Boolean)
+    .join("\n"));
+}
+
+function hashConversationSeed(seed) {
+  const normalized = normalizeFingerprintText(seed);
+  if (!normalized) return null;
+  return createHash("sha1").update(normalized).digest("hex").slice(0, 24);
+}
+
+/**
+ * Derive a stable cache-affinity key from explicit thread metadata when present,
+ * otherwise from the immutable start of the prompt (system + first user turn).
+ * Appended turns should not move an existing conversation to another model.
+ */
+export function getConversationCacheKey(body) {
+  if (!body || typeof body !== "object") return null;
+
+  const explicitCandidates = [
+    body.conversation_id,
+    body.conversationId,
+    body.thread_id,
+    body.threadId,
+    body.session_id,
+    body.sessionId,
+    body.metadata?.conversation_id,
+    body.metadata?.conversationId,
+    body.metadata?.thread_id,
+    body.metadata?.threadId,
+    body.metadata?.session_id,
+    body.metadata?.sessionId,
+  ];
+  const explicit = explicitCandidates.find((v) => v != null && String(v).trim());
+  if (explicit != null) return hashConversationSeed(`explicit:${String(explicit).trim()}`);
+
+  const systemRoles = new Set(["system", "developer"]);
+  const userRoles = new Set(["user"]);
+  const contents = body.contents || body.request?.contents;
+
+  const seedParts = [
+    collectText(body.system).join("\n"),
+    collectText(body.instructions).join("\n"),
+    allRoleText(body.messages, systemRoles),
+    allRoleText(body.input, systemRoles),
+    allRoleText(contents, systemRoles, "parts"),
+    firstRoleText(body.messages, userRoles),
+    typeof body.input === "string" ? body.input : firstRoleText(body.input, userRoles),
+    firstRoleText(contents, userRoles, "parts"),
+    body.query,
+    body.url,
+  ].filter(Boolean);
+
+  return hashConversationSeed(seedParts.join("\n"));
+}
+
+/**
+ * Get rotated model list based on strategy
+ * @param {string[]} models - Array of model strings
+ * @param {string} comboName - Name of the combo
+ * @param {string} strategy - "fallback" or "round-robin"
+ * @param {number|string} [stickyLimit=1] - Requests per combo model before switching
+ * @param {string|null} [conversationCacheKey=null] - Stable key used to keep a conversation on one model
+ * @returns {string[]} Rotated models array
+ */
+export function getRotatedModels(models, comboName, strategy, stickyLimit = 1, conversationCacheKey = null) {
+  if (!models || models.length <= 1 || strategy !== "round-robin") {
+    return models;
+  }
+
+  const rotationKey = comboName || "__default__";
+  const normalizedStickyLimit = normalizeStickyLimit(stickyLimit);
+  const state = getRotationState(rotationKey);
+
+  const currentIndex = state.index % models.length;
+  if (conversationCacheKey) {
+    const now = Date.now();
+    pruneConversationAffinity(now);
+
+    const affinityKey = `${rotationKey}:${conversationCacheKey}`;
+    const affinity = comboConversationAffinity.get(affinityKey);
+    if (affinity) {
+      const pinnedIndex = affinity.index % models.length;
+      comboConversationAffinity.delete(affinityKey);
+      comboConversationAffinity.set(affinityKey, { index: pinnedIndex, lastUsed: now });
+      return rotateModelsFromIndex(models, pinnedIndex);
+    }
+
+    comboConversationAffinity.set(affinityKey, { index: currentIndex, lastUsed: now });
+  }
+
+  const rotatedModels = rotateModelsFromIndex(models, currentIndex);
+  advanceRotationState(rotationKey, currentIndex, models.length, normalizedStickyLimit, state.consecutiveUseCount);
 
   return rotatedModels;
 }
@@ -190,8 +580,16 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
  * @param {string} [comboName] - Combo name to reset; omit to clear all
  */
 export function resetComboRotation(comboName) {
-  if (comboName) comboRotationState.delete(comboName);
-  else comboRotationState.clear();
+  if (comboName) {
+    comboRotationState.delete(comboName);
+    const prefix = `${comboName}:`;
+    for (const key of comboConversationAffinity.keys()) {
+      if (key.startsWith(prefix)) comboConversationAffinity.delete(key);
+    }
+  } else {
+    comboRotationState.clear();
+    comboConversationAffinity.clear();
+  }
 }
 
 /**
@@ -228,9 +626,10 @@ export function getComboModelsFromData(modelStr, combosData) {
  */
 export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true }) {
   // Apply rotation strategy if enabled
-  let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
+  const conversationCacheKey = getConversationCacheKey(body);
+  let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit, conversationCacheKey);
 
-  // Auto-switch: float models that satisfy the request's required capabilities to the front.
+  // Auto-switch: first satisfy hard request capabilities, then route by task weight.
   if (autoSwitch) {
     const required = detectRequiredCapabilities(body);
     if (required.size > 0) {
@@ -240,6 +639,14 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       }
       rotatedModels = reordered;
     }
+
+    const task = classifyTask(body);
+    const taskReordered = reorderByTaskWeight(rotatedModels, task, required);
+    if (taskReordered[0] !== rotatedModels[0]) {
+      const reasons = Array.isArray(task.reasons) && task.reasons.length ? ` (${task.reasons.join(",")})` : "";
+      log.info("COMBO", `smart-route task=${task.level}${reasons} → ${taskReordered[0]}`);
+    }
+    rotatedModels = taskReordered;
   }
   
   let lastError = null;

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -4,7 +4,7 @@
 
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { PROVIDERS } from "../../providers/index.js";
-import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget } from "./thinking.js";
+import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
 const FORMAT_TO_NATIVE = {
@@ -127,6 +127,11 @@ function toLevel(cfg) {
   return null;
 }
 
+function toGeminiThinkingLevel(cfg) {
+  const raw = cfg.mode === "auto" ? "high" : (toLevel(cfg) || "high");
+  return effortToThinkingLevel(raw);
+}
+
 // Gemini nests thinkingConfig under generationConfig. gemini-cli / antigravity wrap
 // the whole request in a { request: { generationConfig } } envelope — target the
 // envelope's generationConfig when present, else the top-level one.
@@ -179,7 +184,7 @@ function applyFormat(fmt, body, cfg, caps) {
       break;
     }
     case "gemini-level": {
-      const level = none ? "minimal" : (toLevel(eff) || "high");
+      const level = none ? "minimal" : toGeminiThinkingLevel(eff);
       setGeminiThinking(body, { thinkingLevel: level, includeThoughts: level !== "minimal" });
       break;
     }

--- a/open-sse/translator/formats/claude.js
+++ b/open-sse/translator/formats/claude.js
@@ -84,6 +84,25 @@ export function fixToolUseOrdering(messages) {
 // Models that reject thinking.type "adaptive" + output_config.effort (Opus 4.5+/Sonnet 4.6+ only)
 const ADAPTIVE_THINKING_UNSUPPORTED = /haiku/i;
 
+function handlesThinkingBlocks(provider) {
+  return provider === "claude" || provider?.startsWith("anthropic-compatible") || provider === "deepseek";
+}
+
+function buildThinkingPlaceholder(provider) {
+  const block = {
+    type: CLAUDE_BLOCK.THINKING,
+    thinking: ".",
+  };
+
+  // DeepSeek's Anthropic-compatible endpoint requires a thinking block in
+  // thinking mode, but it does not need Anthropic's signed-thinking fallback.
+  if (provider !== "deepseek") {
+    block.signature = DEFAULT_THINKING_CLAUDE_SIGNATURE;
+  }
+
+  return block;
+}
+
 // Normalize a native Claude passthrough body to match Anthropic Messages API spec.
 // Newer Cowork/Claude Code clients emit beta-only shapes that OAuth endpoints reject:
 // 1. thinking.type "adaptive" → unsupported on Haiku
@@ -216,23 +235,31 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
           lastAssistantProcessed = true;
         }
 
-        // Handle thinking blocks for Anthropic endpoint only
-        if (provider === "claude" || provider?.startsWith("anthropic-compatible")) {
+        // Handle thinking blocks for Anthropic-compatible endpoints.
+        if (handlesThinkingBlocks(provider)) {
           let hasToolUse = false;
-          let hasThinking = false;
+          let hasKeptThinking = false;
 
           // Claude native: preserve valid signatures, drop invalid blocks.
           // anthropic-compatible: replace with default (safe fallback for lenient upstreams).
+          // DeepSeek: keep existing thinking as-is; add an unsigned placeholder only if missing.
           const isClaudeNative = provider === "claude";
+          const isDeepSeek = provider === "deepseek";
           const kept = [];
           for (const block of msg.content) {
             const isThinking = block.type === CLAUDE_BLOCK.THINKING || block.type === CLAUDE_BLOCK.REDACTED_THINKING;
             if (isThinking) {
-              hasThinking = true;
               if (isClaudeNative) {
-                if (isValidClaudeSignature(block.signature)) kept.push(block);
+                if (isValidClaudeSignature(block.signature)) {
+                  hasKeptThinking = true;
+                  kept.push(block);
+                }
+              } else if (isDeepSeek) {
+                hasKeptThinking = true;
+                kept.push(block);
               } else {
                 block.signature = DEFAULT_THINKING_CLAUDE_SIGNATURE;
+                hasKeptThinking = true;
                 kept.push(block);
               }
               continue;
@@ -243,12 +270,8 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
           msg.content = kept;
 
           // Add thinking block if thinking enabled + has tool_use but no thinking
-          if (thinkingEnabled && !hasThinking && hasToolUse) {
-            msg.content.unshift({
-              type: CLAUDE_BLOCK.THINKING,
-              thinking: ".",
-              signature: DEFAULT_THINKING_CLAUDE_SIGNATURE
-            });
+          if (thinkingEnabled && !hasKeptThinking && hasToolUse) {
+            msg.content.unshift(buildThinkingPlaceholder(provider));
           }
         }
       }
@@ -299,4 +322,3 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
 
   return body;
 }
-

--- a/src/app/(dashboard)/dashboard/console-log/ConsoleLogClient.js
+++ b/src/app/(dashboard)/dashboard/console-log/ConsoleLogClient.js
@@ -47,6 +47,11 @@ export default function ConsoleLogClient() {
           const next = [...prev, msg.line];
           return next.length > CONSOLE_LOG_CONFIG.maxLines ? next.slice(-CONSOLE_LOG_CONFIG.maxLines) : next;
         });
+      } else if (msg.type === "lines") {
+        setLogs((prev) => {
+          const next = [...prev, ...msg.lines];
+          return next.length > CONSOLE_LOG_CONFIG.maxLines ? next.slice(-CONSOLE_LOG_CONFIG.maxLines) : next;
+        });
       } else if (msg.type === "clear") {
         setLogs([]);
       }

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -104,6 +104,53 @@ async function probeClineAccessToken(accessToken) {
   return res;
 }
 
+const CLOUD_CODE_ASSIST_TEST_URL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
+const CLOUD_CODE_ASSIST_TEST_BODY = JSON.stringify({
+  metadata: {
+    ideType: "IDE_UNSPECIFIED",
+    platform: "PLATFORM_UNSPECIFIED",
+    pluginType: "GEMINI",
+  },
+});
+
+function parseProviderErrorMessage(bodyText, fallback) {
+  if (!bodyText) return fallback;
+  try {
+    const parsed = JSON.parse(bodyText);
+    const message = parsed?.error?.message || parsed?.message || parsed?.error;
+    if (typeof message === "string" && message.trim()) return message.trim();
+    if (message) return JSON.stringify(message);
+  } catch {
+    // fall through
+  }
+  return bodyText.trim() || fallback;
+}
+
+async function probeCloudCodeAssistAccess(connection, accessToken, effectiveProxy = null) {
+  const userAgent = connection.provider === "antigravity"
+    ? "google-api-nodejs-client/9.15.1 vscode-antigravity/1.107.0"
+    : "google-api-nodejs-client/9.15.1 gemini-cli/0.34.0";
+
+  const res = await fetchWithConnectionProxy(CLOUD_CODE_ASSIST_TEST_URL, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      "User-Agent": userAgent,
+    },
+    body: CLOUD_CODE_ASSIST_TEST_BODY,
+  }, effectiveProxy);
+
+  if (res.ok) return { valid: true, error: null };
+
+  const bodyText = await res.text().catch(() => "");
+  return {
+    valid: false,
+    error: parseProviderErrorMessage(bodyText, `API returned ${res.status}`),
+    status: res.status,
+  };
+}
+
 async function refreshOAuthToken(connection) {
   const provider = connection.provider;
   const refreshToken = connection.refreshToken;
@@ -251,6 +298,23 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
     if (refreshed) return { valid: true, error: null, refreshed, newTokens };
     if (tokenExpired) return { valid: false, error: "Token expired", refreshed: false };
     return { valid: true, error: null, refreshed: false, newTokens: null };
+  }
+
+  if (connection.provider === "gemini-cli" || connection.provider === "antigravity") {
+    const initial = await probeCloudCodeAssistAccess(connection, accessToken, effectiveProxy);
+    if (initial.valid) return { valid: true, error: null, refreshed, newTokens };
+
+    if (initial.status === 401 && config.refreshable && !refreshed && connection.refreshToken) {
+      const tokens = await refreshOAuthToken(connection);
+      if (tokens?.accessToken) {
+        const retry = await probeCloudCodeAssistAccess(connection, tokens.accessToken, effectiveProxy);
+        if (retry.valid) return { valid: true, error: null, refreshed: true, newTokens: tokens };
+        return { valid: false, error: retry.error, refreshed: true, newTokens: tokens };
+      }
+      return { valid: false, error: "Token invalid or revoked", refreshed: false };
+    }
+
+    return { valid: false, error: initial.error, refreshed };
   }
 
   if (connection.provider === "cline") {

--- a/src/app/api/translator/console-logs/stream/route.js
+++ b/src/app/api/translator/console-logs/stream/route.js
@@ -7,13 +7,14 @@ initConsoleLogCapture();
 export async function GET(request) {
   const encoder = new TextEncoder();
   const emitter = getConsoleEmitter();
-  const state = { closed: false, send: null, sendClear: null, keepalive: null };
+  const state = { closed: false, send: null, sendLines: null, sendClear: null, keepalive: null };
 
   // Idempotent: safe to call from request.signal abort, cancel(), or enqueue failure.
   const cleanup = () => {
     if (state.closed) return;
     state.closed = true;
     if (state.send) emitter.off("line", state.send);
+    if (state.sendLines) emitter.off("lines", state.sendLines);
     if (state.sendClear) emitter.off("clear", state.sendClear);
     if (state.keepalive) clearInterval(state.keepalive);
   };
@@ -40,6 +41,15 @@ export async function GET(request) {
         }
       };
 
+      state.sendLines = (lines) => {
+        if (state.closed || !Array.isArray(lines) || lines.length === 0) return;
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "lines", lines })}\n\n`));
+        } catch {
+          cleanup();
+        }
+      };
+
       // Notify client when cleared
       state.sendClear = () => {
         if (state.closed) return;
@@ -51,6 +61,7 @@ export async function GET(request) {
       };
 
       emitter.on("line", state.send);
+      emitter.on("lines", state.sendLines);
       emitter.on("clear", state.sendClear);
 
       // Keepalive ping every 25s

--- a/src/lib/consoleLogBuffer.js
+++ b/src/lib/consoleLogBuffer.js
@@ -21,6 +21,26 @@ if (!state.emitter) {
   state.emitter.setMaxListeners(50);
 }
 
+if (!state.pendingLines) state.pendingLines = [];
+if (!state.flushTimer) state.flushTimer = null;
+
+const FLUSH_INTERVAL_MS = 100;
+const MAX_BATCH_LINES = 50;
+
+function flushPendingLines() {
+  state.flushTimer = null;
+  if (!state.pendingLines.length) return;
+
+  const lines = state.pendingLines.splice(0, state.pendingLines.length);
+  state.emitter.emit("lines", lines);
+}
+
+function scheduleFlush() {
+  if (state.flushTimer) return;
+  state.flushTimer = setTimeout(flushPendingLines, FLUSH_INTERVAL_MS);
+  state.flushTimer?.unref?.();
+}
+
 function toLogLine(level, args) {
   return args.map(formatArg).join(" ");
 }
@@ -48,7 +68,16 @@ function appendLine(line) {
   if (state.logs.length > maxLines) {
     state.logs = state.logs.slice(-maxLines);
   }
-  state.emitter.emit("line", line);
+  state.pendingLines.push(line);
+  if (state.pendingLines.length >= MAX_BATCH_LINES) {
+    if (state.flushTimer) {
+      clearTimeout(state.flushTimer);
+      state.flushTimer = null;
+    }
+    flushPendingLines();
+  } else {
+    scheduleFlush();
+  }
 }
 
 export function initConsoleLogCapture() {

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -18,14 +18,26 @@ if (!global._statsEmitter) {
 if (!global._pendingTimers) global._pendingTimers = {};
 if (!global._recentRing) global._recentRing = { items: [], initialized: false };
 if (!global._connectionMapCache) global._connectionMapCache = { map: {}, ts: 0 };
+if (!global._statsEmitTimers) global._statsEmitTimers = { pending: null, update: null };
 
 const pendingRequests = global._pendingRequests;
 const lastErrorProvider = global._lastErrorProvider;
 const pendingTimers = global._pendingTimers;
 const recentRing = global._recentRing;
 const connCache = global._connectionMapCache;
+const statsEmitTimers = global._statsEmitTimers;
 
 export const statsEmitter = global._statsEmitter;
+
+function scheduleStatsEvent(event, delayMs = 150) {
+  const key = event === "update" ? "update" : "pending";
+  if (statsEmitTimers[key]) return;
+  statsEmitTimers[key] = setTimeout(() => {
+    statsEmitTimers[key] = null;
+    statsEmitter.emit(event);
+  }, delayMs);
+  statsEmitTimers[key]?.unref?.();
+}
 
 function getLocalDateKey(timestamp) {
   const d = timestamp ? new Date(timestamp) : new Date();
@@ -178,7 +190,7 @@ export function trackPendingRequest(model, provider, connectionId, started, erro
       if (connectionId && pendingRequests.byAccount[connectionId]?.[modelKey] > 0) {
         pendingRequests.byAccount[connectionId][modelKey] = 0;
       }
-      statsEmitter.emit("pending");
+      scheduleStatsEvent("pending");
     }, PENDING_TIMEOUT_MS);
   } else {
     clearTimeout(pendingTimers[timerKey]);
@@ -192,7 +204,7 @@ export function trackPendingRequest(model, provider, connectionId, started, erro
 
   const t = new Date().toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
   console.log(`[${t}] [PENDING] ${started ? "START" : "END"}${error ? " (ERROR)" : ""} | provider=${provider} | model=${model}`);
-  statsEmitter.emit("pending");
+  scheduleStatsEvent("pending");
 }
 
 export async function getActiveRequests() {
@@ -251,9 +263,35 @@ export async function saveRequestUsage(entry) {
     const promptTokens = tokens.prompt_tokens || tokens.input_tokens || 0;
     const completionTokens = tokens.completion_tokens || tokens.output_tokens || 0;
 
+    let inserted = false;
+
     // All 3 writes (history insert, daily upsert, lifetime counter) in ONE transaction.
     // better-sqlite3 is sync → no JS yield mid-transaction → no race in same process.
     db.transaction(() => {
+      const existing = db.get(
+        `SELECT id, endpoint FROM usageHistory
+         WHERE timestamp = ?
+           AND COALESCE(provider, '') = COALESCE(?, '')
+           AND COALESCE(model, '') = COALESCE(?, '')
+           AND COALESCE(connectionId, '') = COALESCE(?, '')
+           AND COALESCE(apiKey, '') = COALESCE(?, '')
+           AND promptTokens = ?
+           AND completionTokens = ?
+         ORDER BY id DESC LIMIT 1`,
+        [
+          entry.timestamp, entry.provider || null, entry.model || null,
+          entry.connectionId || null, entry.apiKey || null,
+          promptTokens, completionTokens,
+        ]
+      );
+
+      if (existing) {
+        if (!existing.endpoint && entry.endpoint) {
+          db.run(`UPDATE usageHistory SET endpoint = ? WHERE id = ?`, [entry.endpoint, existing.id]);
+        }
+        return;
+      }
+
       db.run(
         `INSERT INTO usageHistory(timestamp, provider, model, connectionId, apiKey, endpoint, promptTokens, completionTokens, cost, status, tokens, meta) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
@@ -277,10 +315,13 @@ export async function saveRequestUsage(entry) {
       const cur = db.get(`SELECT value FROM _meta WHERE key = 'totalRequestsLifetime'`);
       const next = (cur ? parseInt(cur.value, 10) : 0) + 1;
       db.run(`INSERT INTO _meta(key, value) VALUES('totalRequestsLifetime', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`, [String(next)]);
+      inserted = true;
     });
 
-    pushToRing(entry);
-    statsEmitter.emit("update");
+    if (inserted) {
+      pushToRing(entry);
+      scheduleStatsEvent("update", 250);
+    }
   } catch (e) {
     console.error("Failed to save usage stats:", e);
   }

--- a/src/sse/utils/logger.js
+++ b/src/sse/utils/logger.js
@@ -7,7 +7,7 @@ const LOG_LEVELS = {
   ERROR: 3
 };
 
-const LEVEL = LOG_LEVELS.DEBUG;
+const LEVEL = LOG_LEVELS[process.env.LOG_LEVEL?.toUpperCase?.()] ?? LOG_LEVELS.INFO;
 
 function formatTime() {
   return new Date().toLocaleTimeString("en-US", { hour12: false });
@@ -72,4 +72,3 @@ export function maskKey(key) {
   if (!key || key.length < 8) return "***";
   return `${key.slice(0, 4)}...${key.slice(-4)}`;
 }
-

--- a/tests/translator/bugs-toClaude-context.test.js
+++ b/tests/translator/bugs-toClaude-context.test.js
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import "./registerAll.js";
 import { translateRequest } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
+import { prepareClaudeRequest } from "../../open-sse/translator/formats/claude.js";
 
 // anthropic-compatible provider so prepareClaudeRequest runs the openai→claude path
 const T = (body) =>
@@ -16,9 +17,7 @@ describe("OpenAI → Claude context mapping", () => {
     expect(JSON.stringify(out.system), "Claude Code prompt injected").not.toContain("Claude Code");
   });
 
-  // openai-to-claude.js:268-273 — assistant.reasoning_content not mapped to a thinking block
-  // KNOWN BUG
-  it.fails("assistant reasoning_content becomes a thinking block", () => {
+  it("assistant reasoning_content becomes a thinking block", () => {
     const out = T({
       messages: [
         { role: "user", content: "q" },
@@ -27,6 +26,11 @@ describe("OpenAI → Claude context mapping", () => {
       ],
     });
     expect(JSON.stringify(out), "reasoning_content lost").toContain("my hidden reasoning");
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.content[0]).toEqual(expect.objectContaining({
+      type: "thinking",
+      thinking: "my hidden reasoning",
+    }));
   });
 
   // openai-to-claude.js:298 — tool_choice "none" mapped to {type:"auto"} (loses "do not call" intent)
@@ -61,5 +65,23 @@ describe("OpenAI → Claude context mapping", () => {
       ] }],
     });
     expect(JSON.stringify(out), "remote image dropped").toContain("pic.png");
+  });
+
+  it("DeepSeek Claude transport adds a thinking placeholder before tool_use in thinking mode", () => {
+    const out = prepareClaudeRequest({
+      model: "deepseek-v4-pro",
+      thinking: { type: "enabled" },
+      messages: [
+        { role: "user", content: [{ type: "text", text: "q" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: "Read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "ok" }] },
+        { role: "user", content: [{ type: "text", text: "continue" }] },
+      ],
+    }, "deepseek");
+
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.content[0]).toEqual({ type: "thinking", thinking: "." });
+    expect(assistant.content[1]).toEqual(expect.objectContaining({ type: "tool_use", id: "toolu_1" }));
+    expect(assistant.content[0].signature).toBeUndefined();
   });
 });

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -68,6 +68,16 @@ describe("applyThinking per provider format", () => {
     const out = apply("gemini", "gemini-3-pro", { reasoning_effort: "medium" }, "gemini");
     expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("medium");
   });
+  it("gemini-3 clamps unsupported max/xhigh thinking levels to high", () => {
+    const outMax = apply("gemini", "gemini-3-pro", { reasoning_effort: "max" }, "gemini");
+    const outXhigh = apply("gemini", "gemini-3-pro", { reasoning_effort: "xhigh" }, "gemini");
+    expect(outMax.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
+    expect(outXhigh.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
+  });
+  it("gemini-3 maps auto thinking level to high instead of sending unsupported auto", () => {
+    const out = apply("gemini", "gemini-3-pro", { reasoning_effort: "auto" }, "gemini");
+    expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
+  });
   it("gemini-2.5 → thinkingBudget", () => {
     const out = apply("gemini", "gemini-2.5-flash", { reasoning_effort: "high" }, "gemini");
     expect(out.generationConfig.thinkingConfig.thinkingBudget).toBe(24576);

--- a/tests/unit/combo-autoswitch.test.js
+++ b/tests/unit/combo-autoswitch.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { detectRequiredCapabilities, reorderByCapabilities } from "../../open-sse/services/combo.js";
+import {
+  classifyTask,
+  detectRequiredCapabilities,
+  reorderByCapabilities,
+  reorderByTaskWeight,
+  scoreModelForTask,
+} from "../../open-sse/services/combo.js";
 
 describe("detectRequiredCapabilities", () => {
   it("text-only -> empty", () => {
@@ -48,6 +54,21 @@ describe("detectRequiredCapabilities", () => {
     ] }] });
     expect(r.has("vision")).toBe(true);
   });
+
+  it("explicit reasoning request -> reasoning", () => {
+    const r = detectRequiredCapabilities({
+      messages: [{ role: "user", content: "solve carefully" }],
+      reasoning_effort: "high",
+    });
+    expect(r.has("reasoning")).toBe(true);
+  });
+
+  it("large prompt -> reasoning", () => {
+    const r = detectRequiredCapabilities({
+      messages: [{ role: "user", content: "x".repeat(50000) }],
+    });
+    expect(r.has("reasoning")).toBe(true);
+  });
 });
 
 describe("reorderByCapabilities", () => {
@@ -74,5 +95,55 @@ describe("reorderByCapabilities", () => {
   it("single model -> unchanged", () => {
     const models = ["a/x"];
     expect(reorderByCapabilities(models, new Set(["vision"]))).toBe(models);
+  });
+
+  it("floats reasoning-capable model for heavy requests", () => {
+    const models = ["deepseek/deepseek-chat", "deepseek/deepseek-reasoner"];
+    const out = reorderByCapabilities(models, new Set(["reasoning"]));
+    expect(out[0]).toBe("deepseek/deepseek-reasoner");
+    expect(out).toContain("deepseek/deepseek-chat");
+  });
+});
+
+describe("smart task routing", () => {
+  it("classifies small simple requests as light", () => {
+    const task = classifyTask({ messages: [{ role: "user", content: "translate this short sentence" }], max_tokens: 256 });
+    expect(task.level).toBe("light");
+  });
+
+  it("classifies security-sensitive tool-heavy requests as critical", () => {
+    const task = classifyTask({
+      messages: [{ role: "user", content: `Find a critical bug bounty attack chain for RCE or supply chain impact.\n${"context ".repeat(2000)}` }],
+      tools: [{ name: "read" }, { name: "grep" }, { name: "web" }, { name: "bash" }],
+      reasoning_effort: "high",
+      max_tokens: 12000,
+    });
+    expect(task.level).toBe("critical");
+  });
+
+  it("routes light tasks to lighter models before expensive models", () => {
+    const models = ["anthropic/claude-opus-4.6", "anthropic/claude-haiku-4.5"];
+    const task = classifyTask({ messages: [{ role: "user", content: "quick rewrite this sentence" }], max_tokens: 300 });
+    const out = reorderByTaskWeight(models, task, new Set());
+    expect(out[0]).toBe("anthropic/claude-haiku-4.5");
+  });
+
+  it("routes critical tasks to stronger models before lighter models", () => {
+    const models = ["anthropic/claude-haiku-4.5", "anthropic/claude-opus-4.6"];
+    const task = classifyTask({
+      messages: [{ role: "user", content: `Security review for account takeover and cross-tenant RCE impact.\n${"code ".repeat(3000)}` }],
+      tools: [{ name: "read" }, { name: "grep" }, { name: "bash" }, { name: "web" }],
+      reasoning_effort: "high",
+    });
+    const out = reorderByTaskWeight(models, task, new Set(["reasoning"]));
+    expect(out[0]).toBe("anthropic/claude-opus-4.6");
+    expect(scoreModelForTask(out[0], task, new Set(["reasoning"]))).toBeGreaterThan(scoreModelForTask(out[1], task, new Set(["reasoning"])));
+  });
+
+  it("keeps hard capability requirements ahead of light-task cost preference", () => {
+    const models = ["deepseek/deepseek-chat", "anthropic/claude-haiku-4.5"];
+    const task = classifyTask({ messages: [{ role: "user", content: "what is in this image?" }] });
+    const out = reorderByTaskWeight(models, task, new Set(["vision"]));
+    expect(out[0]).toBe("anthropic/claude-haiku-4.5");
   });
 });


### PR DESCRIPTION
## Summary

This draft PR groups several local fixes that improve provider compatibility, routing behavior, and dashboard/runtime responsiveness:

- handle Claude/DeepSeek thinking/tool-use edge cases more defensively
- normalize Gemini/Antigravity thinking levels for provider compatibility
- improve provider connection probing for Cloud Code Assist based providers
- batch console log SSE updates and reduce debug log pressure
- make streaming/non-streaming success bookkeeping non-blocking
- add combo smart routing by task weight while preserving hard capability requirements
- deduplicate usage writes so stats are not double-counted when multiple streaming paths report the same usage

## Local verification

- `node --check` on edited source/runtime files passed locally
- direct Node assertions for combo smart routing passed locally
- local 9Router runtime was patched and smoke-tested via `/api/health` and a real `/v1/chat/completions` request
- local usage database was backed up, deduplicated, and dashboard stats dropped to expected values

## Known caveats

- `npm run build` currently hangs locally after `next build --webpack`, so this is opened as a draft for review rather than ready-to-merge
- Vitest runner also hung in this local environment; combo routing logic was verified with direct Node assertions instead
- This PR may be easier to review if split into smaller PRs: provider thinking fixes, usage/logging fixes, and smart routing
