### PR TITLE
feat(api-keys): per-key model allowlist + token/cost limits

### DIFF
--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -24,6 +24,8 @@ export default function APIPageClient({ machineId }) {
   const [newKeyName, setNewKeyName] = useState("");
   const [createdKey, setCreatedKey] = useState(null);
   const [confirmState, setConfirmState] = useState(null);
+  const [editingKeyModels, setEditingKeyModels] = useState(null);
+  const [modelsInput, setModelsInput] = useState("");
 
   const [requireApiKey, setRequireApiKey] = useState(false);
   const [requireLogin, setRequireLogin] = useState(true);
@@ -667,6 +669,35 @@ export default function APIPageClient({ machineId }) {
     }
   };
 
+  const handleEditModels = (key) => {
+    const allowed = key.policy?.allowedModels || [];
+    setEditingKeyModels(key);
+    setModelsInput(allowed.join("\n"));
+  };
+
+  const handleSaveModels = async () => {
+    if (!editingKeyModels) return;
+    const models = modelsInput
+      .split("\n")
+      .map((m) => m.trim())
+      .filter(Boolean);
+    try {
+      const res = await fetch(`/api/keys/${editingKeyModels.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowedModels: models }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setKeys(prev => prev.map(k => k.id === editingKeyModels.id ? { ...k, policy: data.key?.policy || { allowedModels: models } } : k));
+        setEditingKeyModels(null);
+        setModelsInput("");
+      }
+    } catch (error) {
+      console.log("Error saving models:", error);
+    }
+  };
+
   const maskKey = (fullKey) => {
     if (!fullKey || fullKey.length <= 10) return fullKey || "";
     return fullKey.slice(0, 6) + "•".repeat(fullKey.length - 10) + fullKey.slice(-4);
@@ -1024,6 +1055,19 @@ export default function APIPageClient({ machineId }) {
                   <p className="text-xs text-text-muted mt-1">
                     Created {new Date(key.createdAt).toLocaleDateString()}
                   </p>
+                  <div className="flex items-center gap-1.5 mt-1">
+                    <button
+                      onClick={() => handleEditModels(key)}
+                      className="text-xs text-text-muted hover:text-primary transition-colors"
+                    >
+                      {key.policy?.allowedModels?.length > 0
+                        ? `${key.policy.allowedModels.length} model${key.policy.allowedModels.length > 1 ? "s" : ""} allowed`
+                        : "All models"}
+                    </button>
+                    <span className="material-symbols-outlined text-[12px] text-text-muted">
+                      tune
+                    </span>
+                  </div>
                   {key.isActive === false && (
                     <p className="text-xs text-orange-500 mt-1">Paused</p>
                   )}
@@ -1085,6 +1129,47 @@ export default function APIPageClient({ machineId }) {
               onClick={() => {
                 setShowAddModal(false);
                 setNewKeyName("");
+              }}
+              variant="ghost"
+              fullWidth
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Edit Allowed Models Modal */}
+      <Modal
+        isOpen={!!editingKeyModels}
+        title={`Allowed Models — ${editingKeyModels?.name || ""}`}
+        onClose={() => {
+          setEditingKeyModels(null);
+          setModelsInput("");
+        }}
+      >
+        <div className="flex flex-col gap-4">
+          <div>
+            <p className="text-sm text-text-muted mb-2">
+              Enter one model per line. Leave empty to allow all models.
+              Use the exact model string clients send (e.g. <code className="text-xs">openai/gpt-4o-mini</code>, combo names, or aliases).
+            </p>
+            <textarea
+              className="w-full min-h-[160px] px-3 py-2 rounded-lg bg-bg-secondary border border-border text-sm font-mono resize-y focus:outline-none focus:ring-2 focus:ring-primary"
+              value={modelsInput}
+              onChange={(e) => setModelsInput(e.target.value)}
+              placeholder={"openai/gpt-4o-mini\nkr/claude-sonnet-4.5\ncheap-coding"}
+              autoFocus
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={handleSaveModels} fullWidth>
+              Save
+            </Button>
+            <Button
+              onClick={() => {
+                setEditingKeyModels(null);
+                setModelsInput("");
               }}
               variant="ghost"
               fullWidth

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal } from "@/shared/components";
+import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal, ModelSelectModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import {
   TUNNEL_BENEFITS,
@@ -26,6 +26,9 @@ export default function APIPageClient({ machineId }) {
   const [confirmState, setConfirmState] = useState(null);
   const [editingKeyModels, setEditingKeyModels] = useState(null);
   const [modelsInput, setModelsInput] = useState("");
+  const [showModelModal, setShowModelModal] = useState(false);
+  const [connections, setConnections] = useState([]);
+  const [modelAliases, setModelAliases] = useState({});
 
   const [requireApiKey, setRequireApiKey] = useState(false);
   const [requireLogin, setRequireLogin] = useState(true);
@@ -257,10 +260,22 @@ export default function APIPageClient({ machineId }) {
 
   const fetchData = async () => {
     try {
-      const keysRes = await fetch("/api/keys");
-      const keysData = await keysRes.json();
+      const [keysRes, provRes, aliasRes] = await Promise.all([
+        fetch("/api/keys"),
+        fetch("/api/providers"),
+        fetch("/api/models/alias"),
+      ]);
       if (keysRes.ok) {
+        const keysData = await keysRes.json();
         setKeys(keysData.keys || []);
+      }
+      if (provRes.ok) {
+        const provData = await provRes.json();
+        setConnections(provData.connections || []);
+      }
+      if (aliasRes.ok) {
+        const aliasData = await aliasRes.json();
+        setModelAliases(aliasData.aliases || {});
       }
     } catch (error) {
       console.log("Error fetching data:", error);
@@ -670,31 +685,40 @@ export default function APIPageClient({ machineId }) {
   };
 
   const handleEditModels = (key) => {
-    const allowed = key.policy?.allowedModels || [];
     setEditingKeyModels(key);
-    setModelsInput(allowed.join("\n"));
   };
 
-  const handleSaveModels = async () => {
+  const handleModelSelect = (model) => {
+    const current = editingKeyModels?.policy?.allowedModels || [];
+    if (current.includes(model.value)) {
+      // Deselect — remove from list
+      const updated = current.filter((m) => m !== model.value);
+      setEditingKeyModels({ ...editingKeyModels, policy: { ...editingKeyModels.policy, allowedModels: updated } });
+    } else {
+      setEditingKeyModels({ ...editingKeyModels, policy: { ...editingKeyModels.policy, allowedModels: [...current, model.value] } });
+    }
+  };
+
+  const handleSavePolicy = async () => {
     if (!editingKeyModels) return;
-    const models = modelsInput
-      .split("\n")
-      .map((m) => m.trim())
-      .filter(Boolean);
+    const { policy } = editingKeyModels;
     try {
       const res = await fetch(`/api/keys/${editingKeyModels.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ allowedModels: models }),
+        body: JSON.stringify({
+          allowedModels: policy?.allowedModels || [],
+          maxTokens: policy?.maxTokens ?? null,
+          maxCostUsd: policy?.maxCostUsd ?? null,
+        }),
       });
       if (res.ok) {
         const data = await res.json();
-        setKeys(prev => prev.map(k => k.id === editingKeyModels.id ? { ...k, policy: data.key?.policy || { allowedModels: models } } : k));
+        setKeys(prev => prev.map(k => k.id === editingKeyModels.id ? { ...k, ...data.key } : k));
         setEditingKeyModels(null);
-        setModelsInput("");
       }
     } catch (error) {
-      console.log("Error saving models:", error);
+      console.log("Error saving policy:", error);
     }
   };
 
