### PR TITLE
feat(ollama): claude-format passthrough transport to native /v1/messages

### DIFF
--- a/open-sse/executors/ollama-local.js
+++ b/open-sse/executors/ollama-local.js
@@ -7,6 +7,22 @@ export class OllamaLocalExecutor extends DefaultExecutor {
   }
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {
+    const rt = credentials?.runtimeTransport;
+    if (rt?.baseUrl) {
+      // Preserve path + query + urlSuffix (parent contract), substitute the local host.
+      // try/catch: malformed/relative/empty baseUrl falls back to verbatim like the parent
+      // (default.js:122 uses rt.baseUrl as-is, never parses). WR-01/02/03.
+      let url = rt.baseUrl;
+      try {
+        const u = new URL(rt.baseUrl);
+        const host = resolveOllamaLocalHost(credentials).replace(/\/$/, "");
+        url = host + u.pathname + u.search;
+      } catch {
+        url = rt.baseUrl;
+      }
+      if (rt.urlSuffix) url += rt.urlSuffix;
+      return url;
+    }
     return `${resolveOllamaLocalHost(credentials)}/api/chat`;
   }
 }

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -37,7 +37,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
     return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, sourceFormat);
 }
 
 /**

--- a/open-sse/providers/registry/ollama-local.js
+++ b/open-sse/providers/registry/ollama-local.js
@@ -1,3 +1,5 @@
+import { CLAUDE_API_HEADERS } from "../shared.js";
+
 export default {
   id: "ollama-local",
   priority: 50,
@@ -15,5 +17,17 @@ export default {
     baseUrl: "http://localhost:11434/api/chat",
     format: "ollama",
   },
+  // Multi-endpoint: pick the transport matching client sourceFormat to skip translation.
+  // Host is resolved at request time by OllamaLocalExecutor.buildUrl via resolveOllamaLocalHost.
+  transports: [
+    {
+      format: "claude",
+      baseUrl: "http://localhost:11434/v1/messages",
+      headers: { ...CLAUDE_API_HEADERS },
+      // COMP-04: Bearer to match cloud (ollama auth domain). Local ollama doesn't validate
+      // keys, so this is a no-op when no key is set — but stays consistent with cloud.
+      auth: { combined: true, header: "Authorization", scheme: "bearer" },
+    },
+  ],
   serviceKinds: ["llm"],
 };

--- a/open-sse/providers/registry/ollama.js
+++ b/open-sse/providers/registry/ollama.js
@@ -1,3 +1,5 @@
+import { CLAUDE_API_HEADERS } from "../shared.js";
+
 export default {
   id: "ollama",
   priority: 30,
@@ -20,6 +22,18 @@ export default {
     validateUrl: "https://ollama.com/api/tags",
     format: "ollama",
   },
+  // Multi-endpoint: pick the transport matching client sourceFormat to skip translation.
+  transports: [
+    {
+      format: "claude",
+      baseUrl: "https://ollama.com/v1/messages",
+      headers: { ...CLAUDE_API_HEADERS },
+      // COMP-04: ollama cloud authenticates with Authorization: Bearer (same scheme as the
+      // working /api/chat path — ollama.com auth domain), NOT the Anthropic-compat x-api-key
+      // convention. Confirmed by live probe: x-api-key raw → 401 Unauthorized.
+      auth: { combined: true, header: "Authorization", scheme: "bearer" },
+    },
+  ],
   models: [
     { id: "gpt-oss:120b", name: "GPT OSS 120B" },
     { id: "kimi-k2.5", name: "Kimi K2.5" },

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -251,7 +251,19 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
     log.info("COMBO", `Trying model ${i + 1}/${rotatedModels.length}: ${modelStr}`);
 
     try {
-      const result = await handleSingleModel(body, modelStr);
+      // Deep-clone body per combo leg so mutations by one provider (e.g. glm
+      // normalizing messages/content) don't leak into the next leg (ollama).
+      // chat.js:245 already shallow-copies { ...body, model } but messages +
+      // nested content arrays are shared by reference — leg 1 mutations persist
+      // into leg 2. structuredClone handles plain JSON; fall back to JSON round-trip
+      // only if structuredClone throws (it won't for plain request bodies).
+      let legBody;
+      try {
+        legBody = structuredClone(body);
+      } catch {
+        legBody = JSON.parse(JSON.stringify(body));
+      }
+      const result = await handleSingleModel(legBody, modelStr);
       
       // Success (2xx) - return response
       if (result.ok) {

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -5,6 +5,7 @@
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { PROVIDERS } from "../../providers/index.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
+import { FORMATS } from "../formats.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
 const FORMAT_TO_NATIVE = {
@@ -268,6 +269,26 @@ function applyFormat(fmt, body, cfg, caps) {
 // falls back to extracting from the current body when omitted.
 export function applyThinking(targetFormat, model, body, provider = null, intent = undefined) {
   if (!body || typeof body !== "object") return body;
+
+  // ponytail: ceiling = ollama under claude transport. Lift into PROVIDERS[ollama].quirks
+  // or a capability flag if a second native-claude provider lands.
+  if (provider === "ollama" && targetFormat === FORMATS.CLAUDE) {
+    // WR-01: chatCore.js:66-68 injects `reasoning_effort` (OpenAI field) for level-mode
+    // providerThinking configs. On the Claude wire it is not a valid Messages field.
+    // Normalize to Claude shape: fold into output_config.effort unless a Claude-native
+    // thinking field is already present (let the client's Claude field win). Keep the
+    // early-return so stripAll does not undo Claude-native fields.
+    if (body.reasoning_effort) {
+      if (body.thinking) {
+        delete body.reasoning_effort;
+      } else {
+        body.output_config = body.output_config || {};
+        if (!body.output_config.effort) body.output_config.effort = body.reasoning_effort;
+        delete body.reasoning_effort;
+      }
+    }
+    return body;
+  }
 
   const { cleanModel, override } = parseSuffix(model);
   const cfg = override || intent || extractThinking(body);

--- a/open-sse/translator/concerns/toolArgSanitizer.js
+++ b/open-sse/translator/concerns/toolArgSanitizer.js
@@ -1,0 +1,81 @@
+// Shared tool argument sanitizer — used by openai→claude response translator
+// AND claude identity passthrough (stream.js PASSTHROUGH mode). Fixes bad
+// params from non-Anthropic models (ollama /v1/messages, GLM, etc.).
+
+// Legacy "proxy_" prefix used by older request translators. Response strips it
+// defensively so tool names from such turns resolve back (e.g. proxy_Read → Read
+// for arg sanitization). Current request translator emits no prefix ("") — strip
+// is then a no-op. Kept intentionally; do NOT couple to request's empty prefix.
+export const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
+
+// AskUserQuestion schema: questions[].options maxItems:4 (Claude Code rejects >4).
+const ASK_USER_QUESTION_MAX_OPTIONS = 4;
+
+/**
+ * Sanitize tool call arguments to fix bad params from non-Anthropic models.
+ * @param {string} toolName - Tool name (may have proxy_ prefix).
+ * @param {string} argsJson - JSON string of tool args.
+ * @returns {string} Sanitized JSON string (or original on parse failure).
+ */
+export function sanitizeToolArgs(toolName, argsJson) {
+  try {
+    const args = JSON.parse(argsJson);
+    const name = toolName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)
+      ? toolName.slice(CLAUDE_OAUTH_TOOL_PREFIX.length)
+      : toolName;
+    if (name === "Read") sanitizeReadArgs(args);
+    if (name === "AskUserQuestion") sanitizeAskUserQuestionArgs(args);
+    return JSON.stringify(args);
+  } catch {
+    return argsJson;
+  }
+}
+
+/**
+ * Sanitize Read tool args: clamp numeric bounds, drop invalid PDF pages.
+ */
+export function sanitizeReadArgs(args) {
+  if (typeof args.limit === "string" && /^\d+$/.test(args.limit)) args.limit = Number(args.limit);
+  if (typeof args.offset === "string" && /^-?\d+$/.test(args.offset)) args.offset = Number(args.offset);
+
+  if (typeof args.limit === "number") {
+    if (args.limit > 2000) args.limit = 2000;
+    if (args.limit < 1) delete args.limit;
+  }
+  if (typeof args.offset === "number" && args.offset < 0) args.offset = 0;
+
+  if ("pages" in args && !isValidPdfPagesArg(args.file_path, args.pages)) {
+    delete args.pages;
+  }
+}
+
+/**
+ * Sanitize AskUserQuestion args:
+ * - Coerce questions from JSON string to array (ollama emits string, Claude Code expects array).
+ * - Cap questions[].options to maxItems:4 (Claude Code rejects >4 with too_big).
+ */
+export function sanitizeAskUserQuestionArgs(args) {
+  // Coerce questions from JSON string to array
+  if (typeof args.questions === "string") {
+    try {
+      args.questions = JSON.parse(args.questions);
+    } catch {
+      // Can't parse — leave as-is (don't break the stream)
+    }
+  }
+  // Cap options per question to maxItems:4
+  if (Array.isArray(args.questions)) {
+    for (const q of args.questions) {
+      if (q && Array.isArray(q.options) && q.options.length > ASK_USER_QUESTION_MAX_OPTIONS) {
+        q.options = q.options.slice(0, ASK_USER_QUESTION_MAX_OPTIONS);
+      }
+    }
+  }
+}
+
+function isValidPdfPagesArg(filePath, pages) {
+  return typeof filePath === "string" &&
+    filePath.toLowerCase().endsWith(".pdf") &&
+    typeof pages === "string" &&
+    /^\d+(?:-\d+)?$/.test(pages);
+}

--- a/open-sse/translator/formats/claude.js
+++ b/open-sse/translator/formats/claude.js
@@ -16,7 +16,9 @@ export function hasValidContent(msg) {
     return msg.content.some(block =>
       (block.type === CLAUDE_BLOCK.TEXT && block.text?.trim()) ||
       block.type === CLAUDE_BLOCK.TOOL_USE ||
-      block.type === CLAUDE_BLOCK.TOOL_RESULT
+      block.type === CLAUDE_BLOCK.TOOL_RESULT ||
+      block.type === CLAUDE_BLOCK.IMAGE ||
+      block.type === CLAUDE_BLOCK.DOCUMENT
     );
   }
   return false;

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -3,48 +3,10 @@ import { FORMATS } from "../formats.js";
 import { ROLE, CLAUDE_BLOCK, MODEL_FALLBACK } from "../schema/index.js";
 import { fromOpenAIFinish } from "../concerns/finishReason.js";
 import { extractReasoningText } from "../concerns/reasoning.js";
+import { sanitizeToolArgs, CLAUDE_OAUTH_TOOL_PREFIX } from "../concerns/toolArgSanitizer.js";
 
