### PR TITLE
fix: add prefix=true to last assistant message for Mistral compatibility

### DIFF
--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -39,6 +39,20 @@ function stripReasoningFromMessages(body) {
   return modified ? { ...body, messages: [...body.messages] } : body;
 }
 
+/**
+ * Fix message ordering for providers that require specific role sequences.
+ * Mistral requires the last message to be user/tool (or assistant with prefix=true).
+ * If the last message is an assistant without prefix, add prefix: true so the
+ * provider can continue generation from that point.
+ */
+function fixMessageOrdering(messages) {
+  if (!messages || !Array.isArray(messages) || messages.length === 0) return;
+  const last = messages[messages.length - 1];
+  if (last && last.role === "assistant" && !last.prefix) {
+    last.prefix = true;
+  }
+}
+
 
  * Handle chat completion request
  * Supports: OpenAI, Claude, Gemini, OpenAI Responses API formats
@@ -66,6 +80,7 @@ export async function handleChat(request, clientRawRequest = null) {
 
   // Strip reasoning_content from conversation history (providers like Mistral reject it)
   body = stripReasoningFromMessages(body);
+  fixMessageOrdering(body.messages);
 
   // Log request endpoint and model
   const url = new URL(request.url);

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -22,6 +22,24 @@ import { updateProviderCredentials, checkAndRefreshToken } from "../services/tok
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
 
 /**
+ * Strip reasoning_content from assistant messages in conversation history.
+ * Some providers (e.g. Mistral) reject requests containing reasoning_content
+ * in assistant messages with "extra_forbidden" validation errors.
+ * This field is only meaningful in streaming responses, not in request bodies.
+ */
+function stripReasoningFromMessages(body) {
+  if (!body.messages || !Array.isArray(body.messages)) return body;
+  let modified = false;
+  for (const msg of body.messages) {
+    if (msg && msg.role === "assistant" && msg.reasoning_content !== undefined) {
+      delete msg.reasoning_content;
+      modified = true;
+    }
+  }
+  return modified ? { ...body, messages: [...body.messages] } : body;
+}
+
+
  * Handle chat completion request
  * Supports: OpenAI, Claude, Gemini, OpenAI Responses API formats
  * Format detection and translation handled by translator
@@ -45,6 +63,9 @@ export async function handleChat(request, clientRawRequest = null) {
     };
   }
   cacheClaudeHeaders(clientRawRequest.headers);
+
+  // Strip reasoning_content from conversation history (providers like Mistral reject it)
+  body = stripReasoningFromMessages(body);
 
   // Log request endpoint and model
   const url = new URL(request.url);


### PR DESCRIPTION
## Problem
Mistral API rejects requests where the last message in conversation history has role `assistant`. Returns:
```
Expected last role User or Tool (or Assistant with prefix True)
```

## Fix
Automatically adds `prefix: true` to the last message when it's an assistant message. This lets Mistral continue generation from that point.

Applied in `handleChat()` right after `stripReasoningFromMessages()` — same pattern as the reasoning_content fix.

## Testing
- Last assistant message → `prefix: true` added ✓
- Last user message → no change ✓  
- Existing prefix preserved ✓
- Empty/single message arrays handled ✓

## Related
- Follow-up to #2090 (reasoning_content fix)
- Both fixes are needed for Mistral compatibility