### PR TITLE
fix(chat): keep streaming for forceStream providers when client requests JSON (#2031)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -17,6 +17,7 @@ import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDeta
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
+import { resolveStreamFlag } from "./chatCore/streamFlag.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
@@ -69,29 +70,31 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
-
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);
   const isImageGenModel = modelType === "imageGen" || /image|imagen|image-generation/i.test(model);
-  if (isImageGenModel && (provider === "antigravity" || provider === "gemini-cli")) {
-    stream = false;
-  }
 
   // DeepSeek-TUI: interactive TUI panel sends stream:true and needs SSE.
   // Non-interactive mode (-p flag) sends without stream and can't parse SSE.
-  // Only force non-streaming when client didn't explicitly request it.
   const detectedTool = detectClientTool(clientRawRequest?.headers || {}, body);
-  if (detectedTool === "deepseek-tui" && body.stream !== true) stream = false;
 
-  // Check client Accept header preference for non-streaming requests
-  // This fixes AI SDK compatibility where clients send Accept: application/json
+  // Client Accept header preference (AI SDK sends Accept: application/json for
+  // non-streaming responses).
   const acceptHeader = clientRawRequest?.headers?.accept || "";
   const clientPrefersJson = acceptHeader.includes("application/json");
   const clientPrefersSSE = acceptHeader.includes("text/event-stream");
-  if (clientPrefersJson && !clientPrefersSSE && body.stream !== true) {
-    stream = false;
-  }
+
+  // Stream-only providers (forceStream) must keep streaming even when the client
+  // asked for JSON; the accumulated stream is converted to JSON downstream. (#2031)
+  let stream = resolveStreamFlag({
+    providerRequiresStreaming,
+    bodyStream: body.stream,
+    forceNonStreaming:
+      (isImageGenModel && (provider === "antigravity" || provider === "gemini-cli")) ||
+      (detectedTool === "deepseek-tui" && body.stream !== true),
+    clientPrefersJson,
+    clientPrefersSSE,
+  });
 
   const reqLogger = await createRequestLogger(sourceFormat, targetFormat, model);
   if (clientRawRequest) reqLogger.logClientRawRequest(clientRawRequest.endpoint, clientRawRequest.body, clientRawRequest.headers);

--- a/open-sse/handlers/chatCore/streamFlag.js
+++ b/open-sse/handlers/chatCore/streamFlag.js
@@ -1,0 +1,40 @@
+/**
+ * Resolve whether to stream the request to the upstream provider.
+ *
+ * Some providers require streaming (`forceStream: true`, e.g. CommandCode) and
+ * reject non-streaming requests with HTTP 400. Such providers must keep
+ * streaming even when the client asked for a non-streaming/JSON response;
+ * 9Router then accumulates the provider stream and returns a JSON body to the
+ * client (handled downstream by handleForcedSSEToJson). (#2031)
+ *
+ * @param {object} opts
+ * @param {boolean} opts.providerRequiresStreaming - provider has `forceStream: true`
+ * @param {boolean} [opts.bodyStream] - the request body's `stream` value
+ * @param {boolean} [opts.forceNonStreaming] - request must not stream regardless of
+ *   client preference (e.g. image-generation models, deepseek-tui `-p` mode)
+ * @param {boolean} [opts.clientPrefersJson] - Accept header includes `application/json`
+ * @param {boolean} [opts.clientPrefersSSE] - Accept header includes `text/event-stream`
+ * @returns {boolean} whether to stream to the provider
+ */
+export function resolveStreamFlag({
+  providerRequiresStreaming,
+  bodyStream,
+  forceNonStreaming = false,
+  clientPrefersJson = false,
+  clientPrefersSSE = false,
+}) {
+  let stream = providerRequiresStreaming ? true : bodyStream !== false;
+
+  // Hard non-streaming cases (image-gen, deepseek-tui -p) override everything.
+  if (forceNonStreaming) stream = false;
+
+  // Client prefers a JSON (non-streaming) response — honor it, UNLESS the
+  // provider only accepts streaming. For stream-only providers we keep
+  // streaming and convert the accumulated stream to JSON for the client,
+  // instead of sending stream:false upstream (which 400s). (#2031)
+  if (clientPrefersJson && !clientPrefersSSE && bodyStream !== true && !providerRequiresStreaming) {
+    stream = false;
+  }
+
+  return stream;
+}

