### PR TITLE
feat: add Mistral OCR and Moderation endpoint support

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -60,6 +60,8 @@ const SERVICE_KIND_CAPABILITIES = {
   stt: { audioInput: true },
   tts: { audioOutput: true },
   embedding: { tools: false },
+  ocr: { tools: false },
+  moderation: { tools: false },
 };
 
 export function capabilitiesFromServiceKind(kind) {

--- a/open-sse/providers/index.js
+++ b/open-sse/providers/index.js
@@ -24,6 +24,7 @@ const MEDIA_KEYS = new Set([
   "serviceKinds", "ttsConfig", "sttConfig", "embeddingConfig",
   "imageConfig", "imageToTextConfig", "videoConfig", "musicConfig",
   "searchViaChat", "searchConfig", "fetchConfig",
+  "ocrConfig", "moderationConfig",
   "modelsFetcher", "mediaPriority", "hiddenKinds",
 ]);
 

--- a/open-sse/providers/registry/mistral.js
+++ b/open-sse/providers/registry/mistral.js
@@ -25,7 +25,11 @@ export default {
     { id: "codestral-latest", name: "Codestral" },
     { id: "mistral-medium-latest", name: "Mistral Medium 3" },
     { id: "mistral-embed", name: "Mistral Embed", kind: "embedding" },
+    { id: "mistral-ocr-latest", name: "Mistral OCR", kind: "ocr" },
+    { id: "mistral-moderation-latest", name: "Mistral Moderation", kind: "moderation" },
   ],
-  serviceKinds: ["llm","imageToText","embedding"],
+  serviceKinds: ["llm","imageToText","embedding","ocr","moderation"],
   embeddingConfig: { baseUrl: "https://api.mistral.ai/v1/embeddings", authType: "apikey", authHeader: "bearer" },
+  ocrConfig: { baseUrl: "https://api.mistral.ai/v1/ocr", authType: "apikey", authHeader: "bearer" },
+  moderationConfig: { baseUrl: "https://api.mistral.ai/v1/moderations", authType: "apikey", authHeader: "bearer" },
 };

--- a/src/app/api/v1/moderations/route.js
+++ b/src/app/api/v1/moderations/route.js
@@ -1,0 +1,21 @@
+import { handleModerations } from "@/sse/handlers/moderations.js";
+
+/**
+ * Handle CORS preflight
+ */
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*"
+    }
+  });
+}
+
+/**
+ * POST /v1/moderations - Mistral Moderation endpoint
+ */
+export async function POST(request) {
+  return await handleModerations(request);
+}

--- a/src/app/api/v1/ocr/route.js
+++ b/src/app/api/v1/ocr/route.js
@@ -1,0 +1,21 @@
+import { handleOcr } from "@/sse/handlers/ocr.js";
+
+/**
+ * Handle CORS preflight
+ */
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*"
+    }
+  });
+}
+
+/**
+ * POST /v1/ocr - Mistral OCR endpoint
+ */
+export async function POST(request) {
+  return await handleOcr(request);
+}

