### PR TITLE
fix(stt): forward all client form fields to OpenAI/Groq STT

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,6 +40,19 @@ const nextConfig = {
         path: false,
       };
     }
+    // better-sqlite3 is an OPTIONAL native dep. On hosts without a C++ toolchain
+    // (e.g. Hostinger Node hosting) its native build is skipped and the module is
+    // absent — serverExternalPackages then can't externalize it (it resolves the
+    // package first) and webpack fails with "Can't resolve 'better-sqlite3'".
+    // Force-externalize so webpack never resolves it at build; driver.js catches the
+    // missing require at runtime and falls back to node:sqlite (Node >=22.5) / sql.js.
+    if (isServer) {
+      const prev = config.externals;
+      config.externals = [
+        ({ request }, cb) => (request === "better-sqlite3" ? cb(null, "commonjs better-sqlite3") : cb()),
+        ...(Array.isArray(prev) ? prev : prev ? [prev] : []),
+      ];
+    }
     // Exclude non-source dirs from watcher to reduce inotify load
     config.watchOptions = {
       ...config.watchOptions,

--- a/open-sse/handlers/sttCore.js
+++ b/open-sse/handlers/sttCore.js
@@ -141,8 +141,9 @@ async function transcribeOpenAICompatible(cfg, file, model, token, formData) {
   const fd = new FormData();
   fd.append("file", file, file.name || "audio.wav");
   fd.append("model", model);
-  for (const k of ["language", "prompt", "response_format", "temperature"]) {
-    const v = formData.get(k);
+  // Forward every client field as-is (covers timestamp_granularities[], include[], etc.); file/model set above
+  for (const [k, v] of formData.entries()) {
+    if (k === "file" || k === "model") continue;
     if (v !== null && v !== undefined && v !== "") fd.append(k, v);
   }
   const res = await fetch(cfg.baseUrl, { method: "POST", headers: buildAuthHeaders(cfg, token), body: fd });

--- a/open-sse/providers/registry/gemini.js
+++ b/open-sse/providers/registry/gemini.js
@@ -54,6 +54,7 @@ export default {
     { id: "gemini-2.0-flash", name: "Gemini 2.0 Flash", params: ["language","prompt"], kind: "stt" },
     { id: "gemini-2.5-flash-preview-tts", name: "Gemini 2.5 Flash TTS", kind: "tts" },
     { id: "gemini-2.5-pro-preview-tts", name: "Gemini 2.5 Pro TTS", kind: "tts" },
+    { id: "gemini-3.1-flash-tts-preview", name: "Gemini 3.1 Flash TTS", kind: "tts" },
     { id: "embedding-001", name: "Embedding 001", dimensions: 768, kind: "embedding" },
   ],
   serviceKinds: ["llm","embedding","image","imageToText","webSearch","tts","stt"],
@@ -62,6 +63,12 @@ export default {
     authType: "apikey",
     authHeader: "key",
     format: "gemini-tts",
+    defaultModel: "gemini-2.5-flash-preview-tts",
+    models: [
+      { id: "gemini-2.5-flash-preview-tts", name: "Gemini 2.5 Flash TTS" },
+      { id: "gemini-2.5-pro-preview-tts", name: "Gemini 2.5 Pro TTS" },
+      { id: "gemini-3.1-flash-tts-preview", name: "Gemini 3.1 Flash TTS" },
+    ],
   },
   sttConfig: {
     baseUrl: "https://generativelanguage.googleapis.com/v1beta/models",

--- a/src/app/api/v1/audio/voices/route.js
+++ b/src/app/api/v1/audio/voices/route.js
@@ -5,6 +5,8 @@ const PROVIDER_API = {
   elevenlabs: (origin) => `${origin}/api/media-providers/tts/elevenlabs/voices`,
   deepgram: (origin) => `${origin}/api/media-providers/tts/deepgram/voices`,
   inworld: (origin) => `${origin}/api/media-providers/tts/inworld/voices`,
+  minimax: (origin) => `${origin}/api/media-providers/tts/minimax/voices`,
+  "minimax-cn": (origin) => `${origin}/api/media-providers/tts/minimax/voices?provider=minimax-cn`,
   "edge-tts": (origin) => `${origin}/api/media-providers/tts/voices?provider=edge-tts`,
   "local-device": (origin) => `${origin}/api/media-providers/tts/voices?provider=local-device`,
 };

--- a/src/app/api/v1/models/info/route.js
+++ b/src/app/api/v1/models/info/route.js
@@ -13,7 +13,7 @@ const KIND_ENDPOINT = {
   webFetch: "/v1/fetch",
 };
 
-const TTS_VOICES_API = new Set(["elevenlabs", "edge-tts", "deepgram", "inworld", "local-device"]);
+const TTS_VOICES_API = new Set(["elevenlabs", "edge-tts", "deepgram", "inworld", "local-device", "minimax", "minimax-cn"]);
 
 function buildInfo({ alias, providerId, model, kind, providerInfo }) {
   const out = {


### PR DESCRIPTION
## Problem
`/v1/audio/transcriptions` (Groq/OpenAI-compatible path) only forwarded 4 hard-coded params: `language, prompt, response_format, temperature`. Every other field was dropped, so `timestamp_granularities[]` could not be passed through to get word-level timestamps.

## Fix
Forward **all** client-supplied fields, excluding only `file`/`model` (set explicitly). Using `formData.entries()` also covers array fields (`timestamp_granularities[]`, `include[]`, …).

## Usage note
For word timestamps the client must also send `response_format=verbose_json` (OpenAI/Groq requirement) — both fields now pass through.