### PR TITLE
Fix Kimi reasoning_effort normalization

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -132,6 +132,15 @@ function toGeminiThinkingLevel(cfg) {
   return effortToThinkingLevel(raw);
 }
 
+function toKimiReasoningEffort(cfg) {
+  const level = toLevel(cfg);
+  if (level === "auto") return "high";
+  if (level === "minimal") return "low";
+  if (level === "xhigh") return "max";
+  if (["low", "medium", "high", "max"].includes(level)) return level;
+  return null;
+}
+
 // Gemini nests thinkingConfig under generationConfig. gemini-cli / antigravity wrap
 // the whole request in a { request: { generationConfig } } envelope — target the
 // envelope's generationConfig when present, else the top-level one.
@@ -217,8 +226,8 @@ function applyFormat(fmt, body, cfg, caps) {
     }
     case "kimi": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
-      const level = toLevel(eff);
-      if (level) body.reasoning_effort = level === "max" ? "high" : level;
+      const effort = toKimiReasoningEffort(eff);
+      if (effort) body.reasoning_effort = effort;
       break;
     }
     case "minimax": {

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -106,6 +106,16 @@ describe("applyThinking per provider format", () => {
     const out = apply("openai", "kimi-k2.6", { reasoning_effort: "high" }, "kimi");
     expect(out.reasoning_effort).toBe("high");
   });
+  it("Kimi auto → supported reasoning_effort", () => {
+    const out = apply("openai", "kimi-k2.7", { reasoning_effort: "auto" }, "kimchi");
+    expect(out.reasoning_effort).toBe("high");
+  });
+  it("Kimi unsupported OpenAI levels → supported reasoning_effort", () => {
+    const minimal = apply("openai", "kimi-k2.7", { reasoning_effort: "minimal" }, "kimchi");
+    const xhigh = apply("openai", "kimi-k2.7", { reasoning_effort: "xhigh" }, "kimchi");
+    expect(minimal.reasoning_effort).toBe("low");
+    expect(xhigh.reasoning_effort).toBe("max");
+  });
   it("MiniMax M3 → adaptive", () => {
     const out = apply("claude", "MiniMax-M3", { reasoning_effort: "high" }, "minimax");
     expect(out.thinking).toEqual({ type: "adaptive" });


### PR DESCRIPTION
## Summary
- Normalize Kimi reasoning effort values to the enum accepted by Kimi-compatible SGLang backends.
- Map Kimchi/Kimi `reasoning_effort: "auto"` to `high` instead of forwarding the invalid `auto` value.
- Add regression coverage for Kimchi `kimi-k2.7` and unsupported OpenAI effort levels.

## Tests
- `NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run --config tests/vitest.config.js tests/translator/thinking-unified.test.js --reporter=verbose`
- `NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run --config tests/vitest.config.js tests/translator/coverage-all-models.test.js --reporter=verbose`
- Direct smoke: `translateRequest("openai", "openai", "kimi-k2.7", ..., provider="kimchi")` returns `reasoning_effort: "high"` for input `auto`.

## Note
- Full `tests/translator/` was also attempted; it failed on unrelated existing snapshot/context cases: `blackbox` URL snapshot, `cline` header snapshot, and Claude reasoning_content context mapping.