@@ -1068,6 +1092,20 @@ export default function APIPageClient({ machineId }) {
                       tune
                     </span>
                   </div>
+                  {(key.policy?.maxTokens != null || key.policy?.maxCostUsd != null) && (
+                    <div className="flex flex-wrap items-center gap-2 mt-1">
+                      {key.policy?.maxTokens != null && (
+                        <span className={`text-xs ${key.usage?.totalTokens >= key.policy.maxTokens ? "text-red-500" : "text-text-muted"}`}>
+                          {key.usage?.totalTokens?.toLocaleString() || 0} / {key.policy.maxTokens.toLocaleString()} tokens
+                        </span>
+                      )}
+                      {key.policy?.maxCostUsd != null && (
+                        <span className={`text-xs ${key.usage?.totalCost >= key.policy.maxCostUsd ? "text-red-500" : "text-text-muted"}`}>
+                          ${key.usage?.totalCost?.toFixed(4) || "0.0000"} / ${key.policy.maxCostUsd} cost
+                        </span>
+                      )}
+                    </div>
+                  )}
                   {key.isActive === false && (
                     <p className="text-xs text-orange-500 mt-1">Paused</p>
                   )}
@@ -1139,38 +1177,118 @@ export default function APIPageClient({ machineId }) {
         </div>
       </Modal>
 
-      {/* Edit Allowed Models Modal */}
+      {/* Edit Policy Modal */}
       <Modal
         isOpen={!!editingKeyModels}
-        title={`Allowed Models — ${editingKeyModels?.name || ""}`}
-        onClose={() => {
-          setEditingKeyModels(null);
-          setModelsInput("");
-        }}
+        title={`API Key Policy — ${editingKeyModels?.name || ""}`}
+        onClose={() => setEditingKeyModels(null)}
       >
         <div className="flex flex-col gap-4">
+          {/* Allowed Models */}
           <div>
-            <p className="text-sm text-text-muted mb-2">
-              Enter one model per line. Leave empty to allow all models.
-              Use the exact model string clients send (e.g. <code className="text-xs">openai/gpt-4o-mini</code>, combo names, or aliases).
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-sm font-medium">Allowed Models</p>
+              <Button
+                size="sm"
+                variant="ghost"
+                icon="add"
+                onClick={() => setShowModelModal(true)}
+                disabled={connections.filter((c) => c.isActive !== false).length === 0}
+              >
+                Select Models
+              </Button>
+            </div>
+            <p className="text-xs text-text-muted mb-2">
+              Leave empty to allow all models. Click a model chip to add/remove.
             </p>
-            <textarea
-              className="w-full min-h-[160px] px-3 py-2 rounded-lg bg-bg-secondary border border-border text-sm font-mono resize-y focus:outline-none focus:ring-2 focus:ring-primary"
-              value={modelsInput}
-              onChange={(e) => setModelsInput(e.target.value)}
-              placeholder={"openai/gpt-4o-mini\nkr/claude-sonnet-4.5\ncheap-coding"}
-              autoFocus
-            />
+            {(editingKeyModels?.policy?.allowedModels || []).length > 0 ? (
+              <div className="flex flex-wrap gap-1.5 p-2 rounded-lg bg-bg-secondary border border-border min-h-[40px]">
+                {(editingKeyModels?.policy?.allowedModels || []).map((model) => (
+                  <span
+                    key={model}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-xs bg-primary/10 text-primary border border-primary/20"
+                  >
+                    {model}
+                    <button
+                      onClick={() => {
+                        const updated = (editingKeyModels.policy?.allowedModels || []).filter((m) => m !== model);
+                        setEditingKeyModels({ ...editingKeyModels, policy: { ...editingKeyModels.policy, allowedModels: updated } });
+                      }}
+                      className="hover:text-red-500 transition-colors"
+                    >
+                      <span className="material-symbols-outlined text-[12px]">close</span>
+                    </button>
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <div className="p-2 rounded-lg bg-bg-secondary border border-border text-xs text-text-muted">
+                All models allowed
+              </div>
+            )}
           </div>
+
+          {/* Token & Cost Limits */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-sm font-medium mb-1 block">Max Tokens (lifetime)</label>
+              <input
+                type="number"
+                className="w-full px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                value={editingKeyModels?.policy?.maxTokens ?? ""}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setEditingKeyModels({
+                    ...editingKeyModels,
+                    policy: {
+                      ...editingKeyModels.policy,
+                      maxTokens: val === "" ? null : Number(val),
+                    },
+                  });
+                }}
+                placeholder="Unlimited"
+                min="0"
+              />
+              {editingKeyModels?.usage && editingKeyModels?.policy?.maxTokens != null && (
+                <p className="text-xs text-text-muted mt-1">
+                  Used: {editingKeyModels.usage.totalTokens?.toLocaleString() || 0}
+                </p>
+              )}
+            </div>
+            <div>
+              <label className="text-sm font-medium mb-1 block">Max Cost USD (lifetime)</label>
+              <input
+                type="number"
+                step="0.01"
+                className="w-full px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                value={editingKeyModels?.policy?.maxCostUsd ?? ""}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setEditingKeyModels({
+                    ...editingKeyModels,
+                    policy: {
+                      ...editingKeyModels.policy,
+                      maxCostUsd: val === "" ? null : Number(val),
+                    },
+                  });
+                }}
+                placeholder="Unlimited"
+                min="0"
+              />
+              {editingKeyModels?.usage && editingKeyModels?.policy?.maxCostUsd != null && (
+                <p className="text-xs text-text-muted mt-1">
+                  Used: ${editingKeyModels.usage.totalCost?.toFixed(4) || "0.0000"}
+                </p>
+              )}
+            </div>
+          </div>
+
           <div className="flex gap-2">
-            <Button onClick={handleSaveModels} fullWidth>
+            <Button onClick={handleSavePolicy} fullWidth>
               Save
             </Button>
             <Button
-              onClick={() => {
-                setEditingKeyModels(null);
-                setModelsInput("");
-              }}
+              onClick={() => setEditingKeyModels(null)}
               variant="ghost"
               fullWidth
             >
