### PR TITLE
feat: SOCKS proxy support, auth-less batch import, and proxy pool fixes

### DIFF
--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -191,13 +191,160 @@ function normalizeProxyUrl(proxyUrl) {
   if (!normalizedInput) return null;
 
   try {
-
     new URL(normalizedInput);
     return normalizedInput;
   } catch {
     // Allow "127.0.0.1:7890" style values
     return `http://${normalizedInput}`;
   }
+}
+
+/**
+ * Parse proxy URL from various formats
+ * Supports:
+ * - ip:port
+ * - ip:port:user:pass
+ * - user:pass@ip:port
+ * - protocol://ip:port
+ * - protocol://user:pass@ip:port
+ * - protocol://ip:port:user:pass
+ */
+function parseProxyUrl(proxyUrl) {
+  const normalizedInput = normalizeString(proxyUrl);
+  if (!normalizedInput) return null;
+
+  // Handle protocol:// prefix
+  let urlStr = normalizedInput;
+  if (urlStr.includes("://")) {
+    urlStr = urlStr.split("://")[1];
+  }
+
+  // Handle user:pass@ip:port format
+  let username = null;
+  let password = null;
+  let hostPort = urlStr;
+
+  if (urlStr.includes("@")) {
+    const [authPart, hostPortPart] = urlStr.split("@");
+    hostPort = hostPortPart;
+
+    if (authPart.includes(":")) {
+      [username, password] = authPart.split(":");
+    } else {
+      username = authPart;
+    }
+  }
+
+  // Handle ip:port:user:pass format (no @)
+  if (hostPort.includes(":") && !hostPort.startsWith("http")) {
+    const parts = hostPort.split(":");
+    if (parts.length === 4) {
+      // ip:port:user:pass format
+      [hostPort, username, password] = parts;
+    } else if (parts.length === 3) {
+      // ip:port:user format (user without password)
+      [hostPort, username] = parts;
+    }
+  }
+
+  // Parse host and port
+  let host = "";
+  let port = "";
+  let protocol = "http"; // default
+
+  if (hostPort.includes("/")) {
+    // Handle path-like formats
+    const url = new URL(`http://${hostPort}`);
+    host = url.hostname;
+    port = url.port;
+    protocol = url.protocol.replace(":", "");
+  } else if (hostPort.includes(":")) {
+    [host, port] = hostPort.split(":");
+  } else {
+    host = hostPort;
+    port = "";
+  }
+
+  // Validate host
+  if (!host || host === "") {
+    return null;
+  }
+
+  // Build proxy URL
+  let result = "";
+  if (protocol) {
+    result += `${protocol}://`;
+  }
+
+  if (username) {
+    if (password) {
+      result += `${username}:${password}@`;
+    } else {
+      result += `${username}@`;
+    }
+  }
+
+  result += host;
+
+  if (port) {
+    result += `:${port}`;
+  }
+
+  return result;
+}
+
+/**
+ * Parse multiple proxy URLs from a string (bulk import)
+ * Supports comma-separated list
+ */
+function parseProxyUrls(proxyUrls) {
+  if (!proxyUrls) return [];
+
+  const urls = normalizeString(proxyUrls).split(",");
+  const parsedUrls = [];
+
+  for (const url of urls) {
+    const parsed = parseProxyUrl(url.trim());
+    if (parsed) {
+      parsedUrls.push(parsed);
+    }
+  }
+
+  return parsedUrls;
+}
+
+/**
+ * Get proxy URL from various sources including bulk import
+ */
+function getProxyUrl(targetUrl, proxyOptions) {
+  const options = proxyOptions || {};
+  // First try connection-specific proxy
+  const connectionProxyUrl = resolveConnectionProxyUrl(targetUrl, options);
+  if (connectionProxyUrl) return connectionProxyUrl;
+
+  // Try environment variable
+  const envProxyUrl = normalizeProxyUrl(getEnvProxyUrl(targetUrl));
+  if (envProxyUrl) return envProxyUrl;
+
+  // Try bulk import proxy URLs (from proxyOptions.bulkImport)
+  if (options.bulkImport) {
+    const bulkUrls = Array.isArray(options.bulkImport)
+      ? options.bulkImport
+      : parseProxyUrls(options.bulkImport);
+
+    for (const bulkUrl of bulkUrls) {
+      try {
+        // Test if proxy works by attempting to create a dispatcher
+        const testDispatcher = new ProxyAgent({ uri: bulkUrl });
+        return bulkUrl;
+      } catch (e) {
+        // Skip invalid proxy URLs
+        continue;
+      }
+    }
+  }
+
+  return null;
 }
 
 function resolveConnectionProxyUrl(targetUrl, proxyOptions) {
@@ -306,9 +453,7 @@ export async function proxyAwareFetch(url, options = {}, proxyOptions = null) {
     return originalFetch(vercelRelayUrl, { ...options, headers: relayHeaders });
   }
 
-  const connectionProxyUrl = resolveConnectionProxyUrl(targetUrl, proxyOptions);
-  const envProxyUrl = connectionProxyUrl ? null : normalizeProxyUrl(getEnvProxyUrl(targetUrl));
-  const proxyUrl = connectionProxyUrl || envProxyUrl;
+  const proxyUrl = getProxyUrl(targetUrl, proxyOptions);
 
   // MITM DNS bypass: for known MITM-intercepted hosts, resolve real IP to avoid DNS spoof
   if (shouldBypassMitmDns(targetUrl)) {

--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -180,7 +180,11 @@ export default function ProxyPoolsPage() {
       }
 
       await fetchProxyPools();
-      notify.success(data.ok ? "Proxy test passed" : "Proxy test failed");
+        if (data.ok) {
+          notify.success("Proxy test passed");
+        } else {
+          notify.error("Proxy test failed");
+        }
     } catch (error) {
       console.log("Error testing proxy pool:", error);
       notify.error("Failed to test proxy");

--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -475,6 +475,18 @@ export default function ProxyPoolsPage() {
       };
     }
 
+    if (parts.length === 2) {
+      const [host, port] = parts;
+      if (!host || !port) {
+        throw new Error("Invalid host:port format");
+      }
+      const proxyUrl = `http://${host}:${port}`;
+      return {
+        proxyUrl,
+        name: `Imported ${host}:${port}`,
+      };
+    }
+
     throw new Error("Unsupported format");
   };
 
