### PR TITLE
feat(continuity): preserve bounded reasoning checkpoints across model handoffs

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -18,6 +18,8 @@ import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
+import { captureSessionId, extractClientSessionId, getRecentThoughts, saveRecentThought } from "../utils/sessionManager.js";
+import { injectContinuity } from "../rtk/continuity.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { injectPonytail } from "../rtk/ponytail.js";
@@ -34,11 +36,18 @@ import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking, continuityEnabled, continuityCount }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
   const sourceFormat = sourceFormatOverride || detectFormat(body);
+  // Continuity: session ID must be provider-independent so combo switching shares the same thought buffer.
+  // Use apiKey as scope (stable per client across all combo providers) instead of connectionId (provider-specific).
+  const continuitySessionId = captureSessionId(body, credentials, apiKey);
+  // Thought buffer key: decoupled from session ID (which changes on context summarization
+  // because assistantTextSessionId hashes message content that shifts on truncation/summary).
+  // Uses client-provided session ID when available (stable across summarization), falls back to apiKey.
+  const thoughtKey = extractClientSessionId(credentials?.rawHeaders, body) || apiKey || continuitySessionId;
 
   // Check for bypass patterns (warmup, skip, cc naming)
   const bypassResponse = handleBypassRequest(body, model, userAgent, ccFilterNaming);
@@ -185,6 +194,15 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     log?.debug?.("PONYTAIL", `${ponytailLevel} | ${finalFormat}`);
   }
 
+  // Continuity: inject framed recent thoughts into system prompt
+  if (continuityEnabled) {
+    const recentThoughts = getRecentThoughts(thoughtKey, continuityCount);
+    if (recentThoughts && recentThoughts.length > 0) {
+      injectContinuity(translatedBody, finalFormat, recentThoughts);
+      log?.debug?.("CONTINUITY", `injected ${recentThoughts.length} thoughts into system | ${finalFormat}`);
+    }
+  }
+
   const executor = getExecutor(provider);
   trackPendingRequest(model, provider, connectionId, true);
   appendRequestLog({ model, provider, connectionId, status: "PENDING" }).catch(() => { });
@@ -308,7 +326,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, continuityEnabled, saveThinking: continuityEnabled ? (thinking) => { if (thinking) saveRecentThought(thoughtKey, thinking); } : null };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 
@@ -326,8 +344,14 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   // Streaming response
-  const { onStreamComplete } = buildOnStreamComplete({ ...sharedCtx });
-  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete });
+  const { onStreamComplete: _origOnStreamComplete } = buildOnStreamComplete({ ...sharedCtx });
+  const onStreamComplete = (contentObj, usage, ttftAt) => {
+    if (contentObj?.thinking && sharedCtx.saveThinking) {
+      sharedCtx.saveThinking(contentObj.thinking);
+    }
+    return _origOnStreamComplete(contentObj, usage, ttftAt);
+  };
+  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete, continuityEnabled });
 }
 
 export function isTokenExpiringSoon(expiresAt, bufferMs = 5 * 60 * 1000) {

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -4,6 +4,8 @@ import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
+import { extractThinking } from "../../utils/thinkingExtractor.js";
+import { stripTaggedThinking } from "../../utils/taggedThinkingNormalizer.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./requestDetail.js";
@@ -198,7 +200,7 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 /**
  * Handle non-streaming response from provider.
  */
-export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog }) {
+export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, saveThinking, continuityEnabled }) {
   trackDone();
   const contentType = providerResponse.headers.get("content-type") || "";
   let responseBody;
@@ -256,6 +258,16 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   if (!isClaudeMessageResponse) {
     if (!translatedResponse.object) translatedResponse.object = "chat.completion";
     if (!translatedResponse.created) translatedResponse.created = Math.floor(Date.now() / 1000);
+  }
+
+  // Strip content-embedded thinking tags (keep inner text as visible content) and extract thinking (continuity)
+  if (continuityEnabled) {
+    stripTaggedThinking(translatedResponse);
+
+    const extractedThinking = extractThinking(translatedResponse);
+    if (extractedThinking && saveThinking) {
+      saveThinking(extractedThinking);
+    }
   }
 
   // Strip Azure-specific fields

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -4,6 +4,8 @@ import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats } from "./requestDetail.js";
+import { stripTaggedThinking, stripTags } from "../../utils/taggedThinkingNormalizer.js";
+import { extractThinking } from "../../utils/thinkingExtractor.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -102,7 +104,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
  */
-export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog }) {
+export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog, continuityEnabled, saveThinking }) {
   const contentType = providerResponse.headers.get("content-type") || "";
   const isSSE = contentType.includes("text/event-stream") || (contentType === "" && isResponsesProvider(provider));
   if (!isSSE) return null; // not handled here
@@ -126,7 +128,12 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       appendLog({ tokens: usage, status: "200 OK" });
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint });
 
