### PR TITLE
fix(claude): translate non-streaming OpenAI responses back to Anthropic format

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -6,6 +6,7 @@ import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./requestDetail.js";
+import { translateOpenAIToClaudeIfNeeded } from "../../translator/response/openai-to-claude-json.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
 
@@ -13,7 +14,17 @@ import { decloakToolNames } from "../../utils/claudeCloaking.js";
  * Translate non-streaming response body from provider format → OpenAI format.
  */
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat) {
-  if (targetFormat === sourceFormat || targetFormat === FORMATS.OPENAI) return responseBody;
+  if (targetFormat === sourceFormat) return responseBody;
+
+  // When the client spoke Claude but the upstream spoke OpenAI (e.g. gpt-5.5-9router
+  // routes to an OpenAI-format provider), convert the OpenAI body to Anthropic
+  // Messages shape so the Claude client gets a parseable content[] block
+  // instead of a leaked {object:"chat.completion",choices:[...]} payload.
+  if (sourceFormat === FORMATS.CLAUDE && targetFormat === FORMATS.OPENAI) {
+    return translateOpenAIToClaudeIfNeeded(responseBody, sourceFormat);
+  }
+
+  if (targetFormat === FORMATS.OPENAI) return responseBody;
 
   // Gemini / Antigravity
   if (targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.ANTIGRAVITY || targetFormat === FORMATS.GEMINI_CLI || targetFormat === FORMATS.VERTEX) {

--- a/open-sse/translator/response/openai-to-claude-json.js
+++ b/open-sse/translator/response/openai-to-claude-json.js
@@ -1,0 +1,70 @@
+/**
+ * Convert non-streaming OpenAI Chat Completions response to Anthropic Messages format.
+ * Used when client speaks Claude format but upstream provider speaks OpenAI format.
+ *
+ * Input:  OpenAI Chat Completions JSON  {object:"chat.completion", choices:[{message:{...}}]}
+ * Output: Anthropic Messages JSON        {id:"msg_...", type:"message", content:[...]}
+ */
+export function translateOpenAIToClaudeIfNeeded(responseBody, sourceFormat) {
+  if (!responseBody || !responseBody.choices?.[0]) return responseBody;
+
+  const choice = responseBody.choices[0];
+  const msg = choice.message || {};
+  const finishReason = choice.finish_reason || "stop";
+
+  const content = [];
+
+  // Text content
+  if (typeof msg.content === "string" && msg.content.length > 0) {
+    content.push({ type: "text", text: msg.content });
+  }
+
+  // Reasoning / thinking content
+  if (typeof msg.reasoning_content === "string" && msg.reasoning_content.length > 0) {
+    content.push({ type: "thinking", thinking: msg.reasoning_content });
+  }
+
+  // Tool calls
+  if (Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+    for (const tc of msg.tool_calls) {
+      let input = {};
+      if (typeof tc.function?.arguments === "string") {
+        try { input = JSON.parse(tc.function.arguments); } catch { input = {}; }
+      }
+      content.push({
+        type: "tool_use",
+        id: tc.id || `call_${tc.function?.name || "unknown"}_${Date.now()}`,
+        name: tc.function?.name || "unknown",
+        input
+      });
+    }
+  }
+
+  // If no content blocks at all, add empty text block (Anthropic requires at least one)
+  if (content.length === 0) {
+    content.push({ type: "text", text: "" });
+  }
+
+  const stopReasonMap = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "content_filter": "end_turn",
+  };
+
+  const usage = responseBody.usage || {};
+
+  return {
+    id: (responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, "msg_"),
+    type: "message",
+    role: "assistant",
+    content,
+    model: responseBody.model || "claude",
+    stop_reason: stopReasonMap[finishReason] || "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: usage.prompt_tokens || 0,
+      output_tokens: usage.completion_tokens || 0,
+    }
+  };
+}


### PR DESCRIPTION
## Summary

When Claude Code's auto-mode classifier hits the `gpt-5.5-9router` combo that routes to an OpenAI-format upstream, the non-streaming response came back in Chat Completions shape and broke the Anthropic-format client expecting `type: "message"` + `content: [{type:"text"}]`.

This PR adds `translateOpenAIToClaudeIfNeeded()` in a new direct-route translator (`openai-to-claude-json.js`) and wires it into `nonStreamingHandler.js` for the Claude→OpenAI non-streaming path.

## Why direct, not registered

The non-streaming path returns a parsed JSON body (not SSE chunks). The registered OpenAI→Claude translator expects SSE-shaped data. Calling directly keeps the conversion local and synchronous.

## Files

- `open-sse/handlers/chatCore/nonStreamingHandler.js` (+13 / -1)
- `open-sse/translator/response/openai-to-claude-json.js` (+70, new)

## Test plan

- Send a Claude-format request to a Claude→OpenAI route with `stream: false`
- Verify response is Anthropic Messages shape (`type: "message"`, `content: [{type:"text"]`)
- Verify no regression on streaming Claude→OpenAI path

🤖 Generated with [opencode](https://opencode.ai)