### PR TITLE
fix(translator): preserve reasoning/thinking history across the OpenAI request bridge

### DIFF
--- a/open-sse/translator/formats/claude.js
+++ b/open-sse/translator/formats/claude.js
@@ -359,9 +359,14 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
           let hasToolUse = false;
           let hasKeptThinking = false;
 
-          // Claude native: preserve valid signatures, drop invalid blocks.
-          // anthropic-compatible: replace with default (safe fallback for lenient upstreams).
-          // DeepSeek: keep existing thinking as-is; add an unsigned placeholder only if missing.
+          // Claude native: keep a valid Claude signature.
+          // Unsigned / foreign blobs cannot go out as-is (native 400s) and
+          // must not be dropped either (P2: thoughts have to survive). Attach
+          // DEFAULT_THINKING_CLAUDE_SIGNATURE — the same documented bypass
+          // already sent as the native tool_use placeholder and used for
+          // anthropic-compatible. Copy-on-write: the body is reused on fallback.
+          // anthropic-compatible: replace with default (lenient upstreams).
+          // DeepSeek: keep existing thinking as-is; unsigned placeholder if missing.
           const isClaudeNative = provider === "claude";
           const isDeepSeek = provider === "deepseek";
           const kept = [];
@@ -372,6 +377,12 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
                 if (isValidClaudeSignature(block.signature)) {
                   hasKeptThinking = true;
                   kept.push(block);
+                } else if (typeof block.thinking === "string" && block.thinking.length > 0) {
+                  const rest = { ...block };
+                  delete rest.cache_control;
+                  delete rest.signature;
+                  kept.push({ ...rest, signature: DEFAULT_THINKING_CLAUDE_SIGNATURE });
+                  hasKeptThinking = true;
                 }
               } else if (isDeepSeek) {
                 hasKeptThinking = true;

--- a/open-sse/translator/request/claude-to-openai.js
+++ b/open-sse/translator/request/claude-to-openai.js
@@ -160,11 +160,16 @@ function convertClaudeMessage(msg) {
     const parts = [];
     const toolCalls = [];
     const toolResults = [];
+    let reasoningContent = "";
 
     for (const block of msg.content) {
       switch (block.type) {
         case CLAUDE_BLOCK.TEXT:
           parts.push({ type: OPENAI_BLOCK.TEXT, text: block.text });
+          break;
+
+        case CLAUDE_BLOCK.THINKING:
+          if (block.thinking) reasoningContent += block.thinking;
           break;
 
         case CLAUDE_BLOCK.IMAGE:
@@ -225,16 +230,23 @@ function convertClaudeMessage(msg) {
       if (parts.length > 0) {
         result.content = collapseTextParts(parts);
       }
+      if (reasoningContent) {
+        result.reasoning_content = reasoningContent;
+      }
       result.tool_calls = toolCalls;
       return result;
     }
 
     // Return content
-    if (parts.length > 0) {
-      return {
-        role,
-        content: collapseTextParts(parts)
-      };
+    if (parts.length > 0 || reasoningContent) {
+      const result2 = { role };
+      if (parts.length > 0) {
+        result2.content = collapseTextParts(parts);
+      }
+      if (reasoningContent) {
+        result2.reasoning_content = reasoningContent;
+      }
+      return result2;
     }
     
     // Empty content array

--- a/open-sse/translator/request/gemini-to-openai.js
+++ b/open-sse/translator/request/gemini-to-openai.js
@@ -42,7 +42,7 @@ export function geminiToOpenAIRequest(model, body, stream) {
   // Convert contents to messages
   if (body.contents && Array.isArray(body.contents)) {
     for (const content of body.contents) {
-      const converted = convertGeminiContent(content);
+      const converted = convertGeminiContentWithReasoning(content);
       if (converted) {
         result.messages.push(converted);
       }
@@ -137,6 +137,41 @@ function convertGeminiContent(content) {
   return null;
 }
 
+function convertGeminiContentWithReasoning(content) {
+  if (!Array.isArray(content?.parts)) return convertGeminiContent(content);
+
+  let reasoningContent = "";
+  const visibleParts = [];
+  for (const part of content.parts) {
+    if (part?.thought === true) {
+      if (part.text !== undefined) reasoningContent += part.text;
+    } else {
+      visibleParts.push(part);
+    }
+  }
+
+  if (!reasoningContent) return convertGeminiContent(content);
+
+  const converted = convertGeminiContent({ ...content, parts: visibleParts });
+  const messages = Array.isArray(converted) ? [...converted] : (converted ? [converted] : []);
+  let targetIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role !== ROLE.TOOL) {
+      targetIndex = i;
+      break;
+    }
+  }
+
+  if (targetIndex >= 0) {
+    messages[targetIndex] = { ...messages[targetIndex], reasoning_content: reasoningContent };
+  } else {
+    const role = content.role === GEMINI_ROLE.USER ? ROLE.USER : ROLE.ASSISTANT;
+    messages.push({ role, reasoning_content: reasoningContent });
+  }
+
+  return Array.isArray(converted) ? messages : messages[0];
+}
+
 // Extract text from Gemini content
 function extractGeminiText(content) {
   if (typeof content === "string") return content;
@@ -149,4 +184,3 @@ function extractGeminiText(content) {
 // Register
 register(FORMATS.GEMINI, FORMATS.OPENAI, geminiToOpenAIRequest, null);
 register(FORMATS.GEMINI_CLI, FORMATS.OPENAI, geminiToOpenAIRequest, null);
-

--- a/open-sse/translator/request/gemini-to-openai.js
+++ b/open-sse/translator/request/gemini-to-openai.js
@@ -45,7 +45,7 @@ export function geminiToOpenAIRequest(model, body, stream) {
   // one element and the next turn 400s on unpaired tool calls.
   if (body.contents && Array.isArray(body.contents)) {
     for (const content of body.contents) {
-      appendConvertedMessages(result.messages, convertGeminiContent(content));
+      appendConvertedMessages(result.messages, convertGeminiContentWithReasoning(content));
     }
   }
 
@@ -146,6 +146,41 @@ function convertGeminiContent(content) {
   return null;
 }
 
+function convertGeminiContentWithReasoning(content) {
+  if (!Array.isArray(content?.parts)) return convertGeminiContent(content);
+
+  let reasoningContent = "";
+  const visibleParts = [];
+  for (const part of content.parts) {
+    if (part?.thought === true) {
+      if (part.text !== undefined) reasoningContent += part.text;
+    } else {
+      visibleParts.push(part);
+    }
+  }
+
+  if (!reasoningContent) return convertGeminiContent(content);
+
+  const converted = convertGeminiContent({ ...content, parts: visibleParts });
+  const messages = Array.isArray(converted) ? [...converted] : (converted ? [converted] : []);
+  let targetIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role !== ROLE.TOOL) {
+      targetIndex = i;
+      break;
+    }
+  }
+
+  if (targetIndex >= 0) {
+    messages[targetIndex] = { ...messages[targetIndex], reasoning_content: reasoningContent };
+  } else {
+    const role = content.role === GEMINI_ROLE.USER ? ROLE.USER : ROLE.ASSISTANT;
+    messages.push({ role, reasoning_content: reasoningContent });
+  }
+
+  return Array.isArray(converted) ? messages : messages[0];
+}
+
 // Extract text from Gemini content
 function extractGeminiText(content) {
   if (typeof content === "string") return content;
@@ -158,4 +193,3 @@ function extractGeminiText(content) {
 // Register
 register(FORMATS.GEMINI, FORMATS.OPENAI, geminiToOpenAIRequest, null);
 register(FORMATS.GEMINI_CLI, FORMATS.OPENAI, geminiToOpenAIRequest, null);
-

--- a/open-sse/translator/request/gemini-to-openai.js
+++ b/open-sse/translator/request/gemini-to-openai.js
@@ -39,17 +39,13 @@ export function geminiToOpenAIRequest(model, body, stream) {
     }
   }
 
-  // Convert contents to messages
+  // Convert contents to messages.
+  // convertGeminiContent may return one message or an array (tool results +
+  // co-located call/text). Always spread: push(converted) nests the array as
+  // one element and the next turn 400s on unpaired tool calls.
   if (body.contents && Array.isArray(body.contents)) {
     for (const content of body.contents) {
-      const converted = convertGeminiContent(content);
-      if (converted) {
-        if (Array.isArray(converted)) {
-          result.messages.push(...converted);
-        } else {
-          result.messages.push(converted);
-        }
-      }
+      appendConvertedMessages(result.messages, convertGeminiContent(content));
     }
   }
 
@@ -73,6 +69,11 @@ export function geminiToOpenAIRequest(model, body, stream) {
   }
 
   return result;
+}
+
+function appendConvertedMessages(messages, converted) {
+  if (!converted) return;
+  messages.push(...(Array.isArray(converted) ? converted : [converted]));
 }
 
 // Convert Gemini content to OpenAI message

--- a/open-sse/translator/request/gemini-to-openai.js
+++ b/open-sse/translator/request/gemini-to-openai.js
@@ -44,7 +44,11 @@ export function geminiToOpenAIRequest(model, body, stream) {
     for (const content of body.contents) {
       const converted = convertGeminiContent(content);
       if (converted) {
-        result.messages.push(converted);
+        if (Array.isArray(converted)) {
+          result.messages.push(...converted);
+        } else {
+          result.messages.push(converted);
+        }
       }
     }
   }
@@ -80,6 +84,7 @@ function convertGeminiContent(content) {
   }
 
   const parts = [];
+  const toolResults = [];
   const toolCalls = [];
 
   for (const part of content.parts) {
@@ -110,11 +115,11 @@ function convertGeminiContent(content) {
     }
 
     if (part.functionResponse) {
-      return {
+      toolResults.push({
         role: ROLE.TOOL,
         tool_call_id: part.functionResponse.id || `call_${part.functionResponse.name}`,
         content: JSON.stringify(part.functionResponse.response?.result || part.functionResponse.response || {})
-      };
+      });
     }
   }
 
@@ -124,16 +129,19 @@ function convertGeminiContent(content) {
       result.content = parts.length === 1 ? parts[0].text : parts;
     }
     result.tool_calls = toolCalls;
-    return result;
+    return toolResults.length > 0 ? [...toolResults, result] : result;
   }
 
   if (parts.length > 0) {
-    return {
+    const result = {
       role,
       content: collapseTextParts(parts)
     };
+    return toolResults.length > 0 ? [...toolResults, result] : result;
   }
 
+  if (toolResults.length === 1) return toolResults[0];
+  if (toolResults.length > 1) return toolResults;
   return null;
 }
 

--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -253,6 +253,10 @@ function getContentBlocksFromMessage(msg, toolNameMap = new Map()) {
       }
     }
   } else if (msg.role === ROLE.ASSISTANT) {
+    const hasThinkingBlock = Array.isArray(msg.content) && msg.content.some(part => part.type === CLAUDE_BLOCK.THINKING);
+    if (msg.reasoning_content && !hasThinkingBlock) {
+      blocks.push({ type: CLAUDE_BLOCK.THINKING, thinking: msg.reasoning_content });
+    }
     if (Array.isArray(msg.content)) {
       for (const part of msg.content) {
         if (part.type === OPENAI_BLOCK.TEXT && part.text) {

--- a/open-sse/translator/request/openai-to-commandcode.js
+++ b/open-sse/translator/request/openai-to-commandcode.js
@@ -89,6 +89,10 @@ function convertMessages(messages = []) {
     if (role === ROLE.ASSISTANT) {
       const blocks = [];
       const text = flattenText(m.content);
+      // Preserve reasoning_content as a reasoning block (CommandCode/AI SDK v5 supports this)
+      if (m.reasoning_content) {
+        blocks.push({ type: "reasoning", text: m.reasoning_content });
+      }
       if (text) blocks.push({ type: OPENAI_BLOCK.TEXT, text });
       if (Array.isArray(m.tool_calls)) {
         for (const tc of m.tool_calls) {

--- a/open-sse/translator/request/openai-to-ollama.js
+++ b/open-sse/translator/request/openai-to-ollama.js
@@ -113,11 +113,15 @@ function normalizeMessages(messages) {
         }
       }));
 
-      result.push({
+      const assistantMsg = {
         role: ROLE.ASSISTANT,
         content: content,
         tool_calls: ollamaToolCalls
-      });
+      };
+      if (msg.reasoning_content) {
+        assistantMsg.thinking = msg.reasoning_content;
+      }
+      result.push(assistantMsg);
       continue;
     }
 
@@ -136,6 +140,11 @@ function normalizeMessages(messages) {
 
     if (images.length > 0) {
       out.images = images;
+    }
+
+    // Preserve reasoning_content as thinking for assistant messages
+    if (role === ROLE.ASSISTANT && msg.reasoning_content) {
+      out.thinking = msg.reasoning_content;
     }
 
     result.push(out);

--- a/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
+++ b/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
@@ -64,6 +64,10 @@ import { FORMATS } from "../translator/formats.js";
   assert.equal(toolMsgs.length, 2, "both tool results preserved");
   assert.ok(toolMsgs.some(m => m.tool_call_id === "c1"), "first tool result present");
   assert.ok(toolMsgs.some(m => m.tool_call_id === "c2"), "second tool result present");
+  assert.ok(
+    out.messages.every(m => m && typeof m === "object" && !Array.isArray(m) && typeof m.role === "string"),
+    "parent loop must spread array results; push(converted) nests them"
+  );
 }
 
 // 4. functionResponse + text

--- a/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
+++ b/open-sse/utils/geminiFunctionResponseSelfCheck.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import "../../tests/translator/registerAll.js";
+import { translateRequest } from "../translator/index.js";
+import { FORMATS } from "../translator/formats.js";
+
+// 1. functionResponse + functionCall in same content
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "do two things" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "call_a", name: "search", args: { q: "x" } } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "call_a", name: "search", response: { result: "found x" } } },
+        { functionCall: { id: "call_b", name: "edit", args: { pattern: "y" } } },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const json = JSON.stringify(out);
+  assert.ok(json.includes("edit"), "functionCall 'edit' preserved alongside functionResponse");
+  assert.ok(json.includes("search"), "functionResponse 'search' preserved");
+  assert.ok(json.includes("found x"), "functionResponse content preserved");
+}
+
+// 2. functionResponse alone
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "q" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "call_1", name: "search", args: { q: "x" } } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "call_1", name: "search", response: { result: "r1" } } },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const toolMsg = out.messages.find(m => m.role === "tool");
+  assert.ok(toolMsg, "tool message present");
+  assert.equal(toolMsg.tool_call_id, "call_1");
+  assert.equal(toolMsg.content, '"r1"');
+}
+
+// 3. Multiple functionResponses
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "q" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "c1", name: "f1", args: {} } },
+        { functionCall: { id: "c2", name: "f2", args: {} } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "c1", name: "f1", response: { result: "r1" } } },
+        { functionResponse: { id: "c2", name: "f2", response: { result: "r2" } } },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const toolMsgs = out.messages.filter(m => m.role === "tool");
+  assert.equal(toolMsgs.length, 2, "both tool results preserved");
+  assert.ok(toolMsgs.some(m => m.tool_call_id === "c1"), "first tool result present");
+  assert.ok(toolMsgs.some(m => m.tool_call_id === "c2"), "second tool result present");
+}
+
+// 4. functionResponse + text
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "q" }] },
+      { role: "model", parts: [
+        { functionCall: { id: "c1", name: "f1", args: {} } },
+      ] },
+      { role: "user", parts: [
+        { functionResponse: { id: "c1", name: "f1", response: { result: "r1" } } },
+        { text: "and here is some text" },
+      ] },
+    ],
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const toolMsg = out.messages.find(m => m.role === "tool");
+  const userMsg = out.messages.find(m => m.role === "user" && m.content === "and here is some text");
+  assert.ok(toolMsg, "tool message present");
+  assert.ok(userMsg, "user text preserved with correct role:user");
+  const asstWithText = out.messages.find(m => m.role === "assistant" && m.content === "and here is some text");
+  assert.ok(!asstWithText, "user text must NOT be attributed to assistant");
+}
+
+console.log("geminiFunctionResponseSelfCheck: 4/4");

