### PR TITLE
feat(providers): add random-available connection strategy

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -382,12 +382,13 @@ export default function ProviderDetailPage() {
     }
   };
 
-  const handleRoundRobinToggle = (enabled) => {
-    const strategy = enabled ? "round-robin" : null;
-    const sticky = enabled ? (providerStickyLimit || "1") : providerStickyLimit;
-    if (enabled && !providerStickyLimit) setProviderStickyLimit("1");
-    setProviderStrategy(strategy);
-    saveProviderStrategy(strategy, sticky);
+  const handleStrategyChange = (strategy) => {
+    // "priority" means no override (use default fill-first)
+    const normalizedStrategy = strategy === "priority" ? null : strategy;
+    const sticky = strategy === "round-robin" ? (providerStickyLimit || "1") : providerStickyLimit;
+    if (strategy === "round-robin" && !providerStickyLimit) setProviderStickyLimit("1");
+    setProviderStrategy(normalizedStrategy);
+    saveProviderStrategy(normalizedStrategy, sticky);
   };
 
   const handleStickyLimitChange = (value) => {
@@ -1425,12 +1426,18 @@ export default function ProviderDetailPage() {
                   )}
                 </>
               )}
-              {/* Round Robin toggle */}
+              {/* Strategy Selector */}
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-xs text-text-muted font-medium">Round Robin</span>
-                <Toggle
-                  checked={providerStrategy === "round-robin"}
-                  onChange={handleRoundRobinToggle}
+                <span className="text-xs text-text-muted font-medium">Strategy:</span>
+                <Select
+                  value={providerStrategy || "priority"}
+                  onChange={(e) => handleStrategyChange(e.target.value)}
+                  size="sm"
+                  options={[
+                    { value: "priority", label: "Priority" },
+                    { value: "round-robin", label: "Round Robin" },
+                    { value: "random-available", label: "Random Available" }
+                  ]}
                 />
                 {providerStrategy === "round-robin" && (
                   <div className="flex items-center gap-1.5">

--- a/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
@@ -404,15 +404,22 @@ export default function ConnectionsCard({ providerId, isOAuth }) {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
           <h2 className="text-lg font-semibold">Connections</h2>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-xs text-text-muted font-medium">Round Robin</span>
-            <Toggle
-              checked={providerStrategy === "round-robin"}
-              onChange={(enabled) => {
-                const strategy = enabled ? "round-robin" : null;
+            <span className="text-xs text-text-muted font-medium">Strategy:</span>
+            <Select
+              value={providerStrategy || "priority"}
+              onChange={(e) => {
+                const strategy = e.target.value === "priority" ? null : e.target.value;
                 setProviderStrategy(strategy);
-                if (enabled && !providerStickyLimit) setProviderStickyLimit("1");
-                saveStrategy(strategy, enabled ? (providerStickyLimit || "1") : providerStickyLimit);
+                if (e.target.value === "round-robin" && !providerStickyLimit) setProviderStickyLimit("1");
+                const sticky = e.target.value === "round-robin" ? (providerStickyLimit || "1") : providerStickyLimit;
+                saveStrategy(strategy, sticky);
               }}
+              size="sm"
+              options={[
+                { value: "priority", label: "Priority" },
+                { value: "round-robin", label: "Round Robin" },
+                { value: "random-available", label: "Random Available" }
+              ]}
             />
             {providerStrategy === "round-robin" && (
               <div className="flex flex-wrap items-center gap-1.5">

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -119,6 +119,27 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
     }
     if (connection) {
       // skip strategy
+    } else if (strategy === "random-available") {
+      // Random selection from healthy (active/success) connections
+      // availableConnections already filtered out locked ones, so treat "unavailable" as "active"
+      const getEffectiveStatus = (c) => {
+        return c.testStatus === "unavailable" ? "active" : c.testStatus;
+      };
+
+      const healthyConnections = availableConnections.filter(c => {
+        const status = getEffectiveStatus(c);
+        return status === "active" || status === "success";
+      });
+
+      if (healthyConnections.length > 0) {
+        const randomIndex = Math.floor(Math.random() * healthyConnections.length);
+        connection = healthyConnections[randomIndex];
+        log.info("AUTH", `${provider} | random-available: picked ${connection.id?.slice(0, 8)} (${healthyConnections.length} healthy of ${availableConnections.length} available)`);
+      } else {
+        // Fallback to priority order if no healthy connections
+        connection = availableConnections[0];
+        log.warn("AUTH", `${provider} | random-available: no healthy connections, fallback to priority (${connection.testStatus})`);
+      }
     } else if (strategy === "round-robin") {
       const stickyLimit = providerOverride.stickyRoundRobinLimit || settings.stickyRoundRobinLimit || 3;
 


### PR DESCRIPTION
## Summary
Adds "Random Available" connection strategy for fair load distribution across healthy connections.

## Problem Solved
- Priority mode always uses connection #1 → unfair load distribution
- Need random selection from available connections only (not from all)
- Should skip error/unavailable connections

## Solution
Replace Round Robin toggle with Strategy selector dropdown:
- **Priority** (default) - uses priority 1, 2, 3... sequentially
- **Round Robin** - rotates with sticky count (existing behavior)
- **Random Available** (NEW) - randomly picks from healthy connections (testStatus: active/success)

## Implementation
**Backend** (`src/sse/services/auth.js`):
- Add `random-available` strategy in `getProviderCredentials()`
- Filter connections by effective testStatus (active/success)
- Random pick from healthy pool
- Fallback to priority order if no healthy connections
- Logging for debugging

**UI** (`[id]/page.js`, `ConnectionsCard.js`):
- Replace Round Robin toggle with Strategy Select dropdown
- 3 options with clear labels
- Keep Sticky input conditional on Round Robin mode
- Consistent behavior across provider detail and media-providers pages

## Testing
Tested with cloudflare-ai provider (2 connections):
- ✅ Random selection working - log shows `random-available: picked <id> (2 healthy of 2 available)`
- ✅ UI dropdown renders correctly with 3 options
- ✅ Settings persist across page refreshes
- ✅ Fallback behavior (no healthy connections → priority order)

## Log Evidence
```
[AUTH] cloudflare-ai | random-available: picked 80216756 (2 healthy of 2 available)
```

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)