### PR TITLE
fix(codex): preserve GPT-5.6 effort semantics on Codex wire

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -45,6 +45,15 @@ const RESPONSES_API_ALLOWLIST = new Set([
   "text"
 ]);
 
+// Apply Codex transport-level effort aliases after model-aware semantic resolution.
+// Official openai/codex serializes semantic Ultra as Max for requests; other efforts identity-map.
+function resolveCodexWireEffort(effort, config) {
+  const aliases = config?.quirks?.reasoningEffortAliases;
+  if (!aliases || effort == null) return effort;
+  const key = String(effort).toLowerCase();
+  return aliases[key] ?? effort;
+}
+
 // Convert role=system → role=developer in body.input (keeps content in cacheable prefix)
 function convertSystemToDeveloperRole(body) {
   if (!Array.isArray(body.input)) return;
@@ -423,7 +432,7 @@ export class CodexExecutor extends BaseExecutor {
     body.model = getModelUpstreamId("cx", body.model || model);
 
     // Extract thinking level from model name suffix
-    // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → medium (default)
+    // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → low (default)
     const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
     let modelEffort = null;
     for (const level of effortLevels) {
@@ -436,11 +445,14 @@ export class CodexExecutor extends BaseExecutor {
     }
 
     // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (low)
+    // resolveOpenAiEffort keeps model-aware semantic support; resolveCodexWireEffort maps Ultra→Max for wire.
     if (!body.reasoning) {
-      const effort = resolveOpenAiEffort(body.reasoning_effort || modelEffort || 'low', "codex", body.model);
+      const semantic = resolveOpenAiEffort(body.reasoning_effort || modelEffort || 'low', "codex", body.model);
+      const effort = resolveCodexWireEffort(semantic, this.config);
       body.reasoning = { effort, summary: "auto" };
     } else {
-      body.reasoning.effort = resolveOpenAiEffort(body.reasoning.effort, "codex", body.model);
+      const semantic = resolveOpenAiEffort(body.reasoning.effort, "codex", body.model);
+      body.reasoning.effort = resolveCodexWireEffort(semantic, this.config);
       if (!body.reasoning.summary) body.reasoning.summary = "auto";
     }
     delete body.reasoning_effort;

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -7,6 +7,7 @@ import {
 } from "../services/oauthCredentialManager.js";
 import { normalizeResponsesInput } from "../translator/formats/responsesApi.js";
 import { fetchImageAsBase64 } from "../translator/concerns/image.js";
+import { resolveOpenAiEffort } from "../translator/concerns/thinkingUnified.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
@@ -122,10 +123,6 @@ function resolveCacheSessionId(body, credentials) {
     workspaceId: credentials?.providerSpecificData?.workspaceId,
     scope: "codex"
   });
-}
-
-function normalizeReasoningEffort(value) {
-  return value === "max" ? "xhigh" : value;
 }
 
 function findNestedMessage(value, depth = 0) {
@@ -427,7 +424,7 @@ export class CodexExecutor extends BaseExecutor {
 
     // Extract thinking level from model name suffix
     // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → medium (default)
-    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
     let modelEffort = null;
     for (const level of effortLevels) {
       if (body.model.endsWith(`-${level}`)) {
@@ -438,12 +435,12 @@ export class CodexExecutor extends BaseExecutor {
       }
     }
 
-    // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (medium)
+    // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (low)
     if (!body.reasoning) {
-      const effort = normalizeReasoningEffort(body.reasoning_effort || modelEffort || 'low');
+      const effort = resolveOpenAiEffort(body.reasoning_effort || modelEffort || 'low', "codex", body.model);
       body.reasoning = { effort, summary: "auto" };
     } else {
-      body.reasoning.effort = normalizeReasoningEffort(body.reasoning.effort);
+      body.reasoning.effort = resolveOpenAiEffort(body.reasoning.effort, "codex", body.model);
       if (!body.reasoning.summary) body.reasoning.summary = "auto";
     }
     delete body.reasoning_effort;

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -50,8 +50,7 @@ const RESPONSES_API_ALLOWLIST = new Set([
 function resolveCodexWireEffort(effort, config) {
   const aliases = config?.quirks?.reasoningEffortAliases;
   if (!aliases || effort == null) return effort;
-  const key = String(effort).toLowerCase();
-  return aliases[key] ?? effort;
+  return aliases[effort] ?? effort;
 }
 
 // Convert role=system → role=developer in body.input (keeps content in cacheable prefix)

--- a/open-sse/providers/registry/codex.js
+++ b/open-sse/providers/registry/codex.js
@@ -38,6 +38,10 @@ export default {
       originator: "codex_cli_rs",
       "User-Agent": "codex_cli_rs/0.136.0",
     },
+    // Official openai/codex: semantic Ultra serializes as Max for requests.
+    quirks: {
+      reasoningEffortAliases: { ultra: "max" },
+    },
     usage: {
       url: "https://chatgpt.com/backend-api/wham/usage",
       resetCreditsUrl: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -31,9 +31,13 @@ const FORMAT_LEVELS = {
 };
 
 // Model-name pattern overrides (glob, first match wins) — more precise than format default.
+// GPT-5.6 patterns must precede broad *codex* so Sol/Terra/Luna keep their matrix.
 const PATTERN_THINKING = [
-  // gpt-5.6-sol accepts max (maps to xhigh on wire); live probe rejected ultra.
-  { pattern: "*gpt-5.6-sol*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max"] },
+  // Sol/Terra accept max + ultra on the wire.
+  { pattern: "*gpt-5.6-sol*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] },
+  { pattern: "*gpt-5.6-terra*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] },
+  // Luna accepts max; ultra falls back to max in applyThinking.
+  { pattern: "*gpt-5.6-luna*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max"] },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
 ];
 

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -3,6 +3,7 @@
 // never hardcoded per-model here. See .docs/thinking/plan.md MATRIX VI-A.
 
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
+import { getThinkingLevels } from "../../providers/thinkingLevels.js";
 import { PROVIDERS } from "../../providers/index.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
@@ -212,8 +213,22 @@ function stripAll(body) {
   if (body.request?.generationConfig) delete body.request.generationConfig.thinkingConfig;
 }
 
+// Map requested OpenAI effort to a level the model accepts.
+// Preserve when listed in getThinkingLevels; else nearest high-end sibling.
+// Unknown/empty metadata keeps legacy safe max/ultra → xhigh clamp.
+function resolveOpenAiEffort(level, allowed) {
+  if (!level) return level;
+  if (Array.isArray(allowed) && allowed.includes(level)) return level;
+  if (level === "ultra") {
+    if (Array.isArray(allowed) && allowed.includes("max")) return "max";
+    return "xhigh";
+  }
+  if (level === "max") return "xhigh";
+  return level;
+}
+
 // Apply unified thinking config to body in the resolved provider-native format.
-function applyFormat(fmt, body, cfg, caps) {
+function applyFormat(fmt, body, cfg, caps, model = null, provider = null) {
   const none = cfg.mode === "none";
   const canDisable = caps.thinkingCanDisable !== false;
   // Model cannot disable thinking → clamp "none" to minimal effort instead.
@@ -223,8 +238,8 @@ function applyFormat(fmt, body, cfg, caps) {
     case "openai": {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
       const level = toLevel(eff);
-      // OpenAI reasoning_effort enum caps at "xhigh" (no "max"); clamp Claude Code's "max".
-      if (level) body.reasoning_effort = level === "max" ? "xhigh" : level;
+      // Config-driven: preserve supported effort; nearest sibling otherwise.
+      if (level) body.reasoning_effort = resolveOpenAiEffort(level, getThinkingLevels(provider, model));
       break;
     }
     case "claude-adaptive": {
@@ -324,6 +339,6 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
 
   const fmt = resolveFormat(targetFormat, cleanModel, provider);
   stripAll(body);
-  applyFormat(fmt, body, cfg, caps);
+  applyFormat(fmt, body, cfg, caps, cleanModel, provider);
   return body;
 }

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -216,8 +216,9 @@ function stripAll(body) {
 // Map requested OpenAI effort to a level the model accepts.
 // Preserve when listed in getThinkingLevels; else nearest high-end sibling.
 // Unknown/empty metadata keeps legacy safe max/ultra → xhigh clamp.
-function resolveOpenAiEffort(level, allowed) {
+export function resolveOpenAiEffort(level, provider, model) {
   if (!level) return level;
+  const allowed = getThinkingLevels(provider, model);
   if (Array.isArray(allowed) && allowed.includes(level)) return level;
   if (level === "ultra") {
     if (Array.isArray(allowed) && allowed.includes("max")) return "max";
@@ -239,7 +240,7 @@ function applyFormat(fmt, body, cfg, caps, model = null, provider = null) {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
       const level = toLevel(eff);
       // Config-driven: preserve supported effort; nearest sibling otherwise.
-      if (level) body.reasoning_effort = resolveOpenAiEffort(level, getThinkingLevels(provider, model));
+      if (level) body.reasoning_effort = resolveOpenAiEffort(level, provider, model);
       break;
     }
     case "claude-adaptive": {

--- a/tests/unit/codex-effort-wire.test.js
+++ b/tests/unit/codex-effort-wire.test.js
@@ -97,4 +97,12 @@ describe("Codex effort wire encoding (official Ultra→Max)", () => {
     expect(body.model).toBe("gpt-5.6-sol");
     expect(body.reasoning.effort).toBe("max");
   });
+
+  it("does not promote an uppercase unknown effort through the wire alias", async () => {
+    await executeWithEffort("gpt-5.5", { reasoning: { effort: "ULTRA" } });
+
+    const body = parsePostedBody();
+    expect(body.reasoning.effort).toBe("ULTRA");
+    expect(body.reasoning.effort).not.toBe("max");
+  });
 });

--- a/tests/unit/codex-effort-wire.test.js
+++ b/tests/unit/codex-effort-wire.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Outbound wire proof for Codex reasoning.effort.
+ * Official openai/codex: semantic Ultra serializes as Max for requests
+ * (ReasoningEffortConfig::Ultra => Max; ultra_reasoning_uses_max_for_requests).
+ * One POST, no adaptive retry, wire value never "ultra".
+ */
+
+const CODEX_URL = "https://chatgpt.com/backend-api/codex/responses";
+
+function normalSseResponse() {
+  const text = [
+    "event: response.output_text.delta",
+    'data: {"type":"response.output_text.delta","delta":"ok"}',
+    "",
+    "event: response.completed",
+    'data: {"type":"response.completed"}',
+    "",
+  ].join("\n");
+  return new Response(text, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+const proxyAwareFetch = vi.fn(async () => normalSseResponse());
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch,
+}));
+
+describe("Codex effort wire encoding (official Ultra→Max)", () => {
+  beforeEach(() => {
+    proxyAwareFetch.mockClear();
+    proxyAwareFetch.mockImplementation(async () => normalSseResponse());
+  });
+
+  async function executeWithEffort(model, effortFields) {
+    const { CodexExecutor } = await import("../../open-sse/executors/codex.js");
+    const executor = new CodexExecutor();
+    return executor.execute({
+      model,
+      body: {
+        model,
+        input: "hi",
+        ...effortFields,
+      },
+      stream: true,
+      credentials: {
+        accessToken: "test-token",
+        connectionId: "conn_test",
+        providerSpecificData: { chatgptAccountId: "acct_test" },
+      },
+      log: null,
+    });
+  }
+
+  function parsePostedBody() {
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = proxyAwareFetch.mock.calls[0];
+    expect(url).toBe(CODEX_URL);
+    expect(options.method).toBe("POST");
+    return JSON.parse(options.body);
+  }
+
+  it("posts exactly once with reasoning.effort=max for Sol ultra intent", async () => {
+    await executeWithEffort("gpt-5.6-sol", { reasoning: { effort: "ultra" } });
+
+    const body = parsePostedBody();
+    expect(body.reasoning.effort).toBe("max");
+    expect(body.reasoning.effort).not.toBe("ultra");
+    expect(body.reasoning.effort).not.toBe("xhigh");
+    expect(body.model).toBe("gpt-5.6-sol");
+  });
+
+  it("posts exactly once with reasoning.effort=max for explicit Sol max", async () => {
+    await executeWithEffort("gpt-5.6-sol", { reasoning: { effort: "max" } });
+
+    const body = parsePostedBody();
+    expect(body.reasoning.effort).toBe("max");
+    expect(body.model).toBe("gpt-5.6-sol");
+  });
+
+  it("posts max for Terra ultra via legacy reasoning_effort", async () => {
+    await executeWithEffort("gpt-5.6-terra", { reasoning_effort: "ultra" });
+
+    const body = parsePostedBody();
+    expect(body.reasoning.effort).toBe("max");
+    expect(body.model).toBe("gpt-5.6-terra");
+  });
+
+  it("posts max for Sol-ultra model suffix (suffix stripped)", async () => {
+    await executeWithEffort("gpt-5.6-sol-ultra", {});
+
+    const body = parsePostedBody();
+    expect(body.model).toBe("gpt-5.6-sol");
+    expect(body.reasoning.effort).toBe("max");
+  });
+});

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -36,6 +36,8 @@ describe("Codex fast tier and capacity handling", () => {
     ["gpt-5.6-luna", "ultra", "max"],
     ["gpt-5.5", "max", "xhigh"],
     ["gpt-5.5", "ultra", "xhigh"],
+    ["gpt-5.5", "ULTRA", "ULTRA"],
+    ["gpt-5.5", "Ultra", "Ultra"],
     ["gpt-5.6-sol", "xhigh", "xhigh"],
     ["gpt-5.6-sol", "high", "high"],
   ])("normalizes nested reasoning.effort for %s: %s → %s", (model, requested, expected) => {
@@ -56,6 +58,7 @@ describe("Codex fast tier and capacity handling", () => {
     ["gpt-5.6-sol", "max", "max"],
     ["gpt-5.6-luna", "ultra", "max"],
     ["gpt-5.5", "ultra", "xhigh"],
+    ["gpt-5.5", "ULTRA", "ULTRA"],
   ])("normalizes legacy reasoning_effort for %s: %s → %s", (model, requested, expected) => {
     const executor = new CodexExecutor();
     const body = executor.transformRequest(model, {

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -12,7 +12,7 @@ function streamFromText(text) {
 }
 
 describe("Codex fast tier and capacity handling", () => {
-  it("maps Codex fast tier to priority and max reasoning to xhigh", () => {
+  it("maps Codex fast tier to priority and unsupported max reasoning to xhigh", () => {
     const executor = new CodexExecutor();
     const body = executor.transformRequest("gpt-5.5", {
       model: "gpt-5.5",
@@ -23,6 +23,37 @@ describe("Codex fast tier and capacity handling", () => {
 
     expect(body.service_tier).toBe("priority");
     expect(body.reasoning.effort).toBe("xhigh");
+  });
+
+  it.each([
+    ["gpt-5.6-sol", "max", "max"],
+    ["gpt-5.6-sol", "ultra", "ultra"],
+    ["gpt-5.6-terra", "max", "max"],
+    ["gpt-5.6-terra", "ultra", "ultra"],
+    ["gpt-5.6-luna", "max", "max"],
+    ["gpt-5.6-luna", "ultra", "max"],
+    ["gpt-5.5", "ultra", "xhigh"],
+  ])("normalizes %s reasoning effort %s to %s", (model, requested, expected) => {
+    const executor = new CodexExecutor();
+    const body = executor.transformRequest(model, {
+      model,
+      input: "hi",
+      reasoning: { effort: requested },
+    }, true, {});
+
+    expect(body.reasoning.effort).toBe(expected);
+  });
+
+  it.each([
+    ["gpt-5.6-sol-ultra", "gpt-5.6-sol", "ultra"],
+    ["gpt-5.6-terra-max", "gpt-5.6-terra", "max"],
+    ["gpt-5.6-luna-ultra", "gpt-5.6-luna", "max"],
+  ])("normalizes effort suffix %s", (model, expectedModel, expectedEffort) => {
+    const executor = new CodexExecutor();
+    const body = executor.transformRequest(model, { model, input: "hi" }, true, {});
+
+    expect(body.model).toBe(expectedModel);
+    expect(body.reasoning.effort).toBe(expectedEffort);
   });
 
   it("uses ChatGPT workspace header fallback", () => {

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -25,15 +25,20 @@ describe("Codex fast tier and capacity handling", () => {
     expect(body.reasoning.effort).toBe("xhigh");
   });
 
+  // Official openai/codex serializes semantic Ultra as Max for requests.
+  // Sol/Terra keep semantic ultra via resolveOpenAiEffort; Codex wire alias maps ultra→max.
   it.each([
     ["gpt-5.6-sol", "max", "max"],
-    ["gpt-5.6-sol", "ultra", "ultra"],
+    ["gpt-5.6-sol", "ultra", "max"],
     ["gpt-5.6-terra", "max", "max"],
-    ["gpt-5.6-terra", "ultra", "ultra"],
+    ["gpt-5.6-terra", "ultra", "max"],
     ["gpt-5.6-luna", "max", "max"],
     ["gpt-5.6-luna", "ultra", "max"],
+    ["gpt-5.5", "max", "xhigh"],
     ["gpt-5.5", "ultra", "xhigh"],
-  ])("normalizes %s reasoning effort %s to %s", (model, requested, expected) => {
+    ["gpt-5.6-sol", "xhigh", "xhigh"],
+    ["gpt-5.6-sol", "high", "high"],
+  ])("normalizes nested reasoning.effort for %s: %s → %s", (model, requested, expected) => {
     const executor = new CodexExecutor();
     const body = executor.transformRequest(model, {
       model,
@@ -44,11 +49,31 @@ describe("Codex fast tier and capacity handling", () => {
     expect(body.reasoning.effort).toBe(expected);
   });
 
+  // Legacy reasoning_effort also converges through the same semantic→wire path.
   it.each([
-    ["gpt-5.6-sol-ultra", "gpt-5.6-sol", "ultra"],
+    ["gpt-5.6-sol", "ultra", "max"],
+    ["gpt-5.6-terra", "ultra", "max"],
+    ["gpt-5.6-sol", "max", "max"],
+    ["gpt-5.6-luna", "ultra", "max"],
+    ["gpt-5.5", "ultra", "xhigh"],
+  ])("normalizes legacy reasoning_effort for %s: %s → %s", (model, requested, expected) => {
+    const executor = new CodexExecutor();
+    const body = executor.transformRequest(model, {
+      model,
+      input: "hi",
+      reasoning_effort: requested,
+    }, true, {});
+
+    expect(body.reasoning.effort).toBe(expected);
+    expect(body.reasoning_effort).toBeUndefined();
+  });
+
+  it.each([
+    ["gpt-5.6-sol-ultra", "gpt-5.6-sol", "max"],
+    ["gpt-5.6-terra-ultra", "gpt-5.6-terra", "max"],
     ["gpt-5.6-terra-max", "gpt-5.6-terra", "max"],
     ["gpt-5.6-luna-ultra", "gpt-5.6-luna", "max"],
-  ])("normalizes effort suffix %s", (model, expectedModel, expectedEffort) => {
+  ])("normalizes effort suffix %s → model %s effort %s", (model, expectedModel, expectedEffort) => {
     const executor = new CodexExecutor();
     const body = executor.transformRequest(model, { model, input: "hi" }, true, {});
 

--- a/tests/unit/thinking-effort-openai-max-clamp.test.js
+++ b/tests/unit/thinking-effort-openai-max-clamp.test.js
@@ -2,39 +2,105 @@ import { describe, expect, it } from "vitest";
 import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 
-// Regression: Claude Code sends thinking effort "max" (its top level). When
-// 9router routes to an OpenAI-format provider, applyThinking() case "openai"
-// must clamp "max"→"xhigh" because OpenAI's reasoning_effort enum has no "max"
-// (L.openai caps at "xhigh"). Without the clamp, upstream returns HTTP 400
-// "max effort not support". See open-sse/providers/thinkingLevels.js:10.
-describe("applyThinking (openai): clamp max effort to xhigh", () => {
-  it("client output_config.effort:\"max\" → reasoning_effort:\"xhigh\" (not \"max\")", () => {
-    const body = { output_config: { effort: "max" } };
-    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
-    expect(out.reasoning_effort).toBe("xhigh");
+// GPT-5.6 wire matrix for OpenAI-format reasoning_effort:
+// Sol/Terra preserve max+ultra; Luna preserves max, ultra→max;
+// older/unrelated max/ultra → xhigh (legacy safe clamp).
+describe("applyThinking (openai): model-aware effort fallback", () => {
+  describe("legacy older models (max/ultra → xhigh)", () => {
+    it("client output_config.effort:\"max\" → reasoning_effort:\"xhigh\" (not \"max\")", () => {
+      const body = { output_config: { effort: "max" } };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+      expect(out.reasoning_effort).toBe("xhigh");
+    });
+
+    it("direct reasoning_effort:\"max\" clamped to \"xhigh\"", () => {
+      const body = { reasoning_effort: "max" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+      expect(out.reasoning_effort).toBe("xhigh");
+    });
+
+    it("direct reasoning_effort:\"ultra\" clamped to \"xhigh\"", () => {
+      const body = { reasoning_effort: "ultra" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+      expect(out.reasoning_effort).toBe("xhigh");
+    });
+
+    it("gpt-5.5 max → xhigh", () => {
+      const body = { reasoning_effort: "max" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.5", body, "codex");
+      expect(out.reasoning_effort).toBe("xhigh");
+    });
+
+    it("\"xhigh\" passes through unchanged (highest valid OpenAI level)", () => {
+      const body = { reasoning_effort: "xhigh" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+      expect(out.reasoning_effort).toBe("xhigh");
+    });
+
+    it("\"high\" passes through unchanged", () => {
+      const body = { reasoning_effort: "high" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+      expect(out.reasoning_effort).toBe("high");
+    });
+
+    it("max budget (thinking.budget_tokens:128000) → reasoning_effort:\"xhigh\" (budgetToLevel caps at xhigh)", () => {
+      const body = { thinking: { type: "enabled", budget_tokens: 128000 } };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
+      expect(out.reasoning_effort).toBe("xhigh");
+    });
   });
 
-  it("direct reasoning_effort:\"max\" clamped to \"xhigh\"", () => {
-    const body = { reasoning_effort: "max" };
-    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
-    expect(out.reasoning_effort).toBe("xhigh");
+  describe("gpt-5.6-sol preserves max and ultra", () => {
+    it("max preserved", () => {
+      const body = { reasoning_effort: "max" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-sol", body, "codex");
+      expect(out.reasoning_effort).toBe("max");
+    });
+
+    it("ultra preserved", () => {
+      const body = { reasoning_effort: "ultra" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-sol", body, "codex");
+      expect(out.reasoning_effort).toBe("ultra");
+    });
+
+    it("output_config.effort max preserved", () => {
+      const body = { output_config: { effort: "max" } };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-sol", body, "codex");
+      expect(out.reasoning_effort).toBe("max");
+    });
   });
 
-  it("\"xhigh\" passes through unchanged (highest valid OpenAI level)", () => {
-    const body = { reasoning_effort: "xhigh" };
-    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
-    expect(out.reasoning_effort).toBe("xhigh");
+  describe("gpt-5.6-terra preserves max and ultra", () => {
+    it("max preserved", () => {
+      const body = { reasoning_effort: "max" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-terra", body, "openai");
+      expect(out.reasoning_effort).toBe("max");
+    });
+
+    it("ultra preserved", () => {
+      const body = { reasoning_effort: "ultra" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-terra", body, "openai");
+      expect(out.reasoning_effort).toBe("ultra");
+    });
   });
 
-  it("\"high\" passes through unchanged", () => {
-    const body = { reasoning_effort: "high" };
-    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
-    expect(out.reasoning_effort).toBe("high");
-  });
+  describe("gpt-5.6-luna preserves max; ultra → max", () => {
+    it("max preserved", () => {
+      const body = { reasoning_effort: "max" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-luna", body, "openai");
+      expect(out.reasoning_effort).toBe("max");
+    });
 
-  it("max budget (thinking.budget_tokens:128000) → reasoning_effort:\"xhigh\" (budgetToLevel caps at xhigh)", () => {
-    const body = { thinking: { type: "enabled", budget_tokens: 128000 } };
-    const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
-    expect(out.reasoning_effort).toBe("xhigh");
+    it("ultra maps to max (nearest supported sibling)", () => {
+      const body = { reasoning_effort: "ultra" };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-luna", body, "openai");
+      expect(out.reasoning_effort).toBe("max");
+    });
+
+    it("output_config.effort ultra → max", () => {
+      const body = { output_config: { effort: "ultra" } };
+      const out = applyThinking(FORMATS.OPENAI, "gpt-5.6-luna", body, "openai");
+      expect(out.reasoning_effort).toBe("max");
+    });
   });
 });

--- a/tests/unit/thinking-levels-gpt56-sol.test.js
+++ b/tests/unit/thinking-levels-gpt56-sol.test.js
@@ -1,21 +1,45 @@
 import { describe, it, expect } from "vitest";
 import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
 
-describe("getThinkingLevels", () => {
-  it("adds max for gpt-5.6-sol on codex", () => {
+// GPT-5.6 effort matrix (metadata must match wire):
+// Sol/Terra → max + ultra; Luna → max (no ultra); older/unrelated → neither.
+describe("getThinkingLevels GPT-5.6 effort matrix", () => {
+  it("gpt-5.6-sol exposes max and ultra (and keeps xhigh)", () => {
     const levels = getThinkingLevels("codex", "gpt-5.6-sol");
+    expect(levels).toContain("max");
+    expect(levels).toContain("ultra");
+    expect(levels).toContain("xhigh");
+  });
+
+  it("gpt-5.6-terra exposes max and ultra", () => {
+    const levels = getThinkingLevels("openai", "gpt-5.6-terra");
+    expect(levels).toContain("max");
+    expect(levels).toContain("ultra");
+    expect(levels).toContain("xhigh");
+  });
+
+  it("gpt-5.6-luna exposes max but not ultra", () => {
+    const levels = getThinkingLevels("openai", "gpt-5.6-luna");
     expect(levels).toContain("max");
     expect(levels).toContain("xhigh");
     expect(levels).not.toContain("ultra");
   });
 
-  it("does not add max for other codex models", () => {
+  it("does not add max/ultra for other codex models", () => {
     const levels = getThinkingLevels("codex", "gpt-5.3-codex");
     expect(levels).toEqual(["low", "medium", "high", "xhigh"]);
   });
 
-  it("does not add max for other gpt-5.6 models", () => {
+  it("does not add max/ultra for older openai models", () => {
+    const levels = getThinkingLevels("openai", "gpt-5");
+    expect(levels).not.toContain("max");
+    expect(levels).not.toContain("ultra");
+    expect(levels).toEqual(["none", "minimal", "low", "medium", "high", "xhigh"]);
+  });
+
+  it("does not add max/ultra for gpt-5.5", () => {
     const levels = getThinkingLevels("codex", "gpt-5.5");
     expect(levels || []).not.toContain("max");
+    expect(levels || []).not.toContain("ultra");
   });
 });


### PR DESCRIPTION
## Summary

- preserve supported semantic `max` and `ultra` for GPT-5.6 Sol/Terra; preserve Luna `max` and map Luna `ultra` to `max`
- encode semantic `ultra` as `reasoning.effort: "max"` only at the Codex transport boundary, matching the official OpenAI Codex client
- retain legacy `max`/`ultra` → `xhigh` fallback for older models
- cover nested `reasoning.effort`, legacy `reasoning_effort`, model suffixes, and the actual outbound POST body

## Root Cause

The earlier version treated GPT-5.6 model support and the Codex HTTP wire vocabulary as the same layer. Official `openai/codex` keeps Ultra as a semantic mode (including proactive multi-agent behavior) but uses this request mapping:

```text
ReasoningEffortConfig::Ultra -> ReasoningEffortConfig::Max
```

Sending literal `"ultra"` to `https://chatgpt.com/backend-api/codex/responses` therefore produced the reported 400. The fix keeps semantic Ultra in metadata/translation but sends wire Max from `CodexExecutor`.

## Effective Matrix

| Path/model | Requested | Emitted |
|---|---:|---:|
| OpenAI-format, GPT-5.6 Sol/Terra | `ultra` | `ultra` |
| Codex wire, GPT-5.6 Sol/Terra | `ultra` | `max` |
| Codex wire, GPT-5.6 Sol/Terra | `max` | `max` |
| GPT-5.6 Luna | `ultra` | `max` |
| Older models | `max` / `ultra` | `xhigh` |

## Tests

```text
npx vitest run \
  unit/codex-fast-capacity.test.js \
  unit/codex-effort-wire.test.js \
  unit/thinking-effort-openai-max-clamp.test.js \
  unit/thinking-levels-gpt56-sol.test.js
```

Focused suite passes, including case-sensitivity regressions that prevent unknown mixed/uppercase values from being promoted by the transport alias.

## Runtime Verification

Drove the running Next.js `/v1/responses` API with an isolated SQLite data directory and a local relay that captured the real outbound request (no live credentials):

- Sol `ultra` → one Codex POST with wire `max`
- Terra `ultra` → one Codex POST with wire `max`
- Sol `max` → one Codex POST with wire `max`
- Luna `ultra` → one Codex POST with wire `max`
- GPT-5.5 `ultra` → one Codex POST with wire `xhigh`
- uppercase older-model `ULTRA` probe → `xhigh`, never promoted to `max`

Every capture targeted `https://chatgpt.com/backend-api/codex/responses`.

## Notes

- No auth-mode branch or retry was added; `CodexExecutor` has a fixed Codex endpoint.
- No new dependencies.
- Provider registry baseline still reports unrelated pre-existing drift; the new Codex `quirks` field is intentionally excluded from that baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
