### PR TITLE
fix(kilocode): expose full gateway catalog in combo model picker

### DIFF
--- a/open-sse/providers/registry/kilocode.js
+++ b/open-sse/providers/registry/kilocode.js
@@ -36,6 +36,13 @@ export default {
     { id: "deepseek/deepseek-chat", name: "DeepSeek Chat" },
     { id: "deepseek/deepseek-reasoner", name: "DeepSeek Reasoner" },
   ],
+  // Kilo Code proxies the OpenRouter catalog (334 models at time of writing),
+  // so the hardcoded list above is only a fallback. Surfacing the full catalog
+  // requires a fetcher + passthroughModels, matching how openrouter.js is set up.
+  // Without these, only the 8 hardcoded models appear in the combo model picker,
+  // hiding dynamic models like cohere/north-mini-code:free and poolside/laguna-m.1:free.
+  modelsFetcher: { url: "https://api.kilo.ai/api/gateway/models", type: "openrouter-free" },
+  passthroughModels: true,
   oauth: {
     apiBaseUrl: "https://api.kilo.ai",
     initiateUrl: "https://api.kilo.ai/api/device-auth/codes",


### PR DESCRIPTION
## Problem

Kilocode models (e.g. `cohere/north-mini-code:free`, `poolside/laguna-m.1:free`) don't appear when adding models to a combo via the Dashboard UI. Users have to hand-edit the backup JSON to add them.

## Root cause

`open-sse/providers/registry/kilocode.js` only declares a hardcoded `models` array (8 entries) and is missing the two flags that surface a dynamic catalog:

- `modelsFetcher`
- `passthroughModels`

The combo model picker (`src/shared/components/ModelSelectModal.js`) builds each provider's selectable list from three sources: model aliases, custom-registered models, and the registry's hardcoded `models` array via `getModelsByProviderId()`. Providers with a dynamic catalog (like OpenRouter) opt in with `modelsFetcher` + `passthroughModels` so arbitrary gateway models become selectable.

OpenRouter's registry (`open-sse/providers/registry/openrouter.js`) sets both:
```js
modelsFetcher: { url: "https://openrouter.ai/api/v1/models", type: "openrouter-free" },
passthroughModels: true,
```

Kilocode sets neither, so only its 8 hardcoded models show up — hiding every other Kilo Gateway model.

## Fix

Add the same two flags to `kilocode.js`:
```js
modelsFetcher: { url: "https://api.kilo.ai/api/gateway/models", type: "openrouter-free" },
passthroughModels: true,
```

## Why this works

The Kilo Gateway endpoint (`https://api.kilo.ai/api/gateway/models`) returns the OpenRouter shape `{ data: [{ id, name, context_length, pricing, ... }] }` — verified live (334 models). The existing `openrouter-free` filter (`src/app/api/providers/suggested-models/filters.js`) keeps free models (`pricing.prompt === "0"` && `pricing.completion === "0"`) with `context_length >= 200000`.

Both target models pass the filter (verified live):
- `poolside/laguna-m.1:free` — ctx 262144, free
- `cohere/north-mini-code:free` — ctx 256000, free

## Note

The `openrouter-free` filter's `context_length >= 200000` gate fits these two models but would hide sub-200K-context Kilo models (only 11 of 334 gateway models pass). If broader coverage is desired later, a dedicated `kilo-free` filter keyed on `m.id.endsWith(":free")` / `m.isFree` would be cleaner. This PR keeps scope minimal to fix the reported issue.

## Verification

- Live `curl https://api.kilo.ai/api/gateway/models` confirms response shape and that both target models are present and pass the filter.
- After the fix, kilocode models appear in the combo picker, so they can be added from the UI instead of editing the backup JSON.