### PR TITLE
fix(translator): make commandcode ensureState idempotent regardless of pre-set responseId

### DIFF
--- a/open-sse/translator/response/commandcode-to-openai.js
+++ b/open-sse/translator/response/commandcode-to-openai.js
@@ -25,18 +25,16 @@ import { fallbackToolCallId } from "../concerns/toolCall.js";
 import { toOpenAIFinish } from "../concerns/finishReason.js";
 
 function ensureState(state, model) {
-  if (!state.responseId) {
-    state.responseId = `chatcmpl-${Date.now()}`;
-    state.created = Math.floor(Date.now() / 1000);
-    state.model = state.model || model || "commandcode";
-    state.chunkIndex = 0;
-    state.toolIndex = 0;
-    state.toolIndexById = new Map();
-    state.openTools = new Set();
-    state.openText = false;
-    state.finishReason = null;
-    state.usage = null;
-  }
+  state.responseId ??= `chatcmpl-${Date.now()}`;
+  state.created ??= Math.floor(Date.now() / 1000);
+  state.model = state.model || model || "commandcode";
+  state.chunkIndex ??= 0;
+  state.toolIndex ??= 0;
+  state.toolIndexById ??= new Map();
+  state.openTools ??= new Set();
+  state.openText ??= false;
+  state.finishReason ??= null;
+  state.usage ??= null;
 }
 
 function makeChunk(state, delta, finishReason = null) {

--- a/open-sse/utils/commandcodeIdempotentStateSelfCheck.mjs
+++ b/open-sse/utils/commandcodeIdempotentStateSelfCheck.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import "../../tests/translator/registerAll.js";
+import { initState } from "../translator/index.js";
+import { FORMATS } from "../translator/formats.js";
+import { commandCodeToOpenAIResponse } from "../translator/response/commandcode-to-openai.js";
+
+const state = initState(FORMATS.OPENAI_RESPONSES);
+assert.ok(state.responseId, "fixture: responseId pre-set by initState");
+
+const toolCallChunk = '{"type":"tool-call","toolCallId":"call_a","toolName":"Read","input":{"path":"x"}}';
+const out = commandCodeToOpenAIResponse(toolCallChunk, state);
+assert.ok(Array.isArray(out) && out.length > 0, "tool-call emits a chunk");
+assert.equal(out[0].choices[0].delta.tool_calls[0].id, "call_a");
+
+const second = commandCodeToOpenAIResponse(toolCallChunk, state);
+assert.equal(second, null);
+
+const tc2 = '{"type":"tool-call","toolCallId":"call_b","toolName":"Grep","input":{"pattern":"y"}}';
+const out2 = commandCodeToOpenAIResponse(tc2, state);
+assert.equal(out2[0].choices[0].delta.tool_calls[0].index, 1, "second tool call gets index 1");
+
+const textChunk = '{"type":"text-delta","text":"hello"}';
+const out3 = commandCodeToOpenAIResponse(textChunk, state);
+assert.equal(out3[0].choices[0].delta.content, "hello");
+
+console.log("commandcodeIdempotentStateSelfCheck: 4/4");

--- a/tests/unit/commandcode-to-openai.test.js
+++ b/tests/unit/commandcode-to-openai.test.js
@@ -10,6 +10,8 @@
 
 import { describe, it, expect } from "vitest";
 import { commandCodeToOpenAIResponse } from "../../open-sse/translator/response/commandcode-to-openai.js";
+import { initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
 
 function feed(events) {
   const state = {};
@@ -123,5 +125,55 @@ describe("commandcode-to-openai — error event", () => {
     const text = chunks[0].choices[0].delta.content;
     expect(text).toContain("Boom");
     expect(text).not.toContain("[object Object]");
+  });
+});
+
+describe("commandcode-to-openai — state pre-populated by initState (Responses API client)", () => {
+  // initState(FORMATS.OPENAI_RESPONSES) sets state.responseId before this translator
+  // ever runs. ensureState() used to gate ALL of its field init (toolIndexById,
+  // openTools, etc.) behind `if (!state.responseId)`, so a pre-set responseId left
+  // those fields undefined and the first tool-call event crashed with
+  // "Cannot read properties of undefined (reading 'has')".
+  it("does not crash on the first tool-call event (original crash repro)", () => {
+    const state = initState(FORMATS.OPENAI_RESPONSES);
+    expect(state.responseId).toBeTruthy(); // fixture: pre-set by initState, not by this translator
+
+    const out = commandCodeToOpenAIResponse(
+      JSON.stringify({ type: "tool-call", toolCallId: "call_a", toolName: "Read", input: { path: "x" } }),
+      state
+    );
+
+    expect(out?.[0]?.choices[0].delta.tool_calls[0].id).toBe("call_a");
+  });
+
+  it("is idempotent — re-feeding the same tool-call event is a no-op", () => {
+    const state = initState(FORMATS.OPENAI_RESPONSES);
+    const chunk = JSON.stringify({ type: "tool-call", toolCallId: "call_a", toolName: "Read", input: { path: "x" } });
+
+    commandCodeToOpenAIResponse(chunk, state);
+    const second = commandCodeToOpenAIResponse(chunk, state);
+
+    expect(second).toBeNull();
+  });
+
+  it("advances the tool index for a second distinct tool call", () => {
+    const state = initState(FORMATS.OPENAI_RESPONSES);
+    commandCodeToOpenAIResponse(
+      JSON.stringify({ type: "tool-call", toolCallId: "call_a", toolName: "Read", input: { path: "x" } }),
+      state
+    );
+    const out2 = commandCodeToOpenAIResponse(
+      JSON.stringify({ type: "tool-call", toolCallId: "call_b", toolName: "Grep", input: { pattern: "y" } }),
+      state
+    );
+
+    expect(out2[0].choices[0].delta.tool_calls[0].index).toBe(1);
+  });
+
+  it("still handles a text-delta under pre-init state", () => {
+    const state = initState(FORMATS.OPENAI_RESPONSES);
+    const out = commandCodeToOpenAIResponse(JSON.stringify({ type: "text-delta", text: "hello" }), state);
+
+    expect(out[0].choices[0].delta.content).toBe("hello");
   });
 });


### PR DESCRIPTION
Fixes #2395

## Summary

Responses client state pre-populates `responseId`. CommandCode previously used that one field as a proxy for all translator state, leaving `toolIndexById` undefined and crashing on the first tool event. The v0.5.30 fix initializes every CommandCode-owned field independently with `??=`, preserving any already supplied response metadata.

## Changes

- `commandcode-to-openai.js`: field-wise idempotent state initialization.
- `commandcodeIdempotentStateSelfCheck.mjs`: original crash, idempotent replay, second tool index, and text delta (4/4).
- `commandcode-to-openai.test.js`: focused regression coverage; 13/13 including the nine existing cases.

## Verification

- self-check: 4/4
- focused Vitest: 13/13
- production build: 126/126
- standalone apply and `git diff --check`: clean on `9845a17`
