### PR TITLE
fix: include customModels in openai/anthropic-compatible provider model selector

### DIFF
--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -249,9 +249,24 @@ export default function ModelSelectModal({
             value: `${nodePrefix}/${fullModel.replace(`${providerId}/`, "")}`,
           }));
 
+        // Also include customModels registered via /api/models/custom
+        const customModelsForProvider = customModels
+          .filter((m) => m.providerAlias === providerId)
+          .map((m) => ({
+            id: m.id,
+            name: m.name || m.id,
+            value: `${nodePrefix}/${m.id}`,
+            isCustom: true,
+          }));
+
+        // Merge: custom models first, then aliases (deduped by value to avoid duplicates)
+        const mergedModels = customModelsForProvider.length > 0 || nodeModels.length > 0
+          ? [...customModelsForProvider, ...nodeModels.filter(m => !customModelsForProvider.some(cm => cm.value === m.value))]
+          : [];
+
         // Always show compatible providers that are connected, even with no aliases.
         // When no aliases exist, show a placeholder so users know it's available.
-        const modelsToShow = nodeModels.length > 0 ? nodeModels : [{
+        const modelsToShow = mergedModels.length > 0 ? mergedModels : [{
           id: `__placeholder__${providerId}`,
           name: `${nodePrefix}/model-id`,
           value: `${nodePrefix}/model-id`,
@@ -264,7 +279,7 @@ export default function ModelSelectModal({
           color: providerInfo.color,
           models: modelsToShow,
           isCustom: true,
-          hasModels: nodeModels.length > 0,
+          hasModels: mergedModels.length > 0,
         };
       } else {
         const hardcodedModels = getModelsByProviderId(providerId);


### PR DESCRIPTION
## Description

Custom models added via the "Add Model" button on OpenAI-compatible or Anthropic-compatible provider pages are stored as `customModels` (since commit `707a915`), but the combo creation model selector (`ModelSelectModal.js`) only read `modelAliases` in its Branch 2 logic for these provider types. This made all custom models invisible in the combo model picker.

## Root Cause

The `groupedModels` logic in `ModelSelectModal.js` has three branches:

| Branch | Provider Type | Model Sources |
|--------|--------------|---------------|
| 1 | `passthroughModels` | modelAliases + customModels ✅ |
| 2 | openai/anthropic-compatible | modelAliases **only** ❌ |
| 3 | Standard built-in | built-in + modelAliases + customModels ✅ |

Commit `707a915` changed "Add Model" to store models as `customModels` instead of `modelAliases`, but **Branch 2 was never updated** to read from `customModels`.

## Changes

Added `customModels` reading to Branch 2 in `ModelSelectModal.js`, matching the pattern used by Branch 1 and Branch 3:

- Filter `customModels` by `providerAlias === providerId` (for compatible providers, `providerStorageAlias === providerId`)
- Merge custom models with existing alias models (custom models take priority, deduped by value)
- Use merged list for display and `hasModels` flag

## Related Issues

Closes #2098
Fixes #2028
Fixes #1993
Fixes #1990
Fixes #2013

## Testing

- [x] Verified code change in source file
- [x] Patched running Docker instance and confirmed custom models now appear in combo model selector
