### PR TITLE
fix(i18n): add missing zh-CN endpoint key label

### DIFF
--- a/public/i18n/literals/zh-CN.json
+++ b/public/i18n/literals/zh-CN.json
@@ -187,6 +187,7 @@
   "End Date": "结束日期",
   "End-to-end TLS via Cloudflare": "通过 Cloudflare 的端到端 TLS",
   "Endpoint": "端点",
+  "Endpoint & Key": "端点与密钥",
   "Enter current password": "输入当前密码",
   "Enter new API key": "输入新的 API 密钥",
   "Enter new password": "输入新密码",


### PR DESCRIPTION
Add the missing Simplified Chinese translation for the `Endpoint & Key` sidebar label.