### PR TITLE
fix(headroom): translate openai-responses input through OpenAI for compression (#1998)

### DIFF
--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -1,5 +1,9 @@
 import { claudeToOpenAIRequest } from "../translator/request/claude-to-openai.js";
 import { openaiToClaudeRequest } from "../translator/request/openai-to-claude.js";
+import {
+  openaiResponsesToOpenAIRequest,
+  openaiToOpenAIResponsesRequest,
+} from "../translator/request/openai-responses.js";
 
 const DEFAULT_TIMEOUT_MS = 3000;
 
@@ -36,6 +40,25 @@ export async function compressWithHeadroom(body, { enabled, url, model, format, 
       const claudeBody = openaiToClaudeRequest(model, { ...oai, messages: data.messages }, false);
       if (Array.isArray(claudeBody?.messages)) body.messages = claudeBody.messages;
       if (claudeBody?.system !== undefined) body.system = claudeBody.system;
+      return data;
+    }
+
+    // OpenAI Responses shape (Codex): body.input holds Responses items, NOT OpenAI
+    // messages. Translate input -> OpenAI -> compress -> translate back to input so
+    // body.input keeps the Responses contract (the proxy only understands OpenAI). (#1998)
+    if (format === "openai-responses") {
+      const oai = openaiResponsesToOpenAIRequest(model, body, false);
+      if (!Array.isArray(oai?.messages)) return null;
+      const data = await callCompress(url, oai.messages, model, timeoutMs, compressUserMessages);
+      if (!data) return null;
+      // input: undefined so the translator rebuilds input from the compressed
+      // messages instead of returning the original input unchanged.
+      const responsesBody = openaiToOpenAIResponsesRequest(
+        model,
+        { ...oai, input: undefined, messages: data.messages },
+        false
+      );
+      if (Array.isArray(responsesBody?.input)) body.input = responsesBody.input;
       return data;
     }
 

--- a/tests/unit/headroom-responses-format.test.js
+++ b/tests/unit/headroom-responses-format.test.js
@@ -1,0 +1,50 @@
+// #1998 — Headroom compression treated a Codex (openai-responses) body.input
+// array as OpenAI messages: it sent Responses items to /v1/compress and then
+// assigned the returned OpenAI messages back to body.input, violating the
+// Responses format contract. body.input must stay Responses-shaped.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { compressWithHeadroom } from "../../open-sse/rtk/headroom.js";
+
+describe("compressWithHeadroom openai-responses format (#1998)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps body.input in Responses format after compressing an openai-responses request", async () => {
+    // Headroom always returns compressed OpenAI-style messages.
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        messages: [{ role: "user", content: "compressed text" }],
+        tokens_before: 100,
+        tokens_after: 90,
+        tokens_saved: 10,
+      }),
+    }));
+
+    const body = {
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "a long original message ".repeat(20) }],
+        },
+      ],
+    };
+
+    const data = await compressWithHeadroom(body, {
+      enabled: true,
+      url: "http://headroom.test",
+      model: "gpt-5",
+      format: "openai-responses",
+    });
+
+    expect(data).not.toBeNull();
+    // body.input must remain Responses items (type:"message" + content array),
+    // NOT the raw OpenAI messages ({ role, content: "<string>" }) the bug produced.
+    expect(Array.isArray(body.input)).toBe(true);
+    expect(body.input[0]).toMatchObject({ type: "message", role: "user" });
+    expect(Array.isArray(body.input[0].content)).toBe(true);
+    expect(typeof body.input[0].content).not.toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

`compressWithHeadroom()` treated a Codex (`openai-responses`) request's `body.input` array as if it were OpenAI `messages`: it POSTed the Responses items to Headroom's `/v1/compress` and then assigned the returned OpenAI messages straight back to `body.input`. That breaks the Responses format contract — `body.input` must hold Responses items (`{ type: "message", role, content: [...] }`), not OpenAI messages (`{ role, content: "<string>" }`) — so downstream Codex translation/serialization gets a malformed body. (#1998)

This adds an `openai-responses` branch that mirrors the existing `claude` path: translate `input` -> OpenAI messages, compress, translate back to `input`, using the translators already exported from `open-sse/translator/request/openai-responses.js`.

Fixes #1998

## Changes

| File | Change |
|---|---|
| `open-sse/rtk/headroom.js` | Add `openai-responses` branch: `openaiResponsesToOpenAIRequest` -> compress -> `openaiToOpenAIResponsesRequest`; reassign `body.input` as Responses items |
| `tests/unit/headroom-responses-format.test.js` | Unit test: mocks Headroom, asserts `body.input` stays Responses-shaped after compression |

## Testing

- `unit/headroom-responses-format.test.js` -> 1/1 pass (fails before the fix: `body.input[0]` was a raw OpenAI message)
- `eslint` on changed files -> 0 errors
- Additive change — the existing `claude` and OpenAI-`messages` paths are untouched.