@@ -1179,6 +1297,20 @@ export default function APIPageClient({ machineId }) {
           </div>
         </div>
       </Modal>
+
+      {/* Model Select Modal (multi-select for API key allowlist) */}
+      <ModelSelectModal
+        isOpen={showModelModal}
+        onClose={() => setShowModelModal(false)}
+        onSelect={handleModelSelect}
+        onDeselect={handleModelSelect}
+        selectedModel={null}
+        activeProviders={connections.filter((c) => c.isActive !== false)}
+        modelAliases={modelAliases}
+        addedModelValues={editingKeyModels?.policy?.allowedModels || []}
+        closeOnSelect={false}
+        title="Select Allowed Models"
+      />
 
       {/* Created Key Modal */}
       <Modal

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -29,6 +29,7 @@ export default function APIPageClient({ machineId }) {
   const [showModelModal, setShowModelModal] = useState(false);
   const [connections, setConnections] = useState([]);
   const [modelAliases, setModelAliases] = useState({});
+  const [newKeyPolicy, setNewKeyPolicy] = useState({ allowedModels: [], maxTokens: null, maxCostUsd: null });
 
   const [requireApiKey, setRequireApiKey] = useState(false);
   const [requireLogin, setRequireLogin] = useState(true);
@@ -631,7 +632,12 @@ export default function APIPageClient({ machineId }) {
       const res = await fetch("/api/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newKeyName }),
+        body: JSON.stringify({
+          name: newKeyName,
+          allowedModels: newKeyPolicy.allowedModels || [],
+          maxTokens: newKeyPolicy.maxTokens ?? null,
+          maxCostUsd: newKeyPolicy.maxCostUsd ?? null,
+        }),
       });
       const data = await res.json();
 
@@ -639,6 +645,7 @@ export default function APIPageClient({ machineId }) {
         setCreatedKey(data.key);
         await fetchData();
         setNewKeyName("");
+        setNewKeyPolicy({ allowedModels: [], maxTokens: null, maxCostUsd: null });
         setShowAddModal(false);
       }
     } catch (error) {
@@ -1150,6 +1157,7 @@ export default function APIPageClient({ machineId }) {
         onClose={() => {
           setShowAddModal(false);
           setNewKeyName("");
+          setNewKeyPolicy({ allowedModels: [], maxTokens: null, maxCostUsd: null });
         }}
       >
         <div className="flex flex-col gap-4">
@@ -1159,6 +1167,86 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewKeyName(e.target.value)}
             placeholder="Production Key"
           />
+
+          {/* Allowed Models */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-sm font-medium">Allowed Models</p>
+              <Button
+                size="sm"
+                variant="ghost"
+                icon="add"
+                onClick={() => setShowModelModal(true)}
+                disabled={connections.filter((c) => c.isActive !== false).length === 0}
+              >
+                Select Models
+              </Button>
+            </div>
+            <p className="text-xs text-text-muted mb-2">
+              Leave empty to allow all models.
+            </p>
+            {(newKeyPolicy.allowedModels || []).length > 0 ? (
+              <div className="flex flex-wrap gap-1.5 p-2 rounded-lg bg-bg-secondary border border-border min-h-[40px]">
+                {(newKeyPolicy.allowedModels || []).map((model) => (
+                  <span
+                    key={model}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-lg text-xs bg-primary/10 text-primary border border-primary/20"
+                  >
+                    {model}
+                    <button
+                      onClick={() => {
+                        setNewKeyPolicy({
+                          ...newKeyPolicy,
+                          allowedModels: newKeyPolicy.allowedModels.filter((m) => m !== model),
+                        });
+                      }}
+                      className="hover:text-red-500 transition-colors"
+                    >
+                      <span className="material-symbols-outlined text-[12px]">close</span>
+                    </button>
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <div className="p-2 rounded-lg bg-bg-secondary border border-border text-xs text-text-muted">
+                All models allowed
+              </div>
+            )}
+          </div>
+
+          {/* Token & Cost Limits */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-sm font-medium mb-1 block">Max Tokens (lifetime)</label>
+              <input
+                type="number"
+                className="w-full px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                value={newKeyPolicy.maxTokens ?? ""}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setNewKeyPolicy({ ...newKeyPolicy, maxTokens: val === "" ? null : Number(val) });
+                }}
+                placeholder="Unlimited"
+                min="0"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium mb-1 block">Max Cost USD (lifetime)</label>
+              <input
+                type="number"
+                step="0.01"
+                className="w-full px-3 py-1.5 rounded-lg bg-bg-secondary border border-border text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                value={newKeyPolicy.maxCostUsd ?? ""}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setNewKeyPolicy({ ...newKeyPolicy, maxCostUsd: val === "" ? null : Number(val) });
+                }}
+                placeholder="Unlimited"
+                min="0"
+              />
+            </div>
+          </div>
+
           <div className="flex gap-2">
             <Button onClick={handleCreateKey} fullWidth disabled={!newKeyName.trim()}>
               Create
@@ -1167,6 +1255,7 @@ export default function APIPageClient({ machineId }) {
               onClick={() => {
                 setShowAddModal(false);
                 setNewKeyName("");
+                setNewKeyPolicy({ allowedModels: [], maxTokens: null, maxCostUsd: null });
               }}
               variant="ghost"
               fullWidth
@@ -1298,16 +1387,33 @@ export default function APIPageClient({ machineId }) {
         </div>
       </Modal>
 
-      {/* Model Select Modal (multi-select for API key allowlist) */}
+      {/* Model Select Modal (multi-select for API key allowlist — create or edit) */}
       <ModelSelectModal
         isOpen={showModelModal}
         onClose={() => setShowModelModal(false)}
-        onSelect={handleModelSelect}
-        onDeselect={handleModelSelect}
+        onSelect={(model) => {
+          if (editingKeyModels) {
+            handleModelSelect(model);
+          } else {
+            const current = newKeyPolicy.allowedModels || [];
+            if (current.includes(model.value)) {
+              setNewKeyPolicy({ ...newKeyPolicy, allowedModels: current.filter((m) => m !== model.value) });
+            } else {
+              setNewKeyPolicy({ ...newKeyPolicy, allowedModels: [...current, model.value] });
+            }
+          }
+        }}
+        onDeselect={(model) => {
+          if (editingKeyModels) {
+            handleModelSelect(model);
+          } else {
+            setNewKeyPolicy({ ...newKeyPolicy, allowedModels: (newKeyPolicy.allowedModels || []).filter((m) => m !== model.value) });
+          }
+        }}
         selectedModel={null}
         activeProviders={connections.filter((c) => c.isActive !== false)}
         modelAliases={modelAliases}
-        addedModelValues={editingKeyModels?.policy?.allowedModels || []}
+        addedModelValues={editingKeyModels ? (editingKeyModels?.policy?.allowedModels || []) : (newKeyPolicy.allowedModels || [])}
         closeOnSelect={false}
         title="Select Allowed Models"
       />

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { deleteApiKey, getApiKeyById, updateApiKey } from "@/lib/localDb";
+import { deleteApiKey, getApiKeyById, updateApiKey, getApiKeyUsageTotals } from "@/lib/localDb";
 
 // GET /api/keys/[id] - Get single key
 export async function GET(request, { params }) {
@@ -9,7 +9,8 @@ export async function GET(request, { params }) {
     if (!key) {
       return NextResponse.json({ error: "Key not found" }, { status: 404 });
     }
-    return NextResponse.json({ key });
+    const usage = await getApiKeyUsageTotals(id);
+    return NextResponse.json({ key: { ...key, usage } });
   } catch (error) {
     console.log("Error fetching key:", error);
     return NextResponse.json({ error: "Failed to fetch key" }, { status: 500 });
@@ -21,7 +22,7 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { isActive, allowedModels } = body;
+    const { isActive, allowedModels, maxTokens, maxCostUsd } = body;
 
     const existing = await getApiKeyById(id);
     if (!existing) {
@@ -30,8 +31,14 @@ export async function PUT(request, { params }) {
 
     const updateData = {};
     if (isActive !== undefined) updateData.isActive = isActive;
-    if (Array.isArray(allowedModels)) {
-      updateData.policy = { ...existing.policy, allowedModels };
+
+    // Merge policy fields — only update fields that are explicitly provided
+    const policyUpdate = {};
+    if (Array.isArray(allowedModels)) policyUpdate.allowedModels = allowedModels;
+    if (maxTokens !== undefined) policyUpdate.maxTokens = maxTokens != null ? Number(maxTokens) : null;
+    if (maxCostUsd !== undefined) policyUpdate.maxCostUsd = maxCostUsd != null ? Number(maxCostUsd) : null;
+    if (Object.keys(policyUpdate).length > 0) {
+      updateData.policy = { ...existing.policy, ...policyUpdate };
     }
 
     const updated = await updateApiKey(id, updateData);

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -21,7 +21,7 @@ export async function PUT(request, { params }) {
   try {
     const { id } = await params;
     const body = await request.json();
-    const { isActive } = body;
+    const { isActive, allowedModels } = body;
 
     const existing = await getApiKeyById(id);
     if (!existing) {
@@ -30,6 +30,9 @@ export async function PUT(request, { params }) {
 
     const updateData = {};
     if (isActive !== undefined) updateData.isActive = isActive;
+    if (Array.isArray(allowedModels)) {
+      updateData.policy = { ...existing.policy, allowedModels };
+    }
 
     const updated = await updateApiKey(id, updateData);
 

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getApiKeys, createApiKey } from "@/lib/localDb";
+import { getApiKeys, createApiKey, getAllApiKeyUsageTotals } from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 
 export const dynamic = "force-dynamic";
@@ -7,8 +7,15 @@ export const dynamic = "force-dynamic";
 // GET /api/keys - List API keys
 export async function GET() {
   try {
-    const keys = await getApiKeys();
-    return NextResponse.json({ keys });
+    const [keys, usageTotals] = await Promise.all([
+      getApiKeys(),
+      getAllApiKeyUsageTotals(),
+    ]);
+    const keysWithUsage = keys.map((k) => ({
+      ...k,
+      usage: usageTotals[k.id] || { totalTokens: 0, totalCost: 0, totalRequests: 0 },
+    }));
+    return NextResponse.json({ keys: keysWithUsage });
   } catch (error) {
     console.log("Error fetching keys:", error);
     return NextResponse.json({ error: "Failed to fetch keys" }, { status: 500 });
@@ -19,7 +26,7 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name, allowedModels } = body;
+    const { name, allowedModels, maxTokens, maxCostUsd } = body;
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -27,7 +34,11 @@ export async function POST(request) {
 
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
-    const policy = { allowedModels: Array.isArray(allowedModels) ? allowedModels : [] };
+    const policy = {
+      allowedModels: Array.isArray(allowedModels) ? allowedModels : [],
+      maxTokens: maxTokens != null ? Number(maxTokens) : null,
+      maxCostUsd: maxCostUsd != null ? Number(maxCostUsd) : null,
+    };
     const apiKey = await createApiKey(name, machineId, policy);
 
     return NextResponse.json({

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -19,7 +19,7 @@ export async function GET() {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name } = body;
+    const { name, allowedModels } = body;
 
     if (!name) {
       return NextResponse.json({ error: "Name is required" }, { status: 400 });
@@ -27,13 +27,15 @@ export async function POST(request) {
 
     // Always get machineId from server
     const machineId = await getConsistentMachineId();
-    const apiKey = await createApiKey(name, machineId);
+    const policy = { allowedModels: Array.isArray(allowedModels) ? allowedModels : [] };
+    const apiKey = await createApiKey(name, machineId, policy);
 
     return NextResponse.json({
       key: apiKey.key,
       name: apiKey.name,
       id: apiKey.id,
       machineId: apiKey.machineId,
+      policy: apiKey.policy,
     }, { status: 201 });
   } catch (error) {
     console.log("Error creating key:", error);

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -29,7 +29,7 @@ export {
 
 // API keys
 export {
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByKey, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
 } from "./repos/apiKeysRepo.js";
 
 // Combos
@@ -77,7 +77,7 @@ export async function exportDb() {
     providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
-    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
+    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, policy: parseJson(r.policy, { allowedModels: [] }), createdAt: r.createdAt })),
     combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), createdAt: r.createdAt, updatedAt: r.updatedAt })),
     modelAliases: {},
     customModels: [],
@@ -137,8 +137,8 @@ export async function importDb(payload) {
     }
     for (const k of payload.apiKeys || []) {
       db.run(
-        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, policy, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, stringifyJson(k.policy || { allowedModels: [] }), k.createdAt || new Date().toISOString()]
       );
     }
     for (const c of payload.combos || []) {

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -67,6 +67,11 @@ export {
   saveRequestDetail, getRequestDetails, getRequestDetailById,
 } from "./repos/requestDetailsRepo.js";
 
+// API key usage totals
+export {
+  getApiKeyUsageTotals, getAllApiKeyUsageTotals,
+} from "./repos/apiKeyUsageTotalsRepo.js";
+
 // Export/import full DB
 export async function exportDb() {
   const db = await getAdapter();

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -142,8 +142,8 @@ function importLegacyMain(adapter, data) {
 
   importWithAssertion(adapter, "apiKeys", data.apiKeys || [], (k) => {
     adapter.run(
-      `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-      [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+      `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, policy, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+      [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, stringifyJson(k.policy || { allowedModels: [] }), k.createdAt || new Date().toISOString()]
     );
   }, (k) => ({ id: k.id ?? null, name: k.name ?? null }));
 

--- a/src/lib/db/migrations/002-api-key-policy.js
+++ b/src/lib/db/migrations/002-api-key-policy.js
@@ -1,0 +1,13 @@
+// Add `policy` JSON column to apiKeys for per-key model allowlist (and future
+// token/cost limits). Additive only — syncSchemaFromTables also handles this
+// for existing DBs, but the migration stamps the version for traceability.
+export default {
+  version: 2,
+  name: "api-key-policy",
+  up(db) {
+    const cols = db.all(`PRAGMA table_info(apiKeys)`);
+    if (!cols.some((c) => c.name === "policy")) {
+      db.exec(`ALTER TABLE apiKeys ADD COLUMN policy TEXT`);
+    }
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-api-key-policy.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/apiKeyUsageTotalsRepo.js
+++ b/src/lib/db/repos/apiKeyUsageTotalsRepo.js
@@ -1,0 +1,68 @@
+import { getAdapter } from "../driver.js";
+
+/**
+ * Get lifetime usage totals for a single API key.
+ * @param {string} apiKeyId
+ * @returns {Promise<{ totalTokens: number, totalCost: number, totalRequests: number, updatedAt: string } | null>}
+ */
+export async function getApiKeyUsageTotals(apiKeyId) {
+  const db = await getAdapter();
+  const row = db.get(`SELECT * FROM apiKeyUsageTotals WHERE apiKeyId = ?`, [apiKeyId]);
+  if (!row) return { totalTokens: 0, totalCost: 0, totalRequests: 0, updatedAt: null };
+  return {
+    apiKeyId: row.apiKeyId,
+    totalTokens: row.totalTokens || 0,
+    totalCost: row.totalCost || 0,
+    totalRequests: row.totalRequests || 0,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Get lifetime usage totals for all API keys.
+ * @returns {Promise<Record<string, { totalTokens: number, totalCost: number, totalRequests: number }>>}
+ */
+export async function getAllApiKeyUsageTotals() {
+  const db = await getAdapter();
+  const rows = db.all(`SELECT * FROM apiKeyUsageTotals`);
+  const map = {};
+  for (const row of rows) {
+    map[row.apiKeyId] = {
+      totalTokens: row.totalTokens || 0,
+      totalCost: row.totalCost || 0,
+      totalRequests: row.totalRequests || 0,
+    };
+  }
+  return map;
+}
+
+/**
+ * Increment usage totals for an API key. Called inside the saveRequestUsage transaction.
+ * Must be called with a db adapter already obtained (sync context).
+ *
+ * @param {object} db - adapter instance (from getAdapter())
+ * @param {string} apiKeyId
+ * @param {{ tokens: number, cost: number }} usage
+ */
+export function incrementApiKeyUsageSync(db, apiKeyId, { tokens, cost }) {
+  if (!apiKeyId) return;
+  const now = new Date().toISOString();
+  const row = db.get(`SELECT * FROM apiKeyUsageTotals WHERE apiKeyId = ?`, [apiKeyId]);
+  if (row) {
+    db.run(
+      `UPDATE apiKeyUsageTotals SET totalTokens = ?, totalCost = ?, totalRequests = ?, updatedAt = ? WHERE apiKeyId = ?`,
+      [
+        (row.totalTokens || 0) + (tokens || 0),
+        (row.totalCost || 0) + (cost || 0),
+        (row.totalRequests || 0) + 1,
+        now,
+        apiKeyId,
+      ]
+    );
+  } else {
+    db.run(
+      `INSERT INTO apiKeyUsageTotals(apiKeyId, totalTokens, totalCost, totalRequests, updatedAt) VALUES(?, ?, ?, ?, ?)`,
+      [apiKeyId, tokens || 0, cost || 0, 1, now]
+    );
+  }
+}

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 
-const DEFAULT_POLICY = { allowedModels: [] };
+const DEFAULT_POLICY = { allowedModels: [], maxTokens: null, maxCostUsd: null };
 
 function rowToKey(row) {
   if (!row) return null;

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -1,5 +1,8 @@
 import { v4 as uuidv4 } from "uuid";
 import { getAdapter } from "../driver.js";
+import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+
+const DEFAULT_POLICY = { allowedModels: [] };
 
 function rowToKey(row) {
   if (!row) return null;
@@ -9,6 +12,7 @@ function rowToKey(row) {
     name: row.name,
     machineId: row.machineId,
     isActive: row.isActive === 1 || row.isActive === true,
+    policy: parseJson(row.policy, DEFAULT_POLICY),
     createdAt: row.createdAt,
   };
 }
@@ -25,7 +29,7 @@ export async function getApiKeyById(id) {
   return rowToKey(row);
 }
 
-export async function createApiKey(name, machineId) {
+export async function createApiKey(name, machineId, policy = null) {
   if (!machineId) throw new Error("machineId is required");
   const db = await getAdapter();
   const { generateApiKeyWithMachine } = await import("@/shared/utils/apiKey");
@@ -36,11 +40,12 @@ export async function createApiKey(name, machineId) {
     key: result.key,
     machineId,
     isActive: true,
+    policy: policy || { allowedModels: [] },
     createdAt: new Date().toISOString(),
   };
   db.run(
-    `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.createdAt]
+    `INSERT INTO apiKeys(id, key, name, machineId, isActive, policy, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, stringifyJson(apiKey.policy), apiKey.createdAt]
   );
   return apiKey;
 }
@@ -53,8 +58,8 @@ export async function updateApiKey(id, data) {
     if (!row) return;
     const merged = { ...rowToKey(row), ...data };
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ? WHERE id = ?`,
-      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, id]
+      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, policy = ? WHERE id = ?`,
+      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, stringifyJson(merged.policy || DEFAULT_POLICY), id]
     );
     result = merged;
   });
@@ -72,4 +77,10 @@ export async function validateApiKey(key) {
   const row = db.get(`SELECT isActive FROM apiKeys WHERE key = ?`, [key]);
   if (!row) return false;
   return row.isActive === 1 || row.isActive === true;
+}
+
+export async function getApiKeyByKey(key) {
+  const db = await getAdapter();
+  const row = db.get(`SELECT * FROM apiKeys WHERE key = ?`, [key]);
+  return rowToKey(row);
 }

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 import { getMeta, setMeta } from "../helpers/metaStore.js";
+import { incrementApiKeyUsageSync } from "./apiKeyUsageTotalsRepo.js";
 
 function maskApiKey(key) {
   if (!key || typeof key !== "string") return null;
@@ -250,6 +251,13 @@ export async function saveRequestUsage(entry) {
     const promptTokens = tokens.prompt_tokens || tokens.input_tokens || 0;
     const completionTokens = tokens.completion_tokens || tokens.output_tokens || 0;
 
+    // Resolve apiKey string → apiKeyId for usage totals counter
+    let apiKeyId = null;
+    if (entry.apiKey) {
+      const keyRow = db.get(`SELECT id FROM apiKeys WHERE key = ?`, [entry.apiKey]);
+      if (keyRow) apiKeyId = keyRow.id;
+    }
+
     let inserted = false;
 
     // All 3 writes (history insert, daily upsert, lifetime counter) in ONE transaction.
@@ -302,6 +310,14 @@ export async function saveRequestUsage(entry) {
       const cur = db.get(`SELECT value FROM _meta WHERE key = 'totalRequestsLifetime'`);
       const next = (cur ? parseInt(cur.value, 10) : 0) + 1;
       db.run(`INSERT INTO _meta(key, value) VALUES('totalRequestsLifetime', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`, [String(next)]);
+
+      // Increment per-API-key lifetime usage totals
+      if (apiKeyId) {
+        incrementApiKeyUsageSync(db, apiKeyId, {
+          tokens: promptTokens + completionTokens,
+          cost: entry.cost || 0,
+        });
+      }
       inserted = true;
     });
 

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -1,5 +1,5 @@
 // Latest schema version — bumped when a migration is added in ./migrations/
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -78,6 +78,7 @@ export const TABLES = {
       name: "TEXT",
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
+      policy: "TEXT",
       createdAt: "TEXT NOT NULL",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -149,6 +149,15 @@ export const TABLES = {
       "CREATE INDEX IF NOT EXISTS idx_rd_conn ON requestDetails(connectionId)",
     ],
   },
+  apiKeyUsageTotals: {
+    columns: {
+      apiKeyId: "TEXT PRIMARY KEY",
+      totalTokens: "INTEGER DEFAULT 0",
+      totalCost: "REAL DEFAULT 0",
+      totalRequests: "INTEGER DEFAULT 0",
+      updatedAt: "TEXT NOT NULL",
+    },
+  },
 };
 
 export function buildCreateTableSql(name, def) {

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -10,7 +10,7 @@ export {
   createProviderNode, updateProviderNode, deleteProviderNode,
   getProxyPools, getProxyPoolById,
   createProxyPool, updateProxyPool, deleteProxyPool,
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByKey, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
   getCombos, getComboById, getComboByName,
   createCombo, updateCombo, deleteCombo,
   getModelAliases, setModelAlias, deleteModelAlias,

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -17,5 +17,6 @@ export {
   getCustomModels, addCustomModel, deleteCustomModel,
   getMitmAlias, setMitmAliasAll,
   getPricing, getPricingForModel, updatePricing, resetPricing, resetAllPricing,
+  getApiKeyUsageTotals, getAllApiKeyUsageTotals,
   exportDb, importDb,
 } from "@/lib/db/index.js";

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -20,6 +20,7 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+import { enforceApiKeyModelPolicy } from "../services/apiKeyPolicy.js";
 
 /**
  * Handle chat completion request
@@ -84,6 +85,10 @@ export async function handleChat(request, clientRawRequest = null) {
     log.warn("CHAT", "Missing model");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   }
+
+  // Enforce per-API-key model allowlist
+  const policyError = await enforceApiKeyModelPolicy(request, modelStr);
+  if (policyError) return policyError;
 
   // Bypass naming/warmup requests before combo rotation to avoid wasting rotation slots
   const userAgent = request?.headers?.get("user-agent") || "";

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -12,6 +12,7 @@ import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
+import { enforceApiKeyModelPolicy } from "../services/apiKeyPolicy.js";
 
 /**
  * Handle embeddings request for the SSE/Next.js server.
@@ -64,6 +65,9 @@ export async function handleEmbeddings(request) {
     log.warn("EMBEDDINGS", "Missing input");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: input");
   }
+
+  const policyError = await enforceApiKeyModelPolicy(request, modelStr);
+  if (policyError) return policyError;
 
   const modelInfo = await getModelInfo(modelStr);
   if (!modelInfo.provider) {

--- a/src/sse/handlers/fetch.js
+++ b/src/sse/handlers/fetch.js
@@ -13,6 +13,7 @@ import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { handleComboChat, getComboModelsFromData } from "open-sse/services/combo.js";
+import { enforceApiKeyModelPolicy } from "../services/apiKeyPolicy.js";
 import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
 
 /**
@@ -86,6 +87,9 @@ export async function handleFetch(request) {
     log.warn("FETCH", "Blocked URL", { url: targetUrl });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, err.message);
   }
+
+  const policyError = await enforceApiKeyModelPolicy(request, providerInput);
+  if (policyError) return policyError;
 
   // Combo expansion: providerInput may be a combo name → run fallback/round-robin across providers
   const combos = await getCombos();

--- a/src/sse/handlers/imageGeneration.js
+++ b/src/sse/handlers/imageGeneration.js
@@ -13,6 +13,7 @@ import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { handleComboChat } from "open-sse/services/combo.js";
 import * as log from "../utils/logger.js";
+import { enforceApiKeyModelPolicy } from "../services/apiKeyPolicy.js";
 
 // Providers that don't require credentials (noAuth)
 const NO_AUTH_PROVIDERS = new Set(["sdwebui", "comfyui"]);
@@ -45,6 +46,9 @@ export async function handleImageGeneration(request) {
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   if (!body.prompt) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: prompt");
+
+  const policyError = await enforceApiKeyModelPolicy(request, modelStr);
+  if (policyError) return policyError;
 
   // Combo expansion: model may be a combo name → run fallback/round-robin across models
   const comboModels = await getComboModels(modelStr);

--- a/src/sse/handlers/search.js
+++ b/src/sse/handlers/search.js
@@ -13,6 +13,7 @@ import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { handleComboChat, getComboModelsFromData } from "open-sse/services/combo.js";
+import { enforceApiKeyModelPolicy } from "../services/apiKeyPolicy.js";
 
 /**
  * Handle web search request for the SSE/Next.js server.
@@ -67,6 +68,9 @@ export async function handleSearch(request) {
     log.warn("SEARCH", "Missing query");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: query");
   }
+
+  const policyError = await enforceApiKeyModelPolicy(request, providerInput);
+  if (policyError) return policyError;
 
   // Combo expansion: providerInput may be a combo name → run fallback/round-robin across providers
   const combos = await getCombos();

--- a/src/sse/handlers/stt.js
+++ b/src/sse/handlers/stt.js
@@ -9,6 +9,7 @@ import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import * as log from "../utils/logger.js";
+import { enforceApiKeyModelPolicy } from "../services/apiKeyPolicy.js";
 
 // Providers requiring credentials for STT
 const CREDENTIALED_PROVIDERS = new Set(
@@ -38,6 +39,9 @@ export async function handleStt(request) {
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   if (!formData.get("file")) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: file");
+
+  const policyError = await enforceApiKeyModelPolicy(request, modelStr);
+  if (policyError) return policyError;
 
   const modelInfo = await getModelInfo(modelStr);
   if (!modelInfo.provider) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");

--- a/src/sse/handlers/tts.js
+++ b/src/sse/handlers/tts.js
@@ -10,6 +10,7 @@ import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { handleComboChat } from "open-sse/services/combo.js";
 import * as log from "../utils/logger.js";
+import { enforceApiKeyModelPolicy } from "../services/apiKeyPolicy.js";
 
 // Derived from providers.js: any TTS provider not noAuth requires stored credentials
 const CREDENTIALED_PROVIDERS = new Set(
@@ -42,6 +43,9 @@ export async function handleTts(request) {
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   if (!body.input) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: input");
+
+  const policyError = await enforceApiKeyModelPolicy(request, modelStr);
+  if (policyError) return policyError;
 
   // Combo expansion: model may be a combo name → run fallback/round-robin across models
   const comboModels = await getComboModels(modelStr);

--- a/src/sse/services/apiKeyPolicy.js
+++ b/src/sse/services/apiKeyPolicy.js
@@ -1,0 +1,51 @@
+import { getApiKeyByKey } from "@/lib/localDb";
+import { extractApiKey } from "./auth.js";
+import { errorResponse } from "open-sse/utils/error.js";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+import * as log from "../utils/logger.js";
+
+/**
+ * Check if a model is allowed by the API key policy.
+ * Empty allowedModels = all models allowed.
+ * Exact match against the requested model string.
+ *
+ * @param {{ allowedModels?: string[] } | null} policy
+ * @param {string} modelStr
+ * @returns {boolean}
+ */
+export function isModelAllowed(policy, modelStr) {
+  if (!policy || !policy.allowedModels || policy.allowedModels.length === 0) {
+    return true;
+  }
+  return policy.allowedModels.includes(modelStr);
+}
+
+/**
+ * Enforce API key model policy on a request.
+ *
+ * Call this AFTER the existing requireApiKey/isValidApiKey check.
+ * If no API key is provided, returns null (allow — requireApiKey handles that case).
+ * If the key has no policy or an empty allowedModels list, returns null (allow all).
+ * If the model is not in the allowlist, returns a 403 error Response.
+ *
+ * @param {Request} request
+ * @param {string} modelStr - The model string from the request body
+ * @returns {Promise<Response | null>} null if allowed, error Response if rejected
+ */
+export async function enforceApiKeyModelPolicy(request, modelStr) {
+  const apiKey = extractApiKey(request);
+  if (!apiKey) return null;
+
+  const keyRecord = await getApiKeyByKey(apiKey);
+  if (!keyRecord || !keyRecord.isActive) return null;
+
+  if (!isModelAllowed(keyRecord.policy, modelStr)) {
+    log.warn("AUTH", `Model "${modelStr}" not allowed for API key "${keyRecord.name}"`);
+    return errorResponse(
+      HTTP_STATUS.FORBIDDEN,
+      `Model "${modelStr}" is not allowed for this API key`
+    );
+  }
+
+  return null;
+}

--- a/src/sse/services/apiKeyPolicy.js
+++ b/src/sse/services/apiKeyPolicy.js
@@ -1,4 +1,4 @@
-import { getApiKeyByKey } from "@/lib/localDb";
+import { getApiKeyByKey, getApiKeyUsageTotals } from "@/lib/localDb";
 import { extractApiKey } from "./auth.js";
 import { errorResponse } from "open-sse/utils/error.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
@@ -21,12 +21,13 @@ export function isModelAllowed(policy, modelStr) {
 }
 
 /**
- * Enforce API key model policy on a request.
+ * Enforce API key policy on a request: model allowlist + token/cost limits.
  *
  * Call this AFTER the existing requireApiKey/isValidApiKey check.
  * If no API key is provided, returns null (allow — requireApiKey handles that case).
  * If the key has no policy or an empty allowedModels list, returns null (allow all).
  * If the model is not in the allowlist, returns a 403 error Response.
+ * If token or cost limit is exceeded, returns a 429 error Response.
  *
  * @param {Request} request
  * @param {string} modelStr - The model string from the request body
@@ -39,12 +40,39 @@ export async function enforceApiKeyModelPolicy(request, modelStr) {
   const keyRecord = await getApiKeyByKey(apiKey);
   if (!keyRecord || !keyRecord.isActive) return null;
 
-  if (!isModelAllowed(keyRecord.policy, modelStr)) {
+  const policy = keyRecord.policy || {};
+
+  // Check model allowlist
+  if (!isModelAllowed(policy, modelStr)) {
     log.warn("AUTH", `Model "${modelStr}" not allowed for API key "${keyRecord.name}"`);
     return errorResponse(
       HTTP_STATUS.FORBIDDEN,
       `Model "${modelStr}" is not allowed for this API key`
     );
+  }
+
+  // Check token/cost limits
+  const maxTokens = policy.maxTokens != null ? Number(policy.maxTokens) : null;
+  const maxCostUsd = policy.maxCostUsd != null ? Number(policy.maxCostUsd) : null;
+
+  if (maxTokens != null || maxCostUsd != null) {
+    const usage = await getApiKeyUsageTotals(keyRecord.id);
+
+    if (maxTokens != null && usage.totalTokens >= maxTokens) {
+      log.warn("AUTH", `Token limit reached for API key "${keyRecord.name}" (${usage.totalTokens}/${maxTokens})`);
+      return errorResponse(
+        HTTP_STATUS.RATE_LIMITED,
+        `API key token limit reached (${usage.totalTokens}/${maxTokens} tokens)`
+      );
+    }
+
+    if (maxCostUsd != null && usage.totalCost >= maxCostUsd) {
+      log.warn("AUTH", `Cost limit reached for API key "${keyRecord.name}" ($${usage.totalCost.toFixed(4)}/$${maxCostUsd})`);
+      return errorResponse(
+        HTTP_STATUS.RATE_LIMITED,
+        `API key cost limit reached ($${usage.totalCost.toFixed(4)}/$${maxCostUsd})`
+      );
+    }
   }
 
   return null;

--- a/src/sse/services/apiKeyPolicy.js
+++ b/src/sse/services/apiKeyPolicy.js
@@ -34,6 +34,12 @@ export function isModelAllowed(policy, modelStr) {
  * @returns {Promise<Response | null>} null if allowed, error Response if rejected
  */
 export async function enforceApiKeyModelPolicy(request, modelStr) {
+  // Skip policy enforcement for internal dashboard requests (e.g. provider test,
+  // model ping) — these carry an x-9r-cli-token header and are not from external
+  // API consumers. Policy only applies to external client requests.
+  const cliToken = request?.headers?.get("x-9r-cli-token");
+  if (cliToken) return null;
+
   const apiKey = extractApiKey(request);
   if (!apiKey) return null;
 

--- a/tests/unit/api-key-policy.test.js
+++ b/tests/unit/api-key-policy.test.js
@@ -42,9 +42,10 @@ const { isModelAllowed, enforceApiKeyModelPolicy } = await import(
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
-function makeRequest(authHeader = null) {
+function makeRequest(authHeader = null, cliToken = null) {
   const headers = new Headers();
   if (authHeader) headers.set("authorization", `Bearer ${authHeader}`);
+  if (cliToken) headers.set("x-9r-cli-token", cliToken);
   return { headers };
 }
 
@@ -226,5 +227,18 @@ describe("enforceApiKeyModelPolicy", () => {
     const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "anthropic/claude");
     expect(mocks.errorResponse).toHaveBeenCalledWith(403, expect.any(String));
     expect(mocks.errorResponse).not.toHaveBeenCalledWith(429, expect.any(String));
+  });
+
+  it("skips policy enforcement for internal dashboard requests (x-9r-cli-token)", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: ["openai/gpt-4o"], maxTokens: 1, maxCostUsd: 1 },
+    });
+    // Even with a restrictive policy + exceeded limits, internal requests bypass
+    mocks.getApiKeyUsageTotals.mockResolvedValue({ totalTokens: 9999, totalCost: 9999, totalRequests: 1 });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test", "cli-token-abc"), "anthropic/claude");
+    expect(result).toBe(null);
+    expect(mocks.getApiKeyByKey).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/api-key-policy.test.js
+++ b/tests/unit/api-key-policy.test.js
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  getApiKeyByKey: vi.fn(),
+  getApiKeyUsageTotals: vi.fn(),
+  extractApiKey: vi.fn(),
+  errorResponse: vi.fn((status, msg) => ({ status, body: { error: { message: msg } } })),
+  logWarn: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getApiKeyByKey: mocks.getApiKeyByKey,
+  getApiKeyUsageTotals: mocks.getApiKeyUsageTotals,
+}));
+
+vi.mock("@/sse/services/auth.js", () => ({
+  extractApiKey: mocks.extractApiKey,
+}));
+
+vi.mock("open-sse/utils/error.js", () => ({
+  errorResponse: mocks.errorResponse,
+}));
+
+vi.mock("open-sse/config/runtimeConfig.js", () => ({
+  HTTP_STATUS: { FORBIDDEN: 403, RATE_LIMITED: 429 },
+}));
+
+vi.mock("@/sse/utils/logger.js", () => ({
+  warn: mocks.logWarn,
+  info: vi.fn(),
+  debug: vi.fn(),
+  error: vi.fn(),
+  request: vi.fn(),
+  maskKey: vi.fn((k) => k),
+}));
+
+const { isModelAllowed, enforceApiKeyModelPolicy } = await import(
+  "../../src/sse/services/apiKeyPolicy.js"
+);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeRequest(authHeader = null) {
+  const headers = new Headers();
+  if (authHeader) headers.set("authorization", `Bearer ${authHeader}`);
+  return { headers };
+}
+
+// ─── isModelAllowed (pure function) ────────────────────────────────────────
+
+describe("isModelAllowed", () => {
+  it("allows all when policy is null", () => {
+    expect(isModelAllowed(null, "openai/gpt-4o")).toBe(true);
+  });
+
+  it("allows all when allowedModels is empty", () => {
+    expect(isModelAllowed({ allowedModels: [] }, "openai/gpt-4o")).toBe(true);
+  });
+
+  it("allows all when allowedModels is undefined", () => {
+    expect(isModelAllowed({ allowedModels: undefined }, "openai/gpt-4o")).toBe(true);
+  });
+
+  it("allows exact match", () => {
+    expect(isModelAllowed({ allowedModels: ["openai/gpt-4o"] }, "openai/gpt-4o")).toBe(true);
+  });
+
+  it("allows combo name exact match", () => {
+    expect(isModelAllowed({ allowedModels: ["cheap-coding"] }, "cheap-coding")).toBe(true);
+  });
+
+  it("allows alias exact match", () => {
+    expect(isModelAllowed({ allowedModels: ["kr/claude-sonnet-4.5"] }, "kr/claude-sonnet-4.5")).toBe(true);
+  });
+
+  it("rejects model not in list", () => {
+    expect(isModelAllowed({ allowedModels: ["openai/gpt-4o"] }, "openai/gpt-5")).toBe(false);
+  });
+
+  it("rejects when list has different models", () => {
+    expect(
+      isModelAllowed(
+        { allowedModels: ["openai/gpt-4o", "anthropic/claude-sonnet-4.5"] },
+        "openai/o3"
+      )
+    ).toBe(false);
+  });
+
+  it("does not match partial provider prefix", () => {
+    expect(isModelAllowed({ allowedModels: ["openai/gpt-4o"] }, "openai/gpt-4o-mini")).toBe(false);
+  });
+});
+
+// ─── enforceApiKeyModelPolicy (async, with mocks) ──────────────────────────
+
+describe("enforceApiKeyModelPolicy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.extractApiKey.mockReturnValue(null);
+    mocks.getApiKeyByKey.mockResolvedValue(null);
+    mocks.getApiKeyUsageTotals.mockResolvedValue({ totalTokens: 0, totalCost: 0, totalRequests: 0 });
+    mocks.errorResponse.mockReturnValue({ status: 403, body: { error: { message: "blocked" } } });
+  });
+
+  it("returns null (allow) when no API key in request", async () => {
+    mocks.extractApiKey.mockReturnValue(null);
+    const result = await enforceApiKeyModelPolicy(makeRequest(null), "openai/gpt-4o");
+    expect(result).toBe(null);
+    expect(mocks.getApiKeyByKey).not.toHaveBeenCalled();
+  });
+
+  it("returns null (allow) when key not found in DB", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue(null);
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toBe(null);
+  });
+
+  it("returns null (allow) when key is inactive", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({ id: "1", name: "test", isActive: false, policy: {} });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toBe(null);
+  });
+
+  it("returns null (allow) when policy has empty allowedModels", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true, policy: { allowedModels: [] },
+    });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toBe(null);
+  });
+
+  it("returns null (allow) when model is in allowlist", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: ["openai/gpt-4o"], maxTokens: null, maxCostUsd: null },
+    });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toBe(null);
+  });
+
+  it("returns 403 error when model not in allowlist", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: ["openai/gpt-4o"], maxTokens: null, maxCostUsd: null },
+    });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "anthropic/claude-sonnet-4.5");
+    expect(result).toEqual({ status: 403, body: { error: { message: "blocked" } } });
+    expect(mocks.errorResponse).toHaveBeenCalledWith(403, expect.stringContaining("anthropic/claude-sonnet-4.5"));
+    expect(mocks.logWarn).toHaveBeenCalled();
+  });
+
+  it("returns null (allow) when under token limit", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: [], maxTokens: 10000, maxCostUsd: null },
+    });
+    mocks.getApiKeyUsageTotals.mockResolvedValue({ totalTokens: 5000, totalCost: 0, totalRequests: 10 });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toBe(null);
+  });
+
+  it("returns 429 error when token limit exceeded", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: [], maxTokens: 10000, maxCostUsd: null },
+    });
+    mocks.getApiKeyUsageTotals.mockResolvedValue({ totalTokens: 10000, totalCost: 0, totalRequests: 50 });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toEqual({ status: 403, body: { error: { message: "blocked" } } });
+    expect(mocks.errorResponse).toHaveBeenCalledWith(429, expect.stringContaining("token limit"));
+    expect(mocks.logWarn).toHaveBeenCalled();
+  });
+
+  it("returns null (allow) when under cost limit", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: [], maxTokens: null, maxCostUsd: 10 },
+    });
+    mocks.getApiKeyUsageTotals.mockResolvedValue({ totalTokens: 0, totalCost: 5.0, totalRequests: 10 });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toBe(null);
+  });
+
+  it("returns 429 error when cost limit exceeded", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: [], maxTokens: null, maxCostUsd: 10 },
+    });
+    mocks.getApiKeyUsageTotals.mockResolvedValue({ totalTokens: 0, totalCost: 10.0, totalRequests: 50 });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toEqual({ status: 403, body: { error: { message: "blocked" } } });
+    expect(mocks.errorResponse).toHaveBeenCalledWith(429, expect.stringContaining("cost limit"));
+    expect(mocks.logWarn).toHaveBeenCalled();
+  });
+
+  it("returns null (allow) when maxTokens and maxCostUsd are both null", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: [], maxTokens: null, maxCostUsd: null },
+    });
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "openai/gpt-4o");
+    expect(result).toBe(null);
+    expect(mocks.getApiKeyUsageTotals).not.toHaveBeenCalled();
+  });
+
+  it("checks model allowlist first, then token limit", async () => {
+    mocks.extractApiKey.mockReturnValue("sk-test");
+    mocks.getApiKeyByKey.mockResolvedValue({
+      id: "1", name: "test", isActive: true,
+      policy: { allowedModels: ["openai/gpt-4o"], maxTokens: 1, maxCostUsd: null },
+    });
+    mocks.getApiKeyUsageTotals.mockResolvedValue({ totalTokens: 999, totalCost: 0, totalRequests: 1 });
+    // Model not allowed → should get 403, not 429
+    const result = await enforceApiKeyModelPolicy(makeRequest("sk-test"), "anthropic/claude");
+    expect(mocks.errorResponse).toHaveBeenCalledWith(403, expect.any(String));
+    expect(mocks.errorResponse).not.toHaveBeenCalledWith(429, expect.any(String));
+  });
+});


