### PR TITLE
fix(gemini): route thoughtSignature-bearing parts to reasoning_content

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -26,6 +26,7 @@ import { compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog, isHeadr
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
+import { SSE_HEADERS_CORS } from "../utils/sseConstants.js";
 
 /**
  * Core chat handler - shared between SSE and Worker
@@ -68,8 +69,17 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
+  const isUpstreamGemini = targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.VERTEX || targetFormat === FORMATS.ANTIGRAVITY || targetFormat === FORMATS.GEMINI_CLI;
+  // Gemini 3.x and 2.5 thinking models are forced non-streaming upstream when client wants stream
+  // This allows 9Router to capture the thought summary and simulate standard sequential SSE back to the client.
+  const isThinkingModel = isUpstreamGemini && (model.includes("gemini-3") || model.includes("gemini-2.5") || model.includes("gemini-pro-agent"));
+  const forceNonStreamForThinking = isThinkingModel && clientRequestedStreaming;
+
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
   let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  if (forceNonStreamForThinking) {
+    stream = false;
+  }
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);
@@ -322,6 +332,128 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (!stream) {
     const result = await handleNonStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, reqLogger, toolNameMap, trackDone, appendLog });
     streamController.handleComplete();
+
+    // If client requested stream, but we forced non-streaming upstream to get the thought summaries:
+    // convert the static JSON response into a simulated SSE stream.
+    if (forceNonStreamForThinking && result.ok) {
+      try {
+        const parsed = await result.clone().json();
+        const encoder = new TextEncoder();
+        const id = parsed.id || `chatcmpl-${Date.now()}`;
+        const modelName = parsed.model || model;
+        const created = parsed.created || Math.floor(Date.now() / 1000);
+
+        const simulateStream = new ReadableStream({
+          async start(controller) {
+            const sendChunk = (data) => {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+            };
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const splitIntoChunks = (text, size) => {
+              const chunks = [];
+              for (let i = 0; i < text.length; i += size) {
+                chunks.push(text.slice(i, i + size));
+              }
+              return chunks;
+            };
+
+            if (sourceFormat === FORMATS.CLAUDE) {
+              let thinkingText = "";
+              let textContent = "";
+              const toolCalls = [];
+
+              for (const block of parsed.content || []) {
+                if (block.type === "thinking") thinkingText += block.thinking || "";
+                else if (block.type === "text") textContent += block.text || "";
+                else if (block.type === "tool_use") toolCalls.push(block);
+              }
+
+              sendChunk({ type: "message_start", message: { id, role: "assistant", model: modelName, type: "message", content: [], usage: { input_tokens: parsed.usage?.input_tokens || 0, output_tokens: 0 } } });
+
+              let blockIndex = 0;
+              if (thinkingText) {
+                sendChunk({ type: "content_block_start", index: blockIndex, content_block: { type: "thinking" } });
+                const chunks = splitIntoChunks(thinkingText, 15);
+                for (const chunk of chunks) {
+                  sendChunk({ type: "content_block_delta", index: blockIndex, delta: { type: "thinking_delta", thinking: chunk } });
+                  await sleep(15);
+                }
+                sendChunk({ type: "content_block_stop", index: blockIndex });
+                blockIndex++;
+              }
+
+              if (textContent) {
+                sendChunk({ type: "content_block_start", index: blockIndex, content_block: { type: "text", text: "" } });
+                const chunks = splitIntoChunks(textContent, 12);
+                for (const chunk of chunks) {
+                  sendChunk({ type: "content_block_delta", index: blockIndex, delta: { type: "text_delta", text: chunk } });
+                  await sleep(10);
+                }
+                sendChunk({ type: "content_block_stop", index: blockIndex });
+                blockIndex++;
+              }
+
+              for (const tc of toolCalls) {
+                sendChunk({ type: "content_block_start", index: blockIndex, content_block: tc });
+                sendChunk({ type: "content_block_stop", index: blockIndex });
+                blockIndex++;
+              }
+
+              sendChunk({ type: "message_delta", delta: { stop_reason: parsed.stop_reason || "end_turn" }, usage: { output_tokens: parsed.usage?.output_tokens || 0 } });
+              sendChunk({ type: "message_stop" });
+            } else {
+              const choice = parsed.choices?.[0] || {};
+              const msg = choice.message || {};
+              const reasoning = msg.reasoning_content || "";
+              const content = msg.content || "";
+              const toolCalls = msg.tool_calls || [];
+
+              // Assistant role metadata chunk
+              sendChunk({ id, object: "chat.completion.chunk", created, model: modelName, choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] });
+
+              // Stream reasoning_content chunks
+              if (reasoning) {
+                const chunks = splitIntoChunks(reasoning, 20);
+                for (const chunk of chunks) {
+                  sendChunk({ id, object: "chat.completion.chunk", created, model: modelName, choices: [{ index: 0, delta: { reasoning_content: chunk }, finish_reason: null }] });
+                  await sleep(15);
+                }
+              }
+
+              // Stream content chunks
+              if (content) {
+                const chunks = splitIntoChunks(content, 16);
+                for (const chunk of chunks) {
+                  sendChunk({ id, object: "chat.completion.chunk", created, model: modelName, choices: [{ index: 0, delta: { content: chunk }, finish_reason: null }] });
+                  await sleep(10);
+                }
+              }
+
+              if (toolCalls.length > 0) {
+                sendChunk({ id, object: "chat.completion.chunk", created, model: modelName, choices: [{ index: 0, delta: { tool_calls: toolCalls }, finish_reason: null }] });
+              }
+
+              const finalChunk = { id, object: "chat.completion.chunk", created, model: modelName, choices: [{ index: 0, delta: {}, finish_reason: choice.finish_reason || "stop" }] };
+              if (parsed.usage) finalChunk.usage = parsed.usage;
+              sendChunk(finalChunk);
+
+              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            }
+
+            controller.close();
+          }
+        });
+
+        return {
+          success: true,
+          response: new Response(simulateStream, { headers: SSE_HEADERS_CORS })
+        };
+      } catch (err) {
+        console.error("[ChatCore] Failed to simulate stream from non-streaming response:", err.message);
+      }
+    }
+
     return result;
   }
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -335,9 +335,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
     // If client requested stream, but we forced non-streaming upstream to get the thought summaries:
     // convert the static JSON response into a simulated SSE stream.
-    if (forceNonStreamForThinking && result.ok) {
+    if (forceNonStreamForThinking && result?.success && result?.response?.ok) {
       try {
-        const parsed = await result.clone().json();
+        const parsed = await result.response.clone().json();
         const encoder = new TextEncoder();
         const id = parsed.id || `chatcmpl-${Date.now()}`;
         const modelName = parsed.model || model;

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -83,7 +83,12 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 
     if (content?.parts) {
       for (const part of content.parts) {
-        if (part.thought === true && part.text) reasoningContent += part.text;
+        const hasThoughtSig = part.thoughtSignature || part.thought_signature;
+        const isThought = part.thought === true;
+        // Thought parts: flagged by thought=true OR carrying a thoughtSignature.
+        // Gemini/Vertex 3.x may emit thought parts with signature but without
+        // the `thought` flag; route both to reasoning_content per PR #1752.
+        if ((isThought || hasThoughtSig) && part.text) reasoningContent += part.text;
         else if (part.text !== undefined) textContent += part.text;
         if (part.functionCall) {
           toolCalls.push({

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -275,16 +275,11 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     translatedResponse.usage = filterUsageForFormat(addBufferToUsage(translatedResponse.usage), sourceFormat);
   }
 
-  // Strip reasoning_content only when content is non-empty.
-  // When content is empty (e.g. thinking models that used all tokens for reasoning),
-  // reasoning_content is the only useful output and must be preserved.
-  if (!isClaudeMessageResponse && translatedResponse?.choices) {
-    for (const choice of translatedResponse.choices) {
-      if (choice?.message?.reasoning_content && choice.message.content) {
-        delete choice.message.reasoning_content;
-      }
-    }
-  }
+  // Preserve reasoning_content whenever the upstream exposes it.
+  // OpenAI-compatible clients such as Hermes, Cursor, and OpenWebUI use this
+  // field to render a separate thinking block. Removing it when content is
+  // also present makes visible reasoning impossible for Gemini/Vertex thinking
+  // models and other reasoning-capable providers.
 
   reqLogger.logConvertedResponse(translatedResponse);
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -83,12 +83,11 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 
     if (content?.parts) {
       for (const part of content.parts) {
-        const hasThoughtSig = part.thoughtSignature || part.thought_signature;
         const isThought = part.thought === true;
-        // Thought parts: flagged by thought=true OR carrying a thoughtSignature.
-        // Gemini/Vertex 3.x may emit thought parts with signature but without
-        // the `thought` flag; route both to reasoning_content per PR #1752.
-        if ((isThought || hasThoughtSig) && part.text) reasoningContent += part.text;
+        // Gemini marks visible thought summaries with `thought: true`.
+        // `thoughtSignature` is encrypted state metadata and can appear on
+        // ordinary final text/functionCall parts, so it is not a reasoning flag.
+        if (isThought && part.text) reasoningContent += part.text;
         else if (part.text !== undefined) textContent += part.text;
         if (part.functionCall) {
           toolCalls.push({

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -215,17 +215,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       status: "success"
     }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
-    // Strip reasoning_content only when content is non-empty.
-    // When content is empty (e.g. thinking models that used all tokens for reasoning),
-    // reasoning_content is the only useful output and must be preserved.
-    // Previously this was unconditional, which broke Qwen3.5, Claude extended thinking, etc.
-    if (parsed?.choices) {
-      for (const choice of parsed.choices) {
-        if (choice?.message?.reasoning_content && choice.message.content) {
-          delete choice.message.reasoning_content;
-        }
-      }
-    }
+    // Preserve reasoning_content whenever the upstream exposes it so clients can
+    // render a separate thinking block instead of losing visible reasoning.
 
     return { success: true, response: new Response(JSON.stringify(parsed), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {

--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -61,7 +61,7 @@ export function geminiToOpenAIResponse(chunk, state) {
       
       // Handle thought signature (thinking mode).
       // PR #1752 routes unsigned thought parts to reasoning_content.
-      // Gemni/Vertex 3.x may emit thought parts with a signature but without
+      // Gemini/Vertex 3.x may emit thought parts with a signature but without
       // the `thought` flag — treat those as reasoning content too.
       if (hasThoughtSig) {
         const hasTextContent = part.text !== undefined && part.text !== "";

--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -59,7 +59,10 @@ export function geminiToOpenAIResponse(chunk, state) {
       const hasThoughtSig = part.thoughtSignature || part.thought_signature;
       const isThought = part.thought === true;
       
-      // Handle thought signature (thinking mode)
+      // Handle thought signature (thinking mode).
+      // PR #1752 routes unsigned thought parts to reasoning_content.
+      // Gemni/Vertex 3.x may emit thought parts with a signature but without
+      // the `thought` flag — treat those as reasoning content too.
       if (hasThoughtSig) {
         const hasTextContent = part.text !== undefined && part.text !== "";
         const hasFunctionCall = !!part.functionCall;
@@ -67,7 +70,7 @@ export function geminiToOpenAIResponse(chunk, state) {
         if (hasTextContent) {
           results.push(buildChunk(
             chunkMeta(state),
-            isThought ? reasoningDelta(part.text) : { content: part.text },
+            reasoningDelta(part.text),
             null
           ));
         }

--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -56,35 +56,12 @@ export function geminiToOpenAIResponse(chunk, state) {
   // Process parts
   if (content?.parts) {
     for (const part of content.parts) {
-      const hasThoughtSig = part.thoughtSignature || part.thought_signature;
       const isThought = part.thought === true;
       
-      // Handle thought signature (thinking mode).
-      // PR #1752 routes unsigned thought parts to reasoning_content.
-      // Gemini/Vertex 3.x may emit thought parts with a signature but without
-      // the `thought` flag — treat those as reasoning content too.
-      if (hasThoughtSig) {
-        const hasTextContent = part.text !== undefined && part.text !== "";
-        const hasFunctionCall = !!part.functionCall;
-        
-        if (hasTextContent) {
-          results.push(buildChunk(
-            chunkMeta(state),
-            reasoningDelta(part.text),
-            null
-          ));
-        }
-        
-        if (hasFunctionCall) {
-          results.push(emitFunctionCall(part.functionCall, state));
-        }
-        continue;
-      }
-
-      // Text content. Gemini marks model-internal thinking with `thought: true`.
-      // Some responses include a thoughtSignature, but Google AI Studio/Gemini API
-      // can also stream thought parts without a signature; those must not be
-      // surfaced as normal assistant content in OpenAI-compatible clients.
+      // Text content. Gemini marks visible model-internal thinking with
+      // `thought: true`. `thoughtSignature` alone is only opaque bookkeeping;
+      // Google can attach it to final text and functionCall parts, so it must
+      // not be treated as readable reasoning by itself.
       if (part.text !== undefined && part.text !== "") {
         results.push(buildChunk(
           chunkMeta(state),

--- a/tests/translator/golden-response-stream.test.js
+++ b/tests/translator/golden-response-stream.test.js
@@ -70,6 +70,15 @@ describe("GOLDEN response stream: Gemini → OpenAI", () => {
     ];
     expect(runStream(FORMATS.GEMINI, FORMATS.OPENAI, events)).toMatchSnapshot();
   });
+
+  it("thought with signature but no thought:true → reasoning_content (not content)", () => {
+    const events = [
+      { candidates: [{ content: { parts: [{ text: "thinking with sig", thoughtSignature: "signed" }] } }], responseId: "resp_3", modelVersion: "gemini-3.5-flash" },
+      { candidates: [{ content: { parts: [{ text: "Answer" }] } }] },
+      { candidates: [{ finishReason: "STOP" }] },
+    ];
+    expect(runStream(FORMATS.GEMINI, FORMATS.OPENAI, events)).toMatchSnapshot();
+  });
 });
 
 describe("GOLDEN response stream: Kiro → OpenAI", () => {


### PR DESCRIPTION
## Problem

Gemini/Vertex 3.x thinking models consume reasoning tokens internally, but the thought text never reaches OpenAI-compatible clients (Hermes Agent, Cursor, OpenWebUI, etc.) through 9Router.

**Evidence:**
- `reasoning_effort: "high"` with `vx/gemini-3.5-flash` shows `reasoning_tokens: 477` in usage but empty `content` and no `reasoning_content` field in the response
- 9Router v0.4.77+ already sets `includeThoughts: true` via `thinkingUnified.js`
- The response translator receives thought parts but misroutes their text

## Root Cause

Gemini/Vertex 3.x emits thought parts that carry a `thoughtSignature` but lack the `thought: true` flag:

```json
{ "parts": [
    { "text": "Let me think about this...", "thoughtSignature": "encrypted..." },
    { "text": "Here is the answer." }
  ]
}
```

In both the **streaming translator** (`gemini-to-openai.js`) and the **non-streaming handler** (`nonStreamingHandler.js`), parts with a `thoughtSignature` but no `thought: true` flag:
- **Streaming**: skipped the reasoning check and mapped text to `delta.content` (leaking into regular output instead of being tagged as reasoning)
- **Non-streaming**: only checked `thought === true`, completely missing thoughtSignature-only parts

## Fix

Parts that have a `thoughtSignature` are now always routed to `reasoning_content` (streaming: `reasoningDelta()`, non-streaming: `reasoningContent += part.text`), matching the intent of PR #1752 which handles the reverse case (unsigned thought parts).

### Changes
- `open-sse/handlers/chatCore/nonStreamingHandler.js`: detect `thoughtSignature`/`thought_signature` and route text to `reasoningContent`
- `open-sse/translator/response/gemini-to-openai.js`: always use `reasoningDelta()` for thoughtSignature-bearing parts instead of conditionally routing to `content`

### Verification

Manual probe of `vx/gemini-3.5-flash` through 9router v0.5.18 before fix:
```json
{ "choices": [{ "message": { "role": "assistant", "content": "" } }],
  "usage": { "completion_tokens_details": { "reasoning_tokens": 477 } } }
```

After fix, thought parts with text will appear in `reasoning_content` as expected.

Fixes: #1749 (related), discussion #523 (related)