### PR TITLE
fix(antigravity): retry empty streams, surface aborted turns, finalize truncated Claude streams

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -333,7 +333,16 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
         reexecute,
         signal: streamController.signal,
         log,
-        onExhausted: (reason) => onUpstreamEmptyExhausted?.(formatProviderError(new Error(reason), provider, model, HTTP_STATUS.BAD_GATEWAY)),
+        onExhausted: (reason, { upstreamError } = {}) => {
+          if (!onUpstreamEmptyExhausted) return;
+          // Quota-style exhaustion carries the reset time only inside the error
+          // message ("Your quota will reset after 2h7m23s") — bench precisely.
+          const resetMs = executor.parseRetryFromErrorMessage?.(upstreamError?.message || reason);
+          return onUpstreamEmptyExhausted(
+            formatProviderError(new Error(reason), provider, model, HTTP_STATUS.BAD_GATEWAY),
+            resetMs ? Date.now() + resetMs : undefined
+          );
+        },
       }),
       { status: providerResponse.status, headers: providerResponse.headers }
     );

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -18,6 +18,7 @@ import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDeta
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
+import { probeSSEStream, replayStream, EMPTY_STREAM_MAX_RETRIES, EMPTY_STREAM_BASE_DELAY_MS } from "./chatCore/emptyStreamGuard.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
@@ -307,6 +308,59 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     console.log(`${COLORS.red}[ERROR] ${errMsg}${COLORS.reset}`);
     reqLogger.logError(new Error(message), finalBody || translatedBody);
     return createErrorResult(statusCode, errMsg, resetsAtMs);
+  }
+
+  // Antigravity empty-stream guard: probe the upstream SSE before anything is
+  // sent to the client. Gemini occasionally answers 200 with no usable output
+  // (empty candidates / thought-only / bare STOP) or aborts the turn with
+  // MALFORMED_FUNCTION_CALL before emitting content — both usually succeed on a
+  // plain retry with the identical request. On exhaustion return 502 so the
+  // account/combo fallback chain engages instead of the client hanging on an
+  // empty stream (#2188, #2229, #2259).
+  if (provider === "antigravity" && stream && providerResponse.body) {
+    for (let attempt = 0; ; attempt++) {
+      const probe = await probeSSEStream(providerResponse.body, { signal: streamController.signal });
+      if (probe.verdict === "aborted") {
+        trackPendingRequest(model, provider, connectionId, false, true);
+        return createErrorResult(499, "Request aborted");
+      }
+      if (probe.verdict === "ok") {
+        providerResponse = new Response(replayStream(probe.buffered, probe.reader), {
+          status: providerResponse.status,
+          headers: providerResponse.headers,
+        });
+        break;
+      }
+
+      log?.warn?.("STREAM", `${provider.toUpperCase()} | ${probe.verdict}${probe.reason ? ` (${probe.reason})` : ""} | attempt ${attempt + 1}/${EMPTY_STREAM_MAX_RETRIES + 1}`);
+      if (attempt >= EMPTY_STREAM_MAX_RETRIES) {
+        trackPendingRequest(model, provider, connectionId, false, true);
+        appendRequestLog({ model, provider, connectionId, status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` }).catch(() => { });
+        const errMsg = formatProviderError(
+          new Error(`empty response from upstream (${probe.verdict}${probe.reason ? `: ${probe.reason}` : ""}) after ${attempt + 1} attempts`),
+          provider, model, HTTP_STATUS.BAD_GATEWAY
+        );
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, EMPTY_STREAM_BASE_DELAY_MS * 2 ** attempt));
+      let retryResult;
+      try {
+        retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+      } catch (error) {
+        trackPendingRequest(model, provider, connectionId, false, true);
+        if (error.name === "AbortError") return createErrorResult(499, "Request aborted");
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, formatProviderError(error, provider, model, HTTP_STATUS.BAD_GATEWAY));
+      }
+      if (!retryResult.response.ok) {
+        trackPendingRequest(model, provider, connectionId, false, true);
+        const { statusCode, message, resetsAtMs } = await parseUpstreamError(retryResult.response, executor);
+        return createErrorResult(statusCode, formatProviderError(new Error(message), provider, model, statusCode), resetsAtMs);
+      }
+      providerResponse = retryResult.response;
+      providerUrl = retryResult.url;
+      finalBody = retryResult.transformedBody;
+    }
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess };

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -18,7 +18,7 @@ import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDeta
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
-import { probeSSEStream, replayStream, EMPTY_STREAM_MAX_RETRIES, EMPTY_STREAM_BASE_DELAY_MS } from "./chatCore/emptyStreamGuard.js";
+import { createEmptyRetryStream } from "./chatCore/emptyStreamGuard.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
@@ -36,7 +36,7 @@ import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, onUpstreamEmptyExhausted, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
 
@@ -310,57 +310,33 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  // Antigravity empty-stream guard: probe the upstream SSE before anything is
-  // sent to the client. Gemini occasionally answers 200 with no usable output
-  // (empty candidates / thought-only / bare STOP) or aborts the turn with
-  // MALFORMED_FUNCTION_CALL before emitting content — both usually succeed on a
-  // plain retry with the identical request. On exhaustion return 502 so the
-  // account/combo fallback chain engages instead of the client hanging on an
-  // empty stream (#2188, #2229, #2259).
+  // Antigravity empty-stream guard — oh-my-pi parity: bytes (thinking included)
+  // stream to the client live; emptiness is judged per upstream attempt and an
+  // empty attempt is retried in-stream with the identical request, spliced into
+  // the same client message (see emptyStreamGuard.js). Exhaustion surfaces as an
+  // in-stream error event (retryable by Claude Code); onUpstreamEmptyExhausted
+  // lets the caller bench the account so the client's retry rotates to the next
+  // one (#2188, #2229, #2250, #2259).
   if (provider === "antigravity" && stream && providerResponse.body) {
-    for (let attempt = 0; ; attempt++) {
-      const probe = await probeSSEStream(providerResponse.body, { signal: streamController.signal });
-      if (probe.verdict === "aborted") {
-        trackPendingRequest(model, provider, connectionId, false, true);
-        return createErrorResult(499, "Request aborted");
-      }
-      if (probe.verdict === "ok") {
-        providerResponse = new Response(replayStream(probe.buffered, probe.reader), {
-          status: providerResponse.status,
-          headers: providerResponse.headers,
-        });
-        break;
-      }
-
-      log?.warn?.("STREAM", `${provider.toUpperCase()} | ${probe.verdict}${probe.reason ? ` (${probe.reason})` : ""} | attempt ${attempt + 1}/${EMPTY_STREAM_MAX_RETRIES + 1}`);
-      if (attempt >= EMPTY_STREAM_MAX_RETRIES) {
-        trackPendingRequest(model, provider, connectionId, false, true);
-        appendRequestLog({ model, provider, connectionId, status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` }).catch(() => { });
-        const errMsg = formatProviderError(
-          new Error(`empty response from upstream (${probe.verdict}${probe.reason ? `: ${probe.reason}` : ""}) after ${attempt + 1} attempts`),
-          provider, model, HTTP_STATUS.BAD_GATEWAY
-        );
-        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, EMPTY_STREAM_BASE_DELAY_MS * 2 ** attempt));
-      let retryResult;
-      try {
-        retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
-      } catch (error) {
-        trackPendingRequest(model, provider, connectionId, false, true);
-        if (error.name === "AbortError") return createErrorResult(499, "Request aborted");
-        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, formatProviderError(error, provider, model, HTTP_STATUS.BAD_GATEWAY));
-      }
+    const reexecute = async () => {
+      const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
       if (!retryResult.response.ok) {
-        trackPendingRequest(model, provider, connectionId, false, true);
-        const { statusCode, message, resetsAtMs } = await parseUpstreamError(retryResult.response, executor);
-        return createErrorResult(statusCode, formatProviderError(new Error(message), provider, model, statusCode), resetsAtMs);
+        const { statusCode, message } = await parseUpstreamError(retryResult.response, executor);
+        throw new Error(`[${statusCode}] ${message}`);
       }
-      providerResponse = retryResult.response;
-      providerUrl = retryResult.url;
-      finalBody = retryResult.transformedBody;
-    }
+      if (!retryResult.response.body) throw new Error("upstream returned no body");
+      return retryResult.response.body;
+    };
+    providerResponse = new Response(
+      createEmptyRetryStream({
+        body: providerResponse.body,
+        reexecute,
+        signal: streamController.signal,
+        log,
+        onExhausted: (reason) => onUpstreamEmptyExhausted?.(formatProviderError(new Error(reason), provider, model, HTTP_STATUS.BAD_GATEWAY)),
+      }),
+      { status: providerResponse.status, headers: providerResponse.headers }
+    );
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess };

--- a/open-sse/handlers/chatCore/emptyStreamGuard.js
+++ b/open-sse/handlers/chatCore/emptyStreamGuard.js
@@ -7,7 +7,7 @@
 // is sent to the client, so a bad attempt can be retried in place with the
 // identical request; a healthy stream is released on its first meaningful
 // part and replayed byte-identically.
-import { GEMINI_ERROR_FINISH_REASONS } from "../../translator/schema/finishReasons.js";
+import { GEMINI_ERROR_FINISH_REASONS, GEMINI_CONTENT_FILTER_FINISH_REASONS } from "../../translator/schema/finishReasons.js";
 import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
 
 // Mirrors oh-my-pi's empty-response policy: 2 retries, 500ms * 2^attempt backoff.
