### PR TITLE
fix(paramSupport): tolerate strip rules without match/drop (#2097)

### DIFF
--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -15,7 +15,10 @@ const STRIP_RULES = [
 ];
 
 // Test a rule's match (regex or predicate) against the model id.
+// A rule without a `match` (e.g. a provider-wide rule like flattenContent)
+// applies to every model of that provider.
 function matches(rule, model) {
+  if (!rule.match) return true;
   return typeof rule.match === "function" ? rule.match(model) : rule.match.test(model);
 }
 
@@ -25,7 +28,7 @@ export function stripUnsupportedParams(provider, model, body) {
   for (const rule of STRIP_RULES) {
     if (rule.provider && rule.provider !== provider) continue;
     if (!matches(rule, model)) continue;
-    for (const key of rule.drop) {
+    for (const key of rule.drop || []) {
       if (body[key] !== undefined) delete body[key];
     }
     // CF Workers AI oneOf root schema only accepts content as plain string (#1926)

--- a/tests/translator/paramSupport-cloudflare.test.js
+++ b/tests/translator/paramSupport-cloudflare.test.js
@@ -1,0 +1,38 @@
+// Regression tests for paramSupport rules without a `match` predicate or `drop`
+// list (e.g. the provider-wide `cloudflare-ai` flattenContent rule). Previously
+// `matches()` ran `rule.match.test(model)` on an undefined `rule.match` and the
+// drop loop iterated an undefined `rule.drop`, crashing every Cloudflare request
+// with "Cannot read properties of undefined (reading 'test')". Fixes #2097.
+import { describe, it, expect } from "vitest";
+import { stripUnsupportedParams } from "../../open-sse/translator/concerns/paramSupport.js";
+
+describe("stripUnsupportedParams: rule without match/drop (cloudflare-ai)", () => {
+  it("does not throw for a cloudflare-ai model and flattens content", () => {
+    const body = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Reply exactly OK" }] },
+      ],
+    };
+
+    expect(() =>
+      stripUnsupportedParams("cloudflare-ai", "@cf/meta/llama-3.2-1b-instruct", body)
+    ).not.toThrow();
+
+    // flattenContent: OpenAI content-part array collapses to a plain string (#1926)
+    expect(body.messages[0].content).toBe("Reply exactly OK");
+  });
+
+  it("leaves a non-matching provider untouched", () => {
+    const body = { messages: [{ role: "user", content: "hi" }], temperature: 0.7 };
+    const out = stripUnsupportedParams("openai", "gpt-4o", body);
+    expect(out.temperature).toBe(0.7);
+    expect(out.messages[0].content).toBe("hi");
+  });
+
+  it("still drops params for rules that define a drop list", () => {
+    const body = { messages: [{ role: "user", content: "hi" }], temperature: 0.5 };
+    // claude-opus-4 series: temperature is deprecated (Anthropic 400). #1748
+    stripUnsupportedParams("anthropic", "claude-opus-4-20250101", body);
+    expect(body.temperature).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

The built-in `cloudflare-ai` provider fails every chat request with HTTP 502:

```text
[cloudflare-ai/@cf/meta/llama-3.2-1b-instruct] [502]: Cannot read properties of undefined (reading 'test')
```
Root cause is in `open-sse/translator/concerns/paramSupport.js`. `STRIP_RULES` has a provider-wide rule without a `match` predicate or a `drop` list:

```js
{ provider: "cloudflare-ai", flattenContent: true }
```
But two spots assume every rule has those fields:

1. `matches()` runs `rule.match.test(model)` — throws when `rule.match` is `undefined`.
2. `stripUnsupportedParams()` iterates `for (const key of rule.drop)` — throws when `rule.drop` is `undefined` (the second crash, surfaced once the first is fixed).

So any request routed through `cloudflare-ai` crashes before reaching the upstream.

## Fix

Make both spots tolerate rules that omit `match`/`drop`:

- `matches()`: a rule without `match` applies to every model of that provider (`if (!rule.match) return true;`).
- `stripUnsupportedParams()`: iterate `rule.drop || []`.

This keeps the existing `flattenContent` behavior (#1926) working while no longer crashing.

## Why this is safe

- Existing rules that define `match`/`drop` are unaffected (verified by tests).
- A `match`-less rule is intentionally provider-wide; returning `true` matches that intent.
- A `drop`-less rule simply skips the drop loop.

## Tests

Adds `tests/translator/paramSupport-cloudflare.test.js`:

- `cloudflare-ai` model no longer throws and content is flattened to a plain string.
- Non-matching provider (`openai`) is left untouched.
- A rule that defines a `drop` list (claude-opus-4 `temperature`) still drops the param.

```bash
npm exec -- vitest run tests/translator/paramSupport-cloudflare.test.js --config tests/vitest.config.js
npm run build
```
All pass; the full translator concern/request/coverage suites stay green (no regressions).

Fixes #2097