### PR TITLE
fix(codex): avoid bare-email OAuth dedup

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -135,10 +135,17 @@ export class CodexExecutor extends BaseExecutor {
     headers["session_id"] = this._currentSessionId || credentials?.connectionId || "default";
     // Identify client type to Codex backend (matches official codex CLI)
     if (!headers["originator"]) headers["originator"] = "codex_cli_rs";
-    // Workspace binding header — improves account scope + cache affinity
-    const workspaceId = credentials?.providerSpecificData?.workspaceId;
-    if (typeof workspaceId === "string" && workspaceId && !headers["chatgpt-account-id"]) {
-      headers["chatgpt-account-id"] = workspaceId;
+    // Account/workspace binding header — required when multiple Codex accounts
+    // are configured. OAuth import stores ChatGPT account ID as chatgptAccountId;
+    // older/custom rows may use workspaceId/accountId. Prefer explicit workspaceId
+    // but fall back to chatgptAccountId so requests don't cross-bind to the wrong
+    // OpenAI account and surface as token_invalid after adding another account.
+    const accountId =
+      credentials?.providerSpecificData?.workspaceId ||
+      credentials?.providerSpecificData?.chatgptAccountId ||
+      credentials?.providerSpecificData?.accountId;
+    if (typeof accountId === "string" && accountId && !headers["chatgpt-account-id"]) {
+      headers["chatgpt-account-id"] = accountId;
     }
     return headers;
   }

--- a/src/lib/db/repos/connectionsRepo.js
+++ b/src/lib/db/repos/connectionsRepo.js
@@ -102,7 +102,18 @@ export async function createProviderConnection(data) {
       const incomingWs = data.providerSpecificData?.chatgptAccountId;
       existing = all.find(c => {
         if (c.authType !== "oauth" || c.email !== data.email) return false;
-        // Workspace providers (Codex) use workspace ID when both sides have it
+
+        // Codex/OpenAI can issue multiple OAuth grants for the same email.
+        // Refresh tokens are rotated single-use; collapsing a new login onto an
+        // existing bare-email row overwrites the first account's token pair and
+        // makes it look "invalid" after adding a second account. Only update an
+        // existing Codex row when both rows expose the same ChatGPT account ID.
+        if (data.provider === "codex") {
+          const existingWs = c.providerSpecificData?.chatgptAccountId;
+          return !!incomingWs && !!existingWs && incomingWs === existingWs;
+        }
+
+        // Workspace providers use workspace ID when both sides have it
         const existingWs = c.providerSpecificData?.chatgptAccountId;
         if (incomingWs && existingWs) return incomingWs === existingWs;
         if (incomingWs && !existingWs) return false;


### PR DESCRIPTION
## Summary

Avoid merging Codex OAuth connections by email alone when the ChatGPT account id is missing.

## Problem

Codex OAuth tokens are account-scoped and refresh tokens are rotated. The generic OAuth dedup path can merge a new Codex login into an existing row when both rows share the same email but do not both expose `providerSpecificData.chatgptAccountId`.

That can overwrite the first connection's token pair and make the existing account appear invalid after another Codex account is added.

## Changes

- For `provider === "codex"`, only update an existing OAuth row when both existing and incoming rows have the same `providerSpecificData.chatgptAccountId`.
- Use `workspaceId || chatgptAccountId || accountId` when setting the Codex `chatgpt-account-id` request header.

## Related

Related to the existing Codex workspace/account binding work in #941 and #1819. This PR keeps the scope narrow and covers the missing-account-id fallback case.

## Verification

```bash
node --check src/lib/db/repos/connectionsRepo.js
node --check open-sse/executors/codex.js
git diff --check
```
