### PR TITLE
feat: custom system prompt injection

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -21,6 +21,7 @@ import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.j
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { injectPonytail } from "../rtk/ponytail.js";
+import { injectCustomSystemPrompt } from "../rtk/customSystemPrompt.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
 import { compressWithHeadroom, formatHeadroomLog } from "../rtk/headroom.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
@@ -34,7 +35,7 @@ import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, customSystemPromptEnabled, customSystemPrompt, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -176,6 +177,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (ponytailEnabled && ponytailLevel) {
     injectPonytail(translatedBody, finalFormat, ponytailLevel);
     log?.debug?.("PONYTAIL", `${ponytailLevel} | ${finalFormat}`);
+  }
+
+  // Custom system prompt: inject user-defined system prompt
+  if (customSystemPromptEnabled && customSystemPrompt) {
+    injectCustomSystemPrompt(translatedBody, finalFormat, customSystemPrompt);
+    log?.debug?.("CUSTOMSP", `${finalFormat}`);
   }
 
   const executor = getExecutor(provider);

--- a/open-sse/rtk/customSystemPrompt.js
+++ b/open-sse/rtk/customSystemPrompt.js
@@ -1,0 +1,8 @@
+// Custom system prompt injector: appends user-defined system prompt into the
+// system message of the final request body, just before dispatch to the provider executor.
+
+import { injectSystemPrompt } from "./systemInject.js";
+
+export function injectCustomSystemPrompt(body, format, prompt) {
+  injectSystemPrompt(body, format, prompt);
+}

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -45,6 +45,8 @@ export default function APIPageClient({ machineId }) {
   const [cavemanLevel, setCavemanLevel] = useState("full");
   const [ponytailEnabled, setPonytailEnabled] = useState(false);
   const [ponytailLevel, setPonytailLevel] = useState("full");
+  const [customSystemPromptEnabled, setCustomSystemPromptEnabled] = useState(false);
+  const [customSystemPrompt, setCustomSystemPrompt] = useState("");
   const [locale, setLocale] = useState("en");
 
   // Cloudflare Tunnel state
@@ -250,6 +252,8 @@ export default function APIPageClient({ machineId }) {
         setCavemanLevel(data.cavemanLevel || "full");
         setPonytailEnabled(!!data.ponytailEnabled);
         setPonytailLevel(data.ponytailLevel || "full");
+        setCustomSystemPromptEnabled(!!data.customSystemPromptEnabled);
+        setCustomSystemPrompt(data.customSystemPrompt || "");
       }
       if (statusRes.ok) {
         const data = await statusRes.json();
@@ -397,6 +401,16 @@ export default function APIPageClient({ machineId }) {
   const handlePonytailLevel = (level) => {
     setPonytailLevel(level);
     patchSetting({ ponytailLevel: level });
+  };
+
+  const handleCustomSystemPromptEnabled = (value) => {
+    setCustomSystemPromptEnabled(value);
+    patchSetting({ customSystemPromptEnabled: value });
+  };
+
+  const handleCustomSystemPrompt = (value) => {
+    setCustomSystemPrompt(value);
+    patchSetting({ customSystemPrompt: value });
   };
 
   const fetchData = async () => {
@@ -1376,6 +1390,29 @@ export default function APIPageClient({ machineId }) {
             <Toggle
               checked={ponytailEnabled}
               onChange={() => handlePonytailEnabled(!ponytailEnabled)}
+            />
+          </div>
+        </div>
+        <div className="flex items-center justify-between pt-4 mt-4 border-t border-border gap-4 flex-wrap">
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">Custom system prompt</p>
+            <p className="text-sm text-text-muted">
+              Inject a custom system prompt into every model request
+            </p>
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            {customSystemPromptEnabled && (
+              <Input
+                type="text"
+                value={customSystemPrompt}
+                onChange={(e) => handleCustomSystemPrompt(e.target.value)}
+                placeholder="e.g. Always respond in pirate speak..."
+                className="w-64 text-xs"
+              />
+            )}
+            <Toggle
+              checked={customSystemPromptEnabled}
+              onChange={() => handleCustomSystemPromptEnabled(!customSystemPromptEnabled)}
             />
           </div>
         </div>

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -42,6 +42,8 @@ const DEFAULT_SETTINGS = {
   cavemanLevel: "full",
   ponytailEnabled: false,
   ponytailLevel: "full",
+  customSystemPromptEnabled: false,
+  customSystemPrompt: "",
 };
 
 async function readRaw() {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -259,6 +259,8 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       cavemanLevel: chatSettings.cavemanLevel || "full",
       ponytailEnabled: !!chatSettings.ponytailEnabled,
       ponytailLevel: chatSettings.ponytailLevel || "full",
+      customSystemPromptEnabled: !!chatSettings.customSystemPromptEnabled,
+      customSystemPrompt: chatSettings.customSystemPrompt || "",
       providerThinking,
       // Detect source format by endpoint + body
       sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,


### PR DESCRIPTION
## Summary

Adds a toggleable **custom system prompt** feature that lets users type arbitrary text and have it injected as a system message into every model request routed through 9router.

## How it works

- **Settings**: Two new settings `customSystemPromptEnabled` (bool) and `customSystemPrompt` (string) stored in the DB
- **Injector**: `open-sse/rtk/customSystemPrompt.js` — reuses the existing `systemInject.js` infrastructure (same as caveman/ponytail)
- **Injection point**: `chatCore.js`, right after caveman and ponytail injections, so it runs on the final translated body
- **Format support**: All formats (OpenAI messages, Claude system, Gemini system_instruction, OpenAI Responses instructions) — handled by `injectSystemPrompt`

## UI

A new row in the Endpoint settings card with a toggle + text input that appears when enabled:

- Toggle: enable/disable the custom system prompt
- Text input: the prompt text itself (e.g. "Always respond in pirate speak")

## Changes

| File | Change |
|------|--------|
| `src/lib/db/repos/settingsRepo.js` | +2 default settings |
| `open-sse/rtk/customSystemPrompt.js` | new injector |
| `open-sse/handlers/chatCore.js` | import + invoke |
| `src/sse/handlers/chat.js` | pass settings through |
| `src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js` | UI controls |