### PR TITLE
fix(responses): forward usage as input_tokens on response.completed

### DIFF
--- a/open-sse/translator/concerns/usage.js
+++ b/open-sse/translator/concerns/usage.js
@@ -58,3 +58,23 @@ export function toOpenAIUsage(raw, kind) {
   if (!extract || !raw || typeof raw !== "object") return null;
   return buildUsage(extract(raw));
 }
+
+// OpenAI chat-completions usage → Responses API usage (Codex requires input_tokens).
+export function toResponsesUsage(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const inputTokens = n(raw.input_tokens) || n(raw.prompt_tokens);
+  const outputTokens = n(raw.output_tokens) || n(raw.completion_tokens);
+  if (!inputTokens && !outputTokens) return null;
+
+  const usage = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: n(raw.total_tokens) || inputTokens + outputTokens,
+  };
+
+  const cachedTokens = n(raw.input_tokens_details?.cached_tokens) || n(raw.prompt_tokens_details?.cached_tokens);
+  if (cachedTokens > 0) usage.input_tokens_details = { cached_tokens: cachedTokens };
+
+  return usage;
+}

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -5,7 +5,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { buildChunk } from "../concerns/chunk.js";
-import { buildUsage } from "../concerns/usage.js";
+import { buildUsage, toResponsesUsage } from "../concerns/usage.js";
 import { fallbackToolCallId } from "../concerns/toolCall.js";
 import { reasoningDelta, extractReasoningText } from "../concerns/reasoning.js";
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM, OPENAI_FINISH, MODEL_FALLBACK } from "../schema/index.js";
@@ -329,6 +329,7 @@ function closeToolCall(state, emit, idx) {
 function sendCompleted(state, emit) {
   if (!state.completedSent) {
     state.completedSent = true;
+    const usage = toResponsesUsage(state.usage);
     emit("response.completed", {
       type: "response.completed",
       response: {
@@ -337,7 +338,8 @@ function sendCompleted(state, emit) {
         created_at: state.created,
         status: "completed",
         background: false,
-        error: null
+        error: null,
+        ...(usage ? { usage } : {})
       }
     });
   }

--- a/tests/unit/openai-responses-translator-usage.test.js
+++ b/tests/unit/openai-responses-translator-usage.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { toResponsesUsage } from "../../open-sse/translator/concerns/usage.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { initState, translateResponse } from "../../open-sse/translator/index.js";
+import "../../open-sse/translator/response/openai-responses.js";
+
+function completedUsage(chunks) {
+  const state = initState(FORMATS.OPENAI_RESPONSES);
+  for (const chunk of chunks) {
+    if (chunk.usage) state.usage = chunk.usage;
+    const events = translateResponse(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, chunk, state);
+    const completed = events.find((e) => e?.event === "response.completed");
+    if (completed) return completed.data.response.usage;
+  }
+  return undefined;
+}
+
+describe("toResponsesUsage", () => {
+  it("maps prompt_tokens to input_tokens", () => {
+    expect(toResponsesUsage({
+      prompt_tokens: 12,
+      completion_tokens: 7,
+      total_tokens: 19,
+      prompt_tokens_details: { cached_tokens: 4 },
+    })).toEqual({
+      input_tokens: 12,
+      output_tokens: 7,
+      total_tokens: 19,
+      input_tokens_details: { cached_tokens: 4 },
+    });
+  });
+
+  it("returns null when no token counts are present", () => {
+    expect(toResponsesUsage(null)).toBeNull();
+    expect(toResponsesUsage({})).toBeNull();
+  });
+});
+
+describe("openai-responses translator", () => {
+  it("attaches Responses-shaped usage on response.completed", () => {
+    const usage = completedUsage([
+      { id: "chatcmpl-x", choices: [{ index: 0, delta: { role: "assistant", content: "hi" } }] },
+      {
+        id: "chatcmpl-x",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 12, completion_tokens: 7, total_tokens: 19, prompt_tokens_details: { cached_tokens: 4 } },
+      },
+    ]);
+    expect(usage.input_tokens).toBe(12);
+    expect(usage.input_tokens_details.cached_tokens).toBe(4);
+  });
+
+  it("omits usage when upstream never reported token counts", () => {
+    expect(completedUsage([
+      { id: "chatcmpl-z", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
+      { id: "chatcmpl-z", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+    ])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Codex Desktop reads `response.completed.response.usage` to show the context window usage indicator. When `/v1/responses` routes through a chat-completions upstream (e.g. MiniMax), the `openai-responses` translator synthesized `response.completed` without a `usage` field, and even after adding usage it emitted Chat Completions field names (`prompt_tokens`) that Codex cannot parse (`missing field input_tokens`).

This PR maps upstream usage to the Responses API shape in `sendCompleted`.

## Changes

- Add `toResponsesUsage()` in `open-sse/translator/concerns/usage.js` — converts `prompt_tokens` / `completion_tokens` → `input_tokens` / `output_tokens`, preserves `cached_tokens` in `input_tokens_details`
- Attach converted usage on `response.completed` in `openai-responses.js` `sendCompleted`
- Add unit tests for the converter and translator path

## Runtime path

`/v1/responses` → `handleChat` → `handleChatCore` → `stream.js` (`extractUsage`) → `openai-responses` translator (`sendCompleted`). Does **not** go through `responsesTransformer.js` (`handleResponsesCore` is unused).

## Test plan

- [x] `npm run build && npm run start` — Codex Desktop shows context usage
- [x] `response.completed` carries `input_tokens` / `output_tokens` (no parse error)