### PR TITLE
fix(deps): remove fs placeholder package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "bcryptjs": "^3.0.3",
     "confbox": "^0.2.4",
     "express": "^5.2.1",
-    "fs": "^0.0.1-security",
     "http-proxy-middleware": "^3.0.5",
     "jose": "^6.1.3",
     "marked": "^18.0.1",


### PR DESCRIPTION
## Summary

Removes the `fs` npm dependency from the root runtime dependencies.

## Root cause

`fs` is a Node.js built-in module, but `package.json` declared the npm placeholder package:

```json
"fs": "^0.0.1-security"
```

The npm `fs` package is only a security-placeholder/reservation package, not the filesystem implementation used by Node. All `require("fs")`, `import fs from "fs"`, and `node:fs` usages resolve to the Node built-in module, so this dependency is unnecessary and can trigger supply-chain/security scanner noise.

## Changes

- Remove `fs` from `dependencies` in `package.json`.
- Leave `package-lock.json` untouched because it is ignored/untracked in this repository.

## Verification

- `git diff --check`
- Confirmed `fs` is absent from root dependencies.
- `npm run build`

Closes #2360
