### PR TITLE
fix(kiro): preserve IDC region across ARN discovery

### DIFF
--- a/src/app/api/oauth/kiro/auto-import/route.js
+++ b/src/app/api/oauth/kiro/auto-import/route.js
@@ -91,8 +91,11 @@ export async function GET() {
     }
 
     // Read profileArn from Kiro IDE's profile.json.
-    // Important: the runtime gateway requires us-east-1 in the ARN regardless
-    // of the IDC region, so we normalize the region in the ARN to us-east-1.
+    // Preserve the ARN's region exactly as issued by Kiro IDE: IDC users in
+    // eu-west-1 / ap-southeast-1 / etc must keep their regional ARN so
+    // ListAvailableProfiles / GetUsageLimits / generateAssistantResponse hit
+    // the same CodeWhisperer regional endpoint. Rewriting to us-east-1 here
+    // silently 403s any non-us-east-1 IDC connection.
     let profileArn = null;
     const kiroProfilePaths = [
       join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
@@ -103,8 +106,7 @@ export async function GET() {
         const profileContent = await readFile(profilePath, "utf-8");
         const profileData = JSON.parse(profileContent);
         if (profileData.arn) {
-          // Normalize region to us-east-1 for the runtime gateway
-          profileArn = profileData.arn.replace(/arn:aws:codewhisperer:[^:]+:/, "arn:aws:codewhisperer:us-east-1:");
+          profileArn = profileData.arn;
           break;
         }
       } catch (error) {

--- a/src/lib/oauth/providerHelpers.js
+++ b/src/lib/oauth/providerHelpers.js
@@ -1,3 +1,5 @@
+import { assertValidAwsRegion } from "./constants/oauth";
+
 const BASE64_BLOCK_SIZE = 4;
 
 function validateXaiOAuthEndpoint(rawUrl, field) {
@@ -50,13 +52,23 @@ function extractEmailFromAccessToken(accessToken) {
   return payload.email || payload.preferred_username || payload.sub || undefined;
 }
 
-export async function fetchKiroProfileArn(accessToken) {
+export async function fetchKiroProfileArn(accessToken, region = "us-east-1") {
   if (!accessToken) return null;
+  let safeRegion = "us-east-1";
+  if (typeof region === "string" && region.trim()) {
+    try {
+      safeRegion = assertValidAwsRegion(region.trim());
+    } catch {
+      safeRegion = "us-east-1";
+    }
+  }
+  const endpoint = `https://codewhisperer.${safeRegion}.amazonaws.com`;
   try {
-    const response = await fetch("https://codewhisperer.us-east-1.amazonaws.com/ListAvailableProfiles", {
+    const response = await fetch(endpoint, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/x-amz-json-1.0",
+        "x-amz-target": "AmazonCodeWhispererService.ListAvailableProfiles",
         Accept: "application/json",
         Authorization: `Bearer ${accessToken}`,
       },
@@ -64,7 +76,12 @@ export async function fetchKiroProfileArn(accessToken) {
     });
     if (!response.ok) return null;
     const data = await response.json();
-    return data.profiles?.find((p) => p.arn?.trim())?.arn?.trim() || null;
+    const profiles = Array.isArray(data?.profiles) ? data.profiles : [];
+    // Prefer a profile whose ARN region matches the caller's region — IDC users
+    // in eu-west-1 / ap-southeast-1 must not be pinned to a us-east-1 profile.
+    const arnOf = (p) => (p?.arn || p?.profileArn || "").trim() || null;
+    const inRegion = profiles.find((p) => arnOf(p)?.split(":")[3] === safeRegion);
+    return arnOf(inRegion) || arnOf(profiles[0]) || null;
   } catch {
     return null;
   }

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -1433,9 +1433,12 @@ export async function pollForToken(providerName, deviceCode, codeVerifier, extra
         extra = await provider.postExchange(result.data);
       }
       const tokens = provider.mapTokens(result.data, extra);
-      // Kiro IDC/Builder-ID tokens lack profileArn; resolve it to avoid 403
+      // Kiro IDC/Builder-ID tokens lack profileArn; resolve it to avoid 403.
+      // Use the same region the token was issued in so IDC accounts in
+      // eu-west-1 / ap-southeast-1 hit their regional CodeWhisperer endpoint.
       if (providerName === "kiro" && !tokens.providerSpecificData?.profileArn) {
-        const profileArn = await fetchKiroProfileArn(tokens.accessToken);
+        const region = tokens.providerSpecificData?.region || "us-east-1";
+        const profileArn = await fetchKiroProfileArn(tokens.accessToken, region);
         if (profileArn) tokens.providerSpecificData.profileArn = profileArn;
       }
       return { success: true, tokens };

--- a/tests/unit/kiro-auto-import-arn.test.js
+++ b/tests/unit/kiro-auto-import-arn.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Regression test for the Kiro auto-import route.
+ *
+ * Before this fix, the route rewrote the region segment of Kiro IDE's
+ * profileArn to `us-east-1` on the assumption that "the runtime gateway
+ * requires us-east-1". That assumption held only for Builder ID / social
+ * accounts. IDC users signed in through eu-west-1 (or any non-us region)
+ * were silently pinned to a us-east-1 profile ARN, which their token has no
+ * permission to sign with — every subsequent generateAssistantResponse /
+ * GetUsageLimits call 403s.
+ *
+ * The route must preserve the ARN's region exactly as issued by Kiro IDE.
+ *
+ * The route uses `fs/promises` and `next/server`, so we mock both. We import
+ * the route dynamically after mocks are wired.
+ */
+describe("kiro auto-import — preserves profileArn region", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.restoreAllMocks());
+
+  async function loadRoute(fsMock) {
+    vi.doMock("fs/promises", () => fsMock);
+    vi.doMock("next/server", () => ({
+      NextResponse: {
+        json: (body, init) => ({ status: init?.status ?? 200, body }),
+      },
+    }));
+    return await import("../../src/app/api/oauth/kiro/auto-import/route.js");
+  }
+
+  it("returns the ARN unchanged for a non-us-east-1 IDC account", async () => {
+    const idcArn = "arn:aws:codewhisperer:eu-west-1:123456789012:profile/EU";
+    const tokenFile = JSON.stringify({
+      refreshToken: "aorAAAAAG-eu-west-1-refresh",
+      region: "eu-west-1",
+      authMethod: "idc",
+      clientIdHash: "abc123",
+    });
+    const clientFile = JSON.stringify({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    const profileFile = JSON.stringify({ arn: idcArn });
+
+    const fsMock = {
+      readdir: vi.fn(async () => ["kiro-auth-token.json", "abc123.json"]),
+      readFile: vi.fn(async (path) => {
+        const p = String(path);
+        if (p.endsWith("kiro-auth-token.json")) return tokenFile;
+        if (p.endsWith("abc123.json")) return clientFile;
+        if (p.endsWith("profile.json")) return profileFile;
+        throw new Error(`unexpected read: ${p}`);
+      }),
+    };
+
+    const { GET } = await loadRoute(fsMock);
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(res.body.found).toBe(true);
+    expect(res.body.refreshToken).toBe("aorAAAAAG-eu-west-1-refresh");
+    expect(res.body.region).toBe("eu-west-1");
+    expect(res.body.authMethod).toBe("idc");
+    expect(res.body.clientId).toBe("client-id");
+    expect(res.body.clientSecret).toBe("client-secret");
+    // The critical assertion: no region rewrite. The ARN's region segment
+    // must still be eu-west-1, not us-east-1.
+    expect(res.body.profileArn).toBe(idcArn);
+    expect(res.body.profileArn).toMatch(
+      /^arn:aws:codewhisperer:eu-west-1:/
+    );
+  });
+
+  it("still returns a us-east-1 ARN unchanged for Builder ID accounts", async () => {
+    const builderArn = "arn:aws:codewhisperer:us-east-1:638616132270:profile/BUILDER";
+    const tokenFile = JSON.stringify({
+      refreshToken: "aorAAAAAG-builder",
+      region: "us-east-1",
+      authMethod: "builder-id",
+    });
+    const profileFile = JSON.stringify({ arn: builderArn });
+
+    const fsMock = {
+      readdir: vi.fn(async () => ["kiro-auth-token.json"]),
+      readFile: vi.fn(async (path) => {
+        const p = String(path);
+        if (p.endsWith("kiro-auth-token.json")) return tokenFile;
+        if (p.endsWith("profile.json")) return profileFile;
+        throw new Error(`unexpected read: ${p}`);
+      }),
+    };
+
+    const { GET } = await loadRoute(fsMock);
+    const res = await GET();
+
+    expect(res.body.found).toBe(true);
+    expect(res.body.profileArn).toBe(builderArn);
+  });
+});

--- a/tests/unit/kiro-profile-arn-regional.test.js
+++ b/tests/unit/kiro-profile-arn-regional.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchKiroProfileArn } from "../../src/lib/oauth/providerHelpers.js";
+
+/**
+ * Regression tests for regional Kiro profileArn discovery.
+ *
+ * Bug context: fetchKiroProfileArn hard-coded
+ *   https://codewhisperer.us-east-1.amazonaws.com/ListAvailableProfiles
+ * with `Content-Type: application/json`. That breaks two things at once:
+ *
+ *   1. IDC accounts issued in eu-west-1 / ap-southeast-1 / etc. still get
+ *      pinned to a us-east-1 endpoint, silently 403-ing every subsequent
+ *      generateAssistantResponse / GetUsageLimits call.
+ *   2. AWS CodeWhisperer expects x-amz-target dispatch with
+ *      `application/x-amz-json-1.0`. Servers that reject unknown paths return
+ *      401 to the wrong URL shape, masking the real error.
+ *
+ * These tests pin the fix:
+ *   - endpoint is codewhisperer.<region>.amazonaws.com
+ *   - method is POST to the service root with x-amz-target dispatch
+ *   - Content-Type is application/x-amz-json-1.0
+ *   - profile whose ARN region matches the caller region wins over the first
+ *     profile in the list
+ *   - unknown/invalid region falls back to us-east-1 (never crashes)
+ */
+describe("fetchKiroProfileArn — regional endpoint + dispatch shape", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("hits codewhisperer.<region>.amazonaws.com with x-amz-target dispatch", async () => {
+    const expectedArn = "arn:aws:codewhisperer:eu-west-1:123456789012:profile/EU";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ arn: expectedArn }] }),
+    });
+
+    const arn = await fetchKiroProfileArn("token", "eu-west-1");
+    expect(arn).toBe(expectedArn);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://codewhisperer.eu-west-1.amazonaws.com");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/x-amz-json-1.0");
+    expect(init.headers["x-amz-target"]).toBe(
+      "AmazonCodeWhispererService.ListAvailableProfiles"
+    );
+    expect(init.headers.Authorization).toBe("Bearer token");
+  });
+
+  it("prefers the profile whose ARN region matches the caller region", async () => {
+    const usArn = "arn:aws:codewhisperer:us-east-1:111:profile/US";
+    const apArn = "arn:aws:codewhisperer:ap-southeast-1:222:profile/AP";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      // us-east-1 comes back first but we asked for ap-southeast-1 — that
+      // must win, otherwise IDC users get 403 on their regional endpoint.
+      json: async () => ({ profiles: [{ arn: usArn }, { arn: apArn }] }),
+    });
+
+    const arn = await fetchKiroProfileArn("token", "ap-southeast-1");
+    expect(arn).toBe(apArn);
+  });
+
+  it("falls back to the first profile when no ARN matches the region", async () => {
+    const usArn = "arn:aws:codewhisperer:us-east-1:111:profile/US";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ arn: usArn }] }),
+    });
+
+    const arn = await fetchKiroProfileArn("token", "eu-west-1");
+    expect(arn).toBe(usArn);
+  });
+
+  it("accepts both `arn` and `profileArn` field names in the response", async () => {
+    const expectedArn = "arn:aws:codewhisperer:us-east-1:111:profile/ALT";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ profileArn: expectedArn }] }),
+    });
+
+    const arn = await fetchKiroProfileArn("token", "us-east-1");
+    expect(arn).toBe(expectedArn);
+  });
+
+  it("defaults to us-east-1 when region is missing or malformed", async () => {
+    const expectedArn = "arn:aws:codewhisperer:us-east-1:111:profile/X";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ profiles: [{ arn: expectedArn }] }),
+    });
+
+    await fetchKiroProfileArn("token"); // no region
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://codewhisperer.us-east-1.amazonaws.com"
+    );
+
+    await fetchKiroProfileArn("token", "not-a-region");
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "https://codewhisperer.us-east-1.amazonaws.com"
+    );
+
+    await fetchKiroProfileArn("token", null);
+    expect(fetchMock.mock.calls[2][0]).toBe(
+      "https://codewhisperer.us-east-1.amazonaws.com"
+    );
+  });
+
+  it("returns null on non-2xx responses without throwing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => "Forbidden",
+    });
+    const arn = await fetchKiroProfileArn("token", "eu-west-1");
+    expect(arn).toBeNull();
+  });
+
+  it("returns null on network failure without throwing", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("boom"));
+    const arn = await fetchKiroProfileArn("token", "eu-west-1");
+    expect(arn).toBeNull();
+  });
+
+  it("returns null when access token is missing", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    expect(await fetchKiroProfileArn(null, "eu-west-1")).toBeNull();
+    expect(await fetchKiroProfileArn("", "eu-west-1")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fix Kiro IDC profile ARN discovery and auto-import for accounts issued outside `us-east-1`.

This patch preserves regional topology end-to-end:

- `fetchKiroProfileArn(accessToken, region)` now validates the caller region, hits `https://codewhisperer.<region>.amazonaws.com`, and uses AWS JSON RPC dispatch (`x-amz-target: AmazonCodeWhispererService.ListAvailableProfiles`, `Content-Type: application/x-amz-json-1.0`).
- OAuth token exchange now forwards the resolved Kiro region into `fetchKiroProfileArn()` instead of defaulting all profile discovery to `us-east-1`.
- Kiro IDE auto-import now preserves the profile ARN exactly as issued by Kiro IDE instead of rewriting the ARN region to `us-east-1`.
- Regression tests cover regional endpoint selection, AWS dispatch headers, region-preferring profile selection, invalid region fallback, error-safe behavior, and auto-import ARN preservation for both IDC and Builder ID profiles.

## Why

IDC users in regions like `eu-west-1` / `ap-southeast-1` can receive regional CodeWhisperer profile ARNs. Rewriting or discovering those profiles through `us-east-1` silently causes downstream CodeWhisperer calls such as `ListAvailableProfiles`, `GetUsageLimits`, and `generateAssistantResponse` to 403 for non-US IDC accounts.

## Testing

```text
NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run --reporter=verbose --config ./tests/vitest.kiro-verify.config.js tests/unit/kiro-profile-arn.test.js tests/unit/kiro-profile-arn-regional.test.js tests/unit/kiro-auto-import-arn.test.js

Test Files  3 passed (3)
Tests       13 passed (13)
```

Also ran syntax checks:

```text
node -c src/lib/oauth/providerHelpers.js
node -c src/app/api/oauth/kiro/auto-import/route.js
node -c src/lib/oauth/providers.js
node -c tests/unit/kiro-profile-arn-regional.test.js
node -c tests/unit/kiro-auto-import-arn.test.js
```

Note: local Vitest needed a temporary non-committed config to bypass root PostCSS discovery in this environment because `@tailwindcss/postcss` was not installed in the hoisted `/tmp/node_modules` test setup. The committed source and tests are independent of that temp config.
