### PR TITLE
fix(translator): normalize Gemini contents to prevent 400 invalid_argument

### DIFF
--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -35,6 +35,17 @@ function sanitizeGeminiFunctionName(name) {
   return sanitized.substring(0, 64);
 }
 
+function normalizeGeminiContents(contents) {
+  const out = [];
+  for (const c of contents || []) {
+    if (!c?.role || !Array.isArray(c.parts) || c.parts.length === 0) continue;
+    const last = out.at(-1);
+    if (last?.role === c.role) last.parts.push(...c.parts);
+    else out.push({ ...c, parts: [...c.parts] });
+  }
+  return out;
+}
+
 // Core: Convert OpenAI request to Gemini format (base for all variants)
 function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG_SIGNATURE) {
   const result = {
@@ -217,6 +228,7 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
     }
   }
 
+  result.contents = normalizeGeminiContents(result.contents);
   return result;
 }
 
@@ -425,6 +437,7 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
     envelope.request.systemInstruction = { role: GEMINI_ROLE.USER, parts: systemParts };
   }
 
+  envelope.request.contents = normalizeGeminiContents(envelope.request.contents);
   return envelope;
 }
 


### PR DESCRIPTION
Resolves #2191

## Summary

When translating OpenAI/Claude request payloads to the Gemini API format, the resulting request payload can contain consecutive same-role messages (e.g. adjacent `user` messages from system/user prompts or tool history conversion) or empty `parts`. This causes the Gemini API to reject the request with `400 INVALID_ARGUMENT`.

This PR introduces a `normalizeGeminiContents` helper to safely merge adjacent same-role content blocks and strip empty parts, ensuring fully normalized payloads.

## Changes

- **`open-sse/translator/request/openai-to-gemini.js`**:
  - Implemented `normalizeGeminiContents` to concatenate parts of adjacent same-role blocks and filter out empty roles/parts.
  - Normalized `result.contents` in `openaiToGeminiBase` (affects standard OpenAI to Gemini and Gemini CLI requests).
  - Normalized `envelope.request.contents` in `wrapInCloudCodeEnvelopeForClaude` (affects Anthropic/Claude to Gemini conversions).
