### PR TITLE
fix: show custom provider nodes in provider dropdown (#2013)

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/new/page.js
+++ b/src/app/(dashboard)/dashboard/providers/new/page.js
@@ -1,15 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Card, Button, Input, Select, Toggle } from "@/shared/components";
 import { AI_PROVIDERS, AUTH_METHODS } from "@/shared/constants/config";
-
-const providerOptions = Object.values(AI_PROVIDERS).map((p) => ({
-  value: p.id,
-  label: p.name,
-}));
+import {
+  OPENAI_COMPATIBLE_PREFIX,
+  ANTHROPIC_COMPATIBLE_PREFIX,
+} from "@/shared/constants/providers";
 
 const authMethodOptions = Object.values(AUTH_METHODS).map((m) => ({
   value: m.id,
@@ -19,6 +18,7 @@ const authMethodOptions = Object.values(AUTH_METHODS).map((m) => ({
 export default function NewProviderPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [providerNodes, setProviderNodes] = useState([]);
   const [formData, setFormData] = useState({
     provider: "",
     authMethod: "api_key",
@@ -27,6 +27,31 @@ export default function NewProviderPage() {
     isActive: true,
   });
   const [errors, setErrors] = useState({});
+
+  useEffect(() => {
+    fetch("/api/provider-nodes")
+      .then((res) => res.json())
+      .then((data) => setProviderNodes(data.nodes || []))
+      .catch(() => {});
+  }, []);
+
+  // Merge built-in providers + custom provider nodes
+  const providerOptions = [
+    ...Object.values(AI_PROVIDERS).map((p) => ({
+      value: p.id,
+      label: p.name,
+    })),
+    ...providerNodes
+      .filter(
+        (node) =>
+          node.type === "openai-compatible" ||
+          node.type === "anthropic-compatible"
+      )
+      .map((node) => ({
+        value: node.id,
+        label: node.name || node.id,
+      })),
+  ];
 
   const handleChange = (field, value) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
@@ -71,6 +96,10 @@ export default function NewProviderPage() {
   };
 
   const selectedProvider = AI_PROVIDERS[formData.provider];
+  const selectedNode = providerNodes.find((n) => n.id === formData.provider);
+  const isCustomProvider =
+    formData.provider.startsWith(OPENAI_COMPATIBLE_PREFIX) ||
+    formData.provider.startsWith(ANTHROPIC_COMPATIBLE_PREFIX);
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -83,7 +112,9 @@ export default function NewProviderPage() {
           <span className="material-symbols-outlined text-lg">arrow_back</span>
           Back to Providers
         </Link>
-        <h1 className="text-3xl font-semibold tracking-tight">Add New Provider</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">
+          Add New Provider
+        </h1>
         <p className="text-text-muted mt-2">
           Configure a new AI provider to use with your applications.
         </p>
@@ -104,22 +135,24 @@ export default function NewProviderPage() {
           />
 
           {/* Provider Info */}
-          {selectedProvider && (
+          {(selectedProvider || selectedNode) && (
             <Card.Section className="flex items-center gap-3">
-              <div
-                className="size-10 rounded-lg flex items-center justify-center bg-bg border border-border"
-              >
+              <div className="size-10 rounded-lg flex items-center justify-center bg-bg border border-border">
                 <span
                   className="material-symbols-outlined text-xl"
-                  style={{ color: selectedProvider.color }}
+                  style={{
+                    color: selectedProvider?.color || "#10A37F",
+                  }}
                 >
-                  {selectedProvider.icon}
+                  {selectedProvider?.icon || "smart_toy"}
                 </span>
               </div>
               <div>
-                <p className="font-medium">{selectedProvider.name}</p>
+                <p className="font-medium">
+                  {selectedProvider?.name || selectedNode?.name}
+                </p>
                 <p className="text-sm text-text-muted">
-                  Selected provider
+                  {isCustomProvider ? "Custom provider" : "Selected provider"}
                 </p>
               </div>
             </Card.Section>
@@ -217,4 +250,3 @@ export default function NewProviderPage() {
     </div>
   );
 }
-

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -144,10 +144,11 @@ export default function ModelSelectModal({
       ? NO_AUTH_PROVIDER_IDS.filter((id) => (AI_PROVIDERS[id]?.serviceKinds || ["llm"]).includes(kindFilter))
       : NO_AUTH_PROVIDER_IDS;
 
-    // Only show connected providers (including both standard and custom)
+    // Show connected providers, no-auth providers, and custom provider nodes
     const providerIdsToShow = new Set([
-      ...activeConnectionIds,  // Only connected providers
-      ...noAuthIds,            // No-auth providers (kind-filtered)
+      ...activeConnectionIds,           // Connected providers
+      ...noAuthIds,                     // No-auth providers (kind-filtered)
+      ...providerNodes.map(n => n.id),  // Custom provider nodes (openai-compatible, etc.)
     ]);
 
     // Sort by PROVIDER_ORDER


### PR DESCRIPTION
## Problem
Custom providers created via UI (OpenAI/Anthropic-compatible) are saved to `providerNodes` table but don't appear in:
1. Provider dropdown on `/providers/new` page
2. Model selector when creating combos

Root cause: `/providers/new` only reads from `AI_PROVIDERS` (built-in). `ModelSelectModal` only shows `activeConnectionIds` + `noAuthIds`, missing `providerNodes`.

## Fix

### `providers/new/page.js`
- Fetch `/api/provider-nodes` on mount
- Merge `openai-compatible` and `anthropic-compatible` nodes into provider dropdown
- Show custom provider info card when selected

### `ModelSelectModal.js`
- Add `providerNodes.map(n => n.id)` to `providerIdsToShow` set
- Custom provider nodes now appear in combo creation and model selection

Closes #2013