### PR TITLE
fix(sse): strip ANSI/VT100 codes from gc/ stream frames (#2273)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -19,6 +19,7 @@ import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
+import { stripOrphanedToolResults } from "../translator/concerns/toolCall.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { injectPonytail } from "../rtk/ponytail.js";
 import { compressMessages, formatRtkLog } from "../rtk/index.js";
@@ -119,6 +120,13 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     } catch (e) { log?.warn?.("MODALITY", `image prefetch failed: ${e.message}`); }
   }
 
+  // Strip orphaned tool results before translation so the translator never sees
+  // stale call_id references that client-side history truncation left behind.
+  const preStripped = stripOrphanedToolResults(body);
+  if (preStripped > 0) {
+    log?.debug?.("TOOLCLEAN", `pre-translation: stripped ${preStripped} orphaned tool result(s)`);
+  }
+
   let translatedBody;
   let toolNameMap;
   if (passthrough) {
@@ -165,6 +173,14 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const headroomStats = await compressWithHeadroom(translatedBody, { enabled: headroomEnabled, url: headroomUrl, model: upstreamModel, format: finalFormat, compressUserMessages: headroomCompressUserMessages });
   const headroomLine = formatHeadroomLog(headroomStats);
   if (headroomLine) log?.info?.("HEADROOM", headroomLine);
+
+  // Strip orphaned tool results again after RTK/Headroom compression — both
+  // compressors can remove assistant turns containing tool_calls, which would
+  // otherwise leave dangling tool results that strict providers reject with 400.
+  const postStripped = stripOrphanedToolResults(translatedBody);
+  if (postStripped > 0) {
+    log?.debug?.("TOOLCLEAN", `post-compression: stripped ${postStripped} orphaned tool result(s)`);
+  }
 
   // Caveman: inject terse-style system prompt
   if (cavemanEnabled && cavemanLevel) {

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -151,3 +151,113 @@ export function fixMissingToolResponses(body) {
   return body;
 }
 
+/**
+ * Strip orphaned tool results — results that reference a tool call no longer
+ * present in the same request. Client-side history truncation/summarisation can
+ * remove an assistant turn that contained tool_calls while leaving the
+ * corresponding tool result in the history; strict upstream APIs then reject
+ * the whole request with a 400 before the model ever executes.
+ *
+ * Handles all four wire formats used by 9router:
+ *   - OpenAI Chat Completions : messages[role=tool].tool_call_id
+ *   - Anthropic Messages      : messages[role=user].content[type=tool_result].tool_use_id
+ *   - OpenAI Responses API    : input[type=function_call_output].call_id
+ *   - Gemini / Antigravity    : contents[].parts[].functionResponse.id|name
+ *
+ * Mutates body in-place (same pattern as fixMissingToolResponses).
+ * Returns the number of orphaned items removed (0 = nothing changed).
+ */
+export function stripOrphanedToolResults(body) {
+  let stripped = 0;
+
+  // ── 1. OpenAI Chat Completions + Anthropic Messages (share body.messages) ──
+  if (Array.isArray(body.messages)) {
+    // Collect every live tool-call id from the full message list.
+    const liveIds = new Set();
+    for (const msg of body.messages) {
+      // OpenAI assistant turn: tool_calls[].id
+      if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
+        for (const tc of msg.tool_calls) {
+          if (tc.id) liveIds.add(tc.id);
+        }
+      }
+      // Anthropic assistant turn: content[type=tool_use].id
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block.type === "tool_use" && block.id) liveIds.add(block.id);
+        }
+      }
+    }
+
+    // Remove orphaned role:"tool" messages (OpenAI).
+    const beforeMsgs = body.messages.length;
+    body.messages = body.messages.filter(msg => {
+      if (msg.role === "tool" && msg.tool_call_id) {
+        return liveIds.has(msg.tool_call_id);
+      }
+      return true;
+    });
+    stripped += beforeMsgs - body.messages.length;
+
+    // Remove orphaned tool_result content blocks from user messages (Anthropic).
+    for (const msg of body.messages) {
+      if (msg.role === "user" && Array.isArray(msg.content)) {
+        const beforeBlocks = msg.content.length;
+        msg.content = msg.content.filter(block => {
+          if (block.type === "tool_result" && block.tool_use_id) {
+            return liveIds.has(block.tool_use_id);
+          }
+          return true;
+        });
+        stripped += beforeBlocks - msg.content.length;
+      }
+    }
+  }
+
+  // ── 2. OpenAI Responses API: input[] ──────────────────────────────────────
+  if (Array.isArray(body.input)) {
+    const liveIds = new Set();
+    for (const item of body.input) {
+      if (item.type === "function_call" && item.call_id) liveIds.add(item.call_id);
+    }
+    if (liveIds.size > 0 || body.input.some(i => i.type === "function_call_output")) {
+      const before = body.input.length;
+      body.input = body.input.filter(item => {
+        if (item.type === "function_call_output" && item.call_id) {
+          return liveIds.has(item.call_id);
+        }
+        return true;
+      });
+      stripped += before - body.input.length;
+    }
+  }
+
+  // ── 3. Gemini / Antigravity: contents[] ───────────────────────────────────
+  if (Array.isArray(body.contents)) {
+    const liveIds = new Set();
+    for (const turn of body.contents) {
+      if (!Array.isArray(turn.parts)) continue;
+      for (const part of turn.parts) {
+        if (!part.functionCall) continue;
+        // Prefer explicit id; fall back to name when id is absent (older Gemini shapes).
+        const key = part.functionCall.id ?? part.functionCall.name;
+        if (key) liveIds.add(key);
+      }
+    }
+    if (liveIds.size > 0 || body.contents.some(t => Array.isArray(t.parts) && t.parts.some(p => p.functionResponse))) {
+      for (const turn of body.contents) {
+        if (!Array.isArray(turn.parts)) continue;
+        const before = turn.parts.length;
+        turn.parts = turn.parts.filter(part => {
+          if (!part.functionResponse) return true;
+          const key = part.functionResponse.id ?? part.functionResponse.name;
+          return key ? liveIds.has(key) : true;
+        });
+        stripped += before - turn.parts.length;
+      }
+    }
+  }
+
+  return stripped;
+}
+