@@ -29,7 +29,9 @@ function isMeaningfulPart(part) {
  * chunk so a healthy stream can be replayed without loss.
  *
  * Verdicts:
- * - { verdict: "ok", buffered, reader }        first meaningful part seen
+ * - { verdict: "ok", buffered, reader }        first meaningful part seen, or a
+ *   deterministic content block (promptFeedback / safety finish) the translator
+ *   must close as content_filter — never retried
  * - { verdict: "empty", buffered }             stream ended with nothing meaningful
  * - { verdict: "error_finish", reason, buffered } aborted (MALFORMED_FUNCTION_CALL, ...)
  *   or an {error:{...}} object arrived before any meaningful part
@@ -92,6 +94,13 @@ export async function probeSSEStream(body, { signal, stallTimeoutMs = STREAM_STA
         return { verdict: "error_finish", reason: (response.error || parsed.error).status || "error", buffered };
       }
 
+      // Prompt blocked by policy: deterministic for this prompt — a retry resends
+      // the same blocked prompt, wasting quota and benching the account on
+      // exhaustion. Release instead; the translator closes it as content_filter.
+      if (!response.candidates?.length && response.promptFeedback?.blockReason) {
+        return { verdict: "ok", buffered, reader };
+      }
+
       const candidate = response.candidates?.[0];
       if (!candidate) continue;
 
@@ -102,6 +111,11 @@ export async function probeSSEStream(body, { signal, stallTimeoutMs = STREAM_STA
       const finishReason = candidate.finishReason && String(candidate.finishReason).toUpperCase();
       if (finishReason && GEMINI_ERROR_FINISH_REASONS.has(finishReason)) {
         return { verdict: "error_finish", reason: finishReason, buffered };
+      }
+      // Safety-family finishes are content blocks, not flakes (same policy as
+      // promptFeedback above): release so the translator closes as content_filter.
+      if (finishReason && GEMINI_CONTENT_FILTER_FINISH_REASONS.has(finishReason)) {
+        return { verdict: "ok", buffered, reader };
       }
       // Benign finish with nothing meaningful streamed → keep reading; if the
       // stream ends here it's the empty-response failure.

--- a/open-sse/handlers/chatCore/emptyStreamGuard.js
+++ b/open-sse/handlers/chatCore/emptyStreamGuard.js
@@ -16,7 +16,14 @@ export const EMPTY_STREAM_BASE_DELAY_MS = 500;
 
 // A part is meaningful when it carries output the client can act on: a tool
 // call, inline data, or non-whitespace visible text. Thought-only parts are
-// not — thinking that never produced an answer IS the empty-response failure.
+// not — thinking that never produced an answer IS the empty-response failure
+// (#2229). Deliberate trade-off: the client receives nothing (not even
+// message_start) until the first meaningful part, so a long thinking phase
+// renders nothing and then replays in a burst. In exchange, retries are
+// invisible and byte-clean, and thought-only empties stay retryable. oh-my-pi
+// makes the opposite call — it streams thinking live and accepts duplicated
+// thinking blocks when an empty attempt is retried. The per-read stall escape
+// below bounds the worst-case wait.
 function isMeaningfulPart(part) {
   if (part.functionCall) return true;
   if (part.inlineData?.data || part.inline_data?.data) return true;
@@ -50,14 +57,21 @@ export async function probeSSEStream(body, { signal, stallTimeoutMs = STREAM_STA
     }
 
     let readResult;
+    let stallTimer;
     try {
       // Defensive stall escape: a byte-silent upstream must not hang the probe.
       readResult = await Promise.race([
         reader.read(),
-        new Promise((resolve) => setTimeout(() => resolve({ __stalled: true }), stallTimeoutMs)),
+        new Promise((resolve) => { stallTimer = setTimeout(() => resolve({ __stalled: true }), stallTimeoutMs); }),
       ]);
     } catch {
+      // A client abort rejects the pending read. Distinguish it from a truncated
+      // upstream, or the caller retries (or 502s + benches the account) a request
+      // nobody is waiting for.
+      if (signal?.aborted) return { verdict: "aborted" };
       return { verdict: "empty", buffered };
+    } finally {
+      clearTimeout(stallTimer);
     }
     if (readResult.__stalled) {
       try { reader.cancel(); } catch { /* already closed */ }
@@ -91,6 +105,8 @@ export async function probeSSEStream(body, { signal, stallTimeoutMs = STREAM_STA
       if (!response || typeof response !== "object") continue;
 
       if (response.error || parsed.error) {
+        // Discarding the response: release the upstream connection.
+        try { reader.cancel(); } catch { /* already closed */ }
         return { verdict: "error_finish", reason: (response.error || parsed.error).status || "error", buffered };
       }
 
@@ -110,6 +126,7 @@ export async function probeSSEStream(body, { signal, stallTimeoutMs = STREAM_STA
 
       const finishReason = candidate.finishReason && String(candidate.finishReason).toUpperCase();
       if (finishReason && GEMINI_ERROR_FINISH_REASONS.has(finishReason)) {
+        try { reader.cancel(); } catch { /* already closed */ }
         return { verdict: "error_finish", reason: finishReason, buffered };
       }
       // Safety-family finishes are content blocks, not flakes (same policy as

--- a/open-sse/handlers/chatCore/emptyStreamGuard.js
+++ b/open-sse/handlers/chatCore/emptyStreamGuard.js
@@ -1,13 +1,22 @@
-// Empty-stream guard for Antigravity: Gemini occasionally returns a 200 SSE
-// stream that carries no usable output — no candidates at all, thought-only
-// parts, or a benign STOP finish with empty text — or aborts the turn with an
-// error finishReason (MALFORMED_FUNCTION_CALL) before emitting anything.
+// Empty-stream guard for Antigravity — oh-my-pi parity.
+//
+// Gemini occasionally answers HTTP 200 with a stream that carries no usable
+// output (no candidates at all, thought-only parts, a bare STOP with empty
+// text) or aborts the turn (MALFORMED_FUNCTION_CALL) before emitting anything.
 // Delivered as-is the client receives a blank turn and silently halts
-// (#2188, #2229, #2259). The guard probes the upstream stream before anything
-// is sent to the client, so a bad attempt can be retried in place with the
-// identical request; a healthy stream is released on its first meaningful
-// part and replayed byte-identically.
-import { GEMINI_ERROR_FINISH_REASONS, GEMINI_CONTENT_FILTER_FINISH_REASONS } from "../../translator/schema/finishReasons.js";
+// (#2188, #2229, #2250, #2259).
+//
+// Mirrors oh-my-pi: every byte — thinking included — streams to the client
+// live; emptiness is judged per upstream attempt, after the fact. An attempt
+// that ends without meaningful content has its terminal event withheld and is
+// retried in place with the identical request; the retried attempt splices
+// into the same client stream (the translator inits its message once, so the
+// splice continues the same client message). Accepted wart, same as oh-my-pi:
+// the client may see thinking from a discarded attempt followed by the retry's
+// thinking inside one message. On exhaustion an {error:{...}} event is emitted
+// in-stream — the gemini translator turns it into the client-facing error
+// finish, which Anthropic clients treat as retryable.
+import { GEMINI_FINISH, GEMINI_ERROR_FINISH_REASONS, GEMINI_CONTENT_FILTER_FINISH_REASONS } from "../../translator/schema/finishReasons.js";
 import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
 
 // Mirrors oh-my-pi's empty-response policy: 2 retries, 500ms * 2^attempt backoff.
@@ -17,154 +26,226 @@ export const EMPTY_STREAM_BASE_DELAY_MS = 500;
 // A part is meaningful when it carries output the client can act on: a tool
 // call, inline data, or non-whitespace visible text. Thought-only parts are
 // not — thinking that never produced an answer IS the empty-response failure
-// (#2229). Deliberate trade-off: the client receives nothing (not even
-// message_start) until the first meaningful part, so a long thinking phase
-// renders nothing and then replays in a burst. In exchange, retries are
-// invisible and byte-clean, and thought-only empties stay retryable. oh-my-pi
-// makes the opposite call — it streams thinking live and accepts duplicated
-// thinking blocks when an empty attempt is retried. The per-read stall escape
-// below bounds the worst-case wait.
-function isMeaningfulPart(part) {
+// (#2229). Thought parts still stream to the client live; they just don't mark
+// the attempt as non-empty.
+export function isMeaningfulPart(part) {
   if (part.functionCall) return true;
   if (part.inlineData?.data || part.inline_data?.data) return true;
   if (part.thought === true) return false;
   return typeof part.text === "string" && part.text.trim().length > 0;
 }
 
-/**
- * Read the upstream SSE body until a verdict is reached, buffering every raw
- * chunk so a healthy stream can be replayed without loss.
- *
- * Verdicts:
- * - { verdict: "ok", buffered, reader }        first meaningful part seen, or a
- *   deterministic content block (promptFeedback / safety finish) the translator
- *   must close as content_filter — never retried
- * - { verdict: "empty", buffered }             stream ended with nothing meaningful
- * - { verdict: "error_finish", reason, buffered } aborted (MALFORMED_FUNCTION_CALL, ...)
- *   or an {error:{...}} object arrived before any meaningful part
- * - { verdict: "aborted" }                     client disconnected
- */
-export async function probeSSEStream(body, { signal, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS } = {}) {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  const buffered = [];
-  let lineBuffer = "";
+// Decide what to do with one parsed SSE event.
+// - forward: pass the original line through (optionally marking the stream
+//   terminal so the attempt is never retried)
+// - hold: withhold it — it is the terminal of an empty attempt; the message
+//   must stay open so the retried attempt can splice in.
+function classifyEvent(parsed, meaningfulSeen) {
+  // Antigravity wrapper
+  const response = parsed.response || parsed;
+  if (!response || typeof response !== "object") return { action: "forward" };
 
-  while (true) {
-    if (signal?.aborted) {
-      try { reader.cancel(); } catch { /* already closed */ }
-      return { verdict: "aborted" };
-    }
-
-    let readResult;
-    let stallTimer;
-    try {
-      // Defensive stall escape: a byte-silent upstream must not hang the probe.
-      readResult = await Promise.race([
-        reader.read(),
-        new Promise((resolve) => { stallTimer = setTimeout(() => resolve({ __stalled: true }), stallTimeoutMs); }),
-      ]);
-    } catch {
-      // A client abort rejects the pending read. Distinguish it from a truncated
-      // upstream, or the caller retries (or 502s + benches the account) a request
-      // nobody is waiting for.
-      if (signal?.aborted) return { verdict: "aborted" };
-      return { verdict: "empty", buffered };
-    } finally {
-      clearTimeout(stallTimer);
-    }
-    if (readResult.__stalled) {
-      try { reader.cancel(); } catch { /* already closed */ }
-      return { verdict: "empty", buffered };
-    }
-
-    const { done, value } = readResult;
-    if (done) return { verdict: "empty", buffered };
-
-    buffered.push(value);
-    lineBuffer += decoder.decode(value, { stream: true });
-
-    const lines = lineBuffer.split("\n");
-    lineBuffer = lines.pop(); // keep the trailing partial line
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith("data:")) continue;
-      const payload = trimmed.slice(5).trim();
-      if (!payload || payload === "[DONE]") continue;
-
-      let parsed;
-      try {
-        parsed = JSON.parse(payload);
-      } catch {
-        continue; // partial JSON split across reads — wait for more bytes
-      }
-
-      // Antigravity wrapper
-      const response = parsed.response || parsed;
-      if (!response || typeof response !== "object") continue;
-
-      if (response.error || parsed.error) {
-        // Discarding the response: release the upstream connection.
-        try { reader.cancel(); } catch { /* already closed */ }
-        return { verdict: "error_finish", reason: (response.error || parsed.error).status || "error", buffered };
-      }
-
-      // Prompt blocked by policy: deterministic for this prompt — a retry resends
-      // the same blocked prompt, wasting quota and benching the account on
-      // exhaustion. Release instead; the translator closes it as content_filter.
-      if (!response.candidates?.length && response.promptFeedback?.blockReason) {
-        return { verdict: "ok", buffered, reader };
-      }
-
-      const candidate = response.candidates?.[0];
-      if (!candidate) continue;
-
-      for (const part of candidate.content?.parts || []) {
-        if (isMeaningfulPart(part)) return { verdict: "ok", buffered, reader };
-      }
-
-      const finishReason = candidate.finishReason && String(candidate.finishReason).toUpperCase();
-      if (finishReason && GEMINI_ERROR_FINISH_REASONS.has(finishReason)) {
-        try { reader.cancel(); } catch { /* already closed */ }
-        return { verdict: "error_finish", reason: finishReason, buffered };
-      }
-      // Safety-family finishes are content blocks, not flakes (same policy as
-      // promptFeedback above): release so the translator closes as content_filter.
-      if (finishReason && GEMINI_CONTENT_FILTER_FINISH_REASONS.has(finishReason)) {
-        return { verdict: "ok", buffered, reader };
-      }
-      // Benign finish with nothing meaningful streamed → keep reading; if the
-      // stream ends here it's the empty-response failure.
-    }
+  const errorObj = response.error || parsed.error;
+  if (errorObj) {
+    // Embedded error object in a 200 stream. After content: forward — the
+    // translator closes the message with the error finish. Before content:
+    // withhold and retry (usually transient, e.g. RESOURCE_EXHAUSTED blips).
+    if (meaningfulSeen) return { action: "forward", terminal: true };
+    return { action: "hold", kind: "error_object", reason: errorObj.status || errorObj.message || "error" };
   }
+
+  // Prompt blocked by policy: deterministic for this prompt — never retried.
+  // Forward so the translator closes the stream as content_filter (#2188).
+  if (!response.candidates?.length && response.promptFeedback?.blockReason) {
+    return { action: "forward", terminal: true };
+  }
+
+  const candidate = response.candidates?.[0];
+  if (!candidate) return { action: "forward" }; // keep-alive / usage-only
+
+  let meaningful = false;
+  for (const part of candidate.content?.parts || []) {
+    if (isMeaningfulPart(part)) { meaningful = true; break; }
+  }
+
+  const finishReason = candidate.finishReason && String(candidate.finishReason).toUpperCase();
+  if (!finishReason) return { action: "forward", meaningful };
+
+  // Content blocks and token exhaustion are deterministic whatever the content
+  // — retrying re-runs the same outcome (oh-my-pi never retries these either).
+  if (GEMINI_CONTENT_FILTER_FINISH_REASONS.has(finishReason) || finishReason === GEMINI_FINISH.MAX_TOKENS) {
+    return { action: "forward", meaningful, terminal: true };
+  }
+
+  // Any other finish (bare STOP, MALFORMED_FUNCTION_CALL family, unknown) with
+  // content forwards normally — the translator emits the tool_calls upgrade or
+  // the error event. Without content it is the empty attempt's terminal.
+  if (meaningful || meaningfulSeen) return { action: "forward", meaningful, terminal: true };
+  return {
+    action: "hold",
+    kind: GEMINI_ERROR_FINISH_REASONS.has(finishReason) ? "error_finish" : "stop",
+    reason: finishReason,
+  };
 }
 
 /**
- * Rebuild a byte-identical body: replay the probed prefix, then pump the rest
- * of the upstream reader.
+ * Wrap the upstream SSE body so empty attempts are retried in-stream.
+ *
+ * @param {ReadableStream} options.body       attempt 1's body
+ * @param {() => Promise<ReadableStream>} options.reexecute  re-issue the
+ *   identical request; resolves to the new attempt's body, throws on failure
+ * @param {AbortSignal} options.signal        client-disconnect signal
+ * @param {object} options.log
+ * @param {number} options.stallTimeoutMs     per-read stall escape
+ * @param {(reason: string) => void} options.onExhausted  observer for "every
+ *   attempt came back empty" (e.g. bench the account so client retries rotate)
+ * @returns {ReadableStream} byte stream for the SSE transform pipeline
  */
-export function replayStream(buffered, reader) {
+export function createEmptyRetryStream({ body, reexecute, signal, log, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, baseDelayMs = EMPTY_STREAM_BASE_DELAY_MS, onExhausted }) {
+  const encoder = new TextEncoder();
+  let currentReader = null;
+  let downstreamGone = false;
+
   return new ReadableStream({
     async start(controller) {
-      for (const chunk of buffered) controller.enqueue(chunk);
-      if (!reader) {
-        controller.close();
-        return;
-      }
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          controller.enqueue(value);
+      currentReader = body.getReader();
+      let meaningfulSeen = false;
+      let lastHeld = null; // last withheld terminal, kept for the exhaustion event
+
+      const emit = (text) => {
+        if (downstreamGone) return;
+        try { controller.enqueue(encoder.encode(text)); } catch { downstreamGone = true; }
+      };
+      const closeStream = () => {
+        if (downstreamGone) return;
+        try { controller.close(); } catch { /* already closed */ }
+      };
+      const abortStream = () => {
+        // cancel() rejects when the stream already errored — swallow the promise too
+        try { currentReader.cancel().catch(() => { }); } catch { /* already closed */ }
+        if (downstreamGone) return;
+        const err = new Error("Request aborted");
+        err.name = "AbortError";
+        try { controller.error(err); } catch { /* already closed */ }
+      };
+      const exhaust = (reason) => {
+        try { Promise.resolve(onExhausted?.(reason)).catch(() => { }); } catch { /* observer must not break the stream */ }
+        // Re-emit the real upstream error when we held one (true status/message,
+        // e.g. RESOURCE_EXHAUSTED); otherwise synthesize an embedded error. The
+        // gemini translator converts either into the client-facing error finish.
+        const line = lastHeld?.kind === "error_object"
+          ? lastHeld.line
+          : `data: ${JSON.stringify({ error: { code: 502, status: "EMPTY_RESPONSE", message: reason } })}`;
+        emit(`${line}\n\n`);
+        closeStream();
+      };
+
+      for (let attempt = 0; ; attempt++) {
+        const decoder = new TextDecoder();
+        let lineBuffer = "";
+        let held = null; // this attempt's withheld terminal
+        let terminalForwarded = false;
+        let endReason = "empty";
+
+        readAttempt: while (true) {
+          if (signal?.aborted) return abortStream();
+
+          let readResult;
+          let stallTimer;
+          try {
+            // Defensive stall escape: a byte-silent upstream must not hang the pipe.
+            readResult = await Promise.race([
+              currentReader.read(),
+              new Promise((resolve) => { stallTimer = setTimeout(() => resolve({ __stalled: true }), stallTimeoutMs); }),
+            ]);
+          } catch {
+            // A client abort rejects the pending read — never treat it as an
+            // empty attempt or a disconnect turns into a retry/error.
+            if (signal?.aborted) return abortStream();
+            endReason = "read_error";
+            break readAttempt; // truncated attempt
+          } finally {
+            clearTimeout(stallTimer);
+          }
+          if (readResult.__stalled) {
+            try { currentReader.cancel().catch(() => { }); } catch { /* already closed */ }
+            endReason = "stall";
+            break readAttempt;
+          }
+
+          const { done, value } = readResult;
+          if (done) break readAttempt;
+
+          lineBuffer += decoder.decode(value, { stream: true });
+          const lines = lineBuffer.split("\n");
+          lineBuffer = lines.pop(); // trailing partial line
+
+          for (const line of lines) {
+            // Empty-attempt tail: everything after the withheld terminal is
+            // part of the discarded attempt (usage trailers etc.) — drop it.
+            if (held) continue;
+
+            const trimmed = line.trim();
+            if (!trimmed.startsWith("data:")) { emit(line + "\n"); continue; }
+            const payload = trimmed.slice(5).trim();
+            if (!payload || payload === "[DONE]") { emit(line + "\n"); continue; }
+
+            let parsed;
+            try {
+              parsed = JSON.parse(payload);
+            } catch {
+              emit(line + "\n"); // not ours to judge — forward verbatim
+              continue;
+            }
+
+            const decision = classifyEvent(parsed, meaningfulSeen);
+            if (decision.meaningful) meaningfulSeen = true;
+            if (decision.action === "hold") {
+              held = { kind: decision.kind, reason: decision.reason, line };
+              lastHeld = held;
+              continue;
+            }
+            if (decision.terminal) terminalForwarded = true;
+            emit(line + "\n");
+          }
         }
-        controller.close();
-      } catch (error) {
-        controller.error(error);
+
+        // Attempt over. Content or a forwarded terminal ends the stream here —
+        // a truncated-with-content attempt is closed by the translator's flush
+        // finalization and is never retried (replay-unsafe, as in oh-my-pi).
+        if (meaningfulSeen || terminalForwarded) {
+          const remaining = lineBuffer + decoder.decode();
+          if (!held && remaining) emit(remaining);
+          closeStream();
+          return;
+        }
+
+        const reason = held ? held.reason : endReason;
+        log?.warn?.("STREAM", `ANTIGRAVITY | empty (${reason}) | attempt ${attempt + 1}/${EMPTY_STREAM_MAX_RETRIES + 1}`);
+
+        if (attempt >= EMPTY_STREAM_MAX_RETRIES) {
+          return exhaust(`empty response from upstream (${reason}) after ${attempt + 1} attempts`);
+        }
+
+        // Abort-aware backoff, then splice the retried attempt into this stream.
+        await new Promise((resolve) => {
+          const t = setTimeout(resolve, baseDelayMs * 2 ** attempt);
+          signal?.addEventListener?.("abort", () => { clearTimeout(t); resolve(); }, { once: true });
+        });
+        if (signal?.aborted) return abortStream();
+
+        try {
+          currentReader = (await reexecute()).getReader();
+        } catch (error) {
+          if (error?.name === "AbortError" || signal?.aborted) return abortStream();
+          return exhaust(error?.message || "retry request failed");
+        }
       }
     },
+
     cancel(reason) {
-      try { reader?.cancel(reason); } catch { /* already closed */ }
+      downstreamGone = true;
+      try { currentReader?.cancel(reason)?.catch?.(() => { }); } catch { /* already closed */ }
     },
   });
 }

--- a/open-sse/handlers/chatCore/emptyStreamGuard.js
+++ b/open-sse/handlers/chatCore/emptyStreamGuard.js
@@ -51,7 +51,7 @@ function classifyEvent(parsed, meaningfulSeen) {
     // translator closes the message with the error finish. Before content:
     // withhold and retry (usually transient, e.g. RESOURCE_EXHAUSTED blips).
     if (meaningfulSeen) return { action: "forward", terminal: true };
-    return { action: "hold", kind: "error_object", reason: errorObj.status || errorObj.message || "error" };
+    return { action: "hold", kind: "error_object", reason: errorObj.status || errorObj.message || "error", error: errorObj };
   }
 
   // Prompt blocked by policy: deterministic for this prompt — never retried.
@@ -97,8 +97,10 @@ function classifyEvent(parsed, meaningfulSeen) {
  * @param {AbortSignal} options.signal        client-disconnect signal
  * @param {object} options.log
  * @param {number} options.stallTimeoutMs     per-read stall escape
- * @param {(reason: string) => void} options.onExhausted  observer for "every
- *   attempt came back empty" (e.g. bench the account so client retries rotate)
+ * @param {(reason: string, meta: { upstreamError: object|null }) => void|Promise<void>} options.onExhausted
+ *   observer for "every attempt came back empty" (e.g. bench the account so
+ *   client retries rotate); awaited before the error event is emitted, and
+ *   handed the held upstream error object so quota reset times can be parsed
  * @returns {ReadableStream} byte stream for the SSE transform pipeline
  */
 export function createEmptyRetryStream({ body, reexecute, signal, log, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, baseDelayMs = EMPTY_STREAM_BASE_DELAY_MS, onExhausted }) {
@@ -128,8 +130,13 @@ export function createEmptyRetryStream({ body, reexecute, signal, log, stallTime
         err.name = "AbortError";
         try { controller.error(err); } catch { /* already closed */ }
       };
-      const exhaust = (reason) => {
-        try { Promise.resolve(onExhausted?.(reason)).catch(() => { }); } catch { /* observer must not break the stream */ }
+      const exhaust = async (reason) => {
+        // Bench-before-emit: the error event triggers the client's automatic
+        // retry, so the observer (account bench) must complete first or the
+        // retry can land on the account that just failed.
+        try {
+          await Promise.resolve(onExhausted?.(reason, { upstreamError: lastHeld?.error || null }));
+        } catch { /* observer must not break the stream */ }
         // Re-emit the real upstream error when we held one (true status/message,
         // e.g. RESOURCE_EXHAUSTED); otherwise synthesize an embedded error. The
         // gemini translator converts either into the client-facing error finish.
@@ -201,7 +208,7 @@ export function createEmptyRetryStream({ body, reexecute, signal, log, stallTime
             const decision = classifyEvent(parsed, meaningfulSeen);
             if (decision.meaningful) meaningfulSeen = true;
             if (decision.action === "hold") {
-              held = { kind: decision.kind, reason: decision.reason, line };
+              held = { kind: decision.kind, reason: decision.reason, error: decision.error || null, line };
               lastHeld = held;
               continue;
             }

--- a/open-sse/handlers/chatCore/emptyStreamGuard.js
+++ b/open-sse/handlers/chatCore/emptyStreamGuard.js
@@ -1,0 +1,139 @@
+// Empty-stream guard for Antigravity: Gemini occasionally returns a 200 SSE
+// stream that carries no usable output — no candidates at all, thought-only
+// parts, or a benign STOP finish with empty text — or aborts the turn with an
+// error finishReason (MALFORMED_FUNCTION_CALL) before emitting anything.
+// Delivered as-is the client receives a blank turn and silently halts
+// (#2188, #2229, #2259). The guard probes the upstream stream before anything
+// is sent to the client, so a bad attempt can be retried in place with the
+// identical request; a healthy stream is released on its first meaningful
+// part and replayed byte-identically.
+import { GEMINI_ERROR_FINISH_REASONS } from "../../translator/schema/finishReasons.js";
+import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
+
+// Mirrors oh-my-pi's empty-response policy: 2 retries, 500ms * 2^attempt backoff.
+export const EMPTY_STREAM_MAX_RETRIES = 2;
+export const EMPTY_STREAM_BASE_DELAY_MS = 500;
+
+// A part is meaningful when it carries output the client can act on: a tool
+// call, inline data, or non-whitespace visible text. Thought-only parts are
+// not — thinking that never produced an answer IS the empty-response failure.
+function isMeaningfulPart(part) {
+  if (part.functionCall) return true;
+  if (part.inlineData?.data || part.inline_data?.data) return true;
+  if (part.thought === true) return false;
+  return typeof part.text === "string" && part.text.trim().length > 0;
+}
+
+/**
+ * Read the upstream SSE body until a verdict is reached, buffering every raw
+ * chunk so a healthy stream can be replayed without loss.
+ *
+ * Verdicts:
+ * - { verdict: "ok", buffered, reader }        first meaningful part seen
+ * - { verdict: "empty", buffered }             stream ended with nothing meaningful
+ * - { verdict: "error_finish", reason, buffered } aborted (MALFORMED_FUNCTION_CALL, ...)
+ *   or an {error:{...}} object arrived before any meaningful part
+ * - { verdict: "aborted" }                     client disconnected
+ */
+export async function probeSSEStream(body, { signal, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS } = {}) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const buffered = [];
+  let lineBuffer = "";
+
+  while (true) {
+    if (signal?.aborted) {
+      try { reader.cancel(); } catch { /* already closed */ }
+      return { verdict: "aborted" };
+    }
+
+    let readResult;
+    try {
+      // Defensive stall escape: a byte-silent upstream must not hang the probe.
+      readResult = await Promise.race([
+        reader.read(),
+        new Promise((resolve) => setTimeout(() => resolve({ __stalled: true }), stallTimeoutMs)),
+      ]);
+    } catch {
+      return { verdict: "empty", buffered };
+    }
+    if (readResult.__stalled) {
+      try { reader.cancel(); } catch { /* already closed */ }
+      return { verdict: "empty", buffered };
+    }
+
+    const { done, value } = readResult;
+    if (done) return { verdict: "empty", buffered };
+
+    buffered.push(value);
+    lineBuffer += decoder.decode(value, { stream: true });
+
+    const lines = lineBuffer.split("\n");
+    lineBuffer = lines.pop(); // keep the trailing partial line
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data:")) continue;
+      const payload = trimmed.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+
+      let parsed;
+      try {
+        parsed = JSON.parse(payload);
+      } catch {
+        continue; // partial JSON split across reads — wait for more bytes
+      }
+
+      // Antigravity wrapper
+      const response = parsed.response || parsed;
+      if (!response || typeof response !== "object") continue;
+
+      if (response.error || parsed.error) {
+        return { verdict: "error_finish", reason: (response.error || parsed.error).status || "error", buffered };
+      }
+
+      const candidate = response.candidates?.[0];
+      if (!candidate) continue;
+
+      for (const part of candidate.content?.parts || []) {
+        if (isMeaningfulPart(part)) return { verdict: "ok", buffered, reader };
+      }
+
+      const finishReason = candidate.finishReason && String(candidate.finishReason).toUpperCase();
+      if (finishReason && GEMINI_ERROR_FINISH_REASONS.has(finishReason)) {
+        return { verdict: "error_finish", reason: finishReason, buffered };
+      }
+      // Benign finish with nothing meaningful streamed → keep reading; if the
+      // stream ends here it's the empty-response failure.
+    }
+  }
+}
+
+/**
+ * Rebuild a byte-identical body: replay the probed prefix, then pump the rest
+ * of the upstream reader.
+ */
+export function replayStream(buffered, reader) {
+  return new ReadableStream({
+    async start(controller) {
+      for (const chunk of buffered) controller.enqueue(chunk);
+      if (!reader) {
+        controller.close();
+        return;
+      }
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(value);
+        }
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      try { reader?.cancel(reason); } catch { /* already closed */ }
+    },
+  });
+}

--- a/open-sse/translator/concerns/finishReason.js
+++ b/open-sse/translator/concerns/finishReason.js
@@ -1,6 +1,6 @@
 // Concern #6: finish_reason / stop_reason mapping.
 // One entry per direction; switch by special format, default handles common providers.
-import { OPENAI_FINISH, CLAUDE_STOP, GEMINI_FINISH, GEMINI_ERROR_FINISH_REASONS } from "../schema/finishReasons.js";
+import { OPENAI_FINISH, CLAUDE_STOP, GEMINI_FINISH, GEMINI_ERROR_FINISH_REASONS, GEMINI_CONTENT_FILTER_FINISH_REASONS } from "../schema/finishReasons.js";
 
 // upstream finish/stop reason → OpenAI finish_reason
 export function toOpenAIFinish(reason, format) {
@@ -28,15 +28,10 @@ export function toOpenAIFinish(reason, format) {
       // Aborted turns (MALFORMED_FUNCTION_CALL, OTHER, ...) must surface as errors,
       // not clean stops — a clean stop makes the client treat a broken turn as done.
       if (GEMINI_ERROR_FINISH_REASONS.has(geminiReason)) return OPENAI_FINISH.ERROR;
+      if (GEMINI_CONTENT_FILTER_FINISH_REASONS.has(geminiReason)) return OPENAI_FINISH.CONTENT_FILTER;
       switch (geminiReason) {
         case GEMINI_FINISH.STOP: return OPENAI_FINISH.STOP;
         case GEMINI_FINISH.MAX_TOKENS: return OPENAI_FINISH.LENGTH;
-        case GEMINI_FINISH.SAFETY:
-        case GEMINI_FINISH.RECITATION:
-        case GEMINI_FINISH.BLOCKLIST:
-        case GEMINI_FINISH.SPII:
-        case GEMINI_FINISH.IMAGE_SAFETY:
-        case GEMINI_FINISH.PROHIBITED_CONTENT: return OPENAI_FINISH.CONTENT_FILTER;
         // Unknown values stay a clean stop: a future benign Gemini reason must not
         // start erroring every Gemini-family provider at once.
         default: return OPENAI_FINISH.STOP;

--- a/open-sse/translator/concerns/finishReason.js
+++ b/open-sse/translator/concerns/finishReason.js
@@ -1,6 +1,6 @@
 // Concern #6: finish_reason / stop_reason mapping.
 // One entry per direction; switch by special format, default handles common providers.
-import { OPENAI_FINISH, CLAUDE_STOP, GEMINI_FINISH } from "../schema/finishReasons.js";
+import { OPENAI_FINISH, CLAUDE_STOP, GEMINI_FINISH, GEMINI_ERROR_FINISH_REASONS } from "../schema/finishReasons.js";
 
 // upstream finish/stop reason → OpenAI finish_reason
 export function toOpenAIFinish(reason, format) {
@@ -23,16 +23,25 @@ export function toOpenAIFinish(reason, format) {
         case "error": return OPENAI_FINISH.STOP;
         default: return reason || OPENAI_FINISH.STOP;
       }
-    case "gemini":
-      switch (String(reason).toUpperCase()) {
+    case "gemini": {
+      const geminiReason = String(reason).toUpperCase();
+      // Aborted turns (MALFORMED_FUNCTION_CALL, OTHER, ...) must surface as errors,
+      // not clean stops — a clean stop makes the client treat a broken turn as done.
+      if (GEMINI_ERROR_FINISH_REASONS.has(geminiReason)) return OPENAI_FINISH.ERROR;
+      switch (geminiReason) {
         case GEMINI_FINISH.STOP: return OPENAI_FINISH.STOP;
         case GEMINI_FINISH.MAX_TOKENS: return OPENAI_FINISH.LENGTH;
         case GEMINI_FINISH.SAFETY:
         case GEMINI_FINISH.RECITATION:
         case GEMINI_FINISH.BLOCKLIST:
+        case GEMINI_FINISH.SPII:
+        case GEMINI_FINISH.IMAGE_SAFETY:
         case GEMINI_FINISH.PROHIBITED_CONTENT: return OPENAI_FINISH.CONTENT_FILTER;
+        // Unknown values stay a clean stop: a future benign Gemini reason must not
+        // start erroring every Gemini-family provider at once.
         default: return OPENAI_FINISH.STOP;
       }
+    }
     case "kiro":
     case "ollama":
       switch (reason) {

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -179,6 +179,14 @@ export function translateResponse(targetFormat, sourceFormat, chunk, state) {
     }
   }
 
+  // Flush sentinel: a null chunk means "the stream ended" (stream.js flush).
+  // When step 1 has nothing to convert, forward the sentinel so the source-side
+  // translator can finalize a dangling message (all openai→X translators
+  // null-check their chunk, so this is a no-op unless one implements a flush).
+  if (chunk === null && results.length === 0) {
+    results = [null];
+  }
+
   // Step 2: openai -> source (if source is not openai)
   if (sourceFormat !== FORMATS.OPENAI) {
     const fromOpenAI = responseRegistry.get(`${FORMATS.OPENAI}:${sourceFormat}`);

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -163,12 +163,11 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
 
               let name = tcID2Name[fid];
               if (!name) {
-                const idParts = fid.split("-");
-                if (idParts.length > 2) {
-                  name = idParts.slice(0, -2).join("-");
-                } else {
-                  name = fid;
-                }
+                // Generated ids encode the name: `name_<ts>_<idx>` (current) or
+                // `name-<ts>-<idx>` (legacy). Foreign ids (toolu_..., upstream
+                // functionCall.id) don't — fall back to the id itself, as before.
+                const m = fid.match(/^(.+?)[-_]\d{10,}[-_]\d+$/);
+                name = m ? m[1] : fid;
               }
 
               let resp = toolResponses[fid];

--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -19,8 +19,19 @@ function emitFunctionCall(functionCall, state) {
   const fcName = state.toolNameMap?.get(rawName) || rawName;
   const fcArgs = functionCall.args || {};
   const toolCallIndex = state.functionIndex++;
+  // Prefer the upstream-provided call id (Gemini 3 sends one) — it round-trips to
+  // functionResponse without name reconstruction. Fall back to a generated id.
+  // Anthropic tool_use ids must match [a-zA-Z0-9_-], so sanitize either way.
+  if (!state.seenToolCallIds) state.seenToolCallIds = new Set();
+  const upstreamId = functionCall.id;
+  const rawId = upstreamId && !state.seenToolCallIds.has(upstreamId)
+    ? upstreamId
+    : `${fcName}_${Date.now()}_${toolCallIndex}`;
+  const id = rawId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  state.seenToolCallIds.add(id);
+  if (upstreamId) state.seenToolCallIds.add(upstreamId);
   const toolCall = {
-    id: `${fcName}-${Date.now()}-${toolCallIndex}`,
+    id,
     index: toolCallIndex,
     type: OPENAI_BLOCK.FUNCTION,
     function: { name: fcName, arguments: JSON.stringify(fcArgs) },
@@ -38,11 +49,21 @@ export function geminiToOpenAIResponse(chunk, state) {
   
   // Handle Antigravity wrapper
   const response = chunk.response || chunk;
-  if (!response || !response.candidates?.[0]) return null;
+  if (!response) return null;
 
   const results = [];
-  const candidate = response.candidates[0];
-  const content = candidate.content;
+  const candidate = response.candidates?.[0];
+  const upstreamError = response.error || chunk.error;
+  const blockReason = response.promptFeedback?.blockReason;
+
+  // Candidate-less chunk with nothing to surface: harvest usage from keep-alive
+  // chunks (usageMetadata-only) and skip. Dropping error/blockReason chunks here
+  // used to leave the client with an empty 200 stream that never closes.
+  if (!candidate && !upstreamError && !blockReason) {
+    const keepAliveUsage = toOpenAIUsage(response.usageMetadata || chunk.usageMetadata, "gemini");
+    if (keepAliveUsage) state.usage = keepAliveUsage;
+    return null;
+  }
 
   // Initialize state
   if (!state.messageId) {
@@ -52,6 +73,28 @@ export function geminiToOpenAIResponse(chunk, state) {
     state.geminiToolCallCount = 0;
     results.push(buildChunk(chunkMeta(state), { role: ROLE.ASSISTANT }, null));
   }
+
+  // Error object embedded mid-stream in a 200 response (e.g. RESOURCE_EXHAUSTED):
+  // close the message with an error finish so downstream surfaces it instead of hanging.
+  if (!candidate && upstreamError) {
+    state.upstreamError = upstreamError;
+    const errorChunk = buildChunk(chunkMeta(state), {}, OPENAI_FINISH.ERROR);
+    if (state.usage) errorChunk.usage = state.usage;
+    results.push(errorChunk);
+    state.finishReason = OPENAI_FINISH.ERROR;
+    return results;
+  }
+
+  // Prompt blocked before any candidate was produced: close as content_filter.
+  if (!candidate && blockReason) {
+    const blockedChunk = buildChunk(chunkMeta(state), {}, OPENAI_FINISH.CONTENT_FILTER);
+    if (state.usage) blockedChunk.usage = state.usage;
+    results.push(blockedChunk);
+    state.finishReason = OPENAI_FINISH.CONTENT_FILTER;
+    return results;
+  }
+
+  const content = candidate.content;
 
   // Process parts
   if (content?.parts) {

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -87,6 +87,32 @@ function flushToolBlocks(state, results) {
   }
 }
 
+// Convert OpenAI-shaped usage ({prompt_tokens, completion_tokens, ...}) to the
+// Claude shape ({input_tokens, output_tokens, cache_*}).
+function toClaudeUsage(usage) {
+  const promptTokens = typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : 0;
+  const outputTokens = typeof usage.completion_tokens === "number" ? usage.completion_tokens : 0;
+
+  // Extract cache tokens from prompt_tokens_details
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
+  const cacheCreationTokens = usage.prompt_tokens_details?.cache_creation_tokens;
+  const cacheReadTokens = typeof cachedTokens === "number" ? cachedTokens : 0;
+  const cacheCreateTokens = typeof cacheCreationTokens === "number" ? cacheCreationTokens : 0;
+
+  // input_tokens = prompt_tokens - cached_tokens - cache_creation_tokens
+  // Because OpenAI's prompt_tokens includes all prompt-side tokens
+  const claudeUsage = {
+    input_tokens: promptTokens - cacheReadTokens - cacheCreateTokens,
+    output_tokens: outputTokens
+  };
+  if (cacheReadTokens > 0) claudeUsage.cache_read_input_tokens = cacheReadTokens;
+  if (cacheCreateTokens > 0) claudeUsage.cache_creation_input_tokens = cacheCreateTokens;
+
+  // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
+  // No need to add separately as Claude expects total output_tokens
+  return claudeUsage;
+}
+
 // Flush-time finalization: the upstream stream ended without a finish_reason
 // (truncated connection, or a gemini-family stream that closed after content).
 // Close open blocks and emit message_delta + message_stop so the Claude client
@@ -100,11 +126,20 @@ function finalizeOnFlush(state) {
   stopTextBlock(state, results);
   flushToolBlocks(state, results);
 
+  // state.usage may still be OpenAI-shaped here: the gemini stage writes
+  // prompt/completion counts into the shared pivot state, and only a real
+  // finish chunk converts them — which a truncated stream never delivers.
+  const usage = state.usage?.input_tokens != null
+    ? state.usage
+    : state.usage?.prompt_tokens != null
+      ? toClaudeUsage(state.usage)
+      : { input_tokens: 0, output_tokens: 0 };
+
   const stopReason = state.toolCalls.size > 0 ? "tool_use" : "end_turn";
   results.push({
     type: "message_delta",
     delta: { stop_reason: stopReason },
-    usage: state.usage || { input_tokens: 0, output_tokens: 0 }
+    usage
   });
   results.push({ type: "message_stop" });
   return results;
@@ -121,36 +156,7 @@ export function openaiToClaudeResponse(chunk, state) {
 
   // Track usage from OpenAI chunk if available
   if (chunk.usage && typeof chunk.usage === "object") {
-    const promptTokens = typeof chunk.usage.prompt_tokens === "number" ? chunk.usage.prompt_tokens : 0;
-    const outputTokens = typeof chunk.usage.completion_tokens === "number" ? chunk.usage.completion_tokens : 0;
-
-    // Extract cache tokens from prompt_tokens_details
-    const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens;
-    const cacheCreationTokens = chunk.usage.prompt_tokens_details?.cache_creation_tokens;
-    const cacheReadTokens = typeof cachedTokens === "number" ? cachedTokens : 0;
-    const cacheCreateTokens = typeof cacheCreationTokens === "number" ? cacheCreationTokens : 0;
-
-    // input_tokens = prompt_tokens - cached_tokens - cache_creation_tokens
-    // Because OpenAI's prompt_tokens includes all prompt-side tokens
-    const inputTokens = promptTokens - cacheReadTokens - cacheCreateTokens;
-
-    state.usage = {
-      input_tokens: inputTokens,
-      output_tokens: outputTokens
-    };
-
-    // Add cache_read_input_tokens if present
-    if (cacheReadTokens > 0) {
-      state.usage.cache_read_input_tokens = cacheReadTokens;
-    }
-
-    // Add cache_creation_input_tokens if present
-    if (cacheCreateTokens > 0) {
-      state.usage.cache_creation_input_tokens = cacheCreateTokens;
-    }
-
-    // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
-    // No need to add separately as Claude expects total output_tokens
+    state.usage = toClaudeUsage(chunk.usage);
   }
 
   // First chunk - ALWAYS send message_start first

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -1,6 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { ROLE, CLAUDE_BLOCK, MODEL_FALLBACK } from "../schema/index.js";
+import { ROLE, CLAUDE_BLOCK, MODEL_FALLBACK, OPENAI_FINISH } from "../schema/index.js";
 import { fromOpenAIFinish } from "../concerns/finishReason.js";
 import { extractReasoningText } from "../concerns/reasoning.js";
 
@@ -67,9 +67,53 @@ function stopTextBlock(state, results) {
   state.textBlockStarted = false;
 }
 
+// Helper: flush buffered tool args + close every open tool_use block
+function flushToolBlocks(state, results) {
+  for (const [idx, toolInfo] of state.toolCalls) {
+    // Emit buffered + sanitized args as single delta before stop
+    const buffered = state.toolArgBuffers?.get(idx);
+    if (buffered) {
+      const sanitized = sanitizeToolArgs(toolInfo.name, buffered);
+      results.push({
+        type: "content_block_delta",
+        index: toolInfo.blockIndex,
+        delta: { type: "input_json_delta", partial_json: sanitized }
+      });
+    }
+    results.push({
+      type: "content_block_stop",
+      index: toolInfo.blockIndex
+    });
+  }
+}
+
+// Flush-time finalization: the upstream stream ended without a finish_reason
+// (truncated connection, or a gemini-family stream that closed after content).
+// Close open blocks and emit message_delta + message_stop so the Claude client
+// never hangs on a dangling message.
+function finalizeOnFlush(state) {
+  if (!state.messageStartSent || state.claudeFinishHandled) return null;
+  state.claudeFinishHandled = true;
+
+  const results = [];
+  stopThinkingBlock(state, results);
+  stopTextBlock(state, results);
+  flushToolBlocks(state, results);
+
+  const stopReason = state.toolCalls.size > 0 ? "tool_use" : "end_turn";
+  results.push({
+    type: "message_delta",
+    delta: { stop_reason: stopReason },
+    usage: state.usage || { input_tokens: 0, output_tokens: 0 }
+  });
+  results.push({ type: "message_stop" });
+  return results;
+}
+
 // Convert OpenAI stream chunk to Claude format
 export function openaiToClaudeResponse(chunk, state) {
-  if (!chunk || !chunk.choices?.[0]) return null;
+  if (!chunk) return finalizeOnFlush(state);
+  if (!chunk.choices?.[0]) return null;
 
   const results = [];
   const choice = chunk.choices[0];
@@ -221,39 +265,41 @@ export function openaiToClaudeResponse(chunk, state) {
     }
   }
 
-  // Finish
-  if (choice.finish_reason) {
+  // Finish — guard with a Claude-specific flag, NOT the shared state.finishReason:
+  // in a pivot like Antigravity/Gemini → OpenAI → Claude the upstream stage already
+  // sets state.finishReason (for stream.js usage injection); keying on it would
+  // suppress this flush and drop the buffered tool-call input_json_delta. The flag
+  // also dedupes repeated finish_reason chunks from OpenAI-compatible models.
+  if (choice.finish_reason && !state.claudeFinishHandled) {
+    state.claudeFinishHandled = true;
     stopThinkingBlock(state, results);
     stopTextBlock(state, results);
-
-    for (const [idx, toolInfo] of state.toolCalls) {
-      // Emit buffered + sanitized args as single delta before stop
-      const buffered = state.toolArgBuffers?.get(idx);
-      if (buffered) {
-        const sanitized = sanitizeToolArgs(toolInfo.name, buffered);
-        results.push({
-          type: "content_block_delta",
-          index: toolInfo.blockIndex,
-          delta: { type: "input_json_delta", partial_json: sanitized }
-        });
-      }
-      results.push({
-        type: "content_block_stop",
-        index: toolInfo.blockIndex
-      });
-    }
+    flushToolBlocks(state, results);
 
     // Mark finish for later usage injection in stream.js
     state.finishReason = choice.finish_reason;
 
-    // Use tracked usage (will be estimated in stream.js if not valid)
-    const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
-    results.push({
-      type: "message_delta",
-      delta: { stop_reason: convertFinishReason(choice.finish_reason) },
-      usage: finalUsage
-    });
-    results.push({ type: "message_stop" });
+    if (choice.finish_reason === OPENAI_FINISH.ERROR) {
+      // Upstream aborted the turn (e.g. Gemini MALFORMED_FUNCTION_CALL or an error
+      // object embedded in a 200 stream). A clean end_turn here makes the client
+      // treat a broken turn as a finished answer; a mid-stream error event is
+      // retryable by Anthropic clients.
+      const message = state.upstreamError?.message ||
+        "Upstream aborted the response (malformed function call or empty candidate)";
+      results.push({
+        type: "error",
+        error: { type: "api_error", message }
+      });
+    } else {
+      // Use tracked usage (will be estimated in stream.js if not valid)
+      const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
+      results.push({
+        type: "message_delta",
+        delta: { stop_reason: convertFinishReason(choice.finish_reason) },
+        usage: finalUsage
+      });
+      results.push({ type: "message_stop" });
+    }
   }
 
   return results.length > 0 ? results : null;

--- a/open-sse/translator/schema/finishReasons.js
+++ b/open-sse/translator/schema/finishReasons.js
@@ -49,3 +49,16 @@ export const GEMINI_ERROR_FINISH_REASONS = new Set([
   GEMINI_FINISH.LANGUAGE,
   GEMINI_FINISH.NO_IMAGE,
 ]);
+
+// Gemini finishReasons that mean the content was blocked by policy. Deterministic
+// for a given prompt: retrying is pointless (same block every time), so the
+// empty-stream guard must release these instead of retrying — the translator
+// closes them as content_filter. Also the content_filter mapping source.
+export const GEMINI_CONTENT_FILTER_FINISH_REASONS = new Set([
+  GEMINI_FINISH.SAFETY,
+  GEMINI_FINISH.RECITATION,
+  GEMINI_FINISH.BLOCKLIST,
+  GEMINI_FINISH.SPII,
+  GEMINI_FINISH.IMAGE_SAFETY,
+  GEMINI_FINISH.PROHIBITED_CONTENT,
+]);

--- a/open-sse/translator/schema/finishReasons.js
+++ b/open-sse/translator/schema/finishReasons.js
@@ -6,6 +6,9 @@ export const OPENAI_FINISH = {
   LENGTH: "length",
   TOOL_CALLS: "tool_calls",
   CONTENT_FILTER: "content_filter",
+  // Internal hub value: upstream aborted the turn (e.g. Gemini MALFORMED_FUNCTION_CALL).
+  // Response translators surface it as an error instead of a clean stop.
+  ERROR: "error",
 };
 
 // Claude stop_reason values.
@@ -24,4 +27,25 @@ export const GEMINI_FINISH = {
   RECITATION: "RECITATION",
   BLOCKLIST: "BLOCKLIST",
   PROHIBITED_CONTENT: "PROHIBITED_CONTENT",
+  SPII: "SPII",
+  IMAGE_SAFETY: "IMAGE_SAFETY",
+  MALFORMED_FUNCTION_CALL: "MALFORMED_FUNCTION_CALL",
+  UNEXPECTED_TOOL_CALL: "UNEXPECTED_TOOL_CALL",
+  FINISH_REASON_UNSPECIFIED: "FINISH_REASON_UNSPECIFIED",
+  OTHER: "OTHER",
+  LANGUAGE: "LANGUAGE",
+  NO_IMAGE: "NO_IMAGE",
 };
+
+// Gemini finishReasons that mean the turn was aborted upstream, not completed.
+// Forwarding them as a clean stop makes the client treat a broken turn (e.g. an
+// aborted tool call) as a finished answer — the "model says it will act but does
+// nothing" failure. Shared with the antigravity empty-stream guard.
+export const GEMINI_ERROR_FINISH_REASONS = new Set([
+  GEMINI_FINISH.MALFORMED_FUNCTION_CALL,
+  GEMINI_FINISH.UNEXPECTED_TOOL_CALL,
+  GEMINI_FINISH.FINISH_REASON_UNSPECIFIED,
+  GEMINI_FINISH.OTHER,
+  GEMINI_FINISH.LANGUAGE,
+  GEMINI_FINISH.NO_IMAGE,
+]);

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -274,9 +274,10 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       },
       // Empty-stream retries exhausted mid-stream (headers already sent, so no
       // pre-stream fallback is possible): bench the account so the client's
-      // automatic retry of the in-stream error lands on the next one.
-      onUpstreamEmptyExhausted: async (reason) => {
-        await markAccountUnavailable(credentials.connectionId, HTTP_STATUS.BAD_GATEWAY, reason, provider, model);
+      // automatic retry of the in-stream error lands on the next one. Quota
+      // exhaustion passes a precise resetsAtMs instead of the generic cooldown.
+      onUpstreamEmptyExhausted: async (reason, resetsAtMs) => {
+        await markAccountUnavailable(credentials.connectionId, HTTP_STATUS.BAD_GATEWAY, reason, provider, model, resetsAtMs);
       }
     });
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -271,6 +271,12 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       },
       onRequestSuccess: async () => {
         await clearAccountError(credentials.connectionId, credentials, model);
+      },
+      // Empty-stream retries exhausted mid-stream (headers already sent, so no
+      // pre-stream fallback is possible): bench the account so the client's
+      // automatic retry of the in-stream error lands on the next one.
+      onUpstreamEmptyExhausted: async (reason) => {
+        await markAccountUnavailable(credentials.connectionId, HTTP_STATUS.BAD_GATEWAY, reason, provider, model);
       }
     });
 

--- a/tests/translator/__snapshots__/golden-response-stream.test.js.snap
+++ b/tests/translator/__snapshots__/golden-response-stream.test.js.snap
@@ -261,7 +261,7 @@ exports[`GOLDEN response stream: Gemini → OpenAI > text + thought(no-sig) + fu
                 "arguments": "{"q":"x"}",
                 "name": "search",
               },
-              "id": "search-<TS>-0",
+              "id": "search_<TS>_0",
               "index": 0,
               "type": "function",
             },

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -273,6 +273,23 @@ describe("Antigravity → Claude stream finalization", () => {
     expect(flushed.map((e) => e.type)).toContain("message_stop");
   });
 
+  // openai-to-claude.js — the gemini stage stores usageMetadata OpenAI-shaped in
+  // the shared state; a truncated stream never sees the finish chunk that would
+  // convert it. The flush must emit Claude-shaped usage, not prompt_tokens.
+  it("flush converts OpenAI-shaped usage to Claude shape", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-u", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "partial" }] }, index: 0 }],
+      usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 7, totalTokenCount: 27 },
+    }), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    const delta = flushed.find((e) => e.type === "message_delta");
+    expect(delta.usage.input_tokens).toBe(20);
+    expect(delta.usage.output_tokens).toBe(7);
+    expect(delta.usage.prompt_tokens).toBeUndefined();
+  });
+
   // openai-to-claude.js — duplicate finish_reason chunks (common from
   // OpenAI-compatible upstreams) must not emit message_stop twice.
   it("duplicate finish chunks emit a single message_stop", () => {

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -223,3 +223,83 @@ describe("Antigravity → OpenAI stream stability", () => {
     expect(toolChunk.choices[0].delta.tool_calls[0].id).toMatch(/^my-tool_\d+_0$/);
   });
 });
+
+// Claude-side stream finalization: truncated/aborted Antigravity streams must
+// always yield a well-formed Claude SSE sequence (#2229, #2259, #2431).
+describe("Antigravity → Claude stream finalization", () => {
+  const wrap = (response) => ({ response });
+  const textChunk = (text) => wrap({
+    responseId: "resp-x", modelVersion: "gemini-pro-agent",
+    candidates: [{ content: { role: "model", parts: [{ text }] }, index: 0 }],
+  });
+
+  // openai-to-claude.js — stream ends without finishReason (connection dropped):
+  // the message was never closed, Claude Code hung on a dangling message.
+  it("flush closes a stream that ended without finishReason", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, textChunk("partial answer"), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    const types = flushed.map((e) => e.type);
+    expect(types).toContain("content_block_stop");
+    expect(types).toContain("message_delta");
+    expect(types).toContain("message_stop");
+    const delta = flushed.find((e) => e.type === "message_delta");
+    expect(delta.delta.stop_reason).toBe("end_turn");
+  });
+
+  it("flush after a handled finish emits nothing", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-y", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "done" }] }, finishReason: "STOP", index: 0 }],
+    }), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    expect(flushed).toEqual([]);
+  });
+
+  // openai-to-claude.js — a truncated stream with an unfinished tool call must
+  // still flush the buffered input_json_delta and close as tool_use.
+  it("flush finalizes an unfinished tool call as tool_use", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-z", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] }, index: 0 }],
+    }), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    const jsonDelta = flushed.find((e) => e.delta?.type === "input_json_delta");
+    expect(JSON.parse(jsonDelta.delta.partial_json)).toEqual({ command: "ls" });
+    const delta = flushed.find((e) => e.type === "message_delta");
+    expect(delta.delta.stop_reason).toBe("tool_use");
+    expect(flushed.map((e) => e.type)).toContain("message_stop");
+  });
+
+  // openai-to-claude.js — duplicate finish_reason chunks (common from
+  // OpenAI-compatible upstreams) must not emit message_stop twice.
+  it("duplicate finish chunks emit a single message_stop", () => {
+    const state = initState(FORMATS.CLAUDE);
+    const first = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-d", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "hi" }] }, finishReason: "STOP", index: 0 }],
+    }), state);
+    const second = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      candidates: [{ finishReason: "STOP", index: 0 }],
+    }), state);
+    const stops = [...first, ...second].filter((e) => e.type === "message_stop");
+    expect(stops).toHaveLength(1);
+  });
+
+  // Full pivot: MALFORMED_FUNCTION_CALL must reach the Claude client as an error
+  // event, never as a clean end_turn (#2250).
+  it("MALFORMED_FUNCTION_CALL surfaces as an error event, not end_turn", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, textChunk("I'll run the command now."), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL", index: 0 }],
+    }), state);
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeTruthy();
+    expect(error.error.type).toBe("api_error");
+    const endTurn = events.find((e) => e.type === "message_delta" && e.delta?.stop_reason === "end_turn");
+    expect(endTurn).toBeUndefined();
+  });
+});

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -107,3 +107,119 @@ describe("Antigravity executor", () => {
     expect(query).toEqual({ type: "string", description: "Search query" });
   });
 });
+
+// Stability fixes: empty/aborted Antigravity streams must never surface as clean
+// end_turn to Claude Code (#2188, #2229, #2250, #2259, #2431).
+describe("Antigravity → OpenAI stream stability", () => {
+  const wrap = (response) => ({ response });
+
+  // concerns/finishReason.js — MALFORMED_FUNCTION_CALL used to fall through the
+  // default case to "stop" → end_turn: the model narrates a tool call, Gemini
+  // aborts it, and the client thinks the turn finished cleanly (#2250).
+  it("MALFORMED_FUNCTION_CALL maps to error finish, not stop", () => {
+    const state = initState(FORMATS.OPENAI);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r1", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "I'll call the tool now." }] }, index: 0 }],
+    }), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL", index: 0 }],
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("error");
+  });
+
+  // gemini-to-openai.js — an error finish must not be upgraded to tool_calls even
+  // when a functionCall was emitted earlier in the stream.
+  it("error finish is not upgraded to tool_calls", () => {
+    const state = initState(FORMATS.OPENAI);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r2", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] }, index: 0 }],
+    }), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      candidates: [{ finishReason: "UNEXPECTED_TOOL_CALL", index: 0 }],
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("error");
+  });
+
+  it("STOP with emitted tool call still upgrades to tool_calls", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r3", modelVersion: "gemini-pro-agent",
+      candidates: [{
+        content: { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  // gemini-to-openai.js — candidate-less chunk with promptFeedback.blockReason was
+  // dropped (return null) → empty 200 stream that never closes (#2188).
+  it("promptFeedback-only chunk closes the stream as content_filter", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r4", modelVersion: "gemini-pro-agent",
+      promptFeedback: { blockReason: "SAFETY" },
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("content_filter");
+  });
+
+  // gemini-to-openai.js — a {error:{...}} object embedded mid-stream in a 200
+  // response was dropped silently (#2259, #2431).
+  it("mid-stream error object closes the stream with an error finish", () => {
+    const state = initState(FORMATS.OPENAI);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r5", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "partial" }] }, index: 0 }],
+    }), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded" },
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("error");
+    expect(state.upstreamError).toMatchObject({ status: "RESOURCE_EXHAUSTED" });
+  });
+
+  // gemini-to-openai.js — usage-only keep-alive chunks must stay silent but keep usage.
+  it("candidate-less usage chunk returns nothing but preserves usage", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+    }), state);
+    expect(events).toEqual([]);
+    expect(state.usage).toBeTruthy();
+  });
+
+  // gemini-to-openai.js — upstream functionCall.id was discarded and replaced by a
+  // regenerated name-based id, breaking functionResponse matching on replay.
+  it("upstream functionCall.id is preserved on the tool_call", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r6", modelVersion: "gemini-pro-agent",
+      candidates: [{
+        content: { role: "model", parts: [{ functionCall: { id: "call_abc123", name: "bash", args: {} } }] },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].id).toBe("call_abc123");
+  });
+
+  it("generated tool ids use underscore separators and the Anthropic charset", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r7", modelVersion: "gemini-pro-agent",
+      candidates: [{
+        content: { role: "model", parts: [{ functionCall: { name: "my-tool", args: {} } }] },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].id).toMatch(/^my-tool_\d+_0$/);
+  });
+});

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -303,3 +303,51 @@ describe("Antigravity → Claude stream finalization", () => {
     expect(endTurn).toBeUndefined();
   });
 });
+
+// Request-side tool id → name round-trip: functionResponse.name must match the
+// original functionCall name or Gemini rejects/ignores the tool loop.
+describe("OpenAI → Gemini functionResponse name recovery", () => {
+  const O2G = (messages) =>
+    translateRequest(FORMATS.OPENAI, FORMATS.GEMINI, "gemini-2.5-pro", { messages }, true, null, null);
+
+  const findResponse = (out) => {
+    for (const c of out.contents) {
+      const p = (c.parts || []).find((p) => p.functionResponse);
+      if (p) return p.functionResponse;
+    }
+    return null;
+  };
+
+  it("assistant tool_calls in history map id → name (tcID2Name)", () => {
+    const out = O2G([
+      { role: "user", content: "run it" },
+      { role: "assistant", tool_calls: [{ id: "my-tool_1736000000000_0", type: "function", function: { name: "my-tool", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "my-tool_1736000000000_0", content: "ok" },
+    ]);
+    expect(findResponse(out)?.name).toBe("my-tool");
+  });
+
+  // openai-to-gemini.js — the old fallback split the id on "-" and joined
+  // all-but-two segments; ids in the current `name_<ts>_<idx>` shape (or legacy
+  // hyphen shape with hyphenated tool names) must still recover the name when
+  // the assistant turn carrying the name was truncated out of history.
+  it("fallback recovers hyphenated names from generated ids (both separators)", () => {
+    for (const fid of ["my-tool_1736000000000_0", "my-tool-1736000000000-0"]) {
+      const out = O2G([
+        { role: "user", content: "run it" },
+        { role: "assistant", content: null, tool_calls: [{ id: fid, type: "function", function: { name: "my-tool", arguments: "{}" } }] },
+        { role: "tool", tool_call_id: fid, content: "ok" },
+      ]);
+      expect(findResponse(out)?.name, `id ${fid}`).toBe("my-tool");
+    }
+  });
+
+  it("foreign ids fall back to the id itself", () => {
+    const out = O2G([
+      { role: "user", content: "run it" },
+      { role: "assistant", tool_calls: [{ id: "toolu_01AbCdEf", type: "function", function: { name: "", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "toolu_01AbCdEf", content: "ok" },
+    ]);
+    expect(findResponse(out)?.name).toBe("toolu_01AbCdEf");
+  });
+});

--- a/tests/translator/golden-response-stream.test.js
+++ b/tests/translator/golden-response-stream.test.js
@@ -12,7 +12,7 @@ function stripVolatile(chunks) {
     if (key === "created") return 0;
     if (key === "id" && typeof val === "string") {
       return val
-        .replace(/-\d{10,}-(\d+)$/, "-<TS>-$1")   // gemini: name-<ts>-idx
+        .replace(/[-_]\d{10,}[-_](\d+)$/, "_<TS>_$1")   // gemini: name_<ts>_idx
         .replace(/^chatcmpl-\d{10,}$/, "chatcmpl-<TS>")  // kiro/ollama stream id
         .replace(/^call_(\d+)_\d{10,}$/, "call_$1_<TS>"); // ollama tool id
     }

--- a/tests/unit/empty-stream-guard.test.js
+++ b/tests/unit/empty-stream-guard.test.js
@@ -213,6 +213,36 @@ describe("createEmptyRetryStream", () => {
     expect(reexecute).not.toHaveBeenCalled();
   });
 
+  // The error event triggers the client's automatic retry — the bench must have
+  // landed before it, or the retry can re-pick the account that just failed.
+  it("awaits onExhausted (account bench) before emitting the error event", async () => {
+    const order = [];
+    const stream = createEmptyRetryStream({
+      body: sseBody([bareStop()]),
+      reexecute: async () => { throw new Error("no more attempts"); },
+      onExhausted: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        order.push("benched");
+      },
+      baseDelayMs: 1,
+    });
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (decoder.decode(value, { stream: true }).includes("error")) order.push("error-event");
+    }
+    expect(order).toEqual(["benched", "error-event"]);
+  });
+
+  it("passes the held upstream error to onExhausted so quota reset times can be parsed", async () => {
+    const onExhausted = vi.fn();
+    const quota = wrap({ error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded. Your quota will reset after 1h2m3s" } });
+    await runWrapper([[quota], [quota], [quota]], { onExhausted });
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted.mock.calls[0][1].upstreamError.message).toContain("reset after 1h2m3s");
+  });
+
   it("reexecute failure emits an error event carrying the upstream message", async () => {
     const onExhausted = vi.fn();
     const { out } = await runWrapper([[bareStop()]], {

--- a/tests/unit/empty-stream-guard.test.js
+++ b/tests/unit/empty-stream-guard.test.js
@@ -113,4 +113,23 @@ describe("probeSSEStream", () => {
     const replayed = await drain(replayStream(probe.buffered, probe.reader));
     expect(replayed).toBe(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""));
   });
+
+  // Content blocks are deterministic — a retry resends the same blocked prompt and
+  // exhaustion benches the account. The guard must release them so the translator
+  // closes the stream as content_filter (#2188).
+  it("promptFeedback.blockReason-only stream releases as ok, replayed byte-identically", async () => {
+    const events = [wrap({ promptFeedback: { blockReason: "SAFETY" } })];
+    const probe = await probeSSEStream(sseBody(events), {});
+    expect(probe.verdict).toBe("ok");
+    const replayed = await drain(replayStream(probe.buffered, probe.reader));
+    expect(replayed).toBe(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""));
+  });
+
+  it("SAFETY finish before any meaningful content releases as ok, not empty", async () => {
+    const probe = await probeSSEStream(sseBody([
+      wrap({ candidates: [{ content: { parts: [{ text: "hmm", thought: true }] } }] }),
+      wrap({ candidates: [{ finishReason: "SAFETY" }] }),
+    ]), {});
+    expect(probe.verdict).toBe("ok");
+  });
 });

--- a/tests/unit/empty-stream-guard.test.js
+++ b/tests/unit/empty-stream-guard.test.js
@@ -132,4 +132,33 @@ describe("probeSSEStream", () => {
     ]), {});
     expect(probe.verdict).toBe("ok");
   });
+
+  // A client abort rejects the pending read (fetch body errors when the request
+  // signal fires). It must be classified "aborted", not "empty" — "empty" at the
+  // last attempt turns a disconnect into a 502 + a 30s account bench.
+  it("client abort during a pending read returns aborted, not empty", async () => {
+    const ac = new AbortController();
+    let ctrl;
+    const body = new ReadableStream({ start(c) { ctrl = c; } }); // never emits
+    ac.signal.addEventListener("abort", () => {
+      ctrl.error(Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+    });
+    const probePromise = probeSSEStream(body, { signal: ac.signal });
+    setTimeout(() => ac.abort(), 10);
+    expect((await probePromise).verdict).toBe("aborted");
+  });
+
+  // error_finish discards the response — the upstream reader must be cancelled
+  // or the connection lingers until Google closes it.
+  it("error_finish cancels the upstream reader", async () => {
+    let cancelled = false;
+    const raw = `data: ${JSON.stringify(wrap({ candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL" }] }))}\n\n`;
+    const body = new ReadableStream({
+      start(c) { c.enqueue(encoder.encode(raw)); }, // stream stays open
+      cancel() { cancelled = true; },
+    });
+    const probe = await probeSSEStream(body, {});
+    expect(probe.verdict).toBe("error_finish");
+    expect(cancelled).toBe(true);
+  });
 });

--- a/tests/unit/empty-stream-guard.test.js
+++ b/tests/unit/empty-stream-guard.test.js
@@ -1,0 +1,116 @@
+// Antigravity empty-stream guard: probe verdicts + byte-identical replay
+// (#2188, #2229, #2259 — empty 200 streams / MALFORMED_FUNCTION_CALL aborts).
+import { describe, it, expect } from "vitest";
+import { probeSSEStream, replayStream } from "../../open-sse/handlers/chatCore/emptyStreamGuard.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function sseBody(events, { chunkSize } = {}) {
+  const raw = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+  const bytes = encoder.encode(raw);
+  return new ReadableStream({
+    start(controller) {
+      if (!chunkSize) {
+        controller.enqueue(bytes);
+      } else {
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+          controller.enqueue(bytes.slice(i, i + chunkSize));
+        }
+      }
+      controller.close();
+    },
+  });
+}
+
+async function drain(stream) {
+  const reader = stream.getReader();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+const wrap = (response) => ({ response });
+
+describe("probeSSEStream", () => {
+  it("meaningful text releases the stream with a byte-identical replay", async () => {
+    const events = [
+      wrap({ candidates: [{ content: { parts: [{ text: "thinking...", thought: true }] } }] }),
+      wrap({ candidates: [{ content: { parts: [{ text: "Hello there" }] } }] }),
+      wrap({ candidates: [{ finishReason: "STOP" }] }),
+    ];
+    const probe = await probeSSEStream(sseBody(events), {});
+    expect(probe.verdict).toBe("ok");
+    const replayed = await drain(replayStream(probe.buffered, probe.reader));
+    expect(replayed).toBe(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""));
+  });
+
+  it("functionCall-only stream is meaningful", async () => {
+    const probe = await probeSSEStream(sseBody([
+      wrap({ candidates: [{ content: { parts: [{ functionCall: { name: "bash", args: {} } }] } }] }),
+      wrap({ candidates: [{ finishReason: "STOP" }] }),
+    ]), {});
+    expect(probe.verdict).toBe("ok");
+  });
+
+  it("thought-only stream with STOP is empty", async () => {
+    const probe = await probeSSEStream(sseBody([
+      wrap({ candidates: [{ content: { parts: [{ text: "let me think", thought: true }] } }] }),
+      wrap({ candidates: [{ finishReason: "STOP" }] }),
+    ]), {});
+    expect(probe.verdict).toBe("empty");
+  });
+
+  it("whitespace-only text with STOP is empty", async () => {
+    const probe = await probeSSEStream(sseBody([
+      wrap({ candidates: [{ content: { parts: [{ text: "  \n" }] }, finishReason: "STOP" }] }),
+    ]), {});
+    expect(probe.verdict).toBe("empty");
+  });
+
+  it("zero-data 200 stream is empty", async () => {
+    const probe = await probeSSEStream(sseBody([]), {});
+    expect(probe.verdict).toBe("empty");
+    expect(probe.buffered.reduce((n, c) => n + c.length, 0)).toBe(0);
+  });
+
+  it("MALFORMED_FUNCTION_CALL before content is error_finish", async () => {
+    const probe = await probeSSEStream(sseBody([
+      wrap({ candidates: [{ content: { parts: [{ text: "I'll call it now", thought: true }] } }] }),
+      wrap({ candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL" }] }),
+    ]), {});
+    expect(probe.verdict).toBe("error_finish");
+    expect(probe.reason).toBe("MALFORMED_FUNCTION_CALL");
+  });
+
+  it("MALFORMED after meaningful content still releases the stream", async () => {
+    const probe = await probeSSEStream(sseBody([
+      wrap({ candidates: [{ content: { parts: [{ text: "Partial answer" }] } }] }),
+      wrap({ candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL" }] }),
+    ]), {});
+    expect(probe.verdict).toBe("ok");
+  });
+
+  it("embedded error object before content is error_finish", async () => {
+    const probe = await probeSSEStream(sseBody([
+      wrap({ error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded" } }),
+    ]), {});
+    expect(probe.verdict).toBe("error_finish");
+    expect(probe.reason).toBe("RESOURCE_EXHAUSTED");
+  });
+
+  it("handles SSE events split across tiny read chunks", async () => {
+    const events = [
+      wrap({ candidates: [{ content: { parts: [{ text: "Split across reads" }] } }] }),
+      wrap({ candidates: [{ finishReason: "STOP" }] }),
+    ];
+    const probe = await probeSSEStream(sseBody(events, { chunkSize: 7 }), {});
+    expect(probe.verdict).toBe("ok");
+    const replayed = await drain(replayStream(probe.buffered, probe.reader));
+    expect(replayed).toBe(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""));
+  });
+});

--- a/tests/unit/empty-stream-guard.test.js
+++ b/tests/unit/empty-stream-guard.test.js
@@ -1,18 +1,29 @@
-// Antigravity empty-stream guard: probe verdicts + byte-identical replay
-// (#2188, #2229, #2259 — empty 200 streams / MALFORMED_FUNCTION_CALL aborts).
-import { describe, it, expect } from "vitest";
-import { probeSSEStream, replayStream } from "../../open-sse/handlers/chatCore/emptyStreamGuard.js";
+// Antigravity empty-stream guard — oh-my-pi parity: everything (thinking
+// included) streams live; empty attempts are retried in-stream by splicing the
+// retried upstream into the same client stream; exhaustion emits an in-stream
+// {error} event (#2188, #2229, #2250, #2259).
+import { describe, it, expect, vi } from "vitest";
+import { createEmptyRetryStream } from "../../open-sse/handlers/chatCore/emptyStreamGuard.js";
+import { translateResponse, initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
+const wrap = (response) => ({ response });
+const thought = (text) => wrap({ candidates: [{ content: { role: "model", parts: [{ text, thought: true }] } }] });
+const text = (t) => wrap({ candidates: [{ content: { role: "model", parts: [{ text: t }] } }] });
+const finish = (finishReason) => wrap({ candidates: [{ finishReason }] });
+const bareStop = () => wrap({ candidates: [{ content: { role: "model", parts: [] }, finishReason: "STOP" }] });
+
+const sseText = (events) => events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+
 function sseBody(events, { chunkSize } = {}) {
-  const raw = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
-  const bytes = encoder.encode(raw);
+  const bytes = encoder.encode(sseText(events));
   return new ReadableStream({
     start(controller) {
       if (!chunkSize) {
-        controller.enqueue(bytes);
+        if (bytes.length) controller.enqueue(bytes);
       } else {
         for (let i = 0; i < bytes.length; i += chunkSize) {
           controller.enqueue(bytes.slice(i, i + chunkSize));
@@ -34,131 +45,207 @@ async function drain(stream) {
   return out;
 }
 
-const wrap = (response) => ({ response });
+const dataEvents = (out) => out.split("\n")
+  .map((l) => l.trim())
+  .filter((l) => l.startsWith("data:"))
+  .map((l) => JSON.parse(l.slice(5).trim()));
 
-describe("probeSSEStream", () => {
-  it("meaningful text releases the stream with a byte-identical replay", async () => {
-    const events = [
-      wrap({ candidates: [{ content: { parts: [{ text: "thinking...", thought: true }] } }] }),
-      wrap({ candidates: [{ content: { parts: [{ text: "Hello there" }] } }] }),
-      wrap({ candidates: [{ finishReason: "STOP" }] }),
-    ];
-    const probe = await probeSSEStream(sseBody(events), {});
-    expect(probe.verdict).toBe("ok");
-    const replayed = await drain(replayStream(probe.buffered, probe.reader));
-    expect(replayed).toBe(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""));
+const finishEvents = (out) => dataEvents(out).filter((e) => (e.response || e).candidates?.[0]?.finishReason);
+
+// Scripted attempts: attempt 0 is the initial body; each reexecute() serves the
+// next list. Throws when the script runs out (exercises the reexecute-failure path).
+async function runWrapper(attemptLists, { signal, onExhausted, reexecute, chunkSize } = {}) {
+  let calls = 0;
+  const stream = createEmptyRetryStream({
+    body: sseBody(attemptLists[0], { chunkSize }),
+    reexecute: reexecute || (async () => {
+      calls++;
+      const next = attemptLists[calls];
+      if (!next) throw new Error("no scripted attempt left");
+      return sseBody(next, { chunkSize });
+    }),
+    signal,
+    onExhausted,
+    log: null,
+    baseDelayMs: 1,
+  });
+  const out = await drain(stream);
+  return { out, retries: calls };
+}
+
+describe("createEmptyRetryStream", () => {
+  it("streams thought-only chunks live and byte-faithfully before any answer", async () => {
+    const events = [thought("let me think"), thought("still thinking"), text("Answer"), finish("STOP")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
   });
 
-  it("functionCall-only stream is meaningful", async () => {
-    const probe = await probeSSEStream(sseBody([
-      wrap({ candidates: [{ content: { parts: [{ functionCall: { name: "bash", args: {} } }] } }] }),
-      wrap({ candidates: [{ finishReason: "STOP" }] }),
-    ]), {});
-    expect(probe.verdict).toBe("ok");
+  it("suppresses a bare-STOP empty attempt and splices the retry", async () => {
+    const attempt2 = [text("Hello there"), finish("STOP")];
+    const { out, retries } = await runWrapper([[bareStop()], attempt2]);
+    expect(out).toBe(sseText(attempt2)); // attempt 1 fully withheld
+    expect(retries).toBe(1);
+    expect(finishEvents(out)).toHaveLength(1);
   });
 
-  it("thought-only stream with STOP is empty", async () => {
-    const probe = await probeSSEStream(sseBody([
-      wrap({ candidates: [{ content: { parts: [{ text: "let me think", thought: true }] } }] }),
-      wrap({ candidates: [{ finishReason: "STOP" }] }),
-    ]), {});
-    expect(probe.verdict).toBe("empty");
+  it("splices correctly when events are split across tiny reads", async () => {
+    const attempt2 = [text("Split across reads"), finish("STOP")];
+    const { out, retries } = await runWrapper([[bareStop()], attempt2], { chunkSize: 7 });
+    expect(out).toBe(sseText(attempt2));
+    expect(retries).toBe(1);
   });
 
-  it("whitespace-only text with STOP is empty", async () => {
-    const probe = await probeSSEStream(sseBody([
-      wrap({ candidates: [{ content: { parts: [{ text: "  \n" }] }, finishReason: "STOP" }] }),
-    ]), {});
-    expect(probe.verdict).toBe("empty");
+  // The accepted oh-my-pi wart: a discarded thought-only attempt has already
+  // streamed its thinking, so the client sees both attempts' thinking in one message.
+  it("thought-only STOP attempt retries; both attempts' thinking reach the client", async () => {
+    const { out, retries } = await runWrapper([
+      [thought("first try"), bareStop()],
+      [thought("second try"), text("answer"), finish("STOP")],
+    ]);
+    expect(out).toContain("first try");
+    expect(out).toContain("second try");
+    expect(retries).toBe(1);
+    expect(finishEvents(out)).toHaveLength(1); // attempt 1's STOP withheld
   });
 
-  it("zero-data 200 stream is empty", async () => {
-    const probe = await probeSSEStream(sseBody([]), {});
-    expect(probe.verdict).toBe("empty");
-    expect(probe.buffered.reduce((n, c) => n + c.length, 0)).toBe(0);
+  it("exhaustion emits a synthetic error event and reports the reason", async () => {
+    const onExhausted = vi.fn();
+    const { out, retries } = await runWrapper(
+      [[bareStop()], [bareStop()], [bareStop()]],
+      { onExhausted },
+    );
+    expect(retries).toBe(2);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted.mock.calls[0][0]).toContain("after 3 attempts");
+    const events = dataEvents(out);
+    expect(events).toHaveLength(1);
+    expect(events[0].error.status).toBe("EMPTY_RESPONSE");
+    expect(events[0].error.message).toContain("STOP");
   });
 
-  it("MALFORMED_FUNCTION_CALL before content is error_finish", async () => {
-    const probe = await probeSSEStream(sseBody([
-      wrap({ candidates: [{ content: { parts: [{ text: "I'll call it now", thought: true }] } }] }),
-      wrap({ candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL" }] }),
-    ]), {});
-    expect(probe.verdict).toBe("error_finish");
-    expect(probe.reason).toBe("MALFORMED_FUNCTION_CALL");
+  it("exhaustion re-emits a held real upstream error instead of the synthetic one", async () => {
+    const quota = wrap({ error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded" } });
+    const { out, retries } = await runWrapper([[quota], [quota], [quota]]);
+    expect(retries).toBe(2);
+    const events = dataEvents(out);
+    expect(events).toHaveLength(1); // held errors of earlier attempts never forwarded
+    expect(events[0].response.error.status).toBe("RESOURCE_EXHAUSTED");
+    expect(events[0].response.error.message).toBe("Quota exceeded");
   });
 
-  it("MALFORMED after meaningful content still releases the stream", async () => {
-    const probe = await probeSSEStream(sseBody([
-      wrap({ candidates: [{ content: { parts: [{ text: "Partial answer" }] } }] }),
-      wrap({ candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL" }] }),
-    ]), {});
-    expect(probe.verdict).toBe("ok");
+  it("MALFORMED_FUNCTION_CALL before content is withheld and retried", async () => {
+    const attempt2 = [text("recovered"), finish("STOP")];
+    const { out, retries } = await runWrapper([
+      [thought("about to call the tool"), finish("MALFORMED_FUNCTION_CALL")],
+      attempt2,
+    ]);
+    expect(retries).toBe(1);
+    expect(out).not.toContain("MALFORMED_FUNCTION_CALL");
+    expect(finishEvents(out)).toHaveLength(1);
   });
 
-  it("embedded error object before content is error_finish", async () => {
-    const probe = await probeSSEStream(sseBody([
-      wrap({ error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded" } }),
-    ]), {});
-    expect(probe.verdict).toBe("error_finish");
-    expect(probe.reason).toBe("RESOURCE_EXHAUSTED");
+  it("MALFORMED_FUNCTION_CALL after content forwards (translator surfaces the error)", async () => {
+    const events = [text("Partial answer"), finish("MALFORMED_FUNCTION_CALL")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
   });
 
-  it("handles SSE events split across tiny read chunks", async () => {
-    const events = [
-      wrap({ candidates: [{ content: { parts: [{ text: "Split across reads" }] } }] }),
-      wrap({ candidates: [{ finishReason: "STOP" }] }),
-    ];
-    const probe = await probeSSEStream(sseBody(events, { chunkSize: 7 }), {});
-    expect(probe.verdict).toBe("ok");
-    const replayed = await drain(replayStream(probe.buffered, probe.reader));
-    expect(replayed).toBe(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""));
-  });
-
-  // Content blocks are deterministic — a retry resends the same blocked prompt and
-  // exhaustion benches the account. The guard must release them so the translator
-  // closes the stream as content_filter (#2188).
-  it("promptFeedback.blockReason-only stream releases as ok, replayed byte-identically", async () => {
+  // Content blocks are deterministic — never retried; the translator closes
+  // them as content_filter (#2188).
+  it("promptFeedback.blockReason forwards untouched with no retry", async () => {
     const events = [wrap({ promptFeedback: { blockReason: "SAFETY" } })];
-    const probe = await probeSSEStream(sseBody(events), {});
-    expect(probe.verdict).toBe("ok");
-    const replayed = await drain(replayStream(probe.buffered, probe.reader));
-    expect(replayed).toBe(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join(""));
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
   });
 
-  it("SAFETY finish before any meaningful content releases as ok, not empty", async () => {
-    const probe = await probeSSEStream(sseBody([
-      wrap({ candidates: [{ content: { parts: [{ text: "hmm", thought: true }] } }] }),
-      wrap({ candidates: [{ finishReason: "SAFETY" }] }),
-    ]), {});
-    expect(probe.verdict).toBe("ok");
+  it("SAFETY finish with no content forwards untouched with no retry", async () => {
+    const events = [thought("hmm"), finish("SAFETY")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
   });
 
-  // A client abort rejects the pending read (fetch body errors when the request
-  // signal fires). It must be classified "aborted", not "empty" — "empty" at the
-  // last attempt turns a disconnect into a 502 + a 30s account bench.
-  it("client abort during a pending read returns aborted, not empty", async () => {
+  it("MAX_TOKENS with no visible content forwards with no retry", async () => {
+    const events = [thought("thinking ate the budget"), finish("MAX_TOKENS")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  it("a stream truncated after content closes without retry", async () => {
+    const events = [text("half an answer")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  it("cancelling the wrapper cancels the upstream reader", async () => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(sseText([text("hi")])));
+        // stream stays open
+      },
+      cancel() { cancelled = true; },
+    });
+    const stream = createEmptyRetryStream({ body, reexecute: async () => sseBody([]), baseDelayMs: 1 });
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel();
+    expect(cancelled).toBe(true);
+  });
+
+  it("client abort surfaces as an AbortError, not a retry", async () => {
     const ac = new AbortController();
     let ctrl;
     const body = new ReadableStream({ start(c) { ctrl = c; } }); // never emits
     ac.signal.addEventListener("abort", () => {
       ctrl.error(Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
     });
-    const probePromise = probeSSEStream(body, { signal: ac.signal });
+    const reexecute = vi.fn();
+    const stream = createEmptyRetryStream({ body, reexecute, signal: ac.signal, baseDelayMs: 1 });
+    const drained = drain(stream);
     setTimeout(() => ac.abort(), 10);
-    expect((await probePromise).verdict).toBe("aborted");
+    await expect(drained).rejects.toMatchObject({ name: "AbortError" });
+    expect(reexecute).not.toHaveBeenCalled();
   });
 
-  // error_finish discards the response — the upstream reader must be cancelled
-  // or the connection lingers until Google closes it.
-  it("error_finish cancels the upstream reader", async () => {
-    let cancelled = false;
-    const raw = `data: ${JSON.stringify(wrap({ candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL" }] }))}\n\n`;
-    const body = new ReadableStream({
-      start(c) { c.enqueue(encoder.encode(raw)); }, // stream stays open
-      cancel() { cancelled = true; },
+  it("reexecute failure emits an error event carrying the upstream message", async () => {
+    const onExhausted = vi.fn();
+    const { out } = await runWrapper([[bareStop()]], {
+      onExhausted,
+      reexecute: async () => { throw new Error("[429] Quota exceeded for account"); },
     });
-    const probe = await probeSSEStream(body, {});
-    expect(probe.verdict).toBe("error_finish");
-    expect(cancelled).toBe(true);
+    const events = dataEvents(out);
+    expect(events).toHaveLength(1);
+    expect(events[0].error.message).toContain("[429] Quota exceeded for account");
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  // End-to-end sanity: a spliced retry must still translate into ONE well-formed
+  // Claude message (single message_start, single message_stop).
+  it("spliced output translates to a single well-formed Claude message", async () => {
+    const { out } = await runWrapper([
+      [thought("first try"), bareStop()],
+      [thought("second try"), text("final answer"), finish("STOP")],
+    ]);
+    const state = initState(FORMATS.CLAUDE);
+    const claudeEvents = [];
+    for (const parsed of dataEvents(out)) {
+      const translated = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, parsed, state);
+      if (translated?.length) claudeEvents.push(...translated.filter(Boolean));
+    }
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    if (flushed?.length) claudeEvents.push(...flushed.filter(Boolean));
+
+    expect(claudeEvents.filter((e) => e.type === "message_start")).toHaveLength(1);
+    expect(claudeEvents.filter((e) => e.type === "message_stop")).toHaveLength(1);
+    expect(claudeEvents.some((e) => e.delta?.type === "thinking_delta")).toBe(true);
+    expect(claudeEvents.some((e) => e.delta?.type === "text_delta" && e.delta.text === "final answer")).toBe(true);
+    const delta = claudeEvents.find((e) => e.type === "message_delta");
+    expect(delta.delta.stop_reason).toBe("end_turn");
   });
 });

--- a/tests/unit/finish-reason-concern.test.js
+++ b/tests/unit/finish-reason-concern.test.js
@@ -9,7 +9,13 @@ describe("toOpenAIFinish - gemini", () => {
     ["RECITATION", "content_filter"],
     ["BLOCKLIST", "content_filter"],
     ["PROHIBITED_CONTENT", "content_filter"],
-    ["OTHER", "stop"],
+    // Aborted turns surface as error (never a clean stop): forwarding e.g.
+    // MALFORMED_FUNCTION_CALL as "stop" made clients treat a broken turn as a
+    // finished answer. Truly unknown values still default to "stop".
+    ["MALFORMED_FUNCTION_CALL", "error"],
+    ["UNEXPECTED_TOOL_CALL", "error"],
+    ["OTHER", "error"],
+    ["SPII", "content_filter"],
     ["UNKNOWN_XYZ", "stop"],
     ["STOP", "stop"],
     ["MAX_TOKENS", "length"],


### PR DESCRIPTION
## Problem

Claude Code → 9router → Antigravity (Gemini) is unstable in ways the other providers are not:

1. **Empty responses** — upstream answers HTTP 200 with a stream carrying no usable output (no candidates, thought-only parts, or a bare `STOP`). The stream "succeeds", so no retry fires and no combo fallback engages; Claude Code hangs on an empty turn (#2188, #2229).
2. **Model says it will do something but does nothing** — Gemini aborts the tool call with `finishReason: MALFORMED_FUNCTION_CALL`, which was forwarded as a clean `end_turn`. The user sees "I'll run the command now." and must type *continue* (#2250).
3. **Streams truncated mid-turn** (dropped connection, no `finishReason`) never emit `message_delta`/`message_stop` — dangling message, client hangs (#2259, #2431).

## Root Cause

- `translator/response/gemini-to-openai.js` dropped every candidate-less chunk — including `promptFeedback.blockReason`-only chunks and `{error:{...}}` objects embedded mid-stream — and discarded upstream `functionCall.id`s.
- `translator/concerns/finishReason.js` defaulted all unmapped Gemini finish reasons (`MALFORMED_FUNCTION_CALL`, `UNEXPECTED_TOOL_CALL`, `OTHER`, …) to `stop` → `end_turn`.
- `translator/response/openai-to-claude.js` only finalized inside `if (choice.finish_reason)` — no flush-time close; the pivot in `translator/index.js` also never forwarded the flush sentinel past the gemini stage.
- Retries (`executors/base.js`, `executors/antigravity.js`) only fire on non-2xx/network errors — a 200-but-empty stream never reaches any retry or fallback path.

## Fix

Five focused changes (one commit each, scoped to the Gemini-family path), plus three review-fix commits:

1. **Gemini error finish reasons → internal hub finish `"error"`** (`GEMINI_ERROR_FINISH_REASONS`); safety family extended with `SPII`/`IMAGE_SAFETY` (now a shared `GEMINI_CONTENT_FILTER_FINISH_REASONS` set); truly unknown values still map to `stop` so a future benign reason can't regress gemini/gemini-cli/vertex. The `STOP→tool_calls` upgrade no longer fires for aborted turns.
2. **gemini-to-openai hardening**: candidate-less chunks now harvest usage (keep-alives), close as `content_filter` (prompt blocked), or close with `"error"` + `state.upstreamError` (embedded error objects). Upstream `functionCall.id` is preserved (dedup via `state.seenToolCallIds`); generated fallback ids use `name_<ts>_<idx>` and the Anthropic id charset.
3. **Claude-side finalization**: flush-time `finalizeOnFlush()` closes open blocks, flushes buffered tool args, and emits `message_delta` + `message_stop` for truncated streams (usage converted to the Claude shape via `toClaudeUsage()` when the gemini stage left OpenAI-shaped counts in the shared state); `state.claudeFinishHandled` guards duplicate finishes (deliberately NOT keyed on the shared `state.finishReason`, which the gemini stage already sets); hub finish `"error"` emits an Anthropic `error` SSE event (retryable by Claude Code) instead of a fake clean `end_turn`.
4. **Empty-stream guard** (`handlers/chatCore/emptyStreamGuard.js`, gated `provider === "antigravity" && stream`) — oh-my-pi parity: **everything, thinking included, streams to the client live**; emptiness is judged per upstream attempt, after the fact. An attempt that ends with a bare `STOP` (or an aborted/error finish, or dies) having produced no meaningful content (tool call / non-whitespace text; thought-only = empty, same definition as oh-my-pi) has its terminal event withheld and is retried with the identical request up to 2× (`500ms·2^n`); the retried attempt **splices into the same client stream** (the translator inits its message once, so the splice continues the same Claude message). On exhaustion an `{error:{...}}` event is emitted in-stream — the translator turns it into the Anthropic `error` SSE event (auto-retried by Claude Code); a held real upstream error (e.g. `RESOURCE_EXHAUSTED`) is re-emitted verbatim so the true message reaches the client. `onUpstreamEmptyExhausted` benches the account (30s via `markAccountUnavailable`) so the client's automatic retry rotates to the next account — the practical replacement for pre-stream fallback, which is impossible once headers are sent. **Deterministic content blocks are never retried**: `promptFeedback.blockReason` chunks and SAFETY-family/`MAX_TOKENS` finishes forward untouched so the translator closes them as `content_filter`/`max_tokens`. Client aborts are classified as aborts (never retried or misreported), and upstream readers are cancelled on every discard path.
5. **functionResponse name recovery** tolerates both generated-id shapes and degrades to the id itself for foreign ids.

**Not touched** (no overlap with open PRs): #2317 (multipleOf), #2222 (ensureObjectType), #2321 (assistant prefill), #2370 (capacity exhausted), #2443 (system prompt injection), #2135 (fake continue turn).

## Behavior notes / trade-offs (from review vs oh-my-pi & antigravity-claude-proxy)

- **Thinking streams live; a retried empty attempt can duplicate it.** Same trade-off oh-my-pi makes: a thought-only attempt has already streamed its thinking before it can be judged empty, so the client may see the discarded attempt's thinking followed by the retry's thinking inside one message. In exchange the UI is never frozen during long thinking phases, and thought-only empties (#2229) stay retryable.
- **Empty-stream exhaustion is an in-stream error, not a pre-stream 502.** Headers are already sent when exhaustion is known, so account/combo fallback cannot run inside the same request. Instead: the account is benched (awaited **before** the error event is emitted, so the client's automatic retry always lands on the next account; quota-style exhaustion parses "reset after XhYmZs" from the upstream message via `parseRetryFromErrorMessage` and benches until the actual reset instead of the generic 30s). Combo **model**-fallback does not trigger for this case (it still triggers for all pre-stream failures).
- **Truncated streams close cleanly** (`end_turn`, or `tool_use` with the buffered args flushed) rather than surfacing a retryable error like oh-my-pi does. Partial content is preserved and the tool loop continues; the cost is that a mid-answer truncation looks complete. Deliberate choice — strictly better than the current hang either way.
- **MALFORMED-family finishes before any content are retried server-side** (oh-my-pi surfaces them immediately and relies on the client retrying; retrying in place saves a full client round-trip with a large prompt). After content they forward as `error` events, exactly like oh-my-pi.
- **OpenAI-format clients** now receive `finish_reason: "error"` (non-standard enum) for aborted gemini turns instead of a silent empty stream; the upstream error message itself is only attached for Claude clients (possible follow-up).

## Tests

- **17 regression cases** in `tests/translator/bugs-antigravity.test.js` (finish-reason mapping, no-upgrade-on-error, promptFeedback close, keep-alive usage, mid-stream error objects, id preservation, flush finalization, flush usage shape, duplicate-finish dedup, MALFORMED end-to-end, id→name round-trip both separators).
- **18 unit cases** in `tests/unit/empty-stream-guard.test.js` (live thought-streaming byte-fidelity, empty-attempt suppression + splice, split reads, duplicate-thinking wart locked, exhaustion synthetic vs real-error re-emit, bench-awaited-before-error ordering, upstream-error passthrough for quota reset parsing, MALFORMED before/after content, blockReason/SAFETY/MAX_TOKENS never retried, truncation-after-content no-retry, downstream cancel propagation, abort classification, reexecute failure, splice→Claude single-message sanity).
- `tests/unit/finish-reason-concern.test.js`: `OTHER` moves to the aborted-turn set (`error`); `SPII` → `content_filter`; `UNKNOWN_XYZ` still locks the default-to-`stop`.
- **Full suite vs clean master: zero new failures** — verified twice, including after the review fixes, by running the JSON reporter on both trees and diffing the failing-test sets (identical 45-test set, all pre-existing).

## Evidence (before/after)

Pathological Gemini streams pushed through `translateResponse(ANTIGRAVITY → CLAUDE)` on master vs this branch — what the Claude Code client receives:

```
=== 1. Model narrates tool call, Gemini aborts with MALFORMED_FUNCTION_CALL (#2250) ===
master: … content_block_stop → message_delta stop_reason=end_turn → message_stop   ← fake "finished answer"
branch: … content_block_stop → error api_error (retryable)

=== 2. Stream truncated mid-answer, no finishReason (#2259, #2431) ===
master: message_start → content_block_start → content_block_delta                  ← dangling, client hangs
branch: … → content_block_stop → message_delta stop_reason=end_turn → message_stop

=== 3. Stream truncated with an unfinished tool call ===
master: message_start → content_block_start                                        ← tool args lost, hangs
branch: … → input_json_delta flushed → message_delta stop_reason=tool_use → message_stop

=== 4. Prompt blocked: promptFeedback-only chunk (#2188) ===
master: (no events — empty 200 stream)                                             ← hangs
branch: message_start → message_delta → message_stop  (guard releases, no retry)

=== 5. {error:{RESOURCE_EXHAUSTED}} embedded in 200 stream ===
master: message_start → content_block_start → content_block_delta                  ← hangs
branch: … → error api_error: Quota exceeded
```

Fixes #2250. Addresses the antigravity/gemini portion of #2188, #2229, #2259, #2431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
