### PR TITLE
fix(translator): preserve developer instructions in Responses conversion

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -221,13 +221,14 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   const messages = body.messages || [];
 
   for (const msg of messages) {
-    if (msg.role === ROLE.SYSTEM) {
-      // Use first system message as instructions
+    if (msg.role === ROLE.SYSTEM || msg.role === ROLE.DEVELOPER) {
+      // Use the first instruction-bearing message as instructions.
+      // OpenAI recommends role="developer" for GPT-5/Codex as the system-level prompt.
       if (!hasSystemMessage) {
         result.instructions = typeof msg.content === "string" ? msg.content : "";
         hasSystemMessage = true;
       }
-      continue; // Skip system messages in input
+      continue; // Skip instruction messages in input
     }
 
     // Convert user/assistant messages to input items

--- a/tests/translator/bugs-codexCli-responses.test.js
+++ b/tests/translator/bugs-codexCli-responses.test.js
@@ -46,6 +46,20 @@ describe("Codex CLI Responses → OpenAI", () => {
 });
 
 describe("OpenAI → Codex Responses (reverse)", () => {
+  it("maps developer messages to Responses API instructions", () => {
+    const out = O2R({
+      messages: [
+        { role: "developer", content: "Follow the project rules." },
+        { role: "user", content: "Hello" },
+      ],
+    });
+
+    expect(out.instructions).toBe("Follow the project rules.");
+    expect(out.input).toEqual([
+      { type: "message", role: "user", content: [{ type: "input_text", text: "Hello" }] },
+    ]);
+  });
+
   // openai-responses.js:13 — clampCallId NOT applied on Responses→Chat; but here Chat→Responses must clamp
   it("call_id longer than 64 chars is clamped", () => {
     const longId = "call_" + "x".repeat(80);


### PR DESCRIPTION
## Summary

- Preserve `role: "developer"` instruction messages when converting OpenAI Chat Completions requests to OpenAI Responses API requests.
- Add regression coverage for the direct `FORMATS.OPENAI -> FORMATS.OPENAI_RESPONSES` translator path.
- Keep the change scoped to the Responses request translator; no provider config, credential, or executor behavior changed.

Fixes #2433
Refs #1038
Related to #1011

## Root Cause

`openaiToOpenAIResponsesRequest()` maps `ROLE.SYSTEM` messages to top-level `instructions`, but did not handle `ROLE.DEVELOPER`.

The subsequent branches only convert `user`, `assistant`, and `tool` messages into Responses `input` items. As a result, `developer` messages matched no branch and were silently omitted from the translated request.

Existing developer-role normalization in `filterToOpenAIFormat()` does not cover this path because that helper only runs when the target format is `FORMATS.OPENAI`. This translator targets `FORMATS.OPENAI_RESPONSES` directly.

## Fix

Treat `ROLE.DEVELOPER` as an instruction-bearing role alongside `ROLE.SYSTEM` in the OpenAI → OpenAI Responses request translator:

```js
if (msg.role === ROLE.SYSTEM || msg.role === ROLE.DEVELOPER) {
  ...
}
```

This preserves GPT-5/Codex-style developer instructions by mapping them to Responses API `instructions`.

## Test Plan

- [x] `tests/node_modules/.bin/vitest run --config tests/vitest.config.js tests/translator/bugs-codexCli-responses.test.js`
  - `1 passed (1)`
  - `2 passed | 3 expected fail (5)`
- [x] Scoped translator suite excluding unrelated pre-existing failures:
  - excluded `tests/translator/golden-url-header.test.js`
  - excluded `tests/translator/bugs-toClaude-context.test.js`
  - result: `13 passed (13)`, `157 passed | 15 expected fail (172)`
- [x] `npm run build`
  - compiled successfully
- [x] `git diff --check`
- [x] Checked diff for obvious secret/token/password/private key strings

## Notes

The full translator suite was also run during local verification. It has unrelated failures that reproduce without this patch:

- `golden-url-header.test.js`: snapshot drift for Blackbox URL and Cline version/platform headers.
- `bugs-toClaude-context.test.js`: existing OpenAI → Claude `reasoning_content` preservation failure.

Those failures are unrelated to this two-file translator regression fix.

## Risk

Low.

Affected path: OpenAI Chat Completions request format → OpenAI Responses request format.

No credential handling, network behavior, database behavior, provider routing, or runtime service configuration changed.
