### PR TITLE
fix: resolve better-sqlite3 parameter array binding crash

### DIFF
--- a/src/lib/db/adapters/betterSqliteAdapter.js
+++ b/src/lib/db/adapters/betterSqliteAdapter.js
@@ -40,9 +40,9 @@ export function createBetterSqliteAdapter(filePath) {
 
   return {
     driver: "better-sqlite3",
-    run(sql, params = []) { return prepare(sql).run(params); },
-    get(sql, params = []) { return prepare(sql).get(params); },
-    all(sql, params = []) { return prepare(sql).all(params); },
+    run(sql, params = []) { return prepare(sql).run(...params); },
+    get(sql, params = []) { return prepare(sql).get(...params); },
+    all(sql, params = []) { return prepare(sql).all(...params); },
     exec(sql) { return db.exec(sql); },
     transaction(fn) { return db.transaction(fn)(); },
     checkpoint() { try { db.pragma("wal_checkpoint(TRUNCATE)"); } catch {} },


### PR DESCRIPTION
This PR fixes the "Internal Server Error" caused by the `betterSqliteAdapter` passing query parameters as a raw JavaScript array instead of spreading them. 

By using the spread operator (`...params`) on the `run`, `get`, and `all` statements, we prevent `better-sqlite3` from crashing when executing parameterized queries (like updating a user password).

Fixes #2529 
