### PR TITLE
feat(proxy-pools): auto-rotate strategy for no-auth providers

### DIFF
--- a/src/lib/network/connectionProxy.js
+++ b/src/lib/network/connectionProxy.js
@@ -6,6 +6,33 @@ function normalizeString(value) {
   return String(value).trim();
 }
 
+// ─── Proxy pool rotation state (in-memory) ─────────────────────────
+const rotateState = new Map(); // providerId → { index }
+
+/**
+ * Pick one proxy pool ID from a list based on strategy.
+ * round-robin: cycle sequentially (in-memory, resets on restart)
+ * random:      uniform random pick
+ * none/single: return first entry
+ */
+export function pickProxyPoolId(poolIds, strategy, providerId) {
+  if (!poolIds || poolIds.length === 0) return null;
+  if (poolIds.length === 1) return poolIds[0];
+
+  if (strategy === "round-robin") {
+    const state = rotateState.get(providerId) || { index: -1 };
+    state.index = (state.index + 1) % poolIds.length;
+    rotateState.set(providerId, state);
+    return poolIds[state.index];
+  }
+
+  if (strategy === "random") {
+    return poolIds[Math.floor(Math.random() * poolIds.length)];
+  }
+
+  return poolIds[0]; // "none" or unknown
+}
+
 /**
  * Normalize legacy proxy configuration.
  */

--- a/src/shared/components/NoAuthProxyCard.js
+++ b/src/shared/components/NoAuthProxyCard.js
@@ -1,16 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import Card from "./Card";
 import Select from "./Select";
 import Badge from "./Badge";
 
 const NONE_PROXY_POOL_VALUE = "__none__";
