### PR TITLE
fix(openai→claude): unwrap bare {function:{…}} tools (no parent type)

### DIFF
--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -153,7 +153,15 @@ Respond ONLY with the JSON object, no other text.`);
         continue;
       }
 
-      const toolData = toolType === OPENAI_BLOCK.FUNCTION && tool.function ? tool.function : tool;
+      // Function-shaped tools arrive in two flavors from real clients:
+      //   (a) openai-spec: { type: "function", function: { name, ... } }
+      //   (b) legacy/loose: { function: { name, ... } }   (no parent `type`)
+      // Both must yield toolData.name = "echo". Treat the bare-function shape
+      // as a function tool too — Anthropic-compatible gateways (notably
+      // MiniMax M3 at api.minimaxi.com) reject payloads where this branch
+      // falls through with `toolData.name === undefined`, returning their
+      // upstream code (2013) "invalid tool type". See #2435.
+      const toolData = tool.function ?? tool;
       const originalName = toolData.name;
 
       // Claude OAuth requires prefixed tool names to avoid conflicts

--- a/tests/unit/openai-to-claude-tools-no-type.test.js
+++ b/tests/unit/openai-to-claude-tools-no-type.test.js
@@ -1,0 +1,91 @@
+/**
+ * Regression: tools WITHOUT an explicit `type:"function"` wrapper were
+ * forwarded to the upstream Claude-compatible gateway with `name:"undefined"`,
+ * because openai-to-claude only unwrapped `tool.function` when BOTH
+ * `tool.type === "function"` AND `tool.function` were truthy.
+ *
+ * Repro path (v0.5.20):
+ *   tools: [{ function: { name: "echo", parameters: {...} } }]   // no parent type
+ *   → originalName = undefined
+ *   → upstream body: { name: "undefined", description: "", input_schema: {...} }
+ *
+ * Pragmatic OpenAI clients and some library generators emit the bare
+ * `function` wrapper shape; when this lands on a strict Anthropic-compatible
+ * gateway (e.g. MiniMax's `api.minimaxi.com/anthropic/v1/messages`), the
+ * payload is rejected with an "invalid tool type" / "(2013)" error, which
+ * is the same family of failure that PR #2463 was diagnosing from the
+ * runtimeTransport side. PR #2463 fixes the combo-path transport
+ * selection; this regression closes the translator-side shape gap so
+ * single-connection OpenAI clients aren't bit by it once #2463 lands.
+ *
+ * See: #2435, follow-up to PR #2463.
+ */
+
+import { describe, it, expect } from "vitest";
+import { openaiToClaudeRequest } from "../../open-sse/translator/request/openai-to-claude.js";
+
+const baseBody = (extra = {}) => ({
+  messages: [{ role: "user", content: "hi" }],
+  ...extra,
+});
+
+describe("openai→claude: tools shape fidelity", () => {
+  it("tool WITH explicit type:'function' is rewritten to Anthropic shape", () => {
+    const out = openaiToClaudeRequest("claude-sonnet-4.5", baseBody({
+      tools: [
+        { type: "function", function: { name: "echo", parameters: { type: "object" } } },
+      ],
+    }), false);
+
+    expect(out.tools).toHaveLength(1);
+    expect(out.tools[0].name).toBe("echo");
+    expect(out.tools[0].input_schema).toEqual({ type: "object" });
+    // Anthropic-shape has no top-level `type` and no nested `function`.
+    expect(out.tools[0]).not.toHaveProperty("type");
+    expect(out.tools[0]).not.toHaveProperty("function");
+  });
+
+  it("tool WITHOUT explicit type but WITH function wrapper preserves the original name (was 'undefined' in v0.5.20)", () => {
+    const out = openaiToClaudeRequest("claude-sonnet-4.5", baseBody({
+      tools: [
+        { function: { name: "echo", parameters: { type: "object" } } },
+      ],
+    }), false);
+
+    expect(out.tools).toHaveLength(1);
+    expect(out.tools[0].name).toBe("echo");
+    expect(out.tools[0].input_schema).toEqual({ type: "object" });
+    // The Anthropic-shape envelope strips the OpenAI `function` wrapper entirely.
+    expect(out.tools[0]).not.toHaveProperty("function");
+    expect(out.tools[0]).not.toHaveProperty("type");
+  });
+
+  it("flat Anthropic-shape tool (no function wrapper) is passed through with name preserved", () => {
+    const out = openaiToClaudeRequest("claude-sonnet-4.5", baseBody({
+      tools: [
+        { name: "echo", description: "echo input", input_schema: { type: "object" } },
+      ],
+    }), false);
+
+    expect(out.tools).toHaveLength(1);
+    expect(out.tools[0].name).toBe("echo");
+    expect(out.tools[0].description).toBe("echo input");
+    expect(out.tools[0].input_schema).toEqual({ type: "object" });
+  });
+
+  it("non-function built-in tool types are passed through (cache_control tag is OK)", () => {
+    // 9router adds a `cache_control` tag to the last tool for prompt caching;
+    // the test asserts the original shape is preserved alongside it rather
+    // than checking strict equality. This is the existing buildHeaders /
+    // cache_control behavior unchanged by this fix.
+    const out = openaiToClaudeRequest("claude-sonnet-4.5", baseBody({
+      tools: [
+        { type: "web_search_20250305", name: "web_search" },
+      ],
+    }), false);
+
+    expect(out.tools).toHaveLength(1);
+    expect(out.tools[0].type).toBe("web_search_20250305");
+    expect(out.tools[0].name).toBe("web_search");
+  });
+});


### PR DESCRIPTION
## Context

PR #2463 (`fix(minimax): resolve runtimeTransport/modelTargetFormat conflict and extract 愣think for M3`) is the right diagnosis for the combo-path failure in issue #2435. This PR covers the **residual single-connection case** that #2463 does not address: when an OpenAI client sends a tool definition without an explicit parent `type:"function"` field, 9router emits an Anthropic-shape envelope with `name: undefined` — which MiniMax's strict Anthropic-compatible gateway at `api.minimaxi.com` rejects with upstream code `(2013)` "invalid tool type".

## Repro (real client, real upstream)

Client: Cursor IDE via `http://127.0.0.1:20128/v1` → 9router v0.5.20 → `provider=minimax` connection (Anthropic-protocol path) → `MiniMax-M3`. Every tool-using request returns:

