### PR TITLE
fix(usage): avoid API key stats collisions

### DIFF
--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -533,8 +533,9 @@ export async function getUsageStats(period = "all") {
         const keyInfo = apiKeyVal ? apiKeyMap[apiKeyVal] : null;
         const keyName = keyInfo?.name || (apiKeyVal ? apiKeyVal.slice(0, 8) + "..." : "Local (No API Key)");
         const apiKeyMasked = maskApiKey(apiKeyVal);
-        const apiKeyKey = fingerprintApiKey(apiKeyVal) || "local-no-key";
-        const statsKey = apiKeyVal ? getApiKeyStatsKey(apiKeyVal, rawModel, provider) : akKey;
+        const apiKeyFingerprint = fingerprintApiKey(apiKeyVal);
+        const apiKeyKey = apiKeyMasked || "local-no-key";
+        const statsKey = apiKeyFingerprint ? `${apiKeyFingerprint}|${rawModel}|${provider || "unknown"}` : akKey;
         if (!stats.byApiKey[statsKey]) {
           stats.byApiKey[statsKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey, lastUsed: dateKey };
         }
@@ -644,8 +645,9 @@ export async function getUsageStats(period = "all") {
         const keyInfo = apiKeyMap[r.apiKey];
         const keyName = keyInfo?.name || r.apiKey.slice(0, 8) + "...";
         const apiKeyMasked = maskApiKey(r.apiKey);
-        const apiKeyKey = fingerprintApiKey(r.apiKey);
-        const akKey = getApiKeyStatsKey(r.apiKey, r.model, r.provider);
+        const apiKeyFingerprint = fingerprintApiKey(r.apiKey);
+        const apiKeyKey = apiKeyMasked;
+        const akKey = `${apiKeyFingerprint}|${r.model}|${r.provider || "unknown"}`;
         if (!stats.byApiKey[akKey]) {
           stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey, lastUsed: r.timestamp };
         }

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import { createHash } from "node:crypto";
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 import { getMeta, setMeta } from "../helpers/metaStore.js";
@@ -7,6 +8,16 @@ function maskApiKey(key) {
   if (!key || typeof key !== "string") return null;
   if (key.length <= 8) return key.charAt(0) + "***";
   return key.slice(0, 8) + "***";
+}
+
+function fingerprintApiKey(key) {
+  if (!key || typeof key !== "string") return null;
+  return `sha256:${createHash("sha256").update(key).digest("hex")}`;
+}
+
+function getApiKeyStatsKey(apiKey, model, provider) {
+  const keyIdentity = fingerprintApiKey(apiKey) || "local-no-key";
+  return `${keyIdentity}|${model}|${provider || "unknown"}`;
 }
 
 const PENDING_TIMEOUT_MS = 60 * 1000;
@@ -85,8 +96,7 @@ function aggregateEntryToDay(day, entry) {
     addToCounter(day.byAccount, entry.connectionId, { ...vals, meta: { rawModel: entry.model, provider: entry.provider } });
   }
 
-  const apiKeyVal = entry.apiKey && typeof entry.apiKey === "string" ? entry.apiKey : "local-no-key";
-  const akModelKey = `${apiKeyVal}|${entry.model}|${entry.provider || "unknown"}`;
+  const akModelKey = getApiKeyStatsKey(entry.apiKey, entry.model, entry.provider);
   addToCounter(day.byApiKey, akModelKey, { ...vals, meta: { rawModel: entry.model, provider: entry.provider, apiKey: entry.apiKey || null } });
 
   const endpoint = entry.endpoint || "Unknown";
@@ -516,22 +526,23 @@ export async function getUsageStats(period = "all") {
       }
 
       for (const [akKey, ak] of Object.entries(day.byApiKey || {})) {
-        const rawModel = ak.rawModel || "";
-        const provider = ak.provider || "";
+        const rawModel = ak.rawModel || akKey.split("|")[1] || "";
+        const provider = ak.provider || akKey.split("|")[2] || "";
         const providerDisplayName = providerNodeNameMap[provider] || provider;
         const apiKeyVal = ak.apiKey;
         const keyInfo = apiKeyVal ? apiKeyMap[apiKeyVal] : null;
         const keyName = keyInfo?.name || (apiKeyVal ? apiKeyVal.slice(0, 8) + "..." : "Local (No API Key)");
         const apiKeyMasked = maskApiKey(apiKeyVal);
-        const apiKeyKey = apiKeyMasked || "local-no-key";
-        if (!stats.byApiKey[akKey]) {
-          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey, lastUsed: dateKey };
+        const apiKeyKey = fingerprintApiKey(apiKeyVal) || "local-no-key";
+        const statsKey = apiKeyVal ? getApiKeyStatsKey(apiKeyVal, rawModel, provider) : akKey;
+        if (!stats.byApiKey[statsKey]) {
+          stats.byApiKey[statsKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey, lastUsed: dateKey };
         }
-        stats.byApiKey[akKey].requests += ak.requests || 0;
-        stats.byApiKey[akKey].promptTokens += ak.promptTokens || 0;
-        stats.byApiKey[akKey].completionTokens += ak.completionTokens || 0;
-        stats.byApiKey[akKey].cost += ak.cost || 0;
-        if (dateKey > (stats.byApiKey[akKey].lastUsed || "")) stats.byApiKey[akKey].lastUsed = dateKey;
+        stats.byApiKey[statsKey].requests += ak.requests || 0;
+        stats.byApiKey[statsKey].promptTokens += ak.promptTokens || 0;
+        stats.byApiKey[statsKey].completionTokens += ak.completionTokens || 0;
+        stats.byApiKey[statsKey].cost += ak.cost || 0;
+        if (dateKey > (stats.byApiKey[statsKey].lastUsed || "")) stats.byApiKey[statsKey].lastUsed = dateKey;
       }
 
       for (const [epKey, ep] of Object.entries(day.byEndpoint || {})) {
@@ -567,9 +578,7 @@ export async function getUsageStats(period = "all") {
         if (stats.byAccount[accountKey] && new Date(ts) > new Date(stats.byAccount[accountKey].lastUsed)) stats.byAccount[accountKey].lastUsed = ts;
       }
 
-      const apiKeyKey = (e.apiKey && typeof e.apiKey === "string")
-        ? `${e.apiKey}|${e.model}|${e.provider || "unknown"}`
-        : "local-no-key";
+      const apiKeyKey = getApiKeyStatsKey(e.apiKey, e.model, e.provider);
       if (stats.byApiKey[apiKeyKey] && new Date(ts) > new Date(stats.byApiKey[apiKeyKey].lastUsed)) stats.byApiKey[apiKeyKey].lastUsed = ts;
 
       const endpoint = e.endpoint || "Unknown";
@@ -635,18 +644,20 @@ export async function getUsageStats(period = "all") {
         const keyInfo = apiKeyMap[r.apiKey];
         const keyName = keyInfo?.name || r.apiKey.slice(0, 8) + "...";
         const apiKeyMasked = maskApiKey(r.apiKey);
-        const akKey = `${apiKeyMasked}|${r.model}|${r.provider || "unknown"}`;
+        const apiKeyKey = fingerprintApiKey(r.apiKey);
+        const akKey = getApiKeyStatsKey(r.apiKey, r.model, r.provider);
         if (!stats.byApiKey[akKey]) {
-          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey: apiKeyMasked, lastUsed: r.timestamp };
+          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKeyMasked, keyName, apiKeyKey, lastUsed: r.timestamp };
         }
         const ake = stats.byApiKey[akKey];
         ake.requests++; ake.promptTokens += promptTokens; ake.completionTokens += completionTokens; ake.cost += entryCost;
         if (new Date(r.timestamp) > new Date(ake.lastUsed)) ake.lastUsed = r.timestamp;
       } else {
-        if (!stats.byApiKey["local-no-key"]) {
-          stats.byApiKey["local-no-key"] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKeyMasked: null, keyName: "Local (No API Key)", apiKeyKey: "local-no-key", lastUsed: r.timestamp };
+        const akKey = getApiKeyStatsKey(null, r.model, r.provider);
+        if (!stats.byApiKey[akKey]) {
+          stats.byApiKey[akKey] = { requests: 0, promptTokens: 0, completionTokens: 0, cost: 0, rawModel: r.model, provider: providerDisplayName, apiKeyMasked: null, keyName: "Local (No API Key)", apiKeyKey: "local-no-key", lastUsed: r.timestamp };
         }
-        const ake = stats.byApiKey["local-no-key"];
+        const ake = stats.byApiKey[akKey];
         ake.requests++; ake.promptTokens += promptTokens; ake.completionTokens += completionTokens; ake.cost += entryCost;
         if (new Date(r.timestamp) > new Date(ake.lastUsed)) ake.lastUsed = r.timestamp;
       }

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -230,8 +230,9 @@ describe("DB SQLite layer — public API parity", () => {
       expect(entries).toHaveLength(2);
       expect(entries.map((entry) => entry.keyName).sort()).toEqual(["collision-one", "collision-two"]);
       expect(entries.map((entry) => entry.requests).sort()).toEqual([1, 1]);
-      expect(new Set(entries.map((entry) => entry.apiKeyKey)).size).toBe(2);
       expect(new Set(entries.map((entry) => entry.apiKeyMasked)).size).toBe(1);
+      expect(new Set(entries.map((entry) => entry.apiKeyKey)).size).toBe(1);
+      expect(entries.every((entry) => entry.apiKeyKey === entry.apiKeyMasked)).toBe(true);
       expect(Object.keys(stats.byApiKey).some((key) => key.includes("sk-c84eb11fa877e0e9"))).toBe(false);
     }
   });

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -201,6 +201,41 @@ describe("DB SQLite layer — public API parity", () => {
     expect(stats.byProvider.openai.promptTokens).toBeGreaterThanOrEqual(300);
   });
 
