### PR TITLE
fix(translator): preserve functionCall/text co-located with functionResponse in gemini→openai

### DIFF
--- a/open-sse/translator/request/gemini-to-openai.js
+++ b/open-sse/translator/request/gemini-to-openai.js
@@ -39,17 +39,13 @@ export function geminiToOpenAIRequest(model, body, stream) {
     }
   }
 
-  // Convert contents to messages
+  // Convert contents to messages.
+  // convertGeminiContent may return one message or an array (tool results +
+  // co-located call/text). Always spread: push(converted) nests the array as
+  // one element and the next turn 400s on unpaired tool calls.
   if (body.contents && Array.isArray(body.contents)) {
     for (const content of body.contents) {
-      const converted = convertGeminiContent(content);
-      if (converted) {
-        if (Array.isArray(converted)) {
-          result.messages.push(...converted);
-        } else {
-          result.messages.push(converted);
-        }
-      }
+      appendConvertedMessages(result.messages, convertGeminiContent(content));
     }
   }
 
@@ -73,6 +69,11 @@ export function geminiToOpenAIRequest(model, body, stream) {
   }
 
   return result;
+}
+
+function appendConvertedMessages(messages, converted) {
+  if (!converted) return;
+  messages.push(...(Array.isArray(converted) ? converted : [converted]));
 }
 
 // Convert Gemini content to OpenAI message

--- a/open-sse/translator/request/gemini-to-openai.js
+++ b/open-sse/translator/request/gemini-to-openai.js
@@ -44,7 +44,11 @@ export function geminiToOpenAIRequest(model, body, stream) {
     for (const content of body.contents) {
       const converted = convertGeminiContent(content);
       if (converted) {
-        result.messages.push(converted);
+        if (Array.isArray(converted)) {
+          result.messages.push(...converted);
+        } else {
+          result.messages.push(converted);
+        }
       }
     }
   }
@@ -80,6 +84,7 @@ function convertGeminiContent(content) {
   }
 
   const parts = [];
+  const toolResults = [];
   const toolCalls = [];
 
   for (const part of content.parts) {
@@ -110,11 +115,11 @@ function convertGeminiContent(content) {
     }
 
     if (part.functionResponse) {
-      return {
+      toolResults.push({
         role: ROLE.TOOL,
         tool_call_id: part.functionResponse.id || `call_${part.functionResponse.name}`,
         content: JSON.stringify(part.functionResponse.response?.result || part.functionResponse.response || {})
-      };
+      });
     }
   }
 
@@ -124,16 +129,19 @@ function convertGeminiContent(content) {
       result.content = parts.length === 1 ? parts[0].text : parts;
     }
     result.tool_calls = toolCalls;
-    return result;
+    return toolResults.length > 0 ? [...toolResults, result] : result;
   }
 
   if (parts.length > 0) {
-    return {
+    const result = {
       role,
       content: collapseTextParts(parts)
     };
+    return toolResults.length > 0 ? [...toolResults, result] : result;
   }
 
+  if (toolResults.length === 1) return toolResults[0];
+  if (toolResults.length > 1) return toolResults;
   return null;
 }
 

--- a/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
+++ b/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
@@ -64,6 +64,10 @@ import { FORMATS } from "../translator/formats.js";
   assert.equal(toolMsgs.length, 2, "both tool results preserved");
   assert.ok(toolMsgs.some(m => m.tool_call_id === "c1"), "first tool result present");
   assert.ok(toolMsgs.some(m => m.tool_call_id === "c2"), "second tool result present");
+  assert.ok(
+    out.messages.every(m => m && typeof m === "object" && !Array.isArray(m) && typeof m.role === "string"),
+    "parent loop must spread array results; push(converted) nests them"
+  );
 }
 
 // 4. functionResponse + text

