### PR TITLE
fix(codex): support GPT-5.6 Responses Lite clients

### DIFF
--- a/open-sse/config/codexConstants.js
+++ b/open-sse/config/codexConstants.js
@@ -1,0 +1,7 @@
+export const CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite";
+export const CODEX_RESPONSES_LITE_HEADER_VALUE = "true";
+export const CODEX_FORWARD_HEADER_ALLOWLIST = Object.freeze([CODEX_RESPONSES_LITE_HEADER]);
+export const CODEX_RESPONSES_LITE_INPUT_TYPES = Object.freeze([
+  "additional_tools", "function_call", "function_call_output", "custom_tool_call",
+  "custom_tool_call_output", "tool_search_call", "tool_search_output", "reasoning", "message",
+]);

--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -28,6 +28,14 @@ export const DEFAULT_ERROR_MESSAGES = {
   504: "Gateway timeout"
 };
 
+export const CODEX_REQUEST_SCHEMA_ERROR_CODES = new Set([
+  "invalid_request_error",
+  "unknown_parameter",
+  "unsupported_value",
+]);
+
+export const CODEX_REQUEST_SCHEMA_ERROR_PATTERN =
+  /unknown[_ ]parameter|unsupported[_ ]value|(?:invalid|unsupported)[_ ]?(?:parameter|schema)|(?:parameter|schema).*(?:invalid|unsupported)/i;
 // Exponential backoff config for rate limits
 export const BACKOFF_CONFIG = {
   base: 2000,

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -11,6 +11,12 @@ import { getModelUpstreamId } from "../config/providerModels.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import {
+  CODEX_FORWARD_HEADER_ALLOWLIST,
+  CODEX_RESPONSES_LITE_HEADER,
+  CODEX_RESPONSES_LITE_HEADER_VALUE,
+  CODEX_RESPONSES_LITE_INPUT_TYPES,
+} from "../config/codexConstants.js";
 
 // SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
 const CODEX_SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
@@ -41,8 +47,100 @@ const CODEX_PASSTHROUGH_TOOL_TYPES = new Set(["custom"]);
 const RESPONSES_API_ALLOWLIST = new Set([
   "model", "input", "instructions", "tools", "tool_choice", "stream", "store",
   "reasoning", "service_tier", "include", "prompt_cache_key", "client_metadata",
-  "text"
+  "text", "parallel_tool_calls"
 ]);
