### PR TITLE
fix(embeddings): forward input_type to provider request body

### DIFF
--- a/open-sse/handlers/embeddingProviders/openai.js
+++ b/open-sse/handlers/embeddingProviders/openai.js
@@ -17,9 +17,12 @@ export default function createOpenAIEmbeddingAdapter(providerId) {
     buildHeaders: (creds) => {
       return { "Content-Type": "application/json", ...bearerAuth(creds), ...(cfg.headers || {}) };
     },
-    buildBody: (model, { input, encoding_format, dimensions }) => {
+    buildBody: (model, { input, encoding_format, dimensions, input_type }) => {
       const body = { model, input };
       if (encoding_format) body.encoding_format = encoding_format;
+      // Asymmetric embedding models (e.g. NVIDIA NIM nvidia/llama-nemotron-embed-*)
+      // require input_type ("query" | "passage"); forward it when the client sends it.
+      if (input_type != null && input_type !== "") body.input_type = input_type;
       if (dimensions != null && dimensions !== "") {
         const dim = Number(dimensions);
         if (Number.isFinite(dim) && dim > 0) body.dimensions = dim;

--- a/open-sse/handlers/embeddingsCore.js
+++ b/open-sse/handlers/embeddingsCore.js
@@ -44,6 +44,7 @@ export async function handleEmbeddingsCore({
     input,
     encoding_format: body.encoding_format || "float",
     dimensions: body.dimensions,
+    input_type: body.input_type,
   });
 
   log?.debug?.("EMBEDDINGS", `${provider.toUpperCase()} | ${model} | input_type=${Array.isArray(input) ? `array[${input.length}]` : "string"}`);


### PR DESCRIPTION
## Problem

Asymmetric embedding models — e.g. NVIDIA NIM `nvidia/llama-nemotron-embed-vl-1b-v2` — reject any request that omits `input_type`:

```
400: 'input_type' parameter is required for asymmetric models
```

The OpenAI-compatible embeddings path only read `input`, `encoding_format`, and `dimensions` off the incoming request (`embeddingsCore.js` → `adapter.buildBody`), so a client that correctly sends `input_type` had it silently dropped before the upstream fetch. The result is a hard 400 with no way to make these models work through 9Router.

## Fix

Thread `input_type` through `handleEmbeddingsCore` → `adapter.buildBody`, and emit it in the OpenAI-compatible adapter when present.

- `open-sse/handlers/embeddingsCore.js` — pass `input_type: body.input_type` into `buildBody`.
- `open-sse/handlers/embeddingProviders/openai.js` — accept `input_type` and add it to the body, gated on a non-empty value.

Gated so it's a no-op for providers that don't use `input_type` and for clients that don't send it — no behavior change for existing symmetric models (OpenAI, etc.). The Gemini adapter has its own schema and is untouched.

## Testing

Verified end-to-end against NVIDIA NIM via 9Router with `nvd/nvidia/llama-nemotron-embed-vl-1b-v2`:

- Before: `400 'input_type' parameter is required for asymmetric models` (even when the client included `input_type` in the body).
- After: `200` with a valid embedding vector, for both string input and array/batch input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