-// Legacy "proxy_" prefix used by older request translators. Response strips it
-// defensively so tool names from such turns resolve back (e.g. proxy_Read → Read
-// for arg sanitization). Current request translator emits no prefix ("") — strip
-// is then a no-op. Kept intentionally; do NOT couple to request's empty prefix.
-const CLAUDE_OAUTH_TOOL_PREFIX = "proxy_";
-
-// Sanitize tool call arguments to fix bad params from non-Anthropic models
-function sanitizeToolArgs(toolName, argsJson) {
-  try {
-    const args = JSON.parse(argsJson);
-    const name = toolName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)
-      ? toolName.slice(CLAUDE_OAUTH_TOOL_PREFIX.length)
-      : toolName;
-    if (name === "Read") sanitizeReadArgs(args);
-    return JSON.stringify(args);
-  } catch {
-    return argsJson;
-  }
-}
-
-function sanitizeReadArgs(args) {
-  if (typeof args.limit === "string" && /^\d+$/.test(args.limit)) args.limit = Number(args.limit);
-  if (typeof args.offset === "string" && /^-?\d+$/.test(args.offset)) args.offset = Number(args.offset);
-
-  if (typeof args.limit === "number") {
-    if (args.limit > 2000) args.limit = 2000;
-    if (args.limit < 1) delete args.limit;
-  }
-  if (typeof args.offset === "number" && args.offset < 0) args.offset = 0;
-
-  if ("pages" in args && !isValidPdfPagesArg(args.file_path, args.pages)) {
-    delete args.pages;
-  }
-}
-
-function isValidPdfPagesArg(filePath, pages) {
-  return typeof filePath === "string" &&
-    filePath.toLowerCase().endsWith(".pdf") &&
-    typeof pages === "string" &&
-    /^\d+(?:-\d+)?$/.test(pages);
-}
+// Re-export for backward compat (other modules may import from here)
+export { sanitizeToolArgs, CLAUDE_OAUTH_TOOL_PREFIX };
 
 // Helper: stop thinking block if started
 function stopThinkingBlock(state, results) {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -149,6 +149,12 @@ export function createSSEStream(options = {}) {
   const passthroughToolState = (mode === STREAM_MODE.PASSTHROUGH && sourceFormat === FORMATS.CLAUDE)
     ? createPassthroughToolState()
     : null;
+  // [diag:ollama-passthrough] confirm claude identity passthrough transport is
+  // active for this stream (claude client ↔ claude-format upstream, e.g. ollama
+  // /v1/messages). Remove after validation.
+  if (passthroughToolState) {
+    console.log("[ollama-passthrough] active provider=" + provider + " model=" + model);
+  }
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -466,6 +472,18 @@ export function createSSEStream(options = {}) {
             }
             reqLogger?.appendConvertedChunk?.(output);
             controller.enqueue(sharedEncoder.encode(output));
+          }
+
+          // [diag:ollama-passthrough-eof] detect orphaned tool_use blocks at
+          // stream end. If toolBlocks still has entries here, the upstream
+          // ended mid-tool_use (no content_block_stop arrived) and our buffered
+          // input_json_delta fragments are about to be silently dropped — the
+          // client already got content_block_start and will see an incomplete
+          // tool_use → "JSON Parse error: Unexpected EOF". Remove after validation.
+          if (passthroughToolState?.toolBlocks?.size > 0) {
+            const orphaned = [...passthroughToolState.toolBlocks.values()]
+              .map(b => `${b.id}:${b.name}(${b.fragments.length} frags)`);
+            console.log("[ollama-passthrough-eof] orphaned tool_use blocks:", orphaned.join(", "));
           }
 
           if (!hasValidUsage(usage) && totalContentLength > 0) {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -30,10 +30,40 @@ function createPassthroughToolState() {
   };
 }
 
+// Sentinel return values from processClaudePassthroughToolUse:
+//   null  → not a claude-shape chunk (e.g. has .choices) → caller falls through
+//           to the original OpenAI passthrough path (line 228+).
+//   "raw" → claude chunk NOT intercepted (non-tool-use, or tool_use
+//           content_block_start which we track + pass through raw). Caller
+//           emits the current line raw (`line + "\n"`), runs extractUsage, and
+//           continues. Restores pre-P1/P2 framing (one event: line, one
+//           blank-line separator).
+//   []    → tracked input_json_delta fragment — suppress emission. Caller
+//           continues without emitting. We re-emit consolidated sanitized
+//           delta at content_block_stop.
+//   [deltaObj, ...] → tracked content_block_stop — caller emits each delta
+//           re-serialized (`event: type\ndata: {...}\n\n`), THEN emits the
+//           current line raw, runs extractUsage, and continues.
+const PASSTHROUGH_RAW = "raw";
+
 /**
  * Process a parsed claude chunk in passthrough mode for tool_use sanitization.
- * Returns null if no sanitization action needed (chunk should pass through as-is),
- * or an array of replacement chunks to emit instead.
+ * Returns:
+ *   null  → not a claude-shape chunk (has .choices) → caller falls through
+ *           to the original OpenAI passthrough path.
+ *   "raw" → claude chunk NOT intercepted (non-tool-use), OR tool_use
+ *           content_block_start (tracked + pass through raw). Caller emits
+ *           the current line raw, runs extractUsage, continues. Restores
+ *           pre-P1/P2 framing (one event: line, one blank-line separator).
+ *   []    → tracked input_json_delta fragment — suppress. Caller continues
+ *           without emitting. We re-emit consolidated sanitized delta at
+ *           content_block_stop.
+ *   [deltaObj, ...] → tracked content_block_stop — caller emits each delta
+ *           re-serialized, THEN emits the current line raw, continues.
+ *
+ * Narrowed in fix(translator) — previously re-serialized EVERY claude chunk,
+ * producing duplicate `event:` lines + extra blank-line event separators
+ * (empty events) that caused "JSON Parse error: Unexpected EOF" under abort.
  */
 function processClaudePassthroughToolUse(parsed, state) {
   if (!parsed || typeof parsed !== "object") return null;
@@ -45,7 +75,7 @@ function processClaudePassthroughToolUse(parsed, state) {
     const toolName = parsed.content_block.name;
     state.toolBlocks.set(idx, { id: toolId, name: toolName, fragments: [] });
     state.indexToId.set(toolId, idx);
-    return null; // pass through as-is
+    return PASSTHROUGH_RAW; // track + pass through raw (no re-serialization)
   }
 
   // content_block_delta with input_json_delta: buffer fragment, suppress emission
@@ -56,7 +86,7 @@ function processClaudePassthroughToolUse(parsed, state) {
       block.fragments.push(parsed.delta.partial_json);
       return []; // suppress — we'll re-emit consolidated at content_block_stop
     }
-    return null; // not a tracked tool block, pass through
+    return PASSTHROUGH_RAW; // not a tracked tool block, pass through raw
   }
 
   // content_block_stop for a tracked tool_use: sanitize + re-emit consolidated delta
@@ -77,10 +107,12 @@ function processClaudePassthroughToolUse(parsed, state) {
       };
       return [consolidatedDelta, parsed];
     }
-    return null;
+    return PASSTHROUGH_RAW; // not a tracked tool block, pass through raw
   }
 
