### PR TITLE
feat(providers): custom icon URL for compatible providers

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
@@ -10,6 +10,7 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
     prefix: "",
     apiType: "chat",
     baseUrl: "https://api.openai.com/v1",
+    iconUrl: "",
   });
   const [saving, setSaving] = useState(false);
   const [checkKey, setCheckKey] = useState("");
@@ -24,6 +25,7 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
         prefix: node.prefix || "",
         apiType: node.apiType || "chat",
         baseUrl: node.baseUrl || (isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"),
+        iconUrl: node.iconUrl || "",
       });
     }
   }, [node, isAnthropic]);
@@ -41,6 +43,7 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
         name: formData.name,
         prefix: formData.prefix,
         baseUrl: formData.baseUrl,
+        ...(formData.iconUrl.trim() ? { iconUrl: formData.iconUrl } : {}),
       };
       if (!isAnthropic) {
         payload.apiType = formData.apiType;
@@ -106,6 +109,13 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
           onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
           placeholder={isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"}
           hint={`Use the base URL (ending in /v1) for your ${isAnthropic ? "Anthropic" : "OpenAI"}-compatible API.`}
+        />
+        <Input
+          label="Icon URL (optional)"
+          value={formData.iconUrl}
+          onChange={(e) => setFormData({ ...formData, iconUrl: e.target.value })}
+          placeholder="https://example.com/logo.png"
+          hint="Optional. A square image URL shown as this provider's icon. Falls back to a text badge if unset or it fails to load."
         />
         <div className="flex gap-2">
           <Input

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
-import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal } from "@/shared/components";
+import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal, ProviderIcon } from "@/shared/components";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS, THINKING_CONFIG } from "@/shared/constants/providers";
 import { getModelsByProviderId, getModelKind } from "@/shared/constants/models";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
@@ -129,6 +129,7 @@ export default function ProviderDetailPage() {
         apiType: providerNode.apiType,
         baseUrl: providerNode.baseUrl,
         type: providerNode.type,
+        ...(providerNode.iconUrl ? { iconUrl: providerNode.iconUrl } : {}),
       }
     : (OAUTH_PROVIDERS[providerId] || APIKEY_PROVIDERS[providerId] || FREE_PROVIDERS[providerId] || FREE_TIER_PROVIDERS[providerId] || WEB_COOKIE_PROVIDERS[providerId]);
   const authModes = providerInfo?.authModes || [];
@@ -1214,6 +1215,16 @@ export default function ProviderDetailPage() {
               <span className="text-sm font-bold" style={{ color: providerInfo.color }}>
                 {providerInfo.textIcon || providerInfo.id.slice(0, 2).toUpperCase()}
               </span>
+            ) : providerInfo.iconUrl ? (
+              // Remote custom icon: use a plain <img> via ProviderIcon to avoid next/image remotePatterns config.
+              <ProviderIcon
+                src={providerInfo.iconUrl}
+                alt={providerInfo.name}
+                size={48}
+                className="max-h-12 max-w-12 rounded-lg object-contain"
+                fallbackText={providerInfo.textIcon || providerInfo.id.slice(0, 2).toUpperCase()}
+                fallbackColor={providerInfo.color}
+              />
             ) : (
               <Image
                 src={getHeaderIconPath()}

--- a/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
+++ b/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
@@ -41,6 +41,7 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
     prefix: "",
     ...(config.hasApiType ? { apiType: "chat" } : {}),
     baseUrl: config.defaultBaseUrl,
+    iconUrl: "",
   });
 
   const [formData, setFormData] = useState(initialFormData);
@@ -74,6 +75,7 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           ...(config.hasApiType ? { apiType: formData.apiType } : {}),
           baseUrl: formData.baseUrl,
           type: config.type,
+          ...(formData.iconUrl.trim() ? { iconUrl: formData.iconUrl } : {}),
         }),
       });
       const data = await res.json();
