### PR TITLE
fix(kiro): anchor Claude sessions from cache control

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -384,33 +384,12 @@ export class KiroExecutor extends BaseExecutor {
             state.hasMeteringEvent = true;
           }
 
-          // Handle metricsEvent for token usage
-          if (eventType === "metricsEvent") {
-            // Extract usage data from metricsEvent payload
-            const metrics = event.payload?.metricsEvent || event.payload;
-            if (metrics && typeof metrics === 'object') {
-              const inputTokens = metrics.inputTokens || 0;
-              const outputTokens = metrics.outputTokens || 0;
-              // ponytail: Amazon Q upstream does not expose cache fields today,
-              // but pick up cache_read_input_tokens / cache_creation_input_tokens
-              // if the event shape grows them so cost tracking stays accurate.
-              const cachedTokens = metrics.cacheReadInputTokens || metrics.cache_read_input_tokens || 0;
-              const cacheCreationInputTokens = metrics.cacheCreationInputTokens || metrics.cache_creation_input_tokens || 0;
-
-              if (inputTokens > 0 || outputTokens > 0) {
-                state.usage = {
-                  prompt_tokens: inputTokens,
-                  completion_tokens: outputTokens,
-                  total_tokens: inputTokens + outputTokens
-                };
-                // Kiro is Claude-backed: inputTokens EXCLUDES cache (Claude convention),
-                // not inclusive like OpenAI's cached_tokens. Emit cache_read_input_tokens
-                // (not cached_tokens) so canonicalizeUsage takes the Claude fold path and
-                // correctly adds cache back into prompt_tokens instead of undercharging.
-                if (cachedTokens > 0) state.usage.cache_read_input_tokens = cachedTokens;
-                if (cacheCreationInputTokens > 0) state.usage.cache_creation_input_tokens = cacheCreationInputTokens;
-              }
-            }
+          // Handle Kiro token usage. Current CodeWhisperer surfaces can send
+          // metricsEvent fields directly; newer Kiro/Amazon Q schemas carry
+          // usage under metadataEvent.tokenUsage.
+          if (eventType === "metricsEvent" || eventType === "metadataEvent") {
+            const usage = extractKiroUsageFromEvent(eventType, event.payload);
+            if (usage) state.usage = usage;
           }
 
           // Emit final chunk only after receiving BOTH meteringEvent AND contextUsageEvent
@@ -587,6 +566,68 @@ function parseEventFrame(data) {
   } catch {
     return null;
   }
+}
+
+function firstNumber(...values) {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return 0;
+}
+
+function toKiroUsage(raw) {
+  if (!raw || typeof raw !== "object") return null;
+
+  const inputTokens = firstNumber(
+    raw.uncachedInputTokens,
+    raw.inputTokens,
+    raw.input_tokens,
+    raw.prompt_tokens
+  );
+  const outputTokens = firstNumber(
+    raw.outputTokens,
+    raw.output_tokens,
+    raw.completion_tokens
+  );
+  const cachedTokens = firstNumber(
+    raw.cacheReadInputTokens,
+    raw.cache_read_input_tokens,
+    raw.cachedTokens,
+    raw.cached_tokens
+  );
+  const cacheCreationInputTokens = firstNumber(
+    raw.cacheWriteInputTokens,
+    raw.cacheCreationInputTokens,
+    raw.cache_creation_input_tokens
+  );
+
+  if (inputTokens <= 0 && outputTokens <= 0 && cachedTokens <= 0 && cacheCreationInputTokens <= 0) {
+    return null;
+  }
+
+  const usage = {
+    prompt_tokens: inputTokens,
+    completion_tokens: outputTokens,
+    total_tokens: inputTokens + outputTokens
+  };
+  // Kiro native usage follows Claude cache accounting: uncachedInputTokens /
+  // inputTokens exclude cache reads and cache writes. Keep the cache fields
+  // separate so canonicalizeUsage folds them into stored prompt_tokens once.
+  if (cachedTokens > 0) usage.cache_read_input_tokens = cachedTokens;
+  if (cacheCreationInputTokens > 0) usage.cache_creation_input_tokens = cacheCreationInputTokens;
+  return usage;
+}
+
+function extractKiroUsageFromEvent(eventType, payload) {
+  if (!payload || typeof payload !== "object") return null;
+
+  if (eventType === "metadataEvent") {
+    const metadata = payload.metadataEvent || payload;
+    return toKiroUsage(metadata?.tokenUsage);
+  }
+
+  const metrics = payload.metricsEvent || payload;
+  return toKiroUsage(metrics?.tokenUsage || metrics);
 }
 
 export default KiroExecutor;

--- a/open-sse/translator/concerns/usage.js
+++ b/open-sse/translator/concerns/usage.js
@@ -1,12 +1,23 @@
 // Build OpenAI usage object. Caller computes prompt/completion/total (provider math).
 // Optional details added only when > 0 (matches existing claude/gemini/codex behavior).
