### PR TITLE
fix(github): drop trailing assistant prefill for Copilot chat

### DIFF
--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -102,7 +102,24 @@ export class GithubExecutor extends BaseExecutor {
       return msg;
     });
 
+    // GitHub Copilot's /chat/completions rejects a conversation that ends with an
+    // assistant message ("does not support assistant message prefill. The conversation
+    // must end with a user message."). Anthropic clients such as Claude Desktop send a
+    // trailing assistant turn as a prefill seed, which the Anthropic API honors but
+    // Copilot does not — drop it so the request is accepted.
+    sanitized.messages = this.dropTrailingAssistantPrefill(sanitized.messages);
+
     return sanitized;
+  }
+
+  // Remove trailing assistant message(s). Copilot's chat endpoint can't honor prefill
+  // and 400s unless the conversation ends with a user/tool message. Never empties the
+  // array. No-op when the conversation already ends with a non-assistant message.
+  dropTrailingAssistantPrefill(messages) {
+    if (!Array.isArray(messages) || messages.length === 0) return messages;
+    let end = messages.length;
+    while (end > 1 && messages[end - 1]?.role === "assistant") end--;
+    return end === messages.length ? messages : messages.slice(0, end);
   }
 
   // Newer OpenAI models (gpt-5+, o1, o3, o4) require max_completion_tokens instead of max_tokens

--- a/tests/unit/github-prefill-sanitize.test.js
+++ b/tests/unit/github-prefill-sanitize.test.js
@@ -1,0 +1,73 @@
+/**
+ * Regression test: GitHub Copilot's /chat/completions rejects a conversation that
+ * ends with an assistant message ("This model does not support assistant message
+ * prefill. The conversation must end with a user message.").
+ *
+ * Anthropic clients (e.g. newest Claude Desktop) send a trailing assistant turn as a
+ * prefill seed. The Anthropic API honors it but Copilot 400s, so the GitHub executor
+ * must drop trailing assistant message(s) before dispatching to /chat/completions.
+ */
+
+import { describe, it, expect } from "vitest";
+import { GithubExecutor } from "../../open-sse/executors/github.js";
+
+describe("GithubExecutor prefill sanitization", () => {
+  const exec = new GithubExecutor();
+
+  it("drops a trailing assistant prefill message", () => {
+    const body = {
+      model: "claude-sonnet-4.6",
+      messages: [
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Here is the answer:" },
+      ],
+    };
+    const out = exec.sanitizeMessagesForChatCompletions(body);
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].role).toBe("user");
+  });
+
+  it("drops multiple consecutive trailing assistant messages", () => {
+    const out = exec.dropTrailingAssistantPrefill([
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "one" },
+      { role: "assistant", content: "two" },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe("user");
+  });
+
+  it("leaves a conversation ending in a user message untouched", () => {
+    const messages = [
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: "Hello" },
+      { role: "user", content: "More" },
+    ];
+    const out = exec.dropTrailingAssistantPrefill(messages);
+    expect(out).toBe(messages); // same reference — no-op
+    expect(out).toHaveLength(3);
+  });
+
+  it("leaves a conversation ending in a tool message untouched", () => {
+    const messages = [
+      { role: "user", content: "Hi" },
+      { role: "assistant", content: null, tool_calls: [{ id: "x" }] },
+      { role: "tool", tool_call_id: "x", content: "result" },
+    ];
+    const out = exec.dropTrailingAssistantPrefill(messages);
+    expect(out).toHaveLength(3);
+    expect(out[2].role).toBe("tool");
+  });
+
+  it("never empties an assistant-only conversation (keeps at least one message)", () => {
+    const out = exec.dropTrailingAssistantPrefill([
+      { role: "assistant", content: "only" },
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it("is null/empty safe", () => {
+    expect(exec.dropTrailingAssistantPrefill([])).toEqual([]);
+    expect(exec.dropTrailingAssistantPrefill(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

The newest Claude Desktop version ends its Anthropic request with an assistant
message (a prefill seed). The Anthropic API supports this, but GitHub Copilot's
`/chat/completions` endpoint does not and responds with a 400: 

> This model does not support assistant message prefill. The conversation must end with a user message.

For `claude-*` models routed through the **github** provider, the request is
translated claude→openai; the trailing assistant message survives translation
and triggers the 400.

## Fix

`sanitizeMessagesForChatCompletions` (the existing Copilot-specific message
adapter in the GitHub executor) now drops trailing assistant message(s) via a
new `dropTrailingAssistantPrefill` helper before dispatching to
`/chat/completions`.

Deliberately scoped to the GitHub executor only — not the shared translator:
real Anthropic/OpenAI endpoints honor prefill, so it must be preserved there.

- No-op when the conversation already ends with a user/tool message
- Never empties the array (keeps at least one message)

## Test plan

- [x] New regression test `tests/unit/github-prefill-sanitize.test.js` (6 cases): passing
- [x] Existing `github-responses-routing` test: passing (no regression)
- [x] End-to-end verified: `claudeToOpenAIRequest` → `sanitizeMessagesForChatCompletions` — conversation ends with`user` after sanitize
- [x] Live smoke test against real GitHub Copilot with Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

-----
Human message: his was done with Opus 4.8
The fix runs locally from master (cce47dd809b1b01e23ebedeb78ad26e85bad429b).
Claude Desktop App runs again with this fix 🎊