### PR TITLE
feat(xai): surface Grok usage on quota dashboard via local usageHistory aggregation

### DIFF
--- a/open-sse/providers/registry/xai.js
+++ b/open-sse/providers/registry/xai.js
@@ -35,6 +35,9 @@ export default {
   ],
   serviceKinds: ["llm","imageToText","webSearch","image"],
   imageConfig: { baseUrl: "https://api.x.ai/v1/images/generations", bodyFields: ["model","prompt","n","response_format"] },
+  features: {
+    usage: true,
+  },
   searchViaChat: {
     defaultModel: "grok-4.20-reasoning",
     endpoint: "https://api.x.ai/v1/responses",

--- a/src/app/api/usage/[connectionId]/route.js
+++ b/src/app/api/usage/[connectionId]/route.js
@@ -236,19 +236,22 @@ async function aggregateXaiUsage(connection) {
     byModel[r.model] += used;
   }
 
+  // Cumulative aggregates have no cap, so the progress bar is meaningless.
+  // Mark them as unlimited + remaining: 100 so the dashboard renders the
+  // green "🟢 100%" badge and hides the bar instead of "🔴 0%".
+  const unlimited = { remaining: 100, resetAt: null, unlimited: true };
+
   const quotas = {
     'Total spend (30d)': {
       used: Number(totals.cost.toFixed(4)),
       total: 0,
       unit: 'usd',
-      resetAt: null,
-      unlimited: false,
+      ...unlimited,
     },
     'Total tokens (30d)': {
       used: totals.prompt + totals.completion,
       total: 0,
-      resetAt: null,
-      unlimited: false,
+      ...unlimited,
     },
   };
 
@@ -257,8 +260,7 @@ async function aggregateXaiUsage(connection) {
       used,
       total: 0,
       unit: 'tokens',
-      resetAt: null,
-      unlimited: false,
+      ...unlimited,
     };
   }
 

--- a/src/app/api/usage/[connectionId]/route.js
+++ b/src/app/api/usage/[connectionId]/route.js
@@ -2,6 +2,7 @@
 import "open-sse/index.js";
 
 import { getProviderConnectionById, updateProviderConnection } from "@/lib/localDb";
+import { getUsageHistory } from "@/lib/db/repos/usageRepo.js";
 import { getUsageForProvider } from "open-sse/services/usage.js";
 import { getExecutor } from "open-sse/executors/index.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
@@ -167,6 +168,11 @@ export async function GET(request, { params }) {
       }
     }
 
+    // xAI has no public quota API; aggregate from local usageHistory
+    if (connection.provider === 'xai') {
+      return Response.json(await aggregateXaiUsage(connection));
+    }
+
     // Fetch usage from provider API
     let usage = await getUsageForProvider(connection, proxyOptions);
 
@@ -189,3 +195,77 @@ export async function GET(request, { params }) {
     return Response.json({ error: error.message }, { status: 500 });
   }
 }
+
+/**
+ * Aggregate xAI usage from local usageHistory.
+ * xAI does not expose a public per-account quota endpoint (the
+ * billing console at console.x.ai requires a session cookie, not an
+ * API key), so we surface real spend and token usage from 9router's
+ * own request log over the last 30 days, grouped per model.
+ */
+async function aggregateXaiUsage(connection) {
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const rows = await getUsageHistory({ provider: 'xai', startDate: since });
+  const filtered = rows.filter((r) => !connection.id || r.connectionId === connection.id);
+
+  if (!filtered.length) {
+    return {
+      message: 'xAI connected. No requests recorded in the last 30 days.',
+      quotas: {},
+      displayMessage: 'xAI connected. No usage yet.',
+    };
+  }
+
+  const totals = filtered.reduce(
+    (acc, r) => {
+      const t = r.tokens || {};
+      acc.prompt += Number(t.prompt_tokens || t.promptTokens || 0);
+      acc.completion += Number(t.completion_tokens || t.completionTokens || 0);
+      acc.cost += Number(r.cost) || 0;
+      acc.requests += 1;
+      return acc;
+    },
+    { prompt: 0, completion: 0, cost: 0, requests: 0 }
+  );
+
+  const byModel = {};
+  for (const r of filtered) {
+    const t = r.tokens || {};
+    const used = (Number(t.prompt_tokens || t.promptTokens || 0)) + (Number(t.completion_tokens || t.completionTokens || 0));
+    if (!byModel[r.model]) byModel[r.model] = 0;
+    byModel[r.model] += used;
+  }
+
+  const quotas = {
+    'Total spend (30d)': {
+      used: Number(totals.cost.toFixed(4)),
+      total: 0,
+      unit: 'usd',
+      resetAt: null,
+      unlimited: false,
+    },
+    'Total tokens (30d)': {
+      used: totals.prompt + totals.completion,
+      total: 0,
+      resetAt: null,
+      unlimited: false,
+    },
+  };
+
+  for (const [model, used] of Object.entries(byModel)) {
+    quotas[model + ' (30d)'] = {
+      used,
+      total: 0,
+      unit: 'tokens',
+      resetAt: null,
+      unlimited: false,
+    };
+  }
+
+  return {
+    plan: 'xAI / Grok Build',
+    displayMessage: 'xAI connected. ' + totals.requests + ' requests in the last 30 days.',
+    quotas,
+  };
+}
+