-      const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      const { msgItem, textContent: rawTextContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      let textContent = rawTextContent;
+      if (continuityEnabled) {
+        const stripped = stripTags(textContent);
+        if (stripped !== null) textContent = stripped;
+      }
       const totalLatency = Date.now() - requestStartTime;
 
       saveRequestDetail(buildRequestDetail({
@@ -183,6 +190,12 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         };
       }
 
+      // Continuity: extract thinking for session buffer
+      if (continuityEnabled) {
+        const thinkingForBuffer = extractThinking(jsonResponse);
+        if (thinkingForBuffer && saveThinking) saveThinking(thinkingForBuffer);
+      }
+
       return { success: true, response: new Response(JSON.stringify(finalResp), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
     } catch (err) {
       console.error("[ChatCore] Responses API SSE→JSON failed:", err);
@@ -214,6 +227,13 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       },
       status: "success"
     }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
+
+    // Continuity: strip tagged thinking + extract thinking for session buffer
+    if (continuityEnabled) {
+      stripTaggedThinking(parsed);
+      const extractedThinking = extractThinking(parsed);
+      if (extractedThinking && saveThinking) saveThinking(extractedThinking);
+    }
 
     // Strip reasoning_content only when content is non-empty.
     // When content is empty (e.g. thinking models that used all tokens for reasoning),

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -22,7 +22,7 @@ const CODEX_SOURCE_TO_TARGET = {
 /**
  * Determine which SSE transform stream to use based on provider/format.
  */
-function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey }) {
+function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, continuityEnabled }) {
   const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
   // Responses-API providers (e.g. codex) emit Responses SSE → translate into client format
   const isResponsesProvider = PROVIDERS[provider]?.format === FORMATS.OPENAI_RESPONSES;
@@ -30,20 +30,20 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 
   if (needsCodexTranslation) {
     const codexTarget = CODEX_SOURCE_TO_TARGET[sourceFormat] || FORMATS.OPENAI;
-    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
+    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, continuityEnabled);
   }
 
   if (needsTranslation(targetFormat, sourceFormat)) {
-    return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
+    return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, continuityEnabled);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, continuityEnabled);
 }
 
 /**
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
-export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete }) {
+export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, continuityEnabled }) {
   if (onRequestSuccess) {
     Promise.resolve()
       .then(onRequestSuccess)
@@ -60,7 +60,7 @@ export function handleStreamingResponse({ providerResponse, provider, model, sou
     console.warn('[STREAM] ' + provider + ' | ' + model + ' | unexpected Content-Type: ' + upstreamContentType);
   }
 
-  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey });
+  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, continuityEnabled });
 
   // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;

--- a/open-sse/rtk/continuity.js
+++ b/open-sse/rtk/continuity.js
@@ -1,0 +1,8 @@
+import { injectSystemPrompt } from "./systemInject.js";
+import { buildContinuityPrompt } from "./continuityPrompt.js";
+
+export function injectContinuity(body, format, recentThoughts) {
+  const framedContext = buildContinuityPrompt(recentThoughts);
+  if (!framedContext) return;
+  injectSystemPrompt(body, format, framedContext);
+}

--- a/open-sse/rtk/continuityPrompt.js
+++ b/open-sse/rtk/continuityPrompt.js
@@ -1,0 +1,32 @@
+function maxBacktickRun(text) {
+  let max = 0, current = 0;
+  for (const ch of text) {
+    if (ch === '`') { current++; max = Math.max(max, current); }
+    else { current = 0; }
+  }
+  return max;
+}
+
+export function buildContinuityPrompt(recentThoughts) {
+  if (!recentThoughts || recentThoughts.length === 0) return null;
+  const maxRun = recentThoughts.reduce((m, t) => Math.max(m, maxBacktickRun(t)), 0);
+  const fenceLen = Math.max(5, maxRun + 1);
+  const fence = '`'.repeat(fenceLen);
+  return [
+    "[HOST CONTINUATION CHECKPOINT]",
+    "",
+    "<continuation_checkpoint>",
+    "The block below is private continuation context from your immediately preceding turns.",
+    "It is the causal context behind the prior visible conversation history.",
+    "Use it to understand why that history unfolded as it did, then continue from the active user input below.",
+    "",
+    fence + "text",
+    recentThoughts.join("\n\n---\n\n"),
+    fence,
+    "",
+    "</continuation_checkpoint>",
+    "",
+    "[HOST RESUME]",
+    "Continuity restored. Continue from the active input below, using the checkpoint as context for the prior visible history."
+  ].join("\n");
+}

--- a/open-sse/utils/continuitySelfCheck.mjs
+++ b/open-sse/utils/continuitySelfCheck.mjs
@@ -1,0 +1,113 @@
+// continuitySelfCheck.mjs
+// Run: node open-sse/utils/continuitySelfCheck.mjs
+// No framework. No dependencies. Bails on first failure via assertion.
+import assert from "node:assert/strict";
+import { stripTags, stripTaggedThinking } from "./taggedThinkingNormalizer.js";
+import { extractThinking } from "./thinkingExtractor.js";
+import { buildContinuityPrompt } from "../rtk/continuityPrompt.js";
+
+const checks = [];
+
+function check(name, fn) {
+  checks.push({ name, fn });
+}
+
+// --- stripTags -----------------------------------------------------------
+check("stripTags: removes known tag markers, keeps inner text", () => {
+  assert.equal(stripTags("<think>hello</think>"), "hello");
+  assert.equal(stripTags("<thinking>a</thinking><thought>b</thought>"), "ab");
+  assert.equal(stripTags("<reasoning>r</reasoning><analysis>x</analysis>"), "rx");
+  assert.equal(stripTags("no tags here"), null);
+  assert.equal(stripTags(123), null);
+});
+
+// --- stripTaggedThinking -------------------------------------------------
+check("stripTaggedThinking: OpenAI delta.content string leaf", () => {
+  const obj = { choices: [{ delta: { content: "<think>hi</think>" } }] };
+  assert.equal(stripTaggedThinking(obj), true);
+  assert.equal(obj.choices[0].delta.content, "hi");
+});
+
+check("stripTaggedThinking: Claude delta.text + Responses top-level delta string", () => {
+  const obj = {
+    delta: { text: "<thinking>a</thinking>" },
+    response: { type: "response.output_text.delta", delta: "<reasoning>b</reasoning>" },
+  };
+  assert.equal(stripTaggedThinking(obj), true);
+  assert.equal(obj.delta.text, "a");
+  assert.equal(obj.response.delta, "b");
+});
+
+check("stripTaggedThinking: no-op returns false", () => {
+  const obj = { choices: [{ delta: { content: "clean" } }] };
+  assert.equal(stripTaggedThinking(obj), false);
+});
+
+// --- extractThinking -----------------------------------------------------
+check("extractThinking: OpenAI reasoning_content", () => {
+  const r = { choices: [{ message: { reasoning_content: "abc" } }] };
+  assert.equal(extractThinking(r), "abc");
+});
+
+check("extractThinking: Claude content[].type=thinking", () => {
+  const r = { content: [{ type: "thinking", thinking: "head" }, { type: "text", text: "body" }] };
+  assert.equal(extractThinking(r), "head");
+});
+
+check("extractThinking: Gemini thought part", () => {
+  const r = { candidates: [{ content: { parts: [{ text: "g", thought: true }, { text: "c" }] } }] };
+  assert.equal(extractThinking(r), "g");
+});
+
+check("extractThinking: Responses reasoning item", () => {
+  const r = { output: [{ type: "reasoning", content: "r1" }, { type: "message", content: [{ text: "m" }] }] };
+  assert.equal(extractThinking(r), "r1");
+});
+
+check("extractThinking: null on empty", () => {
+  assert.equal(extractThinking({ choices: [{ message: { content: "x" } }] }), null);
+});
+
+check("extractThinking: dedupes identical reasoning across fields", () => {
+  const r = { message: { reasoning_content: "dup", thinking: "dup" } };
+  assert.equal(extractThinking(r), "dup");
+});
+
+// --- buildContinuityPrompt ----------------------------------------------
+check("buildContinuityPrompt: null on empty", () => {
+  assert.equal(buildContinuityPrompt([]), null);
+  assert.equal(buildContinuityPrompt(null), null);
+});
+
+check("buildContinuityPrompt: wraps content in checkpoint markers", () => {
+  const p = buildContinuityPrompt(["my-thought"]);
+  assert.ok(p.includes("[HOST CONTINUATION CHECKPOINT]"));
+  assert.ok(p.includes("<continuation_checkpoint>"));
+  assert.ok(p.includes("my-thought"));
+  assert.ok(p.includes("[HOST RESUME]"));
+});
+
+check("buildContinuityPrompt: fence length grows when thoughts contain backticks", () => {
+  const short = buildContinuityPrompt(["abc"]);
+  const fenceStartShort = short.match(/(`{5,})text/)[1].length;
+  // 6 backticks exceed the default minimum (5), forcing fence to grow to 7
+  const long = buildContinuityPrompt(["``````code``````"]);
+  const fenceStartLong = long.match(/(`{5,})text/)[1].length;
+  assert.ok(fenceStartLong > fenceStartShort, "fence must expand to avoid collision");
+  assert.ok(fenceStartLong > 6, "fence must be longer than the longest backtick run in content");
+});
+
+// --- runner --------------------------------------------------------------
+let failed = 0;
+for (const { name, fn } of checks) {
+  try {
+    fn();
+    console.log(`ok   - ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`FAIL - ${name}`);
+    console.error(err);
+  }
+}
+console.log(`\n${checks.length - failed}/${checks.length} checks passed`);
+if (failed > 0) process.exit(1);

--- a/open-sse/utils/sessionManager.js
+++ b/open-sse/utils/sessionManager.js
@@ -13,6 +13,7 @@ import { MEMORY_CONFIG } from "../config/runtimeConfig.js";
 
 // Runtime storage: Key = connectionId, Value = { sessionId, lastUsed }
 const runtimeSessionStore = new Map();
+const recentThoughtsStore = new Map();
 
 // Periodically evict entries that haven't been used within TTL
 const cleanupInterval = setInterval(() => {
@@ -131,7 +132,7 @@ function extractAntigravitySession(body) {
     return m ? normalizeSessionId(m[1]) : null;
 }
 
-function extractClientSessionId(headers, body) {
+export function extractClientSessionId(headers, body) {
     const claude = extractClaudeCodeSession(body?.metadata?.user_id);
     if (claude) return `claude:${claude}`;
     const antigravity = extractAntigravitySession(body);
@@ -229,3 +230,52 @@ const assistantCleanup = setInterval(() => {
     }
 }, MEMORY_CONFIG.sessionCleanupIntervalMs);
 if (assistantCleanup.unref) assistantCleanup.unref();
+
+const MAX_RECENT_THOUGHT_CHARS = 32000;
+
+function evictLeastRecentlyUsedThoughtSession() {
+    let oldestKey = null;
+    let oldestTs = Infinity;
+    for (const [sid, entry] of recentThoughtsStore) {
+        if (entry.lastUsed < oldestTs) {
+            oldestTs = entry.lastUsed;
+            oldestKey = sid;
+        }
+    }
+    if (oldestKey) recentThoughtsStore.delete(oldestKey);
+}
+
+export function saveRecentThought(sessionId, raw) {
+    if (!sessionId || raw == null || raw === "") return;
+    if (typeof raw === "string" && raw.length > MAX_RECENT_THOUGHT_CHARS) {
+        console.warn(`[continuity] skipping oversize reasoning checkpoint (${raw.length} chars)`);
+        return;
+    }
+    let entry = recentThoughtsStore.get(sessionId);
+    if (!entry) {
+        if (recentThoughtsStore.size >= 1000) evictLeastRecentlyUsedThoughtSession();
+        entry = { thoughts: [], lastUsed: Date.now() };
+        recentThoughtsStore.set(sessionId, entry);
+    }
+    entry.thoughts.push(raw);
+    if (entry.thoughts.length > 100) entry.thoughts.shift();
+    entry.lastUsed = Date.now();
+}
+
+export function getRecentThoughts(sessionId, count = 100) {
+    const entry = recentThoughtsStore.get(sessionId);
+    if (!entry) return [];
+    entry.lastUsed = Date.now();
+    return entry.thoughts.slice(-count);
+}
+
+// Cleanup expired thought entries independently of runtimeSessionStore
+const thoughtsCleanup = setInterval(() => {
+    const now = Date.now();
+    for (const [sid, entry] of recentThoughtsStore) {
+        if (now - entry.lastUsed > MEMORY_CONFIG.sessionTtlMs) {
+            recentThoughtsStore.delete(sid);
+        }
+    }
+}, MEMORY_CONFIG.sessionCleanupIntervalMs);
+if (thoughtsCleanup.unref) thoughtsCleanup.unref();

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -5,6 +5,7 @@ import { extractUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage,
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
+import { stripTaggedThinking } from "./taggedThinkingNormalizer.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
 
@@ -48,7 +49,8 @@ export function createSSEStream(options = {}) {
     connectionId = null,
     body = null,
     onStreamComplete = null,
-    apiKey = null
+    apiKey = null,
+    continuityEnabled = false
   } = options;
 
   let buffer = "";
@@ -130,20 +132,70 @@ export function createSSEStream(options = {}) {
                 }
               }
 
-              if (!hasValuableContent(parsed, FORMATS.OPENAI)) {
+              if (!hasValuableContent(parsed)) {
                 continue;
               }
 
-              const delta = parsed.choices?.[0]?.delta;
-              const content = delta?.content;
-              const reasoning = delta?.reasoning_content;
-              if (content && typeof content === "string") {
-                totalContentLength += content.length;
-                accumulatedContent += content;
+              let tagsStripped = false;
+              if (continuityEnabled) {
+                tagsStripped = stripTaggedThinking(parsed);
               }
-              if (reasoning && typeof reasoning === "string") {
-                totalContentLength += reasoning.length;
-                accumulatedThinking += reasoning;
+
+              const unwrapped = parsed.response || parsed;
+              if (unwrapped.delta?.text) {
+                totalContentLength += unwrapped.delta.text.length;
+                accumulatedContent += unwrapped.delta.text;
+              }
+              if (unwrapped.delta?.thinking) {
+                totalContentLength += unwrapped.delta.thinking.length;
+                accumulatedThinking += unwrapped.delta.thinking;
+              }
+              if (typeof unwrapped.delta === "string" && unwrapped.type) {
+                totalContentLength += unwrapped.delta.length;
+                if (unwrapped.type.includes("reasoning")) {
+                  accumulatedThinking += unwrapped.delta;
+                } else {
+                  accumulatedContent += unwrapped.delta;
+                }
+              }
+              if (unwrapped.choices?.[0]?.delta?.content) {
+                totalContentLength += unwrapped.choices[0].delta.content.length;
+                accumulatedContent += unwrapped.choices[0].delta.content;
+              }
+              if (unwrapped.choices?.[0]?.delta?.reasoning_content) {
+                totalContentLength += unwrapped.choices[0].delta.reasoning_content.length;
+                accumulatedThinking += unwrapped.choices[0].delta.reasoning_content;
+              }
+              if (unwrapped.candidates?.[0]?.content?.parts) {
+                for (const part of unwrapped.candidates[0].content.parts) {
+                  if (part.text && typeof part.text === "string") {
+                    if (part.thought === true) {
+                      totalContentLength += part.text.length;
+                      accumulatedThinking += part.text;
+                    } else {
+                      totalContentLength += part.text.length;
+                      accumulatedContent += part.text;
+                    }
+                  }
+                }
+              }
+              // Ollama format: { message: { content, thinking } }
+              if (unwrapped.message?.content) {
+                totalContentLength += unwrapped.message.content.length;
+                accumulatedContent += unwrapped.message.content;
+              }
+              if (unwrapped.message?.thinking) {
+                totalContentLength += unwrapped.message.thinking.length;
+                accumulatedThinking += unwrapped.message.thinking;
+              }
+              // CommandCode format (AI SDK v5): { type:"text-delta"|"reasoning-delta", text }
+              if (unwrapped.type === "text-delta" && typeof unwrapped.text === "string") {
+                totalContentLength += unwrapped.text.length;
+                accumulatedContent += unwrapped.text;
+              }
+              if (unwrapped.type === "reasoning-delta" && typeof unwrapped.text === "string") {
+                totalContentLength += unwrapped.text.length;
+                accumulatedThinking += unwrapped.text;
               }
 
               const extracted = extractUsage(parsed);
@@ -151,20 +203,24 @@ export function createSSEStream(options = {}) {
                 usage = extracted;
               }
 
-              const isFinishChunk = parsed.choices?.[0]?.finish_reason;
+              const isFinishChunk = unwrapped.choices?.[0]?.finish_reason;
               if (isFinishChunk && !hasValidUsage(parsed.usage)) {
                 const estimated = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
                 parsed.usage = filterUsageForFormat(estimated, FORMATS.OPENAI);
-                output = `data: ${JSON.stringify(parsed)}\n`;
+                const nl = line.endsWith("\r") ? "\r\n" : "\n";
+                output = `data: ${JSON.stringify(parsed)}${nl}`;
                 usage = estimated;
                 injectedUsage = true;
               } else if (isFinishChunk && usage) {
                 const buffered = addBufferToUsage(usage);
                 parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
-                output = `data: ${JSON.stringify(parsed)}\n`;
+                const nl = line.endsWith("\r") ? "\r\n" : "\n";
+                output = `data: ${JSON.stringify(parsed)}${nl}`;
+                usage = buffered;
                 injectedUsage = true;
-              } else if (idFixed || fieldsInjected) {
-                output = `data: ${JSON.stringify(parsed)}\n`;
+              } else if (idFixed || fieldsInjected || tagsStripped) {
+                const nl = line.endsWith("\r") ? "\r\n" : "\n";
+                output = `data: ${JSON.stringify(parsed)}${nl}`;
                 injectedUsage = true;
               }
             } catch {
@@ -193,6 +249,10 @@ export function createSSEStream(options = {}) {
 
         const parsed = parseSSELine(trimmed, targetFormat);
         if (!parsed) continue;
+
+        if (continuityEnabled) {
+          stripTaggedThinking(parsed);
+        }
 
         // Responses API same-format passthrough: preserve event framing + track terminal state
         const isOpenAIResponsesStream = targetFormat === FORMATS.OPENAI_RESPONSES;
@@ -227,41 +287,70 @@ export function createSSEStream(options = {}) {
           continue;
         }
 
+        const unwrapped = parsed.response || parsed;
+
         // Claude format - content
-        if (parsed.delta?.text) {
-          totalContentLength += parsed.delta.text.length;
-          accumulatedContent += parsed.delta.text;
+        if (unwrapped.delta?.text) {
+          totalContentLength += unwrapped.delta.text.length;
+          accumulatedContent += unwrapped.delta.text;
         }
         // Claude format - thinking
-        if (parsed.delta?.thinking) {
-          totalContentLength += parsed.delta.thinking.length;
-          accumulatedThinking += parsed.delta.thinking;
+        if (unwrapped.delta?.thinking) {
+          totalContentLength += unwrapped.delta.thinking.length;
+          accumulatedThinking += unwrapped.delta.thinking;
+        }
+        // Responses API format - delta is a top-level string
+        if (typeof unwrapped.delta === "string" && unwrapped.type) {
+          totalContentLength += unwrapped.delta.length;
+          if (unwrapped.type.includes("reasoning")) {
+            accumulatedThinking += unwrapped.delta;
+          } else {
+            accumulatedContent += unwrapped.delta;
+          }
         }
         
         // OpenAI format - content
-        if (parsed.choices?.[0]?.delta?.content) {
-          totalContentLength += parsed.choices[0].delta.content.length;
-          accumulatedContent += parsed.choices[0].delta.content;
+        if (unwrapped.choices?.[0]?.delta?.content) {
+          totalContentLength += unwrapped.choices[0].delta.content.length;
+          accumulatedContent += unwrapped.choices[0].delta.content;
         }
         // OpenAI format - reasoning
-        if (parsed.choices?.[0]?.delta?.reasoning_content) {
-          totalContentLength += parsed.choices[0].delta.reasoning_content.length;
-          accumulatedThinking += parsed.choices[0].delta.reasoning_content;
+        if (unwrapped.choices?.[0]?.delta?.reasoning_content) {
+          totalContentLength += unwrapped.choices[0].delta.reasoning_content.length;
+          accumulatedThinking += unwrapped.choices[0].delta.reasoning_content;
         }
         
         // Gemini format
-        if (parsed.candidates?.[0]?.content?.parts) {
-          for (const part of parsed.candidates[0].content.parts) {
+        if (unwrapped.candidates?.[0]?.content?.parts) {
+          for (const part of unwrapped.candidates[0].content.parts) {
             if (part.text && typeof part.text === "string") {
-              totalContentLength += part.text.length;
-              // Check if this is thinking content
               if (part.thought === true) {
+                totalContentLength += part.text.length;
                 accumulatedThinking += part.text;
               } else {
+                totalContentLength += part.text.length;
                 accumulatedContent += part.text;
               }
             }
           }
+        }
+        // Ollama format: { message: { content, thinking } }
+        if (unwrapped.message?.content) {
+          totalContentLength += unwrapped.message.content.length;
+          accumulatedContent += unwrapped.message.content;
+        }
+        if (unwrapped.message?.thinking) {
+          totalContentLength += unwrapped.message.thinking.length;
+          accumulatedThinking += unwrapped.message.thinking;
+        }
+        // CommandCode format (AI SDK v5): { type:"text-delta"|"reasoning-delta", text }
+        if (unwrapped.type === "text-delta" && typeof unwrapped.text === "string") {
+          totalContentLength += unwrapped.text.length;
+          accumulatedContent += unwrapped.text;
+        }
+        if (unwrapped.type === "reasoning-delta" && typeof unwrapped.text === "string") {
+          totalContentLength += unwrapped.text.length;
+          accumulatedThinking += unwrapped.text;
         }
 
         // Extract usage
@@ -450,7 +539,7 @@ export function createSSEStream(options = {}) {
   });
 }
 
-export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, continuityEnabled = false) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
     targetFormat,
@@ -462,11 +551,12 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    continuityEnabled
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, continuityEnabled = false) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
     provider,
@@ -475,6 +565,7 @@ export function createPassthroughStreamWithLogger(provider = null, reqLogger = n
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    continuityEnabled
   });
 }

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -34,23 +34,26 @@ export function parseSSELine(line, format = null) {
 }
 
 // Check if chunk has valuable content (not empty)
-export function hasValuableContent(chunk, format) {
+export function hasValuableContent(chunk, format = null) {
+  const unwrapped = chunk.response || chunk;
+  const fmt = format || (unwrapped.candidates !== undefined ? FORMATS.GEMINI : (unwrapped.choices === undefined && (unwrapped.type !== undefined || unwrapped.delta !== undefined) ? FORMATS.CLAUDE : FORMATS.OPENAI));
+
   // OpenAI format
-  if (format === FORMATS.OPENAI && chunk.choices?.[0]?.delta) {
-    const delta = chunk.choices[0].delta;
+  if (fmt === FORMATS.OPENAI && unwrapped.choices?.[0]?.delta) {
+    const delta = unwrapped.choices[0].delta;
     return delta.content && delta.content !== "" ||
            delta.reasoning_content && delta.reasoning_content !== "" ||
            delta.tool_calls && delta.tool_calls.length > 0 ||
-           chunk.choices[0].finish_reason ||
+           unwrapped.choices[0].finish_reason ||
            delta.role;
   }
 
   // Claude format
-  if (format === FORMATS.CLAUDE) {
-    const isContentBlockDelta = chunk.type === "content_block_delta";
-    const hasText = chunk.delta?.text && chunk.delta.text !== "";
-    const hasThinking = chunk.delta?.thinking && chunk.delta.thinking !== "";
-    const hasInputJson = chunk.delta?.partial_json && chunk.delta.partial_json !== "";
+  if (fmt === FORMATS.CLAUDE) {
+    const isContentBlockDelta = unwrapped.type === "content_block_delta";
+    const hasText = unwrapped.delta?.text && unwrapped.delta.text !== "";
+    const hasThinking = unwrapped.delta?.thinking && unwrapped.delta.thinking !== "";
+    const hasInputJson = unwrapped.delta?.partial_json && unwrapped.delta.partial_json !== "";
     
     if (isContentBlockDelta && !hasText && !hasThinking && !hasInputJson) {
       return false;

--- a/open-sse/utils/taggedThinkingNormalizer.js
+++ b/open-sse/utils/taggedThinkingNormalizer.js
@@ -1,0 +1,45 @@
+// continuity: simple tag stripper — removes <think>/<thinking>/<thought>/<reasoning>/<analysis>
+// tag markers from content. Inner text stays as visible content. No migration to
+// thinking fields. Ceiling: streaming chunk-boundary tag splits may leak; upgrade to
+// stateful buffering only if observed in practice.
+const TAG_RE = /<\/?(?:think|thinking|thought|reasoning|analysis)>/gi;
+
+// Returns null when no change, or the stripped string when tags were removed.
+export function stripTags(text) {
+  if (typeof text !== "string") return null;
+  const result = text.replace(TAG_RE, "");
+  return result === text ? null : result;
+}
+
+export function stripTaggedThinking(obj) {
+  if (!obj || typeof obj !== "object") return false;
+  let changed = false;
+
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      if (stripTaggedThinking(item)) changed = true;
+    }
+    return changed;
+  }
+
+  if (typeof obj.content === "string") {
+    const stripped = stripTags(obj.content);
+    if (stripped !== null) { obj.content = stripped; changed = true; }
+  }
+  if (typeof obj.text === "string") {
+    const stripped = stripTags(obj.text);
+    if (stripped !== null) { obj.text = stripped; changed = true; }
+  }
+  if (typeof obj.delta === "string") {
+    const stripped = stripTags(obj.delta);
+    if (stripped !== null) { obj.delta = stripped; changed = true; }
+  }
+
+  for (const key of ["response", "choices", "message", "delta", "output", "content", "candidates", "parts"]) {
+    if (obj[key]) {
+      if (stripTaggedThinking(obj[key])) changed = true;
+    }
+  }
+
+  return changed;
+}

--- a/open-sse/utils/thinkingExtractor.js
+++ b/open-sse/utils/thinkingExtractor.js
@@ -1,0 +1,35 @@
+export function extractThinking(value) {
+  if (!value) return null;
+  const out = [];
+  collectThinking(value, out);
+  return [...new Set(out.filter(Boolean))].join("\n") || null;
+}
+
+function collectThinking(obj, out) {
+  if (!obj || typeof obj !== "object") return;
+
+  if (Array.isArray(obj)) {
+    for (const item of obj) collectThinking(item, out);
+    return;
+  }
+
+  if (typeof obj.reasoning_content === "string") out.push(obj.reasoning_content);
+  if (typeof obj.thinking === "string") out.push(obj.thinking);
+  if (obj.thought === true && typeof obj.text === "string") out.push(obj.text);
+
+  if (obj.type === "thinking" && typeof obj.thinking === "string") out.push(obj.thinking);
+  if (obj.type === "reasoning") {
+    if (typeof obj.text === "string") out.push(obj.text);
+    if (typeof obj.content === "string") out.push(obj.content);
+    if (typeof obj.summary === "string") out.push(obj.summary);
+  }
+
+  if (obj.response) collectThinking(obj.response, out);
+  if (obj.choices) collectThinking(obj.choices, out);
+  if (obj.message) collectThinking(obj.message, out);
+  if (obj.delta) collectThinking(obj.delta, out);
+  if (obj.output) collectThinking(obj.output, out);
+  if (obj.content) collectThinking(obj.content, out);
+  if (obj.candidates) collectThinking(obj.candidates, out);
+  if (obj.parts) collectThinking(obj.parts, out);
+}

--- a/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
+++ b/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
@@ -28,6 +28,8 @@ export default function TokenSaverClient() {
   const [cavemanLevel, setCavemanLevel] = useState("full");
   const [ponytailEnabled, setPonytailEnabled] = useState(false);
   const [ponytailLevel, setPonytailLevel] = useState("full");
+  const [continuityEnabled, setContinuityEnabled] = useState(false);
+  const [continuityCount, setContinuityCount] = useState(3);
   const [locale, setLocale] = useState("en");
 
   const { copied, copy } = useCopyToClipboard();
@@ -152,6 +154,20 @@ export default function TokenSaverClient() {
     patchSetting({ ponytailLevel: level });
   };
 
+  const handleContinuityEnabled = (value) => {
+    setContinuityEnabled(value);
+    patchSetting({ continuityEnabled: value });
+  };
+
+  const handleContinuityCount = (e) => {
+    let val = parseInt(e.target.value, 10);
+    if (isNaN(val)) val = 1;
+    if (val < 1) val = 1;
+    if (val > 100) val = 100;
+    setContinuityCount(val);
+    patchSetting({ continuityCount: val });
+  };
+
   useEffect(() => {
     const loadSettings = async () => {
       try {
@@ -165,6 +181,8 @@ export default function TokenSaverClient() {
           setCavemanLevel(data.cavemanLevel || "full");
           setPonytailEnabled(!!data.ponytailEnabled);
           setPonytailLevel(data.ponytailLevel || "full");
+          setContinuityEnabled(!!data.continuityEnabled);
+          setContinuityCount(parseInt(data.continuityCount) || 3);
           refreshHeadroomStatus();
         }
       } catch {}
@@ -355,6 +373,45 @@ export default function TokenSaverClient() {
             <Toggle
               checked={ponytailEnabled}
               onChange={() => handlePonytailEnabled(!ponytailEnabled)}
+            />
+          </div>
+        </div>
+
+        {/* Continuity Feature (experimental, opt-in) */}
+        <div className="flex items-center justify-between pt-4 mt-4 border-t border-border gap-4 flex-wrap">
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">
+              Continuity{" "}
+              <span className="text-xs font-normal text-primary">(Experimental)</span>
+            </p>
+            <p className="text-sm text-text-muted">
+              Replay recent reasoning checkpoints into the system prompt for cross-model continuation
+            </p>
+          </div>
+          <div className="flex items-center gap-3 shrink-0">
+            {continuityEnabled && (
+              <div className="flex flex-col items-end gap-1">
+                <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-1 bg-surface-2 px-2 py-1 rounded border border-border">
+                    <span className="text-xs text-text-muted">Count:</span>
+                    <input
+                      type="number"
+                      min="1"
+                      max="100"
+                      value={continuityCount}
+                      onChange={handleContinuityCount}
+                      className="w-12 px-1 text-xs bg-transparent border-none focus:outline-none text-text"
+                    />
+                  </div>
+                </div>
+                <p className="text-xs text-primary">
+                  Replaying up to {continuityCount} reasoning checkpoints into the system prompt.
+                </p>
+              </div>
+            )}
+            <Toggle
+              checked={continuityEnabled}
+              onChange={() => handleContinuityEnabled(!continuityEnabled)}
             />
           </div>
         </div>

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -259,6 +259,8 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       cavemanLevel: chatSettings.cavemanLevel || "full",
       ponytailEnabled: !!chatSettings.ponytailEnabled,
       ponytailLevel: chatSettings.ponytailLevel || "full",
