### PR TITLE
fix(auth): avoid stale redirects after auth changes

### DIFF
--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
 import { Card, Button, Toggle, Input } from "@/shared/components";
 import Modal, { ConfirmModal } from "@/shared/components/Modal";
 import LanguageSwitcher from "@/shared/components/LanguageSwitcher";
@@ -21,7 +20,6 @@ function getLocaleFromCookie() {
 }
 
 export default function ProfilePage() {
-  const router = useRouter();
   const { theme, setTheme, isDark } = useTheme();
   const [locale, setLocale] = useState("en");
   const [langOpen, setLangOpen] = useState(false);
@@ -569,8 +567,7 @@ export default function ProfilePage() {
     try {
       const res = await fetch("/api/auth/logout", { method: "POST" });
       if (res.ok) {
-        router.push("/login");
-        router.refresh();
+        window.location.assign("/login");
       }
     } catch (err) {
       console.error("Failed to logout:", err);

--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -8,6 +8,7 @@ import { checkLock, recordFail, recordSuccess, getClientIp } from "@/lib/auth/lo
 import { isLocalRequest } from "@/dashboardGuard";
 
 const RESET_HINT = "Forgot password? Reset to default via 9Router CLI → Settings → Reset Password to Default.";
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
 
 function isTunnelRequest(request, settings) {
   const host = (request.headers.get("host") || "").split(":")[0].toLowerCase();
@@ -61,7 +62,7 @@ export async function POST(request) {
       const mustChangePassword =
         !storedHash && !process.env.INITIAL_PASSWORD && !isLocalRequest(request);
 
-      return NextResponse.json({ success: true, mustChangePassword });
+      return NextResponse.json({ success: true, mustChangePassword }, { headers: NO_STORE_HEADERS });
     }
 
     const { remainingBeforeLock } = recordFail(ip);

--- a/src/app/api/auth/logout/route.js
+++ b/src/app/api/auth/logout/route.js
@@ -8,5 +8,5 @@ export async function POST() {
   cookieStore.delete("oidc_state");
   cookieStore.delete("oidc_nonce");
   cookieStore.delete("oidc_code_verifier");
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true }, { headers: { "Cache-Control": "no-store" } });
 }

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { Card, Button, Input } from "@/shared/components";
-import { useRouter } from "next/navigation";
 
 export default function LoginPage() {
   const [password, setPassword] = useState("");
@@ -16,7 +15,6 @@ export default function LoginPage() {
   const [oidcLoginLabel, setOidcLoginLabel] = useState("Sign in with OIDC");
   const [mustChange, setMustChange] = useState(false);
   const [newPassword, setNewPassword] = useState("");
-  const router = useRouter();
 
   // Countdown for rate-limit
   useEffect(() => {
@@ -40,8 +38,7 @@ export default function LoginPage() {
         if (res.ok) {
           const data = await res.json();
           if (data.requireLogin === false) {
-            router.push("/dashboard");
-            router.refresh();
+            window.location.assign("/dashboard");
             return;
           }
           setHasPassword(!!data.hasPassword);
@@ -58,7 +55,7 @@ export default function LoginPage() {
       }
     }
     checkAuth();
-  }, [router]);
+  }, []);
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -79,8 +76,7 @@ export default function LoginPage() {
           setMustChange(true);
           return;
         }
-        router.push("/dashboard");
-        router.refresh();
+        window.location.assign("/dashboard");
       } else {
         const data = await res.json();
         setError(data.error || "Invalid password");
@@ -106,8 +102,7 @@ export default function LoginPage() {
         body: JSON.stringify({ currentPassword: password, newPassword }),
       });
       if (res.ok) {
-        router.push("/dashboard");
-        router.refresh();
+        window.location.assign("/dashboard");
       } else {
         const data = await res.json();
         setError(data.error || "Failed to set password");

--- a/src/shared/components/Header.js
+++ b/src/shared/components/Header.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import Link from "next/link";
 import PropTypes from "prop-types";
 import ProviderIcon from "@/shared/components/ProviderIcon";
@@ -173,7 +173,6 @@ const getPageInfo = (pathname) => {
 
 export default function Header({ onMenuClick, showMenuButton = true }) {
   const pathname = usePathname();
-  const router = useRouter();
   const [displayName, setDisplayName] = useState("");
   const [loginMethod, setLoginMethod] = useState("");
   const [donateOpen, setDonateOpen] = useState(false);
@@ -212,8 +211,7 @@ export default function Header({ onMenuClick, showMenuButton = true }) {
     try {
       const res = await fetch("/api/auth/logout", { method: "POST" });
       if (res.ok) {
-        router.push("/login");
-        router.refresh();
+        window.location.assign("/login");
       }
     } catch (err) {
       console.error("Failed to logout:", err);


### PR DESCRIPTION
## Summary
- use full-page navigation after password login so dashboard reloads with the fresh auth cookie
- cover the remote default-password change flow before entering the dashboard
- use full-page navigation after logout from header/profile to avoid stale authenticated client state
- mark login/logout auth responses as no-store

Fixes #2100

## Testing
- npm run build
- .\\tests\\node_modules\\.bin\\vitest.cmd run tests/unit/dashboard-guard.test.js tests/unit/web-cookie-validation.test.js --reporter=verbose