--- a/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
+++ b/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import "../../tests/translator/registerAll.js";
+import { translateRequest } from "../translator/index.js";
+import { FORMATS } from "../translator/formats.js";
+
+// 1. functionResponse + functionCall in same content
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "do two things" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "call_a", name: "search", args: { q: "x" } } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "call_a", name: "search", response: { result: "found x" } } },
+        { functionCall: { id: "call_b", name: "edit", args: { pattern: "y" } } },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const json = JSON.stringify(out);
+  assert.ok(json.includes("edit"), "functionCall 'edit' preserved alongside functionResponse");
+  assert.ok(json.includes("search"), "functionResponse 'search' preserved");
+  assert.ok(json.includes("found x"), "functionResponse content preserved");
+}
+
+// 2. functionResponse alone
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "q" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "call_1", name: "search", args: { q: "x" } } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "call_1", name: "search", response: { result: "r1" } } },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const toolMsg = out.messages.find(m => m.role === "tool");
+  assert.ok(toolMsg, "tool message present");
+  assert.equal(toolMsg.tool_call_id, "call_1");
+  assert.equal(toolMsg.content, '"r1"');
+}
+
+// 3. Multiple functionResponses
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "q" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "c1", name: "f1", args: {} } },
+        { functionCall: { id: "c2", name: "f2", args: {} } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "c1", name: "f1", response: { result: "r1" } } },
+        { functionResponse: { id: "c2", name: "f2", response: { result: "r2" } } },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const toolMsgs = out.messages.filter(m => m.role === "tool");
+  assert.equal(toolMsgs.length, 2, "both tool results preserved");
+  assert.ok(toolMsgs.some(m => m.tool_call_id === "c1"), "first tool result present");
+  assert.ok(toolMsgs.some(m => m.tool_call_id === "c2"), "second tool result present");
+}
+
+// 4. functionResponse + text
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "q" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "c1", name: "f1", args: {} } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "c1", name: "f1", response: { result: "r1" } } },
+        { text: "and here is some text" },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const toolMsg = out.messages.find(m => m.role === "tool");
+  const userMsg = out.messages.find(m => m.role === "user" && m.content === "and here is some text");
+  assert.ok(toolMsg, "tool message present");
+  assert.ok(userMsg, "user text preserved with correct role:user");
+  const asstWithText = out.messages.find(m => m.role === "assistant" && m.content === "and here is some text");
+  assert.ok(!asstWithText, "user text must NOT be attributed to assistant");
+}
+
+console.log("geminiFunctionResponseSelfCheck: 4/4");

