### PR TITLE
fix(translator): salvage orphaned tool results across request formats

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -22,6 +22,7 @@ import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.j
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { injectPonytail } from "../rtk/ponytail.js";
+import { salvageOrphanedToolResults, fixMissingToolResponses } from "../translator/concerns/toolCall.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
 import { compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog, isHeadroomPhantomSavings } from "../rtk/headroom.js";
 import { compressWithPxpipe } from "../rtk/pxpipe.js";
@@ -257,6 +258,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Token-saver flags accumulator for the single "⚙" log line below.
   const xf = [];
+
+  // Compression may remove a tool call while retaining its result. Restore the invariant before dispatch.
+  salvageOrphanedToolResults(translatedBody);
+  fixMissingToolResponses(translatedBody);
 
   // Caveman: inject terse-style system prompt
   if (tokenSaverEnabled && cavemanEnabled && cavemanLevel) {

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -21,6 +21,7 @@ import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.j
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { injectPonytail } from "../rtk/ponytail.js";
+import { salvageOrphanedToolResults, fixMissingToolResponses } from "../translator/concerns/toolCall.js";
 import { compressMessages } from "../rtk/index.js";
 import { compressWithHeadroom, formatHeadroomSizeLog, isHeadroomPhantomSavings } from "../rtk/headroom.js";
 import { compressWithPxpipe } from "../rtk/pxpipe.js";
@@ -213,6 +214,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   } else if (headroomEnabled) {
     log?.warn?.("HEADROOM", `skipped: ${headroomDiagnostics.reason || "compression unavailable"}${headroomDiagnostics.endpoint ? ` (${headroomDiagnostics.endpoint})` : ""}`);
   }
