### PR TITLE
fix(combos): hide disabled provider connections

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -8,6 +8,7 @@ import { restrictToVerticalAxis, restrictToParentElement } from "@dnd-kit/modifi
 import { Card, Button, Modal, Input, CardSkeleton, ModelSelectModal, ConfirmModal, CapacityBadges, Select } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
+import { filterActiveConnections } from "@/shared/utils/connectionStatus";
 
 // Validate combo name: only a-z, A-Z, 0-9, -, _
 const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
@@ -42,7 +43,7 @@ export default function CombosPage() {
       // Only LLM combos here - webSearch/webFetch combos belong to media-providers/web
       if (combosRes.ok) setCombos((combosData.combos || []).filter(c => !c.kind || c.kind === "llm"));
       if (providersRes.ok) {
-        setActiveProviders(providersData.connections || []);
+        setActiveProviders(filterActiveConnections(providersData.connections));
       }
       if (modelsRes.ok) {
         const md = await modelsRes.json();

--- a/src/shared/utils/connectionStatus.js
+++ b/src/shared/utils/connectionStatus.js
@@ -4,3 +4,8 @@ export function getStatusVariant(isActive, effectiveStatus) {
   if (effectiveStatus === "error" || effectiveStatus === "expired" || effectiveStatus === "unavailable") return "error";
   return "default";
 }
+
+export function filterActiveConnections(connections) {
+  if (!Array.isArray(connections)) return [];
+  return connections.filter((connection) => connection?.isActive !== false);
+}

--- a/tests/unit/connection-status.test.js
+++ b/tests/unit/connection-status.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { filterActiveConnections } from "../../src/shared/utils/connectionStatus.js";
+
+describe("filterActiveConnections", () => {
+  it("excludes explicitly disabled connections", () => {
+    const active = { id: "active", isActive: true };
+    const legacyActive = { id: "legacy" };
+    const disabled = { id: "disabled", isActive: false };
+
+    expect(filterActiveConnections([active, disabled, legacyActive])).toEqual([
+      active,
+      legacyActive,
+    ]);
+  });
+
+  it("returns an empty list for invalid input", () => {
+    expect(filterActiveConnections()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- filter explicitly disabled provider connections before passing them to combo model selectors
- keep legacy connections without `isActive` visible
- add regression coverage for connection filtering

## Problem
The combos page stores every `/api/providers` connection in a state named `activeProviders`. As a result, disabled providers remain available in the Add Model picker, unlike other model selectors that only expose active connections.

## Testing
- `cd tests && npx vitest run --config ./vitest.config.js unit/connection-status.test.js`
- `npm run build`