### PR TITLE
fix(translator): preserve Z.ai reasoning effort

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -198,6 +198,9 @@ function applyFormat(fmt, body, cfg, caps) {
       // Z.ai ignores thinking.disabled → must use enable_thinking:false to turn off.
       if (none && canDisable) { body.enable_thinking = false; delete body.thinking; break; }
       body.thinking = { type: "enabled" };
+      // Z.ai GLM supports high/max reasoning_effort when thinking is enabled.
+      const level = toLevel(eff);
+      if (level) body.reasoning_effort = level === "xhigh" || level === "max" ? "max" : "high";
       break;
     }
     case "qwen": {

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -88,6 +88,27 @@ describe("applyThinking per provider format", () => {
     expect(out.enable_thinking).toBe(false);
     expect(out.thinking).toBeUndefined();
   });
+  it("Z.ai GLM preserves high reasoning_effort when thinking is enabled", () => {
+    const out = apply("openai", "glm-5.2", { reasoning_effort: "high" }, "glm");
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("high");
+  });
+  it("Z.ai GLM maps max/xhigh reasoning_effort to max", () => {
+    const outMax = apply("openai", "glm-5.2", { reasoning_effort: "max" }, "glm");
+    const outXhigh = apply("openai", "glm-5.2", { reasoning_effort: "xhigh" }, "glm");
+    expect(outMax.thinking).toEqual({ type: "enabled" });
+    expect(outMax.reasoning_effort).toBe("max");
+    expect(outXhigh.thinking).toEqual({ type: "enabled" });
+    expect(outXhigh.reasoning_effort).toBe("max");
+  });
+  it("Z.ai GLM maps lower reasoning_effort levels to high", () => {
+    const outLow = apply("openai", "glm-5.2", { reasoning_effort: "low" }, "glm");
+    const outMedium = apply("openai", "glm-5.2", { reasoning_effort: "medium" }, "glm");
+    expect(outLow.thinking).toEqual({ type: "enabled" });
+    expect(outLow.reasoning_effort).toBe("high");
+    expect(outMedium.thinking).toEqual({ type: "enabled" });
+    expect(outMedium.reasoning_effort).toBe("high");
+  });
   it("Qwen on → enable_thinking + thinking_budget", () => {
     const out = apply("openai", "qwen3-max", { reasoning_effort: "medium" }, "qwen");
     expect(out.enable_thinking).toBe(true);

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -93,6 +93,11 @@ describe("applyThinking per provider format", () => {
     expect(out.thinking).toEqual({ type: "enabled" });
     expect(out.reasoning_effort).toBe("high");
   });
+  it("Z.ai GLM China preserves reasoning_effort when thinking is enabled", () => {
+    const out = apply("openai", "glm-5.2", { reasoning_effort: "max" }, "glm-cn");
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe("max");
+  });
   it("Z.ai GLM maps max/xhigh reasoning_effort to max", () => {
     const outMax = apply("openai", "glm-5.2", { reasoning_effort: "max" }, "glm");
     const outXhigh = apply("openai", "glm-5.2", { reasoning_effort: "xhigh" }, "glm");


### PR DESCRIPTION
## Summary
- Preserve top-level `reasoning_effort` for both Z.ai GLM providers:
  - `glm` / international endpoint (`api.z.ai`)
  - `glm-cn` / China endpoint (`open.bigmodel.cn`)
- Map `max`/`xhigh` to Z.ai `max`, and lower levels to `high`
- Keep existing `none` behavior via `enable_thinking: false`

## Why
Z.ai GLM-5.2 supports high/max reasoning effort when thinking is enabled. The translator already enables thinking for the Z.ai format, but previously dropped the captured effort level, making high/max requests indistinguishable upstream.

The fix lives in the shared `zai` thinking formatter, so it applies to both domestic and international GLM providers that resolve to `thinkingFormat: "zai"`.

## Tests
- Verified red first: new Z.ai GLM tests failed with `reasoning_effort` undefined before the fix
- Added explicit coverage for both `glm` and `glm-cn`
- `npx vitest run --config tests/vitest.config.js --reporter=verbose tests/translator/thinking-unified.test.js tests/translator/golden-translator-concerns.test.js`