### PR TITLE
fix(openai): route GPT-5.6 Sol tools through Responses API

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -116,7 +116,7 @@ export class DefaultExecutor extends BaseExecutor {
   }
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {
-    // Runtime transport (multi-endpoint providers): use the sourceFormat-matched endpoint
+    // Runtime transport (multi-endpoint providers): use the resolved endpoint.
     const rt = credentials?.runtimeTransport;
     if (rt?.baseUrl) {
       return rt.urlSuffix ? `${rt.baseUrl}${rt.urlSuffix}` : rt.baseUrl;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -58,8 +58,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);
-  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation
-  const runtimeTransport = resolveTransport(provider, sourceFormat);
+  // Multi-endpoint providers: model-required formats override client format.
+  // GPT-5.6 tool calls with reasoning must use OpenAI Responses, even when the
+  // client sends Chat Completions format.
+  const runtimeTransport = resolveTransport(provider, modelTargetFormat || sourceFormat);
   const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider);
   if (runtimeTransport && credentials) credentials.runtimeTransport = runtimeTransport;
   const stripList = getModelStrip(alias, model);

--- a/open-sse/providers/registry/openai.js
+++ b/open-sse/providers/registry/openai.js
@@ -27,7 +27,14 @@ export default {
     baseUrl: "https://api.openai.com/v1/chat/completions",
     forceStream: true,
   },
+  // GPT-5.6 tool calls with reasoning require the Responses API.
+  transports: [
+    { format: "openai", baseUrl: "https://api.openai.com/v1/chat/completions" },
+    { format: "openai-responses", baseUrl: "https://api.openai.com/v1/responses" },
+  ],
   models: [
+    { id: "gpt-5.6", name: "GPT-5.6", targetFormat: "openai-responses" },
+    { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", targetFormat: "openai-responses" },
     { id: "gpt-5.4", name: "GPT-5.4" },
     { id: "gpt-5.4-mini", name: "GPT-5.4 Mini" },
     { id: "gpt-5.4-nano", name: "GPT-5.4 Nano" },

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -136,14 +136,14 @@ export function getTargetFormat(provider) {
   return config.format || "openai";
 }
 
-// Resolve which transport to use for a provider given the client sourceFormat.
-// Multi-endpoint providers (transport.transports[]) pick the entry matching sourceFormat
-// to avoid lossy translation; falls back to the default transport when no match.
-export function resolveTransport(provider, sourceFormat) {
+// Resolve which transport to use for a provider and required wire format.
+// Callers usually pass client sourceFormat to avoid translation, but a model may require
+// a different target format (for example, OpenAI GPT-5.6 Responses).
+export function resolveTransport(provider, format) {
   const config = PROVIDERS[provider];
   const transports = config?.transports;
   if (!Array.isArray(transports) || !transports.length) return null;
-  return transports.find(t => t.format === sourceFormat) || null;
+  return transports.find(t => t.format === format) || null;
 }
 
 // Check if last message is from user

--- a/tests/unit/openai-gpt56-responses-routing.test.js
+++ b/tests/unit/openai-gpt56-responses-routing.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+import { getModelTargetFormat } from "../../open-sse/config/providerModels.js";
+import { resolveTransport } from "../../open-sse/services/provider.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+
+describe("OpenAI GPT-5.6 Responses routing", () => {
+  it("routes GPT-5.6 models to Responses while GPT-5.4 stays on Chat Completions", () => {
+    const responsesFormat = getModelTargetFormat("openai", "gpt-5.6-sol");
+    expect(responsesFormat).toBe(FORMATS.OPENAI_RESPONSES);
+    expect(getModelTargetFormat("openai", "gpt-5.4")).toBeNull();
+
+    const responsesTransport = resolveTransport("openai", responsesFormat);
+    expect(responsesTransport?.baseUrl).toBe("https://api.openai.com/v1/responses");
+    expect(resolveTransport("openai", FORMATS.OPENAI)?.baseUrl)
+      .toBe("https://api.openai.com/v1/chat/completions");
+
+    const executor = new DefaultExecutor("openai");
+    expect(executor.buildUrl("gpt-5.6-sol", true, 0, { runtimeTransport: responsesTransport }))
+      .toBe("https://api.openai.com/v1/responses");
+  });
+
+  it("converts Chat Completions tools and reasoning effort into Responses payload", () => {
+    const result = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI_RESPONSES,
+      "gpt-5.6-sol",
+      {
+        model: "openai/gpt-5.6-sol",
+        messages: [{ role: "user", content: "Check weather in Manado." }],
+        reasoning_effort: "high",
+        tools: [{
+          type: "function",
+          function: {
+            name: "weather",
+            description: "Get weather.",
+            parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] },
+          },
+        }],
+      },
+      true,
+      null,
+      "openai",
+    );
+
+    expect(result.input).toEqual([expect.objectContaining({
+      type: "message",
+      role: "user",
+      content: [expect.objectContaining({ type: "input_text", text: "Check weather in Manado." })],
+    })]);
+    expect(result.reasoning_effort).toBe("high");
+    expect(result.tools).toEqual([expect.objectContaining({ type: "function", name: "weather" })]);
+  });
+
+  it("converts tool calls and results for a Responses follow-up", () => {
+    const result = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI_RESPONSES,
+      "gpt-5.6-sol",
+      {
+        model: "openai/gpt-5.6-sol",
+        messages: [
+          { role: "user", content: "Check weather in Manado." },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [{
+              id: "call_weather",
+              type: "function",
+              function: { name: "weather", arguments: "{\"city\":\"Manado\"}" },
+            }],
+          },
+          { role: "tool", tool_call_id: "call_weather", content: "Rain, 28°C" },
+        ],
+      },
+      true,
+      null,
+      "openai",
+    );
+
+    expect(result.input).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "function_call", call_id: "call_weather", name: "weather" }),
+      expect.objectContaining({ type: "function_call_output", call_id: "call_weather", output: "Rain, 28°C" }),
+    ]));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes OpenAI API-key requests for `gpt-5.6` and `gpt-5.6-sol` when they use reasoning and function tools.

