### PR TITLE
fix: handle Antigravity capacity and stream usage

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -7,6 +7,7 @@ import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { cleanJSONSchemaForAntigravity } from "../translator/formats/gemini.js";
 import { DEFAULT_THINKING_AG_SIGNATURE } from "../config/defaultThinkingSignature.js";
+import { isAntigravityCapacityError } from "../services/accountFallback.js";
 
 // Sanitize function name: Gemini requires [a-zA-Z_][a-zA-Z0-9_.:\-]{0,63}
 function sanitizeFunctionName(name) {
@@ -373,6 +374,8 @@ export class AntigravityExecutor extends BaseExecutor {
     }
 
     const errorMessage = this.extractErrorMessage(errorJson, bodyText);
+
+    if (isAntigravityCapacityError(response.status, errorMessage)) return false;
 
     if (!retryMs) {
       retryMs = this.parseRetryFromErrorMessage(errorMessage);

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -44,13 +44,15 @@ export function extractUsageFromResponse(responseBody) {
     };
   }
 
-  // Gemini format
-  if (responseBody.usageMetadata) {
+  // Gemini / Antigravity format. Antigravity wraps the native Gemini response
+  // under `response`, so usage can be either top-level or nested.
+  const usageMetadata = responseBody.usageMetadata || responseBody.response?.usageMetadata;
+  if (usageMetadata) {
     return {
-      prompt_tokens: responseBody.usageMetadata.promptTokenCount || 0,
-      completion_tokens: responseBody.usageMetadata.candidatesTokenCount || 0,
-      cached_tokens: responseBody.usageMetadata.cachedContentTokenCount || 0,
-      reasoning_tokens: responseBody.usageMetadata.thoughtsTokenCount || 0
+      prompt_tokens: usageMetadata.promptTokenCount || 0,
+      completion_tokens: usageMetadata.candidatesTokenCount || 0,
+      cached_tokens: usageMetadata.cachedContentTokenCount || 0,
+      reasoning_tokens: usageMetadata.thoughtsTokenCount || 0
     };
   }
 

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -50,6 +50,19 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
 }
 
 /**
+ * Antigravity capacity is a per-request server saturation signal, not an
+ * account quota/rate-limit. It should skip the current connection only for
+ * this request and must not write cooldown state to DB.
+ */
+export function isAntigravityCapacityError(status, errorText = "") {
+  const text = typeof errorText === "string" ? errorText : JSON.stringify(errorText || "");
+  return Number(status) === 503 && (
+    /MODEL_CAPACITY_EXHAUSTED/i.test(text) ||
+    /No capacity available for model/i.test(text)
+  );
+}
+
+/**
  * Check if account is currently unavailable (cooldown not expired)
  */
 export function isAccountUnavailable(unavailableUntil) {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -160,6 +160,20 @@ export function createSSEStream(options = {}) {
                 accumulatedThinking += reasoning;
               }
 
+              const geminiParts = parsed.response?.candidates?.[0]?.content?.parts || parsed.candidates?.[0]?.content?.parts;
+              if (Array.isArray(geminiParts)) {
+                for (const part of geminiParts) {
+                  if (part.text && typeof part.text === "string") {
+                    totalContentLength += part.text.length;
+                    if (part.thought === true) {
+                      accumulatedThinking += part.text;
+                    } else {
+                      accumulatedContent += part.text;
+                    }
+                  }
+                }
+              }
+
               const extracted = extractUsage(parsed);
               if (extracted) {
                 usage = mergeUsage(usage, extracted);

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -334,6 +334,10 @@ export function createSSEStream(options = {}) {
         const extracted = extractUsage(parsed);
         if (extracted) state.usage = mergeUsage(state.usage, extracted); // Keep original usage for logging
 
+        if (hasGeminiFamilyFinishReason(parsed)) {
+          state.usage = recordStreamCompletion(state.usage);
+        }
+
         // Responses same-format passthrough: re-emit with original event framing
         if (keepsOpenAIResponsesFormat && openAIResponsesEventName) {
           const output = formatSSE({ event: openAIResponsesEventName, data: parsed }, sourceFormat);

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -22,6 +22,20 @@ const STREAM_MODE = {
   PASSTHROUGH: "passthrough" // No translation, normalize output, extract usage
 };
 
+function getGeminiFamilyParts(chunk) {
+  const parts = chunk?.response?.candidates?.[0]?.content?.parts
+    || chunk?.candidates?.[0]?.content?.parts;
+  return Array.isArray(parts) ? parts : [];
+}
+
+function accumulateGeminiFamilyParts(parts, accumulate) {
+  for (const part of parts) {
+    if (part.text && typeof part.text === "string") {
+      accumulate(part.text, part.thought === true);
+    }
+  }
+}
+
 /**
  * Create unified SSE transform stream
  * @param {object} options
@@ -160,19 +174,14 @@ export function createSSEStream(options = {}) {
                 accumulatedThinking += reasoning;
               }
 
-              const geminiParts = parsed.response?.candidates?.[0]?.content?.parts || parsed.candidates?.[0]?.content?.parts;
-              if (Array.isArray(geminiParts)) {
-                for (const part of geminiParts) {
-                  if (part.text && typeof part.text === "string") {
-                    totalContentLength += part.text.length;
-                    if (part.thought === true) {
-                      accumulatedThinking += part.text;
-                    } else {
-                      accumulatedContent += part.text;
-                    }
-                  }
+              accumulateGeminiFamilyParts(getGeminiFamilyParts(parsed), (text, isThought) => {
+                totalContentLength += text.length;
+                if (isThought) {
+                  accumulatedThinking += text;
+                } else {
+                  accumulatedContent += text;
                 }
-              }
+              });
 
               const extracted = extractUsage(parsed);
               if (extracted) {
@@ -277,20 +286,15 @@ export function createSSEStream(options = {}) {
           accumulatedThinking += parsed.choices[0].delta.reasoning_content;
         }
         
-        // Gemini format
-        if (parsed.candidates?.[0]?.content?.parts) {
-          for (const part of parsed.candidates[0].content.parts) {
-            if (part.text && typeof part.text === "string") {
-              totalContentLength += part.text.length;
-              // Check if this is thinking content
-              if (part.thought === true) {
-                accumulatedThinking += part.text;
-              } else {
-                accumulatedContent += part.text;
-              }
-            }
+        // Gemini-family format (Gemini/Vertex direct and Antigravity wrapped)
+        accumulateGeminiFamilyParts(getGeminiFamilyParts(parsed), (text, isThought) => {
+          totalContentLength += text.length;
+          if (isThought) {
+            accumulatedThinking += text;
+          } else {
+            accumulatedContent += text;
           }
-        }
+        });
 
         // Extract usage
         const extracted = extractUsage(parsed);

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -36,6 +36,10 @@ function accumulateGeminiFamilyParts(parts, accumulate) {
   }
 }
 
+function hasGeminiFamilyFinishReason(chunk) {
+  return !!(chunk?.response?.candidates?.[0]?.finishReason || chunk?.candidates?.[0]?.finishReason);
+}
+
 /**
  * Create unified SSE transform stream
  * @param {object} options
@@ -86,6 +90,32 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  let completionRecorded = false;
+
+  const recordStreamCompletion = (currentUsage) => {
+    if (completionRecorded) return currentUsage;
+    let finalUsage = currentUsage;
+
+    if (!hasValidUsage(finalUsage) && totalContentLength > 0) {
+      finalUsage = estimateUsage(body, totalContentLength, mode === STREAM_MODE.PASSTHROUGH ? FORMATS.OPENAI : sourceFormat);
+    }
+
+    if (hasValidUsage(finalUsage)) {
+      logUsage(mode === STREAM_MODE.TRANSLATE ? (state?.provider || targetFormat) : provider, finalUsage, model, connectionId, apiKey);
+    } else {
+      appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
+    }
+
+    if (onStreamComplete) {
+      onStreamComplete({
+        content: accumulatedContent,
+        thinking: accumulatedThinking
+      }, finalUsage, ttftAt);
+    }
+
+    completionRecorded = true;
+    return finalUsage;
+  };
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -203,6 +233,10 @@ export function createSSEStream(options = {}) {
               } else if (idFixed || fieldsInjected) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
+              }
+
+              if (isFinishChunk || hasGeminiFamilyFinishReason(parsed)) {
+                usage = recordStreamCompletion(usage);
               }
             } catch {
               // Skip non-JSON data lines silently — don't forward garbage to clients.
@@ -374,11 +408,7 @@ export function createSSEStream(options = {}) {
             usage = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
           }
 
-          if (hasValidUsage(usage)) {
-            logUsage(provider, usage, model, connectionId, apiKey);
-          } else {
-            appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
-          }
+          usage = recordStreamCompletion(usage);
           
           // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
@@ -392,12 +422,6 @@ export function createSSEStream(options = {}) {
             controller.enqueue(sharedEncoder.encode(doneOutput));
           }
 
-          if (onStreamComplete) {
-            onStreamComplete({
-              content: accumulatedContent,
-              thinking: accumulatedThinking
-            }, usage, ttftAt);
-          }
           return;
         }
 
@@ -463,18 +487,7 @@ export function createSSEStream(options = {}) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);
         }
 
-        if (hasValidUsage(state?.usage)) {
-          logUsage(state.provider || targetFormat, state.usage, model, connectionId, apiKey);
-        } else {
-          appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
-        }
-        
-        if (onStreamComplete) {
-          onStreamComplete({
-            content: accumulatedContent,
-            thinking: accumulatedThinking
-          }, state?.usage, ttftAt);
-        }
+        state.usage = recordStreamCompletion(state?.usage);
       } catch (error) {
         console.log("Error in flush:", error);
       }

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -17,9 +17,12 @@ import { handleComboChat, handleFusionChat } from "open-sse/services/combo.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
+import { isAntigravityCapacityError } from "open-sse/services/accountFallback.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+
+const ANTIGRAVITY_CAPACITY_SWEEP_RETRIES = 2;
 
 /**
  * Handle chat completion request
@@ -203,6 +206,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   const excludeConnectionIds = new Set();
   let lastError = null;
   let lastStatus = null;
+  let antigravityCapacitySweeps = 0;
 
   while (true) {
     const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
@@ -218,6 +222,16 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       if (excludeConnectionIds.size === 0) {
         log.warn("AUTH", `No active credentials for provider: ${provider}`);
         return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
+      }
+      if (
+        provider === "antigravity" &&
+        isAntigravityCapacityError(lastStatus, lastError) &&
+        antigravityCapacitySweeps < ANTIGRAVITY_CAPACITY_SWEEP_RETRIES
+      ) {
+        antigravityCapacitySweeps += 1;
+        log.warn("CHAT", `[${provider}/${model}] all accounts reported capacity; restarting account sweep ${antigravityCapacitySweeps}/${ANTIGRAVITY_CAPACITY_SWEEP_RETRIES}`);
+        excludeConnectionIds.clear();
+        continue;
       }
       log.warn("CHAT", "No more accounts available", { provider });
       return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,6 +1,6 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings } from "@/lib/localDb";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, isAntigravityCapacityError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
@@ -205,6 +205,12 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   const connections = await getProviderConnections({ provider });
   const conn = connections.find(c => c.id === connectionId);
   const backoffLevel = conn?.backoffLevel || 0;
+
+  if (provider === "antigravity" && isAntigravityCapacityError(status, errorText)) {
+    const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8);
+    log.warn("AUTH", `${connName} hit Antigravity capacity for ${model || "unknown model"}; fallback without cooldown [${status}]`);
+    return { shouldFallback: true, cooldownMs: 0 };
+  }
 
   // Provider-specific precise cooldown (e.g. codex usage_limit_reached resets_at) overrides backoff
   let shouldFallback, cooldownMs, newBackoffLevel;

--- a/tests/unit/antigravity-capacity-fallback.test.js
+++ b/tests/unit/antigravity-capacity-fallback.test.js
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  validateApiKey: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: mocks.validateApiKey,
+  getSettings: mocks.getSettings,
+}));
+
+describe("Antigravity capacity fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "ag-1", provider: "antigravity", email: "ag@example.com", backoffLevel: 4 },
+    ]);
+  });
+
+  it("falls back without writing model cooldown for MODEL_CAPACITY_EXHAUSTED", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "ag-1",
+      503,
+      '{"reason":"MODEL_CAPACITY_EXHAUSTED","message":"No capacity available for model claude-opus-4-6-thinking on the server"}',
+      "antigravity",
+      "claude-opus-4-6-thinking",
+    );
+
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0 });
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("keeps normal cooldown behavior for non-Antigravity capacity text", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "ag-1",
+      503,
+      "No capacity available for model x",
+      "kiro",
+      "some-model",
+    );
+
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(0);
+    expect(mocks.updateProviderConnection).toHaveBeenCalledWith(
+      "ag-1",
+      expect.objectContaining({
+        testStatus: "unavailable",
+        errorCode: 503,
+      }),
+    );
+  });
+});

--- a/tests/unit/antigravity-combo-capacity-cycle.test.js
+++ b/tests/unit/antigravity-combo-capacity-cycle.test.js
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getComboModels: vi.fn(),
+  getModelInfo: vi.fn(),
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  extractApiKey: vi.fn(),
+  isValidApiKey: vi.fn(),
+  handleChatCore: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+}));
+
+vi.mock("../../src/sse/services/model.js", () => ({
+  getComboModels: mocks.getComboModels,
+  getModelInfo: mocks.getModelInfo,
+}));
+
+vi.mock("../../src/sse/services/auth.js", () => ({
+  getProviderCredentials: mocks.getProviderCredentials,
+  markAccountUnavailable: mocks.markAccountUnavailable,
+  clearAccountError: mocks.clearAccountError,
+  extractApiKey: mocks.extractApiKey,
+  isValidApiKey: mocks.isValidApiKey,
+}));
+
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_provider, credentials) => credentials),
+  updateProviderCredentials: vi.fn(),
+}));
+
+vi.mock("../../open-sse/handlers/chatCore.js", () => ({
+  handleChatCore: mocks.handleChatCore,
+}));
+
+vi.mock("../../open-sse/services/projectId.js", () => ({
+  getProjectIdForConnection: vi.fn(),
+}));
+
+function makeRequest(model = "combo-ag") {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+}
+
+function capacityError(model = "claude-opus-4-6-thinking") {
+  return JSON.stringify({
+    error: {
+      code: 503,
+      message: `No capacity available for model ${model} on the server`,
+      status: "UNAVAILABLE",
+      details: [{
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        reason: "MODEL_CAPACITY_EXHAUSTED",
+        domain: "cloudcode-pa.googleapis.com",
+        metadata: { model },
+      }],
+    },
+  });
+}
+
+describe("Antigravity combo capacity cycling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      comboStrategy: "fallback",
+      comboStickyRoundRobinLimit: 1,
+      rtkEnabled: false,
+      headroomEnabled: false,
+      cavemanEnabled: false,
+      ponytailEnabled: false,
+    });
+    mocks.getComboModels.mockImplementation(async (model) => (
+      model === "combo-ag"
+        ? ["ag/claude-opus-4-6-thinking", "kiro/claude-sonnet-4.5"]
+        : null
+    ));
+    mocks.getModelInfo.mockImplementation(async (modelStr) => {
+      if (modelStr === "ag/claude-opus-4-6-thinking") {
+        return { provider: "antigravity", model: "claude-opus-4-6-thinking" };
+      }
+      if (modelStr === "kiro/claude-sonnet-4.5") {
+        return { provider: "kiro", model: "claude-sonnet-4.5" };
+      }
+      return { provider: null, model: modelStr };
+    });
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 0 });
+  });
+
+  it("restarts the Antigravity account sweep after all accounts report model capacity before trying the next combo model", async () => {
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+
+    const excludeSnapshots = [];
+    let antigravityEmptySweepCount = 0;
+    mocks.getProviderCredentials.mockImplementation(async (provider, excludeConnectionIds) => {
+      const excluded = [...(excludeConnectionIds || [])];
+      excludeSnapshots.push({ provider, excluded });
+
+      if (provider === "kiro") {
+        return { connectionId: "kiro-1", connectionName: "Kiro 1" };
+      }
+
+      if (excluded.length === 0) {
+        antigravityEmptySweepCount += 1;
+        return { connectionId: "ag-1", connectionName: `AG 1 sweep ${antigravityEmptySweepCount}` };
+      }
+
+      if (excluded.length === 1 && excluded[0] === "ag-1") {
+        return { connectionId: "ag-2", connectionName: "AG 2" };
+      }
+
+      return null;
+    });
+
+    mocks.handleChatCore.mockImplementation(async ({ modelInfo }) => {
+      if (modelInfo.provider === "kiro") {
+        return { success: true, response: new Response("kiro-ok", { status: 200 }) };
+      }
+      if (antigravityEmptySweepCount >= 2) {
+        return { success: true, response: new Response("ag-ok", { status: 200 }) };
+      }
+      return { success: false, status: 503, error: capacityError() };
+    });
+
+    const response = await handleChat(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ag-ok");
+    expect(excludeSnapshots).toEqual([
+      { provider: "antigravity", excluded: [] },
+      { provider: "antigravity", excluded: ["ag-1"] },
+      { provider: "antigravity", excluded: ["ag-1", "ag-2"] },
+      { provider: "antigravity", excluded: [] },
+    ]);
+    expect(mocks.handleChatCore).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelInfo: expect.objectContaining({ provider: "kiro" }),
+      }),
+    );
+  });
+});

--- a/tests/unit/antigravity-recent-requests.test.js
+++ b/tests/unit/antigravity-recent-requests.test.js
@@ -31,6 +31,55 @@ async function writeAndCollect(transform, chunks) {
 }
 
 describe("Antigravity Recent Requests usage", () => {
+  it("finalizes native Antigravity usage when the final chunk arrives before stream close", async () => {
+    let completed = null;
+    const stream = createPassthroughStreamWithLogger(
+      "antigravity",
+      null,
+      "claude-opus-4-6-thinking",
+      "conn-1",
+      { request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] } },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+    const readOne = reader.read();
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "AG_NATIVE_USAGE_OK" }],
+          },
+          finishReason: "STOP",
+        }],
+        usageMetadata: {
+          promptTokenCount: 18,
+          candidatesTokenCount: 12,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+    await readOne;
+
+    expect(completed?.content?.content).toBe("AG_NATIVE_USAGE_OK");
+    expect(completed?.usage).toMatchObject({
+      prompt_tokens: 18,
+      completion_tokens: 12,
+      total_tokens: 30,
+    });
+
+    await writer.abort();
+    await reader.cancel().catch(() => {});
+  });
+
   it("estimates usage for Antigravity passthrough content when upstream omits usageMetadata", async () => {
     let completed = null;
     const stream = createPassthroughStreamWithLogger(

--- a/tests/unit/antigravity-recent-requests.test.js
+++ b/tests/unit/antigravity-recent-requests.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import {
+  createPassthroughStreamWithLogger,
+  createSSETransformStreamWithLogger,
+} from "../../open-sse/utils/stream.js";
 
 vi.mock("@/lib/usageDb.js", () => ({
   trackPendingRequest: vi.fn(),
@@ -56,6 +60,43 @@ describe("Antigravity Recent Requests usage", () => {
     await writeAndCollect(stream, [`data: ${JSON.stringify(event)}\n\n`]);
 
     expect(completed?.content?.content).toBe("A useful Antigravity response.");
+    expect(completed?.usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.completion_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.estimated).toBe(true);
+  });
+
+  it("estimates usage for translated Antigravity wrapped content when upstream omits usageMetadata", async () => {
+    let completed = null;
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.ANTIGRAVITY,
+      FORMATS.OPENAI,
+      "antigravity",
+      null,
+      null,
+      "claude-opus-4-6-thinking",
+      "conn-1",
+      { messages: [{ role: "user", content: "hello" }] },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "Translated Antigravity response." }],
+          },
+          finishReason: "STOP",
+        }],
+      },
+    };
+
+    await writeAndCollect(stream, [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(completed?.content?.content).toBe("Translated Antigravity response.");
     expect(completed?.usage?.prompt_tokens).toBeGreaterThan(0);
     expect(completed?.usage?.completion_tokens).toBeGreaterThan(0);
     expect(completed?.usage?.estimated).toBe(true);

--- a/tests/unit/antigravity-recent-requests.test.js
+++ b/tests/unit/antigravity-recent-requests.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(() => Promise.resolve()),
+}));
+
+async function writeAndCollect(transform, chunks) {
+  const writer = transform.writable.getWriter();
+  const reader = transform.readable.getReader();
+  const readAll = (async () => {
+    const out = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(value);
+    }
+    return out;
+  })();
+
+  for (const chunk of chunks) {
+    await writer.write(new TextEncoder().encode(chunk));
+  }
+  await writer.close();
+  return await readAll;
+}
+
+describe("Antigravity Recent Requests usage", () => {
+  it("estimates usage for Antigravity passthrough content when upstream omits usageMetadata", async () => {
+    let completed = null;
+    const stream = createPassthroughStreamWithLogger(
+      "antigravity",
+      null,
+      "gemini-pro-agent",
+      "conn-1",
+      { request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] } },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "A useful Antigravity response." }],
+          },
+          finishReason: "STOP",
+        }],
+      },
+    };
+
+    await writeAndCollect(stream, [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(completed?.content?.content).toBe("A useful Antigravity response.");
+    expect(completed?.usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.completion_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.estimated).toBe(true);
+  });
+});

--- a/tests/unit/antigravity-recent-requests.test.js
+++ b/tests/unit/antigravity-recent-requests.test.js
@@ -80,6 +80,58 @@ describe("Antigravity Recent Requests usage", () => {
     await reader.cancel().catch(() => {});
   });
 
+  it("finalizes translated Responses API Antigravity usage when the final chunk arrives before stream close", async () => {
+    let completed = null;
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.ANTIGRAVITY,
+      FORMATS.OPENAI_RESPONSES,
+      "antigravity",
+      null,
+      null,
+      "gemini-pro-agent",
+      "conn-1",
+      { input: "hello", stream: true },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+    const readOne = reader.read();
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "AG_RESPONSES_USAGE_OK" }],
+          },
+          finishReason: "STOP",
+        }],
+        usageMetadata: {
+          promptTokenCount: 21,
+          candidatesTokenCount: 13,
+          totalTokenCount: 34,
+        },
+      },
+    };
+
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+    await readOne;
+
+    expect(completed?.content?.content).toBe("AG_RESPONSES_USAGE_OK");
+    expect(completed?.usage).toMatchObject({
+      prompt_tokens: 21,
+      completion_tokens: 13,
+      total_tokens: 34,
+    });
+
+    await writer.abort();
+    await reader.cancel().catch(() => {});
+  });
+
   it("estimates usage for Antigravity passthrough content when upstream omits usageMetadata", async () => {
     let completed = null;
     const stream = createPassthroughStreamWithLogger(

--- a/tests/unit/antigravity-retry-hook.test.js
+++ b/tests/unit/antigravity-retry-hook.test.js
@@ -36,6 +36,16 @@ describe("antigravity computeRetryDelay hook (D3)", () => {
     expect(await ag.computeRetryDelay(res(503), 1)).toBe(2000);
   });
 
+  it("does not retry Antigravity capacity on the same account", async () => {
+    const r = res(503, {}, {
+      error: {
+        reason: "MODEL_CAPACITY_EXHAUSTED",
+        message: "No capacity available for model claude-opus-4-6-thinking on the server",
+      },
+    });
+    expect(await ag.computeRetryDelay(r, 1)).toBe(false);
+  });
+
   it("retries Antigravity agent terminated body even when status is not 429", async () => {
     const r = res(500, {}, { error: { message: "Agent execution terminated due to error" } });
     expect(await ag.computeRetryDelay(r, 1)).toBe(2000);

--- a/tests/unit/request-detail-usage.test.js
+++ b/tests/unit/request-detail-usage.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { extractUsageFromResponse } from "../../open-sse/handlers/chatCore/requestDetail.js";
+
+describe("request detail usage extraction", () => {
+  it("extracts usage from Antigravity wrapped response usageMetadata", () => {
+    const usage = extractUsageFromResponse({
+      response: {
+        usageMetadata: {
+          promptTokenCount: 77187,
+          candidatesTokenCount: 236,
+          totalTokenCount: 77423,
+          cachedContentTokenCount: 69387,
+          thoughtsTokenCount: 12,
+        },
+      },
+    });
+
+    expect(usage).toEqual({
+      prompt_tokens: 77187,
+      completion_tokens: 236,
+      cached_tokens: 69387,
+      reasoning_tokens: 12,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Treat Antigravity `MODEL_CAPACITY_EXHAUSTED` as request-local fallback, not account/model cooldown.
- Preserve normal cooldown behavior for other providers and real quota/rate-limit errors.
- Track Antigravity/Gemini passthrough stream content so successful streams without `usageMetadata` can estimate usage and appear in Recent Requests without showing 0/0 junk rows.

## Test Plan
- `node tests/node_modules/vitest/vitest.mjs run tests/unit/antigravity-retry-hook.test.js tests/unit/base-executor-retry.test.js tests/unit/antigravity-capacity-fallback.test.js tests/unit/antigravity-recent-requests.test.js --config tests/vitest.config.js --configLoader runner`
