### PR TITLE
fix(translator): clamp thinking effort max->xhigh for OpenAI provider (fixes 400 max effort not support)

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -184,7 +184,8 @@ function applyFormat(fmt, body, cfg, caps) {
     case "openai": {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
       const level = toLevel(eff);
-      if (level) body.reasoning_effort = level;
+      // OpenAI reasoning_effort enum caps at "xhigh" (no "max"); clamp Claude Code's "max".
+      if (level) body.reasoning_effort = level === "max" ? "xhigh" : level;
       break;
     }
     case "claude-adaptive": {

--- a/tests/unit/thinking-effort-openai-max-clamp.test.js
+++ b/tests/unit/thinking-effort-openai-max-clamp.test.js
@@ -7,7 +7,7 @@ import { FORMATS } from "../../open-sse/translator/formats.js";
 // must clamp "max"→"xhigh" because OpenAI's reasoning_effort enum has no "max"
 // (L.openai caps at "xhigh"). Without the clamp, upstream returns HTTP 400
 // "max effort not support". See open-sse/providers/thinkingLevels.js:10.
-describe("Quick 260708-k1x: clamp thinking effort max→xhigh for OpenAI target", () => {
+describe("applyThinking (openai): clamp max effort to xhigh", () => {
   it("client output_config.effort:\"max\" → reasoning_effort:\"xhigh\" (not \"max\")", () => {
     const body = { output_config: { effort: "max" } };
     const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");

--- a/tests/unit/thinking-effort-openai-max-clamp.test.js
+++ b/tests/unit/thinking-effort-openai-max-clamp.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+// Regression: Claude Code sends thinking effort "max" (its top level). When
+// 9router routes to an OpenAI-format provider, applyThinking() case "openai"
+// must clamp "max"→"xhigh" because OpenAI's reasoning_effort enum has no "max"
+// (L.openai caps at "xhigh"). Without the clamp, upstream returns HTTP 400
+// "max effort not support". See open-sse/providers/thinkingLevels.js:10.
+describe("Quick 260708-k1x: clamp thinking effort max→xhigh for OpenAI target", () => {
+  it("client output_config.effort:\"max\" → reasoning_effort:\"xhigh\" (not \"max\")", () => {
+    const body = { output_config: { effort: "max" } };
+    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+    expect(out.reasoning_effort).toBe("xhigh");
+  });
+
+  it("direct reasoning_effort:\"max\" clamped to \"xhigh\"", () => {
+    const body = { reasoning_effort: "max" };
+    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+    expect(out.reasoning_effort).toBe("xhigh");
+  });
+
+  it("\"xhigh\" passes through unchanged (highest valid OpenAI level)", () => {
+    const body = { reasoning_effort: "xhigh" };
+    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+    expect(out.reasoning_effort).toBe("xhigh");
+  });
+
+  it("\"high\" passes through unchanged", () => {
+    const body = { reasoning_effort: "high" };
+    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("max budget (thinking.budget_tokens:128000) → reasoning_effort:\"xhigh\" (budgetToLevel caps at xhigh)", () => {
+    const body = { thinking: { type: "enabled", budget_tokens: 128000 } };
+    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+    expect(out.reasoning_effort).toBe("xhigh");
+  });
+});


### PR DESCRIPTION
## Summary

Claude Code sends thinking effort `"max"` (its top effort level). When 9router routes a request to an OpenAI-format upstream, `applyThinking()` case `"openai"` set `body.reasoning_effort = level` verbatim. OpenAI's `reasoning_effort` enum has no `"max"` — it caps at `"xhigh"` (per `open-sse/providers/thinkingLevels.js` `L.openai = ["none","minimal","low","medium","high","xhigh"]`). The upstream returns HTTP 400 `"max effort not support"`.

Other format cases already clamp (`claude-adaptive` maps `xhigh`→`high`, `step` maps `xhigh|max`→`high`, `deepseek` maps `xhigh|max`→`max`). The `openai` case was the lone gap.

## Fix

One-line clamp at the leak point in `open-sse/translator/concerns/thinkingUnified.js` `applyFormat` case `"openai"`:

```js
case "openai": {
  if (none && canDisable) { body.reasoning_effort = "none"; break; }
  const level = toLevel(eff);
  // OpenAI reasoning_effort enum caps at "xhigh" (no "max"); clamp Claude Code's "max".
  if (level) body.reasoning_effort = level === "max" ? "xhigh" : level;
  break;
}
```

No generic clamp layer — YAGNI; every other format case already handles its own ceiling. Single-line fix at the one case that leaked.

## Test

`tests/unit/thinking-effort-openai-max-clamp.test.js` — 5 cases, all green:

1. client `output_config.effort:"max"` → `reasoning_effort:"xhigh"` (not `"max"`)
2. direct `reasoning_effort:"max"` → clamped to `"xhigh"`
3. `"xhigh"` passthrough unchanged (highest valid OpenAI level)
4. `"high"` passthrough unchanged
5. max budget `thinking.budget_tokens:128000` → `"xhigh"` (`budgetToLevel` already caps at `xhigh`, never `max`)

Run: `cd tests && npx vitest run unit/thinking-effort-openai-max-clamp.test.js`

## Files

- `open-sse/translator/concerns/thinkingUnified.js` — 1-line clamp + comment (case `"openai"`)
- `tests/unit/thinking-effort-openai-max-clamp.test.js` — new regression test (5 cases)

No `.planning/` or docs artifacts — code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)