### PR TITLE
fix: Preserve reasoning effort for Codex translations

### DIFF
--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -159,12 +159,10 @@ export function hasThinkingConfig(body) {
   return !!(body.reasoning_effort || body.thinking?.type === "enabled");
 }
 
-// Normalize thinking config based on last message role
-// - If lastMessage is not user → remove thinking config
-// - If lastMessage is user AND has thinking config → keep it (force enable)
+// Normalize provider-native thinking config based on last message role.
+// OpenAI reasoning_effort is request-level and must survive tool-result turns.
 export function normalizeThinkingConfig(body) {
   if (!isLastMessageFromUser(body)) {
-    delete body.reasoning_effort;
     delete body.thinking;
   }
   return body;

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -163,7 +163,7 @@ function applyFormat(fmt, body, cfg, caps) {
     case "openai": {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
       const level = toLevel(eff);
-      if (level) body.reasoning_effort = level === "xhigh" || level === "max" ? "high" : level;
+      if (level) body.reasoning_effort = level;
       break;
     }
     case "claude-adaptive": {

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -70,6 +70,16 @@ export function claudeToOpenAIRequest(model, body, stream) {
     result.tool_choice = convertToolChoice(body.tool_choice);
   }
 
+  if (body.reasoning_effort !== undefined) {
+    result.reasoning_effort = body.reasoning_effort;
+  } else if (body.reasoning?.effort !== undefined) {
+    result.reasoning_effort = body.reasoning.effort;
+  }
+
+  if (body.reasoning !== undefined) {
+    result.reasoning = body.reasoning;
+  }
+
   return result;
 }
 

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -283,6 +283,8 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.temperature !== undefined) result.temperature = body.temperature;
   if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
+  if (body.reasoning !== undefined) result.reasoning = body.reasoning;
+  if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
 
   return result;
 }

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -113,6 +113,10 @@ describe("applyThinking per provider format", () => {
     const out = apply("openai", "gpt-5(low)", { reasoning_effort: "high" }, "openai");
     expect(out.reasoning_effort).toBe("low");
   });
+  it("openai keeps xhigh for reasoning models", () => {
+    const out = apply("openai", "gpt-5.3-codex", { reasoning_effort: "xhigh" }, "codex");
+    expect(out.reasoning_effort).toBe("xhigh");
+  });
 });
 
 describe("extractReasoningText (response shapes)", () => {

--- a/tests/unit/provider-thinking-config.test.js
+++ b/tests/unit/provider-thinking-config.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { normalizeThinkingConfig } from "../../open-sse/services/provider.js";
+
+describe("normalizeThinkingConfig", () => {
+  it("keeps openai reasoning_effort on non-user turns", () => {
+    const body = {
+      messages: [{ role: "assistant", content: "ok" }],
+      reasoning_effort: "xhigh",
+      thinking: { type: "enabled" },
+    };
+
+    normalizeThinkingConfig(body);
+
+    expect(body.reasoning_effort).toBe("xhigh");
+    expect(body.thinking).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Preserve explicit `reasoning_effort` / `reasoning.effort` through Claude -> OpenAI Chat -> OpenAI Responses translation so Codex gets requested effort instead of falling back to default.

## Changes
- Carry Claude reasoning config into OpenAI Chat translation.
- Map OpenAI Chat `reasoning_effort` into OpenAI Responses `reasoning.effort`.
- Add tests for translation path and provider config.

## Related
- Fixes #1459
- Related to #1460