--- a/tests/unit/resolve-stream-flag.test.js
+++ b/tests/unit/resolve-stream-flag.test.js
@@ -1,0 +1,45 @@
+// #2031 — forceStream (stream-only) providers must keep streaming even when the
+// client asks for a non-streaming/JSON response. 9Router then accumulates the
+// provider's stream and returns a normal JSON body to the client.
+import { describe, it, expect } from "vitest";
+import { resolveStreamFlag } from "../../open-sse/handlers/chatCore/streamFlag.js";
+
+describe("resolveStreamFlag (#2031)", () => {
+  it("keeps streaming for a forceStream provider even when client prefers JSON and sets stream:false", () => {
+    // The bug: this returned false, sending stream:false to a stream-only
+    // provider (e.g. CommandCode) → 400 Bad Request.
+    expect(
+      resolveStreamFlag({
+        providerRequiresStreaming: true,
+        bodyStream: false,
+        clientPrefersJson: true,
+        clientPrefersSSE: false,
+      })
+    ).toBe(true);
+  });
+
+  it("non-forceStream provider: client prefers JSON + stream:false → non-streaming (unchanged)", () => {
+    expect(
+      resolveStreamFlag({
+        providerRequiresStreaming: false,
+        bodyStream: false,
+        clientPrefersJson: true,
+        clientPrefersSSE: false,
+      })
+    ).toBe(false);
+  });
+
+  it("forceStream provider streams by default when no stream flag is given", () => {
+    expect(resolveStreamFlag({ providerRequiresStreaming: true })).toBe(true);
+  });
+
+  it("forceNonStreaming (e.g. image-gen) still wins over forceStream", () => {
+    expect(
+      resolveStreamFlag({ providerRequiresStreaming: true, forceNonStreaming: true })
+    ).toBe(false);
+  });
+
+  it("ordinary provider with no special flags streams by default", () => {
+    expect(resolveStreamFlag({ providerRequiresStreaming: false })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Stream-only providers (`forceStream: true`, e.g. **CommandCode**) reject non-streaming requests with `HTTP 400: expected true at "params.stream"`. In `chatCore.js`, the stream flag was correctly initialized to `true` for these providers, but a later check unconditionally set it back to `false` whenever the client sent `Accept: application/json` with `stream: false` (which Claude Code / AI SDK do for auxiliary tasks like title generation). This sent `stream: false` to a stream-only provider → 400.

This guards that override with `!providerRequiresStreaming`, so stream-only providers keep streaming. 9Router's existing accumulator (`handleForcedSSEToJson`) then converts the provider stream into a normal JSON response for the client.

Fixes #2031

## Changes

| File | Change |
|---|---|
| `open-sse/handlers/chatCore.js` | Route the stream-flag decision through a single helper instead of four inline assignments |
| `open-sse/handlers/chatCore/streamFlag.js` | New `resolveStreamFlag()` — pure decision fn; the `forceStream` guard lives here |
| `tests/unit/resolve-stream-flag.test.js` | 5 unit tests (forceStream + JSON-accept stays streaming; ordinary providers unchanged; image-gen still non-streaming) |

## Testing

- `resolve-stream-flag.test.js` → 5/5 pass
- Full suite failure count unchanged vs baseline (the pre-existing failures are env-only: native sqlite + network tests)
- `eslint` on changed files → 0 errors

The change preserves all existing behavior (image-gen non-streaming, deepseek-tui `-p`, AI-SDK JSON for normal providers) and only stops forcing `stream:false` onto stream-only providers.