--- a/src/sse/handlers/moderations.js
+++ b/src/sse/handlers/moderations.js
@@ -1,0 +1,150 @@
+import {
+  getProviderCredentials,
+  markAccountUnavailable,
+  clearAccountError,
+  extractApiKey,
+  isValidApiKey,
+} from "../services/auth.js";
+import { getSettings } from "@/lib/localDb";
+import { getModelInfo } from "../services/model.js";
+import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+import * as log from "../utils/logger.js";
+import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
+
+/**
+ * Handle moderations request (e.g. Mistral Moderation).
+ * Proxies the request to the provider's /v1/moderations endpoint.
+ */
+export async function handleModerations(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    log.warn("MODERATIONS", "Invalid JSON body");
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
+  }
+
+  const url = new URL(request.url);
+  const modelStr = body.model;
+
+  log.request("POST", `${url.pathname} | ${modelStr || "default"}`);
+
+  const apiKey = extractApiKey(request);
+  if (apiKey) {
+    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
+  }
+
+  const settings = await getSettings();
+  if (settings.requireApiKey) {
+    if (!apiKey) {
+      log.warn("AUTH", "Missing API key (requireApiKey=true)");
+      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
+    }
+    const valid = await isValidApiKey(apiKey);
+    if (!valid) {
+      log.warn("AUTH", "Invalid API key (requireApiKey=true)");
+      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    }
+  }
+
+  if (!modelStr) {
+    log.warn("MODERATIONS", "Missing model");
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
+  }
+
+  if (!body.input) {
+    log.warn("MODERATIONS", "Missing input");
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: input");
+  }
+
+  const modelInfo = await getModelInfo(modelStr);
+  if (!modelInfo.provider) {
+    log.warn("MODERATIONS", "Invalid model format", { model: modelStr });
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");
+  }
+
+  const { provider, model } = modelInfo;
+
+  log.info("ROUTING", `Provider: ${provider}, Model: ${model}`);
+
+  // Credential + fallback loop
+  const excludeConnectionIds = new Set();
+  let lastError = null;
+  let lastStatus = null;
+
+  while (true) {
+    const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
+
+    if (!credentials || credentials.allRateLimited) {
+      if (credentials?.allRateLimited) {
+        const errorMsg = lastError || credentials.lastError || "Unavailable";
+        const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
+        log.warn("MODERATIONS", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
+        return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
+      }
+      if (excludeConnectionIds.size === 0) {
+        log.error("AUTH", `No credentials for provider: ${provider}`);
+        return errorResponse(HTTP_STATUS.BAD_REQUEST, `No credentials for provider: ${provider}`);
+      }
+      log.warn("MODERATIONS", "No more accounts available", { provider });
+      return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+    }
+
+    log.info("AUTH", `\x1b[32mUsing ${provider} account: ${credentials.connectionName}\x1b[0m`);
+
+    const refreshedCredentials = await checkAndRefreshToken(provider, credentials);
+
+    // Build upstream request
+    const upstreamUrl = `https://api.${provider}.ai/v1/moderations`;
+    const headers = {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${refreshedCredentials.apiKey || refreshedCredentials.accessToken}`,
+    };
+
+    try {
+      log.debug("MODERATIONS", `Proxying to ${upstreamUrl}`);
+      const providerResponse = await fetch(upstreamUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (providerResponse.ok) {
+        await clearAccountError(credentials.connectionId, credentials, model);
+        const data = await providerResponse.json();
+        return new Response(JSON.stringify(data), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      const errorText = await providerResponse.text();
+      const { shouldFallback } = await markAccountUnavailable(
+        credentials.connectionId, providerResponse.status, errorText, provider, model
+      );
+
+      if (shouldFallback) {
+        log.warn("MODERATIONS", `Account ${credentials.connectionName} unavailable (${providerResponse.status}), trying fallback`);
+        excludeConnectionIds.add(credentials.connectionId);
+        lastError = errorText;
+        lastStatus = providerResponse.status;
+        continue;
+      }
+
+      return errorResponse(providerResponse.status, errorText);
+    } catch (error) {
+      log.error("MODERATIONS", `Fetch error: ${error.message}`);
+      const { shouldFallback } = await markAccountUnavailable(
+        credentials.connectionId, HTTP_STATUS.BAD_GATEWAY, error.message, provider, model
+      );
+      if (shouldFallback) {
+        excludeConnectionIds.add(credentials.connectionId);
+        lastError = error.message;
+        lastStatus = HTTP_STATUS.BAD_GATEWAY;
+        continue;
+      }
+      return errorResponse(HTTP_STATUS.BAD_GATEWAY, error.message);
+    }
+  }
+}

--- a/src/sse/handlers/ocr.js
+++ b/src/sse/handlers/ocr.js
@@ -1,0 +1,147 @@
+import {
+  getProviderCredentials,
+  markAccountUnavailable,
+  clearAccountError,
+  extractApiKey,
+  isValidApiKey,
+} from "../services/auth.js";
+import { getSettings } from "@/lib/localDb";
+import { getModelInfo } from "../services/model.js";
+import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+import * as log from "../utils/logger.js";
+import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
+import { getExecutor } from "open-sse/executors/index.js";
+import { refreshWithRetry } from "open-sse/services/tokenRefresh.js";
+
+/**
+ * Handle OCR request (e.g. Mistral OCR).
+ * Proxies the request to the provider's /v1/ocr endpoint.
+ */
+export async function handleOcr(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    log.warn("OCR", "Invalid JSON body");
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
+  }
+
+  const url = new URL(request.url);
+  const modelStr = body.model;
+
+  log.request("POST", `${url.pathname} | ${modelStr || "default"}`);
+
+  const apiKey = extractApiKey(request);
+  if (apiKey) {
+    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
+  }
+
+  const settings = await getSettings();
+  if (settings.requireApiKey) {
+    if (!apiKey) {
+      log.warn("AUTH", "Missing API key (requireApiKey=true)");
+      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
+    }
+    const valid = await isValidApiKey(apiKey);
+    if (!valid) {
+      log.warn("AUTH", "Invalid API key (requireApiKey=true)");
+      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    }
+  }
+
+  if (!modelStr) {
+    log.warn("OCR", "Missing model");
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
+  }
+
+  const modelInfo = await getModelInfo(modelStr);
+  if (!modelInfo.provider) {
+    log.warn("OCR", "Invalid model format", { model: modelStr });
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");
+  }
+
+  const { provider, model } = modelInfo;
+
+  log.info("ROUTING", `Provider: ${provider}, Model: ${model}`);
+
+  // Credential + fallback loop
+  const excludeConnectionIds = new Set();
+  let lastError = null;
+  let lastStatus = null;
+
+  while (true) {
+    const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
+
+    if (!credentials || credentials.allRateLimited) {
+      if (credentials?.allRateLimited) {
+        const errorMsg = lastError || credentials.lastError || "Unavailable";
+        const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
+        log.warn("OCR", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
+        return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
+      }
+      if (excludeConnectionIds.size === 0) {
+        log.error("AUTH", `No credentials for provider: ${provider}`);
+        return errorResponse(HTTP_STATUS.BAD_REQUEST, `No credentials for provider: ${provider}`);
+      }
+      log.warn("OCR", "No more accounts available", { provider });
+      return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+    }
+
+    log.info("AUTH", `\x1b[32mUsing ${provider} account: ${credentials.connectionName}\x1b[0m`);
+
+    const refreshedCredentials = await checkAndRefreshToken(provider, credentials);
+
+    // Build upstream request
+    const upstreamUrl = `https://api.${provider}.ai/v1/ocr`;
+    const headers = {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${refreshedCredentials.apiKey || refreshedCredentials.accessToken}`,
+    };
+
+    try {
+      log.debug("OCR", `Proxying to ${upstreamUrl}`);
+      const providerResponse = await fetch(upstreamUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+
+      if (providerResponse.ok) {
+        await clearAccountError(credentials.connectionId, credentials, model);
+        const data = await providerResponse.json();
+        return new Response(JSON.stringify(data), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      const errorText = await providerResponse.text();
+      const { shouldFallback } = await markAccountUnavailable(
+        credentials.connectionId, providerResponse.status, errorText, provider, model
+      );
+
+      if (shouldFallback) {
+        log.warn("OCR", `Account ${credentials.connectionName} unavailable (${providerResponse.status}), trying fallback`);
+        excludeConnectionIds.add(credentials.connectionId);
+        lastError = errorText;
+        lastStatus = providerResponse.status;
+        continue;
+      }
+
+      return errorResponse(providerResponse.status, errorText);
+    } catch (error) {
+      log.error("OCR", `Fetch error: ${error.message}`);
+      const { shouldFallback } = await markAccountUnavailable(
+        credentials.connectionId, HTTP_STATUS.BAD_GATEWAY, error.message, provider, model
+      );
+      if (shouldFallback) {
+        excludeConnectionIds.add(credentials.connectionId);
+        lastError = error.message;
+        lastStatus = HTTP_STATUS.BAD_GATEWAY;
+        continue;
+      }
+      return errorResponse(HTTP_STATUS.BAD_GATEWAY, error.message);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds proxy support for two Mistral-specific API endpoints that are currently missing:

- `/v1/ocr` — Mistral OCR (PDF/image to markdown)
- `/v1/moderations` — Mistral Content Moderation (9 categories)

## Changes

### New files
- `src/app/api/v1/ocr/route.js` — Next.js route handler
- `src/app/api/v1/moderations/route.js` — Next.js route handler
- `src/sse/handlers/ocr.js` — OCR proxy handler with auth + fallback
- `src/sse/handlers/moderations.js` — Moderation proxy handler with auth + fallback

### Modified files
- `open-sse/providers/registry/mistral.js` — Added models, serviceKinds, ocrConfig, moderationConfig
- `open-sse/providers/index.js` — Added ocrConfig/moderationConfig to MEDIA_KEYS whitelist
- `open-sse/providers/capabilities.js` — Added ocr/moderation service kind capabilities

## Notes
- Follows the same auth + fallback pattern as embeddings handler
- OCR endpoint proxies JSON body directly (supports document_url and base64 image_url)
- Moderation endpoint supports batch input (array of strings)
