### PR TITLE
fix(codex): inject token saver prompts as instructions

### DIFF
--- a/open-sse/rtk/systemInject.js
+++ b/open-sse/rtk/systemInject.js
@@ -22,14 +22,14 @@ export function injectSystemPrompt(body, format, prompt) {
       return;
     default:
       // OpenAI and OpenAI-shaped formats (responses/codex/cursor/kiro/ollama)
-      injectMessagesSystem(body, prompt);
+      injectMessagesSystem(body, prompt, format);
   }
 }
 
 // OpenAI-shaped: messages[] (chat) or input[] (responses) or instructions (responses string)
-function injectMessagesSystem(body, prompt) {
-  // OpenAI Responses API: top-level string field
-  if (typeof body.instructions === "string") {
+function injectMessagesSystem(body, prompt, format) {
+  // OpenAI Responses API: Codex rejects instruction messages in input[]; use top-level instructions.
+  if (format === FORMATS.OPENAI_RESPONSES || format === FORMATS.OPENAI_RESPONSE || format === FORMATS.CODEX || typeof body.instructions === "string") {
     body.instructions = body.instructions
       ? `${body.instructions}${SEP}${prompt}`
       : prompt;

--- a/tests/unit/system-inject.test.js
+++ b/tests/unit/system-inject.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { injectSystemPrompt } from "../../open-sse/rtk/systemInject.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("injectSystemPrompt", () => {
+  it("uses top-level instructions for openai-responses when instructions is absent (#2497)", () => {
+    const body = {
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hi" }],
+        },
+      ],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "respond tersely");
+
+    expect(body.instructions).toBe("respond tersely");
+    expect(body.input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }],
+      },
+    ]);
+  });
+
+  it("appends top-level instructions for openai-responses", () => {
+    const body = {
+      instructions: "be helpful",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "respond tersely");
+
+    expect(body.instructions).toBe("be helpful\n\nrespond tersely");
+  });
+
+  it("keeps chat completions system injection in messages", () => {
+    const body = { messages: [{ role: "user", content: "hi" }] };
+
+    injectSystemPrompt(body, FORMATS.OPENAI, "respond tersely");
+
+    expect(body.messages[0]).toEqual({ role: "system", content: "respond tersely" });
+    expect(body.messages[1]).toEqual({ role: "user", content: "hi" });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Token Saver/Caveman prompt injection for Codex/OpenAI Responses requests.

When Token Saver injected a system prompt into a Responses-style request with no existing `instructions` field, it fell back to inserting a chat-style message into `input[]`:

```js
{ role: "system", content: "..." }
```

Codex GPT-5.6 rejects that shape because Responses `input[]` entries must use Responses item/content schemas, so requests failed with:

```txt
Unknown parameter: 'input[0].content'
```

## Changes

- Pass the target request format into `injectMessagesSystem`.
- For `openai-responses`, `openai-response`, and `codex` formats, append Token Saver/Caveman prompt text to top-level `instructions` instead of mutating `input[]`.
- Preserve existing chat-completions behavior: non-Responses OpenAI-shaped requests still receive a `system` message in `messages[]`.
- Add regression coverage for:
  - Responses requests with no existing `instructions` field.
  - Responses requests with existing `instructions`.
  - Chat completions `messages[]` injection behavior.

## Verification

```bash
npx --yes vitest@4.1.10 run --environment node tests/unit/system-inject.test.js tests/unit/caveman-prompts.test.js
```

Result:

```txt
Test Files  2 passed (2)
Tests       12 passed (12)
```

Closes #2497