Closes #2540.

## Problem

Requests sent to `openai/gpt-5.6-sol` were always posted to OpenAI Chat Completions (`/v1/chat/completions`). When a client sent `reasoning_effort` together with function tools, OpenAI rejected the request because this GPT-5.6 workflow requires the Responses API (`/v1/responses`).

The issue only affects the OpenAI API-key provider. Codex already has its own Responses transport.

## Root Cause

9Router already has an `openai` to `openai-responses` request translator. It converts:

- Chat Completions messages into Responses `input` items;
- function definitions into Responses `function` tools;
- assistant tool calls and tool results into `function_call` and `function_call_output` items.

However, the OpenAI registry only exposed the Chat Completions endpoint, and runtime transport selection preferred the client source format. A model-specific `targetFormat: "openai-responses"` therefore did not change the upstream URL by itself.

## Fix

- Register `gpt-5.6` and `gpt-5.6-sol` in the OpenAI provider with `targetFormat: "openai-responses"`.
- Add OpenAI transports for both Chat Completions and Responses endpoints.
- Resolve runtime transport from the model-required target format when one is configured, while preserving client-format routing for all other models.
- Update stale routing comments to reflect this intentional model override.

## Tests

Added regression coverage for:

- `gpt-5.6-sol` selecting `https://api.openai.com/v1/responses`;
- GPT-5.4 remaining on `https://api.openai.com/v1/chat/completions`;
- translation of `reasoning_effort` and function definitions to Responses format;
- multi-turn conversion of a function call and its function output.

Validation run locally:

- Manual module-level route and translation assertion passed for endpoint selection, reasoning, function definitions, function calls, and function outputs.
- `node --check` passed for all changed JavaScript files.
- `git diff --check` passed.

The repository Vitest command could not run in this checkout because `tests/package.json` hardcodes `/tmp/node_modules/.bin/vitest`, which is absent.
