### PR TITLE
fix(minimax): OpenAI transport passthrough, reasoning_split, and client stream sanitization

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -58,9 +58,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);
-  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation
+  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation.
+  // Prefer the matched transport's format over per-model targetFormat so OpenAI clients
+  // hit the OpenAI endpoint with OpenAI-shaped tools (MiniMax rejects Anthropic tools on /v1).
   const runtimeTransport = resolveTransport(provider, sourceFormat);
-  const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider);
+  const targetFormat = runtimeTransport?.format || modelTargetFormat || getTargetFormat(provider);
   if (runtimeTransport && credentials) credentials.runtimeTransport = runtimeTransport;
   const stripList = getModelStrip(alias, model);
   const upstreamModel = getModelUpstreamId(alias, model);

--- a/open-sse/providers/registry/minimax-cn.js
+++ b/open-sse/providers/registry/minimax-cn.js
@@ -44,6 +44,7 @@ export default {
       format: "openai",
       baseUrl: "https://api.minimaxi.com/v1/chat/completions",
       auth: { combined: true, header: "Authorization", scheme: "bearer" },
+      requestDefaults: { reasoning_split: true },
     },
     {
       format: "claude",

--- a/open-sse/providers/registry/minimax-cn.js
+++ b/open-sse/providers/registry/minimax-cn.js
@@ -45,6 +45,7 @@ export default {
       baseUrl: "https://api.minimaxi.com/v1/chat/completions",
       auth: { combined: true, header: "Authorization", scheme: "bearer" },
       requestDefaults: { reasoning_split: true },
+      omitStreamReasoning: true,
     },
     {
       format: "claude",

--- a/open-sse/providers/registry/minimax.js
+++ b/open-sse/providers/registry/minimax.js
@@ -44,6 +44,8 @@ export default {
       format: "openai",
       baseUrl: "https://api.minimax.io/v1/chat/completions",
       auth: { combined: true, header: "Authorization", scheme: "bearer" },
+      // MiniMax OpenAI API: split thinking into reasoning_details (vendor-recommended for OpenAI clients).
+      requestDefaults: { reasoning_split: true },
     },
     {
       format: "claude",

--- a/open-sse/providers/registry/minimax.js
+++ b/open-sse/providers/registry/minimax.js
@@ -46,6 +46,8 @@ export default {
       auth: { combined: true, header: "Authorization", scheme: "bearer" },
       // MiniMax OpenAI API: split thinking into reasoning_details (vendor-recommended for OpenAI clients).
       requestDefaults: { reasoning_split: true },
+      // Upstream still reasons; don't forward thinking fields to OpenAI clients (OpenCode shows them).
+      omitStreamReasoning: true,
     },
     {
       format: "claude",

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -4,7 +4,6 @@
 
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { PROVIDERS } from "../../providers/index.js";
-import { FORMATS } from "../formats.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
@@ -329,17 +328,25 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
   return body;
 }
 
-const MINIMAX_REASONING_SPLIT_PROVIDERS = new Set(["minimax", "minimax-cn"]);
+// Apply per-transport requestDefaults from the provider registry when the client
+// did not set a field. Multi-endpoint providers can scope defaults to a format
+// (e.g. MiniMax openai transport → reasoning_split).
+export function applyTransportRequestDefaults(targetFormat, body, provider = null) {
+  if (!body || typeof body !== "object" || !provider) return body;
+  const config = PROVIDERS[provider];
+  if (!config) return body;
 
-// MiniMax M3 OpenAI path: default embeds thinking in content as <think>.
-// Vendor recommends reasoning_split for OpenAI-compatible clients (clean content + reasoning_details).
-export function applyMinimaxReasoningSplit(targetFormat, model, body, provider = null) {
-  if (!body || typeof body !== "object") return body;
-  if (targetFormat !== FORMATS.OPENAI) return body;
-  if (!MINIMAX_REASONING_SPLIT_PROVIDERS.has(provider)) return body;
-  const { cleanModel } = parseSuffix(model);
-  if (!getCapabilitiesForModel(provider, cleanModel).reasoning) return body;
-  if (body.reasoning_split !== undefined) return body;
-  body.reasoning_split = true;
+  let defaults = null;
+  const transports = config.transports;
+  if (Array.isArray(transports) && transports.length) {
+    defaults = transports.find((t) => t.format === targetFormat)?.requestDefaults;
+  } else {
+    defaults = config.requestDefaults ?? config.transport?.requestDefaults;
+  }
+
+  if (!defaults || typeof defaults !== "object") return body;
+  for (const [key, value] of Object.entries(defaults)) {
+    if (body[key] === undefined) body[key] = value;
+  }
   return body;
 }

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -4,6 +4,7 @@
 
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { PROVIDERS } from "../../providers/index.js";
+import { FORMATS } from "../formats.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
@@ -325,5 +326,20 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
   const fmt = resolveFormat(targetFormat, cleanModel, provider);
   stripAll(body);
   applyFormat(fmt, body, cfg, caps);
+  return body;
+}
+
+const MINIMAX_REASONING_SPLIT_PROVIDERS = new Set(["minimax", "minimax-cn"]);
+
+// MiniMax M3 OpenAI path: default embeds thinking in content as <think>.
+// Vendor recommends reasoning_split for OpenAI-compatible clients (clean content + reasoning_details).
+export function applyMinimaxReasoningSplit(targetFormat, model, body, provider = null) {
+  if (!body || typeof body !== "object") return body;
+  if (targetFormat !== FORMATS.OPENAI) return body;
+  if (!MINIMAX_REASONING_SPLIT_PROVIDERS.has(provider)) return body;
+  const { cleanModel } = parseSuffix(model);
+  if (!getCapabilitiesForModel(provider, cleanModel).reasoning) return body;
+  if (body.reasoning_split !== undefined) return body;
+  body.reasoning_split = true;
   return body;
 }

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -4,7 +4,7 @@ import { prepareClaudeRequest } from "./formats/claude.js";
 import { cloakClaudeTools } from "../utils/claudeCloaking.js";
 import { filterToOpenAIFormat } from "./formats/openai.js";
 import { normalizeThinkingConfig } from "../services/provider.js";
-import { applyThinking, captureThinking } from "./concerns/thinkingUnified.js";
+import { applyThinking, applyMinimaxReasoningSplit, captureThinking } from "./concerns/thinkingUnified.js";
 import { captureSessionId } from "../utils/sessionManager.js";
 import { AntigravityExecutor } from "../executors/antigravity.js";
 import { PROVIDERS } from "../providers/index.js";
@@ -105,6 +105,7 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
 
   // Normalize thinking to the target provider-native format (config-driven, capability-aware)
   applyThinking(targetFormat, model, result, provider, thinkingIntent);
+  applyMinimaxReasoningSplit(targetFormat, model, result, provider);
 
   // Always normalize to clean OpenAI format when target is OpenAI
   // This handles hybrid requests (e.g., OpenAI messages + Claude tools)

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -4,7 +4,7 @@ import { prepareClaudeRequest } from "./formats/claude.js";
 import { cloakClaudeTools } from "../utils/claudeCloaking.js";
 import { filterToOpenAIFormat } from "./formats/openai.js";
 import { normalizeThinkingConfig } from "../services/provider.js";
-import { applyThinking, applyMinimaxReasoningSplit, captureThinking } from "./concerns/thinkingUnified.js";
+import { applyThinking, applyTransportRequestDefaults, captureThinking } from "./concerns/thinkingUnified.js";
 import { captureSessionId } from "../utils/sessionManager.js";
 import { AntigravityExecutor } from "../executors/antigravity.js";
 import { PROVIDERS } from "../providers/index.js";
@@ -105,7 +105,7 @@ export function translateRequest(sourceFormat, targetFormat, model, body, stream
 
   // Normalize thinking to the target provider-native format (config-driven, capability-aware)
   applyThinking(targetFormat, model, result, provider, thinkingIntent);
-  applyMinimaxReasoningSplit(targetFormat, model, result, provider);
+  applyTransportRequestDefaults(targetFormat, result, provider);
 
   // Always normalize to clean OpenAI format when target is OpenAI
   // This handles hybrid requests (e.g., OpenAI messages + Claude tools)

--- a/open-sse/utils/minimaxThinkingStream.js
+++ b/open-sse/utils/minimaxThinkingStream.js
@@ -1,6 +1,8 @@
 // MiniMax M3 streaming can leak thinking markers into delta.content even with
 // reasoning_split. Peel markers into reasoning_content for OpenAI clients.
 
+import { PROVIDERS } from "../config/providers.js";
+
 const START_MARKERS = ["<think>", "<mm:think>"];
 const END_MARKERS = ["</think>", "</mm:think>"];
 
@@ -8,6 +10,24 @@ const MINIMAX_THINKING_PROVIDERS = new Set(["minimax", "minimax-cn"]);
 
 export function isMinimaxThinkingProvider(provider) {
   return MINIMAX_THINKING_PROVIDERS.has(provider);
+}
+
+export function shouldOmitStreamReasoning(provider) {
+  const transports = PROVIDERS[provider]?.transports;
+  if (!Array.isArray(transports)) return false;
+  return transports.some((t) => t.format === "openai" && t.omitStreamReasoning === true);
+}
+
+export function stripClientReasoningDelta(delta) {
+  if (!delta || typeof delta !== "object") return false;
+  let changed = false;
+  for (const key of ["reasoning_content", "reasoning", "reasoning_details"]) {
+    if (delta[key] !== undefined) {
+      delete delta[key];
+      changed = true;
+    }
+  }
+  return changed;
 }
 
 export function createMinimaxThinkingStreamState() {
@@ -110,7 +130,10 @@ export function sanitizeMinimaxDelta(delta, state) {
 
   const fromDetails = extractReasoningDetails(delta.reasoning_details);
   if (fromDetails) {
-    delta.reasoning_content = `${delta.reasoning_content || ""}${fromDetails}`;
+    const existing = typeof delta.reasoning_content === "string" ? delta.reasoning_content : "";
+    if (!existing.includes(fromDetails)) {
+      delta.reasoning_content = `${existing}${fromDetails}`;
+    }
     changed = true;
   }
 

--- a/open-sse/utils/minimaxThinkingStream.js
+++ b/open-sse/utils/minimaxThinkingStream.js
@@ -1,0 +1,141 @@
+// MiniMax M3 streaming can leak thinking markers into delta.content even with
+// reasoning_split. Peel markers into reasoning_content for OpenAI clients.
+
+const START_MARKERS = ["<think>", "<mm:think>"];
+const END_MARKERS = ["</think>", "</mm:think>"];
+
+const MINIMAX_THINKING_PROVIDERS = new Set(["minimax", "minimax-cn"]);
+
+export function isMinimaxThinkingProvider(provider) {
+  return MINIMAX_THINKING_PROVIDERS.has(provider);
+}
+
+export function createMinimaxThinkingStreamState() {
+  return { carry: "", inThinking: false };
+}
+
+function extractReasoningDetails(details) {
+  if (!Array.isArray(details)) return "";
+  return details
+    .map((d) => (typeof d === "string" ? d : d?.text || d?.content || ""))
+    .join("");
+}
+
+function findEarliestMarker(text, markers) {
+  let best = { idx: -1, marker: "" };
+  for (const marker of markers) {
+    const idx = text.indexOf(marker);
+    if (idx !== -1 && (best.idx === -1 || idx < best.idx)) {
+      best = { idx, marker };
+    }
+  }
+  return best;
+}
+
+function incompleteMarkerSuffixLen(text, markers) {
+  let hold = 0;
+  for (const marker of markers) {
+    const max = Math.min(text.length, marker.length - 1);
+    for (let len = max; len >= 1; len--) {
+      if (marker.startsWith(text.slice(text.length - len))) {
+        hold = Math.max(hold, len);
+        break;
+      }
+    }
+  }
+  return hold;
+}
+
+export function processMinimaxThinkingText(text, inThinking) {
+  let input = text;
+  let content = "";
+  let reasoning = "";
+  let thinking = inThinking;
+
+  while (input.length > 0) {
+    if (thinking) {
+      const { idx, marker } = findEarliestMarker(input, END_MARKERS);
+      if (idx === -1) {
+        const hold = incompleteMarkerSuffixLen(input, END_MARKERS);
+        reasoning += input.slice(0, input.length - hold);
+        return { content, reasoning, carry: input.slice(input.length - hold), inThinking: true };
+      }
+      reasoning += input.slice(0, idx);
+      input = input.slice(idx + marker.length);
+      thinking = false;
+      continue;
+    }
+
+    const start = findEarliestMarker(input, START_MARKERS);
+    const end = findEarliestMarker(input, END_MARKERS);
+    const useEnd = end.idx !== -1 && (start.idx === -1 || end.idx < start.idx);
+
+    if (useEnd) {
+      content += input.slice(0, end.idx);
+      input = input.slice(end.idx + end.marker.length);
+      continue;
+    }
+
+    if (start.idx === -1) {
+      const hold = incompleteMarkerSuffixLen(input, [...START_MARKERS, ...END_MARKERS]);
+      content += input.slice(0, input.length - hold);
+      return { content, reasoning, carry: input.slice(input.length - hold), inThinking: false };
+    }
+    content += input.slice(0, start.idx);
+    input = input.slice(start.idx + start.marker.length);
+    thinking = true;
+  }
+
+  return { content, reasoning, carry: "", inThinking: thinking };
+}
+
+export function flushMinimaxThinkingStreamState(state) {
+  if (!state?.carry) return { content: "", reasoning: "" };
+  const tail = state.carry;
+  state.carry = "";
+  if (state.inThinking) return { content: "", reasoning: tail };
+  return { content: tail, reasoning: "" };
+}
+
+// Mutates delta in place. Returns true when the delta was changed.
+export function sanitizeMinimaxDelta(delta, state) {
+  if (!delta || typeof delta !== "object" || !state) return false;
+  let changed = false;
+
+  if (typeof delta.reasoning === "string" && delta.reasoning) {
+    delta.reasoning_content = `${delta.reasoning_content || ""}${delta.reasoning}`;
+    delete delta.reasoning;
+    changed = true;
+  }
+
+  const fromDetails = extractReasoningDetails(delta.reasoning_details);
+  if (fromDetails) {
+    delta.reasoning_content = `${delta.reasoning_content || ""}${fromDetails}`;
+    changed = true;
+  }
+
+  if (typeof delta.content !== "string" || !delta.content) return changed;
+
+  const merged = `${state.carry}${delta.content}`;
+  state.carry = "";
+  const split = processMinimaxThinkingText(merged, state.inThinking);
+  state.carry = split.carry;
+  state.inThinking = split.inThinking;
+
+  if (split.content) {
+    if (split.content !== delta.content) {
+      delta.content = split.content;
+      changed = true;
+    }
+  } else {
+    delete delta.content;
+    changed = true;
+  }
+
+  if (split.reasoning) {
+    delta.reasoning_content = `${delta.reasoning_content || ""}${split.reasoning}`;
+    changed = true;
+  }
+
+  return changed;
+}

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -10,6 +10,8 @@ import {
   flushMinimaxThinkingStreamState,
   isMinimaxThinkingProvider,
   sanitizeMinimaxDelta,
+  shouldOmitStreamReasoning,
+  stripClientReasoningDelta,
 } from "./minimaxThinkingStream.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
@@ -82,6 +84,7 @@ export function createSSEStream(options = {}) {
   const minimaxThinkingState = isMinimaxThinkingProvider(provider)
     ? createMinimaxThinkingStreamState()
     : null;
+  const omitStreamReasoning = shouldOmitStreamReasoning(provider);
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -160,10 +163,6 @@ export function createSSEStream(options = {}) {
                 }
               }
 
-              if (!hasValuableContent(parsed, FORMATS.OPENAI)) {
-                continue;
-              }
-
               const delta = parsed.choices?.[0]?.delta;
               const content = delta?.content;
               const reasoning = delta?.reasoning_content;
@@ -174,6 +173,16 @@ export function createSSEStream(options = {}) {
               if (reasoning && typeof reasoning === "string") {
                 totalContentLength += reasoning.length;
                 accumulatedThinking += reasoning;
+              }
+
+              if (omitStreamReasoning && delta) {
+                if (stripClientReasoningDelta(delta)) {
+                  fieldsInjected = true;
+                }
+              }
+
+              if (!hasValuableContent(parsed, FORMATS.OPENAI)) {
+                continue;
               }
 
               const extracted = extractUsage(parsed);
@@ -362,29 +371,31 @@ export function createSSEStream(options = {}) {
           if (minimaxThinkingState) {
             const tail = flushMinimaxThinkingStreamState(minimaxThinkingState);
             if (tail.content || tail.reasoning) {
-              const flushed = {
-                object: "chat.completion.chunk",
-                created: Math.floor(Date.now() / 1000),
-                model: model || "unknown",
-                choices: [{
-                  index: 0,
-                  delta: {
-                    ...(tail.content ? { content: tail.content } : {}),
-                    ...(tail.reasoning ? { reasoning_content: tail.reasoning } : {}),
-                  },
-                }],
-              };
-              if (tail.content) {
-                totalContentLength += tail.content.length;
-                accumulatedContent += tail.content;
-              }
               if (tail.reasoning) {
                 totalContentLength += tail.reasoning.length;
                 accumulatedThinking += tail.reasoning;
               }
+              if (tail.content) {
+                totalContentLength += tail.content.length;
+                accumulatedContent += tail.content;
+              }
+              const flushedDelta = {
+                ...(tail.content ? { content: tail.content } : {}),
+                ...(!omitStreamReasoning && tail.reasoning ? { reasoning_content: tail.reasoning } : {}),
+              };
+              if (Object.keys(flushedDelta).length === 0) {
+                // carry was only reasoning stripped for client
+              } else {
+              const flushed = {
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: model || "unknown",
+                choices: [{ index: 0, delta: flushedDelta }],
+              };
               const flushedOutput = `data: ${JSON.stringify(flushed)}\n`;
               reqLogger?.appendConvertedChunk?.(flushedOutput);
               controller.enqueue(sharedEncoder.encode(flushedOutput));
+              }
             }
           }
 

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -5,6 +5,12 @@ import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBu
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
+import {
+  createMinimaxThinkingStreamState,
+  flushMinimaxThinkingStreamState,
+  isMinimaxThinkingProvider,
+  sanitizeMinimaxDelta,
+} from "./minimaxThinkingStream.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
 
@@ -72,6 +78,10 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+
+  const minimaxThinkingState = isMinimaxThinkingProvider(provider)
+    ? createMinimaxThinkingStreamState()
+    : null;
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -141,6 +151,12 @@ export function createSSEStream(options = {}) {
                     delete choice.delta.tool_calls;
                     fieldsInjected = true;
                   }
+                }
+              }
+
+              if (minimaxThinkingState && parsed?.choices?.[0]?.delta) {
+                if (sanitizeMinimaxDelta(parsed.choices[0].delta, minimaxThinkingState)) {
+                  fieldsInjected = true;
                 }
               }
 
@@ -343,6 +359,35 @@ export function createSSEStream(options = {}) {
         if (remaining) buffer += remaining;
 
         if (mode === STREAM_MODE.PASSTHROUGH) {
+          if (minimaxThinkingState) {
+            const tail = flushMinimaxThinkingStreamState(minimaxThinkingState);
+            if (tail.content || tail.reasoning) {
+              const flushed = {
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: model || "unknown",
+                choices: [{
+                  index: 0,
+                  delta: {
+                    ...(tail.content ? { content: tail.content } : {}),
+                    ...(tail.reasoning ? { reasoning_content: tail.reasoning } : {}),
+                  },
+                }],
+              };
+              if (tail.content) {
+                totalContentLength += tail.content.length;
+                accumulatedContent += tail.content;
+              }
+              if (tail.reasoning) {
+                totalContentLength += tail.reasoning.length;
+                accumulatedThinking += tail.reasoning;
+              }
+              const flushedOutput = `data: ${JSON.stringify(flushed)}\n`;
+              reqLogger?.appendConvertedChunk?.(flushedOutput);
+              controller.enqueue(sharedEncoder.encode(flushedOutput));
+            }
+          }
+
           if (buffer) {
             let output = buffer;
             if (buffer.startsWith("data:") && !buffer.startsWith("data: ")) {

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -5,6 +5,7 @@ import {
   parseSuffix,
   extractThinking,
   applyThinking,
+  applyMinimaxReasoningSplit,
 } from "../../open-sse/translator/concerns/thinkingUnified.js";
 import { extractReasoningText } from "../../open-sse/translator/concerns/reasoning.js";
 
@@ -152,6 +153,29 @@ describe("applyThinking per provider format", () => {
   it("openai keeps xhigh for reasoning models", () => {
     const out = apply("openai", "gpt-5.3-codex", { reasoning_effort: "xhigh" }, "codex");
     expect(out.reasoning_effort).toBe("xhigh");
+  });
+});
+
+describe("applyMinimaxReasoningSplit", () => {
+  const split = (targetFormat, model, body, provider) => {
+    const b = JSON.parse(JSON.stringify(body));
+    applyMinimaxReasoningSplit(targetFormat, model, b, provider);
+    return b;
+  };
+
+  it("enables reasoning_split on MiniMax M3 OpenAI path by default", () => {
+    const out = split("openai", "MiniMax-M3", { messages: [{ role: "user", content: "hi" }] }, "minimax");
+    expect(out.reasoning_split).toBe(true);
+  });
+
+  it("skips on Claude transport path", () => {
+    const out = split("claude", "MiniMax-M3", { messages: [{ role: "user", content: "hi" }] }, "minimax");
+    expect(out.reasoning_split).toBeUndefined();
+  });
+
+  it("respects explicit client override", () => {
+    const out = split("openai", "MiniMax-M3", { reasoning_split: false, messages: [] }, "minimax");
+    expect(out.reasoning_split).toBe(false);
   });
 });
 

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -5,7 +5,7 @@ import {
   parseSuffix,
   extractThinking,
   applyThinking,
-  applyMinimaxReasoningSplit,
+  applyTransportRequestDefaults,
 } from "../../open-sse/translator/concerns/thinkingUnified.js";
 import { extractReasoningText } from "../../open-sse/translator/concerns/reasoning.js";
 
@@ -156,25 +156,25 @@ describe("applyThinking per provider format", () => {
   });
 });
 
-describe("applyMinimaxReasoningSplit", () => {
-  const split = (targetFormat, model, body, provider) => {
+describe("applyTransportRequestDefaults", () => {
+  const defaults = (targetFormat, body, provider) => {
     const b = JSON.parse(JSON.stringify(body));
-    applyMinimaxReasoningSplit(targetFormat, model, b, provider);
+    applyTransportRequestDefaults(targetFormat, b, provider);
     return b;
   };
 
-  it("enables reasoning_split on MiniMax M3 OpenAI path by default", () => {
-    const out = split("openai", "MiniMax-M3", { messages: [{ role: "user", content: "hi" }] }, "minimax");
+  it("applies openai transport requestDefaults for MiniMax", () => {
+    const out = defaults("openai", { messages: [{ role: "user", content: "hi" }] }, "minimax");
     expect(out.reasoning_split).toBe(true);
   });
 
-  it("skips on Claude transport path", () => {
-    const out = split("claude", "MiniMax-M3", { messages: [{ role: "user", content: "hi" }] }, "minimax");
+  it("skips defaults for non-matching transport format", () => {
+    const out = defaults("claude", { messages: [{ role: "user", content: "hi" }] }, "minimax");
     expect(out.reasoning_split).toBeUndefined();
   });
 
   it("respects explicit client override", () => {
-    const out = split("openai", "MiniMax-M3", { reasoning_split: false, messages: [] }, "minimax");
+    const out = defaults("openai", { reasoning_split: false, messages: [] }, "minimax");
     expect(out.reasoning_split).toBe(false);
   });
 });

--- a/tests/unit/minimax-thinking-stream.test.js
+++ b/tests/unit/minimax-thinking-stream.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  createMinimaxThinkingStreamState,
+  processMinimaxThinkingText,
+  sanitizeMinimaxDelta,
+  flushMinimaxThinkingStreamState,
+  isMinimaxThinkingProvider,
+} from "../../open-sse/utils/minimaxThinkingStream.js";
+
+describe("minimaxThinkingStream", () => {
+  it("detects minimax providers", () => {
+    expect(isMinimaxThinkingProvider("minimax")).toBe(true);
+    expect(isMinimaxThinkingProvider("minimax-cn")).toBe(true);
+    expect(isMinimaxThinkingProvider("openai")).toBe(false);
+  });
+
+  it("splits redacted_thinking markers across one chunk", () => {
+    const out = processMinimaxThinkingText(
+      "<think>\nplan\n</think>\nHi",
+      false,
+    );
+    expect(out).toEqual({
+      content: "\nHi",
+      reasoning: "\nplan\n",
+      carry: "",
+      inThinking: false,
+    });
+  });
+
+  it("splits mm:think markers", () => {
+    const out = processMinimaxThinkingText("<mm:think>why</mm:think>ok", false);
+    expect(out.content).toBe("ok");
+    expect(out.reasoning).toBe("why");
+    expect(out.inThinking).toBe(false);
+  });
+
+  it("strips orphaned closing mm:think tag", () => {
+    const out = processMinimaxThinkingText("</mm:think>answer", false);
+    expect(out.content).toBe("answer");
+    expect(out.reasoning).toBe("");
+  });
+
+  it("holds partial end marker across chunks", () => {
+    const state = createMinimaxThinkingStreamState();
+    const d1 = { content: "<mm:think>why</mm:thi" };
+    sanitizeMinimaxDelta(d1, state);
+    expect(d1.content).toBeUndefined();
+    expect(d1.reasoning_content).toBe("why");
+
+    const d2 = { content: "nk>ok" };
+    sanitizeMinimaxDelta(d2, state);
+    expect(d2.content).toBe("ok");
+    expect(state.inThinking).toBe(false);
+  });
+
+  it("sanitizes delta.content and maps delta.reasoning", () => {
+    const state = createMinimaxThinkingStreamState();
+    const delta = { content: "</mm:think>answer", reasoning: "trail" };
+    expect(sanitizeMinimaxDelta(delta, state)).toBe(true);
+    expect(delta.content).toBe("answer");
+    expect(delta.reasoning_content).toBe("trail");
+    expect(delta.reasoning).toBeUndefined();
+  });
+
+  it("flushes trailing carry on stream end", () => {
+    const state = createMinimaxThinkingStreamState();
+    state.carry = "tail";
+    state.inThinking = true;
+    const flushed = flushMinimaxThinkingStreamState(state);
+    expect(flushed).toEqual({ content: "", reasoning: "tail" });
+    expect(state.carry).toBe("");
+  });
+});

--- a/tests/unit/minimax-thinking-stream.test.js
+++ b/tests/unit/minimax-thinking-stream.test.js
@@ -5,6 +5,8 @@ import {
   sanitizeMinimaxDelta,
   flushMinimaxThinkingStreamState,
   isMinimaxThinkingProvider,
+  shouldOmitStreamReasoning,
+  stripClientReasoningDelta,
 } from "../../open-sse/utils/minimaxThinkingStream.js";
 
 describe("minimaxThinkingStream", () => {
@@ -69,5 +71,13 @@ describe("minimaxThinkingStream", () => {
     const flushed = flushMinimaxThinkingStreamState(state);
     expect(flushed).toEqual({ content: "", reasoning: "tail" });
     expect(state.carry).toBe("");
+  });
+
+  it("omits stream reasoning when openai transport requests it", () => {
+    expect(shouldOmitStreamReasoning("minimax")).toBe(true);
+    expect(shouldOmitStreamReasoning("openai")).toBe(false);
+    const delta = { content: "hi", reasoning_content: "secret", reasoning_details: [{ text: "x" }] };
+    expect(stripClientReasoningDelta(delta)).toBe(true);
+    expect(delta).toEqual({ content: "hi" });
   });
 });

--- a/tests/unit/minimax-transport-target-format.test.js
+++ b/tests/unit/minimax-transport-target-format.test.js
@@ -1,0 +1,47 @@
+/**
+ * MiniMax (and other multi-transport providers) expose both OpenAI and Anthropic
+ * endpoints. When the client already speaks OpenAI, we must not let per-model
+ * targetFormat: "claude" override the matched transport — that sends Anthropic-shaped
+ * tools to /v1/chat/completions and triggers MiniMax error 2013.
+ */
+import { describe, expect, it } from "vitest";
+import { getModelTargetFormat } from "../../open-sse/config/providerModels.js";
+import { detectFormat, getTargetFormat, resolveTransport } from "../../open-sse/services/provider.js";
+
+function resolveTargetFormat(provider, model, body) {
+  const sourceFormat = detectFormat(body);
+  const modelTargetFormat = getModelTargetFormat(provider, model);
+  const runtimeTransport = resolveTransport(provider, sourceFormat);
+  return {
+    sourceFormat,
+    modelTargetFormat,
+    runtimeTransportFormat: runtimeTransport?.format ?? null,
+    targetFormat: runtimeTransport?.format || modelTargetFormat || getTargetFormat(provider),
+  };
+}
+
+describe("multi-transport targetFormat resolution", () => {
+  it("prefers matched OpenAI transport over MiniMax-M3 targetFormat: claude", () => {
+    const body = {
+      messages: [{ role: "user", content: "hi" }],
+      tools: [{ type: "function", function: { name: "read", parameters: { type: "object", properties: {} } } }],
+    };
+    const out = resolveTargetFormat("minimax", "MiniMax-M3", body);
+    expect(out.sourceFormat).toBe("openai");
+    expect(out.modelTargetFormat).toBe("claude");
+    expect(out.runtimeTransportFormat).toBe("openai");
+    expect(out.targetFormat).toBe("openai");
+  });
+
+  it("uses Claude transport for Claude-shaped client requests", () => {
+    const body = {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      system: [{ type: "text", text: "sys" }],
+      max_tokens: 1024,
+    };
+    const out = resolveTargetFormat("minimax", "MiniMax-M3", body);
+    expect(out.sourceFormat).toBe("claude");
+    expect(out.runtimeTransportFormat).toBe("claude");
+    expect(out.targetFormat).toBe("claude");
+  });
+});


### PR DESCRIPTION
## Problem

OpenAI-format clients (OpenCode, Cursor, etc.) calling `minimax/MiniMax-M3` through 9router hit several failures:

1. **`invalid tool type: (2013)`** on tool-using requests — Anthropic-shaped tools were sent to MiniMax's `/v1/chat/completions` endpoint.
2. **Empty/broken streaming** — response translation mismatch on the OpenAI path.
3. **Thinking leaked to clients** — reasoning appeared as `<think>` tags in `content`, or as `reasoning_content` / `reasoning_details` fields that OpenCode renders visibly.

Fixes #2435 (OpenAI-client / combo path).

## Root cause

MiniMax is a **multi-transport** provider. `resolveTransport()` correctly picks the OpenAI transport for OpenAI clients, but `modelTargetFormat: "claude"` on `MiniMax-M3` overrode it:

```js
// before
const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider);
```

That translated tools to Anthropic shape while posting to `/v1/chat/completions`.

## Fix

### 1. Prefer matched transport format (zero-translation passthrough)

```js
const targetFormat = runtimeTransport?.format || modelTargetFormat || getTargetFormat(provider);
```

When client format matches a registered transport, use that transport's format instead of the model's declared `targetFormat`.

### 2. Default `reasoning_split: true` on MiniMax OpenAI transport

Per [MiniMax M3 function-call docs](https://platform.minimax.io/docs/guides/text-m3-function-call), inject `reasoning_split: true` via transport `requestDefaults` so upstream splits thinking into `reasoning_content` / `reasoning_details` instead of embedding tags in `content`.

### 3. Streaming sanitizer for leaked thinking markers

New `minimaxThinkingStream.js` peels `<think>` / `<mm:think>` markers from `delta.content` across SSE chunk boundaries, mapping them to `reasoning_content` for internal accumulation.

### 4. Strip reasoning fields from client-facing SSE

Transport flag `omitStreamReasoning: true` removes `reasoning_content`, `reasoning`, and `reasoning_details` from forwarded deltas so OpenAI clients (OpenCode) only see the final answer text. Reasoning is still accumulated internally for usage/observability.

## Files changed

| File | Change |
|------|--------|
| `open-sse/handlers/chatCore.js` | Prefer `runtimeTransport.format` over `modelTargetFormat` |
| `open-sse/providers/registry/minimax.js` | OpenAI transport: `requestDefaults`, `omitStreamReasoning` |
| `open-sse/providers/registry/minimax-cn.js` | Same |
| `open-sse/translator/concerns/thinkingUnified.js` | Apply `reasoning_split` from transport defaults |
| `open-sse/utils/minimaxThinkingStream.js` | Marker sanitizer + client reasoning strip |
| `open-sse/utils/stream.js` | Wire sanitizer/omit into passthrough path |

## Tests

```bash
cd tests && npx vitest run \
  unit/minimax-transport-target-format.test.js \
  unit/minimax-thinking-stream.test.js \
  translator/thinking-unified.test.js
```

**48/48 pass** on this branch.

## Relationship to other PRs

- **Supersedes #2473** (closed) — that PR patched bare `{function:{…}}` tool unwrapping on the Claude translation path. The OpenCode failure was transport/format mismatch, not missing unwrap; OpenAI clients never hit that translator path once transport selection is fixed.
- **Overlaps #2463** — same transport-selection root cause. This PR additionally covers `reasoning_split` defaults, cross-chunk marker sanitization, and stripping reasoning fields from the client stream (tested with OpenCode).

## Verification

- OpenAI client → `http://127.0.0.1:20128/v1` → `minimax/MiniMax-M3`
- Simple chat: only answer text in stream (no `reasoning_content` in SSE)
- Tool-using requests: HTTP 200 (no error 2013)

Made with [Cursor](https://cursor.com)