### PR TITLE
fix(anthropic): lowercase anthropic-version header key to prevent duplication on /v1/messages

### DIFF
--- a/open-sse/providers/registry/anthropic.js
+++ b/open-sse/providers/registry/anthropic.js
@@ -1,5 +1,3 @@
-import { CLAUDE_API_HEADERS } from "../shared.js";
-
 export default {
   id: "anthropic",
   priority: 30,
@@ -19,7 +17,7 @@ export default {
     baseUrl: "https://api.anthropic.com/v1/messages",
     format: "claude",
     headers: {
-      "Anthropic-Version": "2023-06-01",
+      "anthropic-version": "2023-06-01",
       "Anthropic-Beta": "claude-code-20250219,interleaved-thinking-2025-05-14",
     },
   },


### PR DESCRIPTION
## Summary

Fixes #2357 — `POST /v1/messages` routed to an Anthropic API-key account fails with:
```
{"type":"error","error":{"type":"invalid_request_error","message":"anthropic-version: \"2023-06-01, 2023-06-01\" is not a valid version"}}
```

### Root cause

The `anthropic` provider registry (`open-sse/providers/registry/anthropic.js`) sets `"Anthropic-Version"` (Title-Case) in `transport.headers`. In `DefaultExecutor.buildHeaders()`, this gets spread into the outgoing headers object, then `applyAuth()` guards against a duplicate with:

```js
if (desc.anthropicVersion && !headers["anthropic-version"]) headers["anthropic-version"] = ANTHROPIC_API_VERSION;
```

JavaScript object lookup is case-sensitive, so `headers["anthropic-version"]` is `undefined` (the existing entry is under `"Anthropic-Version"`). The guard passes, a second lowercase copy is added, and Node/undici serialises both into `"2023-06-01, 2023-06-01"` on the wire.

This only manifests on `/v1/messages` because the native-Claude passthrough path skips request translation and goes straight to the executor. The `/v1/chat/completions` path goes through translation which resets the body and headers.

The `claude` provider is unaffected because its `claudeOverlay` hook explicitly normalises header casing before `applyAuth` runs, and its auth descriptor has no `anthropicVersion: true`.

### Fix

Lowercase the key in the registry so it matches what the guard checks:

```js
// before
"Anthropic-Version": "2023-06-01",

// after
"anthropic-version": "2023-06-01",
```

Also removes the unused `CLAUDE_API_HEADERS` import that was never referenced in this file.

## Test plan

- [x] Configure an Anthropic API-key account in the gateway
- [x] Send `POST /v1/messages` (e.g. from Claude Desktop or curl) — should succeed, no 400
- [x] Confirm `/v1/chat/completions` still works with the same account (no regression)
- [x] Run `cd tests && npx vitest run unit/` and verify no new failures vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)