### PR TITLE
fix(tray): make Windows context menu DPI-aware

### DIFF
--- a/cli/src/cli/tray/tray.ps1
+++ b/cli/src/cli/tray/tray.ps1
@@ -2,13 +2,64 @@
 # IPC: stdin JSON commands, stdout JSON events
 param([string]$IconPath, [string]$Tooltip)
 
+$ErrorActionPreference = "Stop"
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class WinDpiAwareness {
+  public static IntPtr PerMonitorAwareV2 { get { return new IntPtr(-4); } }
+  public static IntPtr PerMonitorAware { get { return new IntPtr(-3); } }
+
+  [DllImport("user32.dll")]
+  public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
+
+  [DllImport("user32.dll")]
+  public static extern IntPtr SetThreadDpiAwarenessContext(IntPtr value);
+
+  [DllImport("shcore.dll")]
+  public static extern int SetProcessDpiAwareness(int value);
+
+  [DllImport("user32.dll")]
+  public static extern bool SetProcessDPIAware();
+}
+"@
+
+function Enable-HighDpiAwareness {
+  $contexts = @(
+    [WinDpiAwareness]::PerMonitorAwareV2,
+    [WinDpiAwareness]::PerMonitorAware
+  )
+
+  foreach ($context in $contexts) {
+    try {
+      if ([WinDpiAwareness]::SetProcessDpiAwarenessContext($context)) { break }
+    } catch {}
+  }
+
+  try { [WinDpiAwareness]::SetProcessDpiAwareness(2) | Out-Null } catch {}
+  try { [WinDpiAwareness]::SetProcessDPIAware() | Out-Null } catch {}
+
+  foreach ($context in $contexts) {
+    try {
+      $previous = [WinDpiAwareness]::SetThreadDpiAwarenessContext($context)
+      if ($previous -ne [IntPtr]::Zero) { break }
+    } catch {}
+  }
+}
+
+Enable-HighDpiAwareness
+
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 
-$ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 [Console]::InputEncoding = [System.Text.Encoding]::UTF8
 $OutputEncoding = [System.Text.Encoding]::UTF8
+
+[System.Windows.Forms.Application]::EnableVisualStyles()
+[System.Windows.Forms.Application]::SetCompatibleTextRenderingDefault($false)
 
 $script:notifyIcon = New-Object System.Windows.Forms.NotifyIcon
 $script:notifyIcon.Icon = New-Object System.Drawing.Icon($IconPath)


### PR DESCRIPTION
## Summary
- make the Windows PowerShell tray process DPI-aware before WinForms creates the tray context menu
- prefer Per-Monitor V2 DPI awareness, with fallbacks for older Windows APIs
- enable WinForms visual styles before creating `NotifyIcon` / `ContextMenuStrip`

Closes #2161

## Before
<img width="262" height="142" alt="Blurry Windows tray context menu" src="https://github.com/user-attachments/assets/c68ff6ba-1a74-4287-b574-e07433a83102" />

## After
<img width="266" height="131" alt="Sharp Windows tray context menu" src="https://github.com/user-attachments/assets/97b224e4-6a3b-477e-9d46-f0e511d8f1d3" />

## Testing
- Parsed `cli/src/cli/tray/tray.ps1` with PowerShell parser
- Ran `node -c cli/src/cli/tray/trayWin.js`
- Ran `node -c cli/src/cli/tray/tray.js`
- Manually verified tray context menu renders sharper on Windows DPI-scaled display