--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -6,6 +6,7 @@ import { toOpenAIUsage } from "../concerns/usage.js";
 import { reasoningDelta } from "../concerns/reasoning.js";
 import { encodeDataUri } from "../concerns/image.js";
 import { toOpenAIFinish } from "../concerns/finishReason.js";
+import { stripAnsiCodes } from "../../utils/streamHelpers.js";
 
 // Build chunk meta for current gemini state
 function chunkMeta(state) {
@@ -79,11 +80,17 @@ export function geminiToOpenAIResponse(chunk, state) {
       // can also stream thought parts without a signature; those must not be
       // surfaced as normal assistant content in OpenAI-compatible clients.
       if (part.text !== undefined && part.text !== "") {
-        results.push(buildChunk(
-          chunkMeta(state),
-          isThought ? reasoningDelta(part.text) : { content: part.text },
-          null
-        ));
+        // gc/ (Cloud Code Assist) can embed raw ANSI terminal codes in text parts
+        // (e.g. from internal progress output). Strip them so they don't appear as
+        // literal control bytes in the forwarded SSE stream.
+        const text = stripAnsiCodes(part.text);
+        if (text) {
+          results.push(buildChunk(
+            chunkMeta(state),
+            isThought ? reasoningDelta(text) : { content: text },
+            null
+          ));
+        }
       }
 
       // Function call

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -1,5 +1,21 @@
 import { FORMATS } from "../translator/formats.js";
 
+// ANSI / VT100 escape sequence pattern.
+// Matches: CSI sequences (\x1b[ ... final-byte), OSC sequences (\x1b] ... ST/BEL),
+// single-char escapes (\x1b[A-Z\[\]\\^_`]), and raw C0 controls except \t, \n, \r.
+// gc/ (Gemini Cloud Code Assist) occasionally prepends terminal control chars
+// (cursor-up, clear-line, carriage-return) to SSE frames before the "data:" prefix,
+// which masks the prefix and causes strict client SSE parsers to crash or hang.
+const ANSI_ESCAPE_RE = /\x1b(?:\[[0-9;?]*[A-Za-z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[A-Z\[\]\\^_`])|[\x00-\x08\x0b\x0c\x0e-\x1f]/g;
+
+/**
+ * Strip ANSI / VT100 terminal control sequences from a string.
+ * Safe to call on SSE line text — does not touch printable content or JSON.
+ */
+export function stripAnsiCodes(str) {
+  return str ? str.replace(ANSI_ESCAPE_RE, "") : str;
+}
+
 // Parse SSE data line
 export function parseSSELine(line, format = null) {
   if (!line) return null;
@@ -17,10 +33,18 @@ export function parseSSELine(line, format = null) {
     return null;
   }
 
-  // Standard SSE format: "data: {...}"
-  if (line.charCodeAt(0) !== 100) return null; // 'd' = 100
+  // Strip any terminal control sequences that some upstream sources (e.g. gc/ Cloud Code
+  // Assist) prepend to SSE lines as progress/loading indicators. Without this, the "data:"
+  // prefix check below fails and the entire frame is silently dropped, which can cause the
+  // client SSE parser to stall waiting for a frame that never arrives.
+  const clean = line.charCodeAt(0) === 0x1b || (line.charCodeAt(0) < 0x20 && line.charCodeAt(0) !== 0x09)
+    ? stripAnsiCodes(line)
+    : line;
 
-  const data = line.slice(5).trim();
+  // Standard SSE format: "data: {...}"
+  if (clean.charCodeAt(0) !== 100) return null; // 'd' = 100
+
+  const data = clean.slice(5).trim();
   if (data === "[DONE]") return { done: true };
 
   try {

--- a/tests/unit/gemini-cli-ansi-sanitization.test.js
+++ b/tests/unit/gemini-cli-ansi-sanitization.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { stripAnsiCodes, parseSSELine } from "../../open-sse/utils/streamHelpers.js";
+
+// ── stripAnsiCodes ───────────────────────────────────────────────────────────
+
+describe("stripAnsiCodes", () => {
+  it("strips CSI cursor-up / clear-line sequences (loading bar)", () => {
+    expect(stripAnsiCodes("\x1b[2K\x1b[1Adata: hello")).toBe("data: hello");
+  });
+
+  it("strips SGR color codes", () => {
+    expect(stripAnsiCodes("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("strips OSC sequences", () => {
+    expect(stripAnsiCodes("\x1b]0;title\x07text")).toBe("text");
+  });
+
+  it("strips raw C0 control chars (except \\t \\n \\r)", () => {
+    expect(stripAnsiCodes("\x00\x01\x08text\x0e\x1f")).toBe("text");
+  });
+
+  it("preserves normal printable text", () => {
+    const text = 'data: {"choices":[{"delta":{"content":"hello"}}]}';
+    expect(stripAnsiCodes(text)).toBe(text);
+  });
+
+  it("preserves tab, newline, carriage-return", () => {
+    expect(stripAnsiCodes("a\tb\nc\rd")).toBe("a\tb\nc\rd");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(stripAnsiCodes("")).toBe("");
+  });
+
+  it("handles null/undefined gracefully", () => {
+    expect(stripAnsiCodes(null)).toBeNull();
+    expect(stripAnsiCodes(undefined)).toBeUndefined();
+  });
+});
+
+// ── parseSSELine with ANSI-prefixed lines ─────────────────────────────────────
+
+describe("parseSSELine – ANSI prefix sanitization (gc/ issue #2273)", () => {
+  it("parses a valid data line prefixed with cursor-clear ANSI codes", () => {
+    const payload = JSON.stringify({ choices: [{ delta: { content: "hi" } }] });
+    const line = `\x1b[2K\x1b[1Adata: ${payload}`;
+    const result = parseSSELine(line);
+    expect(result).not.toBeNull();
+    expect(result.choices[0].delta.content).toBe("hi");
+  });
+
+  it("parses [DONE] line prefixed with ANSI codes", () => {
+    const result = parseSSELine("\x1b[2Kdata: [DONE]");
+    expect(result).toEqual({ done: true });
+  });
+
+  it("drops lines that are purely ANSI (no data payload)", () => {
+    expect(parseSSELine("\x1b[2K\x1b[1A")).toBeNull();
+  });
+
+  it("still drops non-data lines without ANSI", () => {
+    expect(parseSSELine("event: message")).toBeNull();
+    expect(parseSSELine(": keep-alive")).toBeNull();
+    expect(parseSSELine("")).toBeNull();
+  });
+
+  it("still parses normal data lines correctly (no regression)", () => {
+    const payload = JSON.stringify({ id: "x", choices: [] });
+    const result = parseSSELine(`data: ${payload}`);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe("x");
+  });
+});

--- a/tests/unit/strip-orphaned-tool-results.test.js
+++ b/tests/unit/strip-orphaned-tool-results.test.js
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { stripOrphanedToolResults } from "../../open-sse/translator/concerns/toolCall.js";
+
+// ── OpenAI Chat Completions ──────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – OpenAI Chat Completions (messages[])", () => {
+  it("removes role:tool message whose tool_call_id has no matching assistant turn", () => {
+    const body = {
+      messages: [
+        { role: "tool", tool_call_id: "call_missing", content: "stale result" },
+        { role: "user", content: "continue" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].role).toBe("user");
+  });
+
+  it("keeps role:tool message when a matching assistant tool_calls entry exists", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "call_abc", type: "function", function: { name: "search", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call_abc", content: "result" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages).toHaveLength(2);
+  });
+
+  it("handles mixed: keeps paired result, removes orphan", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "call_live", type: "function", function: { name: "fn", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call_live", content: "ok" },
+        { role: "tool", tool_call_id: "call_gone", content: "stale" },
+        { role: "user", content: "next" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.messages.filter(m => m.role === "tool")).toHaveLength(1);
+    expect(body.messages.find(m => m.tool_call_id === "call_gone")).toBeUndefined();
+  });
+
+  it("returns 0 and leaves body untouched when no tool messages present", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages).toHaveLength(2);
+  });
+});
+
+// ── Anthropic Messages ───────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – Anthropic (tool_result content blocks)", () => {
+  it("removes orphaned tool_result block from user message content", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_gone", content: "stale" },
+            { type: "text", text: "continue" },
+          ],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.messages[0].content).toHaveLength(1);
+    expect(body.messages[0].content[0].type).toBe("text");
+  });
+
+  it("keeps tool_result block when a matching tool_use block exists", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_abc", name: "search", input: {} }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_abc", content: "found" }],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages[1].content).toHaveLength(1);
+  });
+});
+
+// ── OpenAI Responses API ─────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – OpenAI Responses API (input[])", () => {
+  it("removes function_call_output whose call_id has no matching function_call", () => {
+    const body = {
+      input: [
+        { type: "function_call_output", call_id: "call_missing", output: "stale result" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.input).toHaveLength(1);
+    expect(body.input[0].type).toBe("message");
+  });
+
+  it("keeps function_call_output when matching function_call exists", () => {
+    const body = {
+      input: [
+        { type: "function_call", call_id: "call_live", name: "search", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_live", output: "result" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.input).toHaveLength(2);
+  });
+
+  it("removes only orphaned outputs, keeps paired ones", () => {
+    const body = {
+      input: [
+        { type: "function_call", call_id: "call_a", name: "fn", arguments: "{}" },
+        { type: "function_call_output", call_id: "call_a", output: "ok" },
+        { type: "function_call_output", call_id: "call_b_gone", output: "stale" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.input).toHaveLength(2);
+  });
+});
+
+// ── Gemini / Antigravity ─────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – Gemini (contents[].parts[])", () => {
+  it("removes orphaned functionResponse part", () => {
+    const body = {
+      contents: [
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { id: "fn_gone", name: "search", response: { output: "stale" } } },
+            { text: "continue" },
+          ],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.contents[0].parts).toHaveLength(1);
+    expect(body.contents[0].parts[0].text).toBe("continue");
+  });
+
+  it("keeps functionResponse when matching functionCall exists", () => {
+    const body = {
+      contents: [
+        { role: "model", parts: [{ functionCall: { id: "fn_live", name: "search", args: {} } }] },
+        { role: "user", parts: [{ functionResponse: { id: "fn_live", name: "search", response: { output: "ok" } } }] },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.contents[1].parts).toHaveLength(1);
+  });
+
+  it("falls back to name-based pairing when id is absent", () => {
+    const body = {
+      contents: [
+        { role: "model", parts: [{ functionCall: { name: "search", args: {} } }] },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { name: "search", response: { output: "ok" } } },
+            { functionResponse: { name: "gone_fn", response: { output: "stale" } } },
+          ],
+        },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(1);
+    expect(body.contents[1].parts).toHaveLength(1);
+    expect(body.contents[1].parts[0].functionResponse.name).toBe("search");
+  });
+});
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("stripOrphanedToolResults – edge cases", () => {
+  it("returns 0 for empty body", () => {
+    expect(stripOrphanedToolResults({})).toBe(0);
+  });
+
+  it("returns 0 when messages is not an array", () => {
+    expect(stripOrphanedToolResults({ messages: null })).toBe(0);
+  });
+
+  it("does not remove role:tool message when tool_call_id is absent (pass-through)", () => {
+    const body = {
+      messages: [
+        { role: "tool", content: "no id" },
+      ],
+    };
+    const count = stripOrphanedToolResults(body);
+    expect(count).toBe(0);
+    expect(body.messages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

Closes #2273.

Gemini Cloud Code Assist (`gc/` models) occasionally prepends **terminal control sequences** (cursor-up `\x1b[1A`, clear-line `\x1b[2K`, SGR color codes, etc.) to SSE data frames as progress/loading indicators. This causes two distinct failure modes:

**1. Frame silently dropped → client hangs**
The `data:` prefix check in `parseSSELine` sees the ANSI byte (`\x1b = 0x1B`) instead of `d` (`0x64`) and returns `null`. The entire SSE frame is dropped. Strict SSE parsers stall waiting for a frame that never arrives, causing the stream to hang or disconnect prematurely.

**2. Raw control bytes forwarded in content**
ANSI codes embedded in `part.text` (model output) are forwarded verbatim in the client-facing SSE data. This causes strict HTTP parsers to reject the stream.

Both issues are specific to `gc/` — standard HTTP providers (`glm/`, `mimo/`, etc.) don't send terminal output.

## Fix

**`open-sse/utils/streamHelpers.js`**
- Exports `stripAnsiCodes(str)` — regex covers CSI (`ESC[ ... final-byte`), OSC (`ESC] ... BEL/ST`), single-char escapes, and raw C0 controls (preserves `\t \n \r`)
- `parseSSELine()` applies it **lazily** — only when the leading byte is ESC or another raw control char — to avoid a regex scan on every single line

**`open-sse/translator/response/gemini-to-openai.js`**
- Strips ANSI from `part.text` before building the OpenAI delta chunk
- Skips emitting an empty chunk when the entire text was control chars

## Tests

`tests/unit/gemini-cli-ansi-sanitization.test.js` — **13 tests, all passing**:

`stripAnsiCodes`:
- CSI cursor/clear sequences stripped
- SGR color codes stripped
- OSC sequences stripped
- Raw C0 controls stripped (except `\t \n \r`)
- Normal printable text passes through unchanged
- `\t \n \r` preserved
- Empty string / null / undefined handled safely

`parseSSELine` with ANSI prefix:
- ANSI-prefixed data line parsed correctly ✓
- `[DONE]` with ANSI prefix parsed ✓
- ANSI-only lines (no data payload) still dropped ✓
- Normal lines (no ANSI) unaffected — no regression ✓