### PR TITLE
fix: strip 'deprecated' from Antigravity tool schemas before Gemini

### DIFF
--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -19,7 +19,7 @@ export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
   // Dependency keywords (not supported)
   "dependencies", "dependentSchemas", "dependentRequired",
   // Other unsupported keywords
-  "title", "optional", "if", "then", "else", "contentMediaType", "contentEncoding",
+  "title", "optional", "deprecated", "if", "then", "else", "contentMediaType", "contentEncoding",
   // UI/Styling properties (from Cursor tools - NOT JSON Schema standard)
   "cornerRadius", "fillColor", "fontFamily", "fontSize", "fontWeight",
   "gap", "padding", "strokeColor", "strokeThickness", "textColor"


### PR DESCRIPTION
## Summary

Adds `deprecated` to `UNSUPPORTED_SCHEMA_CONSTRAINTS` in `open-sse/translator/formats/gemini.js` so it gets stripped from nested tool schemas before forwarding to Gemini.

This is a follow-up to #1841 (which added `optional`). Without this fix, Gemini rejects requests with `INVALID_ARGUMENT`:

```
Unknown name "deprecated" at 'request.tools[0].function_declarations[25].parameters.properties[1].value': Cannot find field.
```

## Test

```bash
npx vitest run --config tests/vitest.config.js tests/translator/bugs-antigravity.test.js
```