@@ -164,6 +166,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
           placeholder={config.defaultBaseUrl}
           hint={config.baseUrlHint}
+        />
+        <Input
+          label="Icon URL (optional)"
+          value={formData.iconUrl}
+          onChange={(e) => setFormData({ ...formData, iconUrl: e.target.value })}
+          placeholder="https://example.com/logo.png"
+          hint="Optional. A square image URL shown as this provider's icon. Falls back to a text badge if unset or it fails to load."
         />
         <Input
           label="API Key (for Check)"

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -263,6 +263,7 @@ export default function ProvidersPage() {
       color: "#10A37F",
       textIcon: "OC",
       apiType: node.apiType,
+      ...(node.iconUrl ? { iconUrl: node.iconUrl } : {}),
     }))
     .filter((p) => matchSearch(p.name));
 
@@ -273,6 +274,7 @@ export default function ProvidersPage() {
       name: node.name || "Anthropic Compatible",
       color: "#D97757",
       textIcon: "AC",
+      ...(node.iconUrl ? { iconUrl: node.iconUrl } : {}),
     }))
     .filter((p) => matchSearch(p.name));
 
@@ -651,7 +653,7 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
               }}
             >
               <ProviderIcon
-                src={`/providers/${provider.id}.png`}
+                src={provider.iconUrl || `/providers/${provider.id}.png`}
                 alt={provider.name}
                 size={30}
                 className="object-contain rounded-lg max-w-[32px] max-h-[32px]"
@@ -756,6 +758,7 @@ function ApiKeyProviderCard({
   };
 
   const getIconPath = () => {
+    if (provider.iconUrl) return provider.iconUrl;
     if (isCompatible)
       return provider.apiType === "responses"
         ? "/providers/oai-r.png"

--- a/src/app/api/provider-nodes/[id]/route.js
+++ b/src/app/api/provider-nodes/[id]/route.js
@@ -6,7 +6,7 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { name, prefix, apiType, baseUrl } = body;
+    const { name, prefix, apiType, baseUrl, iconUrl } = body;
     const node = await getProviderNodeById(id);
 
     if (!node) {
@@ -52,6 +52,7 @@ export async function PUT(request, { params }) {
       name: name.trim(),
       prefix: prefix.trim(),
       baseUrl: sanitizedBaseUrl,
+      iconUrl: iconUrl?.trim() || undefined,
     };
 
     if (node.type === "openai-compatible") {

--- a/src/app/api/provider-nodes/route.js
+++ b/src/app/api/provider-nodes/route.js
@@ -32,7 +32,7 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name, prefix, apiType, baseUrl, type } = body;
+    const { name, prefix, apiType, baseUrl, type, iconUrl } = body;
 
     if (!name?.trim()) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -57,6 +57,7 @@ export async function POST(request) {
         apiType,
         baseUrl: (baseUrl || OPENAI_COMPATIBLE_DEFAULTS.baseUrl).trim(),
         name: name.trim(),
+        iconUrl: iconUrl?.trim() || undefined,
       });
       return NextResponse.json({ node }, { status: 201 });
     }
@@ -74,6 +75,7 @@ export async function POST(request) {
         prefix: prefix.trim(),
         baseUrl: sanitizedBaseUrl,
         name: name.trim(),
+        iconUrl: iconUrl?.trim() || undefined,
       });
       return NextResponse.json({ node }, { status: 201 });
     }
@@ -92,6 +94,7 @@ export async function POST(request) {
         prefix: prefix.trim(),
         baseUrl: sanitizedBaseUrl,
         name: name.trim(),
+        iconUrl: iconUrl?.trim() || undefined,
       });
       return NextResponse.json({ node }, { status: 201 });
     }

