### PR TITLE
Add task-aware combo routing

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -181,9 +181,12 @@ export function detectRequiredCapabilities(body) {
 
   const effort = body.reasoning_effort || body.reasoning?.effort;
   if (effort && String(effort).toLowerCase() !== "none") required.add("reasoning");
-  if (isHeavyRequest(body)) required.add("reasoning");
 
   return required;
+}
+
+function isTaskRoutingStrategy(strategy) {
+  return ["smart", "task", "task-aware", "task_aware", "auto"].includes(String(strategy || "").toLowerCase());
 }
 
 function normalizeStickyLimit(stickyLimit) {
@@ -553,7 +556,9 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1, c
   const state = getRotationState(rotationKey);
 
   const currentIndex = state.index % models.length;
-  if (conversationCacheKey) {
+  // stickyLimit=1 means pure per-request round robin. Conversation affinity is
+  // only active when sticky rotation is explicitly configured above 1.
+  if (normalizedStickyLimit > 1 && conversationCacheKey) {
     const now = Date.now();
     pruneConversationAffinity(now);
 
@@ -629,7 +634,8 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
   const conversationCacheKey = getConversationCacheKey(body);
   let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit, conversationCacheKey);
 
-  // Auto-switch: first satisfy hard request capabilities, then route by task weight.
+  // Auto-switch satisfies request capabilities only. It must not override the
+  // explicit Fallback/Round Robin order for plain text requests.
   if (autoSwitch) {
     const required = detectRequiredCapabilities(body);
     if (required.size > 0) {
@@ -640,13 +646,15 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       rotatedModels = reordered;
     }
 
-    const task = classifyTask(body);
-    const taskReordered = reorderByTaskWeight(rotatedModels, task, required);
-    if (taskReordered[0] !== rotatedModels[0]) {
-      const reasons = Array.isArray(task.reasons) && task.reasons.length ? ` (${task.reasons.join(",")})` : "";
-      log.info("COMBO", `smart-route task=${task.level}${reasons} → ${taskReordered[0]}`);
+    if (isTaskRoutingStrategy(comboStrategy)) {
+      const task = classifyTask(body);
+      const taskReordered = reorderByTaskWeight(rotatedModels, task, required);
+      if (taskReordered[0] !== rotatedModels[0]) {
+        const reasons = Array.isArray(task.reasons) && task.reasons.length ? ` (${task.reasons.join(",")})` : "";
+        log.info("COMBO", `smart-route task=${task.level}${reasons} → ${taskReordered[0]}`);
+      }
+      rotatedModels = taskReordered;
     }
-    rotatedModels = taskReordered;
   }
   
   let lastError = null;

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -2,6 +2,7 @@
  * Shared combo (model combo) handling with fallback support
  */
 
+import { createHash } from "node:crypto";
 import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
@@ -75,10 +76,47 @@ export function reorderByCapabilities(models, required) {
   };
 
   // Stable sort by tier (Array.prototype.sort is stable in modern engines).
-  return models
+  const reordered = models
     .map((m, i) => ({ m, i, t: tierOf(m) }))
     .sort((a, b) => a.t - b.t || a.i - b.i)
     .map((x) => x.m);
+
+  return reordered.every((m, i) => m === models[i]) ? models : reordered;
+}
+
+const TASK_LEVEL_WEIGHT = {
+  light: 1,
+  standard: 2,
+  heavy: 3,
+  critical: 4,
+};
+
+const TASK_TARGET_POWER = {
+  light: 35,
+  standard: 65,
+  heavy: 95,
+  critical: 120,
+};
+
+const LIGHT_TASK_RE = /\b(hi|hello|thanks|thank you|ping|format|rewrite|grammar|translate|summari[sz]e|short|quick|one[- ]?liner|explain briefly)\b/i;
+const HEAVY_TASK_RE = /\b(debug|root cause|architecture|architectural|refactor|migrate|implementation|implement|design|analy[sz]e|investigate|compare|benchmark|whitebox|codebase|end[- ]?to[- ]?end|e2e)\b/i;
+const CRITICAL_TASK_RE = /\b(critical|security|vulnerability|exploit|rce|remote code execution|supply chain|account takeover|auth bypass|privilege escalation|tenant|cross[- ]tenant|sandbox escape|ssrf|deserialization|prod incident|data exfiltration|bug bounty)\b/i;
+
+function splitModelString(modelStr) {
+  const slash = typeof modelStr === "string" ? modelStr.indexOf("/") : -1;
+  return {
+    provider: slash > 0 ? modelStr.slice(0, slash) : "",
+    model: slash > 0 ? modelStr.slice(slash + 1) : String(modelStr || ""),
+  };
+}
+
+function getModelCapabilities(modelStr) {
+  const { provider, model } = splitModelString(modelStr);
+  return getCapabilitiesForModel(provider, model);
+}
+
+function taskWeight(level) {
+  return TASK_LEVEL_WEIGHT[level] || TASK_LEVEL_WEIGHT.standard;
 }
 
 /**
@@ -86,6 +124,15 @@ export function reorderByCapabilities(models, required) {
  * @type {Map<string, { index: number, consecutiveUseCount: number }>}
  */
 const comboRotationState = new Map();
+
+/**
+ * Keep chat-like traffic on the same first model so provider-side prompt caches
+ * keep hitting. New conversations still use round-robin for distribution.
+ * @type {Map<string, { index: number, lastUsed: number }>}
+ */
+const comboConversationAffinity = new Map();
+const CONVERSATION_AFFINITY_TTL_MS = 60 * 60 * 1000;
+const MAX_CONVERSATION_AFFINITY_ENTRIES = 1000;
 
 // Trailing run of items after the last assistant/model turn = the current user
 // turn. It may span several messages (e.g. text + image split across blocks),
@@ -127,7 +174,14 @@ export function detectRequiredCapabilities(body) {
   const contents = body.contents || body.request?.contents;                      // gemini / antigravity
   for (const c of trailingUserItems(contents)) scanContent(c.parts);
 
-  // search: temporarily disabled in auto-switch (feature not wired yet).
+  for (const tool of body.tools || []) {
+    const type = tool?.type || tool?.function?.name || tool?.name;
+    if (typeof type === "string" && /^web_search/.test(type)) required.add("search");
+  }
+
+  const effort = body.reasoning_effort || body.reasoning?.effort;
+  if (effort && String(effort).toLowerCase() !== "none") required.add("reasoning");
+  if (isHeavyRequest(body)) required.add("reasoning");
 
   return required;
 }
@@ -146,33 +200,19 @@ function rotateModelsFromIndex(models, currentIndex) {
   return rotatedModels;
 }
 
-/**
- * Get rotated model list based on strategy
- * @param {string[]} models - Array of model strings
- * @param {string} comboName - Name of the combo
- * @param {string} strategy - "fallback" or "round-robin"
- * @param {number|string} [stickyLimit=1] - Requests per combo model before switching
- * @returns {string[]} Rotated models array
- */
-export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
-  if (!models || models.length <= 1 || strategy !== "round-robin") {
-    return models;
-  }
-
-  const rotationKey = comboName || "__default__";
-  const normalizedStickyLimit = normalizeStickyLimit(stickyLimit);
+function getRotationState(rotationKey) {
   const existingState = comboRotationState.get(rotationKey);
-  const state = typeof existingState === "number"
+  return typeof existingState === "number"
     ? { index: existingState, consecutiveUseCount: 0 }
     : (existingState || { index: 0, consecutiveUseCount: 0 });
+}
 
-  const currentIndex = state.index % models.length;
-  const rotatedModels = rotateModelsFromIndex(models, currentIndex);
-  const nextUseCount = state.consecutiveUseCount + 1;
+function advanceRotationState(rotationKey, currentIndex, modelCount, normalizedStickyLimit, consecutiveUseCount) {
+  const nextUseCount = consecutiveUseCount + 1;
 
   if (nextUseCount >= normalizedStickyLimit) {
     comboRotationState.set(rotationKey, {
-      index: (currentIndex + 1) % models.length,
+      index: (currentIndex + 1) % modelCount,
       consecutiveUseCount: 0,
     });
   } else {
@@ -181,6 +221,356 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
       consecutiveUseCount: nextUseCount,
     });
   }
+}
+
+function pruneConversationAffinity(now = Date.now()) {
+  for (const [key, value] of comboConversationAffinity) {
+    if (!value || now - value.lastUsed > CONVERSATION_AFFINITY_TTL_MS) {
+      comboConversationAffinity.delete(key);
+    }
+  }
+
+  while (comboConversationAffinity.size > MAX_CONVERSATION_AFFINITY_ENTRIES) {
+    const oldestKey = comboConversationAffinity.keys().next().value;
+    comboConversationAffinity.delete(oldestKey);
+  }
+}
+
+function normalizeFingerprintText(value) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 12000);
+}
+
+function collectText(value, out = []) {
+  if (value == null) return out;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    out.push(String(value));
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectText(item, out);
+    return out;
+  }
+  if (typeof value !== "object") return out;
+
+  if (typeof value.text === "string") out.push(value.text);
+  if (typeof value.input_text === "string") out.push(value.input_text);
+  if (typeof value.output_text === "string") out.push(value.output_text);
+  if (typeof value.content === "string") out.push(value.content);
+  else if (Array.isArray(value.content)) collectText(value.content, out);
+  if (Array.isArray(value.parts)) collectText(value.parts, out);
+  if (typeof value.query === "string") out.push(value.query);
+  if (typeof value.url === "string") out.push(value.url);
+
+  return out;
+}
+
+function estimatePromptChars(body) {
+  const contents = body.contents || body.request?.contents;
+  const parts = [
+    body.system,
+    body.instructions,
+    body.messages,
+    body.input,
+    contents,
+    body.query,
+    body.url,
+  ];
+  return collectText(parts).join("\n").length;
+}
+
+function countMessages(body) {
+  return (Array.isArray(body.messages) ? body.messages.length : 0) +
+    (Array.isArray(body.input) ? body.input.length : 0) +
+    (Array.isArray(body.contents) ? body.contents.length : 0) +
+    (Array.isArray(body.request?.contents) ? body.request.contents.length : 0);
+}
+
+function maxRequestedOutput(body) {
+  const candidates = [
+    body.max_tokens,
+    body.max_output_tokens,
+    body.max_completion_tokens,
+    body.generationConfig?.maxOutputTokens,
+  ].map((v) => Number.parseInt(v, 10)).filter((v) => Number.isFinite(v));
+  return candidates.length > 0 ? Math.max(...candidates) : 0;
+}
+
+function getTaskText(body) {
+  const contents = body?.contents || body?.request?.contents;
+  return collectText([
+    body?.system,
+    body?.instructions,
+    body?.messages,
+    body?.input,
+    contents,
+    body?.query,
+    body?.url,
+  ]).join("\n");
+}
+
+function normalizeEffort(body) {
+  return String(body?.reasoning_effort || body?.reasoning?.effort || "").toLowerCase();
+}
+
+function getTaskSignals(body) {
+  const promptChars = estimatePromptChars(body || {});
+  const messageCount = countMessages(body || {});
+  const toolCount = Array.isArray(body?.tools) ? body.tools.length : 0;
+  const outputTokens = maxRequestedOutput(body || {});
+  const effort = normalizeEffort(body);
+  const text = getTaskText(body || {});
+
+  return {
+    promptChars,
+    messageCount,
+    toolCount,
+    outputTokens,
+    effort,
+    hasExplicitReasoning: Boolean(effort && effort !== "none" && effort !== "off" && effort !== "disabled"),
+    lightKeyword: LIGHT_TASK_RE.test(text),
+    heavyKeyword: HEAVY_TASK_RE.test(text),
+    criticalKeyword: CRITICAL_TASK_RE.test(text),
+  };
+}
+
+/**
+ * Classify request difficulty for smart combo routing.
+ *
+ * This deliberately uses cheap, local signals only. It is not a semantic judge;
+ * it is a routing hint so light requests stay on fast/cheap models while large,
+ * tool-heavy, security-sensitive, or reasoning-heavy requests try stronger
+ * models first. Fallback still tries every model.
+ */
+export function classifyTask(body) {
+  const s = getTaskSignals(body || {});
+  const reasons = [];
+  const add = (condition, reason) => {
+    if (condition) reasons.push(reason);
+    return condition;
+  };
+
+  const effortIsHigh = /^(high|xhigh|max|maximum|hard|deep)$/.test(s.effort);
+  const effortIsLight = !s.hasExplicitReasoning || /^(low|minimal|none|off|disabled)$/.test(s.effort);
+
+  const critical =
+    add(s.promptChars >= 100000, "huge-context") ||
+    add(s.outputTokens >= 32768, "huge-output") ||
+    add(s.toolCount >= 8 && s.promptChars >= 16000, "many-tools-large-context") ||
+    add(s.criticalKeyword && (effortIsHigh || s.toolCount >= 3 || s.promptChars >= 8000), "critical-domain");
+
+  if (critical) {
+    return { level: "critical", weight: taskWeight("critical"), ...s, reasons };
+  }
+
+  const heavySignalCount = [
+    add(s.promptChars >= 50000, "large-context"),
+    add(s.promptChars >= 24000, "medium-large-context"),
+    add(s.messageCount >= 16, "long-conversation"),
+    add(s.toolCount >= 4, "many-tools"),
+    add(s.outputTokens >= 8192, "large-output"),
+    add(effortIsHigh, "high-reasoning-effort"),
+    add(s.criticalKeyword, "security-sensitive"),
+    add(s.heavyKeyword && s.promptChars >= 4000, "complex-task"),
+  ].filter(Boolean).length;
+
+  if (heavySignalCount >= 2 || s.promptChars >= 50000 || effortIsHigh) {
+    return { level: "heavy", weight: taskWeight("heavy"), ...s, reasons };
+  }
+
+  const light =
+    s.promptChars <= 2000 &&
+    s.messageCount <= 3 &&
+    s.toolCount === 0 &&
+    s.outputTokens <= 1500 &&
+    effortIsLight &&
+    !s.criticalKeyword &&
+    !s.heavyKeyword;
+
+  if (light || (s.lightKeyword && s.promptChars <= 4000 && s.toolCount === 0 && effortIsLight && !s.criticalKeyword)) {
+    return { level: "light", weight: taskWeight("light"), ...s, reasons: reasons.length ? reasons : ["small-simple-request"] };
+  }
+
+  return { level: "standard", weight: taskWeight("standard"), ...s, reasons: reasons.length ? reasons : ["default"] };
+}
+
+function modelPowerScore(modelStr) {
+  const { model } = splitModelString(modelStr);
+  const id = `${modelStr || ""} ${model || ""}`.toLowerCase();
+  const caps = getModelCapabilities(modelStr);
+
+  let score = 35;
+  if (caps.reasoning) score += 18;
+  if (caps.search) score += 4;
+  if (caps.tools) score += 3;
+  if (caps.vision) score += 3;
+
+  if (caps.contextWindow >= 1000000) score += 22;
+  else if (caps.contextWindow >= 400000) score += 15;
+  else if (caps.contextWindow >= 200000) score += 9;
+  else if (caps.contextWindow <= 32000) score -= 10;
+
+  if (caps.maxOutput >= 128000) score += 12;
+  else if (caps.maxOutput >= 64000) score += 8;
+  else if (caps.maxOutput <= 8192) score -= 8;
+
+  if (/\b(opus|mythos|gpt-5|o3|o4|pro|max|ultra|deepseek-v4-pro|sonnet-4|glm-5|kimi-k2\.7|minimax-m3|reasoner)\b/i.test(id)) score += 28;
+  if (/\b(coder|code|coding)\b/i.test(id)) score += 8;
+  if (/\b(haiku|flash|mini|lite|small|nano|instant|fast|turbo|3\.5|8b|7b)\b/i.test(id)) score -= 24;
+
+  return Math.max(0, Math.min(150, score));
+}
+
+export function scoreModelForTask(modelStr, task = classifyTask({}), required = new Set()) {
+  const caps = getModelCapabilities(modelStr);
+  const target = TASK_TARGET_POWER[task.level] || TASK_TARGET_POWER.standard;
+  const power = modelPowerScore(modelStr);
+  let score = 100 - Math.abs(power - target);
+
+  const hard = [...(required || [])].filter((c) => HARD_CAPS.has(c));
+  if (!hard.every((c) => caps[c] === true)) score -= 10000;
+
+  if ((required?.has?.("reasoning") || task.weight >= TASK_LEVEL_WEIGHT.heavy) && !caps.reasoning) score -= 120;
+  if (required?.has?.("search") && !caps.search) score -= 30;
+
+  const estimatedPromptTokens = Math.ceil((task.promptChars || 0) / 4);
+  if (caps.contextWindow && estimatedPromptTokens > caps.contextWindow * 0.85) score -= 200;
+  if (caps.maxOutput && task.outputTokens && task.outputTokens > caps.maxOutput) score -= 80;
+
+  if (task.level === "light" && power > 95) score -= 35;
+  if (task.level === "standard" && power > 125) score -= 10;
+  if (task.level === "heavy" && power < 65) score -= 60;
+  if (task.level === "critical" && power < 85) score -= 100;
+
+  return score;
+}
+
+export function reorderByTaskWeight(models, task = classifyTask({}), required = new Set()) {
+  if (!Array.isArray(models) || models.length <= 1) return models;
+
+  const reordered = models
+    .map((m, i) => ({ m, i, score: scoreModelForTask(m, task, required) }))
+    .sort((a, b) => b.score - a.score || a.i - b.i)
+    .map((x) => x.m);
+
+  return reordered.every((m, i) => m === models[i]) ? models : reordered;
+}
+
+function isHeavyRequest(body) {
+  return classifyTask(body).weight >= TASK_LEVEL_WEIGHT.heavy;
+}
+
+function firstRoleText(items, roles, contentKey = "content") {
+  if (!Array.isArray(items)) return "";
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    if (!roles.has(item.role)) continue;
+    const content = contentKey === "parts" ? item.parts : item.content;
+    const text = normalizeFingerprintText(collectText(content).join("\n"));
+    if (text) return text;
+  }
+  return "";
+}
+
+function allRoleText(items, roles, contentKey = "content") {
+  if (!Array.isArray(items)) return "";
+  return normalizeFingerprintText(items
+    .filter((item) => item && typeof item === "object" && roles.has(item.role))
+    .map((item) => collectText(contentKey === "parts" ? item.parts : item.content).join("\n"))
+    .filter(Boolean)
+    .join("\n"));
+}
+
+function hashConversationSeed(seed) {
+  const normalized = normalizeFingerprintText(seed);
+  if (!normalized) return null;
+  return createHash("sha1").update(normalized).digest("hex").slice(0, 24);
+}
+
+/**
+ * Derive a stable cache-affinity key from explicit thread metadata when present,
+ * otherwise from the immutable start of the prompt (system + first user turn).
+ * Appended turns should not move an existing conversation to another model.
+ */
+export function getConversationCacheKey(body) {
+  if (!body || typeof body !== "object") return null;
+
+  const explicitCandidates = [
+    body.conversation_id,
+    body.conversationId,
+    body.thread_id,
+    body.threadId,
+    body.session_id,
+    body.sessionId,
+    body.metadata?.conversation_id,
+    body.metadata?.conversationId,
+    body.metadata?.thread_id,
+    body.metadata?.threadId,
+    body.metadata?.session_id,
+    body.metadata?.sessionId,
+  ];
+  const explicit = explicitCandidates.find((v) => v != null && String(v).trim());
+  if (explicit != null) return hashConversationSeed(`explicit:${String(explicit).trim()}`);
+
+  const systemRoles = new Set(["system", "developer"]);
+  const userRoles = new Set(["user"]);
+  const contents = body.contents || body.request?.contents;
+
+  const seedParts = [
+    collectText(body.system).join("\n"),
+    collectText(body.instructions).join("\n"),
+    allRoleText(body.messages, systemRoles),
+    allRoleText(body.input, systemRoles),
+    allRoleText(contents, systemRoles, "parts"),
+    firstRoleText(body.messages, userRoles),
+    typeof body.input === "string" ? body.input : firstRoleText(body.input, userRoles),
+    firstRoleText(contents, userRoles, "parts"),
+    body.query,
+    body.url,
+  ].filter(Boolean);
+
+  return hashConversationSeed(seedParts.join("\n"));
+}
+
+/**
+ * Get rotated model list based on strategy
+ * @param {string[]} models - Array of model strings
+ * @param {string} comboName - Name of the combo
+ * @param {string} strategy - "fallback" or "round-robin"
+ * @param {number|string} [stickyLimit=1] - Requests per combo model before switching
+ * @param {string|null} [conversationCacheKey=null] - Stable key used to keep a conversation on one model
+ * @returns {string[]} Rotated models array
+ */
+export function getRotatedModels(models, comboName, strategy, stickyLimit = 1, conversationCacheKey = null) {
+  if (!models || models.length <= 1 || strategy !== "round-robin") {
+    return models;
+  }
+
+  const rotationKey = comboName || "__default__";
+  const normalizedStickyLimit = normalizeStickyLimit(stickyLimit);
+  const state = getRotationState(rotationKey);
+
+  const currentIndex = state.index % models.length;
+  if (conversationCacheKey) {
+    const now = Date.now();
+    pruneConversationAffinity(now);
+
+    const affinityKey = `${rotationKey}:${conversationCacheKey}`;
+    const affinity = comboConversationAffinity.get(affinityKey);
+    if (affinity) {
+      const pinnedIndex = affinity.index % models.length;
+      comboConversationAffinity.delete(affinityKey);
+      comboConversationAffinity.set(affinityKey, { index: pinnedIndex, lastUsed: now });
+      return rotateModelsFromIndex(models, pinnedIndex);
+    }
+
+    comboConversationAffinity.set(affinityKey, { index: currentIndex, lastUsed: now });
+  }
+
+  const rotatedModels = rotateModelsFromIndex(models, currentIndex);
+  advanceRotationState(rotationKey, currentIndex, models.length, normalizedStickyLimit, state.consecutiveUseCount);
 
   return rotatedModels;
 }
