### PR TITLE
fix(stream): decloak tool names in claude→claude streaming passthrough

### DIFF
--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -37,7 +37,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
     return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
 }
 
 /**

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -2,7 +2,7 @@ import { translateResponse, initState } from "../translator/index.js";
 import { FORMATS } from "../translator/formats.js";
 import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
-import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
+import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE, decloakClaudeToolUseEvent } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
@@ -109,6 +109,12 @@ export function createSSEStream(options = {}) {
 
               const idFixed = fixInvalidId(parsed);
 
+              // Decloak tool names in Claude content_block_start events.
+              // claude→claude passthrough doesn't go through translateResponse (which
+              // applies toolNameMap in TRANSLATE mode), so without this the client
+              // receives suffixed names (e.g. "Execute_ide") it doesn't recognize.
+              const toolNameDecloaked = decloakClaudeToolUseEvent(parsed, toolNameMap);
+
               // Ensure OpenAI-required fields are present on streaming chunks (Letta compat)
               let fieldsInjected = false;
               if (parsed.choices !== undefined) {
@@ -178,6 +184,10 @@ export function createSSEStream(options = {}) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               } else if (idFixed || fieldsInjected) {
+                output = `data: ${JSON.stringify(parsed)}\n`;
+                injectedUsage = true;
+              }
+              if (toolNameDecloaked && !injectedUsage) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               }
@@ -480,11 +490,12 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
     provider,
     reqLogger,
+    toolNameMap,
     model,
     connectionId,
     body,

--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -33,6 +33,18 @@ export function parseSSELine(line, format = null) {
   }
 }
 
+export function decloakClaudeToolUseEvent(parsed, toolNameMap) {
+  if (!toolNameMap || toolNameMap.size === 0 || parsed?.type !== "content_block_start" || parsed?.content_block?.type !== "tool_use") {
+    return false;
+  }
+
+  const original = toolNameMap.get(parsed.content_block.name);
+  if (!original) return false;
+
+  parsed.content_block = { ...parsed.content_block, name: original };
+  return true;
+}
+
 // Check if chunk has valuable content (not empty)
 export function hasValuableContent(chunk, format) {
   // OpenAI format

--- a/tests/unit/claude-passthrough-decloak.test.js
+++ b/tests/unit/claude-passthrough-decloak.test.js
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the Claude passthrough tool-name decloaking used by stream.js.
+ * The helper is tested directly so this focused test does not load the whole
+ * Next.js-only stream dependency graph.
+ */
+
+import { describe, it, expect } from "vitest";
+import { decloakClaudeToolUseEvent } from "../../open-sse/utils/streamHelpers.js";
+
+function toolUse(name = "Execute_ide") {
+  return {
+    type: "content_block_start",
+    index: 1,
+    content_block: { type: "tool_use", id: "toolu_01", name, input: {} }
+  };
+}
+
+describe("claude→claude passthrough tool-name decloaking", () => {
+  it("decloaks a mapped tool_use name", () => {
+    const event = toolUse();
+    expect(decloakClaudeToolUseEvent(event, new Map([["Execute_ide", "Execute"]]))).toBe(true);
+    expect(event.content_block.name).toBe("Execute");
+  });
+
+  it("leaves non-tool_use events untouched", () => {
+    const event = { type: "content_block_start", content_block: { type: "text", text: "" } };
+    expect(decloakClaudeToolUseEvent(event, new Map([["Execute_ide", "Execute"]]))).toBe(false);
+    expect(event.content_block).toEqual({ type: "text", text: "" });
+  });
+
+  it("is a no-op without a tool-name map", () => {
+    const event = toolUse("Execute");
+    expect(decloakClaudeToolUseEvent(event, null)).toBe(false);
+    expect(event.content_block.name).toBe("Execute");
+  });
+
+  it("does not decloak a name missing from the map", () => {
+    const event = toolUse();
+    expect(decloakClaudeToolUseEvent(event, new Map([["Other_ide", "Other"]]))).toBe(false);
+    expect(event.content_block.name).toBe("Execute_ide");
+  });
+});


### PR DESCRIPTION
Fixes #2391

## Summary

Claude OAuth tool cloaking renames client tools with an `_ide` suffix before dispatch. Translate-mode responses already apply `toolNameMap`, but same-format Claude→Claude streaming passthrough bypasses the response translator and leaks the cloaked name to the client.

The v0.5.30 standalone fix threads only `toolNameMap` through the passthrough factory and decloaks `content_block_start` / `tool_use` names before serialization. Providers without a map are unchanged.

## Changes

- `streamingHandler.js`: pass `toolNameMap` to the passthrough stream factory.
- `stream.js`: apply the pure event helper in the production passthrough loop.
- `streamHelpers.js`: add `decloakClaudeToolUseEvent`; mapped names are copied/rewritten, non-tool, unmapped, and null-map events pass through.
- `claude-passthrough-decloak.test.js`: four focused cases import the pure helper, avoiding the unrelated Next alias/runtime graph.

This parameter seam is intentionally independent of PR #2348: tracing context uses the existing logger object, while this PR alone owns the added positional `toolNameMap`.

## Verification

- focused Vitest: 4/4
- production build: 126/126
- standalone and sequential `git apply --check` / `git diff --check`: clean on `9845a17`
