### PR TITLE
fix(combos): disable circular combo selections

### DIFF
--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -647,6 +647,7 @@ function ComboFormModal({ isOpen, combo, onClose, onSave, activeProviders, kindF
           kindFilter={kindFilter}
           addedModelValues={models}
           closeOnSelect={false}
+          comboContext={{ id: combo?.id, name: name.trim() }}
         />
       )}
     </>

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -20,6 +20,37 @@ const PROVIDER_ORDER = [
 // Providers that need no auth — always show in model selector
 const NO_AUTH_PROVIDER_IDS = Object.keys(FREE_PROVIDERS).filter(id => FREE_PROVIDERS[id].noAuth);
 
+function getCircularComboNames(combos, comboContext) {
+  const targetName = comboContext?.name?.trim();
+  const targetId = comboContext?.id;
+  if (!targetName && !targetId) return new Set();
+
+  const graph = new Map(
+    combos
+      .filter((combo) => combo.id !== targetId)
+      .map((combo) => [combo.name, Array.isArray(combo.models) ? combo.models : []])
+  );
+
+  const reachesTarget = (name, visiting = new Set()) => {
+    if (targetName && name === targetName) return true;
+    if (visiting.has(name)) return false;
+
+    const models = graph.get(name);
+    if (!models) return false;
+
+    visiting.add(name);
+    const reaches = models.some((model) => reachesTarget(model, visiting));
+    visiting.delete(name);
+    return reaches;
+  };
+
+  return new Set(
+    combos
+      .filter((combo) => combo.id === targetId || reachesTarget(combo.name))
+      .map((combo) => combo.name)
+  );
+}
+
 export default function ModelSelectModal({
   isOpen,
   onClose,
@@ -32,6 +63,7 @@ export default function ModelSelectModal({
   kindFilter = null,
   addedModelValues = [],
   closeOnSelect = true,
+  comboContext = null,
 }) {
   // Filter activeProviders by serviceKinds when kindFilter set (e.g. "webSearch", "webFetch")
   const filteredActiveProviders = useMemo(() => {
@@ -403,6 +435,8 @@ export default function ModelSelectModal({
     return combos.filter(c => c.name.toLowerCase().includes(query));
   }, [combos, searchQuery, kindFilter]);
 
+  const circularComboNames = getCircularComboNames(combos, comboContext);
+
   // Sort models alphabetically, with added models floated to top
   const sortModels = (models) => {
     const added = models.filter(m => addedModelValues.includes(m.value)).sort((a, b) => a.name.localeCompare(b.name));
@@ -498,21 +532,29 @@ export default function ModelSelectModal({
             <div className="flex flex-wrap gap-1.5">
               {filteredCombos.map((combo) => {
                 const isSelected = selectedModel === combo.name;
+                const isAdded = addedModelValues.includes(combo.name);
+                const isDisabled = !isAdded && circularComboNames.has(combo.name);
                 return (
                   <button
                     key={combo.id}
+                    disabled={isDisabled}
                     onClick={() => handleSelect({ id: combo.name, name: combo.name, value: combo.name })}
+                    title={isDisabled ? "Selecting this combo would create a circular reference" : undefined}
                     className={`
-                      px-2 py-1 rounded-xl text-xs font-medium transition-all border hover:cursor-pointer flex items-center gap-1
-                      ${isSelected
+                      px-2 py-1 rounded-xl text-xs font-medium transition-all border flex items-center gap-1
+                      ${isDisabled
+                        ? "bg-surface border-border text-text-muted opacity-50 cursor-not-allowed"
+                        : isSelected
                         ? "bg-primary text-white border-primary"
-                        : addedModelValues.includes(combo.name)
+                        : isAdded
                           ? "bg-primary border-primary text-white hover:bg-primary-hover"
-                          : "bg-surface border-border text-text-main hover:border-primary/50 hover:bg-primary/5"
+                          : "bg-surface border-border text-text-main hover:border-primary/50 hover:bg-primary/5 hover:cursor-pointer"
                       }
                     `}
                   >
-                    {addedModelValues.includes(combo.name) && (
+                    {isDisabled ? (
+                      <span className="material-symbols-outlined leading-none" style={{ fontSize: "10px" }}>block</span>
+                    ) : isAdded && (
                       <span className="material-symbols-outlined leading-none" style={{ fontSize: "10px" }}>check</span>
                     )}
                     {combo.name}
@@ -622,4 +664,8 @@ ModelSelectModal.propTypes = {
   kindFilter: PropTypes.string,
   addedModelValues: PropTypes.arrayOf(PropTypes.string),
   closeOnSelect: PropTypes.bool,
+  comboContext: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string,
+  }),
 };


### PR DESCRIPTION
## Summary
- disable selecting the combo currently being edited
- disable combos that transitively reference the current combo
- keep already-selected combos clickable so invalid references can still be removed

## Why
Selecting a combo that references the current combo creates a circular resolution chain and can recurse indefinitely. This prevents the cycle at the model-picker entry point without changing API or runtime behavior.

## Validation
- `DATA_DIR=/tmp/9router-combo-cycle-pr-data npm run build`