### PR TITLE
fix: strip reasoning_content from assistant messages before forwarding

### DIFF
--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -22,6 +22,24 @@ import { updateProviderCredentials, checkAndRefreshToken } from "../services/tok
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
 
 /**
+ * Strip reasoning_content from assistant messages in conversation history.
+ * Some providers (e.g. Mistral) reject requests containing reasoning_content
+ * in assistant messages with "extra_forbidden" validation errors.
+ * This field is only meaningful in streaming responses, not in request bodies.
+ */
+function stripReasoningFromMessages(body) {
+  if (!body.messages || !Array.isArray(body.messages)) return body;
+  let modified = false;
+  for (const msg of body.messages) {
+    if (msg && msg.role === "assistant" && msg.reasoning_content !== undefined) {
+      delete msg.reasoning_content;
+      modified = true;
+    }
+  }
+  return modified ? { ...body, messages: [...body.messages] } : body;
+}
+
+
  * Handle chat completion request
  * Supports: OpenAI, Claude, Gemini, OpenAI Responses API formats
  * Format detection and translation handled by translator
@@ -45,6 +63,9 @@ export async function handleChat(request, clientRawRequest = null) {
     };
   }
   cacheClaudeHeaders(clientRawRequest.headers);
+
+  // Strip reasoning_content from conversation history (providers like Mistral reject it)
+  body = stripReasoningFromMessages(body);
 
   // Log request endpoint and model
   const url = new URL(request.url);

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -39,7 +39,22 @@ function stripReasoningFromMessages(body) {
   return modified ? { ...body, messages: [...body.messages] } : body;
 }
 
+/**
+ * Fix message ordering for providers that require specific role sequences.
+ * Mistral requires the last message to be user/tool (or assistant with prefix=true).
+ * If the last message is an assistant without prefix, add prefix: true so the
+ * provider can continue generation from that point.
+ */
+function fixMessageOrdering(messages) {
+  if (!messages || !Array.isArray(messages) || messages.length === 0) return;
+  const last = messages[messages.length - 1];
+  if (last && last.role === "assistant" && !last.prefix) {
+    last.prefix = true;
+  }
+}
 
+
+/**
  * Handle chat completion request
  * Supports: OpenAI, Claude, Gemini, OpenAI Responses API formats
  * Format detection and translation handled by translator
@@ -65,7 +80,7 @@ export async function handleChat(request, clientRawRequest = null) {
   cacheClaudeHeaders(clientRawRequest.headers);
 
   // Strip reasoning_content from conversation history (providers like Mistral reject it)
-  body = stripReasoningFromMessages(body);
+
 
   // Log request endpoint and model
   const url = new URL(request.url);
@@ -209,6 +224,14 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   }
 
   const { provider, model } = modelInfo;
+
+  // Strip reasoning_content for providers that reject it (Mistral, etc.)
+  // Preserve for providers that require it (DeepSeek thinking mode)
+  if (!provider.startsWith("deepseek")) {
+    body = stripReasoningFromMessages(body);
+  }
+  // Fix message ordering for all providers (prefix: true for last assistant)
+  fixMessageOrdering(body.messages);
 
   // Log model routing (alias → actual model)
   if (modelStr !== `${provider}/${model}`) {


### PR DESCRIPTION
## Problem

When a conversation history contains `reasoning_content` in assistant messages (from previous responses by reasoning models like DeepSeek R1, o1, etc.), and the request is forwarded to a provider that doesn't support this field (e.g. Mistral), the provider rejects the request with:

```json
{
  "error": {
    "detail": [{
      "type": "extra_forbidden",
      "loc": ["body", "messages", 2, "assistant", "reasoning_content"],
      "msg": "Extra inputs are not permitted"
    }]
  }
}
```

## Fix

Added `stripReasoningFromMessages()` in `handleChat` to remove `reasoning_content` from assistant messages in the conversation history before the body reaches the provider.

- Only strips from `assistant` role messages (where it appears in conversation history)
- Creates a shallow copy of messages array to avoid mutating the original body
- Skips processing if no messages or no `reasoning_content` found (zero overhead for clean requests)

## Context

`reasoning_content` is only meaningful in streaming **responses** from reasoning models. It should never appear in request conversation history, but clients like Hermes forward the full conversation history including previous reasoning model outputs.