### PR TITLE
fix(chat): strip orphaned tool results before dispatch (#2236)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -19,6 +19,7 @@ import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
+import { stripOrphanedToolResults } from "../translator/concerns/toolCall.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { injectPonytail } from "../rtk/ponytail.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
@@ -119,6 +120,13 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     } catch (e) { log?.warn?.("MODALITY", `image prefetch failed: ${e.message}`); }
   }
 
+  // Strip orphaned tool results before translation so the translator never sees
+  // stale call_id references that client-side history truncation left behind.
+  const preStripped = stripOrphanedToolResults(body);
+  if (preStripped > 0) {
+    log?.debug?.("TOOLCLEAN", `pre-translation: stripped ${preStripped} orphaned tool result(s)`);
+  }
+
   let translatedBody;
   let toolNameMap;
   if (passthrough) {
@@ -165,6 +173,14 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const headroomStats = await compressWithHeadroom(translatedBody, { enabled: headroomEnabled, url: headroomUrl, model: upstreamModel, format: finalFormat, compressUserMessages: headroomCompressUserMessages });
   const headroomLine = formatHeadroomLog(headroomStats);
   if (headroomLine) log?.info?.("HEADROOM", headroomLine);
+
+  // Strip orphaned tool results again after RTK/Headroom compression — both
+  // compressors can remove assistant turns containing tool_calls, which would
+  // otherwise leave dangling tool results that strict providers reject with 400.
+  const postStripped = stripOrphanedToolResults(translatedBody);
+  if (postStripped > 0) {
+    log?.debug?.("TOOLCLEAN", `post-compression: stripped ${postStripped} orphaned tool result(s)`);
+  }
 
   // Caveman: inject terse-style system prompt
   if (cavemanEnabled && cavemanLevel) {

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -151,3 +151,113 @@ export function fixMissingToolResponses(body) {
   return body;
 }
 
+/**
+ * Strip orphaned tool results — results that reference a tool call no longer
+ * present in the same request. Client-side history truncation/summarisation can
+ * remove an assistant turn that contained tool_calls while leaving the
+ * corresponding tool result in the history; strict upstream APIs then reject
+ * the whole request with a 400 before the model ever executes.
+ *
+ * Handles all four wire formats used by 9router:
+ *   - OpenAI Chat Completions : messages[role=tool].tool_call_id
+ *   - Anthropic Messages      : messages[role=user].content[type=tool_result].tool_use_id
+ *   - OpenAI Responses API    : input[type=function_call_output].call_id
+ *   - Gemini / Antigravity    : contents[].parts[].functionResponse.id|name
+ *
+ * Mutates body in-place (same pattern as fixMissingToolResponses).
+ * Returns the number of orphaned items removed (0 = nothing changed).
+ */
+export function stripOrphanedToolResults(body) {
+  let stripped = 0;
+
+  // ── 1. OpenAI Chat Completions + Anthropic Messages (share body.messages) ──
+  if (Array.isArray(body.messages)) {
+    // Collect every live tool-call id from the full message list.
+    const liveIds = new Set();
+    for (const msg of body.messages) {
+      // OpenAI assistant turn: tool_calls[].id
+      if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
+        for (const tc of msg.tool_calls) {
+          if (tc.id) liveIds.add(tc.id);
+        }
+      }
+      // Anthropic assistant turn: content[type=tool_use].id
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block.type === "tool_use" && block.id) liveIds.add(block.id);
+        }
+      }
+    }
+
+    // Remove orphaned role:"tool" messages (OpenAI).
+    const beforeMsgs = body.messages.length;
+    body.messages = body.messages.filter(msg => {
+      if (msg.role === "tool" && msg.tool_call_id) {
+        return liveIds.has(msg.tool_call_id);
+      }
+      return true;
+    });
+    stripped += beforeMsgs - body.messages.length;
+
+    // Remove orphaned tool_result content blocks from user messages (Anthropic).
+    for (const msg of body.messages) {
+      if (msg.role === "user" && Array.isArray(msg.content)) {
+        const beforeBlocks = msg.content.length;
+        msg.content = msg.content.filter(block => {
+          if (block.type === "tool_result" && block.tool_use_id) {
+            return liveIds.has(block.tool_use_id);
+          }
+          return true;
+        });
+        stripped += beforeBlocks - msg.content.length;
+      }
+    }
+  }
+
+  // ── 2. OpenAI Responses API: input[] ──────────────────────────────────────
+  if (Array.isArray(body.input)) {
+    const liveIds = new Set();
+    for (const item of body.input) {
+      if (item.type === "function_call" && item.call_id) liveIds.add(item.call_id);
+    }
+    if (liveIds.size > 0 || body.input.some(i => i.type === "function_call_output")) {
+      const before = body.input.length;
+      body.input = body.input.filter(item => {
+        if (item.type === "function_call_output" && item.call_id) {
+          return liveIds.has(item.call_id);
+        }
+        return true;
+      });
+      stripped += before - body.input.length;
+    }
+  }
+
+  // ── 3. Gemini / Antigravity: contents[] ───────────────────────────────────
+  if (Array.isArray(body.contents)) {
+    const liveIds = new Set();
+    for (const turn of body.contents) {
+      if (!Array.isArray(turn.parts)) continue;
+      for (const part of turn.parts) {
+        if (!part.functionCall) continue;
+        // Prefer explicit id; fall back to name when id is absent (older Gemini shapes).
+        const key = part.functionCall.id ?? part.functionCall.name;
+        if (key) liveIds.add(key);
+      }
+    }
+    if (liveIds.size > 0 || body.contents.some(t => Array.isArray(t.parts) && t.parts.some(p => p.functionResponse))) {
+      for (const turn of body.contents) {
+        if (!Array.isArray(turn.parts)) continue;
+        const before = turn.parts.length;
+        turn.parts = turn.parts.filter(part => {
+          if (!part.functionResponse) return true;
+          const key = part.functionResponse.id ?? part.functionResponse.name;
+          return key ? liveIds.has(key) : true;
+        });
+        stripped += before - turn.parts.length;
+      }
+    }
+  }
+
+  return stripped;
+}
+