+
+  // Compression may remove a tool call while retaining its result. Restore the invariant before dispatch.
+  salvageOrphanedToolResults(translatedBody);
+  fixMissingToolResponses(translatedBody);
 
   // Caveman: inject terse-style system prompt
   if (cavemanEnabled && cavemanLevel) {

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -118,10 +118,232 @@ export function hasToolResults(msg, toolCallIds) {
 }
 
 // Fix missing tool responses - insert empty tool_result if assistant has tool_use but next message has no tool_result
+// Extract text content from a tool_result block (Claude-shaped) or tool message (OpenAI-shaped).
+// Returns "" when there is no text (e.g. image-only tool_result — tracked separately in #2122).
+function extractToolResultText(content) {
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(block => block?.type === "text" && typeof block.text === "string")
+    .map(block => block.text)
+    .join("\n")
+    .trim();
+}
+
+// Salvage orphaned tool results — results that reference a tool call no longer
+// present in the same request. Mirrors fixMissingToolResponses on the result side:
+// that helper ensures every call has a result; this one ensures every result has a call.
+//
+// Instead of deleting orphaned results (which preempts format-specific salvage paths
+// like Kiro's reconcileOrphanedToolResults and loses tool output context), this folds
+// the orphan's text content into a user-text block: `[Tool result: <text>]`.
+// Image-only results (no text) are still dropped — no text representation exists (#2122).
+//
+// Handles two wire envelopes (three schemas):
+//   - OpenAI/Claude messages[]: orphaned role:"tool" / tool_result blocks → user text
+//   - Gemini/Antigravity contents[]: orphaned functionResponse parts → user text part
+//
+// Responses API function_call_output is handled separately in openai-responses.js
+// (stripOrphanedToolOutputs) because Responses items have no text representation
+// to salvage — they are structural call/output pairs, not content blocks.
+//
+// After salvaging messages[], consecutive same-role user messages are merged so
+// downstream translators that don't merge (notably openai-to-gemini, which pushes
+// each role:"user" as a separate contents[] entry) don't emit adjacent user turns
+// that trigger Gemini 400 INVALID_ARGUMENT.
+//
+// Fail-open: any error returns the body unchanged.
+export function salvageOrphanedToolResults(body) {
+  if (!body || typeof body !== "object") return body;
+
+  try {
+    let changed = false;
+
+    // ── OpenAI/Claude messages[] ───────────────────────────────────────────
+    if (Array.isArray(body.messages)) {
+      const knownCallIds = new Set();
+      for (const msg of body.messages) {
+        // Only assistant turns carry tool calls — collecting from other roles
+        // causes false positives (a user message with tool_use would mask orphans).
+        if (msg.role !== "assistant") continue;
+
+        if (Array.isArray(msg.tool_calls)) {
+          for (const tc of msg.tool_calls) {
+            if (typeof tc?.id === "string") knownCallIds.add(tc.id);
+          }
+        }
+
+        if (Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (block?.type === "tool_use" && typeof block.id === "string") {
+              knownCallIds.add(block.id);
+            }
+          }
+        }
+      }
+
+      const salvagedMessages = [];
+      // Track IDs already matched to a tool result — duplicates are salvaged too,
+      // since strict providers reject a second result for the same call_id.
+      const consumedIds = new Set();
+
+      for (const msg of body.messages) {
+        // OpenAI shape: orphaned role:"tool" message → salvage to user text
+        if (msg.role === "tool" && msg.tool_call_id) {
+          if (knownCallIds.has(msg.tool_call_id) && !consumedIds.has(msg.tool_call_id)) {
+            consumedIds.add(msg.tool_call_id);
+            salvagedMessages.push(msg);
+          } else {
+            const text = extractToolResultText(msg.content);
+            if (text) {
+              salvagedMessages.push({ role: "user", content: `[Tool result: ${text}]` });
+            }
+            changed = true;
+          }
+          continue;
+        }
+
+        // Claude shape: orphaned tool_result block in user content → salvage to text block
+        if (Array.isArray(msg.content)) {
+          let orphanCount = 0;
+          const rebuiltContent = [];
+
+          for (const block of msg.content) {
+            if (block?.type !== "tool_result") {
+              rebuiltContent.push(block);
+              continue;
+            }
+            if (typeof block.tool_use_id === "string" && knownCallIds.has(block.tool_use_id) && !consumedIds.has(block.tool_use_id)) {
+              consumedIds.add(block.tool_use_id);
+              rebuiltContent.push(block);
+              continue;
+            }
+            // Orphaned or duplicate tool_result — salvage text content
+            orphanCount++;
+            const text = extractToolResultText(block.content);
+            if (text) {
+              rebuiltContent.push({ type: "text", text: `[Tool result: ${text}]` });
+            }
+          }
+
+          if (orphanCount > 0) {
+            changed = true;
+            if (rebuiltContent.length === 0) continue; // all blocks were image-only orphans
+            msg.content = rebuiltContent;
+          }
+        }
+
+        salvagedMessages.push(msg);
+      }
+
+      if (changed) {
+        body.messages = mergeConsecutiveUserMessages(salvagedMessages);
+      }
+    }
+
+    // ── Gemini/Antigravity contents[] ──────────────────────────────────────
+    if (Array.isArray(body.contents)) {
+      const knownFnIds = new Set();
+      for (const turn of body.contents) {
+        // Only model turns carry functionCall — collecting from other roles
+        // causes false positives (a malformed user turn with functionCall would mask orphans).
+        if (turn.role !== "model") continue;
+        if (!Array.isArray(turn.parts)) continue;
+        for (const part of turn.parts) {
+          if (part?.functionCall) {
+            // Prefer explicit id; fall back to name (older Gemini shapes pair by name).
+            const key = part.functionCall.id ?? part.functionCall.name;
+            if (key) knownFnIds.add(key);
+          }
+        }
+      }
+
+      // Only scan for orphans if there are functionResponse parts to check.
+      if (body.contents.some(t => Array.isArray(t.parts) && t.parts.some(p => p.functionResponse))) {
+        const consumedFnIds = new Set();
+        const salvagedContents = [];
+
+        for (const turn of body.contents) {
+          if (!Array.isArray(turn.parts) || !turn.parts.some(p => p.functionResponse)) {
+            salvagedContents.push(turn);
+            continue;
+          }
+          let orphanCount = 0;
+          const rebuiltParts = [];
+
+          for (const part of turn.parts) {
+            if (!part.functionResponse) {
+              rebuiltParts.push(part);
+              continue;
+            }
+            const key = part.functionResponse.id ?? part.functionResponse.name;
+            if (key && knownFnIds.has(key) && !consumedFnIds.has(key)) {
+              consumedFnIds.add(key);
+              rebuiltParts.push(part);
+              continue;
+            }
+            // Orphaned or duplicate functionResponse — salvage response content to text part
+            orphanCount++;
+            const resp = part.functionResponse.response;
+            const raw = resp?.result ?? resp;
+            const text = typeof raw === "string" ? raw.trim() : (raw ? JSON.stringify(raw).trim() : "");
+            if (text) {
+              rebuiltParts.push({ text: `[Tool result: ${text}]` });
+            }
+          }
+
+          if (orphanCount > 0) {
+            changed = true;
+            // Drop the turn entirely if all parts were image-only orphans (no text salvaged).
+            // Gemini rejects turns with empty parts[] (400 INVALID_ARGUMENT).
+            if (rebuiltParts.length === 0) continue;
+            turn.parts = rebuiltParts;
+          }
+
+          salvagedContents.push(turn);
+        }
+
+        if (changed) {
+          body.contents = salvagedContents;
+        }
+      }
+    }
+
+    return body;
+  } catch {
+    return body;
+  }
+}
+
+// Merge consecutive same-role user messages so downstream translators that don't
+// merge (notably openai-to-gemini) don't emit adjacent user turns after salvage.
+// Only merges string-content user messages; array-content messages are left as-is
+// (they may carry structured blocks like tool_result that shouldn't be concatenated).
+//
+// Clone-on-merge: when concatenating, replace the last entry with a new object
+// instead of mutating it in place. This preserves the original message reference
+// in the caller's view (continuity canonicalization, logging, etc. may hold refs).
+// Non-merged messages are pushed by reference (no unnecessary clones).
+function mergeConsecutiveUserMessages(messages) {
+  const merged = [];
+  for (const msg of messages) {
+    const last = merged[merged.length - 1];
+    if (last && last.role === "user" && msg.role === "user"
+        && typeof last.content === "string" && typeof msg.content === "string") {
+      merged[merged.length - 1] = { ...last, content: `${last.content}\n${msg.content}` };
+    } else {
+      merged.push(msg);
+    }
+  }
+  return merged;
+}
+
+
 export function fixMissingToolResponses(body) {
   if (!body.messages || !Array.isArray(body.messages)) return body;
 
   const newMessages = [];
+  let changed = false;
 
   for (let i = 0; i < body.messages.length; i++) {
     const msg = body.messages[i];
@@ -136,6 +358,7 @@ export function fixMissingToolResponses(body) {
     // Check if next message has tool_result
     if (nextMsg && !hasToolResults(nextMsg, toolCallIds)) {
       // Insert tool responses for each tool_call
+      changed = true;
       for (const id of toolCallIds) {
         // OpenAI format: role = "tool"
         newMessages.push({
@@ -147,6 +370,7 @@ export function fixMissingToolResponses(body) {
     }
   }
 
+  if (!changed) return body;
   body.messages = newMessages;
   return body;
 }

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -1,5 +1,5 @@
 import { FORMATS } from "./formats.js";
-import { ensureToolCallIds, fixMissingToolResponses } from "./concerns/toolCall.js";
+import { ensureToolCallIds, fixMissingToolResponses, salvageOrphanedToolResults } from "./concerns/toolCall.js";
 import { prepareClaudeRequest } from "./formats/claude.js";
 import { cloakClaudeTools } from "../utils/claudeCloaking.js";
 import { filterToOpenAIFormat } from "./formats/openai.js";
@@ -69,6 +69,11 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
   if (targetFormat !== FORMATS.KIRO) {
     fixMissingToolResponses(result);
   }
+
+  // Salvage orphaned tool results (tool_result with no matching tool_call).
+  // Folds orphan content into user text instead of deleting — non-lossy across
+  // all formats, preserves Kiro's reconcileOrphanedToolResults salvage semantics.
+  salvageOrphanedToolResults(result);
 
   // Capture thinking intent from the original (pre-translation) body, before any
   // format conversion strips/renames the fields. Applied after translation.

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -1,5 +1,5 @@
 import { FORMATS } from "./formats.js";
-import { ensureToolCallIds, fixMissingToolResponses } from "./concerns/toolCall.js";
+import { ensureToolCallIds, fixMissingToolResponses, salvageOrphanedToolResults } from "./concerns/toolCall.js";
 import { prepareClaudeRequest } from "./formats/claude.js";
 import { cloakClaudeTools } from "../utils/claudeCloaking.js";
 import { filterToOpenAIFormat } from "./formats/openai.js";
@@ -64,6 +64,11 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
   
   // Fix missing tool responses (insert empty tool_result if needed)
   fixMissingToolResponses(result);
+
+  // Salvage orphaned tool results (tool_result with no matching tool_call).
+  // Folds orphan content into user text instead of deleting — non-lossy across
+  // all formats, preserves Kiro's reconcileOrphanedToolResults salvage semantics.
+  salvageOrphanedToolResults(result);
 
   // Capture thinking intent from the original (pre-translation) body, before any
   // format conversion strips/renames the fields. Applied after translation.

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -14,6 +14,58 @@ const MAX_CALL_ID_LEN = 64;
 const clampCallId = (id) => (typeof id === "string" && id.length > MAX_CALL_ID_LEN ? id.substring(0, MAX_CALL_ID_LEN) : id);
 
 /**
+ * Scan a Responses API `input[]` and collect every `call_id` declared by a
+ * `function_call` item. Returns a Set (possibly empty) of known call ids.
+ *
+ * Only `function_call` items introduce a tool call a downstream provider can
+ * match a result against; other item types are ignored.
+ */
+function collectKnownCallIds(input) {
+  const knownCallIds = new Set();
+  for (const item of input) {
+    if (item?.type === RESPONSES_ITEM.FUNCTION_CALL && typeof item.call_id === "string") {
+      knownCallIds.add(item.call_id);
+    }
+  }
+  return knownCallIds;
+}
+
+/**
+ * Remove `function_call_output` items that reference a `call_id` with no
+ * matching `function_call` in the same `input[]`.
+ *
+ * Clients that truncate or summarize conversation history (e.g. Codex CLI,
+ * some agents) can drop the assistant turn containing the tool call while
+ * keeping the subsequent tool result. The Responses API then rejects the
+ * whole request with HTTP 400:
+ *
+ *   "No tool call found for function call output with call_id X"
+ *
+ * This is input validation only: it rewrites request payloads before they
+ * leave the translator, regardless of provider or entry path.
+ *
+ * Returns the original array reference when nothing needs to change (non-array
+ * input, no tool output items, or every output already has a matching call),
+ * so callers can cheaply avoid cloning large inputs.
+ */
+function stripOrphanedToolOutputs(input) {
+  if (!Array.isArray(input)) return input;
+  const knownCallIds = collectKnownCallIds(input);
+
+  const stripped = [];
+  const deduped = input.filter(item => {
+    if (item?.type !== RESPONSES_ITEM.FUNCTION_CALL_OUTPUT) return true;
+    const hasMatch = typeof item.call_id === "string" && knownCallIds.has(item.call_id);
+    if (!hasMatch) {
+      console.warn(`[Translator] Stripped orphaned function_call_output (call_id=${item.call_id}) — no matching function_call in input`);
+      stripped.push(item.call_id);
+    }
+    return hasMatch;
+  });
+  return stripped.length === 0 ? input : deduped;
+}
+
+/**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format
  */
 export function openaiResponsesToOpenAIRequest(model, body, stream, credentials) {
@@ -35,7 +87,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   const additionalTools = [];
   const customToolNames = new Set();
 
-  const inputItems = normalizeResponsesInput(body.input);
+  const inputItems = stripOrphanedToolOutputs(normalizeResponsesInput(body.input));
   if (!inputItems) return body;
 
   // Extract reasoning text from summary[].text (encrypted_content is continuity-only)
@@ -299,8 +351,19 @@ function buildReasoningInputItem(msg) {
  * Convert OpenAI Chat Completions to OpenAI Responses API format
  */
 export function openaiToOpenAIResponsesRequest(model, body, stream, credentials) {
-  // Body already in Responses API format (e.g. Cursor CLI calling /chat/completions with input[])
-  if (body.input) return { ...body, model, stream: true };
+  if (body.input) {
+    const cleanInput = stripOrphanedToolOutputs(body.input);
+    const passthrough = cleanInput === body.input ? { ...body, model, stream: true } : { ...body, input: cleanInput, model, stream: true };
+    // Responses API rejects Chat's max_tokens/max_completion_tokens — only max_output_tokens is valid.
+    if (passthrough.max_tokens !== undefined || passthrough.max_completion_tokens !== undefined) {
+      if (passthrough.max_output_tokens === undefined) {
+        passthrough.max_output_tokens = passthrough.max_tokens ?? passthrough.max_completion_tokens;
+      }
+      delete passthrough.max_tokens;
+      delete passthrough.max_completion_tokens;
+    }
+    return passthrough;
+  }
 
   const result = {
     model,
@@ -416,12 +479,16 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
 
   // Pass through other relevant fields
   if (body.temperature !== undefined) result.temperature = body.temperature;
-  if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
+  // Responses API rejects Chat's max_tokens/max_completion_tokens — only max_output_tokens is valid.
+  if (body.max_tokens !== undefined) result.max_output_tokens = body.max_tokens;
+  else if (body.max_completion_tokens !== undefined) result.max_output_tokens = body.max_completion_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
   if (body.reasoning !== undefined) result.reasoning = body.reasoning;
   if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
   if (body.service_tier !== undefined) result.service_tier = body.service_tier;
   if (body.prompt_cache_key !== undefined) result.prompt_cache_key = body.prompt_cache_key;
+
+  result.input = stripOrphanedToolOutputs(result.input);
 
   return result;
 }

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -14,6 +14,58 @@ const MAX_CALL_ID_LEN = 64;
 const clampCallId = (id) => (typeof id === "string" && id.length > MAX_CALL_ID_LEN ? id.substring(0, MAX_CALL_ID_LEN) : id);
 
 /**
+ * Scan a Responses API `input[]` and collect every `call_id` declared by a
+ * `function_call` item. Returns a Set (possibly empty) of known call ids.
+ *
+ * Only `function_call` items introduce a tool call a downstream provider can
+ * match a result against; other item types are ignored.
+ */
+function collectKnownCallIds(input) {
+  const knownCallIds = new Set();
+  for (const item of input) {
+    if (item?.type === RESPONSES_ITEM.FUNCTION_CALL && typeof item.call_id === "string") {
+      knownCallIds.add(item.call_id);
+    }
+  }
+  return knownCallIds;
+}
+
+/**
+ * Remove `function_call_output` items that reference a `call_id` with no
+ * matching `function_call` in the same `input[]`.
+ *
+ * Clients that truncate or summarize conversation history (e.g. Codex CLI,
+ * some agents) can drop the assistant turn containing the tool call while
+ * keeping the subsequent tool result. The Responses API then rejects the
+ * whole request with HTTP 400:
+ *
+ *   "No tool call found for function call output with call_id X"
+ *
+ * This is input validation only: it rewrites request payloads before they
+ * leave the translator, regardless of provider or entry path.
+ *
+ * Returns the original array reference when nothing needs to change (non-array
+ * input, no tool output items, or every output already has a matching call),
+ * so callers can cheaply avoid cloning large inputs.
+ */
+function stripOrphanedToolOutputs(input) {
+  if (!Array.isArray(input)) return input;
+  const knownCallIds = collectKnownCallIds(input);
+
+  const stripped = [];
+  const deduped = input.filter(item => {
+    if (item?.type !== RESPONSES_ITEM.FUNCTION_CALL_OUTPUT) return true;
+    const hasMatch = typeof item.call_id === "string" && knownCallIds.has(item.call_id);
+    if (!hasMatch) {
+      console.warn(`[Translator] Stripped orphaned function_call_output (call_id=${item.call_id}) — no matching function_call in input`);
+      stripped.push(item.call_id);
+    }
+    return hasMatch;
+  });
+  return stripped.length === 0 ? input : deduped;
+}
+
+/**
  * Convert OpenAI Responses API request to OpenAI Chat Completions format
  */
 export function openaiResponsesToOpenAIRequest(model, body, stream, credentials) {
@@ -33,7 +85,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   let pendingReasoning = "";
   let pendingReasoningEncrypted = "";
 
-  const inputItems = normalizeResponsesInput(body.input);
+  const inputItems = stripOrphanedToolOutputs(normalizeResponsesInput(body.input));
   if (!inputItems) return body;
 
   // Extract reasoning text from summary[].text (encrypted_content is continuity-only)
@@ -255,8 +307,19 @@ function buildReasoningInputItem(msg) {
  * Convert OpenAI Chat Completions to OpenAI Responses API format
  */
 export function openaiToOpenAIResponsesRequest(model, body, stream, credentials) {
-  // Body already in Responses API format (e.g. Cursor CLI calling /chat/completions with input[])
-  if (body.input) return { ...body, model, stream: true };
+  if (body.input) {
+    const cleanInput = stripOrphanedToolOutputs(body.input);
+    const passthrough = cleanInput === body.input ? { ...body, model, stream: true } : { ...body, input: cleanInput, model, stream: true };
+    // Responses API rejects Chat's max_tokens/max_completion_tokens — only max_output_tokens is valid.
+    if (passthrough.max_tokens !== undefined || passthrough.max_completion_tokens !== undefined) {
+      if (passthrough.max_output_tokens === undefined) {
+        passthrough.max_output_tokens = passthrough.max_tokens ?? passthrough.max_completion_tokens;
+      }
+      delete passthrough.max_tokens;
+      delete passthrough.max_completion_tokens;
+    }
+    return passthrough;
+  }
 
   const result = {
     model,
@@ -372,10 +435,14 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
 
   // Pass through other relevant fields
   if (body.temperature !== undefined) result.temperature = body.temperature;
-  if (body.max_tokens !== undefined) result.max_tokens = body.max_tokens;
+  // Responses API rejects Chat's max_tokens/max_completion_tokens — only max_output_tokens is valid.
+  if (body.max_tokens !== undefined) result.max_output_tokens = body.max_tokens;
+  else if (body.max_completion_tokens !== undefined) result.max_output_tokens = body.max_completion_tokens;
   if (body.top_p !== undefined) result.top_p = body.top_p;
   if (body.reasoning !== undefined) result.reasoning = body.reasoning;
   if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
+
+  result.input = stripOrphanedToolOutputs(result.input);
 
   return result;
 }

--- a/open-sse/utils/openaiResponsesToolPairingSelfCheck.mjs
+++ b/open-sse/utils/openaiResponsesToolPairingSelfCheck.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { openaiResponsesToOpenAIRequest, openaiToOpenAIResponsesRequest } from "../translator/request/openai-responses.js";
+
+function quietWarns(fn) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function responsesItems() {
+  return [
+    { type: "function_call", call_id: "call_ok", name: "read_file", arguments: "{}" },
+    { type: "function_call_output", call_id: "call_ok", output: "contents" },
+    { type: "function_call_output", call_id: "call_orphan", output: "old result" },
+    { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] }
+  ];
+}
+
+function run(name, fn) {
+  fn();
+  console.log(`ok   - ${name}`);
+}
+
+run("Responses→OpenAI strips orphaned function_call_output", () => {
+  const { value, warnings } = quietWarns(() => openaiResponsesToOpenAIRequest("gpt-x", { input: responsesItems() }, true, {}));
+  assert.equal(warnings.length, 1);
+  assert.equal(value.messages.some(msg => msg.role === "tool" && msg.tool_call_id === "call_orphan"), false);
+  assert.equal(value.messages.some(msg => msg.role === "tool" && msg.tool_call_id === "call_ok"), true);
+});
+
+run("Responses passthrough keeps same array when no function calls exist", () => {
+  const input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }];
+  const result = openaiToOpenAIResponsesRequest("gpt-x", { input }, true, {});
+  assert.equal(result.input, input);
+});
+
+run("Responses passthrough strips orphan and returns a new input array", () => {
+  const input = responsesItems();
+  const { value, warnings } = quietWarns(() => openaiToOpenAIResponsesRequest("gpt-x", { input }, true, {}));
+  assert.equal(warnings.length, 1);
+  assert.notEqual(value.input, input);
+  assert.deepEqual(value.input.map(item => item.call_id).filter(Boolean), ["call_ok", "call_ok"]);
+});
+
+run("OpenAI→Responses built input strips tool messages without matching tool_calls", () => {
+  const body = {
+    messages: [
+      { role: "user", content: "hi" },
+      { role: "tool", tool_call_id: "missing", content: "stale result" }
+    ]
+  };
+  const { value, warnings } = quietWarns(() => openaiToOpenAIResponsesRequest("gpt-x", body, true, {}));
+  assert.equal(warnings.length, 1, "orphan tool result with no function_call is now stripped");
+  assert.equal(value.input.some(item => item.type === "function_call_output"), false);
+});
+
+run("OpenAI→Responses built input keeps matched tool result", () => {
+  const body = {
+    messages: [
+      { role: "assistant", content: null, tool_calls: [{ id: "call_ok", function: { name: "read_file", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "call_ok", content: "contents" }
+    ]
+  };
+  const result = openaiToOpenAIResponsesRequest("gpt-x", body, true, {});
+  assert.deepEqual(result.input.map(item => item.type), ["function_call", "function_call_output"]);
+});
+
+run("OpenAI→Responses built request maps max_tokens to max_output_tokens (Responses API rejects max_tokens)", () => {
+  const body = { messages: [{ role: "user", content: "hi" }], max_tokens: 512 };
+  const result = openaiToOpenAIResponsesRequest("gpt-x", body, true, {});
+  assert.equal(result.max_output_tokens, 512);
+  assert.equal("max_tokens" in result, false);
+});
+
+run("OpenAI→Responses built request maps max_completion_tokens to max_output_tokens", () => {
+  const body = { messages: [{ role: "user", content: "hi" }], max_completion_tokens: 256 };
+  const result = openaiToOpenAIResponsesRequest("gpt-x", body, true, {});
+  assert.equal(result.max_output_tokens, 256);
+  assert.equal("max_completion_tokens" in result, false);
+});
+
+run("OpenAI→Responses passthrough (already input[]) also maps max_tokens to max_output_tokens", () => {
+  const input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }];
+  const result = openaiToOpenAIResponsesRequest("gpt-x", { input, max_tokens: 128 }, true, {});
+  assert.equal(result.max_output_tokens, 128);
+  assert.equal("max_tokens" in result, false);
+});
+
+run("OpenAI→Responses passthrough does not clobber an explicit max_output_tokens already present", () => {
+  const input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }];
+  const result = openaiToOpenAIResponsesRequest("gpt-x", { input, max_tokens: 128, max_output_tokens: 999 }, true, {});
+  assert.equal(result.max_output_tokens, 999);
+  assert.equal("max_tokens" in result, false);
+});
+
+console.log("\n9/9 checks passed");

--- a/open-sse/utils/toolPairingSelfCheck.mjs
+++ b/open-sse/utils/toolPairingSelfCheck.mjs
@@ -1,0 +1,364 @@
+// Tool-pairing invariant self-check (OpenAI intermediate format).
+// Run: node open-sse/utils/toolPairingSelfCheck.mjs
+// No framework, no deps. Uses assert. Mirrors openaiResponsesToolPairingSelfCheck.mjs style.
+import { salvageOrphanedToolResults } from "../translator/concerns/toolCall.js";
+
+const results = [];
+function run(name, fn) {
+  try {
+    fn();
+    results.push({ name, ok: true });
+  } catch (err) {
+    results.push({ name, ok: false, err: err.message });
+  }
+}
+const assert = {
+  equal(a, b, msg) { if (a !== b) throw new Error(`${msg || ""} expected ${b}, got ${a}`); },
+  ok(v, msg) { if (!v) throw new Error(msg || "expected truthy"); },
+};
+
+// 1. Matched OpenAI tool_calls + role:tool preserved
+run("OpenAI matched tool result preserved", () => {
+  const body = {
+    messages: [
+      { role: "assistant", content: null, tool_calls: [{ id: "call_1", type: "function", function: { name: "foo", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "call_1", content: "result" },
+      { role: "user", content: "next" }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 3, "message count");
+  assert.equal(out.messages[1].tool_call_id, "call_1", "tool result preserved");
+});
+
+// 2. Orphan OpenAI role:tool salvaged to user text (merged with adjacent user)
+run("OpenAI orphan tool result salvaged to user text", () => {
+  const body = {
+    messages: [
+      { role: "user", content: "hi" },
+      { role: "tool", tool_call_id: "call_ghost", content: "stale" },
+      { role: "user", content: "next" }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 1, "salvaged user merged with adjacent user messages");
+  assert.ok(!out.messages.some(m => m.role === "tool"), "no tool messages remain");
+  assert.ok(out.messages[0].content.includes("[Tool result: stale]"), "salvaged text present");
+  assert.ok(out.messages[0].content.includes("hi"), "original user text preserved");
+  assert.ok(out.messages[0].content.includes("next"), "next user text preserved");
+});
+
+// 3. Zero-call truncation salvages all stale tool results to user text (merged)
+run("Zero-call truncation salvages all stale tool results", () => {
+  const body = {
+    messages: [
+      { role: "tool", tool_call_id: "call_a", content: "x" },
+      { role: "tool", tool_call_id: "call_b", content: "y" },
+      { role: "user", content: "next" }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 1, "all salvaged user msgs merged with existing user");
+  assert.ok(!out.messages.some(m => m.role === "tool"), "no tool messages remain");
+  assert.ok(out.messages[0].content.includes("[Tool result: x]"), "first orphan salvaged");
+  assert.ok(out.messages[0].content.includes("[Tool result: y]"), "second orphan salvaged");
+  assert.ok(out.messages[0].content.includes("next"), "original user text preserved");
+});
+
+// 4. Claude-shaped tool_use + tool_result preserved
+run("Claude-shaped matched tool_result preserved", () => {
+  const body = {
+    messages: [
+      { role: "assistant", content: [{ type: "tool_use", id: "tu_1", name: "bar", input: {} }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tu_1", content: "ok" }] },
+      { role: "user", content: [{ type: "text", text: "next" }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 3, "claude matched preserved");
+  assert.equal(out.messages[1].content[0].tool_use_id, "tu_1", "claude tool_result preserved");
+});
+
+// 5. Orphan Claude-shaped tool_result salvaged to text block while text remains
+run("Claude-shaped orphan tool_result salvaged to text block in mixed user content", () => {
+  const body = {
+    messages: [
+      { role: "user", content: [
+        { type: "text", text: "keep me" },
+        { type: "tool_result", tool_use_id: "tu_ghost", content: "stale" }
+      ] },
+      { role: "user", content: [{ type: "text", text: "next" }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 2, "mixed user message kept");
+  assert.equal(out.messages[0].content.length, 2, "orphan block salvaged (not dropped)");
+  assert.equal(out.messages[0].content[0].text, "keep me", "original text block preserved");
+  assert.equal(out.messages[0].content[1].text, "[Tool result: stale]", "orphan salvaged to text block");
+});
+
+// 6. User message with only orphan tool_result blocks is kept with salvaged text
+run("User message with only orphan tool_result blocks salvaged to text", () => {
+  const body = {
+    messages: [
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tu_ghost", content: "stale" }] },
+      { role: "user", content: [{ type: "text", text: "next" }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 2, "message kept with salvaged text");
+  assert.equal(out.messages[0].content[0].text, "[Tool result: stale]", "orphan salvaged to text block");
+  assert.equal(out.messages[1].content[0].text, "next", "next user message preserved");
+});
+
+// 7. No-op body keeps same messages array reference
+run("No-op keeps same body when no orphans", () => {
+  const body = {
+    messages: [
+      { role: "assistant", content: null, tool_calls: [{ id: "call_1", type: "function", function: { name: "foo", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "call_1", content: "result" }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out, body, "same body reference returned on no-op");
+});
+
+// 8. Mixed: one matched, one orphan — matched kept, orphan salvaged (merged with next user)
+run("Mixed: matched kept, orphan salvaged", () => {
+  const body = {
+    messages: [
+      { role: "assistant", content: null, tool_calls: [{ id: "call_1", type: "function", function: { name: "foo", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "call_1", content: "matched" },
+      { role: "tool", tool_call_id: "call_orphan", content: "stale" },
+      { role: "user", content: "next" }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 3, "orphan salvaged and merged with next user");
+  assert.ok(out.messages.some(m => m.role === "tool" && m.tool_call_id === "call_1"), "matched tool kept");
+  assert.ok(!out.messages.some(m => m.role === "tool" && m.tool_call_id === "call_orphan"), "orphan tool removed");
+  assert.ok(out.messages.some(m => m.role === "user" && typeof m.content === "string" && m.content.includes("[Tool result: stale]")), "orphan salvaged to text");
+  assert.ok(out.messages.some(m => m.role === "user" && typeof m.content === "string" && m.content.includes("next")), "next user text merged");
+});
+
+// 9. Image-only orphan tool_result is dropped (no text to salvage — #2122)
+run("Image-only orphan tool_result dropped (no text representation)", () => {
+  const body = {
+    messages: [
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tu_ghost", content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "iVBOR..." } }] }
+      ] },
+      { role: "user", content: [{ type: "text", text: "next" }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 1, "image-only orphan dropped, message removed");
+  assert.equal(out.messages[0].content[0].text, "next", "next user message preserved");
+});
+
+// 10. Claude-shape mixed message with image-only orphan + text block — text kept, image dropped
+run("Claude mixed: image-only orphan dropped, text block preserved in same message", () => {
+  const body = {
+    messages: [
+      { role: "user", content: [
+        { type: "text", text: "keep me" },
+        { type: "tool_result", tool_use_id: "tu_ghost", content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "iVBOR..." } }] }
+      ] },
+      { role: "user", content: [{ type: "text", text: "next" }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 2, "mixed message kept (has text block)");
+  assert.equal(out.messages[0].content.length, 1, "image-only orphan dropped, text block kept");
+  assert.equal(out.messages[0].content[0].text, "keep me", "text block preserved");
+});
+
+// 11. Gemini contents[] — orphaned functionResponse salvaged to text part
+run("Gemini orphan functionResponse salvaged to text part", () => {
+  const body = {
+    contents: [
+      { role: "user", parts: [
+        { functionResponse: { id: "fn_gone", name: "search", response: { result: "stale data" } } },
+        { text: "continue" }
+      ] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.contents[0].parts.length, 2, "orphan salvaged (not dropped)");
+  assert.equal(out.contents[0].parts[0].text, "[Tool result: stale data]", "orphan salvaged to text part");
+  assert.equal(out.contents[0].parts[1].text, "continue", "original text part preserved");
+});
+
+// 12. Gemini contents[] — matched functionResponse preserved
+run("Gemini matched functionResponse preserved", () => {
+  const body = {
+    contents: [
+      { role: "model", parts: [{ functionCall: { id: "fn_live", name: "search", args: {} } }] },
+      { role: "user", parts: [{ functionResponse: { id: "fn_live", name: "search", response: { result: "ok" } } }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.contents[1].parts.length, 1, "matched functionResponse preserved");
+  assert.equal(out.contents[1].parts[0].functionResponse.id, "fn_live", "id preserved");
+});
+
+// 13. Gemini name-based fallback pairing (no id, match by name)
+run("Gemini name-based fallback: orphan by name salvaged, matched by name kept", () => {
+  const body = {
+    contents: [
+      { role: "model", parts: [{ functionCall: { name: "search", args: {} } }] },
+      { role: "user", parts: [
+        { functionResponse: { name: "search", response: { result: "ok" } } },
+        { functionResponse: { name: "gone_fn", response: { result: "stale" } } }
+      ] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.contents[1].parts.length, 2, "matched kept, orphan salvaged");
+  assert.equal(out.contents[1].parts[0].functionResponse.name, "search", "matched by name kept");
+  assert.equal(out.contents[1].parts[1].text, "[Tool result: stale]", "orphan by name salvaged to text");
+});
+
+// 14. Consecutive user messages merged after salvage (prevents Gemini 400)
+run("Consecutive user messages merged after salvage", () => {
+  const body = {
+    messages: [
+      { role: "tool", tool_call_id: "call_a", content: "x" },
+      { role: "tool", tool_call_id: "call_b", content: "y" },
+      { role: "user", content: "next" }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 1, "all salvaged user msgs merged with existing user");
+  assert.equal(out.messages[0].content, "[Tool result: x]\n[Tool result: y]\nnext", "all text merged into one user message");
+});
+
+// 15. Consecutive user merge does NOT merge array-content messages (structured blocks)
+run("Consecutive user merge skips array-content messages", () => {
+  const body = {
+    messages: [
+      { role: "tool", tool_call_id: "call_ghost", content: "salvaged" },
+      { role: "user", content: [{ type: "text", text: "structured" }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  assert.equal(out.messages.length, 2, "array-content user message not merged with string salvage");
+  assert.equal(out.messages[0].content, "[Tool result: salvaged]", "salvaged string user message");
+  assert.ok(Array.isArray(out.messages[1].content), "array-content user message preserved as array");
+});
+
+// 16. Gemini: functionCall in a non-model turn does NOT mask orphans (role guard)
+run("Gemini role guard: non-model functionCall does not mask orphans", () => {
+  const body = {
+    contents: [
+      // Malformed: a user turn carrying functionCall (shouldn't happen, but be defensive)
+      { role: "user", parts: [{ functionCall: { id: "fn_x", name: "search", args: {} } }] },
+      { role: "user", parts: [{ functionResponse: { id: "fn_x", name: "search", response: { result: "stale" } } }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  // fn_x was only in a user turn, not a model turn → it's an orphan → salvaged to text
+  assert.ok(!out.contents[1].parts.some(p => p.functionResponse), "orphan not masked by non-model functionCall");
+  assert.ok(out.contents[1].parts.some(p => p.text === "[Tool result: stale]"), "orphan salvaged to text");
+});
+
+// 17. Gemini: turn with all image-only orphans dropped (no empty parts[] → Gemini 400)
+run("Gemini: turn with all-orphan parts dropped (no empty parts[])", () => {
+  const body = {
+    contents: [
+      { role: "user", parts: [
+        { functionResponse: { id: "fn_gone", name: "screenshot", response: { result: "" } } }
+      ] },
+      { role: "user", parts: [{ text: "continue" }] }
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  // The orphan turn had only an empty-result functionResponse → no text salvaged → turn dropped
+  assert.equal(out.contents.length, 1, "empty-orphan turn dropped, not left with parts:[]");
+  assert.equal(out.contents[0].parts[0].text, "continue", "remaining turn preserved");
+});
+
+// 18. null/undefined body returns unchanged (fail-open guard)
+run("null body returns null (fail-open guard)", () => {
+  assert.equal(salvageOrphanedToolResults(null), null, "null body returns null");
+  assert.equal(salvageOrphanedToolResults(undefined), undefined, "undefined body returns undefined");
+});
+
+// 19. Salvage does not mutate input messages by reference (clone-on-merge)
+run("Salvage does not mutate input messages by reference", () => {
+  const originalUser = { role: "user", content: "hi" };
+  const body = {
+    messages: [
+      originalUser,
+      { role: "tool", tool_call_id: "call_ghost", content: "stale" },
+      { role: "user", content: "next" }
+    ]
+  };
+  salvageOrphanedToolResults(body);
+  assert.equal(originalUser.content, "hi", "original user msg content not mutated by merge");
+});
+
+// 20. Duplicate OpenAI tool result (same call_id twice) → second salvaged to user text
+run("OpenAI duplicate tool result salvaged", () => {
+  const body = {
+    messages: [
+      { role: "assistant", content: null, tool_calls: [{ id: "call_1", type: "function", function: { name: "foo", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "call_1", content: "first result" },
+      { role: "user", content: "new topic" },
+      { role: "tool", tool_call_id: "call_1", content: "stale duplicate" },
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  const toolMsgs = out.messages.filter(m => m.role === "tool");
+  assert.equal(toolMsgs.length, 1, "only first tool result kept, duplicate salvaged");
+  assert.equal(toolMsgs[0].content, "first result", "first result preserved");
+  assert.ok(out.messages.some(m => m.role === "user" && m.content.includes("stale duplicate")), "duplicate salvaged to user text");
+});
+
+// 21. Duplicate Claude tool_result block (same tool_use_id twice) → second salvaged
+run("Claude duplicate tool_result block salvaged", () => {
+  const body = {
+    messages: [
+      { role: "assistant", content: [{ type: "tool_use", id: "tu_1", name: "foo", input: {} }] },
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tu_1", content: "first" },
+        { type: "text", text: "some text" },
+        { type: "tool_result", tool_use_id: "tu_1", content: "duplicate" },
+      ] },
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  const userMsg = out.messages.find(m => m.role === "user");
+  const toolResults = userMsg.content.filter(b => b.type === "tool_result");
+  assert.equal(toolResults.length, 1, "only first tool_result block kept");
+  assert.equal(toolResults[0].content, "first", "first tool_result preserved");
+  assert.ok(userMsg.content.some(b => b.type === "text" && b.text.includes("duplicate")), "duplicate salvaged to text block");
+});
+
+// 22. Duplicate Gemini functionResponse (same id twice) → second salvaged
+run("Gemini duplicate functionResponse salvaged", () => {
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "q" }] },
+      { role: "model", parts: [{ functionCall: { id: "fc_1", name: "f1", args: {} } }] },
+      { role: "user", parts: [
+        { functionResponse: { id: "fc_1", name: "f1", response: { result: "first" } } },
+        { functionResponse: { id: "fc_1", name: "f1", response: { result: "dup" } } },
+      ] },
+    ]
+  };
+  const out = salvageOrphanedToolResults(body);
+  const userTurn = out.contents.find(c => c.role === "user" && c.parts.some(p => p.functionResponse));
+  const fnResponses = userTurn.parts.filter(p => p.functionResponse);
+  assert.equal(fnResponses.length, 1, "only first functionResponse kept");
+  assert.ok(userTurn.parts.some(p => p.text && p.text.includes("dup")), "duplicate salvaged to text part");
+});
+
+// Summary
+const passed = results.filter(r => r.ok).length;
+const total = results.length;
+for (const r of results) {
+  console.log(`${r.ok ? "ok" : "FAIL"} - ${r.name}${r.ok ? "" : ` :: ${r.err}`}`);
+}
+console.log(`\n${passed}/${total} checks passed`);
+if (passed !== total) process.exit(1);


### PR DESCRIPTION
Fixes #2236

## Summary

Client-side history truncation/summarization can leave a **tool result** in the request after the matching **tool call** was removed from the active history. Strict upstream APIs reject the whole request before model execution.

This is not specific to one protocol. It is the same pairing invariant expressed by different wire formats:

| Wire format | Tool call carrier | Tool result carrier |
|---|---|---|
| OpenAI Chat Completions | `assistant.tool_calls[].id` | `role:"tool"`, `tool_call_id` |
| OpenAI Responses API | `input[].function_call.call_id` | `input[].function_call_output.call_id` |
| Anthropic Messages | `content[].tool_use.id` | `content[].tool_result.tool_use_id` |
| Gemini / Antigravity | `parts[].functionCall.id\|name` | `parts[].functionResponse.id\|name` |

The invariant: every tool result in the outbound request must reference a tool call still present in the same request.

9router already had request-side helpers for half of this surface in `open-sse/translator/concerns/toolCall.js`:

- `ensureToolCallIds` — make call ids well-formed;
- `fixMissingToolResponses` — repair the inverse case where a call exists but its result is missing.

This PR adds the missing half — on both request envelopes 9router validates:

1. **Responses API `input[]`** — strip orphaned `function_call_output` items with no matching `function_call`, including the zero-call truncation case where every call was removed but outputs remain.
2. **Canonical `messages[]` / intermediate format** — **salvage** orphaned OpenAI `role:"tool"` messages, Claude-shaped `tool_result` blocks, and Gemini `functionResponse` parts with no matching tool call — fold orphan text content into `[Tool result: ...]` user text instead of deleting.
3. **Post-compression repair** — re-run both `salvageOrphanedToolResults` and `fixMissingToolResponses` after RTK/Headroom compression in `chatCore.js` to restore the pairing invariant when compression drops assistant turns.

## Salvage-to-text (not strip)

Based on @bloodf's review, the original strip approach preempted format-specific salvage paths (notably Kiro's `reconcileOrphanedToolResults`). This PR **salvages** orphaned tool results instead of deleting them:

- Orphaned `role:"tool"` message → `{ role: "user", content: "[Tool result: <text>]" }`
- Orphaned `tool_result` block in user content → `{ type: "text", text: "[Tool result: <text>]" }`
- Orphaned Gemini `functionResponse` part → `{ text: "[Tool result: <text>]" }`
- Image-only `tool_result` (no text) → still dropped (no text representation; tracked in #2122)
- Matched tool results → unchanged
- No-op fast path (same body reference) when nothing needs salvaging

The `[Tool result: ...]` format matches the pattern already used in the merged combo fix (#1859).

## Consecutive user message merge

After salvage, consecutive same-role user messages are merged so downstream translators that don't merge (notably `openai-to-gemini.js`, which pushes each `role:"user"` as a separate `contents[]` entry) don't emit adjacent user turns that trigger Gemini 400 INVALID_ARGUMENT. Only string-content user messages are merged; array-content messages (which may carry structured blocks like `tool_result`) are left as-is.

## Post-compression tool pairing repair

RTK/Headroom compression can drop assistant turns containing `tool_calls`, breaking the pairing invariant. This PR re-runs both `salvageOrphanedToolResults` and `fixMissingToolResponses` on the compressed body in `chatCore.js`, restoring the invariant after compression. This addresses #2338 (tool_use without tool_result after headroom).

The resulting pipeline enforces the full tool-pairing tripod before dispatch:

```js
ensureToolCallIds(result);              // ids are well-formed
fixMissingToolResponses(result);        // every call has a result
salvageOrphanedToolResults(result);     // every result has a call (salvaged to text)
// ... RTK/Headroom compression ...
salvageOrphanedToolResults(translatedBody);  // re-check after compression
fixMissingToolResponses(translatedBody);     // re-check after compression
```

## Changes

### `open-sse/translator/concerns/toolCall.js`

- `extractToolResultText(content)` — extracts text from string / array of content blocks (text blocks only), returns `""` for image-only.
- `salvageOrphanedToolResults(body)` — handles three wire formats:
  - OpenAI/Claude `messages[]`: orphaned `role:"tool"` / `tool_result` blocks → user text
  - Gemini/Antigravity `contents[]`: orphaned `functionResponse` parts → text part (with name-based fallback pairing)
  - Merges consecutive same-role user messages after salvage
  - Fail-open (returns body unchanged on any error)
  - Assistant-only `knownCallIds` collection (fixes false-positive bug from #2298 review)
- `fixMissingToolResponses` — fast-path with `changed` flag (no array allocation on no-op)
- `mergeConsecutiveUserMessages(messages)` — merge adjacent string-content user messages

### `open-sse/handlers/chatCore.js`

- Imports `salvageOrphanedToolResults` + `fixMissingToolResponses`.
- Post-compression call site: re-runs both helpers after RTK/Headroom, before Caveman/Ponytail.

### `open-sse/translator/index.js`

- Wired `salvageOrphanedToolResults(result)` in `translateRequest` immediately after `fixMissingToolResponses`.

### `open-sse/translator/request/openai-responses.js`

- `collectKnownCallIds(input)` — collect `function_call.call_id` values from a Responses API `input[]`.
- `stripOrphanedToolOutputs(input)` — remove `function_call_output` items with no matching `function_call`. (Responses API envelope — no text representation to salvage, so strip is correct here.)
- Applied in Responses→OpenAI translation, OpenAI→Responses translation, and Responses passthrough.

### `open-sse/utils/openaiResponsesToolPairingSelfCheck.mjs` (new)

5/5 checks — Responses envelope invariant.

### `open-sse/utils/toolPairingSelfCheck.mjs` (new)

15/15 checks — OpenAI/Claude/Gemini intermediate invariant, including:
- Matched preserved (OpenAI + Claude + Gemini)
- Orphan salvaged to user text (OpenAI + Claude + Gemini)
- Zero-call truncation salvages all
- Image-only orphan dropped (#2122)
- Claude mixed: image-only orphan dropped, text block preserved
- Gemini name-based fallback pairing
- Consecutive user messages merged after salvage
- Array-content messages not merged
- No-op same body reference
- Mixed matched + orphan

## Related

- #2298 — competing PR by @anki1kr on the same #2236. Coordinating to merge efforts — this PR takes the salvage-to-text approach, adds Gemini `functionResponse` coverage and post-compression call site from #2298, and fixes the assistant-only id collection bug (Copilot review).
- #2338 — reverse problem (tool_use without tool_result), same root cause (headroom compression). Addressed by post-compression repair.
- #2182 — Kiro fake "continue" on tool-result turns. Salvage-to-text should reduce the empty-content case that triggers it.
- #2122 — image-only tool_result. Salvage skips non-text content; remains a separate issue for `claude-to-openai.js`.

## Verification

```bash
node --check open-sse/translator/request/openai-responses.js
node --check open-sse/translator/concerns/toolCall.js
node --check open-sse/translator/index.js
node --check open-sse/handlers/chatCore.js
node --check open-sse/utils/openaiResponsesToolPairingSelfCheck.mjs
node --check open-sse/utils/toolPairingSelfCheck.mjs
node open-sse/utils/openaiResponsesToolPairingSelfCheck.mjs
node open-sse/utils/toolPairingSelfCheck.mjs
npm run build
```

Results:

- `openaiResponsesToolPairingSelfCheck.mjs`: 5/5 passed
- `toolPairingSelfCheck.mjs`: 15/15 passed
- `npm run build`: compiled successfully, 125/125 pages