### PR TITLE
fix(providers): allow multiple API-key connections per compatible node

### DIFF
--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -126,17 +126,13 @@ export async function POST(request) {
 
     let providerSpecificData = normalizeProviderSpecificData(provider, body, body.providerSpecificData);
 
-    // Compatible/embedding nodes allow exactly one connection each. These guards were
-    // dropped accidentally during the bun:sqlite refactor (v0.4.28); restored to honor
-    // the contract locked in by tests/unit/compatible-provider-connections.test.js (#925).
+    // Populate providerSpecificData from the node config for compatible provider types.
+    // Multiple API-key connections per node are intentionally allowed — 9Router load-balances
+    // across all active connections, so adding a second key enables round-robin redundancy (#2238).
     if (isOpenAICompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);
       if (!node) {
         return NextResponse.json({ error: "OpenAI Compatible node not found" }, { status: 404 });
-      }
-      const existingConnections = await getProviderConnections({ provider });
-      if (existingConnections.length > 0) {
-        return NextResponse.json({ error: "Only one connection is allowed for this OpenAI Compatible node" }, { status: 400 });
       }
       providerSpecificData = {
         prefix: node.prefix,
@@ -149,10 +145,6 @@ export async function POST(request) {
       if (!node) {
         return NextResponse.json({ error: "Anthropic Compatible node not found" }, { status: 404 });
       }
-      const existingConnections = await getProviderConnections({ provider });
-      if (existingConnections.length > 0) {
-        return NextResponse.json({ error: "Only one connection is allowed for this Anthropic Compatible node" }, { status: 400 });
-      }
       providerSpecificData = {
         prefix: node.prefix,
         baseUrl: node.baseUrl,
@@ -162,10 +154,6 @@ export async function POST(request) {
       const node = await getProviderNodeById(provider);
       if (!node) {
         return NextResponse.json({ error: "Custom Embedding node not found" }, { status: 404 });
-      }
-      const existingConnections = await getProviderConnections({ provider });
-      if (existingConnections.length > 0) {
-        return NextResponse.json({ error: "Only one connection is allowed for this Custom Embedding node" }, { status: 400 });
       }
       providerSpecificData = {
         prefix: node.prefix,

--- a/tests/unit/compatible-provider-connections.test.js
+++ b/tests/unit/compatible-provider-connections.test.js
@@ -145,26 +145,26 @@ describe("compatible provider connections API", () => {
     });
   });
 
-  it("returns 400 for a duplicate connection on the same compatible node", async () => {
+  it("allows multiple API-key connections on the same compatible node for load balancing", async () => {
     const ctx = await setupTestContext({
-      id: "openai-compatible-duplicate-test",
+      id: "openai-compatible-multi-test",
       type: "openai-compatible",
-      name: "Duplicate Guard Node",
-      prefix: "dup",
+      name: "Multi-Key Node",
+      prefix: "mk",
       apiType: "chat",
-      baseUrl: "https://duplicate-guard.test/v1",
+      baseUrl: "https://multi-key.test/v1",
     });
     cleanup = ctx.cleanup;
 
     const firstResponse = await ctx.POST(makeRequest(ctx.node.id));
     const secondResponse = await ctx.POST(makeRequest(ctx.node.id));
-    const secondBody = await secondResponse.json();
     const storedConnections = await ctx.getProviderConnections({ provider: ctx.node.id });
 
     expect(firstResponse.status).toBe(201);
-    expect(secondResponse.status).toBe(400);
-    expect(secondBody.error).toContain("Only one connection is allowed");
-    expect(storedConnections).toHaveLength(1);
-    expectCompatibleConnection(storedConnections[0], ctx.node, { apiType: "chat" });
+    expect(secondResponse.status).toBe(201);
+    expect(storedConnections).toHaveLength(2);
+    for (const conn of storedConnections) {
+      expectCompatibleConnection(conn, ctx.node, { apiType: "chat" });
+    }
   });
 });


### PR DESCRIPTION
Fixes #2238.

## Problem

OpenAI-compatible, Anthropic-compatible, and custom-embedding nodes enforced a one-connection-per-node limit. Attempting to add a second API key returned `400 "Only one connection is allowed"`.

This directly contradicts 9Router's core purpose: load-balancing and failover across multiple API keys/connections. A user with two API keys for the same endpoint had no way to use both.

## Root cause

Lines 132–175 of `src/app/api/providers/route.js` queried existing connections and rejected any POST if `length > 0`. A comment attributed this to restoring a guard that was "dropped accidentally" in the SQLite refactor — but the original guard was wrong to begin with.

## Fix

Remove the `existingConnections.length > 0` guard for all three compatible types. The node-config population (`providerSpecificData = { prefix, baseUrl, ... }`) is kept — it pulls fresh node data on every POST and applies the same transport config to each new connection. Each connection still carries its own unique `apiKey`.

Multiple connections on the same node are now routed through the existing round-robin / fallback load balancer without any new code.

## Test changes

The "returns 400 for a duplicate connection" test is rewritten to assert the opposite:
- Both first and second `POST` return `201`
- The DB contains 2 connections, both with correct node providerSpecificData

## No risk path

- Node not found still returns `404`
- The `providerSpecificData` population is unchanged
- Load balancer already handles multiple connections per provider — no routing changes needed