### PR TITLE
fix: Kiro non-us-east-1 (IDC/Organization) support + token import — centralized region topology

### DIFF
--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -17,6 +17,19 @@
 
 import { extractThinking } from "../translator/concerns/thinkingUnified.js";
 import { effortToBudget } from "../translator/concerns/thinking.js";
+import { resolveKiroRegion, alignProfileArnRegion, KIRO_DEFAULT_REGION } from "./kiroRegions.js";
+
+// Re-export region helpers so existing importers of kiroConstants keep working
+// and there is one obvious place to find all Kiro request-shaping helpers.
+export {
+  resolveKiroRegion,
+  alignProfileArnRegion,
+  buildKiroBaseUrls,
+  buildKiroProfileEndpoint,
+  buildKiroOidcEndpoint,
+  regionFromProfileArn,
+  KIRO_DEFAULT_REGION,
+} from "./kiroRegions.js";
 
 export const KIRO_AGENTIC_SUFFIX = "-agentic";
 export const KIRO_THINKING_SUFFIX = "-thinking";
@@ -36,6 +49,32 @@ export const KIRO_DEFAULT_PROFILE_ARN = KIRO_DEFAULT_PROFILE_ARNS["builder-id"];
 export function resolveDefaultProfileArn(authMethod) {
   const social = authMethod === "google" || authMethod === "github";
   return social ? KIRO_DEFAULT_PROFILE_ARNS.social : KIRO_DEFAULT_PROFILE_ARNS["builder-id"];
+}
+
+/**
+ * Resolve the profileArn to send with a Kiro request, always aligned to the
+ * credential's region. This is the single place that decides which profileArn
+ * (if any) a request carries:
+ *
+ *   - a stored profileArn      → returned, with its region segment aligned to
+ *                                the request region (self-heals mismatches)
+ *   - no ARN, api_key auth     → "" (api keys must use their own account ARN;
+ *                                the shared default would 403)
+ *   - no ARN, us-east-1        → the shared builder-id/social default ARN
+ *   - no ARN, other region     → "" (no shared default exists outside us-east-1;
+ *                                the ARN is resolved on token refresh instead)
+ *
+ * @param {object} credentials Connection record with providerSpecificData
+ * @param {string} [region]    Pre-resolved region (defaults to resolveKiroRegion)
+ * @returns {string} profileArn or "" when none should be sent
+ */
+export function resolveKiroProfileArn(credentials, region) {
+  const psd = credentials?.providerSpecificData || {};
+  const r = region || resolveKiroRegion(credentials);
+  if (psd.profileArn) return alignProfileArnRegion(psd.profileArn, r);
+  if (psd.authMethod === "api_key") return "";
+  if (r === KIRO_DEFAULT_REGION) return resolveDefaultProfileArn(psd.authMethod);
+  return "";
 }
 
 export const KIRO_THINKING_BUDGET_DEFAULT = 16000;

