### PR TITLE
fix(codex): handle Responses stream failures

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -10,11 +10,11 @@ import { fetchImageAsBase64 } from "../translator/concerns/image.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { DEFAULT_RETRY_CONFIG, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
+import { createErrorResult } from "../utils/error.js";
+import { detectRetryableResponsesStreamFailure, hasOpenAIResponsesStreamOutput } from "../utils/responsesStreamHelpers.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 
-// SSE error patterns inside 200-OK body that should trigger retry as if 503
-const CODEX_SSE_OVERLOADED_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
-const CODEX_SSE_PEEK_BYTES = 4096;
+const CODEX_SSE_PEEK_BYTES = 64 * 1024;
 
 // Server-generated item id prefixes that Codex /responses cannot resolve when store=false
 const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
@@ -190,14 +190,14 @@ export class CodexExecutor extends BaseExecutor {
       await this.prefetchImages(args.body);
     }
 
-    // Retry loop for SSE-level overloaded errors (200 OK body contains event: error)
+    // Retry loop for SSE-level retryable semantic failures (200 OK body contains event: error/response.failed)
     // Reuses 503 retry config — same semantic: upstream temporarily unavailable
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
     const { attempts, delayMs } = resolveRetryEntry(retryConfig[503]);
     let attempt = 0;
     while (true) {
       const result = await super.execute(args);
-      const peek = await this._peekSseOverloaded(result.response);
+      const peek = await this._peekRetryableResponsesFailure(result.response);
       if (!peek.matched) {
         // Replace body with re-assembled stream (prefix bytes already read + rest)
         if (peek.replacementBody) {
@@ -210,47 +210,51 @@ export class CodexExecutor extends BaseExecutor {
         return result;
       }
       if (attempt >= attempts) {
-        args.log?.warn?.("RETRY", `CODEX | SSE overloaded "${peek.matched}" — retries exhausted (${attempt}/${attempts})`);
-        // Out of retries → return with replacement body so client gets the error
-        if (peek.replacementBody) {
-          result.response = new Response(peek.replacementBody, {
-            status: result.response.status,
-            statusText: result.response.statusText,
-            headers: result.response.headers,
-          });
-        }
-        return result;
+        args.log?.warn?.("RETRY", `CODEX | SSE retryable failure "${peek.matched}" — retries exhausted (${attempt}/${attempts})`);
+        try { await result.response.body?.cancel?.(); } catch { /* noop */ }
+        return {
+          ...result,
+          ...createErrorResult(peek.status || 503, peek.message || `Retryable SSE failure: ${peek.matched}`),
+        };
       }
       attempt++;
-      args.log?.debug?.("RETRY", `CODEX | SSE "${peek.matched}" retry ${attempt}/${attempts} after ${delayMs / 1000}s`);
-      dbg("CODEX", `SSE overloaded "${peek.matched}" → retry ${attempt}/${attempts} in ${delayMs}ms`);
+      args.log?.debug?.("RETRY", `CODEX | SSE retryable failure "${peek.matched}" retry ${attempt}/${attempts} after ${delayMs / 1000}s`);
+      dbg("CODEX", `SSE retryable failure "${peek.matched}" → retry ${attempt}/${attempts} in ${delayMs}ms`);
       try { await result.response.body?.cancel?.(); } catch { /* noop */ }
       await new Promise(r => setTimeout(r, delayMs));
     }
   }
 
-  // Peek first N bytes of SSE body to detect upstream "overloaded" errors.
-  // Returns { matched: string|null, replacementBody: ReadableStream|null }.
+  // Probe the pre-output SSE prefix to detect upstream retryable semantic failures.
+  // Returns { matched: string|null, status?: number, message?: string, replacementBody: ReadableStream|null }.
   // Caller MUST use replacementBody (original body has been read).
-  async _peekSseOverloaded(response) {
+  async _peekRetryableResponsesFailure(response) {
     if (!response || !response.ok || !response.body) return { matched: null, replacementBody: null };
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     const chunks = [];
     let text = "";
-    let matched = null;
+    let failure = null;
     try {
       while (text.length < CODEX_SSE_PEEK_BYTES) {
         const { done, value } = await reader.read();
         if (done) break;
         chunks.push(value);
         text += decoder.decode(value, { stream: true });
-        const hit = CODEX_SSE_OVERLOADED_PATTERNS.find(p => text.includes(p));
-        if (hit) { matched = hit; break; }
+        failure = detectRetryableResponsesStreamFailure(text);
+        if (failure) break;
+        if (hasOpenAIResponsesStreamOutput(text)) break;
       }
     } catch (e) {
       dbg("CODEX", `peek read error: ${e.message}`);
     }
+
+    if (failure) {
+      try { await reader.cancel(); } catch { /* noop */ }
+      reader.releaseLock();
+      return { matched: failure.matched, status: failure.status, message: failure.message, replacementBody: null };
+    }
+
     reader.releaseLock();
 
     // Re-assemble stream: prefix chunks + remaining upstream body
@@ -272,7 +276,7 @@ export class CodexExecutor extends BaseExecutor {
         try { upstreamReader?.cancel(reason); } catch { /* noop */ }
       },
     });
-    return { matched, replacementBody };
+    return { matched: null, replacementBody };
   }
 
   // Parse Codex usage_limit_reached to extract precise resetsAtMs; fallback to default otherwise

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -241,9 +241,9 @@ export class CodexExecutor extends BaseExecutor {
         if (done) break;
         chunks.push(value);
         text += decoder.decode(value, { stream: true });
+        if (hasOpenAIResponsesStreamOutput(text)) break;
         failure = detectRetryableResponsesStreamFailure(text);
         if (failure) break;
-        if (hasOpenAIResponsesStreamOutput(text)) break;
       }
     } catch (e) {
       dbg("CODEX", `peek read error: ${e.message}`);

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -34,7 +34,7 @@ import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onRequestFailure, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -301,7 +301,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, onRequestFailure };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 
@@ -319,8 +319,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   // Streaming response
-  const { onStreamComplete } = buildOnStreamComplete({ ...sharedCtx });
-  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete });
+  const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
+  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId });
 }
 
 export function isTokenExpiringSoon(expiresAt, bufferMs = 5 * 60 * 1000) {

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -43,9 +43,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 /**
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
-export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete }) {
-  if (onRequestSuccess) onRequestSuccess();
-
+export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId }) {
   const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey });
 
   // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
@@ -54,7 +52,7 @@ export function handleStreamingResponse({ providerResponse, provider, model, sou
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
   const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
 
-  const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  streamDetailId = streamDetailId || `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
   saveRequestDetail(buildRequestDetail({
     provider, model, connectionId,
     latency: { ttft: 0, total: Date.now() - requestStartTime },
@@ -77,16 +75,43 @@ export function handleStreamingResponse({ providerResponse, provider, model, sou
 /**
  * Build onStreamComplete callback for streaming usage tracking.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest }) {
-  const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, onRequestSuccess, onRequestFailure, streamDetailId }) {
+  streamDetailId = streamDetailId || `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
-  const onStreamComplete = (contentObj, usage, ttftAt) => {
+  const onStreamComplete = (contentObj, usage, ttftAt, outcome = { status: "success" }) => {
     const latency = {
       ttft: ttftAt ? ttftAt - requestStartTime : Date.now() - requestStartTime,
       total: Date.now() - requestStartTime
     };
     const safeContent = contentObj?.content || "[Empty streaming response]";
     const safeThinking = contentObj?.thinking || null;
+
+    if (outcome?.status === "failure") {
+      saveRequestDetail(buildRequestDetail({
+        provider, model, connectionId,
+        latency,
+        tokens: usage || { prompt_tokens: 0, completion_tokens: 0 },
+        request: extractRequestConfig(body, stream),
+        providerRequest: finalBody || translatedBody || null,
+        providerResponse: safeContent,
+        response: {
+          content: safeContent,
+          thinking: safeThinking,
+          error: outcome.message || "[Streaming failure]",
+          status: outcome.errorStatus || 502,
+          type: "streaming"
+        },
+        status: "error"
+      }, { id: streamDetailId })).catch(err => {
+        console.error("[RequestDetail] Failed to update streaming failure:", err.message);
+      });
+      if (typeof onRequestFailure === "function") {
+        Promise.resolve(onRequestFailure(outcome)).catch(err => {
+          console.error("[RequestDetail] onRequestFailure failed:", err.message);
+        });
+      }
+      return outcome;
+    }
 
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
@@ -102,6 +127,13 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     });
 
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE" });
+
+    if (typeof onRequestSuccess === "function") {
+      Promise.resolve(onRequestSuccess()).catch(err => {
+        console.error("[RequestDetail] onRequestSuccess failed:", err.message);
+      });
+    }
+    return outcome;
   };
 
   return { onStreamComplete, streamDetailId };

--- a/open-sse/utils/responsesStreamHelpers.js
+++ b/open-sse/utils/responsesStreamHelpers.js
@@ -155,6 +155,38 @@ function classifyRetryableResponsesFailure(parsedFrame) {
   return null;
 }
 
+function classifyOpenAIResponsesFailure(parsedFrame) {
+  if (!parsedFrame || typeof parsedFrame !== "object") return null;
+
+  const eventName = parsedFrame.eventName || parsedFrame.data?.type || parsedFrame.data?.response?.type || null;
+  const data = parsedFrame.data ?? parsedFrame.rawData ?? null;
+  if (!data) return null;
+
+  const isTerminalFailure =
+    eventName === "error" ||
+    eventName === "response.failed" ||
+    data?.type === "error" ||
+    data?.type === "response.failed" ||
+    data?.response?.status === "failed" ||
+    data?.status === "failed";
+
+  if (!isTerminalFailure) return null;
+
+  const payload = extractResponsesFailurePayload(data);
+  const retryable = classifyRetryableResponsesFailure(parsedFrame);
+  return {
+    status: retryable?.status || 502,
+    matched: retryable?.matched || null,
+    code: typeof payload?.code === "string" ? payload.code : null,
+    type: typeof payload?.type === "string" ? payload.type : null,
+    message: typeof payload?.message === "string"
+      ? payload.message
+      : (typeof data?.response?.error?.message === "string"
+        ? data.response.error.message
+        : (typeof data?.message === "string" ? data.message : null)),
+  };
+}
+
 /**
  * Detect retryable semantic failures in OpenAI Responses SSE text.
  * Returns null for successful streams or non-retryable terminal failures.
@@ -166,6 +198,25 @@ export function detectRetryableResponsesStreamFailure(text) {
     const parsedFrame = parseSSEFrame(frame);
     if (!parsedFrame) continue;
     const classified = classifyRetryableResponsesFailure(parsedFrame);
+    if (classified) return classified;
+  }
+
+  return null;
+}
+
+/**
+ * Detect any terminal OpenAI Responses failure in SSE text.
+ * Unlike detectRetryableResponsesStreamFailure(), this is used after streaming
+ * has started, where fallback is no longer safe but accounting still must
+ * record the stream as failed.
+ */
+export function detectOpenAIResponsesStreamFailure(text) {
+  if (typeof text !== "string" || !text.trim()) return null;
+
+  for (const frame of text.split(/\n\n+/)) {
+    const parsedFrame = parseSSEFrame(frame);
+    if (!parsedFrame) continue;
+    const classified = classifyOpenAIResponsesFailure(parsedFrame);
     if (classified) return classified;
   }
 

--- a/open-sse/utils/responsesStreamHelpers.js
+++ b/open-sse/utils/responsesStreamHelpers.js
@@ -9,6 +9,217 @@ const OPENAI_RESPONSES_TERMINAL_EVENTS = new Set([
   "error"
 ]);
 
+const RETRYABLE_FAILURE_RULES = [
+  {
+    status: 503,
+    patterns: [
+      "model_at_capacity",
+      "server_is_overloaded",
+      "service_unavailable_error",
+      "temporarily unavailable",
+      "server busy",
+      "backend overloaded",
+      "overloaded",
+      "capacity",
+    ],
+  },
+  {
+    status: 429,
+    patterns: [
+      "rate_limit_exceeded",
+      "too many requests",
+      "too_many_requests",
+      "usage_limit_reached",
+      "quota_exceeded",
+      "insufficient_quota",
+      "rate limit",
+      "quota exceeded",
+    ],
+  },
+];
+
+const OPENAI_RESPONSES_OUTPUT_EVENTS = new Set([
+  "response.output_text.delta",
+  "response.refusal.delta",
+  "response.function_call_arguments.delta",
+  "response.reasoning_summary_text.delta",
+  "response.output_item.done",
+  "response.content_part.done",
+]);
+
+function toLowerText(value) {
+  if (typeof value === "string") return value.toLowerCase();
+  if (value == null) return "";
+  if (typeof value === "number" || typeof value === "boolean") return String(value).toLowerCase();
+  try {
+    return JSON.stringify(value).toLowerCase();
+  } catch {
+    return String(value).toLowerCase();
+  }
+}
+
+function parseSSEFrame(frame) {
+  if (typeof frame !== "string") return null;
+  const lines = frame.split(/\r?\n/);
+  let eventName = null;
+  const dataLines = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (line.startsWith("event:")) {
+      eventName = line.slice(6).trim();
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).replace(/^\s?/, ""));
+    }
+  }
+
+  if (dataLines.length === 0) return null;
+  const dataStr = dataLines.join("\n").trim();
+  if (!dataStr || dataStr === "[DONE]") {
+    return { eventName, done: dataStr === "[DONE]" };
+  }
+
+  try {
+    return { eventName, data: JSON.parse(dataStr) };
+  } catch {
+    return { eventName, rawData: dataStr };
+  }
+}
+
+function classifyRetryableFailureFromText(text) {
+  const lower = toLowerText(text);
+  if (!lower) return null;
+
+  for (const rule of RETRYABLE_FAILURE_RULES) {
+    for (const pattern of rule.patterns) {
+      if (lower.includes(pattern)) {
+        return { matched: pattern, status: rule.status };
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractResponsesFailurePayload(parsed) {
+  if (!parsed || typeof parsed !== "object") return null;
+  return parsed.error || parsed.response?.error || parsed.response || parsed;
+}
+
+function classifyRetryableResponsesFailure(parsedFrame) {
+  if (!parsedFrame || typeof parsedFrame !== "object") return null;
+
+  const eventName = parsedFrame.eventName || parsedFrame.data?.type || parsedFrame.data?.response?.type || null;
+  const data = parsedFrame.data ?? parsedFrame.rawData ?? null;
+  if (!data) return null;
+
+  const isTerminalFailure =
+    eventName === "error" ||
+    eventName === "response.failed" ||
+    data?.type === "error" ||
+    data?.type === "response.failed" ||
+    data?.response?.status === "failed" ||
+    data?.status === "failed";
+
+  if (!isTerminalFailure) return null;
+
+  const payload = extractResponsesFailurePayload(data);
+  const candidates = [
+    payload?.code,
+    payload?.type,
+    payload?.message,
+    payload?.reason,
+    payload,
+    data?.response?.status,
+    data?.status,
+    data,
+  ];
+
+  for (const candidate of candidates) {
+    const match = classifyRetryableFailureFromText(candidate);
+    if (match) {
+      return {
+        matched: match.matched,
+        status: match.status,
+        message: typeof payload?.message === "string"
+          ? payload.message
+          : (typeof data?.response?.error?.message === "string"
+            ? data.response.error.message
+            : (typeof data?.message === "string" ? data.message : null)),
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Detect retryable semantic failures in OpenAI Responses SSE text.
+ * Returns null for successful streams or non-retryable terminal failures.
+ */
+export function detectRetryableResponsesStreamFailure(text) {
+  if (typeof text !== "string" || !text.trim()) return null;
+
+  for (const frame of text.split(/\n\n+/)) {
+    const parsedFrame = parseSSEFrame(frame);
+    if (!parsedFrame) continue;
+    const classified = classifyRetryableResponsesFailure(parsedFrame);
+    if (classified) return classified;
+  }
+
+  return null;
+}
+
+function hasValuableResponsesOutput(parsedFrame) {
+  if (!parsedFrame || typeof parsedFrame !== "object") return false;
+  const data = parsedFrame.data ?? null;
+  const eventName = parsedFrame.eventName || data?.type || data?.response?.type || null;
+  if (!eventName || !data) return false;
+
+  if (eventName === "response.output_text.delta" || eventName === "response.refusal.delta") {
+    return typeof data.delta === "string" && data.delta.length > 0;
+  }
+
+  if (eventName === "response.function_call_arguments.delta") {
+    return typeof data.delta === "string" && data.delta.length > 0;
+  }
+
+  if (eventName === "response.reasoning_summary_text.delta") {
+    return typeof data.delta === "string" && data.delta.length > 0;
+  }
+
+  if (eventName === "response.output_item.done") {
+    const item = data.item;
+    if (!item || typeof item !== "object") return false;
+    if (item.type === "function_call") return true;
+    if (item.type === "message" && Array.isArray(item.content)) return item.content.length > 0;
+  }
+
+  if (eventName === "response.content_part.done") {
+    return !!data.part;
+  }
+
+  return OPENAI_RESPONSES_OUTPUT_EVENTS.has(eventName);
+}
+
+/**
+ * Detect whether a Responses SSE prefix already reached client-visible output.
+ * Callers can safely fallback only before this returns true.
+ */
+export function hasOpenAIResponsesStreamOutput(text) {
+  if (typeof text !== "string" || !text.trim()) return false;
+
+  for (const frame of text.split(/\n\n+/)) {
+    const parsedFrame = parseSSEFrame(frame);
+    if (!parsedFrame) continue;
+    if (hasValuableResponsesOutput(parsedFrame)) return true;
+  }
+
+  return false;
+}
+
 export function getOpenAIResponsesEventName(eventName, chunk) {
   if (eventName) return eventName;
   if (chunk && typeof chunk.type === "string") return chunk.type;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -3,7 +3,12 @@ import { FORMATS } from "../translator/formats.js";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
-import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
+import {
+  detectOpenAIResponsesStreamFailure,
+  getOpenAIResponsesEventName,
+  isOpenAIResponsesTerminalEvent,
+  formatIncompleteOpenAIResponsesStreamFailure,
+} from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
@@ -71,6 +76,7 @@ export function createSSEStream(options = {}) {
   let currentOpenAIResponsesEvent = null;
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
+  let terminalOutcome = { status: "success" };
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -105,6 +111,16 @@ export function createSSEStream(options = {}) {
           if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
               const parsed = JSON.parse(trimmed.slice(5).trim());
+              const failure = detectOpenAIResponsesStreamFailure(`${trimmed}\n\n`);
+              if (failure) {
+                terminalOutcome = {
+                  status: "failure",
+                  errorStatus: failure.status || 502,
+                  code: failure.code || failure.matched || null,
+                  type: failure.type || null,
+                  message: failure.message || null,
+                };
+              }
 
               const idFixed = fixInvalidId(parsed);
 
@@ -261,6 +277,16 @@ export function createSSEStream(options = {}) {
 
         // Responses same-format passthrough: re-emit with original event framing
         if (keepsOpenAIResponsesFormat && openAIResponsesEventName) {
+          const failure = detectOpenAIResponsesStreamFailure(`${trimmed}\n\n`);
+          if (failure) {
+            terminalOutcome = {
+              status: "failure",
+              errorStatus: failure.status || 502,
+              code: failure.code || failure.matched || null,
+              type: failure.type || null,
+              message: failure.message || null,
+            };
+          }
           const output = formatSSE({ event: openAIResponsesEventName, data: parsed }, sourceFormat);
           reqLogger?.appendConvertedChunk?.(output);
           controller.enqueue(sharedEncoder.encode(output));
@@ -333,10 +359,16 @@ export function createSSEStream(options = {}) {
             usage = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
           }
 
-          if (hasValidUsage(usage)) {
+          if (hasValidUsage(usage) && terminalOutcome.status === "success") {
             logUsage(provider, usage, model, connectionId, apiKey);
           } else {
-            appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
+            appendRequestLog({
+              model,
+              provider,
+              connectionId,
+              tokens: null,
+              status: terminalOutcome.status === "success" ? "200 OK" : `FAILED ${terminalOutcome.errorStatus || 502}`,
+            }).catch(() => { });
           }
           
           // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
@@ -351,7 +383,7 @@ export function createSSEStream(options = {}) {
             onStreamComplete({
               content: accumulatedContent,
               thinking: accumulatedThinking
-            }, usage, ttftAt);
+            }, usage, ttftAt, terminalOutcome);
           }
           return;
         }
@@ -416,17 +448,23 @@ export function createSSEStream(options = {}) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);
         }
 
-        if (hasValidUsage(state?.usage)) {
+        if (hasValidUsage(state?.usage) && terminalOutcome.status === "success") {
           logUsage(state.provider || targetFormat, state.usage, model, connectionId, apiKey);
         } else {
-          appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
+          appendRequestLog({
+            model,
+            provider,
+            connectionId,
+            tokens: null,
+            status: terminalOutcome.status === "success" ? "200 OK" : `FAILED ${terminalOutcome.errorStatus || 502}`,
+          }).catch(() => { });
         }
         
         if (onStreamComplete) {
           onStreamComplete({
             content: accumulatedContent,
             thinking: accumulatedThinking
-          }, state?.usage, ttftAt);
+          }, state?.usage, ttftAt, terminalOutcome);
         }
       } catch (error) {
         console.log("Error in flush:", error);

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -271,6 +271,11 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       },
       onRequestSuccess: async () => {
         await clearAccountError(credentials.connectionId, credentials, model);
+      },
+      onRequestFailure: async (outcome) => {
+        const status = outcome?.errorStatus || HTTP_STATUS.BAD_GATEWAY;
+        const message = outcome?.message || "Streaming request failed";
+        await markAccountUnavailable(credentials.connectionId, status, message, provider, model);
       }
     });
 

--- a/tests/unit/codex-sse-capacity.test.js
+++ b/tests/unit/codex-sse-capacity.test.js
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BaseExecutor } from "../../open-sse/executors/base.js";
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+function responseSse(text) {
+  return new Response(text, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function responseSseChunks(chunks) {
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(new TextEncoder().encode(chunk));
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CodexExecutor SSE capacity detection", () => {
+  it("returns a retryable error when a 200 SSE stream carries a model_at_capacity failure", async () => {
+    const executor = new CodexExecutor();
+    executor.config = { ...executor.config, retry: { 503: { attempts: 0, delayMs: 0 } } };
+
+    vi.spyOn(BaseExecutor.prototype, "execute").mockResolvedValue({
+      response: responseSse([
+        "event: response.failed",
+        `data: ${JSON.stringify({
+          type: "response.failed",
+          response: {
+            status: "failed",
+            error: {
+              code: "model_at_capacity",
+              message: "Selected model is at capacity. Please try a different model.",
+            },
+          },
+        })}`,
+        "",
+      ].join("\n")),
+      url: "https://provider.invalid/responses",
+      headers: {},
+      transformedBody: {},
+    });
+
+    const result = await executor.execute({
+      model: "gpt-5.5",
+      body: {},
+      stream: true,
+      credentials: { apiKey: "k" },
+      signal: new AbortController().signal,
+      log: {},
+    });
+
+    expect(result.response.status).toBe(503);
+    expect(await result.response.json()).toMatchObject({
+      error: {
+        message: "Selected model is at capacity. Please try a different model.",
+      },
+    });
+  });
+
+  it("keeps probing beyond the first peek window until a pre-output capacity failure arrives", async () => {
+    const executor = new CodexExecutor();
+    executor.config = { ...executor.config, retry: { 503: { attempts: 0, delayMs: 0 } } };
+
+    const padding = [
+      "event: response.created",
+      `data: ${JSON.stringify({
+        type: "response.created",
+        response: { id: "resp_1", status: "in_progress", metadata: "x".repeat(5000) },
+      })}`,
+      "",
+      "",
+    ].join("\n");
+    const failure = [
+      "event: response.failed",
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: {
+            code: "model_at_capacity",
+            message: "Selected model is at capacity. Please try a different model.",
+          },
+        },
+      })}`,
+      "",
+      "",
+    ].join("\n");
+
+    vi.spyOn(BaseExecutor.prototype, "execute").mockResolvedValue({
+      response: responseSseChunks([padding, failure]),
+      url: "https://provider.invalid/responses",
+      headers: {},
+      transformedBody: {},
+    });
+
+    const result = await executor.execute({
+      model: "gpt-5.5",
+      body: {},
+      stream: true,
+      credentials: { apiKey: "k" },
+      signal: new AbortController().signal,
+      log: {},
+    });
+
+    expect(result.response.status).toBe(503);
+    expect(await result.response.json()).toMatchObject({
+      error: {
+        message: "Selected model is at capacity. Please try a different model.",
+      },
+    });
+  });
+});

--- a/tests/unit/codex-sse-capacity.test.js
+++ b/tests/unit/codex-sse-capacity.test.js
@@ -120,4 +120,50 @@ describe("CodexExecutor SSE capacity detection", () => {
       },
     });
   });
+
+  it("does not retry after client-visible Responses output has started", async () => {
+    const executor = new CodexExecutor();
+    executor.config = { ...executor.config, retry: { 503: { attempts: 3, delayMs: 0 } } };
+
+    const text = [
+      "event: response.output_text.delta",
+      `data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        delta: "partial output",
+      })}`,
+      "",
+      "event: response.failed",
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: {
+            code: "model_at_capacity",
+            message: "Selected model is at capacity. Please try a different model.",
+          },
+        },
+      })}`,
+      "",
+    ].join("\n");
+
+    const executeSpy = vi.spyOn(BaseExecutor.prototype, "execute").mockResolvedValue({
+      response: responseSse(text),
+      url: "https://provider.invalid/responses",
+      headers: {},
+      transformedBody: {},
+    });
+
+    const result = await executor.execute({
+      model: "gpt-5.5",
+      body: {},
+      stream: true,
+      credentials: { apiKey: "k" },
+      signal: new AbortController().signal,
+      log: {},
+    });
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result.response.status).toBe(200);
+    expect(await result.response.text()).toContain("model_at_capacity");
+  });
 });

