### PR TITLE
feat(caveman): add targeted upstream-aligned style rules

### DIFF
--- a/open-sse/rtk/cavemanPrompts.js
+++ b/open-sse/rtk/cavemanPrompts.js
@@ -20,7 +20,7 @@ const SHARED_PERSISTENCE = "ACTIVE EVERY RESPONSE. No revert after many turns. N
 
 const SHARED_NO_INVENTED_ABBREV = "No invented abbreviations. Standard well-known tech acronyms (DB, API, HTTP, URL, JSON, ID, OS, CPU) OK. Names of code symbols, function names, API names, error strings: keep verbatim.";
 
-const SHARED_PRESERVE_LANGUAGE = "Preserve the user's dominant language. User wrote Vietnamese, reply Vietnamese. User wrote English, reply English. Code identifiers, error strings, file paths, commands: keep in their original form regardless of language.";
+const SHARED_PRESERVE_LANGUAGE = "Preserve the user's dominant language. User wrote Vietnamese, reply Vietnamese. User wrote English, reply English. Wenyan/classical-Chinese levels override this language-preservation rule. Code identifiers, error strings, file paths, commands: keep in their original form regardless of language.";
 
 const SHARED_NO_SELF_REFERENCE = 'No self-reference. Do not name or announce the style (no "caveman mode", no "me caveman think", no "compressed mode active"). Just respond.';
 
