### PR TITLE
fix(cli): fast-path help and version flags

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -43,9 +43,48 @@ function createSpinner(text) {
 }
 
 const pkg = require("./package.json");
+const args = process.argv.slice(2);
+
+// Configuration constants
+const APP_NAME = pkg.name; // Use from package.json
+const INSTALL_CMD_LATEST = `npm i -g ${APP_NAME}@latest --prefer-online`;
+
+const DEFAULT_PORT = 20128;
+const DEFAULT_HOST = "0.0.0.0";
+
+function hasFlag(flag, shortFlag) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === flag || arg === shortFlag) return true;
+    if (["--port", "-p", "--host", "-H"].includes(arg)) i++;
+  }
+  return false;
+}
+
+if (hasFlag("--help", "-h")) {
+  console.log(`
+Usage: ${APP_NAME} [options]
+
+Options:
+  -p, --port <port>   Port to run the server (default: ${DEFAULT_PORT})
+  -H, --host <host>   Host to bind (default: ${DEFAULT_HOST})
+  -n, --no-browser    Don't open browser automatically
+  -l, --log           Show server logs (default: hidden)
+  -t, --tray          Run in system tray mode (background)
+  --skip-update       Skip auto-update check
+  -h, --help          Show this help message
+  -v, --version       Show version
+`);
+  process.exit(0);
+}
+
+if (hasFlag("--version", "-v")) {
+  console.log(pkg.version);
+  process.exit(0);
+}
+
 const { ensureSqliteRuntime, buildEnvWithRuntime } = require("./hooks/sqliteRuntime");
 const { ensureTrayRuntime } = require("./hooks/trayRuntime");
-const args = process.argv.slice(2);
 
 // Self-heal SQLite runtime deps (sql.js + better-sqlite3) into ~/.9router/runtime
 // so the server can resolve them via NODE_PATH. Best-effort — sql.js is required,
@@ -54,13 +93,6 @@ try { ensureSqliteRuntime({ silent: true }); } catch {}
 
 // Self-heal tray runtime (systray for macOS/Linux only). Windows skipped.
 try { ensureTrayRuntime({ silent: true }); } catch {}
-
-// Configuration constants
-const APP_NAME = pkg.name; // Use from package.json
-const INSTALL_CMD_LATEST = `npm i -g ${APP_NAME}@latest --prefer-online`;
-
-const DEFAULT_PORT = 20128;
-const DEFAULT_HOST = "0.0.0.0";
 
 // First non-internal IPv4 — the address remote peers actually reach when bound to 0.0.0.0.
 function getLanIp() {
@@ -106,24 +138,6 @@ for (let i = 0; i < args.length; i++) {
   } else if (args[i] === "--tray" || args[i] === "-t") {
     trayMode = true;
     process.env.TRAY_MODE = "1";
-  } else if (args[i] === "--help" || args[i] === "-h") {
-    console.log(`
-Usage: ${APP_NAME} [options]
-
-Options:
-  -p, --port <port>   Port to run the server (default: ${DEFAULT_PORT})
-  -H, --host <host>   Host to bind (default: ${DEFAULT_HOST})
-  -n, --no-browser    Don't open browser automatically
-  -l, --log           Show server logs (default: hidden)
-  -t, --tray          Run in system tray mode (background)
-  --skip-update       Skip auto-update check
-  -h, --help          Show this help message
-  -v, --version       Show version
-`);
-    process.exit(0);
-  } else if (args[i] === "--version" || args[i] === "-v") {
-    console.log(pkg.version);
-    process.exit(0);
   }
 }
 


### PR DESCRIPTION
## Description

Fixes #2363.

`9router --help` and `9router --version` should be metadata-only commands, but they were slow because the CLI performed runtime self-healing before handling those flags.

## Root cause

`cli/cli.js` imported and ran these hooks before parsing `--help` / `--version`:

- `ensureSqliteRuntime({ silent: true })`
- `ensureTrayRuntime({ silent: true })`

Those hooks can perform expensive best-effort runtime setup, including npm installs for packages such as `sql.js`, `better-sqlite3`, and `systray2`. That work is needed for normal server/tray startup, but not for help/version output.

## Changes

- Fast-path `--help` / `-h` before importing/running runtime self-healing hooks
- Fast-path `--version` / `-v` before importing/running runtime self-healing hooks
- Keep normal startup behavior unchanged for server/tray runs
- Use a small parser-aware flag scan so option values like `--host -h` are not misread as help flags

## Verification

Before this change on upstream master:

```sh
$ time node cli/cli.js --version
0.5.18

real    0m5.008s
```

After this change:

```sh
$ time node cli/cli.js --version
0.5.18

real    0m0.088s
```

```sh
$ time node cli/cli.js --help >/tmp/9router-help.out

real    0m0.063s
```

```sh
$ node --check cli/cli.js
```

```sh
$ tmp="$(mktemp -d)"
$ HOME="$tmp" node cli/cli.js --help >/tmp/9router-clean-help.out
$ HOME="$tmp" node cli/cli.js --version >/tmp/9router-clean-version.out
$ test ! -e "$tmp/.9router/runtime/node_modules"
```

Clean-runtime smoke check passed: help/version did not create runtime `node_modules`.
Smoke-checked parser behavior so `--host -h` is not treated as `--help` by the fast-path scanner.
