### PR TITLE
fix(antigravity): strip deprecated/readOnly/writeOnly from tool schemas

### DIFF
--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -12,6 +12,8 @@ export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
   "default", "examples",
   // JSON Schema meta keywords
   "$schema", "$defs", "definitions", "const", "$ref", "$comment",
+  // Annotation keywords (rejected by Gemini/Antigravity - e.g. MCP tool schemas set these)
+  "deprecated", "readOnly", "writeOnly",
   // Object validation keywords (not supported)
   "additionalProperties", "propertyNames", "patternProperties", "enumDescriptions",
   // Complex schema keywords (handled by flattenAnyOfOneOf/mergeAllOf)


### PR DESCRIPTION
## Problem

Requests to Antigravity that include tools fail with a `400 INVALID_ARGUMENT` when any tool schema carries the JSON Schema annotation keyword `deprecated` (and likewise `readOnly` / `writeOnly`):

```
[400]: Invalid JSON payload received. Unknown name "deprecated" at
'request.tools[0].function_declarations[137].parameters.properties[1].value':
Cannot find field.
```

Google's `generateContent` schema dialect does not accept these annotation keywords. MCP tool schemas — e.g. those emitted by Claude Code — routinely set `deprecated: true` on properties, so **every** request carrying such a tool is rejected before it reaches the model.

## Root cause

`cleanJSONSchemaForAntigravity()` strips unsupported keywords via `UNSUPPORTED_SCHEMA_CONSTRAINTS` (`open-sse/translator/formats/gemini.js`), but the list was missing the JSON Schema annotation keywords `deprecated`, `readOnly`, and `writeOnly`.

## Fix

Add `deprecated`, `readOnly`, `writeOnly` to `UNSUPPORTED_SCHEMA_CONSTRAINTS` so they are removed (recursively, at all nesting levels) before the request is sent to Antigravity.

## Verification

Patched the installed build locally and confirmed via direct API probes against `ag/gemini-3-flash` and `ag/gemini-3-flash-agent`: the `400 Unknown name "deprecated"/"readOnly"` error no longer occurs — schemas carrying these keywords now pass schema validation cleanly.

> Note: this is a one-line constant change; no behavior change for schemas that don't use these keywords.