### PR TITLE
fix(mitm): generate root ca on server startup

### DIFF
--- a/src/mitm/cert/generate.js
+++ b/src/mitm/cert/generate.js
@@ -7,8 +7,8 @@ const { generateRootCA, loadRootCA, generateLeafCert } = require("./rootCA");
  * Generate Root CA certificate (one-time setup)
  * This replaces the old static wildcard cert approach
  */
-async function generateCert() {
-  return await generateRootCA();
+function generateCert() {
+  return generateRootCA();
 }
 
 /**

--- a/src/mitm/cert/rootCA.js
+++ b/src/mitm/cert/rootCA.js
@@ -23,7 +23,7 @@ function isCertExpired(certPath) {
  * Generate Root CA certificate (only once, auto-regenerate if expired)
  * This Root CA will sign all dynamic leaf certificates
  */
-async function generateRootCA() {
+function generateRootCA() {
   const exists = fs.existsSync(ROOT_CA_KEY_PATH) && fs.existsSync(ROOT_CA_CERT_PATH);
   if (exists && !isCertExpired(ROOT_CA_CERT_PATH)) {
     console.log("✅ Root CA already exists");

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -9,7 +9,7 @@ const { execSync } = require("child_process");
 const { log, err, dumpRequest, createResponseDumper, clearDumpDir } = require("./logger");
 const { IS_DEV, LSOF_BIN, TARGET_HOSTS, URL_PATTERNS, MODEL_SYNONYMS, MODEL_PATTERNS, MODEL_NO_MAP, getToolForHost } = require("./config");
 const { DATA_DIR, MITM_DIR } = require("./paths");
-const { getCertForDomain } = require("./cert/generate");
+const { generateCert, getCertForDomain } = require("./cert/generate");
 const { getMitmAlias } = require("./dbReader");
 const { applyAntigravityIdeVersionOverride } = require("./antigravityIdeVersion");
 const LOCAL_PORT = 443;
@@ -57,6 +57,11 @@ function sniCallback(servername, cb) {
 
 let sslOptions;
 try {
+  if (!fs.existsSync(path.join(MITM_DIR, "rootCA.key")) || !fs.existsSync(path.join(MITM_DIR, "rootCA.crt"))) {
+    log("Root CA missing, generating...");
+    generateCert();
+  }
+
   const rootKey = fs.readFileSync(path.join(MITM_DIR, "rootCA.key"));
   const rootCert = fs.readFileSync(path.join(MITM_DIR, "rootCA.crt"));
   rootCAPem = rootCert.toString("utf8");

--- a/tests/unit/mitm-root-ca.test.js
+++ b/tests/unit/mitm-root-ca.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createRequire } from "module";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const require = createRequire(import.meta.url);
+
+function loadRootCAWithDataDir(dataDir) {
+  const rootCAPath = require.resolve("../../src/mitm/cert/rootCA.js");
+  const pathsPath = require.resolve("../../src/mitm/paths.js");
+  delete require.cache[rootCAPath];
+  delete require.cache[pathsPath];
+
+  const oldDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = dataDir;
+  try {
+    return require("../../src/mitm/cert/rootCA.js");
+  } finally {
+    if (oldDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = oldDataDir;
+  }
+}
+
+describe("MITM Root CA generation", () => {
+  it("creates Root CA files synchronously for direct server startup", () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-mitm-ca-"));
+    const { generateRootCA } = loadRootCAWithDataDir(dataDir);
+
+    generateRootCA();
+
+    expect(fs.existsSync(path.join(dataDir, "mitm", "rootCA.key"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "mitm", "rootCA.crt"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2224.

Direct MITM server startup could fail before the Root CA was ever created because `server.js` read `rootCA.key` / `rootCA.crt` immediately and exited when either file was missing. That bypasses the `manager.js` setup path that normally generates the CA.

## Changes

- Generate the MITM Root CA from `server.js` when `rootCA.key` or `rootCA.crt` is missing.
- Make `generateRootCA()` / `generateCert()` synchronous, matching their filesystem work and avoiding a startup race before `readFileSync`.
- Add a targeted unit test proving Root CA files are created synchronously for direct server startup.

## Verification

```sh
./node_modules/.bin/vitest run tests/unit/mitm-root-ca.test.js
node --check src/mitm/server.js && node --check src/mitm/cert/rootCA.js && node --check src/mitm/cert/generate.js
git diff --check
```

Also ran:

```sh
./node_modules/.bin/vitest run tests/unit/mitm-root-ca.test.js tests/unit/antigravity-mitm.test.js
```

The new MITM Root CA test passed. `tests/unit/antigravity-mitm.test.js` has an unrelated existing failure on the out-of-box Antigravity mandatory model assertion (`expected undefined to be true`).
