### PR TITLE
Fix Gemini CLI thinking and tool calls

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -148,16 +148,55 @@ function toKimiReasoningEffort(cfg) {
   return null;
 }
 
+const GEMINI_LEVEL_OUTPUT_FLOOR = {
+  minimal: 4096,
+  low: 8192,
+  medium: 16384,
+  high: 65535,
+};
+
+function geminiBudgetOutputFloor(budget) {
+  if (budget === -1) return 32768;
+  if (!Number.isFinite(budget)) return 32768;
+  if (budget <= 1024) return 8192;
+  if (budget <= 8192) return 16384;
+  if (budget <= 24576) return 32768;
+  return 65535;
+}
+
+function geminiLevelOutputFloor(level) {
+  return GEMINI_LEVEL_OUTPUT_FLOOR[level] || GEMINI_LEVEL_OUTPUT_FLOOR.high;
+}
+
 // Gemini nests thinkingConfig under generationConfig. gemini-cli / antigravity wrap
 // the whole request in a { request: { generationConfig } } envelope — target the
 // envelope's generationConfig when present, else the top-level one.
+function getGeminiGenerationConfig(body) {
+  if (body.request && typeof body.request === "object") {
+    if (!body.request.generationConfig || typeof body.request.generationConfig !== "object") {
+      body.request.generationConfig = {};
+    }
+    return body.request.generationConfig;
+  }
+  if (!body.generationConfig || typeof body.generationConfig !== "object") {
+    body.generationConfig = {};
+  }
+  return body.generationConfig;
+}
+
 function setGeminiThinking(body, tc) {
-  const gc = body.request?.generationConfig
-    ? body.request.generationConfig
-    : (body.generationConfig && typeof body.generationConfig === "object"
-        ? body.generationConfig
-        : (body.generationConfig = {}));
+  const gc = getGeminiGenerationConfig(body);
   gc.thinkingConfig = tc;
+}
+
+function ensureGeminiOutputFloor(body, floor, caps) {
+  const cap = Number.isFinite(caps?.maxOutput) ? caps.maxOutput : floor;
+  const target = Math.min(floor, cap);
+  const gc = getGeminiGenerationConfig(body);
+  const current = Number(gc.maxOutputTokens);
+  if (!Number.isFinite(current) || current < target) {
+    gc.maxOutputTokens = target;
+  }
 }
 
 // Strip every known thinking field from a body (used before re-applying / when unsupported).
