### PR TITLE
fix: allow application/x-ndjson streaming from ollama-local (closes #2386)

### DIFF
--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -8,6 +8,7 @@ import { buildAbortedResponsesTerminalBytes } from "../../utils/responsesStreamH
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
+import { createErrorResult } from "../../utils/error.js";
 
 // Codex returns Responses API SSE → which client format to translate INTO, by request sourceFormat.
 // Gemini-family all map to ANTIGRAVITY decoder; unknown sources fall back to OPENAI.
@@ -59,8 +60,15 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
   // return a clean JSON error instead. The message is stripped of HTML tags
   // and clamped so untrusted upstream text never reaches the client verbatim
   // (the UI may render error.message as HTML).
+  //
+  // Ollama's native /api/chat streams as `application/x-ndjson` (raw JSON
+  // lines), never SSE — that's expected for targetFormat OLLAMA and is fully
+  // handled by the translate-mode transform stream below (parseSSELine +
+  // ollamaToOpenAIResponse, see translator/response/ollama-to-openai.js), so
+  // it must not be treated as an upstream error page (issue #2386).
   const upstreamContentType = (providerResponse.headers.get('content-type') || '').toLowerCase();
-  if (upstreamContentType && !upstreamContentType.includes('text/event-stream') && !upstreamContentType.includes('application/json')) {
+  const isExpectedOllamaNdjson = targetFormat === FORMATS.OLLAMA && upstreamContentType.includes('application/x-ndjson');
+  if (upstreamContentType && !isExpectedOllamaNdjson && !upstreamContentType.includes('text/event-stream') && !upstreamContentType.includes('application/json')) {
     const bodyText = await providerResponse.text().catch(() => '');
     const titleMatch = bodyText.match(/<title>([^<]+)<\/title>/i);
     const sanitizedTitle = (titleMatch?.[1] || '').replace(/<[^>]*>/g, '').replace(/[\r\n]+/g, ' ').trim().slice(0, 160);
@@ -70,13 +78,11 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
     if (log?.errorLine) log.errorLine(reqTag, "✗", `BLOCKED ${status} · ${provider}/${model} · non-SSE (${upstreamContentType})\n    ${shortMsg}`);
     else console.warn(`[STREAM] ${provider} | ${model} | blocked pipe: ${shortMsg} [${status}]`);
     streamController?.handleError?.(new Error(`upstream non-SSE: ${status}`));
-    return {
-      success: false,
-      response: new Response(JSON.stringify({ error: { message: `[${status}]: ${shortMsg}` } }), {
-        status,
-        headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' },
-      }),
-    };
+    // Use the shared error-result shape (status/error/response) so callers like
+    // handleSingleModelChat can correctly log and fall back — a locally built
+    // { success, response } object here silently drops status/error and causes
+    // the real cause to be lost downstream (see markAccountUnavailable).
+    return createErrorResult(status, `[${status}]: ${shortMsg}`);
   }
 
   const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey });

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -198,6 +198,22 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
 }
 
 /**
+ * Best-effort stringification of a non-string error value (Error without a
+ * usable .message, plain object, etc.) so the real cause can still be logged
+ * instead of silently collapsing to a generic placeholder.
+ * @param {*} err
+ * @returns {string}
+ */
+function safeStringifyError(err) {
+  if (err === null || err === undefined) return "";
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+/**
  * Mark account+model as unavailable — locks modelLock_${model} in DB.
  * All errors (429, 401, 5xx, etc.) lock per model, not per account.
  * @param {string} connectionId
@@ -224,7 +240,14 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   }
   if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
 
-  const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
+  // errorText is usually a string, but callers can pass an Error (or omit it
+  // entirely, e.g. when a caught exception isn't a string). Falling straight
+  // back to a generic "Provider error" without ever logging the real value
+  // hides the actual cause server-side (no status, no trace). Extract the
+  // best available message before giving up, and always log the raw cause.
+  const reason = typeof errorText === "string"
+    ? errorText.slice(0, 100)
+    : (errorText?.message || safeStringifyError(errorText) || "Provider error");
   const lockUpdate = buildModelLockUpdate(model, cooldownMs);
 
   await updateProviderConnection(connectionId, {
@@ -240,8 +263,11 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8);
   log.warn("AUTH", `${connName} locked ${lockKey} for ${Math.round(cooldownMs / 1000)}s [${status}]`);
 
-  if (provider && status && reason) {
-    console.error(`❌ ${provider} [${status}]: ${reason}`);
+  // Log the real cause even when there's no numeric HTTP status (e.g. a stream
+  // parsing crash rather than an upstream HTTP error) — a status-only gate here
+  // means non-HTTP failures never surface a usable server-side trace.
+  if (provider && reason) {
+    console.error(`❌ ${provider} [${status ?? "no-status"}]: ${reason}`);
   }
 
   return { shouldFallback: true, cooldownMs };

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -207,7 +207,8 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
 function safeStringifyError(err) {
   if (err === null || err === undefined) return "";
   try {
-    return JSON.stringify(err);
+    const json = JSON.stringify(err);
+    return typeof json === "string" ? json : String(err);
   } catch {
     return String(err);
   }
@@ -245,9 +246,10 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   // back to a generic "Provider error" without ever logging the real value
   // hides the actual cause server-side (no status, no trace). Extract the
   // best available message before giving up, and always log the raw cause.
-  const reason = typeof errorText === "string"
-    ? errorText.slice(0, 100)
+  const reasonRaw = typeof errorText === "string"
+    ? errorText
     : (errorText?.message || safeStringifyError(errorText) || "Provider error");
+  const reason = String(reasonRaw).slice(0, 100);
   const lockUpdate = buildModelLockUpdate(model, cooldownMs);
 
   await updateProviderConnection(connectionId, {
@@ -261,7 +263,7 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
 
   const lockKey = Object.keys(lockUpdate)[0];
   const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8);
-  log.warn("AUTH", `${connName} locked ${lockKey} for ${Math.round(cooldownMs / 1000)}s [${status}]`);
+  log.warn("AUTH", `${connName} locked ${lockKey} for ${Math.round(cooldownMs / 1000)}s [${status ?? "no-status"}]`);
 
   // Log the real cause even when there's no numeric HTTP status (e.g. a stream
   // parsing crash rather than an upstream HTTP error) — a status-only gate here


### PR DESCRIPTION
Closes #2386.

## Root cause

Ollama's native /api/chat streams as `application/x-ndjson`, never SSE. The non-SSE guard in `handleStreamingResponse` (open-sse/handlers/chatCore/streamingHandler.js) only special-cased `text/event-stream` and `application/json`, so any ndjson response from Ollama was treated as an upstream error page (e.g. a Cloudflare 5xx page) and blocked - before it ever reached the existing Ollama ndjson->SSE transcoder (parseSSELine + ollamaToOpenAIResponse). This matches the log captured in #2386 exactly: `blocked pipe: ... / upstream non-SSE: 200`.

`stream:false` always worked because it skips this streaming code path entirely - which is why the bug only shows up with clients that default to streaming (Cursor, Claude Code, etc).

While tracing this I found a second, related bug: when this (or any non-HTTP) error occurs, `markAccountUnavailable` (src/sse/services/auth.js) collapses the real error into a generic "Provider error" string whenever errorText isn't a plain string, and only logs to console when a numeric HTTP status is present. So a streaming-parse failure like this one left zero usable trace server-side - just the generic error surfaced to the client.

## Fix

- `streamingHandler.js`: let `application/x-ndjson` through the guard specifically when `targetFormat === FORMATS.OLLAMA`; reuse the shared `createErrorResult` helper for the remaining blocked-response path instead of a hand-built `{ success, response }` object, so status/error survive downstream.
- `auth.js`: extract `errorText.message` (or a JSON-stringified fallback) instead of defaulting straight to "Provider error", and log the real cause even when there's no numeric HTTP status.

## Testing

Repro'd locally against a real `ollama-local` connection (v0.5.18 and v0.5.30): `stream:true` requests to `ollama-local/*` models failed 100% of the time with the generic "Provider error" before this change, and succeeded consistently after, producing well-formed `chat.completion.chunk` SSE events ending in the usual `finish_reason`. Verified `stream:false` and non-Ollama streaming providers (tested against groq and mistral) are unaffected.

The repo's Vitest suite fails to run independent of this change (pre-existing circular import error, reproducible on an unmodified checkout), so I validated the transcode/guard logic with a standalone script driving the real production modules directly instead.