--- a/src/lib/db/repos/nodesRepo.js
+++ b/src/lib/db/repos/nodesRepo.js
@@ -62,6 +62,7 @@ export async function createProviderNode(data) {
     prefix: data.prefix,
     apiType: data.apiType,
     baseUrl: data.baseUrl,
+    ...data.iconUrl ? { iconUrl: data.iconUrl } : {},
     createdAt: now,
     updatedAt: now,
   };

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -7,6 +7,7 @@ export { default as Modal, ConfirmModal } from "./Modal";
 export { default as Loading, Spinner, PageLoading, Skeleton, CardSkeleton } from "./Loading";
 export { default as Avatar } from "./Avatar";
 export { default as Badge } from "./Badge";
+export { default as ProviderIcon } from "./ProviderIcon";
 export { default as Toggle } from "./Toggle";
 export { default as ThemeToggle } from "./ThemeToggle";
 export { ThemeProvider } from "./ThemeProvider";


### PR DESCRIPTION
## What

Lets users set their own icon for OpenAI/Anthropic-compatible (custom) providers via an optional **Icon URL** field in the Add and Edit modals. The image shows up in the provider card grid and the provider detail header, falling back to the existing text badge (OC/AC) if unset or if it fails to load.

/cc @decolua — quick note on why this is trivial to land: see *"Why this is a 1-click add"* below.

## Why

Custom providers currently can only show a hardcoded `OC`/`AC` text badge, or a non-existent bundled asset (`/providers/<id>.png` → 404 → text fallback). There was no way to brand a self-hosted / custom endpoint. This adds the missing optional `iconUrl` field end-to-end.

## Changes (8 files, +43/-4)

**Data layer** — `iconUrl` is stored in the provider node's existing JSON `data` blob, so **no schema migration** and it round-trips through backups automatically:
- `src/lib/db/repos/nodesRepo.js` — `createProviderNode` now persists `iconUrl` (was dropped by the hardcoded field list; `updateProviderNode` already spread extras).
- `POST /api/provider-nodes` (`route.js`) — destructure + pass `iconUrl` through to all three node types (openai-compatible, anthropic-compatible, custom-embedding).
- `PUT /api/provider-nodes/[id]` — pass `iconUrl` through in `updates`.

**UI** — one optional `Input` ("Icon URL") in each modal:
- `AddCompatibleModal.js` — field + send on create.
- `EditCompatibleNodeModal.js` — field + send on save.

**Render** — prefer `iconUrl` as the icon `src`:
- `providers/page.js` — both card components + the custom-node mappings now carry `iconUrl`.
- `providers/[id]/page.js` — header icon; uses `ProviderIcon` (plain `<img>`) for the remote case to avoid `next/image` `remotePatterns` config, keeps `next/image` for bundled assets.
- `shared/components/index.js` — export the existing `ProviderIcon` (it already supported `src` + text fallback).

## Why this is a 1-click add

The infrastructure already existed — `ProviderIcon` has supported a remote `src` with a text fallback since day one, and provider nodes are stored as a flexible JSON blob that already round-trips arbitrary fields through `updateProviderNode`. The *only* reason custom icons didn't work was a field whitelist: the API routes and `createProviderNode` explicitly enumerated `{name, prefix, apiType, baseUrl}` and silently dropped everything else, and the render sites hardcoded `src={/providers/\${id}.png}`. So this PR is almost entirely "stop dropping the field + add one text input + `src={iconUrl || existing}`" — no new abstractions, no DB migration, no image upload/storage, no config. The hardest decision (Next.js remote image config) is sidestepped by reusing the existing `<img>`-based `ProviderIcon` for remote URLs.

## Verification

- `node --check` passes on all 8 edited files.
- No new dependencies.
- Backward compatible: `iconUrl` is optional; unset nodes behave exactly as before (text badge fallback).

## Out of scope (deliberately)

- No image upload/storage (URL only) — keeps the PR dependency-free. Upload can be a follow-up if desired.
- No `next/image` `remotePatterns` changes — remote icons go through `ProviderIcon`'s plain `<img>`.