### PR TITLE
fix(api): support Codex model catalog responses

### DIFF
--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -475,10 +475,24 @@ export async function OPTIONS() {
  * GET /v1/models - OpenAI compatible models list (LLM/chat models only by default).
  * For other capabilities use /v1/models/{kind} (image, tts, stt, embedding, image-to-text, web).
  */
-export async function GET() {
+export function isCodexModelsRequest(request) {
+  if (!request?.url || typeof request.headers?.get !== "function") return false;
+  const clientVersion = new URL(request.url).searchParams.get("client_version");
+  const userAgent = request.headers.get("user-agent") || "";
+  return Boolean(clientVersion) && /\bcodex(?:[_ -](?:desktop|cli_rs|cli|exec))?\b/i.test(userAgent);
+}
+
+export function buildCompatibleModelsResponse(data, { includeCodexCatalog = false } = {}) {
+  const response = { object: "list", data };
+  if (includeCodexCatalog) response.models = [];
+  return response;
+}
+export async function GET(request) {
   try {
     const data = await buildModelsList([LLM_KIND]);
-    return Response.json({ object: "list", data }, {
+    return Response.json(buildCompatibleModelsResponse(data, {
+      includeCodexCatalog: isCodexModelsRequest(request),
+    }), {
       headers: { "Access-Control-Allow-Origin": "*" },
     });
   } catch (error) {

--- a/tests/unit/models-response-compatibility.test.js
+++ b/tests/unit/models-response-compatibility.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCompatibleModelsResponse,
+  isCodexModelsRequest,
+} from "@/app/api/v1/models/route.js";
+
+const data = [
+  { id: "gpt-5.6-sol", object: "model", owned_by: "combo" },
+  { id: "cx/gpt-5.6-sol", object: "model", owned_by: "cx" },
+];
+
+describe("GET /v1/models response compatibility", () => {
+  it("preserves the exact OpenAI model-list envelope by default", () => {
+    expect(buildCompatibleModelsResponse(data)).toEqual({ object: "list", data });
+  });
+
+  it("adds an empty Codex catalog without changing OpenAI data", () => {
+    expect(buildCompatibleModelsResponse(data, { includeCodexCatalog: true })).toEqual({
+      object: "list",
+      data,
+      models: [],
+    });
+  });
+
+  it.each([
+    ["Codex Desktop/0.144.0-alpha.4", true],
+    ["codex_cli_rs/0.144.1", true],
+    ["codex_exec/0.144.1", true],
+    ["openai-node/6.0.0", false],
+  ])("detects %s only when client_version is present", (userAgent, expected) => {
+    const request = new Request("https://router.example/v1/models?client_version=0.144.0", {
+      headers: { "User-Agent": userAgent },
+    });
+    expect(isCodexModelsRequest(request)).toBe(expected);
+  });
+
+  it("does not alter Codex-looking requests without the version query", () => {
+    const request = new Request("https://router.example/v1/models", {
+      headers: { "User-Agent": "Codex Desktop/0.144.0-alpha.4" },
+    });
+    expect(isCodexModelsRequest(request)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Codex Desktop requests `GET /v1/models?client_version=...` and decodes a Codex catalog envelope containing `models`. 9Router correctly returns the OpenAI-compatible `{ object, data }` envelope, which causes Codex Desktop to log `missing field models` even though `/v1/responses` still works.

## Root cause

The same `/models` path is used by two compatible clients with different response envelopes.

## Behavior before

- OpenAI-compatible clients receive `{ object: list, data: [...] }`.
- Codex Desktop model refresh fails to decode that response.

## Behavior after

- Standard clients still receive the exact existing OpenAI envelope.
- Requests with both a Codex user agent and `client_version` receive the same OpenAI fields plus `models: []`.
- The empty Codex catalog intentionally lets Codex use its bundled, version-matched model capabilities instead of 9Router fabricating private `ModelInfo` fields.

## Backward compatibility

Content negotiation is narrow. OpenAI SDKs, OpenCode, and clients without the Codex version query receive byte-shape-compatible JSON with no additional field.

## Tests

- `cd tests && npx vitest run unit/models-response-compatibility.test.js`
- 7 tests passed.
- Covers Codex Desktop, `codex_cli_rs`, `codex_exec`, standard OpenAI user agents, and missing version queries.
- `git diff --check` passed.

## Live verification

Verified with Codex Desktop 0.144.0-alpha.4 through the production HTTPS reverse proxy. Model refresh decoded successfully and GPT-5.6 Sol returned a streamed response.

## Related 9Router PRs

- #2511 Responses Lite transport (independent request-path concern)

## Security/header-forwarding notes

No auth, credential, proxy, or header-forwarding behavior changes. The user agent is used only to select the response envelope.