### PR TITLE
fix(capabilities): mark Claude Opus 4.8/4.7 (dashed ids) as 1M context

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -71,9 +71,15 @@ export function capabilitiesFromServiceKind(kind) {
  * otherwise mis-match. Only declare deltas vs DEFAULT.
  */
 export const MODEL_CAPABILITIES = {
-  // Claude 4.6/4.7 have 1M context + adaptive thinking (override generic claude pattern)
-  "claude-opus-4.6":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  // Claude Opus 4.6+ ship a 1M context window (GA, standard pricing) + adaptive
+  // thinking (override generic claude pattern). The registry exposes dashed ids
+  // (claude-opus-4-8, claude-opus-4-7); matchPattern treats "." as a literal, so
+  // the dashed forms don't hit the dotted patterns and each needs an exact entry.
+  "claude-opus-4.8":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-4-8":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4.7":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-4-7":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-4.6":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4-6":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-sonnet-4.6": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 64000 },
   "claude-sonnet-4-6": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 64000 },

--- a/tests/unit/capabilities-opus-context.test.js
+++ b/tests/unit/capabilities-opus-context.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+
+// Claude Opus 4.6+ ships a 1M-token context window (GA, standard pricing).
+// The registry exposes dashed ids (claude-opus-4-8, claude-opus-4-7), which
+// must resolve to the 1M context + adaptive thinking caps rather than falling
+// through to the generic *claude*opus* pattern (200k / budget thinking).
+describe("Claude Opus 1M context capabilities", () => {
+  const expected = {
+    contextWindow: 1000000,
+    maxOutput: 128000,
+    thinkingFormat: "claude-adaptive",
+    reasoning: true,
+    vision: true,
+    search: true,
+  };
+
+  for (const model of [
+    "claude-opus-4-8",
+    "claude-opus-4.8",
+    "claude-opus-4-7",
+    "claude-opus-4.7",
+    "claude-opus-4-6",
+  ]) {
+    it(`resolves ${model} to a 1M context window`, () => {
+      expect(getCapabilitiesForModel("cc", model)).toMatchObject(expected);
+    });
+  }
+
+  it("keeps the older Opus 4.5 at the standard 200k context", () => {
+    expect(getCapabilitiesForModel("cc", "claude-opus-4-5-20251101").contextWindow).toBe(200000);
+  });
+});


### PR DESCRIPTION
## Summary

`claude-opus-4-8` (and `claude-opus-4-7`) resolve to a **200k** context window with `claude-budget` thinking instead of the correct **1M** context + `claude-adaptive`.

Claude Opus 4.6+ ship a 1M-token context window — GA at standard pricing since March 2026 (the old `context-1m-2025-08-07` beta only ever applied to Sonnet 4 / 4.5 and has been retired). So Opus 4.7 and 4.8 are 1M-context models, but `MODEL_CAPABILITIES` was missing them.

### Root cause

`MODEL_CAPABILITIES` only had `claude-opus-4.7` (dotted) and `claude-opus-4-6` (dashed). The registry (`open-sse/providers/registry/claude.js`) exposes **dashed** ids (`claude-opus-4-8`, `claude-opus-4-7`). `matchPattern` escapes `.` to a literal dot, so a dashed id like `claude-opus-4-8` does **not** match the dotted `*claude*opus-4.8*` pattern — it falls through to the generic `*claude*opus*` entry, which has no `contextWindow` (→ DEFAULT 200k) and `thinkingFormat: claude-budget`.

### Fix

Add exact `MODEL_CAPABILITIES` entries for:
- `claude-opus-4-8` / `claude-opus-4.8` (new — latest Opus)
- `claude-opus-4-7` (dashed — the registry id was previously uncovered)
- `claude-opus-4.6` (dotted, for symmetry)

Values match the project's authoritative source [models.dev](https://models.dev/api.json): `contextWindow: 1000000`, `maxOutput: 128000`, `thinkingFormat: claude-adaptive`.

This is metadata-only — it changes what `/v1/models/info` reports (and anything downstream that reads a model's context budget). The transport already sends the bare model id upstream, so 1M requests were already accepted by the API; only 9router's reported capability was wrong.

## Test

Adds `tests/unit/capabilities-opus-context.test.js` asserting both dashed and dotted spellings of Opus 4.6/4.7/4.8 resolve to 1M + `claude-adaptive`, and that Opus 4.5 stays at 200k.

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

No new failures in the existing unit suite (pre-existing environmental failures unchanged).