--- a/open-sse/config/kiroRegions.js
+++ b/open-sse/config/kiroRegions.js
@@ -1,0 +1,101 @@
+/**
+ * Kiro regional topology — SINGLE SOURCE OF TRUTH.
+ *
+ * Kiro / AWS CodeWhisperer is region-scoped: the access token, its profileArn,
+ * the GenerateAssistantResponse runtime endpoint, the OIDC refresh endpoint and
+ * the ListAvailableProfiles control-plane call must ALL agree on one AWS region.
+ * A token minted in eu-central-1 is rejected by a us-east-1 endpoint (403), and
+ * a us-east-1 profileArn sent to an eu-central-1 endpoint yields 400
+ * "Improperly formed request".
+ *
+ * `us-east-1` is only the DEFAULT when no region is known — it is not a special
+ * case that every other region has to bend around. The single genuine asymmetry
+ * is an AWS infrastructure fact: the legacy `codewhisperer.<region>.amazonaws.com`
+ * host is deployed ONLY in us-east-1, while every region (including us-east-1) is
+ * served by `q.<region>.amazonaws.com` and `runtime.<region>.kiro.dev`. That fact
+ * is encoded exactly once, as data, in KIRO_RUNTIME_HOSTS below.
+ *
+ * This module is intentionally dependency-free so both the SSE hot path
+ * (executors/translators) and the OAuth helpers (src/lib/oauth) can import it.
+ */
+
+export const KIRO_DEFAULT_REGION = "us-east-1";
+
+const GENERATE_PATH = "/generateAssistantResponse";
+
+/**
+ * Runtime host templates for GenerateAssistantResponse, in preference order.
+ *   availableIn: "all"          → host exists in every region
+ *   availableIn: ["us-east-1"]  → host only exists in the listed regions
+ *
+ * To add/adjust Kiro's regional topology, edit ONLY this table.
+ */
+const KIRO_RUNTIME_HOSTS = [
+  { host: (r) => `runtime.${r}.kiro.dev`, availableIn: "all" },
+  { host: (r) => `codewhisperer.${r}.amazonaws.com`, availableIn: [KIRO_DEFAULT_REGION] },
+  { host: (r) => `q.${r}.amazonaws.com`, availableIn: "all" },
+];
+
+function hostAvailable(entry, region) {
+  return entry.availableIn === "all" || entry.availableIn.includes(region);
+}
+
+/** Extract the AWS region from a CodeWhisperer profileArn, or null if absent. */
+export function regionFromProfileArn(profileArn) {
+  if (typeof profileArn !== "string") return null;
+  // arn:aws:codewhisperer:<region>:<account>:profile/<id>
+  const parts = profileArn.split(":");
+  return parts.length >= 4 && parts[3] ? parts[3] : null;
+}
+
+/**
+ * Resolve the AWS region for a Kiro credential.
+ * Priority: explicit providerSpecificData.region → profileArn region → default.
+ */
+export function resolveKiroRegion(credentials) {
+  const psd = credentials?.providerSpecificData;
+  return psd?.region || regionFromProfileArn(psd?.profileArn) || KIRO_DEFAULT_REGION;
+}
+
+/**
+ * Build the ordered GenerateAssistantResponse base URLs for a region,
+ * automatically excluding hosts that do not exist in that region.
+ */
+export function buildKiroBaseUrls(region = KIRO_DEFAULT_REGION) {
+  const r = region || KIRO_DEFAULT_REGION;
+  return KIRO_RUNTIME_HOSTS
+    .filter((e) => hostAvailable(e, r))
+    .map((e) => `https://${e.host(r)}${GENERATE_PATH}`);
+}
+
+/**
+ * Return the amazonaws.com control-plane BASE URL (bare host, no path) for a
+ * region's CodeWhisperer service. Callers invoke ListAvailableProfiles via the
+ * AWS JSON-RPC style (`x-amz-target` header). Prefers codewhisperer.* where it
+ * exists (us-east-1) and falls back to q.* everywhere else.
+ */
+export function buildKiroProfileEndpoint(region = KIRO_DEFAULT_REGION) {
+  const r = region || KIRO_DEFAULT_REGION;
+  const amazonHost = KIRO_RUNTIME_HOSTS
+    .filter((e) => hostAvailable(e, r) && e.host(r).includes("amazonaws.com"))
+    .map((e) => e.host(r))
+    .find(Boolean);
+  return `https://${amazonHost}`;
+}
+
+/** Region-scoped AWS SSO-OIDC token endpoint (IDC refresh). */
+export function buildKiroOidcEndpoint(region = KIRO_DEFAULT_REGION) {
+  return `https://oidc.${region || KIRO_DEFAULT_REGION}.amazonaws.com/token`;
+}
+
+/**
+ * Force a profileArn's region segment to match `region`. This guarantees we
+ * never send a us-east-1 ARN to an eu-central-1 endpoint (or vice versa), and
+ * self-heals credentials that were stored with a mismatched/rewritten region.
+ * The account id and profile id are region-invariant, so only the region
+ * segment changes.
+ */
+export function alignProfileArnRegion(profileArn, region) {
+  if (!profileArn || !region) return profileArn || "";
+  return profileArn.replace(/^(arn:aws:codewhisperer:)[^:]+(:)/, `$1${region}$2`);
+}

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -3,6 +3,7 @@ import { PROVIDERS } from "../config/providers.js";
 import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
