### PR TITLE
fix(combo): show user-added customModels for custom providers in model picker

### DIFF
--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -241,13 +241,33 @@ export default function ModelSelectModal({
 
         // Aliases are stored using the raw providerId as key (e.g. "openai-compatible-chat-<uuid>/glm-4.7"),
         // so we must filter by providerId, not by the display prefix.
-        const nodeModels = Object.entries(modelAliases)
+        const aliasNodeModels = Object.entries(modelAliases)
           .filter(([, fullModel]) => fullModel.startsWith(`${providerId}/`))
           .map(([aliasName, fullModel]) => ({
             id: fullModel.replace(`${providerId}/`, ""),
             name: aliasName,
             value: `${nodePrefix}/${fullModel.replace(`${providerId}/`, "")}`,
           }));
+
+        // Models added via the provider's "Available Models" UI are stored in customModels
+        // (keyed by providerAlias === providerId), NOT in modelAliases. Read them here too,
+        // otherwise user-added models on custom providers never appear in the combo builder
+        // and only a "<prefix>/model-id" placeholder shows up.
+        const customNodeModels = customModels
+          .filter((m) => m.providerAlias === providerId && (!getModelKind(m) || getModelKind(m) === "llm"))
+          .map((m) => ({
+            id: m.id,
+            name: m.name || m.id,
+            value: `${nodePrefix}/${m.id}`,
+            isCustom: true,
+          }));
+
+        // Merge alias-based and customModels-based entries, de-duplicating by value.
+        const seenNodeValues = new Set(customNodeModels.map((m) => m.value));
+        const nodeModels = [
+          ...customNodeModels,
+          ...aliasNodeModels.filter((m) => !seenNodeValues.has(m.value)),
+        ];
 
         // Always show compatible providers that are connected, even with no aliases.
         // When no aliases exist, show a placeholder so users know it's available.


### PR DESCRIPTION
## Problem

Models added through a custom (OpenAI/Anthropic-compatible) provider's **"Available Models"** UI do not appear in the combo builder's model picker. Instead the picker only shows a `<prefix>/model-id` placeholder, so the user-added model can't be selected when creating a combo.

Steps to reproduce:
1. Add a custom OpenAI-compatible provider (e.g. an EvoMap / B.AI gateway).
2. On the provider page, under **Available Models**, add a model ID (e.g. `evomap-claude-opus-4-7`) — it saves successfully and shows under the provider.
3. Go to create/edit a **combo** and open the model picker.
4. The provider group shows only `evo/model-id` (placeholder) — the model you added is missing.

## Root cause

User-added models from the "Available Models" UI are persisted to the **`customModels`** kv scope (keyed by `providerAlias`), via `addCustomModel()` in `aliasRepo.js`.

In `src/shared/components/ModelSelectModal.js`, the `groupedModels` builder handles two relevant branches:

- The **`passthroughModels`** branch already merges `customModels` (see `customRegisteredModels`).
- The **`isCustomProvider`** branch (OpenAI/Anthropic-compatible providers) only reads `modelAliases`:

```js
const nodeModels = Object.entries(modelAliases)
  .filter(([, fullModel]) => fullModel.startsWith(`${providerId}/`))
  ...
```

Because `customModels` is never read in this branch, `nodeModels` stays empty for providers whose models were added via "Available Models", and the code falls through to the `__placeholder__` entry (`<prefix>/model-id`).

This also matches the regression report from users: older versions stored "Add Model" entries in `modelAliases` (which this branch reads), while the newer "Available Models" flow writes to `customModels` (which it doesn't).

## Fix

In the `isCustomProvider` branch, also read matching `customModels` entries (filtered by `providerAlias === providerId`, LLM kind), map them to the node-prefixed `value`, and merge with the alias-based entries (de-duplicated by `value`). This mirrors what the `passthroughModels` branch already does. `hasModels` now reflects the combined set automatically.

## Testing

- `node -c src/shared/components/ModelSelectModal.js` — syntax OK.
- Manually verified against a live instance: after adding `evomap-claude-opus-4-7` and `glm-5.2` on custom providers, both now appear in the combo model picker and route correctly (HTTP 200 from upstream) instead of sending the literal `model-id` placeholder.

No change to the placeholder fallback behaviour for providers that genuinely have no models registered.