+
+const RESPONSES_LITE_INPUT_TYPES = new Set(CODEX_RESPONSES_LITE_INPUT_TYPES);
+
+function getHeaderValue(rawHeaders, name) {
+  if (!rawHeaders) return null;
+  if (typeof rawHeaders.get === "function") return rawHeaders.get(name);
+  const entry = Object.entries(rawHeaders).find(([key]) => key.toLowerCase() === name);
+  return entry?.[1] ?? null;
+}
+
+export function isCodexResponsesLiteRequest(rawHeaders) {
+  const value = getHeaderValue(rawHeaders, CODEX_RESPONSES_LITE_HEADER);
+  return typeof value === "string"
+    && value.trim().toLowerCase() === CODEX_RESPONSES_LITE_HEADER_VALUE;
+}
+
+export function hasCodexResponsesLitePayload(body) {
+  if (Array.isArray(body?.input) && body.input.some((item) =>
+    item?.type === "additional_tools" || typeof item?.namespace === "string"
+  )) return true;
+  return Array.isArray(body?.tools) && body.tools.some((tool) => tool?.type === "namespace");
+}
+
+export function stripRejectedCodexInputNamespaces(body) {
+  if (!Array.isArray(body?.input)) return false;
+  let stripped = false;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !("namespace" in item)) continue;
+    delete item.namespace;
+    stripped = true;
+  }
+  return stripped;
+}
+
+function isRejectedCodexInputNamespace(status, errorText) {
+  return Number(status) === 400
+    && /unknown parameter:\s*['"]input\[\d+\]\.namespace['"]/i.test(String(errorText || ""));
+}
+export function applyCodexForwardHeaders(headers, rawHeaders, responsesLite = false) {
+  for (const name of CODEX_FORWARD_HEADER_ALLOWLIST) {
+    if (name === CODEX_RESPONSES_LITE_HEADER && (responsesLite || isCodexResponsesLiteRequest(rawHeaders))) {
+      headers[name] = CODEX_RESPONSES_LITE_HEADER_VALUE;
+    }
+  }
+  return headers;
+}
+
+function isMessageItem(item) {
+  return item?.type === "message" || (!item?.type && typeof item?.role === "string");
+}
+
+export function normalizeCodexInputItems(body, { responsesLite = false } = {}) {
+  if (!Array.isArray(body.input)) return;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    if (!isMessageItem(item)) {
+      if (responsesLite && item.type && RESPONSES_LITE_INPUT_TYPES.has(item.type)) continue;
+      continue;
+    }
+    if (!item.type) item.type = "message";
+    if (typeof item.content === "string") {
+      const type = item.role === "assistant" ? "output_text" : "input_text";
+      item.content = [{ type, text: item.content }];
+    }
+  }
+}
+
+export function hasResponsesLiteInstructions(body) {
+  if (!Array.isArray(body.input)) return false;
+  return body.input.some((item) => {
+    if (!isMessageItem(item) || !["developer", "system"].includes(item.role)) return false;
+    if (typeof item.content === "string") return item.content.trim().length > 0;
+    return Array.isArray(item.content) && item.content.some((part) =>
+      typeof part?.text === "string" && part.text.trim().length > 0
+    );
+  });
+}
+
+function ensureResponsesLiteInstructions(body) {
+  const instructions = typeof body.instructions === "string" && body.instructions.trim()
+    ? body.instructions
+    : CODEX_DEFAULT_INSTRUCTIONS;
+  if (!hasResponsesLiteInstructions(body)) {
+    const additionalToolsIndex = body.input.findIndex((item) => item?.type === "additional_tools");
+    const insertAt = additionalToolsIndex >= 0 ? additionalToolsIndex + 1 : 0;
+    body.input.splice(insertAt, 0, {
+      type: "message", role: "developer",
+      content: [{ type: "input_text", text: instructions }],
+    });
+  }
+  delete body.instructions;
+}
 
 // Convert role=system → role=developer in body.input (keeps content in cacheable prefix)
 function convertSystemToDeveloperRole(body) {
@@ -124,8 +222,8 @@ function resolveCacheSessionId(body, credentials) {
   });
 }
 
