### PR TITLE
fix(tools): default type:"custom" on Claude-format tools when missing

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -26,6 +26,7 @@ import { compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog, isHeadr
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
+import { defaultClaudeToolType } from "../translator/concerns/toolCall.js";
 
 /**
  * Core chat handler - shared between SSE and Worker
@@ -154,6 +155,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (getModelType(alias, model) === "tts" && translatedBody.messages) {
     translatedBody.messages = translatedBody.messages.filter(msg => msg.role !== "tool");
     delete translatedBody.tools;
+  }
+
+  // Claude tool schema requires `type` to be explicitly set; strict gateways (e.g., MiniMax)
+  // reject legacy payloads that omit it with HTTP 400. Default to "custom" when missing.
+  if (finalFormat === "claude" && Array.isArray(translatedBody.tools)) {
+    translatedBody.tools = defaultClaudeToolType(translatedBody.tools);
   }
 
   // RTK: compress tool_result content

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -151,3 +151,16 @@ export function fixMissingToolResponses(body) {
   return body;
 }
 
+// Default `type: "custom"` on Claude-format tools that arrive without one.
+// Anthropic's Claude tool schema requires `type` to be explicitly set; strict gateways
+// (e.g., MiniMax Anthropic-compatible endpoint, error 2013) reject legacy payloads that
+// omit it with HTTP 400. Tools that already carry a truthy `type` (e.g., `computer_use`,
+// `bash`, `web_search_20250305`) are passed through untouched.
+//
+// Spread order matters: `{ ...tool, type: "custom" }` (spread first, override last)
+// ensures that falsy `type` values (null, undefined, "") in the original tool don't
+// overwrite the default. `{ type: "custom", ...tool }` would let `type: null` survive.
+export function defaultClaudeToolType(tools) {
+  if (!Array.isArray(tools)) return tools;
+  return tools.map(tool => tool?.type ? tool : { ...tool, type: "custom" });
+}

--- a/open-sse/utils/claudeToolTypeSelfCheck.mjs
+++ b/open-sse/utils/claudeToolTypeSelfCheck.mjs
@@ -1,0 +1,117 @@
+// Claude tool type default self-check.
+// Run: node open-sse/utils/claudeToolTypeSelfCheck.mjs
+// No framework, no deps. Uses assert. Mirrors toolPairingSelfCheck.mjs style.
+import { defaultClaudeToolType } from "../translator/concerns/toolCall.js";
+
+const results = [];
+function run(name, fn) {
+  try {
+    fn();
+    results.push({ name, ok: true });
+  } catch (err) {
+    results.push({ name, ok: false, err: err.message });
+  }
+}
+const assert = {
+  equal(a, b, msg) { if (a !== b) throw new Error(`${msg || ""} expected ${b}, got ${a}`); },
+  ok(v, msg) { if (!v) throw new Error(msg || "expected truthy"); },
+};
+
+// 1. Tool without `type` property → defaults to "custom"
+run("Tool without type property defaults to custom", () => {
+  const tools = [{ name: "foo", description: "bar", input_schema: {} }];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "custom", "type defaulted");
+  assert.equal(out[0].name, "foo", "other fields preserved");
+});
+
+// 2. Tool with type:null → defaults to "custom" (the spread-order bug case)
+run("Tool with type:null defaults to custom", () => {
+  const tools = [{ name: "foo", type: null, input_schema: {} }];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "custom", "null type overwritten to custom");
+});
+
+// 3. Tool with type:undefined → defaults to "custom"
+run("Tool with type:undefined defaults to custom", () => {
+  const tools = [{ name: "foo", type: undefined, input_schema: {} }];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "custom", "undefined type overwritten to custom");
+});
+
+// 4. Tool with type:"" (empty string) → defaults to "custom"
+run("Tool with type:empty-string defaults to custom", () => {
+  const tools = [{ name: "foo", type: "", input_schema: {} }];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "custom", "empty-string type overwritten to custom");
+});
+
+// 5. Built-in tool with type:"computer_use" → passed through untouched
+run("Built-in tool (computer_use) passed through", () => {
+  const tools = [{ type: "computer_use", name: "computer", display_width: 1024 }];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "computer_use", "built-in type preserved");
+  assert.equal(out[0], tools[0], "same reference — not cloned");
+});
+
+// 6. Tool already with type:"custom" → passed through untouched
+run("Tool already with type:custom passed through", () => {
+  const tools = [{ type: "custom", name: "foo", input_schema: {} }];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "custom", "existing custom type preserved");
+  assert.equal(out[0], tools[0], "same reference — not cloned");
+});
+
+// 7. Mixed: built-in + function tool → only function tool gets default
+run("Mixed: built-in kept, function tool defaulted", () => {
+  const tools = [
+    { type: "computer_use", name: "computer", display_width: 1024 },
+    { name: "search", description: "search the web", input_schema: {} },
+    { type: "web_search_20250305", name: "web_search" },
+  ];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "computer_use", "built-in preserved");
+  assert.equal(out[1].type, "custom", "function tool defaulted");
+  assert.equal(out[2].type, "web_search_20250305", "web_search preserved");
+});
+
+// 8. Non-array input → returned unchanged
+run("Non-array input returned unchanged", () => {
+  assert.equal(defaultClaudeToolType(null), null, "null returned as-is");
+  assert.equal(defaultClaudeToolType(undefined), undefined, "undefined returned as-is");
+  assert.equal(defaultClaudeToolType("not array"), "not array", "string returned as-is");
+});
+
+// 9. Empty array → empty array
+run("Empty array returns empty array", () => {
+  const out = defaultClaudeToolType([]);
+  assert.equal(Array.isArray(out), true, "returns array");
+  assert.equal(out.length, 0, "empty array");
+});
+
+// 10. Original tools not mutated by reference (new objects for defaulted tools)
+run("Original tools not mutated by reference", () => {
+  const original = { name: "foo", input_schema: {} };
+  const tools = [original];
+  defaultClaudeToolType(tools);
+  assert.equal(original.type, undefined, "original tool not mutated");
+  assert.ok(!("type" in original), "type property not added to original");
+});
+
+// 11. Array with null entry → defaults to { type: "custom" } (optional chaining guard)
+// tool?.type returns undefined for null, and { ...null, type: "custom" } === { type: "custom" }
+run("Array with null entry defaults to custom", () => {
+  const tools = [null];
+  const out = defaultClaudeToolType(tools);
+  assert.equal(out[0].type, "custom", "null tool gets type custom");
+  assert.equal(Object.keys(out[0]).length, 1, "no other keys from spread of null");
+});
+
+// Summary
+const passed = results.filter(r => r.ok).length;
+const total = results.length;
+for (const r of results) {
+  console.log(`${r.ok ? "ok" : "FAIL"} - ${r.name}${r.ok ? "" : ` :: ${r.err}`}`);
+}
+console.log(`\n${passed}/${total} checks passed`);
+if (passed !== total) process.exit(1);


### PR DESCRIPTION
Fixes #2195
Related: #1939 (same MiniMax error 2013 `invalid tool type`), #2047 (MiniMax-M3 incompatibility)

## Summary

When proxying Claude-format tool definitions through strict Anthropic-compatible gateways (e.g. the MiniMax Anthropic-compatible endpoint), requests are rejected with `400 Bad Request` (MiniMax error code `2013`) whenever individual tools in the `tools` array arrive without an explicit `type` field.

Anthropic's Claude tool schema documents `type` as a required discriminator (e.g. `"custom"`, `"computer_20241022"`, `"bash_20241022"`). Legacy clients and older SDK versions frequently omit this field, relying on Anthropic's first-party API to infer `"custom"`. While Anthropic's own API tolerates the omission, strict Anthropic-compatible gateways such as MiniMax enforce the documented schema and reject the payload.

This PR normalizes `tools[].type` for every Claude-format request before dispatch, ensuring 9router emits a valid Anthropic Messages payload regardless of the originating client.

## Changes

- **`open-sse/translator/concerns/toolCall.js`**: New exported function `defaultClaudeToolType(tools)` — maps tools without a truthy `type` to `{ ...tool, type: "custom" }`. Uses optional chaining (`tool?.type`) so `null`/`undefined` array entries don't crash. Spread-first ensures falsy `type` values (`null`, `undefined`, `""`) don't survive the override — the original `{ type: "custom", ...tool }` order let `type: null` overwrite the default (confirmed with test cases). Tools that already carry a truthy `type` are returned by reference (no clone).

- **`open-sse/handlers/chatCore.js`**: Calls `defaultClaudeToolType(translatedBody.tools)` when `finalFormat === "claude"`, positioned immediately after the TTS special case and before the RTK compress step. Import line extended to include `defaultClaudeToolType` alongside the existing `salvageOrphanedToolResults` and `fixMissingToolResponses` imports.

- **`open-sse/utils/claudeToolTypeSelfCheck.mjs`**: New 11/11 no-framework assert self-check covering: no-type, type:null, type:undefined, type:"", built-in pass-through (computer_use), already-custom, mixed (built-in + function + web_search), non-array input, empty array, non-mutation by reference, and null-array-entry (optional chaining guard).

## Spread order fix

The original inline implementation `tool.type ? tool : { type: "custom", ...tool }` had a subtle bug: when `tool.type` was a falsy value (`null`, `undefined`, `""`), the spread `{ ...tool }` would overwrite `type: "custom"` with the falsy value, reintroducing the exact condition that causes MiniMax to reject the payload.

```js
// Buggy: type:null survives the spread
{ type: "custom", ...tool }  // → { type: null, name: "foo", ... }

// Fixed: type:"custom" always wins (spread first, override last)
{ ...tool, type: "custom" }  // → { type: "custom", name: "foo", ... }
```

This affects the passthrough path (Claude client → Claude/anthropic-compatible provider) where legacy clients may send `"type": null` in JSON. The translated path (`openai-to-claude.js`) was not affected as it does not generate a `type` property for custom tools.

## Related issues

- **#1939** — `[ERROR] [400] when using minimax token plan` — reports the exact same MiniMax error `invalid tool type: (2013)`. This PR fixes that root cause.
- **#2047** — `[BUG] 0.5.8 is incompatible with Minimax-M3` — may be related (streaming issue, not tool type, but same provider/gateway).

## Notes

This is a general schema-conformance fix, not provider-specific. It benefits any Anthropic-compatible gateway that enforces the documented tool schema. The placement was chosen to run after translation and after the TTS special case (which can delete `translatedBody.tools`), and before the RTK/headroom compression passes that operate on the final outbound body.

## Verification

```bash
node open-sse/utils/claudeToolTypeSelfCheck.mjs   # 11/11
npm run build                                      # 125/125 pages
```

Applies cleanly and independently on a fresh `origin/HEAD` checkout.
