### PR TITLE
fix(antigravity): preserve Claude tool delta index

### DIFF
--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -25,7 +25,10 @@ function emitFunctionCall(functionCall, state) {
     type: OPENAI_BLOCK.FUNCTION,
     function: { name: fcName, arguments: JSON.stringify(fcArgs) },
   };
-  state.toolCalls.set(toolCallIndex, toolCall);
+  // Keep Gemini bookkeeping separate from the shared translator state.toolCalls map.
+  // The downstream OpenAI→Claude translator uses state.toolCalls for Claude block
+  // metadata; pre-populating it here makes Anthropic tool deltas lose index.
+  state.geminiToolCallCount = (state.geminiToolCallCount || 0) + 1;
   return buildChunk(chunkMeta(state), { tool_calls: [toolCall] }, null);
 }
 
@@ -46,6 +49,7 @@ export function geminiToOpenAIResponse(chunk, state) {
     state.messageId = response.responseId || `msg_${Date.now()}`;
     state.model = response.modelVersion || "gemini";
     state.functionIndex = 0;
+    state.geminiToolCallCount = 0;
     results.push(buildChunk(chunkMeta(state), { role: ROLE.ASSISTANT }, null));
   }
 
@@ -117,7 +121,7 @@ export function geminiToOpenAIResponse(chunk, state) {
   // Finish reason - include usage in final chunk
   if (candidate.finishReason) {
     let finishReason = toOpenAIFinish(candidate.finishReason, "gemini");
-    if (finishReason === OPENAI_FINISH.STOP && state.toolCalls.size > 0) {
+    if (finishReason === OPENAI_FINISH.STOP && state.geminiToolCallCount > 0) {
       finishReason = OPENAI_FINISH.TOOL_CALLS;
     }
     

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -1,7 +1,7 @@
 // Real Antigravity-MITM requests (Gemini-internal: { request: { contents, ... } }) → OpenAI.
 import { describe, it, expect } from "vitest";
 import "./registerAll.js";
-import { translateRequest } from "../../open-sse/translator/index.js";
+import { translateRequest, translateResponse, initState } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
 
@@ -51,6 +51,32 @@ describe("Antigravity → OpenAI", () => {
       ? content.some((c) => c.type === "text" && c.text === "")
       : content === "";
     expect(hasEmpty, "empty text part emitted").toBe(false);
+  });
+});
+
+describe("Antigravity → Claude", () => {
+  it("tool call input_json_delta includes Anthropic index", () => {
+    const state = initState(FORMATS.CLAUDE);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, {
+      response: {
+        responseId: "resp-1",
+        modelVersion: "gemini-pro-agent",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ functionCall: { name: "bash", args: { command: "git status" } } }],
+          },
+          finishReason: "STOP",
+          index: 0,
+        }],
+      },
+    }, state);
+
+    const jsonDelta = events.find(
+      (event) => event.type === "content_block_delta" && event.delta?.type === "input_json_delta"
+    );
+    expect(jsonDelta).toMatchObject({ index: expect.any(Number) });
+    expect(JSON.parse(jsonDelta.delta.partial_json)).toEqual({ command: "git status" });
   });
 });
 

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -171,6 +171,7 @@ describe("Kiro → Claude (direct route, OpenAI-shaped chunks from executor)", (
     const jsonDelta = events.find(
       (e) => e.type === "content_block_delta" && e.delta.type === "input_json_delta"
     );
+    expect(jsonDelta.index).toBeDefined();
     expect(jsonDelta.delta.partial_json).toBe('{"q":"x"}');
     const md = events.find((e) => e.type === "message_delta");
     expect(md.delta.stop_reason).toBe("tool_use");


### PR DESCRIPTION
## Issue

When Antigravity/Gemini emits a tool call and the client expects Claude/Anthropic streaming format, the response can contain a malformed Claude SSE event.

Observed bad shape:

```json
{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{...}"}}
```

For Anthropic tool argument deltas, `content_block_delta.index` is required because it points to the `tool_use` content block started earlier in the stream. Without it, Claude-compatible clients cannot associate the JSON argument delta with the correct content block.

This affects the response translation path:

```txt
Antigravity/Gemini response
→ gemini-to-openai.js
→ openai-to-claude.js
→ Claude SSE client
```

## Findings / Root cause

The bug was not caused by `index` being deleted later in the stream layer. It was caused by shared translator state being reused for two different meanings.

`gemini-to-openai.js` stored Gemini/OpenAI-shaped tool-call bookkeeping in the shared `state.toolCalls` map:

```js
state.toolCalls.set(toolCallIndex, toolCall);
```

Those entries look like OpenAI tool calls:

```js
{
  id,
  index,
  type: "function",
  function: { name, arguments }
}
```

But the downstream `openai-to-claude.js` translator also uses `state.toolCalls`. In that translator, the map is expected to contain Claude content block metadata:

```js
{
  id,
  name,
  blockIndex
}
```

Because Gemini had already populated `state.toolCalls`, OpenAI→Claude saw the tool-call index as already initialized:

```js
if (tc.id && !state.toolCalls.has(idx)) {
  // create Claude tool_use block metadata with blockIndex
}
```

That branch was skipped, so no Claude `blockIndex` was created. Later, when emitting the buffered tool arguments:

```js
index: toolInfo.blockIndex
```

`toolInfo.blockIndex` was `undefined`. JSON serialization then omitted `index`, producing the malformed Anthropic event.

## Fix

Keep Gemini-specific bookkeeping out of the shared `state.toolCalls` map.

Changes:

- Removed Gemini response translation writes to `state.toolCalls`.
- Added `state.geminiToolCallCount` to track whether Gemini emitted any function calls.
- Kept existing finish-reason behavior: Gemini `STOP` is still converted to OpenAI `tool_calls` when a function call was emitted.
- Left `state.toolCalls` available for `openai-to-claude.js` to create and store Claude block metadata safely.

Relevant change:

```diff
- state.toolCalls.set(toolCallIndex, toolCall);
+ state.geminiToolCallCount = (state.geminiToolCallCount || 0) + 1;
```

and:

```diff
- if (finishReason === OPENAI_FINISH.STOP && state.toolCalls.size > 0) {
+ if (finishReason === OPENAI_FINISH.STOP && state.geminiToolCallCount > 0) {
    finishReason = OPENAI_FINISH.TOOL_CALLS;
  }
```

## Tests

Added regression coverage for the exact failing translation path:

- `Antigravity → Claude` tool call response emits `content_block_delta` with Anthropic `index`.
- The emitted `input_json_delta.partial_json` still contains the expected tool arguments.

Also added a small guard for the existing direct `Kiro → Claude` path so its `input_json_delta` continues to include `index`.

Verification command:

```sh
npx vitest run tests/translator/bugs-antigravity.test.js tests/translator/claude-kiro-direct.test.js tests/translator/golden-response-stream.test.js
```

Result:

```txt
Test Files  3 passed (3)
Tests       20 passed | 1 expected fail (21)
```

## Impact

This is a narrow state-isolation fix. It does not change Gemini/OpenAI tool-call output shape; it only prevents Gemini-side bookkeeping from corrupting the downstream Claude translator state.

Closes #2218