--- a/open-sse/utils/openaiToClaudeReasoningHistorySelfCheck.mjs
+++ b/open-sse/utils/openaiToClaudeReasoningHistorySelfCheck.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import "../../tests/translator/registerAll.js";
+import { translateRequest } from "../translator/index.js";
+import { FORMATS } from "../translator/formats.js";
+
+// 1. OpenAI → Claude: reasoning_content becomes a thinking block
+{
+  const body = {
+    messages: [
+      { role: "system", content: "sys" },
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1", reasoning_content: "r1" },
+      { role: "user", content: "u2" }
+    ]
+  };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+  const assistant = out.messages.find(m => m.role === "assistant");
+  assert.equal(assistant.content[0].type, "thinking", "thinking block comes first");
+  assert.equal(assistant.content[0].thinking, "r1");
+  assert.equal(assistant.content[1].type, "text");
+  assert.equal(assistant.content[1].text, "a1");
+}
+
+// 2. OpenAI → Claude: reasoning_content with tool_calls
+{
+  const body = {
+    messages: [
+      { role: "user", content: "u" },
+      {
+        role: "assistant",
+        content: null,
+        reasoning_content: "planning",
+        tool_calls: [{ id: "c1", type: "function", function: { name: "Read", arguments: '{"path":"x"}' } }]
+      }
+    ]
+  };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+  const assistant = out.messages.find(m => m.role === "assistant");
+  assert.equal(assistant.content[0].type, "thinking");
+  assert.equal(assistant.content[0].thinking, "planning");
+  assert.equal(assistant.content[1].type, "tool_use");
+}
+
+// 3. OpenAI → Claude: no reasoning_content → no thinking block
+{
+  const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a" }] };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+  const assistant = out.messages.find(m => m.role === "assistant");
+  assert.equal(assistant.content.find(b => b.type === "thinking"), undefined);
+}
+
+// 4. OpenAI → Claude: existing thinking block not duplicated
+{
+  const body = {
+    messages: [
+      { role: "user", content: "u" },
+      { role: "assistant", content: [{ type: "thinking", thinking: "already" }, { type: "text", text: "a" }] }
+    ]
+  };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+  const assistant = out.messages.find(m => m.role === "assistant");
+  const thinkingBlocks = assistant.content.filter(b => b.type === "thinking");
+  assert.equal(thinkingBlocks.length, 1, "no duplicate thinking block from reasoning_content");
+  assert.equal(thinkingBlocks[0].thinking, "already");
+}
+
+// 5. Claude → OpenAI: thinking block becomes reasoning_content
+{
+  const body = {
+    system: "sys",
+    max_tokens: 100,
+    messages: [
+      { role: "user", content: [{ type: "text", text: "u" }] },
+      { role: "assistant", content: [{ type: "thinking", thinking: "my reasoning" }, { type: "text", text: "my answer" }] }
+    ]
+  };
+  const out = translateRequest(FORMATS.CLAUDE, FORMATS.OPENAI, "m", body, true);
+  const assistant = out.messages.find(m => m.role === "assistant");
+  assert.equal(assistant.reasoning_content, "my reasoning", "thinking → reasoning_content");
+  const textPart = assistant.content;
+  assert.ok(textPart, "content preserved");
+}
+
+// 6. Claude → OpenAI → Claude roundtrip: thinking survives
+{
+  const body = {
+    system: "sys",
+    max_tokens: 100,
+    messages: [
+      { role: "user", content: [{ type: "text", text: "u" }] },
+      { role: "assistant", content: [{ type: "thinking", thinking: "roundtrip reasoning" }, { type: "text", text: "roundtrip answer" }] }
+    ]
+  };
+  const mid = translateRequest(FORMATS.CLAUDE, FORMATS.OPENAI, "m", body, true);
+  const final = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", mid, true, {}, "anthropic");
+  const assistant = final.messages.find(m => m.role === "assistant");
+  const thinkingBlocks = assistant.content.filter(b => b.type === "thinking");
+  assert.equal(thinkingBlocks.length, 1, "roundtrip: one thinking block");
+  assert.equal(thinkingBlocks[0].thinking, "roundtrip reasoning", "roundtrip: reasoning preserved");
+}
+
+// 7. OpenAI → Ollama: reasoning_content → message.thinking
+{
+  const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a", reasoning_content: "ollama thinking" }] };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.OLLAMA, "m", body, true);
+  const assistant = out.messages.find(m => m.role === "assistant");
+  assert.equal(assistant.thinking, "ollama thinking", "reasoning_content → thinking for ollama");
+}
+
+// 8. OpenAI → CommandCode: reasoning_content → reasoning block
+{
+  const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a", reasoning_content: "cc reasoning" }] };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.COMMANDCODE, "m", body, true);
+  const assistant = out.params.messages.find(m => m.role === "assistant");
+  const reasoningBlock = assistant.content.find(b => b.type === "reasoning");
+  assert.ok(reasoningBlock, "reasoning block present in commandcode output");
+  assert.equal(reasoningBlock.text, "cc reasoning", "reasoning_content → reasoning block for commandcode");
+}
+
+// 9. OpenAI → OpenAI Responses: reasoning_content → reasoning item
+{
+  const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a", reasoning_content: "responses reasoning" }] };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, "m", body, true);
+  const reasoningItem = out.input.find(i => i.type === "reasoning");
+  assert.ok(reasoningItem, "reasoning item present in responses input");
+  assert.equal(reasoningItem.summary[0].text, "responses reasoning", "reasoning_content → reasoning summary for responses");
+}
+
+// 10. Gemini → OpenAI: thought:true → reasoning_content
+{
+  const body = {
+    contents: [
+      { role: "user", parts: [{ text: "u" }] },
+      { role: "model", parts: [{ thought: true, text: "gemini thinking" }, { text: "gemini answer" }] }
+    ]
+  };
+  const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+  const assistant = out.messages.find(m => m.role === "assistant");
+  assert.equal(assistant.reasoning_content, "gemini thinking", "thought:true → reasoning_content for gemini");
+}
+
+console.log("openaiToClaudeReasoningHistorySelfCheck: 10/10");

