### PR TITLE
fix(kiro+paramSupport): external_idp tokentype + Sakana/xAI strip rules

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -6,7 +6,7 @@ import { buildClineHeaders } from "../shared/clineAuth.js";
 import { getCachedClaudeHeaders } from "../utils/claudeHeaderCache.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
-import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
+import { stripUnsupportedParams, enforceParamMinimums } from "../translator/concerns/paramSupport.js";
 
 // Auth header descriptors — derived from registry transport.auth, fallback to hardcoded defaults.
 const BEARER = { combined: true, header: "Authorization", scheme: "bearer" };
@@ -90,6 +90,9 @@ export class DefaultExecutor extends BaseExecutor {
         delete transformed.client_metadata;
       }
       stripUnsupportedParams(this.provider, model, transformed);
+      // Enforce provider/model-specific param floors (e.g. Sakana fugu-ultra
+      // requires max_tokens >= 16 across chat, completion, and Responses APIs).
+      enforceParamMinimums(this.provider, model, transformed);
     }
 
     return injectReasoningContent({ provider: this.provider, model, body: transformed });

--- a/open-sse/executors/default.paramSupport.test.js
+++ b/open-sse/executors/default.paramSupport.test.js
@@ -1,0 +1,55 @@
+// Integration tests: paramSupport wires into DefaultExecutor.transformRequest
+//
+// Asserts that the strip + enforce-minimum pipeline runs on the real executor
+// path (not just when calling paramSupport helpers directly). Without this
+// wiring, MIN_RULES are dead code at runtime.
+//
+// Run from 9router/open-sse: `node --test executors/default.paramSupport.test.js`
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { DefaultExecutor } from "./default.js";
+
+test("DefaultExecutor clamps max_tokens for Sakana fugu-ultra below the floor", () => {
+  const executor = new DefaultExecutor("openai-compatible-chat-fugu");
+  const body = {
+    model: "fugu-ultra",
+    max_tokens: 1,
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const out = executor.transformRequest("fugu-ultra", body);
+  assert.equal(out.max_tokens, 16);
+});
+
+test("DefaultExecutor leaves max_tokens alone for non-fugu models", () => {
+  const executor = new DefaultExecutor("openai-compatible-chat-x");
+  const body = {
+    model: "gpt-5",
+    max_tokens: 1,
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const out = executor.transformRequest("gpt-5", body);
+  assert.equal(out.max_tokens, 1);
+});
+
+test("DefaultExecutor strips xai grok reasoning_effort end-to-end", () => {
+  const executor = new DefaultExecutor("xai");
+  const body = {
+    model: "grok-build-0.1",
+    reasoning_effort: "high",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const out = executor.transformRequest("grok-build-0.1", body);
+  assert.equal(out.reasoning_effort, undefined);
+});
+
+test("DefaultExecutor strips fugu reasoning_effort=low (Sakana allow-list)", () => {
+  const executor = new DefaultExecutor("openai-compatible-chat-fugu");
+  const body = {
+    model: "fugu-ultra",
+    reasoning_effort: "low",
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const out = executor.transformRequest("fugu-ultra", body);
+  assert.equal(out.reasoning_effort, undefined);
+});

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -24,12 +24,21 @@ export class KiroExecutor extends BaseExecutor {
     // exactly like an OAuth access token, but with an extra `tokentype: API_KEY`
     // header so CodeWhisperer treats it as a long-lived API key rather than an
     // OIDC/social access token. Mirrors the Kiro IDE headless-auth behavior.
-    const isApiKey = credentials?.providerSpecificData?.authMethod === "api_key";
+    const authMethod = credentials?.providerSpecificData?.authMethod;
+    const isApiKey = authMethod === "api_key";
+    // External IdP tokens (Microsoft Entra ID / Azure AD via SSO) must be
+    // tagged with `tokentype: EXTERNAL_IDP` on every CodeWhisperer call
+    // (data plane, ListAvailableModels, usage). Without it, upstream rejects
+    // the request as "The bearer token included in the request is invalid".
+    const isExternalIdp = authMethod === "external_idp";
 
     const apiKey = credentials?.apiKey || (isApiKey ? credentials?.accessToken : null);
     if (isApiKey && apiKey) {
       headers["Authorization"] = `Bearer ${apiKey}`;
       headers["tokentype"] = "API_KEY";
+    } else if (isExternalIdp && credentials.accessToken) {
+      headers["Authorization"] = `Bearer ${credentials.accessToken}`;
+      headers["tokentype"] = "EXTERNAL_IDP";
     } else if (credentials.accessToken) {
       headers["Authorization"] = `Bearer ${credentials.accessToken}`;
     }

--- a/open-sse/services/kiroModels.js
+++ b/open-sse/services/kiroModels.js
@@ -166,7 +166,14 @@ async function fetchKiroCatalogRaw(credentials, signal) {
 
   const headers = {
     ...buildKiroFingerprintHeaders(credentials),
-    "Authorization": `Bearer ${credentials?.accessToken || ""}`
+    "Authorization": `Bearer ${credentials?.accessToken || ""}`,
+    // External IdP tokens (Microsoft Entra ID / Azure AD via SSO) need a
+    // `tokentype: EXTERNAL_IDP` header on every CodeWhisperer call —
+    // including ListAvailableModels — or upstream returns 403
+    // "The bearer token included in the request is invalid".
+    ...(credentials?.providerSpecificData?.authMethod === "external_idp"
+      ? { tokentype: "EXTERNAL_IDP" }
+      : {}),
   };
 
   const controller = new AbortController();

--- a/open-sse/services/usage/kiro.js
+++ b/open-sse/services/usage/kiro.js
@@ -55,7 +55,15 @@ export async function getKiroUsage(accessToken, providerSpecificData, proxyOptio
   // CodeWhisperer treats it as a long-lived API key rather than an OIDC token.
   // Without this header the GetUsageLimits call is rejected (401/403).
   const isApiKey = authMethod === "api_key";
-  const apiKeyHeaders = isApiKey ? { tokentype: "API_KEY" } : {};
+  // External IdP tokens (Microsoft Entra ID / Azure AD via SSO) need the
+  // same treatment on the quota API: `tokentype: EXTERNAL_IDP` or upstream
+  // rejects the request as an invalid bearer token.
+  const isExternalIdp = authMethod === "external_idp";
+  const apiKeyHeaders = isApiKey
+    ? { tokentype: "API_KEY" }
+    : isExternalIdp
+      ? { tokentype: "EXTERNAL_IDP" }
+      : {};
 
   // For api-key auth, never inject the shared default placeholder profileArn —
   // CodeWhisperer 403s a request whose profileArn isn't owned by the key's

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -3,6 +3,8 @@
 
 // Each rule: optional provider, regex match on model, list of params to drop.
 // A param is removed only when it is present (!== undefined).
+// For Sakana we also need a conditional drop: drop reasoning_effort ONLY
+// when its value is not in the Sakana-accepted enum {high, xhigh, max}.
 const STRIP_RULES = [
   // claude-opus-4 series: temperature is deprecated (Anthropic 400). #1748
   { match: /claude-opus-4/i, drop: ["temperature"] },
@@ -10,13 +12,55 @@ const STRIP_RULES = [
   { provider: "github", match: /gpt-5\.4/i, drop: ["temperature"] },
   // GitHub Copilot Claude (except opus/sonnet 4.6): thinking + reasoning_effort rejected. #713
   { provider: "github", match: (m) => /claude/i.test(m) && !/claude.*(opus|sonnet).*4\.6/i.test(m), drop: ["thinking", "reasoning_effort"] },
+  // xAI Grok: reasoning_effort / reasoning / thinking rejected ("Model grok-build-0.1 does not support parameter reasoning")
+  { provider: "xai", match: /grok/i, drop: ["reasoning_effort", "reasoning", "thinking"] },
   // Cloudflare Workers AI: content must be plain string, rejects OpenAI content-part array (#1926)
   { provider: "cloudflare-ai", flattenContent: true },
+  // Sakana fugu / fugu-ultra / fugu-ultra-20260615:
+  //   - reasoning_effort only accepts `high` | `xhigh` | `max`. Any other value
+  //     is rejected by the API. Claude Code may send `low`/`medium`/`minimal`,
+  //     so we drop it (Sakana will fall back to its own default — `high` for
+  //     fugu, `xhigh` for fugu-ultra).
+  //   - `reasoning` (object form) is similarly constrained.
+  //   - `previous_response_id` is rejected by the Responses API shape; drop.
+  // Match by model id (covers any 9router provider id that routes fugu).
+  {
+    match: /(^|\/)fugu(-ultra)?(-[0-9]+)?$/i,
+    drop: ["previous_response_id"],
+  },
+  {
+    match: /(^|\/)fugu(-ultra)?(-[0-9]+)?$/i,
+    dropIfValueNotIn: { reasoning_effort: ["high", "xhigh", "max"] },
+  },
+  {
+    match: /(^|\/)fugu(-ultra)?(-[0-9]+)?$/i,
+    dropReasoningObjectUnless: { field: "reasoning", allow: ["high", "xhigh", "max"] },
+  },
+];
+
+// Enforce minimum values for params (e.g. max_tokens floor).
+// Each rule: optional provider, regex match on model, map of { param: minValue }.
+// If the body param is undefined, it is left alone (we don't silently invent
+// values; the upstream executor / client supplies defaults). If it is present
+// but below the floor, it is bumped up to the minimum in place.
+const MIN_RULES = [
+  // Sakana fugu-ultra: rejects `max_tokens < 16` ("must be greater than or
+  // equal to 16"). Also applies to the Responses API field `max_output_tokens`
+  // and the legacy `max_completion_tokens`. Model id is the authoritative
+  // signal here — covers openai-compatible-chat-<uuid> user configurations
+  // that route fugu-ultra upstream.
+  {
+    match: /(^|\/)fugu(-ultra)?(-[0-9]+)?$/i,
+    min: { max_tokens: 16, max_completion_tokens: 16, max_output_tokens: 16 },
+  },
 ];
 
 // Test a rule's match (regex or predicate) against the model id.
+// Rules without `match` apply whenever the provider matches (or is unset).
 function matches(rule, model) {
-  return typeof rule.match === "function" ? rule.match(model) : rule.match.test(model);
+  if (typeof rule.match === "function") return rule.match(model);
+  if (rule.match instanceof RegExp) return rule.match.test(model);
+  return true;
 }
 
 // Remove unsupported params from body in place; returns body.
@@ -25,8 +69,23 @@ export function stripUnsupportedParams(provider, model, body) {
   for (const rule of STRIP_RULES) {
     if (rule.provider && rule.provider !== provider) continue;
     if (!matches(rule, model)) continue;
-    for (const key of rule.drop) {
+    for (const key of rule.drop || []) {
       if (body[key] !== undefined) delete body[key];
+    }
+    // Conditional drop: remove key unless its value is in the allow-list.
+    for (const [key, allowed] of Object.entries(rule.dropIfValueNotIn || {})) {
+      if (body[key] !== undefined && !allowed.includes(body[key])) {
+        delete body[key];
+      }
+    }
+    // Conditional drop for object form: remove the object unless its inner
+    // `effort` field is in the allow-list.
+    if (rule.dropReasoningObjectUnless) {
+      const { field, allow } = rule.dropReasoningObjectUnless;
+      const obj = body[field];
+      if (obj && typeof obj === "object" && !allow.includes(obj.effort)) {
+        delete body[field];
+      }
     }
     // CF Workers AI oneOf root schema only accepts content as plain string (#1926)
     if (rule.flattenContent && Array.isArray(body.messages)) {
@@ -36,6 +95,22 @@ export function stripUnsupportedParams(provider, model, body) {
             .map(b => (b?.type === "text" && typeof b.text === "string") ? b.text : "")
             .join("");
         }
+      }
+    }
+  }
+  return body;
+}
+
+// Clamp numeric params up to a model-specific floor in place; returns body.
+// Pairs with stripUnsupportedParams — same rule shape, different action.
+export function enforceParamMinimums(provider, model, body) {
+  if (!model || !body || typeof body !== "object") return body;
+  for (const rule of MIN_RULES) {
+    if (rule.provider && rule.provider !== provider) continue;
+    if (!matches(rule, model)) continue;
+    for (const [key, minVal] of Object.entries(rule.min || {})) {
+      if (typeof body[key] === "number" && body[key] < minVal) {
+        body[key] = minVal;
       }
     }
   }

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -57,6 +57,11 @@ const MIN_RULES = [
 
 // Test a rule's match (regex or predicate) against the model id.
 // Rules without `match` apply whenever the provider matches (or is unset).
+// IMPORTANT: this falls through to `true` when neither `match` nor `provider`
+// is present. Today every STRIP_RULES / MIN_RULES entry sets at least one, so
+// the fallthrough is safe — but a future rule that sets neither would silently
+// fire on every model. Add an explicit `match` (or a `provider` guard) on any
+// new rule.
 function matches(rule, model) {
   if (typeof rule.match === "function") return rule.match(model);
   if (rule.match instanceof RegExp) return rule.match.test(model);

--- a/open-sse/translator/concerns/paramSupport.test.js
+++ b/open-sse/translator/concerns/paramSupport.test.js
@@ -1,0 +1,183 @@
+// Tests for paramSupport.js — strip + minimum enforcement for Sakana fugu
+// and the other providers already wired into STRIP_RULES / MIN_RULES.
+//
+// Run from 9router/open-sse: `node --test translator/concerns/paramSupport.test.js`
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripUnsupportedParams, enforceParamMinimums } from "./paramSupport.js";
+
+// ---------- Sakana fugu / fugu-ultra ----------
+
+test("fugu-ultra: bumps max_tokens from 1 up to floor 16", () => {
+  const body = { model: "fugu-ultra", max_tokens: 1, messages: [] };
+  enforceParamMinimums("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.max_tokens, 16);
+});
+
+test("fugu-ultra: leaves max_tokens at 8000 alone (above floor)", () => {
+  const body = { model: "fugu-ultra", max_tokens: 8000 };
+  enforceParamMinimums("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.max_tokens, 8000);
+});
+
+test("fugu-ultra dated alias (fugu-ultra-20260615): bumps max_tokens", () => {
+  const body = { model: "fugu-ultra-20260615", max_tokens: 8 };
+  enforceParamMinimums("openai-compatible-chat-x", "fugu-ultra-20260615", body);
+  assert.equal(body.max_tokens, 16);
+});
+
+test("fugu: bumps max_completion_tokens below floor", () => {
+  const body = { model: "fugu", max_completion_tokens: 4 };
+  enforceParamMinimums("openai-compatible-chat-x", "fugu", body);
+  assert.equal(body.max_completion_tokens, 16);
+});
+
+test("fugu-ultra: max_output_tokens bumped (Responses API field)", () => {
+  const body = { model: "fugu-ultra", max_output_tokens: 2 };
+  enforceParamMinimums("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.max_output_tokens, 16);
+});
+
+test("fugu-ultra: leaves max_tokens undefined alone", () => {
+  const body = { model: "fugu-ultra" };
+  enforceParamMinimums("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.max_tokens, undefined);
+});
+
+test("fugu-ultra: strips reasoning_effort=low (not in Sakana allow-list)", () => {
+  const body = { model: "fugu-ultra", reasoning_effort: "low" };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("fugu-ultra: keeps reasoning_effort=high (allowed)", () => {
+  const body = { model: "fugu-ultra", reasoning_effort: "high" };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.reasoning_effort, "high");
+});
+
+test("fugu-ultra: keeps reasoning_effort=xhigh (allowed)", () => {
+  const body = { model: "fugu-ultra", reasoning_effort: "xhigh" };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.reasoning_effort, "xhigh");
+});
+
+test("fugu-ultra: keeps reasoning_effort=max (alias of xhigh, allowed)", () => {
+  const body = { model: "fugu-ultra", reasoning_effort: "max" };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.reasoning_effort, "max");
+});
+
+test("fugu: keeps reasoning_effort=minimal? no — drops it", () => {
+  const body = { model: "fugu", reasoning_effort: "minimal" };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu", body);
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("fugu-ultra: strips reasoning object when effort is not allowed", () => {
+  const body = { model: "fugu-ultra", reasoning: { effort: "low" } };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.reasoning, undefined);
+});
+
+test("fugu-ultra: keeps reasoning object when effort=high", () => {
+  const body = { model: "fugu-ultra", reasoning: { effort: "high" } };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.deepEqual(body.reasoning, { effort: "high" });
+});
+
+test("fugu-ultra: strips previous_response_id (Responses API rejects)", () => {
+  const body = { model: "fugu-ultra", previous_response_id: "resp_abc" };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.previous_response_id, undefined);
+});
+
+test("fugu-ultra: keeps temperature/top_p (accepted but ignored upstream)", () => {
+  const body = { model: "fugu-ultra", temperature: 0.7, top_p: 0.9 };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.temperature, 0.7);
+  assert.equal(body.top_p, 0.9);
+});
+
+test("fugu-ultra: integrated strip + min pipeline clamps and strips", () => {
+  const body = {
+    model: "fugu-ultra",
+    max_tokens: 1,
+    reasoning_effort: "low",
+    previous_response_id: "resp_xyz",
+    messages: [],
+  };
+  stripUnsupportedParams("openai-compatible-chat-x", "fugu-ultra", body);
+  enforceParamMinimums("openai-compatible-chat-x", "fugu-ultra", body);
+  assert.equal(body.max_tokens, 16);
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(body.previous_response_id, undefined);
+});
+
+// ---------- existing rules should still pass ----------
+
+test("claude-opus-4: temperature is stripped (existing rule #1748)", () => {
+  const body = { model: "claude-opus-4-7", temperature: 0.5 };
+  stripUnsupportedParams("anthropic", "claude-opus-4-7", body);
+  assert.equal(body.temperature, undefined);
+});
+
+test("github copilot gpt-5.4: temperature stripped", () => {
+  const body = { model: "gpt-5.4", temperature: 0.5 };
+  stripUnsupportedParams("github", "gpt-5.4", body);
+  assert.equal(body.temperature, undefined);
+});
+
+test("github copilot claude (non 4.6): reasoning_effort stripped", () => {
+  const body = { model: "claude-sonnet-4.5", reasoning_effort: "high" };
+  stripUnsupportedParams("github", "claude-sonnet-4.5", body);
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("github copilot claude opus 4.6: reasoning_effort kept", () => {
+  const body = { model: "claude-opus-4.6", reasoning_effort: "high" };
+  stripUnsupportedParams("github", "claude-opus-4.6", body);
+  assert.equal(body.reasoning_effort, "high");
+});
+
+test("xai grok: reasoning_effort / reasoning / thinking stripped", () => {
+  const body = { model: "grok-build-0.1", reasoning_effort: "high", reasoning: { x: 1 }, thinking: { y: 2 } };
+  stripUnsupportedParams("xai", "grok-build-0.1", body);
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(body.reasoning, undefined);
+  assert.equal(body.thinking, undefined);
+});
+
+test("cloudflare-ai: content array flattens to string", () => {
+  const body = {
+    model: "@cf/meta/llama-3-8b-instruct",
+    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+  };
+  stripUnsupportedParams("cloudflare-ai", "@cf/meta/llama-3-8b-instruct", body);
+  assert.equal(body.messages[0].content, "hi");
+});
+
+// ---------- guard rails ----------
+
+test("non-matching model: no changes", () => {
+  const body = { model: "gpt-5", max_tokens: 1, reasoning_effort: "low" };
+  stripUnsupportedParams("openai", "gpt-5", body);
+  enforceParamMinimums("openai", "gpt-5", body);
+  assert.equal(body.max_tokens, 1);
+  assert.equal(body.reasoning_effort, "low");
+});
+
+test("null model: returns body unchanged", () => {
+  const body = { max_tokens: 1 };
+  stripUnsupportedParams("openai-compatible-x", null, body);
+  enforceParamMinimums("openai-compatible-x", null, body);
+  assert.equal(body.max_tokens, 1);
+});
+
+test("non-object body: returns body unchanged", () => {
+  stripUnsupportedParams("openai-compatible-x", "fugu-ultra", null);
+  enforceParamMinimums("openai-compatible-x", "fugu-ultra", null);
+  // Just ensure no throw.
+  assert.ok(true);
+});


### PR DESCRIPTION
## Summary
- `xAI Grok` (`grok-*`): strip `reasoning_effort` / `reasoning` / `thinking` — upstream rejects with 'Model grok-build-0.1 does not support parameter reasoning'
- `Sakana fugu` / `fugu-ultra` (and dated variants): only accept `reasoning_effort ∈ {high, xhigh, max}`; drop any other value (Claude Code sends `low`/`medium`/`minimal`)
- `Sakana fugu`: `reasoning` object form is similarly constrained — drop unless its inner `effort` matches the allow-list
- `Sakana fugu-ultra`: `max_tokens` floor of 16 across chat (`max_tokens`), legacy (`max_completion_tokens`), and Responses (`max_output_tokens`) APIs
- `Sakana fugu`: drop `previous_response_id` (rejected by Responses API shape)

Also extends `paramSupport.js` with a new `enforceParamMinimums(provider, model, body)` helper for the `max_tokens` floor so the minimum value is bumped in place rather than silently invented. Both helpers are now wired into `DefaultExecutor.transformRequest` so the strip + clamp pipeline runs on every real request.

## Bug fix from review
Without the executor wiring commit, the `MIN_RULES` table and the `enforceParamMinimums` helper were dead code at runtime — `stripUnsupportedParams` ran but the min-enforcement helper never executed. Fixed by calling `enforceParamMinimums(this.provider, model, transformed)` immediately after `stripUnsupportedParams` in `default.js`.

## Test plan
- `node --test open-sse/executors/default.paramSupport.test.js open-sse/translator/concerns/paramSupport.test.js` (29 tests, all pass)
  - `open-sse/executors/default.paramSupport.test.js` — 4 integration tests that hit `DefaultExecutor.transformRequest` end-to-end (Sakana floor, xai grok strip, fugu enum strip, non-fugu unaffected)
  - `open-sse/translator/concerns/paramSupport.test.js` — 25 unit tests for the helpers themselves (Sakana max_tokens floor across 3 fields, dated model aliases, Sakana allow-list reasoning_effort, reasoning object form, previous_response_id, plus guard rails for null/non-object input)

## Files
- `open-sse/translator/concerns/paramSupport.js` — adds 3 rules (xai, fugu strip, fugu enum, fugu reasoning object, previous_response_id), `MIN_RULES` table, `enforceParamMinimums` helper, documents the `matches()` fallthrough footgun
- `open-sse/translator/concerns/paramSupport.test.js` — 25 unit tests
- `open-sse/executors/default.js` — imports and calls `enforceParamMinimums` after `stripUnsupportedParams`
- `open-sse/executors/default.paramSupport.test.js` — 4 integration tests