@@ -190,8 +580,16 @@ export function getRotatedModels(models, comboName, strategy, stickyLimit = 1) {
  * @param {string} [comboName] - Combo name to reset; omit to clear all
  */
 export function resetComboRotation(comboName) {
-  if (comboName) comboRotationState.delete(comboName);
-  else comboRotationState.clear();
+  if (comboName) {
+    comboRotationState.delete(comboName);
+    const prefix = `${comboName}:`;
+    for (const key of comboConversationAffinity.keys()) {
+      if (key.startsWith(prefix)) comboConversationAffinity.delete(key);
+    }
+  } else {
+    comboRotationState.clear();
+    comboConversationAffinity.clear();
+  }
 }
 
 /**
@@ -228,9 +626,10 @@ export function getComboModelsFromData(modelStr, combosData) {
  */
 export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true }) {
   // Apply rotation strategy if enabled
-  let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
+  const conversationCacheKey = getConversationCacheKey(body);
+  let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit, conversationCacheKey);
 
-  // Auto-switch: float models that satisfy the request's required capabilities to the front.
+  // Auto-switch: first satisfy hard request capabilities, then route by task weight.
   if (autoSwitch) {
     const required = detectRequiredCapabilities(body);
     if (required.size > 0) {
@@ -240,6 +639,14 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       }
       rotatedModels = reordered;
     }
