### PR TITLE
fix(xai): strip reasoning_effort for grok-composer; dashboard thinking None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Fixes
 - **xAI**: strip `reasoning_effort` for `grok-composer` models (upstream rejects any reasoningEffort); honor provider thinking mode `none` — Joseph Yaksich
+- **grok-cli**: guard `transformRequest()` with capabilities (no reasoning on composer/build); cap tools at 200 for cli-chat-proxy — folded from #2539 / @hameduc
 - **Cloudflare-AI**: support accountId in bulk key import (#2449)
 - **DB**: backup on schema change, MCP child cleanup, codex models, usage providers OOM
 - **Codex**: avoid bare-email OAuth dedup (#2477)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Proxy-Pools**: auto-rotate strategy for no-auth providers (#2409)
 
 ## Fixes
+- **xAI**: strip `reasoning_effort` for `grok-composer` models (upstream rejects any reasoningEffort); honor provider thinking mode `none` — Joseph Yaksich
 - **Cloudflare-AI**: support accountId in bulk key import (#2449)
 - **DB**: backup on schema change, MCP child cleanup, codex models, usage providers OOM
 - **Codex**: avoid bare-email OAuth dedup (#2477)

--- a/open-sse/executors/grok-cli.js
+++ b/open-sse/executors/grok-cli.js
@@ -9,6 +9,7 @@ import { normalizeResponsesInput } from "../translator/formats/responsesApi.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { getConsistentMachineId } from "../shared/machineId.js";
+import { getCapabilitiesForModel } from "../providers/capabilities.js";
 
 // Server-generated item id prefixes that /responses cannot resolve when store=false
 const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
@@ -305,6 +306,11 @@ export class GrokCliExecutor extends BaseExecutor {
     stripStoredItemReferences(body);
     normalizeGrokCliTools(body);
 
+    // xAI cli-chat-proxy enforces a maximum of 200 tools per request
+    if (Array.isArray(body.tools) && body.tools.length > 200) {
+      body.tools = body.tools.slice(0, 200);
+    }
+
     // Turn index after input is finalized (user-message count, monotonic per session)
     this._currentTurnIdx = resolveGrokCliTurnIdx(this._currentSessionId, body.input);
 
@@ -326,14 +332,20 @@ export class GrokCliExecutor extends BaseExecutor {
     this._currentModel = resolvedModel;
 
     // Reasoning effort priority: explicit > reasoning_effort > model suffix > default high
-    if (!body.reasoning || typeof body.reasoning !== "object") {
-      const effort = body.reasoning_effort || modelEffort || "high";
-      body.reasoning = { effort, summary: "concise" };
-    } else {
-      if (!body.reasoning.effort) {
-        body.reasoning.effort = body.reasoning_effort || modelEffort || "high";
+    // Non-reasoning models (grok-composer-2.5-fast, grok-build) must not send reasoning
+    const caps = getCapabilitiesForModel("grok-cli", resolvedModel);
+    if (caps.reasoning !== false) {
+      if (!body.reasoning || typeof body.reasoning !== "object") {
+        const effort = body.reasoning_effort || modelEffort || "high";
+        body.reasoning = { effort, summary: "concise" };
+      } else {
+        if (!body.reasoning.effort) {
+          body.reasoning.effort = body.reasoning_effort || modelEffort || "high";
+        }
+        if (!body.reasoning.summary) body.reasoning.summary = "concise";
       }
-      if (!body.reasoning.summary) body.reasoning.summary = "concise";
+    } else {
+      delete body.reasoning;
     }
     delete body.reasoning_effort;
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -69,7 +69,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
   if (providerThinking?.mode && providerThinking.mode !== "auto") {
     const mode = providerThinking.mode;
-    if (mode === "on" && !body.thinking) {
+    if (mode === "none") {
+      delete body.thinking;
+      delete body.reasoning_effort;
+      delete body.reasoning;
+    } else if (mode === "on" && !body.thinking) {
       console.log("Injecting provider-level thinking config override: on");
       body = { ...body, thinking: { type: "enabled", budget_tokens: 10000 } };
     } else if (mode === "off" && !body.thinking) {

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -96,6 +96,10 @@ export const MODEL_CAPABILITIES = {
   // Qwen plain coder/text (no vision) — registry "vision-model" / "coder-model" aliases
   "vision-model":      { vision: true, reasoning: true, thinkingFormat: "qwen", contextWindow: 1000000 },
   "coder-model":       { reasoning: true, thinkingFormat: "qwen", contextWindow: 1000000 },
+
+  // Grok CLI non-reasoning coding models (cli-chat-proxy rejects reasoningEffort)
+  "grok-composer-2.5-fast": { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 200000, maxOutput: 30000 },
+  "grok-build":            { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 512000, maxOutput: 30000 },
 };
 
 /**
@@ -185,8 +189,9 @@ export const PATTERN_CAPABILITIES = [
 
   // ── Grok (vision + Live Search) ──────────────────────────────────
   { pattern: "*grok*image*",    caps: { imageOutput: true } },
-  // Grok Composer chat API: no client-controlled reasoningEffort (xAI 400 if sent).
-  { pattern: "*grok-composer*", caps: { vision: true, search: true, reasoning: false, contextWindow: 256000 } },
+  // Grok Composer / Build (Grok CLI): no client-controlled reasoningEffort (xAI 400 if sent).
+  { pattern: "*grok-composer*", caps: { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 200000, maxOutput: 30000 } },
+  { pattern: "*grok-build*",    caps: { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 512000, maxOutput: 30000 } },
   { pattern: "*grok-code*",     caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 256000 } },
   // Grok 4.5 (Grok CLI / Grok Build): 500k context per cli-chat-proxy /v1/models
   { pattern: "*grok-4.5*",      caps: { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 500000, maxOutput: 64000 } },

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -185,6 +185,8 @@ export const PATTERN_CAPABILITIES = [
 
   // ── Grok (vision + Live Search) ──────────────────────────────────
   { pattern: "*grok*image*",    caps: { imageOutput: true } },
+  // Grok Composer chat API: no client-controlled reasoningEffort (xAI 400 if sent).
+  { pattern: "*grok-composer*", caps: { vision: true, search: true, reasoning: false, contextWindow: 256000 } },
   { pattern: "*grok-code*",     caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 256000 } },
   // Grok 4.5 (Grok CLI / Grok Build): 500k context per cli-chat-proxy /v1/models
   { pattern: "*grok-4.5*",      caps: { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 500000, maxOutput: 64000 } },

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -12,9 +12,10 @@ const STRIP_RULES = [
   { provider: "github", match: /gpt-5\.4/i, drop: ["temperature"] },
   // GitHub Copilot Claude (except opus/sonnet 4.6): thinking + reasoning_effort rejected. #713
   { provider: "github", match: (m) => /claude/i.test(m) && !/claude.*(opus|sonnet).*4\.6/i.test(m), drop: ["thinking", "reasoning_effort"] },
+  // xAI Grok Composer: rejects reasoningEffort entirely (including "none") — omit param upstream.
+  { provider: "xai", match: /grok-composer/i, drop: ["thinking", "reasoning_effort", "reasoning"] },
   // Cloudflare Workers AI: content must be plain string, rejects OpenAI content-part array (#1926)
   { provider: "cloudflare-ai", flattenContent: true },
-  { provider: "volcengine-ark", match: /glm-5/i, clampToModelMaxOutput: true },
   // VolcEngine Ark caps the Kimi family at max_tokens <= 32768, but the model's
   // advertised ceiling is far higher (Kimi-K2.7-Code resolves to maxOutput 262144),
   // so clampToModelMaxOutput alone leaves it uncapped and the request 400s with

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -155,7 +155,7 @@ export default function ProviderDetailPage() {
   const apiKeyConnectionLabel = providerId === "xai" ? "xAI API Key" : "API Key";
   // Resolve suffix "(level)" for a model when a thinking level is picked and the model supports it.
   const resolveThinkingSuffix = (modelId) => {
-    if (!thinkingMode || thinkingMode === "auto") return null;
+    if (!thinkingMode || thinkingMode === "auto" || thinkingMode === "none") return null;
     const levels = getThinkingLevels(providerId, modelId);
     return levels && levels.includes(thinkingMode) ? thinkingMode : null;
   };
@@ -169,7 +169,7 @@ export default function ProviderDetailPage() {
       if (!modelId || seen.has(modelId)) return;
       seen.add(modelId);
       const lv = getThinkingLevels(providerId, modelId);
-      if (lv) lv.forEach((l) => { if (l !== "none") set.add(l); });
+      if (lv) lv.forEach((l) => set.add(l));
     };
     for (const m of models) addLevels(m.id);
     for (const m of kiloFreeModels) addLevels(m.id);
@@ -178,7 +178,9 @@ export default function ProviderDetailPage() {
       if ((entry.kind || entry.type || "llm") !== "llm") continue;
       addLevels(entry.id);
     }
-    return set.size ? ["auto", ...[...set]] : null;
+    if (!set.size) return null;
+    const rest = [...set].filter((l) => l !== "none");
+    return ["auto", "none", ...rest];
   })();
   const providerDisplayAlias = isCompatible
     ? (providerNode?.prefix || providerId)

--- a/tests/unit/param-support.test.js
+++ b/tests/unit/param-support.test.js
@@ -52,4 +52,20 @@ describe("stripUnsupportedParams", () => {
 
     expect(body.max_tokens).toBe(64000);
   });
+
+  it("strips reasoning params for xAI grok-composer models", () => {
+    const body = {
+      reasoning_effort: "medium",
+      reasoning: { effort: "medium" },
+      thinking: { type: "enabled", budget_tokens: 8192 },
+      messages: [{ role: "user", content: "hi" }],
+    };
+
+    stripUnsupportedParams("xai", "grok-composer-2.5-fast", body);
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toBeUndefined();
+    expect(body.thinking).toBeUndefined();
+    expect(body.messages).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Problem

`grok-composer-2.5-fast` (xAI) returns HTTP 400 when the chat request includes `reasoningEffort` / `reasoning_effort`, including when clients send `none`. Hermes and other OpenAI-compatible clients that set `agent.reasoning_effort` therefore fail through 9router while bare requests succeed.

The provider dashboard thinking picker also hid **None** (filtered out of dropdown options), so there was no way to tell the gateway to omit reasoning params for a provider.

## Fix

- **paramSupport**: strip `thinking`, `reasoning_effort`, and `reasoning` for `xai` + `grok-composer` models before upstream call.
- **capabilities**: mark `*grok-composer*` as non-reasoning so unified thinking normalization does not re-inject effort.
- **chatCore**: when `providerThinking.mode === "none"`, delete thinking/reasoning fields instead of injecting effort.
- **Dashboard**: include **None** in the thinking dropdown; `none` does not append a model suffix.
- **Test**: unit coverage in `param-support.test.js`.
- **CHANGELOG**: v0.5.30 fixes entry.

## Verification

`npx vitest run unit/param-support.test.js -t grok-composer` passes.

Fixes Mattermost/Hermes failures when global model is `grok-composer-2.5-fast` via rerouted with `reasoning_effort: medium`.