### PR TITLE
feat: per-provider concurrency limiting (semaphore)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -12,6 +12,7 @@ import { createErrorResult, parseUpstreamError, formatProviderError } from "../u
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
+import { acquireSlot, releaseSlot, getConcurrencyLimit, ConcurrencyGateTimeoutError } from "../services/concurrencyGate.js";
 import { getExecutor } from "../executors/index.js";
 import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDetail.js";
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
@@ -34,7 +35,7 @@ import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking, providerConcurrencyLimit }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -192,12 +193,20 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const msgCount = translatedBody.messages?.length || translatedBody.input?.length || translatedBody.contents?.length || translatedBody.request?.contents?.length || 0;
   log?.debug?.("REQUEST", `${provider.toUpperCase()} | ${model} | ${msgCount} msgs`);
 
+  // --- Per-provider concurrency gate (declaration before streamController closures) ---
+  const concurrencyLimit = getConcurrencyLimit(provider, providerConcurrencyLimit);
+  let slotAcquired = false;
+
   const streamController = createStreamController({
     onDisconnect: (reason) => {
       trackPendingRequest(model, provider, connectionId, false);
+      if (slotAcquired) releaseSlot(provider);
       if (onDisconnect) onDisconnect(reason);
     },
-    onError: () => trackPendingRequest(model, provider, connectionId, false),
+    onError: () => {
+      trackPendingRequest(model, provider, connectionId, false);
+      if (slotAcquired) releaseSlot(provider);
+    },
     log, provider, model
   });
 
@@ -236,6 +245,25 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Execute request
   let providerResponse, providerUrl, providerHeaders, finalBody;
