### PR TITLE
fix(usage): Fix duplicate 0-token log rows for streaming requests

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -326,8 +326,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   // Streaming response
-  const { onStreamComplete } = buildOnStreamComplete({ ...sharedCtx });
-  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete });
+  const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
+  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId });
 }
 
 export function isTokenExpiringSoon(expiresAt, bufferMs = 5 * 60 * 1000) {

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -43,7 +43,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 /**
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
-export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete }) {
+export function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId }) {
   if (onRequestSuccess) {
     Promise.resolve()
       .then(onRequestSuccess)
@@ -68,7 +68,6 @@ export function handleStreamingResponse({ providerResponse, provider, model, sou
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
   const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
 
-  const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
   saveRequestDetail(buildRequestDetail({
     provider, model, connectionId,
     latency: { ttft: 0, total: Date.now() - requestStartTime },


### PR DESCRIPTION

## What's wrong

Every streaming request leaves a junk entry behind on the **Usage → Request Details** page. You end up with two rows for a single request: an empty placeholder showing 0 tokens, and the real one with actual usage. The placeholder never goes away.

## Why it happens

Streaming intentionally writes the log twice for one request:

1. A **placeholder** row right away (0 tokens), before the stream finishes — so the request shows up immediately.
2. The **final** row at the end, once the real token counts are known.

These two writes are meant to be *the same database row* — they're merged with an upsert keyed on the record's id. The bug: the two code paths each generated their *own* random id, so the ids never matched, the upsert never merged them, and the 0-token placeholder was left orphaned forever.

## The fix

Generate the id once and pass it from the final-write path into the placeholder path, so both writes hit the same row. The final usage now correctly overwrites the placeholder.

**Result:** one clean row per streaming request, with real token counts. No more 0-token stubs.

## How to test

Send any streaming request, open Usage → Request Details, and confirm there's a single row showing real input/output tokens (previously there were two, one of them empty).