--- a/tests/unit/gemini-to-openai-function-response.test.js
+++ b/tests/unit/gemini-to-openai-function-response.test.js
@@ -71,6 +71,9 @@ describe("gemini -> openai request translation — functionResponse co-located w
 
     expect(toolMsgs).toHaveLength(2);
     expect(toolMsgs.map(m => m.tool_call_id).sort()).toEqual(["call_a", "call_b"]);
+    // Spread invariant: a parent `push(converted)` would nest the two tool
+    // messages as one array element, so none of messages[] would have role:tool.
+    expect(result.messages.every((m) => m && typeof m === "object" && !Array.isArray(m) && typeof m.role === "string")).toBe(true);
   });
 
   it("preserves text co-located with a functionResponse, keeping the original turn role", () => {

--- a/tests/unit/gemini-to-openai-function-response.test.js
+++ b/tests/unit/gemini-to-openai-function-response.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for open-sse/translator/request/gemini-to-openai.js —
+ * functionResponse co-located with other parts in the same Gemini content.
+ *
+ * convertGeminiContent() early-returns on the first `functionResponse` part
+ * it finds in a content's `parts` array, dropping any `functionCall` or
+ * `text` parts that were co-located in the same content. Gemini clients can
+ * send `functionResponse` alongside `functionCall` (e.g. multi-tool turns)
+ * or alongside `text` (a user follow-up next to a tool result).
+ *
+ * Exercised through translateRequest(), the same registry path the router uses.
+ */
+
+import { describe, it, expect } from "vitest";
+import "../translator/registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("gemini -> openai request translation — functionResponse co-located with other parts", () => {
+  it("preserves a functionCall co-located with a functionResponse in the same content", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { id: "call_b", name: "tool_b", args: {} } }]
+        },
+        {
+          role: "user",
+          parts: [
+            { functionCall: { id: "call_a", name: "tool_a", args: {} } },
+            { functionResponse: { id: "call_b", name: "tool_b", response: { result: "b done" } } }
+          ]
+        }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+
+    const toolMsg = result.messages.find(m => m.role === "tool");
+    const assistantMsg = result.messages.find(m =>
+      m.role === "assistant" && m.tool_calls?.some(call => call.function.name === "tool_a")
+    );
+
+    expect(toolMsg).toBeDefined();
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg.tool_calls[0].function.name).toBe("tool_a");
+  });
+
+  it("preserves multiple functionResponses in the same content", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            { functionCall: { id: "call_a", name: "tool_a", args: {} } },
+            { functionCall: { id: "call_b", name: "tool_b", args: {} } }
+          ]
+        },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { id: "call_a", name: "tool_a", response: { result: "a done" } } },
+            { functionResponse: { id: "call_b", name: "tool_b", response: { result: "b done" } } }
+          ]
+        }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+    const toolMsgs = result.messages.filter(m => m.role === "tool");
+
+    expect(toolMsgs).toHaveLength(2);
+    expect(toolMsgs.map(m => m.tool_call_id).sort()).toEqual(["call_a", "call_b"]);
+  });
+
+  it("preserves text co-located with a functionResponse, keeping the original turn role", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { id: "call_a", name: "tool_a", args: {} } }]
+        },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { id: "call_a", name: "tool_a", response: { result: "a done" } } },
+            { text: "also please summarize" }
+          ]
+        }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+
+    const toolMsg = result.messages.find(m => m.role === "tool");
+    const userMsg = result.messages.find(m => m.role === "user" && m.content === "also please summarize");
+    const asstWithText = result.messages.find(m => m.role === "assistant" && m.content === "also please summarize");
+
+    expect(toolMsg).toBeDefined();
+    expect(userMsg).toBeDefined();
+    expect(asstWithText).toBeUndefined();
+  });
+
+  it("still works for a functionResponse alone (no regression)", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { id: "call_a", name: "tool_a", args: {} } }]
+        },
+        { role: "user", parts: [{ functionResponse: { id: "call_a", name: "tool_a", response: { result: "a done" } } }] }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+
+    const toolMsgs = result.messages.filter(m => m.role === "tool");
+    expect(toolMsgs).toHaveLength(1);
+    expect(toolMsgs[0].tool_call_id).toBe("call_a");
+  });
+});


### PR DESCRIPTION
Fixes #2393

## Summary

`convertGeminiContent()` returned on the first `functionResponse`, silently dropping later/co-located `functionCall`, text, or additional responses. The v0.5.30 root-cause fix removes that terminal control flow: it accumulates every tool result, finishes scanning the content, and returns tool results together with the remaining message.

When a result is co-located with text but no call, the text keeps the original turn role. The parent request loop spreads array results instead of nesting the array as one message.

## Changes

- `gemini-to-openai.js`: direct `toolResults` accumulator, no early return; return one message or an ordered result/message array; spread arrays in the parent loop.
- `geminiFunctionResponseSelfCheck.mjs`: 4/4 standalone cases.
- `gemini-to-openai-function-response.test.js`: 4/4 registry-path cases with valid prior calls, so pairing validation does not intentionally salvage them as orphans.

This replaces the previous registry-override wrapper with the smaller direct root-cause fix and remains compatible with the reasoning wrapper in PR #2401.

## Verification

- self-check: 4/4
- focused Vitest: 4/4
- production build: 126/126
- standalone/sequential apply and `git diff --check`: clean on `9845a17`
