### PR TITLE
fix(alicode): preserve cache_control in content blocks for DashScope providers (#2069)

### DIFF
--- a/open-sse/providers/registry/alicode-intl.js
+++ b/open-sse/providers/registry/alicode-intl.js
@@ -16,6 +16,7 @@ export default {
   transport: {
     baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions",
     headers: {},
+    quirks: { preserveCacheControl: true },
   },
   models: [
     { id: "qwen3.5-plus", name: "Qwen3.5 Plus" },

--- a/open-sse/providers/registry/alicode.js
+++ b/open-sse/providers/registry/alicode.js
@@ -16,6 +16,7 @@ export default {
   transport: {
     baseUrl: "https://coding.dashscope.aliyuncs.com/v1/chat/completions",
     headers: {},
+    quirks: { preserveCacheControl: true },
   },
   models: [
     { id: "qwen3.5-plus", name: "Qwen3.5 Plus" },

--- a/open-sse/translator/formats/openai.js
+++ b/open-sse/translator/formats/openai.js
@@ -6,42 +6,46 @@ export { VALID_OPENAI_CONTENT_TYPES, VALID_OPENAI_MESSAGE_TYPES };
 
 // Filter messages to OpenAI standard format
 // Remove: thinking, redacted_thinking, signature, and other non-OpenAI blocks
-export function filterToOpenAIFormat(body) {
+// opts.preserveCacheControl: keep cache_control on content blocks (e.g. for DashScope/alicode)
+export function filterToOpenAIFormat(body, opts = {}) {
   if (!body.messages || !Array.isArray(body.messages)) return body;
-  
+  const keepCache = !!opts.preserveCacheControl;
+
+  function stripBlock(block) {
+    const { signature, cache_control, ...rest } = block;
+    return keepCache && cache_control ? { ...rest, cache_control } : rest;
+  }
+
   body.messages = body.messages.map(msg => {
     // Normalize developer role to system (many providers don't support developer)
     if (msg.role === ROLE.DEVELOPER) msg = { ...msg, role: ROLE.SYSTEM };
-    
+
     // Keep tool messages as-is (OpenAI format)
     if (msg.role === ROLE.TOOL) return msg;
-    
+
     // Keep assistant messages with tool_calls as-is
     if (msg.role === ROLE.ASSISTANT && msg.tool_calls) return msg;
-    
+
     // Handle string content
     if (typeof msg.content === "string") return msg;
-    
+
     // Handle array content
     if (Array.isArray(msg.content)) {
       const filteredContent = [];
-      
+
       for (const block of msg.content) {
         // Skip thinking blocks
         if (block.type === CLAUDE_BLOCK.THINKING || block.type === CLAUDE_BLOCK.REDACTED_THINKING) continue;
-        
+
         // Only keep valid OpenAI content types
         if (VALID_OPENAI_CONTENT_TYPES.includes(block.type)) {
-          // Remove signature field if exists
-          const { signature, cache_control, ...cleanBlock } = block;
-          filteredContent.push(cleanBlock);
+          filteredContent.push(stripBlock(block));
         } else if (block.type === CLAUDE_BLOCK.TOOL_USE) {
           // Convert tool_use to tool_calls format (handled separately)
           continue;
         } else if (block.type === CLAUDE_BLOCK.TOOL_RESULT) {
           // Keep tool_result but clean it
-          const { signature, cache_control, ...cleanBlock } = block;
-          filteredContent.push(cleanBlock);
+          filteredContent.push(stripBlock(block));
         }
       }
       

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -109,7 +109,9 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
   // Always normalize to clean OpenAI format when target is OpenAI
   // This handles hybrid requests (e.g., OpenAI messages + Claude tools)
   if (targetFormat === FORMATS.OPENAI) {
-    result = filterToOpenAIFormat(result);
+    result = filterToOpenAIFormat(result, {
+      preserveCacheControl: !!PROVIDERS[provider]?.quirks?.preserveCacheControl,
+    });
   }
 
   // Final step: prepare request for Claude format endpoints

--- a/tests/unit/alicode-cache-control-2069.test.js
+++ b/tests/unit/alicode-cache-control-2069.test.js
@@ -1,0 +1,66 @@
+// #2069 — cache_control markers stripped for alicode/alicode-intl (DashScope) providers.
+// DashScope supports explicit cache_control: { type: "ephemeral" } in content blocks,
+// but the default filterToOpenAIFormat strips them. preserveCacheControl quirk opts-in.
+import { describe, it, expect } from "vitest";
+import { filterToOpenAIFormat } from "../../open-sse/translator/formats/openai.js";
+
+const msgWithCache = [
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "large context", cache_control: { type: "ephemeral" } },
+    ],
+  },
+  {
+    role: "assistant",
+    content: [
+      { type: "text", text: "reply", cache_control: { type: "ephemeral" } },
+    ],
+  },
+];
+
+describe("filterToOpenAIFormat cache_control handling (#2069)", () => {
+  it("strips cache_control by default (all standard OpenAI providers)", () => {
+    const body = { messages: JSON.parse(JSON.stringify(msgWithCache)) };
+    filterToOpenAIFormat(body);
+    for (const msg of body.messages) {
+      for (const block of msg.content) {
+        expect(block.cache_control).toBeUndefined();
+      }
+    }
+  });
+
+  it("preserves cache_control when preserveCacheControl option is true (alicode/DashScope)", () => {
+    const body = { messages: JSON.parse(JSON.stringify(msgWithCache)) };
+    filterToOpenAIFormat(body, { preserveCacheControl: true });
+    for (const msg of body.messages) {
+      for (const block of msg.content) {
+        expect(block.cache_control).toEqual({ type: "ephemeral" });
+      }
+    }
+  });
+
+  it("always strips signature regardless of preserveCacheControl", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi", signature: "sig123", cache_control: { type: "ephemeral" } },
+          ],
+        },
+      ],
+    };
+    filterToOpenAIFormat(body, { preserveCacheControl: true });
+    expect(body.messages[0].content[0].signature).toBeUndefined();
+    expect(body.messages[0].content[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("does not add cache_control when block had none (preserveCacheControl: true)", () => {
+    const body = {
+      messages: [{ role: "user", content: [{ type: "text", text: "no cache" }] }],
+    };
+    filterToOpenAIFormat(body, { preserveCacheControl: true });
+    expect(body.messages[0].content[0].cache_control).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2069.

DashScope (`alicode` / `alicode-intl`) supports explicit `cache_control: { type: "ephemeral" }` markers on content blocks, enabling prompt caching. The default `filterToOpenAIFormat` was stripping `cache_control` unconditionally, causing every request to arrive at DashScope without cache markers and resulting in zero cache hits.

## Changes

- **`open-sse/providers/registry/alicode.js`** and **`alicode-intl.js`**: add `quirks: { preserveCacheControl: true }` to the transport config (same pattern as existing `dropOutputConfig`, `cloakToolsOnOAuth`, etc.).
- **`open-sse/translator/formats/openai.js`**: `filterToOpenAIFormat` now accepts an `opts` argument. When `opts.preserveCacheControl` is true, `cache_control` is kept on content blocks; `signature` is always stripped regardless.
- **`open-sse/translator/index.js`**: passes `{ preserveCacheControl: PROVIDERS[provider]?.quirks?.preserveCacheControl }` to `filterToOpenAIFormat`.
- **`tests/unit/alicode-cache-control-2069.test.js`**: 4 unit tests covering default stripping, opt-in preservation, always-strip signature, and no spurious addition.

## What is NOT changed

System-message caching (the `claudeToOpenAIRequest` system→string flattening at stripping point 2) is left for a follow-up — it requires verifying that DashScope accepts array-format system content with `cache_control`, which is outside standard OpenAI spec.

## Test

```
npx vitest run tests/unit/alicode-cache-control-2069.test.js
# 4/4 passed
```