-export function buildUsage({ promptTokens, completionTokens, totalTokens, cachedTokens = 0, cacheCreationTokens = 0, reasoningTokens = 0 }) {
+export function buildUsage({
+  promptTokens,
+  completionTokens,
+  totalTokens,
+  cachedTokens = 0,
+  cacheCreationTokens = 0,
+  reasoningTokens = 0,
+  cacheReadInputTokens = 0,
+  cacheCreationInputTokens = 0
+}) {
   const usage = { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: totalTokens };
   if (cachedTokens > 0 || cacheCreationTokens > 0) {
     usage.prompt_tokens_details = {};
     if (cachedTokens > 0) usage.prompt_tokens_details.cached_tokens = cachedTokens;
     if (cacheCreationTokens > 0) usage.prompt_tokens_details.cache_creation_tokens = cacheCreationTokens;
   }
+  if (cacheReadInputTokens > 0) usage.cache_read_input_tokens = cacheReadInputTokens;
+  if (cacheCreationInputTokens > 0) usage.cache_creation_input_tokens = cacheCreationInputTokens;
   if (reasoningTokens > 0) {
     usage.completion_tokens_details = { reasoning_tokens: reasoningTokens };
   }
@@ -14,6 +25,22 @@ export function buildUsage({ promptTokens, completionTokens, totalTokens, cached
 }
 
 const n = (v) => (typeof v === "number" ? v : 0);
+const firstNumber = (...values) => {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return 0;
+};
+
+const kiroUsagePayload = (raw) => {
+  if (!raw || typeof raw !== "object") return raw;
+  if (raw.tokenUsage) return raw.tokenUsage;
+  if (raw.metadataEvent?.tokenUsage) return raw.metadataEvent.tokenUsage;
+  if (raw.metricsEvent?.tokenUsage) return raw.metricsEvent.tokenUsage;
+  if (raw.usageEvent) return raw.usageEvent;
+  if (raw.metricsEvent && typeof raw.metricsEvent === "object") return raw.metricsEvent;
+  return raw;
+};
 
 // Per-provider raw token field-map + math. Returns buildUsage() args (NOT the usage object).
 // Keeps each provider's exact semantics: claude/gemini fold cache+reasoning, others don't.
@@ -38,16 +65,40 @@ const USAGE_EXTRACTORS = {
     return { promptTokens: prompt, completionTokens: candidates + thoughts, totalTokens: total, cachedTokens: cached, reasoningTokens: thoughts };
   },
   kiro(raw) {
-    const input = n(raw.inputTokens), output = n(raw.outputTokens);
-    // ponytail: Amazon Q (Kiro upstream) does not expose cache fields today,
-    // but pass through any cache_read/cache_creation/cached_tokens if the
-    // event shape grows them later so cost tracking keeps working without
-    // a second pass.
-    const cached = n(raw.cache_read_input_tokens) || n(raw.cachedTokens) || n(raw.cached_tokens);
-    const cacheCreation = n(raw.cache_creation_input_tokens);
-    const out = { promptTokens: input, completionTokens: output, totalTokens: input + output };
+    const usage = kiroUsagePayload(raw) || {};
+    const input = firstNumber(
+      usage.uncachedInputTokens,
+      usage.inputTokens,
+      usage.input_tokens,
+      usage.prompt_tokens
+    );
+    const output = firstNumber(
+      usage.outputTokens,
+      usage.output_tokens,
+      usage.completion_tokens
+    );
+    const cached = firstNumber(
+      usage.cacheReadInputTokens,
+      usage.cache_read_input_tokens,
+      usage.cachedTokens,
+      usage.cached_tokens
+    );
+    const cacheCreation = firstNumber(
+      usage.cacheWriteInputTokens,
+      usage.cacheCreationInputTokens,
+      usage.cache_creation_input_tokens
+    );
+    const out = {
+      promptTokens: input,
+      completionTokens: output,
+      totalTokens: input + output
+    };
     if (cached > 0) out.cachedTokens = cached;
     if (cacheCreation > 0) out.cacheCreationTokens = cacheCreation;
+    // Kiro native input is cache-exclusive. Carry Claude-style cache fields so
+    // canonical storage can fold them into prompt_tokens exactly once.
+    if (cached > 0) out.cacheReadInputTokens = cached;
+    if (cacheCreation > 0) out.cacheCreationInputTokens = cacheCreation;
     return out;
   },
   ollama(raw) {

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -44,6 +44,8 @@ const SLACK_TS_URL_RE = "\\d{10}(?:(?:\\.|%2E)\\d{1,6})?|\\d{16}";
 const FIRST_USER_ANCHOR_MAX = 2048;
 const CACHE_CONTROL_KEY = "cache_control";
 const KIRO_DEFAULT_CACHE_POINT = { type: "default" };
+const KIRO_CONTEXT_ASSISTANT_ACK =
+  "I will fully incorporate this information when generating my responses, and explicitly acknowledge relevant parts of the summary when answering questions.";
 
 function withoutVolatileSessionHeaders(headers) {
   if (!headers || typeof headers !== "object") return headers;
@@ -177,6 +179,40 @@ function applyDefaultKiroCachePoint(userInputMessage) {
   if (userInputMessage) {
     userInputMessage.cachePoint = { ...KIRO_DEFAULT_CACHE_POINT };
   }
+}
+
+function closeHistoryUserCachePointBoundaries(history) {
+  const normalized = [];
+
+  for (let i = 0; i < history.length; i++) {
+    const item = history[i];
+    const userInputMessage = item.userInputMessage;
+    const cachePoint = userInputMessage?.cachePoint;
+    if (!cachePoint) {
+      normalized.push(item);
+      continue;
+    }
+
+    delete userInputMessage.cachePoint;
+    normalized.push(item);
+
+    const next = history[i + 1];
+    if (next?.assistantResponseMessage) {
+      if (!next.assistantResponseMessage.cachePoint) {
+        next.assistantResponseMessage.cachePoint = { ...cachePoint };
+      }
+      continue;
+    }
+
+    normalized.push({
+      assistantResponseMessage: {
+        content: KIRO_CONTEXT_ASSISTANT_ACK,
+        cachePoint: { ...cachePoint },
+      },
+    });
+  }
+
+  return normalized;
 }
 
 function systemPartText(part) {
@@ -747,7 +783,7 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     messages = flattenClaudeToolInteractions(messages);
   }
 
-  const { history, currentMessage } = convertClaudeMessagesToKiro(
+  let { history, currentMessage } = convertClaudeMessagesToKiro(
     messages,
     tools,
     upstreamModel
@@ -799,13 +835,20 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
       agentic
     );
     if (cachedPrefixContent) {
-      history.unshift({
-        userInputMessage: {
-          content: cachedPrefixContent,
-          modelId: upstreamModel,
-          cachePoint: { ...KIRO_DEFAULT_CACHE_POINT },
+      history.unshift(
+        {
+          userInputMessage: {
+            content: cachedPrefixContent,
+            modelId: upstreamModel,
+          },
         },
-      });
+        {
+          assistantResponseMessage: {
+            content: KIRO_CONTEXT_ASSISTANT_ACK,
+            cachePoint: { ...KIRO_DEFAULT_CACHE_POINT },
+          },
+        }
+      );
     }
     finalContent = `[Context: Current time is ${timestamp}]\n\n${finalContent}`;
   } else {
@@ -815,6 +858,8 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
     finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
   }
+
+  history = closeHistoryUserCachePointBoundaries(history);
 
   const userInputMessage = {
     content: finalContent,

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -42,6 +42,7 @@ const SLACK_CHANNEL_RE = "[CGD][A-Z0-9]{8,}";
 const SLACK_TS_RE = "\\d{10}(?:\\.\\d{1,6})?|\\d{16}";
 const SLACK_TS_URL_RE = "\\d{10}(?:(?:\\.|%2E)\\d{1,6})?|\\d{16}";
 const FIRST_USER_ANCHOR_MAX = 2048;
+const CACHE_CONTROL_KEY = "cache_control";
 
 function withoutVolatileSessionHeaders(headers) {
   if (!headers || typeof headers !== "object") return headers;
@@ -71,6 +72,90 @@ function normalizeAnchorText(value) {
   } catch {
     return "";
   }
+}
+
+function hasCacheControl(value) {
+  return value && typeof value === "object" && value[CACHE_CONTROL_KEY] !== undefined;
+}
+
+function stripCacheControlForAnchor(value) {
+  if (Array.isArray(value)) return value.map(stripCacheControlForAnchor);
+  if (!value || typeof value !== "object") return value;
+
+  const clean = {};
+  for (const key of Object.keys(value).sort()) {
+    if (key === CACHE_CONTROL_KEY) continue;
+    const child = stripCacheControlForAnchor(value[key]);
+    if (child !== undefined) clean[key] = child;
+  }
+  return clean;
+}
+
+function stableAnchorJson(value) {
+  return JSON.stringify(stripCacheControlForAnchor(value));
+}
+
+function collectCacheControlAnchorSegments(body) {
+  const segments = [];
+  const pushSegment = (kind, value, cacheControlBearing = false) => {
+    segments.push({
+      cacheControlBearing,
+      value: stableAnchorJson([kind, value]),
+    });
+  };
+
+  if (typeof body?.system === "string") {
+    pushSegment("system:text", body.system);
+  } else if (Array.isArray(body?.system)) {
+    for (const part of body.system) {
+      pushSegment("system:block", part, hasCacheControl(part));
+    }
+  } else if (body?.system) {
+    pushSegment("system:block", body.system, hasCacheControl(body.system));
+  }
+
+  if (Array.isArray(body?.tools)) {
+    for (const tool of body.tools) {
+      pushSegment("tool", tool, hasCacheControl(tool));
+    }
+  }
+
+  if (Array.isArray(body?.messages)) {
+    for (const message of body.messages) {
+      const role = message?.role || "unknown";
+      const content = message?.content;
+      if (typeof content === "string") {
+        pushSegment(`message:${role}:text`, content);
+      } else if (Array.isArray(content)) {
+        for (const block of content) {
+          const kind =
+            typeof block === "string"
+              ? `message:${role}:text`
+              : `message:${role}:${block?.type || "block"}`;
+          pushSegment(kind, block, hasCacheControl(block));
+        }
+      } else if (content !== undefined && content !== null) {
+        pushSegment(`message:${role}:block`, content, hasCacheControl(content));
+      }
+    }
+  }
+
+  return segments;
+}
+
+function findClaudeCacheControlAnchor(body) {
+  const segments = collectCacheControlAnchorSegments(body);
+  let lastCacheControlIndex = -1;
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].cacheControlBearing) lastCacheControlIndex = i;
+  }
+  if (lastCacheControlIndex === -1) return null;
+
+  const prefix = segments
+    .slice(0, lastCacheControlIndex + 1)
+    .map((segment) => segment.value)
+    .join("\n");
+  return `cache-control:${prefix}`;
 }
 
 function normalizeSlackTs(value) {
@@ -165,7 +250,7 @@ function bodyHasExplicitSessionId(body) {
 function bodyWithKiroPromptCacheKey(body, connectionId) {
   if (bodyHasExplicitSessionId(body)) return body;
 
-  const anchor = findKiroStableAnchor(body, connectionId);
+  const anchor = findClaudeCacheControlAnchor(body) || findKiroStableAnchor(body, connectionId);
   return {
     ...body,
     prompt_cache_key: deterministicUuid(`kiro:${anchor}`),

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -43,6 +43,7 @@ const SLACK_TS_RE = "\\d{10}(?:\\.\\d{1,6})?|\\d{16}";
 const SLACK_TS_URL_RE = "\\d{10}(?:(?:\\.|%2E)\\d{1,6})?|\\d{16}";
 const FIRST_USER_ANCHOR_MAX = 2048;
 const CACHE_CONTROL_KEY = "cache_control";
+const KIRO_DEFAULT_CACHE_POINT = { type: "default" };
 
 function withoutVolatileSessionHeaders(headers) {
   if (!headers || typeof headers !== "object") return headers;
@@ -99,6 +100,7 @@ function collectCacheControlAnchorSegments(body) {
   const segments = [];
   const pushSegment = (kind, value, cacheControlBearing = false) => {
     segments.push({
+      kind,
       cacheControlBearing,
       value: stableAnchorJson([kind, value]),
     });
@@ -156,6 +158,25 @@ function findClaudeCacheControlAnchor(body) {
     .map((segment) => segment.value)
     .join("\n");
   return `cache-control:${prefix}`;
+}
+
+function findLastClaudeCacheControlKind(body) {
+  const segments = collectCacheControlAnchorSegments(body);
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (segments[i].cacheControlBearing) return segments[i].kind;
+  }
+  return null;
+}
+
+function cachePointBelongsOnCurrentMessage(body) {
+  const kind = findLastClaudeCacheControlKind(body);
+  return kind === "tool" || kind?.startsWith("system:");
+}
+
+function applyDefaultKiroCachePoint(userInputMessage) {
+  if (userInputMessage) {
+    userInputMessage.cachePoint = { ...KIRO_DEFAULT_CACHE_POINT };
+  }
 }
 
 function normalizeSlackTs(value) {
@@ -342,7 +363,11 @@ function flattenClaudeToolInteractions(messages) {
     if (msg.role === ROLE.USER && Array.isArray(msg.content)) {
       const newContent = msg.content.map((block) =>
         block.type === CLAUDE_BLOCK.TOOL_RESULT
-          ? { type: CLAUDE_BLOCK.TEXT, text: toolResultBlockToText(block.content) }
+          ? {
+              type: CLAUDE_BLOCK.TEXT,
+              text: toolResultBlockToText(block.content),
+              ...(hasCacheControl(block) && { [CACHE_CONTROL_KEY]: block[CACHE_CONTROL_KEY] }),
+            }
           : block
       );
       out.push({ ...msg, content: newContent });
@@ -367,6 +392,8 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
   let pendingAssistantContent = [];
   let pendingToolResults = [];
   let pendingImages = [];
+  let pendingUserCachePoint = false;
+  let pendingCachePointForNextUser = false;
   let currentRole = null;
   let toolsInjected = false;
 
@@ -398,6 +425,10 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
       if (pendingImages.length > 0) {
         userMsg.userInputMessage.images = pendingImages;
       }
+      if (pendingUserCachePoint || pendingCachePointForNextUser) {
+        applyDefaultKiroCachePoint(userMsg.userInputMessage);
+        pendingCachePointForNextUser = false;
+      }
       if (pendingToolResults.length > 0) {
         userMsg.userInputMessage.userInputMessageContext = {
           toolResults: pendingToolResults,
@@ -417,6 +448,7 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
       pendingUserContent = [];
       pendingToolResults = [];
       pendingImages = [];
+      pendingUserCachePoint = false;
     } else if (currentRole === ROLE.ASSISTANT) {
       const content = pendingAssistantContent.join("\n\n").trim() || "...";
       history.push({ assistantResponseMessage: { content } });
@@ -434,6 +466,7 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
         pendingUserContent.push(msg.content);
       } else if (Array.isArray(msg.content)) {
         for (const block of msg.content) {
+          if (hasCacheControl(block)) pendingUserCachePoint = true;
           if (block.type === CLAUDE_BLOCK.TEXT) {
             pendingUserContent.push(block.text);
           } else if (block.type === CLAUDE_BLOCK.IMAGE && block.source?.type === "base64") {
@@ -468,6 +501,7 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
         textContent = msg.content;
       } else if (Array.isArray(msg.content)) {
         for (const block of msg.content) {
+          if (hasCacheControl(block)) pendingCachePointForNextUser = true;
           if (block.type === CLAUDE_BLOCK.TEXT) {
             textContent += block.text;
           } else if (block.type === CLAUDE_BLOCK.TOOL_USE) {
@@ -527,6 +561,9 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
     const prev = mergedHistory[mergedHistory.length - 1];
     if (current.userInputMessage && prev?.userInputMessage) {
       prev.userInputMessage.content += "\n\n" + current.userInputMessage.content;
+      if (current.userInputMessage.cachePoint) {
+        applyDefaultKiroCachePoint(prev.userInputMessage);
+      }
       const prevCtx = prev.userInputMessage.userInputMessageContext;
       const curCtx = current.userInputMessage.userInputMessageContext;
       if (curCtx) {
@@ -638,6 +675,10 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     upstreamModel
   );
 
+  if (cachePointBelongsOnCurrentMessage(body)) {
+    applyDefaultKiroCachePoint(currentMessage?.userInputMessage);
+  }
+
   // Guard 2: tools present → reconcile dangling tool_results.
   if (clientProvidedTools) {
     reconcileOrphanedToolResults(history, currentMessage);
@@ -689,6 +730,9 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     }),
     ...(currentMessage?.userInputMessage?.images && {
       images: currentMessage.userInputMessage.images,
+    }),
+    ...(currentMessage?.userInputMessage?.cachePoint && {
+      cachePoint: currentMessage.userInputMessage.cachePoint,
     }),
   };
 

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -24,7 +24,7 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { v4 as uuidv4 } from "uuid";
+import { resolveSessionId } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
   resolveKiroThinkingBudget,
@@ -449,7 +449,7 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   const payload = {
     conversationState: {
       chatTriggerType: "MANUAL",
-      conversationId: uuidv4(),
+      conversationId: resolveSessionId({ headers: credentials?.rawHeaders, body, connectionId: credentials?.connectionId, scope: "kiro" }),
       currentMessage: {
         userInputMessage,
       },

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -22,6 +22,7 @@
  * the `<thinking_mode>enabled</thinking_mode>` reasoning trigger, matching
  * buildKiroPayload.
  */
+import crypto from "crypto";
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { resolveSessionId } from "../../utils/sessionManager.js";
@@ -34,6 +35,151 @@ import {
 } from "../../config/kiroConstants.js";
 import { DEFAULT_IMAGE_MIME } from "../schema/index.js";
 import { ROLE, CLAUDE_BLOCK } from "../schema/index.js";
+
+const VOLATILE_SESSION_HEADER_KEYS = new Set(["x-client-request-id"]);
+const EXPLICIT_SESSION_BODY_KEYS = ["prompt_cache_key", "session_id", "conversation_id"];
+const SLACK_CHANNEL_RE = "[CGD][A-Z0-9]{8,}";
+const SLACK_TS_RE = "\\d{10}(?:\\.\\d{1,6})?|\\d{16}";
+const SLACK_TS_URL_RE = "\\d{10}(?:(?:\\.|%2E)\\d{1,6})?|\\d{16}";
+const FIRST_USER_ANCHOR_MAX = 2048;
+
+function withoutVolatileSessionHeaders(headers) {
+  if (!headers || typeof headers !== "object") return headers;
+
+  const stableHeaders = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (VOLATILE_SESSION_HEADER_KEYS.has(String(key).toLowerCase())) continue;
+    stableHeaders[key] = value;
+  }
+  return stableHeaders;
+}
+
+function deterministicUuid(value) {
+  const bytes = crypto.createHash("sha256").update(String(value)).digest().subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function normalizeAnchorText(value) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value.replace(/\s+/g, " ").trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value).replace(/\s+/g, " ").trim();
+  } catch {
+    return "";
+  }
+}
+
+function normalizeSlackTs(value) {
+  if (!value) return null;
+  const ts = String(value).replace(/%2E/gi, ".").replace(/_/g, ".");
+  if (/^\d{16}$/.test(ts)) return `${ts.slice(0, 10)}.${ts.slice(10)}`;
+  if (/^\d{10}\.\d{1,6}$/.test(ts)) return ts;
+  return null;
+}
+
+function extractSlackThreadAnchor(text) {
+  const normalized = normalizeAnchorText(text);
+  if (!normalized) return null;
+
+  const permalinkRe = new RegExp(
+    `/archives/(${SLACK_CHANNEL_RE})/[^\\s<>)]*?[?&]thread_ts=(${SLACK_TS_URL_RE})`,
+    "i"
+  );
+  const permalink = normalized.match(permalinkRe);
+  if (permalink) {
+    const ts = normalizeSlackTs(permalink[2]);
+    if (ts) return `slack:${permalink[1].toUpperCase()}:${ts}`;
+  }
+
+  const anchorRe = new RegExp(`\\b(${SLACK_CHANNEL_RE})[:/](${SLACK_TS_RE})\\b`, "i");
+  const anchor = normalized.match(anchorRe);
+  if (anchor) {
+    const ts = normalizeSlackTs(anchor[2]);
+    if (ts) return `slack:${anchor[1].toUpperCase()}:${ts}`;
+  }
+
+  return null;
+}
+
+function claudeContentToText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return normalizeAnchorText(content);
+
+  return content
+    .map((block) => {
+      if (typeof block === "string") return block;
+      if (block?.type === CLAUDE_BLOCK.TEXT || typeof block?.text === "string") {
+        return block.text || "";
+      }
+      if (block?.type === CLAUDE_BLOCK.TOOL_RESULT) {
+        return claudeContentToText(block.content);
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function systemToText(system) {
+  if (typeof system === "string") return system;
+  if (!Array.isArray(system)) return "";
+  return system
+    .map((part) => (typeof part === "string" ? part : part?.text || ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+function findKiroStableAnchor(body, connectionId) {
+  const metadataAnchor = extractSlackThreadAnchor(body?.metadata);
+  if (metadataAnchor) return metadataAnchor;
+
+  const systemAnchor = extractSlackThreadAnchor(systemToText(body?.system));
+  if (systemAnchor) return systemAnchor;
+
+  const firstUser = Array.isArray(body?.messages)
+    ? body.messages.find((message) => message?.role === ROLE.USER)
+    : null;
+  const firstUserText = claudeContentToText(firstUser?.content);
+  const userAnchor = extractSlackThreadAnchor(firstUserText);
+  if (userAnchor) return userAnchor;
+
+  return [
+    "fallback",
+    normalizeAnchorText(connectionId),
+    normalizeAnchorText(body?.metadata?.user_id),
+    normalizeAnchorText(firstUserText).slice(0, FIRST_USER_ANCHOR_MAX),
+  ].join(":");
+}
+
+function bodyHasExplicitSessionId(body) {
+  return EXPLICIT_SESSION_BODY_KEYS.some((key) => {
+    const value = body?.[key];
+    return typeof value === "string" ? value.trim() : value !== undefined && value !== null;
+  });
+}
+
+function bodyWithKiroPromptCacheKey(body, connectionId) {
+  if (bodyHasExplicitSessionId(body)) return body;
+
+  const anchor = findKiroStableAnchor(body, connectionId);
+  return {
+    ...body,
+    prompt_cache_key: deterministicUuid(`kiro:${anchor}`),
+  };
+}
+
+function resolveKiroConversationId(body, credentials) {
+  return resolveSessionId({
+    headers: withoutVolatileSessionHeaders(credentials?.rawHeaders),
+    body: bodyWithKiroPromptCacheKey(body, credentials?.connectionId),
+    connectionId: credentials?.connectionId,
+    scope: "kiro",
+  });
+}
 
 /** Stringify a tool_use input as a readable line. */
 function toolUseToText(name, input) {
@@ -449,7 +595,7 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   const payload = {
     conversationState: {
       chatTriggerType: "MANUAL",
-      conversationId: resolveSessionId({ headers: credentials?.rawHeaders, body, connectionId: credentials?.connectionId, scope: "kiro" }),
+      conversationId: resolveKiroConversationId(body, credentials),
       currentMessage: {
         userInputMessage,
       },

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -170,13 +170,70 @@ function findLastClaudeCacheControlKind(body) {
 
 function cachePointBelongsOnCurrentMessage(body) {
   const kind = findLastClaudeCacheControlKind(body);
-  return kind === "tool" || kind?.startsWith("system:");
+  return kind === "tool";
 }
 
 function applyDefaultKiroCachePoint(userInputMessage) {
   if (userInputMessage) {
     userInputMessage.cachePoint = { ...KIRO_DEFAULT_CACHE_POINT };
   }
+}
+
+function systemPartText(part) {
+  if (typeof part === "string") return part;
+  if (!part || typeof part !== "object") return "";
+  if (typeof part.text === "string") return part.text;
+  return "";
+}
+
+function splitSystemCacheControl(system) {
+  if (!system) return { fullText: "", cachedText: "", uncachedText: "" };
+
+  const parts = Array.isArray(system) ? system : [system];
+  const texts = parts.map(systemPartText);
+  const fullText = texts.filter(Boolean).join("\n");
+  let lastCacheControlIndex = -1;
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (hasCacheControl(parts[i])) {
+      lastCacheControlIndex = i;
+      break;
+    }
+  }
+
+  if (lastCacheControlIndex === -1) {
+    return { fullText, cachedText: "", uncachedText: fullText };
+  }
+
+  return {
+    fullText,
+    cachedText: texts.slice(0, lastCacheControlIndex + 1).filter(Boolean).join("\n"),
+    uncachedText: texts.slice(lastCacheControlIndex + 1).filter(Boolean).join("\n"),
+  };
+}
+
+function renderInstructions(text) {
+  return `<instructions>\n${text}\n</instructions>`;
+}
+
+function buildCachedSystemPrefix(systemText, thinkingBudget, agentic) {
+  const prefixParts = [];
+  if (thinkingBudget !== null) prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
+  if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
+  if (systemText) prefixParts.push(renderInstructions(systemText));
+  return prefixParts.filter(Boolean).join("\n\n");
+}
+
+function isRenderableUserBlock(block) {
+  if (typeof block === "string") return block.trim().length > 0;
+  if (!block || typeof block !== "object") return false;
+  if (block.type === CLAUDE_BLOCK.TEXT) return Boolean(block.text);
+  if (block.type === CLAUDE_BLOCK.IMAGE && block.source?.type === "base64") return true;
+  if (block.type === CLAUDE_BLOCK.TOOL_RESULT) return true;
+  return false;
+}
+
+function hasRenderableUserBlockAfter(blocks, startIndex) {
+  return blocks.slice(startIndex).some(isRenderableUserBlock);
 }
 
 function normalizeSlackTs(value) {
@@ -398,6 +455,10 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
   let toolsInjected = false;
 
   const clientProvidedTools = Array.isArray(tools) && tools.length > 0;
+  const lastUserMessageIndex = messages.reduce(
+    (lastIndex, message, index) => (message?.role === ROLE.USER ? index : lastIndex),
+    -1
+  );
 
   const buildToolSpecs = () =>
     tools.map((t) => {
@@ -456,7 +517,8 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
     }
   };
 
-  for (const msg of messages) {
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+    const msg = messages[messageIndex];
     const role = msg.role;
     if (role !== currentRole && currentRole !== null) flushPending();
     currentRole = role;
@@ -465,9 +527,15 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
       if (typeof msg.content === "string") {
         pendingUserContent.push(msg.content);
       } else if (Array.isArray(msg.content)) {
-        for (const block of msg.content) {
-          if (hasCacheControl(block)) pendingUserCachePoint = true;
-          if (block.type === CLAUDE_BLOCK.TEXT) {
+        const canSplitCurrentUserCache = messageIndex === lastUserMessageIndex;
+        for (let blockIndex = 0; blockIndex < msg.content.length; blockIndex++) {
+          const block = msg.content[blockIndex];
+          const blockHasCacheControl = hasCacheControl(block);
+          if (blockHasCacheControl) pendingUserCachePoint = true;
+
+          if (typeof block === "string") {
+            pendingUserContent.push(block);
+          } else if (block.type === CLAUDE_BLOCK.TEXT) {
             pendingUserContent.push(block.text);
           } else if (block.type === CLAUDE_BLOCK.IMAGE && block.source?.type === "base64") {
             const mediaType = block.source.media_type || DEFAULT_IMAGE_MIME;
@@ -491,6 +559,14 @@ function convertClaudeMessagesToKiro(messages, tools, model) {
               status: "success",
               content: [{ text: resultContent }],
             });
+          }
+
+          if (
+            canSplitCurrentUserCache &&
+            blockHasCacheControl &&
+            hasRenderableUserBlockAfter(msg.content, blockIndex + 1)
+          ) {
+            flushPending();
           }
         }
       }
@@ -663,6 +739,8 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
 
   const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
+  const systemCache = splitSystemCacheControl(body.system);
+  const hasCachedSystemPrefix = Boolean(systemCache.cachedText);
 
   // Guard 1: no client tools → flatten all tool interactions to text.
   if (!clientProvidedTools) {
@@ -695,30 +773,48 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
 
   let finalContent = currentMessage?.userInputMessage?.content || "";
 
-  // System prompt: pass via native systemInstruction field (Kiro/Q API supports it)
-  // and also prepend as <instructions> in user content as fallback for upstreams
-  // that don't support the native field.
+  // Uncached system prompts keep the existing native systemInstruction + content
+  // fallback. Cached system prompts move into a history message so the cache
+  // point lands before the volatile timestamp and current user text.
   let systemInstruction = undefined;
-  if (body.system) {
-    let systemText = "";
-    if (typeof body.system === "string") {
-      systemText = body.system;
-    } else if (Array.isArray(body.system)) {
-      systemText = body.system.map((s) => s.text || "").join("\n");
-    }
-    if (systemText) {
-      systemInstruction = systemText;
-      finalContent = `<instructions>\n${systemText}\n</instructions>\n\n${finalContent}`;
+  if (systemCache.fullText) {
+    if (hasCachedSystemPrefix) {
+      if (systemCache.uncachedText) {
+        finalContent = `${renderInstructions(systemCache.uncachedText)}\n\n${finalContent}`;
+      }
+    } else {
+      systemInstruction = systemCache.fullText;
+      finalContent = `${renderInstructions(systemCache.fullText)}\n\n${finalContent}`;
     }
   }
 
-  // Prefix order: thinking_mode tag, timestamp marker, then agentic prompt.
+  // Prefix order without cached system: thinking_mode tag, timestamp marker,
+  // then agentic prompt. With cached system, stable thinking/agentic/system text
+  // lives before the cache point; the volatile timestamp stays current.
   const timestamp = new Date().toISOString();
-  const prefixParts = [];
-  if (thinkingBudget !== null) prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
-  prefixParts.push(`[Context: Current time is ${timestamp}]`);
-  if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
-  finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
+  if (hasCachedSystemPrefix) {
+    const cachedPrefixContent = buildCachedSystemPrefix(
+      systemCache.cachedText,
+      thinkingBudget,
+      agentic
+    );
+    if (cachedPrefixContent) {
+      history.unshift({
+        userInputMessage: {
+          content: cachedPrefixContent,
+          modelId: upstreamModel,
+          cachePoint: { ...KIRO_DEFAULT_CACHE_POINT },
+        },
+      });
+    }
+    finalContent = `[Context: Current time is ${timestamp}]\n\n${finalContent}`;
+  } else {
+    const prefixParts = [];
+    if (thinkingBudget !== null) prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
+    prefixParts.push(`[Context: Current time is ${timestamp}]`);
+    if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
+    finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
+  }
 
   const userInputMessage = {
     content: finalContent,

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -247,6 +247,19 @@ function bodyHasExplicitSessionId(body) {
   });
 }
 
+function explicitBodySessionId(body) {
+  for (const key of EXPLICIT_SESSION_BODY_KEYS) {
+    const value = body?.[key];
+    if (typeof value === "string") {
+      const normalized = value.trim();
+      if (normalized) return normalized;
+    } else if (value !== undefined && value !== null) {
+      return String(value);
+    }
+  }
+  return null;
+}
+
 function bodyWithKiroPromptCacheKey(body, connectionId) {
   if (bodyHasExplicitSessionId(body)) return body;
 
@@ -258,6 +271,12 @@ function bodyWithKiroPromptCacheKey(body, connectionId) {
 }
 
 function resolveKiroConversationId(body, credentials) {
+  const explicitSessionId = explicitBodySessionId(body);
+  if (explicitSessionId) return explicitSessionId;
+
+  const cacheControlAnchor = findClaudeCacheControlAnchor(body);
+  if (cacheControlAnchor) return deterministicUuid(`kiro:${cacheControlAnchor}`);
+
   return resolveSessionId({
     headers: withoutVolatileSessionHeaders(credentials?.rawHeaders),
     body: bodyWithKiroPromptCacheKey(body, credentials?.connectionId),

--- a/open-sse/translator/response/kiro-to-claude.js
+++ b/open-sse/translator/response/kiro-to-claude.js
@@ -42,6 +42,10 @@ function convertFinishReason(reason) {
   }
 }
 
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
 /**
  * Convert one OpenAI-format chunk (from KiroExecutor) into Claude SSE events.
  * Returns an array of Claude events, or null when the chunk yields nothing.
@@ -69,12 +73,25 @@ export function kiroToClaudeResponse(chunk, state) {
   // Track usage if present on the chunk.
   if (data.usage && typeof data.usage === "object") {
     const promptTokens =
-      typeof data.usage.prompt_tokens === "number" ? data.usage.prompt_tokens : 0;
+      finiteNumber(data.usage.prompt_tokens);
     const outputTokens =
-      typeof data.usage.completion_tokens === "number"
-        ? data.usage.completion_tokens
-        : 0;
-    state.usage = { input_tokens: promptTokens, output_tokens: outputTokens };
+      finiteNumber(data.usage.completion_tokens);
+    const cacheReadTokens =
+      finiteNumber(data.usage.cache_read_input_tokens) ||
+      finiteNumber(data.usage.prompt_tokens_details?.cached_tokens);
+    const cacheCreationTokens =
+      finiteNumber(data.usage.cache_creation_input_tokens) ||
+      finiteNumber(data.usage.prompt_tokens_details?.cache_creation_tokens);
+    const hasExclusiveCacheFields =
+      data.usage.cache_read_input_tokens !== undefined ||
+      data.usage.cache_creation_input_tokens !== undefined;
+    const inputTokens = hasExclusiveCacheFields
+      ? promptTokens
+      : Math.max(0, promptTokens - cacheReadTokens - cacheCreationTokens);
+
+    state.usage = { input_tokens: inputTokens, output_tokens: outputTokens };
+    if (cacheReadTokens > 0) state.usage.cache_read_input_tokens = cacheReadTokens;
+    if (cacheCreationTokens > 0) state.usage.cache_creation_input_tokens = cacheCreationTokens;
   }
 
   // First chunk → emit message_start.

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -271,10 +271,17 @@ export function extractUsage(chunk) {
 
   // OpenAI format (also covers DeepSeek which uses prompt_cache_hit_tokens)
   if (chunk.usage && typeof chunk.usage === "object" && chunk.usage.prompt_tokens !== undefined) {
+    const hasExclusiveCacheFields =
+      chunk.usage.cache_read_input_tokens !== undefined ||
+      chunk.usage.cache_creation_input_tokens !== undefined;
     return normalizeUsage({
       prompt_tokens: chunk.usage.prompt_tokens,
       completion_tokens: chunk.usage.completion_tokens || 0,
-      cached_tokens: chunk.usage.prompt_tokens_details?.cached_tokens || chunk.usage.prompt_cache_hit_tokens,
+      cache_read_input_tokens: chunk.usage.cache_read_input_tokens,
+      cache_creation_input_tokens: chunk.usage.cache_creation_input_tokens,
+      cached_tokens: hasExclusiveCacheFields
+        ? undefined
+        : chunk.usage.prompt_tokens_details?.cached_tokens || chunk.usage.prompt_cache_hit_tokens,
       reasoning_tokens: chunk.usage.completion_tokens_details?.reasoning_tokens,
       prompt_tokens_details: chunk.usage.prompt_tokens_details,
       completion_tokens_details: chunk.usage.completion_tokens_details

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -426,6 +426,42 @@ describe("Kiro → Claude (direct route, OpenAI-shaped chunks from executor)", (
     expect(events.some((e) => e.type === "message_stop")).toBe(true);
   });
 
+  it("finish chunk reports native Kiro cache read/write usage to Claude clients", () => {
+    const state = {};
+    R(
+      {
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        model: "m",
+        choices: [{ index: 0, delta: { content: "x" }, finish_reason: null }],
+      },
+      state
+    );
+    const events = R(
+      {
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        model: "m",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: {
+          prompt_tokens: 500,
+          completion_tokens: 100,
+          cache_read_input_tokens: 200,
+          cache_creation_input_tokens: 50,
+        },
+      },
+      state
+    );
+    const md = events.find((e) => e.type === "message_delta");
+
+    expect(md.usage).toEqual({
+      input_tokens: 500,
+      output_tokens: 100,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 50,
+    });
+  });
+
   it("reasoning_content maps to a thinking block", () => {
     const state = {};
     const events = R(

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -6,14 +6,44 @@ import "./registerAll.js";
 import { translateRequest, translateResponse } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 
-const C2K = (body) =>
-  translateRequest(FORMATS.CLAUDE, FORMATS.KIRO, "claude-sonnet-4.5", body, true, null, "kiro");
+const C2K = (body, credentials = null) =>
+  translateRequest(FORMATS.CLAUDE, FORMATS.KIRO, "claude-sonnet-4.5", body, true, credentials, "kiro");
 
 describe("Claude → Kiro (direct route)", () => {
   it("produces a Kiro conversationState payload", () => {
     const out = C2K({ messages: [{ role: "user", content: "hello" }] });
     expect(out.conversationState).toBeTruthy();
     expect(out.conversationState.currentMessage.userInputMessage.content).toContain("hello");
+  });
+
+  it("keeps the same conversationId for the same client session header", () => {
+    const credentials = {
+      rawHeaders: { "x-session-id": "client-session-123" },
+      connectionId: "conn-a",
+    };
+    const body = { messages: [{ role: "user", content: "hello" }] };
+
+    const first = C2K(body, credentials);
+    const second = C2K(body, credentials);
+
+    expect(first.conversationState.conversationId).toBe("client-session-123");
+    expect(second.conversationState.conversationId).toBe("client-session-123");
+  });
+
+  it("uses different conversationIds for different client session headers", () => {
+    const body = { messages: [{ role: "user", content: "hello" }] };
+
+    const first = C2K(body, {
+      rawHeaders: { "x-session-id": "client-session-a" },
+      connectionId: "conn-a",
+    });
+    const second = C2K(body, {
+      rawHeaders: { "x-session-id": "client-session-b" },
+      connectionId: "conn-a",
+    });
+
+    expect(first.conversationState.conversationId).toBe("client-session-a");
+    expect(second.conversationState.conversationId).toBe("client-session-b");
   });
 
   it("guard 1: with no tools, a dangling tool_result is flattened to text (no structured ref)", () => {

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -19,6 +19,14 @@ const userInputMessages = (payload) => [
 const cachePointMessages = (payload) =>
   userInputMessages(payload).filter((message) => message.cachePoint);
 
+const assistantResponseMessages = (payload) =>
+  payload.conversationState.history
+    .map((item) => item.assistantResponseMessage)
+    .filter(Boolean);
+
+const assistantCachePointMessages = (payload) =>
+  assistantResponseMessages(payload).filter((message) => message.cachePoint);
+
 const cacheControlledBody = ({
   systemText = "Stable system instructions",
   toolDescription = "Lookup stable project context",
@@ -151,7 +159,7 @@ describe("Claude → Kiro (direct route)", () => {
     );
 
     expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
-    expect(cachePointMessages(first).length).toBeGreaterThan(0);
+    expect(assistantCachePointMessages(first).length).toBeGreaterThan(0);
     expect(JSON.stringify(first)).not.toContain("cache_control");
   });
 
@@ -168,18 +176,24 @@ describe("Claude → Kiro (direct route)", () => {
       ],
     });
     const current = out.conversationState.currentMessage.userInputMessage;
-    const cached = cachePointMessages(out);
+    const cached = assistantCachePointMessages(out);
     const serialized = JSON.stringify(out);
 
     expect(cached).toHaveLength(1);
-    expect(out.conversationState.history).toContainEqual({
+    expect(out.conversationState.history[0]).toEqual({
       userInputMessage: expect.objectContaining({
         content: "Stable user prefix",
+      }),
+    });
+    expect(out.conversationState.history[0].userInputMessage.cachePoint).toBeUndefined();
+    expect(out.conversationState.history[1]).toEqual({
+      assistantResponseMessage: expect.objectContaining({
         cachePoint: { type: "default" },
       }),
     });
-    expect(cached[0].content).toContain("Stable user prefix");
-    expect(cached[0].content).not.toContain("Dynamic tail");
+    expect(JSON.stringify(out.conversationState.history.slice(0, 2))).toContain("Stable user prefix");
+    expect(JSON.stringify(out.conversationState.history.slice(0, 2))).not.toContain("Dynamic tail");
+    expect(cachePointMessages(out)).toHaveLength(0);
     expect(current.cachePoint).toBeUndefined();
     expect(current.content).not.toContain("Stable user prefix");
     expect(current.content).toContain("Dynamic tail");
@@ -240,21 +254,28 @@ describe("Claude → Kiro (direct route)", () => {
     expect(first.conversationState.currentMessage.userInputMessage.content).toContain(firstTail);
     expect(second.conversationState.currentMessage.userInputMessage.content).toContain(secondTail);
 
-    const firstCached = cachePointMessages(first);
-    const secondCached = cachePointMessages(second);
-    expect(firstCached).toHaveLength(1);
-    expect(secondCached).toHaveLength(1);
-    expect(first.conversationState.history).toContainEqual({
+    const firstAssistantCached = assistantCachePointMessages(first);
+    const secondAssistantCached = assistantCachePointMessages(second);
+    expect(firstAssistantCached).toHaveLength(1);
+    expect(secondAssistantCached).toHaveLength(1);
+    expect(first.conversationState.history[0]).toEqual({
       userInputMessage: expect.objectContaining({
+        content: expect.stringContaining("Large stable Claude system prefix"),
+      }),
+    });
+    expect(first.conversationState.history[0].userInputMessage.cachePoint).toBeUndefined();
+    expect(first.conversationState.history[1]).toEqual({
+      assistantResponseMessage: expect.objectContaining({
         cachePoint: { type: "default" },
       }),
     });
-    expect(firstCached[0].content).toContain("Large stable Claude system prefix");
-    expect(firstCached[0].content).not.toContain("[Context: Current time is");
-    expect(JSON.stringify(firstCached[0])).not.toContain(firstTail);
-    expect(JSON.stringify(firstCached[0])).not.toContain(secondTail);
-    expect(JSON.stringify(secondCached[0])).not.toContain(firstTail);
-    expect(JSON.stringify(secondCached[0])).not.toContain(secondTail);
+    const firstCachedContext = JSON.stringify(first.conversationState.history.slice(0, 2));
+    const secondCachedContext = JSON.stringify(second.conversationState.history.slice(0, 2));
+    expect(firstCachedContext).not.toContain("[Context: Current time is");
+    expect(firstCachedContext).not.toContain(firstTail);
+    expect(firstCachedContext).not.toContain(secondTail);
+    expect(secondCachedContext).not.toContain(firstTail);
+    expect(secondCachedContext).not.toContain(secondTail);
     expect(JSON.stringify(first)).not.toContain("cache_control");
     expect(JSON.stringify(first)).not.toContain("ephemeral");
     expect(JSON.stringify(first)).not.toContain("clientCacheConfig");

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -35,6 +35,19 @@ const cacheControlledBody = ({
   ],
 });
 
+const systemCacheControlledBody = (trailingUserText) => ({
+  model: "kr/claude-opus-4.8",
+  max_tokens: 64,
+  system: [
+    {
+      type: "text",
+      text: "Large stable Claude system prefix\n" + "cache me\n".repeat(100),
+      cache_control: { type: "ephemeral" },
+    },
+  ],
+  messages: [{ role: "user", content: trailingUserText }],
+});
+
 describe("Claude → Kiro (direct route)", () => {
   it("produces a Kiro conversationState payload", () => {
     const out = C2K({ messages: [{ role: "user", content: "hello" }] });
@@ -130,6 +143,34 @@ describe("Claude → Kiro (direct route)", () => {
     expect(JSON.stringify(first)).not.toContain("cache_control");
   });
 
+  it("uses system cache_control prefix before x-session-id for Anthropic messages requests", () => {
+    const sessionId = "ruby-cache-control-probe-20260709";
+    const first = C2K(
+      systemCacheControlledBody("Probe call one: summarize the cached prefix."),
+      {
+        rawHeaders: {
+          "x-session-id": sessionId,
+          "x-client-request-id": "volatile-request-a",
+        },
+        connectionId: "kiro-conn",
+      }
+    );
+    const second = C2K(
+      systemCacheControlledBody("Probe call two: answer a different trailing question."),
+      {
+        rawHeaders: {
+          "x-session-id": sessionId,
+          "x-client-request-id": "volatile-request-b",
+        },
+        connectionId: "kiro-conn",
+      }
+    );
+
+    expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
+    expect(first.conversationState.conversationId).not.toBe(sessionId);
+    expect(JSON.stringify(first)).not.toContain("cache_control");
+  });
+
   it("uses different Kiro conversationIds for different cache_control prefixes", () => {
     const first = C2K(cacheControlledBody({ cachedUserText: "Cached thread context A" }));
     const second = C2K(cacheControlledBody({ cachedUserText: "Cached thread context B" }));
@@ -158,7 +199,10 @@ describe("Claude → Kiro (direct route)", () => {
         messages: [{ role: "user", content: "summarize this thread" }],
       },
       {
-        rawHeaders: { "x-client-request-id": "volatile-request-id" },
+        rawHeaders: {
+          "x-session-id": "header-session-should-not-win",
+          "x-client-request-id": "volatile-request-id",
+        },
         connectionId: "kiro-conn",
       }
     );
@@ -177,7 +221,10 @@ describe("Claude → Kiro (direct route)", () => {
         [key]: value,
       },
       {
-        rawHeaders: { "x-client-request-id": "volatile-request-id" },
+        rawHeaders: {
+          "x-session-id": "header-session-should-not-win",
+          "x-client-request-id": "volatile-request-id",
+        },
         connectionId: "kiro-conn",
       }
     );

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -9,6 +9,32 @@ import { FORMATS } from "../../open-sse/translator/formats.js";
 const C2K = (body, credentials = null) =>
   translateRequest(FORMATS.CLAUDE, FORMATS.KIRO, "claude-sonnet-4.5", body, true, credentials, "kiro");
 
+const cacheControlledBody = ({
+  systemText = "Stable system instructions",
+  toolDescription = "Lookup stable project context",
+  cachedUserText = "Cached thread context",
+  trailingUserText = "What should we do next?",
+} = {}) => ({
+  system: [{ type: "text", text: systemText, cache_control: { type: "ephemeral" } }],
+  tools: [
+    {
+      name: "lookup_context",
+      description: toolDescription,
+      input_schema: { type: "object", properties: { query: { type: "string" } } },
+      cache_control: { type: "ephemeral" },
+    },
+  ],
+  messages: [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: cachedUserText, cache_control: { type: "ephemeral" } },
+        { type: "text", text: trailingUserText },
+      ],
+    },
+  ],
+});
+
 describe("Claude → Kiro (direct route)", () => {
   it("produces a Kiro conversationState payload", () => {
     const out = C2K({ messages: [{ role: "user", content: "hello" }] });
@@ -90,6 +116,36 @@ describe("Claude → Kiro (direct route)", () => {
     expect(first.conversationState.conversationId).not.toBe(second.conversationState.conversationId);
   });
 
+  it("uses cache_control prefix for Kiro conversationId and ignores trailing user text", () => {
+    const first = C2K(
+      cacheControlledBody({ trailingUserText: "Please summarize action items." }),
+      { rawHeaders: { "x-client-request-id": "req-a" }, connectionId: "kiro-conn" }
+    );
+    const second = C2K(
+      cacheControlledBody({ trailingUserText: "Please draft a reply instead." }),
+      { rawHeaders: { "x-client-request-id": "req-b" }, connectionId: "kiro-conn" }
+    );
+
+    expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
+    expect(JSON.stringify(first)).not.toContain("cache_control");
+  });
+
+  it("uses different Kiro conversationIds for different cache_control prefixes", () => {
+    const first = C2K(cacheControlledBody({ cachedUserText: "Cached thread context A" }));
+    const second = C2K(cacheControlledBody({ cachedUserText: "Cached thread context B" }));
+    const differentToolPrefix = C2K(
+      cacheControlledBody({
+        cachedUserText: "Cached thread context A",
+        toolDescription: "Lookup different stable project context",
+      })
+    );
+
+    expect(first.conversationState.conversationId).not.toBe(second.conversationState.conversationId);
+    expect(first.conversationState.conversationId).not.toBe(
+      differentToolPrefix.conversationState.conversationId
+    );
+  });
+
   it.each([
     ["prompt_cache_key", "explicit-cache-key"],
     ["session_id", "explicit-session-id"],
@@ -100,6 +156,25 @@ describe("Claude → Kiro (direct route)", () => {
         [key]: value,
         metadata: { slack_thread: "C0130M8P4HK:1783546858.709689" },
         messages: [{ role: "user", content: "summarize this thread" }],
+      },
+      {
+        rawHeaders: { "x-client-request-id": "volatile-request-id" },
+        connectionId: "kiro-conn",
+      }
+    );
+
+    expect(out.conversationState.conversationId).toBe(value);
+  });
+
+  it.each([
+    ["prompt_cache_key", "explicit-cache-key"],
+    ["session_id", "explicit-session-id"],
+    ["conversation_id", "explicit-conversation-id"],
+  ])("respects explicit %s and does not replace it with a cache_control anchor", (key, value) => {
+    const out = C2K(
+      {
+        ...cacheControlledBody({ cachedUserText: "Cached prefix should not win" }),
+        [key]: value,
       },
       {
         rawHeaders: { "x-client-request-id": "volatile-request-id" },

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -9,6 +9,16 @@ import { FORMATS } from "../../open-sse/translator/formats.js";
 const C2K = (body, credentials = null) =>
   translateRequest(FORMATS.CLAUDE, FORMATS.KIRO, "claude-sonnet-4.5", body, true, credentials, "kiro");
 
+const userInputMessages = (payload) => [
+  ...payload.conversationState.history
+    .map((item) => item.userInputMessage)
+    .filter(Boolean),
+  payload.conversationState.currentMessage.userInputMessage,
+];
+
+const cachePointMessages = (payload) =>
+  userInputMessages(payload).filter((message) => message.cachePoint);
+
 const cacheControlledBody = ({
   systemText = "Stable system instructions",
   toolDescription = "Lookup stable project context",
@@ -141,9 +151,7 @@ describe("Claude → Kiro (direct route)", () => {
     );
 
     expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
-    expect(first.conversationState.currentMessage.userInputMessage.cachePoint).toEqual({
-      type: "default",
-    });
+    expect(cachePointMessages(first).length).toBeGreaterThan(0);
     expect(JSON.stringify(first)).not.toContain("cache_control");
   });
 
@@ -160,10 +168,20 @@ describe("Claude → Kiro (direct route)", () => {
       ],
     });
     const current = out.conversationState.currentMessage.userInputMessage;
+    const cached = cachePointMessages(out);
     const serialized = JSON.stringify(out);
 
-    expect(current.cachePoint).toEqual({ type: "default" });
-    expect(current.content).toContain("Stable user prefix");
+    expect(cached).toHaveLength(1);
+    expect(out.conversationState.history).toContainEqual({
+      userInputMessage: expect.objectContaining({
+        content: "Stable user prefix",
+        cachePoint: { type: "default" },
+      }),
+    });
+    expect(cached[0].content).toContain("Stable user prefix");
+    expect(cached[0].content).not.toContain("Dynamic tail");
+    expect(current.cachePoint).toBeUndefined();
+    expect(current.content).not.toContain("Stable user prefix");
     expect(current.content).toContain("Dynamic tail");
     expect(serialized).not.toContain("cache_control");
     expect(serialized).not.toContain("ephemeral");
@@ -192,8 +210,10 @@ describe("Claude → Kiro (direct route)", () => {
 
   it("uses system cache_control prefix before x-session-id for Anthropic messages requests", () => {
     const sessionId = "ruby-cache-control-probe-20260709";
+    const firstTail = "Probe call one: summarize the cached prefix.";
+    const secondTail = "Probe call two: answer a different trailing question.";
     const first = C2K(
-      systemCacheControlledBody("Probe call one: summarize the cached prefix."),
+      systemCacheControlledBody(firstTail),
       {
         rawHeaders: {
           "x-session-id": sessionId,
@@ -203,7 +223,7 @@ describe("Claude → Kiro (direct route)", () => {
       }
     );
     const second = C2K(
-      systemCacheControlledBody("Probe call two: answer a different trailing question."),
+      systemCacheControlledBody(secondTail),
       {
         rawHeaders: {
           "x-session-id": sessionId,
@@ -215,12 +235,26 @@ describe("Claude → Kiro (direct route)", () => {
 
     expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
     expect(first.conversationState.conversationId).not.toBe(sessionId);
-    expect(first.conversationState.currentMessage.userInputMessage.cachePoint).toEqual({
-      type: "default",
+    expect(first.conversationState.currentMessage.userInputMessage.cachePoint).toBeUndefined();
+    expect(second.conversationState.currentMessage.userInputMessage.cachePoint).toBeUndefined();
+    expect(first.conversationState.currentMessage.userInputMessage.content).toContain(firstTail);
+    expect(second.conversationState.currentMessage.userInputMessage.content).toContain(secondTail);
+
+    const firstCached = cachePointMessages(first);
+    const secondCached = cachePointMessages(second);
+    expect(firstCached).toHaveLength(1);
+    expect(secondCached).toHaveLength(1);
+    expect(first.conversationState.history).toContainEqual({
+      userInputMessage: expect.objectContaining({
+        cachePoint: { type: "default" },
+      }),
     });
-    expect(second.conversationState.currentMessage.userInputMessage.cachePoint).toEqual({
-      type: "default",
-    });
+    expect(firstCached[0].content).toContain("Large stable Claude system prefix");
+    expect(firstCached[0].content).not.toContain("[Context: Current time is");
+    expect(JSON.stringify(firstCached[0])).not.toContain(firstTail);
+    expect(JSON.stringify(firstCached[0])).not.toContain(secondTail);
+    expect(JSON.stringify(secondCached[0])).not.toContain(firstTail);
+    expect(JSON.stringify(secondCached[0])).not.toContain(secondTail);
     expect(JSON.stringify(first)).not.toContain("cache_control");
     expect(JSON.stringify(first)).not.toContain("ephemeral");
     expect(JSON.stringify(first)).not.toContain("clientCacheConfig");

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -46,6 +46,97 @@ describe("Claude → Kiro (direct route)", () => {
     expect(second.conversationState.conversationId).toBe("client-session-b");
   });
 
+  it("keeps the same Kiro conversationId for the same Slack thread despite volatile request ids", () => {
+    const metadataAnchor = {
+      metadata: { slack_thread: "C0130M8P4HK:1783546858.709689" },
+      messages: [{ role: "user", content: "summarize this thread" }],
+    };
+    const systemPermalink = {
+      system:
+        "Slack thread: https://example.slack.com/archives/C0130M8P4HK/p1783546858709689?thread_ts=1783546858%2E709689&cid=C0130M8P4HK",
+      messages: [{ role: "user", content: "summarize this thread" }],
+    };
+    const userSlashAnchor = {
+      messages: [{ role: "user", content: "Follow up on C0130M8P4HK/1783546858.709689" }],
+    };
+
+    const first = C2K(metadataAnchor, {
+      rawHeaders: { "x-client-request-id": "req-a" },
+      connectionId: "kiro-conn",
+    });
+    const second = C2K(systemPermalink, {
+      rawHeaders: { "x-client-request-id": "req-b" },
+      connectionId: "kiro-conn",
+    });
+    const third = C2K(userSlashAnchor, {
+      rawHeaders: { "x-client-request-id": "req-c" },
+      connectionId: "kiro-conn",
+    });
+
+    expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
+    expect(second.conversationState.conversationId).toBe(third.conversationState.conversationId);
+  });
+
+  it("uses different Kiro conversationIds for different Slack thread anchors", () => {
+    const first = C2K({
+      metadata: { slack_thread: "C0130M8P4HK:1783546858.709689" },
+      messages: [{ role: "user", content: "summarize this thread" }],
+    });
+    const second = C2K({
+      metadata: { slack_thread: "C0130M8P4HK:1783546859.709689" },
+      messages: [{ role: "user", content: "summarize this thread" }],
+    });
+
+    expect(first.conversationState.conversationId).not.toBe(second.conversationState.conversationId);
+  });
+
+  it.each([
+    ["prompt_cache_key", "explicit-cache-key"],
+    ["session_id", "explicit-session-id"],
+    ["conversation_id", "explicit-conversation-id"],
+  ])("respects explicit %s and does not replace it with a Kiro prompt cache key", (key, value) => {
+    const out = C2K(
+      {
+        [key]: value,
+        metadata: { slack_thread: "C0130M8P4HK:1783546858.709689" },
+        messages: [{ role: "user", content: "summarize this thread" }],
+      },
+      {
+        rawHeaders: { "x-client-request-id": "volatile-request-id" },
+        connectionId: "kiro-conn",
+      }
+    );
+
+    expect(out.conversationState.conversationId).toBe(value);
+  });
+
+  it("keeps non-Slack fallback conversationIds deterministic across volatile request ids", () => {
+    const body = {
+      metadata: { user_id: "slack-user-without-thread-anchor" },
+      messages: [{ role: "user", content: "plain non Slack request" }],
+    };
+    const changedUserContent = {
+      metadata: { user_id: "slack-user-without-thread-anchor" },
+      messages: [{ role: "user", content: "different plain non Slack request" }],
+    };
+
+    const first = C2K(body, {
+      rawHeaders: { "x-client-request-id": "req-a" },
+      connectionId: "kiro-conn",
+    });
+    const second = C2K(body, {
+      rawHeaders: { "x-client-request-id": "req-b" },
+      connectionId: "kiro-conn",
+    });
+    const different = C2K(changedUserContent, {
+      rawHeaders: { "x-client-request-id": "req-c" },
+      connectionId: "kiro-conn",
+    });
+
+    expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
+    expect(first.conversationState.conversationId).not.toBe(different.conversationState.conversationId);
+  });
+
   it("guard 1: with no tools, a dangling tool_result is flattened to text (no structured ref)", () => {
     // Client omitted `tools` but kept a tool_result after compaction.
     const out = C2K({

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -53,6 +53,7 @@ describe("Claude → Kiro (direct route)", () => {
     const out = C2K({ messages: [{ role: "user", content: "hello" }] });
     expect(out.conversationState).toBeTruthy();
     expect(out.conversationState.currentMessage.userInputMessage.content).toContain("hello");
+    expect(out.conversationState.currentMessage.userInputMessage.cachePoint).toBeUndefined();
   });
 
   it("keeps the same conversationId for the same client session header", () => {
@@ -140,7 +141,53 @@ describe("Claude → Kiro (direct route)", () => {
     );
 
     expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
+    expect(first.conversationState.currentMessage.userInputMessage.cachePoint).toEqual({
+      type: "default",
+    });
     expect(JSON.stringify(first)).not.toContain("cache_control");
+  });
+
+  it("maps message content cache_control to a Kiro cachePoint", () => {
+    const out = C2K({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Stable user prefix", cache_control: { type: "ephemeral" } },
+            { type: "text", text: "Dynamic tail" },
+          ],
+        },
+      ],
+    });
+    const current = out.conversationState.currentMessage.userInputMessage;
+    const serialized = JSON.stringify(out);
+
+    expect(current.cachePoint).toEqual({ type: "default" });
+    expect(current.content).toContain("Stable user prefix");
+    expect(current.content).toContain("Dynamic tail");
+    expect(serialized).not.toContain("cache_control");
+    expect(serialized).not.toContain("ephemeral");
+  });
+
+  it("maps tool cache_control to the current Kiro cachePoint", () => {
+    const out = C2K({
+      tools: [
+        {
+          name: "lookup_context",
+          description: "Lookup stable project context",
+          input_schema: { type: "object", properties: {} },
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [{ role: "user", content: "Use the stable tool prefix." }],
+    });
+    const current = out.conversationState.currentMessage.userInputMessage;
+    const serialized = JSON.stringify(out);
+
+    expect(current.cachePoint).toEqual({ type: "default" });
+    expect(current.userInputMessageContext?.tools).toHaveLength(1);
+    expect(serialized).not.toContain("cache_control");
+    expect(serialized).not.toContain("ephemeral");
   });
 
   it("uses system cache_control prefix before x-session-id for Anthropic messages requests", () => {
@@ -168,7 +215,15 @@ describe("Claude → Kiro (direct route)", () => {
 
     expect(first.conversationState.conversationId).toBe(second.conversationState.conversationId);
     expect(first.conversationState.conversationId).not.toBe(sessionId);
+    expect(first.conversationState.currentMessage.userInputMessage.cachePoint).toEqual({
+      type: "default",
+    });
+    expect(second.conversationState.currentMessage.userInputMessage.cachePoint).toEqual({
+      type: "default",
+    });
     expect(JSON.stringify(first)).not.toContain("cache_control");
+    expect(JSON.stringify(first)).not.toContain("ephemeral");
+    expect(JSON.stringify(first)).not.toContain("clientCacheConfig");
   });
 
   it("uses different Kiro conversationIds for different cache_control prefixes", () => {

--- a/tests/unit/cached-token-usage.test.js
+++ b/tests/unit/cached-token-usage.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { canonicalizeUsage, extractUsage, mergeUsage } from "../../open-sse/utils/usageTracking.js";
 import { calculateCostFromTokens } from "../../open-sse/providers/pricing.js";
 import { toOpenAIUsage } from "../../open-sse/translator/concerns/usage.js";
+import { KiroExecutor } from "../../open-sse/executors/kiro.js";
 
 // Canonical convention (single source of truth for storage + cost):
 //   prompt_tokens             = total input INCLUDING cache read + cache creation
@@ -10,6 +11,62 @@ import { toOpenAIUsage } from "../../open-sse/translator/concerns/usage.js";
 //   completion_tokens         = output
 // Discriminator: Claude reports cache separately (prompt EXCLUDES cache);
 // OpenAI/Gemini report prompt INCLUDING cached_tokens.
+
+function createKiroMockFrame(eventType, payloadObj = {}) {
+  const payloadStr = JSON.stringify(payloadObj);
+  const payloadBytes = new TextEncoder().encode(payloadStr);
+  const headerName = ":event-type";
+  const headerNameBytes = new TextEncoder().encode(headerName);
+  const headerValueBytes = new TextEncoder().encode(eventType);
+  const headerLength = 1 + headerNameBytes.length + 1 + 2 + headerValueBytes.length;
+  const totalLength = 12 + headerLength + payloadBytes.length + 4;
+  const buffer = new Uint8Array(totalLength);
+  const view = new DataView(buffer.buffer);
+
+  view.setUint32(0, totalLength, false);
+  view.setUint32(4, headerLength, false);
+
+  let offset = 12;
+  buffer[offset++] = headerNameBytes.length;
+  buffer.set(headerNameBytes, offset);
+  offset += headerNameBytes.length;
+  buffer[offset++] = 7;
+  view.setUint16(offset, headerValueBytes.length, false);
+  offset += 2;
+  buffer.set(headerValueBytes, offset);
+  offset += headerValueBytes.length;
+  buffer.set(payloadBytes, offset);
+  return buffer;
+}
+
+async function readKiroSSEObjects(frames) {
+  const executor = new KiroExecutor();
+  const readableStream = new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(frame);
+      controller.close();
+    },
+  });
+  const transformedResponse = executor.transformEventStreamToSSE(
+    { body: readableStream },
+    "claude-test"
+  );
+  const reader = transformedResponse.body.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  return output
+    .split("\n")
+    .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+    .map((line) => JSON.parse(line.slice(6)));
+}
+
 describe("canonicalizeUsage", () => {
   it("folds Claude exclusive cache into an inclusive prompt count", () => {
     // Claude: input_tokens excludes cache; cache_read + cache_creation are separate
@@ -184,5 +241,93 @@ describe("Kiro usage pass-through", () => {
     expect(out.prompt_tokens_details).toBeDefined();
     expect(out.prompt_tokens_details.cached_tokens).toBe(200);
     expect(out.prompt_tokens_details.cache_creation_tokens).toBe(50);
+  });
+
+  it("canonicalizes native Kiro cache read/write tokenUsage fields", () => {
+    const out = toOpenAIUsage(
+      {
+        uncachedInputTokens: 500,
+        outputTokens: 100,
+        cacheReadInputTokens: 200,
+        cacheWriteInputTokens: 50,
+      },
+      "kiro"
+    );
+
+    expect(out.prompt_tokens).toBe(500);
+    expect(out.cache_read_input_tokens).toBe(200);
+    expect(out.cache_creation_input_tokens).toBe(50);
+
+    const canonical = canonicalizeUsage(out);
+    expect(canonical.prompt_tokens).toBe(750);
+    expect(canonical.completion_tokens).toBe(100);
+    expect(canonical.cached_tokens).toBe(200);
+    expect(canonical.cache_creation_input_tokens).toBe(50);
+    expect(canonical.total_tokens).toBe(850);
+  });
+});
+
+describe("Kiro EventStream native cache usage", () => {
+  it("extracts metadataEvent.tokenUsage and preserves cache fields for canonical storage", async () => {
+    const objects = await readKiroSSEObjects([
+      createKiroMockFrame("metadataEvent", {
+        metadataEvent: {
+          tokenUsage: {
+            uncachedInputTokens: 500,
+            outputTokens: 100,
+            totalTokens: 850,
+            cacheReadInputTokens: 200,
+            cacheWriteInputTokens: 50,
+          },
+        },
+      }),
+      createKiroMockFrame("meteringEvent", {}),
+      createKiroMockFrame("contextUsageEvent", { contextUsagePercentage: 1 }),
+    ]);
+    const finalChunk = objects.find((obj) => obj.choices?.[0]?.finish_reason);
+
+    expect(finalChunk.usage).toMatchObject({
+      prompt_tokens: 500,
+      completion_tokens: 100,
+      total_tokens: 600,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 50,
+    });
+
+    const extracted = extractUsage(finalChunk);
+    expect(extracted.cache_read_input_tokens).toBe(200);
+    expect(extracted.cache_creation_input_tokens).toBe(50);
+
+    const canonical = canonicalizeUsage(extracted);
+    expect(canonical.prompt_tokens).toBe(750);
+    expect(canonical.cached_tokens).toBe(200);
+    expect(canonical.cache_creation_input_tokens).toBe(50);
+    expect(canonical.total_tokens).toBe(850);
+  });
+
+  it("extracts metricsEvent cacheWriteInputTokens as cache creation", async () => {
+    const objects = await readKiroSSEObjects([
+      createKiroMockFrame("metricsEvent", {
+        metricsEvent: {
+          inputTokens: 120,
+          outputTokens: 30,
+          cacheWriteInputTokens: 40,
+        },
+      }),
+      createKiroMockFrame("meteringEvent", {}),
+      createKiroMockFrame("contextUsageEvent", { contextUsagePercentage: 1 }),
+    ]);
+    const finalChunk = objects.find((obj) => obj.choices?.[0]?.finish_reason);
+
+    expect(finalChunk.usage).toMatchObject({
+      prompt_tokens: 120,
+      completion_tokens: 30,
+      cache_creation_input_tokens: 40,
+    });
+
+    const canonical = canonicalizeUsage(extractUsage(finalChunk));
+    expect(canonical.prompt_tokens).toBe(160);
+    expect(canonical.cache_creation_input_tokens).toBe(40);
+    expect(canonical.total_tokens).toBe(190);
   });
 });

--- a/tests/unit/usage-concern.test.js
+++ b/tests/unit/usage-concern.test.js
@@ -48,6 +48,41 @@ describe("toOpenAIUsage", () => {
     expect(u.total_tokens).toBe(15);
   });
 
+  it("kiro: metadata tokenUsage maps native cache read/write fields", () => {
+    const u = toOpenAIUsage(
+      {
+        metadataEvent: {
+          tokenUsage: {
+            uncachedInputTokens: 100,
+            outputTokens: 20,
+            totalTokens: 150,
+            cacheReadInputTokens: 25,
+            cacheWriteInputTokens: 5,
+          },
+        },
+      },
+      "kiro"
+    );
+    expect(u.prompt_tokens).toBe(100);
+    expect(u.completion_tokens).toBe(20);
+    expect(u.total_tokens).toBe(120);
+    expect(u.prompt_tokens_details.cached_tokens).toBe(25);
+    expect(u.prompt_tokens_details.cache_creation_tokens).toBe(5);
+    expect(u.cache_read_input_tokens).toBe(25);
+    expect(u.cache_creation_input_tokens).toBe(5);
+  });
+
+  it("kiro: metrics cacheWriteInputTokens maps to cache creation", () => {
+    const u = toOpenAIUsage(
+      { metricsEvent: { inputTokens: 40, outputTokens: 6, cacheWriteInputTokens: 10 } },
+      "kiro"
+    );
+    expect(u.prompt_tokens).toBe(40);
+    expect(u.completion_tokens).toBe(6);
+    expect(u.cache_creation_input_tokens).toBe(10);
+    expect(u.prompt_tokens_details.cache_creation_tokens).toBe(10);
+  });
+
   it("ollama: prompt_eval_count/eval_count", () => {
     const u = toOpenAIUsage({ prompt_eval_count: 7, eval_count: 4 }, "ollama");
     expect(u.prompt_tokens).toBe(7);


### PR DESCRIPTION
## Problem

The direct Claude -> Kiro translator could generate a fresh Kiro `conversationState.conversationId` for requests that were semantically part of the same cached Claude prompt prefix. Hermes/Slack requests also include volatile request ids and changing trailing user text, so Kiro cache/session affinity was unstable and Opus traffic missed cache reuse.

## Fix

Use `resolveSessionId` for Claude -> Kiro conversation ids, matching the OpenAI -> Kiro path.

Session resolution now preserves explicit `prompt_cache_key`, `session_id`, and `conversation_id` fields first. If those are absent, Anthropic `cache_control` markers on system blocks, tools, or message content blocks are treated as an internal affinity hint: the translator hashes the prompt prefix through the last cache breakpoint and feeds that as the internal `prompt_cache_key`. This keeps same cached-prefix requests on the same Kiro conversation while still ignoring later uncached user text.

The translator does not forward `cache_control` as a made-up Kiro payload field. Requests without `cache_control` keep the Slack/thread anchor and deterministic fallback behavior.

## Tests

- `NODE_PATH=tests/node_modules tests/node_modules/.bin/vitest run --reporter=verbose --config tests/vitest.config.js tests/translator/claude-kiro-direct.test.js` (22/22)
- `git diff --check`
