### PR TITLE
fix(auth): avoid stale dashboard redirects after login

### DIFF
--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -7,6 +7,7 @@ import { isOidcConfigured } from "@/lib/auth/oidc";
 import { checkLock, recordFail, recordSuccess, getClientIp } from "@/lib/auth/loginLimiter";
 
 const RESET_HINT = "Forgot password? Reset to default via 9Router CLI → Settings → Reset Password to Default.";
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
 
 function isTunnelRequest(request, settings) {
   const host = (request.headers.get("host") || "").split(":")[0].toLowerCase();
@@ -55,7 +56,7 @@ export async function POST(request) {
       const cookieStore = await cookies();
       await setDashboardAuthCookie(cookieStore, request);
 
-      return NextResponse.json({ success: true });
+      return NextResponse.json({ success: true }, { headers: NO_STORE_HEADERS });
     }
 
     const { remainingBeforeLock } = recordFail(ip);

--- a/src/app/api/auth/logout/route.js
+++ b/src/app/api/auth/logout/route.js
@@ -8,5 +8,5 @@ export async function POST() {
   cookieStore.delete("oidc_state");
   cookieStore.delete("oidc_nonce");
   cookieStore.delete("oidc_code_verifier");
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true }, { headers: { "Cache-Control": "no-store" } });
 }

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -72,8 +72,7 @@ export default function LoginPage() {
       });
 
       if (res.ok) {
-        router.push("/dashboard");
-        router.refresh();
+        window.location.assign("/dashboard");
       } else {
         const data = await res.json();
         setError(data.error || "Invalid password");

--- a/src/shared/components/Header.js
+++ b/src/shared/components/Header.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import Link from "next/link";
 import PropTypes from "prop-types";
 import ProviderIcon from "@/shared/components/ProviderIcon";
@@ -173,7 +173,6 @@ const getPageInfo = (pathname) => {
 
 export default function Header({ onMenuClick, showMenuButton = true }) {
   const pathname = usePathname();
-  const router = useRouter();
   const [displayName, setDisplayName] = useState("");
   const [loginMethod, setLoginMethod] = useState("");
   const [donateOpen, setDonateOpen] = useState(false);
@@ -212,8 +211,7 @@ export default function Header({ onMenuClick, showMenuButton = true }) {
     try {
       const res = await fetch("/api/auth/logout", { method: "POST" });
       if (res.ok) {
-        router.push("/login");
-        router.refresh();
+        window.location.assign("/login");
       }
     } catch (err) {
       console.error("Failed to logout:", err);


### PR DESCRIPTION
## Summary
- use full-page navigation after successful password login so dashboard reloads with the fresh auth cookie
- use full-page navigation after logout to clear stale authenticated client state
- mark login/logout auth responses as no-store

Fixes #2100

## Testing
- git diff --check
- Not run: app tests/build because this checkout has no node_modules and no lockfile; avoided npm install to prevent unrelated dependency/lock changes.