### PR TITLE
fix(github): classify Copilot profile status

### DIFF
--- a/open-sse/services/copilotStatus.js
+++ b/open-sse/services/copilotStatus.js
@@ -1,0 +1,247 @@
+import { GITHUB_COPILOT } from "../config/appConstants.js";
+import { proxyAwareFetch } from "../utils/proxyFetch.js";
+
+const TOKEN_EXCHANGE_URL = "https://api.github.com/copilot_internal/v2/token";
+const COMPLETIONS_URL = "https://api.githubcopilot.com/chat/completions";
+const MODELS_URL = "https://api.githubcopilot.com/models";
+export const COPILOT_STATUS_PROBE_MODEL = "claude-opus-4.7";
+const PREFERRED_PROBE_MODELS = [
+  "claude-opus-4.7",
+  "claude-sonnet-4.6",
+  "claude-opus-4.6",
+  "gpt-5.4-mini",
+  "claude-haiku-4.5",
+];
+
+const FREE_SKUS = new Set(["free_limited_copilot"]);
+const BANNED_NOTIFICATION_IDS = new Set(["spammy_user", "suspended_user", "flagged_user"]);
+const DEFAULT_ACCOUNT_LOCK_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RATE_LIMIT_MS = 10 * 60 * 1000;
+const DEFAULT_WEEKLY_RATE_LIMIT_MS = 7 * 24 * 60 * 60 * 1000;
+
+const SKU_TIERS = {
+  free_limited_copilot: "free",
+  monthly_subscriber_quota: "pro",
+  yearly_subscriber_quota: "pro",
+  plus_monthly_subscriber_quota: "pro+",
+  plus_yearly_subscriber_quota: "pro+",
+  copilot_enterprise_seat_quota: "enterprise",
+  copilot_business_seat_quota: "business",
+};
+
+function getHeader(headers, name) {
+  if (!headers) return "";
+  if (typeof headers.get === "function") return headers.get(name) || "";
+  if (typeof headers.entries === "function") {
+    const lower = name.toLowerCase();
+    for (const [k, v] of headers.entries()) {
+      if (String(k).toLowerCase() === lower) return Array.isArray(v) ? v[0] : String(v);
+    }
+  }
+  return "";
+}
+
+function parseJsonMaybe(text) {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return null;
+  }
+}
+
+function nowPlus(ms) {
+  return new Date(Date.now() + ms).toISOString();
+}
+
+export function parseCopilotRuntimeToken(runtimeToken = "") {
+  const meta = {};
+  for (const field of String(runtimeToken).split(";")) {
+    const [key, ...rest] = field.trim().split("=");
+    if (key && rest.length) meta[key] = rest.join("=");
+  }
+  const sku = meta.sku || "";
+  return {
+    sku,
+    tier: SKU_TIERS[sku] || (sku ? sku : "?"),
+    proxyEndpoint: meta["proxy-ep"] || "",
+  };
+}
+
+export function classifyCopilotTokenExchange(status, bodyText = "") {
+  const body = parseJsonMaybe(bodyText);
+  const errorDetails = body?.error_details || {};
+  const notificationId = errorDetails.notification_id || "";
+  const message = body?.message || body?.error_description || body?.error || bodyText || `http_${status}`;
+  const lower = String(message).toLowerCase();
+
+  if (status === 401) {
+    return { status: "dead", valid: false, error: "token_invalid", lockUntil: nowPlus(DEFAULT_ACCOUNT_LOCK_MS) };
+  }
+  if (status === 403) {
+    if (BANNED_NOTIFICATION_IDS.has(notificationId) || (!notificationId && (lower.includes("not accessible") || lower.includes("scraping")))) {
+      return { status: "banned", valid: false, error: notificationId || String(message).slice(0, 120), lockUntil: nowPlus(DEFAULT_ACCOUNT_LOCK_MS) };
+    }
+    return { status: "forbidden", valid: false, error: notificationId || String(message).slice(0, 120), lockUntil: nowPlus(DEFAULT_ACCOUNT_LOCK_MS) };
+  }
+  return { status: "error", valid: false, error: String(message).slice(0, 120), lockUntil: nowPlus(DEFAULT_RATE_LIMIT_MS) };
+}
+
+async function resolveProbeModel(runtimeToken, proxyOptions, requestedModel) {
+  if (requestedModel) return requestedModel;
+  try {
+    const response = await proxyAwareFetch(MODELS_URL, {
+      headers: buildCopilotHeaders(runtimeToken, true),
+    }, proxyOptions);
+    if (!response.ok) return COPILOT_STATUS_PROBE_MODEL;
+    const data = await response.json();
+    const enabled = new Set((Array.isArray(data?.data) ? data.data : [])
+      .filter((m) => m?.capabilities?.type === "chat" && (!m.policy || m.policy.state === "enabled"))
+      .map((m) => m.id));
+    return PREFERRED_PROBE_MODELS.find((model) => enabled.has(model)) || enabled.values().next().value || COPILOT_STATUS_PROBE_MODEL;
+  } catch {
+    return COPILOT_STATUS_PROBE_MODEL;
+  }
+}
+
+function buildCopilotHeaders(token, bearer = true) {
+  const authValue = bearer ? `Bearer ${token}` : `token ${token}`;
+  return {
+    Authorization: authValue,
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "Copilot-Integration-Id": "vscode-chat",
+    "Editor-Version": `vscode/${GITHUB_COPILOT.VSCODE_VERSION}`,
+    "Editor-Plugin-Version": `copilot-chat/${GITHUB_COPILOT.COPILOT_CHAT_VERSION}`,
+    "User-Agent": GITHUB_COPILOT.USER_AGENT,
+    "X-GitHub-Api-Version": GITHUB_COPILOT.API_VERSION,
+  };
+}
+
+export async function exchangeCopilotRuntimeToken(accessToken, proxyOptions = null) {
+  if (!accessToken) return { valid: false, status: "dead", error: "No GitHub access token", lockUntil: nowPlus(DEFAULT_ACCOUNT_LOCK_MS) };
+
+  const response = await proxyAwareFetch(TOKEN_EXCHANGE_URL, {
+    headers: buildCopilotHeaders(accessToken, false),
+  }, proxyOptions);
+  const text = await response.text();
+
+  if (!response.ok) {
+    return {
+      ...classifyCopilotTokenExchange(response.status, text),
+      httpStatus: response.status,
+    };
+  }
+
+  const payload = parseJsonMaybe(text);
+  const runtimeToken = payload?.token || "";
+  const tokenExpiresAt = payload?.expires_at || null;
+  const meta = parseCopilotRuntimeToken(runtimeToken);
+
+  if (!runtimeToken) {
+    return { valid: false, status: "error", error: "Copilot token exchange returned no runtime token", lockUntil: nowPlus(DEFAULT_RATE_LIMIT_MS) };
+  }
+
+  if (FREE_SKUS.has(meta.sku)) {
+    return {
+      valid: false,
+      status: "free",
+      error: "free_limited_copilot",
+      runtimeToken,
+      tokenExpiresAt,
+      ...meta,
+      lockUntil: nowPlus(DEFAULT_ACCOUNT_LOCK_MS),
+    };
+  }
+
+  return {
+    valid: true,
+    status: "exchange_ok",
+    runtimeToken,
+    tokenExpiresAt,
+    ...meta,
+  };
+}
+
+function classifyCompletionRateLimit(response, bodyText, model) {
+  const retryAfterRaw = getHeader(response.headers, "retry-after") || getHeader(response.headers, "x-ratelimit-timeremaining");
+  const retryAfterSeconds = Number.parseInt(retryAfterRaw || "0", 10);
+  const retryMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+    ? retryAfterSeconds * 1000
+    : 0;
+  const rateLimitType = getHeader(response.headers, "x-ratelimit-type").toLowerCase();
+  const bodyLower = String(bodyText || "").toLowerCase();
+
+  let status = "ratelimit";
+  let lockUntil = nowPlus(retryMs || DEFAULT_RATE_LIMIT_MS);
+  let modelLockUntil = null;
+
+  if (rateLimitType.includes("byweek") || bodyLower.includes("weekly rate limit") || bodyLower.includes("weekly_rate_limit")) {
+    status = "weekly_ratelimit";
+    lockUntil = nowPlus(retryMs || DEFAULT_WEEKLY_RATE_LIMIT_MS);
+  } else if (rateLimitType.includes("global") || bodyLower.includes("global")) {
+    status = "global_ratelimit";
+    lockUntil = nowPlus(retryMs || DEFAULT_RATE_LIMIT_MS);
+  } else if (rateLimitType.includes("byday") || rateLimitType.includes("bymodelby")) {
+    status = "daily_ratelimit";
+    modelLockUntil = nowPlus(retryMs || DEFAULT_RATE_LIMIT_MS);
+    lockUntil = null;
+  }
+
+  return {
+    valid: false,
+    status,
+    error: [rateLimitType || "429", retryAfterSeconds ? `retry-after=${retryAfterSeconds}s` : ""].filter(Boolean).join(" "),
+    lockUntil,
+    modelLock: modelLockUntil ? { model, until: modelLockUntil } : null,
+    retryAfterSeconds: retryAfterSeconds || null,
+  };
+}
+
+export async function probeCopilotCompletion(runtimeToken, options = {}) {
+  const model = await resolveProbeModel(runtimeToken, options.proxyOptions || null, options.model);
+  const response = await proxyAwareFetch(COMPLETIONS_URL, {
+    method: "POST",
+    headers: buildCopilotHeaders(runtimeToken, true),
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 1,
+      stream: false,
+    }),
+  }, options.proxyOptions || null);
+
+  const text = await response.text();
+  if (response.ok) return { valid: true, status: "active", error: null, probeModel: model };
+  if (response.status === 429) return { ...classifyCompletionRateLimit(response, text, model), probeModel: model };
+
+  const parsed = parseJsonMaybe(text);
+  const message = parsed?.error?.message || parsed?.message || text || `http_${response.status}`;
+  return {
+    valid: false,
+    status: response.status === 401 ? "dead" : response.status === 403 ? "forbidden" : "error",
+    error: String(message).slice(0, 160),
+    lockUntil: nowPlus(response.status === 401 || response.status === 403 ? DEFAULT_ACCOUNT_LOCK_MS : DEFAULT_RATE_LIMIT_MS),
+    probeModel: model,
+  };
+}
+
+export async function checkCopilotProfileStatus(accessToken, options = {}) {
+  const exchanged = await exchangeCopilotRuntimeToken(accessToken, options.proxyOptions || null);
+  if (!exchanged.valid) return exchanged;
+  if (!options.probeCompletion) return { ...exchanged, status: "active" };
+
+  const probed = await probeCopilotCompletion(exchanged.runtimeToken, {
+    proxyOptions: options.proxyOptions || null,
+    model: options.model,
+  });
+
+  return {
+    ...exchanged,
+    ...probed,
+    runtimeToken: exchanged.runtimeToken,
+    tokenExpiresAt: exchanged.tokenExpiresAt,
+    sku: exchanged.sku,
+    tier: exchanged.tier,
+    proxyEndpoint: exchanged.proxyEndpoint,
+  };
+}

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -4,6 +4,8 @@ import { testProxyUrl } from "@/lib/network/proxyTest";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { getDefaultModel } from "open-sse/config/providerModels.js";
 import { resolveOllamaLocalHost, PROVIDERS } from "open-sse/config/providers.js";
