### PR TITLE
fix(kiro): nest thinking/output_config/max_tokens in additionalModelRequestFields

### DIFF
--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -273,6 +273,39 @@ export function resolveKiroEffort(body, model) {
   return cfg.level;
 }
 
+// Per-model max output token ceiling (per https://kiro.dev/docs/cli/chat/effort/).
+// Opus 4.8 = 128000; Opus 4.7/4.6 + Sonnet 4.6 = 64000. Unknown models keep the
+// conservative 32000 default the Kiro path shipped with.
+const KIRO_MAX_TOKENS_FLOOR = 1024;
+const KIRO_MAX_TOKENS_DEFAULT = 32000;
+function modelMaxTokensCap(model) {
+  const m = String(model || "").toLowerCase();
+  if (m.includes("opus-4-8") || m.includes("opus-4.8")) return 128000;
+  if (m.includes("opus-4-7") || m.includes("opus-4.7")
+    || m.includes("opus-4-6") || m.includes("opus-4.6")
+    || m.includes("sonnet-4-6") || m.includes("sonnet-4.6")) return 64000;
+  return KIRO_MAX_TOKENS_DEFAULT;
+}
+
+/**
+ * Resolve the max output tokens for a Kiro inferenceConfig. Honors the client's
+ * requested max_tokens, clamped to [1024, model cap]. Falls back to the model
+ * cap when the client sends nothing (previously hardcoded to 32000, which
+ * silently capped Opus 4.8 at a quarter of its 128000 ceiling).
+ *
+ * @param {object} body Request body (Claude max_tokens / OpenAI max_tokens)
+ * @param {string} [model] Upstream Kiro model id
+ * @returns {number} clamped max output tokens
+ */
+export function resolveKiroMaxTokens(body, model) {
+  const cap = modelMaxTokensCap(model);
+  const requested = Number(body?.max_tokens);
+  if (Number.isFinite(requested) && requested > 0) {
+    return Math.max(KIRO_MAX_TOKENS_FLOOR, Math.min(cap, requested));
+  }
+  return cap;
+}
+
 function pickHeader(headers, name) {
   if (!headers) return undefined;
   if (typeof headers.get === "function") {

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -238,6 +238,31 @@ export function buildThinkingSystemPrefix() {
   return `<thinking_mode>enabled</thinking_mode>`;
 }
 
+// A/B toggle: when KIRO_THINKING_FIELD=1, reasoning is signalled via a native
+// `thinking` payload field (per the Kiro CLI chat docs) instead of the
+// <thinking_mode> content-tag, so we can test whether the CodeWhisperer
+// generateAssistantResponse endpoint honors the field on its own. Default off
+// keeps the proven tag behavior.
+export function useKiroThinkingField() {
+  return process.env.KIRO_THINKING_FIELD === "1";
+}
+
+/**
+ * Build the native `thinking` payload field for a Kiro request, or null when
+ * thinking is disabled. Shape follows the Kiro CLI chat docs
+ * (https://kiro.dev/docs/cli/chat/effort/): { type: "adaptive"|"disabled" }.
+ * `display` is included for adaptive so summarized reasoning is returned.
+ *
+ * @param {object} body Request body
+ * @param {string} [model] Upstream Kiro model id
+ * @returns {{type: string, display?: string}|null}
+ */
+export function resolveKiroThinkingField(body, model) {
+  const effort = resolveKiroEffort(body, model);
+  if (effort === null) return { type: "disabled" };
+  return { type: "adaptive", display: "summarized" };
+}
+
 // xhigh is Opus 4.7/4.8 only (per Kiro effort docs). Opus 4.6 + Sonnet 4.6
 // top out at max and reject xhigh → clamp down to high there.
 function supportsXhigh(model) {

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -16,7 +16,7 @@
  */
 
 import { extractThinking } from "../translator/concerns/thinkingUnified.js";
-import { effortToBudget } from "../translator/concerns/thinking.js";
+import { effortToBudget, budgetToLevel } from "../translator/concerns/thinking.js";
 
 export const KIRO_AGENTIC_SUFFIX = "-agentic";
 export const KIRO_THINKING_SUFFIX = "-thinking";
@@ -227,13 +227,50 @@ export function resolveKiroModel(model) {
 
 /**
  * Build the magic system-prompt prefix that turns Kiro reasoning on.
- * Same shape as CLIProxyAPIPlus.
  *
- * @param {number} [budget=KIRO_THINKING_BUDGET_DEFAULT]
+ * Per official Kiro docs (https://kiro.dev/docs/cli/chat/effort/), reasoning
+ * depth is controlled by `output_config.effort` on the payload (see
+ * resolveKiroEffort), not a thinking-length tag — so only the on/off
+ * `<thinking_mode>` signal remains here. The legacy `<max_thinking_length>`
+ * tag (CLIProxyAPIPlus reverse-engineered hack, hard-clamped to 32000) is gone.
  */
-export function buildThinkingSystemPrefix(budget = KIRO_THINKING_BUDGET_DEFAULT) {
-  const safeBudget = Math.max(1, Math.min(32000, Number(budget) || KIRO_THINKING_BUDGET_DEFAULT));
-  return `<thinking_mode>enabled</thinking_mode>\n<max_thinking_length>${safeBudget}</max_thinking_length>`;
+export function buildThinkingSystemPrefix() {
+  return `<thinking_mode>enabled</thinking_mode>`;
+}
+
+// xhigh is Opus 4.7/4.8 only (per Kiro effort docs). Opus 4.6 + Sonnet 4.6
+// top out at max and reject xhigh → clamp down to high there.
+function supportsXhigh(model) {
+  const m = String(model || "").toLowerCase();
+  return m.includes("opus-4-7") || m.includes("opus-4-8")
+    || m.includes("opus-4.7") || m.includes("opus-4.8");
+}
+
+/**
+ * Resolve the `output_config.effort` level for a Kiro request from client
+ * thinking intent. Returns "low"|"medium"|"high"|"xhigh"|"max", or null when
+ * thinking is explicitly disabled.
+ *
+ * Reuses extractThinking so every client shape (Claude output_config.effort /
+ * thinking.budget_tokens, OpenAI reasoning_effort, Gemini, Qwen) maps
+ * consistently. Callers gate this on the existing thinking-enabled check
+ * (resolveKiroThinkingBudget !== null) — when thinking is on but the client
+ * gave no explicit level, this returns "high" (preserves the prior default-on
+ * behaviour).
+ *
+ * @param {object} body OpenAI/Claude-shaped request body
+ * @param {string} [model] Upstream Kiro model id (for the xhigh capability check)
+ * @returns {string|null} effort level, or null when thinking is disabled
+ */
+export function resolveKiroEffort(body, model) {
+  const cfg = extractThinking(body);
+  if (!cfg) return "high";                 // thinking on via signal, no explicit level
+  if (cfg.mode === "none") return null;
+  if (cfg.mode === "auto") return "high";
+  if (cfg.mode === "budget") return budgetToLevel(cfg.budget) || "high";
+  // mode === "level"
+  if (cfg.level === "xhigh" && !supportsXhigh(model)) return "high";
+  return cfg.level;
 }
 
 function pickHeader(headers, name) {

--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -8,8 +8,9 @@
  *   - `-agentic` model suffix detection + chunked-write system prompt
  *   - reasoning / thinking trigger detection (Anthropic-Beta header,
  *     Claude `thinking`, OpenAI `reasoning_effort`, AMP/Cursor magic tag)
- *   - the `<thinking_mode>enabled</thinking_mode>` system-prompt injection
- *     that turns Kiro reasoning on
+ *   - reasoning depth + adaptive field, nested inside
+ *     `additionalModelRequestFields` to match the real Kiro IDE wire format
+ *     (reverse-engineered from the kiro.kiro-agent bundle)
  *
  * Kiro upstream does not advertise `-agentic` model IDs; they are a 9router
  * fiction. The suffix is stripped before the request leaves this process.
@@ -97,8 +98,7 @@ REMEMBER: When in doubt, write LESS per operation. Multiple small operations > o
  * Reuses the shared thinkingUnified parser (extractThinking) so every client
  * shape (Claude output_config.effort / thinking.budget_tokens, OpenAI
  * reasoning_effort / reasoning.effort, Gemini, Qwen) maps consistently. Explicit
- * `none`/`off`/disabled wins and returns null (no prefix injected).
- * buildThinkingSystemPrefix performs Kiro's final 1..32000 clamp.
+ * `none`/`off`/disabled wins and returns null (no effort shipped).
  *
  * @param {object} body OpenAI/Claude-shaped request body
  * @param {object} [headers] Original inbound HTTP headers (case-insensitive)
@@ -170,7 +170,8 @@ export function stripAgenticSuffix(model) {
 /**
  * Detect whether a model id is a 9router synthetic thinking variant
  * (e.g. `claude-sonnet-4.5-thinking`). Same upstream model as the base; the
- * only difference is `<thinking_mode>enabled</thinking_mode>` injection.
+ * only difference is reasoning defaults to ON (effort + adaptive field ship
+ * inside `additionalModelRequestFields`).
  *
  * Note: real Kiro thinking-capable variants exist (e.g. `kimi-k2-thinking` in
  * other providers), but for the `kr/` namespace there is no `-thinking`
@@ -225,26 +226,13 @@ export function resolveKiroModel(model) {
   return { upstream, agentic, thinking };
 }
 
-/**
- * Build the magic system-prompt prefix that turns Kiro reasoning on.
- *
- * Per official Kiro docs (https://kiro.dev/docs/cli/chat/effort/), reasoning
- * depth is controlled by `output_config.effort` on the payload (see
- * resolveKiroEffort), not a thinking-length tag — so only the on/off
- * `<thinking_mode>` signal remains here. The legacy `<max_thinking_length>`
- * tag (CLIProxyAPIPlus reverse-engineered hack, hard-clamped to 32000) is gone.
- */
-export function buildThinkingSystemPrefix() {
-  return `<thinking_mode>enabled</thinking_mode>`;
-}
-
-// A/B toggle: when KIRO_THINKING_FIELD=1, reasoning is signalled via a native
-// `thinking` payload field (per the Kiro CLI chat docs) instead of the
-// <thinking_mode> content-tag, so we can test whether the CodeWhisperer
-// generateAssistantResponse endpoint honors the field on its own. Default off
-// keeps the proven tag behavior.
-export function useKiroThinkingField() {
-  return process.env.KIRO_THINKING_FIELD === "1";
+// Adaptive `thinking` payload field ships by default — matches the real Kiro
+// IDE wire format (reverse-engineered from the kiro.kiro-agent bundle: the
+// `Er` builder at extension.js:419837 nests {thinking, output_config} inside
+// `additionalModelRequestFields`). Set KIRO_THINKING_FIELD=0 to suppress the
+// adaptive field; output_config.effort still ships.
+export function kiroThinkingFieldEnabled() {
+  return process.env.KIRO_THINKING_FIELD !== "0";
 }
 
 /**
@@ -298,37 +286,44 @@ export function resolveKiroEffort(body, model) {
   return cfg.level;
 }
 
-// Per-model max output token ceiling (per https://kiro.dev/docs/cli/chat/effort/).
-// Opus 4.8 = 128000; Opus 4.7/4.6 + Sonnet 4.6 = 64000. Unknown models keep the
-// conservative 32000 default the Kiro path shipped with.
-const KIRO_MAX_TOKENS_FLOOR = 1024;
-const KIRO_MAX_TOKENS_DEFAULT = 32000;
+// Effort → additionalModelRequestFields.max_tokens bucket (clean buckets).
+// max_tokens is a sibling of thinking/output_config inside the model's
+// additionalModelRequestFieldsSchema; the gateway maps it to output budget.
+const EFFORT_MAX_TOKENS = {
+  low: 16000, medium: 32000, high: 64000, xhigh: 96000, max: 128000
+};
+
+// Per-model max_tokens ceiling, from each model's live
+// additionalModelRequestFieldsSchema (captured via `kiro-cli chat --list-models`
+// with KIRO_LOG_LEVEL=trace). Models not listed don't expose max_tokens in
+// their schema → null (caller must omit the field or the gateway rejects it).
+// ponytail: Opus 4.7 ceiling is 128000 on the live gateway (the kiro.dev docs
+// table is stale — shows 64000); update if the schema changes.
 function modelMaxTokensCap(model) {
   const m = String(model || "").toLowerCase();
   if (m.includes("opus-4-8") || m.includes("opus-4.8")) return 128000;
-  if (m.includes("opus-4-7") || m.includes("opus-4.7")
-    || m.includes("opus-4-6") || m.includes("opus-4.6")
-    || m.includes("sonnet-4-6") || m.includes("sonnet-4.6")) return 64000;
-  return KIRO_MAX_TOKENS_DEFAULT;
+  if (m.includes("opus-4-7") || m.includes("opus-4.7")) return 128000;
+  if (m.includes("opus-4-6") || m.includes("opus-4.6")) return 64000;
+  if (m.includes("sonnet-4-6") || m.includes("sonnet-4.6")) return 64000;
+  return null;
 }
 
 /**
- * Resolve the max output tokens for a Kiro inferenceConfig. Honors the client's
- * requested max_tokens, clamped to [1024, model cap]. Falls back to the model
- * cap when the client sends nothing (previously hardcoded to 32000, which
- * silently capped Opus 4.8 at a quarter of its 128000 ceiling).
+ * Resolve additionalModelRequestFields.max_tokens from the effort level.
+ * Returns null when effort is unset/unknown or the model has no max_tokens
+ * schema (caller omits the field). Clamped to [1024, model cap] per the schema.
  *
- * @param {object} body Request body (Claude max_tokens / OpenAI max_tokens)
- * @param {string} [model] Upstream Kiro model id
- * @returns {number} clamped max output tokens
+ * @param {string|null} effort effort level from resolveKiroEffort
+ * @param {string} [model] upstream Kiro model id
+ * @returns {number|null}
  */
-export function resolveKiroMaxTokens(body, model) {
+export function resolveKiroMaxTokens(effort, model) {
+  if (!effort) return null;
+  const bucket = EFFORT_MAX_TOKENS[effort];
+  if (!bucket) return null;
   const cap = modelMaxTokensCap(model);
-  const requested = Number(body?.max_tokens);
-  if (Number.isFinite(requested) && requested > 0) {
-    return Math.max(KIRO_MAX_TOKENS_FLOOR, Math.min(cap, requested));
-  }
-  return cap;
+  if (cap === null) return null;
+  return Math.max(1024, Math.min(bucket, cap));
 }
 
 function pickHeader(headers, name) {

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -140,6 +140,12 @@ export class BaseExecutor {
         const bodyStr = JSON.stringify(transformedBody);
         const fetchT0 = Date.now();
         dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${timeoutMs}ms`);
+        // Opt-in wire-body dump (DEBUG_WIRE_BODY=1) — prints the exact JSON sent
+        // upstream, so effort/thinking fields (output_config, reasoning_effort,
+        // thinking) can be verified on the wire rather than inferred from intent.
+        if (process.env.DEBUG_WIRE_BODY === "1") {
+          dbg("WIRE", `${this.provider.toUpperCase()} → ${bodyStr}`);
+        }
         const response = await proxyAwareFetch(url, {
           method: "POST",
           headers,

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -136,7 +136,11 @@ export class KiroExecutor extends BaseExecutor {
       reasoningChunkCount: 0,
       toolCallIndex: 0,
       seenToolIds: new Map(),
-      inThinking: false
+      inThinking: false,
+      // Effort A/B instrumentation (DEBUG_KIRO_EFFORT=1): tally reasoning vs
+      // answer bytes so effort=low can be compared to effort=max on the wire.
+      reasoningChars: 0,
+      answerChars: 0
     };
 
     const transformStream = new TransformStream({
@@ -204,6 +208,7 @@ export class KiroExecutor extends BaseExecutor {
             }
 
             state.totalContentLength += content.length;
+            state.answerChars += content.length;
 
             const chunk = {
               id: responseId,
@@ -235,6 +240,7 @@ export class KiroExecutor extends BaseExecutor {
             if (reasoningText) {
               state.hasReasoningContent = true;
               state.totalContentLength += reasoningText.length;
+              state.reasoningChars += reasoningText.length;
 
               const reasoningDelta = state.reasoningChunkCount === 0 && chunkIndex === 0
                 ? { role: "assistant", reasoning_content: reasoningText }
@@ -469,6 +475,16 @@ export class KiroExecutor extends BaseExecutor {
       },
 
       flush(controller) {
+        // Effort A/B (DEBUG_KIRO_EFFORT=1): one-line reasoning-vs-answer tally
+        // so effort=low and effort=max can be compared for the same prompt.
+        if (process.env.DEBUG_KIRO_EFFORT === "1") {
+          const r = state.reasoningChars, a = state.answerChars;
+          const ratio = a > 0 ? (r / a).toFixed(2) : "n/a";
+          console.log(
+            `[KIRO-EFFORT] model=${model} reasoning=${r}c answer=${a}c ratio=${ratio} reasoningChunks=${state.reasoningChunkCount}`
+          );
+        }
+
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -26,6 +26,20 @@ import { compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog, isHeadr
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
+import { extractThinking } from "../translator/concerns/thinkingUnified.js";
+
+// Format a one-line reasoning-effort/thinking indicator for the console log.
+// Returns "" when no thinking intent is present (caller skips empty lines).
+function formatThinkingLine(body, provider, model) {
+  const cfg = extractThinking(body);
+  if (!cfg) return "";
+  const effort = cfg.mode === "none" ? "off"
+    : cfg.mode === "auto" ? "auto"
+    : cfg.mode === "budget" ? `budget:${cfg.budget}`
+    : cfg.level;
+  const ts = new Date().toLocaleTimeString("en-US", { hour12: false });
+  return `${COLORS.cyan}[${ts}] 🧠 [THINK] ${provider} | ${model} | effort=${effort}${COLORS.reset}`;
+}
 
 /**
  * Core chat handler - shared between SSE and Worker
@@ -136,6 +150,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     delete translatedBody._toolNameMap;
     translatedBody.model = upstreamModel;
   }
+
+  // Log resolved reasoning effort/thinking for the upstream provider call.
+  const thinkLine = formatThinkingLine(translatedBody, provider, model);
+  if (thinkLine) console.log(thinkLine);
 
   // Dedupe duplicate built-in tools when equivalent MCP tools are present (Claude clients only).
   if (clientTool === "claude" && Array.isArray(translatedBody.tools)) {

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -239,7 +239,9 @@ function applyFormat(fmt, body, cfg, caps) {
       break;
     }
     case "kiro":
-      // Kiro thinking handled via system-tag injection in openai-to-kiro.js; no body field here.
+      // Handled natively by the translator (output_config.effort + thinking_mode
+      // content tag). applyThinking passthroughs kiro before stripAll — this case
+      // is unreachable but kept for completeness.
       break;
     default:
       break;
@@ -265,6 +267,12 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
   if (!cfg) return body;
 
   const fmt = resolveFormat(targetFormat, cleanModel, provider);
+  // Kiro owns its thinking wire-up natively in the translator: the
+  // `<thinking_mode>` content tag (on/off) + `output_config.effort` (depth).
+  // stripAll here would delete the translator-set output_config, so passthrough.
+  // Key on targetFormat (not fmt) — fmt resolves to a Claude thinking format via
+  // model caps even when the wire target is kiro.
+  if (targetFormat === "kiro") return body;
   stripAll(body);
   applyFormat(fmt, body, cfg, caps);
   return body;

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -40,8 +40,18 @@ export function parseSuffix(model) {
 export function extractThinking(body) {
   if (!body || typeof body !== "object") return null;
 
+  // Kiro nests { thinking, output_config } inside additionalModelRequestFields
+  // (the CodeWhisperer SDK envelope — see claude-to-kiro.js). Read those two
+  // fields from the envelope when present so a post-translation Kiro body
+  // extracts the same as a top-level shape. Pre-translation bodies (and every
+  // other target) lack the envelope, so `nested` stays `body` for them.
+  const amrf = body.additionalModelRequestFields;
+  const nested = amrf && typeof amrf === "object" && (amrf.output_config || amrf.thinking)
+    ? amrf
+    : body;
+
   // Claude output_config.effort (explicit) — priority over adaptive thinking
-  const oc = body.output_config?.effort;
+  const oc = nested.output_config?.effort;
   if (typeof oc === "string" && oc) {
     const e = oc.toLowerCase();
     if (e === "none" || e === "off") return { mode: "none" };
@@ -50,7 +60,7 @@ export function extractThinking(body) {
   }
 
   // Claude shape
-  const t = body.thinking;
+  const t = nested.thinking;
   if (t && typeof t === "object") {
     if (t.type === "disabled") return { mode: "none" };
     if (t.type === "adaptive" || t.type === "enabled") {

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -30,6 +30,7 @@ import {
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   resolveKiroEffort,
+  resolveKiroMaxTokens,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn,
 } from "../../config/kiroConstants.js";
@@ -371,7 +372,8 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   let messages = Array.isArray(body.messages) ? body.messages : [];
   const tools = Array.isArray(body.tools) ? body.tools : [];
   const clientProvidedTools = tools.length > 0;
-  const maxTokens = body.max_tokens || 32000;
+  // Honor client max_tokens, clamped to the model ceiling (Opus 4.8 = 128000).
+  const maxTokens = resolveKiroMaxTokens(body, resolveKiroModel(model).upstream);
   const temperature = body.temperature;
   const topP = body.top_p;
 

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -31,6 +31,8 @@ import {
   buildThinkingSystemPrefix,
   resolveKiroEffort,
   resolveKiroMaxTokens,
+  resolveKiroThinkingField,
+  useKiroThinkingField,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn,
 } from "../../config/kiroConstants.js";
@@ -419,9 +421,11 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   }
 
   // Prefix order: thinking_mode tag, timestamp marker, then agentic prompt.
+  // Reasoning on-signal: <thinking_mode> content tag by default, or (when
+  // KIRO_THINKING_FIELD=1) the native thinking payload field added below.
   const timestamp = new Date().toISOString();
   const prefixParts = [];
-  if (thinkingBudget !== null) prefixParts.push(buildThinkingSystemPrefix());
+  if (thinkingBudget !== null && !useKiroThinkingField()) prefixParts.push(buildThinkingSystemPrefix());
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
   finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
@@ -462,6 +466,12 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   if (thinkingBudget !== null) {
     const effort = resolveKiroEffort(body, upstreamModel);
     if (effort) payload.output_config = { effort };
+  }
+
+  // A/B (KIRO_THINKING_FIELD=1): native thinking payload field in place of the
+  // <thinking_mode> content tag, to test whether CodeWhisperer honors it.
+  if (thinkingBudget !== null && useKiroThinkingField()) {
+    payload.thinking = resolveKiroThinkingField(body, upstreamModel);
   }
 
   // Non-enumerable hint so the executor can route the upstream model id.

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -18,9 +18,9 @@
  *      tool_result whose tool_use_id has no matching tool_use back into the
  *      user text instead of leaving a dangling structured reference.
  *
- * It also handles the 9router-synthetic `-agentic` / `-thinking` suffixes and
- * the `<thinking_mode>enabled</thinking_mode>` reasoning trigger, matching
- * buildKiroPayload.
+ * It also handles the 9router-synthetic `-agentic` / `-thinking` suffixes.
+ * Reasoning depth + the adaptive `thinking` field ship nested inside
+ * `additionalModelRequestFields` (real Kiro IDE wire format).
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
@@ -28,11 +28,10 @@ import { v4 as uuidv4 } from "uuid";
 import {
   resolveKiroModel,
   resolveKiroThinkingBudget,
-  buildThinkingSystemPrefix,
   resolveKiroEffort,
-  resolveKiroMaxTokens,
   resolveKiroThinkingField,
-  useKiroThinkingField,
+  resolveKiroMaxTokens,
+  kiroThinkingFieldEnabled,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn,
 } from "../../config/kiroConstants.js";
@@ -374,13 +373,13 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   let messages = Array.isArray(body.messages) ? body.messages : [];
   const tools = Array.isArray(body.tools) ? body.tools : [];
   const clientProvidedTools = tools.length > 0;
-  // Honor client max_tokens, clamped to the model ceiling (Opus 4.8 = 128000).
-  const maxTokens = resolveKiroMaxTokens(body, resolveKiroModel(model).upstream);
-  const temperature = body.temperature;
-  const topP = body.top_p;
 
   const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
+  // Real Kiro sends no inferenceConfig — effort (nested in
+  // additionalModelRequestFields below) is the sole output knob, applied
+  // server-side by the gateway.
+  const effort = thinkingBudget !== null ? resolveKiroEffort(body, upstreamModel) : null;
 
   // Guard 1: no client tools → flatten all tool interactions to text.
   if (!clientProvidedTools) {
@@ -420,12 +419,10 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     if (systemText) finalContent = `${systemText}\n\n${finalContent}`;
   }
 
-  // Prefix order: thinking_mode tag, timestamp marker, then agentic prompt.
-  // Reasoning on-signal: <thinking_mode> content tag by default, or (when
-  // KIRO_THINKING_FIELD=1) the native thinking payload field added below.
+  // Prefix order: timestamp marker, then agentic prompt. Real Kiro signals
+  // reasoning only via the `thinking` payload field below — never a content tag.
   const timestamp = new Date().toISOString();
   const prefixParts = [];
-  if (thinkingBudget !== null && !useKiroThinkingField()) prefixParts.push(buildThinkingSystemPrefix());
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
   finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
@@ -454,25 +451,18 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
 
   if (profileArn) payload.profileArn = profileArn;
 
-  if (maxTokens || temperature !== undefined || topP !== undefined) {
-    payload.inferenceConfig = {};
-    if (maxTokens) payload.inferenceConfig.maxTokens = maxTokens;
-    if (temperature !== undefined) payload.inferenceConfig.temperature = temperature;
-    if (topP !== undefined) payload.inferenceConfig.topP = topP;
+  // Reasoning + output budget: real Kiro nests { thinking, output_config,
+  // max_tokens } inside additionalModelRequestFields — the only CodeWhisperer
+  // SDK input member that carries them. Top-level placement is silently dropped
+  // by the gateway, so effort never took effect before this nesting.
+  const amrf = {};
+  if (thinkingBudget !== null && kiroThinkingFieldEnabled()) {
+    amrf.thinking = resolveKiroThinkingField(body, upstreamModel);
   }
-
-  // Reasoning depth (official Kiro effort, per https://kiro.dev/docs/cli/chat/effort/).
-  // Gated on thinkingBudget so effort ships only when reasoning is enabled.
-  if (thinkingBudget !== null) {
-    const effort = resolveKiroEffort(body, upstreamModel);
-    if (effort) payload.output_config = { effort };
-  }
-
-  // A/B (KIRO_THINKING_FIELD=1): native thinking payload field in place of the
-  // <thinking_mode> content tag, to test whether CodeWhisperer honors it.
-  if (thinkingBudget !== null && useKiroThinkingField()) {
-    payload.thinking = resolveKiroThinkingField(body, upstreamModel);
-  }
+  if (effort) amrf.output_config = { effort };
+  const maxTokens = resolveKiroMaxTokens(effort, upstreamModel);
+  if (maxTokens) amrf.max_tokens = maxTokens;
+  if (Object.keys(amrf).length) payload.additionalModelRequestFields = amrf;
 
   // Non-enumerable hint so the executor can route the upstream model id.
   Object.defineProperty(payload, "_kiroUpstreamModel", {

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -29,6 +29,7 @@ import {
   resolveKiroModel,
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
+  resolveKiroEffort,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn,
 } from "../../config/kiroConstants.js";
@@ -418,7 +419,7 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   // Prefix order: thinking_mode tag, timestamp marker, then agentic prompt.
   const timestamp = new Date().toISOString();
   const prefixParts = [];
-  if (thinkingBudget !== null) prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
+  if (thinkingBudget !== null) prefixParts.push(buildThinkingSystemPrefix());
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
   finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
@@ -452,6 +453,13 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     if (maxTokens) payload.inferenceConfig.maxTokens = maxTokens;
     if (temperature !== undefined) payload.inferenceConfig.temperature = temperature;
     if (topP !== undefined) payload.inferenceConfig.topP = topP;
+  }
+
+  // Reasoning depth (official Kiro effort, per https://kiro.dev/docs/cli/chat/effort/).
+  // Gated on thinkingBudget so effort ships only when reasoning is enabled.
+  if (thinkingBudget !== null) {
+    const effort = resolveKiroEffort(body, upstreamModel);
+    if (effort) payload.output_config = { effort };
   }
 
   // Non-enumerable hint so the executor can route the upstream model id.

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -9,11 +9,10 @@ import { resolveSessionId } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
   resolveKiroThinkingBudget,
-  buildThinkingSystemPrefix,
   resolveKiroEffort,
-  resolveKiroMaxTokens,
   resolveKiroThinkingField,
-  useKiroThinkingField,
+  resolveKiroMaxTokens,
+  kiroThinkingFieldEnabled,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn
 } from "../../config/kiroConstants.js";
@@ -509,24 +508,22 @@ function convertMessages(messages, tools, model) {
  *    Kiro's 2-3 minute server timeout. The suffix is stripped before being
  *    sent upstream.
  *
- * 2. Thinking / reasoning. Kiro does not accept `thinking.type` or
- *    `reasoning_effort` natively. The only way to enable reasoning is to
- *    inject `<thinking_mode>enabled</thinking_mode>` into the user content
- *    sent upstream. Detection covers Anthropic-Beta header, Claude API
- *    `thinking`, OpenAI `reasoning_effort`, AMP/Cursor magic tags, and model
- *    name hints.
+ * 2. Thinking / reasoning. Reasoning depth + the adaptive `thinking` field
+ *    are nested inside `additionalModelRequestFields` (the only CodeWhisperer
+ *    SDK input member that carries them — matches the real Kiro IDE wire
+ *    format). Detection covers Anthropic-Beta header, Claude API `thinking`,
+ *    OpenAI `reasoning_effort`, AMP/Cursor magic tags, and model name hints.
  */
 export function openaiToKiroRequest(model, body, stream, credentials) {
   const messages = body.messages || [];
   const tools = body.tools || [];
-  const temperature = body.temperature;
-  const topP = body.top_p;
 
   const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
-  // Honor client max_tokens, clamped to the model's ceiling (Opus 4.8 = 128000).
-  // Was hardcoded to 32000, which silently capped Opus 4.8 at a quarter of its range.
-  const maxTokens = resolveKiroMaxTokens(body, upstreamModel);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
+  // Real Kiro sends no inferenceConfig — effort (nested in
+  // additionalModelRequestFields below) is the sole output knob, applied
+  // server-side by the gateway.
+  const effort = thinkingBudget !== null ? resolveKiroEffort(body, upstreamModel) : null;
 
   const { history, currentMessage } = convertMessages(messages, tools, upstreamModel);
 
@@ -553,14 +550,9 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   const timestamp = new Date().toISOString();
 
   // Build the system-prompt prefix that goes ABOVE the user message body.
-  // Order: thinking_mode tag first (so Kiro sees it before any user text),
-  // then context/timestamp marker, then optional agentic chunked-write prompt.
+  // Real Kiro signals reasoning only via the `thinking` payload field below —
+  // never a content tag — so the prefix is just context + optional agentic prompt.
   const prefixParts = [];
-  // Reasoning on-signal: the <thinking_mode> content tag by default, or (when
-  // KIRO_THINKING_FIELD=1) the native thinking payload field added below instead.
-  if (thinkingBudget !== null && !useKiroThinkingField()) {
-    prefixParts.push(buildThinkingSystemPrefix());
-  }
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) {
     prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
@@ -592,25 +584,18 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
     payload.profileArn = profileArn;
   }
 
-  if (maxTokens || temperature !== undefined || topP !== undefined) {
-    payload.inferenceConfig = {};
-    if (maxTokens) payload.inferenceConfig.maxTokens = maxTokens;
-    if (temperature !== undefined) payload.inferenceConfig.temperature = temperature;
-    if (topP !== undefined) payload.inferenceConfig.topP = topP;
+  // Reasoning + output budget: real Kiro nests { thinking, output_config,
+  // max_tokens } inside additionalModelRequestFields — the only CodeWhisperer
+  // SDK input member that carries them. Top-level placement is silently dropped
+  // by the gateway, so effort never took effect before this nesting.
+  const amrf = {};
+  if (thinkingBudget !== null && kiroThinkingFieldEnabled()) {
+    amrf.thinking = resolveKiroThinkingField(body, upstreamModel);
   }
-
-  // Reasoning depth (official Kiro effort, per https://kiro.dev/docs/cli/chat/effort/).
-  // Gated on thinkingBudget so effort ships only when reasoning is enabled.
-  if (thinkingBudget !== null) {
-    const effort = resolveKiroEffort(body, upstreamModel);
-    if (effort) payload.output_config = { effort };
-  }
-
-  // A/B (KIRO_THINKING_FIELD=1): native thinking payload field in place of the
-  // <thinking_mode> content tag, to test whether CodeWhisperer honors it.
-  if (thinkingBudget !== null && useKiroThinkingField()) {
-    payload.thinking = resolveKiroThinkingField(body, upstreamModel);
-  }
+  if (effort) amrf.output_config = { effort };
+  const maxTokens = resolveKiroMaxTokens(effort, upstreamModel);
+  if (maxTokens) amrf.max_tokens = maxTokens;
+  if (Object.keys(amrf).length) payload.additionalModelRequestFields = amrf;
 
   // Tag payload so the executor can route the upstream model id correctly.
   Object.defineProperty(payload, "_kiroUpstreamModel", {

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -11,6 +11,7 @@ import {
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   resolveKiroEffort,
+  resolveKiroMaxTokens,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn
 } from "../../config/kiroConstants.js";
@@ -516,11 +517,13 @@ function convertMessages(messages, tools, model) {
 export function openaiToKiroRequest(model, body, stream, credentials) {
   const messages = body.messages || [];
   const tools = body.tools || [];
-  const maxTokens = 32000;
   const temperature = body.temperature;
   const topP = body.top_p;
 
   const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
+  // Honor client max_tokens, clamped to the model's ceiling (Opus 4.8 = 128000).
+  // Was hardcoded to 32000, which silently capped Opus 4.8 at a quarter of its range.
+  const maxTokens = resolveKiroMaxTokens(body, upstreamModel);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
 
   const { history, currentMessage } = convertMessages(messages, tools, upstreamModel);

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -12,6 +12,8 @@ import {
   buildThinkingSystemPrefix,
   resolveKiroEffort,
   resolveKiroMaxTokens,
+  resolveKiroThinkingField,
+  useKiroThinkingField,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn
 } from "../../config/kiroConstants.js";
@@ -554,7 +556,9 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   // Order: thinking_mode tag first (so Kiro sees it before any user text),
   // then context/timestamp marker, then optional agentic chunked-write prompt.
   const prefixParts = [];
-  if (thinkingBudget !== null) {
+  // Reasoning on-signal: the <thinking_mode> content tag by default, or (when
+  // KIRO_THINKING_FIELD=1) the native thinking payload field added below instead.
+  if (thinkingBudget !== null && !useKiroThinkingField()) {
     prefixParts.push(buildThinkingSystemPrefix());
   }
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
@@ -600,6 +604,12 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   if (thinkingBudget !== null) {
     const effort = resolveKiroEffort(body, upstreamModel);
     if (effort) payload.output_config = { effort };
+  }
+
+  // A/B (KIRO_THINKING_FIELD=1): native thinking payload field in place of the
+  // <thinking_mode> content tag, to test whether CodeWhisperer honors it.
+  if (thinkingBudget !== null && useKiroThinkingField()) {
+    payload.thinking = resolveKiroThinkingField(body, upstreamModel);
   }
 
   // Tag payload so the executor can route the upstream model id correctly.

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -10,6 +10,7 @@ import {
   resolveKiroModel,
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
+  resolveKiroEffort,
   KIRO_AGENTIC_SYSTEM_PROMPT,
   resolveDefaultProfileArn
 } from "../../config/kiroConstants.js";
@@ -551,7 +552,7 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   // then context/timestamp marker, then optional agentic chunked-write prompt.
   const prefixParts = [];
   if (thinkingBudget !== null) {
-    prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
+    prefixParts.push(buildThinkingSystemPrefix());
   }
   prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) {
@@ -589,6 +590,13 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
     if (maxTokens) payload.inferenceConfig.maxTokens = maxTokens;
     if (temperature !== undefined) payload.inferenceConfig.temperature = temperature;
     if (topP !== undefined) payload.inferenceConfig.topP = topP;
+  }
+
+  // Reasoning depth (official Kiro effort, per https://kiro.dev/docs/cli/chat/effort/).
+  // Gated on thinkingBudget so effort ships only when reasoning is enabled.
+  if (thinkingBudget !== null) {
+    const effort = resolveKiroEffort(body, upstreamModel);
+    if (effort) payload.output_config = { effort };
   }
 
   // Tag payload so the executor can route the upstream model id correctly.

--- a/tests/translator/__snapshots__/golden-request.test.js.snap
+++ b/tests/translator/__snapshots__/golden-request.test.js.snap
@@ -308,10 +308,6 @@ What's in this image?",
       },
     ],
   },
-  "inferenceConfig": {
-    "maxTokens": 32000,
-    "temperature": 0.7,
-  },
   "profileArn": "arn:aws:codewhisperer:us-east-1:638616132270:profile/AAAACCCCXXXX",
 }
 `;

--- a/tests/translator/bugs-kiro.test.js
+++ b/tests/translator/bugs-kiro.test.js
@@ -22,13 +22,6 @@ describe("OpenAI → Kiro", () => {
     ).not.toThrow();
   });
 
-  // openai-to-kiro.js:309 — maxTokens hardcoded to 32000, ignores body.max_tokens
-  // KNOWN BUG
-  it.fails("respects client max_tokens", () => {
-    const out = O2K({ max_tokens: 100, messages: [{ role: "user", content: "hi" }] });
-    expect(out.inferenceConfig?.maxTokens, "client max_tokens ignored").toBe(100);
-  });
-
   // openai-to-kiro.js:132-134 — remote http image becomes "[Image: url]" text (lost)
   // KNOWN BUG
   it.fails("remote image url is preserved as an image, not text", () => {

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -63,16 +63,37 @@ describe("Claude → Kiro (direct route)", () => {
     expect(out.conversationState.currentMessage.userInputMessage.content).toContain(
       "<thinking_mode>enabled</thinking_mode>"
     );
+    // Legacy <max_thinking_length> tag is gone — depth now rides output_config.effort.
+    expect(out.conversationState.currentMessage.userInputMessage.content).not.toContain(
+      "<max_thinking_length>"
+    );
+    // Effort ships as a model-level param when thinking is on.
+    expect(out.output_config?.effort).toBe("high");
   });
 
-  it("maps output_config.effort high to Kiro max_thinking_length 24576", () => {
+  it("maps client reasoning_effort to output_config.effort", () => {
+    const out = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.KIRO,
+      "claude-opus-4-8-thinking",
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "max" },
+      true,
+      null,
+      "kiro"
+    );
+    expect(out.output_config?.effort).toBe("max");
+  });
+
+  it("maps output_config.effort high through to the Kiro payload", () => {
     const out = C2K({
       output_config: { effort: "high" },
       messages: [{ role: "user", content: "think with adaptive effort" }],
     });
 
-    expect(out.conversationState.currentMessage.userInputMessage.content).toContain(
-      "<max_thinking_length>24576</max_thinking_length>"
+    // Effort rides output_config on the payload (not a max_thinking_length tag).
+    expect(out.output_config?.effort).toBe("high");
+    expect(out.conversationState.currentMessage.userInputMessage.content).not.toContain(
+      "<max_thinking_length>"
     );
   });
 });

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -50,7 +50,7 @@ describe("Claude → Kiro (direct route)", () => {
     expect(cur.userInputMessageContext?.toolResults?.length ?? 0).toBe(0);
   });
 
-  it("injects thinking_mode tag when model implies thinking", () => {
+  it("nests adaptive thinking field when model implies thinking (no tag)", () => {
     const out = translateRequest(
       FORMATS.CLAUDE,
       FORMATS.KIRO,
@@ -60,18 +60,22 @@ describe("Claude → Kiro (direct route)", () => {
       null,
       "kiro"
     );
-    expect(out.conversationState.currentMessage.userInputMessage.content).toContain(
-      "<thinking_mode>enabled</thinking_mode>"
+    // Real Kiro signals reasoning via the nested thinking field, never a content tag.
+    expect(out.conversationState.currentMessage.userInputMessage.content).not.toContain(
+      "<thinking_mode"
     );
-    // Legacy <max_thinking_length> tag is gone — depth now rides output_config.effort.
     expect(out.conversationState.currentMessage.userInputMessage.content).not.toContain(
       "<max_thinking_length>"
     );
-    // Effort ships as a model-level param when thinking is on.
-    expect(out.output_config?.effort).toBe("high");
+    expect(out.thinking).toBeUndefined();
+    expect(out.additionalModelRequestFields?.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    expect(out.additionalModelRequestFields?.output_config?.effort).toBe("high");
+    // sonnet-4.5 has no max_tokens in its schema → field omitted.
+    expect(out.additionalModelRequestFields?.max_tokens).toBeUndefined();
+    expect(out.inferenceConfig).toBeUndefined();
   });
 
-  it("maps client reasoning_effort to output_config.effort", () => {
+  it("maps client reasoning_effort to nested output_config.effort + max_tokens", () => {
     const out = translateRequest(
       FORMATS.CLAUDE,
       FORMATS.KIRO,
@@ -81,17 +85,19 @@ describe("Claude → Kiro (direct route)", () => {
       null,
       "kiro"
     );
-    expect(out.output_config?.effort).toBe("max");
+    expect(out.additionalModelRequestFields?.output_config?.effort).toBe("max");
+    expect(out.additionalModelRequestFields?.max_tokens).toBe(128000);
   });
 
-  it("maps output_config.effort high through to the Kiro payload", () => {
+  it("maps output_config.effort high through to the nested Kiro payload", () => {
     const out = C2K({
       output_config: { effort: "high" },
       messages: [{ role: "user", content: "think with adaptive effort" }],
     });
 
-    // Effort rides output_config on the payload (not a max_thinking_length tag).
-    expect(out.output_config?.effort).toBe("high");
+    // Effort rides nested output_config (not a tag, not top-level).
+    expect(out.additionalModelRequestFields?.output_config?.effort).toBe("high");
+    expect(out.output_config).toBeUndefined();
     expect(out.conversationState.currentMessage.userInputMessage.content).not.toContain(
       "<max_thinking_length>"
     );

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -52,6 +52,24 @@ describe("extractThinking", () => {
   it("no intent → null", () => {
     expect(extractThinking({ messages: [] })).toBeNull();
   });
+  it("kiro envelope: output_config.effort nested in additionalModelRequestFields", () => {
+    expect(extractThinking({
+      additionalModelRequestFields: { output_config: { effort: "max" }, thinking: { type: "adaptive", display: "summarized" } },
+    })).toEqual({ mode: "level", level: "max" });
+  });
+  it("kiro envelope: adaptive thinking (no output_config) → auto", () => {
+    expect(extractThinking({
+      additionalModelRequestFields: { thinking: { type: "adaptive", display: "summarized" } },
+    })).toEqual({ mode: "auto" });
+  });
+  it("kiro envelope: disabled thinking → none", () => {
+    expect(extractThinking({
+      additionalModelRequestFields: { thinking: { type: "disabled" } },
+    })).toEqual({ mode: "none" });
+  });
+  it("empty additionalModelRequestFields → falls through to top-level (null)", () => {
+    expect(extractThinking({ additionalModelRequestFields: {}, messages: [] })).toBeNull();
+  });
 });
 
 describe("applyThinking per provider format", () => {

--- a/tests/unit/kiro-effort.test.js
+++ b/tests/unit/kiro-effort.test.js
@@ -1,7 +1,37 @@
 // Unit tests for resolveKiroEffort — maps client thinking intent to the
 // output_config.effort level Kiro accepts natively (per official docs).
 import { describe, it, expect } from "vitest";
-import { resolveKiroEffort } from "../../open-sse/config/kiroConstants.js";
+import { resolveKiroEffort, resolveKiroMaxTokens } from "../../open-sse/config/kiroConstants.js";
+
+describe("resolveKiroMaxTokens", () => {
+  it("honors client max_tokens within the model cap", () => {
+    expect(resolveKiroMaxTokens({ max_tokens: 64000 }, "claude-opus-4-8")).toBe(64000);
+  });
+
+  it("clamps to the model ceiling (Opus 4.8 = 128000)", () => {
+    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-opus-4-8")).toBe(128000);
+  });
+
+  it("Opus 4.7 / 4.6 / Sonnet 4.6 cap at 64000", () => {
+    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-opus-4-7")).toBe(64000);
+    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-opus-4-6")).toBe(64000);
+    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-sonnet-4-6")).toBe(64000);
+  });
+
+  it("defaults to the model cap when client sends no max_tokens", () => {
+    expect(resolveKiroMaxTokens({}, "claude-opus-4-8")).toBe(128000);
+    expect(resolveKiroMaxTokens({}, "claude-opus-4-7")).toBe(64000);
+  });
+
+  it("unknown models keep the conservative 32000 default", () => {
+    expect(resolveKiroMaxTokens({}, "some-other-model")).toBe(32000);
+    expect(resolveKiroMaxTokens({ max_tokens: 999999 }, "some-other-model")).toBe(32000);
+  });
+
+  it("floors at 1024", () => {
+    expect(resolveKiroMaxTokens({ max_tokens: 10 }, "claude-opus-4-8")).toBe(1024);
+  });
+});
 
 describe("resolveKiroEffort", () => {
   it("passes reasoning_effort levels through", () => {

--- a/tests/unit/kiro-effort.test.js
+++ b/tests/unit/kiro-effort.test.js
@@ -1,0 +1,40 @@
+// Unit tests for resolveKiroEffort — maps client thinking intent to the
+// output_config.effort level Kiro accepts natively (per official docs).
+import { describe, it, expect } from "vitest";
+import { resolveKiroEffort } from "../../open-sse/config/kiroConstants.js";
+
+describe("resolveKiroEffort", () => {
+  it("passes reasoning_effort levels through", () => {
+    expect(resolveKiroEffort({ reasoning_effort: "low" })).toBe("low");
+    expect(resolveKiroEffort({ reasoning_effort: "medium" })).toBe("medium");
+    expect(resolveKiroEffort({ reasoning_effort: "high" })).toBe("high");
+    expect(resolveKiroEffort({ reasoning_effort: "max" })).toBe("max");
+  });
+
+  it("xhigh clamps to high on Opus 4.6 / Sonnet 4.6 (unsupported)", () => {
+    expect(resolveKiroEffort({ reasoning_effort: "xhigh" }, "claude-opus-4-6")).toBe("high");
+    expect(resolveKiroEffort({ reasoning_effort: "xhigh" }, "claude-sonnet-4-6")).toBe("high");
+  });
+
+  it("xhigh passes through on Opus 4.7 / 4.8", () => {
+    expect(resolveKiroEffort({ reasoning_effort: "xhigh" }, "claude-opus-4-7")).toBe("xhigh");
+    expect(resolveKiroEffort({ reasoning_effort: "xhigh" }, "claude-opus-4-8")).toBe("xhigh");
+  });
+
+  it("maps Claude thinking.budget_tokens via budgetToLevel", () => {
+    // 20000 tokens → "high" (≤ 28672)
+    expect(resolveKiroEffort({ thinking: { type: "enabled", budget_tokens: 20000 } })).toBe("high");
+    // 4096 tokens → "low"
+    expect(resolveKiroEffort({ thinking: { type: "enabled", budget_tokens: 4096 } })).toBe("low");
+  });
+
+  it("returns null when thinking is explicitly disabled", () => {
+    expect(resolveKiroEffort({ reasoning_effort: "none" })).toBeNull();
+    expect(resolveKiroEffort({ thinking: { type: "disabled" } })).toBeNull();
+  });
+
+  it("auto / no intent → high (preserves default-on)", () => {
+    expect(resolveKiroEffort({ reasoning_effort: "auto" })).toBe("high");
+    expect(resolveKiroEffort({ messages: [] })).toBe("high");
+  });
+});

--- a/tests/unit/kiro-effort.test.js
+++ b/tests/unit/kiro-effort.test.js
@@ -1,35 +1,35 @@
-// Unit tests for resolveKiroEffort — maps client thinking intent to the
-// output_config.effort level Kiro accepts natively (per official docs).
+// Unit tests for resolveKiroEffort + resolveKiroMaxTokens — effort is the
+// output_config.effort level; max_tokens is its effort-derived sibling inside
+// additionalModelRequestFields (per the live additionalModelRequestFieldsSchema).
 import { describe, it, expect } from "vitest";
 import { resolveKiroEffort, resolveKiroMaxTokens } from "../../open-sse/config/kiroConstants.js";
 
 describe("resolveKiroMaxTokens", () => {
-  it("honors client max_tokens within the model cap", () => {
-    expect(resolveKiroMaxTokens({ max_tokens: 64000 }, "claude-opus-4-8")).toBe(64000);
+  it("maps effort levels to clean buckets", () => {
+    expect(resolveKiroMaxTokens("low", "claude-opus-4-8")).toBe(16000);
+    expect(resolveKiroMaxTokens("medium", "claude-opus-4-8")).toBe(32000);
+    expect(resolveKiroMaxTokens("high", "claude-opus-4-8")).toBe(64000);
+    expect(resolveKiroMaxTokens("xhigh", "claude-opus-4-8")).toBe(96000);
+    expect(resolveKiroMaxTokens("max", "claude-opus-4-8")).toBe(128000);
   });
 
-  it("clamps to the model ceiling (Opus 4.8 = 128000)", () => {
-    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-opus-4-8")).toBe(128000);
+  it("clamps to the per-model ceiling (opus-4-6 / sonnet-4-6 = 64000)", () => {
+    expect(resolveKiroMaxTokens("max", "claude-opus-4-6")).toBe(64000);
+    expect(resolveKiroMaxTokens("max", "claude-sonnet-4-6")).toBe(64000);
+    expect(resolveKiroMaxTokens("xhigh", "claude-opus-4-6")).toBe(64000);
   });
 
-  it("Opus 4.7 / 4.6 / Sonnet 4.6 cap at 64000", () => {
-    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-opus-4-7")).toBe(64000);
-    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-opus-4-6")).toBe(64000);
-    expect(resolveKiroMaxTokens({ max_tokens: 200000 }, "claude-sonnet-4-6")).toBe(64000);
+  it("opus-4-7 ceiling is 128000 on the live gateway (docs table is stale)", () => {
+    expect(resolveKiroMaxTokens("max", "claude-opus-4-7")).toBe(128000);
   });
 
-  it("defaults to the model cap when client sends no max_tokens", () => {
-    expect(resolveKiroMaxTokens({}, "claude-opus-4-8")).toBe(128000);
-    expect(resolveKiroMaxTokens({}, "claude-opus-4-7")).toBe(64000);
+  it("returns null when effort is unset (thinking off → omit max_tokens)", () => {
+    expect(resolveKiroMaxTokens(null, "claude-opus-4-8")).toBeNull();
   });
 
-  it("unknown models keep the conservative 32000 default", () => {
-    expect(resolveKiroMaxTokens({}, "some-other-model")).toBe(32000);
-    expect(resolveKiroMaxTokens({ max_tokens: 999999 }, "some-other-model")).toBe(32000);
-  });
-
-  it("floors at 1024", () => {
-    expect(resolveKiroMaxTokens({ max_tokens: 10 }, "claude-opus-4-8")).toBe(1024);
+  it("returns null for models without a max_tokens schema (omit the field)", () => {
+    expect(resolveKiroMaxTokens("high", "some-other-model")).toBeNull();
+    expect(resolveKiroMaxTokens("max", "deepseek-3.2")).toBeNull();
   });
 });
 

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -285,7 +285,7 @@ describe("openaiToKiroRequest", () => {
   });
 
   describe("thinking budget", () => {
-    it("maps reasoning_effort low to max_thinking_length 1024", () => {
+    it("maps reasoning_effort low to output_config.effort low (no max_thinking_length tag)", () => {
       const body = {
         reasoning_effort: "low",
         messages: [{ role: "user", content: "Think lightly" }]
@@ -293,10 +293,11 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(contentOf(result)).toContain("<max_thinking_length>1024</max_thinking_length>");
+      expect(result.output_config?.effort).toBe("low");
+      expect(contentOf(result)).not.toContain("<max_thinking_length>");
     });
 
-    it("maps reasoning_effort high to max_thinking_length 24576", () => {
+    it("maps reasoning_effort high to output_config.effort high", () => {
       const body = {
         reasoning_effort: "high",
         messages: [{ role: "user", content: "Think deeply" }]
@@ -304,10 +305,10 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(result.output_config?.effort).toBe("high");
     });
 
-    it("clamps reasoning_effort max to Kiro max_thinking_length 32000", () => {
+    it("passes reasoning_effort max through to output_config.effort", () => {
       const body = {
         reasoning_effort: "max",
         messages: [{ role: "user", content: "Think as much as possible" }]
@@ -315,10 +316,10 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(contentOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
+      expect(result.output_config?.effort).toBe("max");
     });
 
-    it("clamps OpenAI Responses reasoning.effort xhigh to max_thinking_length 32000", () => {
+    it("clamps xhigh to high on Sonnet 4.6 (no xhigh support)", () => {
       const body = {
         reasoning: { effort: "xhigh" },
         messages: [{ role: "user", content: "Think extra deeply" }]
@@ -326,10 +327,10 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(contentOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
+      expect(result.output_config?.effort).toBe("high");
     });
 
-    it("uses Claude thinking.budget_tokens as max_thinking_length", () => {
+    it("maps Claude thinking.budget_tokens to an effort level via budgetToLevel", () => {
       const body = {
         thinking: { type: "enabled", budget_tokens: 4096 },
         messages: [{ role: "user", content: "Use a fixed budget" }]
@@ -337,17 +338,18 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(contentOf(result)).toContain("<max_thinking_length>4096</max_thinking_length>");
+      // 4096 tokens → "low"
+      expect(result.output_config?.effort).toBe("low");
     });
 
-    it("uses the default budget for synthetic -thinking models with no explicit config", () => {
+    it("defaults to effort high for synthetic -thinking models with no explicit config", () => {
       const body = {
         messages: [{ role: "user", content: "Think by model suffix" }]
       };
 
       const result = openaiToKiroRequest("claude-sonnet-4.6-thinking", body, true, {});
 
-      expect(contentOf(result)).toContain("<max_thinking_length>16000</max_thinking_length>");
+      expect(result.output_config?.effort).toBe("high");
     });
 
     it("does not inject thinking prefix for reasoning_effort none", () => {

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -6,7 +6,7 @@
  *  - Image forwarding fix: images in currentMessage must be included in payload
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { openaiToKiroRequest } from "../../open-sse/translator/request/openai-to-kiro.js";
 
 const contentOf = (result) =>
@@ -362,6 +362,52 @@ describe("openaiToKiroRequest", () => {
 
       expect(contentOf(result)).not.toContain("<thinking_mode>enabled</thinking_mode>");
       expect(contentOf(result)).not.toContain("<max_thinking_length>");
+    });
+  });
+
+  describe("KIRO_THINKING_FIELD toggle", () => {
+    // Save/restore the env flag so the A/B toggle doesn't leak across tests.
+    const prev = process.env.KIRO_THINKING_FIELD;
+    afterEach(() => {
+      if (prev === undefined) delete process.env.KIRO_THINKING_FIELD;
+      else process.env.KIRO_THINKING_FIELD = prev;
+    });
+
+    it("off (default): uses the <thinking_mode> tag, no thinking payload field", () => {
+      delete process.env.KIRO_THINKING_FIELD;
+      const result = openaiToKiroRequest(
+        "claude-opus-4-8",
+        { reasoning_effort: "max", messages: [{ role: "user", content: "think" }] },
+        true, {}
+      );
+      expect(contentOf(result)).toContain("<thinking_mode>enabled</thinking_mode>");
+      expect(result.thinking).toBeUndefined();
+      expect(result.output_config?.effort).toBe("max");
+    });
+
+    it("on: swaps the tag for a native thinking payload field", () => {
+      process.env.KIRO_THINKING_FIELD = "1";
+      const result = openaiToKiroRequest(
+        "claude-opus-4-8",
+        { reasoning_effort: "max", messages: [{ role: "user", content: "think" }] },
+        true, {}
+      );
+      // Tag gone from content, native field present alongside output_config.
+      expect(contentOf(result)).not.toContain("<thinking_mode>");
+      expect(result.thinking).toEqual({ type: "adaptive", display: "summarized" });
+      expect(result.output_config?.effort).toBe("max");
+    });
+
+    it("on + disabled: thinking field type is disabled, tag still absent", () => {
+      process.env.KIRO_THINKING_FIELD = "1";
+      const result = openaiToKiroRequest(
+        "claude-opus-4-8",
+        { reasoning_effort: "none", messages: [{ role: "user", content: "no think" }] },
+        true, {}
+      );
+      // reasoning_effort:none → thinkingBudget null → neither tag nor field ship.
+      expect(contentOf(result)).not.toContain("<thinking_mode>");
+      expect(result.thinking).toBeUndefined();
     });
   });
 });

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -285,7 +285,12 @@ describe("openaiToKiroRequest", () => {
   });
 
   describe("thinking budget", () => {
-    it("maps reasoning_effort low to output_config.effort low (no max_thinking_length tag)", () => {
+    // Real Kiro nests { thinking, output_config, max_tokens } inside
+    // additionalModelRequestFields; there is no top-level output_config, no
+    // inferenceConfig, and no <thinking_mode> tag.
+    const amrf = (result) => result.additionalModelRequestFields;
+
+    it("maps reasoning_effort low to nested output_config.effort low + max_tokens bucket", () => {
       const body = {
         reasoning_effort: "low",
         messages: [{ role: "user", content: "Think lightly" }]
@@ -293,121 +298,127 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(result.output_config?.effort).toBe("low");
-      expect(contentOf(result)).not.toContain("<max_thinking_length>");
+      expect(amrf(result)?.output_config?.effort).toBe("low");
+      expect(amrf(result)?.max_tokens).toBe(16000);
+      expect(amrf(result)?.thinking).toEqual({ type: "adaptive", display: "summarized" });
+      expect(result.output_config).toBeUndefined();
+      expect(result.inferenceConfig).toBeUndefined();
+      expect(contentOf(result)).not.toContain("<thinking_mode");
     });
 
-    it("maps reasoning_effort high to output_config.effort high", () => {
-      const body = {
-        reasoning_effort: "high",
-        messages: [{ role: "user", content: "Think deeply" }]
-      };
-
-      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
-
-      expect(result.output_config?.effort).toBe("high");
+    it("maps reasoning_effort high to nested output_config.effort high", () => {
+      const result = openaiToKiroRequest(
+        "claude-sonnet-4.6",
+        { reasoning_effort: "high", messages: [{ role: "user", content: "Think deeply" }] },
+        true, {}
+      );
+      expect(amrf(result)?.output_config?.effort).toBe("high");
+      expect(amrf(result)?.max_tokens).toBe(64000);
     });
 
-    it("passes reasoning_effort max through to output_config.effort", () => {
-      const body = {
-        reasoning_effort: "max",
-        messages: [{ role: "user", content: "Think as much as possible" }]
-      };
+    it("passes reasoning_effort max through; max_tokens clamps to the model ceiling", () => {
+      const result = openaiToKiroRequest(
+        "claude-sonnet-4.6",
+        { reasoning_effort: "max", messages: [{ role: "user", content: "Think as much as possible" }] },
+        true, {}
+      );
+      expect(amrf(result)?.output_config?.effort).toBe("max");
+      // Sonnet 4.6 ceiling = 64000, so max clamps down from the 128000 bucket.
+      expect(amrf(result)?.max_tokens).toBe(64000);
+    });
 
-      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
-
-      expect(result.output_config?.effort).toBe("max");
+    it("Opus 4.8 keeps the full 128000 bucket at max_tokens max", () => {
+      const result = openaiToKiroRequest(
+        "claude-opus-4-8",
+        { reasoning_effort: "max", messages: [{ role: "user", content: "max out" }] },
+        true, {}
+      );
+      expect(amrf(result)?.max_tokens).toBe(128000);
     });
 
     it("clamps xhigh to high on Sonnet 4.6 (no xhigh support)", () => {
-      const body = {
-        reasoning: { effort: "xhigh" },
-        messages: [{ role: "user", content: "Think extra deeply" }]
-      };
-
-      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
-
-      expect(result.output_config?.effort).toBe("high");
+      const result = openaiToKiroRequest(
+        "claude-sonnet-4.6",
+        { reasoning: { effort: "xhigh" }, messages: [{ role: "user", content: "Think extra deeply" }] },
+        true, {}
+      );
+      expect(amrf(result)?.output_config?.effort).toBe("high");
     });
 
     it("maps Claude thinking.budget_tokens to an effort level via budgetToLevel", () => {
-      const body = {
-        thinking: { type: "enabled", budget_tokens: 4096 },
-        messages: [{ role: "user", content: "Use a fixed budget" }]
-      };
-
-      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
-
+      const result = openaiToKiroRequest(
+        "claude-sonnet-4.6",
+        { thinking: { type: "enabled", budget_tokens: 4096 }, messages: [{ role: "user", content: "Use a fixed budget" }] },
+        true, {}
+      );
       // 4096 tokens → "low"
-      expect(result.output_config?.effort).toBe("low");
+      expect(amrf(result)?.output_config?.effort).toBe("low");
     });
 
     it("defaults to effort high for synthetic -thinking models with no explicit config", () => {
-      const body = {
-        messages: [{ role: "user", content: "Think by model suffix" }]
-      };
-
-      const result = openaiToKiroRequest("claude-sonnet-4.6-thinking", body, true, {});
-
-      expect(result.output_config?.effort).toBe("high");
+      const result = openaiToKiroRequest(
+        "claude-sonnet-4.6-thinking",
+        { messages: [{ role: "user", content: "Think by model suffix" }] },
+        true, {}
+      );
+      expect(amrf(result)?.output_config?.effort).toBe("high");
     });
 
     it("does not inject thinking prefix for reasoning_effort none", () => {
-      const body = {
-        reasoning_effort: "none",
-        messages: [{ role: "user", content: "Do not think" }]
-      };
-
-      const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
-
-      expect(contentOf(result)).not.toContain("<thinking_mode>enabled</thinking_mode>");
+      const result = openaiToKiroRequest(
+        "claude-sonnet-4.6",
+        { reasoning_effort: "none", messages: [{ role: "user", content: "Do not think" }] },
+        true, {}
+      );
+      expect(contentOf(result)).not.toContain("<thinking_mode");
       expect(contentOf(result)).not.toContain("<max_thinking_length>");
+      // effort null → no max_tokens, no additionalModelRequestFields at all
+      expect(amrf(result)).toBeUndefined();
     });
   });
 
   describe("KIRO_THINKING_FIELD toggle", () => {
-    // Save/restore the env flag so the A/B toggle doesn't leak across tests.
+    // Save/restore the env flag so it doesn't leak across tests.
     const prev = process.env.KIRO_THINKING_FIELD;
     afterEach(() => {
       if (prev === undefined) delete process.env.KIRO_THINKING_FIELD;
       else process.env.KIRO_THINKING_FIELD = prev;
     });
 
-    it("off (default): uses the <thinking_mode> tag, no thinking payload field", () => {
+    it("default (unset): adaptive thinking field nests inside additionalModelRequestFields", () => {
       delete process.env.KIRO_THINKING_FIELD;
       const result = openaiToKiroRequest(
         "claude-opus-4-8",
         { reasoning_effort: "max", messages: [{ role: "user", content: "think" }] },
         true, {}
       );
-      expect(contentOf(result)).toContain("<thinking_mode>enabled</thinking_mode>");
+      expect(contentOf(result)).not.toContain("<thinking_mode");
       expect(result.thinking).toBeUndefined();
-      expect(result.output_config?.effort).toBe("max");
+      expect(result.additionalModelRequestFields?.thinking).toEqual({ type: "adaptive", display: "summarized" });
+      expect(result.additionalModelRequestFields?.output_config?.effort).toBe("max");
+      expect(result.inferenceConfig).toBeUndefined();
     });
 
-    it("on: swaps the tag for a native thinking payload field", () => {
-      process.env.KIRO_THINKING_FIELD = "1";
+    it("=0: suppresses the adaptive thinking field; effort still ships", () => {
+      process.env.KIRO_THINKING_FIELD = "0";
       const result = openaiToKiroRequest(
         "claude-opus-4-8",
         { reasoning_effort: "max", messages: [{ role: "user", content: "think" }] },
         true, {}
       );
-      // Tag gone from content, native field present alongside output_config.
-      expect(contentOf(result)).not.toContain("<thinking_mode>");
-      expect(result.thinking).toEqual({ type: "adaptive", display: "summarized" });
-      expect(result.output_config?.effort).toBe("max");
+      expect(result.additionalModelRequestFields?.thinking).toBeUndefined();
+      expect(result.additionalModelRequestFields?.output_config?.effort).toBe("max");
     });
 
-    it("on + disabled: thinking field type is disabled, tag still absent", () => {
-      process.env.KIRO_THINKING_FIELD = "1";
+    it("disabled intent: no additionalModelRequestFields at all", () => {
+      delete process.env.KIRO_THINKING_FIELD;
       const result = openaiToKiroRequest(
         "claude-opus-4-8",
         { reasoning_effort: "none", messages: [{ role: "user", content: "no think" }] },
         true, {}
       );
-      // reasoning_effort:none → thinkingBudget null → neither tag nor field ship.
-      expect(contentOf(result)).not.toContain("<thinking_mode>");
-      expect(result.thinking).toBeUndefined();
+      expect(contentOf(result)).not.toContain("<thinking_mode");
+      expect(result.additionalModelRequestFields).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

The Kiro request path controlled reasoning with a `<thinking_mode>enabled</thinking_mode>` system-prompt tag and, in later iterations, an `output_config.effort` field placed at the **payload top level**. Reverse-engineering the real Kiro clients showed both are wrong: the CodeWhisperer `GenerateAssistantResponse` request carries reasoning fields **only inside `additionalModelRequestFields`**, and each model's schema is `additionalProperties: false` — so a top-level `output_config` is silently dropped by the gateway. Effort never actually took effect.

This PR makes 9router emit the exact wire shape the real Kiro IDE and Kiro CLI send.

## How this was verified (reverse engineering)

Two independent sources, cross-checked:

**Kiro IDE** (`kiro.kiro-agent/dist/extension.js`) — the request builder sends exactly:
```js
new GenerateAssistantResponseCommand({
  conversationState,
  profileArn,
  additionalModelRequestFields: {          // built by fn `Er`
    thinking:      { type: "adaptive", display: "summarized" },
    output_config: { effort }
  }
})
```

**Kiro CLI** (`kiro-cli.exe`, a Rust binary) — same shape, plus `agentMode`. Its `chat.modelDefaults` config (from `~/.kiro/settings/cli.json`, documented at [kiro.dev/docs/cli/chat/effort](https://kiro.dev/docs/cli/chat/effort/)) also carries a `max_tokens`, validated against the model schema and shipped as a **third sibling** inside `additionalModelRequestFields`.

**Zero hits in either binary** for `inferenceConfig`, `textInferenceConfig`, `max_thinking_length`, `thinking_budget`, or `reasoning_effort` — confirming those forms are not part of the wire protocol.

**Live schema** captured via `kiro-cli chat --list-models` with `KIRO_LOG_LEVEL=trace`. For Claude models the `additionalModelRequestFieldsSchema` is exactly three properties, `additionalProperties: false`:
```json
{ "type": "object", "additionalProperties": false, "properties": {
  "thinking":      { "required": ["type"], "properties": {
                     "type":    { "enum": ["adaptive","disabled"] },
                     "display": { "enum": ["summarized","omitted"] } } },
  "output_config": { "properties": { "effort": {
                     "enum": ["low","medium","high","xhigh","max"], "default": "high" } } },
  "max_tokens":    { "type": "integer", "minimum": 1024, "maximum": <per-model> }
} }
```
Per-model `max_tokens.maximum`: **opus-4.7 / opus-4.8 = 128000**, opus-4.6 / sonnet-4.6 = 64000. (The kiro.dev docs table is stale — it lists 64000 for 4.7; the live gateway returns 128000.) Non-Claude models expose none of these fields.

## Changes

- **`open-sse/translator/request/openai-to-kiro.js`** + **`claude-to-kiro.js`** — nest `{ thinking, output_config, max_tokens }` inside `payload.additionalModelRequestFields`. Remove the invented `inferenceConfig` block and the `<thinking_mode>` content tag (neither exists in real Kiro; both were dropped/ignored by the gateway).
- **`open-sse/config/kiroConstants.js`** — adaptive `thinking` field ships by default (`kiroThinkingFieldEnabled()`, `KIRO_THINKING_FIELD=0` opts out); delete `buildThinkingSystemPrefix`. New `resolveKiroMaxTokens(effort, model)` maps effort→token buckets clamped to the per-model schema cap, returning `null` when a model exposes no `max_tokens` (so we never trip `additionalProperties:false`).
- **`open-sse/executors/kiro.js`** — opt-in `DEBUG_KIRO_EFFORT=1` logs a reasoning-vs-answer byte tally per response, for verifying effort end-to-end.
- **`open-sse/translator/concerns/thinkingUnified.js`** — follow-on to the nesting change: `extractThinking` now unwraps `additionalModelRequestFields` when it carries `thinking`/`output_config`, so the `🧠 [THINK]` console line (emitted from the post-translation body in `chatCore.js`) prints for Kiro too. Before this it only read top-level fields, so the line showed for providers like GLM but silently skipped Kiro once effort moved into the envelope. Wire request unchanged; log read only. Other providers and pre-translation bodies are unaffected.

## Effort → max_tokens

| effort | bucket | opus-4.8 | sonnet-4.6 (cap 64000) |
|---|---|---|---|
| low | 16000 | 16000 | 16000 |
| medium | 32000 | 32000 | 32000 |
| high | 64000 | 64000 | 64000 |
| xhigh | 96000 | 96000 | clamped→64000 (xhigh unsupported→high) |
| max | 128000 | 128000 | clamped→64000 |

## A/B test (effort honored end-to-end)

Same prompt (a two-equation word problem) to Opus 4.8, comparing high vs low effort with `DEBUG_KIRO_EFFORT=1`:

```
[KIRO-EFFORT] model=claude-opus-4.8 reasoning=892c answer=1579c ratio=0.56 reasoningChunks=105
[KIRO-EFFORT] model=claude-opus-4.8 reasoning=377c answer=892c  ratio=0.42 reasoningChunks=43
```

Higher effort produced **2.4× the reasoning bytes** (892 vs 377) and **2.4× the reasoning chunks** (105 vs 43) — the gateway is now scaling reasoning depth with effort, which was impossible while `output_config` sat at the top level and was dropped.

## Test plan

- **`tests/unit/kiro-effort.test.js`** — `resolveKiroMaxTokens` (effort buckets, per-model clamp, opus-4.7=128000, null on no-schema models) + `resolveKiroEffort`.
- **`tests/unit/openai-to-kiro.test.js`** + **`tests/translator/claude-kiro-direct.test.js`** — assert the nested `additionalModelRequestFields` shape, effort→max_tokens, no top-level `output_config`/`thinking`/`inferenceConfig`, no `<thinking_mode>` tag.
- **`tests/translator/bugs-kiro.test.js`** — dropped the obsolete top-level max_tokens case.
- Emit side proven deterministically: `KiroExecutor.transformRequest` returns the body unchanged, so the translator output is the exact wire body.
- Target suites: **87 pass, 1 expected-fail** (pre-existing image-url bug, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

