### PR TITLE
claude-to-openai: forward image tool_result blocks as image_url instead of stringifying base64

### DIFF
--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -177,10 +177,25 @@ function convertClaudeMessage(msg) {
           if (typeof block.content === "string") {
             resultContent = block.content;
           } else if (Array.isArray(block.content)) {
-            resultContent = block.content
-              .filter(c => c.type === CLAUDE_BLOCK.TEXT)
-              .map(c => c.text)
-              .join("\n") || JSON.stringify(block.content);
+            // Keep text in the tool message; lift any images out as a following user
+            // turn (OpenAI `tool` messages can't carry images). Without this, an
+            // image-only tool_result is JSON.stringify'd -> base64 as text -> Codex
+            // "input exceeds the context window".
+            const textParts = [];
+            let hasImage = false;
+            for (const c of block.content) {
+              if (c.type === CLAUDE_BLOCK.TEXT) {
+                textParts.push(c.text);
+              } else if (c.type === CLAUDE_BLOCK.IMAGE && c.source?.type === "base64") {
+                parts.push({
+                  type: OPENAI_BLOCK.IMAGE_URL,
+                  image_url: { url: encodeDataUri(c.source.media_type, c.source.data) }
+                });
+                hasImage = true;
+              }
+            }
+            resultContent = textParts.join("\n")
+              || (hasImage ? "[tool returned an image; see attached]" : JSON.stringify(block.content));
           } else if (block.content) {
             resultContent = JSON.stringify(block.content);
           }


### PR DESCRIPTION
### What
Fixes #2122. In `open-sse/translator/request/claude-to-openai.js`, when a `tool_result`'s content
array contains image blocks, extract them as `image_url` parts (reusing the file's existing
`encodeDataUri` + `OPENAI_BLOCK.IMAGE_URL`) and push them into `parts`. Text stays in the `tool`
message; when the result was image-only the `tool` message gets a short placeholder.

This needs no new return logic — the function already does:
```js
if (toolResults.length > 0) {
  if (parts.length > 0) return [...toolResults, { role: ROLE.USER, content: collapseTextParts(parts) }];
  return toolResults;
}
```
so images pushed to `parts` are emitted as the following user turn — the correct OpenAI shape
(`role: "tool"` messages can't carry images).

### Why
Image-only `tool_result`s currently serialize ~200KB of base64 as text, which makes Codex (and other
OpenAI-protocol clients) hit *"Your input exceeds the context window."* With this change the model
receives the actual image at normal token cost and the error goes away.

### Compatibility & safety
- String and text-only `tool_result`s are byte-identical to before.
- The `JSON.stringify` fallback is kept for the genuinely-unknown case (no text, no images).
- Reuses existing helpers (`encodeDataUri`, `collapseTextParts`, `OPENAI_BLOCK`/`CLAUDE_BLOCK`); no new deps.
- Only the Claude→OpenAI request path changes.

### Testing
- Image-only `tool_result` → outbound request carries an `image_url` user part, not base64 text; Codex stops erroring.
- Mixed text+image `tool_result` → text stays in the `tool` message, image(s) follow as a user turn.
- Text-only / string `tool_result` → unchanged.

### Optional follow-up (separate PR)
Large images can still be heavy. A companion change in `open-sse/translator/concerns/prefetch.js`
(used by `open-sse/executors/codex.js`) downscales codex-bound images (long edge 1568 / JPEG ≤200KB)
with graceful fallback. Happy to open it separately if useful.
