### PR TITLE
fix(codex): preserve Responses text format

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -32,7 +32,8 @@ const CODEX_PASSTHROUGH_TOOL_TYPES = new Set(["custom"]);
 // Allowlist of fields accepted by Codex Responses API — anything else is stripped
 const RESPONSES_API_ALLOWLIST = new Set([
   "model", "input", "instructions", "tools", "tool_choice", "stream", "store",
-  "reasoning", "service_tier", "include", "prompt_cache_key", "client_metadata"
+  "reasoning", "service_tier", "include", "prompt_cache_key", "client_metadata",
+  "text"
 ]);
 
 // Convert role=system → role=developer in body.input (keeps content in cacheable prefix)

--- a/tests/unit/codex-tool-normalization.test.js
+++ b/tests/unit/codex-tool-normalization.test.js
@@ -20,6 +20,47 @@ function normalizeTools(tools) {
 }
 
 describe("CodexExecutor tool normalization", () => {
+  it("preserves Responses text.format for structured outputs", () => {
+    const executor = new CodexExecutor();
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        title: { type: "string" },
+      },
+      required: ["title"],
+    };
+    const body = {
+      model: "gpt-5.4-mini",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "test for session title" }] }],
+      stream: true,
+      metadata: { unsupported: true },
+      text: {
+        format: {
+          type: "json_schema",
+          name: "codex_output_schema",
+          strict: true,
+          schema,
+        },
+      },
+    };
+
+    executor.transformRequest("gpt-5.4-mini", body, true, {
+      connectionId: "test-codex-structured-output",
+      providerSpecificData: {},
+    });
+
+    expect(body.text).toEqual({
+      format: {
+        type: "json_schema",
+        name: "codex_output_schema",
+        strict: true,
+        schema,
+      },
+    });
+    expect(body.metadata).toBeUndefined();
+  });
+
   it("preserves Responses-native tool_search tools", () => {
     const tools = normalizeTools([
       {


### PR DESCRIPTION
## Summary
- Preserve the Responses API `text` field when normalizing Codex requests.
- Add a regression test for `text.format.json_schema` passthrough in `CodexExecutor`.

## Why
Codex Desktop uses `text.format.json_schema` for structured title generation. `CodexExecutor` previously stripped `text` in its final allowlist filter, so the Codex Responses backend did not receive the schema and could return plain text instead of JSON.

Keeping `text` allows structured output requests to reach the upstream Codex Responses API while the executor still strips unsupported fields.

## Tests
- `NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/codex-tool-normalization.test.js --reporter=verbose`