### PR DESCRIPTION
## Summary

Add per-API-key policy with three controls:

- **Model allowlist** — restrict which models an API key can access. Empty = all models allowed. Exact match against the model string clients send (e.g. `openai/gpt-4o-mini`, combo names, aliases).
- **Max tokens (lifetime)** — reject requests when cumulative token usage exceeds the limit. Null = unlimited.
- **Max cost USD (lifetime)** — reject requests when cumulative cost exceeds the limit. Null = unlimited.

## Changes

### DB
- Add `policy` JSON column to `apiKeys` table (schema v2, migration 002)
- New `apiKeyUsageTotals` table for per-key lifetime token/cost counters
- `saveRequestUsage()` increments API key totals in the same transaction as usage history

### Backend
- New `src/sse/services/apiKeyPolicy.js` — enforces model allowlist (403) and token/cost limits (429) before provider routing
- Wired into all 7 SSE handlers: chat, tts, stt, embeddings, imageGeneration, search, fetch
- Policy enforcement skipped for internal dashboard requests (`x-9r-cli-token` header)

### API
- `POST /api/keys` — accepts `allowedModels`, `maxTokens`, `maxCostUsd`
- `PUT /api/keys/[id]` — accepts same fields for updating
- `GET /api/keys` — returns policy + usage totals per key

