### PR TITLE
fix(mitm): replace net session with fltmc for Windows admin check

### DIFF
--- a/src/app/api/cli-tools/antigravity-mitm/route.js
+++ b/src/app/api/cli-tools/antigravity-mitm/route.js
@@ -48,7 +48,7 @@ function requiresSudoPassword(pwd) {
 function checkIsAdmin() {
   if (isWin) {
     try {
-      require("child_process").execSync("net session >nul 2>&1", { windowsHide: true });
+      require("child_process").execSync("fltmc", { windowsHide: true, stdio: "ignore" });
       return true;
     } catch {
       return false;

--- a/src/mitm/winElevated.js
+++ b/src/mitm/winElevated.js
@@ -9,7 +9,7 @@ const IS_WIN = process.platform === "win32";
 function isAdmin() {
   if (IS_WIN) {
     try {
-      execSync("net session >nul 2>&1", { windowsHide: true, stdio: "ignore" });
+      execSync("fltmc", { windowsHide: true, stdio: "ignore" });
       return true;
     } catch {
       return false;

--- a/tests/unit/mitm-admin-check.test.js
+++ b/tests/unit/mitm-admin-check.test.js
@@ -1,0 +1,47 @@
+import { vi, describe, expect, it, beforeEach } from "vitest";
+
+// Use vi.hoisted to patch child_process before winElevated.js is imported
+const mockExecSync = vi.hoisted(() => vi.fn());
+
+vi.hoisted(() => {
+  const child_process = require("child_process");
+  child_process.execSync = mockExecSync;
+});
+
+// Import after the hoisted patch is executed
+import { isAdmin } from "../../src/mitm/winElevated.js";
+
+describe("Windows Admin Privilege Check (winElevated.js)", () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+  });
+
+  it("returns true when fltmc succeeds (elevated process)", () => {
+    mockExecSync.mockReturnValue(Buffer.from(""));
+    
+    const result = isAdmin();
+    
+    if (process.platform === "win32") {
+      expect(result).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith("fltmc", { windowsHide: true, stdio: "ignore" });
+    } else {
+      // On non-Windows, it checks process.getuid
+      expect(result).toBe(typeof process.getuid === "function" && process.getuid() === 0);
+    }
+  });
+
+  it("returns false when fltmc throws an error (non-elevated process)", () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error("Access is denied");
+    });
+    
+    const result = isAdmin();
+    
+    if (process.platform === "win32") {
+      expect(result).toBe(false);
+      expect(mockExecSync).toHaveBeenCalledWith("fltmc", { windowsHide: true, stdio: "ignore" });
+    } else {
+      expect(result).toBe(typeof process.getuid === "function" && process.getuid() === 0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Replace the `net session` command with `fltmc` to verify Administrator privileges on Windows. This fixes a bug where the MITM server fails to initialize when the LanmanServer service is stopped or disabled, even if the terminal is running as Administrator.

## Problem

On Windows, the `isAdmin()` and `checkIsAdmin()` functions check for elevation using `net session >nul 2>&1`. This command relies on the **LanmanServer (Server)** service to be running. If the service is disabled or stopped (common in Home editions or hardened environments), the command fails with `System error 2114` even if elevated. This locks users out of the MITM proxy features on the dashboard.

## Files changed

- **`src/app/api/cli-tools/antigravity-mitm/route.js`** — Replaces the `net session` check with `fltmc` in `checkIsAdmin()`
- **`src/mitm/winElevated.js`** — Replaces the `net session` check with `fltmc` in `isAdmin()`

## Test Plan

- Unit tests pass (2 tests covering `fltmc` execution success for elevated processes and execution failure/throwing for non-elevated processes in `tests/unit/mitm-admin-check.test.js`)

## Notes

- `fltmc` is standard on all modern Windows installations, lightweight, and requires Administrator privileges to run, failing with access denied (exit code 1) otherwise. Unlike `net session`, it does not depend on the LanmanServer network service.

## Related Issues

Fixes #2224
