### PR TITLE
Add compatible provider client identity profiles

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -3,6 +3,10 @@ import { PROVIDERS, PROVIDER_OAUTH } from "../config/providers.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE } from "../providers/shared.js";
 import { OAUTH_ENDPOINTS, buildKimiHeaders } from "../config/appConstants.js";
 import { buildClineHeaders } from "../shared/clineAuth.js";
+import {
+  buildClientIdentityHeaders,
+  shouldStripClaudeIdentityHeaders,
+} from "../shared/clientIdentityHeaders.js";
 import { getCachedClaudeHeaders } from "../utils/claudeHeaderCache.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
@@ -166,19 +170,32 @@ export class DefaultExecutor extends BaseExecutor {
     const desc = rt?.auth || AUTH_DESCRIPTORS[this.provider] || this.resolveAuthDescriptor();
     // Hooks run BEFORE auth so dynamic overlays (claude cached headers) can't clobber the token.
     for (const hook of desc.hooks || []) HEADER_HOOKS[hook]?.(headers, credentials);
-    applyAuth(headers, desc, credentials);
+    const identityConfig = credentials?.providerSpecificData || {};
+    const identityHeaders = buildClientIdentityHeaders(identityConfig);
+    Object.assign(headers, identityHeaders);
 
-    // Strip first-party Claude Code identity headers for non-Anthropic anthropic-compatible upstreams
+    const authHeaders = {};
+    applyAuth(authHeaders, desc, credentials);
+    Object.assign(headers, authHeaders);
+
     if (this.provider?.startsWith?.("anthropic-compatible-")) {
       const baseUrl = credentials?.providerSpecificData?.baseUrl || "";
       const isOfficialAnthropic = baseUrl === "" || baseUrl.includes("api.anthropic.com");
+      if (!isOfficialAnthropic && credentials.apiKey && !headers["Authorization"]) {
+        headers["Authorization"] = `Bearer ${credentials.apiKey}`;
+      }
+    }
+
+    // Strip first-party Claude Code identity headers for non-Anthropic anthropic-compatible upstreams
+    if (shouldStripClaudeIdentityHeaders({
+      provider: this.provider,
+      baseUrl: credentials?.providerSpecificData?.baseUrl || "",
+      clientIdentityProfile: identityConfig.clientIdentityProfile,
+      identityHeaders,
+    })) {
+      const baseUrl = credentials?.providerSpecificData?.baseUrl || "";
+      const isOfficialAnthropic = baseUrl === "" || baseUrl.includes("api.anthropic.com");
       if (!isOfficialAnthropic) {
-        // Some third-party Anthropic-compatible gateways require Bearer auth in
-        // addition to x-api-key. Send both (x-api-key already set above) so
-        // gateways that read either header succeed.
-        if (credentials.apiKey && !headers["Authorization"]) {
-          headers["Authorization"] = `Bearer ${credentials.apiKey}`;
-        }
         delete headers["anthropic-dangerous-direct-browser-access"];
         delete headers["Anthropic-Dangerous-Direct-Browser-Access"];
         delete headers["x-app"];

--- a/open-sse/handlers/embeddingProviders/openaiCompatNode.js
+++ b/open-sse/handlers/embeddingProviders/openaiCompatNode.js
@@ -1,5 +1,6 @@
 // Custom node providers (openai-compatible-* / custom-embedding-*) — baseUrl from credentials
 import createOpenAIEmbeddingAdapter from "./openai.js";
+import { mergeClientIdentityHeaders } from "../../shared/clientIdentityHeaders.js";
 
 const baseAdapter = createOpenAIEmbeddingAdapter("openai");
 
@@ -10,4 +11,9 @@ export default {
     const baseUrl = rawBaseUrl.replace(/\/$/, "").replace(/\/embeddings$/, "");
     return `${baseUrl}/embeddings`;
   },
+  buildHeaders: (creds) => mergeClientIdentityHeaders(
+    { "Content-Type": "application/json" },
+    creds?.providerSpecificData || {},
+    { "Authorization": `Bearer ${creds?.apiKey || creds?.accessToken}` },
+  ),
 };

--- a/open-sse/shared/clientIdentityHeaders.js
+++ b/open-sse/shared/clientIdentityHeaders.js
@@ -1,0 +1,138 @@
+import { CLAUDE_CLI_SPOOF_HEADERS } from "../providers/shared.js";
+
+export const CLIENT_IDENTITY_PROFILES = {
+  default: {
+    label: "Default",
+    headers: {},
+  },
+  "claude-cli": {
+    label: "Claude CLI",
+    headers: CLAUDE_CLI_SPOOF_HEADERS,
+  },
+  "codex-cli": {
+    label: "Codex CLI",
+    headers: {
+      originator: "codex_cli_rs",
+      "User-Agent": "codex_cli_rs/0.136.0",
+    },
+  },
+  openclaw: {
+    label: "OpenClaw",
+    headers: {
+      "User-Agent": "openclaw/2026.2.3",
+    },
+  },
+  custom: {
+    label: "Custom",
+    headers: {},
+  },
+};
+
+const AUTH_HEADER_NAMES = new Set([
+  "authorization",
+  "x-api-key",
+  "api-key",
+  "cookie",
+]);
+
+export function normalizeClientIdentityProfile(profile) {
+  return CLIENT_IDENTITY_PROFILES[profile] ? profile : "default";
+}
+
+export function isBlockedClientIdentityHeader(name) {
+  return AUTH_HEADER_NAMES.has(String(name || "").trim().toLowerCase());
+}
+
+function sanitizeHeaderEntries(entries) {
+  const headers = {};
+  for (const [rawName, rawValue] of entries) {
+    const name = String(rawName || "").trim();
+    if (!name || isBlockedClientIdentityHeader(name)) continue;
+    if (rawValue === undefined || rawValue === null) continue;
+    const value = String(rawValue).trim();
+    if (!value) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function parseHeaderLines(input) {
+  const entries = [];
+  for (const line of String(input || "").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const sep = trimmed.indexOf(":");
+    if (sep <= 0) continue;
+    entries.push([trimmed.slice(0, sep), trimmed.slice(sep + 1)]);
+  }
+  return entries;
+}
+
+export function parseClientIdentityHeaders(input) {
+  if (!input) return {};
+
+  if (typeof input === "object" && !Array.isArray(input)) {
+    return sanitizeHeaderEntries(Object.entries(input));
+  }
+
+  const text = String(input).trim();
+  if (!text) return {};
+
+  if (text.startsWith("{")) {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return sanitizeHeaderEntries(Object.entries(parsed));
+  }
+
+  return sanitizeHeaderEntries(parseHeaderLines(text));
+}
+
+export function buildClientIdentityHeaders(identity = {}) {
+  const profile = normalizeClientIdentityProfile(identity.clientIdentityProfile);
+  if (profile === "custom") {
+    return parseClientIdentityHeaders(identity.clientIdentityHeaders);
+  }
+  return { ...(CLIENT_IDENTITY_PROFILES[profile]?.headers || {}) };
+}
+
+export function mergeClientIdentityHeaders(baseHeaders = {}, identity = {}, authHeaders = {}) {
+  return {
+    ...(baseHeaders || {}),
+    ...buildClientIdentityHeaders(identity),
+    ...(authHeaders || {}),
+  };
+}
+
+export function normalizeClientIdentityData(data = {}) {
+  const clientIdentityProfile = normalizeClientIdentityProfile(data.clientIdentityProfile);
+  return {
+    clientIdentityProfile,
+    clientIdentityHeaders: clientIdentityProfile === "custom"
+      ? parseClientIdentityHeaders(data.clientIdentityHeaders)
+      : {},
+  };
+}
+
+export function hasClaudeClientIdentityHeaders(headers = {}) {
+  for (const [rawName, rawValue] of Object.entries(headers || {})) {
+    const name = rawName.toLowerCase();
+    const value = String(rawValue || "").toLowerCase();
+    if (name === "x-app" && value === "cli") return true;
+    if (name === "anthropic-dangerous-direct-browser-access") return true;
+    if (name === "anthropic-beta" && value.includes("claude-code-20250219")) return true;
+    if (name === "user-agent" && (value.includes("claude-cli/") || value.includes("claude-code/"))) return true;
+  }
+  return false;
+}
+
+export function shouldStripClaudeIdentityHeaders({ provider, baseUrl = "", clientIdentityProfile, identityHeaders = {} } = {}) {
+  if (!provider?.startsWith?.("anthropic-compatible-")) return false;
+  const normalizedBaseUrl = String(baseUrl || "");
+  const isOfficialAnthropic = normalizedBaseUrl === "" || normalizedBaseUrl.includes("api.anthropic.com");
+  if (isOfficialAnthropic) return false;
+
+  const profile = normalizeClientIdentityProfile(clientIdentityProfile);
+  if (profile === "claude-cli") return false;
+  if (profile === "custom" && hasClaudeClientIdentityHeaders(identityHeaders)) return false;
+  return true;
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -8,7 +8,7 @@ import { planBulkAdd } from "@/shared/utils/bulkAdd";
 
 const BULK_PLACEHOLDER = `name1|sk-key1\nname2|sk-key2\nsk-key-only-auto-named`;
 
-export default function AddApiKeyModal({ isOpen, provider, providerName, isCompatible, isAnthropic, authType, authHint, website, proxyPools, error, existingNames, onSave, onBulkDone, onClose }) {
+export default function AddApiKeyModal({ isOpen, provider, providerName, isCompatible, isAnthropic, providerNode, authType, authHint, website, proxyPools, error, existingNames, onSave, onBulkDone, onClose }) {
   const NONE_PROXY_POOL_VALUE = "__none__";
   const isOllamaLocal = provider === "ollama-local";
   const isCookie = authType === "cookie";
@@ -51,6 +51,16 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   const [bulkResult, setBulkResult] = useState(null); // { success, failed }
 
   const buildProviderSpecificData = () => {
+    if (isCompatible && providerNode) {
+      return {
+        prefix: providerNode.prefix,
+        ...(providerNode.apiType ? { apiType: providerNode.apiType } : {}),
+        baseUrl: providerNode.baseUrl,
+        nodeName: providerNode.name,
+        clientIdentityProfile: providerNode.clientIdentityProfile || "default",
+        clientIdentityHeaders: providerNode.clientIdentityHeaders || {},
+      };
+    }
     if (isOllamaLocal && formData.ollamaHostUrl.trim()) {
       return { baseUrl: formData.ollamaHostUrl.trim() };
     }
@@ -72,12 +82,21 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   };
 
   const handleValidate = async () => {
+    if (isCompatible && !formData.defaultModel.trim()) {
+      setValidationResult("failed");
+      return;
+    }
     setValidating(true);
     try {
       const res = await fetch("/api/providers/validate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider, apiKey: formData.apiKey, providerSpecificData: buildProviderSpecificData() }),
+        body: JSON.stringify({
+          provider,
+          apiKey: formData.apiKey,
+          defaultModel: isCompatible ? formData.defaultModel.trim() : undefined,
+          providerSpecificData: buildProviderSpecificData(),
+        }),
       });
       const data = await res.json();
       setValidationResult(data.valid ? "success" : "failed");
@@ -106,7 +125,12 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         const res = await fetch("/api/providers/validate", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ provider, apiKey: formData.apiKey, providerSpecificData: buildProviderSpecificData() }),
+          body: JSON.stringify({
+            provider,
+            apiKey: formData.apiKey,
+            defaultModel: isCompatible ? formData.defaultModel.trim() : undefined,
+            providerSpecificData: buildProviderSpecificData(),
+          }),
         });
         const data = await res.json();
         isValid = !!data.valid;
@@ -393,6 +417,14 @@ AddApiKeyModal.propTypes = {
   providerName: PropTypes.string,
   isCompatible: PropTypes.bool,
   isAnthropic: PropTypes.bool,
+  providerNode: PropTypes.shape({
+    name: PropTypes.string,
+    prefix: PropTypes.string,
+    apiType: PropTypes.string,
+    baseUrl: PropTypes.string,
+    clientIdentityProfile: PropTypes.string,
+    clientIdentityHeaders: PropTypes.object,
+  }),
   authType: PropTypes.string,
   authHint: PropTypes.string,
   website: PropTypes.string,

--- a/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
@@ -4,12 +4,60 @@ import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Button, Badge, Input, Modal, Select } from "@/shared/components";
 
+const CLIENT_IDENTITY_OPTIONS = [
+  { value: "default", label: "Default" },
+  { value: "claude-cli", label: "Claude CLI" },
+  { value: "codex-cli", label: "Codex CLI" },
+  { value: "openclaw", label: "OpenClaw" },
+  { value: "custom", label: "Custom Headers" },
+];
+
+const BLOCKED_CUSTOM_HEADERS = new Set(["authorization", "x-api-key", "api-key", "cookie"]);
+
+function parseCustomIdentityHeaders(text) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed) return { headers: {} };
+
+  try {
+    let entries;
+    if (trimmed.startsWith("{")) {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { error: "Use a JSON object or Header: value lines." };
+      }
+      entries = Object.entries(parsed);
+    } else {
+      entries = [];
+      for (const line of trimmed.split(/\r?\n/)) {
+        const value = line.trim();
+        if (!value || value.startsWith("#")) continue;
+        const sep = value.indexOf(":");
+        if (sep <= 0) return { error: "Each custom header line must use Header: value." };
+        entries.push([value.slice(0, sep), value.slice(sep + 1)]);
+      }
+    }
+
+    const headers = {};
+    for (const [rawName, rawValue] of entries) {
+      const name = String(rawName || "").trim();
+      const value = String(rawValue || "").trim();
+      if (!name || !value || BLOCKED_CUSTOM_HEADERS.has(name.toLowerCase())) continue;
+      headers[name] = value;
+    }
+    return { headers };
+  } catch {
+    return { error: "Use valid JSON or Header: value lines." };
+  }
+}
+
 export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose, isAnthropic }) {
   const [formData, setFormData] = useState({
     name: "",
     prefix: "",
     apiType: "chat",
     baseUrl: "https://api.openai.com/v1",
+    clientIdentityProfile: "default",
+    clientIdentityHeadersText: "",
   });
   const [saving, setSaving] = useState(false);
   const [checkKey, setCheckKey] = useState("");
@@ -24,6 +72,10 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
         prefix: node.prefix || "",
         apiType: node.apiType || "chat",
         baseUrl: node.baseUrl || (isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"),
+        clientIdentityProfile: node.clientIdentityProfile || "default",
+        clientIdentityHeadersText: node.clientIdentityHeaders
+          ? JSON.stringify(node.clientIdentityHeaders, null, 2)
+          : "",
       });
     }
   }, [node, isAnthropic]);
