### PR TITLE
fix(gemini): handle Gemma 4 thinking replay

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -163,6 +163,8 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*gemini-2.5*",    caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-budget", thinkingRange: { min: 0, max: 24576 }, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini-2*",      caps: { vision: true, audioInput: true, videoInput: true, search: true, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini*",        caps: { vision: true, search: true, contextWindow: 1048576 } },
+  // Gemma 4 on Gemini API accepts thinkingLevel, not Gemini 2.5 thinkingBudget.
+  { pattern: "*gemma-4*",       caps: { vision: true, reasoning: true, thinkingFormat: "gemini-level", contextWindow: 128000 } },
   { pattern: "*gemma*",         caps: { vision: true, contextWindow: 128000 } },
   { pattern: "*nanobanana*",    caps: { vision: true, imageOutput: true } },
 

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -48,6 +48,7 @@ function normalizeGeminiContents(contents) {
 
 // Core: Convert OpenAI request to Gemini format (base for all variants)
 function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG_SIGNATURE) {
+  const isGemma4 = typeof model === "string" && /gemma-4/i.test(model);
   const result = {
     model: model,
     contents: [],
@@ -113,8 +114,9 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
       } else if (role === ROLE.ASSISTANT) {
         const parts = [];
 
-        // Thinking/reasoning → thought part with signature
-        if (msg.reasoning_content) {
+        // Thinking/reasoning → thought part with signature.
+        // Gemma 4 rejects replayed synthetic thought parts in multi-turn history.
+        if (msg.reasoning_content && !isGemma4) {
           parts.push({
             thought: true,
             text: msg.reasoning_content
@@ -138,14 +140,18 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
             if (tc.type !== OPENAI_BLOCK.FUNCTION) continue;
 
             const args = tryParseJSON(tc.function?.arguments || "{}");
-            parts.push({
-              thoughtSignature: signature,
+            const functionCallPart = {
               functionCall: {
                 id: tc.id,
                 name: sanitizeGeminiFunctionName(tc.function.name),
                 args: args
               }
-            });
+            };
+            // Synthetic thought signatures are useful for Gemini/Antigravity
+            // replay, but Gemma 4 on Gemini API rejects them on functionCall
+            // history parts with a generic INVALID_ARGUMENT.
+            if (!isGemma4) functionCallPart.thoughtSignature = signature;
+            parts.push(functionCallPart);
             toolCallIds.push(tc.id);
           }
 

--- a/tests/translator/gemma4-gemini.test.js
+++ b/tests/translator/gemma4-gemini.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import "./registerAll.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
+
+function gemmaToolBody() {
+  return {
+    messages: [
+      { role: "user", content: "Look something up." },
+      {
+        role: "assistant",
+        content: "I will check.",
+        reasoning_content: "internal reasoning should not be replayed to Gemma 4",
+        tool_calls: [
+          {
+            id: "call_search",
+            type: "function",
+            function: { name: "search_files", arguments: '{"pattern":"x"}' }
+          }
+        ]
+      },
+      { role: "tool", tool_call_id: "call_search", content: '{"result":"ok"}' },
+      { role: "user", content: "Summarize briefly." }
+    ],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "search_files",
+          description: "Search files",
+          parameters: {
+            type: "object",
+            properties: { pattern: { type: "string" } },
+            required: ["pattern"]
+          }
+        }
+      }
+    ],
+    reasoning_effort: "high",
+    max_tokens: 128
+  };
+}
+
+describe("Gemma 4 on Gemini API", () => {
+  it("uses thinkingLevel rather than thinkingBudget", () => {
+    expect(getCapabilitiesForModel("gemini", "gemma-4-31b-it")).toMatchObject({
+      reasoning: true,
+      thinkingFormat: "gemini-level"
+    });
+
+    const body = { reasoning_effort: "high" };
+    applyThinking(FORMATS.GEMINI, "gemma-4-31b-it", body, "gemini");
+
+    expect(body.generationConfig.thinkingConfig).toEqual({
+      thinkingLevel: "high",
+      includeThoughts: true
+    });
+    expect(body.generationConfig.thinkingConfig.thinkingBudget).toBeUndefined();
+  });
+
+  it("does not replay synthetic thoughts or thought signatures in tool history", () => {
+    const out = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.GEMINI,
+      "gemma-4-31b-it",
+      gemmaToolBody(),
+      false,
+      { apiKey: "test" },
+      "gemini"
+    );
+
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("thoughtSignature");
+    expect(serialized).not.toContain("internal reasoning should not be replayed");
+
+    const modelTurn = out.contents.find((turn) => turn.role === "model");
+    expect(modelTurn.parts).toContainEqual({ text: "I will check." });
+    expect(modelTurn.parts).toContainEqual({
+      functionCall: {
+        id: "call_search",
+        name: "search_files",
+        args: { pattern: "x" }
+      }
+    });
+  });
+
+  it("keeps synthetic thought signatures for regular Gemini tool history", () => {
+    const out = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.GEMINI,
+      "gemini-2.5-flash",
+      gemmaToolBody(),
+      false,
+      { apiKey: "test" },
+      "gemini"
+    );
+
+    const serialized = JSON.stringify(out);
+    expect(serialized).toContain("thoughtSignature");
+    expect(serialized).toContain("internal reasoning should not be replayed");
+  });
+});


### PR DESCRIPTION
## Summary

- Map Gemma 4 models on the Gemini API to `gemini-level` thinking instead of budget-based Gemini thinking.
- Avoid replaying synthetic Gemini thought parts and `thoughtSignature` fields for Gemma 4 multi-turn tool history.
- Add regression coverage for Gemma 4 thinking config and OpenAI-to-Gemini tool-history conversion.

## Why

Gemma 4 on the Gemini API rejects some request shapes that are valid for other Gemini-family routes:

1. `generationConfig.thinkingConfig.thinkingBudget` / `includeThoughts` can produce `400 INVALID_ARGUMENT`; Gemma 4 expects level-based thinking (`thinkingLevel`) when thinking is explicitly requested.
2. Multi-turn tool history converted from OpenAI format can include synthetic replay artifacts such as assistant `reasoning_content` converted to Gemini `thought` parts and `thoughtSignature` attached to replayed `functionCall` parts. Gemma 4 rejects these with the same generic `400 INVALID_ARGUMENT`.

This keeps existing behavior for regular Gemini routes while special-casing Gemma 4.

## Test Plan

```bash
NODE_PATH=./node_modules ./tests/node_modules/.bin/vitest run \
  tests/translator/gemma4-gemini.test.js \
  tests/translator/thinking-unified.test.js \
  tests/unit/capabilities.test.js \
  --reporter=verbose
```

Result: 3 files passed, 38 tests passed.

Also ran:

```bash
git diff --check
```
