### PR TITLE
fix: surface malformed upstream responses

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -5,9 +5,41 @@ import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTrackin
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
+import { reportMalformed200 } from "../../utils/diagnostics.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+
+// Decide whether a translated non-streaming body is empty/malformed for the client.
+// Returns a reason string ("empty_choices" | "no_terminal") or null when valid.
+// Reasoning-only responses (content="" + reasoning_content) are intentionally allowed.
+function detectMalformedNonStream(resp) {
+  if (!resp || typeof resp !== "object") return "empty_choices";
+  // Responses API shape
+  if (resp.object === "response") {
+    const hasOutput = Array.isArray(resp.output) && resp.output.some((it) => {
+      if (it?.type === "message") {
+        return Array.isArray(it.content) && it.content.some((c) => typeof c?.text === "string" && c.text.length > 0);
+      }
+      return it && it.type; // function_call / other structural items count as output
+    });
+    if (!hasOutput) return "empty_choices";
+    if (resp.status && !["completed", "done"].includes(resp.status)) return "no_terminal";
+    return null;
+  }
+  // Chat Completions shape
+  const choices = resp.choices;
+  if (!Array.isArray(choices) || choices.length === 0) return "empty_choices";
+  const anyChoiceHasOutput = choices.some((choice) => {
+    const msg = choice?.message;
+    if (typeof msg?.content === "string" && msg.content.length > 0) return true;
+    if (Array.isArray(msg?.tool_calls) && msg.tool_calls.length > 0) return true;
+    if (typeof msg?.reasoning_content === "string" && msg.reasoning_content.length > 0) return true;
+    return false;
+  });
+  if (!anyChoiceHasOutput) return "empty_choices";
+  return null;
+}
 
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
@@ -150,12 +182,29 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   if (contentType.includes("text/event-stream")) {
     const sseText = await providerResponse.text();
-    const parsed = parseSSEToOpenAIResponse(sseText, model);
-    if (!parsed) {
+    const parsedResult = parseSSEToOpenAIResponse(sseText, model);
+    if (!parsedResult?.parsed || parsedResult.empty) {
+      const totalLatency = Date.now() - requestStartTime;
+      const reason = parsedResult?.empty ? "empty_stream" : "parse_fail";
+      reportMalformed200({
+        mode: "sse2json", provider, model, connectionId, reason,
+        recvBytes: parsedResult?.recvBytes ?? sseText.length, recvLines: sseText.split("\n").length,
+        emitted: 0, events: {}, ttftMs: totalLatency, elapsedMs: totalLatency,
+      });
       appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
-      return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
+      saveRequestDetail(buildRequestDetail({
+        provider, model, connectionId,
+        latency: { ttft: totalLatency, total: totalLatency },
+        tokens: { prompt_tokens: 0, completion_tokens: 0 },
+        request: extractRequestConfig(body, stream),
+        providerRequest: finalBody || translatedBody || null,
+        providerResponse: sseText.slice(0, 2000),
+        response: { error: `${reason}: empty SSE response`, thinking: null, finish_reason: "failed" },
+        status: "malformed"
+      }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
+      return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `[${provider}/${model}] returned an empty SSE response`);
     }
-    responseBody = parsed;
+    responseBody = parsedResult.parsed;
   } else {
     try {
       responseBody = await providerResponse.json();
@@ -216,6 +265,31 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   }
 
   reqLogger.logConvertedResponse(translatedResponse);
+
+  // Validate the translated body actually carries client-usable output.
+  // A 200 with no choices/output is the "empty or malformed response" the client reports.
+  const malformedReason = detectMalformedNonStream(translatedResponse);
+  if (malformedReason) {
+    const totalLatency = Date.now() - requestStartTime;
+    const rawBytes = (() => { try { return JSON.stringify(responseBody || {}).length; } catch { return -1; } })();
+    reportMalformed200({
+      mode: "nonstream", provider, model, connectionId, reason: malformedReason,
+      recvBytes: rawBytes, recvLines: -1, emitted: -1, events: {},
+      ttftMs: totalLatency, elapsedMs: totalLatency,
+    });
+    appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+    saveRequestDetail(buildRequestDetail({
+      provider, model, connectionId,
+      latency: { ttft: totalLatency, total: totalLatency },
+      tokens: usage || { prompt_tokens: 0, completion_tokens: 0 },
+      request: extractRequestConfig(body, stream),
+      providerRequest: finalBody || translatedBody || null,
+      providerResponse: responseBody || null,
+      response: { error: `${malformedReason}: no usable output`, thinking: null, finish_reason: "failed" },
+      status: "malformed"
+    }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
+    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `[${provider}/${model}] returned an empty response (no usable choices/output)`);
+  }
 
   const totalLatency = Date.now() - requestStartTime;
   saveRequestDetail(buildRequestDetail({

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -1,4 +1,5 @@
 import { convertResponsesStreamToJson } from "../../transformer/streamToJsonConverter.js";
+import { reportMalformed200 } from "../../utils/diagnostics.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
@@ -40,8 +41,9 @@ function pickAssistantMessageForChatCompletion(output) {
  */
 export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
   const chunks = [];
+  const rawText = String(rawSSE || "");
 
-  for (const line of String(rawSSE || "").split("\n")) {
+  for (const line of rawText.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("data:")) continue;
     const payload = trimmed.slice(5).trim();
@@ -49,7 +51,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
     try { chunks.push(JSON.parse(payload)); } catch { /* ignore malformed lines */ }
   }
 
-  if (chunks.length === 0) return null;
+  if (chunks.length === 0) return { parsed: null, empty: true, recvBytes: rawText.length };
 
   const first = chunks[0];
   const contentParts = [];
@@ -95,7 +97,8 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
     choices: [{ index: 0, message, finish_reason: finishReason }]
   };
   if (usage) result.usage = usage;
-  return result;
+  const empty = contentParts.length === 0 && reasoningParts.length === 0 && toolCallMap.size === 0;
+  return { parsed: result, empty, recvBytes: rawText.length };
 }
 
 /**
@@ -120,6 +123,22 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
   if (isCodexResponsesApi) {
     try {
       const jsonResponse = await convertResponsesStreamToJson(providerResponse.body);
+      if (jsonResponse?.empty) {
+        const totalLatency = Date.now() - requestStartTime;
+        reportMalformed200({
+          mode: "sse2json", provider, model, connectionId, reason: jsonResponse.status === "failed" ? "no_terminal" : "empty_stream",
+          recvBytes: -1, recvLines: -1, emitted: 0, events: {}, ttftMs: totalLatency, elapsedMs: totalLatency,
+        });
+        saveRequestDetail(buildRequestDetail({
+          ...ctx,
+          latency: { ttft: totalLatency, total: totalLatency },
+          tokens: { prompt_tokens: 0, completion_tokens: 0 },
+          response: { error: "empty Responses API stream", thinking: null, finish_reason: jsonResponse.status || "failed" },
+          status: "malformed"
+        }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
+        appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `[${provider}/${model}] returned an empty response (stream closed without usable Responses output)`);
+      }
       if (onRequestSuccess) await onRequestSuccess();
 
       const usage = jsonResponse.usage || {};
@@ -137,9 +156,10 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         status: "success"
       }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
-      // Client is Responses API → return as-is
+      // Client is Responses API → return as-is (strip internal `empty` flag)
       if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
-        return { success: true, response: new Response(JSON.stringify(jsonResponse), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
+        const { empty: _omit, ...clientResponse } = jsonResponse;
+        return { success: true, response: new Response(JSON.stringify(clientResponse), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
       }
 
       // Build client-format response
@@ -193,8 +213,25 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
   // Standard Chat Completions SSE path
   try {
     const sseText = await providerResponse.text();
-    const parsed = parseSSEToOpenAIResponse(sseText, model);
-    if (!parsed) return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
+    const parsedResult = parseSSEToOpenAIResponse(sseText, model);
+    if (!parsedResult?.parsed || parsedResult.empty) {
+      const totalLatency = Date.now() - requestStartTime;
+      reportMalformed200({
+        mode: "sse2json", provider, model, connectionId, reason: parsedResult?.empty ? "empty_stream" : "parse_fail",
+        recvBytes: parsedResult?.recvBytes ?? sseText.length, recvLines: sseText.split("\n").length, emitted: 0,
+        events: {}, ttftMs: totalLatency, elapsedMs: totalLatency,
+      });
+      saveRequestDetail(buildRequestDetail({
+        ...ctx,
+        latency: { ttft: totalLatency, total: totalLatency },
+        tokens: { prompt_tokens: 0, completion_tokens: 0 },
+        response: { error: "empty Chat Completions stream", thinking: null, finish_reason: "failed" },
+        status: "malformed"
+      }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
+      appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+      return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `[${provider}/${model}] returned an empty response (stream had no usable chat output)`);
+    }
+    const parsed = parsedResult.parsed;
 
     if (onRequestSuccess) await onRequestSuccess();
 

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -22,7 +22,7 @@ const CODEX_SOURCE_TO_TARGET = {
 /**
  * Determine which SSE transform stream to use based on provider/format.
  */
-function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey }) {
+function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, streamController }) {
   const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
   // Responses-API providers (e.g. codex) emit Responses SSE → translate into client format
   const isResponsesProvider = PROVIDERS[provider]?.format === FORMATS.OPENAI_RESPONSES;
@@ -30,14 +30,14 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 
   if (needsCodexTranslation) {
     const codexTarget = CODEX_SOURCE_TO_TARGET[sourceFormat] || FORMATS.OPENAI;
-    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
+    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, streamController);
   }
 
   if (needsTranslation(targetFormat, sourceFormat)) {
-    return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
+    return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, streamController);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, streamController, sourceFormat);
 }
 
 /**
@@ -46,11 +46,13 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete }) {
   if (onRequestSuccess) onRequestSuccess();
 
-  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey });
+  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, streamController });
 
-  // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
-  const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
-  const onAbortTerminal = isResponsesPassthrough ? buildAbortedResponsesTerminalBytes : null;
+  // Responses clients should always receive response.failed + [DONE] on abort/stall,
+  // even when the upstream provider is Claude/Gemini/OpenAI-chat rather than Responses-native.
+  const onAbortTerminal = sourceFormat === FORMATS.OPENAI_RESPONSES
+    ? buildAbortedResponsesTerminalBytes
+    : null;
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
   const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
 

--- a/open-sse/handlers/responsesHandler.js
+++ b/open-sse/handlers/responsesHandler.js
@@ -7,6 +7,9 @@ import { handleChatCore } from "./chatCore.js";
 import { convertResponsesApiFormat } from "../translator/formats/responsesApi.js";
 import { createResponsesApiTransformStream } from "../transformer/responsesTransformer.js";
 import { convertResponsesStreamToJson } from "../transformer/streamToJsonConverter.js";
+import { reportMalformed200 } from "../utils/diagnostics.js";
+import { createErrorResult } from "../utils/error.js";
+import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { SSE_HEADERS_CORS } from "../utils/sseConstants.js";
 
 /**
@@ -58,9 +61,20 @@ export async function handleResponsesCore({ body, modelInfo, credentials, log, o
     try {
       const jsonResponse = await convertResponsesStreamToJson(response.body);
 
+      // Empty/aborted Responses stream → surface a real error instead of a 200 with output:[].
+      if (jsonResponse?.empty) {
+        reportMalformed200({
+          mode: "sse2json", provider: modelInfo?.provider, model: modelInfo?.model, connectionId,
+          reason: jsonResponse.status === "failed" ? "no_terminal" : "empty_stream",
+          recvBytes: -1, recvLines: -1, emitted: 0, events: {}, ttftMs: -1, elapsedMs: -1,
+        });
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `[${modelInfo?.provider}/${modelInfo?.model}] returned an empty Responses API stream`);
+      }
+
+      const { empty: _omit, ...clientResponse } = jsonResponse;
       return {
         success: true,
-        response: new Response(JSON.stringify(jsonResponse), {
+        response: new Response(JSON.stringify(clientResponse), {
           status: 200,
           headers: {
             "Content-Type": "application/json",

--- a/open-sse/transformer/streamToJsonConverter.js
+++ b/open-sse/transformer/streamToJsonConverter.js
@@ -4,6 +4,15 @@
  * Used when client requests non-streaming but provider forces streaming (e.g., Codex)
  */
 
+// Extract visible text from a Responses message item.
+function textFromMessageItem(item) {
+  if (!item?.content || !Array.isArray(item.content)) return "";
+  const byType = item.content.find((c) => c.type === "output_text");
+  if (typeof byType?.text === "string") return byType.text;
+  const anyText = item.content.find((c) => typeof c.text === "string");
+  return typeof anyText?.text === "string" ? anyText.text : "";
+}
+
 /**
  * Process a single SSE message and update state accordingly.
  */
@@ -27,15 +36,33 @@ function processSSEMessage(msg, state) {
     state.created = parsed.response?.created_at || state.created;
   } else if (eventType === "response.output_item.done") {
     state.items.set(parsed.output_index ?? 0, parsed.item);
+  } else if (eventType === "response.output_text.delta") {
+    const index = parsed.output_index ?? 0;
+    state.textDeltas.set(index, (state.textDeltas.get(index) || "") + (parsed.delta || ""));
+  } else if (eventType === "response.output_text.done") {
+    const index = parsed.output_index ?? 0;
+    const text = parsed.text || state.textDeltas.get(index) || "";
+    if (text && !state.items.has(index)) {
+      state.items.set(index, { type: "message", role: "assistant", content: [{ type: "output_text", text }] });
+    }
   } else if (eventType === "response.completed" || eventType === "response.done") {
     state.status = "completed";
+    state.sawTerminal = true;
     if (parsed.response?.usage) {
       state.usage.input_tokens = parsed.response.usage.input_tokens || 0;
       state.usage.output_tokens = parsed.response.usage.output_tokens || 0;
       state.usage.total_tokens = parsed.response.usage.total_tokens || 0;
     }
+    // Hydrate output from the terminal payload when granular output_item.done events
+    // were absent (some providers only emit the final response.completed with output).
+    if (Array.isArray(parsed.response?.output)) {
+      parsed.response.output.forEach((item, i) => {
+        if (item) state.items.set(i, item);
+      });
+    }
   } else if (eventType === "response.failed") {
     state.status = "failed";
+    state.sawTerminal = true;
   }
 }
 
