### PR TITLE
fix: show compatible custom models in combo picker

### DIFF
--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -8,6 +8,7 @@ import CapacityBadges from "./CapacityBadges";
 import { useModelCaps } from "@/shared/hooks/useModelCaps";
 import { getModelsByProviderId, getModelKind } from "@/shared/constants/models";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, AI_PROVIDERS, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, getProviderAlias } from "@/shared/constants/providers";
+import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
 
 // Provider order: OAuth first, then Free Tier, then API Key (matches dashboard/providers)
 const PROVIDER_ORDER = [
@@ -239,15 +240,21 @@ export default function ModelSelectModal({
         const displayName = matchedNode?.name || connection?.name || providerInfo.name;
         const nodePrefix = connection?.providerSpecificData?.prefix || matchedNode?.prefix || providerId;
 
-        // Aliases are stored using the raw providerId as key (e.g. "openai-compatible-chat-<uuid>/glm-4.7"),
-        // so we must filter by providerId, not by the display prefix.
-        const nodeModels = Object.entries(modelAliases)
-          .filter(([, fullModel]) => fullModel.startsWith(`${providerId}/`))
-          .map(([aliasName, fullModel]) => ({
-            id: fullModel.replace(`${providerId}/`, ""),
-            name: aliasName,
-            value: `${nodePrefix}/${fullModel.replace(`${providerId}/`, "")}`,
-          }));
+        // Compatible provider models are stored under the raw providerId, but
+        // combo values must use the user-facing node prefix so runtime routing
+        // matches /v1/models and copied model IDs.
+        const nodeModels = getProviderCustomModelRows({
+          customModels,
+          modelAliases,
+          providerAlias: providerId,
+          displayAlias: nodePrefix,
+          type: "llm",
+        }).map((model) => ({
+          id: model.id,
+          name: model.name || model.alias || model.id,
+          value: model.fullModel,
+          isCustom: model.source === "custom",
+        }));
 
         // Always show compatible providers that are connected, even with no aliases.
         // When no aliases exist, show a placeholder so users know it's available.

--- a/src/shared/utils/providerCustomModels.js
+++ b/src/shared/utils/providerCustomModels.js
@@ -6,6 +6,7 @@ export function getProviderCustomModelRows({
   customModels = [],
   modelAliases = {},
   providerAlias,
+  displayAlias = providerAlias,
   builtInModels = [],
   type = "llm",
   includeLegacyAliases = true,
@@ -20,13 +21,13 @@ export function getProviderCustomModelRows({
     if (type && rowType !== type) continue;
     if (builtInIds.has(model.id)) continue;
 
-    const fullModel = `${providerAlias}/${model.id}`;
-    if (seenFullModels.has(fullModel)) continue;
-    seenFullModels.add(fullModel);
+    const storageFullModel = `${providerAlias}/${model.id}`;
+    if (seenFullModels.has(storageFullModel)) continue;
+    seenFullModels.add(storageFullModel);
     rows.push({
       id: model.id,
       name: model.name || model.id,
-      fullModel,
+      fullModel: `${displayAlias}/${model.id}`,
       source: "custom",
       type: rowType,
     });
@@ -44,7 +45,7 @@ export function getProviderCustomModelRows({
     rows.push({
       id,
       alias,
-      fullModel,
+      fullModel: `${displayAlias}/${id}`,
       source: "legacyAlias",
       type: type || "llm",
     });

--- a/tests/unit/provider-custom-models.test.js
+++ b/tests/unit/provider-custom-models.test.js
@@ -81,4 +81,35 @@ describe("provider custom model rows", () => {
       },
     ]);
   });
+
+  it("filters compatible provider models by storage alias but returns display prefix", () => {
+    const rows = getProviderCustomModelRows({
+      customModels: [
+        { providerAlias: "openai-compatible-chat-node-1", id: "glm-4.7", type: "llm", name: "GLM 4.7" },
+        { providerAlias: "other-compatible-node", id: "glm-4.7", type: "llm", name: "Wrong Provider" },
+      ],
+      modelAliases: {
+        "legacy-qwen": "openai-compatible-chat-node-1/qwen3-coder",
+      },
+      providerAlias: "openai-compatible-chat-node-1",
+      displayAlias: "corp-ai",
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "glm-4.7",
+        name: "GLM 4.7",
+        fullModel: "corp-ai/glm-4.7",
+        source: "custom",
+        type: "llm",
+      },
+      {
+        id: "qwen3-coder",
+        alias: "legacy-qwen",
+        fullModel: "corp-ai/qwen3-coder",
+        source: "legacyAlias",
+        type: "llm",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- Include custom models registered for OpenAI/Anthropic-compatible provider nodes in the Combo Add Model picker.
- Keep filtering by the provider node storage id while returning combo values with the user-facing node prefix.
- Add regression coverage for compatible provider custom models and legacy aliases using a display prefix.

## Test Plan
- node node_modules/vitest/vitest.mjs run tests/unit/provider-custom-models.test.js --config tests/vitest.config.js
- git diff --check -- src/shared/components/ModelSelectModal.js src/shared/utils/providerCustomModels.js tests/unit/provider-custom-models.test.js
- npm run build