### PR TITLE
fix(claude): return summarized adaptive thinking

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -4,6 +4,20 @@ import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE } from "../providers/shared.js";
 
+function removeBetaFlag(headers, flag) {
+  for (const key of ["anthropic-beta", "Anthropic-Beta"]) {
+    if (!headers[key]) continue;
+    const filtered = headers[key]
+      .split(",")
+      .map(s => s.trim())
+      .filter(Boolean)
+      .filter(f => f !== flag)
+      .join(",");
+    if (filtered) headers[key] = filtered;
+    else delete headers[key];
+  }
+}
+
 /**
  * BaseExecutor - Base class for provider executors
  */
@@ -127,6 +141,9 @@ export class BaseExecutor {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
       const transformedBody = this.transformRequest(model, body, stream, credentials);
       const headers = this.buildHeaders(credentials, stream);
+      if (transformedBody?.thinking?.display === "summarized") {
+        removeBetaFlag(headers, "redact-thinking-2026-02-12");
+      }
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
 

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -172,9 +172,14 @@ function applyFormat(fmt, body, cfg, caps) {
       break;
     }
     case "claude-adaptive": {
+      // disabled must NOT carry display (Anthropic rejects display on type:"disabled").
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
       const level = toLevel(eff);
       body.output_config = { effort: level === "xhigh" ? "high" : level };
+      // Opus 4.7/4.8/Sonnet5/Fable5/Mythos5 default thinking.display to "omitted",
+      // so explicitly request summarized to keep reasoning summary flowing to clients.
+      // Harmless on 4.6/Sonnet4.6 where "summarized" is already the default.
+      body.thinking = { type: "adaptive", display: "summarized" };
       break;
     }
     case "claude-budget": {

--- a/tests/translator/__snapshots__/golden-request.test.js.snap
+++ b/tests/translator/__snapshots__/golden-request.test.js.snap
@@ -118,6 +118,10 @@ exports[`GOLDEN request: OpenAI → Claude > reasoning_effort → adaptive outpu
       "type": "text",
     },
   ],
+  "thinking": {
+    "display": "summarized",
+    "type": "adaptive",
+  },
 }
 `;
 

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -55,10 +55,22 @@ describe("extractThinking", () => {
 });
 
 describe("applyThinking per provider format", () => {
-  it("claude 4.6+ → adaptive output_config (no budget_tokens)", () => {
+  it("claude 4.6+ → adaptive output_config (no budget_tokens) + summarized display", () => {
     const out = apply("claude", "claude-opus-4.7", { reasoning_effort: "high" }, "claude");
     expect(out.output_config).toEqual({ effort: "high" });
-    expect(out.thinking).toBeUndefined();
+    // Opus 4.7/4.8 default thinking.display to "omitted"; we explicitly request
+    // summarized so reasoning summary flows back to clients.
+    expect(out.thinking).toEqual({ type: "adaptive", display: "summarized" });
+  });
+  it("claude adaptive none → disabled WITHOUT display (Anthropic rejects display on disabled)", () => {
+    const out = apply("claude", "claude-opus-4.8", { reasoning_effort: "none" }, "claude");
+    expect(out.thinking).toEqual({ type: "disabled" });
+    expect(out.output_config).toBeUndefined();
+  });
+  it("claude opus-4.8 adaptive → summarized display", () => {
+    const out = apply("claude", "claude-opus-4.8", { reasoning_effort: "high" }, "claude");
+    expect(out.output_config).toEqual({ effort: "high" });
+    expect(out.thinking).toEqual({ type: "adaptive", display: "summarized" });
   });
   it("claude haiku → enabled+budget", () => {
     const out = apply("claude", "claude-haiku-4.5", { reasoning_effort: "high" }, "claude");

--- a/tests/unit/base-executor-retry.test.js
+++ b/tests/unit/base-executor-retry.test.js
@@ -84,6 +84,48 @@ describe("BaseExecutor.execute — network error retry/fallback", () => {
   });
 });
 
+describe("BaseExecutor.execute — Anthropic summarized thinking headers", () => {
+  it("removes redact-thinking beta when summarized thinking is requested", async () => {
+    const ex = makeExec({
+      baseUrl: "https://x/api",
+      headers: {
+        "Anthropic-Beta": "claude-code-20250219,redact-thinking-2026-02-12,effort-2025-11-24",
+      },
+    });
+    fetchMock.mockResolvedValueOnce(res(200));
+
+    await ex.execute({
+      model: "m",
+      body: { thinking: { type: "adaptive", display: "summarized" } },
+      stream: false,
+      credentials: creds,
+    });
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers["Anthropic-Beta"]).toBe("claude-code-20250219,effort-2025-11-24");
+  });
+
+  it("keeps redact-thinking beta when summarized thinking is not requested", async () => {
+    const ex = makeExec({
+      baseUrl: "https://x/api",
+      headers: {
+        "Anthropic-Beta": "claude-code-20250219,redact-thinking-2026-02-12,effort-2025-11-24",
+      },
+    });
+    fetchMock.mockResolvedValueOnce(res(200));
+
+    await ex.execute({
+      model: "m",
+      body: { thinking: { type: "adaptive" } },
+      stream: false,
+      credentials: creds,
+    });
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers["Anthropic-Beta"]).toContain("redact-thinking-2026-02-12");
+  });
+});
+
 describe("BaseExecutor.execute — computeRetryDelay hook veto", () => {
   it("only invokes computeRetryDelay when status has retry config", async () => {
     const ex = makeExec({ baseUrl: "https://x/api", retry: { 503: { attempts: 1, delayMs: 0 } } });


### PR DESCRIPTION
## Problem

Claude adaptive-thinking models can produce summarized thinking, but 9router was not returning it for newer Claude reasoning models such as Opus 4.7/4.8.

There are two separate reasons this can happen:

1. Newer Claude reasoning models may default `thinking.display` to `omitted`, so sending only `output_config.effort` is not enough to request a visible summary.
2. The Claude provider headers include the beta flag `redact-thinking-2026-02-12`, which redacts the returned thinking text even when the request explicitly asks for `thinking.display: "summarized"`.

The second point was verified against Anthropic's official Messages API:

- Without `redact-thinking-2026-02-12`, `thinking.display: "summarized"` returns a non-empty `content[].thinking` summary.
- With `redact-thinking-2026-02-12`, the same request returns a thinking block with an empty `thinking` string and only a `signature`.

That means 9router must both request summarized thinking in the request body and avoid sending the redact-thinking beta for summarized-thinking requests.

## Changes

- For Claude adaptive-thinking translation, explicitly add:

  ```json
  "thinking": {
    "type": "adaptive",
    "display": "summarized"
  }
  ```

  alongside `output_config.effort`.

- Keep disabled thinking safe by sending only:

  ```json
  "thinking": {
    "type": "disabled"
  }
  ```

  because Anthropic rejects `display` on `type: "disabled"`.

- When the transformed upstream request asks for `thinking.display: "summarized"`, remove only this beta flag from Anthropic beta headers:

  ```text
  redact-thinking-2026-02-12
  ```

  Other beta flags are preserved.

- Add tests for:
  - Claude adaptive thinking requesting `display: "summarized"`.
  - Disabled thinking not carrying `display`.
  - Header filtering removing `redact-thinking-2026-02-12` only for summarized-thinking requests.
  - Header filtering preserving `redact-thinking-2026-02-12` when summarized thinking is not requested.

## Why this approach

`display: "summarized"` is necessary but not sufficient: if the redact-thinking beta remains present, Anthropic redacts the summary text and returns an empty thinking block. Removing the beta unconditionally would change Claude Code / redacted-thinking behavior for unrelated requests, so this PR removes it only when the request explicitly asks for summarized thinking.

## Test plan

- `NODE_PATH=/Users/duwan/Workspaces/babelcloud/9router/tests/node_modules ./node_modules/.bin/vitest run --reporter=verbose unit/base-executor-retry.test.js translator/thinking-unified.test.js`
- Verified against Anthropic's official endpoint that `redact-thinking-2026-02-12` returns an empty thinking block, while omitting it returns a non-empty summarized thinking block.
- Verified in deployment that Claude Opus 4.8 returns non-empty thinking summary through 9router after this fix.