### PR TITLE
fix(claude): keep thinking out of visible content

### DIFF
--- a/open-sse/translator/response/claude-to-openai.js
+++ b/open-sse/translator/response/claude-to-openai.js
@@ -43,7 +43,6 @@ export function claudeToOpenAIResponse(chunk, state) {
       } else if (block?.type === CLAUDE_BLOCK.THINKING) {
         state.inThinkingBlock = true;
         state.currentBlockIndex = chunk.index;
-        results.push(createChunk(state, { content: "<think>" }));
       } else if (block?.type === CLAUDE_BLOCK.TOOL_USE) {
         const toolCallIndex = state.toolCallIndex++;
         // Restore original tool name from mapping (Claude OAuth)
@@ -94,7 +93,6 @@ export function claudeToOpenAIResponse(chunk, state) {
         break;
       }
       if (state.inThinkingBlock && chunk.index === state.currentBlockIndex) {
-        results.push(createChunk(state, { content: "</think>" }));
         state.inThinkingBlock = false;
       }
       state.textBlockStarted = false;

--- a/tests/unit/claude-reasoning-response.test.js
+++ b/tests/unit/claude-reasoning-response.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { claudeToOpenAIResponse } from "../../open-sse/translator/response/claude-to-openai.js";
+
+function collect(chunks) {
+  const state = { toolCalls: new Map() };
+  return chunks.flatMap((chunk) => claudeToOpenAIResponse(chunk, state) || []);
+}
+
+describe("Claude reasoning response translation (#2158)", () => {
+  it("keeps thinking deltas in reasoning_content without leaking think tags into content", () => {
+    const output = collect([
+      { type: "message_start", message: { id: "msg_12345678", model: "claude", usage: {} } },
+      { type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "private chain" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "visible answer" } },
+      { type: "content_block_stop", index: 1 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 1, output_tokens: 2 } },
+    ]);
+
+    const contentDeltas = output.map((chunk) => chunk.choices?.[0]?.delta?.content).filter(Boolean);
+    const content = contentDeltas.join("");
+    const reasoning = output.map((chunk) => chunk.choices?.[0]?.delta?.reasoning_content || "").join("");
+
+    expect(contentDeltas).toEqual(["visible answer"]);
+    expect(contentDeltas).not.toContain("<think>");
+    expect(contentDeltas).not.toContain("</think>");
+    expect(content).toBe("visible answer");
+    expect(reasoning).toBe("private chain");
+  });
+});


### PR DESCRIPTION
## Description

Fixes a Claude-to-OpenAI streaming translation leak where Claude `thinking` blocks were emitted both as OpenAI-compatible `reasoning_content` and as visible `content` chunks containing `<think>` / `</think>` markers.

## Root cause

In `open-sse/translator/response/claude-to-openai.js`, the Claude `thinking` block lifecycle emitted synthetic OpenAI content chunks:

- `content_block_start` for `thinking` emitted `delta.content: "<think>"`
- `content_block_delta` correctly emitted `delta.reasoning_content`
- `content_block_stop` emitted `delta.content: "</think>"`

This meant OpenAI-compatible clients could receive reasoning markers through normal visible `content`, even though the actual thinking text was already carried separately in `reasoning_content`.

## Changes

- Stop emitting synthetic `<think>` / `</think>` chunks into `delta.content` for Claude thinking blocks.
- Keep `thinking_delta` mapped to `delta.reasoning_content`, preserving reasoning for clients/providers that support it.
- Add a regression test covering a Claude stream with thinking followed by visible text.

## Verification

- `npx vitest run tests/unit/claude-reasoning-response.test.js`
- `git diff --check`

The regression test verifies:

- visible `content` only contains the final answer text
- no `delta.content` chunk is `<think>` or `</think>`
- thinking text remains available through `reasoning_content`

## Notes

There is a separate non-streaming cleanup opportunity around how mixed `content` + `reasoning_content` responses are handled, but this PR intentionally keeps the scope limited to the streaming leak reported in #2158.

Closes #2158