@@ -48,7 +75,7 @@ const EMPTY_RESPONSE = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
  */
 export async function convertResponsesStreamToJson(stream) {
   if (!stream || typeof stream.getReader !== "function") {
-    return { id: `resp_${Date.now()}`, object: "response", created_at: Math.floor(Date.now() / 1000), status: "failed", output: [], usage: { ...EMPTY_RESPONSE } };
+    return { id: `resp_${Date.now()}`, object: "response", created_at: Math.floor(Date.now() / 1000), status: "failed", output: [], usage: { ...EMPTY_RESPONSE }, empty: true };
   }
 
   const reader = stream.getReader();
@@ -60,7 +87,9 @@ export async function convertResponsesStreamToJson(stream) {
     created: Math.floor(Date.now() / 1000),
     status: "in_progress",
     usage: { ...EMPTY_RESPONSE },
-    items: new Map()
+    items: new Map(),
+    textDeltas: new Map(),
+    sawTerminal: false,
   };
 
   try {
@@ -85,6 +114,18 @@ export async function convertResponsesStreamToJson(stream) {
     reader.releaseLock();
   }
 
+  // Materialize any accumulated text deltas even if the provider never sent
+  // a matching output_text.done / response.completed payload.
+  for (const [index, text] of state.textDeltas) {
+    if (text && !state.items.has(index)) {
+      state.items.set(index, {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text }],
+      });
+    }
+  }
+
   // Build output array from accumulated items (ordered by index)
   const output = [];
   const maxIndex = state.items.size > 0 ? Math.max(...state.items.keys()) : -1;
