### PR TITLE
fix(docker): copy real package.json into runner stage for correct version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV DATA_DIR=/app/data
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/custom-server.js ./custom-server.js
 COPY --from=builder /app/open-sse ./open-sse
 # Next file tracing can omit sibling files; MITM runs server.js as a separate process.


### PR DESCRIPTION
## Summary
Docker images report stale version (e.g. `v0.5.8`) instead of the actual release version (`v0.5.12`).

## Root Cause
The standalone output generated by Next.js includes a minimal `package.json` stub that does not carry the real app version. At runtime, `getAppVersion()` in `src/lib/db/version.js` reads from `process.cwd()/package.json` and picks up that stub instead of the source `package.json`.

## Fix
Explicitly copy the real `package.json` into the runner stage after the standalone layer, ensuring it overwrites the stub and the correct version is always available at `/app/package.json`.

Fixes #2175