### UI
- Create key modal includes allowed models selector + token/cost limit inputs
- Edit key modal (click gear icon) with same fields
- Model picker uses existing `ModelSelectModal` (chip-based, same as cli_tools page)
- Key list shows used/max counters (red when exceeded)

### Tests
- 22 unit tests covering: null policy, empty allowlist, exact match, combo/alias, inactive key, token/cost limit exceeded (429), model not allowed (403), internal dashboard bypass

## Backward Compatibility

- Existing API keys get default `{ allowedModels: [], maxTokens: null, maxCostUsd: null }` = unlimited
- `validateApiKey()` behavior unchanged
- DB migration is additive (ALTER TABLE ADD COLUMN)
- Internal dashboard requests bypass policy enforcement


### UI Screenshots
**Create Key:**
<img width="1638" height="1027" alt="image" src="https://github.com/user-attachments/assets/62028646-4d67-42f2-ac7e-337b6981f2da" />

**Edit Policy:**
<img width="1631" height="1024" alt="image" src="https://github.com/user-attachments/assets/18e37327-77b0-4449-a1cb-bdab2571d8f2" />

**Key list with Usage:**
<img width="1957" height="1030" alt="image" src="https://github.com/user-attachments/assets/d07a666f-72cb-4c71-96c2-d3c2e1abcc77" />