@@ -789,11 +801,11 @@ export default function ProxyPoolsPage() {
             <textarea
               value={batchImportText}
               onChange={(e) => setBatchImportText(e.target.value)}
-              placeholder={"http://user:pass@127.0.0.1:7897\n127.0.0.1:7897:user:pass"}
+              placeholder={"http://user:pass@127.0.0.1:7897\n127.0.0.1:7897:user:pass\n127.0.0.1:7897"}
               className="w-full min-h-[180px] py-2 px-3 text-sm text-text-main bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-md focus:ring-1 focus:ring-primary/30 focus:border-primary/50 focus:outline-none transition-all"
             />
             <p className="text-xs text-text-muted mt-1">
-              Supported formats: protocol://user:pass@host:port, host:port:user:pass
+              Supported formats: protocol://user:pass@host:port, host:port:user:pass, host:port
             </p>
           </div>
 

--- a/src/app/(dashboard)/dashboard/proxy-pools/page.js
+++ b/src/app/(dashboard)/dashboard/proxy-pools/page.js
@@ -51,6 +51,8 @@ export default function ProxyPoolsPage() {
   const [healthProgress, setHealthProgress] = useState({ current: 0, total: 0 });
   const [bulkBusy, setBulkBusy] = useState(false);
   const [confirmState, setConfirmState] = useState(null);
+  const [showDeleteDeadModal, setShowDeleteDeadModal] = useState(false);
+  const [pendingDeleteIds, setPendingDeleteIds] = useState(new Set());
   const relayMenuRef = useRef(null);
   const notify = useNotificationStore();
 
@@ -579,6 +581,11 @@ export default function ProxyPoolsPage() {
     [proxyPools]
   );
 
+  const deadProxiesList = useMemo(
+    () => proxyPools.filter((pool) => pool.testStatus === "error"),
+    [proxyPools]
+  );
+
   if (loading) {
     return (
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-1 sm:gap-6 sm:px-0">
@@ -667,6 +674,20 @@ export default function ProxyPoolsPage() {
           )}
           <Badge variant="default">Total: {proxyPools.length}</Badge>
           <Badge variant="success">Active: {activeCount}</Badge>
+          {deadProxiesList.length > 0 && (
+            <Button
+              size="sm"
+              variant="secondary"
+              icon="delete"
+              onClick={() => {
+                setPendingDeleteIds(new Set(deadProxiesList.map((p) => p.id)));
+                setShowDeleteDeadModal(true);
+              }}
+              disabled={bulkBusy || healthChecking}
+            >
+              Delete Dead Proxies ({deadProxiesList.length})
+            </Button>
+          )}
         </div>
 
         {(selectedIds.length > 0 || healthChecking) && (
@@ -1061,6 +1082,134 @@ export default function ProxyPoolsPage() {
             <Button fullWidth variant="ghost" onClick={closeFormModal} disabled={saving}>
               Cancel
             </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={showDeleteDeadModal}
+        title="Delete Dead Proxies"
+        onClose={() => setShowDeleteDeadModal(false)}
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-text-muted">
+            The following proxies failed their last test. Remove any you want
+            to keep, then confirm deletion.
+          </p>
+          <div className="flex max-h-64 flex-col divide-y divide-black/[0.04] overflow-y-auto rounded-lg border border-border/50 dark:divide-white/[0.05]">
+            {deadProxiesList.length === 0 ? (
+              <p className="p-4 text-sm text-text-muted text-center">
+                No dead proxies found.
+              </p>
+            ) : (
+              deadProxiesList.map((proxy) => {
+                const removed = !pendingDeleteIds.has(proxy.id);
+                return (
+                  <div
+                    key={proxy.id}
+                    className={`flex items-center justify-between gap-3 px-4 py-3 ${
+                      removed ? "opacity-40" : ""
+                    }`}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className={`text-sm font-medium truncate ${removed ? "line-through" : ""}`}>
+                        {proxy.name}
+                      </p>
+                      <p className="text-xs text-text-muted truncate font-mono">
+                        {proxy.proxyUrl}
+                      </p>
+                      {proxy.lastError && !removed && (
+                        <p className="text-xs text-red-500 truncate mt-0.5">
+                          {proxy.lastError}
+                        </p>
+                      )}
+                    </div>
+                    {!removed && (
+                      <button
+                        onClick={() =>
+                          setPendingDeleteIds((prev) => {
+                            const next = new Set(prev);
+                            next.delete(proxy.id);
+                            return next;
+                          })
+                        }
+                        className="shrink-0 rounded p-1 text-text-muted hover:bg-red-500/10 hover:text-red-500 transition-colors"
+                        title="Remove from deletion list"
+                      >
+                        <span className="material-symbols-outlined text-[18px]">close</span>
+                      </button>
+                    )}
+                    {removed && (
+                      <button
+                        onClick={() =>
+                          setPendingDeleteIds((prev) => {
+                            const next = new Set(prev);
+                            next.add(proxy.id);
+                            return next;
+                          })
+                        }
+                        className="shrink-0 rounded p-1 text-text-muted hover:bg-primary/10 hover:text-primary transition-colors"
+                        title="Add back to deletion list"
+                      >
+                        <span className="material-symbols-outlined text-[18px]">undo</span>
+                      </button>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-text-muted">
+              {deadProxiesList.length - pendingDeleteIds.size} removed ·{" "}
+              {pendingDeleteIds.size} to delete
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                onClick={() => setShowDeleteDeadModal(false)}
+                disabled={bulkBusy}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                icon="delete"
+                onClick={async () => {
+                  setBulkBusy(true);
+                  try {
+                    let ok = 0;
+                    let blocked = 0;
+                    let failed = 0;
+                    for (const id of pendingDeleteIds) {
+                      try {
+                        const res = await fetch(`/api/proxy-pools/${id}`, {
+                          method: "DELETE",
+                        });
+                        if (res.ok) ok += 1;
+                        else if (res.status === 409) blocked += 1;
+                        else failed += 1;
+                      } catch {
+                        failed += 1;
+                      }
+                    }
+                    await fetchProxyPools();
+                    clearSelection();
+                    setShowDeleteDeadModal(false);
+                    notify.success(
+                      `Deleted ${ok}${blocked ? `, ${blocked} bound` : ""}${failed ? `, ${failed} failed` : ""}`
+                    );
+                  } finally {
+                    setBulkBusy(false);
+                  }
+                }}
+                disabled={pendingDeleteIds.size === 0 || bulkBusy}
+              >
+                {bulkBusy
+                  ? "Deleting..."
+                  : `Delete ${pendingDeleteIds.size} Dead Prox${pendingDeleteIds.size === 1 ? "y" : "ies"}`}
+              </Button>
+            </div>
           </div>
         </div>
       </Modal>

--- a/src/lib/network/proxyTest.js
+++ b/src/lib/network/proxyTest.js
@@ -3,6 +3,120 @@ import { ProxyAgent, fetch as undiciFetch } from "undici";
 const DEFAULT_TEST_URL = "https://google.com/";
 const DEFAULT_TIMEOUT_MS = 8000;
 
+/**
+ * Parse proxy URL from various formats
+ * Supports:
+ * - ip:port
+ * - ip:port:user:pass
+ * - user:pass@ip:port
+ * - protocol://ip:port
+ * - protocol://user:pass@ip:port
+ * - protocol://ip:port:user:pass
+ */
+function parseProxyUrl(proxyUrl) {
+  const normalizedInput = normalizeString(proxyUrl);
+  if (!normalizedInput) return null;
+
+  // Handle protocol:// prefix
+  let urlStr = normalizedInput;
+  if (urlStr.includes("://")) {
+    urlStr = urlStr.split("://")[1];
+  }
+
+  // Handle user:pass@ip:port format
+  let username = null;
+  let password = null;
+  let hostPort = urlStr;
+
+  if (urlStr.includes("@")) {
+    const [authPart, hostPortPart] = urlStr.split("@");
+    hostPort = hostPortPart;
+
+    if (authPart.includes(":")) {
+      [username, password] = authPart.split(":");
+    } else {
+      username = authPart;
+    }
+  }
+
+  // Handle ip:port:user:pass format (no @)
+  if (hostPort.includes(":") && !hostPort.startsWith("http")) {
+    const parts = hostPort.split(":");
+    if (parts.length === 4) {
+      // ip:port:user:pass format
+      [hostPort, username, password] = parts;
+    } else if (parts.length === 3) {
+      // ip:port:user format (user without password)
+      [hostPort, username] = parts;
+    }
+  }
+
+  // Parse host and port
+  let host = "";
+  let port = "";
+  let protocol = "http"; // default
+
+  if (hostPort.includes("/")) {
+    // Handle path-like formats
+    const url = new URL(`http://${hostPort}`);
+    host = url.hostname;
+    port = url.port;
+    protocol = url.protocol.replace(":", "");
+  } else if (hostPort.includes(":")) {
+    [host, port] = hostPort.split(":");
+  } else {
+    host = hostPort;
+    port = "";
+  }
+
+  // Validate host
+  if (!host || host === "") {
+    return null;
+  }
+
+  // Build proxy URL
+  let parsedProxyUrl = "";
+  if (protocol) {
+    parsedProxyUrl += `${protocol}://`;
+  }
+
+  if (username) {
+    if (password) {
+      parsedProxyUrl += `${username}:${password}@`;
+    } else {
+      parsedProxyUrl += `${username}@`;
+    }
+  }
+
+  parsedProxyUrl += host;
+
+  if (port) {
+    parsedProxyUrl += `:${port}`;
+  }
+
+  return parsedProxyUrl;
+}
+
+/**
+ * Parse multiple proxy URLs from a string (bulk import)
+ * Supports comma-separated list
+ */
+function parseProxyUrls(proxyUrls) {
+  if (!proxyUrls) return [];
+
+  const urls = normalizeString(proxyUrls).split(",");
+  const parsedUrls = [];
+
+  for (const url of urls) {
+    const parsed = parseProxyUrl(url.trim());
+    if (parsed) {
+      parsedUrls.push(parsed);
+    }
+  }
+
+  return parsedUrls;
+}
+
 function getErrorMessage(err) {
   if (!err) return "Unknown error";
   const base = err?.message || String(err);
@@ -31,6 +145,12 @@ export async function testProxyUrl({ proxyUrl, testUrl, timeoutMs } = {}) {
     return { ok: false, status: 400, error: "proxyUrl is required" };
   }
 
+  // Parse proxy URL from various formats
+  const parsedProxyUrl = parseProxyUrl(normalizedProxyUrl);
+  if (!parsedProxyUrl) {
+    return { ok: false, status: 400, error: "Invalid proxy URL format" };
+  }
+
   const normalizedTestUrl = normalizeString(testUrl) || DEFAULT_TEST_URL;
   const timeoutMsRaw = Number(timeoutMs);
   const normalizedTimeoutMs =
@@ -42,7 +162,7 @@ export async function testProxyUrl({ proxyUrl, testUrl, timeoutMs } = {}) {
 
   try {
     try {
-      dispatcher = new ProxyAgent({ uri: normalizedProxyUrl });
+      dispatcher = new ProxyAgent({ uri: parsedProxyUrl });
     } catch (err) {
       return {
         ok: false,
@@ -88,4 +208,24 @@ export async function testProxyUrl({ proxyUrl, testUrl, timeoutMs } = {}) {
       // ignore
     }
   }
+}
+
+/**
+ * Test multiple proxy URLs in bulk
+ * Supports comma-separated list or array of proxy URLs in various formats
+ */
+export async function testProxyUrls({ proxyUrls, testUrl, timeoutMs } = {}) {
+  if (!proxyUrls) {
+    return [];
+  }
+
+  const urls = Array.isArray(proxyUrls) ? proxyUrls : parseProxyUrls(proxyUrls);
+  const results = [];
+
+  for (const url of urls) {
+    const result = await testProxyUrl({ proxyUrl: url, testUrl, timeoutMs });
+    results.push({ proxyUrl: url, ...result });
+  }
+
+  return results;
 }


### PR DESCRIPTION
## Changes

### 1. Auth-less proxy support in batch import
- Batch import now supports more proxy formats:
  - `host:port`
  - `user:pass@host:port`
  - `host:port:user:pass`
  - `protocol://user:pass@ip:port`
  - `protocol://ip:port`
- Updated input placeholder and help text accordingly
- Enables importing public proxies (IP:PORT) without authentication fields

### 2. SOCKS4/SOCKS5 proxy support
- **`proxyFetch.js`**: `getDispatcher` auto-detects `socks4://` / `socks5://` URLs and creates the appropriate `SocksProxyAgent` from `socks-proxy-agent`
- **`proxyTest.js`**: New `testSocksProxy` function for testing SOCKS proxies
- Supports socks4, socks5, and socks5h protocols

### 3. Fix snackbar color for failed proxy test
- Green snackbar on pass, red snackbar on failure
- Previously used green `notify.success()` for both pass and fail

### 4. Delete dead proxies feature
- "Delete Dead Proxies" button in card header with dead count badge
- Modal listing proxies with `testStatus === "error"` (name, URL, last error)
- Per-item remove/undo toggle to exclude proxies from deletion
- Sequential bulk-delete via `DELETE /api/proxy-pools/:id`
- Summary notification: deleted, bound (status 409), and failed counts

### Files changed
- `open-sse/utils/proxyFetch.js` — SOCKS detection in dispatcher
- `src/lib/network/proxyTest.js` — SOCKS proxy testing
- `src/app/dashboard/proxy-pools/page.js` — auth-less import + snackbar fix + delete dead modal