--- a/open-sse/utils/openaiToClaudeReasoningHistorySelfCheck.mjs
+++ b/open-sse/utils/openaiToClaudeReasoningHistorySelfCheck.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import "../../tests/translator/registerAll.js";
 import { translateRequest } from "../translator/index.js";
 import { FORMATS } from "../translator/formats.js";
+import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../config/defaultThinkingSignature.js";
 
 // 1. OpenAI → Claude: reasoning_content becomes a thinking block
 {
@@ -139,4 +140,46 @@ import { FORMATS } from "../translator/formats.js";
   assert.equal(assistant.reasoning_content, "gemini thinking", "thought:true → reasoning_content for gemini");
 }
 
-console.log("openaiToClaudeReasoningHistorySelfCheck: 10/10");
+// 11. Native Claude (provider === "claude"): unsigned thinking kept with DEFAULT signature.
+// translateRequest(..., "anthropic") skips handlesThinkingBlocks and cannot see this filter.
+{
+  const body = {
+    messages: [
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1", reasoning_content: "r1" },
+      { role: "user", content: "u2" }
+    ]
+  };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "claude");
+  const assistant = out.messages.find(m => m.role === "assistant");
+  const thinking = assistant.content.find(b => b.type === "thinking");
+  assert.equal(thinking.thinking, "r1", "native: thinking text preserved");
+  assert.equal(thinking.signature, DEFAULT_THINKING_CLAUDE_SIGNATURE, "native: DEFAULT bypass signature attached");
+  const text = assistant.content.find(b => b.type === "text");
+  assert.equal(text.text, "a1", "native: visible text unchanged");
+  assert.equal(text.text.includes("r1"), false, "native: thoughts not in visible content");
+}
+
+// 12. Native Claude: foreign signature is replaced, not forwarded.
+{
+  const body = {
+    messages: [
+      { role: "user", content: "u" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "stolen", signature: "gAAAA-not-claude" },
+          { type: "text", text: "a" }
+        ]
+      },
+      { role: "user", content: "u2" }
+    ]
+  };
+  const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "claude");
+  const assistant = out.messages.find(m => m.role === "assistant");
+  const thinking = assistant.content.find(b => b.type === "thinking");
+  assert.equal(thinking.thinking, "stolen", "native: thinking text kept after foreign-sig strip");
+  assert.equal(thinking.signature, DEFAULT_THINKING_CLAUDE_SIGNATURE, "native: foreign blob not forwarded");
+}
+
+console.log("openaiToClaudeReasoningHistorySelfCheck: 12/12");

