### PR TITLE
feat(usage): add 90d, 180d, 365d, and all-time analytics periods

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -36,9 +36,9 @@ function UsageContent() {
 
   return (
     <div className="flex min-w-0 flex-col gap-6 px-1 sm:px-0">
-      {/* Tabs on their own row so long period selectors cannot cover tab clicks */}
-      <div className="flex flex-col gap-3">
-        <div className="relative z-20 w-fit max-w-full shrink-0">
+      {/* Keep tabs and periods on one line without letting periods cover tab clicks */}
+      <div className="flex min-w-0 items-center gap-2">
+        <div className="relative z-20 shrink-0">
           <SegmentedControl
             options={[
               { value: "overview", label: "Overview" },
@@ -46,17 +46,17 @@ function UsageContent() {
             ]}
             value={activeTab}
             onChange={handleTabChange}
-            className="w-full sm:w-auto"
+            className="w-auto shrink-0"
           />
         </div>
         {activeTab === "overview" && (
-          <div className="min-w-0 max-w-full overflow-x-auto">
+          <div className="min-w-0 flex-1 overflow-x-auto">
             <SegmentedControl
               options={PERIODS}
               value={period}
               onChange={setPeriod}
               size="sm"
-              className="max-w-full"
+              className="min-w-max"
             />
           </div>
         )}

--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -3,15 +3,10 @@
 import { Suspense, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { UsageStats, RequestLogger, CardSkeleton, SegmentedControl } from "@/shared/components";
+import { USAGE_PERIOD_OPTIONS } from "@/lib/usagePeriods.js";
 import RequestDetailsTab from "./components/RequestDetailsTab";
 
-const PERIODS = [
-  { value: "today", label: "Today" },
-  { value: "24h", label: "24h" },
-  { value: "7d", label: "7D" },
-  { value: "30d", label: "30D" },
-  { value: "60d", label: "60D" },
-];
+const PERIODS = USAGE_PERIOD_OPTIONS;
 
 export default function UsagePage() {
   return (
@@ -58,7 +53,7 @@ function UsageContent() {
             value={period}
             onChange={setPeriod}
             size="sm"
-            className="w-full sm:w-auto"
+            className="w-full overflow-x-auto sm:w-auto"
           />
         )}
       </div>

--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -36,25 +36,29 @@ function UsageContent() {
 
   return (
     <div className="flex min-w-0 flex-col gap-6 px-1 sm:px-0">
-      {/* Tabs + period selector on same row */}
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <SegmentedControl
-          options={[
-            { value: "overview", label: "Overview" },
-            { value: "details", label: "Details" },
-          ]}
-          value={activeTab}
-          onChange={handleTabChange}
-          className="w-full sm:w-auto"
-        />
-        {activeTab === "overview" && (
+      {/* Tabs on their own row so long period selectors cannot cover tab clicks */}
+      <div className="flex flex-col gap-3">
+        <div className="relative z-20 w-fit max-w-full shrink-0">
           <SegmentedControl
-            options={PERIODS}
-            value={period}
-            onChange={setPeriod}
-            size="sm"
-            className="w-full overflow-x-auto sm:w-auto"
+            options={[
+              { value: "overview", label: "Overview" },
+              { value: "details", label: "Details" },
+            ]}
+            value={activeTab}
+            onChange={handleTabChange}
+            className="w-full sm:w-auto"
           />
+        </div>
+        {activeTab === "overview" && (
+          <div className="min-w-0 max-w-full overflow-x-auto">
+            <SegmentedControl
+              options={PERIODS}
+              value={period}
+              onChange={setPeriod}
+              size="sm"
+              className="max-w-full"
+            />
+          </div>
         )}
       </div>
 

--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -36,8 +36,8 @@ function UsageContent() {
 
   return (
     <div className="flex min-w-0 flex-col gap-6 px-1 sm:px-0">
-      {/* Keep tabs and periods on one line without letting periods cover tab clicks */}
-      <div className="flex min-w-0 items-center gap-2">
+      {/* Keep tabs left and periods right on one line without overlap */}
+      <div className="flex min-w-0 items-center justify-between gap-2">
         <div className="relative z-20 shrink-0">
           <SegmentedControl
             options={[
@@ -50,14 +50,16 @@ function UsageContent() {
           />
         </div>
         {activeTab === "overview" && (
-          <div className="min-w-0 flex-1 overflow-x-auto">
-            <SegmentedControl
-              options={PERIODS}
-              value={period}
-              onChange={setPeriod}
-              size="sm"
-              className="min-w-max"
-            />
+          <div className="flex min-w-0 flex-1 justify-end overflow-hidden">
+            <div className="overflow-x-auto">
+              <SegmentedControl
+                options={PERIODS}
+                value={period}
+                onChange={setPeriod}
+                size="sm"
+                className="min-w-max"
+              />
+            </div>
           </div>
         )}
       </div>

--- a/src/app/api/usage/chart/route.js
+++ b/src/app/api/usage/chart/route.js
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server";
 import { getChartData } from "@/lib/usageDb";
-
-const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d"]);
+import { VALID_USAGE_CHART_PERIODS } from "@/lib/usagePeriods.js";
 
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
     const period = searchParams.get("period") || "7d";
 
-    if (!VALID_PERIODS.has(period)) {
+    if (!VALID_USAGE_CHART_PERIODS.has(period)) {
       return NextResponse.json({ error: "Invalid period" }, { status: 400 });
     }
 

--- a/src/app/api/usage/stats/route.js
+++ b/src/app/api/usage/stats/route.js
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getUsageStats } from "@/lib/usageDb";
-
-const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "all"]);
+import { VALID_USAGE_STATS_PERIODS } from "@/lib/usagePeriods.js";
 
 export const dynamic = "force-dynamic";
 
@@ -10,7 +9,7 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const period = searchParams.get("period") || "7d";
 
-    if (!VALID_PERIODS.has(period)) {
+    if (!VALID_USAGE_STATS_PERIODS.has(period)) {
       return NextResponse.json({ error: "Invalid period" }, { status: 400 });
     }
 

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 import { getMeta, setMeta } from "../helpers/metaStore.js";
+import { getChartDayBucketCount, getUsagePeriodDays } from "@/lib/usagePeriods.js";
 
 function maskApiKey(key) {
   if (!key || typeof key !== "string") return null;
@@ -11,8 +12,17 @@ function maskApiKey(key) {
 
 const PENDING_TIMEOUT_MS = 60 * 1000;
 const RING_CAP = 50;
+
 const CONN_CACHE_TTL_MS = 30 * 1000;
-const PERIOD_MS = { "24h": 86400000, "7d": 604800000, "30d": 2592000000, "60d": 5184000000 };
+const PERIOD_MS = {
+  "24h": 86400000,
+  "7d": 604800000,
+  "30d": 2592000000,
+  "60d": 5184000000,
+  "90d": 7776000000,
+  "180d": 15552000000,
+  "365d": 31536000000,
+};
 
 // In-memory state shared across Next.js modules
 if (!global._pendingRequests) global._pendingRequests = { byModel: {}, byAccount: {} };
@@ -447,8 +457,7 @@ export async function getUsageStats(period = "all") {
   const useDailySummary = period !== "24h" && period !== "today";
 
   if (useDailySummary) {
-    const periodDays = { "7d": 7, "30d": 30, "60d": 60 };
-    const maxDays = periodDays[period] || null;
+    const maxDays = getUsagePeriodDays(period);
     const dayRows = loadDaysInRange(db, maxDays);
 
     for (const dr of dayRows) {
@@ -710,7 +719,25 @@ export async function getChartData(period = "7d") {
     return buckets;
   }
 
-  const bucketCount = period === "7d" ? 7 : period === "30d" ? 30 : 60;
+  if (period === "all") {
+    const dayRows = loadDaysInRange(db, null);
+    const labelFn = (dateKey) => {
+      const [y, m, d] = dateKey.split("-").map(Number);
+      return new Date(y, m - 1, d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    };
+    return dayRows
+      .sort((a, b) => a.dateKey.localeCompare(b.dateKey))
+      .map((r) => {
+        const dayData = parseJson(r.data, {});
+        return {
+          label: labelFn(r.dateKey),
+          tokens: (dayData.promptTokens || 0) + (dayData.completionTokens || 0),
+          cost: dayData.cost || 0,
+        };
+      });
+  }
+
+  const bucketCount = getChartDayBucketCount(period) ?? 60;
   const today = new Date();
   const labelFn = (d) => d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 

--- a/src/lib/usagePeriods.js
+++ b/src/lib/usagePeriods.js
@@ -1,0 +1,54 @@
+/**
+ * Shared Usage & Analytics period definitions (UI + API validation + aggregation).
+ */
+
+export const USAGE_PERIOD_OPTIONS = [
+  { value: "today", label: "Today" },
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7D" },
+  { value: "30d", label: "30D" },
+  { value: "60d", label: "60D" },
+  { value: "90d", label: "90D" },
+  { value: "180d", label: "180D" },
+  { value: "365d", label: "365D" },
+  { value: "all", label: "All" },
+];
+
+/** @type {Set<string>} */
+export const VALID_USAGE_STATS_PERIODS = new Set(USAGE_PERIOD_OPTIONS.map((o) => o.value));
+
+/** Chart supports the same day-based periods as stats (including all-time). */
+export const VALID_USAGE_CHART_PERIODS = VALID_USAGE_STATS_PERIODS;
+
+/** Calendar-day lookback for daily rollup queries; `all` → null (no date filter). */
+export const USAGE_PERIOD_DAYS = {
+  "7d": 7,
+  "30d": 30,
+  "60d": 60,
+  "90d": 90,
+  "180d": 180,
+  "365d": 365,
+  all: null,
+};
+
+/**
+ * @param {string} period
+ * @returns {number | null}
+ */
+export function getUsagePeriodDays(period) {
+  if (period === "today" || period === "24h") return null;
+  if (period === "all") return null;
+  return Object.prototype.hasOwnProperty.call(USAGE_PERIOD_DAYS, period)
+    ? USAGE_PERIOD_DAYS[period]
+    : null;
+}
+
+/**
+ * Fixed bucket count for chart (daily bars). Returns null for `all` (variable length).
+ * @param {string} period
+ * @returns {number | null}
+ */
+export function getChartDayBucketCount(period) {
+  const days = getUsagePeriodDays(period);
+  return days;
+}

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { FREE_PROVIDERS, AI_PROVIDERS } from "@/shared/constants/providers";
+import { USAGE_PERIOD_OPTIONS } from "@/lib/usagePeriods.js";
 
 // Keep providers without serviceKinds (default LLM) or with "llm" in serviceKinds
 function isLLMProvider(id) {
@@ -190,13 +191,7 @@ const TABLE_OPTIONS = [
   { value: "endpoint", label: "Usage by Endpoint" },
 ];
 
-const PERIODS = [
-  { value: "today", label: "Today" },
-  { value: "24h", label: "24h" },
-  { value: "7d", label: "7D" },
-  { value: "30d", label: "30D" },
-  { value: "60d", label: "60D" },
-];
+const PERIODS = USAGE_PERIOD_OPTIONS;
 
 export default function UsageStats({ period: periodProp, setPeriod: setPeriodProp, hidePeriodSelector = false } = {}) {
   const router = useRouter();
@@ -444,7 +439,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       {/* Period selector (hidden when controlled by parent) */}
       {!hidePeriodSelector && (
         <div className="flex w-full items-center gap-2 sm:w-auto sm:self-end">
-          <div className="grid flex-1 grid-cols-5 items-center gap-1 rounded-lg border border-border bg-bg-subtle p-1 sm:flex sm:flex-none">
+          <div className="flex flex-1 flex-wrap items-center gap-1 rounded-lg border border-border bg-bg-subtle p-1 sm:flex-none">
             {PERIODS.map((p) => (
               <button
                 key={p.value}

--- a/tests/unit/db-sqlite-vs-lowdb.test.js
+++ b/tests/unit/db-sqlite-vs-lowdb.test.js
@@ -271,4 +271,19 @@ describe("DB SQLite layer — public API parity", () => {
     const data = await sqliteDb.getChartData("7d");
     expect(data).toHaveLength(7);
   });
+
+  it("getChartData: 90d buckets", async () => {
+    const data = await sqliteDb.getChartData("90d");
+    expect(data).toHaveLength(90);
+  });
+
+  it("getChartData: all-time returns sorted daily series", async () => {
+    const data = await sqliteDb.getChartData("all");
+    expect(Array.isArray(data)).toBe(true);
+    for (const point of data) {
+      expect(point).toHaveProperty("label");
+      expect(point).toHaveProperty("tokens");
+      expect(point).toHaveProperty("cost");
+    }
+  });
 });

--- a/tests/unit/usage-periods.test.js
+++ b/tests/unit/usage-periods.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  USAGE_PERIOD_OPTIONS,
+  VALID_USAGE_STATS_PERIODS,
+  VALID_USAGE_CHART_PERIODS,
+  getUsagePeriodDays,
+  getChartDayBucketCount,
+} from "@/lib/usagePeriods.js";
+
+describe("usagePeriods", () => {
+  it("exposes extended analytics periods including all-time", () => {
+    const values = USAGE_PERIOD_OPTIONS.map((o) => o.value);
+    expect(values).toContain("90d");
+    expect(values).toContain("180d");
+    expect(values).toContain("365d");
+    expect(values).toContain("all");
+    expect(values.indexOf("60d")).toBeLessThan(values.indexOf("90d"));
+  });
+
+  it("stats and chart validators accept the same extended set", () => {
+    for (const period of ["90d", "180d", "365d", "all"]) {
+      expect(VALID_USAGE_STATS_PERIODS.has(period)).toBe(true);
+      expect(VALID_USAGE_CHART_PERIODS.has(period)).toBe(true);
+    }
+    expect(VALID_USAGE_STATS_PERIODS.has("not-a-period")).toBe(false);
+  });
+
+  it("maps day periods to calendar lookback counts", () => {
+    expect(getUsagePeriodDays("90d")).toBe(90);
+    expect(getUsagePeriodDays("180d")).toBe(180);
+    expect(getUsagePeriodDays("365d")).toBe(365);
+    expect(getUsagePeriodDays("all")).toBeNull();
+    expect(getUsagePeriodDays("today")).toBeNull();
+  });
+
+  it("chart bucket count matches day periods; all is dynamic", () => {
+    expect(getChartDayBucketCount("90d")).toBe(90);
+    expect(getChartDayBucketCount("365d")).toBe(365);
+    expect(getChartDayBucketCount("all")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extends **Usage & Analytics** period options beyond the current **60-day** maximum to **90d**, **180d**, **365d**, and **All** (full retained `usageDaily` history).

Motivation: 30–60 day windows are useful for recent usage, but longer ranges help spot slower trends, month-over-month comparisons, and year-scale context on self-hosted installs—without changing default behavior (`today` / `7d` still work as before).

## Changes

- Add `src/lib/usagePeriods.js` — single source for UI labels, API validation, and day lookback
- Dashboard (`usage/page.js`, `UsageStats.js`) — new period chips + horizontal scroll/wrap for small screens
- `/api/usage/stats` — accept `90d`, `180d`, `365d` (already had `all`; now aligned with chart)
- `/api/usage/chart` — accept extended periods + **all-time** daily series (sorted by `dateKey`)
- `usageRepo.js` — daily aggregation via shared lookback map; chart buckets for 90/180/365

## Tests

```bash
npx vitest run --config tests/vitest.config.js \
  tests/unit/usage-periods.test.js \
  tests/unit/db-sqlite-vs-lowdb.test.js
```

- `usage-periods.test.js` — options list, validators, day/bucket helpers
- `db-sqlite-vs-lowdb.test.js` — `getChartData("90d")` length 90; `getChartData("all")` shape

**Result:** 25 tests passed (2 files) on Node 18+.

## Notes

- **All** is bounded by what is stored locally in `usageDaily` / `usageHistory` (no schema change).
- Chart for **All** returns one point per stored day (can be dense on very old DBs).

## Checklist

- [x] Source-level change (not runtime bundle patch)
- [x] Unit tests added/updated
- [x] Backward compatible defaults