+      continuityEnabled: !!chatSettings.continuityEnabled,
+      continuityCount: parseInt(chatSettings.continuityCount) || 3,
       providerThinking,
       // Detect source format by endpoint + body
       sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,


### PR DESCRIPTION
# feat(continuity): preserve bounded reasoning checkpoints across model handoffs

## Feature request

This PR proposes an **experimental, opt-in continuity layer** for 9router.

The feature is not a smart model selector and not an attempt to make switching providers “always better”. It solves a narrower routing problem:

> when 9router continues a multi-turn session through another provider, model family, or API format, the visible dialogue history usually survives, but provider-native reasoning often does not.

The implementation attached here keeps a small **reasoning sidecar** per session. It captures native reasoning from successful responses, stores a bounded checkpoint buffer, and injects recent checkpoints into the next request’s system prompt when the user enables the feature.

Default: **off**.

## Why this belongs in 9router

9router’s core value is not only “send request to provider X”. It is the translation and fallback layer between many clients, many API shapes, and many providers.

That makes reasoning continuity a router-level problem:

- Claude thinking blocks are not the same shape as OpenAI `reasoning_content`.
- Gemini / Antigravity thought parts are not the same shape as Claude content blocks.
- Responses API reasoning items/deltas are not the same shape as Chat Completions messages.
- Some providers reject reasoning fields they do not understand.
- Some clients drop reasoning fields when rebuilding conversation history.
- Combo/fallback routes can switch provider families mid-session.

