### PR TITLE
fix(responses): handle response.done terminal events

### DIFF
--- a/open-sse/utils/responsesStreamHelpers.js
+++ b/open-sse/utils/responsesStreamHelpers.js
@@ -5,6 +5,7 @@ import { formatSSE } from "./streamHelpers.js";
 // Responses API events that signal the stream has reached a terminal state
 const OPENAI_RESPONSES_TERMINAL_EVENTS = new Set([
   "response.completed",
+  "response.done",
   "response.failed",
   "error"
 ]);

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -217,9 +217,11 @@ export function createSSEStream(options = {}) {
             sseEmittedCount++;
           }
 
-          // [DONE] not emitted in translate mode — some clients' SSE decoders
-          // fail to parse the OpenAI sentinel on Claude-format translated streams.
-          // message_stop already signals end-of-response; stream close handles it.
+          if (keepsOpenAIResponsesFormat && !streamDoneSent) {
+            const doneOutput = "data: [DONE]\n\n";
+            reqLogger?.appendConvertedChunk?.(doneOutput);
+            controller.enqueue(sharedEncoder.encode(doneOutput));
+          }
           streamDoneSent = true;
           if (keepsOpenAIResponsesFormat) openAIResponsesDoneSent = true;
           continue;
@@ -415,8 +417,13 @@ export function createSSEStream(options = {}) {
           openAIResponsesTerminalSeen = true;
         }
 
-        // [DONE] not emitted in translate mode — see comment above.
-        // Passthrough mode still emits it for standard OpenAI clients.
+        if (keepsOpenAIResponsesFormat && !openAIResponsesDoneSent && !streamDoneSent) {
+          const doneOutput = "data: [DONE]\n\n";
+          reqLogger?.appendConvertedChunk?.(doneOutput);
+          controller.enqueue(sharedEncoder.encode(doneOutput));
+          openAIResponsesDoneSent = true;
+          streamDoneSent = true;
+        }
 
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);

--- a/tests/unit/openai-responses-terminal-event.test.js
+++ b/tests/unit/openai-responses-terminal-event.test.js
@@ -67,6 +67,19 @@ describe("OpenAI Responses streaming termination", () => {
     expect(output).toContain("data: [DONE]");
   });
 
+  it("does not add response.failed when a Responses stream sends response.done", async () => {
+    const output = await runTransform([
+      `event: response.done`,
+      `data: ${JSON.stringify({ type: "response.done", response: { id: "resp_test" } })}`,
+      "",
+    ].join("\n"));
+
+    expect(output).toContain("event: response.done");
+    expect(output).not.toContain("event: response.failed");
+    expect(output).not.toContain("data: null");
+    expect(output).toContain("data: [DONE]");
+  });
+
   it("emits response.failed before DONE when a Responses stream sends DONE without a terminal event", async () => {
     const output = await runTransform([
       `event: response.created`,


### PR DESCRIPTION
## Summary

- treat `response.done` as a terminal OpenAI Responses stream event
- keep emitting the OpenAI `data: [DONE]` sentinel for same-format Responses passthrough streams
- add a regression test for `response.done`

## Why

Codex/OpenAI Responses streams can terminate with:

```text
event: response.done
data: {"type":"response.done", ...}
```

9router already recognizes `response.done` in some older response conversion paths, but the current Responses passthrough terminal-event helper only accepts `response.completed`, `response.failed`, and `error`. When upstream sends `response.done`, the stream can be treated as incomplete and a synthetic `response.failed` may be emitted, which causes clients to surface errors like `stream closed before response.completed` / stream disconnected before completion.

This patch makes the same-format Responses passthrough path accept `response.done` as terminal, and restores the `[DONE]` sentinel for Responses passthrough streams so OpenAI-compatible SSE clients see a clean stream ending.

## Related scan

I checked the current open PRs/issues before opening this:

- #2089 is related to retryable/semantic Responses stream failures, but does not add `response.done` to the terminal event set and is currently conflicting.
- #2082 and #2112 cover Responses usage/text-format issues, not stream termination.
- #1618 previously mentioned `response.done`, but it was closed without merge and the current `master` terminal helper still does not include it.
- #1648 introduced the incomplete Responses stream test coverage, but was also closed without merge.

## Tests

```bash
./node_modules/.bin/vitest run --config tests/vitest.config.js \
  tests/unit/openai-responses-terminal-event.test.js \
  tests/unit/responses-abort-terminal.test.js \
  tests/unit/headroom-responses-format.test.js \
  tests/unit/codex-tool-normalization.test.js
```

Result: 4 files passed, 11 tests passed.
