### PR TITLE
fix(cli): rename next-server process to a unique name

### DIFF
--- a/custom-server.js
+++ b/custom-server.js
@@ -1,5 +1,14 @@
 const http = require("http");
 
+// Renaming next-server process to a unique name while keeping "next-server"
+// in the name for backward compatibility with existing process-matching whitelists.
+process.title = "9router next-server";
+Object.defineProperty(process, "title", {
+  get: () => "9router next-server",
+  set: () => {},
+  configurable: true
+});
+
 const origCreate = http.createServer.bind(http);
 
 // Wrap Next standalone HTTP server: derive client IP from the TCP socket

--- a/tests/unit/custom-server.test.js
+++ b/tests/unit/custom-server.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+import path from "path";
+import fs from "fs";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+describe("Next.js Server Process Title", () => {
+  it("sets the process title to '9router next-server'", () => {
+    // Save original title
+    const originalTitle = process.title;
+
+    // Resolve server.js relative to custom-server.js (which is at the root)
+    const serverPath = path.resolve(__dirname, "../../server.js");
+
+    // Write a dummy server.js so Node.js resolver finds it on disk
+    fs.writeFileSync(serverPath, "module.exports = {};");
+
+    // Populate require.cache to mock require("./server.js")
+    require.cache[serverPath] = {
+      id: serverPath,
+      filename: serverPath,
+      loaded: true,
+      exports: {},
+    };
+
+    try {
+      // Require custom-server.js
+      require("../../custom-server.js");
+
+      // Verify process.title is updated
+      expect(process.title).toBe("9router next-server");
+
+      // Try to set it to something else
+      process.title = "next-server";
+      expect(process.title).toBe("9router next-server");
+    } finally {
+      // Restore original title
+      const originalSetTitle = Object.getOwnPropertyDescriptor(process, "title")?.set;
+      if (originalSetTitle) {
+        Object.defineProperty(process, "title", {
+          value: originalTitle,
+          writable: true,
+          configurable: true
+        });
+      } else {
+        process.title = originalTitle;
+      }
+
+      // Clean up require.cache
+      delete require.cache[serverPath];
+      delete require.cache[path.resolve(__dirname, "../../custom-server.js")];
+
+      // Remove dummy server.js
+      try {
+        fs.unlinkSync(serverPath);
+      } catch {}
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Renames the spawned Next.js server process to a unique process title (`9router next-server`) to make it easily distinguishable in OS process lists and Task Manager.

## Problem

The Next.js standalone server previously ran with the default generic process title `next-server`, making it difficult to differentiate from other Next.js applications on the same machine and potentially clashing.

## Files changed

- **`custom-server.js`** — Intercepts `process.title` at boot using a custom descriptor, setting it to `9router next-server` and ignoring subsequent attempts to reset it to `next-server`.

## Test Plan

- Unit/Integration tests pass (a new unit test in `tests/unit/custom-server.test.js` successfully mocks `server.js`, imports `custom-server.js`, asserts that `process.title` is correctly configured to `9router next-server`, and verifies that attempted overrides are intercepted and ignored).

## Notes

- The unique name `9router next-server` still contains the substring `"next-server"`, ensuring full backward compatibility with all existing process termination whitelists in the repository (e.g. in `cli/cli.js` or `appUpdater.js`).

## Related Issues

Fixes #2117
