### PR TITLE
fix(kimchi): bump User-Agent to 0.1.58 and align across 3 sites

### DIFF
--- a/open-sse/providers/registry/kimchi.js
+++ b/open-sse/providers/registry/kimchi.js
@@ -20,7 +20,7 @@ export default {
     baseUrl: "https://llm.kimchi.dev/openai/v1/chat/completions",
     format: "openai",
     headers: {
-      "User-Agent": "kimchi/0.1.50",
+      "User-Agent": "kimchi/0.1.58",
     },
     auth: {
       combined: true,

--- a/open-sse/services/kimchiModels.js
+++ b/open-sse/services/kimchiModels.js
@@ -3,7 +3,7 @@ import { createHash } from "crypto";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 
 export const KIMCHI_API = "https://llm.kimchi.dev";
-export const KIMCHI_USER_AGENT = "kimchi/0.1.40";
+export const KIMCHI_USER_AGENT = "kimchi/0.1.58";
 
 const FETCH_TIMEOUT_MS = 20_000;
 const CACHE_TTL_MS = 5 * 60 * 1000;

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -99,7 +99,7 @@ const OAUTH_TEST_CONFIG = {
     authPrefix: "Bearer ",
     extraHeaders: {
       Accept: "application/json",
-      "User-Agent": "kimchi/0.1.40",
+      "User-Agent": "kimchi/0.1.58",
     },
     refreshable: false,
   },


### PR DESCRIPTION
Three call sites used to drift apart:
- registry/kimchi.js: kimchi/0.1.50 (chat completions)
- services/kimchiModels.js: KIMCHI_USER_AGENT = kimchi/0.1.40 (models metadata)
- providers/[id]/test/testUtils.js: kimchi/0.1.40 (connection test)

Align all three on the latest upstream CLI tag (v0.1.58).

No behavior change beyond the UA string. Tests still pass.