--- a/tests/unit/xai-usage.test.js
+++ b/tests/unit/xai-usage.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "path";
+import os from "os";
+import fs from "fs";
+import Database from "better-sqlite3";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+
+function makeTempDb() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-xai-test-"));
+  const dbDir = path.join(tmpDir, "db");
+  fs.mkdirSync(dbDir, { recursive: true });
+  const dbPath = path.join(dbDir, "data.sqlite");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE usageHistory (
+      id INTEGER PRIMARY KEY,
+      timestamp TEXT NOT NULL,
+      provider TEXT,
+      model TEXT,
+      connectionId TEXT,
+      apiKey TEXT,
+      endpoint TEXT,
+      promptTokens INTEGER DEFAULT 0,
+      completionTokens INTEGER DEFAULT 0,
+      cost REAL DEFAULT 0,
+      status TEXT,
+      tokens TEXT,
+      meta TEXT
+    );
+  `);
+  return { dbPath, tmpDir };
+}
+
+function seedHistory(dbPath, rows) {
+  const db = new Database(dbPath);
+  const insert = db.prepare(
+    `INSERT INTO usageHistory
+       (timestamp, provider, model, connectionId, promptTokens, completionTokens, cost, status)
+     VALUES (?, 'xai', ?, ?, ?, ?, ?, 'success')`,
+  );
+  for (const r of rows) {
+    insert.run(r.timestamp, r.model, r.connectionId, r.prompt, r.completion, r.cost);
+  }
+  db.close();
+}
+
+describe("xAI (Grok) usage", () => {
+  let dbPath;
+  let tmpDir;
+  const originalDataDir = process.env.DATA_DIR;
+
+  beforeEach(() => {
+    const t = makeTempDb();
+    dbPath = t.dbPath;
+    tmpDir = t.tmpDir;
+    process.env.DATA_DIR = tmpDir;
+  });
+
+  it("aggregates tokens and cost per model from usageHistory", async () => {
+    const now = Date.now();
+    seedHistory(dbPath, [
+      { timestamp: new Date(now - 1000).toISOString(), model: "grok-4", connectionId: "conn-1", prompt: 100, completion: 50, cost: 0.0006 },
+      { timestamp: new Date(now - 2000).toISOString(), model: "grok-4", connectionId: "conn-1", prompt: 200, completion: 75, cost: 0.0009 },
+      { timestamp: new Date(now - 3000).toISOString(), model: "grok-code-fast-1", connectionId: "conn-1", prompt: 400, completion: 25, cost: 0.0005 },
+    ]);
+
+    const result = await getUsageForProvider({ provider: "xai", id: "conn-1" });
+
+    expect(result.plan).toBe("xAI / Grok Build");
+    expect(result.quotas).toBeDefined();
+    expect(result.quotas["Total tokens (30d)"].used).toBe(850);
+    expect(result.quotas["Total spend (30d)"].used).toBeCloseTo(0.002, 4);
+    expect(result.quotas["grok-4 (30d)"].used).toBe(425);
+    expect(result.quotas["grok-code-fast-1 (30d)"].used).toBe(425);
+  });
+
+  it("returns graceful message when no xai history exists", async () => {
+    const result = await getUsageForProvider({ provider: "xai", id: "conn-1" });
+    expect(result.message).toMatch(/No requests recorded/);
+    expect(result.quotas).toEqual({});
+  });
+
+  it("scopes aggregation to the requested connectionId", async () => {
+    const now = Date.now();
+    seedHistory(dbPath, [
+      { timestamp: new Date(now - 1000).toISOString(), model: "grok-4", connectionId: "conn-A", prompt: 100, completion: 0, cost: 0.0001 },
+      { timestamp: new Date(now - 1000).toISOString(), model: "grok-4", connectionId: "conn-B", prompt: 999, completion: 999, cost: 0.5 },
+    ]);
+
+    const resultA = await getUsageForProvider({ provider: "xai", id: "conn-A" });
+    expect(resultA.quotas["Total tokens (30d)"].used).toBe(100);
+    expect(resultA.quotas["Total spend (30d)"].used).toBeCloseTo(0.0001, 4);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the xAI (Grok) quota dashboard. Aggregates 30-day usage from the local `usageHistory` SQLite table since xAI has no public quota API.

## What it does

- **Route handler aggregation** — `src/app/api/usage/[connectionId]/route.js` adds a fallback path that pulls Grok usage from the local `usageHistory` table when the upstream quota API is unavailable. Returns aggregated quotas (Total spend, Total tokens) in the same shape as the other providers.
- **Cumulative rows marked unlimited** — Grok cumulative rows (Total spend, Total tokens) have no hard cap. The fix sets `unlimited: true` + `remaining: 100` so the UI renders the green "100%" badge instead of a misleading "0%" progress bar.
- **Provider registry flag** — `open-sse/providers/registry/xai.js` gains `features.usage: true` so upstream's dynamic `USAGE_SUPPORTED_PROVIDERS` filter (derived from REGISTRY) picks xAI up automatically. Replaces the hardcoded list in the original commit.

## Files

- `src/app/api/usage/[connectionId]/route.js` (+82)
- `tests/unit/xai-usage.test.js` (+99, new)
- `open-sse/providers/registry/xai.js` (+3, `features.usage: true`)

## Why route-handler aggregation (not service-layer)

The original implementation attempted a service-layer `getXaiUsage` in `open-sse/services/usage.js` but was reverted (`0856aef`) to avoid a `better-sqlite3` ABI mismatch in the Node 25 runtime. This PR keeps aggregation in the route handler instead, which already runs in the Node-compatible Next.js context where `better-sqlite3` works.

## Test plan

- `cd tests && ./node_modules/.bin/vitest run tests/unit/xai-usage.test.js`
- Manual: hit the quota dashboard with an xAI connection → verify Grok quota row renders with the green unlimited badge.

🤖 Generated with [opencode](https://opencode.ai)