@@ -92,12 +133,26 @@ export async function convertResponsesStreamToJson(stream) {
     output.push(state.items.get(i) || { type: "message", content: [], role: "assistant" });
   }
 
+  // Flag streams that never produced output the client can use (no items and no
+  // terminal event, or terminal but empty) so callers can surface a real error
+  // instead of a silent 200 with `output: []`.
+  const hasOutput = output.some((item) => {
+    if (!item) return false;
+    if (item.type === "message") return textFromMessageItem(item).length > 0;
+    return true; // function_call / other non-empty structural items
+  });
+  const empty = !hasOutput;
+
+  // If the stream closed without a terminal event and produced nothing, treat it as failed.
+  const status = (!state.sawTerminal && empty) ? "failed" : (state.status || "completed");
+
   return {
     id: state.responseId || `resp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     object: "response",
     created_at: state.created,
-    status: state.status || "completed",
+    status,
     output,
-    usage: state.usage
+    usage: state.usage,
+    empty,
   };
 }

--- a/open-sse/utils/diagnostics.js
+++ b/open-sse/utils/diagnostics.js
@@ -20,6 +20,11 @@ function describeReason(reason) {
   return REASON_MESSAGES[reason] || reason || "empty response";
 }
 
+function emptyResponseMessage({ provider, reason }) {
+  return `[${provider || "?"}] returned an empty response (${describeReason(reason)}). ` +
+    "Likely quota exhaustion, an overloaded upstream, or a proxy/gateway intercepting the stream.";
+}
+
 /**
  * Log one structured [MALFORMED-200] line. Noop-safe (any field optional).
  * Surfaced to stdout so it is grep/SQL-correlatable with requestDetails.
@@ -52,12 +57,50 @@ export function synthOpenAIErrorChunk({ provider, model, reason }) {
     model: model || "unknown",
     choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
     error: {
-      message: `[${provider || "?"}] returned an empty response (${describeReason(reason)}). ` +
-        "Likely quota exhaustion, an overloaded upstream, or a proxy/gateway intercepting the stream.",
+      message: emptyResponseMessage({ provider, reason }),
       type: "upstream_empty_response",
     },
   };
   return `data: ${JSON.stringify(body)}\n\n`;
+}
+
+/** Claude Messages API failure events (SSE text) for an empty stream. */
+export function synthClaudeErrorEvents({ provider, model, reason }) {
+  const message = emptyResponseMessage({ provider, reason });
+  const id = `msg_empty_${Date.now()}`;
+  const events = [
+    {
+      type: "message_start",
+      message: {
+        id,
+        type: "message",
+        role: "assistant",
+        model: model || "unknown",
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: message },
+    },
+    { type: "content_block_stop", index: 0 },
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 0 },
+    },
+    { type: "message_stop" },
+  ];
+  return events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join("");
 }
 
 /**

--- a/open-sse/utils/diagnostics.js
+++ b/open-sse/utils/diagnostics.js
@@ -1,0 +1,71 @@
+// Diagnostics for empty / malformed HTTP 200 responses.
+// Used by streaming + non-streaming handlers to log one structured line and
+// synthesize a client-shaped error payload instead of a silent empty body.
+// Reuses formatIncompleteOpenAIResponsesStreamFailure for Responses clients.
+import { formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
+
+// Human-readable reason text surfaced to the client + logs.
+const REASON_MESSAGES = {
+  empty: "no content produced",
+  stall: "stream stalled (no data within the stall window)",
+  abort: "stream aborted",
+  client_closed: "client closed the connection",
+  no_terminal: "stream closed without a terminal event",
+  parse_fail: "failed to parse upstream stream",
+  empty_choices: "response had no usable choices/output",
+  empty_stream: "upstream stream carried no content",
+};
+
+function describeReason(reason) {
+  return REASON_MESSAGES[reason] || reason || "empty response";
+}
+
+/**
+ * Log one structured [MALFORMED-200] line. Noop-safe (any field optional).
+ * Surfaced to stdout so it is grep/SQL-correlatable with requestDetails.
+ */
+export function reportMalformed200({
+  mode, provider, model, connectionId, reason,
+  recvBytes, recvLines, emitted, events, ttftMs, elapsedMs,
+}) {
+  const evt = events && typeof events === "object"
+    ? `[${Object.entries(events).map(([k, v]) => `${k}=${v}`).join(",")}]`
+    : "[]";
+  console.log(
+    `[MALFORMED-200] mode=${mode || "?"} provider=${provider || "?"} model=${model || "?"} ` +
+    `conn=${connectionId || "-"} reason=${reason || "empty"} recvBytes=${recvBytes ?? -1} ` +
+    `recvLines=${recvLines ?? -1} emitted=${emitted ?? -1} events=${evt} ` +
+    `ttft=${ttftMs ?? -1}ms dur=${elapsedMs ?? -1}ms`,
+  );
+}
+
+/**
+ * Streaming chat-completion error chunk (SSE text) for an empty stream.
+ * Caller enqueues this before the terminal `data: [DONE]`.
+ * Keeps finish_reason:"stop" + adds `error` for broad client compatibility.
+ */
+export function synthOpenAIErrorChunk({ provider, model, reason }) {
+  const body = {
+    id: `chatcmpl-empty-${Date.now()}`,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: model || "unknown",
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    error: {
+      message: `[${provider || "?"}] returned an empty response (${describeReason(reason)}). ` +
+        "Likely quota exhaustion, an overloaded upstream, or a proxy/gateway intercepting the stream.",
+      type: "upstream_empty_response",
+    },
+  };
+  return `data: ${JSON.stringify(body)}\n\n`;
+}
+
+/**
+ * Responses-API failure event (SSE text) for an empty/aborted passthrough stream.
+ * Wraps the shared terminal helper so reasons stay consistent.
+ */
+export function synthResponsesFailure(reason) {
+  return formatIncompleteOpenAIResponsesStreamFailure(describeReason(reason));
+}
+
+export const __test = { describeReason };

--- a/open-sse/utils/responsesStreamHelpers.js
+++ b/open-sse/utils/responsesStreamHelpers.js
@@ -24,13 +24,19 @@ export function isOpenAIResponsesTerminalEvent(eventName, chunk) {
 
 const sharedEncoder = new TextEncoder();
 
-// Encoded response.failed + [DONE] payload for aborted/stalled Responses passthrough streams
-export function buildAbortedResponsesTerminalBytes() {
-  return sharedEncoder.encode(`${formatIncompleteOpenAIResponsesStreamFailure()}data: [DONE]\n\n`);
+// Encoded response.failed + [DONE] payload for aborted/stalled Responses passthrough streams.
+// Optional `reason` is folded into the error message for actionable diagnostics.
+export function buildAbortedResponsesTerminalBytes(reason) {
+  return sharedEncoder.encode(`${formatIncompleteOpenAIResponsesStreamFailure(reason)}data: [DONE]\n\n`);
 }
 
-// Synthesize a response.failed event for streams that close without a terminal event
-export function formatIncompleteOpenAIResponsesStreamFailure() {
+// Synthesize a response.failed event for streams that close without a terminal event.
+// Optional `reason` overrides the default message when a specific cause is known
+// (e.g. "stream stalled", "upstream stream carried no content").
+export function formatIncompleteOpenAIResponsesStreamFailure(reason) {
+  const message = reason
+    ? `stream closed before response.completed (${reason})`
+    : "stream closed before response.completed";
   return formatSSE({
     event: "response.failed",
     data: {
@@ -41,9 +47,9 @@ export function formatIncompleteOpenAIResponsesStreamFailure() {
         error: {
           type: "stream_error",
           code: "stream_disconnected",
-          message: "stream closed before response.completed"
-        }
-      }
-    }
+          message,
+        },
+      },
+    },
   }, FORMATS.OPENAI_RESPONSES);
 }

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -125,7 +125,10 @@ export function createSSEStream(options = {}) {
 
   // Did this stream produce any output the client can use (text/reasoning/tool/Responses output)?
   // Used in flush() to detect the empty/malformed HTTP-200 case.
-  const producedOutput = () => totalContentLength > 0 || sawToolCalls || sawResponsesContent;
+  // `sseEmittedCount > 0` guards translators whose parsed shape isn't covered by the
+  // accumulators above (e.g. openai-responses → claude); if we emitted valuable chunks,
+  // the stream is not empty regardless of accumulator state.
+  const producedOutput = () => totalContentLength > 0 || sawToolCalls || sawResponsesContent || sseEmittedCount > 0;
 
   // Emit one structured [MALFORMED-200] line + return the client-shaped error SSE text.
   const emitEmptyDiagnostics = (reasonOverride) => {
@@ -206,9 +209,14 @@ export function createSSEStream(options = {}) {
                 }
               }
 
-              if (!hasValuableContent(parsed, FORMATS.OPENAI)) {
+              // Filter by the client-facing format, not a hard-coded OpenAI shape.
+              // Passthrough preserves the provider's native format, which may be Claude
+              // (e.g. GLM) — checking OpenAI here would drop every Claude chunk and
+              // starve the client (the GLM empty-stream bug).
+              if (!hasValuableContent(parsed, sourceFormat)) {
                 continue;
               }
+              sseEmittedCount++;
 
               const delta = parsed.choices?.[0]?.delta;
               const content = delta?.content;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -4,7 +4,7 @@ import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
-import { reportMalformed200, synthOpenAIErrorChunk, synthResponsesFailure } from "./diagnostics.js";
+import { reportMalformed200, synthClaudeErrorEvents, synthOpenAIErrorChunk, synthResponsesFailure } from "./diagnostics.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
@@ -460,7 +460,9 @@ export function createSSEStream(options = {}) {
             const reason = emitEmptyDiagnostics();
             const emptyOutput = sourceFormat === FORMATS.OPENAI_RESPONSES
               ? synthResponsesFailure(reason)
-              : synthOpenAIErrorChunk({ provider, model, reason });
+              : sourceFormat === FORMATS.CLAUDE
+                ? synthClaudeErrorEvents({ provider, model, reason })
+                : synthOpenAIErrorChunk({ provider, model, reason });
             reqLogger?.appendConvertedChunk?.(emptyOutput);
             controller.enqueue(sharedEncoder.encode(emptyOutput));
             sseEmittedCount++;
@@ -533,7 +535,9 @@ export function createSSEStream(options = {}) {
           const reason = emitEmptyDiagnostics(openAIResponsesTerminalSeen ? "empty" : "no_terminal");
           const emptyOutput = wantsResponses
             ? synthResponsesFailure(reason)
-            : synthOpenAIErrorChunk({ provider, model, reason });
+            : sourceFormat === FORMATS.CLAUDE
+              ? synthClaudeErrorEvents({ provider, model, reason })
+              : synthOpenAIErrorChunk({ provider, model, reason });
           reqLogger?.appendConvertedChunk?.(emptyOutput);
           controller.enqueue(sharedEncoder.encode(emptyOutput));
           sseEmittedCount++;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -4,9 +4,60 @@ import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
+import { reportMalformed200, synthOpenAIErrorChunk, synthResponsesFailure } from "./diagnostics.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
+
+// Responses-API event names that carry actual client output (content/tool args).
+// Used to decide whether a passthrough stream "produced output" for empty-detection.
+const RESPONSES_OUTPUT_EVENTS = new Set([
+  "response.output_text.delta",
+  "response.output_text.done",
+  "response.output_item.done",
+  "response.function_call_arguments.delta",
+  "response.function_call_arguments.done",
+]);
+
+function hasUsableResponsesItem(item) {
+  if (!item || typeof item !== "object") return false;
+  if (item.type && item.type !== "message") return true;
+  if (!Array.isArray(item.content)) return false;
+  return item.content.some((part) => {
+    if (typeof part?.text === "string" && part.text.length > 0) return true;
+    if (part?.type === "output_text" && typeof part.text === "string" && part.text.length > 0) return true;
+    return false;
+  });
+}
+
+function hasUsableResponsesOutput(output) {
+  return Array.isArray(output) && output.some(hasUsableResponsesItem);
+}
+
+function markResponsesOutput(eventName, parsed) {
+  if (eventName === "response.output_text.delta") {
+    return typeof parsed?.delta === "string" && parsed.delta.length > 0;
+  }
+  if (eventName === "response.output_text.done") {
+    return typeof parsed?.text === "string" && parsed.text.length > 0;
+  }
+  if (eventName === "response.output_item.done") {
+    return hasUsableResponsesItem(parsed?.item);
+  }
+  if (eventName === "response.function_call_arguments.delta") {
+    return typeof parsed?.delta === "string" && parsed.delta.length > 0;
+  }
+  if (eventName === "response.function_call_arguments.done") {
+    return typeof parsed?.arguments === "string"
+      ? parsed.arguments.length > 0
+      : Boolean(parsed?.arguments || parsed?.name || parsed?.call_id || parsed?.item);
+  }
+  if (eventName === "response.completed") {
+    return hasUsableResponsesOutput(parsed?.response?.output);
+  }
+  return RESPONSES_OUTPUT_EVENTS.has(eventName);
+}
+
 
 export { COLORS, formatSSE };
 export { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER };
@@ -48,7 +99,8 @@ export function createSSEStream(options = {}) {
     connectionId = null,
     body = null,
     onStreamComplete = null,
-    apiKey = null
+    apiKey = null,
+    getAbortReason = null
   } = options;
 
   let buffer = "";
@@ -62,20 +114,43 @@ export function createSSEStream(options = {}) {
   let totalContentLength = 0;
   let accumulatedContent = "";
   let accumulatedThinking = "";
+  let totalDecodedLen = 0;     // raw upstream bytes (decoded length) for diagnostics
+  let sawToolCalls = false;    // tool-call deltas emitted (content can be 0 for tool-only responses)
+  let sawResponsesContent = false; // Responses passthrough carried actual output
   let ttftAt = null;
   let sseLineCount = 0;
   let sseEmittedCount = 0;
   const eventTypeCounts = {};
+  const requestStart = Date.now();
+
+  // Did this stream produce any output the client can use (text/reasoning/tool/Responses output)?
+  // Used in flush() to detect the empty/malformed HTTP-200 case.
+  const producedOutput = () => totalContentLength > 0 || sawToolCalls || sawResponsesContent;
+
+  // Emit one structured [MALFORMED-200] line + return the client-shaped error SSE text.
+  const emitEmptyDiagnostics = (reasonOverride) => {
+    const reason = reasonOverride || getAbortReason?.() || "empty";
+    reportMalformed200({
+      mode: "stream", provider, model, connectionId, reason,
+      recvBytes: totalDecodedLen, recvLines: sseLineCount, emitted: sseEmittedCount,
+      events: eventTypeCounts,
+      ttftMs: ttftAt ? ttftAt - requestStart : -1,
+      elapsedMs: Date.now() - requestStart,
+    });
+    return reason;
+  };
 
   // Track Responses API event framing for same-format passthrough (codex)
   let currentOpenAIResponsesEvent = null;
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
+  let emptyDiagnosticEmitted = false;
 
   return new TransformStream({
     transform(chunk, controller) {
       if (!ttftAt) ttftAt = Date.now();
       const text = decoder.decode(chunk, { stream: true });
+      totalDecodedLen += text.length;
       buffer += text;
       reqLogger?.appendProviderChunk?.(text);
 
@@ -84,16 +159,18 @@ export function createSSEStream(options = {}) {
 
       for (const line of lines) {
         const trimmed = line.trim();
-        if (isDebugEnabled && trimmed) {
+        if (trimmed) {
           sseLineCount++;
           if (trimmed.startsWith("event:")) {
             const evt = trimmed.slice(6).trim();
             eventTypeCounts[evt] = (eventTypeCounts[evt] || 0) + 1;
           }
+          if (isDebugEnabled) { /* counters are intentionally always-on for diagnostics */ }
         }
 
-        // Capture Responses API event name to preserve framing in same-format passthrough
-        if (mode === STREAM_MODE.TRANSLATE && targetFormat === FORMATS.OPENAI_RESPONSES && trimmed.startsWith("event:")) {
+        // Capture Responses API event name so we can preserve framing and detect
+        // whether a Responses client actually received usable output.
+        if (sourceFormat === FORMATS.OPENAI_RESPONSES && trimmed.startsWith("event:")) {
           currentOpenAIResponsesEvent = trimmed.slice(6).trim();
         }
 
@@ -143,6 +220,15 @@ export function createSSEStream(options = {}) {
               if (reasoning && typeof reasoning === "string") {
                 totalContentLength += reasoning.length;
                 accumulatedThinking += reasoning;
+              }
+              if (delta?.tool_calls) sawToolCalls = true;
+
+              if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+                const eventName = getOpenAIResponsesEventName(currentOpenAIResponsesEvent, parsed);
+                if (markResponsesOutput(eventName, parsed)) {
+                  sawResponsesContent = true;
+                }
+                currentOpenAIResponsesEvent = null;
               }
 
               const extracted = extractUsage(parsed);
@@ -198,6 +284,10 @@ export function createSSEStream(options = {}) {
         if (isOpenAIResponsesStream && isOpenAIResponsesTerminalEvent(openAIResponsesEventName, parsed)) {
           openAIResponsesTerminalSeen = true;
         }
+        // Detect real output for any Responses client (sourceFormat), not only same-format passthrough.
+        if (sourceFormat === FORMATS.OPENAI_RESPONSES && markResponsesOutput(openAIResponsesEventName, parsed)) {
+          sawResponsesContent = true;
+        }
 
         // For Ollama: done=true is the final chunk with finish_reason/usage, must translate
         // For other formats: done=true is the [DONE] sentinel, skip
@@ -239,6 +329,11 @@ export function createSSEStream(options = {}) {
           totalContentLength += parsed.choices[0].delta.reasoning_content.length;
           accumulatedThinking += parsed.choices[0].delta.reasoning_content;
         }
+        // OpenAI format - tool calls (content can be 0 for tool-only responses)
+        if (parsed.choices?.[0]?.delta?.tool_calls) sawToolCalls = true;
+        // Claude format - tool_use blocks
+        if (parsed.type === "content_block_start" && parsed.content_block?.type === "tool_use") sawToolCalls = true;
+        if (parsed.delta?.partial_json) sawToolCalls = true;
         
         // Gemini format
         if (parsed.candidates?.[0]?.content?.parts) {
@@ -320,6 +415,17 @@ export function createSSEStream(options = {}) {
         if (remaining) buffer += remaining;
 
         if (mode === STREAM_MODE.PASSTHROUGH) {
+          // Mark a final buffered Responses line (upstream closed without trailing newline)
+          // so flush doesn't wrongly append a synthetic response.failed after valid output.
+          if (sourceFormat === FORMATS.OPENAI_RESPONSES && buffer.trim().startsWith("data:")) {
+            try {
+              const parsed = JSON.parse(buffer.trim().slice(5).trim());
+              const eventName = getOpenAIResponsesEventName(currentOpenAIResponsesEvent, parsed);
+              if (markResponsesOutput(eventName, parsed)) sawResponsesContent = true;
+            } catch { /* leave buffer handling intact */ }
+            currentOpenAIResponsesEvent = null;
+          }
+
           if (buffer) {
             let output = buffer;
             if (buffer.startsWith("data:") && !buffer.startsWith("data: ")) {
@@ -339,6 +445,19 @@ export function createSSEStream(options = {}) {
             appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
           }
           
+          // Empty passthrough streams are valid HTTP but malformed for OpenAI clients.
+          // Surface one client-shaped error chunk before [DONE] so callers get a useful cause.
+          if (!emptyDiagnosticEmitted && !producedOutput()) {
+            emptyDiagnosticEmitted = true;
+            const reason = emitEmptyDiagnostics();
+            const emptyOutput = sourceFormat === FORMATS.OPENAI_RESPONSES
+              ? synthResponsesFailure(reason)
+              : synthOpenAIErrorChunk({ provider, model, reason });
+            reqLogger?.appendConvertedChunk?.(emptyOutput);
+            controller.enqueue(sharedEncoder.encode(emptyOutput));
+            sseEmittedCount++;
+          }
+
           // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
           //   data: [DONE]\n\n
@@ -397,9 +516,22 @@ export function createSSEStream(options = {}) {
           }
         }
 
-        // Synthesize response.failed if a Responses passthrough stream never reached a terminal event
+        // Empty/aborted stream: no content, tool calls, or Responses output was produced.
+        // Emit one client-shaped error (chat chunk or Responses response.failed) before [DONE].
+        const wantsResponses = sourceFormat === FORMATS.OPENAI_RESPONSES;
         const keepsOpenAIResponsesFormat = targetFormat === FORMATS.OPENAI_RESPONSES && sourceFormat === FORMATS.OPENAI_RESPONSES;
-        if (keepsOpenAIResponsesFormat && !openAIResponsesTerminalSeen) {
+        if (!emptyDiagnosticEmitted && !producedOutput()) {
+          emptyDiagnosticEmitted = true;
+          const reason = emitEmptyDiagnostics(openAIResponsesTerminalSeen ? "empty" : "no_terminal");
+          const emptyOutput = wantsResponses
+            ? synthResponsesFailure(reason)
+            : synthOpenAIErrorChunk({ provider, model, reason });
+          reqLogger?.appendConvertedChunk?.(emptyOutput);
+          controller.enqueue(sharedEncoder.encode(emptyOutput));
+          sseEmittedCount++;
+          openAIResponsesTerminalSeen = true;
+        } else if (keepsOpenAIResponsesFormat && !openAIResponsesTerminalSeen) {
+          // Content was delivered but the stream closed without response.completed — close it cleanly.
           const failedOutput = formatIncompleteOpenAIResponsesStreamFailure();
           reqLogger?.appendConvertedChunk?.(failedOutput);
           controller.enqueue(sharedEncoder.encode(failedOutput));
@@ -435,7 +567,7 @@ export function createSSEStream(options = {}) {
   });
 }
 
-export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, streamController = null) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
     targetFormat,
@@ -447,19 +579,22 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    getAbortReason: streamController?.getAbortReason,
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, streamController = null, sourceFormat = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
+    sourceFormat,
     provider,
     reqLogger,
     model,
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    getAbortReason: streamController?.getAbortReason,
   });
 }

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -20,6 +20,7 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
   const startTime = Date.now();
   let disconnected = false;
   let abortTimeout = null;
+  let abortReason = null;
 
   const logStream = (status) => {
     const duration = Date.now() - startTime;
@@ -30,6 +31,8 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
   return {
     signal: abortController.signal,
     startTime,
+    // Last known termination cause: "stall" | "abort" | "client_closed" | "error" | null
+    getAbortReason: () => abortReason,
 
     isConnected: () => !disconnected,
 
@@ -37,6 +40,7 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
     handleDisconnect: (reason = "client_closed") => {
       if (disconnected) return;
       disconnected = true;
+      if (!abortReason) abortReason = "client_closed";
 
       logStream(`disconnect: ${reason}`);
       dbg("CTRL", `${provider}/${model} | disconnect=${reason} | dur=${Date.now() - startTime}ms`);
@@ -63,7 +67,7 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
     },
 
     // Call on error
-    handleError: (error) => {
+    handleError: (error, reason) => {
       if (disconnected) return;
       disconnected = true;
 
@@ -73,15 +77,20 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
       }
 
       if (error.name === "AbortError") {
+        if (!abortReason) abortReason = reason || "abort";
         logStream("aborted");
         return;
       }
 
+      if (!abortReason) abortReason = reason || "error";
       logStream(`error: ${error.message}`);
       onError?.(error);
     },
 
-    abort: () => abortController.abort()
+    abort: (reason) => {
+      if (!abortReason) abortReason = reason || "abort";
+      abortController.abort();
+    }
   };
 }
 
@@ -104,7 +113,7 @@ export function createDisconnectAwareStream(transformStream, streamController, o
     if (terminalEmitted || !onAbortTerminal) return;
     terminalEmitted = true;
     try {
-      const bytes = onAbortTerminal();
+      const bytes = onAbortTerminal(streamController?.getAbortReason?.());
       if (bytes) controller.enqueue(bytes);
     } catch { /* best-effort terminal */ }
   };
@@ -202,8 +211,8 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
     stallTimer = setTimeout(() => {
       stallTimer = null;
       dbg(tag, `STALL TIMEOUT ${stallTimeoutMs}ms | chunks=${chunkCount} | bytes=${totalBytes} | sinceLast=${Date.now() - lastChunkAt}ms`);
-      streamController.handleError?.(new Error("stream stall timeout"));
-      streamController.abort?.();
+      streamController.handleError?.(new Error("stream stall timeout"), "stall");
+      streamController.abort?.("stall");
     }, stallTimeoutMs);
   };
 
@@ -213,11 +222,12 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
   const wrappedController = {
     signal: streamController.signal,
     startTime: streamController.startTime,
+    getAbortReason: streamController.getAbortReason,
     isConnected: () => streamController.isConnected(),
     handleComplete: () => { dbg(tag, `complete | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleComplete(); },
     handleError: (e) => { dbg(tag, `error: ${e?.message} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleError(e); },
     handleDisconnect: (r) => { dbg(tag, `disconnect: ${r} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleDisconnect(r); },
-    abort: () => { clearStall(); streamController.abort(); }
+    abort: (reason) => { clearStall(); streamController.abort(reason); }
   };
 
   armStall();

