### PR TITLE
perf(v1/models): resolve provider catalogs concurrently instead of serially

### DIFF
--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -286,164 +286,18 @@ export async function buildModelsList(kindFilter) {
       });
     }
   } else {
-    for (const [providerId, conn] of activeConnectionByProvider.entries()) {
-      if (!providerMatchesKinds(providerId, kindFilter)) continue;
-
-      const staticAlias = PROVIDER_ID_TO_ALIAS[providerId] || providerId;
-      const outputAlias = (
-        conn?.providerSpecificData?.prefix
-        || getProviderAlias(providerId)
-        || staticAlias
-      ).trim();
-      const providerModels = PROVIDER_MODELS[staticAlias] || [];
-      const enabledModels = conn?.providerSpecificData?.enabledModels;
-      const hasExplicitEnabledModels =
-        Array.isArray(enabledModels) && enabledModels.length > 0;
-      const isCompatibleProvider =
-        isOpenAICompatibleProvider(providerId) || isAnthropicCompatibleProvider(providerId);
-
-      // Build kind lookup for static models so we can filter even when only IDs are exposed
-      const staticModelKindById = new Map(
-        providerModels.map((m) => [m.id, modelKind(m)])
-      );
-      let liveModelKindById = new Map();
-      let liveCapabilitiesById = new Map();
-
-      let rawModelIds = hasExplicitEnabledModels
-        ? Array.from(
-            new Set(
-              enabledModels.filter(
-                (modelId) => typeof modelId === "string" && modelId.trim() !== "",
-              ),
-            ),
-          )
-        : providerModels.map((model) => model.id);
-
-      if (isCompatibleProvider && rawModelIds.length === 0 && !UPSTREAM_CONNECTION_RE.test(providerId)) {
-        rawModelIds = await fetchCompatibleModelIds(conn);
-      }
-
-      // Config-driven live catalog override (e.g. Kiro returns dynamic
-      // -thinking/-agentic variants per account). On failure, fall back to
-      // whatever rawModelIds already holds.
-      const liveResolver = LIVE_MODEL_RESOLVERS[providerId];
-      if (liveResolver && !hasExplicitEnabledModels) {
-        try {
-          const live = await liveResolver(conn);
-          if (live?.models?.length) {
-            rawModelIds = live.models.map((m) => m.id);
-            liveModelKindById = new Map(
-              live.models
-                .filter((m) => m?.id)
-                .map((m) => [m.id, modelKind(m)])
-            );
-            liveCapabilitiesById = new Map(
-              live.models
-                .filter((m) => m?.id && m.capabilities)
-                .map((m) => [m.id, m.capabilities])
-            );
-          }
-        } catch (err) {
-          console.log(`Live model fetch failed for ${providerId}: ${err?.message || err}`);
-        }
-      }
-
-      const modelIds = rawModelIds
-        .map((modelId) => {
-          if (modelId.startsWith(`${outputAlias}/`)) {
-            return modelId.slice(outputAlias.length + 1);
-          }
-          if (modelId.startsWith(`${staticAlias}/`)) {
-            return modelId.slice(staticAlias.length + 1);
-          }
-          if (modelId.startsWith(`${providerId}/`)) {
-            return modelId.slice(providerId.length + 1);
-          }
-          return modelId;
-        })
-        .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
-
-      const customModelKindById = new Map();
-      const customModelIds = customModels
-        .filter((m) => {
-          if (!m?.id) return false;
-          const kind = getModelKind(m) || LLM_KIND;
-          // imageToText custom models are vision-capable chat models: expose them
-          // both in the default LLM list and in /v1/models/image-to-text.
-          if (!kindFilter.includes(kind) && !(kind === "imageToText" && kindFilter.includes(LLM_KIND))) return false;
-          const alias = m.providerAlias;
-          return alias === staticAlias || alias === outputAlias || alias === providerId;
-        })
-        .map((m) => {
-          const modelId = String(m.id).trim();
-          if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
-          return modelId;
-        })
-        .filter((modelId) => modelId !== "");
-
-      const aliasModelIds = Object.values(modelAliases || {})
-        .filter((fullModel) => {
-          if (typeof fullModel !== "string" || !fullModel.includes("/")) return false;
-          return (
-            fullModel.startsWith(`${outputAlias}/`) ||
-            fullModel.startsWith(`${staticAlias}/`) ||
-            fullModel.startsWith(`${providerId}/`)
-          );
-        })
-        .map((fullModel) => {
-          if (fullModel.startsWith(`${outputAlias}/`)) {
-            return fullModel.slice(outputAlias.length + 1);
-          }
-          if (fullModel.startsWith(`${staticAlias}/`)) {
-            return fullModel.slice(staticAlias.length + 1);
-          }
-          if (fullModel.startsWith(`${providerId}/`)) {
-            return fullModel.slice(providerId.length + 1);
-          }
-          return fullModel;
-        })
-        .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
-
-      const mergedModelIds = Array.from(new Set([...modelIds, ...customModelIds, ...aliasModelIds]));
-
-      for (const modelId of mergedModelIds) {
-        // Resolve kind: prefer custom/live metadata, then static, then ID heuristics.
-        const customKind = customModelKindById.get(modelId);
-        const liveKind = liveModelKindById.get(modelId);
-        const kind = customKind || liveKind || staticModelKindById.get(modelId) || inferKindFromUnknownModelId(modelId);
-        // imageToText custom models stay in the LLM list (vision-capable chat models)
-        const allowAsLlm = kind === "imageToText" && kindFilter.includes(LLM_KIND);
-        if (!kindFilter.includes(kind) && !allowAsLlm) continue;
-        if (isDisabled(outputAlias, modelId) || isDisabled(staticAlias, modelId)) continue;
-
-        const model = {
-          id: `${outputAlias}/${modelId}`,
-          object: "model",
-          owned_by: outputAlias,
-        };
-        const caps = liveCapabilitiesById.get(modelId) || capabilitiesFromServiceKind(customKind || liveKind);
-        if (caps) model.capabilities = caps;
-        models.push(model);
-      }
-
-      // Web search/fetch — provider IS the model, expose as {alias}/search and/or {alias}/fetch with explicit kind
-      const providerInfo = AI_PROVIDERS[providerId];
-      if (kindFilter.includes("webSearch") && providerInfo?.searchConfig) {
-        models.push({
-          id: `${outputAlias}/search`,
-          object: "model",
-          kind: "webSearch",
-          owned_by: outputAlias,
-        });
-      }
-      if (kindFilter.includes("webFetch") && providerInfo?.fetchConfig) {
-        models.push({
-          id: `${outputAlias}/fetch`,
-          object: "model",
-          kind: "webFetch",
-          owned_by: outputAlias,
-        });
-      }
+    // Each connection's model resolution is independent and may perform a live
+    // upstream fetch (fetchCompatibleModelIds / LIVE_MODEL_RESOLVERS) with
+    // timeouts up to 30s. Running them sequentially made /v1/models latency the
+    // SUM of every provider's fetch. Resolve them concurrently and preserve the
+    // original connection order when flattening the results.
+    const perConnectionModels = await Promise.all(
+      Array.from(activeConnectionByProvider.entries()).map(([providerId, conn]) =>
+        buildConnectionModels(providerId, conn)
+      )
+    );
+    for (const connModels of perConnectionModels) {
+      for (const model of connModels) models.push(model);
     }
   }
 
@@ -456,6 +310,169 @@ export async function buildModelsList(kindFilter) {
   }
 
   return dedupedModels;
+
+  async function buildConnectionModels(providerId, conn) {
+    const connModels = [];
+    if (!providerMatchesKinds(providerId, kindFilter)) return connModels;
+
+    const staticAlias = PROVIDER_ID_TO_ALIAS[providerId] || providerId;
+    const outputAlias = (
+      conn?.providerSpecificData?.prefix
+      || getProviderAlias(providerId)
+      || staticAlias
+    ).trim();
+    const providerModels = PROVIDER_MODELS[staticAlias] || [];
+    const enabledModels = conn?.providerSpecificData?.enabledModels;
+    const hasExplicitEnabledModels =
+      Array.isArray(enabledModels) && enabledModels.length > 0;
+    const isCompatibleProvider =
+      isOpenAICompatibleProvider(providerId) || isAnthropicCompatibleProvider(providerId);
+
+    // Build kind lookup for static models so we can filter even when only IDs are exposed
+    const staticModelKindById = new Map(
+      providerModels.map((m) => [m.id, modelKind(m)])
+    );
+    let liveModelKindById = new Map();
+    let liveCapabilitiesById = new Map();
+
+    let rawModelIds = hasExplicitEnabledModels
+      ? Array.from(
+          new Set(
+            enabledModels.filter(
+              (modelId) => typeof modelId === "string" && modelId.trim() !== "",
+            ),
+          ),
+        )
+      : providerModels.map((model) => model.id);
+
+    if (isCompatibleProvider && rawModelIds.length === 0 && !UPSTREAM_CONNECTION_RE.test(providerId)) {
+      rawModelIds = await fetchCompatibleModelIds(conn);
+    }
+
+    // Config-driven live catalog override (e.g. Kiro returns dynamic
+    // -thinking/-agentic variants per account). On failure, fall back to
+    // whatever rawModelIds already holds.
+    const liveResolver = LIVE_MODEL_RESOLVERS[providerId];
+    if (liveResolver && !hasExplicitEnabledModels) {
+      try {
+        const live = await liveResolver(conn);
+        if (live?.models?.length) {
+          rawModelIds = live.models.map((m) => m.id);
+          liveModelKindById = new Map(
+            live.models
+              .filter((m) => m?.id)
+              .map((m) => [m.id, modelKind(m)])
+          );
+          liveCapabilitiesById = new Map(
+            live.models
+              .filter((m) => m?.id && m.capabilities)
+              .map((m) => [m.id, m.capabilities])
+          );
+        }
+      } catch (err) {
+        console.log(`Live model fetch failed for ${providerId}: ${err?.message || err}`);
+      }
+    }
+
+    const modelIds = rawModelIds
+      .map((modelId) => {
+        if (modelId.startsWith(`${outputAlias}/`)) {
+          return modelId.slice(outputAlias.length + 1);
+        }
+        if (modelId.startsWith(`${staticAlias}/`)) {
+          return modelId.slice(staticAlias.length + 1);
+        }
+        if (modelId.startsWith(`${providerId}/`)) {
+          return modelId.slice(providerId.length + 1);
+        }
+        return modelId;
+      })
+      .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
+
+    const customModelKindById = new Map();
+    const customModelIds = customModels
+      .filter((m) => {
+        if (!m?.id) return false;
+        const kind = getModelKind(m) || LLM_KIND;
+        // imageToText custom models are vision-capable chat models: expose them
+        // both in the default LLM list and in /v1/models/image-to-text.
+        if (!kindFilter.includes(kind) && !(kind === "imageToText" && kindFilter.includes(LLM_KIND))) return false;
+        const alias = m.providerAlias;
+        return alias === staticAlias || alias === outputAlias || alias === providerId;
+      })
+      .map((m) => {
+        const modelId = String(m.id).trim();
+        if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
+        return modelId;
+      })
+      .filter((modelId) => modelId !== "");
+
+    const aliasModelIds = Object.values(modelAliases || {})
+      .filter((fullModel) => {
+        if (typeof fullModel !== "string" || !fullModel.includes("/")) return false;
+        return (
+          fullModel.startsWith(`${outputAlias}/`) ||
+          fullModel.startsWith(`${staticAlias}/`) ||
+          fullModel.startsWith(`${providerId}/`)
+        );
+      })
+      .map((fullModel) => {
+        if (fullModel.startsWith(`${outputAlias}/`)) {
+          return fullModel.slice(outputAlias.length + 1);
+        }
+        if (fullModel.startsWith(`${staticAlias}/`)) {
+          return fullModel.slice(staticAlias.length + 1);
+        }
+        if (fullModel.startsWith(`${providerId}/`)) {
+          return fullModel.slice(providerId.length + 1);
+        }
+        return fullModel;
+      })
+      .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
+
+    const mergedModelIds = Array.from(new Set([...modelIds, ...customModelIds, ...aliasModelIds]));
+
+    for (const modelId of mergedModelIds) {
+      // Resolve kind: prefer custom/live metadata, then static, then ID heuristics.
+      const customKind = customModelKindById.get(modelId);
+      const liveKind = liveModelKindById.get(modelId);
+      const kind = customKind || liveKind || staticModelKindById.get(modelId) || inferKindFromUnknownModelId(modelId);
+      // imageToText custom models stay in the LLM list (vision-capable chat models)
+      const allowAsLlm = kind === "imageToText" && kindFilter.includes(LLM_KIND);
+      if (!kindFilter.includes(kind) && !allowAsLlm) continue;
+      if (isDisabled(outputAlias, modelId) || isDisabled(staticAlias, modelId)) continue;
+
+      const model = {
+        id: `${outputAlias}/${modelId}`,
+        object: "model",
+        owned_by: outputAlias,
+      };
+      const caps = liveCapabilitiesById.get(modelId) || capabilitiesFromServiceKind(customKind || liveKind);
+      if (caps) model.capabilities = caps;
+      connModels.push(model);
+    }
+
+    // Web search/fetch — provider IS the model, expose as {alias}/search and/or {alias}/fetch with explicit kind
+    const providerInfo = AI_PROVIDERS[providerId];
+    if (kindFilter.includes("webSearch") && providerInfo?.searchConfig) {
+      connModels.push({
+        id: `${outputAlias}/search`,
+        object: "model",
+        kind: "webSearch",
+        owned_by: outputAlias,
+      });
+    }
+    if (kindFilter.includes("webFetch") && providerInfo?.fetchConfig) {
+      connModels.push({
+        id: `${outputAlias}/fetch`,
+        object: "model",
+        kind: "webFetch",
+        owned_by: outputAlias,
+      });
+    }
+
+    return connModels;
+  }
 }
 
 /**


### PR DESCRIPTION
## Why `/v1/models` is so slow

`GET /v1/models` calls `buildModelsList()`, which iterates every active provider connection in a **sequential** `for...of` loop (`src/app/api/v1/models/route.js`):

```js
for (const [providerId, conn] of activeConnectionByProvider.entries()) {
  ...
  if (isCompatibleProvider && rawModelIds.length === 0 && ...) {
    rawModelIds = await fetchCompatibleModelIds(conn);   // network, 5s timeout
  }
  const liveResolver = LIVE_MODEL_RESOLVERS[providerId];
  if (liveResolver && !hasExplicitEnabledModels) {
    const live = await liveResolver(conn);               // network, up to 30s
  }
  ...
}
```

Each iteration can fire a live upstream HTTP request:

| resolver | upstream | timeout |
|---|---|---|
| `resolveKiroModels` | `q.<region>.amazonaws.com/ListAvailableModels` | **30s** |
| `resolveKimchiModels` | `llm.kimchi.dev` | 20s |
| `resolveQoderModels` | Qoder catalog | 15s |
| `resolveCopilotModels` | `api.githubcopilot.com/models` | 10s |
| `resolveClinepassModels` | `api.cline.bot/api/v1/models` | 5s |
| `fetchCompatibleModelIds` | user base URL | 5s |

Because they run one after another, **total latency is the SUM of every connected provider's fetch**. On a cold cache (or whenever one upstream is slow/hanging), a handful of connected providers stacks into tens of seconds — and the worst case approaches ~80s if several time out in series. The per-resolver in-memory caches only help *after* the first slow call and reset on restart / TTL expiry.

## The fix

These per-connection fetches are fully independent — nothing in one iteration depends on another; they only push into a shared `models` array at the end. So:

- Extract the loop body into `buildConnectionModels(providerId, conn)` returning a local list.
- Run all connections via `Promise.all(...)` and flatten the results **in the original connection order** before the existing dedup pass.

This turns total latency from the **sum** of provider fetches into the **max** of a single one, with byte-identical output.

## Behavior preserved

Ordering and dedup are unchanged — `Promise.all` preserves array order, and results are flattened in connection order before the first-wins dedup. Per-provider error handling is unchanged (the live-resolver `try/catch` still lives inside the extracted function). Verified with a standalone simulation:

```
OLD  time≈ 1504 ms  order: kiro/a,kiro/b,dup/x,qoder/a,qoder/b,kimchi/a,kimchi/b
NEW  time≈  502 ms  order: kiro/a,kiro/b,dup/x,qoder/a,qoder/b,kimchi/a,kimchi/b
ORDER IDENTICAL: true
```

The diff looks large only because the extracted block is dedented one level; the logic is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)