### PR TITLE
fix(antigravity): preserve Claude tool delta index

### DIFF
--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -25,7 +25,10 @@ function emitFunctionCall(functionCall, state) {
     type: OPENAI_BLOCK.FUNCTION,
     function: { name: fcName, arguments: JSON.stringify(fcArgs) },
   };
-  state.toolCalls.set(toolCallIndex, toolCall);
+  // Keep Gemini bookkeeping separate from the shared translator state.toolCalls map.
+  // The downstream OpenAI→Claude translator uses state.toolCalls for Claude block
+  // metadata; pre-populating it here makes Anthropic tool deltas lose index.
+  state.geminiToolCallCount = (state.geminiToolCallCount || 0) + 1;
   return buildChunk(chunkMeta(state), { tool_calls: [toolCall] }, null);
 }
 
@@ -46,6 +49,7 @@ export function geminiToOpenAIResponse(chunk, state) {
     state.messageId = response.responseId || `msg_${Date.now()}`;
     state.model = response.modelVersion || "gemini";
     state.functionIndex = 0;
+    state.geminiToolCallCount = 0;
     results.push(buildChunk(chunkMeta(state), { role: ROLE.ASSISTANT }, null));
   }
 
@@ -117,7 +121,7 @@ export function geminiToOpenAIResponse(chunk, state) {
   // Finish reason - include usage in final chunk
   if (candidate.finishReason) {
     let finishReason = toOpenAIFinish(candidate.finishReason, "gemini");
-    if (finishReason === OPENAI_FINISH.STOP && state.toolCalls.size > 0) {
+    if (finishReason === OPENAI_FINISH.STOP && state.geminiToolCallCount > 0) {
       finishReason = OPENAI_FINISH.TOOL_CALLS;
     }
     

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -1,7 +1,7 @@
 // Real Antigravity-MITM requests (Gemini-internal: { request: { contents, ... } }) → OpenAI.
 import { describe, it, expect } from "vitest";
 import "./registerAll.js";
-import { translateRequest } from "../../open-sse/translator/index.js";
+import { translateRequest, translateResponse, initState } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
 
@@ -51,6 +51,32 @@ describe("Antigravity → OpenAI", () => {
       ? content.some((c) => c.type === "text" && c.text === "")
       : content === "";
     expect(hasEmpty, "empty text part emitted").toBe(false);
+  });
+});
+
+describe("Antigravity → Claude", () => {
+  it("tool call input_json_delta includes Anthropic index", () => {
+    const state = initState(FORMATS.CLAUDE);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, {
+      response: {
+        responseId: "resp-1",
+        modelVersion: "gemini-pro-agent",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ functionCall: { name: "bash", args: { command: "git status" } } }],
+          },
+          finishReason: "STOP",
+          index: 0,
+        }],
+      },
+    }, state);
+
+    const jsonDelta = events.find(
+      (event) => event.type === "content_block_delta" && event.delta?.type === "input_json_delta"
+    );
+    expect(jsonDelta).toMatchObject({ index: expect.any(Number) });
+    expect(JSON.parse(jsonDelta.delta.partial_json)).toEqual({ command: "git status" });
   });
 });
 

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -171,6 +171,7 @@ describe("Kiro → Claude (direct route, OpenAI-shaped chunks from executor)", (
     const jsonDelta = events.find(
       (e) => e.type === "content_block_delta" && e.delta.type === "input_json_delta"
     );
+    expect(jsonDelta.index).toBeDefined();
     expect(jsonDelta.delta.partial_json).toBe('{"q":"x"}');
     const md = events.find((e) => e.type === "message_delta");
     expect(md.delta.stop_reason).toBe("tool_use");


### PR DESCRIPTION
## Summary

Fixes a Claude Code streaming failure when using the Antigravity provider.

Issue #2225 reports `API Error: Content block not found` after upgrading to 9Router `0.5.15`. The report first mentioned Google Pro, but follow-up comments indicate the same error can happen with Free accounts too, so this fix treats it as an Antigravity → Claude Code stream translation issue rather than an account-tier or OAuth issue.

## Findings

The Antigravity/Gemini response path is translated through OpenAI before being translated to Claude:

```text
Antigravity/Gemini response → OpenAI response → Claude response
```

`geminiToOpenAIResponse()` was using the shared `state.toolCalls` map for Gemini-side bookkeeping. The downstream `openaiToClaudeResponse()` also uses `state.toolCalls`, but for Claude content-block metadata.

When a Gemini `functionCall` arrived, the upstream translator pre-populated `state.toolCalls`. Then the Claude translator saw the tool-call index as already present and did not emit the matching `content_block_start` for the Claude `tool_use` block. Later tool argument/stop events could still be emitted for that block index, which can make Claude Code reject the stream with:

```text
API Error: Content block not found
```

## Fix

Keep Gemini bookkeeping separate from Claude tool-block state:

- replace Gemini-side `state.toolCalls` mutation with `state.geminiToolCallCount`
- use `state.geminiToolCallCount` when normalizing Gemini `STOP` to OpenAI `tool_calls`
- add a regression test for `Antigravity → Claude` tool-call streaming that verifies `input_json_delta` keeps a valid Claude block index
- keep the existing Kiro/Claude direct-route coverage aligned with the same invariant

## Verification

```bash
npx vitest run tests/translator/bugs-antigravity.test.js tests/translator/claude-kiro-direct.test.js tests/unit/openai-to-claude-response-tools.test.js
```

Result:

```text
Test Files  3 passed (3)
Tests       15 passed | 1 expected fail (16)
```

Fixes #2225