--- a/tests/unit/strip-orphaned-tool-results.test.js
+++ b/tests/unit/strip-orphaned-tool-results.test.js
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { stripOrphanedToolResults } from "../../open-sse/translator/concerns/toolCall.js";
+
+// ── OpenAI Chat Completions ──────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – OpenAI Chat Completions (messages[])", () => {
+  it("removes role:tool message whose tool_call_id has no matching assistant turn", () => {
+    const body = {
+      messages: [
+        { role: "tool", tool_call_id: "call_missing", content: "stale result" },
+        { role: "user", content: "continue" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].role).toBe("user");
+  });
+
+  it("keeps role:tool message when a matching assistant tool_calls entry exists", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "call_abc", type: "function", function: { name: "search", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call_abc", content: "result" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages).toHaveLength(2);
+  });
+
+  it("handles mixed: keeps paired result, removes orphan", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "call_live", type: "function", function: { name: "fn", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call_live", content: "ok" },
+        { role: "tool", tool_call_id: "call_gone", content: "stale" },
+        { role: "user", content: "next" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.messages.filter(m => m.role === "tool")).toHaveLength(1);
+    expect(body.messages.find(m => m.tool_call_id === "call_gone")).toBeUndefined();
+  });
+
+  it("returns 0 and leaves body untouched when no tool messages present", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages).toHaveLength(2);
+  });
+});
+
+// ── Anthropic Messages ───────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – Anthropic (tool_result content blocks)", () => {
+  it("removes orphaned tool_result block from user message content", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_gone", content: "stale" },
+            { type: "text", text: "continue" },
+          ],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.messages[0].content).toHaveLength(1);
+    expect(body.messages[0].content[0].type).toBe("text");
+  });
+
+  it("keeps tool_result block when a matching tool_use block exists", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_abc", name: "search", input: {} }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_abc", content: "found" }],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages[1].content).toHaveLength(1);
+  });
+});
+
+// ── OpenAI Responses API ─────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – OpenAI Responses API (input[])", () => {
+  it("removes function_call_output whose call_id has no matching function_call", () => {
+    const body = {
+      input: [
+        { type: "function_call_output", call_id: "call_missing", output: "stale result" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.input).toHaveLength(1);
+    expect(body.input[0].type).toBe("message");
+  });
+
+  it("keeps function_call_output when matching function_call exists", () => {
+    const body = {
+      input: [
+        { type: "function_call", call_id: "call_live", name: "search", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_live", output: "result" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.input).toHaveLength(2);
+  });
+
+  it("removes only orphaned outputs, keeps paired ones", () => {
+    const body = {
+      input: [
+        { type: "function_call", call_id: "call_a", name: "fn", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_a", output: "ok" },
+        { type: "function_call_output", call_id: "call_b_gone", output: "stale" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.input).toHaveLength(2);
+  });
+});
+
+// ── Gemini / Antigravity ─────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – Gemini (contents[].parts[])", () => {
+  it("removes orphaned functionResponse part", () => {
+    const body = {
+      contents: [
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { id: "fn_gone", name: "search", response: { output: "stale" } } },
+            { text: "continue" },
+          ],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.contents[0].parts).toHaveLength(1);
+    expect(body.contents[0].parts[0].text).toBe("continue");
+  });
+
+  it("keeps functionResponse when matching functionCall exists", () => {
+    const body = {
+      contents: [
+        { role: "model", parts: [{ functionCall: { id: "fn_live", name: "search", args: {} } }] },
+        { role: "user", parts: [{ functionResponse: { id: "fn_live", name: "search", response: { output: "ok" } } }] },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.contents[1].parts).toHaveLength(1);
+  });
+
+  it("falls back to name-based pairing when id is absent", () => {
+    const body = {
+      contents: [
+        { role: "model", parts: [{ functionCall: { name: "search", args: {} } }] },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { name: "search", response: { output: "ok" } } },
+            { functionResponse: { name: "gone_fn", response: { output: "stale" } } },
+          ],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.contents[1].parts).toHaveLength(1);
+    expect(body.contents[1].parts[0].functionResponse.name).toBe("search");
+  });
+});
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – edge cases", () => {
+  it("returns 0 for empty body", () => {
+    expect(stripOrphanedToolResults({})).toBe(0);
+  });
+
+  it("returns 0 when messages is not an array", () => {
+    expect(stripOrphanedToolResults({ messages: null })).toBe(0);
+  });
+
+  it("does not remove role:tool message when tool_call_id is absent (pass-through)", () => {
+    const body = {
+      messages: [
+        { role: "tool", content: "no id" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #2236.

Client-side history truncation (summarisation, context-window management) can remove an **assistant turn that contained `tool_calls` / `tool_use`** while leaving the corresponding tool result sitting in the history. Strict upstream APIs then reject the whole request with a **400 before the model executes**:

```
No tool call found for function call output with call_id <id>
```

The same invariant appears in all four wire formats 9router handles:

| Format | Call carrier | Result carrier | Pairing key |
|--------|-------------|----------------|-------------|
| OpenAI Chat Completions | `assistant.tool_calls[].id` | `role:"tool"`, `tool_call_id` | `tool_call_id` ↔ `id` |
| OpenAI Responses API | `input[type=function_call].call_id` | `input[type=function_call_output].call_id` | `call_id` ↔ `call_id` |
| Anthropic Messages | `content[type=tool_use].id` | `content[type=tool_result].tool_use_id` | `tool_use_id` ↔ `id` |
| Gemini / Antigravity | `parts[].functionCall.id\|name` | `parts[].functionResponse.id\|name` | `id` or `name` |

## Fix

**`open-sse/translator/concerns/toolCall.js`** — adds `stripOrphanedToolResults(body)`:
- Collects every live tool-call id present in the request
- Removes any result item whose call id has no matching call — across all four formats
- Mutates body in-place; returns count of removed items (0 = nothing changed)

**`open-sse/handlers/chatCore.js`** — calls it twice:
1. **Pre-translation** — removes client-sent orphans before format conversion
2. **Post-RTK/Headroom** — removes orphans that compression creates by dropping assistant turns mid-history

Both call-sites log at `debug` level (`TOOLCLEAN`) so operators can observe when stripping fires.

## Tests

`tests/unit/strip-orphaned-tool-results.test.js` — **15 tests, all passing**:
- OpenAI: orphan removed, paired kept, mixed, no-tool-messages
- Anthropic: `tool_result` block orphan removed, paired kept
- Responses API: `function_call_output` orphan removed, paired kept, mixed
- Gemini: `functionResponse` orphan removed, paired kept, name-based fallback
- Edge cases: empty body, null messages, result-without-id (pass-through)