### PR TITLE
fix(translator): register openai response projection for gemini-family clients

### DIFF
--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -276,6 +276,7 @@ import "./response/claude-to-openai.js";
 import "./response/openai-to-claude.js";
 import "./response/gemini-to-openai.js";
 import "./response/openai-to-antigravity.js";
+import "./response/openai-to-gemini.js";
 import "./response/openai-responses.js";
 import "./response/kiro-to-openai.js";
 import "./response/cursor-to-openai.js";

--- a/open-sse/translator/response/openai-to-gemini.js
+++ b/open-sse/translator/response/openai-to-gemini.js
@@ -1,0 +1,8 @@
+import { register } from "../index.js";
+import { FORMATS } from "../formats.js";
+import { openaiToAntigravityResponse } from "./openai-to-antigravity.js";
+
+// Gemini-family streaming responses share the same response.candidates envelope here.
+register(FORMATS.OPENAI, FORMATS.GEMINI, null, openaiToAntigravityResponse);
+register(FORMATS.OPENAI, FORMATS.GEMINI_CLI, null, openaiToAntigravityResponse);
+register(FORMATS.OPENAI, FORMATS.VERTEX, null, openaiToAntigravityResponse);

--- a/open-sse/utils/openaiToGeminiResponseSelfCheck.mjs
+++ b/open-sse/utils/openaiToGeminiResponseSelfCheck.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import "../../tests/translator/registerAll.js";
+import { translateResponse, initState } from "../translator/index.js";
+import { FORMATS } from "../translator/formats.js";
+
+function runFor(sourceFormat) {
+  const state = initState(sourceFormat);
+  const chunks = [
+    { id: "chatcmpl_1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { reasoning_content: "think" }, finish_reason: null }] },
+    { id: "chatcmpl_1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { content: "answer" }, finish_reason: null }] },
+    { id: "chatcmpl_1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "lookup", arguments: "{\"q\":\"x\"}" } }] }, finish_reason: null }] },
+    { id: "chatcmpl_1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }], usage: { prompt_tokens: 3, completion_tokens: 5, total_tokens: 8, completion_tokens_details: { reasoning_tokens: 1 } } },
+  ];
+  return chunks.flatMap(chunk => translateResponse(FORMATS.OPENAI, sourceFormat, chunk, state) || []);
+}
+
+for (const sourceFormat of [FORMATS.GEMINI, FORMATS.GEMINI_CLI, FORMATS.VERTEX]) {
+  const out = runFor(sourceFormat);
+  assert.equal(out[0].response.candidates[0].content.parts[0].thought, true);
+  assert.equal(out[0].response.candidates[0].content.parts[0].text, "think");
+  assert.equal(out[1].response.candidates[0].content.parts[0].text, "answer");
+  const finish = out[out.length - 1].response;
+  assert.equal(finish.candidates[0].content.parts[0].functionCall.name, "lookup");
+  assert.deepEqual(finish.candidates[0].content.parts[0].functionCall.args, { q: "x" });
+  assert.equal(finish.usageMetadata.totalTokenCount, 8);
+}
+
+console.log("openaiToGeminiResponseSelfCheck: 3/3");

--- a/tests/unit/openai-to-gemini-response.test.js
+++ b/tests/unit/openai-to-gemini-response.test.js
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for open-sse/translator/response/openai-to-gemini.js
+ *
+ * Upstream only registered an "openai -> antigravity" response translator.
+ * Gemini, Gemini CLI, and Vertex clients streaming from an OpenAI-native
+ * provider had no "openai -> X" response translator registered, so
+ * translateResponse() fell through unchanged and the client (which expects
+ * a Gemini response.candidates[] envelope) received a raw OpenAI
+ * chat.completion.chunk instead.
+ */
+
+import { describe, it, expect } from "vitest";
+import "../translator/registerAll.js";
+import { translateResponse, initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const openaiChunks = [
+  { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { reasoning_content: "think" }, finish_reason: null }] },
+  { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { content: "answer" }, finish_reason: null }] },
+  { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "lookup", arguments: "{\"q\":\"x\"}" } }] }, finish_reason: null }] },
+  { id: "c1", object: "chat.completion.chunk", created: 1, model: "m", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }], usage: { prompt_tokens: 3, completion_tokens: 5, total_tokens: 8 } },
+];
+
+describe.each([FORMATS.GEMINI, FORMATS.GEMINI_CLI, FORMATS.VERTEX])(
+  "openai -> %s streaming response projection",
+  (clientFormat) => {
+    it("projects OpenAI chunks into the Gemini response.candidates envelope", () => {
+      const state = initState(clientFormat);
+      const out = openaiChunks.flatMap(chunk => translateResponse(FORMATS.OPENAI, clientFormat, chunk, state) || []);
+
+      expect(out[0].response.candidates[0].content.parts[0]).toEqual({ thought: true, text: "think" });
+      expect(out[1].response.candidates[0].content.parts[0].text).toBe("answer");
+
+      const finish = out[out.length - 1].response;
+      expect(finish.candidates[0].content.parts[0].functionCall.name).toBe("lookup");
+      expect(finish.candidates[0].content.parts[0].functionCall.args).toEqual({ q: "x" });
+      expect(finish.usageMetadata.totalTokenCount).toBe(8);
+    });
+
+    it("never returns a raw OpenAI chat.completion.chunk shape to the client (the original bug)", () => {
+      const state = initState(clientFormat);
+      const out = openaiChunks.flatMap(chunk => translateResponse(FORMATS.OPENAI, clientFormat, chunk, state) || []);
+
+      for (const item of out) {
+        expect(item.object).not.toBe("chat.completion.chunk");
+        expect(item.choices).toBeUndefined();
+      }
+    });
+  }
+);


### PR DESCRIPTION
Fixes #2398

## Summary

The response registry has OpenAI→Antigravity projection but no OpenAI→Gemini, Gemini CLI, or Vertex registration. An OpenAI-native provider therefore streams raw `chat.completion.chunk` objects to clients expecting the shared Gemini `response.candidates[]` envelope.

The v0.5.30 fix reuses the existing `openaiToAntigravityResponse` implementation for all three missing registrations; no duplicate projection logic is introduced.

## Changes

- `openai-to-gemini.js`: register OpenAI→Gemini/Gemini CLI/Vertex response handlers.
- `translator/index.js`: load the registration module.
- standalone self-check: reasoning→`thought:true`, text, function call, and usage for all formats (3/3).
- focused Vitest: six registry-path cases including a raw-OpenAI negative control (6/6).

## Verification

- self-check: 3/3
- focused Vitest: 6/6
- production build: 126/126
- standalone apply and `git diff --check`: clean on `9845a17`
