### PR TITLE
fix(stream): prevent non-JSON SSE lines and duplicate [DONE] from breaking clients

### DIFF
--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -46,6 +46,14 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete }) {
   if (onRequestSuccess) onRequestSuccess();
 
+  // Warn when upstream returns unexpected Content-Type for a streaming response.
+  // This often means the provider returned an HTML error page or plain-text error
+  // that the SSE transform stream would forward as garbage to the client.
+  const upstreamContentType = (providerResponse.headers.get('content-type') || '').toLowerCase();
+  if (upstreamContentType && !upstreamContentType.includes('text/event-stream') && !upstreamContentType.includes('application/json')) {
+    console.warn('[STREAM] ' + provider + ' | ' + model + ' | unexpected Content-Type: ' + upstreamContentType);
+  }
+
   const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey });
 
   // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -71,6 +71,7 @@ export function createSSEStream(options = {}) {
   let currentOpenAIResponsesEvent = null;
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
+  let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -166,7 +167,12 @@ export function createSSEStream(options = {}) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               }
-            } catch { }
+            } catch {
+              // Skip non-JSON data lines silently — don't forward garbage to clients.
+              // Upstream providers sometimes return plain-text errors (HTML, rate-limit
+              // messages) in the SSE stream that would break downstream JSON decoders.
+              continue;
+            }
           }
 
           if (!injectedUsage) {
@@ -211,9 +217,10 @@ export function createSSEStream(options = {}) {
             sseEmittedCount++;
           }
 
-          const output = "data: [DONE]\n\n";
-          reqLogger?.appendConvertedChunk?.(output);
-          controller.enqueue(sharedEncoder.encode(output));
+          // [DONE] not emitted in translate mode — some clients' SSE decoders
+          // fail to parse the OpenAI sentinel on Claude-format translated streams.
+          // message_stop already signals end-of-response; stream close handles it.
+          streamDoneSent = true;
           if (keepsOpenAIResponsesFormat) openAIResponsesDoneSent = true;
           continue;
         }
@@ -343,9 +350,11 @@ export function createSSEStream(options = {}) {
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
           //   data: [DONE]\n\n
           // Without it they can hang until timeout and trigger failover.
-          const doneOutput = "data: [DONE]\n\n";
-          reqLogger?.appendConvertedChunk?.(doneOutput);
-          controller.enqueue(sharedEncoder.encode(doneOutput));
+          if (!streamDoneSent) {
+            const doneOutput = "data: [DONE]\n\n";
+            reqLogger?.appendConvertedChunk?.(doneOutput);
+            controller.enqueue(sharedEncoder.encode(doneOutput));
+          }
 
           if (onStreamComplete) {
             onStreamComplete({
@@ -406,11 +415,8 @@ export function createSSEStream(options = {}) {
           openAIResponsesTerminalSeen = true;
         }
 
-        if (!keepsOpenAIResponsesFormat || !openAIResponsesDoneSent) {
-          const doneOutput = "data: [DONE]\n\n";
-          reqLogger?.appendConvertedChunk?.(doneOutput);
-          controller.enqueue(sharedEncoder.encode(doneOutput));
-        }
+        // [DONE] not emitted in translate mode — see comment above.
+        // Passthrough mode still emits it for standard OpenAI clients.
 
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);


### PR DESCRIPTION
## Problem

When using 9router as a translate-mode proxy (Claude-format client → OpenAI-format upstream), clients intermittently receive errors like:

```
oc: decode stream: invalid character 'D' looking for beginning of value
```

This has two root causes:

### 1. Non-JSON data lines forwarded in passthrough mode
In `stream.js` passthrough mode, when `JSON.parse()` fails on a `data:` line, the empty `catch {}` block silently swallows the error — but the fallback code at line 172-178 then **forwards the raw non-JSON line to the client**. Upstream providers sometimes return plain-text errors or HTML error pages embedded in the SSE stream, which break downstream JSON decoders.

### 2. `data: [DONE]` sentinel in translate mode
In translate mode, 9router emits the OpenAI-style `data: [DONE]` sentinel after `message_stop`. Some clients (e.g. Reasonix, which uses a Go JSON decoder) attempt to parse `[DONE]` as JSON, causing: `invalid character 'D' looking for beginning of value`. The `message_stop` event already signals end-of-response; the `[DONE]` sentinel is redundant in Claude-format output.

## Fix

**`open-sse/utils/stream.js`:**
1. **Passthrough mode**: Changed `catch {}` to `catch { continue; }` — non-JSON `data:` lines are now skipped silently instead of being forwarded raw to the client.
2. **Translate mode**: Removed `data: [DONE]` emission from both the transform loop and flush. The `message_stop` event already terminates the response.
3. **Passthrough mode**: Added `streamDoneSent` flag to prevent duplicate `[DONE]` emission (transform + flush were both sending it).

**`open-sse/handlers/chatCore/streamingHandler.js`:**
4. Added diagnostic `console.warn` when upstream returns an unexpected Content-Type (e.g. `text/html` instead of `text/event-stream`) for a streaming response — helps diagnose upstream errors.

## Testing

Tested with **CodeBuddy CN** (`cbcn/glm-5.2`) via 9router translate mode (Claude format client → OpenAI format upstream).

- **Before**: Intermittent `decode stream: invalid character 'D'` errors on every tool-call response
- **After**: Stable, no errors across 50+ requests including tool calls

## Related Issues

- #1996 (Combo fallback not triggering on stream errors — same class of problem: upstream errors embedded in SSE stream)
- #1396 (SSE-tainted JSON body — `data: [DONE]` appended to non-streaming responses)
- #1930 (upstream returning `<!doctype` HTML instead of JSON)