+import { checkCopilotProfileStatus } from "open-sse/services/copilotStatus.js";
+import { MODEL_LOCK_ALL, getModelLockKey } from "open-sse/services/accountFallback.js";
 import {
   refreshProviderCredentials,
   shouldRefreshCredentials,
@@ -16,6 +18,7 @@ import {
   CLAUDE_CONFIG,
   CLINE_CONFIG,
   KILOCODE_CONFIG,
+  GITHUB_CONFIG,
   KIMCHI_CONFIG,
 } from "@/lib/oauth/constants/oauth";
 import { buildClineHeaders } from "@/shared/utils/clineAuth";
@@ -163,7 +166,7 @@ async function probeCloudCodeAssistAccess(connection, accessToken, effectiveProx
   };
 }
 
-async function refreshOAuthToken(connection) {
+async function refreshOAuthToken(connection, effectiveProxy = null) {
   const provider = connection.provider;
   const refreshToken = connection.refreshToken;
   if (!refreshToken) return null;
@@ -188,6 +191,23 @@ async function refreshOAuthToken(connection) {
 
     if (provider === "codex") {
       return await refreshProviderCredentials(provider, connection, console);
+    }
+
+    if (provider === "github") {
+      const response = await fetchWithConnectionProxy("https://github.com/login/oauth/access_token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+          client_id: GITHUB_CONFIG.clientId,
+        }),
+      }, effectiveProxy);
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.access_token) {
+        return { error: data.error_description || data.error || `GitHub refresh returned ${response.status}` };
+      }
+      return { accessToken: data.access_token, expiresIn: data.expires_in, refreshToken: data.refresh_token || refreshToken };
     }
 
     if (provider === "claude") {
@@ -280,6 +300,53 @@ function isTokenExpired(connection) {
   return shouldRefreshCredentials(connection.provider, connection);
 }
 
+async function testGitHubCopilotConnection(connection, accessToken, effectiveProxy, refreshed = false, newTokens = null) {
+  let status = await checkCopilotProfileStatus(accessToken, {
+    proxyOptions: effectiveProxy,
+    probeCompletion: true,
+  });
+
+  if (!status.valid && connection.refreshToken) {
+    const tokens = await refreshOAuthToken(connection, effectiveProxy);
+    if (tokens?.accessToken) {
+      refreshed = true;
+      newTokens = tokens;
+      status = await checkCopilotProfileStatus(tokens.accessToken, {
+        proxyOptions: effectiveProxy,
+        probeCompletion: true,
+      });
+    } else if (status.status === "dead" || status.status === "forbidden") {
+      status.error = `GitHub OAuth refresh failed: ${tokens?.error || "re-authorize profile"}`;
+    }
+  }
+
+  if (status.runtimeToken) {
+    newTokens = {
+      ...(newTokens || {}),
+      providerSpecificData: {
+        ...(newTokens?.providerSpecificData || {}),
+        copilotToken: status.runtimeToken,
+        copilotTokenExpiresAt: status.tokenExpiresAt,
+      },
+    };
+  }
+
+  return {
+    valid: status.valid,
+    error: status.valid ? null : status.error,
+    refreshed,
+    newTokens,
+    status: status.status,
+    tier: status.tier,
+    sku: status.sku,
+    proxyEndpoint: status.proxyEndpoint,
+    lockUntil: status.lockUntil,
+    modelLock: status.modelLock,
+    probeModel: status.probeModel,
+    retryAfterSeconds: status.retryAfterSeconds,
+  };
+}
+
 async function testOAuthConnection(connection, effectiveProxy = null) {
   const config = OAUTH_TEST_CONFIG[connection.provider];
   if (!config) return { valid: false, error: "Provider test not supported", refreshed: false };
@@ -294,10 +361,14 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
   let refreshed = false;
   let newTokens = null;
 
+  if (connection.provider === "github") {
+    return testGitHubCopilotConnection(connection, accessToken, effectiveProxy, refreshed, newTokens);
+  }
+
   const tokenExpired = isTokenExpired(connection);
   if (config.refreshable && tokenExpired && connection.refreshToken) {
-    const tokens = await refreshOAuthToken(connection);
-    if (tokens) {
+    const tokens = await refreshOAuthToken(connection, effectiveProxy);
+    if (tokens?.accessToken) {
       accessToken = tokens.accessToken;
       refreshed = true;
       newTokens = tokens;
@@ -317,7 +388,7 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
     if (initial.valid) return { valid: true, error: null, refreshed, newTokens };
 
     if (initial.status === 401 && config.refreshable && !refreshed && connection.refreshToken) {
-      const tokens = await refreshOAuthToken(connection);
+      const tokens = await refreshOAuthToken(connection, effectiveProxy);
       if (tokens?.accessToken) {
         const retry = await probeCloudCodeAssistAccess(connection, tokens.accessToken, effectiveProxy);
         if (retry.valid) return { valid: true, error: null, refreshed: true, newTokens: tokens };
@@ -343,7 +414,7 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
       return initial;
     }
 
-    const tokens = await refreshOAuthToken(connection);
+    const tokens = await refreshOAuthToken(connection, effectiveProxy);
     if (!tokens?.accessToken) {
       return { valid: false, error: "Token invalid or revoked", refreshed: false };
     }
@@ -367,8 +438,8 @@ async function testOAuthConnection(connection, effectiveProxy = null) {
     if (accepted) return { valid: true, error: null, refreshed, newTokens };
 
     if (res.status === 401 && config.refreshable && !refreshed && connection.refreshToken) {
-      const tokens = await refreshOAuthToken(connection);
-      if (tokens) {
+      const tokens = await refreshOAuthToken(connection, effectiveProxy);
+      if (tokens?.accessToken) {
         const retryUrl = config.buildUrl ? config.buildUrl(tokens.accessToken) : testUrl;
         const retryHeaders = config.noAuth
           ? { ...config.extraHeaders }
@@ -751,12 +822,20 @@ export async function testSingleConnection(id) {
   }
 
   const latencyMs = Date.now() - start;
+  const isGithubUnavailable = connection.provider === "github" && (result.lockUntil || result.modelLock?.until);
 
   const updateData = {
-    testStatus: result.valid ? "active" : "error",
+    testStatus: result.valid ? "active" : (isGithubUnavailable ? "unavailable" : "error"),
     lastError: result.valid ? null : result.error,
     lastErrorAt: result.valid ? null : new Date().toISOString(),
   };
+
+  if (connection.provider === "github") {
+    updateData[MODEL_LOCK_ALL] = result.valid ? null : (result.lockUntil || null);
+    if (result.probeModel) {
+      updateData[getModelLockKey(result.probeModel)] = result.valid ? null : (result.modelLock?.until || null);
+    }
+  }
 
   if (result.refreshed && result.newTokens) {
     if (result.newTokens.accessToken) updateData.accessToken = result.newTokens.accessToken;
@@ -779,5 +858,16 @@ export async function testSingleConnection(id) {
 
   await updateProviderConnection(id, updateData);
 
-  return { valid: result.valid, error: result.error, refreshed: !!result.refreshed, latencyMs, testedAt: new Date().toISOString() };
+  return {
+    valid: result.valid,
+    error: result.error,
+    refreshed: !!result.refreshed,
+    latencyMs,
+    testedAt: new Date().toISOString(),
+    status: result.status,
+    tier: result.tier,
+    sku: result.sku,
+    proxyEndpoint: result.proxyEndpoint,
+    retryAfterSeconds: result.retryAfterSeconds,
+  };
 }

--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -27,6 +27,7 @@ import {
   refreshProviderCredentials as _refreshProviderCredentials,
   shouldRefreshCredentials as _shouldRefreshCredentials,
 } from "open-sse/services/oauthCredentialManager.js";
+import { exchangeCopilotRuntimeToken } from "open-sse/services/copilotStatus.js";
 
 export const TOKEN_EXPIRY_BUFFER_MS = BUFFER_MS;
 
@@ -105,6 +106,23 @@ function normalizeExpiresAt(expiresAt) {
   const date = new Date(expiresAt);
   if (!Number.isFinite(date.getTime())) return null;
   return date.toISOString();
+}
+
+function toEpochMs(expiresAt) {
+  if (!expiresAt) return 0;
+  if (typeof expiresAt === "number") return expiresAt < 1e12 ? expiresAt * 1000 : expiresAt;
+  if (/^\d+$/.test(String(expiresAt))) {
+    const n = Number(expiresAt);
+    return n < 1e12 ? n * 1000 : n;
+  }
+  const parsed = new Date(expiresAt).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function copilotStatusToHttp(status) {
+  if (status === "dead") return 401;
+  if (status && status.includes("ratelimit")) return 429;
+  return 403;
 }
 
 /**
@@ -266,9 +284,7 @@ export async function checkAndRefreshToken(provider, credentials) {
   // ── 2. GitHub Copilot token expiry ────────────────────────────────────────
   if (provider === "github") {
     const copilotToken = creds.providerSpecificData?.copilotToken;
-    const copilotExpiresAt = creds.providerSpecificData?.copilotTokenExpiresAt
-      ? creds.providerSpecificData.copilotTokenExpiresAt * 1000
-      : 0;
+    const copilotExpiresAt = toEpochMs(creds.providerSpecificData?.copilotTokenExpiresAt);
     const now              = Date.now();
     const remaining        = copilotExpiresAt - now;
 
@@ -278,12 +294,21 @@ export async function checkAndRefreshToken(provider, credentials) {
         expiresIn: copilotToken ? Math.round(remaining / 1000) : "missing",
       });
 
-      const copilotTokenResult = await refreshCopilotToken(creds.accessToken);
-      if (copilotTokenResult) {
+      const proxyOptions = {
+        connectionProxyEnabled: creds.providerSpecificData?.connectionProxyEnabled === true,
+        connectionProxyUrl: creds.providerSpecificData?.connectionProxyUrl || "",
+        connectionNoProxy: creds.providerSpecificData?.connectionNoProxy || "",
+        vercelRelayUrl: creds.providerSpecificData?.vercelRelayUrl || "",
+      };
+      const copilotTokenResult = await exchangeCopilotRuntimeToken(creds.accessToken, proxyOptions);
+      if (copilotTokenResult.valid) {
         const updatedSpecific = {
           ...creds.providerSpecificData,
-          copilotToken:          copilotTokenResult.token,
-          copilotTokenExpiresAt: copilotTokenResult.expiresAt,
+          copilotToken:          copilotTokenResult.runtimeToken,
+          copilotTokenExpiresAt: copilotTokenResult.tokenExpiresAt,
+          copilotSku:            copilotTokenResult.sku,
+          copilotTier:           copilotTokenResult.tier,
+          copilotProxyEndpoint:  copilotTokenResult.proxyEndpoint,
         };
 
         await updateProviderCredentials(creds.connectionId, {
@@ -291,7 +316,21 @@ export async function checkAndRefreshToken(provider, credentials) {
         });
 
         creds.providerSpecificData = updatedSpecific;
-        creds.copilotToken = copilotTokenResult.token;
+        creds.copilotToken = copilotTokenResult.runtimeToken;
+      } else {
+        const lockUntilMs = copilotTokenResult.lockUntil ? new Date(copilotTokenResult.lockUntil).getTime() : null;
+        log.warn("TOKEN_REFRESH", "Copilot profile status check failed", {
+          connectionId: creds.connectionId,
+          status: copilotTokenResult.status,
+          error: copilotTokenResult.error,
+        });
+        return {
+          ...creds,
+          refreshAccountWide: true,
+          refreshError: copilotTokenResult.error || copilotTokenResult.status || "Copilot token refresh failed",
+          refreshStatus: copilotTokenResult.httpStatus || copilotStatusToHttp(copilotTokenResult.status),
+          refreshLockUntilMs: Number.isFinite(lockUntilMs) ? lockUntilMs : null,
+        };
       }
     }
   }

--- a/tests/unit/copilot-status.test.mjs
+++ b/tests/unit/copilot-status.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import {
+  classifyCopilotTokenExchange,
+  parseCopilotRuntimeToken,
+} from "../../open-sse/services/copilotStatus.js";
+
+const meta = parseCopilotRuntimeToken("token; sku=plus_monthly_subscriber_quota; proxy-ep=proxy.individual.githubcopilot.com;");
+assert.equal(meta.sku, "plus_monthly_subscriber_quota");
+assert.equal(meta.tier, "pro+");
+assert.equal(meta.proxyEndpoint, "proxy.individual.githubcopilot.com");
+
+const banned = classifyCopilotTokenExchange(403, JSON.stringify({
+  message: "Forbidden",
+  error_details: { notification_id: "spammy_user" },
+}));
+assert.equal(banned.status, "banned");
+assert.equal(banned.valid, false);
+
+const invalid = classifyCopilotTokenExchange(401, JSON.stringify({ message: "Bad credentials" }));
+assert.equal(invalid.status, "dead");
+assert.equal(invalid.error, "token_invalid");
+
+console.log("copilot-status ok");


### PR DESCRIPTION
## Summary
- adds Copilot runtime-token exchange classification for dead/free/banned/forbidden/rate-limited profiles
- probes completion availability and records model/account locks for unavailable profiles
- refreshes Copilot runtime tokens through proxy-aware paths

## Checks
- node tests/unit/copilot-status.test.mjs
- git diff --cached --check before commit

## Note
- excludes local-only model alias/routing changes