-function normalizeReasoningEffort(value) {
-  return value === "max" ? "xhigh" : value;
+function normalizeReasoningEffort(value, responsesLite = false) {
+  return value === "max" && !responsesLite ? "xhigh" : value;
 }
 
 function findNestedMessage(value, depth = 0) {
@@ -188,6 +286,7 @@ export class CodexExecutor extends BaseExecutor {
   constructor() {
     super("codex", PROVIDERS.codex);
     this._currentSessionId = null;
+    this._responsesLite = false;
   }
 
   /**
@@ -196,6 +295,7 @@ export class CodexExecutor extends BaseExecutor {
    */
   buildHeaders(credentials, stream = true) {
     const headers = super.buildHeaders(credentials, stream);
+    applyCodexForwardHeaders(headers, credentials?.rawHeaders, this._responsesLite);
     headers["session_id"] = this._currentSessionId || credentials?.connectionId || "default";
     // Identify client type to Codex backend (matches official codex CLI)
     if (!headers["originator"]) headers["originator"] = "codex_cli_rs";
@@ -267,8 +367,18 @@ export class CodexExecutor extends BaseExecutor {
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
     const { attempts, delayMs } = resolveRetryEntry(retryConfig[503]);
     let attempt = 0;
+    let namespaceSchemaRetried = false;
     while (true) {
       const result = await super.execute(args);
+      if (!namespaceSchemaRetried && result.response?.status === 400) {
+        const errorText = await result.response.clone().text();
+        if (isRejectedCodexInputNamespace(result.response.status, errorText)
+            && stripRejectedCodexInputNamespaces(args.body)) {
+          namespaceSchemaRetried = true;
+          args.log?.warn?.("CODEX", "Upstream rejected input namespace; retrying once without history namespace fields");
+          continue;
+        }
+      }
       const peek = await this._peekSseTransientError(result.response);
       if (!peek.matched) {
         // Replace body with re-assembled stream (prefix bytes already read + rest)
@@ -388,6 +498,8 @@ export class CodexExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     this._isCompact = !!body._compact;
     delete body._compact;
+    const responsesLite = isCodexResponsesLiteRequest(credentials?.rawHeaders) || hasCodexResponsesLitePayload(body);
+    this._responsesLite = responsesLite;
     // Resolve conversation-stable session_id (priority: body → assistant-text → workspace → machine)
     this._currentSessionId = resolveCacheSessionId(body, credentials);
     // Convert string input to array format (Codex API requires input as array)
@@ -399,6 +511,8 @@ export class CodexExecutor extends BaseExecutor {
       body.input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }];
     }
 
+    normalizeCodexInputItems(body, { responsesLite });
+
     // Keep system prompts in body.input as role=developer so they stay in the cacheable prefix
     convertSystemToDeveloperRole(body);
     // Strip server-generated item IDs (rs_/fc_/resp_/msg_) — Codex /responses can't resolve when store=false
@@ -409,8 +523,9 @@ export class CodexExecutor extends BaseExecutor {
     // Ensure streaming is enabled (Codex API requires it)
     body.stream = true;
 
-    // If no instructions provided, inject default Codex instructions
-    if (!body.instructions || body.instructions.trim() === "") {
+    if (responsesLite) {
+      ensureResponsesLiteInstructions(body);
+    } else if (!body.instructions || body.instructions.trim() === "") {
       body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
     }
 
@@ -427,7 +542,7 @@ export class CodexExecutor extends BaseExecutor {
 
     // Extract thinking level from model name suffix
     // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → medium (default)
-    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
     let modelEffort = null;
     for (const level of effortLevels) {
       if (body.model.endsWith(`-${level}`)) {
@@ -440,12 +555,13 @@ export class CodexExecutor extends BaseExecutor {
 
     // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (medium)
     if (!body.reasoning) {
-      const effort = normalizeReasoningEffort(body.reasoning_effort || modelEffort || 'low');
+      const effort = normalizeReasoningEffort(body.reasoning_effort || modelEffort || 'low', responsesLite);
       body.reasoning = { effort, summary: "auto" };
     } else {
-      body.reasoning.effort = normalizeReasoningEffort(body.reasoning.effort);
+      body.reasoning.effort = normalizeReasoningEffort(body.reasoning.effort, responsesLite);
       if (!body.reasoning.summary) body.reasoning.summary = "auto";
     }
+    if (responsesLite) body.reasoning.context = "all_turns";
     delete body.reasoning_effort;
 
     // Include reasoning encrypted content (required by Codex backend for reasoning models)

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -1,4 +1,29 @@
-import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
+import {
+  ERROR_RULES,
+  BACKOFF_CONFIG,
+  TRANSIENT_COOLDOWN_MS,
+  CODEX_REQUEST_SCHEMA_ERROR_CODES,
+  CODEX_REQUEST_SCHEMA_ERROR_PATTERN,
+} from "../config/errorConfig.js";
+
+function parseErrorPayload(errorText) {
+  if (errorText && typeof errorText === "object") return errorText;
+  if (typeof errorText !== "string") return {};
+  try { return JSON.parse(errorText); } catch { return { message: errorText }; }
+}
+
+export function isCodexRequestSchemaError(provider, status, errorText = "") {
+  if (provider !== "codex" || Number(status) !== 400) return false;
+  const payload = parseErrorPayload(errorText);
+  const error = payload?.error && typeof payload.error === "object" ? payload.error : payload;
+  const message = String(error?.message || errorText || "");
+  const code = String(error?.code || "").toLowerCase();
+  const type = String(error?.type || "").toLowerCase();
+  const recognizedMetadata = !code && !type
+    || CODEX_REQUEST_SCHEMA_ERROR_CODES.has(code)
+    || CODEX_REQUEST_SCHEMA_ERROR_CODES.has(type);
+  return recognizedMetadata && CODEX_REQUEST_SCHEMA_ERROR_PATTERN.test(message || code || type);
+}
 
 /**
  * Calculate exponential backoff cooldown for rate limits (429)

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -2,7 +2,7 @@
  * Shared combo (model combo) handling with fallback support
  */
 
-import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
+import { checkFallbackError, formatRetryAfter, isCodexRequestSchemaError } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
@@ -280,6 +280,10 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
         try { errorText = JSON.stringify(errorText); } catch { errorText = String(errorText); }
       }
 
+      if (modelStr.startsWith("cx/") && isCodexRequestSchemaError("codex", result.status, errorText)) {
+        log.warn("COMBO", `Model ${modelStr} failed with a non-retryable request schema error`, { status: result.status });
+        return result;
+      }
       // Check if should fallback to next model
       const { shouldFallback, cooldownMs } = checkFallbackError(result.status, errorText);
 

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -475,10 +475,24 @@ export async function OPTIONS() {
  * GET /v1/models - OpenAI compatible models list (LLM/chat models only by default).
  * For other capabilities use /v1/models/{kind} (image, tts, stt, embedding, image-to-text, web).
  */
-export async function GET() {
+export function isCodexModelsRequest(request) {
+  if (!request?.url || typeof request.headers?.get !== "function") return false;
+  const clientVersion = new URL(request.url).searchParams.get("client_version");
+  const userAgent = request.headers.get("user-agent") || "";
+  return Boolean(clientVersion) && /\bcodex(?:[_ -](?:desktop|cli_rs|cli|exec))?\b/i.test(userAgent);
+}
+
+export function buildCompatibleModelsResponse(data, { includeCodexCatalog = false } = {}) {
+  const response = { object: "list", data };
+  if (includeCodexCatalog) response.models = [];
+  return response;
+}
+export async function GET(request) {
   try {
     const data = await buildModelsList([LLM_KIND]);
-    return Response.json({ object: "list", data }, {
+    return Response.json(buildCompatibleModelsResponse(data, {
+      includeCodexCatalog: isCodexModelsRequest(request),
+    }), {
       headers: { "Access-Control-Allow-Origin": "*" },
     });
   } catch (error) {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -1,4 +1,5 @@
 import "open-sse/index.js";
+import { isCodexRequestSchemaError } from "open-sse/services/accountFallback.js";
 
 import {
   getProviderCredentials,
@@ -270,6 +271,11 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     });
 
     if (result.success) return result.response;
+
+    if (isCodexRequestSchemaError(provider, result.status, result.error)) {
+      log.warn("REQUEST", `Non-retryable Codex request schema error (${result.status})`);
+      return result.response;
+    }
 
     // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise resetsAtMs)
     const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);

--- a/tests/unit/codex-namespace-retry.test.js
+++ b/tests/unit/codex-namespace-retry.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BaseExecutor } from "../../open-sse/executors/base.js";
+import { CodexExecutor, stripRejectedCodexInputNamespaces } from "../../open-sse/executors/codex.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Codex rejected input namespace compatibility", () => {
+  it("removes namespace only from input history", () => {
+    const body = {
+      input: [{ type: "function_call", namespace: "collaboration", name: "spawn_agent" }],
+      tools: [{ type: "namespace", name: "collaboration", tools: [] }],
+    };
+
+    expect(stripRejectedCodexInputNamespaces(body)).toBe(true);
+    expect(body.input[0].namespace).toBeUndefined();
+    expect(body.tools[0].type).toBe("namespace");
+  });
+
+  it("retries once after the exact upstream schema error", async () => {
+    const executeSpy = vi.spyOn(BaseExecutor.prototype, "execute")
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          error: { message: "Unknown parameter: 'input[150].namespace'.", type: "invalid_request_error", code: "unknown_parameter" },
+        }), { status: 400 }),
+      })
+      .mockResolvedValueOnce({ response: new Response("ok", { status: 200 }) });
+    const executor = new CodexExecutor();
+    executor._peekSseTransientError = vi.fn().mockResolvedValue({ matched: null, replacementBody: null });
+    const body = {
+      input: [{ type: "function_call", namespace: "collaboration", name: "spawn_agent" }],
+      tools: [{ type: "namespace", name: "collaboration", tools: [] }],
+    };
+
+    const result = await executor.execute({ body, credentials: {}, log: { warn: vi.fn() } });
+
+    expect(result.response.status).toBe(200);
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(body.input[0].namespace).toBeUndefined();
+    expect(body.tools[0].type).toBe("namespace");
+  });
+
+  it("does not retry unrelated 400 responses", async () => {
+    const executeSpy = vi.spyOn(BaseExecutor.prototype, "execute").mockResolvedValue({
+      response: new Response("unsupported model", { status: 400 }),
+    });
+    const executor = new CodexExecutor();
+    executor._peekSseTransientError = vi.fn().mockResolvedValue({ matched: null, replacementBody: null });
+
+    await executor.execute({
+      body: { input: [{ type: "function_call", namespace: "collaboration" }] },
+      credentials: {},
+      log: { warn: vi.fn() },
+    });
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/codex-responses-lite.test.js
+++ b/tests/unit/codex-responses-lite.test.js
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+import { CODEX_RESPONSES_LITE_HEADER } from "../../open-sse/config/codexConstants.js";
+
+function credentials(rawHeaders = {}) {
+  return {
+    accessToken: "upstream-token",
+    connectionId: "codex-test",
+    providerSpecificData: {},
+    rawHeaders,
+  };
+}
+
+describe("Codex Responses Lite compatibility", () => {
+  it("forwards only an explicitly enabled Responses Lite header", () => {
+    const executor = new CodexExecutor();
+    const headers = executor.buildHeaders(credentials({
+      [CODEX_RESPONSES_LITE_HEADER]: "true",
+      authorization: "Bearer client-token",
+      cookie: "session=private",
+      "x-api-key": "private",
+    }));
+
+    expect(headers[CODEX_RESPONSES_LITE_HEADER]).toBe("true");
+    expect(headers.Authorization).toBe("Bearer upstream-token");
+    expect(headers.cookie).toBeUndefined();
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("does not infer Responses Lite from the model name", () => {
+    const executor = new CodexExecutor();
+    const headers = executor.buildHeaders(credentials());
+
+    expect(headers[CODEX_RESPONSES_LITE_HEADER]).toBeUndefined();
+  });
+
+  it("preserves Responses Lite input, namespace calls, and parallel tool settings", () => {
+    const executor = new CodexExecutor();
+    const additionalTools = {
+      type: "additional_tools",
+      role: "developer",
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        description: "agent tools",
+        tools: [{
+          type: "function",
+          name: "spawn_agent",
+          description: "spawn",
+          strict: false,
+          parameters: { type: "object", properties: {} },
+        }],
+      }],
+    };
+    const developerMessage = {
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "Codex instructions" }],
+    };
+    const namespacedCall = {
+      type: "function_call",
+      name: "spawn_agent",
+      namespace: "collaboration",
+      arguments: "{}",
+      call_id: "call-1",
+    };
+    const output = {
+      type: "function_call_output",
+      call_id: "call-1",
+      output: "done",
+    };
+    const body = {
+      model: "gpt-5.6-sol",
+      input: [additionalTools, developerMessage, namespacedCall, output],
+      parallel_tool_calls: false,
+      stream: true,
+      reasoning: { effort: "high", summary: "auto" },
+    };
+
+    executor.transformRequest("gpt-5.6-sol", body, true, credentials({
+      [CODEX_RESPONSES_LITE_HEADER]: "true",
+    }));
+
+    expect(body.instructions).toBeUndefined();
+    expect(body.parallel_tool_calls).toBe(false);
+    expect(body.input).toEqual([additionalTools, developerMessage, namespacedCall, output]);
+  });
+
+  it("normalizes legacy message content without changing non-message items", () => {
+    const executor = new CodexExecutor();
+    const functionCall = {
+      type: "function_call",
+      name: "run",
+      arguments: "{}",
+      call_id: "call-2",
+    };
+    const body = {
+      model: "gpt-5.5",
+      input: [{ role: "user", content: "hello" }, functionCall],
+      stream: true,
+    };
+
+    executor.transformRequest("gpt-5.5", body, true, credentials());
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "hello" }],
+    });
+    expect(body.input[1]).toEqual(functionCall);
+    expect(body.instructions).toBeTypeOf("string");
+  });
+
+  it("keeps max on the Responses Lite wire contract", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.6-sol-max",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }],
+      stream: true,
+    };
+
+    executor.transformRequest("gpt-5.6-sol-max", body, true, credentials({
+      [CODEX_RESPONSES_LITE_HEADER]: "true",
+    }));
+
+    expect(body.model).toBe("gpt-5.6-sol");
+    expect(body.reasoning).toEqual({ effort: "max", summary: "auto", context: "all_turns" });
+  });
+  it("detects namespace payloads without a client Lite header", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.6-sol",
+      input: [{ type: "function_call", name: "run", namespace: "tools", arguments: "{}", call_id: "call-3" }],
+      tools: [{ type: "namespace", name: "tools", tools: [] }],
+      stream: true,
+    };
+
+    executor.transformRequest("gpt-5.6-sol", body, true, credentials());
+    const headers = executor.buildHeaders(credentials());
+
+    expect(headers[CODEX_RESPONSES_LITE_HEADER]).toBe("true");
+    expect(body.reasoning.context).toBe("all_turns");
+    expect(body.input.find((item) => item.namespace === "tools")).toBeDefined();
+  });
+});

--- a/tests/unit/codex-schema-fallback.test.js
+++ b/tests/unit/codex-schema-fallback.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isCodexRequestSchemaError } from "../../open-sse/services/accountFallback.js";
+import { handleComboChat } from "../../open-sse/services/combo.js";
+
+const log = { info: vi.fn(), warn: vi.fn() };
+
+function errorResponse(status, error) {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Codex request schema fallback", () => {
+  it.each([
+    ["Unknown parameter: 'input[150].namespace'.", true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "unknown_parameter", message: "Unknown parameter: input[2].namespace" } }), true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "unsupported_value", message: "Unsupported value for input[2].type" } }), true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "invalid_prompt", message: "Prompt is too long" } }), false],
+    ["The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.", false],
+  ])("classifies only request schema incompatibilities", (message, expected) => {
+    expect(isCodexRequestSchemaError("codex", 400, message)).toBe(expected);
+  });
+
+  it("does not intercept other providers or retryable statuses", () => {
+    expect(isCodexRequestSchemaError("openai", 400, "Unknown parameter: input[0].x")).toBe(false);
+    expect(isCodexRequestSchemaError("codex", 429, "rate limit")).toBe(false);
+    expect(isCodexRequestSchemaError("codex", 401, "invalid token")).toBe(false);
+  });
+
+  it("stops a combo after a Codex schema error", async () => {
+    const handleSingleModel = vi.fn().mockResolvedValue(errorResponse(400, {
+      message: "Unknown parameter: 'input[150].namespace'.",
+      type: "invalid_request_error",
+      code: "unknown_parameter",
+    }));
+
+    const response = await handleComboChat({
+      body: {},
+      models: ["cx/gpt-5.6-sol", "cx/gpt-5.5"],
+      handleSingleModel,
+      log,
+    });
+
+    expect(response.status).toBe(400);
+    expect(handleSingleModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps normal combo fallback for rate limits", async () => {
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce(errorResponse(429, { message: "rate limit" }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const response = await handleComboChat({
+      body: {},
+      models: ["cx/gpt-5.6-sol", "cx/gpt-5.5"],
+      handleSingleModel,
+      log,
+    });
+
+    expect(response.status).toBe(200);
+    expect(handleSingleModel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/models-response-compatibility.test.js
+++ b/tests/unit/models-response-compatibility.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCompatibleModelsResponse,
+  isCodexModelsRequest,
+} from "@/app/api/v1/models/route.js";
+
+const data = [
+  { id: "gpt-5.6-sol", object: "model", owned_by: "combo" },
+  { id: "cx/gpt-5.6-sol", object: "model", owned_by: "cx" },
+];
+
+describe("GET /v1/models response compatibility", () => {
+  it("preserves the exact OpenAI model-list envelope by default", () => {
+    expect(buildCompatibleModelsResponse(data)).toEqual({ object: "list", data });
+  });
+
+  it("adds an empty Codex catalog without changing OpenAI data", () => {
+    expect(buildCompatibleModelsResponse(data, { includeCodexCatalog: true })).toEqual({
+      object: "list",
+      data,
+      models: [],
+    });
+  });
+
+  it.each([
+    ["Codex Desktop/0.144.0-alpha.4", true],
+    ["codex_cli_rs/0.144.1", true],
+    ["codex_exec/0.144.1", true],
+    ["openai-node/6.0.0", false],
+  ])("detects %s only when client_version is present", (userAgent, expected) => {
+    const request = new Request("https://router.example/v1/models?client_version=0.144.0", {
+      headers: { "User-Agent": userAgent },
+    });
+    expect(isCodexModelsRequest(request)).toBe(expected);
+  });
+
+  it("does not alter Codex-looking requests without the version query", () => {
+    const request = new Request("https://router.example/v1/models", {
+      headers: { "User-Agent": "Codex Desktop/0.144.0-alpha.4" },
+    });
+    expect(isCodexModelsRequest(request)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Codex GPT-5.6 Responses Lite clients expose several related compatibility failures through 9Router:

- the Lite opt-in header and native payload contract can be lost or normalized incorrectly;
- resumed tool history can fail with `Unknown parameter: 'input[n].namespace'`;
- deterministic schema 400 responses can rotate/lock healthy accounts and fan out through combos;
- Codex Desktop model refresh expects a `models` catalog envelope while the shared endpoint returns the OpenAI-compatible `{ object, data }` envelope.

These failures belong to the same Codex client compatibility path and are fixed together here.

## Root cause

9Router previously treated Codex requests as standard Responses requests at several boundaries:

1. The Codex executor did not preserve the Responses Lite header, native input items, `parallel_tool_calls`, or Lite reasoning context.
2. The current upstream Codex backend can reject `namespace` on historical `input[]` function calls even though namespace tool declarations remain valid.
3. Generic account/combo fallback treats unmatched errors as transient, but request-schema incompatibilities are deterministic.
4. `/v1/models` is shared by standard OpenAI clients and Codex clients with different response-envelope expectations.

## Behavior before

- Responses Lite metadata or native items could be dropped or rewritten.
- `input[n].namespace` caused a terminal 400 or repeated fallback attempts.
- Healthy Codex accounts could be marked unavailable for a malformed request.
- Codex Desktop logged `missing field models` during catalog refresh.

## Behavior after

- Forward only the explicit Responses Lite opt-in header; client authorization, cookies, and API keys are never forwarded.
- Preserve `additional_tools`, namespace declarations/calls, call IDs, encrypted reasoning, input order, and `parallel_tool_calls`.
- Keep GPT-5.6 `max` reasoning on the Lite wire contract while preserving existing model behavior.
- Retry the same selected account once after the exact `input[n].namespace` rejection, removing only historical input namespace fields and preserving tool declarations.
- Return classified Codex schema 400 errors without locking/rotating accounts or fanning through combo models.
- Content-negotiate `/v1/models`: standard clients retain the exact `{ object, data }` envelope; Codex clients with `client_version` receive the same data plus `models: []` so Codex uses its bundled version-matched capabilities.

## Backward compatibility

- Standard Responses requests and GPT-5.5/GPT-5.4 behavior remain unchanged.
- Existing 401, 403, 429, quota, capacity, overload, and token-refresh fallback behavior remains unchanged.
- Unsupported-account/model 400 errors are not classified as request-schema errors.
- OpenAI SDKs, OpenCode, and clients without the Codex version query receive the unchanged model-list envelope.

## Tests

```bash
cd tests
npx vitest run \
  unit/codex-responses-lite.test.js \
  unit/codex-namespace-retry.test.js \
  unit/codex-schema-fallback.test.js \
  unit/combo-routing.test.js \
  unit/models-response-compatibility.test.js \
  unit/codex-tool-normalization.test.js
```

- 6 test files passed.
- 32 tests passed.
- `git diff --check` passed.
- Production Next.js build passed on Linux through the deployment updater.

## Live verification

Verified against GPT-5.6 Sol using both Codex CLI and Codex Desktop 0.144.0-alpha.4 through a production HTTPS reverse proxy:

- text response;
- shell tool call;
- resumed turn containing tool history;
- Responses Lite namespace history;
- combo routing/account fallback;
- Desktop `/v1/models?client_version=0.144.0` refresh;
- streamed `/v1/responses` completion.

The original `input[150].namespace` failure no longer occurs, and Desktop model refresh no longer reports `missing field models`.

## Related OpenAI issues

- OpenAI Codex #31760
- OpenAI Codex #31875
- OpenAI Codex #31882

## Related 9Router PRs

- #2511 independently covers Responses Lite transport and compact handling. Credit to @ryanngit for that work; this PR includes the production-verified GPT-5.6 compatibility path together with namespace retry, fallback policy, and Desktop catalog negotiation.
- #1193 covers broader namespace round-trip behavior; no unrelated changes from that PR are copied.
- #2503 addressed malformed Responses message injection; its normalization direction was reviewed but not copied wholesale.
- #2500 covered GPT-5.6 Sol reasoning-level UI; this PR does not claim that work.

## Security/header-forwarding notes

- Forwarded Codex headers are allowlisted in `open-sse/config`.
- Client `authorization`, `cookie`, `proxy-authorization`, and `x-api-key` are not forwarded.
- 9Router continues to use the OAuth account selected by its own account router.
- No tokens, account IDs, emails, captures, runtime scripts, deployment patches, or personal configuration are included.