+  it("usage: 24h and today byApiKey keep keys with the same masked prefix separate", async () => {
+    await sqliteDb.importDb({
+      settings: {},
+      apiKeys: [
+        { id: "ak-collision-1", key: "sk-c84eb11fa877e0e9-aaaaaa-11111111", name: "collision-one", machineId: "m1", isActive: true },
+        { id: "ak-collision-2", key: "sk-c84eb11fa877e0e9-bbbbbb-22222222", name: "collision-two", machineId: "m2", isActive: true },
+      ],
+    });
+
+    await sqliteDb.saveRequestUsage({
+      provider: "codex", model: "gpt-5.5", connectionId: "c1",
+      apiKey: "sk-c84eb11fa877e0e9-aaaaaa-11111111",
+      tokens: { prompt_tokens: 11, completion_tokens: 5 },
+      endpoint: "/v1/chat/completions", status: "ok",
+    });
+    await sqliteDb.saveRequestUsage({
+      provider: "codex", model: "gpt-5.5", connectionId: "c1",
+      apiKey: "sk-c84eb11fa877e0e9-bbbbbb-22222222",
+      tokens: { prompt_tokens: 17, completion_tokens: 7 },
+      endpoint: "/v1/chat/completions", status: "ok",
+    });
+
+    for (const period of ["24h", "today"]) {
+      const stats = await sqliteDb.getUsageStats(period);
+      const entries = Object.values(stats.byApiKey).filter((entry) => entry.rawModel === "gpt-5.5" && entry.provider === "codex");
+
+      expect(entries).toHaveLength(2);
+      expect(entries.map((entry) => entry.keyName).sort()).toEqual(["collision-one", "collision-two"]);
+      expect(entries.map((entry) => entry.requests).sort()).toEqual([1, 1]);
+      expect(new Set(entries.map((entry) => entry.apiKeyKey)).size).toBe(2);
+      expect(new Set(entries.map((entry) => entry.apiKeyMasked)).size).toBe(1);
+      expect(Object.keys(stats.byApiKey).some((key) => key.includes("sk-c84eb11fa877e0e9"))).toBe(false);
+    }
+  });
+
   it("usage: pending tracking in-memory", () => {
     sqliteDb.trackPendingRequest("gpt-4", "openai", "c1", true);
     expect(global._pendingRequests.byModel["gpt-4 (openai)"]).toBe(1);

--- a/tests/unit/security-audit.test.js
+++ b/tests/unit/security-audit.test.js
@@ -48,14 +48,15 @@ describe("AUDIT-002: API key masking", () => {
     expect(livePath.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("byApiKey object keys should use masked key, not raw key", () => {
+  it("byApiKey object keys should use a secret-safe fingerprint, not raw key", () => {
     const source = fs.readFileSync(
       path.resolve("src/lib/db/repos/usageRepo.js"),
       "utf-8"
     );
-    // The 24h path should use apiKeyMasked in the akKey template
-    expect(source).toContain("${apiKeyMasked}|${r.model}|${r.provider");
-    // Should NOT use raw r.apiKey in the key
+    // Internal aggregation keys need stable identity without exposing raw API keys.
+    expect(source).toContain("function fingerprintApiKey");
+    expect(source).toContain("getApiKeyStatsKey(r.apiKey, r.model, r.provider)");
+    // Should NOT use raw r.apiKey directly in the aggregation key template.
     expect(source).not.toContain("${r.apiKey}|${r.model}|${r.provider");
   });
 });

--- a/tests/unit/security-audit.test.js
+++ b/tests/unit/security-audit.test.js
@@ -55,7 +55,8 @@ describe("AUDIT-002: API key masking", () => {
     );
     // Internal aggregation keys need stable identity without exposing raw API keys.
     expect(source).toContain("function fingerprintApiKey");
-    expect(source).toContain("getApiKeyStatsKey(r.apiKey, r.model, r.provider)");
+    expect(source).toContain("const apiKeyFingerprint = fingerprintApiKey(r.apiKey)");
+    expect(source).toContain("${apiKeyFingerprint}|${r.model}|${r.provider");
     // Should NOT use raw r.apiKey directly in the aggregation key template.
     expect(source).not.toContain("${r.apiKey}|${r.model}|${r.provider");
   });


### PR DESCRIPTION
## Summary
- use a SHA-256 fingerprint as the internal byApiKey aggregation identity instead of the masked API key
- keep usage stats responses secret-safe with apiKeyMasked while preventing same-prefix key collisions
- add regression coverage for 24h/today stats with colliding masked API key prefixes

Closes #2206

## Tests
- NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run --reporter=verbose --config ./tests/vitest.config.js tests/unit/db-sqlite-vs-lowdb.test.js tests/unit/security-audit.test.js
- git diff --check