### PR TITLE
fix(minimax): resolve runtimeTransport/modelTargetFormat conflict and extract <think> for M3

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -47,10 +47,16 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);
-  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation
+  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation.
+  // If found, force targetFormat=sourceFormat so we skip translation entirely —
+  // otherwise the body could be translated to modelTargetFormat and sent to a
+  // transport that doesn't understand it.
   const runtimeTransport = resolveTransport(provider, sourceFormat);
-  const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider);
-  if (runtimeTransport && credentials) credentials.runtimeTransport = runtimeTransport;
+  const skipTranslation = runtimeTransport?.format === sourceFormat;
+  if (skipTranslation && credentials) credentials.runtimeTransport = runtimeTransport;
+  const targetFormat = skipTranslation
+    ? sourceFormat
+    : (modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider));
   const stripList = getModelStrip(alias, model);
   const upstreamModel = getModelUpstreamId(alias, model);
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -9,6 +9,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { extractThinkTags } from "../../utils/thinkExtractor.js";
 
 function parseToolArguments(value) {
   if (!value) return {};
@@ -242,6 +243,25 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     : responseBody;
   const isClaudeMessageResponse = sourceFormat === FORMATS.CLAUDE && translatedResponse?.type === "message";
 
+  // Extract <think>...</think> from content into reasoning_content for providers
+  // that inline thinking as XML tags in the content field (e.g. MiniMax M3 on
+  // OpenAI-format tiers). Non-streaming responses are a single JSON blob — a
+  // simple regex pass suffices.
+  let extractedThink = false;
+  if (translatedResponse?.choices) {
+    for (const choice of translatedResponse.choices) {
+      const msg = choice?.message;
+      if (msg?.content && typeof msg.content === "string") {
+        const { content, reasoning } = extractThinkTags(msg.content);
+        if (reasoning) {
+          msg.reasoning_content = reasoning;
+          msg.content = content;
+          extractedThink = true;
+        }
+      }
+    }
+  }
+
   // Fix finish_reason for tool_calls: some providers return non-standard values (e.g. "other")
   if (translatedResponse?.choices?.[0]) {
     const choice = translatedResponse.choices[0];
@@ -270,10 +290,9 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     translatedResponse.usage = filterUsageForFormat(addBufferToUsage(translatedResponse.usage), sourceFormat);
   }
 
-  // Strip reasoning_content only when content is non-empty.
-  // When content is empty (e.g. thinking models that used all tokens for reasoning),
-  // reasoning_content is the only useful output and must be preserved.
-  if (!isClaudeMessageResponse && translatedResponse?.choices) {
+  // Strip reasoning_content only when content is non-empty AND we didn't just
+  // extract it from <think> tags above (those models need both fields exposed).
+  if (!isClaudeMessageResponse && translatedResponse?.choices && !extractedThink) {
     for (const choice of translatedResponse.choices) {
       if (choice?.message?.reasoning_content && choice.message.content) {
         delete choice.message.reasoning_content;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -7,6 +7,7 @@ import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatInco
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
+import { createThinkExtractor } from "./thinkExtractor.js";
 
 export { COLORS, formatSSE };
 export { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER };
@@ -72,6 +73,9 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+
+  // State for extracting <think>...</think> to reasoning_content across SSE chunks
+  const extractThink = createThinkExtractor();
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -149,6 +153,25 @@ export function createSSEStream(options = {}) {
               }
 
               const delta = parsed.choices?.[0]?.delta;
+
+              // Extract <think>...</think> from content into reasoning_content.
+              // MiniMax M3 on OpenAI-format provider tiers embeds thinking as XML
+              // tags inside `content` instead of a separate `reasoning_content`.
+              if (typeof delta?.content === "string") {
+                const { content: text, reasoning } = extractThink(delta.content);
+                if (reasoning) {
+                  delta.reasoning_content = reasoning;
+                }
+                if (text !== delta.content) {
+                  if (delta.reasoning_content && (!text || !text.trim())) {
+                    delete delta.content;
+                  } else {
+                    delta.content = text || "";
+                  }
+                  fieldsInjected = true;
+                }
+              }
+
               const content = delta?.content;
               const reasoning = delta?.reasoning_content;
               if (content && typeof content === "string") {

--- a/open-sse/utils/thinkExtractor.js
+++ b/open-sse/utils/thinkExtractor.js
@@ -1,0 +1,54 @@
+// Match `<think>...</think>` (non-global — lastIndex state is shared across
+// concurrent calls and would cause races). Stripping below uses the same
+// pattern to avoid relying on a shared regex.
+const OPEN_TAG = "<think>";
+const CLOSE_TAG = "</think>";
+const PAIR_RE = new RegExp(`${OPEN_TAG}([\\s\\S]*?)${CLOSE_TAG}\\s*`);
+
+export function extractThinkTags(content) {
+  if (typeof content !== "string") return { content, reasoning: null };
+  const m = content.match(PAIR_RE);
+  if (!m) return { content, reasoning: null };
+  return {
+    content: content.replace(new RegExp(`${OPEN_TAG}[\\s\\S]*?${CLOSE_TAG}\\s*`, "g"), "").trimStart(),
+    reasoning: m[1].trim(),
+  };
+}
+
+export function createThinkExtractor() {
+  let buf = "";
+  let inThink = false;
+  return function process(text) {
+    let reasoning = null;
+    if (typeof text !== "string") return { content: text, reasoning };
+    if (inThink) {
+      const endIdx = text.indexOf(CLOSE_TAG);
+      if (endIdx >= 0) {
+        buf += text.slice(0, endIdx);
+        reasoning = buf.trim();
+        buf = "";
+        inThink = false;
+        text = text.slice(endIdx + 8).trimStart();
+      } else {
+        buf += text;
+        text = "";
+      }
+    }
+    if (!inThink) {
+      const startIdx = text.indexOf(OPEN_TAG);
+      if (startIdx >= 0) {
+        const after = text.slice(startIdx + 7);
+        const endIdx = after.indexOf(CLOSE_TAG);
+        if (endIdx >= 0) {
+          reasoning = (reasoning ? reasoning + "\n" : "") + after.slice(0, endIdx).trim();
+          text = text.slice(0, startIdx) + after.slice(endIdx + 8).trimStart();
+        } else {
+          inThink = true;
+          buf = after;
+          text = text.slice(0, startIdx);
+        }
+      }
+    }
+    return { content: text, reasoning };
+  };
+}


### PR DESCRIPTION
## Problem

### 1. `invalid tool type: (2013)` errors (#2435)

When an OpenAI client requests `minimax-cn/MiniMax-M3`, the `modelTargetFormat: "claude"` overrides the matching `runtimeTransport` (openai), causing the request body to be translated to Claude format before being sent to the OpenAI endpoint — resulting in 400 errors.

**Root cause**: `chatCore.js` used `modelTargetFormat || runtimeTransport?.format` — `modelTargetFormat` always wins.

**Fix**: When `runtimeTransport.format === sourceFormat`, prefer the transport for zero-translation passthrough instead of the model's declared targetFormat. This aligns with `buildUrl()` and `buildHeaders()` which already prioritize `runtimeTransport`.

### 2. MiniMax M3 embeds reasoning as `<think>` tags

M3's OpenAI endpoint returns reasoning as `<think>...</think>` XML tags inside the `content` field rather than using `reasoning_content`. This leaks raw XML to downstream clients and prevents tools like OpenCode from displaying the reasoning process.

**Fix**: New `thinkExtractor.js` module extracts `<think>` tags for both streaming (cross-chunk state tracking via `createThinkExtractor()`) and non-streaming (single-pass regex via `extractThinkTags()`) responses.

## Changes

| File | Description |
|------|------------|
| `chatCore.js` | Prefer `runtimeTransport.format` when it matches `sourceFormat` |
| `stream.js` | Extract `<think>` to `reasoning_content` during passthrough streaming |
| `nonStreamingHandler.js` | Extract `<think>` for non-streaming; guard extracted content from being stripped |
| `thinkExtractor.js` | New module: `extractThinkTags()` (non-streaming) + `createThinkExtractor()` (streaming) |

## Testing

- `npm run build` ✅
- End-to-end verified on arm64 deployment: streaming + non-streaming both correctly extract reasoning
- 48/48 related unit tests pass

Fixes #2435
Closes #2231