### PR TITLE
feat(api-keys): add expiry support

### DIFF
--- a/cli/src/cli/api/client.js
+++ b/cli/src/cli/api/client.js
@@ -293,10 +293,11 @@ async function getApiKeys() {
 /**
  * Create new API key
  * @param {string} name - Key name
+ * @param {string|null} expiresAt - Optional ISO expiry timestamp
  * @returns {Promise<Object>} { success, data: { key, name, id, machineId } }
  */
-async function createApiKey(name) {
-  return makeRequest("POST", "/api/keys", { name });
+async function createApiKey(name, expiresAt = null) {
+  return makeRequest("POST", "/api/keys", { name, expiresAt });
 }
 
 /**

--- a/cli/src/cli/menus/apiKeys.js
+++ b/cli/src/cli/menus/apiKeys.js
@@ -1,10 +1,55 @@
 const api = require("../api/client");
-const { prompt, confirm, pause } = require("../utils/input");
+const { prompt, select, confirm, pause } = require("../utils/input");
 const { clearScreen, showStatus, showHeader } = require("../utils/display");
 const { maskKey, formatDate, getRelativeTime } = require("../utils/format");
 const { showMenuWithBack } = require("../utils/menuHelper");
 const { copyToClipboard } = require("../utils/clipboard");
 const { getEndpoint } = require("../utils/endpoint");
+
+const EXPIRY_OPTIONS = [
+  { label: "Never expires", value: null },
+  { label: "1 day", ms: 24 * 60 * 60 * 1000 },
+  { label: "7 days", ms: 7 * 24 * 60 * 60 * 1000 },
+  { label: "30 days", ms: 30 * 24 * 60 * 60 * 1000 },
+  { label: "90 days", ms: 90 * 24 * 60 * 60 * 1000 },
+  { label: "Custom ISO datetime", custom: true },
+];
+
+function isExpired(expiresAt) {
+  if (!expiresAt) return false;
+  const time = new Date(expiresAt).getTime();
+  return !Number.isFinite(time) || time <= Date.now();
+}
+
+function formatExpiry(expiresAt) {
+  if (!expiresAt) return "Never expires";
+  const date = new Date(expiresAt);
+  if (!Number.isFinite(date.getTime())) return "Invalid expiry";
+  return `${isExpired(expiresAt) ? "Expired" : "Expires"}: ${formatDate(expiresAt)}`;
+}
+
+async function promptExpiry() {
+  const index = await select("Expiry:", EXPIRY_OPTIONS.map((option) => option.label));
+  const option = EXPIRY_OPTIONS[index];
+  if (!option || option.value === null) return null;
+  if (option.ms) return new Date(Date.now() + option.ms).toISOString();
+
+  while (option.custom) {
+    const input = await prompt("Custom expiry (ISO, e.g. 2026-12-31T23:59:00Z): ");
+    if (!input) return null;
+    const date = new Date(input);
+    if (!Number.isFinite(date.getTime())) {
+      console.log("Invalid date. Use ISO datetime.");
+      continue;
+    }
+    if (date.getTime() <= Date.now()) {
+      console.log("Expiry must be in the future.");
+      continue;
+    }
+    return date.toISOString();
+  }
+  return null;
+}
 
 /**
  * Display API keys list with formatted output
@@ -32,6 +77,8 @@ function displayApiKeys(keys, port) {
       
       const created = formatDate(key.createdAt);
       console.log(`│     Created: ${created}${" ".repeat(43 - created.length)}│`);
+      const expiry = formatExpiry(key.expiresAt);
+      console.log(`│     Expiry: ${expiry}${" ".repeat(Math.max(0, 44 - expiry.length))}│`);
       
       if (key.lastUsedAt) {
         const lastUsed = getRelativeTime(key.lastUsedAt);
@@ -68,7 +115,8 @@ async function handleCreateKey() {
     return false;
   }
   
-  const result = await api.createApiKey(name);
+  const expiresAt = await promptExpiry();
+  const result = await api.createApiKey(name, expiresAt);
   
   if (!result.success) {
     showStatus(`Failed to create key: ${result.error}`, "error");
@@ -81,6 +129,7 @@ async function handleCreateKey() {
   console.log(`\nKey: ${result.data.key}`);
   console.log(`Name: ${result.data.name}`);
   console.log(`ID: ${result.data.id}`);
+  console.log(`Expiry: ${formatExpiry(result.data.expiresAt)}`);
   
   const shouldCopy = await confirm("\nCopy key to clipboard?");
   if (shouldCopy) {
@@ -106,6 +155,7 @@ async function handleViewFullKey(key) {
   console.log(`Key: ${key.key}`);
   console.log(`ID: ${key.id}`);
   console.log(`Created: ${formatDate(key.createdAt)}`);
+  console.log(`Expiry: ${formatExpiry(key.expiresAt)}`);
   
   if (key.lastUsedAt) {
     console.log(`Last used: ${getRelativeTime(key.lastUsedAt)}`);
@@ -139,6 +189,7 @@ async function handleDeleteKey(key) {
   console.log("─".repeat(30));
   console.log(`Key: ${maskKey(key.key)}`);
   console.log(`Created: ${formatDate(key.createdAt)}`);
+  console.log(`Expiry: ${formatExpiry(key.expiresAt)}`);
   
   const confirmed = await confirm("\nAre you sure you want to delete this key?");
   
@@ -172,7 +223,7 @@ async function showKeyActions(key, port, breadcrumb = []) {
   await showMenuWithBack({
     title: `🔑 ${key.name}`,
     breadcrumb: [...breadcrumb, key.name],
-    headerContent: `Name: ${key.name}\nKey: ${key.key}\nEndpoint: ${endpoint}`,
+    headerContent: `Name: ${key.name}\nKey: ${key.key}\nExpiry: ${formatExpiry(key.expiresAt)}\nEndpoint: ${endpoint}`,
     items: [
       {
         label: "Copy to Clipboard",
@@ -215,7 +266,7 @@ async function showApiKeysMenu(port, breadcrumb = []) {
       }
       return { items: result.data.keys || [] };
     },
-    formatItem: (key) => `${key.name} (${maskKey(key.key)})`,
+    formatItem: (key) => `${key.name} (${maskKey(key.key)}) — ${formatExpiry(key.expiresAt)}`,
     onSelect: async (key) => {
       await showKeyActions(key, port, breadcrumb);
     },

--- a/public/i18n/literals/ar.json
+++ b/public/i18n/literals/ar.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "انقر للإضافة، انقر مرة أخرى للإزالة. يتم حفظ التغييرات تلقائيًا.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ تنبيه مخاطر: يستخدم هذا الموفر اشتراكًا/جلسة OAuth غير مرخصة رسميًا للاستخدام عبر البروكسي/الراوتر. قد يتم تقييد الحساب أو حظره. الاستخدام على مسؤوليتك الخاصة.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ يعترض MITM حركة مرور HTTPS لأدوات IDE (Antigravity، GitHub Copilot، Kiro) عبر CA محلية لإعادة توجيه الطلبات إلى مزوديك. قد ينتهك شروط الخدمة → خطر حظر الحساب. الاستخدام على مسؤوليتك الخاصة.",
-  "Endpoint is exposed without an API key.": "نقطة النهاية مكشوفة بدون مفتاح API."
+  "Endpoint is exposed without an API key.": "نقطة النهاية مكشوفة بدون مفتاح API.",
+  "Never expires": "لا تنتهي الصلاحية أبداً",
+  "Invalid expiry": "انتهاء صلاحية غير صالح",
+  "Expired": "منتهية الصلاحية",
+  "Expires": "تنتهي الصلاحية",
+  "Expiry": "انتهاء الصلاحية",
+  "1 day": "يوم واحد",
+  "7 days": "7 أيام",
+  "30 days": "30 يوماً",
+  "90 days": "90 يوماً",
+  "Custom date/time": "تاريخ/وقت مخصص",
+  "Custom Expiry": "انتهاء صلاحية مخصص",
+  "Choose a custom expiry date.": "اختر تاريخ انتهاء صلاحية مخصصاً.",
+  "Choose a valid expiry date.": "اختر تاريخ انتهاء صلاحية صالحاً.",
+  "Expiry must be in the future.": "يجب أن يكون تاريخ انتهاء الصلاحية في المستقبل.",
+  "Expired keys stay visible but stop authenticating requests.": "تبقى المفاتيح المنتهية الصلاحية مرئية لكنها تتوقف عن مصادقة الطلبات.",
+  "Failed to create key": "فشل إنشاء المفتاح"
 }

--- a/public/i18n/literals/bn.json
+++ b/public/i18n/literals/bn.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "যোগ করতে ক্লিক করুন, সরাতে আবার ক্লিক করুন। পরিবর্তনগুলি স্বয়ংক্রিয়ভাবে সংরক্ষিত হয়।",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ ঝুঁকি বিজ্ঞপ্তি: এই প্রদানকারী একটি সাবস্ক্রিপশন/OAuth সেশন ব্যবহার করে যা প্রক্সি/রাউটার ব্যবহারের জন্য আনুষ্ঠানিকভাবে লাইসেন্সপ্রাপ্ত নয়। অ্যাকাউন্ট সীমাবদ্ধ বা নিষিদ্ধ হতে পারে। নিজের ঝুঁকিতে ব্যবহার করুন।",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM স্থানীয় CA এর মাধ্যমে IDE টুলগুলির (Antigravity, GitHub Copilot, Kiro) HTTPS ট্রাফিক ইন্টারসেপ্ট করে আপনার প্রদানকারীদের কাছে অনুরোধ পুনঃনির্দেশ করতে। ToS লঙ্ঘন করতে পারে → অ্যাকাউন্ট নিষিদ্ধ ঝুঁকি। নিজের ঝুঁকিতে ব্যবহার করুন।",
-  "Endpoint is exposed without an API key.": "এপিআই কী ছাড়াই এন্ডপয়েন্ট উন্মুক্ত।"
+  "Endpoint is exposed without an API key.": "এপিআই কী ছাড়াই এন্ডপয়েন্ট উন্মুক্ত।",
+  "Never expires": "কখনও মেয়াদ শেষ হয় না",
+  "Invalid expiry": "অবৈধ মেয়াদ",
+  "Expired": "মেয়াদ শেষ",
+  "Expires": "মেয়াদ শেষ হবে",
+  "Expiry": "মেয়াদ",
+  "1 day": "১ দিন",
+  "7 days": "৭ দিন",
+  "30 days": "৩০ দিন",
+  "90 days": "৯০ দিন",
+  "Custom date/time": "কাস্টম তারিখ/সময়",
+  "Custom Expiry": "কাস্টম মেয়াদ",
+  "Choose a custom expiry date.": "একটি কাস্টম মেয়াদোত্তীর্ণের তারিখ বেছে নিন।",
+  "Choose a valid expiry date.": "একটি বৈধ মেয়াদোত্তীর্ণের তারিখ বেছে নিন।",
+  "Expiry must be in the future.": "মেয়াদোত্তীর্ণের সময় ভবিষ্যতে হতে হবে।",
+  "Expired keys stay visible but stop authenticating requests.": "মেয়াদোত্তীর্ণ কী দৃশ্যমান থাকে, কিন্তু অনুরোধ প্রমাণীকরণ বন্ধ করে।",
+  "Failed to create key": "কী তৈরি করতে ব্যর্থ"
 }

--- a/public/i18n/literals/cs.json
+++ b/public/i18n/literals/cs.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Kliknutím přidáte, dalším kliknutím odeberete. Změny se ukládají automaticky.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Upozornění na riziko: Tento poskytovatel používá předplatné/OAuth relaci, která není oficiálně licencována pro použití přes proxy/router. Účet může být omezen nebo zablokován. Používejte na vlastní riziko.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM zachytává HTTPS provoz IDE nástrojů (Antigravity, GitHub Copilot, Kiro) přes místní CA pro přesměrování požadavků na vaše poskytovatele. Může porušit ToS → riziko zákazu účtu. Používejte na vlastní riziko.",
-  "Endpoint is exposed without an API key.": "Koncový bod je vystaven bez API klíče."
+  "Endpoint is exposed without an API key.": "Koncový bod je vystaven bez API klíče.",
+  "Never expires": "Nikdy nevyprší",
+  "Invalid expiry": "Neplatné vypršení",
+  "Expired": "Vypršelo",
+  "Expires": "Vyprší",
+  "Expiry": "Vypršení",
+  "1 day": "1 den",
+  "7 days": "7 dní",
+  "30 days": "30 dní",
+  "90 days": "90 dní",
+  "Custom date/time": "Vlastní datum/čas",
+  "Custom Expiry": "Vlastní vypršení",
+  "Choose a custom expiry date.": "Vyberte vlastní datum vypršení.",
+  "Choose a valid expiry date.": "Vyberte platné datum vypršení.",
+  "Expiry must be in the future.": "Vypršení musí být v budoucnosti.",
+  "Expired keys stay visible but stop authenticating requests.": "Vypršené klíče zůstanou viditelné, ale přestanou ověřovat požadavky.",
+  "Failed to create key": "Nepodařilo se vytvořit klíč"
 }

--- a/public/i18n/literals/da.json
+++ b/public/i18n/literals/da.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Klik for at tilføje, klik igen for at fjerne. Ændringer gemmes automatisk.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Risikomeddelelse: Denne udbyder bruger et abonnement/OAuth-session, der ikke er officielt licenseret til proxy/router-brug. Kontoen kan blive begrænset eller forbudt. Brug på eget ansvar.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM opfanger HTTPS-trafik fra IDE-værktøjer (Antigravity, GitHub Copilot, Kiro) via lokal CA for at omdirigere anmodninger til dine udbydere. Kan overtræde ToS → risiko for kontoforbud. Brug på eget ansvar.",
-  "Endpoint is exposed without an API key.": "Endpointet er eksponeret uden en API-nøgle."
+  "Endpoint is exposed without an API key.": "Endpointet er eksponeret uden en API-nøgle.",
+  "Never expires": "Udløber aldrig",
+  "Invalid expiry": "Ugyldig udløbsdato",
+  "Expired": "Udløbet",
+  "Expires": "Udløber",
+  "Expiry": "Udløb",
+  "1 day": "1 dag",
+  "7 days": "7 dage",
+  "30 days": "30 dage",
+  "90 days": "90 dage",
+  "Custom date/time": "Brugerdefineret dato/tid",
+  "Custom Expiry": "Brugerdefineret udløb",
+  "Choose a custom expiry date.": "Vælg en brugerdefineret udløbsdato.",
+  "Choose a valid expiry date.": "Vælg en gyldig udløbsdato.",
+  "Expiry must be in the future.": "Udløbsdatoen skal være i fremtiden.",
+  "Expired keys stay visible but stop authenticating requests.": "Udløbne nøgler forbliver synlige, men stopper med at godkende anmodninger.",
+  "Failed to create key": "Kunne ikke oprette nøgle"
 }

--- a/public/i18n/literals/de.json
+++ b/public/i18n/literals/de.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Klicken zum Hinzufügen, erneut klicken zum Entfernen. Änderungen werden automatisch gespeichert.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Risikohinweis: Dieser Anbieter verwendet eine Abonnement-/OAuth-Sitzung, die nicht offiziell für die Proxy-/Router-Nutzung lizenziert ist. Das Konto kann eingeschränkt oder gesperrt werden. Nutzung auf eigene Gefahr.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM fängt HTTPS-Verkehr von IDE-Tools (Antigravity, GitHub Copilot, Kiro) über lokale CA ab, um Anfragen an Ihre Anbieter umzuleiten. Kann gegen ToS verstoßen → Risiko der Kontosperrung. Nutzung auf eigene Gefahr.",
-  "Endpoint is exposed without an API key.": "Der Endpunkt ist ohne API-Schlüssel offengelegt."
+  "Endpoint is exposed without an API key.": "Der Endpunkt ist ohne API-Schlüssel offengelegt.",
+  "Never expires": "Läuft nie ab",
+  "Invalid expiry": "Ungültiges Ablaufdatum",
+  "Expired": "Abgelaufen",
+  "Expires": "Läuft ab",
+  "Expiry": "Ablauf",
+  "1 day": "1 Tag",
+  "7 days": "7 Tage",
+  "30 days": "30 Tage",
+  "90 days": "90 Tage",
+  "Custom date/time": "Benutzerdefiniertes Datum/Uhrzeit",
+  "Custom Expiry": "Benutzerdefinierter Ablauf",
+  "Choose a custom expiry date.": "Wählen Sie ein benutzerdefiniertes Ablaufdatum.",
+  "Choose a valid expiry date.": "Wählen Sie ein gültiges Ablaufdatum.",
+  "Expiry must be in the future.": "Das Ablaufdatum muss in der Zukunft liegen.",
+  "Expired keys stay visible but stop authenticating requests.": "Abgelaufene Schlüssel bleiben sichtbar, authentifizieren aber keine Anfragen mehr.",
+  "Failed to create key": "Schlüssel konnte nicht erstellt werden"
 }

--- a/public/i18n/literals/el.json
+++ b/public/i18n/literals/el.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Κάντε κλικ για προσθήκη, κάντε ξανά κλικ για αφαίρεση. Οι αλλαγές αποθηκεύονται αυτόματα.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Ειδοποίηση κινδύνου: Αυτός ο πάροχος χρησιμοποιεί συνδρομή/συνεδρία OAuth που δεν έχει επίσημη άδεια για χρήση μέσω proxy/router. Ο λογαριασμός ενδέχεται να περιοριστεί ή να αποκλειστεί. Χρήση με δική σας ευθύνη.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ Το MITM υποκλέπτει την κίνηση HTTPS των εργαλείων IDE (Antigravity, GitHub Copilot, Kiro) μέσω τοπικού CA για ανακατεύθυνση αιτημάτων στους παρόχους σας. Μπορεί να παραβιάσει τους ToS → κίνδυνος αποκλεισμού λογαριασμού. Χρήση με δική σας ευθύνη.",
-  "Endpoint is exposed without an API key.": "Το τελικό σημείο είναι εκτεθειμένο χωρίς κλειδί API."
+  "Endpoint is exposed without an API key.": "Το τελικό σημείο είναι εκτεθειμένο χωρίς κλειδί API.",
+  "Never expires": "Δεν λήγει ποτέ",
+  "Invalid expiry": "Μη έγκυρη λήξη",
+  "Expired": "Έληξε",
+  "Expires": "Λήγει",
+  "Expiry": "Λήξη",
+  "1 day": "1 ημέρα",
+  "7 days": "7 ημέρες",
+  "30 days": "30 ημέρες",
+  "90 days": "90 ημέρες",
+  "Custom date/time": "Προσαρμοσμένη ημερομηνία/ώρα",
+  "Custom Expiry": "Προσαρμοσμένη λήξη",
+  "Choose a custom expiry date.": "Επιλέξτε προσαρμοσμένη ημερομηνία λήξης.",
+  "Choose a valid expiry date.": "Επιλέξτε έγκυρη ημερομηνία λήξης.",
+  "Expiry must be in the future.": "Η λήξη πρέπει να είναι στο μέλλον.",
+  "Expired keys stay visible but stop authenticating requests.": "Τα ληγμένα κλειδιά παραμένουν ορατά, αλλά σταματούν να πιστοποιούν αιτήματα.",
+  "Failed to create key": "Αποτυχία δημιουργίας κλειδιού"
 }

--- a/public/i18n/literals/es.json
+++ b/public/i18n/literals/es.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Haz clic para agregar, haz clic de nuevo para eliminar. Los cambios se guardan automáticamente.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Aviso de Riesgo: Este proveedor usa una sesión de suscripción/OAuth no licenciada oficialmente para uso de proxy/router. La cuenta puede ser restringida o baneada. Use bajo su propio riesgo.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM intercepta el tráfico HTTPS de herramientas IDE (Antigravity, GitHub Copilot, Kiro) mediante CA local para redirigir solicitudes a sus proveedores. Puede violar los ToS → riesgo de baneo de cuenta. Use bajo su propio riesgo.",
-  "Endpoint is exposed without an API key.": "El endpoint está expuesto sin una clave de API."
+  "Endpoint is exposed without an API key.": "El endpoint está expuesto sin una clave de API.",
+  "Never expires": "Nunca expira",
+  "Invalid expiry": "Caducidad no válida",
+  "Expired": "Expiró",
+  "Expires": "Expira",
+  "Expiry": "Caducidad",
+  "1 day": "1 día",
+  "7 days": "7 días",
+  "30 days": "30 días",
+  "90 days": "90 días",
+  "Custom date/time": "Fecha/hora personalizada",
+  "Custom Expiry": "Caducidad personalizada",
+  "Choose a custom expiry date.": "Elija una fecha de caducidad personalizada.",
+  "Choose a valid expiry date.": "Elija una fecha de caducidad válida.",
+  "Expiry must be in the future.": "La caducidad debe estar en el futuro.",
+  "Expired keys stay visible but stop authenticating requests.": "Las claves expiradas permanecen visibles, pero dejan de autenticar solicitudes.",
+  "Failed to create key": "No se pudo crear la clave"
 }

--- a/public/i18n/literals/fi.json
+++ b/public/i18n/literals/fi.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Napsauta lisätäksesi, napsauta uudelleen poistaaksesi. Muutokset tallennetaan automaattisesti.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Riski-ilmoitus: Tämä palveluntarjoaja käyttää tilaus-/OAuth-istuntoa, jota ei ole virallisesti lisensoitu välityspalvelin-/reititinkäyttöön. Tili voidaan rajoittaa tai estää. Käyttö omalla vastuulla.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM sieppaa IDE-työkalujen (Antigravity, GitHub Copilot, Kiro) HTTPS-liikennettä paikallisen CA:n kautta uudelleenohjatakseen pyyntöjä palveluntarjoajillesi. Voi rikkoa ToS:ää → tilin estoriski. Käyttö omalla vastuulla.",
-  "Endpoint is exposed without an API key.": "Päätepiste on alttiina ilman API-avainta."
+  "Endpoint is exposed without an API key.": "Päätepiste on alttiina ilman API-avainta.",
+  "Never expires": "Ei vanhene koskaan",
+  "Invalid expiry": "Virheellinen vanhentumisaika",
+  "Expired": "Vanhentunut",
+  "Expires": "Vanhenee",
+  "Expiry": "Vanhentuminen",
+  "1 day": "1 päivä",
+  "7 days": "7 päivää",
+  "30 days": "30 päivää",
+  "90 days": "90 päivää",
+  "Custom date/time": "Mukautettu päivämäärä/aika",
+  "Custom Expiry": "Mukautettu vanhentuminen",
+  "Choose a custom expiry date.": "Valitse mukautettu vanhentumispäivä.",
+  "Choose a valid expiry date.": "Valitse kelvollinen vanhentumispäivä.",
+  "Expiry must be in the future.": "Vanhentumisajan on oltava tulevaisuudessa.",
+  "Expired keys stay visible but stop authenticating requests.": "Vanhentuneet avaimet pysyvät näkyvissä, mutta eivät enää todenna pyyntöjä.",
+  "Failed to create key": "Avaimen luonti epäonnistui"
 }

--- a/public/i18n/literals/fr.json
+++ b/public/i18n/literals/fr.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Cliquez pour ajouter, cliquez à nouveau pour supprimer. Les modifications sont enregistrées automatiquement.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Avis de risque : Ce fournisseur utilise une session d'abonnement/OAuth non officiellement autorisée pour une utilisation proxy/routeur. Le compte peut être restreint ou banni. Utilisez à vos propres risques.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM intercepte le trafic HTTPS des outils IDE (Antigravity, GitHub Copilot, Kiro) via une CA locale pour rediriger les requêtes vers vos fournisseurs. Peut violer les CGU → risque de bannissement de compte. Utilisez à vos propres risques.",
-  "Endpoint is exposed without an API key.": "Le point de terminaison est exposé sans clé API."
+  "Endpoint is exposed without an API key.": "Le point de terminaison est exposé sans clé API.",
+  "Never expires": "N’expire jamais",
+  "Invalid expiry": "Expiration non valide",
+  "Expired": "Expiré",
+  "Expires": "Expire",
+  "Expiry": "Expiration",
+  "1 day": "1 jour",
+  "7 days": "7 jours",
+  "30 days": "30 jours",
+  "90 days": "90 jours",
+  "Custom date/time": "Date/heure personnalisée",
+  "Custom Expiry": "Expiration personnalisée",
+  "Choose a custom expiry date.": "Choisissez une date d’expiration personnalisée.",
+  "Choose a valid expiry date.": "Choisissez une date d’expiration valide.",
+  "Expiry must be in the future.": "L’expiration doit être dans le futur.",
+  "Expired keys stay visible but stop authenticating requests.": "Les clés expirées restent visibles, mais cessent d’authentifier les requêtes.",
+  "Failed to create key": "Échec de création de la clé"
 }

--- a/public/i18n/literals/he.json
+++ b/public/i18n/literals/he.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "לחץ להוספה, לחץ שוב להסרה. השינויים נשמרים אוטומטית.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ הודעת סיכון: ספק זה משתמש במנוי/הפעלת OAuth שאינה מורשית רשמית לשימוש פרוקסי/ראוטר. החשבון עלול להיות מוגבל או חסום. השימוש על אחריותך בלבד.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM יירוט תעבורת HTTPS של כלי IDE (Antigravity, GitHub Copilot, Kiro) באמצעות CA מקומי כדי להפנות בקשות לספקים שלך. עלול להפר את תנאי השירות → סיכון חסימת חשבון. השימוש על אחריותך.",
-  "Endpoint is exposed without an API key.": "נקודת הקצה חשופה ללא מפתח API."
+  "Endpoint is exposed without an API key.": "נקודת הקצה חשופה ללא מפתח API.",
+  "Never expires": "לעולם לא פג",
+  "Invalid expiry": "תפוגה לא תקינה",
+  "Expired": "פג תוקף",
+  "Expires": "פג ב-",
+  "Expiry": "תפוגה",
+  "1 day": "יום אחד",
+  "7 days": "7 ימים",
+  "30 days": "30 ימים",
+  "90 days": "90 ימים",
+  "Custom date/time": "תאריך/שעה מותאמים אישית",
+  "Custom Expiry": "תפוגה מותאמת אישית",
+  "Choose a custom expiry date.": "בחר תאריך תפוגה מותאם אישית.",
+  "Choose a valid expiry date.": "בחר תאריך תפוגה תקין.",
+  "Expiry must be in the future.": "התפוגה חייבת להיות בעתיד.",
+  "Expired keys stay visible but stop authenticating requests.": "מפתחות שפג תוקפם נשארים גלויים, אך מפסיקים לאמת בקשות.",
+  "Failed to create key": "יצירת המפתח נכשלה"
 }

--- a/public/i18n/literals/hi.json
+++ b/public/i18n/literals/hi.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "जोड़ने के लिए क्लिक करें, हटाने के लिए फिर से क्लिक करें। परिवर्तन स्वचालित रूप से सहेजे जाते हैं।",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ जोखिम सूचना: यह प्रदाता एक सब्सक्रिप्शन/OAuth सत्र का उपयोग करता है जो प्रॉक्सी/राउटर उपयोग के लिए आधिकारिक रूप से लाइसेंस प्राप्त नहीं है। खाता प्रतिबंधित या बैन हो सकता है। अपने जोखिम पर उपयोग करें।",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM स्थानीय CA के माध्यम से IDE टूल्स (Antigravity, GitHub Copilot, Kiro) के HTTPS ट्रैफिक को इंटरसेप्ट करता है ताकि अनुरोधों को आपके प्रदाताओं पर पुनर्निर्देशित किया जा सके। ToS का उल्लंघन हो सकता है → खाता बैन का जोखिम। अपने जोखिम पर उपयोग करें।",
-  "Endpoint is exposed without an API key.": "एंडपॉइंट बिना API कुंजी के उजागर है।"
+  "Endpoint is exposed without an API key.": "एंडपॉइंट बिना API कुंजी के उजागर है।",
+  "Never expires": "कभी समाप्त नहीं होता",
+  "Invalid expiry": "अमान्य समाप्ति",
+  "Expired": "समाप्त",
+  "Expires": "समाप्त होगा",
+  "Expiry": "समाप्ति",
+  "1 day": "1 दिन",
+  "7 days": "7 दिन",
+  "30 days": "30 दिन",
+  "90 days": "90 दिन",
+  "Custom date/time": "कस्टम तारीख/समय",
+  "Custom Expiry": "कस्टम समाप्ति",
+  "Choose a custom expiry date.": "कस्टम समाप्ति तारीख चुनें।",
+  "Choose a valid expiry date.": "मान्य समाप्ति तारीख चुनें।",
+  "Expiry must be in the future.": "समाप्ति भविष्य में होनी चाहिए।",
+  "Expired keys stay visible but stop authenticating requests.": "समाप्त कुंजियाँ दिखाई देती रहती हैं, लेकिन अनुरोधों को प्रमाणित करना बंद कर देती हैं।",
+  "Failed to create key": "कुंजी बनाने में विफल"
 }

--- a/public/i18n/literals/hu.json
+++ b/public/i18n/literals/hu.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Kattintson a hozzáadáshoz, kattintson újra az eltávolításhoz. A változtatások automatikusan mentésre kerülnek.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Kockázati figyelmeztetés: Ez a szolgáltató olyan előfizetést/OAuth munkamenetet használ, amely hivatalosan nincs proxy/router használatra engedélyezve. A fiók korlátozható vagy letiltható. Saját felelősségre használja.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ A MITM elfogja az IDE eszközök (Antigravity, GitHub Copilot, Kiro) HTTPS forgalmát helyi CA-n keresztül, hogy átirányítsa a kéréseket a szolgáltatóidhoz. Megsértheti a ToS-t → fiók letiltási kockázat. Saját felelősségre használja.",
-  "Endpoint is exposed without an API key.": "A végpont API-kulcs nélkül van kitéve."
+  "Endpoint is exposed without an API key.": "A végpont API-kulcs nélkül van kitéve.",
+  "Never expires": "Soha nem jár le",
+  "Invalid expiry": "Érvénytelen lejárat",
+  "Expired": "Lejárt",
+  "Expires": "Lejár",
+  "Expiry": "Lejárat",
+  "1 day": "1 nap",
+  "7 days": "7 nap",
+  "30 days": "30 nap",
+  "90 days": "90 nap",
+  "Custom date/time": "Egyéni dátum/idő",
+  "Custom Expiry": "Egyéni lejárat",
+  "Choose a custom expiry date.": "Válasszon egyéni lejárati dátumot.",
+  "Choose a valid expiry date.": "Válasszon érvényes lejárati dátumot.",
+  "Expiry must be in the future.": "A lejáratnak a jövőben kell lennie.",
+  "Expired keys stay visible but stop authenticating requests.": "A lejárt kulcsok láthatók maradnak, de nem hitelesítik tovább a kéréseket.",
+  "Failed to create key": "Nem sikerült létrehozni a kulcsot"
 }

--- a/public/i18n/literals/id.json
+++ b/public/i18n/literals/id.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Klik untuk menambah, klik lagi untuk menghapus. Perubahan disimpan secara otomatis.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Pemberitahuan Risiko: Penyedia ini menggunakan sesi langganan/OAuth yang tidak dilisensikan secara resmi untuk penggunaan proxy/router. Akun mungkin dibatasi atau diblokir. Gunakan dengan risiko Anda sendiri.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM mencegat lalu lintas HTTPS alat IDE (Antigravity, GitHub Copilot, Kiro) melalui CA lokal untuk mengalihkan permintaan ke penyedia Anda. Mungkin melanggar ToS → risiko ban akun. Gunakan dengan risiko Anda sendiri.",
-  "Endpoint is exposed without an API key.": "Endpoint terekspos tanpa kunci API."
+  "Endpoint is exposed without an API key.": "Endpoint terekspos tanpa kunci API.",
+  "Never expires": "Tidak pernah kedaluwarsa",
+  "Invalid expiry": "Kedaluwarsa tidak valid",
+  "Expired": "Kedaluwarsa",
+  "Expires": "Kedaluwarsa",
+  "Expiry": "Kedaluwarsa",
+  "1 day": "1 hari",
+  "7 days": "7 hari",
+  "30 days": "30 hari",
+  "90 days": "90 hari",
+  "Custom date/time": "Tanggal/waktu khusus",
+  "Custom Expiry": "Kedaluwarsa khusus",
+  "Choose a custom expiry date.": "Pilih tanggal kedaluwarsa khusus.",
+  "Choose a valid expiry date.": "Pilih tanggal kedaluwarsa yang valid.",
+  "Expiry must be in the future.": "Kedaluwarsa harus berada di masa mendatang.",
+  "Expired keys stay visible but stop authenticating requests.": "Kunci kedaluwarsa tetap terlihat, tetapi berhenti mengautentikasi permintaan.",
+  "Failed to create key": "Gagal membuat kunci"
 }

--- a/public/i18n/literals/it.json
+++ b/public/i18n/literals/it.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Clicca per aggiungere, clicca di nuovo per rimuovere. Le modifiche vengono salvate automaticamente.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Avviso di Rischio: Questo provider utilizza una sessione abbonamento/OAuth non ufficialmente autorizzata per l'uso proxy/router. L'account potrebbe essere limitato o bannato. Usa a tuo rischio.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM intercetta il traffico HTTPS degli strumenti IDE (Antigravity, GitHub Copilot, Kiro) tramite CA locale per reindirizzare le richieste ai tuoi provider. Può violare i ToS → rischio ban account. Usa a tuo rischio.",
-  "Endpoint is exposed without an API key.": "L'endpoint è esposto senza una chiave API."
+  "Endpoint is exposed without an API key.": "L'endpoint è esposto senza una chiave API.",
+  "Never expires": "Non scade mai",
+  "Invalid expiry": "Scadenza non valida",
+  "Expired": "Scaduta",
+  "Expires": "Scade",
+  "Expiry": "Scadenza",
+  "1 day": "1 giorno",
+  "7 days": "7 giorni",
+  "30 days": "30 giorni",
+  "90 days": "90 giorni",
+  "Custom date/time": "Data/ora personalizzata",
+  "Custom Expiry": "Scadenza personalizzata",
+  "Choose a custom expiry date.": "Scegli una data di scadenza personalizzata.",
+  "Choose a valid expiry date.": "Scegli una data di scadenza valida.",
+  "Expiry must be in the future.": "La scadenza deve essere nel futuro.",
+  "Expired keys stay visible but stop authenticating requests.": "Le chiavi scadute restano visibili, ma smettono di autenticare le richieste.",
+  "Failed to create key": "Impossibile creare la chiave"
 }

--- a/public/i18n/literals/ja.json
+++ b/public/i18n/literals/ja.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "クリックで追加、もう一度クリックで削除。変更は自動的に保存されます。",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ リスク通知: このプロバイダーは、プロキシ/ルーター使用について公式にライセンスされていないサブスクリプション/OAuthセッションを使用しています。アカウントが制限または禁止される可能性があります。自己責任でご使用ください。",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITMはローカルCAを介してIDEツール (Antigravity, GitHub Copilot, Kiro) のHTTPSトラフィックを傍受し、リクエストをプロバイダーにリダイレクトします。ToS違反の可能性 → アカウントBANリスク。自己責任でご使用ください。",
-  "Endpoint is exposed without an API key.": "API キーなしでエンドポイントが公開されています。"
+  "Endpoint is exposed without an API key.": "API キーなしでエンドポイントが公開されています。",
+  "Never expires": "期限なし",
+  "Invalid expiry": "無効な有効期限",
+  "Expired": "期限切れ",
+  "Expires": "有効期限",
+  "Expiry": "有効期限",
+  "1 day": "1日",
+  "7 days": "7日",
+  "30 days": "30日",
+  "90 days": "90日",
+  "Custom date/time": "カスタム日時",
+  "Custom Expiry": "カスタム有効期限",
+  "Choose a custom expiry date.": "カスタム有効期限の日付を選択してください。",
+  "Choose a valid expiry date.": "有効な有効期限の日付を選択してください。",
+  "Expiry must be in the future.": "有効期限は未来の日時にしてください。",
+  "Expired keys stay visible but stop authenticating requests.": "期限切れのキーは表示されたままですが、リクエスト認証には使えません。",
+  "Failed to create key": "キーの作成に失敗しました"
 }

--- a/public/i18n/literals/ko.json
+++ b/public/i18n/literals/ko.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "클릭하여 추가, 다시 클릭하여 제거. 변경 사항은 자동으로 저장됩니다.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ 위험 알림: 이 공급자는 프록시/라우터 사용에 대해 공식적으로 라이선스가 부여되지 않은 구독/OAuth 세션을 사용합니다. 계정이 제한되거나 차단될 수 있습니다. 사용에 대한 책임은 본인에게 있습니다.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM은 로컬 CA를 통해 IDE 도구(Antigravity, GitHub Copilot, Kiro)의 HTTPS 트래픽을 가로채 요청을 공급자로 리다이렉트합니다. ToS 위반 가능성 → 계정 차단 위험. 사용에 대한 책임은 본인에게 있습니다.",
-  "Endpoint is exposed without an API key.": "API 키 없이 엔드포인트가 노출되어 있습니다."
+  "Endpoint is exposed without an API key.": "API 키 없이 엔드포인트가 노출되어 있습니다.",
+  "Never expires": "만료되지 않음",
+  "Invalid expiry": "잘못된 만료",
+  "Expired": "만료됨",
+  "Expires": "만료",
+  "Expiry": "만료",
+  "1 day": "1일",
+  "7 days": "7일",
+  "30 days": "30일",
+  "90 days": "90일",
+  "Custom date/time": "사용자 지정 날짜/시간",
+  "Custom Expiry": "사용자 지정 만료",
+  "Choose a custom expiry date.": "사용자 지정 만료 날짜를 선택하세요.",
+  "Choose a valid expiry date.": "유효한 만료 날짜를 선택하세요.",
+  "Expiry must be in the future.": "만료 시간은 미래여야 합니다.",
+  "Expired keys stay visible but stop authenticating requests.": "만료된 키는 계속 표시되지만 요청 인증은 중지됩니다.",
+  "Failed to create key": "키 생성 실패"
 }

--- a/public/i18n/literals/nl.json
+++ b/public/i18n/literals/nl.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Klik om toe te voegen, klik opnieuw om te verwijderen. Wijzigingen worden automatisch opgeslagen.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Risicokennisgeving: Deze provider gebruikt een abonnement/OAuth-sessie die niet officieel is gelicentieerd voor proxy/router-gebruik. Account kan worden beperkt of verbannen. Gebruik op eigen risico.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM onderschept HTTPS-verkeer van IDE-tools (Antigravity, GitHub Copilot, Kiro) via lokale CA om verzoeken om te leiden naar uw providers. Kan ToS schenden → risico op accountban. Gebruik op eigen risico.",
-  "Endpoint is exposed without an API key.": "Het eindpunt is blootgesteld zonder API-sleutel."
+  "Endpoint is exposed without an API key.": "Het eindpunt is blootgesteld zonder API-sleutel.",
+  "Never expires": "Verloopt nooit",
+  "Invalid expiry": "Ongeldige vervaldatum",
+  "Expired": "Verlopen",
+  "Expires": "Verloopt",
+  "Expiry": "Vervaldatum",
+  "1 day": "1 dag",
+  "7 days": "7 dagen",
+  "30 days": "30 dagen",
+  "90 days": "90 dagen",
+  "Custom date/time": "Aangepaste datum/tijd",
+  "Custom Expiry": "Aangepaste vervaldatum",
+  "Choose a custom expiry date.": "Kies een aangepaste vervaldatum.",
+  "Choose a valid expiry date.": "Kies een geldige vervaldatum.",
+  "Expiry must be in the future.": "De vervaldatum moet in de toekomst liggen.",
+  "Expired keys stay visible but stop authenticating requests.": "Verlopen sleutels blijven zichtbaar, maar authenticeren geen aanvragen meer.",
+  "Failed to create key": "Sleutel maken mislukt"
 }

--- a/public/i18n/literals/no.json
+++ b/public/i18n/literals/no.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Klikk for å legge til, klikk igjen for å fjerne. Endringer lagres automatisk.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Risikovarsel: Denne leverandøren bruker en abonnements-/OAuth-økt som ikke er offisielt lisensiert for proxy-/ruterbruk. Kontoen kan bli begrenset eller utestengt. Bruk på eget ansvar.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM avskjærer HTTPS-trafikk fra IDE-verktøy (Antigravity, GitHub Copilot, Kiro) via lokal CA for å omdirigere forespørsler til dine leverandører. Kan bryte ToS → risiko for kontoutestengelse. Bruk på eget ansvar.",
-  "Endpoint is exposed without an API key.": "Endepunktet er eksponert uten en API-nøkkel."
+  "Endpoint is exposed without an API key.": "Endepunktet er eksponert uten en API-nøkkel.",
+  "Never expires": "Utløper aldri",
+  "Invalid expiry": "Ugyldig utløp",
+  "Expired": "Utløpt",
+  "Expires": "Utløper",
+  "Expiry": "Utløp",
+  "1 day": "1 dag",
+  "7 days": "7 dager",
+  "30 days": "30 dager",
+  "90 days": "90 dager",
+  "Custom date/time": "Egendefinert dato/tid",
+  "Custom Expiry": "Egendefinert utløp",
+  "Choose a custom expiry date.": "Velg en egendefinert utløpsdato.",
+  "Choose a valid expiry date.": "Velg en gyldig utløpsdato.",
+  "Expiry must be in the future.": "Utløpet må være i fremtiden.",
+  "Expired keys stay visible but stop authenticating requests.": "Utløpte nøkler forblir synlige, men slutter å autentisere forespørsler.",
+  "Failed to create key": "Kunne ikke opprette nøkkel"
 }

--- a/public/i18n/literals/pl.json
+++ b/public/i18n/literals/pl.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Kliknij, aby dodać, kliknij ponownie, aby usunąć. Zmiany są zapisywane automatycznie.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Ostrzeżenie o ryzyku: Ten dostawca używa sesji subskrypcji/OAuth, która nie jest oficjalnie licencjonowana do użytku proxy/routera. Konto może zostać ograniczone lub zbanowane. Używaj na własne ryzyko.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM przechwytuje ruch HTTPS narzędzi IDE (Antigravity, GitHub Copilot, Kiro) przez lokalne CA, aby przekierować żądania do twoich dostawców. Może naruszyć ToS → ryzyko zbanowania konta. Używaj na własne ryzyko.",
-  "Endpoint is exposed without an API key.": "Punkt końcowy jest dostępny bez klucza API."
+  "Endpoint is exposed without an API key.": "Punkt końcowy jest dostępny bez klucza API.",
+  "Never expires": "Nigdy nie wygasa",
+  "Invalid expiry": "Nieprawidłowa data wygaśnięcia",
+  "Expired": "Wygasł",
+  "Expires": "Wygasa",
+  "Expiry": "Wygaśnięcie",
+  "1 day": "1 dzień",
+  "7 days": "7 dni",
+  "30 days": "30 dni",
+  "90 days": "90 dni",
+  "Custom date/time": "Niestandardowa data/godzina",
+  "Custom Expiry": "Niestandardowe wygaśnięcie",
+  "Choose a custom expiry date.": "Wybierz niestandardową datę wygaśnięcia.",
+  "Choose a valid expiry date.": "Wybierz prawidłową datę wygaśnięcia.",
+  "Expiry must be in the future.": "Data wygaśnięcia musi być w przyszłości.",
+  "Expired keys stay visible but stop authenticating requests.": "Wygasłe klucze pozostają widoczne, ale przestają uwierzytelniać żądania.",
+  "Failed to create key": "Nie udało się utworzyć klucza"
 }

--- a/public/i18n/literals/pt-BR.json
+++ b/public/i18n/literals/pt-BR.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Clique para adicionar, clique novamente para remover. As alterações são salvas automaticamente.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Aviso de Risco: Este provedor usa uma sessão de assinatura/OAuth não licenciada oficialmente para uso de proxy/roteador. A conta pode ser restrita ou banida. Use por sua conta e risco.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM intercepta tráfego HTTPS de ferramentas IDE (Antigravity, GitHub Copilot, Kiro) via CA local para redirecionar solicitações aos seus provedores. Pode violar ToS → risco de banimento de conta. Use por sua conta e risco.",
-  "Endpoint is exposed without an API key.": "O endpoint está exposto sem uma chave de API."
+  "Endpoint is exposed without an API key.": "O endpoint está exposto sem uma chave de API.",
+  "Never expires": "Nunca expira",
+  "Invalid expiry": "Expiração inválida",
+  "Expired": "Expirado",
+  "Expires": "Expira",
+  "Expiry": "Expiração",
+  "1 day": "1 dia",
+  "7 days": "7 dias",
+  "30 days": "30 dias",
+  "90 days": "90 dias",
+  "Custom date/time": "Data/hora personalizada",
+  "Custom Expiry": "Expiração personalizada",
+  "Choose a custom expiry date.": "Escolha uma data de expiração personalizada.",
+  "Choose a valid expiry date.": "Escolha uma data de expiração válida.",
+  "Expiry must be in the future.": "A expiração deve estar no futuro.",
+  "Expired keys stay visible but stop authenticating requests.": "Chaves expiradas permanecem visíveis, mas deixam de autenticar solicitações.",
+  "Failed to create key": "Falha ao criar chave"
 }

--- a/public/i18n/literals/pt-PT.json
+++ b/public/i18n/literals/pt-PT.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Clique para adicionar, clique novamente para remover. As alterações são guardadas automaticamente.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Aviso de Risco: Este fornecedor utiliza uma sessão de subscrição/OAuth não licenciada oficialmente para uso de proxy/router. A conta pode ser restringida ou banida. Use por sua conta e risco.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM interceta tráfego HTTPS de ferramentas IDE (Antigravity, GitHub Copilot, Kiro) via CA local para redirecionar pedidos para os seus fornecedores. Pode violar ToS → risco de banimento de conta. Use por sua conta e risco.",
-  "Endpoint is exposed without an API key.": "O endpoint está exposto sem uma chave de API."
+  "Endpoint is exposed without an API key.": "O endpoint está exposto sem uma chave de API.",
+  "Never expires": "Nunca expira",
+  "Invalid expiry": "Expiração inválida",
+  "Expired": "Expirado",
+  "Expires": "Expira",
+  "Expiry": "Expiração",
+  "1 day": "1 dia",
+  "7 days": "7 dias",
+  "30 days": "30 dias",
+  "90 days": "90 dias",
+  "Custom date/time": "Data/hora personalizada",
+  "Custom Expiry": "Expiração personalizada",
+  "Choose a custom expiry date.": "Escolha uma data de expiração personalizada.",
+  "Choose a valid expiry date.": "Escolha uma data de expiração válida.",
+  "Expiry must be in the future.": "A expiração deve estar no futuro.",
+  "Expired keys stay visible but stop authenticating requests.": "Chaves expiradas permanecem visíveis, mas deixam de autenticar pedidos.",
+  "Failed to create key": "Falha ao criar chave"
 }

--- a/public/i18n/literals/ro.json
+++ b/public/i18n/literals/ro.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Faceți clic pentru a adăuga, faceți clic din nou pentru a elimina. Modificările sunt salvate automat.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Notificare de risc: Acest furnizor folosește un abonament/sesiune OAuth care nu este licențiat oficial pentru utilizare proxy/router. Contul poate fi restricționat sau interzis. Utilizați pe propriul risc.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM interceptează traficul HTTPS al instrumentelor IDE (Antigravity, GitHub Copilot, Kiro) prin CA locală pentru a redirecționa cererile către furnizorii dvs. Poate încălca ToS → risc de interzicere a contului. Utilizați pe propriul risc.",
-  "Endpoint is exposed without an API key.": "Endpointul este expus fără o cheie API."
+  "Endpoint is exposed without an API key.": "Endpointul este expus fără o cheie API.",
+  "Never expires": "Nu expiră niciodată",
+  "Invalid expiry": "Expirare nevalidă",
+  "Expired": "Expirat",
+  "Expires": "Expiră",
+  "Expiry": "Expirare",
+  "1 day": "1 zi",
+  "7 days": "7 zile",
+  "30 days": "30 de zile",
+  "90 days": "90 de zile",
+  "Custom date/time": "Dată/oră personalizată",
+  "Custom Expiry": "Expirare personalizată",
+  "Choose a custom expiry date.": "Alegeți o dată de expirare personalizată.",
+  "Choose a valid expiry date.": "Alegeți o dată de expirare validă.",
+  "Expiry must be in the future.": "Expirarea trebuie să fie în viitor.",
+  "Expired keys stay visible but stop authenticating requests.": "Cheile expirate rămân vizibile, dar nu mai autentifică cereri.",
+  "Failed to create key": "Nu s-a putut crea cheia"
 }

--- a/public/i18n/literals/ru.json
+++ b/public/i18n/literals/ru.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Нажмите, чтобы добавить, нажмите ещё раз, чтобы удалить. Изменения сохраняются автоматически.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Уведомление о риске: Этот провайдер использует сессию подписки/OAuth, не имеющую официальной лицензии для использования через прокси/маршрутизатор. Аккаунт может быть ограничен или заблокирован. Используйте на свой страх и риск.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM перехватывает HTTPS-трафик IDE-инструментов (Antigravity, GitHub Copilot, Kiro) через локальный CA для перенаправления запросов вашим провайдерам. Может нарушить ToS → риск блокировки аккаунта. Используйте на свой страх и риск.",
-  "Endpoint is exposed without an API key.": "Эндпоинт открыт без API-ключа."
+  "Endpoint is exposed without an API key.": "Эндпоинт открыт без API-ключа.",
+  "Never expires": "Никогда не истекает",
+  "Invalid expiry": "Недопустимый срок действия",
+  "Expired": "Истёк",
+  "Expires": "Истекает",
+  "Expiry": "Срок действия",
+  "1 day": "1 день",
+  "7 days": "7 дней",
+  "30 days": "30 дней",
+  "90 days": "90 дней",
+  "Custom date/time": "Пользовательские дата/время",
+  "Custom Expiry": "Пользовательский срок действия",
+  "Choose a custom expiry date.": "Выберите пользовательскую дату истечения срока действия.",
+  "Choose a valid expiry date.": "Выберите допустимую дату истечения срока действия.",
+  "Expiry must be in the future.": "Срок действия должен быть в будущем.",
+  "Expired keys stay visible but stop authenticating requests.": "Истёкшие ключи остаются видимыми, но перестают аутентифицировать запросы.",
+  "Failed to create key": "Не удалось создать ключ"
 }

--- a/public/i18n/literals/sv.json
+++ b/public/i18n/literals/sv.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Klicka för att lägga till, klicka igen för att ta bort. Ändringar sparas automatiskt.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Riskmeddelande: Denna leverantör använder en prenumerations-/OAuth-session som inte är officiellt licensierad för proxy-/routeranvändning. Kontot kan begränsas eller bannlysas. Användning sker på egen risk.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM avlyssnar HTTPS-trafik från IDE-verktyg (Antigravity, GitHub Copilot, Kiro) via lokal CA för att omdirigera förfrågningar till dina leverantörer. Kan bryta mot ToS → risk för kontoavstängning. Användning sker på egen risk.",
-  "Endpoint is exposed without an API key.": "Slutpunkten är exponerad utan en API-nyckel."
+  "Endpoint is exposed without an API key.": "Slutpunkten är exponerad utan en API-nyckel.",
+  "Never expires": "Upphör aldrig",
+  "Invalid expiry": "Ogiltigt utgångsdatum",
+  "Expired": "Upphört",
+  "Expires": "Upphör",
+  "Expiry": "Utgång",
+  "1 day": "1 dag",
+  "7 days": "7 dagar",
+  "30 days": "30 dagar",
+  "90 days": "90 dagar",
+  "Custom date/time": "Anpassat datum/tid",
+  "Custom Expiry": "Anpassad utgång",
+  "Choose a custom expiry date.": "Välj ett anpassat utgångsdatum.",
+  "Choose a valid expiry date.": "Välj ett giltigt utgångsdatum.",
+  "Expiry must be in the future.": "Utgångsdatumet måste ligga i framtiden.",
+  "Expired keys stay visible but stop authenticating requests.": "Utgångna nycklar förblir synliga men slutar autentisera förfrågningar.",
+  "Failed to create key": "Det gick inte att skapa nyckeln"
 }

--- a/public/i18n/literals/th.json
+++ b/public/i18n/literals/th.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "คลิกเพื่อเพิ่ม คลิกอีกครั้งเพื่อลบ การเปลี่ยนแปลงจะถูกบันทึกโดยอัตโนมัติ",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ ประกาศความเสี่ยง: ผู้ให้บริการนี้ใช้เซสชันสมัครสมาชิก/OAuth ที่ไม่ได้รับอนุญาตอย่างเป็นทางการสำหรับการใช้งานพร็อกซี/เราเตอร์ บัญชีอาจถูกจำกัดหรือถูกแบน ใช้งานด้วยความเสี่ยงของคุณเอง",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM ดักจับการรับส่งข้อมูล HTTPS ของเครื่องมือ IDE (Antigravity, GitHub Copilot, Kiro) ผ่าน CA ท้องถิ่นเพื่อเปลี่ยนเส้นทางคำขอไปยังผู้ให้บริการของคุณ อาจละเมิด ToS → เสี่ยงถูกแบนบัญชี ใช้งานด้วยความเสี่ยงของคุณเอง",
-  "Endpoint is exposed without an API key.": "เอนด์พอยต์เปิดให้เข้าถึงโดยไม่มีคีย์ API"
+  "Endpoint is exposed without an API key.": "เอนด์พอยต์เปิดให้เข้าถึงโดยไม่มีคีย์ API",
+  "Never expires": "ไม่มีวันหมดอายุ",
+  "Invalid expiry": "วันหมดอายุไม่ถูกต้อง",
+  "Expired": "หมดอายุแล้ว",
+  "Expires": "หมดอายุ",
+  "Expiry": "วันหมดอายุ",
+  "1 day": "1 วัน",
+  "7 days": "7 วัน",
+  "30 days": "30 วัน",
+  "90 days": "90 วัน",
+  "Custom date/time": "วันที่/เวลาแบบกำหนดเอง",
+  "Custom Expiry": "วันหมดอายุแบบกำหนดเอง",
+  "Choose a custom expiry date.": "เลือกวันหมดอายุแบบกำหนดเอง",
+  "Choose a valid expiry date.": "เลือกวันหมดอายุที่ถูกต้อง",
+  "Expiry must be in the future.": "วันหมดอายุต้องอยู่ในอนาคต",
+  "Expired keys stay visible but stop authenticating requests.": "คีย์ที่หมดอายุยังคงมองเห็นได้ แต่หยุดตรวจสอบสิทธิ์คำขอ",
+  "Failed to create key": "สร้างคีย์ไม่สำเร็จ"
 }

--- a/public/i18n/literals/tl.json
+++ b/public/i18n/literals/tl.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "I-click para idagdag, i-click muli para alisin. Ang mga pagbabago ay awtomatikong nase-save.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Babala sa Panganib: Ang provider na ito ay gumagamit ng subscription/OAuth session na hindi opisyal na lisensyado para sa proxy/router na paggamit. Maaaring marestrikta o ma-ban ang account. Gamitin sa sarili mong panganib.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ Hinaharang ng MITM ang HTTPS traffic ng mga IDE tool (Antigravity, GitHub Copilot, Kiro) sa pamamagitan ng lokal na CA upang i-redirect ang mga kahilingan sa iyong mga provider. Maaaring lumabag sa ToS → panganib ng pag-ban sa account. Gamitin sa sarili mong panganib.",
-  "Endpoint is exposed without an API key.": "Nakalantad ang endpoint nang walang API key."
+  "Endpoint is exposed without an API key.": "Nakalantad ang endpoint nang walang API key.",
+  "Never expires": "Hindi kailanman nag-e-expire",
+  "Invalid expiry": "Di-wastong expiry",
+  "Expired": "Nag-expire na",
+  "Expires": "Mag-e-expire",
+  "Expiry": "Expiry",
+  "1 day": "1 araw",
+  "7 days": "7 araw",
+  "30 days": "30 araw",
+  "90 days": "90 araw",
+  "Custom date/time": "Custom na petsa/oras",
+  "Custom Expiry": "Custom na expiry",
+  "Choose a custom expiry date.": "Pumili ng custom na petsa ng expiry.",
+  "Choose a valid expiry date.": "Pumili ng wastong petsa ng expiry.",
+  "Expiry must be in the future.": "Dapat nasa hinaharap ang expiry.",
+  "Expired keys stay visible but stop authenticating requests.": "Nananatiling nakikita ang mga expired na key, pero humihinto sa pag-authenticate ng mga request.",
+  "Failed to create key": "Nabigong gumawa ng key"
 }

--- a/public/i18n/literals/tr.json
+++ b/public/i18n/literals/tr.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Eklemek için tıklayın, kaldırmak için tekrar tıklayın. Değişiklikler otomatik olarak kaydedilir.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Risk Bildirimi: Bu sağlayıcı, proxy/yönlendirici kullanımı için resmi olarak lisanslı olmayan bir abonelik/OAuth oturumu kullanır. Hesap kısıtlanabilir veya yasaklanabilir. Kendi sorumluluğunuzda kullanın.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM, isteklerinizi sağlayıcılarınıza yönlendirmek için yerel CA aracılığıyla IDE araçlarının (Antigravity, GitHub Copilot, Kiro) HTTPS trafiğini engeller. ToS'u ihlal edebilir → hesap yasaklama riski. Kendi sorumluluğunuzda kullanın.",
-  "Endpoint is exposed without an API key.": "Uç nokta API anahtarı olmadan açıkta."
+  "Endpoint is exposed without an API key.": "Uç nokta API anahtarı olmadan açıkta.",
+  "Never expires": "Asla süresi dolmaz",
+  "Invalid expiry": "Geçersiz süre bitimi",
+  "Expired": "Süresi doldu",
+  "Expires": "Süresi dolar",
+  "Expiry": "Süre bitimi",
+  "1 day": "1 gün",
+  "7 days": "7 gün",
+  "30 days": "30 gün",
+  "90 days": "90 gün",
+  "Custom date/time": "Özel tarih/saat",
+  "Custom Expiry": "Özel süre bitimi",
+  "Choose a custom expiry date.": "Özel bir süre bitimi tarihi seçin.",
+  "Choose a valid expiry date.": "Geçerli bir süre bitimi tarihi seçin.",
+  "Expiry must be in the future.": "Süre bitimi gelecekte olmalıdır.",
+  "Expired keys stay visible but stop authenticating requests.": "Süresi dolmuş anahtarlar görünür kalır, ancak istekleri doğrulamayı durdurur.",
+  "Failed to create key": "Anahtar oluşturulamadı"
 }

--- a/public/i18n/literals/uk.json
+++ b/public/i18n/literals/uk.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Натисніть, щоб додати, натисніть ще раз, щоб видалити. Зміни зберігаються автоматично.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Сповіщення про ризик: Цей провайдер використовує сесію підписки/OAuth, яка офіційно не ліцензована для використання через проксі/маршрутизатор. Обліковий запис може бути обмежений або заблокований. Використовуйте на свій страх і ризик.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM перехоплює HTTPS-трафік IDE-інструментів (Antigravity, GitHub Copilot, Kiro) через локальний CA для перенаправлення запитів до ваших провайдерів. Може порушити ToS → ризик блокування облікового запису. Використовуйте на свій страх і ризик.",
-  "Endpoint is exposed without an API key.": "Кінцеву точку відкрито без API-ключа."
+  "Endpoint is exposed without an API key.": "Кінцеву точку відкрито без API-ключа.",
+  "Never expires": "Ніколи не завершується",
+  "Invalid expiry": "Недійсний термін дії",
+  "Expired": "Термін минув",
+  "Expires": "Термін дії",
+  "Expiry": "Термін дії",
+  "1 day": "1 день",
+  "7 days": "7 днів",
+  "30 days": "30 днів",
+  "90 days": "90 днів",
+  "Custom date/time": "Власна дата/час",
+  "Custom Expiry": "Власний термін дії",
+  "Choose a custom expiry date.": "Виберіть власну дату завершення терміну дії.",
+  "Choose a valid expiry date.": "Виберіть дійсну дату завершення терміну дії.",
+  "Expiry must be in the future.": "Термін дії має бути в майбутньому.",
+  "Expired keys stay visible but stop authenticating requests.": "Ключі з минулим терміном залишаються видимими, але більше не автентифікують запити.",
+  "Failed to create key": "Не вдалося створити ключ"
 }

--- a/public/i18n/literals/ur.json
+++ b/public/i18n/literals/ur.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "شامل کرنے کے لیے کلک کریں، ہٹانے کے لیے دوبارہ کلک کریں۔ تبدیلیاں خودکار طور پر محفوظ ہو جاتی ہیں۔",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ خطرے کا نوٹس: یہ فراہم کنندہ ایک سبسکرپشن/OAuth سیشن استعمال کرتا ہے جو پراکسی/راؤٹر استعمال کے لیے سرکاری طور پر لائسنس یافتہ نہیں ہے۔ اکاؤنٹ محدود یا پابند ہو سکتا ہے۔ اپنے خطرے پر استعمال کریں۔",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM آپ کے فراہم کنندگان کو درخواستوں کو ری ڈائریکٹ کرنے کے لیے مقامی CA کے ذریعے IDE ٹولز (Antigravity, GitHub Copilot, Kiro) کے HTTPS ٹریفک کو روکتا ہے۔ ToS کی خلاف ورزی کر سکتا ہے → اکاؤنٹ پابندی کا خطرہ۔ اپنے خطرے پر استعمال کریں۔",
-  "Endpoint is exposed without an API key.": "اینڈ پوائنٹ API کلید کے بغیر بے نقاب ہے۔"
+  "Endpoint is exposed without an API key.": "اینڈ پوائنٹ API کلید کے بغیر بے نقاب ہے۔",
+  "Never expires": "کبھی ختم نہیں ہوتی",
+  "Invalid expiry": "غلط میعاد",
+  "Expired": "میعاد ختم",
+  "Expires": "میعاد ختم ہوگی",
+  "Expiry": "میعاد",
+  "1 day": "1 دن",
+  "7 days": "7 دن",
+  "30 days": "30 دن",
+  "90 days": "90 دن",
+  "Custom date/time": "حسب ضرورت تاریخ/وقت",
+  "Custom Expiry": "حسب ضرورت میعاد",
+  "Choose a custom expiry date.": "حسب ضرورت میعاد ختم ہونے کی تاریخ منتخب کریں۔",
+  "Choose a valid expiry date.": "درست میعاد ختم ہونے کی تاریخ منتخب کریں۔",
+  "Expiry must be in the future.": "میعاد مستقبل میں ہونی چاہیے۔",
+  "Expired keys stay visible but stop authenticating requests.": "میعاد ختم شدہ کلیدیں نظر آتی رہتی ہیں، لیکن درخواستوں کی تصدیق بند کر دیتی ہیں۔",
+  "Failed to create key": "کلید بنانے میں ناکام"
 }

--- a/public/i18n/literals/vi.json
+++ b/public/i18n/literals/vi.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "Nhấp để thêm, nhấp lại để xóa. Thay đổi được lưu tự động.",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ Cảnh báo rủi ro: Provider này sử dụng subscription/OAuth không được cấp phép chính thức cho mục đích proxy/router. Tài khoản có thể bị hạn chế hoặc cấm. Người dùng tự chịu trách nhiệm.",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM chặn lưu lượng HTTPS của các IDE tools (Antigravity, GitHub Copilot, Kiro) qua CA cục bộ để chuyển hướng request đến providers của bạn. Có thể vi phạm ToS → rủi ro bị ban tài khoản. Sử dụng với rủi ro của bạn.",
-  "Endpoint is exposed without an API key.": "Endpoint đang mở mà không có API key."
+  "Endpoint is exposed without an API key.": "Endpoint đang mở mà không có API key.",
+  "Never expires": "Không bao giờ hết hạn",
+  "Invalid expiry": "Thời hạn không hợp lệ",
+  "Expired": "Đã hết hạn",
+  "Expires": "Hết hạn",
+  "Expiry": "Thời hạn",
+  "1 day": "1 ngày",
+  "7 days": "7 ngày",
+  "30 days": "30 ngày",
+  "90 days": "90 ngày",
+  "Custom date/time": "Ngày/giờ tùy chỉnh",
+  "Custom Expiry": "Thời hạn tùy chỉnh",
+  "Choose a custom expiry date.": "Chọn ngày hết hạn tùy chỉnh.",
+  "Choose a valid expiry date.": "Chọn ngày hết hạn hợp lệ.",
+  "Expiry must be in the future.": "Thời hạn phải ở trong tương lai.",
+  "Expired keys stay visible but stop authenticating requests.": "Khóa đã hết hạn vẫn hiển thị nhưng ngừng xác thực yêu cầu.",
+  "Failed to create key": "Không tạo được khóa"
 }

--- a/public/i18n/literals/zh-CN.json
+++ b/public/i18n/literals/zh-CN.json
@@ -769,5 +769,21 @@
   "Close": "关闭",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ 风险提示：此提供商使用的订阅/OAuth 会话未获官方授权用于代理/路由器使用。账户可能被限制或封禁。使用风险自负。",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM 通过本地 CA 拦截 IDE 工具（Antigravity、GitHub Copilot、Kiro）的 HTTPS 流量，将请求重定向到您的提供商。可能违反 ToS → 账户封禁风险。使用风险自负。",
-  "Endpoint is exposed without an API key.": "端点未设置 API 密钥即对外暴露。"
+  "Endpoint is exposed without an API key.": "端点未设置 API 密钥即对外暴露。",
+  "Never expires": "永不过期",
+  "Invalid expiry": "无效的过期时间",
+  "Expired": "已过期",
+  "Expires": "过期时间",
+  "Expiry": "过期时间",
+  "1 day": "1 天",
+  "7 days": "7 天",
+  "30 days": "30 天",
+  "90 days": "90 天",
+  "Custom date/time": "自定义日期/时间",
+  "Custom Expiry": "自定义过期时间",
+  "Choose a custom expiry date.": "请选择自定义过期日期。",
+  "Choose a valid expiry date.": "请选择有效的过期日期。",
+  "Expiry must be in the future.": "过期时间必须在未来。",
+  "Expired keys stay visible but stop authenticating requests.": "已过期的密钥仍会显示，但不再用于请求认证。",
+  "Failed to create key": "创建密钥失败"
 }

--- a/public/i18n/literals/zh-TW.json
+++ b/public/i18n/literals/zh-TW.json
@@ -191,5 +191,21 @@
   "Click to add, click again to remove. Changes are saved automatically.": "點擊新增，再次點擊移除。變更將自動儲存。",
   "⚠️ Risk Notice: This provider uses a subscription/OAuth session not officially licensed for proxy/router use. Account may be restricted or banned. Use at your own risk.": "⚠️ 風險提示：此提供商使用的訂閱/OAuth 工作階段未獲官方授權用於代理/路由器使用。帳戶可能被限制或封禁。使用風險自負。",
   "⚠️ MITM intercepts HTTPS traffic of IDE tools (Antigravity, GitHub Copilot, Kiro) via local CA to redirect requests to your providers. May violate ToS → account ban. Use at your own risk.": "⚠️ MITM 透過本地 CA 攔截 IDE 工具（Antigravity、GitHub Copilot、Kiro）的 HTTPS 流量，將請求重新導向到您的提供商。可能違反 ToS → 帳戶封禁風險。使用風險自負。",
-  "Endpoint is exposed without an API key.": "端點未設定 API 金鑰即對外暴露。"
+  "Endpoint is exposed without an API key.": "端點未設定 API 金鑰即對外暴露。",
+  "Never expires": "永不過期",
+  "Invalid expiry": "無效的過期時間",
+  "Expired": "已過期",
+  "Expires": "過期時間",
+  "Expiry": "過期時間",
+  "1 day": "1 天",
+  "7 days": "7 天",
+  "30 days": "30 天",
+  "90 days": "90 天",
+  "Custom date/time": "自訂日期/時間",
+  "Custom Expiry": "自訂過期時間",
+  "Choose a custom expiry date.": "請選擇自訂過期日期。",
+  "Choose a valid expiry date.": "請選擇有效的過期日期。",
+  "Expiry must be in the future.": "過期時間必須在未來。",
+  "Expired keys stay visible but stop authenticating requests.": "已過期的金鑰仍會顯示，但不再用於請求驗證。",
+  "Failed to create key": "建立金鑰失敗"
 }

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+import { translate, getCurrentLocale, onLocaleChange } from "@/i18n/runtime";
 import {
   TUNNEL_BENEFITS,
   TUNNEL_PING_INTERVAL_MS,
@@ -17,12 +18,51 @@ import EndpointRow from "./components/EndpointRow";
 import StatusAlert from "./components/StatusAlert";
 import Tooltip from "./components/Tooltip";
 import SecurityWarning from "./components/SecurityWarning";
+
+const API_KEY_EXPIRY_PRESETS = [
+  { value: "never", labelKey: "Never expires" },
+  { value: "1d", labelKey: "1 day", ms: 24 * 60 * 60 * 1000 },
+  { value: "7d", labelKey: "7 days", ms: 7 * 24 * 60 * 60 * 1000 },
+  { value: "30d", labelKey: "30 days", ms: 30 * 24 * 60 * 60 * 1000 },
+  { value: "90d", labelKey: "90 days", ms: 90 * 24 * 60 * 60 * 1000 },
+  { value: "custom", labelKey: "Custom date/time" },
+];
+
+function isApiKeyExpired(key) {
+  if (!key?.expiresAt) return false;
+  const time = new Date(key.expiresAt).getTime();
+  return !Number.isFinite(time) || time <= Date.now();
+}
+
+function formatApiKeyExpiry(expiresAt, locale = getCurrentLocale()) {
+  if (!expiresAt) return { kind: "text", text: translate("Never expires") };
+  const date = new Date(expiresAt);
+  if (!Number.isFinite(date.getTime())) return { kind: "text", text: translate("Invalid expiry") };
+  return { kind: "date", text: date.toLocaleString(locale) };
+}
+
+function getApiKeyExpiryLabel(key, locale = getCurrentLocale()) {
+  if (!key?.expiresAt) return { kind: "text", text: translate("Never expires") };
+  const date = new Date(key.expiresAt);
+  if (!Number.isFinite(date.getTime())) return { kind: "text", text: translate("Invalid expiry") };
+  return {
+    kind: "dated",
+    prefix: translate(isApiKeyExpired(key) ? "Expired" : "Expires"),
+    text: date.toLocaleString(locale),
+  };
+}
+
 export default function APIPageClient({ machineId }) {
+  const [locale, setLocale] = useState(getCurrentLocale());
   const [keys, setKeys] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyExpiryPreset, setNewKeyExpiryPreset] = useState("never");
+  const [newKeyCustomExpiry, setNewKeyCustomExpiry] = useState("");
+  const [newKeyError, setNewKeyError] = useState("");
   const [createdKey, setCreatedKey] = useState(null);
+  const [createdKeyExpiresAt, setCreatedKeyExpiresAt] = useState(null);
   const [confirmState, setConfirmState] = useState(null);
 
   const [requireApiKey, setRequireApiKey] = useState(false);
@@ -607,25 +647,56 @@ export default function APIPageClient({ machineId }) {
     }
   };
 
+  const resetNewKeyForm = () => {
+    setNewKeyName("");
+    setNewKeyExpiryPreset("never");
+    setNewKeyCustomExpiry("");
+    setNewKeyError("");
+  };
+
+  const buildNewKeyExpiresAt = () => {
+    if (newKeyExpiryPreset === "never") return null;
+    if (newKeyExpiryPreset === "custom") {
+      if (!newKeyCustomExpiry) return { error: "Choose a custom expiry date." };
+      const date = new Date(newKeyCustomExpiry);
+      if (!Number.isFinite(date.getTime())) return { error: "Choose a valid expiry date." };
+      if (date.getTime() <= Date.now()) return { error: "Expiry must be in the future." };
+      return date.toISOString();
+    }
+    const preset = API_KEY_EXPIRY_PRESETS.find((item) => item.value === newKeyExpiryPreset);
+    if (!preset?.ms) return null;
+    return new Date(Date.now() + preset.ms).toISOString();
+  };
+
   const handleCreateKey = async () => {
     if (!newKeyName.trim()) return;
+
+    const expiresAt = buildNewKeyExpiresAt();
+    if (expiresAt?.error) {
+      setNewKeyError(expiresAt.error);
+      return;
+    }
 
     try {
       const res = await fetch("/api/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newKeyName }),
+        body: JSON.stringify({ name: newKeyName.trim(), expiresAt }),
       });
       const data = await res.json();
 
       if (res.ok) {
         setCreatedKey(data.key);
+        setCreatedKeyExpiresAt(data.expiresAt || null);
         await fetchData();
-        setNewKeyName("");
+        resetNewKeyForm();
         setShowAddModal(false);
+      } else {
+        setNewKeyError(data.error || "Failed to create key");
       }
     } catch (error) {
       console.log("Error creating key:", error);
+      setNewKeyError("Failed to create key");
     }
   };
 
@@ -682,6 +753,8 @@ export default function APIPageClient({ machineId }) {
   };
 
   const [baseUrl, setBaseUrl] = useState("/v1");
+
+  useEffect(() => onLocaleChange(() => setLocale(getCurrentLocale())), []);
 
   // Hydration fix: Only access window on client side
   useEffect(() => {
@@ -992,10 +1065,13 @@ export default function APIPageClient({ machineId }) {
           </div>
         ) : (
           <div className="flex flex-col">
-            {keys.map((key) => (
+            {keys.map((key) => {
+              const expired = isApiKeyExpired(key);
+              const expiryLabel = getApiKeyExpiryLabel(key, locale);
+              return (
               <div
                 key={key.id}
-                className={`group flex items-center justify-between py-3 border-b border-black/[0.03] dark:border-white/[0.03] last:border-b-0 ${key.isActive === false ? "opacity-60" : ""}`}
+                className={`group flex items-center justify-between py-3 border-b border-black/[0.03] dark:border-white/[0.03] last:border-b-0 ${(key.isActive === false || expired) ? "opacity-60" : ""}`}
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium">{key.name}</p>
@@ -1022,11 +1098,12 @@ export default function APIPageClient({ machineId }) {
                     </button>
                   </div>
                   <p className="text-xs text-text-muted mt-1">
-                    Created {new Date(key.createdAt).toLocaleDateString()}
+                    {translate("Created")} {new Date(key.createdAt).toLocaleDateString(locale)}
                   </p>
-                  {key.isActive === false && (
-                    <p className="text-xs text-orange-500 mt-1">Paused</p>
-                  )}
+                  <p className={`text-xs mt-1 ${expired ? "text-red-500" : "text-text-muted"}`}>
+                    {expiryLabel.kind === "text" ? expiryLabel.text : (<><span>{expiryLabel.prefix}</span>{" "}<span data-i18n-skip>{expiryLabel.text}</span></>)}
+                  </p>
+                  {key.isActive === false && <p className="text-xs text-orange-500 mt-1">{translate("Paused")}</p>}
                 </div>
                 <div className="flex items-center gap-2">
                   <Toggle
@@ -1056,7 +1133,8 @@ export default function APIPageClient({ machineId }) {
                   </button>
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </Card>
@@ -1067,7 +1145,7 @@ export default function APIPageClient({ machineId }) {
         title="Create API Key"
         onClose={() => {
           setShowAddModal(false);
-          setNewKeyName("");
+          resetNewKeyForm();
         }}
       >
         <div className="flex flex-col gap-4">
@@ -1077,6 +1155,39 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewKeyName(e.target.value)}
             placeholder="Production Key"
           />
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Expiry</label>
+            <select
+              value={newKeyExpiryPreset}
+              onChange={(e) => {
+                setNewKeyExpiryPreset(e.target.value);
+                setNewKeyError("");
+              }}
+              className="w-full py-2.5 px-3 text-sm text-text-main bg-surface-2 rounded-[10px] border border-transparent focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:border-brand-500/40"
+            >
+              {API_KEY_EXPIRY_PRESETS.map((preset) => (
+                <option key={preset.value} value={preset.value}>{translate(preset.labelKey)}</option>
+              ))}
+            </select>
+            <p className="text-xs text-text-muted">{translate("Expired keys stay visible but stop authenticating requests.")}</p>
+          </div>
+          {newKeyExpiryPreset === "custom" && (
+            <Input
+              label={translate("Custom Expiry")}
+              type="datetime-local"
+              value={newKeyCustomExpiry}
+              onChange={(e) => {
+                setNewKeyCustomExpiry(e.target.value);
+                setNewKeyError("");
+              }}
+            />
+          )}
+          {newKeyError && (
+            <p className="text-xs text-red-500 flex items-center gap-1">
+              <span className="material-symbols-outlined text-[14px]">error</span>
+              {translate(newKeyError)}
+            </p>
+          )}
           <div className="flex gap-2">
             <Button onClick={handleCreateKey} fullWidth disabled={!newKeyName.trim()}>
               Create
@@ -1084,7 +1195,7 @@ export default function APIPageClient({ machineId }) {
             <Button
               onClick={() => {
                 setShowAddModal(false);
-                setNewKeyName("");
+                resetNewKeyForm();
               }}
               variant="ghost"
               fullWidth
@@ -1099,7 +1210,10 @@ export default function APIPageClient({ machineId }) {
       <Modal
         isOpen={!!createdKey}
         title="API Key Created"
-        onClose={() => setCreatedKey(null)}
+        onClose={() => {
+          setCreatedKey(null);
+          setCreatedKeyExpiresAt(null);
+        }}
       >
         <div className="flex flex-col gap-4">
           <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
@@ -1124,7 +1238,20 @@ export default function APIPageClient({ machineId }) {
               {copied === "created_key" ? "Copied!" : "Copy"}
             </Button>
           </div>
-          <Button onClick={() => setCreatedKey(null)} fullWidth>
+          <p className="text-sm text-text-muted">
+            {(() => {
+              const createdExpiry = formatApiKeyExpiry(createdKeyExpiresAt, locale);
+              return createdExpiry.kind === "text" ? (
+                <>{translate("Expiry")}: {createdExpiry.text}</>
+              ) : (
+                <>{translate("Expiry")}: <span data-i18n-skip>{createdExpiry.text}</span></>
+              );
+            })()}
+          </p>
+          <Button onClick={() => {
+            setCreatedKey(null);
+            setCreatedKeyExpiresAt(null);
+          }} fullWidth>
             Done
           </Button>
         </div>

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -4,6 +4,16 @@ import { getConsistentMachineId } from "@/shared/utils/machineId";
 
 export const dynamic = "force-dynamic";
 
+function normalizeExpiresAt(value) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value !== "string") return { error: "expiresAt must be an ISO date string or null" };
+  const date = new Date(value);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) return { error: "expiresAt must be a valid date" };
+  if (time <= Date.now()) return { error: "expiresAt must be in the future" };
+  return date.toISOString();
+}
+
 // GET /api/keys - List API keys
 export async function GET() {
   try {
@@ -19,21 +29,27 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name } = body;
+    const name = typeof body.name === "string" ? body.name.trim() : "";
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
+    const expiresAt = normalizeExpiresAt(body.expiresAt);
+    if (expiresAt?.error) {
+      return NextResponse.json({ error: expiresAt.error }, { status: 400 });
+    }
+
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
-    const apiKey = await createApiKey(name, machineId);
+    const apiKey = await createApiKey(name, machineId, expiresAt);
 
     return NextResponse.json({
       key: apiKey.key,
       name: apiKey.name,
       id: apiKey.id,
       machineId: apiKey.machineId,
+      expiresAt: apiKey.expiresAt,
     }, { status: 201 });
   } catch (error) {
     console.log("Error creating key:", error);

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -77,7 +77,7 @@ export async function exportDb() {
     providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
-    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
+    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt, expiresAt: r.expiresAt || null })),
     combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), createdAt: r.createdAt, updatedAt: r.updatedAt })),
     modelAliases: {},
     customModels: [],
@@ -137,8 +137,8 @@ export async function importDb(payload) {
     }
     for (const k of payload.apiKeys || []) {
       db.run(
-        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt, expiresAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString(), k.expiresAt || null]
       );
     }
     for (const c of payload.combos || []) {

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -142,8 +142,8 @@ function importLegacyMain(adapter, data) {
 
   importWithAssertion(adapter, "apiKeys", data.apiKeys || [], (k) => {
     adapter.run(
-      `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-      [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+      `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt, expiresAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+      [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString(), k.expiresAt || null]
     );
   }, (k) => ({ id: k.id ?? null, name: k.name ?? null }));
 

--- a/src/lib/db/migrations/002-api-key-expiry.js
+++ b/src/lib/db/migrations/002-api-key-expiry.js
@@ -1,0 +1,10 @@
+export default {
+  version: 2,
+  name: "api-key-expiry",
+  up(db) {
+    const columns = db.all(`PRAGMA table_info(apiKeys)`).map((row) => row.name);
+    if (!columns.includes("expiresAt")) {
+      db.exec(`ALTER TABLE apiKeys ADD COLUMN expiresAt TEXT`);
+    }
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-api-key-expiry.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -10,7 +10,15 @@ function rowToKey(row) {
     machineId: row.machineId,
     isActive: row.isActive === 1 || row.isActive === true,
     createdAt: row.createdAt,
+    expiresAt: row.expiresAt || null,
   };
+}
+
+function isExpired(expiresAt) {
+  if (!expiresAt) return false;
+  const time = new Date(expiresAt).getTime();
+  if (!Number.isFinite(time)) return true;
+  return time <= Date.now();
 }
 
 export async function getApiKeys() {
@@ -25,7 +33,7 @@ export async function getApiKeyById(id) {
   return rowToKey(row);
 }
 
-export async function createApiKey(name, machineId) {
+export async function createApiKey(name, machineId, expiresAt = null) {
   if (!machineId) throw new Error("machineId is required");
   const db = await getAdapter();
   const { generateApiKeyWithMachine } = await import("@/shared/utils/apiKey");
@@ -37,10 +45,11 @@ export async function createApiKey(name, machineId) {
     machineId,
     isActive: true,
     createdAt: new Date().toISOString(),
+    expiresAt: expiresAt || null,
   };
   db.run(
-    `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.createdAt]
+    `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt, expiresAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.createdAt, apiKey.expiresAt]
   );
   return apiKey;
 }
@@ -53,8 +62,8 @@ export async function updateApiKey(id, data) {
     if (!row) return;
     const merged = { ...rowToKey(row), ...data };
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ? WHERE id = ?`,
-      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, id]
+      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, expiresAt = ? WHERE id = ?`,
+      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, merged.expiresAt || null, id]
     );
     result = merged;
   });
@@ -69,7 +78,8 @@ export async function deleteApiKey(id) {
 
 export async function validateApiKey(key) {
   const db = await getAdapter();
-  const row = db.get(`SELECT isActive FROM apiKeys WHERE key = ?`, [key]);
+  const row = db.get(`SELECT isActive, expiresAt FROM apiKeys WHERE key = ?`, [key]);
   if (!row) return false;
-  return row.isActive === 1 || row.isActive === true;
+  if (!(row.isActive === 1 || row.isActive === true)) return false;
+  return !isExpired(row.expiresAt);
 }

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -1,5 +1,5 @@
 // Latest schema version — bumped when a migration is added in ./migrations/
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -79,6 +79,7 @@ export const TABLES = {
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
       createdAt: "TEXT NOT NULL",
+      expiresAt: "TEXT",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],
   },

--- a/tests/unit/api-keys-route.test.js
+++ b/tests/unit/api-keys-route.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createApiKey: vi.fn(),
+  getApiKeys: vi.fn(),
+  getConsistentMachineId: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json(body, init = {}) {
+      return new Response(JSON.stringify(body), {
+        status: init.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  },
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getApiKeys: mocks.getApiKeys,
+  createApiKey: mocks.createApiKey,
+}));
+
+vi.mock("@/shared/utils/machineId", () => ({
+  getConsistentMachineId: mocks.getConsistentMachineId,
+}));
+
+function request(body) {
+  return new Request("https://9router.local/api/keys", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function json(response) {
+  return await response.json();
+}
+
+describe("API keys route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getConsistentMachineId.mockResolvedValue("machine-abc");
+    mocks.createApiKey.mockImplementation(async (name, machineId, expiresAt) => ({
+      id: "key-id",
+      key: "sk-machine-abc-key001-crc12345",
+      name,
+      machineId,
+      expiresAt,
+    }));
+  });
+
+  it("creates non-expiring API key by default", async () => {
+    const { POST } = await import("@/app/api/keys/route.js");
+
+    const response = await POST(request({ name: " prod " }));
+    const body = await json(response);
+
+    expect(response.status).toBe(201);
+    expect(body.expiresAt).toBeNull();
+    expect(mocks.createApiKey).toHaveBeenCalledWith("prod", "machine-abc", null);
+  });
+
+  it("rejects blank name", async () => {
+    const { POST } = await import("@/app/api/keys/route.js");
+
+    const response = await POST(request({ name: "   " }));
+
+    expect(response.status).toBe(400);
+    expect(mocks.createApiKey).not.toHaveBeenCalled();
+  });
+
+  it("normalizes future expiresAt and returns it", async () => {
+    const { POST } = await import("@/app/api/keys/route.js");
+    const expiresAt = new Date(Date.now() + 60_000).toISOString();
+
+    const response = await POST(request({ name: "short", expiresAt }));
+    const body = await json(response);
+
+    expect(response.status).toBe(201);
+    expect(body.expiresAt).toBe(expiresAt);
+    expect(mocks.createApiKey).toHaveBeenCalledWith("short", "machine-abc", expiresAt);
+  });
+
+  it("rejects invalid or past expiresAt", async () => {
+    const { POST } = await import("@/app/api/keys/route.js");
+
+    const invalid = await POST(request({ name: "bad", expiresAt: "not-a-date" }));
+    expect(invalid.status).toBe(400);
+
+    const past = await POST(request({ name: "bad", expiresAt: new Date(Date.now() - 60_000).toISOString() }));
+    expect(past.status).toBe(400);
+    expect(mocks.createApiKey).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/db-migration-chain.test.js
+++ b/tests/unit/db-migration-chain.test.js
@@ -37,6 +37,9 @@ describe("Schema migrations", () => {
       "_meta", "settings", "providerConnections", "providerNodes",
       "proxyPools", "apiKeys", "combos", "kv", "usageHistory", "usageDaily", "requestDetails",
     ]));
+
+    const apiKeyColumns = db.all(`PRAGMA table_info(apiKeys)`).map(c => c.name);
+    expect(apiKeyColumns).toContain("expiresAt");
   });
 
   it("existing DB at older schemaVersion → re-applies pending migrations on restart", async () => {
@@ -78,6 +81,7 @@ describe("Schema migrations", () => {
     const keys = db.all(`SELECT * FROM apiKeys`);
     expect(keys).toHaveLength(1);
     expect(keys[0].key).toBe("abc");
+    expect(keys[0].expiresAt).toBeNull();
 
     const aliases = db.all(`SELECT * FROM kv WHERE scope='modelAliases'`);
     expect(aliases).toHaveLength(1);

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -18,6 +18,8 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+  try { global._dbAdapter?.instance?.close?.(); } catch {}
+  delete global._dbAdapter;
   if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
   if (originalDataDir === undefined) delete process.env.DATA_DIR;
   else process.env.DATA_DIR = originalDataDir;
@@ -53,12 +55,22 @@ describe("DB SQLite layer — public API parity", () => {
     expect(k.key).toMatch(/^sk-/);
     expect(k.machineId).toBe("machine-abc");
     expect(k.isActive).toBe(true);
+    expect(k.expiresAt).toBeNull();
 
     const all = await sqliteDb.getApiKeys();
     expect(all.find((x) => x.id === k.id)).toBeDefined();
 
     expect(await sqliteDb.validateApiKey(k.key)).toBeTruthy();
     expect(await sqliteDb.validateApiKey("invalid")).toBeFalsy();
+
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const futureKey = await sqliteDb.createApiKey("future-key", "machine-abc", future);
+    expect(futureKey.expiresAt).toBe(future);
+    expect(await sqliteDb.validateApiKey(futureKey.key)).toBeTruthy();
+
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const pastKey = await sqliteDb.createApiKey("past-key", "machine-abc", past);
+    expect(await sqliteDb.validateApiKey(pastKey.key)).toBeFalsy();
 
     const deleted = await sqliteDb.deleteApiKey(k.id);
     expect(deleted).toBe(true);
@@ -234,6 +246,7 @@ describe("DB SQLite layer — public API parity", () => {
     const exported = await sqliteDb.exportDb();
     expect(exported.settings).toBeDefined();
     expect(Array.isArray(exported.providerConnections)).toBe(true);
+    expect(exported.apiKeys.every((key) => Object.hasOwn(key, "expiresAt"))).toBe(true);
     expect(typeof exported.modelAliases).toBe("object");
 
     // Add marker, export, import a different payload, verify reset


### PR DESCRIPTION
Closes #2351

## Summary

Adds API key expiration support across the dashboard, CLI/TUI, persistence layer, and request authentication.

- Adds `expiresAt` metadata for API keys.
- Keeps existing API keys valid by migrating them with `expiresAt = null` (never expires).
- Supports never-expiring keys, preset expirations, and custom datetime expiration.
- Rejects expired keys during request authentication instead of deleting them.
- Shows expired/future expiry state in the dashboard and CLI/TUI.
- Localizes new expiry UI literals across all non-English locale files.

## Database and migration

- Bumps schema version to `2`.
- Adds migration `002-api-key-expiry` for `apiKeys.expiresAt`.
- Updates legacy migration/import/export paths so `expiresAt` is preserved when present and defaults to `null` for existing/legacy keys.
- Existing keys remain backward-compatible and continue working unless manually given an expiration in future data.

## Dashboard

- API key creation now includes expiry options:
  - Never expires
  - 1 day
  - 7 days
  - 30 days
  - 90 days
  - Custom date/time
- Key list displays `Expired <date>` or `Expires <date>`.
- Expired keys are visually muted and shown in red, but remain visible for audit/history.
- Dynamic expiry labels are split into translatable static text plus locale-formatted date/time.

<img width="1450" height="351" alt="expired" src="https://github.com/user-attachments/assets/0952294d-9a99-4d61-99c0-334dcaf332d9" />

## Authentication behavior

Expired API keys now fail validation and return 401 Unauthorized for protected API requests.

<img width="1462" height="432" alt="expiredusage" src="https://github.com/user-attachments/assets/c00e3feb-8e65-4f2e-a17e-e846030a8d6b" />

## CLI/TUI

- API key creation prompts for expiry.
- List/detail/action views show expiry status.

<img width="870" height="502" alt="api-keys-tui" src="https://github.com/user-attachments/assets/1bf19a77-adcd-418b-a5b3-212cd11424eb" />

## Validation

- `node -e "...parse public/i18n/literals/*.json and check required expiry keys..."`
  - `ok 32 locale files`
- `npm run build`
  - passed
- `npx vitest run --config vitest.config.js unit/db-sqlite-vs-lowdb.test.js unit/db-migration-chain.test.js unit/api-keys-route.test.js unit/dashboard-guard.test.js --reporter=verbose`
  - passed: 4 files, 49 tests
- `npx vitest run --config vitest.config.js unit/api-keys-route.test.js unit/dashboard-guard.test.js --reporter=verbose`
  - passed: 2 files, 26 tests
- `git diff --check`
  - no whitespace errors; Windows line-ending warnings only