@@ -202,12 +241,14 @@ function applyFormat(fmt, body, cfg, caps) {
     case "gemini-level": {
       const level = none ? "minimal" : toGeminiThinkingLevel(eff);
       setGeminiThinking(body, { thinkingLevel: level, includeThoughts: level !== "minimal" });
+      ensureGeminiOutputFloor(body, geminiLevelOutputFloor(level), caps);
       break;
     }
     case "gemini-budget": {
       if (none && canDisable) { setGeminiThinking(body, { thinkingBudget: 0, includeThoughts: false }); break; }
       const budget = toBudget(eff, caps.thinkingRange);
       setGeminiThinking(body, { thinkingBudget: budget ?? -1, includeThoughts: true });
+      ensureGeminiOutputFloor(body, geminiBudgetOutputFloor(budget ?? -1), caps);
       break;
     }
     case "zai": {

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -296,15 +296,15 @@ function wrapInCloudCodeEnvelope(model, geminiCLI, credentials = null, isAntigra
       envelope.request.systemInstruction = { role: GEMINI_ROLE.USER, parts: systemParts };
     }
 
-    // Add toolConfig for Antigravity
-    if (geminiCLI.tools?.length > 0) {
-      envelope.request.toolConfig = {
-        functionCallingConfig: { mode: "VALIDATED" }
-      };
-    }
   } else {
     // Keep safetySettings for Gemini CLI
     envelope.request.safetySettings = geminiCLI.safetySettings;
+  }
+
+  if (geminiCLI.tools?.length > 0) {
+    envelope.request.toolConfig = {
+      functionCallingConfig: { mode: "VALIDATED" }
+    };
   }
 
   return envelope;
@@ -463,4 +463,3 @@ export function openaiToAntigravityRequest(model, body, stream, credentials = nu
 register(FORMATS.OPENAI, FORMATS.GEMINI, openaiToGeminiRequest, null);
 register(FORMATS.OPENAI, FORMATS.GEMINI_CLI, (model, body, stream, credentials) => wrapInCloudCodeEnvelope(model, openaiToGeminiCLIRequest(model, body, stream), credentials), null);
 register(FORMATS.OPENAI, FORMATS.ANTIGRAVITY, openaiToAntigravityRequest, null);
-

--- a/tests/translator/golden-request.test.js
+++ b/tests/translator/golden-request.test.js
@@ -54,6 +54,45 @@ describe("GOLDEN request: OpenAI → Gemini", () => {
     const out = translateRequest(FORMATS.OPENAI, FORMATS.GEMINI, "gemini-3-pro", baseBody(), true, { apiKey: "k" }, "gemini");
     expect(clean(out)).toMatchSnapshot();
   });
+
+  it("Gemini CLI tool requests include validated toolConfig and enough output for high thinking", () => {
+    const body = {
+      messages: [{ role: "user", content: "Call add with 7 and 35." }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "add",
+            description: "Add two numbers",
+            parameters: {
+              type: "object",
+              properties: {
+                a: { type: "number" },
+                b: { type: "number" },
+              },
+              required: ["a", "b"],
+            },
+          },
+        },
+      ],
+      reasoning_effort: "high",
+      max_tokens: 128,
+    };
+    const out = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.GEMINI_CLI,
+      "gemini-3.1-pro-preview",
+      body,
+      true,
+      { accessToken: "t", projectId: "p" },
+      "gemini-cli"
+    );
+
+    expect(out.request.toolConfig).toEqual({ functionCallingConfig: { mode: "VALIDATED" } });
+    expect(out.request.safetySettings).toBeDefined();
+    expect(out.request.generationConfig.thinkingConfig).toEqual({ thinkingLevel: "high", includeThoughts: true });
+    expect(out.request.generationConfig.maxOutputTokens).toBe(65535);
+  });
 });
 
 describe("GOLDEN request: OpenAI → Kiro", () => {

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -78,10 +78,26 @@ describe("applyThinking per provider format", () => {
     const out = apply("gemini", "gemini-3-pro", { reasoning_effort: "auto" }, "gemini");
     expect(out.generationConfig.thinkingConfig.thinkingLevel).toBe("high");
   });
+  it("gemini-3 high thinking raises too-small maxOutputTokens", () => {
+    const out = apply("gemini-cli", "gemini-3.1-pro-preview", {
+      request: { generationConfig: { maxOutputTokens: 128 } },
+      reasoning_effort: "high",
+    }, "gemini-cli");
+    expect(out.request.generationConfig.thinkingConfig).toEqual({ thinkingLevel: "high", includeThoughts: true });
+    expect(out.request.generationConfig.maxOutputTokens).toBe(65535);
+  });
   it("gemini-2.5 → thinkingBudget", () => {
     const out = apply("gemini", "gemini-2.5-flash", { reasoning_effort: "high" }, "gemini");
     expect(out.generationConfig.thinkingConfig.thinkingBudget).toBe(24576);
     expect(out.generationConfig.thinkingConfig.thinkingLevel).toBeUndefined();
+  });
+  it("gemini-2.5 budget thinking keeps enough room for answer tokens", () => {
+    const out = apply("gemini-cli", "gemini-2.5-pro", {
+      request: { generationConfig: { maxOutputTokens: 1024 } },
+      reasoning_effort: "high",
+    }, "gemini-cli");
+    expect(out.request.generationConfig.thinkingConfig).toEqual({ thinkingBudget: 24576, includeThoughts: true });
+    expect(out.request.generationConfig.maxOutputTokens).toBe(32768);
   });
   it("GLM off → enable_thinking:false (not thinking.disabled)", () => {
     const out = apply("openai", "glm-4.6", { reasoning_effort: "none" }, "glm");


### PR DESCRIPTION
## Summary

- Raise Gemini `maxOutputTokens` floors when applying Gemini thinking config so explicit thinking modes have enough room for reasoning plus answer tokens.
- Add `request.toolConfig.functionCallingConfig.mode = "VALIDATED"` for Gemini CLI tool requests, matching the existing Antigravity behavior.
- Cover both behaviors with translator tests.

## Root Cause

Gemini CLI (`gc/*`) requests can arrive with small OpenAI `max_tokens` values. After translating `reasoning_effort` to Gemini `thinkingConfig`, Gemini can spend that output budget on thoughts and return blank content or `length`. Tool requests also lacked Cloud Code `toolConfig`, which can produce `MALFORMED_FUNCTION_CALL` for Gemini CLI even when `functionDeclarations` are valid.

## Validation

- `npx vitest run --config tests/vitest.config.js tests/translator/thinking-unified.test.js`
- `npx vitest run --config tests/vitest.config.js tests/translator/golden-request.test.js -t "Gemini CLI tool requests"`

Note: running the full `tests/translator/golden-request.test.js` currently fails on an unrelated Kiro snapshot mismatch in the existing suite; the new Gemini CLI targeted test passes.

## Runtime Verification

The same behavior was verified locally against the installed 9router runtime on `gc/gemini-3.1-pro-preview` high thinking for text, long-context, non-stream tool call, and stream tool call scenarios.