### PR TITLE
feat(providers): add DigitalOcean AI provider (serverless inference)

### DIFF
--- a/open-sse/providers/registry/digitalocean.js
+++ b/open-sse/providers/registry/digitalocean.js
@@ -1,0 +1,27 @@
+export default {
+  id: "digitalocean",
+  priority: 80,
+  alias: "digitalocean",
+  aliases: [
+    "do",
+  ],
+  uiAlias: "do",
+  display: {
+    name: "DigitalOcean",
+    icon: "cloud",
+    color: "#0060FF",
+    textIcon: "DO",
+    website: "https://docs.digitalocean.com/products/ai-platform/",
+    notice: {
+      text: "Use a DigitalOcean Personal Access Token (dop_v1_...) or a Model Access Key from the Inference console. OAuth tokens (doo_v1_...) may not have the required scopes.",
+      apiKeyUrl: "https://cloud.digitalocean.com/account/api/tokens",
+    },
+  },
+  category: "apikey",
+  transport: {
+    baseUrl: "https://inference.do-ai.run/v1/chat/completions",
+    validateUrl: "https://inference.do-ai.run/v1/models",
+  },
+  serviceKinds: ["llm"],
+  passthroughModels: true,
+};

--- a/open-sse/providers/registry/index.js
+++ b/open-sse/providers/registry/index.js
@@ -96,6 +96,7 @@ import p93 from "./xai.js";
 import p94 from "./xiaomi-mimo.js";
 import p95 from "./xiaomi-tokenplan.js";
 import p96 from "./youcom.js";
+import p97 from "./digitalocean.js";
 
 export default [
   p0,
@@ -194,5 +195,6 @@ export default [
   p93,
   p94,
   p95,
-  p96
+  p96,
+  p97
 ];

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -711,6 +711,12 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         }, effectiveProxy);
         return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
       }
+      case "digitalocean": {
+        const res = await fetchWithConnectionProxy("https://inference.do-ai.run/v1/models", {
+          headers: { Authorization: `Bearer ${connection.apiKey}` },
+        }, effectiveProxy);
+        return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
+      }
       default:
         return { valid: false, error: "Provider test not supported" };
     }


### PR DESCRIPTION

This pull request adds support for DigitalOcean as a provider in the system. The changes include registering DigitalOcean with the provider registry and implementing API key validation logic for it.

**DigitalOcean provider integration:**

* Added a new provider definition for DigitalOcean in `digitalocean.js`, specifying its metadata, display information, supported authentication methods, and API endpoints.
* Registered the DigitalOcean provider in the main provider registry by importing it in `index.js` and adding it to the exported array of providers. [[1]](diffhunk://#diff-5b491d21ca2da4b0a7b2348ba26aad734b2cb57c37c4bddaf4ac61f3533af66fR99) [[2]](diffhunk://#diff-5b491d21ca2da4b0a7b2348ba26aad734b2cb57c37c4bddaf4ac61f3533af66fL197-R199)

**API key validation:**

* Implemented DigitalOcean API key validation logic in `testUtils.js`, enabling the system to verify DigitalOcean credentials by making a request to the appropriate endpoint. ([src/app/api/providers/[id]/test/testUtils.jsR714-R719](diffhunk://#diff-b31d1291bc4414ec6be105f254faa71bbcc3c9305258370c8897f21938059709R714-R719))