+const STRATEGIES = [
+  { value: "none", label: "None (single pool)" },
+  { value: "round-robin", label: "Round-robin" },
+  { value: "random", label: "Random" },
+];
 
 export default function NoAuthProxyCard({ providerId }) {
   const [proxyPools, setProxyPools] = useState([]);
   const [proxyPoolId, setProxyPoolId] = useState(NONE_PROXY_POOL_VALUE);
+  const [rotateStrategy, setRotateStrategy] = useState("none");
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
 
@@ -24,20 +30,22 @@ export default function NoAuthProxyCard({ providerId }) {
       setProxyPools(poolData.proxyPools || []);
       const override = (settingsData.providerStrategies || {})[providerId] || {};
       setProxyPoolId(override.proxyPoolId || NONE_PROXY_POOL_VALUE);
+      setRotateStrategy(override.rotateStrategy || "none");
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [providerId]);
 
-  const handleChange = async (newValue) => {
-    setProxyPoolId(newValue);
+  const save = useCallback(async (poolId, strategy) => {
     setSaving(true);
     try {
       const res = await fetch("/api/settings", { cache: "no-store" });
       const data = res.ok ? await res.json() : {};
       const current = data.providerStrategies || {};
       const override = { ...(current[providerId] || {}) };
-      if (newValue === NONE_PROXY_POOL_VALUE) delete override.proxyPoolId;
-      else override.proxyPoolId = newValue;
+      if (poolId === NONE_PROXY_POOL_VALUE) delete override.proxyPoolId;
+      else override.proxyPoolId = poolId;
+      if (strategy === "none") delete override.rotateStrategy;
+      else override.rotateStrategy = strategy;
       const updated = { ...current };
       if (Object.keys(override).length === 0) delete updated[providerId];
       else updated[providerId] = override;
@@ -49,11 +57,24 @@ export default function NoAuthProxyCard({ providerId }) {
       setSavedFlash(true);
       setTimeout(() => setSavedFlash(false), 1500);
     } catch (e) {
-      console.log("Save proxyPoolId error:", e);
+      console.log("Save proxy config error:", e);
     } finally {
       setSaving(false);
     }
+  }, [providerId]);
+
+  const handlePoolChange = (newPoolId) => {
+    setProxyPoolId(newPoolId);
+    save(newPoolId, rotateStrategy);
   };
+
+  const handleStrategyChange = (newStrategy) => {
+    setRotateStrategy(newStrategy);
+    save(proxyPoolId, newStrategy);
+  };
+
+  const canRotate = proxyPools.length >= 2;
+  const isRotation = rotateStrategy !== "none";
 
   return (
     <Card>
@@ -67,16 +88,43 @@ export default function NoAuthProxyCard({ providerId }) {
         </div>
         {savedFlash && <Badge variant="success" size="sm">Saved</Badge>}
       </div>
+
       <Select
         label="Proxy Pool"
         value={proxyPoolId}
-        onChange={(e) => handleChange(e.target.value)}
-        disabled={saving}
+        onChange={(e) => handlePoolChange(e.target.value)}
+        disabled={saving || isRotation}
         options={[
           { value: NONE_PROXY_POOL_VALUE, label: "None (direct)" },
           ...proxyPools.map((pool) => ({ value: pool.id, label: pool.name })),
         ]}
+        hint={isRotation ? "Pool selector is ignored when rotation is active — all active pools are used." : undefined}
       />
+
+      <div className="flex flex-col gap-2 mt-4">
+        <label className="text-sm font-medium text-text-main">Rotation Strategy</label>
+        <select
+          value={rotateStrategy}
+          onChange={(e) => handleStrategyChange(e.target.value)}
+          disabled={saving}
+          className="py-2 px-3 text-sm text-text-main bg-white dark:bg-white/5 border border-black/10 dark:border-white/10 rounded-md focus:ring-1 focus:ring-primary/30 focus:border-primary/50 focus:outline-none transition-all disabled:opacity-50"
+        >
+          {STRATEGIES.map((s) => (
+            <option key={s.value} value={s.value} disabled={s.value !== "none" && !canRotate}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+        <p className="text-xs text-text-muted">
+          {!canRotate
+            ? `Need at least 2 active proxy pools for rotation.`
+            : isRotation
+              ? rotateStrategy === "round-robin"
+                ? `Rotating through all ${proxyPools.length} active pools in order. State is in-memory (resets on restart).`
+                : `Picking a random pool from ${proxyPools.length} active pools each request.`
+              : `Uses the selected pool above. Set to Round-robin or Random to rotate across all active pools.`}
+        </p>
+      </div>
     </Card>
   );
 }

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,5 +1,5 @@
-import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings } from "@/lib/localDb";
-import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
+import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
+import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
@@ -36,7 +36,14 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
     if (FREE_PROVIDERS[providerId]?.noAuth) {
       const settings = await getSettings();
       const override = (settings.providerStrategies || {})[providerId] || {};
-      const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: override.proxyPoolId || "" });
+      const strategy = override.rotateStrategy || "none";
+      let pickedId = override.proxyPoolId || null;
+      if (strategy !== "none") {
+        const allPools = await getProxyPools({ isActive: true });
+        const poolIds = allPools.filter(p => p.proxyUrl).map(p => p.id);
+        pickedId = pickProxyPoolId(poolIds, strategy, providerId);
+      }
+      const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: pickedId || "" });
       return {
         id: "noauth",
         connectionName: "Public",


### PR DESCRIPTION
## Summary

Add a rotation strategy selector to **NoAuthProxyCard** (provider detail page, e.g. OpenCode Free) that allows no-auth providers to automatically rotate requests across **all active proxy pools** — round-robin or random.

## Problem

Free-tier providers like OpenCode Free share public upstream IPs, making them prone to per-IP rate limits. Previously, users could only assign a **single** static proxy pool. When that proxy IP got rate-limited, requests would fail until the user manually switched pools. No fallback, no load distribution.

## Solution

### UI — `NoAuthProxyCard.js`

- **Proxy Pool dropdown** preserved as-is — default mode "None (single pool)"
- **Rotation Strategy dropdown** added (None / Round-robin / Random)
- Pool dropdown is disabled with an explanatory hint when rotation is active
- Round-robin/Random options are disabled if fewer than 2 active pools exist
- Both values are persisted to `settings.providerStrategies[providerId]` and auto-save on change

### Backend — `auth.js`

```
getProviderCredentials("opencode")
  → strategy = override.rotateStrategy
  → if "none":         use override.proxyPoolId (existing behavior)
  → if "round-robin":  getProxyPools({isActive:true}) → pickProxyPoolId()
  → if "random":       getProxyPools({isActive:true}) → pickProxyPoolId()
  → resolveConnectionProxyConfig() → proxyAwareFetch()
```

### Shared utility — `connectionProxy.js`

New function `pickProxyPoolId(poolIds, strategy, providerId)`:
- **round-robin**: in-memory Map keyed by `providerId → { index }`, cycles on each call
- **random**: `Math.random()` per request
- **none**: returns poolIds[0] (fallback)

## Why in-memory?

The round-robin state is deliberately **not persisted** — resetting the index on server restart is fairer than resuming from a potentially biased last index. If a pool is deleted, the cycle automatically adjusts without stale DB state.

## Testing

This change only affects pool ID selection logic in the no-auth credential path. All API-key provider paths are untouched. The downstream proxy resolution (`resolveConnectionProxyConfig` → `proxyAwareFetch`) is completely unchanged.

## Files Changed

| File | Changes |
|------|---------|
| `src/shared/components/NoAuthProxyCard.js` | + rotation strategy dropdown, auto-save, pool selector disabled hint |
| `src/sse/services/auth.js` | + import `getProxyPools`, `pickProxyPoolId`; rotation vs single pool resolution |
| `src/lib/network/connectionProxy.js` | + `pickProxyPoolId()` with in-memory round-robin + random |