--- a/tests/unit/gemini-to-openai-function-response.test.js
+++ b/tests/unit/gemini-to-openai-function-response.test.js
@@ -71,6 +71,9 @@ describe("gemini -> openai request translation — functionResponse co-located w
 
     expect(toolMsgs).toHaveLength(2);
     expect(toolMsgs.map(m => m.tool_call_id).sort()).toEqual(["call_a", "call_b"]);
+    // Spread invariant: a parent `push(converted)` would nest the two tool
+    // messages as one array element, so none of messages[] would have role:tool.
+    expect(result.messages.every((m) => m && typeof m === "object" && !Array.isArray(m) && typeof m.role === "string")).toBe(true);
   });
 
   it("preserves text co-located with a functionResponse, keeping the original turn role", () => {

--- a/tests/unit/gemini-to-openai-function-response.test.js
+++ b/tests/unit/gemini-to-openai-function-response.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for open-sse/translator/request/gemini-to-openai.js —
+ * functionResponse co-located with other parts in the same Gemini content.
+ *
+ * convertGeminiContent() early-returns on the first `functionResponse` part
+ * it finds in a content's `parts` array, dropping any `functionCall` or
+ * `text` parts that were co-located in the same content. Gemini clients can
+ * send `functionResponse` alongside `functionCall` (e.g. multi-tool turns)
+ * or alongside `text` (a user follow-up next to a tool result).
+ *
+ * Exercised through translateRequest(), the same registry path the router uses.
+ */
+
+import { describe, it, expect } from "vitest";
+import "../translator/registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("gemini -> openai request translation — functionResponse co-located with other parts", () => {
+  it("preserves a functionCall co-located with a functionResponse in the same content", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { id: "call_b", name: "tool_b", args: {} } }]
+        },
+        {
+          role: "user",
+          parts: [
+            { functionCall: { id: "call_a", name: "tool_a", args: {} } },
+            { functionResponse: { id: "call_b", name: "tool_b", response: { result: "b done" } } }
+          ]
+        }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+
+    const toolMsg = result.messages.find(m => m.role === "tool");
+    const assistantMsg = result.messages.find(m =>
+      m.role === "assistant" && m.tool_calls?.some(call => call.function.name === "tool_a")
+    );
+
+    expect(toolMsg).toBeDefined();
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg.tool_calls[0].function.name).toBe("tool_a");
+  });
+
+  it("preserves multiple functionResponses in the same content", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            { functionCall: { id: "call_a", name: "tool_a", args: {} } },
+            { functionCall: { id: "call_b", name: "tool_b", args: {} } }
+          ]
+        },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { id: "call_a", name: "tool_a", response: { result: "a done" } } },
+            { functionResponse: { id: "call_b", name: "tool_b", response: { result: "b done" } } }
+          ]
+        }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+    const toolMsgs = result.messages.filter(m => m.role === "tool");
+
+    expect(toolMsgs).toHaveLength(2);
+    expect(toolMsgs.map(m => m.tool_call_id).sort()).toEqual(["call_a", "call_b"]);
+  });
+
+  it("preserves text co-located with a functionResponse, keeping the original turn role", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { id: "call_a", name: "tool_a", args: {} } }]
+        },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { id: "call_a", name: "tool_a", response: { result: "a done" } } },
+            { text: "also please summarize" }
+          ]
+        }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+
+    const toolMsg = result.messages.find(m => m.role === "tool");
+    const userMsg = result.messages.find(m => m.role === "user" && m.content === "also please summarize");
+    const asstWithText = result.messages.find(m => m.role === "assistant" && m.content === "also please summarize");
+
+    expect(toolMsg).toBeDefined();
+    expect(userMsg).toBeDefined();
+    expect(asstWithText).toBeUndefined();
+  });
+
+  it("still works for a functionResponse alone (no regression)", () => {
+    const body = {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { id: "call_a", name: "tool_a", args: {} } }]
+        },
+        { role: "user", parts: [{ functionResponse: { id: "call_a", name: "tool_a", response: { result: "a done" } } }] }
+      ]
+    };
+
+    const result = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gemini-pro", body, false);
+
+    const toolMsgs = result.messages.filter(m => m.role === "tool");
+    expect(toolMsgs).toHaveLength(1);
+    expect(toolMsgs[0].tool_call_id).toBe("call_a");
+  });
+});

