### PR TITLE
fix(codebuddy): only send reasoning params when the client requests reasoning (#2071)

### DIFF
--- a/open-sse/executors/codebuddy-cn.js
+++ b/open-sse/executors/codebuddy-cn.js
@@ -25,10 +25,14 @@ export class CodeBuddyExecutor extends DefaultExecutor {
     const eff = transformed.reasoning_effort;
     if (eff === "none" || eff === "off") {
       delete transformed.reasoning_effort; // gateway has no "none" — just omit
-    } else {
-      if (!eff) transformed.reasoning_effort = "medium";
+    } else if (eff) {
+      // Client explicitly asked for reasoning — mirror the CLI's reasoning_summary
+      // so CodeBuddy surfaces the model's reasoning.
       transformed.reasoning_summary = "auto";
     }
+    // No reasoning requested: leave both unset. Forcing reasoning_effort:"medium"
+    // + reasoning_summary on plain requests makes CodeBuddy trip its content
+    // filter and return an error (#2071).
     return transformed;
   }
 }

--- a/tests/unit/codebuddy-reasoning-optin.test.js
+++ b/tests/unit/codebuddy-reasoning-optin.test.js
@@ -1,0 +1,37 @@
+// #2071 — CodeBuddy forced reasoning_effort:"medium" + reasoning_summary:"auto"
+// on requests where the client never asked for reasoning, tripping CodeBuddy's
+// content filter ("model return error"). Reasoning params must be opt-in.
+import { describe, it, expect } from "vitest";
+import { CodeBuddyExecutor } from "../../open-sse/executors/codebuddy-cn.js";
+
+describe("CodeBuddyExecutor reasoning params are opt-in (#2071)", () => {
+  const exec = new CodeBuddyExecutor();
+
+  it("does NOT force reasoning when the client did not request it", () => {
+    const out = exec.transformRequest("glm-5.2", { messages: [{ role: "user", content: "hi" }] }, false, {});
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning_summary).toBeUndefined();
+  });
+
+  it("mirrors reasoning_summary:auto when the client explicitly requested reasoning", () => {
+    const out = exec.transformRequest(
+      "glm-5.2",
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      false,
+      {}
+    );
+    expect(out.reasoning_effort).toBe("high");
+    expect(out.reasoning_summary).toBe("auto");
+  });
+
+  it("omits reasoning_effort for none/off and adds no reasoning_summary", () => {
+    const out = exec.transformRequest(
+      "glm-5.2",
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "none" },
+      false,
+      {}
+    );
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning_summary).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`CodeBuddyExecutor.transformRequest` added `reasoning_effort: "medium"` and `reasoning_summary: "auto"` to **every** request that did not already carry an explicit `reasoning_effort`. Forcing reasoning on plain (non-reasoning) requests makes CodeBuddy trip its content filter and return an error — the "CodeBuddy model return error" reported in #2071.

This makes the reasoning params **opt-in**: `reasoning_summary: "auto"` is only added when the client explicitly set `reasoning_effort`. Plain requests are left untouched; `none`/`off` still drops `reasoning_effort`. This keeps the original intent (surface reasoning when the client asks) without forcing it on requests that did not.

Fixes #2071

## Changes

| File | Change |
|---|---|
| `open-sse/executors/codebuddy-cn.js` | Gate `reasoning_summary` behind an explicit `reasoning_effort`; remove the forced `medium` default |
| `tests/unit/codebuddy-reasoning-optin.test.js` | 3 unit tests (no request -> no params; explicit effort -> summary added; none/off -> dropped) |

## Testing

- `unit/codebuddy-reasoning-optin.test.js` -> 3/3 pass
- `eslint` on changed files -> 0 errors