### PR TITLE
fix(codebuddy-cn): strip empty tool_calls arrays to preserve reasoning

### DIFF
--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -130,6 +130,20 @@ export function createSSEStream(options = {}) {
                 }
               }
 
+              // Strip empty tool_calls arrays that break AI SDK reasoning tracking.
+              // Some providers (e.g. CodeBuddy CN) include `"tool_calls": []` in
+              // every streaming delta. @ai-sdk/openai-compatible checks
+              // `delta.tool_calls != null` — an empty array passes this check,
+              // causing premature `reasoning-end` on every chunk.
+              if (parsed?.choices) {
+                for (const choice of parsed.choices) {
+                  if (choice.delta?.tool_calls && Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length === 0) {
+                    delete choice.delta.tool_calls;
+                    fieldsInjected = true;
+                  }
+                }
+              }
+
               if (!hasValuableContent(parsed, FORMATS.OPENAI)) {
                 continue;
               }


### PR DESCRIPTION
CodeBuddy CN API includes `"tool_calls": []` (empty array) in every SSE streaming delta. @ai-sdk/openai-compatible checks `delta.tool_calls != null` — an empty array passes this check ([] != null is true in JS), triggering premature `reasoning-end` on every chunk that contains reasoning_content.

This causes tools like OpenCode to show zero or 1ms reasoning durations instead of the actual thinking time.

Fix: in passthrough mode, delete empty tool_calls arrays from delta before hasValuableContent filtering. This is a zero-side-effect change — real tool_calls always have at least one element.