### PR TITLE
fix(antigravity): resolve 403 CONSUMER_INVALID by updating API fingerprint to match real IDE

### DIFF
--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -58,8 +58,23 @@ export function getPlatformEnum() {
   return PLATFORM.UNSPECIFIED;
 }
 
+// Map Node.js os identifiers to the format used by the real Antigravity IDE
+function getIdePlatform() {
+  const p = platform();
+  if (p === "win32") return "windows";
+  if (p === "darwin") return "darwin";
+  return p; // linux, etc.
+}
+function getIdeArch() {
+  const a = arch();
+  if (a === "x64") return "amd64";
+  return a; // arm64, etc.
+}
+
+export const ANTIGRAVITY_IDE_VERSION = "2.1.1";
+
 export function getPlatformUserAgent() {
-  return `antigravity/1.104.0 ${platform()}/${arch()}`;
+  return `antigravity/ide/${ANTIGRAVITY_IDE_VERSION} ${getIdePlatform()}/${getIdeArch()}`;
 }
 
 export const CLIENT_METADATA = {
@@ -127,9 +142,9 @@ export const AG_DEFAULT_TOOLS = new Set([
   "write_to_file"
 ]);
 
-// Antigravity chat/stream headers
+// Antigravity chat/stream headers — must match real IDE fingerprint
 export const ANTIGRAVITY_HEADERS = {
-  "User-Agent": `antigravity/1.107.0 ${platform()}/${arch()}`
+  "User-Agent": getPlatformUserAgent()
 };
 
 // Cloud Code Assist API
@@ -140,9 +155,7 @@ export const CLOUD_CODE_API = {
 
 export const LOAD_CODE_ASSIST_HEADERS = {
   "Content-Type": "application/json",
-  "User-Agent": "google-api-nodejs-client/9.15.1",
-  "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
-  "Client-Metadata": JSON.stringify({ ideType: IDE_TYPE.ANTIGRAVITY, platform: getPlatformEnum(), pluginType: PLUGIN_TYPE.GEMINI }),
+  "User-Agent": getPlatformUserAgent(),
 };
 
 export const LOAD_CODE_ASSIST_METADATA = {

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -1,6 +1,10 @@
 import { platform, arch } from "os";
 import { ANTIGRAVITY_OAUTH_CLIENT } from "../shared.js";
 
+// Inline IDE User-Agent (cannot import from appConstants — circular dependency)
+const _p = platform() === "win32" ? "windows" : platform();
+const _a = arch() === "x64" ? "amd64" : arch();
+const AG_IDE_UA = `antigravity/ide/2.1.1 ${_p}/${_a}`;
 export default {
   id: "antigravity",
   priority: 20,
@@ -26,7 +30,7 @@ export default {
     ],
     format: "antigravity",
     headers: {
-      "User-Agent": "antigravity/1.107.0 darwin/arm64",
+      "User-Agent": AG_IDE_UA,
     },
     retry: {
       "429": {
@@ -75,8 +79,7 @@ export default {
     apiVersion: "v1internal",
     loadCodeAssistEndpoint: "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
     onboardUserEndpoint: "https://cloudcode-pa.googleapis.com/v1internal:onboardUser",
-    loadCodeAssistUserAgent: "google-api-nodejs-client/9.15.1",
-    loadCodeAssistApiClient: "google-cloud-sdk vscode_cloudshelleditor/0.1",
+    loadCodeAssistUserAgent: AG_IDE_UA,
     refreshLeadMs: 300000,
   },
   features: {

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { platform, arch } from "os";
 import { getProviderConnectionById } from "@/models";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { GEMINI_CONFIG } from "@/lib/oauth/constants/oauth";
@@ -8,6 +9,13 @@ import { getModelsByProviderId } from "open-sse/config/providerModels.js";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 import { resolveKimchiModels } from "open-sse/services/kimchiModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
+
+// Build User-Agent matching the real Antigravity IDE format
+function getAntigravityUserAgent() {
+  const p = platform() === "win32" ? "windows" : platform();
+  const a = arch() === "x64" ? "amd64" : arch();
+  return `antigravity/ide/2.1.1 ${p}/${a}`;
+}
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
@@ -358,8 +366,7 @@ const PROVIDER_MODELS_CONFIG = {
           headers: {
             "Content-Type": "application/json",
             "Authorization": `Bearer ${token}`,
-            "User-Agent": "google-api-nodejs-client/9.15.1",
-            "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1"
+            "User-Agent": getAntigravityUserAgent(),
           },
           body: JSON.stringify(body)
         });

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -1,3 +1,4 @@
+import { platform, arch } from "os";
 import { getProviderConnectionById, updateProviderConnection } from "@/lib/localDb";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { testProxyUrl } from "@/lib/network/proxyTest";
@@ -139,8 +140,10 @@ function parseProviderErrorMessage(bodyText, fallback) {
 }
 
 async function probeCloudCodeAssistAccess(connection, accessToken, effectiveProxy = null) {
+  const _p = platform() === "win32" ? "windows" : platform();
+  const _a = arch() === "x64" ? "amd64" : arch();
   const userAgent = connection.provider === "antigravity"
-    ? "google-api-nodejs-client/9.15.1 vscode-antigravity/1.107.0"
+    ? `antigravity/ide/2.1.1 ${_p}/${_a}`
     : "google-api-nodejs-client/9.15.1 gemini-cli/0.34.0";
 
   const res = await fetchWithConnectionProxy(CLOUD_CODE_ASSIST_TEST_URL, {

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -381,8 +381,6 @@ const PROVIDERS = {
         "Authorization": `Bearer ${tokens.access_token}`,
         "Content-Type": "application/json",
         "User-Agent": ANTIGRAVITY_CONFIG.loadCodeAssistUserAgent,
-        "X-Goog-Api-Client": ANTIGRAVITY_CONFIG.loadCodeAssistApiClient,
-        "Client-Metadata": ANTIGRAVITY_CONFIG.loadCodeAssistClientMetadata,
         "x-request-source": "local",
       };
       const metadata = getOAuthClientMetadata();

--- a/src/lib/oauth/services/antigravity.js
+++ b/src/lib/oauth/services/antigravity.js
@@ -85,8 +85,6 @@ export class AntigravityService {
       "Authorization": `Bearer ${accessToken}`,
       "Content-Type": "application/json",
       "User-Agent": this.config.loadCodeAssistUserAgent,
-      "X-Goog-Api-Client": this.config.loadCodeAssistApiClient,
-      "Client-Metadata": this.config.loadCodeAssistClientMetadata,
     };
   }
 

--- a/src/lib/oauth/services/gemini.js
+++ b/src/lib/oauth/services/gemini.js
@@ -1,9 +1,17 @@
 import crypto from "crypto";
 import open from "open";
+import { platform, arch } from "os";
 import { GEMINI_CONFIG, getOAuthClientMetadata } from "../constants/oauth.js";
 import { getServerCredentials } from "../config/index.js";
 import { startLocalServer } from "../utils/server.js";
 import { spinner as createSpinner } from "../utils/ui.js";
+
+// Build User-Agent matching the real Antigravity IDE format
+function getAntigravityUserAgent() {
+  const p = platform() === "win32" ? "windows" : platform();
+  const a = arch() === "x64" ? "amd64" : arch();
+  return `antigravity/ide/2.1.1 ${p}/${a}`;
+}
 
 /**
  * Gemini CLI (Google Cloud Code Assist) OAuth Service
@@ -69,9 +77,7 @@ export class GeminiCLIService {
         headers: {
           "Authorization": `Bearer ${accessToken}`,
           "Content-Type": "application/json",
-          "User-Agent": "google-api-nodejs-client/9.15.1",
-          "X-Goog-Api-Client": "google-cloud-sdk vscode_cloudshelleditor/0.1",
-          "Client-Metadata": JSON.stringify(getOAuthClientMetadata())
+          "User-Agent": getAntigravityUserAgent(),
         },
         body: JSON.stringify({
           metadata: getOAuthClientMetadata(),


### PR DESCRIPTION
## fix(antigravity): resolve 403 CONSUMER_INVALID by updating API fingerprint to match real IDE

### Summary

The Antigravity provider was failing with `403 CONSUMER_INVALID` on every request. Investigation revealed that Google's backend was **fingerprinting the HTTP request** and silently refusing to provision a `cloudaicompanionProject` because 9router was identifying itself as **Cloud Shell Editor** instead of the real **Antigravity IDE**.

The `onboardUser` endpoint returned `200 OK` with `cloudaicompanionProject: {}` (empty object), which caused a cascade failure: 5x retry loop → fallback to a randomly generated project ID → `CONSUMER_INVALID` rejection by `streamGenerateContent`.

A manual control test confirmed the same account works perfectly in the real Antigravity IDE, proving this was not an account ban — it was a fingerprint mismatch.

### Root Cause

9router was sending these headers on `onboardUser`/`loadCodeAssist`:

```
User-Agent: google-api-nodejs-client/9.15.1
X-Goog-Api-Client: google-cloud-sdk vscode_cloudshelleditor/0.1
Client-Metadata: {"ideType":9,"platform":5,"pluginType":2}
```

The real Antigravity IDE (v2.1.1) sends:

```
User-Agent: antigravity/ide/2.1.1 windows/amd64
```

No `X-Goog-Api-Client`. No `Client-Metadata`.

Google's backend was comparing these fields and silently downgrading the response — returning an empty project object instead of a real provisioned project ID.

### Changes

#### Core Fingerprint Update
- **`open-sse/config/appConstants.js`**: Updated `LOAD_CODE_ASSIST_HEADERS` and `ANTIGRAVITY_HEADERS` to use the real IDE User-Agent format (`antigravity/ide/2.1.1 <platform>/<arch>`). Removed `X-Goog-Api-Client` and `Client-Metadata` headers. Added platform mapping helpers (`win32→windows`, `x64→amd64`). Centralized version as `ANTIGRAVITY_IDE_VERSION`.
- **`open-sse/providers/registry/antigravity.js`**: Replaced hardcoded `antigravity/1.107.0 darwin/arm64` with dynamic `AG_IDE_UA`. Removed stale `loadCodeAssistApiClient` field.

#### Frontend OAuth Alignment
- **`src/lib/oauth/services/antigravity.js`**: Removed `X-Goog-Api-Client` and `Client-Metadata` from `getApiHeaders()` (were resolving to `undefined` after registry cleanup → crashed Node.js HTTP).
- **`src/lib/oauth/providers.js`**: Same removal from `postExchange` `loadHeaders`.
- **`src/lib/oauth/services/gemini.js`**: Updated `fetchProjectId()` User-Agent to match real IDE format.

#### Peripheral Fixes
- **`src/app/api/providers/[id]/models/route.js`**: Updated User-Agent for `fetchAvailableModels`.
- **`src/app/api/providers/[id]/test/testUtils.js`**: Updated `probeCloudCodeAssistAccess()` User-Agent.

#### Regressions Fixed During Development
- Removed `Accept-Encoding: gzip` — Node.js native `fetch` does not auto-decompress; was causing `Unexpected token \x1f` JSON parse errors.
- Fixed `TypeError: Invalid value "undefined" for header "X-Goog-Api-Client"` caused by removing registry fields while downstream consumers still referenced them.

### Files Changed (7)

| File | Change |
|------|--------|
| `open-sse/config/appConstants.js` | UA format, removed stale headers, added platform mapping |
| `open-sse/providers/registry/antigravity.js` | Dynamic UA, removed `loadCodeAssistApiClient` |
| `src/lib/oauth/services/antigravity.js` | Removed undefined header values |
| `src/lib/oauth/providers.js` | Removed undefined header values |
| `src/lib/oauth/services/gemini.js` | Updated UA, removed gzip |
| `src/app/api/providers/[id]/models/route.js` | Updated UA for model fetching |
| `src/app/api/providers/[id]/test/testUtils.js` | Updated UA for connection test probe |

### Testing

- ✅ `onboardUser` now returns a real `cloudaicompanionProject` (no longer empty `{}`)
- ✅ `streamGenerateContent` no longer returns `403 CONSUMER_INVALID`
- ✅ Token exchange completes without `TypeError` crash
- ✅ JSON responses parse correctly (no gzip decompression errors)
- ✅ Build completes successfully (`node cli/scripts/build-cli.js`)

Fixes the Antigravity 403 portion of #2464
