### PR TITLE
fix(kiro): stop injecting fake 'continue' user turn on tool-result turns

### DIFF
--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -142,7 +142,16 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
 
   const flushPending = () => {
     if (currentRole === ROLE.USER) {
-      const content = pendingUserContent.join("\n\n").trim() || "continue";
+      // Kiro's CodeWhisperer API rejects a fully-empty user `content`, so a
+      // placeholder is only needed for a genuinely bare turn. When the turn
+      // carries toolResults/images (the agentic tool-loop case), empty content
+      // is accepted by Kiro and avoids injecting a fake "continue" user
+      // instruction that the model reads as a real prompt and that leaks into
+      // the visible conversation. Verified against live Kiro: a tool-result
+      // turn with content:"" returns 200 and the model answers correctly.
+      const text = pendingUserContent.join("\n\n").trim();
+      const hasContext = pendingToolResults.length > 0 || pendingImages.length > 0;
+      const content = text || (hasContext ? "" : "continue");
       const userMsg = { userInputMessage: { content, modelId: model } };
 
       if (pendingImages.length > 0) {

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -196,7 +196,16 @@ function convertMessages(messages, tools, model) {
 
   const flushPending = () => {
     if (currentRole === "user") {
-      const content = pendingUserContent.join("\n\n").trim() || "continue";
+      // Kiro's CodeWhisperer API rejects a fully-empty user `content`, so a
+      // placeholder is only needed for a genuinely bare turn. When the turn
+      // carries toolResults/images (the agentic tool-loop case), empty content
+      // is accepted by Kiro and avoids injecting a fake "continue" user
+      // instruction that the model reads as a real prompt and that leaks into
+      // the visible conversation. Verified against live Kiro: a tool-result
+      // turn with content:"" returns 200 and the model answers correctly.
+      const text = pendingUserContent.join("\n\n").trim();
+      const hasContext = pendingToolResults.length > 0 || pendingImages.length > 0;
+      const content = text || (hasContext ? "" : "continue");
       const userMsg = {
         userInputMessage: {
           content: content,

--- a/tests/translator/__snapshots__/golden-request.test.js.snap
+++ b/tests/translator/__snapshots__/golden-request.test.js.snap
@@ -236,7 +236,7 @@ exports[`GOLDEN request: OpenAI → Kiro > full body (image base64 + tool_result
       "userInputMessage": {
         "content": "[Context: Current time is <TS>
 
-continue",
+",
         "modelId": "claude-sonnet-4.5",
         "origin": "AI_EDITOR",
         "userInputMessageContext": {

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -282,6 +282,42 @@ describe("openaiToKiroRequest", () => {
       // ...but the content is preserved as salvaged text, not discarded.
       expect(allJson).toContain("[Tool result: important orphaned output]");
     });
+
+    it("does not inject a fake 'continue' user message on a tool-result-only turn", () => {
+      // Regression: in an agentic loop the turn after an assistant tool_use is
+      // tool-results-only with no user text. The translator must NOT substitute
+      // the literal word "continue" (Kiro accepts empty content when toolResults
+      // are present, and "continue" leaks into the visible conversation as if the
+      // user typed it). See openai-to-kiro.js flushPending.
+      const body = {
+        messages: [
+          { role: "user", content: "What is 2+2? Use the calc tool." },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "calc", arguments: '{"expr":"2+2"}' } }
+            ]
+          },
+          { role: "tool", tool_call_id: "call_1", content: "4" }
+        ],
+        tools: [
+          { type: "function", function: { name: "calc", description: "Eval", parameters: { type: "object", properties: { expr: { type: "string" } }, required: ["expr"] } } }
+        ]
+      };
+
+      const result = openaiToKiroRequest("claude-sonnet-4.5", body, true, {});
+      const current = result.conversationState.currentMessage.userInputMessage;
+
+      // The current (tool-result) turn carries the tool results...
+      expect(current.userInputMessageContext.toolResults).toBeDefined();
+      expect(current.userInputMessageContext.toolResults[0].toolUseId).toBe("call_1");
+      // ...and its user body (content minus any injected system prefix) is empty,
+      // NOT the literal "continue".
+      const body0 = current.content.split("\n\n").pop();
+      expect(body0).toBe("");
+      expect(current.content).not.toMatch(/(^|\n)continue$/);
+    });
   });
 
   describe("thinking budget", () => {


### PR DESCRIPTION
## What

Stops the Kiro request translator from injecting a fake `continue` user message on tool-result turns.

Fixes #2182 

## Why

In an agentic tool loop, the turn after an assistant `tool_use` carries only tool results with no user text. Both Kiro `flushPending` paths substituted the literal `"continue"` for the empty `content`:

```js
const content = pendingUserContent.join("\n\n").trim() || "continue";
```

The model reads `"continue"` as a real user instruction, and it leaks into the visible conversation as if the user typed it on every tool turn.

The placeholder exists because Kiro's CodeWhisperer API rejects a fully-empty `content`. But when the turn carries `toolResults`/`images`, Kiro accepts empty content — so the placeholder is unnecessary there and `"continue"` is actively harmful.

## Verification (live Kiro)

Posted the exact translator payload to `codewhisperer.us-east-1.amazonaws.com`, varying only `content` on a tool-result turn, decoding the model's actual answer:

| `content` | status | model answer |
|---|---|---|
| `"continue"` (old) | 200 | "The result is 4." |
| `""` (new) | 200 | **"2+2 equals 4."** ✅ |
| `"."` | 200 | "Is there something I can help you with?" ❌ treated as prompt |

Empty content is accepted and gives the cleanest answer.

## Change

```js
const text = pendingUserContent.join("\n\n").trim();
const hasContext = pendingToolResults.length > 0 || pendingImages.length > 0;
const content = text || (hasContext ? "" : "continue");
```

Applied to both `open-sse/translator/request/openai-to-kiro.js` and `claude-to-kiro.js`. A genuinely empty turn (no tool results/images) still gets the `"continue"` fallback to satisfy Kiro's non-empty requirement.

## Tests

- New regression test in `tests/unit/openai-to-kiro.test.js`: asserts a tool-result-only turn produces empty user-body content (not `"continue"`) while still carrying `toolResults`.
- Updated golden snapshot `tests/translator/__snapshots__/golden-request.test.js.snap` (the `continue` line is gone).
- `npx vitest run --config tests/vitest.config.js tests/unit/openai-to-kiro.test.js tests/translator/golden-request.test.js` → all green.

Not RTK-related — RTK only compresses tool-result text and never adds `continue`.