### PR TITLE
feat(minimax): extract <think> to reasoning_content for M3

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -8,6 +8,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { stripThinkFromResponse } from "../../utils/thinkStripper.js";
 
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
@@ -185,6 +186,9 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
     ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat)
     : responseBody;
+
+  // Strip embedded <think>...</think> tags from providers that inline thinking (MiniMax M3)
+  stripThinkFromResponse(translatedResponse);
 
   // Fix finish_reason for tool_calls: some providers return non-standard values (e.g. "other")
   if (translatedResponse?.choices?.[0]) {

--- a/open-sse/providers/registry/minimax-cn.js
+++ b/open-sse/providers/registry/minimax-cn.js
@@ -54,7 +54,7 @@ export default {
     },
   ],
   models: [
-    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "claude" },
+    { id: "MiniMax-M3", name: "MiniMax M3" },
     { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
     { id: "MiniMax-M2.1", name: "MiniMax M2.1" },

--- a/open-sse/providers/registry/minimax.js
+++ b/open-sse/providers/registry/minimax.js
@@ -54,7 +54,7 @@ export default {
     },
   ],
   models: [
-    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "claude" },
+    { id: "MiniMax-M3", name: "MiniMax M3" },
     { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
     { id: "MiniMax-M2.1", name: "MiniMax M2.1" },

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -73,6 +73,10 @@ export function createSSEStream(options = {}) {
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
 
+  // State for extracting <think>...</think> to reasoning_content across SSE chunks
+  let thinkBuf = "";
+  let inThink = false;
+
   return new TransformStream({
     transform(chunk, controller) {
       if (!ttftAt) ttftAt = Date.now();
@@ -135,6 +139,35 @@ export function createSSEStream(options = {}) {
               }
 
               const delta = parsed.choices?.[0]?.delta;
+              // Extract <think>...</think> from content to reasoning_content (MiniMax M3)
+              if (typeof delta?.content === "string") {
+                let t = delta.content;
+                let gotThink = false;
+                if (inThink) {
+                  let ei = t.indexOf("</think>");
+                  if (ei >= 0) {
+                    thinkBuf += t.slice(0, ei);
+                    delta.reasoning_content = thinkBuf.trim();
+                    thinkBuf = ""; inThink = false;
+                    t = t.slice(ei + 8).trimStart();
+                    gotThink = true;
+                  } else { thinkBuf += t; t = ""; gotThink = true; }
+                }
+                if (!inThink) {
+                  let si = t.indexOf("<think>");
+                  if (si >= 0) {
+                    let aft = t.slice(si + 7), ei = aft.indexOf("</think>");
+                    if (ei >= 0) {
+                      delta.reasoning_content = aft.slice(0, ei).trim();
+                      t = t.slice(0, si) + aft.slice(ei + 8).trimStart();
+                    } else { inThink = true; thinkBuf = aft; t = t.slice(0, si); }
+                    gotThink = true;
+                  }
+                }
+                if (gotThink) { fieldsInjected = true; }
+                if (delta.reasoning_content && (!t || !t.trim())) delete delta.content;
+                else delta.content = t || "";
+              }
               const content = delta?.content;
               const reasoning = delta?.reasoning_content;
               if (content && typeof content === "string") {

--- a/open-sse/utils/thinkStripper.js
+++ b/open-sse/utils/thinkStripper.js
@@ -1,0 +1,72 @@
+/**
+ * Strip MiniMax M3 <think>...</think> tags from OpenAI-format responses.
+ * MiniMax embeds thinking as XML tags inside the content field in its
+ * native OpenAI endpoint — we strip them here so clients see clean output.
+ */
+
+// Non-streaming: simple regex (everything in one JSON blob)
+export function stripThinkFromResponse(responseBody) {
+  if (!responseBody?.choices) return responseBody;
+  for (const choice of responseBody.choices) {
+    const msg = choice?.message || choice?.delta;
+    if (msg?.content && typeof msg.content === "string") {
+      msg.content = stripThinkTags(msg.content);
+    }
+  }
+  return responseBody;
+}
+
+// Apply to a raw SSE data string (used in passthrough streaming)
+export function stripThinkFromSSEChunk(dataStr) {
+  try {
+    const parsed = JSON.parse(dataStr);
+    const delta = parsed?.choices?.[0]?.delta;
+    if (delta?.content && typeof delta.content === "string") {
+      delta.content = stripThinkTags(delta.content);
+    }
+    return JSON.stringify(parsed);
+  } catch {
+    return dataStr;
+  }
+}
+
+// Core: strip <think>...</think> (with optional newlines) from text.
+// Handles multi-line thinking blocks via the `s` flag (dot matches newlines).
+// Also strips leading whitespace that follows a </think> tag.
+export function stripThinkTags(text) {
+  if (typeof text !== "string") return text;
+  return text
+    .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
+    .trimStart();
+}
+
+// Stream-safe version: strips <think> tags across chunks using a state object.
+// Returns the stripped content string. Mutates state.
+export function stripThinkFromDelta(deltaContent, state) {
+  if (typeof deltaContent !== "string" || !deltaContent) return deltaContent;
+
+  let s = deltaContent;
+  if (state.inside) {
+    const ei = s.indexOf("</think>");
+    if (ei >= 0) {
+      state.inside = false;
+      s = s.slice(ei + 8).trimStart();
+    } else {
+      return "";
+    }
+  }
+  if (!state.inside) {
+    const si = s.indexOf("<think>");
+    if (si >= 0) {
+      const after = s.slice(si + 7);
+      const ei = after.indexOf("</think>");
+      if (ei >= 0) {
+        s = s.slice(0, si) + after.slice(ei + 8).trimStart();
+      } else {
+        state.inside = true;
+        s = s.slice(0, si);
+      }
+    }
+  }
+  return s || "";
+}


### PR DESCRIPTION
MiniMax M3's OpenAI endpoint embeds thinking content as <think>...</think> XML tags inside the `content` field instead of providing a separate `reasoning_content`. This prevents tools like OpenCode from displaying the reasoning process.

Changes:
- stream.js: extract <think> tags from content into reasoning_content during passthrough streaming, with cross-chunk state tracking
- thinkStripper.js: utility for stripping <think> from non-streaming responses
- nonStreamingHandler.js: integrate thinkStripper for non-streaming
- minimax-cn.js / minimax.js: remove targetFormat:"claude" from MiniMax-M3 to use native OpenAI transport (zero-translation) The Claude endpoint has issues: streaming returns empty [DONE], tool calls return invalid tool type (2013)

This makes MiniMax M3 reasoning visible in OpenCode and other tools using @ai-sdk/openai-compatible.

#2047

