### PR TITLE
fix(codex): retry rejected input namespaces once

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -44,6 +44,21 @@ const RESPONSES_API_ALLOWLIST = new Set([
   "text"
 ]);
 
+export function stripRejectedCodexInputNamespaces(body) {
+  if (!Array.isArray(body?.input)) return false;
+  let stripped = false;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !("namespace" in item)) continue;
+    delete item.namespace;
+    stripped = true;
+  }
+  return stripped;
+}
+
+function isRejectedCodexInputNamespace(status, errorText) {
+  return Number(status) === 400
+    && /unknown parameter:\s*['"]input\[\d+\]\.namespace['"]/i.test(String(errorText || ""));
+}
 // Convert role=system → role=developer in body.input (keeps content in cacheable prefix)
 function convertSystemToDeveloperRole(body) {
   if (!Array.isArray(body.input)) return;
@@ -267,8 +282,18 @@ export class CodexExecutor extends BaseExecutor {
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
     const { attempts, delayMs } = resolveRetryEntry(retryConfig[503]);
     let attempt = 0;
+    let namespaceSchemaRetried = false;
     while (true) {
       const result = await super.execute(args);
+      if (!namespaceSchemaRetried && result.response?.status === 400) {
+        const errorText = await result.response.clone().text();
+        if (isRejectedCodexInputNamespace(result.response.status, errorText)
+            && stripRejectedCodexInputNamespaces(args.body)) {
+          namespaceSchemaRetried = true;
+          args.log?.warn?.("CODEX", "Upstream rejected input namespace; retrying once without history namespace fields");
+          continue;
+        }
+      }
       const peek = await this._peekSseTransientError(result.response);
       if (!peek.matched) {
         // Replace body with re-assembled stream (prefix bytes already read + rest)

--- a/tests/unit/codex-namespace-retry.test.js
+++ b/tests/unit/codex-namespace-retry.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BaseExecutor } from "../../open-sse/executors/base.js";
+import { CodexExecutor, stripRejectedCodexInputNamespaces } from "../../open-sse/executors/codex.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Codex rejected input namespace compatibility", () => {
+  it("removes namespace only from input history", () => {
+    const body = {
+      input: [{ type: "function_call", namespace: "collaboration", name: "spawn_agent" }],
+      tools: [{ type: "namespace", name: "collaboration", tools: [] }],
+    };
+
+    expect(stripRejectedCodexInputNamespaces(body)).toBe(true);
+    expect(body.input[0].namespace).toBeUndefined();
+    expect(body.tools[0].type).toBe("namespace");
+  });
+
+  it("retries once after the exact upstream schema error", async () => {
+    const executeSpy = vi.spyOn(BaseExecutor.prototype, "execute")
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          error: { message: "Unknown parameter: 'input[150].namespace'.", type: "invalid_request_error", code: "unknown_parameter" },
+        }), { status: 400 }),
+      })
+      .mockResolvedValueOnce({ response: new Response("ok", { status: 200 }) });
+    const executor = new CodexExecutor();
+    executor._peekSseTransientError = vi.fn().mockResolvedValue({ matched: null, replacementBody: null });
+    const body = {
+      input: [{ type: "function_call", namespace: "collaboration", name: "spawn_agent" }],
+      tools: [{ type: "namespace", name: "collaboration", tools: [] }],
+    };
+
+    const result = await executor.execute({ body, credentials: {}, log: { warn: vi.fn() } });
+
+    expect(result.response.status).toBe(200);
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(body.input[0].namespace).toBeUndefined();
+    expect(body.tools[0].type).toBe("namespace");
+  });
+
+  it("does not retry unrelated 400 responses", async () => {
+    const executeSpy = vi.spyOn(BaseExecutor.prototype, "execute").mockResolvedValue({
+      response: new Response("unsupported model", { status: 400 }),
+    });
+    const executor = new CodexExecutor();
+    executor._peekSseTransientError = vi.fn().mockResolvedValue({ matched: null, replacementBody: null });
+
+    await executor.execute({
+      body: { input: [{ type: "function_call", namespace: "collaboration" }] },
+      credentials: {},
+      log: { warn: vi.fn() },
+    });
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Codex GPT-5.6 Responses Lite sessions can fail after a tool call with:

```
400 Unknown parameter: 'input[150].namespace'
```

The rejected field is attached to a historical `input[]` function call. The namespace tool declaration itself is still valid and must be preserved.

## Root cause

The upstream Codex endpoint can reject `namespace` on historical input items even though the current client contract uses namespaced tools. Retrying accounts or combo models cannot change that request-schema incompatibility.

## Behavior before

- The exact schema error is returned immediately.
- Higher layers may rotate accounts or combo models with the same invalid history.

## Behavior after

- Retry the same request once after the exact `input[n].namespace` error.
- Remove only `namespace` fields from `input[]` history.
- Preserve namespace tool declarations, call IDs, ordering, auth, and all other input fields.
- Unrelated 400 responses are not retried.

## Backward compatibility

The compatibility retry is gated by HTTP 400 plus the exact upstream parameter path. Standard Responses requests and other Codex errors are unchanged.

## Tests

- `cd tests && npx vitest run unit/codex-namespace-retry.test.js unit/codex-tool-normalization.test.js`
- 7 tests passed.
- `git diff --check` passed.

## Live verification

Verified with Codex CLI and Codex Desktop 0.144.0-alpha.4 against GPT-5.6 Sol through 9Router. Tool execution and the following resumed turn completed without the namespace error.

## Related OpenAI issues

- OpenAI Codex #31760
- OpenAI Codex #31875
- OpenAI Codex #31882

## Related 9Router PRs

- #2511 handles the broader Responses Lite transport contract; this PR is a narrow backend-compatibility retry for the observed historical namespace rejection.
- #1193 covers broader namespace round-trip behavior and is not copied here.

## Security/header-forwarding notes

No header or credential behavior changes. The retry stays on the selected account and mutates only the request body copy already owned by the executor.