### PR TITLE
feat(usage): add all time period

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/page.js
+++ b/src/app/(dashboard)/dashboard/usage/page.js
@@ -11,6 +11,7 @@ const PERIODS = [
   { value: "7d", label: "7D" },
   { value: "30d", label: "30D" },
   { value: "60d", label: "60D" },
+  { value: "all", label: "All Time" },
 ];
 
 export default function UsagePage() {

--- a/src/app/api/usage/chart/route.js
+++ b/src/app/api/usage/chart/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getChartData } from "@/lib/usageDb";
 
-const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d"]);
+const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "all"]);
 
 export async function GET(request) {
   try {

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -710,9 +710,22 @@ export async function getChartData(period = "7d") {
     return buckets;
   }
 
+  const labelFn = (d, opts = { month: "short", day: "numeric" }) => d.toLocaleDateString("en-US", opts);
+
+  if (period === "all") {
+    const dayRows = loadDaysInRange(db, null).sort((a, b) => a.dateKey.localeCompare(b.dateKey));
+    return dayRows.map((r) => {
+      const dayData = parseJson(r.data, {});
+      return {
+        label: labelFn(new Date(`${r.dateKey}T00:00:00`), { month: "short", day: "numeric", year: "numeric" }),
+        tokens: (dayData.promptTokens || 0) + (dayData.completionTokens || 0),
+        cost: dayData.cost || 0,
+      };
+    });
+  }
+
   const bucketCount = period === "7d" ? 7 : period === "30d" ? 30 : 60;
   const today = new Date();
-  const labelFn = (d) => d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 
   // Build map of dateKey → day data
   const dayRows = loadDaysInRange(db, bucketCount);


### PR DESCRIPTION
## Description

Implements #2410.

Adds an **All Time** period to the Usage dashboard so users can view lifetime usage totals and chart data.

## Root cause

The stats API already accepted `period=all`, but the option was not wired through everywhere:

- Usage dashboard period selector omitted `all`
- `/api/usage/chart` rejected `period=all`
- `getChartData()` only bucketed fixed windows (`7d`, `30d`, `60d`) after `today` / `24h`, so direct `all` calls would silently fall back to a 60-day chart

## Changes

- Add `All Time` to the Usage dashboard period selector
- Allow `period=all` in `/api/usage/chart`
- Return all daily usage rows for all-time chart data, sorted oldest to newest
- Include the year in all-time chart labels to avoid duplicate labels across years

## Verification

```sh
$ node --check src/app/api/usage/chart/route.js
$ node --check src/lib/db/repos/usageRepo.js
$ npm run build
```

Build completed successfully and included `/api/usage/chart`, `/api/usage/stats`, and `/dashboard/usage`.

Review notes checked:

- No duplicate PR found for #2410
- Empty all-time data returns `[]`, so the existing chart empty state applies
- Chart reads `usageDaily` summaries, not raw `usageHistory`

Closes #2410.
