### PR TITLE
fix(kimchi): use current CLI user agent

### DIFF
--- a/open-sse/executors/kimchi.js
+++ b/open-sse/executors/kimchi.js
@@ -1,5 +1,6 @@
 import { DefaultExecutor } from "./default.js";
 import { getCachedKimchiModelMetadata } from "../services/kimchiModels.js";
+import { buildKimchiUserAgent, refreshKimchiCliVersion } from "../services/kimchiUserAgent.js";
 
 const TOP_LEVEL_OPENAI_GATEWAY_DROPS = [
   "anthropic_version",
@@ -76,6 +77,17 @@ function isAnthropicBackedKimchiModel(model) {
 export class KimchiExecutor extends DefaultExecutor {
   constructor() {
     super("kimchi");
+  }
+
+  buildHeaders(credentials, stream = true) {
+    const headers = super.buildHeaders(credentials, stream);
+    headers["User-Agent"] = buildKimchiUserAgent();
+    return headers;
+  }
+
+  async execute(args) {
+    await refreshKimchiCliVersion({ log: args.log });
+    return super.execute(args);
   }
 
   transformRequest(model, body, stream, credentials) {

--- a/open-sse/providers/registry/kimchi.js
+++ b/open-sse/providers/registry/kimchi.js
@@ -1,3 +1,5 @@
+import { buildKimchiUserAgent } from "../../services/kimchiUserAgent.js";
+
 export default {
   id: "kimchi",
   priority: 95,
@@ -20,7 +22,7 @@ export default {
     baseUrl: "https://llm.kimchi.dev/openai/v1/chat/completions",
     format: "openai",
     headers: {
-      "User-Agent": "kimchi/0.0.0",
+      "User-Agent": buildKimchiUserAgent(),
     },
     auth: {
       combined: true,

--- a/open-sse/services/kimchiModels.js
+++ b/open-sse/services/kimchiModels.js
@@ -1,9 +1,9 @@
 import { createHash } from "crypto";
 
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
+import { buildKimchiUserAgent, refreshKimchiCliVersion } from "./kimchiUserAgent.js";
 
 export const KIMCHI_API = "https://llm.kimchi.dev";
-export const KIMCHI_USER_AGENT = "kimchi/0.0.0";
 
 const FETCH_TIMEOUT_MS = 20_000;
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -104,6 +104,7 @@ export function getCachedKimchiModelMetadata(modelId) {
 }
 
 async function fetchKimchiCatalogRaw(token, endpoint, options = {}) {
+  await refreshKimchiCliVersion({ log: options.log });
   const url = buildKimchiModelsUrl(endpoint);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(new Error("Kimchi models fetch timeout")), FETCH_TIMEOUT_MS);
@@ -117,7 +118,7 @@ async function fetchKimchiCatalogRaw(token, endpoint, options = {}) {
       headers: {
         "Accept": "application/json",
         "Authorization": `Bearer ${token}`,
-        "User-Agent": KIMCHI_USER_AGENT,
+        "User-Agent": buildKimchiUserAgent(),
       },
       cache: "no-store",
       signal,

--- a/open-sse/services/kimchiUserAgent.js
+++ b/open-sse/services/kimchiUserAgent.js
@@ -1,0 +1,76 @@
+export const KIMCHI_CLI_RELEASE_URL = "https://api.github.com/repos/getkimchi/kimchi/releases/latest";
+export const KIMCHI_FALLBACK_CLI_VERSION = "0.1.53";
+export const KIMCHI_VERSION_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+let cachedVersion = KIMCHI_FALLBACK_CLI_VERSION;
+let cacheExpiresAt = 0;
+let refreshPromise = null;
+
+export function normalizeKimchiCliVersion(value) {
+  if (typeof value !== "string") return null;
+  const version = value.trim().replace(/^v/i, "");
+  if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) return null;
+  return version;
+}
+
+export function buildKimchiUserAgent(version = cachedVersion || KIMCHI_FALLBACK_CLI_VERSION) {
+  const normalized = normalizeKimchiCliVersion(version) || KIMCHI_FALLBACK_CLI_VERSION;
+  return `kimchi/${normalized}`;
+}
+
+export function resetKimchiCliVersionCache() {
+  cachedVersion = KIMCHI_FALLBACK_CLI_VERSION;
+  cacheExpiresAt = 0;
+  refreshPromise = null;
+}
+
+async function fetchLatestKimchiCliVersion(fetchImpl, signal) {
+  const response = await fetchImpl(KIMCHI_CLI_RELEASE_URL, {
+    method: "GET",
+    headers: {
+      "Accept": "application/vnd.github+json",
+      "User-Agent": "9router",
+    },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Kimchi release lookup failed: ${response.status}`);
+  }
+  const data = await response.json();
+  const version = normalizeKimchiCliVersion(data?.tag_name || data?.name);
+  if (!version) throw new Error("Kimchi release lookup returned no valid version");
+  return version;
+}
+
+export async function refreshKimchiCliVersion(options = {}) {
+  const now = options.now || Date.now();
+  if (!options.force && cacheExpiresAt > now) return cachedVersion;
+  if (refreshPromise) return refreshPromise;
+
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== "function") return cachedVersion || KIMCHI_FALLBACK_CLI_VERSION;
+
+  refreshPromise = (async () => {
+    const controller = new AbortController();
+    const timeoutMs = options.timeoutMs || 5000;
+    const timer = setTimeout(() => controller.abort(new Error("Kimchi release lookup timeout")), timeoutMs);
+
+    try {
+      const signal = options.signal
+        ? AbortSignal.any([options.signal, controller.signal])
+        : controller.signal;
+      cachedVersion = await fetchLatestKimchiCliVersion(fetchImpl, signal);
+    } catch (error) {
+      options.log?.warn?.("KIMCHI_VERSION", error.message);
+      cachedVersion = cachedVersion || KIMCHI_FALLBACK_CLI_VERSION;
+    } finally {
+      clearTimeout(timer);
+      cacheExpiresAt = now + KIMCHI_VERSION_CACHE_TTL_MS;
+      refreshPromise = null;
+    }
+
+    return cachedVersion || KIMCHI_FALLBACK_CLI_VERSION;
+  })();
+
+  return refreshPromise;
+}

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -19,6 +19,7 @@ import {
   KIMCHI_CONFIG,
 } from "@/lib/oauth/constants/oauth";
 import { buildClineHeaders } from "@/shared/utils/clineAuth";
+import { buildKimchiUserAgent } from "open-sse/services/kimchiUserAgent.js";
 
 // OAuth provider test endpoints
 const OAUTH_TEST_CONFIG = {
@@ -99,7 +100,7 @@ const OAUTH_TEST_CONFIG = {
     authPrefix: "Bearer ",
     extraHeaders: {
       Accept: "application/json",
-      "User-Agent": "kimchi/0.0.0",
+      "User-Agent": buildKimchiUserAgent(),
     },
     refreshable: false,
   },
@@ -352,6 +353,25 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
     newTokens = tokens;
     accessToken = tokens.accessToken;
     return await tryProbe(accessToken);
+  }
+
+  if (connection.provider === "kimchi") {
+    const warnings = [];
+    const { resolveKimchiModels } = await import("open-sse/services/kimchiModels.js");
+    const result = await resolveKimchiModels({
+      accessToken,
+      providerSpecificData: connection.providerSpecificData || {},
+    }, {
+      forceRefresh: true,
+      proxyOptions: effectiveProxy,
+      log: { warn: (_scope, message) => warnings.push(message) },
+    });
+    if (result?.models?.length) return { valid: true, error: null, refreshed, newTokens };
+    return {
+      valid: false,
+      error: warnings[0] || "Kimchi model metadata unavailable",
+      refreshed,
+    };
   }
 
   try {

--- a/tests/unit/kimchi-user-agent.test.js
+++ b/tests/unit/kimchi-user-agent.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const proxyFetchMocks = vi.hoisted(() => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+vi.mock("open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: proxyFetchMocks.proxyAwareFetch,
+}));
+
+const originalFetch = global.fetch;
+
+describe("Kimchi CLI User-Agent", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("normalizes GitHub release tags into Kimchi CLI User-Agent values", async () => {
+    const {
+      buildKimchiUserAgent,
+      normalizeKimchiCliVersion,
+      resetKimchiCliVersionCache,
+    } = await import("open-sse/services/kimchiUserAgent.js");
+
+    resetKimchiCliVersionCache();
+
+    expect(normalizeKimchiCliVersion("v0.1.53")).toBe("0.1.53");
+    expect(normalizeKimchiCliVersion(" 0.2.0 ")).toBe("0.2.0");
+    expect(normalizeKimchiCliVersion("latest")).toBeNull();
+    expect(buildKimchiUserAgent("0.1.53")).toBe("kimchi/0.1.53");
+  });
+
+  it("resolves the latest Kimchi CLI release and falls back when GitHub is unavailable", async () => {
+    const {
+      buildKimchiUserAgent,
+      refreshKimchiCliVersion,
+      resetKimchiCliVersionCache,
+    } = await import("open-sse/services/kimchiUserAgent.js");
+
+    resetKimchiCliVersionCache();
+
+    global.fetch = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ tag_name: "v0.1.54" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    await expect(refreshKimchiCliVersion({ force: true })).resolves.toBe("0.1.54");
+    expect(buildKimchiUserAgent()).toBe("kimchi/0.1.54");
+
+    resetKimchiCliVersionCache();
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("network down"));
+
+    await expect(refreshKimchiCliVersion({ force: true })).resolves.toBe("0.1.53");
+    expect(buildKimchiUserAgent()).toBe("kimchi/0.1.53");
+  });
+
+  it("uses the resolved Kimchi CLI User-Agent when fetching live model metadata", async () => {
+    const {
+      refreshKimchiCliVersion,
+      resetKimchiCliVersionCache,
+    } = await import("open-sse/services/kimchiUserAgent.js");
+
+    resetKimchiCliVersionCache();
+
+    global.fetch = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ tag_name: "v0.1.54" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+    await refreshKimchiCliVersion({ force: true });
+
+    proxyFetchMocks.proxyAwareFetch.mockResolvedValueOnce(new Response(JSON.stringify({
+      models: [
+        {
+          slug: "minimax-m3",
+          display_name: "MiniMax M3",
+          provider: "ai-enabler",
+          reasoning: false,
+          input_modalities: ["text"],
+          limits: { context_window: 1048576, max_output_tokens: 65536 },
+        },
+      ],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { resolveKimchiModels } = await import("open-sse/services/kimchiModels.js");
+    const result = await resolveKimchiModels({ accessToken: "token" }, { forceRefresh: true });
+
+    expect(result.models.map((m) => m.id)).toEqual(["minimax-m3"]);
+    expect(proxyFetchMocks.proxyAwareFetch).toHaveBeenCalledWith(
+      "https://llm.kimchi.dev/v1/models/metadata?include_in_cli=true",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "kimchi/0.1.54",
+        }),
+      }),
+      null,
+    );
+  });
+
+  it("refreshes Kimchi CLI version before chat requests and sends that User-Agent upstream", async () => {
+    const {
+      resetKimchiCliVersionCache,
+    } = await import("open-sse/services/kimchiUserAgent.js");
+
+    resetKimchiCliVersionCache();
+
+    global.fetch = vi.fn().mockResolvedValueOnce(new Response(JSON.stringify({ tag_name: "v0.1.54" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+    proxyFetchMocks.proxyAwareFetch.mockResolvedValueOnce(new Response(JSON.stringify({
+      choices: [{ message: { role: "assistant", content: "OK" } }],
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }));
+
+    const { KimchiExecutor } = await import("open-sse/executors/kimchi.js");
+    const executor = new KimchiExecutor();
+
+    await executor.execute({
+      model: "minimax-m3",
+      body: { model: "minimax-m3", messages: [{ role: "user", content: "Reply OK only." }] },
+      stream: false,
+      credentials: { accessToken: "token" },
+      signal: undefined,
+      log: undefined,
+      proxyOptions: null,
+    });
+
+    expect(proxyFetchMocks.proxyAwareFetch).toHaveBeenCalledWith(
+      "https://llm.kimchi.dev/openai/v1/chat/completions",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "kimchi/0.1.54",
+        }),
+      }),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- resolve the latest Kimchi CLI release and use a current `kimchi/<version>` User-Agent for Kimchi gateway calls
- apply the same User-Agent to Kimchi model metadata fetches and provider validation
- validate Kimchi OAuth connections against the live Kimchi model metadata path instead of relying only on the Cast AI supported-providers endpoint

## Evidence
- direct Kimchi with `User-Agent: kimchi/0.0.0` returns 402 provider exhausted for `minimax-m3`
- direct Kimchi with `User-Agent: kimchi/0.1.53` returns 200 for the same token/model/endpoint
- after this patch, local 9router `kimchi/minimax-m3` returns 200

## Tests
- `node node_modules/vitest/vitest.mjs run tests/unit/kimchi-user-agent.test.js --config tests/vitest.config.js`
- `node node_modules/vitest/vitest.mjs run tests/unit/provider-test-models-routing.test.js tests/unit/provider-models-minimax-m3.test.js tests/unit/provider-validation.test.js tests/unit/kimchi-user-agent.test.js --config tests/vitest.config.js`
- `npm run build`