### PR TITLE
fix(models): show custom provider models in combo picker

### DIFF
--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -249,9 +249,22 @@ export default function ModelSelectModal({
             value: `${nodePrefix}/${fullModel.replace(`${providerId}/`, "")}`,
           }));
 
+        // Merge custom models registered via /api/models/custom for this provider
+        // providerAlias in DB uses the raw providerId, not the display prefix
+        const registeredCustom = customModels
+          .filter((m) => m.providerAlias === providerId)
+          .map((m) => ({
+            id: m.id,
+            name: m.name || m.id,
+            value: `${nodePrefix}/${m.id}`,
+            isCustom: true,
+          }));
+        const seen = new Set(nodeModels.map((m) => m.value));
+        const mergedModels = [...nodeModels, ...registeredCustom.filter((m) => !seen.has(m.value))];
+
         // Always show compatible providers that are connected, even with no aliases.
         // When no aliases exist, show a placeholder so users know it's available.
-        const modelsToShow = nodeModels.length > 0 ? nodeModels : [{
+        const modelsToShow = mergedModels.length > 0 ? mergedModels : [{
           id: `__placeholder__${providerId}`,
           name: `${nodePrefix}/model-id`,
           value: `${nodePrefix}/model-id`,
@@ -264,7 +277,7 @@ export default function ModelSelectModal({
           color: providerInfo.color,
           models: modelsToShow,
           isCustom: true,
-          hasModels: nodeModels.length > 0,
+          hasModels: mergedModels.length > 0,
         };
       } else {
         const hardcodedModels = getModelsByProviderId(providerId);


### PR DESCRIPTION
## Problem
Commit 707a915 added `customModels` merge for the `passthroughModels` provider branch, but the `isCustomProvider` branch (OpenAI/Anthropic compatible) was missed. Custom compatible providers show a placeholder `prefix/model-id` instead of the actual imported models in the "Add Model to Combo" modal.

## Fix
Merge `customModels` from `/api/models/custom` into the model list for custom compatible providers, matching the same pattern already applied to passthrough providers.

Key detail: filter by `providerId` (not `nodePrefix`) because `providerAlias` in the DB uses the raw provider ID, not the display prefix.

## Before / After
- **Before**: Custom compatible providers (e.g. EV evo, bai, tokenrouter) show placeholder `ev/model-id` with pencil icon
- **After**: Actual imported models (e.g. `evomap-kimi-k2.6`, `evomap-deepseek-v4-flash`) appear and can be added to combos