+
+    const task = classifyTask(body);
+    const taskReordered = reorderByTaskWeight(rotatedModels, task, required);
+    if (taskReordered[0] !== rotatedModels[0]) {
+      const reasons = Array.isArray(task.reasons) && task.reasons.length ? ` (${task.reasons.join(",")})` : "";
+      log.info("COMBO", `smart-route task=${task.level}${reasons} → ${taskReordered[0]}`);
+    }
+    rotatedModels = taskReordered;
   }
   
   let lastError = null;

--- a/tests/unit/combo-autoswitch.test.js
+++ b/tests/unit/combo-autoswitch.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { detectRequiredCapabilities, reorderByCapabilities } from "../../open-sse/services/combo.js";
+import {
+  classifyTask,
+  detectRequiredCapabilities,
+  reorderByCapabilities,
+  reorderByTaskWeight,
+  scoreModelForTask,
+} from "../../open-sse/services/combo.js";
 
 describe("detectRequiredCapabilities", () => {
   it("text-only -> empty", () => {
@@ -48,6 +54,21 @@ describe("detectRequiredCapabilities", () => {
     ] }] });
     expect(r.has("vision")).toBe(true);
   });
+
+  it("explicit reasoning request -> reasoning", () => {
+    const r = detectRequiredCapabilities({
+      messages: [{ role: "user", content: "solve carefully" }],
+      reasoning_effort: "high",
+    });
+    expect(r.has("reasoning")).toBe(true);
+  });
+
+  it("large prompt -> reasoning", () => {
+    const r = detectRequiredCapabilities({
+      messages: [{ role: "user", content: "x".repeat(50000) }],
+    });
+    expect(r.has("reasoning")).toBe(true);
+  });
 });
 
 describe("reorderByCapabilities", () => {
@@ -74,5 +95,55 @@ describe("reorderByCapabilities", () => {
   it("single model -> unchanged", () => {
     const models = ["a/x"];
     expect(reorderByCapabilities(models, new Set(["vision"]))).toBe(models);
+  });
+
+  it("floats reasoning-capable model for heavy requests", () => {
+    const models = ["deepseek/deepseek-chat", "deepseek/deepseek-reasoner"];
+    const out = reorderByCapabilities(models, new Set(["reasoning"]));
+    expect(out[0]).toBe("deepseek/deepseek-reasoner");
+    expect(out).toContain("deepseek/deepseek-chat");
+  });
+});
+
+describe("smart task routing", () => {
+  it("classifies small simple requests as light", () => {
+    const task = classifyTask({ messages: [{ role: "user", content: "translate this short sentence" }], max_tokens: 256 });
+    expect(task.level).toBe("light");
+  });
+
+  it("classifies security-sensitive tool-heavy requests as critical", () => {
+    const task = classifyTask({
+      messages: [{ role: "user", content: `Find a critical bug bounty attack chain for RCE or supply chain impact.\n${"context ".repeat(2000)}` }],
+      tools: [{ name: "read" }, { name: "grep" }, { name: "web" }, { name: "bash" }],
+      reasoning_effort: "high",
+      max_tokens: 12000,
+    });
+    expect(task.level).toBe("critical");
+  });
+
+  it("routes light tasks to lighter models before expensive models", () => {
+    const models = ["anthropic/claude-opus-4.6", "anthropic/claude-haiku-4.5"];
+    const task = classifyTask({ messages: [{ role: "user", content: "quick rewrite this sentence" }], max_tokens: 300 });
+    const out = reorderByTaskWeight(models, task, new Set());
+    expect(out[0]).toBe("anthropic/claude-haiku-4.5");
+  });
+
+  it("routes critical tasks to stronger models before lighter models", () => {
+    const models = ["anthropic/claude-haiku-4.5", "anthropic/claude-opus-4.6"];
+    const task = classifyTask({
+      messages: [{ role: "user", content: `Security review for account takeover and cross-tenant RCE impact.\n${"code ".repeat(3000)}` }],
+      tools: [{ name: "read" }, { name: "grep" }, { name: "bash" }, { name: "web" }],
+      reasoning_effort: "high",
+    });
+    const out = reorderByTaskWeight(models, task, new Set(["reasoning"]));
+    expect(out[0]).toBe("anthropic/claude-opus-4.6");
+    expect(scoreModelForTask(out[0], task, new Set(["reasoning"]))).toBeGreaterThan(scoreModelForTask(out[1], task, new Set(["reasoning"])));
+  });
+
+  it("keeps hard capability requirements ahead of light-task cost preference", () => {
+    const models = ["deepseek/deepseek-chat", "anthropic/claude-haiku-4.5"];
+    const task = classifyTask({ messages: [{ role: "user", content: "what is in this image?" }] });
+    const out = reorderByTaskWeight(models, task, new Set(["vision"]));
+    expect(out[0]).toBe("anthropic/claude-haiku-4.5");
   });
 });

--- a/tests/unit/combo-autoswitch.test.js
+++ b/tests/unit/combo-autoswitch.test.js
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   classifyTask,
   detectRequiredCapabilities,
+  getRotatedModels,
   reorderByCapabilities,
   reorderByTaskWeight,
+  resetComboRotation,
   scoreModelForTask,
 } from "../../open-sse/services/combo.js";
 
@@ -63,11 +65,12 @@ describe("detectRequiredCapabilities", () => {
     expect(r.has("reasoning")).toBe(true);
   });
 
-  it("large prompt -> reasoning", () => {
+  it("large prompt alone is not a capability auto-switch signal", () => {
     const r = detectRequiredCapabilities({
       messages: [{ role: "user", content: "x".repeat(50000) }],
     });
-    expect(r.has("reasoning")).toBe(true);
+    expect(r.has("reasoning")).toBe(false);
+    expect(classifyTask({ messages: [{ role: "user", content: "x".repeat(50000) }] }).level).toBe("heavy");
   });
 });
 
@@ -145,5 +148,26 @@ describe("smart task routing", () => {
     const task = classifyTask({ messages: [{ role: "user", content: "what is in this image?" }] });
     const out = reorderByTaskWeight(models, task, new Set(["vision"]));
     expect(out[0]).toBe("anthropic/claude-haiku-4.5");
+  });
+});
+
+describe("round robin strategy", () => {
+  it("rotates every request when sticky limit is 1, even for the same conversation", () => {
+    const comboName = `rr-${Date.now()}-pure`;
+    const models = ["provider/a", "provider/b", "provider/c"];
+    resetComboRotation(comboName);
+
+    expect(getRotatedModels(models, comboName, "round-robin", 1, "same-conversation")[0]).toBe("provider/a");
+    expect(getRotatedModels(models, comboName, "round-robin", 1, "same-conversation")[0]).toBe("provider/b");
+    expect(getRotatedModels(models, comboName, "round-robin", 1, "same-conversation")[0]).toBe("provider/c");
+  });
+
+  it("uses conversation affinity only when sticky limit is above 1", () => {
+    const comboName = `rr-${Date.now()}-sticky`;
+    const models = ["provider/a", "provider/b", "provider/c"];
+    resetComboRotation(comboName);
+
+    expect(getRotatedModels(models, comboName, "round-robin", 2, "same-conversation")[0]).toBe("provider/a");
+    expect(getRotatedModels(models, comboName, "round-robin", 2, "same-conversation")[0]).toBe("provider/a");
   });
 });


### PR DESCRIPTION
## Summary

- classify incoming combo requests as light, standard, heavy, or critical based on prompt size, tools, output budget, reasoning hints, and task keywords
- score/reorder combo candidates by task weight while preserving hard capability requirements such as vision/PDF/audio/video
- keep fallback behavior intact but prefer lighter models for simple tasks and stronger reasoning models for critical/heavy tasks
- add focused unit coverage for classification, task-aware reordering, and hard capability preservation

## Verification

- `node --check` passed locally for `open-sse/services/combo.js` and the updated unit test
- direct Node assertions for the smart routing helpers passed locally
- local Vitest runner hung in my environment, so this remains a draft for maintainer CI/review

This is split out from the larger draft PR #2042 to make review easier.
