### PR TITLE
feat(kenari): add Kenari OpenAI-compatible gateway provider

### DIFF
--- a/open-sse/providers/registry/index.js
+++ b/open-sse/providers/registry/index.js
@@ -119,6 +119,7 @@ import p116 from "./tokenrouter.js";
 import p117 from "./selfhosted-stt.js";
 import p118 from "./selfhosted-tts.js";
 import p119 from "./selfhosted-embedding.js";
+import p120 from "./kenari.js";
 
 export default [
   p0,
@@ -239,4 +240,5 @@ export default [
   p117,
   p118,
   p119,
+  p120,
 ];

--- a/open-sse/providers/registry/kenari.js
+++ b/open-sse/providers/registry/kenari.js
@@ -1,0 +1,24 @@
+export default {
+  id: "kenari",
+  priority: 60,
+  alias: "kenari",
+  display: {
+    name: "Kenari",
+    icon: "cloud",
+    color: "#B5362A",
+    textIcon: "KN",
+    website: "https://kenari.id",
+    notice: {
+      text: "Indonesian OpenAI-compatible AI gateway billed in Rupiah (IDR). One kn- API key covers the whole catalog (Claude, GPT, DeepSeek, GLM, Kimi and more). Docs: kenari.id/docs.",
+      apiKeyUrl: "https://kenari.id/login?next=/keys",
+    },
+  },
+  category: "apikey",
+  transport: {
+    baseUrl: "https://kenari.id/v1/chat/completions",
+    validateUrl: "https://kenari.id/v1/models",
+  },
+  modelsFetcher: { url: "https://kenari.id/v1/models", type: "openai" },
+  passthroughModels: true,
+  models: [],
+};


### PR DESCRIPTION
### What

Adds [Kenari](https://kenari.id) as an API-key provider. Kenari is an Indonesian OpenAI-compatible AI gateway billed in Rupiah (IDR): one `kn-` API key covers the whole catalog (Claude, GPT, DeepSeek, GLM, Kimi and more).

### How

- New registry entry `open-sse/providers/registry/kenari.js`, wired into `registry/index.js`.
- Standard `Authorization: Bearer` auth and OpenAI format (registry defaults), so no executor or translator changes.
- Live model list via `modelsFetcher` on the public `https://kenari.id/v1/models` catalog (no key needed) plus `passthroughModels: true`, mirroring the vercel-ai-gateway pattern. `validateUrl` powers the dashboard key test.

### Verified

- `https://kenari.id/v1/models` returns the catalog with no auth (24 models).
- `POST https://kenari.id/v1/chat/completions` returns 401 without a key, 200 with a `kn-` key.
- Registry loads: `PROVIDERS.kenari` resolves with `format: "openai"`.
- Docs: https://kenari.id/docs, OpenAPI: https://kenari.id/openapi.json.

Disclosure: I run kenari.id.
