### PR TITLE
fix: rename next-server process to 9router (#2117)

### DIFF
--- a/src/instrumentation.js
+++ b/src/instrumentation.js
@@ -1,0 +1,6 @@
+// Rename process to distinguish 9router from generic next-server
+export function register() {
+  if (process.title.startsWith('next-server')) {
+    process.title = process.title.replace('next-server', '9router');
+  }
+}


### PR DESCRIPTION
## Problem
Process shows as generic `next-server (v16.2.9)` in `ps`/`top`/`htop`, making it hard to identify among other Next.js apps.

## Fix
Uses Next.js instrumentation hook (`src/instrumentation.js`) to rename the process from `next-server` to `9router` after startup.

**Before:** `next-server (v16.2.9)`
**After:** `9router (v16.2.9)`

Closes #2117