@@ -35,12 +87,21 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
 
   const handleSubmit = async () => {
     if (!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim()) return;
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult("failed");
+      return;
+    }
     setSaving(true);
     try {
       const payload = {
         name: formData.name,
         prefix: formData.prefix,
         baseUrl: formData.baseUrl,
+        clientIdentityProfile: formData.clientIdentityProfile,
+        clientIdentityHeaders: customHeaders.headers,
       };
       if (!isAnthropic) {
         payload.apiType = formData.apiType;
@@ -52,6 +113,13 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
   };
 
   const handleValidate = async () => {
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult("failed");
+      return;
+    }
     setValidating(true);
     try {
       const res = await fetch("/api/provider-nodes/validate", {
@@ -61,7 +129,9 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
           baseUrl: formData.baseUrl,
           apiKey: checkKey,
           type: isAnthropic ? "anthropic-compatible" : "openai-compatible",
-          modelId: checkModelId.trim() || undefined
+          modelId: checkModelId.trim() || undefined,
+          clientIdentityProfile: formData.clientIdentityProfile,
+          clientIdentityHeaders: customHeaders.headers,
         }),
       });
       const data = await res.json();
@@ -107,6 +177,26 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
           placeholder={isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"}
           hint={`Use the base URL (ending in /v1) for your ${isAnthropic ? "Anthropic" : "OpenAI"}-compatible API.`}
         />
+        <Select
+          label="Client Identity"
+          options={CLIENT_IDENTITY_OPTIONS}
+          value={formData.clientIdentityProfile}
+          onChange={(e) => setFormData({ ...formData, clientIdentityProfile: e.target.value })}
+          hint="Optional. Adds client fingerprint headers for compatible gateways."
+        />
+        {formData.clientIdentityProfile === "custom" && (
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Custom Headers</label>
+            <textarea
+              value={formData.clientIdentityHeadersText}
+              onChange={(e) => setFormData({ ...formData, clientIdentityHeadersText: e.target.value })}
+              placeholder={'{\n  "User-Agent": "custom/1.0"\n}'}
+              rows={5}
+              className="w-full resize-y rounded-[10px] border border-transparent bg-surface-2 px-3 py-2.5 text-[16px] text-text-main placeholder-text-muted/70 transition-all duration-150 focus:border-brand-500/40 focus:outline-none focus:ring-2 focus:ring-brand-500/30 sm:text-sm"
+            />
+            <p className="text-xs text-text-muted">JSON object or Header: value lines. Auth headers are ignored.</p>
+          </div>
+        )}
         <div className="flex gap-2">
           <Input
             label="API Key (for Check)"
@@ -154,6 +244,8 @@ EditCompatibleNodeModal.propTypes = {
     prefix: PropTypes.string,
     apiType: PropTypes.string,
     baseUrl: PropTypes.string,
+    clientIdentityProfile: PropTypes.string,
+    clientIdentityHeaders: PropTypes.object,
   }),
   onSave: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -1685,6 +1685,7 @@ export default function ProviderDetailPage() {
         providerName={providerInfo.name}
         isCompatible={isCompatible}
         isAnthropic={isAnthropicCompatible}
+        providerNode={providerNode}
         authType={providerInfo?.authType}
         authHint={providerInfo?.authHint}
         website={providerInfo?.website}

--- a/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
+++ b/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
@@ -34,6 +34,52 @@ const API_TYPE_OPTIONS = [
   { value: "responses", label: "Responses API" },
 ];
 
+const CLIENT_IDENTITY_OPTIONS = [
+  { value: "default", label: "Default" },
+  { value: "claude-cli", label: "Claude CLI" },
+  { value: "codex-cli", label: "Codex CLI" },
+  { value: "openclaw", label: "OpenClaw" },
+  { value: "custom", label: "Custom Headers" },
+];
+
+const BLOCKED_CUSTOM_HEADERS = new Set(["authorization", "x-api-key", "api-key", "cookie"]);
+
+function parseCustomIdentityHeaders(text) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed) return { headers: {} };
+
+  try {
+    let entries;
+    if (trimmed.startsWith("{")) {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { error: "Use a JSON object or Header: value lines." };
+      }
+      entries = Object.entries(parsed);
+    } else {
+      entries = [];
+      for (const line of trimmed.split(/\r?\n/)) {
+        const value = line.trim();
+        if (!value || value.startsWith("#")) continue;
+        const sep = value.indexOf(":");
+        if (sep <= 0) return { error: "Each custom header line must use Header: value." };
+        entries.push([value.slice(0, sep), value.slice(sep + 1)]);
+      }
+    }
+
+    const headers = {};
+    for (const [rawName, rawValue] of entries) {
+      const name = String(rawName || "").trim();
+      const value = String(rawValue || "").trim();
+      if (!name || !value || BLOCKED_CUSTOM_HEADERS.has(name.toLowerCase())) continue;
+      headers[name] = value;
+    }
+    return { headers };
+  } catch {
+    return { error: "Use valid JSON or Header: value lines." };
+  }
+}
+
 function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
   const config = VARIANT_CONFIG[variant];
   const initialFormData = () => ({
@@ -41,6 +87,8 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
     prefix: "",
     ...(config.hasApiType ? { apiType: "chat" } : {}),
     baseUrl: config.defaultBaseUrl,
+    clientIdentityProfile: "default",
+    clientIdentityHeadersText: "",
   });
 
   const [formData, setFormData] = useState(initialFormData);