--- a/tests/unit/combo-semantic-failure.test.js
+++ b/tests/unit/combo-semantic-failure.test.js
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { handleComboChat } from "../../open-sse/services/combo.js";
+
+function okResponse(content) {
+  return new Response(JSON.stringify({ choices: [{ message: { role: "assistant", content } }] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function errResponse(message) {
+  return new Response(JSON.stringify({ error: { message } }), {
+    status: 503,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("combo fallback on semantic upstream failure", () => {
+  it("falls through to the next model after a retryable 503 capacity error", async () => {
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
+      if (typeof fn === "function") fn();
+      return 0;
+    });
+
+    const handleSingleModel = vi.fn(async (_body, modelStr) => {
+      if (modelStr === "cx/gpt-5.4") {
+        return errResponse("Selected model is at capacity. Please try a different model.");
+      }
+      return okResponse("fallback ok");
+    });
+
+    const res = await handleComboChat({
+      body: { messages: [{ role: "user", content: "hello" }] },
+      models: ["cx/gpt-5.4", "cx/gpt-5.5"],
+      handleSingleModel,
+      log: { info: () => {}, warn: () => {}, debug: () => {} },
+      comboStrategy: "fallback",
+    });
+
+    expect(handleSingleModel).toHaveBeenCalledTimes(2);
+    expect(handleSingleModel.mock.calls[0][1]).toBe("cx/gpt-5.4");
+    expect(handleSingleModel.mock.calls[1][1]).toBe("cx/gpt-5.5");
+    expect(res.ok).toBe(true);
+    expect(await res.json()).toMatchObject({
+      choices: [{ message: { content: "fallback ok" } }],
+    });
+  });
+});

--- a/tests/unit/responses-semantic-failure.test.js
+++ b/tests/unit/responses-semantic-failure.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { detectRetryableResponsesStreamFailure } from "../../open-sse/utils/responsesStreamHelpers.js";
+import {
+  detectOpenAIResponsesStreamFailure,
+  detectRetryableResponsesStreamFailure,
+} from "../../open-sse/utils/responsesStreamHelpers.js";
 
 describe("Responses SSE semantic failure detection", () => {
   it("detects retryable capacity failures carried inside a 200 Responses stream", () => {
@@ -54,5 +57,34 @@ describe("Responses SSE semantic failure detection", () => {
     ].join("\n");
 
     expect(detectRetryableResponsesStreamFailure(text)).toBeNull();
+  });
+
+  it("detects late Responses failures even after client-visible output", () => {
+    const text = [
+      "event: response.output_text.delta",
+      `data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        delta: "partial output",
+      })}`,
+      "",
+      "event: response.failed",
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: {
+            code: "model_at_capacity",
+            message: "Selected model is at capacity. Please try a different model.",
+          },
+        },
+      })}`,
+      "",
+    ].join("\n");
+
+    expect(detectOpenAIResponsesStreamFailure(text)).toMatchObject({
+      code: "model_at_capacity",
+      message: "Selected model is at capacity. Please try a different model.",
+      status: 503,
+    });
   });
 });

--- a/tests/unit/responses-semantic-failure.test.js
+++ b/tests/unit/responses-semantic-failure.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { detectRetryableResponsesStreamFailure } from "../../open-sse/utils/responsesStreamHelpers.js";
+
+describe("Responses SSE semantic failure detection", () => {
+  it("detects retryable capacity failures carried inside a 200 Responses stream", () => {
+    const text = [
+      "event: response.failed",
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: {
+            code: "model_at_capacity",
+            message: "Selected model is at capacity. Please try a different model.",
+          },
+        },
+      })}`,
+      "",
+    ].join("\n");
+
+    const failure = detectRetryableResponsesStreamFailure(text);
+
+    expect(failure).toMatchObject({
+      matched: "model_at_capacity",
+      status: 503,
+      message: "Selected model is at capacity. Please try a different model.",
+    });
+  });
+
+  it("keeps legacy overloaded text detection", () => {
+    const failure = detectRetryableResponsesStreamFailure("event: error\ndata: {\"code\":\"server_is_overloaded\"}\n\n");
+
+    expect(failure).toMatchObject({
+      matched: "server_is_overloaded",
+      status: 503,
+    });
+  });
+
+  it("does not classify non-retryable semantic failures as transient capacity errors", () => {
+    const text = [
+      "event: response.failed",
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: {
+            code: "model_not_found",
+            message: "The requested model does not exist.",
+          },
+        },
+      })}`,
+      "",
+    ].join("\n");
+
+    expect(detectRetryableResponsesStreamFailure(text)).toBeNull();
+  });
+});

--- a/tests/unit/stream-complete-callback.test.js
+++ b/tests/unit/stream-complete-callback.test.js
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {}),
+}));
+
+import { saveRequestDetail, saveRequestUsage } from "@/lib/usageDb.js";
+import { buildOnStreamComplete } from "../../open-sse/handlers/chatCore/streamingHandler.js";
+
+function makeComplete(overrides = {}) {
+  return buildOnStreamComplete({
+    provider: "codex",
+    model: "gpt-5.5",
+    connectionId: "conn_1",
+    apiKey: "sk-test",
+    requestStartTime: Date.now(),
+    body: { input: [{ role: "user", content: "hello" }], stream: true },
+    stream: true,
+    finalBody: null,
+    translatedBody: { input: [{ role: "user", content: "hello" }] },
+    clientRawRequest: { endpoint: "/v1/responses" },
+    ...overrides,
+  }).onStreamComplete;
+}
+
+describe("stream completion callbacks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs success bookkeeping only on terminal stream success", async () => {
+    const onRequestSuccess = vi.fn(async () => {});
+    const onRequestFailure = vi.fn(async () => {});
+    const onStreamComplete = makeComplete({ onRequestSuccess, onRequestFailure });
+
+    onStreamComplete(
+      { content: "done", thinking: null },
+      { prompt_tokens: 10, completion_tokens: 2 },
+      Date.now(),
+      { status: "success" },
+    );
+    await vi.waitFor(() => expect(onRequestSuccess).toHaveBeenCalledTimes(1));
+
+    expect(onRequestFailure).not.toHaveBeenCalled();
+    expect(saveRequestUsage).toHaveBeenCalledTimes(1);
+    expect(saveRequestDetail).toHaveBeenCalledWith(expect.objectContaining({
+      status: "success",
+      response: expect.objectContaining({ content: "done" }),
+    }));
+  });
+
+  it("runs failure bookkeeping and skips success on terminal stream failure", async () => {
+    const onRequestSuccess = vi.fn(async () => {});
+    const onRequestFailure = vi.fn(async () => {});
+    const onStreamComplete = makeComplete({ onRequestSuccess, onRequestFailure });
+    const outcome = {
+      status: "failure",
+      errorStatus: 503,
+      code: "model_at_capacity",
+      message: "Selected model is at capacity. Please try a different model.",
+    };
+
+    onStreamComplete(
+      { content: "partial", thinking: null },
+      { prompt_tokens: 10, completion_tokens: 2 },
+      Date.now(),
+      outcome,
+    );
+    await vi.waitFor(() => expect(onRequestFailure).toHaveBeenCalledTimes(1));
+
+    expect(onRequestFailure).toHaveBeenCalledWith(outcome);
+    expect(onRequestSuccess).not.toHaveBeenCalled();
+    expect(saveRequestUsage).not.toHaveBeenCalled();
+    expect(saveRequestDetail).toHaveBeenCalledWith(expect.objectContaining({
+      status: "error",
+      response: expect.objectContaining({
+        error: "Selected model is at capacity. Please try a different model.",
+        status: 503,
+      }),
+    }));
+  });
+});

--- a/tests/unit/stream-terminal-outcome.test.js
+++ b/tests/unit/stream-terminal-outcome.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+
+async function readStream(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+function streamFromText(text) {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe("stream terminal outcome reporting", () => {
+  it("reports a late Responses capacity failure from passthrough streams", async () => {
+    const outcomes = [];
+    const source = streamFromText([
+      "event: response.output_text.delta",
+      `data: ${JSON.stringify({
+        type: "response.output_text.delta",
+        delta: "partial output",
+      })}`,
+      "",
+      "event: response.failed",
+      `data: ${JSON.stringify({
+        type: "response.failed",
+        response: {
+          status: "failed",
+          error: {
+            code: "model_at_capacity",
+            message: "Selected model is at capacity. Please try a different model.",
+          },
+        },
+      })}`,
+      "",
+    ].join("\n"));
+
+    const transform = createPassthroughStreamWithLogger(
+      "codex",
+      null,
+      "gpt-5.5",
+      "conn_1",
+      { input: [{ role: "user", content: "hello" }] },
+      (_content, _usage, _ttftAt, outcome) => outcomes.push(outcome),
+      "sk-test",
+    );
+
+    await readStream(source.pipeThrough(transform));
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toMatchObject({
+      status: "failure",
+      errorStatus: 503,
+      message: "Selected model is at capacity. Please try a different model.",
+      code: "model_at_capacity",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- detect retryable OpenAI Responses SSE failures returned inside HTTP 200 before client-visible output, so combos can fall back to the next model/account
- avoid retrying after Responses output has already started, because fallback is no longer safe once the client has seen stream content
- mark late terminal Responses failures as failed request details/account failures instead of recording them as successful streams

## Tests

- `npm --prefix tests test -- unit/stream-complete-callback.test.js unit/stream-terminal-outcome.test.js unit/responses-semantic-failure.test.js unit/codex-sse-capacity.test.js unit/combo-semantic-failure.test.js`
- `npm run build`

## Local runtime verification on tiny

- Applied temporary production patch under `/opt/9router` without resetting existing local patches.
- Ran existing production targeted tests: `unit/responses-semantic-failure.test.js`, `unit/codex-sse-capacity.test.js`, `unit/combo-semantic-failure.test.js`.
- Built `/opt/9router`, refreshed standalone runtime links, restarted `9router`.
- Verified service active, `/login` 200, `/providers/gemini.png` 200, and a Next static asset 200.