The normal message history remains client-owned and is still passed as before. This feature only carries the missing “reasoning trace” that tends to be lost at router boundaries.

This is closely related to issues already reported in the repo:

- [#1189](https://github.com/decolua/9router/issues/1189) — DeepSeek thinking mode requires previous `reasoning_content` to be passed back in multi-turn conversations.
- [#1321](https://github.com/decolua/9router/issues/1321) — Xiaomi/MiMo thinking models fail because `reasoning_content` is not preserved across turns.
- [#1459](https://github.com/decolua/9router/issues/1459) — reasoning effort/config can be lost during Claude → Codex translation.
- [#2158](https://github.com/decolua/9router/issues/2158) — reasoning leaks into visible `content` through `<thinking>` tags.
- [#2190](https://github.com/decolua/9router/pull/2190) — another PR addresses a streaming leak where Claude thinking markers reach visible content.

This PR does not replace those narrower protocol fixes. It adds a router-level continuation mechanism for the class of cases where provider-native reasoning cannot be faithfully round-tripped through the client’s normal history.

## What the feature does

### 1. Capture native reasoning from successful responses

The router extracts reasoning from the response shape it actually receives:

- OpenAI-compatible: `reasoning_content`
- Claude-compatible: `thinking`
- Gemini / Antigravity: `parts[]` with `thought: true`
- Responses API: `reasoning` output items and reasoning delta events
- Ollama-like shape: `message.thinking`
- AI SDK / CommandCode style: `reasoning-delta`

Streaming responses use the existing assembled `contentObj.thinking` path after the stream completes. Non-streaming and forced SSE→JSON paths use the same extractor utility.

Failed responses do not replace the buffer.

### 2. Store a bounded per-session sidecar

The feature adds a small in-memory `recentThoughtsStore` in `sessionManager.js`.

Bounds:

- max 100 reasoning checkpoints per session;
- max 1000 active session keys;
- session cap eviction is LRU using `lastUsed`;
- a single checkpoint above `MAX_RECENT_THOUGHT_CHARS` is skipped with a warning, not truncated.

The “not truncated” part is intentional. Partial reasoning traces are worse than no trace because they can turn the checkpoint into corrupted instructions or misleading context. If a trace is too large, the safer behavior is to drop it and keep the normal visible conversation intact.

### 3. Replay recent checkpoints into the next request

When enabled, the next request receives up to `continuityCount` recent checkpoints through the existing system-prompt injection path.

The prompt is explicitly framed as a host continuation checkpoint:

```text
[HOST CONTINUATION CHECKPOINT]
<continuation_checkpoint>
The block below is private continuation context from your immediately preceding turns.
It is the causal context behind the prior visible conversation history.
Use it to understand why that history unfolded as it did, then continue from the active user input below.
...
</continuation_checkpoint>
[HOST RESUME]
```

This is deliberately injected into the system prompt, not as a synthetic user message. It mirrors the existing RTK/caveman style of system-level prompt augmentation and avoids polluting user history.

## The important architecture detail: two different session IDs

The feature separates two concepts that look similar but behave differently:

1. `continuitySessionId` — existing prompt-cache/session identity used for upstream compatibility.
2. `thoughtKey` — reasoning sidecar key used to keep checkpoints across route changes and summarization.

The thought key is:

```js
extractClientSessionId(headers, body) || apiKey || continuitySessionId
```

This is the result of the earlier debugging work in this patch series.

Using only the existing `captureSessionId()` looked attractive at first, but it can fall back to `assistantTextSessionId`, which hashes assistant text. When a client summarizes or truncates a long conversation, that assistant-text hash changes. The normal visible history still exists, but the sidecar buffer becomes orphaned under the old hash.

Using `connectionId` also failed for combo routes because each provider/account can have a different connection id, so reasoning captured from provider A would not be visible when the route moved to provider B.

The current split keeps prompt caching behavior unchanged while giving the reasoning sidecar a stable key when the client supplies one. If no stable client session exists, it falls back to `apiKey`, then the existing session id.

## Why this is not “full context transfer”

The feature intentionally does **not** claim to transfer the whole model/session state.

It does not preserve:

- hidden provider runtime state;
- exact decoder state;
- provider cache state;
- pending tool calls;
- tool runtime state;
- files/workspace state;
- arbitrary provider-private metadata;
- the full visible conversation history beyond what the client already sends.

It only replays a bounded number of recent reasoning traces as continuation context.

That makes it safe enough to ship as an experimental opt-in feature without pretending it is a perfect cross-provider session migration system.

## Why the tag normalizer is included

Some providers/translation paths surface reasoning markers as visible text, for example:

```text
<thinking>...</thinking>
<think>...</think>
<reasoning>...</reasoning>
```

When continuity is enabled, this PR removes only the tag markers from visible content and keeps the inner text visible.

Important behavior:

- tagged visible text is **not** promoted into the reasoning sidecar;
- native provider reasoning remains the source of sidecar capture;
- tag stripping runs in both translate and passthrough paths;
- this reduces downstream trigger-token leakage without deleting user-visible text.

This is intentionally conservative. It does not try to infer hidden reasoning from arbitrary visible text.

## Why it is opt-in

The research does not support the claim “switching models with prior reasoning is always better”. The effect is directional and pair/task dependent.

This PR therefore exposes the feature as a dashboard toggle:

- `continuityEnabled` — default `false`
- `continuityCount` — default `3`, range `1..100`

Users who are actively using combo/fallback routes with thinking models can enable it. Others see no behavior change.

## Research motivation

The design is based on a modest claim: a bounded reasoning checkpoint can be useful handoff context for some model pairs and tasks, but it must be configurable and measured.

Relevant work:

1. [Evaluating Performance Drift from Model Switching in Multi-Turn LLM Systems](https://arxiv.org/abs/2603.03111) studies multi-turn handoff where one model produces the dialogue prefix and another model completes the final turn. The reported effect is source→target specific: some switches improve, others degrade. This supports the feature being opt-in and route-dependent rather than enabled as a universal quality optimization.

2. [Reasoning that Travels: Dissecting How Chain-of-Thought Transfers Across Models](https://arxiv.org/abs/2605.28913) shows that reasoning traces can transfer between models in some settings. It also cautions that trace transfer can leak or nearly reveal answers on some tasks. This supports bounded replay and explicit framing instead of blindly copying unbounded reasoning.

3. [Mixture-of-Agents Enhances Large Language Model Capabilities](https://ar5iv.org/html/2406.04692v1) is not the same architecture as 9router fallback, but it is useful evidence that outputs from one model can serve as auxiliary context for another.

4. [Rethinking Mixture-of-Agents: Is Mixing Different Large Language Models Beneficial?](https://arxiv.org/abs/2502.00674) is the counterweight: heterogeneous model mixing is not automatically better. This is why the PR avoids any claim that cross-provider continuation always improves quality.

## Implementation map

### `open-sse/utils/thinkingExtractor.js`

Small recursive extractor for native reasoning fields across response families.

It recognizes provider-native reasoning fields but does not infer reasoning from ordinary visible text.

### `open-sse/utils/taggedThinkingNormalizer.js`

Removes known thinking tag markers from response content while preserving the inner text.

This is deliberately a simple marker stripper. It does not try to solve split tags across streaming chunk boundaries with stateful buffering yet; that would add complexity before there is evidence it is needed.

### `open-sse/rtk/continuityPrompt.js`

Builds the framed continuation checkpoint.

It uses dynamic backtick fences so checkpoint text containing backticks cannot prematurely close the fenced block.

### `open-sse/rtk/continuity.js`

Thin wrapper around the existing system-prompt injection helper.

The feature does not create synthetic user messages.

### `open-sse/utils/sessionManager.js`

Adds `recentThoughtsStore` next to existing in-memory session stores.

There is no DB, Redis, second persistent store, or provider-specific session scheme. Cleanup uses the same TTL rhythm as runtime session cleanup, while the thought store has its own `lastUsed` updates.

### `open-sse/handlers/chatCore*.js`

Wires the feature through:

- normal streaming responses;
- non-streaming responses;
- forced SSE→JSON responses;
- translate and passthrough paths.

### `open-sse/utils/stream.js`

Accumulates thinking/content from stream chunks across OpenAI, Claude, Gemini, Responses, Ollama, and CommandCode/AI SDK style events.

### `src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js`

Adds the experimental toggle and replay count control.

## Operational notes

- Default off: no behavior change unless enabled.
- Client-facing responses are unchanged except for optional thinking-tag marker stripping when enabled.
- Reasoning checkpoints are bounded by count, session cap, and single-checkpoint size.
- Oversize checkpoints are skipped, not truncated.
- The normal visible conversation remains client-owned.
- The sidecar is in-memory and follows the process lifetime, matching the lightweight nature of existing runtime session state.

## Related PRs / prior work

This builds on the same compatibility direction as:

- [#2192](https://github.com/decolua/9router/pull/2192) — Gemini contents normalization.
- [#2194](https://github.com/decolua/9router/pull/2194) — Gemini `thoughtSignature` and stream sentinel compatibility.
- [#2196](https://github.com/decolua/9router/pull/2196) — Claude tool schema normalization for strict gateways.
- [#2190](https://github.com/decolua/9router/pull/2190) — keeping Claude thinking out of visible content in a narrower translator path.

Those are protocol-shape fixes. This PR is the feature-layer continuation mechanism above those translators.
