### PR TITLE
feat(providers): add max thinking level for gpt-5.6-sol

### DIFF
--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -32,6 +32,8 @@ const FORMAT_LEVELS = {
 
 // Model-name pattern overrides (glob, first match wins) — more precise than format default.
 const PATTERN_THINKING = [
+  // gpt-5.6-sol accepts max (maps to xhigh on wire); live probe rejected ultra.
+  { pattern: "*gpt-5.6-sol*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max"] },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
 ];
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -156,17 +156,27 @@ export default function ProviderDetailPage() {
     const levels = getThinkingLevels(providerId, modelId);
     return levels && levels.includes(thinkingMode) ? thinkingMode : null;
   };
+  const providerStorageAlias = isCompatible ? providerId : providerAlias;
   // Union of levels across this provider's reasoning models — drives the level picker options.
+  // Include custom models too (e.g. manually added gpt-5.6-sol → max).
   const providerThinkingLevels = (() => {
     const set = new Set();
-    for (const m of models) {
-      const lv = getThinkingLevels(providerId, m.id);
+    const seen = new Set();
+    const addLevels = (modelId) => {
+      if (!modelId || seen.has(modelId)) return;
+      seen.add(modelId);
+      const lv = getThinkingLevels(providerId, modelId);
       if (lv) lv.forEach((l) => { if (l !== "none") set.add(l); });
+    };
+    for (const m of models) addLevels(m.id);
+    for (const m of kiloFreeModels) addLevels(m.id);
+    for (const entry of customModels) {
+      if (entry.providerAlias !== providerStorageAlias) continue;
+      if ((entry.kind || entry.type || "llm") !== "llm") continue;
+      addLevels(entry.id);
     }
     return set.size ? ["auto", ...[...set]] : null;
   })();
-  
-  const providerStorageAlias = isCompatible ? providerId : providerAlias;
   const providerDisplayAlias = isCompatible
     ? (providerNode?.prefix || providerId)
     : providerAlias;

--- a/tests/unit/thinking-levels-gpt56-sol.test.js
+++ b/tests/unit/thinking-levels-gpt56-sol.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
+
+describe("getThinkingLevels", () => {
+  it("adds max for gpt-5.6-sol on codex", () => {
+    const levels = getThinkingLevels("codex", "gpt-5.6-sol");
+    expect(levels).toContain("max");
+    expect(levels).toContain("xhigh");
+    expect(levels).not.toContain("ultra");
+  });
+
+  it("does not add max for other codex models", () => {
+    const levels = getThinkingLevels("codex", "gpt-5.3-codex");
+    expect(levels).toEqual(["low", "medium", "high", "xhigh"]);
+  });
+
+  it("does not add max for other gpt-5.6 models", () => {
+    const levels = getThinkingLevels("codex", "gpt-5.5");
+    expect(levels || []).not.toContain("max");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `max` to the thinking-level picker for `gpt-5.6-sol` only (Codex / OpenAI GPT-5.6 Sol).
- Other Codex models keep existing levels (`low` / `medium` / `high` / `xhigh`).
- Unit tests cover inclusion for `gpt-5.6-sol` and non-regression for other models.

## Context
- OpenAI docs list GPT-5.6 Sol reasoning efforts including `max`.
- Live probes via local 9Router against ChatGPT/Codex: `max` returns 200; `ultra` is rejected as invalid `reasoning.effort` (Ultra is a Codex subagent mode, not a wire effort).
- Wire path already maps internal `max` appropriately in the thinking layer.

## Test plan
- [x] `cd tests && npx vitest run unit/thinking-levels-gpt56-sol.test.js --config vitest.config.js`
- [ ] Open dashboard → Providers → OpenAI Codex with `gpt-5.6-sol` available
- [ ] Confirm Thinking dropdown includes **Max**
- [ ] Select Max and copy model name → suffix `(max)` only on `gpt-5.6-sol`
- [ ] Request `cx/gpt-5.6-sol` with `reasoning_effort: "max"` succeeds