### PR TITLE
fix(responses): default text.format for openai-compatible responses providers (#2093)

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -89,10 +89,24 @@ export class DefaultExecutor extends BaseExecutor {
       if (this.config.quirks?.dropClientMetadata) {
         delete transformed.client_metadata;
       }
+      this.defaultResponsesTextFormat(transformed);
       stripUnsupportedParams(this.provider, model, transformed);
     }
 
     return injectReasoningContent({ provider: this.provider, model, body: transformed });
+  }
+
+  // Some Responses-compatible upstreams (e.g. LM Studio) reject a request whose
+  // `text` is an object missing `text.format` with a 400 missing_required_parameter.
+  // The Responses API default for that field is { type: "text" }, so default it
+  // for openai-compatible "responses" providers before forwarding upstream. #2093
+  defaultResponsesTextFormat(body) {
+    if (!this.provider?.startsWith?.("openai-compatible-")) return;
+    if (!this.provider.includes("responses")) return;
+    const text = body.text;
+    if (!text || typeof text !== "object" || Array.isArray(text)) return;
+    if (text.format !== undefined) return;
+    body.text = { ...text, format: { type: "text" } };
   }
 
   // Fallback json_schema → json_object for openai-compatible providers without native Structured Output.

--- a/tests/unit/openai-compat-responses-text-format.test.js
+++ b/tests/unit/openai-compat-responses-text-format.test.js
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for DefaultExecutor.defaultResponsesTextFormat (issue #2093).
+ *
+ * OpenAI-compatible providers configured with API Type "responses" route the
+ * client request to /v1/responses. When the client sends a `text` object that
+ * omits `text.format` (e.g. `{ verbosity: "medium" }`), some Responses-compatible
+ * upstreams (LM Studio) reject it with 400 missing_required_parameter for
+ * `text.format`. The Responses API default for that field is { type: "text" },
+ * so the executor defaults it before forwarding. These tests lock that behavior
+ * and guard that it stays scoped to openai-compatible responses providers.
+ */
+import { describe, it, expect } from "vitest";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+
+function run(provider, body) {
+  const executor = new DefaultExecutor(provider);
+  return executor.transformRequest("some-model", body);
+}
+
+const RESPONSES_PROVIDER = "openai-compatible-responses-1234";
+const CHAT_PROVIDER = "openai-compatible-chat-1234";
+
+describe("DefaultExecutor: default text.format for openai-compatible responses (#2093)", () => {
+  it("defaults text.format to { type: 'text' } when text is an object without format", () => {
+    const out = run(RESPONSES_PROVIDER, { input: "Say OK", text: { verbosity: "medium" } });
+    expect(out.text).toEqual({ verbosity: "medium", format: { type: "text" } });
+  });
+
+  it("preserves an existing text.format instead of overwriting it", () => {
+    const fmt = { type: "json_schema", name: "x", schema: { type: "object" } };
+    const out = run(RESPONSES_PROVIDER, { input: "Say OK", text: { verbosity: "low", format: fmt } });
+    expect(out.text.format).toBe(fmt);
+  });
+
+  it("does nothing when there is no text object", () => {
+    const out = run(RESPONSES_PROVIDER, { input: "Say OK" });
+    expect(out.text).toBeUndefined();
+  });
+
+  it("does not touch a non-responses openai-compatible (chat) provider", () => {
+    const out = run(CHAT_PROVIDER, { messages: [{ role: "user", content: "hi" }], text: { verbosity: "medium" } });
+    expect(out.text).toEqual({ verbosity: "medium" });
+  });
+
+  it("ignores a non-object text value", () => {
+    const out = run(RESPONSES_PROVIDER, { input: "Say OK", text: "plain" });
+    expect(out.text).toBe("plain");
+  });
+});


### PR DESCRIPTION
## Problem

When using a custom OpenAI-compatible provider configured with API Type `responses`, 9Router forwards a request body whose `text` is an object missing `text.format`. Some Responses-compatible upstreams (e.g. LM Studio) reject this with:

```json
{ "error": { "message": "Required", "type": "invalid_request_error", "param": "text.format", "code": "missing_required_parameter" } }
```
This happens because a client calling `/v1/responses` (source format `openai-responses`) routed to an openai-compatible `responses` provider (target format `openai-responses`) hits the translator passthrough path — `source === target`, so translation is skipped and the client's `text` object is forwarded verbatim, without a default `text.format`.

## Fix

Default `text.format` to `{ type: "text" }` (the Responses API default for that field) in the executor before forwarding upstream, scoped to openai-compatible `responses` providers:

- Only applies when the provider id is `openai-compatible-*` and includes `responses`.
- Only applies when `body.text` is a plain object without a `format`.
- Builds a new `text` object instead of mutating the caller's, and never overwrites an existing `format`.

## Why this is safe

- Scoped to openai-compatible responses providers; official OpenAI/codex/github executors are untouched.
- No-op when `text` is absent, non-object, or already has `format`.
- `{ type: "text" }` is the documented Responses API default, so it does not change behavior for upstreams that were already accepting the request.

## Tests

Adds `tests/unit/openai-compat-responses-text-format.test.js`:

- Defaults `text.format` to `{ type: "text" }` when `text` is an object without `format`.
- Preserves an existing `text.format`.
- No-op when there is no `text`.
- Does not touch a non-responses (chat) openai-compatible provider.
- Ignores a non-object `text` value.

```bash
npm exec -- vitest run tests/unit/openai-compat-responses-text-format.test.js --config tests/vitest.config.js
npm run build
```
All pass; related executor unit suites stay green (no regressions).

Fixes #2093