### PR TITLE
fix(volcengine-ark): clamp Kimi max_tokens to 32768 endpoint cap

### DIFF
--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -15,6 +15,12 @@ const STRIP_RULES = [
   // Cloudflare Workers AI: content must be plain string, rejects OpenAI content-part array (#1926)
   { provider: "cloudflare-ai", flattenContent: true },
   { provider: "volcengine-ark", match: /glm-5/i, clampToModelMaxOutput: true },
+  // VolcEngine Ark caps the Kimi family at max_tokens <= 32768, but the model's
+  // advertised ceiling is far higher (Kimi-K2.7-Code resolves to maxOutput 262144),
+  // so clampToModelMaxOutput alone leaves it uncapped and the request 400s with
+  // "integer above maximum value, expected <= 32768". Pin an explicit endpoint cap;
+  // min() with the model ceiling still applies if a variant's own limit is lower.
+  { provider: "volcengine-ark", match: /kimi/i, maxOutputCap: 32768, clampToModelMaxOutput: true },
 ];
 
 // Test a rule's match (regex or predicate) against the model id.
@@ -48,9 +54,17 @@ export function stripUnsupportedParams(provider, model, body) {
         }
       }
     }
-    if (rule.clampToModelMaxOutput) {
-      const ceiling = getCapabilitiesForModel(provider, model).maxOutput;
-      if (Number.isFinite(ceiling) && ceiling > 0) {
+    if (rule.clampToModelMaxOutput || Number.isFinite(rule.maxOutputCap)) {
+      const modelCeiling = getCapabilitiesForModel(provider, model).maxOutput;
+      const candidates = [];
+      if (rule.clampToModelMaxOutput && Number.isFinite(modelCeiling) && modelCeiling > 0) {
+        candidates.push(modelCeiling);
+      }
+      if (Number.isFinite(rule.maxOutputCap) && rule.maxOutputCap > 0) {
+        candidates.push(rule.maxOutputCap);
+      }
+      if (candidates.length > 0) {
+        const ceiling = Math.min(...candidates);
         clampNumber(body, "max_tokens", ceiling);
         clampNumber(body, "max_completion_tokens", ceiling);
         clampNumber(body, "max_output_tokens", ceiling);


### PR DESCRIPTION
## The error

Requests to VolcEngine Ark for Kimi models fail with a 400 whenever `max_tokens` exceeds 32768:

```
[PROXY] VOLCENGINE-ARK | Kimi-K2.7-Code
[ERROR] [400]: {"error":{"code":"InvalidParameter","message":"The parameter `max_tokens`
specified in the request are not valid: integer above maximum value, expected a value
<= 32768, but got 256693 instead.","param":"max_tokens","type":"BadRequest"}}
```

## Root cause

On VolcEngine Ark the **Kimi family is capped at `max_tokens <= 32768`**, but the model's advertised ceiling is much higher — `Kimi-K2.7-Code` resolves to `maxOutput: 262144` in `capabilities.js`. Nothing trims the incoming `max_tokens` (256693) down to what the endpoint accepts, so it 400s.

There's a clamp rule in `open-sse/translator/concerns/paramSupport.js`, but it only matches `/glm-5/i`:

```js
{ provider: "volcengine-ark", match: /glm-5/i, clampToModelMaxOutput: true },
```

So Kimi models are never clamped.

This is **model-specific, not endpoint-wide.** The glm-5 rule is correct and must stay as-is: glm-5.x on Ark legitimately allows up to 128000 (well above 32768), so a blanket provider-wide 32768 cap would wrongly shrink glm-5.2 and other larger-output models.

## The fix

Add a **Kimi-scoped** rule with an explicit numeric cap, and leave the glm-5 rule untouched:

```js
{ provider: "volcengine-ark", match: /glm-5/i, clampToModelMaxOutput: true },
{ provider: "volcengine-ark", match: /kimi/i, maxOutputCap: 32768, clampToModelMaxOutput: true },
```

The clamp mechanism is extended to accept a numeric `maxOutputCap` and combine it with the model's own ceiling via `min(...)`, so a Kimi variant whose own limit is lower than 32768 is still respected. Applies to `max_tokens`, `max_completion_tokens`, and `max_output_tokens`.

## Verification

Importing the real module and reproducing the reported case plus regressions:

```
PASS  Kimi-K2.7-Code         256693 -> 32768    (the reported failure)
PASS  Kimi-K2.6              100000 -> 32768
PASS  glm-5.2                256693 -> 128000   (existing clamp preserved, stays > 32k)
PASS  GLM-5.1                256693 -> 128000
PASS  Doubao-Seed-2.0-Code    20000 ->  20000   (no rule, untouched)
PASS  DeepSeek-V4-Pro         50000 ->  50000   (no rule, untouched)
PASS  Kimi-K2.7-Code           5000 ->   5000   (already under cap, untouched)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)