### PR TITLE
fix(headroom): proxy dashboard through app

### DIFF
--- a/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
+++ b/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
@@ -374,6 +374,16 @@ export default function TokenSaverClient() {
               {headroomStatusLabel}
             </span>
           </div>
+          {headroomRunning && (
+            <a
+              href="/api/headroom/proxy/dashboard"
+              target="_blank"
+              rel="noreferrer"
+              className="w-full rounded border border-border px-4 py-2 text-center text-sm hover:bg-surface-2"
+            >
+              Open Headroom Dashboard
+            </a>
+          )}
           <div className="flex flex-col gap-1">
             <p className="text-sm font-medium">Proxy URL</p>
             <Input

--- a/src/app/api/headroom/proxy/[...path]/route.js
+++ b/src/app/api/headroom/proxy/[...path]/route.js
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { getSettings } from "@/lib/localDb";
+import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
+
+export const dynamic = "force-dynamic";
+
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const DASHBOARD_PREFIX = "/api/headroom/proxy";
+
+async function getTargetBase() {
+  const settings = await getSettings();
+  const url = settings.headroomUrl || DEFAULT_HEADROOM_URL;
+  const target = new URL(url);
+  if (!["http:", "https:"].includes(target.protocol)) {
+    throw new Error("Headroom URL must use http or https");
+  }
+  return target;
+}
+
+function buildTargetUrl(base, path, search) {
+  const target = new URL(base);
+  target.pathname = `/${path.join("/")}`;
+  target.search = search;
+  return target;
+}
+
+function forwardedHeaders(request) {
+  const headers = new Headers(request.headers);
+  for (const header of headers.keys()) {
+    if (HOP_BY_HOP_HEADERS.has(header.toLowerCase())) headers.delete(header);
+  }
+  headers.delete("host");
+  return headers;
+}
+
+function rewriteDashboardHtml(html) {
+  return html.replace(
+    /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
+    `fetch('${DASHBOARD_PREFIX}`,
+  );
+}
+
+async function proxy(request, { params }) {
+  try {
+    const base = await getTargetBase();
+    const { search } = new URL(request.url);
+    const path = (await params).path || [];
+    const target = buildTargetUrl(base, path, search);
+    const method = request.method;
+    const hasBody = !["GET", "HEAD"].includes(method);
+
+    const response = await fetch(target, {
+      method,
+      headers: forwardedHeaders(request),
+      body: hasBody ? request.body : undefined,
+      duplex: hasBody ? "half" : undefined,
+      redirect: "manual",
+    });
+
+    const headers = new Headers(response.headers);
+    for (const header of headers.keys()) {
+      if (HOP_BY_HOP_HEADERS.has(header.toLowerCase())) headers.delete(header);
+    }
+
+    if (path.join("/") === "dashboard") {
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("text/html")) {
+        headers.delete("content-length");
+        return new NextResponse(rewriteDashboardHtml(await response.text()), {
+          status: response.status,
+          headers,
+        });
+      }
+    }
+
+    return new NextResponse(response.body, { status: response.status, headers });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;
+export const HEAD = proxy;
+export const OPTIONS = proxy;


### PR DESCRIPTION
## Issue

Starting Headroom from the Token Saver modal can successfully launch the local Headroom proxy, but opening the Headroom dashboard from a browser that is not running on the same host can still fail to load token-saver data.

The dashboard page itself may load, but its data widgets cannot reach Headroom, so the dashboard looks broken even though Headroom is running.

## Findings

Headroom serves the dashboard HTML from its own proxy and the page uses root-relative fetch calls for dashboard data:

- `/stats?cached=1`
- `/health`
- `/stats-history`
- `/transformations/feed`

That works when the browser opens Headroom directly at `http://localhost:8787/dashboard` on the same machine.

It does not work reliably when 9Router starts Headroom on the server and the user opens the dashboard from another device/browser through the 9Router app. In that case, those root-relative requests resolve against the 9Router origin instead of the Headroom origin.

## Root cause

9Router managed the Headroom process server-side, but did not provide a browser-safe path for the Headroom dashboard and its data endpoints.

So the browser could end up requesting dashboard data from 9Router paths such as `/stats` and `/health`, while the actual endpoints live on the Headroom proxy.

## Fix

This PR adds a 9Router-side Headroom dashboard proxy:

- proxy Headroom requests through `/api/headroom/proxy/[...path]`
- add an `Open Headroom Dashboard` link in the Token Saver modal
- open the dashboard at `/api/headroom/proxy/dashboard`
- rewrite Headroom dashboard HTML fetch calls so dashboard data stays on the proxy path:
  - `/stats` → `/api/headroom/proxy/stats`
  - `/health` → `/api/headroom/proxy/health`
  - `/stats-history` → `/api/headroom/proxy/stats-history`
  - `/transformations/feed` → `/api/headroom/proxy/transformations/feed`

## Why this approach

This keeps Headroom private to the 9Router host while still giving the user's browser a same-origin URL that can reach both the dashboard page and its backing data endpoints.

It also avoids requiring users to manually expose `localhost:8787` or know whether Headroom is running locally, in Docker, or on the 9Router server.

## Verification

- `git diff --check`
- `npm run build`

Closes #2330
