### PR TITLE
fix(usage): honor provider remaining percentages in quota cards

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/ProviderLimitCard.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/ProviderLimitCard.js
@@ -5,7 +5,7 @@ import Card from "@/shared/components/Card";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import Badge from "@/shared/components/Badge";
 import QuotaProgressBar from "./QuotaProgressBar";
-import { calculatePercentage } from "./utils";
+import { getRemainingPercentage } from "./utils";
 
 const planVariants = {
   free: "default",
@@ -149,11 +149,7 @@ export default function ProviderLimitCard({
       {!loading && !error && !message && quotas?.length > 0 && (
         <div className="space-y-4">
           {quotas.map((quota, index) => {
-            // For Antigravity, use remainingPercentage if available, otherwise calculate
-            const percentage =
-              quota.remainingPercentage !== undefined
-                ? Math.round(((quota.total - quota.used) / quota.total) * 100)
-                : calculatePercentage(quota.used, quota.total);
+            const percentage = getRemainingPercentage(quota);
             const unlimited = quota.total === 0 || quota.total === null;
 
             return (

--- a/tests/unit/quota-remaining-percentage.test.js
+++ b/tests/unit/quota-remaining-percentage.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getRemainingPercentage,
+  parseQuotaData,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+describe("quota remaining percentage normalization", () => {
+  it("prefers provider-supplied remainingPercentage over used/total math", () => {
+    expect(getRemainingPercentage({
+      used: 0,
+      total: 1000,
+      remainingPercentage: 64,
+    })).toBe(64);
+  });
+
+  it("preserves Antigravity remainingPercentage for the dashboard cards and table", () => {
+    const quotas = parseQuotaData("antigravity", {
+      quotas: {
+        "gemini-3-pro": {
+          displayName: "Gemini 3 Pro",
+          used: 0,
+          total: 1000,
+          remainingPercentage: 42,
+          resetAt: "2026-06-26T20:00:00.000Z",
+        },
+      },
+    });
+
+    expect(quotas).toHaveLength(1);
+    expect(quotas[0].remainingPercentage).toBe(42);
+    expect(getRemainingPercentage(quotas[0])).toBe(42);
+  });
+});


### PR DESCRIPTION
## Description

Fixes quota dashboard cards so they respect provider-supplied `remainingPercentage` values instead of always recalculating remaining quota from `used` / `total`.

Some providers expose quota in forms where `used` / `total` can be stale, normalized, rounded, or not directly representative of the currently displayed provider quota. Antigravity is one example: the usage endpoint can return an explicit `remainingPercentage`, while the dashboard card path previously recalculated from `used` / `total`, which could keep the card/progress bar at `100%` even when the provider-reported remaining percentage had already decreased.

This also aligns the card view with the table view, which already uses `getRemainingPercentage()` and therefore already preferred explicit provider percentages.

Closes #2058  
Related #1609

## Root cause

`ProviderLimitCard` had a comment saying it should use `remainingPercentage` when available, but the implementation did the opposite path:

- when `quota.remainingPercentage !== undefined`, it recalculated `((total - used) / total) * 100`
- otherwise it fell back to `calculatePercentage(used, total)`

So the explicit provider percentage was preserved by `parseQuotaData()`, but ignored by the card UI.

## Changes

- Use `getRemainingPercentage(quota)` in `ProviderLimitCard`, matching `QuotaTable` behavior.
- Add regression coverage for:
  - preferring provider-supplied `remainingPercentage` over `used` / `total` math
  - preserving Antigravity `remainingPercentage` through quota parsing

## Verification

- `npm install --no-save vitest`
- `./node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/quota-remaining-percentage.test.js`
- `npm run build`
- `git diff --check`
