### PR TITLE
feat(quota): add opencode and opencode-go to quota tracking via local usageHistory aggregation

### DIFF
--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -38,4 +38,8 @@ export default {
     { id: "qwen3.7-plus", name: "Qwen 3.7 Plus", targetFormat: "claude" },
     { id: "qwen3.6-plus", name: "Qwen 3.6 Plus", targetFormat: "claude" },
   ],
+  features: {
+    usage: true,
+    usageApikey: true,
+  },
 };

--- a/open-sse/providers/registry/opencode.js
+++ b/open-sse/providers/registry/opencode.js
@@ -22,4 +22,8 @@ export default {
   models: [],
   modelsFetcher: { url: "https://opencode.ai/zen/v1/models", type: "opencode-free" },
   passthroughModels: true,
+  features: {
+    usage: true,
+    usageApikey: true,
+  },
 };

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -441,6 +441,8 @@ export function parseQuotaData(provider, data) {
               name,
               used: quota.used || 0,
               total: quota.total || 0,
+              remaining: quota.remaining !== undefined ? quota.remaining : undefined,
+              unlimited: quota.unlimited || false,
               resetAt: quota.resetAt || null,
             });
           });

--- a/src/app/api/usage/[connectionId]/route.js
+++ b/src/app/api/usage/[connectionId]/route.js
@@ -167,6 +167,14 @@ export async function GET(request, { params }) {
       }
     }
 
+    // Providers without a public quota API — aggregate from local usageHistory
+    if (connection.provider === 'opencode-go') {
+      return Response.json(await aggregateLocalUsage(connection, 'OpenCode Go'));
+    }
+    if (connection.provider === 'opencode') {
+      return Response.json(await aggregateLocalUsage(connection, 'OpenCode'));
+    }
+
     // Fetch usage from provider API
     let usage = await getUsageForProvider(connection, proxyOptions);
 
@@ -189,3 +197,69 @@ export async function GET(request, { params }) {
     return Response.json({ error: error.message }, { status: 500 });
   }
 }
+
+async function aggregateLocalUsage(connection, label) {
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const rows = await getUsageHistory({ provider: connection.provider, startDate: since });
+  const filtered = rows.filter((r) => !connection.id || r.connectionId === connection.id);
+
+  if (!filtered.length) {
+    return {
+      message: `${label} connected. No requests recorded in the last 30 days.`,
+      quotas: {},
+      displayMessage: `${label} connected. No usage yet.`,
+    };
+  }
+
+  const totals = filtered.reduce(
+    (acc, r) => {
+      const t = r.tokens || {};
+      acc.prompt += Number(t.prompt_tokens || t.promptTokens || 0);
+      acc.completion += Number(t.completion_tokens || t.completionTokens || 0);
+      acc.cost += Number(r.cost) || 0;
+      acc.requests += 1;
+      return acc;
+    },
+    { prompt: 0, completion: 0, cost: 0, requests: 0 }
+  );
+
+  const byModel = {};
+  for (const r of filtered) {
+    const t = r.tokens || {};
+    const used = (Number(t.prompt_tokens || t.promptTokens || 0)) + (Number(t.completion_tokens || t.completionTokens || 0));
+    if (!byModel[r.model]) byModel[r.model] = 0;
+    byModel[r.model] += used;
+  }
+
+  const unlimited = { remaining: 100, resetAt: null, unlimited: true };
+
+  const quotas = {
+    'Total spend (30d)': {
+      used: Number(totals.cost.toFixed(4)),
+      total: 0,
+      unit: 'usd',
+      ...unlimited,
+    },
+    'Total tokens (30d)': {
+      used: totals.prompt + totals.completion,
+      total: 0,
+      ...unlimited,
+    },
+  };
+
+  for (const [model, used] of Object.entries(byModel)) {
+    quotas[model + ' (30d)'] = {
+      used,
+      total: 0,
+      unit: 'tokens',
+      ...unlimited,
+    };
+  }
+
+  return {
+    plan: label,
+    displayMessage: `${label} connected. ${totals.requests} requests in the last 30 days.`,
+    quotas,
+  };
+}
+


### PR DESCRIPTION
## Summary

Adds OpenCode and OpenCode Go to the quota dashboard. Like xAI, these providers have no public quota API — usage is aggregated from the local `usageHistory` SQLite table.

## What it does

- **Route handler aggregation** — `src/app/api/usage/[connectionId]/route.js` adds an early-return path for `opencode` and `opencode-go` connections that calls `aggregateLocalUsage()` instead of `getUsageForProvider()`.
- **`aggregateLocalUsage()` helper** — aggregates the last 30 days of `usageHistory` rows for the connection, returns quotas for Total spend (30d), Total tokens (30d), and per-model usage. Cumulative rows are marked `unlimited: true` with `remaining: 100` so the UI renders the green "100%" badge.
- **Provider registry flags** — `opencode.js` and `opencode-go.js` gain `features.usage` and `features.usageApikey` so upstream's dynamic `USAGE_SUPPORTED_PROVIDERS` filter (derived from REGISTRY) picks them up automatically. Replaces the hardcoded list in the original commit.

## Files

- `src/app/api/usage/[connectionId]/route.js` (+74 — opencode/opencode-go handlers + aggregateLocalUsage helper)
- `open-sse/providers/registry/opencode.js` (+4 — features flags)
- `open-sse/providers/registry/opencode-go.js` (+4 — features flags)
- `src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js` (+2 — auto-merged)

## Why route-handler aggregation (not service-layer)

The original implementation attempted a service-layer `getOpenCodeUsage` in `open-sse/services/usage.js` but that file has been completely refactored upstream into per-provider modules. Aggregation lives in the route handler instead, which already runs in the Node-compatible Next.js context where `usageHistory` queries work.

## Test plan

- Manual: hit the quota dashboard with an opencode or opencode-go connection → verify usage rows render with the green unlimited badge.
- Manual: confirm requests in the last 30 days show up under their model names.

🤖 Generated with [opencode](https://opencode.ai)