### PR TITLE
fix(minimax): route M3 tool calls through standard API

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -58,8 +58,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);
-  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation
-  const runtimeTransport = resolveTransport(provider, sourceFormat);
+  // Multi-endpoint providers: honor model format overrides, otherwise match sourceFormat.
+  const runtimeTransport = resolveTransport(provider, sourceFormat, modelTargetFormat);
   const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider);
   if (runtimeTransport && credentials) credentials.runtimeTransport = runtimeTransport;
   const stripList = getModelStrip(alias, model);

--- a/open-sse/providers/registry/minimax-cn.js
+++ b/open-sse/providers/registry/minimax-cn.js
@@ -42,7 +42,7 @@ export default {
   transports: [
     {
       format: "openai",
-      baseUrl: "https://api.minimaxi.com/v1/chat/completions",
+      baseUrl: "https://api.minimaxi.com/v1/text/chatcompletion_v2",
       auth: { combined: true, header: "Authorization", scheme: "bearer" },
     },
     {
@@ -54,7 +54,7 @@ export default {
     },
   ],
   models: [
-    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "claude" },
+    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "openai" },
     { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
     { id: "MiniMax-M2.1", name: "MiniMax M2.1" },

--- a/open-sse/providers/registry/minimax.js
+++ b/open-sse/providers/registry/minimax.js
@@ -42,7 +42,7 @@ export default {
   transports: [
     {
       format: "openai",
-      baseUrl: "https://api.minimax.io/v1/chat/completions",
+      baseUrl: "https://api.minimax.io/v1/text/chatcompletion_v2",
       auth: { combined: true, header: "Authorization", scheme: "bearer" },
     },
     {
@@ -54,7 +54,7 @@ export default {
     },
   ],
   models: [
-    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "claude" },
+    { id: "MiniMax-M3", name: "MiniMax M3", targetFormat: "openai" },
     { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
     { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
     { id: "MiniMax-M2.1", name: "MiniMax M2.1" },

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -137,13 +137,16 @@ export function getTargetFormat(provider) {
 }
 
 // Resolve which transport to use for a provider given the client sourceFormat.
-// Multi-endpoint providers (transport.transports[]) pick the entry matching sourceFormat
-// to avoid lossy translation; falls back to the default transport when no match.
-export function resolveTransport(provider, sourceFormat) {
+// A model-level format override also overrides transport selection so the translated
+// request body and upstream endpoint always use the same wire format.
+// Otherwise, multi-endpoint providers pick the entry matching sourceFormat to avoid
+// lossy translation; callers fall back to the default transport when no match exists.
+export function resolveTransport(provider, sourceFormat, modelTargetFormat = null) {
   const config = PROVIDERS[provider];
   const transports = config?.transports;
   if (!Array.isArray(transports) || !transports.length) return null;
-  return transports.find(t => t.format === sourceFormat) || null;
+  const transportFormat = modelTargetFormat || sourceFormat;
+  return transports.find(t => t.format === transportFormat) || null;
 }
 
 // Check if last message is from user

--- a/tests/unit/minimax-m3-tool-routing.test.js
+++ b/tests/unit/minimax-m3-tool-routing.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { PROVIDERS } from "../../open-sse/config/providers.js";
+import { getModelTargetFormat } from "../../open-sse/config/providerModels.js";
+import { resolveTransport } from "../../open-sse/services/provider.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const providers = [
+  ["minimax", "https://api.minimax.io/v1/text/chatcompletion_v2"],
+  ["minimax-cn", "https://api.minimaxi.com/v1/text/chatcompletion_v2"],
+];
+
+const request = {
+  model: "MiniMax-M3",
+  messages: [{ role: "user", content: "Call test." }],
+  tools: [
+    {
+      type: "function",
+      function: {
+        name: "test",
+        description: "Test tool",
+        parameters: { type: "object", properties: {} },
+      },
+    },
+  ],
+};
+
+describe("MiniMax-M3 tool routing", () => {
+  it.each(providers)("routes %s M3 through the standard OpenAI-format endpoint", (provider, baseUrl) => {
+    const modelTargetFormat = getModelTargetFormat(provider, "MiniMax-M3");
+    const transport = resolveTransport(provider, FORMATS.CLAUDE, modelTargetFormat);
+
+    expect(modelTargetFormat).toBe(FORMATS.OPENAI);
+    expect(transport).toMatchObject({
+      format: FORMATS.OPENAI,
+      baseUrl,
+      auth: { header: "Authorization", scheme: "bearer" },
+    });
+  });
+
+  it.each(providers)("preserves function tool type for %s M3", (provider) => {
+    const modelTargetFormat = getModelTargetFormat(provider, "MiniMax-M3");
+    const translated = translateRequest(
+      FORMATS.OPENAI,
+      modelTargetFormat,
+      "MiniMax-M3",
+      request,
+      false,
+      null,
+      provider,
+    );
+
+    expect(translated.tools).toEqual(request.tools);
+    expect(translated.tools[0].type).toBe("function");
+  });
+
+  it.each(providers)("keeps %s M2.7 on its existing format-aware transports", (provider) => {
+    expect(getModelTargetFormat(provider, "MiniMax-M2.7")).toBeNull();
+    expect(resolveTransport(provider, FORMATS.CLAUDE)?.format).toBe(FORMATS.CLAUDE);
+    expect(resolveTransport(provider, FORMATS.OPENAI)?.format).toBe(FORMATS.OPENAI);
+    expect(PROVIDERS[provider].format).toBe(FORMATS.CLAUDE);
+  });
+});

--- a/tests/unit/provider-models-minimax-m3.test.js
+++ b/tests/unit/provider-models-minimax-m3.test.js
@@ -1,7 +1,7 @@
 /**
  * Unit tests verifying MiniMax-M3 is registered as a first-class
  * built-in model for both the `minimax` (international) and
- * `minimax-cn` (China) providers, with `targetFormat: "claude"`.
+ * `minimax-cn` (China) providers, with `targetFormat: "openai"`.
  *
  * Run: cd tests && NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run tests/unit/provider-models-minimax-m3.test.js --reporter=verbose
  */
@@ -17,7 +17,7 @@ describe("MiniMax-M3 model registration", () => {
     expect(m3).toMatchObject({
       id: "MiniMax-M3",
       name: "MiniMax M3",
-      targetFormat: "claude",
+      targetFormat: "openai",
     });
   });
 
@@ -28,7 +28,7 @@ describe("MiniMax-M3 model registration", () => {
     expect(m3).toMatchObject({
       id: "MiniMax-M3",
       name: "MiniMax M3",
-      targetFormat: "claude",
+      targetFormat: "openai",
     });
   });
 


### PR DESCRIPTION
## Summary

- route `MiniMax-M3` through MiniMax's standard OpenAI-format API for both global and China providers
- make a model-level `targetFormat` select the matching runtime transport, keeping request schema and endpoint format aligned
- preserve the existing source-format-aware Anthropic/OpenAI routing for MiniMax M2.x
- add regression coverage for endpoint selection and `tools[].type: "function"` preservation

## Root cause

OpenAI clients send function tools as:

```json
{"type":"function","function":{"name":"test","parameters":{"type":"object"}}}
```

`MiniMax-M3` was registered with `targetFormat: "claude"`. 9Router therefore converted the tool to Anthropic shape (`name` + `input_schema`) even when M3 needed the standard API. The provider request no longer contained `tools[].type`, and strict M3 validation returned HTTP 400:

```text
invalid params, invalid tool type:  (2013)
```

MiniMax's current documentation lists M3 on the standard `/v1/text/chatcompletion_v2` API, while the Anthropic compatibility page lists the M2.x family. This change encodes that model-level distinction instead of selecting M3's wire format from the client type.

- Standard API: https://platform.minimax.io/docs/api-reference/text-post
- Anthropic compatibility: https://platform.minimax.io/docs/api-reference/text-anthropic-api

## Impact

OpenClaw and other OpenAI-format agents can call tools with `minimax/MiniMax-M3` and `minimax-cn/MiniMax-M3` without error 2013. Claude-format clients are translated to M3's supported OpenAI wire format and sent to the matching standard endpoint. M2.7, M2.5, and M2.1 retain their existing format-aware transport behavior.

## Validation

- `npx vitest run unit/provider-models-minimax-m3.test.js unit/minimax-m3-tool-routing.test.js translator/coverage-all-models.test.js --reporter=verbose` — 92 passed
- full-suite comparison against the same `master` commit — branch adds 6 passing tests; both runs have the same 43 pre-existing failures and no new failures
- `npx eslint ...` on all changed source/test files — 0 errors
- `npm run build` — passed
- live local call through 9Router to `minimax-cn/MiniMax-M3` — HTTP 200, `finish_reason: tool_calls`, returned tool type `function`

This is a model-directed alternative to #2463 and #2525, which retain M3's Claude default and resolve the mismatch by preferring the client-matched transport.

Fixes #2435
