### PR TITLE
fix(backup): preserve API key restrictions on export/import

### DIFF
--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -77,7 +77,7 @@ export async function exportDb() {
     providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
-    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
+    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, allowedModels: parseJson(r.allowedModels, []), blockedModels: parseJson(r.blockedModels, []), allowedCombos: parseJson(r.allowedCombos, []), scopes: parseJson(r.scopes, ["manage"]), expiresAt: r.expiresAt || null, createdAt: r.createdAt })),
     combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), createdAt: r.createdAt, updatedAt: r.updatedAt })),
     modelAliases: {},
     customModels: [],
@@ -137,8 +137,8 @@ export async function importDb(payload) {
     }
     for (const k of payload.apiKeys || []) {
       db.run(
-        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, allowedModels, blockedModels, allowedCombos, scopes, expiresAt, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, JSON.stringify(k.allowedModels || []), JSON.stringify(k.blockedModels || []), JSON.stringify(k.allowedCombos || []), JSON.stringify(k.scopes || ["manage"]), k.expiresAt || null, k.createdAt || new Date().toISOString()]
       );
     }
     for (const c of payload.combos || []) {


### PR DESCRIPTION
## Problem

When exporting the database (**Profile → Export Database**) and restoring from backup, all API key restrictions are silently dropped:

- `allowedModels` → reset to `[]`
- `blockedModels` → reset to `[]`
- `allowedCombos` → reset to `[]`
- `scopes` → reset to `["manage"]`
- `expiresAt` → reset to `null`

**Root cause:** `exportDb()` only projected 6 columns (`id, key, name, machineId, isActive, createdAt`), and the `importDb()` INSERT only wrote those same 6 — restriction columns were never included in either direction.

## Fix

**`src/lib/db/index.js`** — 3-line change:

- `exportDb()`: include all restriction fields in the `apiKeys` array via `parseJson()`
- `importDb()`: write all restriction fields back on `INSERT OR REPLACE` with `JSON.stringify()` and safe defaults

No schema changes. No new dependencies. Backward-compatible: old backup files without restriction fields restore cleanly (defaults to empty arrays / `["manage"]` scopes).