@@ -63,6 +111,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
 
   const handleSubmit = async () => {
     if (!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim()) return;
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult({ valid: false, error: customHeaders.error });
+      return;
+    }
     setSubmitting(true);
     try {
       const res = await fetch("/api/provider-nodes", {
@@ -74,6 +129,8 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           ...(config.hasApiType ? { apiType: formData.apiType } : {}),
           baseUrl: formData.baseUrl,
           type: config.type,
+          clientIdentityProfile: formData.clientIdentityProfile,
+          clientIdentityHeaders: customHeaders.headers,
         }),
       });
       const data = await res.json();
@@ -91,6 +148,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
   };
 
   const handleValidate = async () => {
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult({ valid: false, error: customHeaders.error });
+      return;
+    }
     setValidating(true);
     try {
       const res = await fetch("/api/provider-nodes/validate", {
@@ -101,6 +165,8 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           apiKey: checkKey,
           type: config.type,
           modelId: checkModelId.trim() || undefined,
+          clientIdentityProfile: formData.clientIdentityProfile,
+          clientIdentityHeaders: customHeaders.headers,
         }),
       });
       const data = await res.json();
@@ -165,6 +231,26 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           placeholder={config.defaultBaseUrl}
           hint={config.baseUrlHint}
         />
+        <Select
+          label="Client Identity"
+          options={CLIENT_IDENTITY_OPTIONS}
+          value={formData.clientIdentityProfile}
+          onChange={(e) => setFormData({ ...formData, clientIdentityProfile: e.target.value })}
+          hint="Optional. Adds client fingerprint headers for compatible gateways."
+        />
+        {formData.clientIdentityProfile === "custom" && (
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Custom Headers</label>
+            <textarea
+              value={formData.clientIdentityHeadersText}
+              onChange={(e) => setFormData({ ...formData, clientIdentityHeadersText: e.target.value })}
+              placeholder={'{\n  "User-Agent": "custom/1.0"\n}'}
+              rows={5}
+              className="w-full resize-y rounded-[10px] border border-transparent bg-surface-2 px-3 py-2.5 text-[16px] text-text-main placeholder-text-muted/70 transition-all duration-150 focus:border-brand-500/40 focus:outline-none focus:ring-2 focus:ring-brand-500/30 sm:text-sm"
+            />
+            <p className="text-xs text-text-muted">JSON object or Header: value lines. Auth headers are ignored.</p>
+          </div>
+        )}
         <Input
           label="API Key (for Check)"
           type="password"