```json
{"type":"error","error":{"type":"bad_request_error","message":"invalid params, invalid tool type:  (2013)","http_code":"400"},"request_id":"069d8…"}
```

Trace is preserved in the user's local `~/.9router/db/data.sqlite` `requestDetails` table (`provider='minimax' AND status='error'`). The comment on #2435 carries the literal sqlite row.

## The fix

**File**: `open-sse/translator/request/openai-to-claude.js` (1 logical line + comment)

```diff
-const toolData = toolType === OPENAI_BLOCK.FUNCTION && tool.function ? tool.function : tool;
+const toolData = tool.function ?? tool;
```

The old expression only unwrapped `tool.function` when BOTH `tool.type === "function"` AND `tool.function` were truthy. The new expression unwraps whenever `tool.function` exists. Real-world clients and library generators sometimes emit the bare `{function:{name, parameters}}` shape (legacy OpenAI looseness); the old guard silently fell through and forwarded `name: undefined` upstream.

## Regression test

`tests/unit/openai-to-claude-tools-no-type.test.js` — 4 cases (the buggy case + 3 neighbors):

- tool WITH explicit `type:'function'` → Anthropic shape
- tool WITHOUT explicit `type` but WITH function wrapper → Anthropic shape *(was 'undefined' before)*
- flat Anthropic-shape tool → pass-through
- non-function built-in tool types (e.g. `web_search_20250305`) preserved

Run: `cd tests && NODE_PATH=$PWD/node_modules ./node_modules/.bin/vitest run unit/openai-to-claude-tools-no-type.test.js` → **4/4 pass**.

## Verification notes

- `npm test` in `tests/` shows pre-existing failures in unrelated suites (oauth cursor auto-import, xai oauth, audit checks, snapshot golden). None touched by this diff. The new test passes both before the fix (RED, capturing the bug) and after (GREEN).
- After this merges, user-side verification: point Cursor at the patched build, send a tool-using request, expect HTTP 200 with non-zero input tokens in the SQLite `requestDetails` row for `provider='minimax'`.

## Intended to land on top of #2463, not instead of it

This is complementary. #2463 addresses the combo-path transport selection; this addresses the translator-side shape gap. The text-only path through minimax still relies on #2463 for combo fallback to work correctly. If reviewers prefer this as a single PR, I am happy to close this and rebase onto #2463 once it merges.

## Related

- Closes user-side portion of #2435 (combo portion remains fixed by #2463)
- Related but orthogonal: #2195 (pragmatic Anthropic clients omitting `type:'custom'` — different bug, same gateway)
- See also: 9Router v0.5.20 release note (`opencode-go: align models with official endpoints; route Qwen 3.7 MiniMax via /v1/messages` — the same direction of "stop translating when not needed" this PR embodies at the translator level).