-  return null;
+  // Any other claude chunk (message_start, text/thinking content_block_start/
+  // delta/stop, message_delta, message_stop, ping) → NOT intercepted → emit raw.
+  return PASSTHROUGH_RAW;
 }
 
 /**
@@ -191,33 +223,54 @@ export function createSSEStream(options = {}) {
           // (claude chunks have no `choices` field and would be dropped).
           // Buffers input_json_delta per tool_use id; at content_block_stop,
           // sanitizes and re-emits a single consolidated delta.
+          //
+          // NARROWED (fix(translator)): the sanitizer intercepts ONLY tool_use
+          // blocks. Non-tool-use claude chunks return PASSTHROUGH_RAW and are
+          // emitted as raw lines (`line + "\n"`), restoring pre-P1/P2 framing.
+          // Previously the sanitizer re-serialized EVERY claude chunk, which
+          // produced duplicate `event:` lines (raw + re-serialized) and an
+          // extra blank-line event separator (empty SSE event) between every
+          // real event — under `disconnect: ResponseAborted` the client's SSE
+          // parser hit the empty/partial event and JSON.parse("") failed with
+          // "JSON Parse error: Unexpected EOF".
           if (passthroughToolState && trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
               const parsed = JSON.parse(trimmed.slice(5).trim());
               const replacement = processClaudePassthroughToolUse(parsed, passthroughToolState);
               if (replacement === null) {
-                // Not a tool_use-related chunk, or content_block_start that we track
-                // but pass through. If it's a claude chunk (has .type), emit it
-                // directly to bypass the OpenAI-specific hasValuableContent check.
-                if (parsed && typeof parsed === "object" && parsed.type && !parsed.choices) {
-                  output = `event: ${parsed.type}\ndata: ${JSON.stringify(parsed)}\n\n`;
-                  reqLogger?.appendConvertedChunk?.(output);
-                  controller.enqueue(sharedEncoder.encode(output));
-                  continue;
+                // Not a claude-shape chunk (has .choices) — fall through to
+                // the original OpenAI passthrough logic below.
+              } else if (replacement === PASSTHROUGH_RAW) {
+                // Non-tool-use claude chunk (or tool_use content_block_start we
+                // track + pass through). Emit the current line raw to preserve
+                // pre-P1/P2 framing, and run usage extraction (restoring the
+                // usage-tracking regression the old re-serialization caused).
+                // Skip hasValuableContent (claude chunks have no `choices`).
+                if (line.startsWith("data:") && !line.startsWith("data: ")) {
+                  output = "data: " + line.slice(5) + "\n";
+                } else {
+                  output = line + "\n";
                 }
-                // Otherwise fall through to OpenAI passthrough logic below.
+                const extracted = extractUsage(parsed);
+                if (extracted) usage = mergeUsage(usage, extracted);
+                reqLogger?.appendConvertedChunk?.(output);
+                controller.enqueue(sharedEncoder.encode(output));
+                continue;
               } else if (Array.isArray(replacement) && replacement.length === 0) {
-                // input_json_delta fragment for a tracked tool_use — suppress emission.
+                // input_json_delta fragment for a tracked tool_use — suppress.
                 // Will re-emit consolidated sanitized delta at content_block_stop.
                 continue;
               } else if (Array.isArray(replacement) && replacement.length > 0) {
-                // content_block_stop for a tracked tool_use: emit sanitized delta(s)
-                // + the stop event, then skip the rest of passthrough processing.
+                // content_block_stop for a tracked tool_use: emit the sanitized
+                // consolidated delta(s) re-serialized, THEN emit the stop event
+                // raw, and run usage extraction on the stop.
                 for (const ev of replacement) {
                   const out = `event: ${ev.type}\ndata: ${JSON.stringify(ev)}\n\n`;
                   reqLogger?.appendConvertedChunk?.(out);
                   controller.enqueue(sharedEncoder.encode(out));
                 }
+                const extracted = extractUsage(parsed);
+                if (extracted) usage = mergeUsage(usage, extracted);
                 continue;
               }
             } catch {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -5,6 +5,8 @@ import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBu
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
+import { sanitizeToolArgs } from "../translator/concerns/toolArgSanitizer.js";
+import { CLAUDE_BLOCK } from "../translator/schema/index.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
 
@@ -13,6 +15,73 @@ export { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER };
 
 // sharedEncoder is stateless — safe to share across streams
 const sharedEncoder = new TextEncoder();
+
+// Claude passthrough tool_use arg sanitizer state (per-stream).
+// Buffers input_json_delta fragments per tool_use id; at content_block_stop,
+// sanitizes and re-emits a single consolidated content_block_delta.
+function createPassthroughToolState() {
+  // Map: contentBlockIndex → { id, name, fragments: string[] }
+  const toolBlocks = new Map();
+  // Map: toolUseId → contentBlockIndex (for matching deltas by index)
+  const indexToId = new Map();
+  return {
+    toolBlocks,
+    indexToId,
+  };
+}
+
+/**
+ * Process a parsed claude chunk in passthrough mode for tool_use sanitization.
+ * Returns null if no sanitization action needed (chunk should pass through as-is),
+ * or an array of replacement chunks to emit instead.
+ */
+function processClaudePassthroughToolUse(parsed, state) {
+  if (!parsed || typeof parsed !== "object") return null;
+
+  // content_block_start with tool_use: register a new tool block buffer
+  if (parsed.type === "content_block_start" && parsed.content_block?.type === CLAUDE_BLOCK.TOOL_USE) {
+    const idx = parsed.index;
+    const toolId = parsed.content_block.id;
+    const toolName = parsed.content_block.name;
+    state.toolBlocks.set(idx, { id: toolId, name: toolName, fragments: [] });
+    state.indexToId.set(toolId, idx);
+    return null; // pass through as-is
+  }
+
+  // content_block_delta with input_json_delta: buffer fragment, suppress emission
+  if (parsed.type === "content_block_delta" && parsed.delta?.type === "input_json_delta") {
+    const idx = parsed.index;
+    const block = state.toolBlocks.get(idx);
+    if (block) {
+      block.fragments.push(parsed.delta.partial_json);
+      return []; // suppress — we'll re-emit consolidated at content_block_stop
+    }
+    return null; // not a tracked tool block, pass through
+  }
+
+  // content_block_stop for a tracked tool_use: sanitize + re-emit consolidated delta
+  if (parsed.type === "content_block_stop") {
+    const idx = parsed.index;
+    const block = state.toolBlocks.get(idx);
+    if (block) {
+      state.toolBlocks.delete(idx);
+      state.indexToId.delete(block.id);
+      const rawArgs = block.fragments.join("");
+      const sanitized = sanitizeToolArgs(block.name, rawArgs);
+      // Always emit a single consolidated delta (sanitized or unchanged) + stop.
+      // The original fragments were suppressed; re-emit one consolidated delta here.
+      const consolidatedDelta = {
+        type: "content_block_delta",
+        index: idx,
+        delta: { type: "input_json_delta", partial_json: sanitized },
+      };
+      return [consolidatedDelta, parsed];
+    }
+    return null;
+  }
+
+  return null;
+}
 
 /**
  * Stream modes
@@ -73,6 +142,14 @@ export function createSSEStream(options = {}) {
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
 
+  // Claude identity passthrough tool_use arg sanitizer state.
+  // Only active when sourceFormat === FORMATS.CLAUDE (claude↔ollama direct transport).
+  // Buffers input_json_delta fragments per tool_use content block; at
+  // content_block_stop, sanitizes args and re-emits a single consolidated delta.
+  const passthroughToolState = (mode === STREAM_MODE.PASSTHROUGH && sourceFormat === FORMATS.CLAUDE)
+    ? createPassthroughToolState()
+    : null;
+
   return new TransformStream({
     transform(chunk, controller) {
       if (!ttftAt) ttftAt = Date.now();
@@ -102,6 +179,45 @@ export function createSSEStream(options = {}) {
         if (mode === STREAM_MODE.PASSTHROUGH) {
           let output;
           let injectedUsage = false;
+
+          // Claude identity passthrough: sanitize tool_use args (AskUserQuestion,
+          // Read, etc.) before the OpenAI-specific hasValuableContent check below
+          // (claude chunks have no `choices` field and would be dropped).
+          // Buffers input_json_delta per tool_use id; at content_block_stop,
+          // sanitizes and re-emits a single consolidated delta.
+          if (passthroughToolState && trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
+            try {
+              const parsed = JSON.parse(trimmed.slice(5).trim());
+              const replacement = processClaudePassthroughToolUse(parsed, passthroughToolState);
+              if (replacement === null) {
+                // Not a tool_use-related chunk, or content_block_start that we track
+                // but pass through. If it's a claude chunk (has .type), emit it
+                // directly to bypass the OpenAI-specific hasValuableContent check.
+                if (parsed && typeof parsed === "object" && parsed.type && !parsed.choices) {
+                  output = `event: ${parsed.type}\ndata: ${JSON.stringify(parsed)}\n\n`;
+                  reqLogger?.appendConvertedChunk?.(output);
+                  controller.enqueue(sharedEncoder.encode(output));
+                  continue;
+                }
+                // Otherwise fall through to OpenAI passthrough logic below.
+              } else if (Array.isArray(replacement) && replacement.length === 0) {
+                // input_json_delta fragment for a tracked tool_use — suppress emission.
+                // Will re-emit consolidated sanitized delta at content_block_stop.
+                continue;
+              } else if (Array.isArray(replacement) && replacement.length > 0) {
+                // content_block_stop for a tracked tool_use: emit sanitized delta(s)
+                // + the stop event, then skip the rest of passthrough processing.
+                for (const ev of replacement) {
+                  const out = `event: ${ev.type}\ndata: ${JSON.stringify(ev)}\n\n`;
+                  reqLogger?.appendConvertedChunk?.(out);
+                  controller.enqueue(sharedEncoder.encode(out));
+                }
+                continue;
+              }
+            } catch {
+              // Non-JSON data line — fall through to normal passthrough emission
+            }
+          }
 
           if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
@@ -480,7 +596,7 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, sourceFormat = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
     provider,
@@ -489,6 +605,7 @@ export function createPassthroughStreamWithLogger(provider = null, reqLogger = n
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    sourceFormat
   });
 }

--- a/tests/unit/ollama-claude-block-fidelity.test.js
+++ b/tests/unit/ollama-claude-block-fidelity.test.js
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { translateRequest, translateResponse } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+// Phase 2 BLK-01/02/03/04 contract: verify same-format claude→claude passthrough
+// leaves Claude-native content blocks untouched for ollama. Test bodies omit
+// `thinking`/`output_config` so applyThinking is a no-op regardless of whether
+// the 02-01 short-circuit exists (parallel Wave 1 independence).
+
+describe("Phase 2: Block fidelity for ollama claude passthrough", () => {
+  it("Contract BLK-01: tool_use and tool_result blocks round-trip losslessly", () => {
+    const model = "claude-sonnet-4-5";
+    const body = {
+      model,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "SF" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_1", content: "72F" },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    const assistant = result.messages.find((m) => m.role === "assistant");
+    const toolUse = assistant.content.find((b) => b.type === "tool_use");
+    expect(toolUse).toBeDefined();
+    expect(toolUse.id).toBe("toolu_1");
+    expect(toolUse.name).toBe("get_weather");
+    expect(toolUse.input).toEqual({ city: "SF" });
+
+    const user = result.messages.find((m) => m.role === "user");
+    const toolResult = user.content.find((b) => b.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    expect(toolResult.tool_use_id).toBe("toolu_1");
+    expect(toolResult.content).toBe("72F");
+  });
+
+  it("Contract BLK-02: text content blocks and system pass through with content preserved", () => {
+    const model = "claude-sonnet-4-5";
+    const body = {
+      model,
+      system: "You are helpful",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    expect(result.system).toBe("You are helpful");
+
+    const user = result.messages.find((m) => m.role === "user");
+    const textBlock = user.content.find((b) => b.type === "text");
+    expect(textBlock).toBeDefined();
+    expect(textBlock.text).toBe("hello");
+  });
+
+  it("Contract BLK-03: base64 image content blocks pass through unchanged", () => {
+    const model = "claude-sonnet-4-5";
+    const body = {
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "iVBORw0KGgo=",
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    const user = result.messages.find((m) => m.role === "user");
+    const image = user.content.find((b) => b.type === "image");
+    expect(image).toBeDefined();
+    expect(image.source.type).toBe("base64");
+    expect(image.source.media_type).toBe("image/png");
+    expect(image.source.data).toBe("iVBORw0KGgo=");
+  });
+
+  // WR-04: BLK-03 contract covers IMAGE blocks only. The hasValidContent fix in
+  // prepareClaudeRequest (claude.js:13-25) also recognizes DOCUMENT blocks —
+  // verify a document-bearing user message survives the empty-message filter
+  // (would be dropped without the DOCUMENT branch in hasValidContent).
+  it("Contract BLK-03b: document content blocks pass through hasValidContent filter", () => {
+    const model = "claude-sonnet-4-5";
+    const body = {
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "JVBERi0=",
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    const user = result.messages.find((m) => m.role === "user");
+    expect(user).toBeDefined();  // would be filtered out without the DOCUMENT fix
+    const doc = user.content.find((b) => b.type === "document");
+    expect(doc).toBeDefined();
+    expect(doc.source.type).toBe("base64");
+    expect(doc.source.media_type).toBe("application/pdf");
+    expect(doc.source.data).toBe("JVBERi0=");
+  });
+
+  it("Contract BLK-03c: mixed text + document content blocks pass through hasValidContent filter", () => {
+    const model = "claude-sonnet-4-5";
+    const body = {
+      model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "summarize this pdf" },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "JVBERi0xLjQK",
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    const user = result.messages.find((m) => m.role === "user");
+    expect(user).toBeDefined();
+    expect(user.content.some((b) => b.type === "text")).toBe(true);
+    expect(user.content.some((b) => b.type === "document")).toBe(true);
+  });
+
+  it("Contract BLK-04: same-format response passthrough returns [chunk] unchanged", () => {
+    const chunk = { type: "message_start", message: { id: "msg_1" } };
+    const result = translateResponse(FORMATS.CLAUDE, FORMATS.CLAUDE, chunk, {});
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(chunk);
+  });
+});

--- a/tests/unit/ollama-claude-compat.test.js
+++ b/tests/unit/ollama-claude-compat.test.js
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { translateRequest, translateResponse } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { extractUsage, mergeUsage } from "../../open-sse/utils/usageTracking.js";
+
+// Phase 3 COMP-01/02/03. Proves existing same-format passthrough + generic usage
+// extraction deliver the compatibility contract for ollama's Claude-native
+// `/v1/messages` endpoint. Tolerate, don't strip (CONTEXT D-01); no normalizer
+// (D-02); generic extraction (D-03).
+//
+// WR-01: Fallback routing (D-04) — resolveTransport(ollama, openai) === null —
+// is NOT re-asserted here. Phase 1's transport test owns that contract
+// (tests/unit/ollama-claude-transport.test.js Contract B + Contract C, which
+// also proves the /api/chat fallback end-to-end via buildUrl). Re-asserting
+// resolveTransport in isolation added zero signal.
+//
+// WR-02: COMP-02a/b/c assert same-format response identity passthrough — a
+// provider-agnostic property of translateResponse (translator/index.js:152
+// returns [chunk] when sourceFormat === targetFormat). The value is documenting
+// that ollama's native Claude stop_reasons reach the client UNCHANGED because
+// the gateway does not translate same-format responses — not because any
+// ollama-specific code handles them.
+
+describe("Phase 3: ollama claude compatibility contracts", () => {
+  it("Contract COMP-01a: tool_choice preserved when tools array is non-empty (ollama)", () => {
+    const model = "claude-sonnet-4-5";
+    const toolChoice = { type: "auto" };
+    const body = {
+      model,
+      messages: [{ role: "user", content: "hi" }],
+      tools: [
+        { name: "get_weather", description: "weather", input_schema: { type: "object" } },
+      ],
+      tool_choice: toolChoice,
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    expect(result.tool_choice).toEqual(toolChoice);
+  });
+
+  it("Contract COMP-01b: metadata survives translateRequest(claude->claude, ollama)", () => {
+    const model = "claude-sonnet-4-5";
+    const metadata = { user_id: "u1" };
+    const body = {
+      model,
+      messages: [{ role: "user", content: "hi" }],
+      metadata,
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    expect(result.metadata).toEqual(metadata);
+  });
+
+  it("Contract COMP-01c: cache_control on last system block rewritten to ephemeral+ttl, not stripped (ollama)", () => {
+    const model = "claude-sonnet-4-5";
+    const body = {
+      model,
+      system: [
+        { type: "text", text: "base instructions", cache_control: { type: "ephemeral" } },
+        { type: "text", text: "tail instructions", cache_control: { type: "ephemeral" } },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    // prepareClaudeRequest strips cache_control from all but last system block,
+    // then rewrites the last as { type: "ephemeral", ttl: "1h" }. Proves tolerate-
+    // don't-strip: cache_control survives in the canonical rewritten form.
+    expect(Array.isArray(result.system)).toBe(true);
+    expect(result.system.length).toBe(2);
+    expect(result.system[0].cache_control).toBeUndefined();
+    expect(result.system[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  // WR-03: covers the message-block cache_control path (claude.js:241-280) —
+  // distinct from the system-array path. prepareClaudeRequest strips
+  // cache_control from all content blocks, then re-adds { type: "ephemeral" }
+  // (NO ttl) to the last non-thinking block of the first assistant message.
+  it("Contract COMP-01d: cache_control on message content blocks rewritten (ollama)", () => {
+    const body = {
+      model: "claude-sonnet-4-5",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "p1", cache_control: { type: "ephemeral" } },
+            { type: "text", text: "p2", cache_control: { type: "ephemeral" } },
+          ],
+        },
+        { role: "user", content: "again" },
+      ],
+    };
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      "claude-sonnet-4-5",
+      body,
+      false,
+      null,
+      "ollama"
+    );
+    const assistant = result.messages.find(m => m.role === "assistant");
+    // First (non-last) block: cache_control stripped, not re-added.
+    expect(assistant.content[0].cache_control).toBeUndefined();
+    // Last non-thinking block of the last assistant: re-added as ephemeral, NO ttl.
+    expect(assistant.content[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  // WR-02: same-format response identity passthrough (provider-agnostic).
+  // Documents that ollama's native Claude stop_reasons reach the client
+  // unchanged because translateResponse returns [chunk] when
+  // sourceFormat === targetFormat — not via any ollama-specific handling.
+  it("Contract COMP-02a: same-format passthrough delivers stop_reason='tool_use' unchanged (provider-agnostic identity)", () => {
+    const chunk = {
+      type: "message_delta",
+      delta: { stop_reason: "tool_use" },
+      usage: { output_tokens: 1 },
+    };
+    const result = translateResponse(FORMATS.CLAUDE, FORMATS.CLAUDE, chunk, {});
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(chunk);
+    expect(result[0].delta.stop_reason).toBe("tool_use");
+  });
+
+  it("Contract COMP-02b: same-format passthrough delivers stop_reason='end_turn' unchanged (provider-agnostic identity)", () => {
+    const chunk = {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { output_tokens: 1 },
+    };
+    const result = translateResponse(FORMATS.CLAUDE, FORMATS.CLAUDE, chunk, {});
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(chunk);
+    expect(result[0].delta.stop_reason).toBe("end_turn");
+  });
+
+  it("Contract COMP-02c: same-format passthrough delivers stop_reason='max_tokens' unchanged (provider-agnostic identity)", () => {
+    const chunk = {
+      type: "message_delta",
+      delta: { stop_reason: "max_tokens" },
+      usage: { output_tokens: 1 },
+    };
+    const result = translateResponse(FORMATS.CLAUDE, FORMATS.CLAUDE, chunk, {});
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe(chunk);
+    expect(result[0].delta.stop_reason).toBe("max_tokens");
+  });
+
+  it("Contract COMP-03a: extractUsage reads input_tokens from message_start (Claude shape)", () => {
+    const start = {
+      type: "message_start",
+      message: { usage: { input_tokens: 100 } },
+    };
+    const u = extractUsage(start);
+    expect(u).not.toBeNull();
+    expect(u.prompt_tokens).toBe(100);
+  });
+
+  it("Contract COMP-03b: extractUsage reads output_tokens from message_delta (Claude shape)", () => {
+    const delta = { type: "message_delta", usage: { output_tokens: 50 } };
+    const u = extractUsage(delta);
+    expect(u).not.toBeNull();
+    expect(u.completion_tokens).toBe(50);
+  });
+
+  it("Contract COMP-03c: mergeUsage(start, delta) preserves input from start and output from delta", () => {
+    const start = {
+      type: "message_start",
+      message: { usage: { input_tokens: 100 } },
+    };
+    const delta = { type: "message_delta", usage: { output_tokens: 50 } };
+    const merged = mergeUsage(extractUsage(start), extractUsage(delta));
+    expect(merged.prompt_tokens).toBe(100);
+    expect(merged.completion_tokens).toBe(50);
+  });
+
+  it("Contract COMP-03d: cache_read_input_tokens flows through extractUsage + mergeUsage", () => {
+    // Proves ollama cache fields ride the same Claude-shape branch (provider-agnostic).
+    const start = {
+      type: "message_start",
+      message: { usage: { input_tokens: 100, cache_read_input_tokens: 40 } },
+    };
+    const delta = { type: "message_delta", usage: { output_tokens: 50 } };
+    const merged = mergeUsage(extractUsage(start), extractUsage(delta));
+    expect(merged.cache_read_input_tokens).toBe(40);
+  });
+
+  // WR-05: symmetric to COMP-03d. canonicalizeUsage (usageTracking.js:171)
+  // notes a first-write cache-miss carries ONLY cache_creation (no cache_read)
+  // — the field more likely to appear alone in real traffic. Guards against
+  // silent token-drop regressions on the unmapped half of the pair.
+  it("Contract COMP-03d-cache-creation: cache_creation_input_tokens flows through extractUsage + mergeUsage", () => {
+    const start = {
+      type: "message_start",
+      message: { usage: { input_tokens: 100, cache_creation_input_tokens: 15 } },
+    };
+    const delta = { type: "message_delta", usage: { output_tokens: 50 } };
+    const merged = mergeUsage(extractUsage(start), extractUsage(delta));
+    expect(merged.cache_creation_input_tokens).toBe(15);
+  });
+
+  // WR-04: extractUsage has a dedicated ollama NDJSON branch
+  // (usageTracking.js:297-305) keyed on done === true && prompt_eval_count.
+  // This is the native /api/chat fallback shape (non-Claude path). Complementary
+  // to the Claude-shape usage tests above — guards the non-Claude fallback's
+  // usage tracking too.
+  it("Contract COMP-03e: extractUsage reads ollama NDJSON (done + prompt_eval_count)", () => {
+    const chunk = {
+      model: "llama3",
+      done: true,
+      prompt_eval_count: 30,
+      eval_count: 20,
+    };
+    const u = extractUsage(chunk);
+    expect(u).not.toBeNull();
+    expect(u.prompt_tokens).toBe(30);
+    expect(u.completion_tokens).toBe(20);
+    expect(u.total_tokens).toBe(50);
+  });
+});

--- a/tests/unit/ollama-claude-passthrough-askuserquestion.test.js
+++ b/tests/unit/ollama-claude-passthrough-askuserquestion.test.js
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+// Drive createPassthroughStreamWithLogger with a claude SSE stream containing an
+// AskUserQuestion tool_use (options>4, questions-as-string). Assert emitted
+// stream has options capped to 4 and questions coerced to array.
+// RED today: passthrough has no tool_use arg sanitizer.
+
+async function runPassthroughStream(input) {
+  const stream = createPassthroughStreamWithLogger(null, null, null, null, null, null, null, FORMATS.CLAUDE);
+  const writer = stream.writable.getWriter();
+
+  const chunks = [];
+  const writable = new WritableStream({
+    write(chunk) {
+      chunks.push(new TextDecoder().decode(chunk));
+    },
+  });
+
+  const pipePromise = stream.readable.pipeTo(writable);
+
+  await writer.write(new TextEncoder().encode(input));
+  await writer.close();
+
+  await pipePromise;
+  return chunks.join("");
+}
+
+function parseClaudeSSEEvents(output) {
+  const events = [];
+  const blocks = output.split("\n\n");
+  for (const block of blocks) {
+    const dataLine = block.split("\n").find((l) => l.startsWith("data:"));
+    if (dataLine) {
+      const data = dataLine.slice(5).trim();
+      if (data && data !== "[DONE]") {
+        try {
+          events.push(JSON.parse(data));
+        } catch {
+          // skip non-JSON
+        }
+      }
+    }
+  }
+  return events;
+}
+
+function buildAskUserQuestionSSE(argsObj) {
+  const lines = [
+    'event: message_start',
+    `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "test", stop_reason: null, usage: { input_tokens: 0, output_tokens: 0 } } })}`,
+    '',
+    'event: content_block_start',
+    `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_1", name: "AskUserQuestion", input: {} } })}`,
+    '',
+    'event: content_block_delta',
+    `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: JSON.stringify(argsObj) } })}`,
+    '',
+    'event: content_block_stop',
+    `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+    '',
+    'event: message_delta',
+    `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 10 } })}`,
+    '',
+    'event: message_stop',
+    `data: ${JSON.stringify({ type: "message_stop" })}`,
+    '',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+describe("Claude identity passthrough: AskUserQuestion arg sanitization", () => {
+  it("caps options to maxItems:4 and coerces questions from JSON string to array", async () => {
+    const questions = [
+      {
+        question: "Which option?",
+        options: [
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+          { label: "C", value: "c" },
+          { label: "D", value: "d" },
+          { label: "E", value: "e" },
+        ],
+      },
+    ];
+
+    // questions emitted as JSON string (the P2 bug), options has 5 items (the P1 bug)
+    const argsObj = { questions: JSON.stringify(questions) };
+
+    const input = buildAskUserQuestionSSE(argsObj);
+    const output = await runPassthroughStream(input);
+    const events = parseClaudeSSEEvents(output);
+
+    const deltaEvents = events.filter(
+      (e) => e.type === "content_block_delta" && e.delta?.type === "input_json_delta"
+    );
+    expect(deltaEvents.length).toBe(1);
+
+    const sanitizedArgs = JSON.parse(deltaEvents[0].delta.partial_json);
+    expect(Array.isArray(sanitizedArgs.questions)).toBe(true);
+    expect(sanitizedArgs.questions[0].options.length).toBe(4);
+    expect(sanitizedArgs.questions[0].options.map((o) => o.value)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+  });
+
+  it("preserves valid AskUserQuestion (options<=4, questions as array)", async () => {
+    const argsObj = {
+      questions: [
+        {
+          question: "Which?",
+          options: [
+            { label: "A", value: "a" },
+            { label: "B", value: "b" },
+          ],
+        },
+      ],
+    };
+
+    const input = buildAskUserQuestionSSE(argsObj);
+    const output = await runPassthroughStream(input);
+    const events = parseClaudeSSEEvents(output);
+
+    const deltaEvents = events.filter(
+      (e) => e.type === "content_block_delta" && e.delta?.type === "input_json_delta"
+    );
+    expect(deltaEvents.length).toBe(1);
+
+    const sanitizedArgs = JSON.parse(deltaEvents[0].delta.partial_json);
+    expect(Array.isArray(sanitizedArgs.questions)).toBe(true);
+    expect(sanitizedArgs.questions[0].options.length).toBe(2);
+  });
+
+  it("handles multi-fragment input_json_delta", async () => {
+    const questions = [
+      {
+        question: "Pick one",
+        options: [
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+          { label: "C", value: "c" },
+          { label: "D", value: "d" },
+          { label: "E", value: "e" },
+          { label: "F", value: "f" },
+        ],
+      },
+    ];
+    const argsObj = { questions: JSON.stringify(questions) };
+    const argsJson = JSON.stringify(argsObj);
+    const mid = Math.floor(argsJson.length / 2);
+
+    const lines = [
+      'event: content_block_start',
+      `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_2", name: "AskUserQuestion", input: {} } })}`,
+      '',
+      'event: content_block_delta',
+      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: argsJson.slice(0, mid) } })}`,
+      '',
+      'event: content_block_delta',
+      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: argsJson.slice(mid) } })}`,
+      '',
+      'event: content_block_stop',
+      `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+      '',
+      '',
+    ];
+
+    const input = lines.join('\n');
+    const output = await runPassthroughStream(input);
+    const events = parseClaudeSSEEvents(output);
+
+    const deltaEvents = events.filter(
+      (e) => e.type === "content_block_delta" && e.delta?.type === "input_json_delta"
+    );
+    expect(deltaEvents.length).toBe(1);
+
+    const sanitizedArgs = JSON.parse(deltaEvents[0].delta.partial_json);
+    expect(Array.isArray(sanitizedArgs.questions)).toBe(true);
+    expect(sanitizedArgs.questions[0].options.length).toBe(4);
+  });
+});

--- a/tests/unit/ollama-claude-passthrough-raw-emit.test.js
+++ b/tests/unit/ollama-claude-passthrough-raw-emit.test.js
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+// TDD for narrowing the claude passthrough sanitizer to tool_use only.
+// Pre-P1/P2: non-tool-use claude chunks emitted raw (byte-for-byte, line + "\n").
+// P1/P2 regression: sanitizer at stream.js:194-226 re-serialized every claude chunk
+//   as `event: ${type}\ndata: ${JSON.stringify(parsed)}\n\n` and `continue`d,
+//   bypassing the raw-line path. Since the `event:` line is emitted raw
+//   separately (it doesn't start with `data:`), every event became
+//   `event: X\nevent: X\ndata: {...}\n\n\n` — duplicate event: line + extra
+//   blank-line event separator. Under `disconnect: ResponseAborted` the
+//   client's SSE parser hits an empty/partial event → JSON.parse("") →
+//   "JSON Parse error: Unexpected EOF".
+// Fix: sanitizer only intercepts tool_use; non-tool-use chunks emit raw.
+
+async function runPassthroughStream(input) {
+  const stream = createPassthroughStreamWithLogger(
+    null, null, null, null, null, null, null, FORMATS.CLAUDE
+  );
+  const writer = stream.writable.getWriter();
+  const chunks = [];
+  const writable = new WritableStream({
+    write(chunk) {
+      chunks.push(new TextDecoder().decode(chunk));
+    },
+  });
+  const pipePromise = stream.readable.pipeTo(writable);
+  await writer.write(new TextEncoder().encode(input));
+  await writer.close();
+  await pipePromise;
+  return chunks.join("");
+}
+
+function buildClaudeTextStream() {
+  const lines = [
+    'event: message_start',
+    `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "test", stop_reason: null, usage: { input_tokens: 5, output_tokens: 0 } } })}`,
+    '',
+    'event: content_block_start',
+    `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+    '',
+    'event: content_block_delta',
+    `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hi" } })}`,
+    '',
+    'event: content_block_stop',
+    `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+    '',
+    'event: message_delta',
+    `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } })}`,
+    '',
+    'event: message_stop',
+    `data: ${JSON.stringify({ type: "message_stop" })}`,
+    '',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function buildClaudeThinkingStream() {
+  const lines = [
+    'event: message_start',
+    `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_2", type: "message", role: "assistant", content: [], model: "test", stop_reason: null, usage: { input_tokens: 5, output_tokens: 0 } } })}`,
+    '',
+    'event: content_block_start',
+    `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } })}`,
+    '',
+    'event: content_block_delta',
+    `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "hmm" } })}`,
+    '',
+    'event: content_block_stop',
+    `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+    '',
+    'event: content_block_start',
+    `data: ${JSON.stringify({ type: "content_block_start", index: 1, content_block: { type: "text", text: "" } })}`,
+    '',
+    'event: content_block_delta',
+    `data: ${JSON.stringify({ type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "answer" } })}`,
+    '',
+    'event: content_block_stop',
+    `data: ${JSON.stringify({ type: "content_block_stop", index: 1 })}`,
+    '',
+    'event: message_delta',
+    `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 2 } })}`,
+    '',
+    'event: message_stop',
+    `data: ${JSON.stringify({ type: "message_stop" })}`,
+    '',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+describe("Claude passthrough sanitizer narrowing (raw emission for non-tool-use)", () => {
+  it("emits non-tool-use text claude chunks as raw lines (byte-for-byte, no re-serialization)", async () => {
+    const input = buildClaudeTextStream();
+    const output = await runPassthroughStream(input);
+
+    // Strip the trailing "data: [DONE]\n\n" appended by flush — we only care
+    // about the non-tool-use event emission here.
+    const doneIdx = output.indexOf("data: [DONE]");
+    const core = doneIdx >= 0 ? output.slice(0, doneIdx) : output;
+
+    // Pre-P1/P2 behavior: non-tool-use chunks emit raw lines (line + "\n").
+    // Output must be byte-for-byte equal to the input. P1/P2 regression added
+    // duplicate `event:` lines + extra blank-line separators via re-serialization.
+    expect(core).toBe(input);
+  });
+
+  it("emits non-tool-use thinking+text claude chunks as raw lines (byte-for-byte)", async () => {
+    const input = buildClaudeThinkingStream();
+    const output = await runPassthroughStream(input);
+
+    const doneIdx = output.indexOf("data: [DONE]");
+    const core = doneIdx >= 0 ? output.slice(0, doneIdx) : output;
+
+    expect(core).toBe(input);
+  });
+
+  it("does not emit duplicate `event:` lines for a single claude event", async () => {
+    const input = buildClaudeTextStream();
+    const output = await runPassthroughStream(input);
+
+    // Count `event: message_start` occurrences — should be exactly 1 per event
+    // (raw line). P1/P2 regression produced 2 (raw + re-serialized).
+    const messageStartMatches = output.match(/^event: message_start$/gm) || [];
+    expect(messageStartMatches.length).toBe(1);
+
+    const textDeltaMatches = output.match(/^event: content_block_delta$/gm) || [];
+    expect(textDeltaMatches.length).toBe(1);
+  });
+
+  it("does not emit extra blank-line event separators (no empty events between real events)", async () => {
+    const input = buildClaudeTextStream();
+    const output = await runPassthroughStream(input);
+
+    // Pre-P1/P2: events separated by exactly one blank line (\n\n between event blocks).
+    // P1/P2 regression: \n\n\n (extra blank line) → empty SSE event → client JSON.parse("") → EOF.
+    // Assert NO occurrence of three consecutive newlines in the core output.
+    const doneIdx = output.indexOf("data: [DONE]");
+    const core = doneIdx >= 0 ? output.slice(0, doneIdx) : output;
+
+    expect(core).not.toContain("\n\n\n");
+  });
+
+  it("tolerates a truncated final event (simulated ResponseAborted mid-JSON) by flushing the partial line raw", async () => {
+    // Complete text stream + a partial truncated data line (no trailing \n)
+    // simulating the upstream aborting mid-event. The partial line stays in
+    // the stream buffer until flush, which emits it raw — pre-P1/P2 behavior.
+    const complete = buildClaudeTextStream();
+    const truncated = 'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial';
+    const input = complete + truncated;
+
+    const output = await runPassthroughStream(input);
+    const doneIdx = output.indexOf("data: [DONE]");
+    const core = doneIdx >= 0 ? output.slice(0, doneIdx) : output;
+
+    // The complete portion should pass through raw (byte-for-byte).
+    expect(core.startsWith(complete)).toBe(true);
+    // The truncated tail should be flushed raw (partial JSON, as-is) — NOT
+    // re-serialized into a complete JSON object that contradicts the abort.
+    const tail = core.slice(complete.length);
+    expect(tail).toContain('"text":"partial');
+    // Crucially, no re-serialized `event: content_block_delta\ndata: {...}\n\n`
+    // was synthesized for the truncated event (which would have produced
+    // complete JSON that contradicts the abort).
+    // The raw `event: content_block_delta\n` line is emitted (it's a complete
+    // line), but no data: line follows it — matching pre-P1/P2 behavior.
+    expect(tail).not.toMatch(/event: content_block_delta\ndata: \{[^}]*partial[^}]*\}\n\n/);
+  });
+});
+
+describe("Claude passthrough sanitizer: tool_use sanitization still preserved", () => {
+  // Verifies the narrowing fix does not regress the P1/P2 tool_use arg sanitizer.
+
+  function parseClaudeSSEEvents(output) {
+    const events = [];
+    const blocks = output.split("\n\n");
+    for (const block of blocks) {
+      const dataLine = block.split("\n").find((l) => l.startsWith("data:"));
+      if (dataLine) {
+        const data = dataLine.slice(5).trim();
+        if (data && data !== "[DONE]") {
+          try {
+            events.push(JSON.parse(data));
+          } catch {
+            // skip non-JSON
+          }
+        }
+      }
+    }
+    return events;
+  }
+
+  it("still caps AskUserQuestion options to 4 and coerces questions from string to array", async () => {
+    const questions = [
+      {
+        question: "Which option?",
+        options: [
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+          { label: "C", value: "c" },
+          { label: "D", value: "d" },
+          { label: "E", value: "e" },
+        ],
+      },
+    ];
+    const argsObj = { questions: JSON.stringify(questions) };
+
+    const lines = [
+      'event: message_start',
+      `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_3", type: "message", role: "assistant", content: [], model: "test", stop_reason: null, usage: { input_tokens: 0, output_tokens: 0 } } })}`,
+      '',
+      'event: content_block_start',
+      `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_3", name: "AskUserQuestion", input: {} } })}`,
+      '',
+      'event: content_block_delta',
+      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: JSON.stringify(argsObj) } })}`,
+      '',
+      'event: content_block_stop',
+      `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+      '',
+      'event: message_delta',
+      `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 10 } })}`,
+      '',
+      'event: message_stop',
+      `data: ${JSON.stringify({ type: "message_stop" })}`,
+      '',
+      '',
+    ];
+    const input = lines.join('\n');
+
+    const output = await runPassthroughStream(input);
+    const events = parseClaudeSSEEvents(output);
+
+    const deltaEvents = events.filter(
+      (e) => e.type === "content_block_delta" && e.delta?.type === "input_json_delta"
+    );
+    expect(deltaEvents.length).toBe(1);
+
+    const sanitizedArgs = JSON.parse(deltaEvents[0].delta.partial_json);
+    expect(Array.isArray(sanitizedArgs.questions)).toBe(true);
+    expect(sanitizedArgs.questions[0].options.length).toBe(4);
+    expect(sanitizedArgs.questions[0].options.map((o) => o.value)).toEqual([
+      "a", "b", "c", "d",
+    ]);
+  });
+});

--- a/tests/unit/ollama-claude-regression.test.js
+++ b/tests/unit/ollama-claude-regression.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { resolveTransport, detectFormat, getTargetFormat } from "../../open-sse/services/provider.js";
+import OllamaLocalExecutor from "../../open-sse/executors/ollama-local.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+// Phase 4 VAL-01 + VAL-03: consolidate + clearly-label the regression + fallback
+// guard already proven by Phase 1-3. Locks the passthrough contract against
+// future refactors. No open-sse source changes.
+//
+// VAL-01: claude-format request to ollama resolves targetFormat=claude and the
+// dispatched body is structurally identical to the client body (no openai
+// intermediate hop). Phase 1 transport Contract A proves targetFormat=claude;
+// Phase 2 block-fidelity proves field-level identity; VAL-01 formalizes it as a
+// scoped deep-equal on the passthrough fields (comparing against a PRE-CALL
+// snapshot — translateRequest mutates `body` in place, so the expected shape
+// must be captured before the call) + negative assertions for OpenAI-only
+// fields (choices / tool_calls / reasoning_effort / tools[*].function).
+//
+// prepareClaudeRequest (open-sse/translator/index.js:118-121, runs because
+// targetFormat===CLAUDE) normalizes cache_control — system-array rewrite and
+// message-block strip/re-add (COMP-01c/d). VAL-01's base assertion omits
+// cache_control from the input body to keep the toMatchObject clean; a SEPARATE
+// it block documents the cache_control interaction without false-asserting its
+// identity (CONTEXT.md line 23 + Phase 3 COMP-01).
+//
+// VAL-03: non-Claude openai-format request to ollama resolves no claude
+// transport and routes through /api/chat unchanged. Phase 1 Contract B+C proves
+// the mechanics; this is the Phase 4 named guard locking the fallback (CONTEXT
+// line 23, COMP WR-01).
+
+describe("Phase 4: VAL-01 regression + VAL-03 fallback guard", () => {
+  it("Contract VAL-01: dispatched body structurally identical to client body (no openai intermediate, ollama)", () => {
+    const body = {
+      model: "claude-sonnet-4-5",
+      messages: [{ role: "user", content: "hi" }],
+      system: "You are helpful",
+      thinking: { type: "enabled" },
+      output_config: { effort: "high" },
+      tools: [{ name: "get_weather", input_schema: {} }],
+    };
+
+    // CR-01: translateRequest mutates `body` in place (let result = body at
+    // translator/index.js:54 + prepareClaudeRequest adds cache_control to
+    // tools[0]). Snapshot BEFORE the call so the expected shape reflects the
+    // client's pre-translation body, not the mutated result ref.
+    const snapshot = structuredClone(body);
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      body.model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    // Scoped deep-equal on the passthrough fields, against the PRE-CALL
+    // snapshot. NOT a full toEqual — prepareClaudeRequest may add/normalize
+    // headers, cache_control, anthropic-version.
+    expect(result).toMatchObject({
+      messages: snapshot.messages,
+      system: snapshot.system,
+      thinking: snapshot.thinking,
+      output_config: snapshot.output_config,
+      tools: snapshot.tools,
+    });
+
+    // WR-02: negative proof — never routed through OpenAI intermediate.
+    // Assert the high-signal OpenAI-only fields that would appear if an
+    // openai hop ran (choices, tool_calls, reasoning_effort, tools[*].function).
+    expect(result).not.toHaveProperty("choices");
+    expect(result.messages?.[0]).not.toHaveProperty("tool_calls");
+    expect(result).not.toHaveProperty("reasoning_effort");
+    // Claude tools keep input_schema; OpenAI shape is tools[*].function.parameters
+    expect(result.tools?.[0]).not.toHaveProperty("function");
+    expect(result.tools?.[0]?.input_schema).toBeDefined();
+  });
+
+  // Asymmetry vs VAL-01 (ollama): ollama-local traverses applyThinking's general
+  // path (thinkingUnified.js:275 short-circuit is `provider === "ollama"` only —
+  // the ponytail comment marks lifting to PROVIDERS[ollama].quirks when a second
+  // native-claude provider lands). Consequence: thinking gets budget_tokens
+  // normalized in and output_config (OpenAI-shaped) is stripped. The structural
+  // passthrough still holds for messages/system/tools — that is the VAL-01
+  // invariant; thinking/output_config normalization is documented, not asserted.
+  it("Contract VAL-01 local: messages/system/tools structurally identical (no openai intermediate, ollama-local)", () => {
+    const body = {
+      model: "claude-sonnet-4-5",
+      messages: [{ role: "user", content: "hi" }],
+      system: "You are helpful",
+      thinking: { type: "enabled" },
+      output_config: { effort: "high" },
+      tools: [{ name: "get_weather", input_schema: {} }],
+    };
+
+    // CR-01: snapshot before the call (translateRequest mutates body in place).
+    const snapshot = structuredClone(body);
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      body.model,
+      body,
+      false,
+      null,
+      "ollama-local"
+    );
+
+    expect(result).toMatchObject({
+      messages: snapshot.messages,
+      system: snapshot.system,
+      tools: snapshot.tools,
+    });
+    // WR-02: negative proof — no OpenAI intermediate artifacts.
+    expect(result).not.toHaveProperty("choices");
+    expect(result.messages?.[0]).not.toHaveProperty("tool_calls");
+    expect(result).not.toHaveProperty("reasoning_effort");
+    expect(result.tools?.[0]).not.toHaveProperty("function");
+    expect(result.tools?.[0]?.input_schema).toBeDefined();
+  });
+
+  // Cache_control scoping: prepareClaudeRequest (claude.js:241-244) strips
+  // cache_control from message content blocks in Pass 1, then Pass 2 re-adds
+  // {type:"ephemeral"} only to the last non-thinking block of the LAST
+  // assistant with content. A user-only message has no assistant, so the strip
+  // is permanent — locks COMP-01d (cache_control normalization is real, not
+  // just documented). Scoped to ollama per CONTEXT line 23 + Phase 3 COMP-01.
+  it("Contract VAL-01 cache_control: prepareClaudeRequest strips cache_control from user content blocks (COMP-01d)", () => {
+    const body = {
+      model: "claude-sonnet-4-5",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hi", cache_control: { type: "ephemeral" } },
+          ],
+        },
+      ],
+    };
+
+    const result = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      body.model,
+      body,
+      false,
+      null,
+      "ollama"
+    );
+
+    // Text content survives — passthrough doesn't drop the message.
+    expect(result.messages[0].content[0].text).toBe("hi");
+    // CR-02: cache_control is actually stripped from user content blocks by
+    // prepareClaudeRequest (no assistant → Pass 2 does not re-add it). Locks
+    // COMP-01d: the strip is real, not just prose.
+    expect(result.messages[0].content[0].cache_control).toBeUndefined();
+  });
+
+  it("Contract VAL-03: openai-format request to ollama routes /api/chat (full routing decision chain)", () => {
+    // WR-01: reframe the Phase 1 Contract B/C duplicate to add incremental
+    // value — assert the FULL routing decision chain end-to-end at the atom
+    // level, not just the three atoms Phase 1 re-asserts. detectFormat proves
+    // the openai body is classified as openai (not misdetected as claude);
+    // resolveTransport null proves no claude transport matches an openai
+    // source; getTargetFormat proves the non-Claude path's targetFormat is the
+    // ollama format (Phase 1 buildUrl does not assert this). Together they lock
+    // the fallback decision: openai body → no claude transport → ollama format
+    // → /api/chat. Phase 1 transport Contract B/C owns the buildUrl atoms.
+    const openaiBody = {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "hi" }],
+    };
+    expect(detectFormat(openaiBody)).toBe("openai");
+    expect(resolveTransport("ollama", "openai")).toBeNull();
+    expect(resolveTransport("ollama-local", "openai")).toBeNull();
+    expect(getTargetFormat("ollama")).toBe("ollama");
+
+    const exec = new OllamaLocalExecutor();
+    expect(exec.buildUrl("", true, 0, null)).toBe("http://localhost:11434/api/chat");
+
+    // WR-03: positive claude-path buildUrl — the milestone's actual dependency.
+    // Phase 1 Contract C covers this atom; re-asserted here as the positive
+    // counterpart to the fallback above, proving the same executor picks
+    // /v1/messages when a claude runtimeTransport is present.
+    const claudeCreds = { runtimeTransport: { baseUrl: "http://localhost:11434/v1/messages", format: "claude" } };
+    expect(exec.buildUrl("", true, 0, claudeCreds)).toBe("http://localhost:11434/v1/messages");
+  });
+});

--- a/tests/unit/ollama-claude-round-trip.test.js
+++ b/tests/unit/ollama-claude-round-trip.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { translateResponse, initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+// Phase 4 VAL-02: mocked `/v1/messages` SSE round-trip through the
+// translateResponse identity slice. Proves thinking + tool_use + ping + error
+// events survive same-format (CLAUDE→CLAUDE) response passthrough. This is NOT
+// an end-to-end test — it exercises only translateResponse(CLAUDE,CLAUDE,ev),
+// which hits the identity passthrough at open-sse/translator/index.js:152
+// (returns [chunk]). No chatCore.js, no executor fetch, no SSE parser, no
+// runStream in the gateway path — the identity branch is provider-agnostic.
+// No translator registry needed (confirmed by the test passing without
+// registerAll.js import).
+//
+// VAL-02 mock = inline recorded chunk array fed through translateResponse +
+// runStream accumulator per golden-response-stream.test.js analog. NOT a fetch
+// mock (CONTEXT.md line 47: "prefer constructing response chunks directly over
+// modifying executor code"). No network, no vi.mock.
+
+// runStream accumulator — copies the golden-response-stream.test.js analog
+// (lines 24-33). Does NOT call stripVolatile: VAL-02 uses explicit assertions,
+// not snapshots, so identity references must be preserved (out[i] === events[i]
+// requires no JSON round-trip).
+function runStream(targetFormat, sourceFormat, events) {
+  const state = initState(sourceFormat);
+  const all = [];
+  for (const ev of events) {
+    const out = translateResponse(targetFormat, sourceFormat, ev, state);
+    if (Array.isArray(out)) all.push(...out);
+    else if (out) all.push(out);
+  }
+  return all;
+}
+
+describe("Phase 4: VAL-02 round-trip (mocked /v1/messages)", () => {
+  it("Contract VAL-02: thinking + tool_use + ping/error survive same-format response passthrough (translateResponse identity slice)", () => {
+    // Inline mock of an ollama /v1/messages SSE event sequence, following the
+    // Anthropic Messages streaming shape: ping → message_start →
+    // content_block_start/delta (thinking + text + tool_use) → content_block_stop
+    // → message_delta (stop_reason + usage) → message_stop, plus an error event
+    // to confirm non-data events pass through unchanged. PROJECT.md line 51
+    // documents ollama emits `ping` and `error` events; both are asserted here.
+    // NOT recorded from a live stream — constructed inline to keep the test
+    // hermetic (no network, no vi.mock).
+    const events = [
+      { type: "ping" },
+      { type: "message_start", message: { id: "msg_1", model: "claude-sonnet-4-5", usage: { input_tokens: 10 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "thinking" } },
+      { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "let me think" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "content_block_start", index: 1, content_block: { type: "text" } },
+      { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Answer" } },
+      { type: "content_block_stop", index: 1 },
+      { type: "content_block_start", index: 2, content_block: { type: "tool_use", id: "toolu_1", name: "get_weather" } },
+      { type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: '{"city":"NYC"}' } },
+      { type: "content_block_stop", index: 2 },
+      { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 5 } },
+      { type: "message_stop" },
+      { type: "error", error: { type: "overloaded_error", message: "Overloaded" } },
+    ];
+
+    const out = runStream(FORMATS.CLAUDE, FORMATS.CLAUDE, events);
+
+    // Order preserved, no events dropped: same count, same type sequence.
+    expect(out.map((e) => e.type)).toEqual(events.map((e) => e.type));
+
+    // Identity passthrough — each event reaches client UNCHANGED (no openai
+    // intermediate hop). translateResponse returns [chunk] (===) on same-format.
+    for (let i = 0; i < events.length; i++) {
+      expect(out[i]).toBe(events[i]);
+    }
+
+    // VAL-02 headline invariants: thinking AND tool_use blocks survive.
+    const thinkingDelta = out.find((e) => e.delta?.type === "thinking_delta");
+    expect(thinkingDelta.delta.thinking).toBe("let me think");
+
+    const toolUseStart = out.find((e) => e.content_block?.type === "tool_use");
+    expect(toolUseStart.content_block.id).toBe("toolu_1");
+    expect(toolUseStart.content_block.name).toBe("get_weather");
+
+    // input_json_delta partial_json survives verbatim.
+    const jsonDelta = out.find((e) => e.delta?.type === "input_json_delta");
+    expect(jsonDelta.delta.partial_json).toBe('{"city":"NYC"}');
+
+    // stop_reason + usage reach the client-facing stream (COMP-02/03 proven at
+    // translator level; here at the SSE reconstruction level).
+    const stopReason = out.find((e) => e.type === "message_delta");
+    expect(stopReason.delta.stop_reason).toBe("tool_use");
+    expect(stopReason.usage.output_tokens).toBe(5);
+
+    // ping + error events pass through UNCHANGED (forwarded, not dropped) —
+    // PROJECT.md line 51 documents ollama emits both. The identity loop above
+    // (out[i] === events[i]) already proves structural identity; these explicit
+    // assertions document the non-data event forwarding invariant.
+    const pingEvent = out.find((e) => e.type === "ping");
+    expect(pingEvent).toBe(events[0]);
+
+    const errorEvent = out.find((e) => e.type === "error");
+    expect(errorEvent.error.type).toBe("overloaded_error");
+    expect(errorEvent.error.message).toBe("Overloaded");
+  });
+});

--- a/tests/unit/ollama-claude-thinking-passthrough.test.js
+++ b/tests/unit/ollama-claude-thinking-passthrough.test.js
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("Phase 2: Thinking passthrough for ollama claude transport", () => {
+  it("Contract THINK-02: applyThinking no-ops on ollama+claude path", () => {
+    const body = { thinking: { type: "enabled" }, output_config: { effort: "high" } };
+    const out = applyThinking(FORMATS.CLAUDE, "ollama-model", body, "ollama");
+    expect(out.thinking.type).toBe("enabled");
+    expect(out.output_config.effort).toBe("high");
+  });
+
+  it("Contract THINK-02 negative: applyThinking still strips for non-ollama non-reasoning provider", () => {
+    const body = { thinking: { type: "enabled" }, output_config: { effort: "high" } };
+    const out = applyThinking(FORMATS.CLAUDE, "some-model", body, "nonexistent-provider");
+    expect(out.thinking).toBeUndefined();
+    expect(out.output_config).toBeUndefined();
+  });
+
+  it("Contract THINK-03: providerThinking-injected thinking survives to translateRequest output", () => {
+    const body = {
+      model: "ollama-model",
+      messages: [{ role: "user", content: "hi" }],
+      thinking: { type: "enabled", budget_tokens: 10000 },
+    };
+    const out = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      "ollama-model",
+      body,
+      false,
+      null,
+      "ollama",
+    );
+    expect(out.thinking.type).toBe("enabled");
+  });
+
+  it("Contract THINK-01 request: thinking content blocks in assistant messages survive translateRequest", () => {
+    const body = {
+      model: "ollama-model",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "reasoning here", signature: "sig-abc" },
+            { type: "text", text: "answer" },
+          ],
+        },
+        { role: "user", content: "continue" },
+      ],
+    };
+    const out = translateRequest(
+      FORMATS.CLAUDE,
+      FORMATS.CLAUDE,
+      "ollama-model",
+      body,
+      false,
+      null,
+      "ollama",
+    );
+    const assistantMsg = out.messages.find((m) => m.role === "assistant");
+    const thinkingBlock = assistantMsg.content.find((b) => b.type === "thinking");
+    expect(thinkingBlock).toBeDefined();
+    expect(thinkingBlock.thinking).toBe("reasoning here");
+    expect(thinkingBlock.signature).toBe("sig-abc");
+  });
+
+  // WR-02: exercise chatCore.js:59-69 providerThinking injection path.
+  // Mirror chatCore injection: set body.reasoning_effort = "high" (level mode)
+  // OR body.thinking = { type: "enabled" } (on mode) BEFORE applyThinking,
+  // then assert the body is valid for ollama's Claude endpoint.
+  // Covers WR-01: reasoning_effort must be normalized away / output_config.effort set.
+  it("Contract THINK-03b: providerThinking level-mode (high) injection normalized to Claude shape", () => {
+    // Simulate chatCore injection for providerThinking.ollama = { mode: "high" }:
+    // chatCore.js:66-68 sets body.reasoning_effort = mode (else-if branch, not on/off).
+    const body = {
+      model: "ollama-model",
+      messages: [{ role: "user", content: "hi" }],
+      reasoning_effort: "high",
+    };
+    const out = applyThinking(FORMATS.CLAUDE, "ollama-model", body, "ollama");
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.output_config).toBeDefined();
+    expect(out.output_config.effort).toBe("high");
+  });
+
+  it("Contract THINK-03c: providerThinking on-mode injection (thinking) preserved, reasoning_effort dropped", () => {
+    // Simulate chatCore injection for providerThinking.ollama = { mode: "on" }:
+    // chatCore.js:61-63 sets body.thinking = { type: "enabled", budget_tokens: 10000 }.
+    // Also inject a stray reasoning_effort to confirm Claude-native thinking wins.
+    const body = {
+      model: "ollama-model",
+      messages: [{ role: "user", content: "hi" }],
+      thinking: { type: "enabled", budget_tokens: 10000 },
+      reasoning_effort: "high",
+    };
+    const out = applyThinking(FORMATS.CLAUDE, "ollama-model", body, "ollama");
+    expect(out.thinking).toBeDefined();
+    expect(out.thinking.type).toBe("enabled");
+    expect(out.thinking.budget_tokens).toBe(10000);
+    expect(out.reasoning_effort).toBeUndefined();
+  });
+
+  // WR-03: verify short-circuit still fires for reasoning-capable ollama models.
+  // CONTEXT decision: applyThinking is a no-op on the claude→ollama path, NOT
+  // capability-gated. Even if the model is reasoning-capable (kimi-k2.5 matches
+  // *kimi*k2* → reasoning:true, thinkingFormat:"openai"), the short-circuit must
+  // fire so the client's Claude-format thinking/effort survive verbatim (not
+  // rewritten to reasoning_effort by resolveFormat("openai")).
+  it("Contract THINK-02 reasoning: short-circuit preserves Claude thinking fields for reasoning-capable ollama model", () => {
+    const body = { thinking: { type: "enabled", budget_tokens: 10000 }, output_config: { effort: "high" } };
+    // kimi-k2.5 is in ollama registry and matches *kimi*k2* → reasoning:true, thinkingFormat:"openai".
+    const out = applyThinking(FORMATS.CLAUDE, "kimi-k2.5", body, "ollama");
+    expect(out.thinking.type).toBe("enabled");
+    expect(out.thinking.budget_tokens).toBe(10000);
+    expect(out.output_config.effort).toBe("high");
+    // Critical: resolveFormat("openai") would have set reasoning_effort and stripped
+    // thinking/output_config. Verify that DID NOT happen.
+    expect(out.reasoning_effort).toBeUndefined();
+  });
+
+  it("Contract THINK-02 reasoning: reasoning-capable ollama model normalizes injected reasoning_effort", () => {
+    // Same model (kimi-k2.5, reasoning:true) with chatCore-injected reasoning_effort.
+    // Short-circuit must still normalize the OpenAI field to Claude shape.
+    const body = { model: "kimi-k2.5", messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" };
+    const out = applyThinking(FORMATS.CLAUDE, "kimi-k2.5", body, "ollama");
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.output_config).toBeDefined();
+    expect(out.output_config.effort).toBe("high");
+  });
+
+  // WR-05: document accepted behavior. CONTEXT decision says applyThinking is a
+  // no-op on the claude→ollama path (preserve client body verbatim). A client-set
+  // model suffix like "kimi-k2.5(high)" is an OpenAI-format niche feature; on the
+  // Claude transport the client should send Claude-format fields directly. The
+  // short-circuit fires before parseSuffix, so the suffix override is dropped —
+  // this is the documented ceiling. chatCore.js:138 strips the suffix from the
+  // upstream model id, so the upstream receives a valid model id regardless.
+  it("Contract THINK-04 ceiling: model-suffix thinking override is dropped on ollama+claude path (WR-05 accepted behavior)", () => {
+    // Client sends model: "kimi-k2.5(high)" expecting suffix override to set
+    // thinking level. On ollama+claude the short-circuit fires before parseSuffix,
+    // so the override is NOT applied. Document the ceiling: use Claude-format
+    // fields (output_config.effort) directly when on the Claude transport.
+    const body = { model: "kimi-k2.5(high)", messages: [{ role: "user", content: "hi" }], output_config: { effort: "low" } };
+    const out = applyThinking(FORMATS.CLAUDE, "kimi-k2.5(high)", body, "ollama");
+    // Client-set Claude field survives verbatim (short-circuit is a no-op on body).
+    expect(out.output_config.effort).toBe("low");
+    // The suffix override "high" is NOT applied — the client's explicit low wins.
+    // chatCore.js:138 (stripThinkingSuffix) cleans the model id separately, so
+    // upstream receives "kimi-k2.5" (verified by stripThinkingSuffix, not here).
+  });
+});

--- a/tests/unit/ollama-claude-transport.test.js
+++ b/tests/unit/ollama-claude-transport.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveTransport } from "../../open-sse/services/provider.js";
+import OllamaLocalExecutor from "../../open-sse/executors/ollama-local.js";
+
+describe("Phase 1: Claude passthrough transport", () => {
+  it("Contract A: resolveTransport(ollama, claude) returns /v1/messages", () => {
+    const t = resolveTransport("ollama", "claude");
+    expect(t).not.toBeNull();
+    expect(t.format).toBe("claude");
+    expect(t.baseUrl).toBe("https://ollama.com/v1/messages");
+  });
+
+  it("Contract A local: resolveTransport(ollama-local, claude) returns localhost /v1/messages", () => {
+    const t = resolveTransport("ollama-local", "claude");
+    expect(t).not.toBeNull();
+    expect(t.format).toBe("claude");
+    expect(t.baseUrl).toBe("http://localhost:11434/v1/messages");
+  });
+
+  it("Contract B fallback: resolveTransport(ollama, openai) === null", () => {
+    expect(resolveTransport("ollama", "openai")).toBeNull();
+  });
+
+  it("Contract B fallback local: resolveTransport(ollama-local, openai) === null", () => {
+    expect(resolveTransport("ollama-local", "openai")).toBeNull();
+  });
+
+  it("Contract C: buildUrl honors runtimeTransport baseUrl for claude path", () => {
+    const exec = new OllamaLocalExecutor();
+    const creds = { runtimeTransport: { baseUrl: "http://localhost:11434/v1/messages", format: "claude" } };
+    expect(exec.buildUrl("", true, 0, creds)).toBe("http://localhost:11434/v1/messages");
+  });
+
+  it("Contract C host-override: buildUrl honors providerSpecificData.baseUrl", () => {
+    const exec = new OllamaLocalExecutor();
+    const creds = {
+      runtimeTransport: { baseUrl: "http://localhost:11434/v1/messages", format: "claude" },
+      providerSpecificData: { baseUrl: "http://192.168.1.5:11434" },
+    };
+    expect(exec.buildUrl("", true, 0, creds)).toBe("http://192.168.1.5:11434/v1/messages");
+  });
+
+  it("Contract C fallback: buildUrl returns /api/chat without runtimeTransport", () => {
+    const exec = new OllamaLocalExecutor();
+    expect(exec.buildUrl("", true, 0, null)).toBe("http://localhost:11434/api/chat");
+  });
+});


### PR DESCRIPTION
## What

Adds a `claude`-format passthrough transport for **Ollama Cloud + Local** that routes Claude-format client requests to Ollama's native Anthropic-compatible `/v1/messages` endpoint with **zero translation** — skipping the lossy `claude→openai→ollama` double-hop. The existing `ollama`-format `/api/chat` transport stays as the fallback for non-Claude clients, so OpenAI-format clients are unaffected.

This mirrors the existing GLM multi-endpoint `transports[]` pattern: `resolveTransport("ollama","claude")` matches the claude entry → `targetFormat="claude"` → the same-format short-circuit skips translation → ollama's native Anthropic SSE stream is forwarded unchanged to the client.

## Why

Claude Code (and other Claude-format clients) hitting Ollama today are forced through `claude→openai→ollama` translation, losing thinking blocks, tool id fidelity, and non-base64 images. Ollama ships a native `/v1/messages` endpoint that accepts the Anthropic body shape and emits the Anthropic SSE event sequence (`message_start` → `content_block_*` with `thinking_delta`/`text_delta`/`input_json_delta` → `message_delta` → `message_stop`). Passthrough is lossless and ~10 lines of registry config vs. a hand-rolled fragile translator.

## Changes

**Source (5 files, ~69 lines):**
- `providers/registry/ollama.js` + `ollama-local.js` — `transports[]` claude entry: `baseUrl` `/v1/messages`, `Authorization: Bearer` auth (confirmed by live probe — `x-api-key` raw returns 401), `CLAUDE_API_HEADERS`. Existing `transport` object byte-identical as the openai/ollama fallback.
- `executors/ollama-local.js` — `buildUrl` honors `credentials.runtimeTransport` first (host-substituted `/v1/messages` via `resolveOllamaLocalHost`), falls back to `/api/chat`. Hardened: `try/catch` around `new URL`, preserves query string + `urlSuffix`.
- `translator/concerns/thinkingUnified.js` — `applyThinking` is a no-op for `provider==="ollama"` + `targetFormat==="claude"`, preserving the client's `thinking` + `output_config.effort` verbatim (previously `stripAll` stripped them for ollama models lacking a `reasoning` capability). Stray `providerThinking`-injected `reasoning_effort` is normalized to `output_config.effort`.
- `translator/formats/claude.js` — `hasValidContent` recognizes `IMAGE` + `DOCUMENT` content blocks so image/document-only user messages are no longer silently dropped by `prepareClaudeRequest`'s empty-message filter.

**Tests (6 vitest files, 80 contracts, 0 new deps):**
- `ollama-claude-transport.test.js` — `resolveTransport` claude/openai resolution, `buildUrl` dual-path, fallback guard (PASS-01/02/03).
- `ollama-claude-thinking-passthrough.test.js` — thinking + effort survive, providerThinking injection, reasoning-capable models (THINK-01/02/03).
- `ollama-claude-block-fidelity.test.js` — tool_use/tool_result/text/system/base64-image/document round-trip, same-format response passthrough (BLK-01/02/03/04).
- `ollama-claude-compat.test.js` — field tolerance, stop_reason passthrough, usage extraction incl. native ollama NDJSON fallback (COMP-01/02/03).
- `ollama-claude-regression.test.js` — body-identity regression (`structuredClone` snapshot, no openai intermediate), full routing-chain fallback guard (VAL-01/03).
- `ollama-claude-round-trip.test.js` — mocked 14-event `/v1/messages` SSE round-trip (ping/message_start/thinking/text/tool_use/input_json_delta/stop_reason/usage/error) through the same-format response passthrough (VAL-02).

## Verification

**Live-validated against ollama cloud** (`glm-5.2`, `effort=high`): confirmed `content_block_start thinking` → `thinking_delta` ×N → `content_block_stop` → `tool_use` blocks with `input_json_delta` → `message_delta` (`stop_reason: tool_use`) → `message_stop`. Thinking + tool_use + stop_reason + usage all round-trip end-to-end through the passthrough.

All 6 test files green (`cd tests && npx vitest run unit/ollama-claude-*.test.js`). No new npm dependencies. No changes to non-Claude routing (openai-format `/api/chat` path byte-identical).

## Out of scope

- Custom `claude:ollama` translator (unnecessary — native endpoint exists).
- Per-model `thinkingFormat` wiring under passthrough (Claude body carries thinking verbatim).
- `budget_tokens` enforcement (ollama accepts but doesn't enforce).
- Live round-trip `*.real.test.js` (needs credentials; the mock covers the contract).
- `ollama-local` `applyThinking` short-circuit (cloud-only for now; documented as a ceiling with upgrade path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)