--- a/scripts/selfcheck-empty-stream.mjs
+++ b/scripts/selfcheck-empty-stream.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 
 import { readFile } from "node:fs/promises";
 
-import { synthOpenAIErrorChunk, synthResponsesFailure } from "../open-sse/utils/diagnostics.js";
+import { synthClaudeErrorEvents, synthOpenAIErrorChunk, synthResponsesFailure } from "../open-sse/utils/diagnostics.js";
 import { convertResponsesStreamToJson } from "../open-sse/transformer/streamToJsonConverter.js";
 
 function streamFromText(text) {
@@ -14,6 +14,12 @@ const chatError = synthOpenAIErrorChunk({ provider: "test", model: "model", reas
 assert.match(chatError, /^data: /);
 assert.match(chatError, /"chat\.completion\.chunk"/);
 assert.match(chatError, /"upstream_empty_response"/);
+
+const claudeError = synthClaudeErrorEvents({ provider: "test", model: "model", reason: "empty_stream" });
+assert.match(claudeError, /event: message_start/);
+assert.match(claudeError, /event: content_block_delta/);
+assert.match(claudeError, /event: message_stop/);
+assert.doesNotMatch(claudeError, /^data: \{"object":"chat\.completion\.chunk"/m);
 
 const responsesFailure = synthResponsesFailure("empty_stream");
 assert.match(responsesFailure, /event: response\.failed/);
@@ -61,6 +67,14 @@ assert.match(
   streamSrc,
   /producedOutput = \(\) => totalContentLength > 0 \|\| sawToolCalls \|\| sawResponsesContent \|\| sseEmittedCount > 0/,
   "producedOutput() must include sseEmittedCount > 0",
+);
+
+// Bug 3: truly-empty streams must synthesize the client's stream format. Claude
+// clients reject OpenAI chat chunks on /v1/messages as malformed HTTP 200 bodies.
+assert.match(
+  streamSrc,
+  /sourceFormat === FORMATS\.CLAUDE\s*\? synthClaudeErrorEvents/,
+  "empty-stream fallback must emit Claude-shaped events for Claude clients",
 );
 
 console.log("selfcheck-empty-stream: ok");

--- a/scripts/selfcheck-empty-stream.mjs
+++ b/scripts/selfcheck-empty-stream.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 
+import { readFile } from "node:fs/promises";
+
 import { synthOpenAIErrorChunk, synthResponsesFailure } from "../open-sse/utils/diagnostics.js";
 import { convertResponsesStreamToJson } from "../open-sse/transformer/streamToJsonConverter.js";
 
@@ -33,5 +35,32 @@ const okResponses = await convertResponsesStreamToJson(streamFromText([
 assert.equal(okResponses.status, "completed");
 assert.equal(okResponses.empty, false);
 assert.equal(okResponses.output[0].content[0].text, "hi");
+
+// Regression guards for the two empty-stream false-positives fixed in stream.js.
+// Full behavioral import pulls the translator graph (needs 'undici'); assert the
+// guards directly from source instead so this check stays self-contained.
+const streamSrc = await readFile(new URL("../open-sse/utils/stream.js", import.meta.url), "utf8");
+
+// Bug 1: passthrough must filter by the client-facing sourceFormat, not a hard-coded
+// OpenAI shape (which dropped every Claude chunk and starved GLM clients).
+assert.match(
+  streamSrc,
+  /hasValuableContent\(parsed, sourceFormat\)/,
+  "passthrough must call hasValuableContent with sourceFormat (not hard-coded OPENAI)",
+);
+assert.doesNotMatch(
+  streamSrc,
+  /hasValuableContent\(parsed, FORMATS\.OPENAI\)/,
+  "passthrough must not hard-code FORMATS.OPENAI in the valuable-content filter",
+);
+
+// Bug 2: producedOutput() must treat emitted valuable chunks as output, so translators
+// whose parsed shape isn't accumulator-tracked (e.g. openai-responses → claude) do not
+// raise a false MALFORMED-200 after a successful stream.
+assert.match(
+  streamSrc,
+  /producedOutput = \(\) => totalContentLength > 0 \|\| sawToolCalls \|\| sawResponsesContent \|\| sseEmittedCount > 0/,
+  "producedOutput() must include sseEmittedCount > 0",
+);
 
 console.log("selfcheck-empty-stream: ok");

--- a/scripts/selfcheck-empty-stream.mjs
+++ b/scripts/selfcheck-empty-stream.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+
+import { synthOpenAIErrorChunk, synthResponsesFailure } from "../open-sse/utils/diagnostics.js";
+import { convertResponsesStreamToJson } from "../open-sse/transformer/streamToJsonConverter.js";
+
+function streamFromText(text) {
+  return new Response(text, { headers: { "content-type": "text/event-stream" } }).body;
+}
+
+const chatError = synthOpenAIErrorChunk({ provider: "test", model: "model", reason: "empty_stream" });
+assert.match(chatError, /^data: /);
+assert.match(chatError, /"chat\.completion\.chunk"/);
+assert.match(chatError, /"upstream_empty_response"/);
+
+const responsesFailure = synthResponsesFailure("empty_stream");
+assert.match(responsesFailure, /event: response\.failed/);
+assert.match(responsesFailure, /stream closed before response\.completed/);
+
+const emptyResponses = await convertResponsesStreamToJson(streamFromText("data: [DONE]\n\n"));
+assert.equal(emptyResponses.status, "failed");
+assert.equal(emptyResponses.empty, true);
+assert.deepEqual(emptyResponses.output, []);
+
+const okResponses = await convertResponsesStreamToJson(streamFromText([
+  "event: response.output_item.done",
+  "data: {\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"hi\"}]}}",
+  "",
+  "event: response.completed",
+  "data: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}",
+  "",
+].join("\n")));
+assert.equal(okResponses.status, "completed");
+assert.equal(okResponses.empty, false);
+assert.equal(okResponses.output[0].content[0].text, "hi");
+
+console.log("selfcheck-empty-stream: ok");


### PR DESCRIPTION
## Problem

When using 9Router as an OpenAI-compatible router/translator, clients can intermittently receive errors like:

```text
API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request
```

This means 9Router returned `HTTP 200`, but the response body was not usable by the downstream client. The main failure modes were:

### 1. Empty streaming responses still ended as successful `200`

In `open-sse/utils/stream.js`, streaming transform/flush paths could receive no usable content/tool output, then still emit only a terminal marker such as:

```text
data: [DONE]
```

For OpenAI/Responses clients, this looks like a successful stream transport-wise, but semantically empty/malformed.

### 2. Abort/stall paths lacked client-shaped terminal errors

In `open-sse/utils/streamHandler.js`, the stream controller could abort on stall, disconnect, or network close, but the final stream did not always include a valid client-format error payload.

For Responses API clients, this could close without:

```text
event: response.failed
data: {...}

data: [DONE]
```

### 3. Non-streaming responses were not validated before returning `200`

In `open-sse/handlers/chatCore/nonStreamingHandler.js`, provider JSON was translated and returned after minor normalization, but there was no validation that the final body actually contained usable output:

- Chat Completions: `choices[]` could be empty or carry no `content`, `reasoning_content`, or `tool_calls`
- Responses API: `output[]` could be empty or status non-terminal

This produced malformed `200` JSON for strict clients.

### 4. SSE-to-JSON conversion accepted empty streams as success

In `open-sse/handlers/chatCore/sseToJsonHandler.js` and `open-sse/transformer/streamToJsonConverter.js`, forced streaming providers converted to non-streaming JSON could produce:

```json
{
  "status": "completed",
  "output": []
}
```

or Chat Completions JSON with empty assistant content. These should be surfaced as upstream-empty errors, not successful responses.

### 5. Responses stream edge cases were under-detected

Responses streams could carry valid output in:

- `response.output_text.delta`
- `response.output_text.done`
- `response.output_item.done`
- `response.completed.response.output`

Some paths did not materialize these into final `output[]`, and passthrough flush could misclassify the final buffered `data:` line as empty if upstream closed without a trailing newline.

## Fix

### `open-sse/utils/diagnostics.js`

Added centralized diagnostics helpers:

1. `reportMalformed200()` logs one structured line:

```text
[MALFORMED-200] mode=... provider=... model=... reason=... recvBytes=... recvLines=... emitted=...
```

2. `synthOpenAIErrorChunk()` creates a valid OpenAI streaming error chunk for empty Chat Completions streams.

3. `synthResponsesFailure()` creates a valid Responses API `response.failed` event.

### `open-sse/utils/stream.js`

1. Added output tracking via `producedOutput()` for:
   - text content
   - reasoning content
   - tool calls
   - Responses output events

2. Added `emitEmptyDiagnostics()` so empty stream flushes now log `[MALFORMED-200]`.

3. When a stream ends with no usable output:
   - Responses clients receive `response.failed`
   - OpenAI chat clients receive an OpenAI-shaped error chunk
   - then the stream terminates normally

4. Added stricter Responses output detection:
   - `response.completed` only counts as output when it carries usable output
   - `response.output_text.*` requires non-empty text
   - `response.output_item.done` requires usable item content or non-message structural output

5. Fixed passthrough Responses edge case:
   - final buffered `data:` line is parsed in `flush()`
   - prevents false `response.failed` when upstream closes without a trailing newline

### `open-sse/utils/streamHandler.js`

1. Added `abortReason` tracking:
   - `stall`
   - `abort`
   - `client_closed`
   - `error`

2. Exposed `getAbortReason()` so terminal error payloads include the real cause.

3. Forwarded abort reason through wrapped controller abort path.

### `open-sse/handlers/chatCore/streamingHandler.js`

1. Responses clients now always receive `response.failed + [DONE]` on abort/stall:

```js
sourceFormat === FORMATS.OPENAI_RESPONSES
```

This applies even when the upstream provider is not Responses-native.

### `open-sse/handlers/chatCore/nonStreamingHandler.js`

1. Added `detectMalformedNonStream()`.

2. Chat Completions validation now rejects final bodies where no choices contain usable output.

3. Responses API validation now rejects empty `output[]` or non-terminal status.

4. Malformed non-streaming responses now return `502` with a clear upstream-empty message instead of malformed `200`.

### `open-sse/handlers/chatCore/sseToJsonHandler.js`

1. `parseSSEToOpenAIResponse()` now returns:

```js
{ parsed, empty, recvBytes }
```

2. Usage-only streams no longer count as usable output.

3. Empty SSE-to-JSON conversions now:
   - log `[MALFORMED-200]`
   - save request detail with `status: "malformed"`
   - return `502`

### `open-sse/transformer/streamToJsonConverter.js`

1. Added `empty` detection for Responses SSE-to-JSON conversion.

2. Added `sawTerminal` tracking.

3. Hydrates output from:
   - `response.completed.response.output`
   - `response.output_text.delta`
   - `response.output_text.done`

4. Materializes accumulated text deltas before building `output[]`, even if upstream closes before `output_text.done`.

### `open-sse/utils/responsesStreamHelpers.js`

1. `buildAbortedResponsesTerminalBytes(reason)` now accepts a reason.

2. `formatIncompleteOpenAIResponsesStreamFailure(reason)` includes the reason in the failure message.

### `scripts/selfcheck-empty-stream.mjs`

Added an assert-based self-check covering:

- synthetic OpenAI error chunk
- synthetic Responses failure event
- empty Responses stream conversion
- valid Responses stream conversion

## Testing

Verified locally:

```bash
node scripts/selfcheck-empty-stream.mjs
```

Result:

```text
selfcheck-empty-stream: ok
```

Also verified:

```bash
node --input-type=module --check <touched-file>
git diff --check
```

Results:

- all touched files pass syntax checks
- whitespace check clean
- tester agent final pass: no remaining testable issues
- code-reviewer final pass: all found correctness issues fixed

Expected follow-up:

```bash
npm install
npm run build
```

## Result

Before:

- clients could receive empty or malformed `HTTP 200`
- strict decoders reported generic upstream/proxy errors
- Responses streams could close without a terminal `response.failed`
- SSE-to-JSON conversion could return successful empty output

After:

- empty/malformed upstream `200` paths are detected
- `[MALFORMED-200]` logs identify provider/model/reason
- streaming clients receive valid client-shaped error payloads
- non-streaming clients receive `502` instead of malformed `200`
- Responses clients get proper `response.failed + [DONE]` on abort/stall
- Responses SSE-to-JSON handles text deltas and terminal output correctly

Unresolved questions: none.
