### PR TITLE
test(antigravity): cover deprecated schema stripping

### DIFF
--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -55,7 +55,7 @@ describe("Antigravity → OpenAI", () => {
 });
 
 describe("Antigravity executor", () => {
-  it("strips optional from nested tool schemas", () => {
+  it("strips optional and deprecated from nested tool schemas", () => {
     const out = new AntigravityExecutor().transformRequest("gemini-2.5-pro", {
       request: {
         contents: [{ role: "user", parts: [{ text: "hi" }] }],
@@ -70,6 +70,17 @@ describe("Antigravity executor", () => {
                   type: "string",
                   description: "Search query",
                   optional: true,
+                  deprecated: true,
+                },
+                nested: {
+                  type: "object",
+                  deprecated: true,
+                  properties: {
+                    value: {
+                      type: "string",
+                      deprecated: true,
+                    },
+                  },
                 },
               },
             },
@@ -78,7 +89,11 @@ describe("Antigravity executor", () => {
       },
     }, true, { projectId: "project-1", connectionId: "conn-1" });
 
-    const query = out.request.tools[0].functionDeclarations[0].parameters.properties.query;
+    const parameters = out.request.tools[0].functionDeclarations[0].parameters;
+    const query = parameters.properties.query;
+    const nested = parameters.properties.nested;
     expect(query).toEqual({ type: "string", description: "Search query" });
+    expect(nested).toEqual({ type: "object", properties: { value: { type: "string" } } });
+    expect(JSON.stringify(parameters)).not.toContain("deprecated");
   });
 });


### PR DESCRIPTION
## Issue

Antigravity/Gemini can reject tool schemas when a client/MCP tool includes JSON Schema annotation keywords such as `deprecated`.

Observed failure from #2199:

```txt
Antigravity HTTP Code 400 : Invalid JSON payload received. Unknown name "deprecated" at 'request.tools[0].function_declarations[25].parameters.properties[1].value': Cannot find field.
Invalid JSON payload received. Unknown name "deprecated" at 'request.tools[0].function_declarations[25].parameters.properties[2].value': Cannot find field.
```

That means the request never reaches model execution: Google rejects the `function_declarations[*].parameters` payload during validation.

## Finding

The Antigravity request path already sanitizes tool schemas through `cleanJSONSchemaForAntigravity()` before sending them to Gemini:

```txt
open-sse/executors/antigravity.js
open-sse/translator/formats/gemini.js
```

Current upstream already strips unsupported schema keywords recursively, including:

```txt
deprecated
readOnly
writeOnly
optional
```

The missing piece was a focused regression guard that matches the failure shape from #2199: `deprecated` appearing not only on a direct property schema, but also on a nested object schema and nested property value.

## Change

Expanded the existing Antigravity executor schema test:

```txt
tests/translator/bugs-antigravity.test.js
```

from:

```txt
strips optional from nested tool schemas
```

to:

```txt
strips optional and deprecated from nested tool schemas
```

The test now verifies:

- `optional` is still stripped from nested tool schema properties
- `deprecated` is stripped from a direct nested property
- `deprecated` is stripped from a nested object schema
- `deprecated` is stripped from a nested property's value schema
- the final serialized `parameters` payload does not contain `"deprecated"`

## Verification

```txt
npx vitest run tests/translator/bugs-antigravity.test.js
```

Result:

```txt
✓ tests/translator/bugs-antigravity.test.js (4 tests)
3 passed | 1 expected fail
```

Closes #2199
