### PR TITLE
fix(grok-cli): strip reasoning + cap tools for non-reasoning models

### DIFF
--- a/open-sse/executors/grok-cli.js
+++ b/open-sse/executors/grok-cli.js
@@ -9,6 +9,7 @@ import { normalizeResponsesInput } from "../translator/formats/responsesApi.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { getConsistentMachineId } from "../shared/machineId.js";
+import { getCapabilitiesForModel } from "../providers/capabilities.js";
 
 // Server-generated item id prefixes that /responses cannot resolve when store=false
 const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
@@ -305,6 +306,11 @@ export class GrokCliExecutor extends BaseExecutor {
     stripStoredItemReferences(body);
     normalizeGrokCliTools(body);
 
+    // xAI cli-chat-proxy enforces a maximum of 200 tools per request
+    if (Array.isArray(body.tools) && body.tools.length > 200) {
+      body.tools = body.tools.slice(0, 200);
+    }
+
     // Turn index after input is finalized (user-message count, monotonic per session)
     this._currentTurnIdx = resolveGrokCliTurnIdx(this._currentSessionId, body.input);
 
@@ -326,14 +332,20 @@ export class GrokCliExecutor extends BaseExecutor {
     this._currentModel = resolvedModel;
 
     // Reasoning effort priority: explicit > reasoning_effort > model suffix > default high
-    if (!body.reasoning || typeof body.reasoning !== "object") {
-      const effort = body.reasoning_effort || modelEffort || "high";
-      body.reasoning = { effort, summary: "concise" };
-    } else {
-      if (!body.reasoning.effort) {
-        body.reasoning.effort = body.reasoning_effort || modelEffort || "high";
+    // Non-reasoning models (grok-composer-2.5-fast, grok-build) must not send reasoning
+    const caps = getCapabilitiesForModel("grok-cli", resolvedModel);
+    if (caps.reasoning !== false) {
+      if (!body.reasoning || typeof body.reasoning !== "object") {
+        const effort = body.reasoning_effort || modelEffort || "high";
+        body.reasoning = { effort, summary: "concise" };
+      } else {
+        if (!body.reasoning.effort) {
+          body.reasoning.effort = body.reasoning_effort || modelEffort || "high";
+        }
+        if (!body.reasoning.summary) body.reasoning.summary = "concise";
       }
-      if (!body.reasoning.summary) body.reasoning.summary = "concise";
+    } else {
+      delete body.reasoning;
     }
     delete body.reasoning_effort;
 

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -96,6 +96,10 @@ export const MODEL_CAPABILITIES = {
   // Qwen plain coder/text (no vision) — registry "vision-model" / "coder-model" aliases
   "vision-model":      { vision: true, reasoning: true, thinkingFormat: "qwen", contextWindow: 1000000 },
   "coder-model":       { reasoning: true, thinkingFormat: "qwen", contextWindow: 1000000 },
+
+  // Grok CLI non-reasoning coding models (cli-chat-proxy.grok.com)
+  "grok-composer-2.5-fast": { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 200000, maxOutput: 30000 },
+  "grok-build":            { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 512000, maxOutput: 30000 },
 };
 
 /**
@@ -185,6 +189,9 @@ export const PATTERN_CAPABILITIES = [
 
   // ── Grok (vision + Live Search) ──────────────────────────────────
   { pattern: "*grok*image*",    caps: { imageOutput: true } },
+  // Non-reasoning Grok CLI coding models — must come before *grok* catch-all
+  { pattern: "*grok-composer*", caps: { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 200000, maxOutput: 30000 } },
+  { pattern: "*grok-build*",    caps: { vision: true, reasoning: false, search: false, thinkingFormat: null, contextWindow: 512000, maxOutput: 30000 } },
   { pattern: "*grok-code*",     caps: { reasoning: true, thinkingFormat: "openai", contextWindow: 256000 } },
   // Grok 4.5 (Grok CLI / Grok Build): 500k context per cli-chat-proxy /v1/models
   { pattern: "*grok-4.5*",      caps: { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 500000, maxOutput: 64000 } },


### PR DESCRIPTION
## Problem

`grok-composer-2.5-fast` and `grok-build` are non-reasoning coding models served via the Grok CLI OAuth provider (`cli-chat-proxy.grok.com`). Two bugs prevent them from working:

### Bug 1: `reasoningEffort` sent unconditionally

The grok-cli executor's `transformRequest()` always adds `body.reasoning = { effort: "high", summary: "concise" }` regardless of whether the model supports reasoning. The xAI API rejects this with:

```
HTTP 400: {"code":"invalid-argument","error":"Model grok-composer-2.5-fast does not support parameter reasoningEffort."}
```

The capabilities system also misclassifies these models: the `*grok*` catch-all pattern sets `reasoning: true` for all Grok models, with no specific override for composer/build.

### Bug 2: Tool count exceeds maximum

The xAI CLI proxy enforces a maximum of 200 tools per request. CLI tools like OpenCode send 200+ tools, causing:

```
HTTP 400: {"code":"invalid-argument","error":"Maximum tools limit reached. 206 tools have been provided but the maximum is 200."}
```

## Fix

### 1. Capabilities (`open-sse/providers/capabilities.js`)

- Added `MODEL_CAPABILITIES` exact-id entries for `grok-composer-2.5-fast` and `grok-build` with `reasoning: false`
- Added `PATTERN_CAPABILITIES` entries `*grok-composer*` and `*grok-build*` **before** the `*grok*` catch-all, so the thinking translator correctly strips reasoning fields

### 2. Executor (`open-sse/executors/grok-cli.js`)

- Imported `getCapabilitiesForModel` and guarded the reasoning block in `transformRequest()`: when `caps.reasoning === false`, `body.reasoning` is deleted entirely (and the subsequent `reasoning.encrypted_content` inclusion block naturally skips)
- Added tool count truncation after `normalizeGrokCliTools()`: if `body.tools.length > 200`, slice to 200

## Verification

Tested against the installed v0.5.30 bundled runtime:
- `grok-composer-2.5-fast` no longer sends `reasoning.effort` → no more 400 on `reasoningEffort`
- 206 tools from OpenCode truncated to 200 → no more 400 on tool count
- `grok-4.5` still sends reasoning as before (no regression)

Fixes #2538