### PR TITLE
feat: Per-Key Combo Access Control

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -24,6 +24,10 @@ export default function APIPageClient({ machineId }) {
   const [newKeyName, setNewKeyName] = useState("");
   const [createdKey, setCreatedKey] = useState(null);
   const [confirmState, setConfirmState] = useState(null);
+  const [combos, setCombos] = useState([]);
+  const [newKeyAllowedCombos, setNewKeyAllowedCombos] = useState([]);
+  const [editKey, setEditKey] = useState(null);
+  const [editKeyAllowedCombos, setEditKeyAllowedCombos] = useState([]);
 
   const [requireApiKey, setRequireApiKey] = useState(false);
   const [requireLogin, setRequireLogin] = useState(true);
@@ -255,10 +259,17 @@ export default function APIPageClient({ machineId }) {
 
   const fetchData = async () => {
     try {
-      const keysRes = await fetch("/api/keys");
+      const [keysRes, combosRes] = await Promise.all([
+        fetch("/api/keys"),
+        fetch("/api/combos"),
+      ]);
       const keysData = await keysRes.json();
       if (keysRes.ok) {
         setKeys(keysData.keys || []);
+      }
+      if (combosRes.ok) {
+        const combosData = await combosRes.json();
+        setCombos(combosData.combos || combosData || []);
       }
     } catch (error) {
       console.log("Error fetching data:", error);
@@ -614,7 +625,7 @@ export default function APIPageClient({ machineId }) {
       const res = await fetch("/api/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newKeyName }),
+        body: JSON.stringify({ name: newKeyName, allowedCombos: newKeyAllowedCombos }),
       });
       const data = await res.json();
 
@@ -622,6 +633,7 @@ export default function APIPageClient({ machineId }) {
         setCreatedKey(data.key);
         await fetchData();
         setNewKeyName("");
+        setNewKeyAllowedCombos([]);
         setShowAddModal(false);
       }
     } catch (error) {
@@ -664,6 +676,22 @@ export default function APIPageClient({ machineId }) {
       }
     } catch (error) {
       console.log("Error toggling key:", error);
+    }
+  };
+
+  const handleUpdateKeyCombos = async (id, allowedCombos) => {
+    try {
+      const res = await fetch(`/api/keys/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowedCombos }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setKeys(prev => prev.map(k => k.id === id ? { ...k, allowedCombos: data.key?.allowedCombos || allowedCombos } : k));
+      }
+    } catch (error) {
+      console.log("Error updating key combos:", error);
     }
   };
 
@@ -1027,6 +1055,23 @@ export default function APIPageClient({ machineId }) {
                   {key.isActive === false && (
                     <p className="text-xs text-orange-500 mt-1">Paused</p>
                   )}
+                  <div className="flex flex-wrap items-center gap-1 mt-1">
+                    <span className="text-xs text-text-muted">Combos:</span>
+                    {Array.isArray(key.allowedCombos) && key.allowedCombos.length > 0 ? (
+                      key.allowedCombos.map((c) => (
+                        <span key={c} className="text-xs bg-primary/10 text-primary px-1.5 py-0.5 rounded">{c}</span>
+                      ))
+                    ) : (
+                      <span className="text-xs text-text-muted">All</span>
+                    )}
+                    <button
+                      onClick={() => { setEditKey(key); setEditKeyAllowedCombos(Array.isArray(key.allowedCombos) ? [...key.allowedCombos] : []); }}
+                      className="p-1 hover:bg-black/5 dark:hover:bg-white/5 rounded text-text-muted hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
+                      title="Edit combo access"
+                    >
+                      <span className="material-symbols-outlined text-[14px]">edit</span>
+                    </button>
+                  </div>
                 </div>
                 <div className="flex items-center gap-2">
                   <Toggle
@@ -1077,6 +1122,32 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewKeyName(e.target.value)}
             placeholder="Production Key"
           />
+          {combos.length > 0 && (
+            <div>
+              <p className="text-sm font-medium mb-2">Allowed Combos</p>
+              <p className="text-xs text-text-muted mb-2">Leave empty to allow all combos. Select specific combos to restrict access.</p>
+              <div className="flex flex-col gap-1.5 max-h-40 overflow-y-auto border border-border rounded-lg p-2">
+                {combos.map((combo) => (
+                  <label key={combo.id || combo.name} className="flex items-center gap-2 cursor-pointer text-sm">
+                    <input
+                      type="checkbox"
+                      checked={newKeyAllowedCombos.includes(combo.name)}
+                      onChange={() => {
+                        setNewKeyAllowedCombos(prev =>
+                          prev.includes(combo.name)
+                            ? prev.filter(c => c !== combo.name)
+                            : [...prev, combo.name]
+                        );
+                      }}
+                      className="rounded border-border"
+                    />
+                    <span>{combo.name}</span>
+                    {combo.kind && <span className="text-xs text-text-muted">({combo.kind})</span>}
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
           <div className="flex gap-2">
             <Button onClick={handleCreateKey} fullWidth disabled={!newKeyName.trim()}>
               Create
@@ -1272,6 +1343,58 @@ export default function APIPageClient({ machineId }) {
               {tsLoading ? "Disabling..." : "Disable"}
             </Button>
             <Button onClick={() => setShowDisableTsModal(false)} variant="ghost" fullWidth disabled={tsLoading}>Cancel</Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Edit Combo Access Modal */}
+      <Modal
+        isOpen={!!editKey}
+        title={`Edit Combo Access — ${editKey?.name || ""}`}
+        onClose={() => { setEditKey(null); setEditKeyAllowedCombos([]); }}
+      >
+        <div className="flex flex-col gap-4">
+          {combos.length > 0 ? (
+            <div>
+              <p className="text-sm text-text-muted mb-2">Select which combos this key can access. Leave empty to allow all.</p>
+              <div className="flex flex-col gap-1.5 max-h-40 overflow-y-auto border border-border rounded-lg p-2">
+                {combos.map((combo) => (
+                  <label key={combo.id || combo.name} className="flex items-center gap-2 cursor-pointer text-sm">
+                    <input
+                      type="checkbox"
+                      checked={editKeyAllowedCombos.includes(combo.name)}
+                      onChange={() => {
+                        setEditKeyAllowedCombos(prev =>
+                          prev.includes(combo.name)
+                            ? prev.filter(c => c !== combo.name)
+                            : [...prev, combo.name]
+                        );
+                      }}
+                      className="rounded border-border"
+                    />
+                    <span>{combo.name}</span>
+                    {combo.kind && <span className="text-xs text-text-muted">({combo.kind})</span>}
+                  </label>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-text-muted">No combos available.</p>
+          )}
+          <div className="flex gap-2">
+            <Button
+              onClick={async () => {
+                if (editKey) {
+                  await handleUpdateKeyCombos(editKey.id, editKeyAllowedCombos);
+                  setEditKey(null);
+                  setEditKeyAllowedCombos([]);
+                }
+              }}
+              fullWidth
+            >
+              Save
+            </Button>
+            <Button onClick={() => { setEditKey(null); setEditKeyAllowedCombos([]); }} variant="ghost" fullWidth>Cancel</Button>
           </div>
         </div>
       </Modal>

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -21,7 +21,7 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { isActive } = body;
+    const { isActive, allowedCombos } = body;
 
     const existing = await getApiKeyById(id);
     if (!existing) {
@@ -30,6 +30,7 @@ export async function PUT(request, { params }) {
 
     const updateData = {};
     if (isActive !== undefined) updateData.isActive = isActive;
+    if (allowedCombos !== undefined) updateData.allowedCombos = allowedCombos;
 
     const updated = await updateApiKey(id, updateData);
 

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -19,7 +19,7 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name } = body;
+    const { name, allowedCombos } = body;
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -27,13 +27,14 @@ export async function POST(request) {
 
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
-    const apiKey = await createApiKey(name, machineId);
+    const apiKey = await createApiKey(name, machineId, allowedCombos || []);
 
     return NextResponse.json({
       key: apiKey.key,
       name: apiKey.name,
       id: apiKey.id,
       machineId: apiKey.machineId,
+      allowedCombos: apiKey.allowedCombos,
     }, { status: 201 });
   } catch (error) {
     console.log("Error creating key:", error);

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -29,7 +29,7 @@ export {
 
 // API keys
 export {
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByKey, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
 } from "./repos/apiKeysRepo.js";
 
 // Combos
@@ -77,7 +77,7 @@ export async function exportDb() {
     providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
-    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
+    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => { let ac = []; try { ac = JSON.parse(r.allowedCombos); if (!Array.isArray(ac)) ac = []; } catch {} return { id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, allowedCombos: ac, createdAt: r.createdAt }; }),
     combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), createdAt: r.createdAt, updatedAt: r.updatedAt })),
     modelAliases: {},
     customModels: [],
@@ -137,8 +137,8 @@ export async function importDb(payload) {
     }
     for (const k of payload.apiKeys || []) {
       db.run(
-        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, allowedCombos, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, JSON.stringify(k.allowedCombos || []), k.createdAt || new Date().toISOString()]
       );
     }
     for (const c of payload.combos || []) {

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -9,6 +9,7 @@ function rowToKey(row) {
     name: row.name,
     machineId: row.machineId,
     isActive: row.isActive === 1 || row.isActive === true,
+    allowedCombos: (() => { try { const v = JSON.parse(row.allowedCombos); return Array.isArray(v) ? v : []; } catch { return []; } })(),
     createdAt: row.createdAt,
   };
 }
@@ -25,7 +26,13 @@ export async function getApiKeyById(id) {
   return rowToKey(row);
 }
 
-export async function createApiKey(name, machineId) {
+export async function getApiKeyByKey(key) {
+  const db = await getAdapter();
+  const row = db.get(`SELECT * FROM apiKeys WHERE key = ?`, [key]);
+  return rowToKey(row);
+}
+
+export async function createApiKey(name, machineId, allowedCombos = []) {
   if (!machineId) throw new Error("machineId is required");
   const db = await getAdapter();
   const { generateApiKeyWithMachine } = await import("@/shared/utils/apiKey");
@@ -36,11 +43,12 @@ export async function createApiKey(name, machineId) {
     key: result.key,
     machineId,
     isActive: true,
+    allowedCombos: Array.isArray(allowedCombos) ? allowedCombos : [],
     createdAt: new Date().toISOString(),
   };
   db.run(
-    `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.createdAt]
+    `INSERT INTO apiKeys(id, key, name, machineId, isActive, allowedCombos, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, JSON.stringify(apiKey.allowedCombos), apiKey.createdAt]
   );
   return apiKey;
 }
@@ -53,8 +61,8 @@ export async function updateApiKey(id, data) {
     if (!row) return;
     const merged = { ...rowToKey(row), ...data };
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ? WHERE id = ?`,
-      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, id]
+      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, allowedCombos = ? WHERE id = ?`,
+      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, JSON.stringify(merged.allowedCombos || []), id]
     );
     result = merged;
   });

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -78,6 +78,7 @@ export const TABLES = {
       name: "TEXT",
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
+      allowedCombos: "TEXT",
       createdAt: "TEXT NOT NULL",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -10,7 +10,7 @@ export {
   createProviderNode, updateProviderNode, deleteProviderNode,
   getProxyPools, getProxyPoolById,
   createProxyPool, updateProxyPool, deleteProxyPool,
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByKey, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
   getCombos, getComboById, getComboByName,
   createCombo, updateCombo, deleteCombo,
   getModelAliases, setModelAlias, deleteModelAlias,

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -8,7 +8,7 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
-import { getSettings } from "@/lib/localDb";
+import { getSettings, getApiKeyByKey } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
@@ -77,6 +77,18 @@ export async function handleChat(request, clientRawRequest = null) {
     if (!valid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    }
+  }
+
+  // Per-key combo access control
+  if (apiKey && modelStr) {
+    const keyData = await getApiKeyByKey(apiKey);
+    if (keyData && Array.isArray(keyData.allowedCombos) && keyData.allowedCombos.length > 0) {
+      const comboCheck = await getComboModels(modelStr);
+      if (comboCheck && !keyData.allowedCombos.includes(modelStr)) {
+        log.warn("AUTH", `API key "${keyData.name}" not allowed to access combo "${modelStr}"`);
+        return errorResponse(HTTP_STATUS.FORBIDDEN, `Access denied: combo "${modelStr}" is not allowed for this API key`);
+      }
     }
   }
 

--- a/src/sse/handlers/fetch.js
+++ b/src/sse/handlers/fetch.js
@@ -5,7 +5,7 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth.js";
-import { getSettings, getCombos } from "@/lib/localDb";
+import { getSettings, getCombos, getApiKeyByKey } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
 import { handleFetchCore } from "open-sse/handlers/fetch/index.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -85,6 +85,19 @@ export async function handleFetch(request) {
   } catch (err) {
     log.warn("FETCH", "Blocked URL", { url: targetUrl });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, err.message);
+  }
+
+  // Per-key combo access control
+  if (apiKey && providerInput) {
+    const keyData = await getApiKeyByKey(apiKey);
+    if (keyData && Array.isArray(keyData.allowedCombos) && keyData.allowedCombos.length > 0) {
+      const combosData = await getCombos();
+      const isCombo = getComboModelsFromData(providerInput, combosData);
+      if (isCombo && !keyData.allowedCombos.includes(providerInput)) {
+        log.warn("AUTH", `API key "${keyData.name}" not allowed to access combo "${providerInput}"`);
+        return errorResponse(HTTP_STATUS.FORBIDDEN, `Access denied: combo "${providerInput}" is not allowed for this API key`);
+      }
+    }
   }
 
   // Combo expansion: providerInput may be a combo name → run fallback/round-robin across providers

--- a/src/sse/handlers/imageGeneration.js
+++ b/src/sse/handlers/imageGeneration.js
@@ -5,7 +5,7 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth.js";
-import { getSettings } from "@/lib/localDb";
+import { getSettings, getApiKeyByKey } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleImageGenerationCore } from "open-sse/handlers/imageGenerationCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -41,6 +41,18 @@ export async function handleImageGeneration(request) {
     if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     const valid = await isValidApiKey(apiKey);
     if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  }
+
+  // Per-key combo access control
+  if (apiKey && modelStr) {
+    const keyData = await getApiKeyByKey(apiKey);
+    if (keyData && Array.isArray(keyData.allowedCombos) && keyData.allowedCombos.length > 0) {
+      const comboCheck = await getComboModels(modelStr);
+      if (comboCheck && !keyData.allowedCombos.includes(modelStr)) {
+        log.warn("AUTH", `API key "${keyData.name}" not allowed to access combo "${modelStr}"`);
+        return errorResponse(HTTP_STATUS.FORBIDDEN, `Access denied: combo "${modelStr}" is not allowed for this API key`);
+      }
+    }
   }
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");

--- a/src/sse/handlers/search.js
+++ b/src/sse/handlers/search.js
@@ -5,7 +5,7 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth.js";
-import { getSettings, getCombos } from "@/lib/localDb";
+import { getSettings, getCombos, getApiKeyByKey } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
 import { handleSearchCore } from "open-sse/handlers/search/index.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -66,6 +66,19 @@ export async function handleSearch(request) {
   if (!query || typeof query !== "string" || !query.trim()) {
     log.warn("SEARCH", "Missing query");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: query");
+  }
+
+  // Per-key combo access control
+  if (apiKey && providerInput) {
+    const keyData = await getApiKeyByKey(apiKey);
+    if (keyData && Array.isArray(keyData.allowedCombos) && keyData.allowedCombos.length > 0) {
+      const combosData = await getCombos();
+      const isCombo = getComboModelsFromData(providerInput, combosData);
+      if (isCombo && !keyData.allowedCombos.includes(providerInput)) {
+        log.warn("AUTH", `API key "${keyData.name}" not allowed to access combo "${providerInput}"`);
+        return errorResponse(HTTP_STATUS.FORBIDDEN, `Access denied: combo "${providerInput}" is not allowed for this API key`);
+      }
+    }
   }
 
   // Combo expansion: providerInput may be a combo name → run fallback/round-robin across providers

--- a/src/sse/handlers/tts.js
+++ b/src/sse/handlers/tts.js
@@ -2,7 +2,7 @@ import {
   extractApiKey, isValidApiKey,
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
-import { getSettings } from "@/lib/localDb";
+import { getSettings, getApiKeyByKey } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleTtsCore } from "open-sse/handlers/ttsCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -33,11 +33,23 @@ export async function handleTts(request) {
   log.request("POST", `${url.pathname} | ${modelStr} | format=${responseFormat}${language ? ` | lang=${language}` : ""}`);
 
   const settings = await getSettings();
+  const apiKey = extractApiKey(request);
   if (settings.requireApiKey) {
-    const apiKey = extractApiKey(request);
     if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     const valid = await isValidApiKey(apiKey);
     if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  }
+
+  // Per-key combo access control
+  if (apiKey && modelStr) {
+    const keyData = await getApiKeyByKey(apiKey);
+    if (keyData && Array.isArray(keyData.allowedCombos) && keyData.allowedCombos.length > 0) {
+      const comboCheck = await getComboModels(modelStr);
+      if (comboCheck && !keyData.allowedCombos.includes(modelStr)) {
+        log.warn("AUTH", `API key "${keyData.name}" not allowed to access combo "${modelStr}"`);
+        return errorResponse(HTTP_STATUS.FORBIDDEN, `Access denied: combo "${modelStr}" is not allowed for this API key`);
+      }
+    }
   }
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");


### PR DESCRIPTION
## Feature: Per-Key Combo Access Control

Adds ability to restrict which combos an API key can access.

### Changes
- **Schema**: `allowedCombos TEXT` column in `apiKeys` table (JSON array storage)
- **Middleware**: Combo access control in ALL SSE handlers (chat, image, tts, search, fetch)
- **Dashboard UI**: Multi-select combo checkboxes in Create/Edit API Key modal
- **Migration**: Auto-add column via `syncSchemaFromTables` (no versioned migration needed)

### Behavior
- `allowedCombos: []` or `null` → allow all (backward compatible)
- Combo name in `model` param → check permission, 403 if not allowed
- Regular model string (`openai/gpt-4`) → always allowed

### Architecture
![Excalidraw](https://excalidraw.com/#json=51BCJNRjS-I_K5BMNk9PF,pz6cPkA9VQHShcRBhLzTQg)

### Testing
- Build passes (`npm run build` exit 0)
- All 5 SSE handlers consistently enforce `allowedCombos`
- Backward compatible with existing API keys (empty = allow all)