--- a/src/app/api/provider-nodes/[id]/route.js
+++ b/src/app/api/provider-nodes/[id]/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { deleteProviderConnectionsByProvider, deleteProviderNode, getProviderConnections, getProviderNodeById, updateProviderConnection, updateProviderNode } from "@/models";
+import { normalizeClientIdentityData } from "open-sse/shared/clientIdentityHeaders.js";
 
 // PUT /api/provider-nodes/[id] - Update provider node
 export async function PUT(request, { params }) {
@@ -8,6 +9,15 @@ export async function PUT(request, { params }) {
     const body = await request.json();
     const { name, prefix, apiType, baseUrl } = body;
     const node = await getProviderNodeById(id);
+    const isCompatibleNode = node?.type === "openai-compatible" || node?.type === "anthropic-compatible";
+    const hasIdentityUpdate = Object.prototype.hasOwnProperty.call(body, "clientIdentityProfile") ||
+      Object.prototype.hasOwnProperty.call(body, "clientIdentityHeaders");
+    const identityData = isCompatibleNode
+      ? (hasIdentityUpdate ? normalizeClientIdentityData(body) : {
+          clientIdentityProfile: node.clientIdentityProfile || "default",
+          clientIdentityHeaders: node.clientIdentityHeaders || {},
+        })
+      : {};
 
     if (!node) {
       return NextResponse.json({ error: "Provider node not found" }, { status: 404 });
@@ -52,6 +62,7 @@ export async function PUT(request, { params }) {
       name: name.trim(),
       prefix: prefix.trim(),
       baseUrl: sanitizedBaseUrl,
+      ...identityData,
     };
 
     if (node.type === "openai-compatible") {
@@ -69,6 +80,7 @@ export async function PUT(request, { params }) {
           apiType: node.type === "openai-compatible" ? apiType : undefined,
           baseUrl: sanitizedBaseUrl,
           nodeName: updated.name,
+          ...identityData,
         }
       })
     )));

--- a/src/app/api/provider-nodes/route.js
+++ b/src/app/api/provider-nodes/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createProviderNode, getProviderNodes } from "@/models";
 import { OPENAI_COMPATIBLE_PREFIX, ANTHROPIC_COMPATIBLE_PREFIX, CUSTOM_EMBEDDING_PREFIX } from "@/shared/constants/providers";
 import { generateId } from "@/shared/utils";
+import { normalizeClientIdentityData } from "open-sse/shared/clientIdentityHeaders.js";
 
 export const dynamic = "force-dynamic";
 
@@ -46,6 +47,7 @@ export async function POST(request) {
     const nodeType = type || "openai-compatible";
 
     if (nodeType === "openai-compatible") {
+      const identityData = normalizeClientIdentityData(body);
       if (!apiType || !["chat", "responses"].includes(apiType)) {
         return NextResponse.json({ error: "Invalid OpenAI compatible API type" }, { status: 400 });
       }
@@ -57,6 +59,7 @@ export async function POST(request) {
         apiType,
         baseUrl: (baseUrl || OPENAI_COMPATIBLE_DEFAULTS.baseUrl).trim(),
         name: name.trim(),
+        ...identityData,
       });
       return NextResponse.json({ node }, { status: 201 });
     }
@@ -79,6 +82,7 @@ export async function POST(request) {
     }
 
     if (nodeType === "anthropic-compatible") {
+      const identityData = normalizeClientIdentityData(body);
       // Sanitize Base URL: remove trailing slash, and remove trailing /messages if user added it
       // This prevents double-appending /messages at runtime
       let sanitizedBaseUrl = (baseUrl || ANTHROPIC_COMPATIBLE_DEFAULTS.baseUrl).trim().replace(/\/$/, "");
@@ -92,6 +96,7 @@ export async function POST(request) {
         prefix: prefix.trim(),
         baseUrl: sanitizedBaseUrl,
         name: name.trim(),
+        ...identityData,
       });
       return NextResponse.json({ node }, { status: 201 });
     }

