### PR TITLE
fix(gemini): resolve thoughtSignature requirements and suppress stream done sentinel

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -6,6 +6,7 @@ import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { cleanJSONSchemaForAntigravity } from "../translator/formats/gemini.js";
+import { DEFAULT_THINKING_AG_SIGNATURE } from "../config/defaultThinkingSignature.js";
 
 // Sanitize function name: Gemini requires [a-zA-Z_][a-zA-Z0-9_.:\-]{0,63}
 function sanitizeFunctionName(name) {
@@ -177,8 +178,19 @@ export class AntigravityExecutor extends BaseExecutor {
         if (p.thoughtSignature && !p.functionCall && !p.text) return false;
         return true;
       });
-      if (role !== c.role || parts?.length !== c.parts?.length) {
-        return { ...c, role, parts };
+      // Gemini 3+ rejects functionCall parts without thoughtSignature. Clients (Claude Code, IDE)
+      // don't persist thoughtSignature in their history, so backfill the default signature on any
+      // functionCall part that arrives without one.
+      const needsBackfill = parts?.some(p => p.functionCall && !p.thoughtSignature) ?? false;
+      if (role !== c.role || parts?.length !== c.parts?.length || needsBackfill) {
+        return {
+          ...c, role,
+          parts: needsBackfill
+            ? parts.map(p => (p.functionCall && !p.thoughtSignature)
+                ? { ...p, thoughtSignature: DEFAULT_THINKING_AG_SIGNATURE }
+                : p)
+            : parts,
+        };
       }
       return c;
     });

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -299,7 +299,7 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
 }
 
 // Wrap Claude format in Cloud Code envelope for Antigravity
-function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = null) {
+function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = null, signature = DEFAULT_THINKING_AG_SIGNATURE) {
   const projectId = credentials?.projectId || generateProjectId();
 
   const envelope = {
@@ -343,6 +343,7 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
             parts.push({ text: block.text });
           } else if (block.type === CLAUDE_BLOCK.TOOL_USE) {
             parts.push({
+              thoughtSignature: signature,
               functionCall: {
                 id: block.id,
                 name: sanitizeGeminiFunctionName(block.name),

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -350,7 +350,9 @@ export function createSSEStream(options = {}) {
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
           //   data: [DONE]\n\n
           // Without it they can hang until timeout and trigger failover.
-          if (!streamDoneSent) {
+          // Gemini-family clients (Antigravity, Vertex, Gemini) reject this sentinel with 400 syntax errors.
+          const isGeminiFamily = provider === "antigravity" || provider === "gemini" || provider === "vertex";
+          if (!streamDoneSent && !isGeminiFamily) {
             const doneOutput = "data: [DONE]\n\n";
             reqLogger?.appendConvertedChunk?.(doneOutput);
             controller.enqueue(sharedEncoder.encode(doneOutput));


### PR DESCRIPTION
## Summary

This PR addresses two upstream Gemini compatibility bugs that cause HTTP `400 Bad Request` and client-side stream parser failures on Gemini-family APIs (including Vertex AI and Antigravity endpoints). 

Fixes #2193.

1. **Missing `thoughtSignature`**:
   - Claude-format `tool_use` blocks translated to Gemini `functionCall` parts were missing the required `thoughtSignature` field, triggering a `400 INVALID_ARGUMENT` from Gemini-family APIs. 
   - Additionally, when clients (like Claude Code or IDE) replay conversation history, they do not persist the `thoughtSignature` property on prior `functionCall` blocks. Re-sending this history without signatures to Gemini triggers the same 400 validation error.
   
2. **OpenAI stream sentinel crash**:
   - Gemini-family clients expect the connection to end implicitly. Appending the OpenAI-style `data: [DONE]\n\n` sentinel at the end of SSE streams causes syntax/parser errors on Gemini-compatible clients.

## Changes

1. **`open-sse/translator/request/openai-to-gemini.js`** — Updated `wrapInCloudCodeEnvelopeForClaude` to accept a `signature` parameter (defaulting to `DEFAULT_THINKING_AG_SIGNATURE`) and dynamically append it to converted `functionCall` blocks.
2. **`open-sse/executors/antigravity.js`** — Refactored the `contents` transformation pipeline to backfill `DEFAULT_THINKING_AG_SIGNATURE` to any `functionCall` part in request history arriving without a signature, only allocating new arrays/objects if a mutation actually occurs (maintaining upstream's zero-copy fast path).
3. **`open-sse/utils/stream.js`** — Suppressed writing the `data: [DONE]\n\n` stream completion sentinel if the target provider is part of the Gemini family (`antigravity`, `gemini`, `vertex`).