--- a/tests/unit/reasoning-history-bridge.test.js
+++ b/tests/unit/reasoning-history-bridge.test.js
@@ -16,6 +16,7 @@ import { describe, it, expect } from "vitest";
 import "../translator/registerAll.js";
 import { translateRequest } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
+import { DEFAULT_THINKING_CLAUDE_SIGNATURE } from "../../open-sse/config/defaultThinkingSignature.js";
 
 describe("reasoning/thinking bridge", () => {
   it("openai -> claude: reasoning_content becomes a leading thinking block", () => {
@@ -136,5 +137,79 @@ describe("reasoning/thinking bridge", () => {
     const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
     const assistant = out.messages.find((m) => m.role === "assistant");
     expect(assistant.reasoning_content).toBe("gemini thinking");
+  });
+
+  // Production seam: prepareClaudeRequest with provider === "claude" (OAuth
+  // native). translateRequest(..., "anthropic") never enters
+  // handlesThinkingBlocks and so cannot see the unsigned-thinking filter.
+  it("openai -> claude native: unsigned thinking is kept with DEFAULT signature", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1", reasoning_content: "r1" },
+        { role: "user", content: "u2" },
+      ],
+    };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "claude");
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    const thinking = assistant.content.find((b) => b.type === "thinking");
+    expect(thinking).toEqual({
+      type: "thinking",
+      thinking: "r1",
+      signature: DEFAULT_THINKING_CLAUDE_SIGNATURE,
+    });
+    expect(assistant.content.find((b) => b.type === "text")?.text).toBe("a1");
+    expect(JSON.stringify(assistant.content.filter((b) => b.type === "text"))).not.toContain("r1");
+  });
+
+  it("openai -> claude native: foreign signature is replaced, not forwarded", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "u" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "stolen", signature: "gAAAA-not-claude" },
+            { type: "text", text: "a" },
+          ],
+        },
+        { role: "user", content: "u2" },
+      ],
+    };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "claude");
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    const thinking = assistant.content.find((b) => b.type === "thinking");
+    expect(thinking.thinking).toBe("stolen");
+    expect(thinking.signature).toBe(DEFAULT_THINKING_CLAUDE_SIGNATURE);
+    expect(thinking.signature).not.toBe("gAAAA-not-claude");
+  });
+
+  it("gemini -> openai: thought plus functionResponse is spread, not nested", () => {
+    const body = {
+      contents: [
+        { role: "user", parts: [{ text: "q" }] },
+        {
+          role: "model",
+          parts: [
+            { thought: true, text: "plan" },
+            { functionCall: { id: "c1", name: "f1", args: {} } },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { id: "c1", name: "f1", response: { result: "r1" } } },
+            { text: "thanks" },
+          ],
+        },
+      ],
+    };
+    const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+    expect(out.messages.every((m) => m && !Array.isArray(m) && typeof m.role === "string")).toBe(true);
+    expect(out.messages.filter((m) => m.role === "tool")).toHaveLength(1);
+    const asst = out.messages.find((m) => m.role === "assistant");
+    expect(asst.reasoning_content).toBe("plan");
+    const user = out.messages.find((m) => m.role === "user" && m.content === "thanks");
+    expect(user).toBeDefined();
   });
 });