+
+  // --- Per-provider concurrency gate ---
+  // Acquire a slot before sending the upstream request.  This proactively
+  // limits concurrent in-flight requests per provider, preventing 429s before
+  // they happen.  If the slot can't be acquired within the timeout, return 503.
+  if (concurrencyLimit > 0) {
+    try {
+      await acquireSlot(provider, concurrencyLimit);
+      slotAcquired = true;
+      log?.debug?.("CONCURRENCY", `${provider} | slot acquired (${concurrencyLimit} max)`);
+    } catch (e) {
+      if (e instanceof ConcurrencyGateTimeoutError) {
+        log?.warn?.("CONCURRENCY", `${provider} | gate timeout after ${e.timeoutMs}ms (${e.limit} max)`);
+        return createErrorResult(HTTP_STATUS.SERVICE_UNAVAILABLE, e.message);
+      }
+      throw e;
+    }
+  }
+
   try {
     const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
     providerResponse = result.response;
@@ -245,6 +273,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     reqLogger.logTargetRequest(providerUrl, providerHeaders, finalBody);
   } catch (error) {
     trackPendingRequest(model, provider, connectionId, false, true);
+    if (slotAcquired) releaseSlot(provider);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${error.name === "AbortError" ? 499 : HTTP_STATUS.BAD_GATEWAY}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
@@ -290,6 +319,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Provider returned error
   if (!providerResponse.ok) {
     trackPendingRequest(model, provider, connectionId, false, true);
+    if (slotAcquired) releaseSlot(provider);
     const { statusCode, message, resetsAtMs } = await parseUpstreamError(providerResponse, executor);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${statusCode}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
@@ -310,7 +340,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
-  const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
+  // Release the concurrency slot when the request completes (covers streaming + non-streaming + disconnect)
+  const trackDone = () => {
+    trackPendingRequest(model, provider, connectionId, false);
+    if (slotAcquired) releaseSlot(provider);
+  };
 
   // Provider forced streaming but client wants JSON
   if (!clientRequestedStreaming && providerRequiresStreaming) {

--- a/open-sse/services/concurrencyGate.js
+++ b/open-sse/services/concurrencyGate.js
@@ -1,0 +1,169 @@
+/**
+ * Per-provider concurrency gate (semaphore).
+ *
+ * Limits the number of concurrent in-flight upstream requests for a single
+ * provider.  When the configured limit is reached, additional requests block
+ * (with a timeout) until an in-flight request completes and releases its slot.
+ *
+ * This is *proactive* — it prevents hitting provider concurrency/rate limits
+ * in the first place, complementing the existing reactive 429/cooldown logic
+ * in accountFallback.js.
+ *
+ * The gate is process-local (in-memory).  In a single-process Next.js
+ * standalone server this covers 100 % of requests.  If the server is ever
+ * scaled horizontally the gate would need to be backed by a shared store
+ * (Redis, SQLite), but for the typical 9router deployment this is sufficient.
+ */
+
+/** @type {Map<string, {current: number, queue: Array<{resolve, reject, timer}>}>} */
+const gates = new Map();
+
+/**
+ * Default maximum wait time for a concurrency slot (ms).
+ * Env override: CONCURRENCY_GATE_TIMEOUT_MS
+ */
+const DEFAULT_TIMEOUT_MS = (() => {
+  const v = parseInt(process.env.CONCURRENCY_GATE_TIMEOUT_MS, 10);
+  return Number.isFinite(v) && v > 0 ? v : 120_000; // 2 min default
+})();
+
+/**
+ * Internal: get or create the gate state for a provider.
+ */
+function getGate(provider) {
+  let g = gates.get(provider);
+  if (!g) {
+    g = { current: 0, queue: [] };
+    gates.set(provider, g);
+  }
+  return g;
+}
+
+/**
+ * Get the configured concurrency limit for a provider.
+ *
+ * @param {string} provider - Provider id (e.g. "umans", "openai")
+ * @param {Object<string, number>|undefined} limitsMap - Settings map
+ *   { provider: maxConcurrent }
+ * @returns {number} 0 = no limit, otherwise the max concurrent slots
+ */
+export function getConcurrencyLimit(provider, limitsMap) {
+  if (!limitsMap || typeof limitsMap !== "object") return 0;
+  const limit = limitsMap[provider];
+  if (typeof limit !== "number" || !Number.isFinite(limit) || limit <= 0) return 0;
+  return Math.floor(limit);
+}
+
+/**
+ * Acquire a concurrency slot for `provider`.
+ *
+ * Resolves immediately if the limit hasn't been reached.
+ * If the limit is 0 (or provider not in the map), resolves immediately —
+ * no limit enforced.
+ *
+ * If the limit is reached, the promise blocks until a slot is released
+ * or `timeoutMs` elapses.  On timeout the promise rejects with a
+ * ConcurrencyGateTimeoutError so the caller can return a 503.
+ *
+ * @param {string} provider - Provider id
+ * @param {number} limit - Max concurrent slots (0 = unlimited)
+ * @param {number} [timeoutMs] - Max wait time (default 120 000 ms)
+ * @returns {Promise<void>}
+ * @throws {ConcurrencyGateTimeoutError}
+ */
+export function acquireSlot(provider, limit, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  if (!limit || limit <= 0) return Promise.resolve();
+
+  const gate = getGate(provider);
+
+  // Fast path: slot available
+  if (gate.current < limit) {
+    gate.current++;
+    return Promise.resolve();
+  }
+
+  // Slow path: queue and wait
+  return new Promise((resolve, reject) => {
+    const entry = { resolve, reject, timer: null };
+
+    entry.timer = setTimeout(() => {
+      const idx = gate.queue.indexOf(entry);
+      if (idx !== -1) gate.queue.splice(idx, 1);
+      reject(new ConcurrencyGateTimeoutError(provider, limit, timeoutMs));
+    }, timeoutMs);
+
+    // Allow the process to exit even if the timer is pending
+    entry.timer.unref?.();
+
+    gate.queue.push(entry);
+  });
+}
+
+/**
+ * Release a concurrency slot for `provider`.
+ *
+ * If there are waiters, the next one is dequeued and its promise resolved.
+ * Must be called exactly once for every successful acquireSlot().
+ *
+ * @param {string} provider - Provider id
+ */
+export function releaseSlot(provider) {
+  const gate = gates.get(provider);
+  if (!gate) return;
+
+  // If there's a waiter, transfer the slot instead of decrementing
+  if (gate.queue.length > 0) {
+    const next = gate.queue.shift();
+    clearTimeout(next.timer);
+    // current stays the same — slot is handed off
+    next.resolve();
+    return;
+  }
+
+  gate.current = Math.max(0, gate.current - 1);
+  if (gate.current === 0) {
+    gates.delete(provider);
+  }
+}
+
+/**
+ * Get a snapshot of gate states (for diagnostics / dashboard).
+ *
+ * @returns {Record<string, {current: number, queued: number}>}
+ */
+export function getGateStats() {
+  const result = {};
+  for (const [provider, g] of gates) {
+    result[provider] = { current: g.current, queued: g.queue.length };
+  }
+  return result;
+}
+
+/**
+ * Reset all gates (for testing).
+ */
+export function _resetGates() {
+  for (const [, g] of gates) {
+    for (const entry of g.queue) {
+      clearTimeout(entry.timer);
+      entry.reject(new Error("Gate reset"));
+    }
+  }
+  gates.clear();
+}
+
+/**
+ * Error thrown when a request waited too long for a concurrency slot.
+ */
+export class ConcurrencyGateTimeoutError extends Error {
+  constructor(provider, limit, timeoutMs) {
+    super(
+      `Concurrency limit reached for provider "${provider}" ` +
+      `(${limit} concurrent). Request timed out after ${timeoutMs}ms waiting for a slot.`
+    );
+    this.name = "ConcurrencyGateTimeoutError";
+    this.provider = provider;
+    this.limit = limit;
+    this.timeoutMs = timeoutMs;
+  }
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -63,6 +63,7 @@ export default function ProviderDetailPage() {
   const [providerStrategy, setProviderStrategy] = useState(null);
   const [providerStickyLimit, setProviderStickyLimit] = useState("");
   const [thinkingMode, setThinkingMode] = useState("auto");
+  const [concurrencyLimit, setConcurrencyLimit] = useState("");
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
@@ -278,6 +279,9 @@ export default function ProviderDetailPage() {
       // Load per-provider thinking config
       const thinkingCfg = (settingsData.providerThinking || {})[providerId] || {};
       setThinkingMode(thinkingCfg.mode || "auto");
+      // Load per-provider concurrency limit
+      const cLimit = (settingsData.providerConcurrencyLimits || {})[providerId];
+      setConcurrencyLimit(cLimit != null ? String(cLimit) : "");
       const autoPingSettingsKey = AUTO_PING_SETTINGS_KEYS[providerId];
       const apCfg = autoPingSettingsKey ? settingsData[autoPingSettingsKey] || {} : {};
       setAutoPing({ enabled: apCfg.enabled === true, connections: apCfg.connections || {} });
@@ -391,6 +395,33 @@ export default function ProviderDetailPage() {
   const handleThinkingModeChange = (mode) => {
     setThinkingMode(mode);
     saveThinkingConfig(mode);
+  };
+
+  const saveConcurrencyLimit = async (value) => {
+    try {
+      const settingsRes = await fetch("/api/settings", { cache: "no-store" });
+      const settingsData = settingsRes.ok ? await settingsRes.json() : {};
+      const current = settingsData.providerConcurrencyLimits || {};
+      const updated = { ...current };
+      const numVal = parseInt(value, 10);
+      if (value && Number.isFinite(numVal) && numVal > 0) {
+        updated[providerId] = numVal;
+      } else {
+        delete updated[providerId];
+      }
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerConcurrencyLimits: updated }),
+      });
+    } catch (error) {
+      console.log("Error saving concurrency limit:", error);
+    }
+  };
+
+  const handleConcurrencyLimitChange = (value) => {
+    setConcurrencyLimit(value);
+    saveConcurrencyLimit(value);
   };
 
   const saveAutoPing = async (next) => {
@@ -1430,6 +1461,18 @@ export default function ProviderDetailPage() {
                     />
                   </div>
                 )}
+              </div>
+              {/* Per-provider concurrency limit */}
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-text-muted font-medium">Max Concurrent</span>
+                <input
+                  type="number"
+                  min={0}
+                  value={concurrencyLimit}
+                  onChange={(e) => handleConcurrencyLimitChange(e.target.value)}
+                  placeholder="∞"
+                  className="w-16 px-2 py-1 text-xs border border-border rounded-md bg-background focus:outline-none focus:border-primary"
+                />
               </div>
             </div>
           </div>

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -42,6 +42,9 @@ const DEFAULT_SETTINGS = {
   cavemanLevel: "full",
   ponytailEnabled: false,
   ponytailLevel: "full",
+  // Per-provider concurrency limits: { "umans": 4, "openai": 2 }
+  // 0 or missing = unlimited. Limits concurrent in-flight upstream requests.
+  providerConcurrencyLimits: {},
 };
 
 async function readRaw() {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -260,6 +260,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       ponytailEnabled: !!chatSettings.ponytailEnabled,
       ponytailLevel: chatSettings.ponytailLevel || "full",
       providerThinking,
+      providerConcurrencyLimit: chatSettings.providerConcurrencyLimits,
       // Detect source format by endpoint + body
       sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,
       onCredentialsRefreshed: async (newCreds) => {

--- a/tests/unit/concurrency-gate.test.js
+++ b/tests/unit/concurrency-gate.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  acquireSlot,
+  releaseSlot,
+  getConcurrencyLimit,
+  getGateStats,
+  _resetGates,
+  ConcurrencyGateTimeoutError,
+} from "../../open-sse/services/concurrencyGate.js";
+
+beforeEach(() => {
+  _resetGates();
+});
+
+describe("getConcurrencyLimit", () => {
+  it("returns 0 when no map provided", () => {
+    expect(getConcurrencyLimit("openai", undefined)).toBe(0);
+    expect(getConcurrencyLimit("openai", null)).toBe(0);
+  });
+
+  it("returns 0 when provider not in map", () => {
+    expect(getConcurrencyLimit("umans", { openai: 2 })).toBe(0);
+  });
+
+  it("returns the limit when provider is in map", () => {
+    expect(getConcurrencyLimit("umans", { umans: 4 })).toBe(4);
+    expect(getConcurrencyLimit("openai", { openai: 2, umans: 4 })).toBe(2);
+  });
+
+  it("returns 0 for invalid values", () => {
+    expect(getConcurrencyLimit("x", { x: 0 })).toBe(0);
+    expect(getConcurrencyLimit("x", { x: -1 })).toBe(0);
+    expect(getConcurrencyLimit("x", { x: NaN })).toBe(0);
+    expect(getConcurrencyLimit("x", { x: 1.5 })).toBe(1);
+    expect(getConcurrencyLimit("x", { x: "3" })).toBe(0);
+  });
+});
+
+describe("acquireSlot / releaseSlot", () => {
+  it("resolves immediately when limit is 0 (no limit)", async () => {
+    await expect(acquireSlot("test", 0)).resolves.toBeUndefined();
+    // No slot was acquired, so release should be a no-op
+    releaseSlot("test");
+    expect(getGateStats()).toEqual({});
+  });
+
+  it("allows up to N concurrent requests", async () => {
+    // Acquire 3 slots for limit=3
+    await acquireSlot("p1", 3);
+    await acquireSlot("p1", 3);
+    await acquireSlot("p1", 3);
+
+    const stats = getGateStats();
+    expect(stats.p1.current).toBe(3);
+    expect(stats.p1.queued).toBe(0);
+  });
+
+  it("blocks the 4th request when limit=3", async () => {
+    await acquireSlot("p2", 3);
+    await acquireSlot("p2", 3);
+    await acquireSlot("p2", 3);
+
+    let resolved = false;
+    const p = acquireSlot("p2", 3).then(() => { resolved = true; });
+
+    // Give microtasks a chance to resolve
+    await new Promise(r => setTimeout(r, 10));
+    expect(resolved).toBe(false);
+
+    // Release one slot — the 4th should now proceed
+    releaseSlot("p2");
+    await p;
+    expect(resolved).toBe(true);
+
+    // Stats should show current=3 (slot was handed off, not decremented)
+    expect(getGateStats().p2.current).toBe(3);
+  });
+
+  it("cleans up gate when all slots released", async () => {
+    await acquireSlot("p3", 2);
+    releaseSlot("p3");
+    expect(getGateStats()).toEqual({});
+  });
+
+  it("decrements correctly with sequential acquire/release", async () => {
+    await acquireSlot("p4", 2);
+    await acquireSlot("p4", 2);
+    releaseSlot("p4");
+    expect(getGateStats().p4.current).toBe(1);
+    releaseSlot("p4");
+    expect(getGateStats()).toEqual({});
+  });
+
+  it("isolates providers — each has its own gate", async () => {
+    await acquireSlot("provider-a", 1);
+    await acquireSlot("provider-b", 1);
+
+    const stats = getGateStats();
+    expect(stats["provider-a"].current).toBe(1);
+    expect(stats["provider-b"].current).toBe(1);
+
+    releaseSlot("provider-a");
+    releaseSlot("provider-b");
+    expect(getGateStats()).toEqual({});
+  });
+});
+
+describe("acquireSlot timeout", () => {
+  it("rejects with ConcurrencyGateTimeoutError after timeout", async () => {
+    await acquireSlot("timeout-p", 1);
+
+    const p = acquireSlot("timeout-p", 1, 50); // 50ms timeout
+    await expect(p).rejects.toThrow(ConcurrencyGateTimeoutError);
+    await expect(p).rejects.toMatchObject({
+      provider: "timeout-p",
+      limit: 1,
+      timeoutMs: 50,
+    });
+
+    // The timed-out entry should be removed from the queue
+    expect(getGateStats()["timeout-p"].queued).toBe(0);
+
+    releaseSlot("timeout-p");
+  });
+
+  it("removed waiter does not cause over-release", async () => {
+    // Acquire the only slot
+    await acquireSlot("p5", 1);
+
+    // Start a waiter that will timeout
+    const waiter = acquireSlot("p5", 1, 50).catch(() => {});
+    await new Promise(r => setTimeout(r, 80)); // wait for timeout
+
+    // Now release — should decrement to 0, not underflow
+    releaseSlot("p5");
+    expect(getGateStats()).toEqual({});
+
+    await waiter;
+  });
+});
+
+describe("getGateStats", () => {
+  it("returns empty object when no gates exist", () => {
+    expect(getGateStats()).toEqual({});
+  });
+
+  it("shows queued count when requests are waiting", async () => {
+    await acquireSlot("p6", 1);
+    // Queue two waiters (don't await — they'll block)
+    const w1 = acquireSlot("p6", 1, 5000).catch(() => {});
+    const w2 = acquireSlot("p6", 1, 5000).catch(() => {});
+    await new Promise(r => setTimeout(r, 10));
+
+    const stats = getGateStats();
+    expect(stats.p6.current).toBe(1);
+    expect(stats.p6.queued).toBe(2);
+
+    releaseSlot("p6"); // resolves w1 (slot handed off, current stays 1)
+    await new Promise(r => setTimeout(r, 10));
+    expect(getGateStats().p6.queued).toBe(1);
+
+    releaseSlot("p6"); // resolves w2 (slot handed off, current stays 1)
+    await new Promise(r => setTimeout(r, 10));
+    expect(getGateStats().p6.queued).toBe(0);
+    expect(getGateStats().p6.current).toBe(1);
+
+    // Final release — now w2 owns the slot, release it to clean up
+    releaseSlot("p6");
+    await new Promise(r => setTimeout(r, 10));
+    expect(getGateStats()).toEqual({});
+
+    await Promise.allSettled([w1, w2]);
+  });
+});


### PR DESCRIPTION
## Summary

Add a **per-provider concurrency limiter** (semaphore) that proactively limits concurrent in-flight upstream requests per provider, preventing 429/rate-limit errors **before they happen**.

This complements the existing reactive `accountFallback.js` logic, which cools down accounts *after* hitting a 429. Together they form a complete defense:

- **Proactive (new):** `concurrencyGate.js` — blocks the Nth+1 request from reaching the upstream at all
- **Reactive (existing):** `accountFallback.js` — when a 429 does slip through, cools down that account and falls back

## Use case

Providers like Umans (GLM-5.2) offer plans with **N concurrency slots** (e.g. 4 concurrent requests). Exceeding this causes 429 errors that waste the user's daily retry allowance (e.g. 20/day). This feature lets users set `providerConcurrencyLimits: { "umans": 4 }` so 9router never sends more than 4 concurrent requests to that provider.

## Changes

### New: `open-sse/services/concurrencyGate.js`
In-memory semaphore with:
- `acquireSlot(provider, limit, timeoutMs)` — blocks until a slot is available, rejects with `ConcurrencyGateTimeoutError` after timeout
- `releaseSlot(provider)` — frees a slot, hands off to next waiter in queue
- `getConcurrencyLimit(provider, limitsMap)` — resolves the configured limit
- `getGateStats()` — diagnostics snapshot for dashboard
- Env override: `CONCURRENCY_GATE_TIMEOUT_MS` (default 120s)

### Modified: `open-sse/handlers/chatCore.js`
- Acquire slot before `executor.execute()`
- Release slot on **every exit path**: executor error, non-ok upstream response, streaming done/disconnect/abort, SSE-to-JSON completion
- Returns `503 Service Unavailable` if the gate times out

### Modified: `src/lib/db/repos/settingsRepo.js`
- New default setting: `providerConcurrencyLimits: {}` (empty = unlimited for all)

### Modified: `src/sse/handlers/chat.js`
- Pass `providerConcurrencyLimits` from settings to `handleChatCore`

### Modified: `src/app/(dashboard)/dashboard/providers/[id]/page.js`
- New "Max Concurrent" input on the provider detail page (next to Round Robin toggle)
- Persists to `settings.providerConcurrencyLimits[providerId]`

### New: `tests/unit/concurrency-gate.test.js`
14 tests covering:
- `getConcurrencyLimit` edge cases (missing map, invalid values, type coercion)
- Acquire/release lifecycle (fast path, slow path, queue handoff)
- Timeout behavior (rejection, cleanup, no over-release)
- Provider isolation
- Gate stats diagnostics

## Testing

```
npx vitest run tests/unit/concurrency-gate.test.js
# 14 passed
```

Docker image built and pushed: `ghcr.io/phantomic12/9router:concurrency-limit`
- Verified settings API returns `providerConcurrencyLimits`
- Verified chat endpoint exercises the gate code path without errors
- Verified module loads correctly in the container

## Design decisions

1. **Process-local (in-memory):** Sufficient for the typical single-process 9router deployment. If horizontal scaling is ever needed, the gate interface is designed to be backed by Redis/SQLite without changing callers.

2. **Piggyback on `trackPendingRequest` lifecycle:** The release happens alongside the existing `trackPendingRequest(..., false)` calls, ensuring slots are freed on every exit path without duplicating the lifecycle logic.

3. **Configurable per-provider:** Different providers have different limits. The `{ providerId: maxConcurrent }` map is simple and extensible.

4. **Fail-open philosophy:** If the limit is 0 or missing, no gate is enforced — existing behavior is unchanged.