--- a/src/app/api/provider-nodes/validate/route.js
+++ b/src/app/api/provider-nodes/validate/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
 import { isLocalRequest } from "@/dashboardGuard";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // Fetch with timeout wrapper
 const fetchWithTimeout = (url, options, timeout = 10000) => {
@@ -55,7 +56,8 @@ const getChatErrorMessage = (status) => {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { baseUrl, apiKey, type, modelId } = body;
+    const { baseUrl, apiKey, type, modelId, clientIdentityProfile, clientIdentityHeaders } = body;
+    const identity = { clientIdentityProfile, clientIdentityHeaders };
 
     if (!baseUrl || !apiKey) {
       return NextResponse.json({ error: "Base URL and API key required" }, { status: 400 });
@@ -115,11 +117,15 @@ export async function POST(request) {
       const modelsUrl = `${normalizedBase}/models`;
       const res = await fetchWithTimeout(modelsUrl, {
         method: "GET",
-        headers: {
-          "x-api-key": apiKey,
-          "anthropic-version": "2023-06-01",
-          "Authorization": `Bearer ${apiKey}`
-        }
+        headers: mergeClientIdentityHeaders(
+          {},
+          identity,
+          {
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+            "Authorization": `Bearer ${apiKey}`,
+          },
+        ),
       });
 
       if (res.ok) return NextResponse.json({ valid: true });
@@ -133,12 +139,15 @@ export async function POST(request) {
       if (modelId) {
         const chatRes = await fetchWithTimeout(`${normalizedBase}/chat/completions`, {
           method: "POST",
-          headers: {
-            "Authorization": `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-            "anthropic-version": "2023-06-01"
-          },
+          headers: mergeClientIdentityHeaders(
+            { "Content-Type": "application/json" },
+            identity,
+            {
+              "Authorization": `Bearer ${apiKey}`,
+              "x-api-key": apiKey,
+              "anthropic-version": "2023-06-01",
+            },
+          ),
           body: JSON.stringify({
             model: modelId,
             messages: [{ role: "user", content: "ping" }],
@@ -161,7 +170,11 @@ export async function POST(request) {
     // OpenAI Compatible Validation (Default)
     const modelsUrl = `${baseUrl.replace(/\/$/, "")}/models`;
     const res = await fetchWithTimeout(modelsUrl, {
-      headers: { "Authorization": `Bearer ${apiKey}` },
+      headers: mergeClientIdentityHeaders(
+        {},
+        identity,
+        { "Authorization": `Bearer ${apiKey}` },
+      ),
     });
 
     if (res.ok) return NextResponse.json({ valid: true });
@@ -175,10 +188,11 @@ export async function POST(request) {
     if (modelId) {
       const chatRes = await fetchWithTimeout(`${baseUrl.replace(/\/$/, "")}/chat/completions`, {
         method: "POST",
-        headers: {
-          "Authorization": `Bearer ${apiKey}`,
-          "Content-Type": "application/json"
-        },
+        headers: mergeClientIdentityHeaders(
+          { "Content-Type": "application/json" },
+          identity,
+          { "Authorization": `Bearer ${apiKey}` },
+        ),
         body: JSON.stringify({
           model: modelId,
           messages: [{ role: "user", content: "ping" }],

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -10,6 +10,7 @@ import { resolveKimchiModels } from "open-sse/services/kimchiModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
@@ -438,10 +439,11 @@ export async function GET(request, { params }) {
       const url = `${baseUrl.replace(/\/$/, "")}/models`;
       const response = await fetch(url, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${connection.apiKey}`,
-        },
+        headers: mergeClientIdentityHeaders(
+          { "Content-Type": "application/json" },
+          connection.providerSpecificData || {},
+          { "Authorization": `Bearer ${connection.apiKey}` },
+        ),
       });
 
       if (!response.ok) {
@@ -477,12 +479,17 @@ export async function GET(request, { params }) {
       const url = `${baseUrl}/models`;
       const response = await fetch(url, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": connection.apiKey,
-          "anthropic-version": "2023-06-01",
-          "Authorization": `Bearer ${connection.apiKey}`
-        },
+        headers: mergeClientIdentityHeaders(
+          {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+          },
+          connection.providerSpecificData || {},
+          {
+            "x-api-key": connection.apiKey,
+            "Authorization": `Bearer ${connection.apiKey}`,
+          },
+        ),
       });
 
       if (!response.ok) {

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -19,6 +19,7 @@ import {
   KIMCHI_CONFIG,
 } from "@/lib/oauth/constants/oauth";
 import { buildClineHeaders } from "@/shared/utils/clineAuth";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // OAuth provider test endpoints
 const OAUTH_TEST_CONFIG = {
@@ -487,7 +488,11 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
     if (!modelsBase) return { valid: false, error: "Missing base URL" };
     try {
       const res = await fetchWithConnectionProxy(`${modelsBase.replace(/\/$/, "")}/models`, {
-        headers: { "Authorization": `Bearer ${connection.apiKey}` },
+        headers: mergeClientIdentityHeaders(
+          {},
+          connection.providerSpecificData || {},
+          { "Authorization": `Bearer ${connection.apiKey}` },
+        ),
       }, effectiveProxy);
       return { valid: res.ok, error: res.ok ? null : "Invalid API key or base URL" };
     } catch (err) {
@@ -501,16 +506,20 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
     try {
       modelsBase = modelsBase.replace(/\/$/, "");
       if (modelsBase.endsWith("/messages")) modelsBase = modelsBase.slice(0, -9);
+      if (modelsBase.endsWith("/v1")) modelsBase = modelsBase.slice(0, -3);
       const messagesUrl = `${modelsBase}/v1/messages`;
       const model = connection.defaultModel || "claude-3-haiku-20240307";
       const res = await fetchWithConnectionProxy(messagesUrl, {
         method: "POST",
-        headers: {
-          "x-api-key": connection.apiKey,
-          "anthropic-version": "2023-06-01",
-          "content-type": "application/json",
-          "Authorization": `Bearer ${connection.apiKey}`,
-        },
+        headers: mergeClientIdentityHeaders(
+          { "content-type": "application/json" },
+          connection.providerSpecificData || {},
+          {
+            "x-api-key": connection.apiKey,
+            "anthropic-version": "2023-06-01",
+            "Authorization": `Bearer ${connection.apiKey}`,
+          },
+        ),
         body: JSON.stringify({
           model,
           max_tokens: 1,

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -138,6 +138,8 @@ export async function POST(request) {
         apiType: node.apiType,
         baseUrl: node.baseUrl,
         nodeName: node.name,
+        clientIdentityProfile: node.clientIdentityProfile || "default",
+        clientIdentityHeaders: node.clientIdentityHeaders || {},
       };
     } else if (isAnthropicCompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);
@@ -148,6 +150,8 @@ export async function POST(request) {
         prefix: node.prefix,
         baseUrl: node.baseUrl,
         nodeName: node.name,
+        clientIdentityProfile: node.clientIdentityProfile || "default",
+        clientIdentityHeaders: node.clientIdentityHeaders || {},
       };
     } else if (isCustomEmbeddingProvider(provider)) {
       const node = await getProviderNodeById(provider);

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -5,6 +5,7 @@ import { getDefaultModel } from "open-sse/config/providerModels.js";
 import { resolveOllamaLocalHost, resolveXiaomiTokenplanBaseUrl, PROVIDERS } from "open-sse/config/providers.js";
 import { openaiToCommandCodeRequest } from "open-sse/translator/request/openai-to-commandcode.js";
 import { normalizeProviderId } from "@/lib/providerNormalization";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
@@ -104,7 +105,14 @@ export async function POST(request) {
         }
         const modelsUrl = `${node.baseUrl?.replace(/\/$/, "")}/models`;
         const res = await fetch(modelsUrl, {
-          headers: { "Authorization": `Bearer ${apiKey}` },
+          headers: mergeClientIdentityHeaders(
+            { "Content-Type": "application/json" },
+            {
+              clientIdentityProfile: providerSpecificData?.clientIdentityProfile ?? node.clientIdentityProfile,
+              clientIdentityHeaders: providerSpecificData?.clientIdentityHeaders ?? node.clientIdentityHeaders,
+            },
+            { "Authorization": `Bearer ${apiKey}` },
+          ),
         });
         isValid = res.ok;
         return NextResponse.json({
@@ -154,18 +162,29 @@ export async function POST(request) {
         if (normalizedBase.endsWith("/messages")) {
           normalizedBase = normalizedBase.slice(0, -9); // remove /messages
         }
+        if (normalizedBase.endsWith("/v1")) {
+          normalizedBase = normalizedBase.slice(0, -3);
+        }
 
         const messagesUrl = `${normalizedBase}/v1/messages`;
-        const model = node.defaultModel || "claude-3-haiku-20240307";
+        const model = body.defaultModel || node.defaultModel || "claude-3-haiku-20240307";
 
         const res = await fetch(messagesUrl, {
           method: "POST",
-          headers: {
-            "x-api-key": apiKey,
-            "anthropic-version": "2023-06-01",
-            "content-type": "application/json",
-            "Authorization": `Bearer ${apiKey}`,
-          },
+          headers: mergeClientIdentityHeaders(
+            {
+              "content-type": "application/json",
+              "anthropic-version": "2023-06-01",
+            },
+            {
+              clientIdentityProfile: providerSpecificData?.clientIdentityProfile ?? node.clientIdentityProfile,
+              clientIdentityHeaders: providerSpecificData?.clientIdentityHeaders ?? node.clientIdentityHeaders,
+            },
+            {
+              "x-api-key": apiKey,
+              "Authorization": `Bearer ${apiKey}`,
+            },
+          ),
           body: JSON.stringify({
             model,
             max_tokens: 1,

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -16,6 +16,7 @@ import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -138,7 +139,7 @@ function inferKindFromUnknownModelId(modelId) {
   return LLM_KIND;
 }
 
-async function fetchCompatibleModelIds(connection) {
+export async function fetchCompatibleModelIds(connection) {
   if (!connection?.apiKey) return [];
 
   const baseUrl = typeof connection?.providerSpecificData?.baseUrl === "string"
@@ -148,24 +149,33 @@ async function fetchCompatibleModelIds(connection) {
   if (!baseUrl) return [];
 
   let url = `${baseUrl}/models`;
-  const headers = {
+  const baseHeaders = {
     "Content-Type": "application/json",
   };
+  let authHeaders = {};
 
   if (isOpenAICompatibleProvider(connection.provider)) {
-    headers.Authorization = `Bearer ${connection.apiKey}`;
+    authHeaders = { Authorization: `Bearer ${connection.apiKey}` };
   } else if (isAnthropicCompatibleProvider(connection.provider)) {
     if (url.endsWith("/messages/models")) {
       url = url.slice(0, -9);
     } else if (url.endsWith("/messages")) {
       url = `${url.slice(0, -9)}/models`;
     }
-    headers["x-api-key"] = connection.apiKey;
-    headers["anthropic-version"] = "2023-06-01";
-    headers.Authorization = `Bearer ${connection.apiKey}`;
+    authHeaders = {
+      "x-api-key": connection.apiKey,
+      "anthropic-version": "2023-06-01",
+      Authorization: `Bearer ${connection.apiKey}`,
+    };
   } else {
     return [];
   }
+
+  const headers = mergeClientIdentityHeaders(
+    baseHeaders,
+    connection.providerSpecificData || {},
+    authHeaders,
+  );
 
   try {
     const controller = new AbortController();

--- a/src/lib/db/repos/nodesRepo.js
+++ b/src/lib/db/repos/nodesRepo.js
@@ -62,6 +62,8 @@ export async function createProviderNode(data) {
     prefix: data.prefix,
     apiType: data.apiType,
     baseUrl: data.baseUrl,
+    clientIdentityProfile: data.clientIdentityProfile,
+    clientIdentityHeaders: data.clientIdentityHeaders,
     createdAt: now,
     updatedAt: now,
   };

--- a/tests/unit/claude-header-forwarding.test.js
+++ b/tests/unit/claude-header-forwarding.test.js
@@ -269,6 +269,67 @@ describe("DefaultExecutor.buildHeaders() — anthropic-compatible stripping", ()
     expect(betaVal).not.toContain("claude-code-20250219");
   });
 
+  it("keeps Claude identity headers for claude-cli profile on non-Anthropic host", () => {
+    const executor = new DefaultExecutor("anthropic-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "key",
+        providerSpecificData: {
+          baseUrl: "https://myproxy.example.com/v1",
+          clientIdentityProfile: "claude-cli",
+        },
+      },
+      true
+    );
+
+    expect(headers["X-App"]).toBe("cli");
+    expect(headers["Anthropic-Beta"]).toContain("claude-code-20250219");
+    expect(headers["Authorization"]).toBe("Bearer key");
+    expect(headers["x-api-key"]).toBe("key");
+  });
+
+  it("keeps custom Claude identity headers on non-Anthropic host", () => {
+    const executor = new DefaultExecutor("anthropic-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "key",
+        providerSpecificData: {
+          baseUrl: "https://myproxy.example.com/v1",
+          clientIdentityProfile: "custom",
+          clientIdentityHeaders: {
+            "X-App": "cli",
+            "Anthropic-Beta": "claude-code-20250219",
+          },
+        },
+      },
+      false
+    );
+
+    expect(headers["X-App"]).toBe("cli");
+    expect(headers["Anthropic-Beta"]).toBe("claude-code-20250219");
+  });
+
+  it("keeps auth headers ahead of custom identity headers", () => {
+    const executor = new DefaultExecutor("openai-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "real-key",
+        providerSpecificData: {
+          baseUrl: "https://openai-compatible.example.com/v1",
+          clientIdentityProfile: "custom",
+          clientIdentityHeaders: {
+            Authorization: "Bearer fake-key",
+            "User-Agent": "custom/1.0",
+          },
+        },
+      },
+      false
+    );
+
+    expect(headers["Authorization"]).toBe("Bearer real-key");
+    expect(headers["User-Agent"]).toBe("custom/1.0");
+  });
+
   it("keeps other beta flags intact after stripping", () => {
     const executor = new DefaultExecutor("anthropic-compatible-custom");
     // The static CLAUDE_API_HEADERS used by anthropic-compatible providers include

--- a/tests/unit/client-identity-headers.test.js
+++ b/tests/unit/client-identity-headers.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildClientIdentityHeaders,
+  mergeClientIdentityHeaders,
+  parseClientIdentityHeaders,
+} from "open-sse/shared/clientIdentityHeaders.js";
+
+describe("client identity headers", () => {
+  it("default profile does not add headers", () => {
+    expect(buildClientIdentityHeaders({ clientIdentityProfile: "default" })).toEqual({});
+  });
+
+  it("claude-cli profile includes Claude CLI fingerprint headers", () => {
+    const headers = buildClientIdentityHeaders({ clientIdentityProfile: "claude-cli" });
+
+    expect(headers["User-Agent"]).toContain("claude-cli/");
+    expect(headers["X-App"]).toBe("cli");
+    expect(headers["Anthropic-Beta"]).toContain("claude-code-20250219");
+  });
+
+  it("codex-cli profile includes Codex originator headers", () => {
+    const headers = buildClientIdentityHeaders({ clientIdentityProfile: "codex-cli" });
+
+    expect(headers.originator).toBe("codex_cli_rs");
+    expect(headers["User-Agent"]).toContain("codex_cli_rs/");
+  });
+
+  it("openclaw profile includes OpenClaw user agent", () => {
+    expect(buildClientIdentityHeaders({ clientIdentityProfile: "openclaw" })).toEqual({
+      "User-Agent": "openclaw/2026.2.3",
+    });
+  });
+
+  it("invalid profile normalizes to default headers", () => {
+    expect(buildClientIdentityHeaders({ clientIdentityProfile: "unknown-profile" })).toEqual({});
+  });
+
+  it("parses custom headers from JSON and blocks auth headers", () => {
+    const headers = parseClientIdentityHeaders(JSON.stringify({
+      "User-Agent": "custom/1.0",
+      Authorization: "Bearer wrong",
+      "x-api-key": "wrong",
+      "X-Trace": "abc",
+    }));
+
+    expect(headers).toEqual({
+      "User-Agent": "custom/1.0",
+      "X-Trace": "abc",
+    });
+  });
+
+  it("parses custom headers from Header: value lines", () => {
+    const headers = parseClientIdentityHeaders([
+      "User-Agent: custom/1.0",
+      "X-App: cli",
+      "api-key: blocked",
+      "Malformed",
+    ].join("\n"));
+
+    expect(headers).toEqual({
+      "User-Agent": "custom/1.0",
+      "X-App": "cli",
+    });
+  });
+
+  it("merges base, identity, and auth with auth winning", () => {
+    const headers = mergeClientIdentityHeaders(
+      { "Content-Type": "application/json", Authorization: "Bearer base" },
+      {
+        clientIdentityProfile: "custom",
+        clientIdentityHeaders: {
+          "User-Agent": "custom/1.0",
+          Authorization: "Bearer custom",
+        },
+      },
+      { Authorization: "Bearer real-token" },
+    );
+
+    expect(headers).toEqual({
+      "Content-Type": "application/json",
+      "User-Agent": "custom/1.0",
+      Authorization: "Bearer real-token",
+    });
+  });
+});

--- a/tests/unit/compatible-client-identity-routes.test.js
+++ b/tests/unit/compatible-client-identity-routes.test.js
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalFetch = globalThis.fetch;
+
+function mockNextResponse() {
+  vi.doMock("next/server", () => ({
+    NextResponse: {
+      json(body, init = {}) {
+        return new Response(JSON.stringify(body), {
+          status: init.status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+  }));
+}
+
+describe("compatible client identity route headers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockNextResponse();
+    vi.doMock("@/dashboardGuard", () => ({ isLocalRequest: () => true }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.doUnmock("next/server");
+    vi.doUnmock("@/dashboardGuard");
+    vi.resetModules();
+  });
+
+  it("provider node validation sends identity headers for OpenAI compatible", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/provider-nodes/validate/route.js");
+
+    const response = await POST(new Request("https://9router.local/api/provider-nodes/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: "https://gateway.example.com/v1",
+        apiKey: "real-key",
+        type: "openai-compatible",
+        clientIdentityProfile: "openclaw",
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("provider node validation sends identity headers for Anthropic compatible", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/provider-nodes/validate/route.js");
+
+    await POST(new Request("https://9router.local/api/provider-nodes/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: "https://gateway.example.com/v1",
+        apiKey: "real-key",
+        type: "anthropic-compatible",
+        clientIdentityProfile: "claude-cli",
+      }),
+    }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "x-api-key": "real-key",
+          "X-App": "cli",
+          "Anthropic-Beta": expect.stringContaining("claude-code-20250219"),
+        }),
+      }),
+    );
+  });
+
+  it("/v1/models compatible discovery sends identity headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "glm-5.2" }] }),
+    });
+    globalThis.fetch = fetchMock;
+    const { fetchCompatibleModelIds } = await import("@/app/api/v1/models/route.js");
+
+    const models = await fetchCompatibleModelIds({
+      provider: "openai-compatible-chat-node",
+      apiKey: "real-key",
+      providerSpecificData: {
+        baseUrl: "https://gateway.example.com/v1",
+        clientIdentityProfile: "openclaw",
+      },
+    });
+
+    expect(models).toEqual(["glm-5.2"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("/api/providers/validate sends identity headers for OpenAI compatible saved node validation", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderNodeById: vi.fn().mockResolvedValue({
+        id: "openai-compatible-chat-node",
+        type: "openai-compatible",
+        baseUrl: "https://gateway.example.com/v1",
+        clientIdentityProfile: "openclaw",
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/providers/validate/route.js");
+
+    const response = await POST(new Request("https://9router.local/api/providers/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider: "openai-compatible-chat-node",
+        apiKey: "real-key",
+        providerSpecificData: {
+          clientIdentityProfile: "openclaw",
+        },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("/api/providers/validate sends identity headers and body defaultModel for Anthropic compatible", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderNodeById: vi.fn().mockResolvedValue({
+        id: "anthropic-compatible-node",
+        type: "anthropic-compatible",
+        baseUrl: "https://gateway.example.com/v1/messages",
+        defaultModel: "node-model",
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "bad request" }),
+      text: async () => "bad request",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/providers/validate/route.js");
+
+    const response = await POST(new Request("https://9router.local/api/providers/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider: "anthropic-compatible-node",
+        apiKey: "real-key",
+        defaultModel: "body-model",
+        providerSpecificData: {
+          clientIdentityProfile: "claude-cli",
+        },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ valid: true, error: null });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "x-api-key": "real-key",
+          "X-App": "cli",
+          "Anthropic-Beta": expect.stringContaining("claude-code-20250219"),
+        }),
+        body: expect.any(String),
+      }),
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body).model).toBe("body-model");
+  });
+
+  it("/api/providers/[id]/models uses saved OpenAI compatible connection identity", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderConnectionById: vi.fn().mockResolvedValue({
+        id: "conn-1",
+        provider: "openai-compatible-chat-node",
+        apiKey: "real-key",
+        providerSpecificData: {
+          baseUrl: "https://gateway.example.com/v1",
+          clientIdentityProfile: "openclaw",
+        },
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "model-a" }] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { GET } = await import("@/app/api/providers/[id]/models/route.js");
+
+    const response = await GET(new Request("https://9router.local/api/providers/conn-1/models"), {
+      params: Promise.resolve({ id: "conn-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("/api/providers/[id]/models uses saved Anthropic compatible connection identity", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderConnectionById: vi.fn().mockResolvedValue({
+        id: "conn-1",
+        provider: "anthropic-compatible-node",
+        apiKey: "real-key",
+        providerSpecificData: {
+          baseUrl: "https://gateway.example.com/v1/messages",
+          clientIdentityProfile: "claude-cli",
+        },
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "claude-like" }] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { GET } = await import("@/app/api/providers/[id]/models/route.js");
+
+    const response = await GET(new Request("https://9router.local/api/providers/conn-1/models"), {
+      params: Promise.resolve({ id: "conn-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "x-api-key": "real-key",
+          "X-App": "cli",
+          "Anthropic-Beta": expect.stringContaining("claude-code-20250219"),
+        }),
+      }),
+    );
+  });
+});

--- a/tests/unit/compatible-provider-connections.test.js
+++ b/tests/unit/compatible-provider-connections.test.js
@@ -115,6 +115,98 @@ describe("compatible provider connections API", () => {
     });
   });
 
+  it("copies client identity settings from compatible node into its connection", async () => {
+    const ctx = await setupTestContext({
+      id: "openai-compatible-identity-test",
+      type: "openai-compatible",
+      name: "Identity Test Node",
+      prefix: "ident",
+      apiType: "chat",
+      baseUrl: "https://identity.test/v1",
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+        "X-App": "cli",
+      },
+    });
+    cleanup = ctx.cleanup;
+
+    expect(ctx.node.clientIdentityProfile).toBe("custom");
+    expect(ctx.node.clientIdentityHeaders).toEqual({
+      "User-Agent": "custom/1.0",
+      "X-App": "cli",
+    });
+
+    const response = await ctx.POST(makeRequest(ctx.node.id));
+    const body = await response.json();
+    const storedConnections = await ctx.getProviderConnections({ provider: ctx.node.id });
+
+    expect(response.status).toBe(201);
+    expect(body.connection.providerSpecificData).toMatchObject({
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+        "X-App": "cli",
+      },
+    });
+    expect(storedConnections[0].providerSpecificData).toMatchObject({
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+        "X-App": "cli",
+      },
+    });
+  });
+
+  it("preserves and propagates existing client identity when updating a compatible node without identity fields", async () => {
+    const ctx = await setupTestContext({
+      id: "openai-compatible-update-identity-test",
+      type: "openai-compatible",
+      name: "Identity Update Test Node",
+      prefix: "ident",
+      apiType: "chat",
+      baseUrl: "https://identity.test/v1",
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+      },
+    });
+    cleanup = ctx.cleanup;
+    const createResponse = await ctx.POST(makeRequest(ctx.node.id));
+    expect(createResponse.status).toBe(201);
+
+    const { PUT } = await import("@/app/api/provider-nodes/[id]/route.js");
+    const response = await PUT(new Request(`https://9router.local/api/provider-nodes/${ctx.node.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Renamed Identity Node",
+        prefix: "ident2",
+        apiType: "responses",
+        baseUrl: "https://identity-updated.test/v1",
+      }),
+    }), {
+      params: Promise.resolve({ id: ctx.node.id }),
+    });
+    const body = await response.json();
+    const storedConnections = await ctx.getProviderConnections({ provider: ctx.node.id });
+
+    expect(response.status).toBe(200);
+    expect(body.node).toMatchObject({
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+      },
+    });
+    expect(storedConnections[0].providerSpecificData).toMatchObject({
+      baseUrl: "https://identity-updated.test/v1",
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+      },
+    });
+  });
+
   it("creates one API-key connection for an Anthropic-compatible node", async () => {
     const ctx = await setupTestContext({
       id: "anthropic-compatible-test",

--- a/tests/unit/embeddingsCore.test.js
+++ b/tests/unit/embeddingsCore.test.js
@@ -368,6 +368,48 @@ describe("buildEmbeddingsHeaders", () => {
     expect(init.headers["HTTP-Referer"]).toBeUndefined();
     expect(init.headers["X-Title"]).toBeUndefined();
   });
+
+  it("openai-compatible-* sends client identity headers for embeddings", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
+
+    await handleEmbeddingsCore(makeOptions({
+      modelInfo: { provider: "openai-compatible-local", model: "nomic-embed" },
+      credentials: {
+        apiKey: "local-key",
+        providerSpecificData: {
+          baseUrl: "http://localhost:11434/v1",
+          clientIdentityProfile: "openclaw",
+        },
+      },
+    }));
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init.headers["Authorization"]).toBe("Bearer local-key");
+    expect(init.headers["User-Agent"]).toBe("openclaw/2026.2.3");
+  });
+
+  it("openai-compatible-* embeddings auth header wins over custom identity Authorization", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
+
+    await handleEmbeddingsCore(makeOptions({
+      modelInfo: { provider: "openai-compatible-local", model: "nomic-embed" },
+      credentials: {
+        apiKey: "local-key",
+        providerSpecificData: {
+          baseUrl: "http://localhost:11434/v1",
+          clientIdentityProfile: "custom",
+          clientIdentityHeaders: {
+            Authorization: "Bearer wrong-key",
+            "User-Agent": "custom/1.0",
+          },
+        },
+      },
+    }));
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init.headers["Authorization"]).toBe("Bearer local-key");
+    expect(init.headers["User-Agent"]).toBe("custom/1.0");
+  });
 });
 
 // ─── Test: handleEmbeddingsCore — input validation ───────────────────────────


### PR DESCRIPTION
## Summary

- Add generic client identity profiles for OpenAI-compatible and Anthropic-compatible provider nodes.
- Persist the selected identity profile on compatible nodes and copy it into provider connection `providerSpecificData`.
- Apply the same identity header merge path across validation, saved connection model listing, `/v1/models`, runtime chat/messages/responses, and OpenAI-compatible embeddings.

## Notes

- This is generic compatible-provider plumbing, with no gateway-specific hardcoding.
- Auth headers always win over preset/custom identity headers.
- Custom identity headers are sanitized so they cannot override `Authorization`, `x-api-key`, `api-key`, or `cookie`.

## Test Plan

- `git diff --check && git diff --cached --check`
- `vitest run --config tests/vitest.config.js --reporter=verbose tests/unit/client-identity-headers.test.js tests/unit/compatible-provider-connections.test.js tests/unit/compatible-client-identity-routes.test.js tests/unit/claude-header-forwarding.test.js tests/unit/embeddingsCore.test.js -t 'client identity|compatible provider connections API|compatible client identity route headers|DefaultExecutor\\.buildHeaders|buildEmbeddingsHeaders'`
- `npm run build`
