### PR TITLE
fix(headroom): allow larger prompt compression to finish

### DIFF
--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -5,7 +5,7 @@ import {
   openaiToOpenAIResponsesRequest,
 } from "../translator/request/openai-responses.js";
 
-const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_TIMEOUT_MS = 15000;
 
 function jsonBytes(value) {
   try {

--- a/tests/unit/headroom.test.js
+++ b/tests/unit/headroom.test.js
@@ -202,6 +202,22 @@ describe("compressWithHeadroom", () => {
     expect(stats).toBeNull();
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it("uses a 15s default timeout so large prompt compression can finish", async () => {
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({
+      messages: [{ role: "user", content: "short" }],
+      tokens_before: 100,
+      tokens_after: 20,
+      tokens_saved: 80,
+    }), { status: 200 }));
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => new AbortController().signal);
+    const body = { messages: [{ role: "user", content: "long" }] };
+
+    const stats = await compressWithHeadroom(body, { enabled: true, url: "http://localhost:8787" });
+
+    expect(stats.tokens_saved).toBe(80);
+    expect(timeoutSpy).toHaveBeenCalledWith(15000);
+  });
 });
 
 describe("formatHeadroomLog", () => {


### PR DESCRIPTION
## Problem

9router aborted Headroom `/v1/compress` after 3 seconds. Large local compression can take longer, so affected requests continued without compression.

## Change

Raise fail-open bridge timeout from 3s to 15s. Add regression test for default timeout.

## Scope

No routing, provider, OAuth, dashboard, or retry behavior changed. If compression exceeds 15s, 9router keeps existing fail-open behavior and sends original request.

## Test

`npx vitest run tests/unit/headroom.test.js`