### PR TITLE
fix(mitm): bypass legacy antigravity interceptor for Antigravity

### DIFF
--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -366,6 +366,15 @@ const server = https.createServer(sslOptions, async (req, res) => {
       return passthrough(req, res, bodyBuffer);
     }
 
+    // Antigravity chat endpoints already have a native Gemini-compatible route at
+    // /v1beta/models/[...path]. Intercepting them here and piping OpenAI SSE back to
+    // the Google client breaks the SDK parser (proto/textproto expects Gemini SSE / JSON,
+    // not OpenAI chat-completions chunks). Keep MITM for DNS/TLS passthrough, but let the
+    // upstream Gemini route handle request/response translation.
+    if (tool === "antigravity") {
+      return passthrough(req, res, bodyBuffer);
+    }
+
     return handlers[tool].intercept(req, res, bodyBuffer, mappedModel, passthrough);
   } catch (e) {
     err(`Unhandled error: ${e.message}`);

--- a/tests/unit/antigravity-mitm-bypass.test.js
+++ b/tests/unit/antigravity-mitm-bypass.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const serverPath = path.resolve(process.cwd(), "../src/mitm/server.js");
+const source = fs.readFileSync(serverPath, "utf8");
+
+describe("Antigravity MITM routing", () => {
+  it("bypasses the legacy antigravity interceptor after model mapping", () => {
+    expect(source).toContain('if (tool === "antigravity") {');
+    expect(source).toContain('return passthrough(req, res, bodyBuffer);');
+  });
+});


### PR DESCRIPTION
## Summary
- bypass the legacy Antigravity MITM interceptor once a request is identified as an Antigravity chat request
- keep DNS/TLS MITM passthrough intact
- add a regression test covering the bypass guard

## Why
Antigravity requests were still being routed through the legacy MITM handler in `src/mitm/handlers/antigravity.js`, which forwards the request to `/v1/chat/completions` and pipes OpenAI SSE back to the Google client.

That breaks Antigravity's parser because the repo already has a native Gemini-compatible route at `src/app/api/v1beta/models/[...path]/route.js`, while the legacy MITM path returns OpenAI chat-completions SSE instead of Gemini SSE / JSON.

In practice this shows up as generation failures like:

```text
proto: syntax error (line 1:1): unexpected token [
```

## What this changes
After model mapping succeeds in `src/mitm/server.js`, Antigravity requests now bypass the legacy interceptor and fall back to normal passthrough.

This preserves:
- MITM DNS/SSL behavior
- host rewrite / upstream forwarding behavior
- the existing native Gemini-compatible translation route

while avoiding the incompatible OpenAI-SSE response path for Antigravity clients.

## Test
- added `tests/unit/antigravity-mitm-bypass.test.js`
- verified with:

```bash
cd tests
npx vitest run unit/antigravity-mitm-bypass.test.js --reporter=verbose
```

## Notes
I also noticed `tests/unit/antigravity-mitm.test.js` currently has a separate failing assertion around the mandatory default model flag; I left that untouched because it appears unrelated to this MITM routing fix.
