### PR TITLE
fix(kimchi): bump User-Agent to kimchi/0.1.40

### DIFF
--- a/open-sse/providers/registry/kimchi.js
+++ b/open-sse/providers/registry/kimchi.js
@@ -20,7 +20,7 @@ export default {
     baseUrl: "https://llm.kimchi.dev/openai/v1/chat/completions",
     format: "openai",
     headers: {
-      "User-Agent": "kimchi/0.0.0",
+      "User-Agent": "kimchi/0.1.40",
     },
     auth: {
       combined: true,

--- a/open-sse/services/kimchiModels.js
+++ b/open-sse/services/kimchiModels.js
@@ -3,7 +3,7 @@ import { createHash } from "crypto";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 
 export const KIMCHI_API = "https://llm.kimchi.dev";
-export const KIMCHI_USER_AGENT = "kimchi/0.0.0";
+export const KIMCHI_USER_AGENT = "kimchi/0.1.40";
 
 const FETCH_TIMEOUT_MS = 20_000;
 const CACHE_TTL_MS = 5 * 60 * 1000;

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -99,7 +99,7 @@ const OAUTH_TEST_CONFIG = {
     authPrefix: "Bearer ",
     extraHeaders: {
       Accept: "application/json",
-      "User-Agent": "kimchi/0.0.0",
+      "User-Agent": "kimchi/0.1.40",
     },
     refreshable: false,
   },


### PR DESCRIPTION
### Summary
Update the Kimchi `User-Agent` header from `kimchi/0.0.0` to `kimchi/0.1.40` so requests match the current Kimchi CLI version and aren't rejected as outdated clients.

### Changes
- `open-sse/providers/registry/kimchi.js` — provider default header
- `open-sse/services/kimchiModels.js` — `KIMCHI_USER_AGENT` constant used during model discovery
- `src/app/api/providers/[id]/test/testUtils.js` — OAuth provider connection-test header

### Testing
Grep-verified no remaining `kimchi/0.0.0` references in the tree.