### PR TITLE
fix: prevent duplicate system prompt injection in multi-turn conversations

### DIFF
--- a/open-sse/rtk/systemInject.js
+++ b/open-sse/rtk/systemInject.js
@@ -6,6 +6,16 @@ import { FORMATS } from "../translator/formats.js";
 
 const SEP = "\n\n";
 
+function isPromptAlreadyInjected(content, prompt) {
+  if (!content || !prompt) return false;
+  const needle = typeof prompt === 'string' ? prompt.trim() : '';
+  if (!needle) return false;
+
+  // Check if the first 100 chars of the prompt appear in content
+  const signature = needle.slice(0, 100);
+  return content.includes(signature);
+}
+
 export function injectSystemPrompt(body, format, prompt) {
   if (!body || !prompt) return;
 
@@ -30,6 +40,7 @@ export function injectSystemPrompt(body, format, prompt) {
 function injectMessagesSystem(body, prompt) {
   // OpenAI Responses API: top-level string field
   if (typeof body.instructions === "string") {
+    if (isPromptAlreadyInjected(body.instructions, prompt)) return;
     body.instructions = body.instructions
       ? `${body.instructions}${SEP}${prompt}`
       : prompt;
@@ -43,10 +54,22 @@ function injectMessagesSystem(body, prompt) {
 
   const idx = arr.findIndex(m => m && (m.role === "system" || m.role === "developer"));
   if (idx >= 0) {
+    // Check if already injected before appending
+    const existing = extractTextFromOpenAIMessage(arr[idx]);
+    if (isPromptAlreadyInjected(existing, prompt)) return;
     appendToOpenAIMessage(arr[idx], prompt);
   } else {
     arr.unshift({ role: "system", content: prompt });
   }
+}
+
+function extractTextFromOpenAIMessage(msg) {
+  if (typeof msg.content === "string") {
+    return msg.content;
+  } else if (Array.isArray(msg.content)) {
+    return msg.content.map(part => part.text || '').join(' ');
+  }
+  return '';
 }
 
 function appendToOpenAIMessage(msg, prompt) {
@@ -64,10 +87,15 @@ function appendToOpenAIMessage(msg, prompt) {
 // Insert before the last cache_control block to keep injection inside the cached prefix.
 function injectClaudeSystem(body, prompt) {
   if (typeof body.system === "string" && body.system.length > 0) {
+    if (isPromptAlreadyInjected(body.system, prompt)) return;
     body.system = `${body.system}${SEP}${prompt}`;
     return;
   }
   if (Array.isArray(body.system)) {
+    // Check if already injected
+    const existingText = body.system.map(block => block?.text || '').join(' ');
+    if (isPromptAlreadyInjected(existingText, prompt)) return;
+
     const block = { type: "text", text: prompt };
     let lastCacheIdx = -1;
     for (let i = body.system.length - 1; i >= 0; i--) {
@@ -91,6 +119,9 @@ function injectGeminiSystem(body, prompt) {
   const key = useSnake ? "system_instruction" : "systemInstruction";
   const sys = target[key];
   if (sys && Array.isArray(sys.parts)) {
+    // Check if already injected
+    const existingText = sys.parts.map(part => part.text || '').join(' ');
+    if (isPromptAlreadyInjected(existingText, prompt)) return;
     sys.parts.push({ text: prompt });
     return;
   }

--- a/tests/unit/systemInject-dedup.test.js
+++ b/tests/unit/systemInject-dedup.test.js
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { injectSystemPrompt } from "../../open-sse/rtk/systemInject.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("systemInject deduplication", () => {
+  const TEST_PROMPT = "Respond like terse caveman. All technical substance stay exact, only fluff die.";
+  const SHORT_SIGNATURE = TEST_PROMPT.slice(0, 100);
+
+  describe("Claude format", () => {
+    it("injects prompt into empty system string", () => {
+      const body = { system: "" };
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toBe(TEST_PROMPT);
+    });
+
+    it("appends prompt to existing system string", () => {
+      const body = { system: "Existing instruction." };
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toContain("Existing instruction.");
+      expect(body.system).toContain(TEST_PROMPT);
+    });
+
+    it("does NOT duplicate when called twice on system string", () => {
+      const body = { system: "Existing instruction." };
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      const afterFirst = body.system;
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toBe(afterFirst);
+    });
+
+    it("injects into system array without cache_control", () => {
+      const body = { system: [{ type: "text", text: "Existing." }] };
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toHaveLength(2);
+      expect(body.system[1].text).toBe(TEST_PROMPT);
+    });
+
+    it("does NOT duplicate when called twice on system array", () => {
+      const body = { system: [{ type: "text", text: "Existing." }] };
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toHaveLength(2);
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toHaveLength(2);
+    });
+
+    it("inserts before cache_control block", () => {
+      const body = {
+        system: [
+          { type: "text", text: "First." },
+          { type: "text", text: "Second.", cache_control: { type: "ephemeral" } },
+        ],
+      };
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toHaveLength(3);
+      expect(body.system[1].text).toBe(TEST_PROMPT);
+      expect(body.system[2].cache_control).toBeDefined();
+    });
+
+    it("does NOT duplicate before cache_control on second call", () => {
+      const body = {
+        system: [
+          { type: "text", text: "First." },
+          { type: "text", text: "Second.", cache_control: { type: "ephemeral" } },
+        ],
+      };
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toHaveLength(3);
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toHaveLength(3);
+    });
+  });
+
+  describe("OpenAI format", () => {
+    it("creates system message if none exists", () => {
+      const body = { messages: [{ role: "user", content: "Hello" }] };
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.messages[0].role).toBe("system");
+      expect(body.messages[0].content).toBe(TEST_PROMPT);
+    });
+
+    it("appends to existing system message", () => {
+      const body = { messages: [{ role: "system", content: "Existing." }] };
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.messages[0].content).toContain("Existing.");
+      expect(body.messages[0].content).toContain(TEST_PROMPT);
+    });
+
+    it("does NOT duplicate when called twice", () => {
+      const body = { messages: [{ role: "system", content: "Existing." }] };
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      const afterFirst = body.messages[0].content;
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.messages[0].content).toBe(afterFirst);
+    });
+
+    it("handles developer role", () => {
+      const body = { messages: [{ role: "developer", content: "Existing." }] };
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.messages[0].content).toContain(TEST_PROMPT);
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.messages[0].content.split(SHORT_SIGNATURE)).toHaveLength(2);
+    });
+
+    it("handles array content in Responses API", () => {
+      const body = {
+        messages: [
+          { role: "system", content: [{ type: "input_text", text: "Existing." }] },
+        ],
+      };
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.messages[0].content).toHaveLength(2);
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.messages[0].content).toHaveLength(2);
+    });
+
+    it("handles instructions field", () => {
+      const body = { instructions: "Existing instruction." };
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.instructions).toContain("Existing instruction.");
+      expect(body.instructions).toContain(TEST_PROMPT);
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      expect(body.instructions.split(SHORT_SIGNATURE)).toHaveLength(2);
+    });
+  });
+
+  describe("Gemini format", () => {
+    it("creates systemInstruction if none exists", () => {
+      const body = {};
+      injectSystemPrompt(body, FORMATS.GEMINI, TEST_PROMPT);
+      expect(body.systemInstruction).toBeDefined();
+      expect(body.systemInstruction.parts[0].text).toBe(TEST_PROMPT);
+    });
+
+    it("appends to existing systemInstruction", () => {
+      const body = { systemInstruction: { parts: [{ text: "Existing." }] } };
+      injectSystemPrompt(body, FORMATS.GEMINI, TEST_PROMPT);
+      expect(body.systemInstruction.parts).toHaveLength(2);
+    });
+
+    it("does NOT duplicate when called twice", () => {
+      const body = { systemInstruction: { parts: [{ text: "Existing." }] } };
+      injectSystemPrompt(body, FORMATS.GEMINI, TEST_PROMPT);
+      expect(body.systemInstruction.parts).toHaveLength(2);
+      injectSystemPrompt(body, FORMATS.GEMINI, TEST_PROMPT);
+      expect(body.systemInstruction.parts).toHaveLength(2);
+    });
+
+    it("handles snake_case system_instruction", () => {
+      const body = { system_instruction: { parts: [{ text: "Existing." }] } };
+      injectSystemPrompt(body, FORMATS.GEMINI, TEST_PROMPT);
+      expect(body.system_instruction.parts).toHaveLength(2);
+      injectSystemPrompt(body, FORMATS.GEMINI, TEST_PROMPT);
+      expect(body.system_instruction.parts).toHaveLength(2);
+    });
+
+    it("handles Antigravity wrapped format", () => {
+      const body = { request: { systemInstruction: { parts: [{ text: "Existing." }] } } };
+      injectSystemPrompt(body, FORMATS.ANTIGRAVITY, TEST_PROMPT);
+      expect(body.request.systemInstruction.parts).toHaveLength(2);
+      injectSystemPrompt(body, FORMATS.ANTIGRAVITY, TEST_PROMPT);
+      expect(body.request.systemInstruction.parts).toHaveLength(2);
+    });
+  });
+
+  describe("multi-turn conversation simulation", () => {
+    it("does NOT accumulate duplicates across multiple turns (Claude)", () => {
+      const body = { system: "Base instruction." };
+
+      // Turn 1
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      const turn1 = body.system;
+      expect(turn1.split(SHORT_SIGNATURE)).toHaveLength(2);
+
+      // Turn 2 (simulating same conversation continuing)
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toBe(turn1);
+
+      // Turn 3
+      injectSystemPrompt(body, FORMATS.CLAUDE, TEST_PROMPT);
+      expect(body.system).toBe(turn1);
+      expect(body.system.split(SHORT_SIGNATURE)).toHaveLength(2);
+    });
+
+    it("does NOT accumulate duplicates across multiple turns (OpenAI)", () => {
+      const body = { messages: [{ role: "system", content: "Base instruction." }] };
+
+      // Turn 1
+      injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      const turn1 = body.messages[0].content;
+      expect(turn1.split(SHORT_SIGNATURE)).toHaveLength(2);
+
+      // Turn 2-5
+      for (let i = 0; i < 4; i++) {
+        injectSystemPrompt(body, FORMATS.OPENAI, TEST_PROMPT);
+      }
+      expect(body.messages[0].content).toBe(turn1);
+      expect(body.messages[0].content.split(SHORT_SIGNATURE)).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Problem
Caveman and Ponytail system prompts were being appended on **every request** without checking if already present, causing exponential growth in multi-turn conversations.

After 5 turns with the same conversation:
- ❌ Before: caveman prompt injected 5 times (5x token waste)
- ✅ After: caveman prompt injected once (idempotent)

## Root Cause
`systemInject.js` had no deduplication logic. The injection was stateless and blindly appended on every call.

## Solution
Added `isPromptAlreadyInjected()` that checks if the first 100 characters of the prompt already exist in the system message before appending.

Applied to all formats:
- Claude (string and array with cache_control support)
- OpenAI (messages, developer role, instructions field, array content)
- Gemini (systemInstruction, system_instruction, Antigravity wrapper)

## Testing
- ✅ 20 new tests covering all formats and multi-turn scenarios
- ✅ All existing tests pass
- ✅ Handles edge cases: cache_control, array content, wrapped formats

## Impact
- Prevents unbounded token waste in long conversations
- Fixes potential context limit issues
- Makes caveman/ponytail features production-ready

## Files Changed
- `open-sse/rtk/systemInject.js` - added deduplication logic
- `tests/unit/systemInject-dedup.test.js` - comprehensive test coverage