### PR TITLE
fix: convert max_tokens to max_completion_tokens for gpt-5+ models (#1745)

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -6,7 +6,7 @@ import { buildClineHeaders } from "../shared/clineAuth.js";
 import { getCachedClaudeHeaders } from "../utils/claudeHeaderCache.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
-import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
+import { stripUnsupportedParams, applyParamRenames } from "../translator/concerns/paramSupport.js";
 
 // Auth header descriptors — derived from registry transport.auth, fallback to hardcoded defaults.
 const BEARER = { combined: true, header: "Authorization", scheme: "bearer" };
@@ -89,6 +89,7 @@ export class DefaultExecutor extends BaseExecutor {
       if (this.config.quirks?.dropClientMetadata) {
         delete transformed.client_metadata;
       }
+      applyParamRenames(this.provider, model, transformed);
       stripUnsupportedParams(this.provider, model, transformed);
     }
 

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -42,3 +42,30 @@ export function stripUnsupportedParams(provider, model, body) {
   }
   return body;
 }
+
+// Model-specific param renames (max_tokens → max_completion_tokens for newer OpenAI models)
+const MODEL_PARAM_RENAMES = {
+  "openai": [
+    { match: /gpt-5|o[134]-/, rename: { max_tokens: "max_completion_tokens" } },
+  ],
+};
+
+/**
+ * Apply model-specific param renames (e.g. max_tokens → max_completion_tokens for gpt-5+).
+ * @param {string} provider
+ * @param {string} model
+ * @param {object} body
+ */
+export function applyParamRenames(provider, model, body) {
+  const rules = MODEL_PARAM_RENAMES[provider] || [];
+  for (const rule of rules) {
+    if (rule.match.test(model)) {
+      for (const [from, to] of Object.entries(rule.rename)) {
+        if (body[from] !== undefined && body[to] === undefined) {
+          body[to] = body[from];
+          delete body[from];
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem
Newer OpenAI models (gpt-5, gpt-5.4-nano, gpt-5.4-mini, o1, o3, o4) require `max_completion_tokens` instead of `max_tokens`. Sending `max_tokens` causes 400 errors.

GitHub executor already has this fix, but the default executor (used by most OpenAI-compatible providers) doesn't.

## Fix
- Extends `paramSupport.js` with `applyParamRenames()` for model-specific param transformations
- Adds rename rule: `max_tokens` → `max_completion_tokens` for models matching `/gpt-5|o[134]-/i`
- Applied in default executor's `transformRequest()` before `stripUnsupportedParams()`

## Pattern
```js
// paramSupport.js
const MODEL_PARAM_RENAMES = {
  "openai": [
    { match: /gpt-5|o[134]-/, rename: { max_tokens: "max_completion_tokens" } },
  ],
};
```

Closes #1745