### PR TITLE
fix(headroom): skip unsafe responses tool history

### DIFF
--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -73,6 +73,14 @@ function maskEndpoint(endpoint) {
   }
 }
 
+function hasUnsafeResponsesInputForCompression(body) {
+  if (!Array.isArray(body?.input)) return false;
+  return body.input.some((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+    return typeof item.type === "string" && item.type !== "message";
+  });
+}
+
 // POST messages to Headroom /v1/compress; returns compressed messages + stats or null.
 async function callCompress(url, messages, model, timeoutMs, compressUserMessages, diagnostics) {
   const endpoint = buildCompressEndpoint(url);
@@ -143,6 +151,10 @@ export async function compressWithHeadroom(body, { enabled, url, model, format, 
     // messages. Translate input -> OpenAI -> compress -> translate back to input so
     // body.input keeps the Responses contract (the proxy only understands OpenAI). (#1998)
     if (format === "openai-responses") {
+      if (hasUnsafeResponsesInputForCompression(body)) {
+        setDiagnostic(diagnostics, "skipped: openai-responses tool/reasoning input is not safe to compress");
+        return null;
+      }
       const oai = openaiResponsesToOpenAIRequest(model, body, false);
       if (!Array.isArray(oai?.messages)) return null;
       const data = await callCompress(url, oai.messages, model, timeoutMs, compressUserMessages, diagnostics || {});

--- a/tests/unit/headroom-responses-format.test.js
+++ b/tests/unit/headroom-responses-format.test.js
@@ -47,4 +47,61 @@ describe("compressWithHeadroom openai-responses format (#1998)", () => {
     expect(Array.isArray(body.input[0].content)).toBe(true);
     expect(typeof body.input[0].content).not.toBe("string");
   });
+
+  it("skips Responses tool/reasoning history instead of collapsing it into a message (#2132)", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        messages: [{ role: "user", content: "compressed tool history" }],
+        tokens_saved: 10,
+      }),
+    }));
+
+    const input = [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "investigate bug" }],
+      },
+      {
+        type: "function_call",
+        call_id: "call_apply_patch_123",
+        name: "apply_patch",
+        arguments: "*** Begin Patch\n*** End Patch",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_apply_patch_123",
+        output: "ok",
+      },
+      {
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "Need a plan" }],
+      },
+    ];
+    const body = {
+      input: structuredClone(input),
+      tools: [
+        {
+          type: "custom",
+          name: "apply_patch",
+          format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+        },
+      ],
+    };
+    const diagnostics = {};
+
+    const data = await compressWithHeadroom(body, {
+      enabled: true,
+      url: "http://headroom.test",
+      model: "gpt-5",
+      format: "openai-responses",
+      diagnostics,
+    });
+
+    expect(data).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(body.input).toEqual(input);
+    expect(diagnostics.reason).toBe("skipped: openai-responses tool/reasoning input is not safe to compress");
+  });
 });


### PR DESCRIPTION
## Description

Fixes #2132 by preventing Headroom compression from running on OpenAI Responses requests that contain structured non-message history, such as tool calls, tool outputs, or reasoning summaries.

Headroom compression only understands OpenAI Chat Completions-style `messages`. For Responses-format requests, 9Router currently converts `body.input` into chat messages before sending it to Headroom. That is safe for plain text/message-only Responses input, but unsafe once the history contains Responses-native items.

## Issue

Codex / OpenAI Responses requests can include history entries like:

- `type: "function_call"`
- `type: "function_call_output"`
- `type: "reasoning"`
- grammar/custom tool definitions, for example `apply_patch`

Those entries are not plain chat messages. If Headroom compression runs on that mixed history, the structured Responses items can be collapsed into normal OpenAI messages. That loses the Responses contract and can break downstream providers/tools because `body.input` no longer preserves the original tool/reasoning structure.

## Findings

- The existing Responses compression path was already fixed to keep `body.input` Responses-shaped for message-only input (#1998).
- The unsafe case is different: `body.input` can be Responses-shaped but still contain non-message item types.
- Headroom cannot preserve those items because its `/v1/compress` API returns Chat Completions-style `messages`, not Responses items.
- Best safe behavior is to skip compression for mixed Responses history instead of attempting a lossy conversion.

## Changes

- Add a guard for OpenAI Responses compression:
  - if `body.input` contains an object item with string `type` other than `message`, skip Headroom compression.
- Record a diagnostic reason:
  - `skipped: openai-responses tool/reasoning input is not safe to compress`
- Leave the original request body untouched when skipped.
- Add regression test coverage for Responses tool/reasoning history.

## Why skip instead of partially compress?

Partial compression would need to split message content from tool/reasoning entries and then reconstruct valid Responses history after Headroom returns chat messages. That is riskier and easy to get wrong, especially around `call_id`, reasoning summaries, and custom/grammar tool calls.

This patch chooses the conservative behavior: preserve correctness over token savings. Message-only Responses requests can still use Headroom compression.

## Verification

```bash
git diff --check
npx vitest run tests/unit/headroom-responses-format.test.js
```

Result:

```text
Test Files  1 passed (1)
Tests       2 passed (2)
```

Closes #2132