--- a/tests/unit/reasoning-history-bridge.test.js
+++ b/tests/unit/reasoning-history-bridge.test.js
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the reasoning/thinking bridge across the OpenAI intermediate
+ * request-translation format.
+ *
+ * The OpenAI Chat Completions spec has no native thinking/reasoning field for
+ * request *history* (only reasoning_content on assistant messages, which
+ * upstream itself uses). Several source -> openai translators dropped
+ * incoming thinking/thought content instead of mapping it to reasoning_content,
+ * and several openai -> target translators dropped reasoning_content instead of
+ * mapping it to the target's native thinking representation. Once dropped on
+ * one hop, thinking content is gone for good on every subsequent hop (combo
+ * switch, retry, translation) because nothing carries it forward.
+ */
+
+import { describe, it, expect } from "vitest";
+import "../translator/registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("reasoning/thinking bridge", () => {
+  it("openai -> claude: reasoning_content becomes a leading thinking block", () => {
+    const body = {
+      messages: [
+        { role: "system", content: "sys" },
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1", reasoning_content: "r1" },
+        { role: "user", content: "u2" },
+      ],
+    };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.content[0]).toEqual({ type: "thinking", thinking: "r1" });
+    expect(assistant.content[1]).toMatchObject({ type: "text", text: "a1" });
+  });
+
+  it("openai -> claude: reasoning_content survives alongside tool_calls", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "u" },
+        {
+          role: "assistant",
+          content: null,
+          reasoning_content: "planning",
+          tool_calls: [{ id: "c1", type: "function", function: { name: "Read", arguments: '{"path":"x"}' } }],
+        },
+      ],
+    };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.content[0]).toMatchObject({ type: "thinking", thinking: "planning" });
+    expect(assistant.content[1].type).toBe("tool_use");
+  });
+
+  it("openai -> claude: no reasoning_content means no thinking block (negative control)", () => {
+    const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a" }] };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.content.find((b) => b.type === "thinking")).toBeUndefined();
+  });
+
+  it("openai -> claude: an already-present thinking block is not duplicated", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "u" },
+        { role: "assistant", content: [{ type: "thinking", thinking: "already" }, { type: "text", text: "a" }] },
+      ],
+    };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", body, true, {}, "anthropic");
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    const thinkingBlocks = assistant.content.filter((b) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(1);
+    expect(thinkingBlocks[0].thinking).toBe("already");
+  });
+
+  it("claude -> openai: a thinking block becomes reasoning_content", () => {
+    const body = {
+      system: "sys",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: [{ type: "text", text: "u" }] },
+        { role: "assistant", content: [{ type: "thinking", thinking: "my reasoning" }, { type: "text", text: "my answer" }] },
+      ],
+    };
+    const out = translateRequest(FORMATS.CLAUDE, FORMATS.OPENAI, "m", body, true);
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.reasoning_content).toBe("my reasoning");
+    expect(assistant.content).toBeTruthy();
+  });
+
+  it("claude -> openai -> claude roundtrip: thinking survives a full hop and back", () => {
+    const body = {
+      system: "sys",
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: [{ type: "text", text: "u" }] },
+        { role: "assistant", content: [{ type: "thinking", thinking: "roundtrip reasoning" }, { type: "text", text: "roundtrip answer" }] },
+      ],
+    };
+    const mid = translateRequest(FORMATS.CLAUDE, FORMATS.OPENAI, "m", body, true);
+    const final = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.5", mid, true, {}, "anthropic");
+    const assistant = final.messages.find((m) => m.role === "assistant");
+    const thinkingBlocks = assistant.content.filter((b) => b.type === "thinking");
+    expect(thinkingBlocks).toHaveLength(1);
+    expect(thinkingBlocks[0].thinking).toBe("roundtrip reasoning");
+  });
+
+  it("openai -> ollama: reasoning_content maps to message.thinking", () => {
+    const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a", reasoning_content: "ollama thinking" }] };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.OLLAMA, "m", body, true);
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.thinking).toBe("ollama thinking");
+  });
+
+  it("openai -> commandcode: reasoning_content becomes a leading reasoning block", () => {
+    const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a", reasoning_content: "cc reasoning" }] };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.COMMANDCODE, "m", body, true);
+    const assistant = out.params.messages.find((m) => m.role === "assistant");
+    const reasoningBlock = assistant.content.find((b) => b.type === "reasoning");
+    expect(reasoningBlock?.text).toBe("cc reasoning");
+  });
+
+  it("openai -> openai-responses: reasoning_content becomes a reasoning item", () => {
+    const body = { messages: [{ role: "user", content: "u" }, { role: "assistant", content: "a", reasoning_content: "responses reasoning" }] };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, "m", body, true);
+    const reasoningItem = out.input.find((i) => i.type === "reasoning");
+    expect(reasoningItem?.summary?.[0]?.text).toBe("responses reasoning");
+  });
+
+  it("gemini -> openai: a thought:true part maps to reasoning_content", () => {
+    const body = {
+      contents: [
+        { role: "user", parts: [{ text: "u" }] },
+        { role: "model", parts: [{ thought: true, text: "gemini thinking" }, { text: "gemini answer" }] },
+      ],
+    };
+    const out = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "m", body, true);
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.reasoning_content).toBe("gemini thinking");
+  });
+});


### PR DESCRIPTION
Fixes #2400

## Summary

Reasoning/thinking in assistant request history is still lost on several v0.5.30 translations through the OpenAI-shaped pivot. This standalone fix preserves the semantic field in five currently missing directions:

- Claude `thinking` → OpenAI `reasoning_content`
- Gemini `thought:true` → OpenAI `reasoning_content`
- OpenAI `reasoning_content` → Claude `thinking`
- OpenAI `reasoning_content` → Ollama `thinking`
- OpenAI `reasoning_content` → CommandCode `reasoning`

OpenAI→Responses is no longer changed: v0.5.30 already implements `buildReasoningInputItem()`, including summary and encrypted continuity data. Keeping a second implementation would now be redundant.

## Stack-safe Gemini design

Gemini reasoning is added by `convertGeminiContentWithReasoning`, which wraps the existing converter and accepts either a single message or an array result. It therefore composes with PR #2394's direct multi-result `functionResponse` fix without either patch modifying the other's control-flow seam.

## Files and verification

7 files: five request translators, a 10/10 standalone self-check, and a 10/10 focused Vitest suite.

- self-check: 10/10
- focused Vitest: 10/10
- production build: 126/126
- standalone/sequential apply and `git diff --check`: clean on `9845a17`
