### PR TITLE
feat(providers): add reorder connections by availability button

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -804,6 +804,43 @@ export default function ProviderDetailPage() {
     }
   };
 
+  const handleReorderByStatus = async () => {
+    const getEffectiveStatus = (conn) => {
+      const isCooldown = Object.entries(conn).some(
+        ([k, v]) => k.startsWith("modelLock_") && v && new Date(v).getTime() > Date.now()
+      );
+      return conn.testStatus === "unavailable" && !isCooldown ? "active" : conn.testStatus;
+    };
+
+    const sorted = [...connections].sort((a, b) => {
+      const statusA = getEffectiveStatus(a);
+      const statusB = getEffectiveStatus(b);
+      const availableA = statusA === "active" || statusA === "success";
+      const availableB = statusB === "active" || statusB === "success";
+
+      if (availableA && !availableB) return -1;
+      if (!availableA && availableB) return 1;
+      return 0;
+    });
+
+    setConnections(sorted);
+
+    try {
+      await Promise.all(
+        sorted.map((conn, idx) =>
+          fetch(`/api/providers/${conn.id}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ priority: idx }),
+          })
+        )
+      );
+    } catch (error) {
+      console.log("Error reordering by status:", error);
+      await fetchConnections();
+    }
+  };
+
   const selectedConnections = connections.filter((conn) => selectedConnectionIds.includes(conn.id));
   const allSelected = connections.length > 0 && selectedConnectionIds.length === connections.length;
 
@@ -1424,6 +1461,17 @@ export default function ProviderDetailPage() {
                     </Button>
                   )}
                 </>
+              )}
+              {connections.length > 1 && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  icon="swap_vert"
+                  onClick={handleReorderByStatus}
+                  title="Reorder by availability status"
+                >
+                  Reorder
+                </Button>
               )}
               {/* Round Robin toggle */}
               <div className="flex flex-wrap items-center gap-2">

--- a/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js
@@ -396,6 +396,42 @@ export default function ConnectionsCard({ providerId, isOAuth }) {
     } catch (e) { console.log("update connection error:", e); }
   };
 
+  const handleReorderByStatus = async () => {
+    const getEffectiveStatus = (conn) => {
+      const isCooldown = Object.entries(conn).some(
+        ([k, v]) => k.startsWith("modelLock_") && v && new Date(v).getTime() > Date.now()
+      );
+      return conn.testStatus === "unavailable" && !isCooldown ? "active" : conn.testStatus;
+    };
+
+    const sorted = [...connections].sort((a, b) => {
+      const statusA = getEffectiveStatus(a);
+      const statusB = getEffectiveStatus(b);
+      const availableA = statusA === "active" || statusA === "success";
+      const availableB = statusB === "active" || statusB === "success";
+
+      if (availableA && !availableB) return -1;
+      if (!availableA && availableB) return 1;
+      return 0;
+    });
+
+    setConnections(sorted);
+
+    try {
+      await Promise.all(
+        sorted.map((conn, idx) =>
+          fetch(`/api/providers/${conn.id}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ priority: idx }),
+          })
+        )
+      );
+    } catch {
+      await fetch_();
+    }
+  };
+
   if (loading) return <Card><div className="h-20 animate-pulse bg-black/5 rounded-lg" /></Card>;
 
   return (
@@ -404,6 +440,17 @@ export default function ConnectionsCard({ providerId, isOAuth }) {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
           <h2 className="text-lg font-semibold">Connections</h2>
           <div className="flex flex-wrap items-center gap-2">
+            {connections.length > 1 && (
+              <Button
+                size="sm"
+                variant="secondary"
+                icon="swap_vert"
+                onClick={handleReorderByStatus}
+                title="Reorder by availability status"
+              >
+                Reorder
+              </Button>
+            )}
             <span className="text-xs text-text-muted font-medium">Round Robin</span>
             <Toggle
               checked={providerStrategy === "round-robin"}


### PR DESCRIPTION
## Summary
Adds "Reorder" button to Connections card that automatically sorts connections by availability status.

## Problem Solved
Manual reordering via up/down arrows is tedious when you have many connections and want to prioritize available ones.

## Solution
Add "Reorder" button that:
- Sorts connections by `testStatus`
- **Available** (`active`/`success`) → move to top
- **Unavailable** (`error`/`expired`/`unavailable`/`unknown`) → move to bottom
- Preserves relative order within each group (stable sort)
- Updates priorities via API and persists changes

## Implementation

**UI Changes:**
- `src/app/(dashboard)/dashboard/providers/[id]/page.js` - provider detail page
- `src/app/(dashboard)/dashboard/providers/components/ConnectionsCard.js` - media-providers page

Added:
- "Reorder" button (Material icon: `swap_vert`)
- Only shows when provider has 2+ connections
- Placed between action buttons and strategy selector

**Logic:**
```javascript
// Uses same effectiveStatus logic as ConnectionRow
const getEffectiveStatus = (conn) => {
  const isCooldown = modelLock check
  return conn.testStatus === 'unavailable' && !isCooldown ? 'active' : conn.testStatus;
};

// Sort: available first, unavailable last
sorted.sort((a, b) => {
  const availableA = status === 'active' || status === 'success';
  const availableB = status === 'active' || status === 'success';
  if (availableA && !availableB) return -1;
  if (!availableA && availableB) return 1;
  return 0; // stable sort
});

// Update priorities via API
await Promise.all(sorted.map((conn, idx) => 
  PUT /api/providers/${conn.id} { priority: idx }
));
```

## Testing
- ✅ Button appears when 2+ connections exist
- ✅ Available connections move to top after click
- ✅ Priority numbers (#1, #2, #3) update correctly
- ✅ Order persists after page refresh
- ✅ Error handling: reverts to server state on API failure
- ✅ Works on both provider detail page and media-providers page

## UI Screenshot
Button location: After "Test Connection One-by-One", before "Strategy" selector

```
[Apply Proxy] [Delete Selected] [Test Connection] [Reorder] [Strategy: ▼] [Sticky: 1]
```

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)