+import { resolveKiroRegion, buildKiroBaseUrls } from "../config/kiroRegions.js";
 
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
@@ -38,46 +39,28 @@ export class KiroExecutor extends BaseExecutor {
   }
 
   /**
-   * Auth-aware endpoint ordering.
+   * Build the region-correct, auth-aware ordered endpoint list.
    *
-   * API-key Kiro connections store a raw CodeWhisperer credential (validated
-   * against codewhisperer.us-east-1.amazonaws.com via ListAvailableProfiles).
-   * The Kiro IDE gateway (runtime.*.kiro.dev) expects Kiro OIDC/social tokens
-   * and rejects an `tokentype: API_KEY` token with 401/403 — which
-   * BaseExecutor.execute() returns immediately (only 429 / network errors fall
-   * through to the next host). So for api-key auth we must try the *.amazonaws.com
-   * CodeWhisperer hosts FIRST, mirroring the Kiro-Go reference fork which never
-   * routes api-key traffic through kiro.dev. OAuth keeps the default order
-   * (kiro.dev first) since its token is what that gateway accepts.
+   * Endpoints are derived from the credential's region via buildKiroBaseUrls()
+   * (the single source of truth in kiroRegions.js), so a eu-central-1 token is
+   * sent to eu-central-1 hosts and hosts that don't exist in the region are
+   * never attempted.
+   *
+   * API-key connections store a raw CodeWhisperer credential. The Kiro IDE
+   * gateway (runtime.*.kiro.dev) expects OIDC/social tokens and rejects an
+   * `tokentype: API_KEY` token with 401/403 — which BaseExecutor.execute()
+   * returns immediately (only 429 / network errors fall through to the next
+   * host). So for api-key auth we try the *.amazonaws.com CodeWhisperer hosts
+   * FIRST, mirroring the Kiro-Go reference fork. OAuth/IDC keep the default
+   * order (kiro.dev first) since that gateway accepts their tokens.
    */
   getOrderedBaseUrls(credentials) {
-    const baseUrls = this.getBaseUrls();
+    const baseUrls = buildKiroBaseUrls(resolveKiroRegion(credentials));
     const isApiKey = credentials?.providerSpecificData?.authMethod === "api_key";
-
-    // Resolve the credential's region from explicit field or from the profileArn
-    // (ARN format: arn:aws:codewhisperer:<region>:<account>:profile/...)
-    const profileArn = credentials?.providerSpecificData?.profileArn || "";
-    const region = credentials?.providerSpecificData?.region
-      || (profileArn ? profileArn.split(":")[3] : "")
-      || "us-east-1";
-
-    let urls = isApiKey
-      ? (() => {
-          const amazon = baseUrls.filter((u) => u.includes("amazonaws.com"));
-          const others = baseUrls.filter((u) => !u.includes("amazonaws.com"));
-          return amazon.length > 0 ? [...amazon, ...others] : baseUrls;
-        })()
-      : baseUrls;
-
-    // For non-us-east-1 regions: replace region in URLs and remove codewhisperer.*
-    // URLs (that subdomain only exists for us-east-1).
-    if (region && region !== "us-east-1") {
-      urls = urls
-        .filter((u) => !u.includes("codewhisperer."))
-        .map((u) => u.replace(/us-east-1/g, region));
-    }
-
-    return urls;
+    if (!isApiKey) return baseUrls;
+    const amazon = baseUrls.filter((u) => u.includes("amazonaws.com"));
+    const others = baseUrls.filter((u) => !u.includes("amazonaws.com"));
+    return amazon.length > 0 ? [...amazon, ...others] : baseUrls;
   }
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -53,10 +53,31 @@ export class KiroExecutor extends BaseExecutor {
   getOrderedBaseUrls(credentials) {
     const baseUrls = this.getBaseUrls();
     const isApiKey = credentials?.providerSpecificData?.authMethod === "api_key";
-    if (!isApiKey) return baseUrls;
-    const amazon = baseUrls.filter((u) => u.includes("amazonaws.com"));
-    const others = baseUrls.filter((u) => !u.includes("amazonaws.com"));
-    return amazon.length > 0 ? [...amazon, ...others] : baseUrls;
+
+    // Resolve the credential's region from explicit field or from the profileArn
+    // (ARN format: arn:aws:codewhisperer:<region>:<account>:profile/...)
+    const profileArn = credentials?.providerSpecificData?.profileArn || "";
+    const region = credentials?.providerSpecificData?.region
+      || (profileArn ? profileArn.split(":")[3] : "")
+      || "us-east-1";
+
+    let urls = isApiKey
+      ? (() => {
+          const amazon = baseUrls.filter((u) => u.includes("amazonaws.com"));
+          const others = baseUrls.filter((u) => !u.includes("amazonaws.com"));
+          return amazon.length > 0 ? [...amazon, ...others] : baseUrls;
+        })()
+      : baseUrls;
+
+    // For non-us-east-1 regions: replace region in URLs and remove codewhisperer.*
+    // URLs (that subdomain only exists for us-east-1).
+    if (region && region !== "us-east-1") {
+      urls = urls
+        .filter((u) => !u.includes("codewhisperer."))
+        .map((u) => u.replace(/us-east-1/g, region));
+    }
+
+    return urls;
   }
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {

--- a/open-sse/services/tokenRefresh/providers.js
+++ b/open-sse/services/tokenRefresh/providers.js
@@ -1,6 +1,7 @@
 import { PROVIDERS, PROVIDER_OAUTH } from "../../config/providers.js";
 import { OAUTH_ENDPOINTS, GITHUB_COPILOT } from "../../config/appConstants.js";
 import { proxyAwareFetch } from "../../utils/proxyFetch.js";
+import { buildKiroOidcEndpoint, KIRO_DEFAULT_REGION } from "../../config/kiroRegions.js";
 import { dedupRefresh } from "./dedup.js";
 
 let _xaiServiceSingleton = null;
@@ -296,7 +297,7 @@ async function resolveKiroProfileArnPatch(providerSpecificData, accessToken, ref
   let profileArn = refreshedArn?.trim?.() || null;
   if (!profileArn) {
     const { fetchKiroProfileArn } = await import("../../../src/lib/oauth/providers.js");
-    const region = providerSpecificData?.region || "us-east-1";
+    const region = providerSpecificData?.region || KIRO_DEFAULT_REGION;
     profileArn = await fetchKiroProfileArn(accessToken, region);
   }
   return profileArn ? { providerSpecificData: { profileArn } } : {};
@@ -312,9 +313,7 @@ export async function refreshKiroToken(refreshToken, providerSpecificData, log, 
 
   if (clientId && clientSecret) {
     const isIDC = authMethod === "idc";
-    const endpoint = isIDC && region
-      ? `https://oidc.${region}.amazonaws.com/token`
-      : "https://oidc.us-east-1.amazonaws.com/token";
+    const endpoint = buildKiroOidcEndpoint(isIDC ? region : KIRO_DEFAULT_REGION);
 
     const response = await proxyAwareFetch(endpoint, {
       method: "POST",

--- a/open-sse/services/tokenRefresh/providers.js
+++ b/open-sse/services/tokenRefresh/providers.js
@@ -296,7 +296,8 @@ async function resolveKiroProfileArnPatch(providerSpecificData, accessToken, ref
   let profileArn = refreshedArn?.trim?.() || null;
   if (!profileArn) {
     const { fetchKiroProfileArn } = await import("../../../src/lib/oauth/providers.js");
-    profileArn = await fetchKiroProfileArn(accessToken);
+    const region = providerSpecificData?.region || "us-east-1";
+    profileArn = await fetchKiroProfileArn(accessToken, region);
   }
   return profileArn ? { providerSpecificData: { profileArn } } : {};
 }

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -394,10 +394,12 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   }
 
   // API-key auth must never use the shared default ARN (403); OAuth/social fall back to it.
+  // For non-us-east-1 regions, skip the default ARN (it's us-east-1 and gets rejected by EU endpoints).
   const authMethod = credentials?.providerSpecificData?.authMethod;
+  const credRegion = credentials?.providerSpecificData?.region;
   const profileArn = authMethod === "api_key"
     ? (credentials?.providerSpecificData?.profileArn || "")
-    : (credentials?.providerSpecificData?.profileArn || resolveDefaultProfileArn(authMethod));
+    : (credentials?.providerSpecificData?.profileArn || (credRegion && credRegion !== "us-east-1" ? "" : resolveDefaultProfileArn(authMethod)));
 
   let finalContent = currentMessage?.userInputMessage?.content || "";
 

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -30,7 +30,7 @@ import {
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
-  resolveDefaultProfileArn,
+  resolveKiroProfileArn,
 } from "../../config/kiroConstants.js";
 import { DEFAULT_IMAGE_MIME } from "../schema/index.js";
 import { ROLE, CLAUDE_BLOCK } from "../schema/index.js";
@@ -393,13 +393,8 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     reconcileOrphanedToolResults(history, currentMessage);
   }
 
-  // API-key auth must never use the shared default ARN (403); OAuth/social fall back to it.
-  // For non-us-east-1 regions, skip the default ARN (it's us-east-1 and gets rejected by EU endpoints).
-  const authMethod = credentials?.providerSpecificData?.authMethod;
-  const credRegion = credentials?.providerSpecificData?.region;
-  const profileArn = authMethod === "api_key"
-    ? (credentials?.providerSpecificData?.profileArn || "")
-    : (credentials?.providerSpecificData?.profileArn || (credRegion && credRegion !== "us-east-1" ? "" : resolveDefaultProfileArn(authMethod)));
+  // Resolve the profileArn (region-aligned) via the single source of truth.
+  const profileArn = resolveKiroProfileArn(credentials);
 
   let finalContent = currentMessage?.userInputMessage?.content || "";
 

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -531,9 +531,10 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   // profileArn that was actually resolved for this connection — never the default.
   // OAuth/social keep the default fallback (their tokens accept it).
   const authMethod = credentials?.providerSpecificData?.authMethod;
+  const credRegion = credentials?.providerSpecificData?.region;
   const profileArn = authMethod === "api_key"
     ? (credentials?.providerSpecificData?.profileArn || "")
-    : (credentials?.providerSpecificData?.profileArn || resolveDefaultProfileArn(authMethod));
+    : (credentials?.providerSpecificData?.profileArn || (credRegion && credRegion !== "us-east-1" ? "" : resolveDefaultProfileArn(authMethod)));
 
   let finalContent = currentMessage?.userInputMessage?.content || "";
 

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -11,7 +11,7 @@ import {
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
-  resolveDefaultProfileArn
+  resolveKiroProfileArn
 } from "../../config/kiroConstants.js";
 import { parseDataUri } from "../concerns/image.js";
 import { DEFAULT_IMAGE_MIME } from "../schema/index.js";
@@ -524,17 +524,10 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
 
   const { history, currentMessage } = convertMessages(messages, tools, upstreamModel);
 
-  // API-key (headless) auth uses a raw CodeWhisperer credential whose profile is
-  // account-specific. Injecting the shared builder-id/social *default* placeholder
-  // ARN makes CodeWhisperer reject the request with 403 "bearer token invalid"
-  // (the ARN doesn't belong to the key's account). So for api_key, only send a
-  // profileArn that was actually resolved for this connection — never the default.
-  // OAuth/social keep the default fallback (their tokens accept it).
-  const authMethod = credentials?.providerSpecificData?.authMethod;
-  const credRegion = credentials?.providerSpecificData?.region;
-  const profileArn = authMethod === "api_key"
-    ? (credentials?.providerSpecificData?.profileArn || "")
-    : (credentials?.providerSpecificData?.profileArn || (credRegion && credRegion !== "us-east-1" ? "" : resolveDefaultProfileArn(authMethod)));
+  // Resolve the profileArn (region-aligned) via the single source of truth.
+  // Handles api_key (never the shared default), us-east-1 default fallback, and
+  // region alignment so a stored us-east-1 ARN is corrected to the request region.
+  const profileArn = resolveKiroProfileArn(credentials);
 
   let finalContent = currentMessage?.userInputMessage?.content || "";
 

--- a/src/app/api/oauth/kiro/auto-import/route.js
+++ b/src/app/api/oauth/kiro/auto-import/route.js
@@ -5,13 +5,14 @@ import { join } from "path";
 
 /**
  * GET /api/oauth/kiro/auto-import
- * Auto-detect and extract Kiro refresh token from AWS SSO cache
+ * Auto-detect and extract Kiro refresh token from AWS SSO cache.
+ * For IDC (organization) tokens, also resolves clientId/clientSecret from the
+ * linked client registration file so token refresh works.
  */
 export async function GET() {
   try {
     const cachePath = join(homedir(), ".aws/sso/cache");
 
-    // Try to read cache directory
     let files;
     try {
       files = await readdir(cachePath);
@@ -22,9 +23,9 @@ export async function GET() {
       });
     }
 
-    // Look for kiro-auth-token.json or any .json file with refreshToken
     let refreshToken = null;
     let foundFile = null;
+    let tokenData = null;
 
     // First try kiro-auth-token.json
     const kiroTokenFile = "kiro-auth-token.json";
@@ -35,6 +36,7 @@ export async function GET() {
         if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
           refreshToken = data.refreshToken;
           foundFile = kiroTokenFile;
+          tokenData = data;
         }
       } catch (error) {
         // Continue to search other files
@@ -45,19 +47,16 @@ export async function GET() {
     if (!refreshToken) {
       for (const file of files) {
         if (!file.endsWith(".json")) continue;
-
         try {
           const content = await readFile(join(cachePath, file), "utf-8");
           const data = JSON.parse(content);
-
-          // Look for Kiro refresh token (starts with aorAAAAAG)
           if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
             refreshToken = data.refreshToken;
             foundFile = file;
+            tokenData = data;
             break;
           }
         } catch (error) {
-          // Skip invalid JSON files
           continue;
         }
       }
@@ -70,10 +69,58 @@ export async function GET() {
       });
     }
 
+    // For IDC/organization tokens, resolve clientId and clientSecret from
+    // the linked client registration file (referenced by clientIdHash).
+    let clientId = null;
+    let clientSecret = null;
+    const region = tokenData?.region || null;
+    const authMethod = tokenData?.authMethod || null;
+
+    if (tokenData?.clientIdHash) {
+      const clientFile = `${tokenData.clientIdHash}.json`;
+      try {
+        const clientContent = await readFile(join(cachePath, clientFile), "utf-8");
+        const clientData = JSON.parse(clientContent);
+        if (clientData.clientId && clientData.clientSecret) {
+          clientId = clientData.clientId;
+          clientSecret = clientData.clientSecret;
+        }
+      } catch (error) {
+        // Client registration file not found - continue without it
+      }
+    }
+
+    // Read profileArn from Kiro IDE's profile.json.
+    // Important: the runtime gateway requires us-east-1 in the ARN regardless
+    // of the IDC region, so we normalize the region in the ARN to us-east-1.
+    let profileArn = null;
+    const kiroProfilePaths = [
+      join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
+      join(homedir(), ".config", "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
+    ];
+    for (const profilePath of kiroProfilePaths) {
+      try {
+        const profileContent = await readFile(profilePath, "utf-8");
+        const profileData = JSON.parse(profileContent);
+        if (profileData.arn) {
+          // Normalize region to us-east-1 for the runtime gateway
+          profileArn = profileData.arn.replace(/arn:aws:codewhisperer:[^:]+:/, "arn:aws:codewhisperer:us-east-1:");
+          break;
+        }
+      } catch (error) {
+        continue;
+      }
+    }
+
     return NextResponse.json({
       found: true,
       refreshToken,
       source: foundFile,
+      clientId,
+      clientSecret,
+      region,
+      authMethod,
+      profileArn,
     });
   } catch (error) {
     console.log("Kiro auto-import error:", error);

--- a/src/app/api/oauth/kiro/auto-import/route.js
+++ b/src/app/api/oauth/kiro/auto-import/route.js
@@ -90,9 +90,11 @@ export async function GET() {
       }
     }
 
-    // Read profileArn from Kiro IDE's profile.json.
-    // Important: the runtime gateway requires us-east-1 in the ARN regardless
-    // of the IDC region, so we normalize the region in the ARN to us-east-1.
+    // Read profileArn from Kiro IDE's profile.json. Kiro already stores the ARN
+    // with the correct region (e.g. arn:aws:codewhisperer:eu-central-1:...), so
+    // we use it verbatim. Rewriting the region here breaks IDC/Organization
+    // accounts outside us-east-1 (400 "Improperly formed request"). Request-time
+    // region alignment (resolveKiroProfileArn) is the safety net if it ever drifts.
     let profileArn = null;
     const kiroProfilePaths = [
       join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
@@ -103,8 +105,7 @@ export async function GET() {
         const profileContent = await readFile(profilePath, "utf-8");
         const profileData = JSON.parse(profileContent);
         if (profileData.arn) {
-          // Normalize region to us-east-1 for the runtime gateway
-          profileArn = profileData.arn.replace(/arn:aws:codewhisperer:[^:]+:/, "arn:aws:codewhisperer:us-east-1:");
+          profileArn = profileData.arn;
           break;
         }
       } catch (error) {

--- a/src/app/api/oauth/kiro/import/route.js
+++ b/src/app/api/oauth/kiro/import/route.js
@@ -4,11 +4,13 @@ import { createProviderConnection } from "@/models";
 
 /**
  * POST /api/oauth/kiro/import
- * Import and validate refresh token from Kiro IDE
+ * Import and validate refresh token from Kiro IDE.
+ * For IDC (organization) tokens, accepts clientId/clientSecret/region so the
+ * token can be refreshed via the regional AWS OIDC endpoint.
  */
 export async function POST(request) {
   try {
-    const { refreshToken } = await request.json();
+    const { refreshToken, clientId, clientSecret, region, authMethod, profileArn } = await request.json();
 
     if (!refreshToken || typeof refreshToken !== "string") {
       return NextResponse.json(
@@ -18,25 +20,33 @@ export async function POST(request) {
     }
 
     const kiroService = new KiroService();
+    const isIdc = !!(clientId && clientSecret);
 
-    // Validate and refresh token
-    const tokenData = await kiroService.validateImportToken(refreshToken.trim());
+    // For IDC tokens, refresh via the regional OIDC endpoint with client credentials.
+    // For social/builder-id tokens, use the standard social refresh endpoint.
+    const providerSpecificData = isIdc
+      ? { clientId, clientSecret, region: region || "us-east-1", authMethod: "idc" }
+      : {};
 
-    // Extract email from JWT if available
+    const tokenData = await kiroService.refreshToken(refreshToken.trim(), providerSpecificData);
+
     const email = kiroService.extractEmailFromJWT(tokenData.accessToken);
+    const resolvedAuthMethod = isIdc ? "idc" : "imported";
+    const providerLabel = isIdc ? "Enterprise" : "Imported";
+    const resolvedProfileArn = profileArn || tokenData.profileArn || null;
 
-    // Save to database
     const connection = await createProviderConnection({
       provider: "kiro",
       authType: "oauth",
       accessToken: tokenData.accessToken,
-      refreshToken: tokenData.refreshToken,
-      expiresAt: new Date(Date.now() + tokenData.expiresIn * 1000).toISOString(),
+      refreshToken: tokenData.refreshToken || refreshToken.trim(),
+      expiresAt: new Date(Date.now() + (tokenData.expiresIn || 3600) * 1000).toISOString(),
       email: email || null,
       providerSpecificData: {
-        profileArn: tokenData.profileArn,
-        authMethod: "imported",
-        provider: "Imported",
+        profileArn: resolvedProfileArn,
+        authMethod: resolvedAuthMethod,
+        provider: providerLabel,
+        ...(isIdc ? { clientId, clientSecret, region: region || "us-east-1" } : {}),
       },
       testStatus: "active",
     });

--- a/src/lib/oauth/providerHelpers.js
+++ b/src/lib/oauth/providerHelpers.js
@@ -1,3 +1,5 @@
+import { buildKiroProfileEndpoint } from "../../../open-sse/config/kiroRegions.js";
+
 const BASE64_BLOCK_SIZE = 4;
 
 function validateXaiOAuthEndpoint(rawUrl, field) {
@@ -52,9 +54,7 @@ function extractEmailFromAccessToken(accessToken) {
 
 export async function fetchKiroProfileArn(accessToken, region = "us-east-1") {
   if (!accessToken) return null;
-  const endpoint = region === "us-east-1"
-    ? "https://codewhisperer.us-east-1.amazonaws.com/ListAvailableProfiles"
-    : `https://q.${region}.amazonaws.com/ListAvailableProfiles`;
+  const endpoint = buildKiroProfileEndpoint(region);
   try {
     const response = await fetch(endpoint, {
       method: "POST",

--- a/src/lib/oauth/providerHelpers.js
+++ b/src/lib/oauth/providerHelpers.js
@@ -50,13 +50,17 @@ function extractEmailFromAccessToken(accessToken) {
   return payload.email || payload.preferred_username || payload.sub || undefined;
 }
 
-export async function fetchKiroProfileArn(accessToken) {
+export async function fetchKiroProfileArn(accessToken, region = "us-east-1") {
   if (!accessToken) return null;
+  const endpoint = region === "us-east-1"
+    ? "https://codewhisperer.us-east-1.amazonaws.com/ListAvailableProfiles"
+    : `https://q.${region}.amazonaws.com/ListAvailableProfiles`;
   try {
-    const response = await fetch("https://codewhisperer.us-east-1.amazonaws.com/ListAvailableProfiles", {
+    const response = await fetch(endpoint, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/x-amz-json-1.0",
+        "x-amz-target": "AmazonCodeWhispererService.ListAvailableProfiles",
         Accept: "application/json",
         Authorization: `Bearer ${accessToken}`,
       },
@@ -64,7 +68,10 @@ export async function fetchKiroProfileArn(accessToken) {
     });
     if (!response.ok) return null;
     const data = await response.json();
-    return data.profiles?.find((p) => p.arn?.trim())?.arn?.trim() || null;
+    const profiles = data.profiles || [];
+    return profiles.find((p) => p.arn?.includes(region))?.arn?.trim()
+      || profiles.find((p) => p.arn?.trim())?.arn?.trim()
+      || null;
   } catch {
     return null;
   }

--- a/src/lib/oauth/services/kiro.js
+++ b/src/lib/oauth/services/kiro.js
@@ -1,4 +1,5 @@
 import { KIRO_CONFIG, assertValidAwsRegion } from "../constants/oauth.js";
+import { buildKiroProfileEndpoint } from "../../../../open-sse/config/kiroRegions.js";
 
 /**
  * Kiro OAuth Service
@@ -268,7 +269,7 @@ export class KiroService {
    */
   async listAvailableProfiles(accessToken, region = "us-east-1") {
     assertValidAwsRegion(region);
-    const endpoint = `https://codewhisperer.${region}.amazonaws.com`;
+    const endpoint = buildKiroProfileEndpoint(region);
 
     const response = await fetch(endpoint, {
       method: "POST",

--- a/src/shared/components/KiroAuthModal.js
+++ b/src/shared/components/KiroAuthModal.js
@@ -19,6 +19,7 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
   const [importing, setImporting] = useState(false);
   const [autoDetecting, setAutoDetecting] = useState(false);
   const [autoDetected, setAutoDetected] = useState(false);
+  const [idcCredentials, setIdcCredentials] = useState(null);
 
   // Auto-detect token when import method is selected
   useEffect(() => {
@@ -28,6 +29,7 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
       setAutoDetecting(true);
       setError(null);
       setAutoDetected(false);
+      setIdcCredentials(null);
 
       try {
         const res = await fetch("/api/oauth/kiro/auto-import");
@@ -36,6 +38,16 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
         if (data.found) {
           setRefreshToken(data.refreshToken);
           setAutoDetected(true);
+          // Store IDC/organization credentials if present
+          if (data.clientId && data.clientSecret) {
+            setIdcCredentials({
+              clientId: data.clientId,
+              clientSecret: data.clientSecret,
+              region: data.region,
+              authMethod: data.authMethod,
+              profileArn: data.profileArn,
+            });
+          }
         } else {
           setError(data.error || "Could not auto-detect token");
         }
@@ -72,7 +84,10 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
       const res = await fetch("/api/oauth/kiro/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refreshToken: refreshToken.trim() }),
+        body: JSON.stringify({
+          refreshToken: refreshToken.trim(),
+          ...(idcCredentials || {}),
+        }),
       });
 
       const data = await res.json();

--- a/tests/unit/kiro-regions.test.js
+++ b/tests/unit/kiro-regions.test.js
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for open-sse/config/kiroRegions.js — the single source of truth
+ * for Kiro's regional endpoint topology.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  KIRO_DEFAULT_REGION,
+  regionFromProfileArn,
+  resolveKiroRegion,
+  buildKiroBaseUrls,
+  buildKiroProfileEndpoint,
+  buildKiroOidcEndpoint,
+  alignProfileArnRegion,
+} from "../../open-sse/config/kiroRegions.js";
+import { resolveKiroProfileArn } from "../../open-sse/config/kiroConstants.js";
+
+const EU = "eu-central-1";
+const US = "us-east-1";
+const arn = (r) => `arn:aws:codewhisperer:${r}:966063511238:profile/QN4AXVDKDEX7`;
+
+describe("regionFromProfileArn", () => {
+  it("extracts the region segment", () => {
+    expect(regionFromProfileArn(arn(EU))).toBe(EU);
+    expect(regionFromProfileArn(arn(US))).toBe(US);
+  });
+  it("returns null for junk", () => {
+    expect(regionFromProfileArn(null)).toBeNull();
+    expect(regionFromProfileArn("not-an-arn")).toBeNull();
+    expect(regionFromProfileArn(123)).toBeNull();
+  });
+});
+
+describe("resolveKiroRegion", () => {
+  it("prefers explicit region", () => {
+    expect(resolveKiroRegion({ providerSpecificData: { region: EU, profileArn: arn(US) } })).toBe(EU);
+  });
+  it("falls back to profileArn region", () => {
+    expect(resolveKiroRegion({ providerSpecificData: { profileArn: arn(EU) } })).toBe(EU);
+  });
+  it("defaults to us-east-1", () => {
+    expect(resolveKiroRegion({})).toBe(US);
+    expect(resolveKiroRegion(null)).toBe(US);
+  });
+});
+
+describe("buildKiroBaseUrls", () => {
+  it("includes codewhisperer only for us-east-1", () => {
+    const urls = buildKiroBaseUrls(US);
+    expect(urls).toEqual([
+      "https://runtime.us-east-1.kiro.dev/generateAssistantResponse",
+      "https://codewhisperer.us-east-1.amazonaws.com/generateAssistantResponse",
+      "https://q.us-east-1.amazonaws.com/generateAssistantResponse",
+    ]);
+  });
+  it("excludes codewhisperer for other regions and rewrites region", () => {
+    const urls = buildKiroBaseUrls(EU);
+    expect(urls).toEqual([
+      "https://runtime.eu-central-1.kiro.dev/generateAssistantResponse",
+      "https://q.eu-central-1.amazonaws.com/generateAssistantResponse",
+    ]);
+    expect(urls.some((u) => u.includes("codewhisperer"))).toBe(false);
+    expect(urls.every((u) => u.includes(EU))).toBe(true);
+  });
+  it("defaults to us-east-1 when no region given", () => {
+    expect(buildKiroBaseUrls()).toEqual(buildKiroBaseUrls(US));
+  });
+});
+
+describe("buildKiroProfileEndpoint", () => {
+  it("uses codewhisperer host for us-east-1", () => {
+    expect(buildKiroProfileEndpoint(US)).toBe("https://codewhisperer.us-east-1.amazonaws.com");
+  });
+  it("uses q host for other regions", () => {
+    expect(buildKiroProfileEndpoint(EU)).toBe("https://q.eu-central-1.amazonaws.com");
+  });
+});
+
+describe("buildKiroOidcEndpoint", () => {
+  it("is region-scoped", () => {
+    expect(buildKiroOidcEndpoint(EU)).toBe("https://oidc.eu-central-1.amazonaws.com/token");
+    expect(buildKiroOidcEndpoint()).toBe("https://oidc.us-east-1.amazonaws.com/token");
+  });
+});
+
+describe("alignProfileArnRegion", () => {
+  it("rewrites the region segment to match", () => {
+    expect(alignProfileArnRegion(arn(US), EU)).toBe(arn(EU));
+    expect(alignProfileArnRegion(arn(EU), US)).toBe(arn(US));
+  });
+  it("is a no-op when already aligned", () => {
+    expect(alignProfileArnRegion(arn(EU), EU)).toBe(arn(EU));
+  });
+  it("handles empty input", () => {
+    expect(alignProfileArnRegion("", EU)).toBe("");
+    expect(alignProfileArnRegion(null, EU)).toBe("");
+  });
+});
+
+describe("resolveKiroProfileArn (integration with kiroConstants)", () => {
+  it("aligns a stored us-east-1 ARN to the EU credential region (self-heal)", () => {
+    const creds = { providerSpecificData: { region: EU, authMethod: "idc", profileArn: arn(US) } };
+    expect(resolveKiroProfileArn(creds)).toBe(arn(EU));
+  });
+  it("keeps a correct EU ARN as-is", () => {
+    const creds = { providerSpecificData: { region: EU, authMethod: "idc", profileArn: arn(EU) } };
+    expect(resolveKiroProfileArn(creds)).toBe(arn(EU));
+  });
+  it("never returns the shared default for api_key without an ARN", () => {
+    const creds = { providerSpecificData: { region: US, authMethod: "api_key" } };
+    expect(resolveKiroProfileArn(creds)).toBe("");
+  });
+  it("uses the shared default for us-east-1 builder-id without an ARN", () => {
+    const creds = { providerSpecificData: { region: US, authMethod: "builder-id" } };
+    expect(resolveKiroProfileArn(creds)).toContain("arn:aws:codewhisperer:us-east-1:");
+  });
+  it("returns empty for a non-us-east-1 credential without an ARN (resolved on refresh instead)", () => {
+    const creds = { providerSpecificData: { region: EU, authMethod: "idc" } };
+    expect(resolveKiroProfileArn(creds)).toBe("");
+  });
+});


### PR DESCRIPTION
## Problem

Kiro connections whose AWS region is **not us-east-1** (e.g. IAM Identity Center / Organization accounts in `eu-central-1`) fail:

- **403** `bearer token is invalid` — a region-scoped token sent to the us-east-1 runtime endpoint
- **400** `profileArn is required` / `Improperly formed request` — a us-east-1 profileArn sent to a non-us-east-1 endpoint

Two paths were affected: chat requests (wrong endpoint + wrong ARN) and **token import** (the auto-import route rewrote the profileArn region to `us-east-1`).

## Approach — one source of truth, not scattered special-cases

Kiro / CodeWhisperer is region-scoped: the token, its profileArn, the runtime endpoint, the OIDC refresh endpoint and the ListAvailableProfiles control-plane must all agree on one region. `us-east-1` is only the **default**, not a special case.

New module **`open-sse/config/kiroRegions.js`** is the single source of truth:

| Helper | Purpose |
|--------|---------|
| `resolveKiroRegion(creds)` | region from `providerSpecificData.region` → profileArn → default |
| `buildKiroBaseUrls(region)` | region-correct GenerateAssistantResponse URLs |
| `buildKiroProfileEndpoint(region)` | ListAvailableProfiles control-plane host |
| `buildKiroOidcEndpoint(region)` | IDC token-refresh endpoint |
| `alignProfileArnRegion(arn, region)` | force an ARN's region segment to match |

The one genuine AWS asymmetry — `codewhisperer.<region>.amazonaws.com` exists **only** in us-east-1, while `q.<region>.amazonaws.com` and `runtime.<region>.kiro.dev` exist everywhere — is encoded **once**, as data, in a host table. Adding/adjusting regions is a data edit, no logic changes.

`resolveKiroProfileArn()` (in `kiroConstants.js`) becomes the single profileArn resolver: it **aligns a stored ARN to the request region** (self-heals a mismatched or wrongly-imported ARN), and never sends the shared default for `api_key` or non-us-east-1 connections.

## Changes

- **`open-sse/config/kiroRegions.js`** (new) — region topology + helpers (dependency-free)
- **`open-sse/config/kiroConstants.js`** — `resolveKiroProfileArn()`; re-exports region helpers
- **`open-sse/executors/kiro.js`** — endpoints via `buildKiroBaseUrls(resolveKiroRegion(creds))`
- **`open-sse/translator/request/openai-to-kiro.js`**, **`claude-to-kiro.js`** — `resolveKiroProfileArn(credentials)`
- **`open-sse/services/tokenRefresh/providers.js`** — OIDC via `buildKiroOidcEndpoint`; region passed to profile fetch
- **`src/lib/oauth/providerHelpers.js`** — `fetchKiroProfileArn(token, region)` via `buildKiroProfileEndpoint`
- **`src/lib/oauth/services/kiro.js`** — `listAvailableProfiles` via `buildKiroProfileEndpoint`
- **`src/app/api/oauth/kiro/auto-import/route.js`** — **stop rewriting the ARN region to us-east-1** (root cause of the token-import 400); use Kiro IDE's ARN verbatim

## Testing

- **`tests/unit/kiro-regions.test.js`** — 19 new cases (region resolution, URL building, ARN alignment, profileArn resolution incl. self-heal)
- Existing Kiro / translator suites: no new regressions
- Verified live against a real IDC account in `eu-central-1`:
  - `kiro/claude-opus-4.8` (OpenAI **and** Anthropic formats) → 200
  - `kiro/claude-sonnet-4.5` → 200
  - Deliberately corrupting the stored ARN to `us-east-1` still returns 200 (self-heal aligns it at request time)
  - Token refresh via `oidc.eu-central-1.amazonaws.com`; profileArn resolved via `q.eu-central-1.amazonaws.com`
  - auto-import now yields the `eu-central-1` ARN instead of a rewritten `us-east-1` one