@@ -56,8 +56,8 @@ export const CAVEMAN_PROMPTS = {
 
   [CAVEMAN_LEVELS.ULTRA]: [
     "Respond ultra-terse. Maximum compression. Telegraphic.",
-    "Strip conjunctions. One word when one word enough. Standard acronyms only (DB/API/HTTP/URL/JSON/ID). Never invent abbreviations or use causal arrow shorthand.",
-    "Pattern: [thing] → [result]. [fix].",
+    "Strip conjunctions. One word when one word enough.",
+    "Pattern: [thing] [action] [reason]. [next step].",
     SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
     SHARED_AUTO_CLARITY,

--- a/open-sse/rtk/cavemanPrompts.js
+++ b/open-sse/rtk/cavemanPrompts.js
@@ -18,6 +18,14 @@ const SHARED_AUTO_CLARITY = "Auto-Clarity: drop caveman for security warnings, i
 
 const SHARED_PERSISTENCE = "ACTIVE EVERY RESPONSE. No revert after many turns. No filler drift. Still active if unsure.";
 
+const SHARED_NO_INVENTED_ABBREV = "No invented abbreviations. Standard well-known tech acronyms (DB, API, HTTP, URL, JSON, ID, OS, CPU) OK. Names of code symbols, function names, API names, error strings: keep verbatim.";
+
+const SHARED_PRESERVE_LANGUAGE = "Preserve the user's dominant language. User wrote Vietnamese, reply Vietnamese. User wrote English, reply English. Code identifiers, error strings, file paths, commands: keep in their original form regardless of language.";
+
+const SHARED_NO_SELF_REFERENCE = 'No self-reference. Do not name or announce the style (no "caveman mode", no "me caveman think", no "compressed mode active"). Just respond.';
+
+const SHARED_NO_DECORATION = 'No decorative emoji. No narrating tool calls ("I will now search", "I used X to find Y"). No status phrases ("Sure!", "Of course!", "I\'d be happy to"). No causal arrow shorthand ("A -> B -> fails"). State the thing, the action, the reason. Then next step.';
+
 export const CAVEMAN_PROMPTS = {
   [CAVEMAN_LEVELS.LITE]: [
     "Respond tersely. Keep grammar and full sentences but drop filler, hedging and pleasantries (just/really/basically/sure/of course/I'd be happy to).",
@@ -26,6 +34,10 @@ export const CAVEMAN_PROMPTS = {
     SHARED_BOUNDARIES,
     SHARED_AUTO_CLARITY,
     SHARED_PERSISTENCE,
+    SHARED_NO_INVENTED_ABBREV,
+    SHARED_PRESERVE_LANGUAGE,
+    SHARED_NO_SELF_REFERENCE,
+    SHARED_NO_DECORATION,
   ].join(" "),
 
   [CAVEMAN_LEVELS.FULL]: [
@@ -36,16 +48,24 @@ export const CAVEMAN_PROMPTS = {
     SHARED_BOUNDARIES,
     SHARED_AUTO_CLARITY,
     SHARED_PERSISTENCE,
+    SHARED_NO_INVENTED_ABBREV,
+    SHARED_PRESERVE_LANGUAGE,
+    SHARED_NO_SELF_REFERENCE,
+    SHARED_NO_DECORATION,
   ].join(" "),
 
   [CAVEMAN_LEVELS.ULTRA]: [
     "Respond ultra-terse. Maximum compression. Telegraphic.",
-    "Abbreviate (DB/auth/config/req/res/fn/impl), strip conjunctions, use arrows for causality (X → Y). One word when one word enough.",
+    "Strip conjunctions. One word when one word enough. Standard acronyms only (DB/API/HTTP/URL/JSON/ID). Never invent abbreviations or use causal arrow shorthand.",
     "Pattern: [thing] → [result]. [fix].",
     SHARED_EXAMPLES,
     SHARED_BOUNDARIES,
     SHARED_AUTO_CLARITY,
     SHARED_PERSISTENCE,
+    SHARED_NO_INVENTED_ABBREV,
+    SHARED_PRESERVE_LANGUAGE,
+    SHARED_NO_SELF_REFERENCE,
+    SHARED_NO_DECORATION,
   ].join(" "),
 
   [CAVEMAN_LEVELS.WENYAN_LITE]: [
@@ -55,6 +75,10 @@ export const CAVEMAN_PROMPTS = {
     SHARED_BOUNDARIES,
     SHARED_AUTO_CLARITY,
     SHARED_PERSISTENCE,
+    SHARED_NO_INVENTED_ABBREV,
+    SHARED_PRESERVE_LANGUAGE,
+    SHARED_NO_SELF_REFERENCE,
+    SHARED_NO_DECORATION,
   ].join(" "),
 
   [CAVEMAN_LEVELS.WENYAN]: [
@@ -65,6 +89,10 @@ export const CAVEMAN_PROMPTS = {
     SHARED_BOUNDARIES,
     SHARED_AUTO_CLARITY,
     SHARED_PERSISTENCE,
+    SHARED_NO_INVENTED_ABBREV,
+    SHARED_PRESERVE_LANGUAGE,
+    SHARED_NO_SELF_REFERENCE,
+    SHARED_NO_DECORATION,
   ].join(" "),
 
   [CAVEMAN_LEVELS.WENYAN_ULTRA]: [
@@ -74,5 +102,9 @@ export const CAVEMAN_PROMPTS = {
     SHARED_BOUNDARIES,
     SHARED_AUTO_CLARITY,
     SHARED_PERSISTENCE,
+    SHARED_NO_INVENTED_ABBREV,
+    SHARED_PRESERVE_LANGUAGE,
+    SHARED_NO_SELF_REFERENCE,
+    SHARED_NO_DECORATION,
   ].join(" "),
 };

--- a/tests/unit/caveman-prompts.test.js
+++ b/tests/unit/caveman-prompts.test.js
@@ -11,9 +11,14 @@ const LEVEL_KEYS = [
 ];
 
 describe("Caveman prompt coverage", () => {
-  it("has exactly six declared levels", () => {
-    expect(Object.keys(CAVEMAN_LEVELS).length).toBe(6);
-    expect(LEVEL_KEYS.length).toBe(6);
+  it("every level key has matching prompt and vice versa", () => {
+    const levelValues = Object.values(CAVEMAN_LEVELS);
+    for (const key of LEVEL_KEYS) {
+      expect(levelValues).toContain(key);
+    }
+    for (const value of levelValues) {
+      expect(LEVEL_KEYS).toContain(value);
+    }
   });
 
   it("has a prompt string for every level", () => {
@@ -44,6 +49,17 @@ describe("Caveman prompt coverage", () => {
   it("adds no-decorative-emoji guidance to every level", () => {
     for (const level of LEVEL_KEYS) {
       expect(CAVEMAN_PROMPTS[level]).toContain("No decorative emoji");
+    }
+  });
+});
+
+describe("Caveman internal consistency", () => {
+  it("no level uses Unicode arrow (SHARED_NO_DECORATION bans arrow shorthand)", () => {
+    // SHARED_NO_DECORATION uses ASCII -> to quote the banned pattern.
+    // Unicode → is the character old ULTRA used in "Pattern: [thing] → [result]".
+    // Verify no level now uses it.
+    for (const level of LEVEL_KEYS) {
+      expect(CAVEMAN_PROMPTS[level]).not.toContain("→");
     }
   });
 });

--- a/tests/unit/caveman-prompts.test.js
+++ b/tests/unit/caveman-prompts.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { CAVEMAN_LEVELS, CAVEMAN_PROMPTS } from "../../open-sse/rtk/cavemanPrompts.js";
+
+const LEVEL_KEYS = [
+  CAVEMAN_LEVELS.LITE,
+  CAVEMAN_LEVELS.FULL,
+  CAVEMAN_LEVELS.ULTRA,
+  CAVEMAN_LEVELS.WENYAN_LITE,
+  CAVEMAN_LEVELS.WENYAN,
+  CAVEMAN_LEVELS.WENYAN_ULTRA,
+];
+
+describe("Caveman prompt coverage", () => {
+  it("has exactly six declared levels", () => {
+    expect(Object.keys(CAVEMAN_LEVELS).length).toBe(6);
+    expect(LEVEL_KEYS.length).toBe(6);
+  });
+
+  it("has a prompt string for every level", () => {
+    for (const level of LEVEL_KEYS) {
+      expect(typeof CAVEMAN_PROMPTS[level]).toBe("string");
+      expect(CAVEMAN_PROMPTS[level].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("adds no-invented-abbreviations guidance to every level", () => {
+    for (const level of LEVEL_KEYS) {
+      expect(CAVEMAN_PROMPTS[level]).toContain("No invented abbreviations");
+    }
+  });
+
+  it("adds preserve-user-language guidance to every level", () => {
+    for (const level of LEVEL_KEYS) {
+      expect(CAVEMAN_PROMPTS[level]).toContain("Preserve the user's dominant language");
+    }
+  });
+
+  it("adds no-self-reference guidance to every level", () => {
+    for (const level of LEVEL_KEYS) {
+      expect(CAVEMAN_PROMPTS[level]).toContain("No self-reference");
+    }
+  });
+
+  it("adds no-decorative-emoji guidance to every level", () => {
+    for (const level of LEVEL_KEYS) {
+      expect(CAVEMAN_PROMPTS[level]).toContain("No decorative emoji");
+    }
+  });
+});
+
+describe("Caveman ULTRA targeted sync", () => {
+  it("does not encourage invented abbreviations", () => {
+    const ultra = CAVEMAN_PROMPTS[CAVEMAN_LEVELS.ULTRA];
+    expect(ultra).not.toContain("req/res/fn/impl");
+    expect(ultra).not.toContain("Abbreviate (DB/auth/config/req/res/fn/impl)");
+  });
+
+  it("does not encourage arrow shorthand", () => {
+    const ultra = CAVEMAN_PROMPTS[CAVEMAN_LEVELS.ULTRA];
+    expect(ultra).not.toContain("use arrows for causality");
+    expect(ultra).not.toContain("X → Y");
+  });
+});


### PR DESCRIPTION
## Summary
- add four targeted upstream-aligned Caveman rules to all six Caveman levels
- remove ULTRA prompt contradictions around invented abbreviations and arrow shorthand
- add dedicated Caveman prompt regression tests

## Why
9router’s embedded Caveman prompts were already close to upstream in spirit, but still missed a few useful guardrails:
- no invented abbreviations
- preserve the user’s dominant language
- no self-reference
- no decorative emoji / no tool-call narration

Also, the local ULTRA prompt still contradicted those goals by encouraging abbreviated forms and arrow shorthand.

This PR intentionally does **not** wholesale replace Caveman with upstream text. It only cherry-picks the rules that materially improve output hygiene while preserving the existing 9router Caveman structure.

## Design
### Changed file
- `open-sse/rtk/cavemanPrompts.js`

### Added test file
- `tests/unit/caveman-prompts.test.js`

### Explicitly unchanged
- `open-sse/rtk/caveman.js`
- `open-sse/rtk/systemInject.js`
- Ponytail
- RTK
- Headroom
- CLI/dashboard/settings/packaging

## Exact rule additions
Added shared prompt fragments for:
- no invented abbreviations
- preserve user language
- no self-reference
- no decorative emoji / no tool narration / no status fluff

Applied to all six levels:
- `lite`
- `full`
- `ultra`
- `wenyan-lite`
- `wenyan`
- `wenyan-ultra`

## ULTRA cleanup
This PR also removes the old ULTRA contradiction.

Before, ULTRA encouraged:
- invented abbreviations (`req/res/fn/impl`-style)
- arrow shorthand

Now ULTRA stays terse without contradicting the new shared rules.

## Blast radius
Low.
- prompt text only
- injector wrappers untouched
- no routing or provider logic changes
- no settings/UI changes
- detect_changes reported low risk and 0 affected processes

## Focused verification
Fresh run on this branch:
```bash
npx vitest run tests/unit/caveman-prompts.test.js
```

Result:
- `Test Files  1 passed (1)`
- `Tests  9 passed (9)`

## Reviewer guide
Fastest path to check:
1. review `open-sse/rtk/cavemanPrompts.js`
2. verify the four added shared rules
3. check ULTRA no longer uses the old contradictory patterning
4. run the focused Caveman test above

## Why not wholesale sync
A full upstream text replacement would create much more output-distribution drift for users, with larger review surface and weaker isolation. This PR keeps the existing 9router Caveman design and only applies the most useful rule-level corrections.

## Out of scope by design
- syncing all upstream Caveman text verbatim
- changing Ponytail alongside Caveman
- any runtime or settings behavior changes
