### PR TITLE
fix(codex): avoid fallback on request schema errors

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -28,6 +28,14 @@ export const DEFAULT_ERROR_MESSAGES = {
   504: "Gateway timeout"
 };
 
+export const CODEX_REQUEST_SCHEMA_ERROR_CODES = new Set([
+  "invalid_request_error",
+  "unknown_parameter",
+  "unsupported_value",
+]);
+
+export const CODEX_REQUEST_SCHEMA_ERROR_PATTERN =
+  /unknown[_ ]parameter|unsupported[_ ]value|(?:invalid|unsupported)[_ ]?(?:parameter|schema)|(?:parameter|schema).*(?:invalid|unsupported)/i;
 // Exponential backoff config for rate limits
 export const BACKOFF_CONFIG = {
   base: 2000,

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -1,4 +1,29 @@
-import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
+import {
+  ERROR_RULES,
+  BACKOFF_CONFIG,
+  TRANSIENT_COOLDOWN_MS,
+  CODEX_REQUEST_SCHEMA_ERROR_CODES,
+  CODEX_REQUEST_SCHEMA_ERROR_PATTERN,
+} from "../config/errorConfig.js";
+
+function parseErrorPayload(errorText) {
+  if (errorText && typeof errorText === "object") return errorText;
+  if (typeof errorText !== "string") return {};
+  try { return JSON.parse(errorText); } catch { return { message: errorText }; }
+}
+
+export function isCodexRequestSchemaError(provider, status, errorText = "") {
+  if (provider !== "codex" || Number(status) !== 400) return false;
+  const payload = parseErrorPayload(errorText);
+  const error = payload?.error && typeof payload.error === "object" ? payload.error : payload;
+  const message = String(error?.message || errorText || "");
+  const code = String(error?.code || "").toLowerCase();
+  const type = String(error?.type || "").toLowerCase();
+  const recognizedMetadata = !code && !type
+    || CODEX_REQUEST_SCHEMA_ERROR_CODES.has(code)
+    || CODEX_REQUEST_SCHEMA_ERROR_CODES.has(type);
+  return recognizedMetadata && CODEX_REQUEST_SCHEMA_ERROR_PATTERN.test(message || code || type);
+}
 
 /**
  * Calculate exponential backoff cooldown for rate limits (429)

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -2,7 +2,7 @@
  * Shared combo (model combo) handling with fallback support
  */
 
-import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
+import { checkFallbackError, formatRetryAfter, isCodexRequestSchemaError } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
@@ -280,6 +280,10 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
         try { errorText = JSON.stringify(errorText); } catch { errorText = String(errorText); }
       }
 
+      if (modelStr.startsWith("cx/") && isCodexRequestSchemaError("codex", result.status, errorText)) {
+        log.warn("COMBO", `Model ${modelStr} failed with a non-retryable request schema error`, { status: result.status });
+        return result;
+      }
       // Check if should fallback to next model
       const { shouldFallback, cooldownMs } = checkFallbackError(result.status, errorText);
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -1,4 +1,5 @@
 import "open-sse/index.js";
+import { isCodexRequestSchemaError } from "open-sse/services/accountFallback.js";
 
 import {
   getProviderCredentials,
@@ -270,6 +271,11 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     });
 
     if (result.success) return result.response;
+
+    if (isCodexRequestSchemaError(provider, result.status, result.error)) {
+      log.warn("REQUEST", `Non-retryable Codex request schema error (${result.status})`);
+      return result.response;
+    }
 
     // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise resetsAtMs)
     const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);

--- a/tests/unit/codex-schema-fallback.test.js
+++ b/tests/unit/codex-schema-fallback.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isCodexRequestSchemaError } from "../../open-sse/services/accountFallback.js";
+import { handleComboChat } from "../../open-sse/services/combo.js";
+
+const log = { info: vi.fn(), warn: vi.fn() };
+
+function errorResponse(status, error) {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Codex request schema fallback", () => {
+  it.each([
+    ["Unknown parameter: 'input[150].namespace'.", true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "unknown_parameter", message: "Unknown parameter: input[2].namespace" } }), true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "unsupported_value", message: "Unsupported value for input[2].type" } }), true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "invalid_prompt", message: "Prompt is too long" } }), false],
+    ["The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.", false],
+  ])("classifies only request schema incompatibilities", (message, expected) => {
+    expect(isCodexRequestSchemaError("codex", 400, message)).toBe(expected);
+  });
+
+  it("does not intercept other providers or retryable statuses", () => {
+    expect(isCodexRequestSchemaError("openai", 400, "Unknown parameter: input[0].x")).toBe(false);
+    expect(isCodexRequestSchemaError("codex", 429, "rate limit")).toBe(false);
+    expect(isCodexRequestSchemaError("codex", 401, "invalid token")).toBe(false);
+  });
+
+  it("stops a combo after a Codex schema error", async () => {
+    const handleSingleModel = vi.fn().mockResolvedValue(errorResponse(400, {
+      message: "Unknown parameter: 'input[150].namespace'.",
+      type: "invalid_request_error",
+      code: "unknown_parameter",
+    }));
+
+    const response = await handleComboChat({
+      body: {},
+      models: ["cx/gpt-5.6-sol", "cx/gpt-5.5"],
+      handleSingleModel,
+      log,
+    });
+
+    expect(response.status).toBe(400);
+    expect(handleSingleModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps normal combo fallback for rate limits", async () => {
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce(errorResponse(429, { message: "rate limit" }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const response = await handleComboChat({
+      body: {},
+      models: ["cx/gpt-5.6-sol", "cx/gpt-5.5"],
+      handleSingleModel,
+      log,
+    });
+
+    expect(response.status).toBe(200);
+    expect(handleSingleModel).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem

A Codex request-schema 400 currently enters the generic fallback path. That can mark a healthy account unavailable, rotate through other accounts, and fan the same malformed request across every model in a combo.

## Root cause

`checkFallbackError()` deliberately treats unmatched errors as transient. Request-schema incompatibilities are deterministic and model/account independent, so the generic policy is incorrect for this narrow Codex case.

## Behavior before

- Codex schema 400 errors can lock or rotate accounts.
- Combo routing can send the same invalid request to subsequent models.

## Behavior after

- Classify only Codex HTTP 400 schema incompatibilities with recognized metadata and schema-specific messages.
- Return the original error without calling `markAccountUnavailable()`.
- Stop combo fan-out when a `cx/*` model returns the classified error.
- Keep normal fallback for 401, 403, 429, usage limits, capacity, overload, and unsupported-account/model errors.

## Backward compatibility

The classifier requires provider `codex`, status 400, recognized error metadata, and a schema-specific message. Other providers and existing retry/fallback rules are unchanged.

## Tests

- `cd tests && npx vitest run unit/codex-schema-fallback.test.js unit/combo-routing.test.js`
- 12 tests passed.
- `git diff --check` passed.

## Live verification

The original `input[150].namespace` failure was reproduced through a GPT-5.6 Sol combo. After applying the classifier with the namespace compatibility fix, the request completed without locking the account or falling through the combo.

## Related OpenAI issues

- OpenAI Codex #31760
- OpenAI Codex #31875
- OpenAI Codex #31882

## Related 9Router PRs

- #2511 Responses Lite transport
- Companion namespace-retry PR from this fork

## Security/header-forwarding notes

No auth or header changes. Client error bodies are inspected only for classification and are not logged with credentials.