### PR TITLE
feat(token-saver): add aggregate Token Saver dashboard

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -22,7 +22,7 @@ import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
 import { injectPonytail } from "../rtk/ponytail.js";
 import { compressMessages } from "../rtk/index.js";
-import { compressWithHeadroom, formatHeadroomSizeLog, isHeadroomPhantomSavings } from "../rtk/headroom.js";
+import { classifyHeadroomDiagnostic, compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog, isHeadroomPhantomSavings } from "../rtk/headroom.js";
 import { compressWithPxpipe } from "../rtk/pxpipe.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
@@ -37,7 +37,7 @@ import { resolveSessionId } from "../utils/sessionManager.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, onTokenSaverEvent, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -207,6 +207,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     const delta = headroomStats.tokens_saved || 0;
     const pct = before > 0 ? ((delta / before) * 100).toFixed(1) : "0";
     xf.push(`HEADROOM −${delta}tok(${pct}%)`);
+    log?.info?.("HEADROOM", `${formatHeadroomLog(headroomStats)} | ${formatHeadroomSizeLog(headroomDiagnostics)}`);
     if (isHeadroomPhantomSavings(headroomStats, headroomDiagnostics)) {
       log?.warn?.("HEADROOM", `reported token delta, but outbound JSON shrank <5%; provider may bill near-original payload | ${formatHeadroomSizeLog(headroomDiagnostics)}`);
     }
@@ -240,6 +241,35 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   if (xf.length && log?.line) log.line(reqTag, "⚙", xf.join(" · "));
+
+  const headroomState = headroomStats ? "compressed" : headroomEnabled ? "skipped" : "disabled";
+  const headroomPhantomSavings = isHeadroomPhantomSavings(headroomStats, headroomDiagnostics);
+
+  // Hand the telemetry payload to the caller. The caller decides when to persist
+  // it — chat.js fires exactly once after the final routing attempt so account
+  // fallback retries don't double-count. Fail-open: never break the request path.
+  if (onTokenSaverEvent) {
+    try {
+      onTokenSaverEvent({
+        requestsObserved: 1,
+        rtkRequestsWithHits: rtkStats?.hits?.length ? 1 : 0,
+        rtkHits: rtkStats?.hits?.length || 0,
+        rtkBytesBefore: rtkStats?.bytesBefore || 0,
+        rtkBytesAfter: rtkStats?.bytesAfter || 0,
+        rtkBytesSaved: Math.max(0, (rtkStats?.bytesBefore || 0) - (rtkStats?.bytesAfter || 0)),
+        headroomState,
+        headroomDiagnostic: headroomState === "skipped" ? classifyHeadroomDiagnostic(headroomDiagnostics, null, true) : null,
+        headroomTokensBefore: headroomStats?.tokens_before || 0,
+        headroomTokensAfter: headroomStats?.tokens_after || 0,
+        headroomTokensSaved: headroomStats?.tokens_saved || 0,
+        headroomBodyBytesBefore: headroomDiagnostics.before?.bodyBytes || 0,
+        headroomBodyBytesAfter: headroomDiagnostics.after?.bodyBytes || 0,
+        headroomMessageBytesBefore: headroomDiagnostics.before?.messageBytes || 0,
+        headroomMessageBytesAfter: headroomDiagnostics.after?.messageBytes || 0,
+        headroomPhantomSavings: headroomPhantomSavings ? 1 : 0,
+      });
+    } catch { /* observability must not break requests */ }
+  }
 
   const executor = getExecutor(provider);
   trackPendingRequest(model, provider, connectionId, true);

--- a/open-sse/handlers/responsesHandler.js
+++ b/open-sse/handlers/responsesHandler.js
@@ -8,6 +8,7 @@ import { convertResponsesApiFormat } from "../translator/formats/responsesApi.js
 import { createResponsesApiTransformStream } from "../transformer/responsesTransformer.js";
 import { convertResponsesStreamToJson } from "../transformer/streamToJsonConverter.js";
 import { SSE_HEADERS_CORS } from "../utils/sseConstants.js";
+import { recordTokenSaverEvent } from "@/lib/usageDb.js";
 
 /**
  * Handle /v1/responses request
@@ -34,6 +35,7 @@ export async function handleResponsesCore({ body, modelInfo, credentials, log, o
   }
 
   // Call chat core handler — force sourceFormat so streaming path knows this is a Responses API client
+  let lastTokenSaverEvent = null;
   const result = await handleChatCore({
     body: convertedBody,
     modelInfo,
@@ -43,8 +45,13 @@ export async function handleResponsesCore({ body, modelInfo, credentials, log, o
     onRequestSuccess,
     onDisconnect,
     connectionId,
-    sourceFormatOverride: "openai-responses"
+    sourceFormatOverride: "openai-responses",
+    onTokenSaverEvent: (evt) => { lastTokenSaverEvent = evt; }
   });
+
+  if (lastTokenSaverEvent) {
+    try { Promise.resolve(recordTokenSaverEvent(lastTokenSaverEvent)).catch(() => {}); } catch { /* observability must not break requests */ }
+  }
 
   if (!result.success || !result.response) {
     return result;

--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -273,7 +273,10 @@ export async function compressWithHeadroom(body, { enabled, url, model, format, 
         return null;
       }
       const oai = openaiResponsesToOpenAIRequest(model, body, false);
-      if (!Array.isArray(oai?.messages)) return null;
+      if (!Array.isArray(oai?.messages)) {
+        setDiagnostic(diagnostics, "Responses request did not translate to messages[]");
+        return null;
+      }
       const data = await callCompress(url, oai.messages, model, timeoutMs, compressUserMessages, diagnostics || {});
       if (!data) return null;
       // input: undefined so the translator rebuilds input from the compressed
@@ -321,6 +324,22 @@ export async function compressWithHeadroom(body, { enabled, url, model, format, 
     setDiagnostic(diagnostics, `unexpected error: ${error?.message || String(error)}`);
     return null;
   }
+}
+
+export function classifyHeadroomDiagnostic(diagnostics, stats, enabled) {
+  if (stats) return "compressed";
+  if (!enabled) return "disabled";
+
+  const reason = String(diagnostics?.reason || "").toLowerCase();
+  if (reason.includes("missing proxy url")) return "missing-proxy-url";
+  if (reason.includes("timeout") || reason.includes("abort")) return "timeout";
+  if (reason.includes("proxy returned http")) return "http-error";
+  if (reason.includes("openai-responses tool/reasoning")) return "unsafe-responses-input";
+  if (reason.includes("did not translate") || reason.includes("translate to messages")) return "translation-failed";
+  if (reason.includes("unsupported") || reason.includes("did not project")) return "unsupported-shape";
+  if (reason.includes("proxy response")) return "invalid-proxy-response";
+  if (reason.includes("unexpected error")) return "unexpected-error";
+  return "other-skip";
 }
 
 export function formatHeadroomLog(stats) {

--- a/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
+++ b/src/app/(dashboard)/dashboard/token-saver/TokenSaverClient.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Card, Button, Input, Modal, Toggle, ConfirmModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+import TokenSaverOverview from "./components/TokenSaverOverview";
 import { getCurrentLocale, onLocaleChange } from "@/i18n/runtime";
 import {
   WENYAN_LOCALES,
@@ -11,6 +12,7 @@ import {
 } from "../endpoint/endpointConstants";
 
 export default function TokenSaverClient() {
+  const [tab, setTab] = useState("overview");
   const [rtkEnabled, setRtkEnabledState] = useState(true);
   const [headroomEnabled, setHeadroomEnabled] = useState(false);
   const [headroomUrl, setHeadroomUrl] = useState("http://localhost:8787");
@@ -466,6 +468,22 @@ export default function TokenSaverClient() {
 
   return (
     <div className="space-y-6 p-6">
+      <div className="flex w-fit rounded-lg border border-border bg-surface-2 p-1">
+        <button
+          onClick={() => setTab("overview")}
+          className={`rounded-md px-4 py-1.5 text-sm font-medium ${tab === "overview" ? "bg-primary text-white" : "text-text-muted hover:text-text"}`}
+        >
+          Overview
+        </button>
+        <button
+          onClick={() => setTab("settings")}
+          className={`rounded-md px-4 py-1.5 text-sm font-medium ${tab === "settings" ? "bg-primary text-white" : "text-text-muted hover:text-text"}`}
+        >
+          Settings
+        </button>
+      </div>
+
+      {tab === "overview" ? <TokenSaverOverview /> : <>
       <Card id="rtk">
         <div className="flex items-center justify-between mb-2">
           <h2 className="text-lg font-semibold flex items-center gap-2">
@@ -1010,6 +1028,7 @@ export default function TokenSaverClient() {
         confirmText={extrasConfirm?.confirmText}
         variant={extrasConfirm?.variant}
       />
+      </>}
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/token-saver/components/TokenSaverOverview.js
+++ b/src/app/(dashboard)/dashboard/token-saver/components/TokenSaverOverview.js
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { Card } from "@/shared/components";
+
+const PERIODS = [
+  ["today", "Today"],
+  ["7d", "7D"],
+  ["30d", "30D"],
+  ["60d", "60D"],
+  ["365d", "365D"],
+];
+
+const bytes = (value) => {
+  const n = Number(value) || 0;
+  if (n >= 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+};
+
+const number = (value) => new Intl.NumberFormat().format(Number(value) || 0);
+
+function StatCard({ label, value, detail, tone = "text-text" }) {
+  return (
+    <Card className="p-4">
+      <p className="text-xs font-medium uppercase tracking-wide text-text-muted">{label}</p>
+      <p className={`mt-2 text-2xl font-semibold ${tone}`}>{value}</p>
+      <p className="mt-1 text-xs text-text-muted">{detail}</p>
+    </Card>
+  );
+}
+
+export default function TokenSaverOverview() {
+  const [period, setPeriod] = useState("30d");
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const stream = new EventSource(`/api/token-saver/stream?period=${period}`);
+    stream.onerror = () => setLoading(false);
+    stream.onmessage = (event) => {
+      try {
+        setStats(JSON.parse(event.data));
+        setLoading(false);
+      } catch {}
+    };
+    return () => stream.close();
+  }, [period]);
+
+  const rtk = stats?.rtk || {};
+  const headroom = stats?.headroom || {};
+  const points = (stats?.dailyPoints || []).map((point) => ({
+    ...point,
+    label: new Date(`${point.dateKey}T00:00:00`).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+  }));
+  const skipReasons = Object.entries(headroom.skipReasons || {}).sort((a, b) => b[1] - a[1]);
+  const isEmpty = !stats?.requestsObserved;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold">Overview</h2>
+          <p className="text-sm text-text-muted">Aggregate pre-provider compression metrics. No provider billing estimate.</p>
+        </div>
+        <div className="flex rounded-lg border border-border bg-surface-2 p-1">
+          {PERIODS.map(([id, label]) => (
+            <button
+              key={id}
+              onClick={() => setPeriod(id)}
+              className={`rounded-md px-3 py-1 text-xs font-medium ${period === id ? "bg-primary text-white" : "text-text-muted hover:text-text"}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <Card className="p-8 text-center text-sm text-text-muted">Loading Token Saver metrics…</Card>
+      ) : isEmpty ? (
+        <Card className="p-8 text-center text-sm text-text-muted">No Token Saver events yet. Send a request through 9router after enabling RTK or Headroom.</Card>
+      ) : (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <StatCard label="RTK bytes saved" value={bytes(rtk.bytesSaved)} detail={`${number(rtk.requestsWithHits)} requests with ${number(rtk.hits)} hits`} tone="text-success" />
+            <StatCard label="Headroom token delta" value={number(headroom.tokensSaved)} detail={`${number(headroom.compressed)} compressed requests; reported by Headroom`} tone="text-primary" />
+            <StatCard label="Actual payload shrink" value={bytes(stats?.totals?.actualBytesSaved)} detail={`${bytes(headroom.bodyBytesBefore)} → ${bytes(headroom.bodyBytesAfter)} Headroom body`} />
+            <StatCard label="Headroom skipped" value={number(headroom.skipped)} detail={`${number(headroom.phantomSavings)} sub-5% body shrink (phantom)`} tone={headroom.skipped || headroom.phantomSavings ? "text-warning" : "text-text"} />
+          </div>
+
+          <Card className="p-4">
+            <div className="mb-3">
+              <h3 className="font-medium">Actual bytes saved</h3>
+              <p className="text-xs text-text-muted">RTK output reduction plus non-negative Headroom body reduction.</p>
+            </div>
+            {points.some((point) => point.actualBytesSaved > 0) ? (
+              <ResponsiveContainer width="100%" height={220}>
+                <AreaChart data={points} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="tokenSaverBytes" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#6366f1" stopOpacity={0.25} />
+                      <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.1} />
+                  <XAxis dataKey="label" tick={{ fontSize: 10, fill: "currentColor", fillOpacity: 0.5 }} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+                  <YAxis tick={{ fontSize: 10, fill: "currentColor", fillOpacity: 0.5 }} tickLine={false} axisLine={false} tickFormatter={bytes} width={56} />
+                  <Tooltip contentStyle={{ backgroundColor: "var(--color-bg)", border: "1px solid var(--color-border)", borderRadius: "8px", fontSize: "12px" }} formatter={(value) => [bytes(value), "Bytes saved"]} />
+                  <Area type="monotone" dataKey="actualBytesSaved" stroke="#6366f1" strokeWidth={2} fill="url(#tokenSaverBytes)" dot={false} activeDot={{ r: 4 }} />
+                </AreaChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="py-10 text-center text-sm text-text-muted">No actual payload reduction in this period.</p>
+            )}
+          </Card>
+
+          <Card className="overflow-hidden">
+            <div className="border-b border-border px-4 py-3">
+              <h3 className="font-medium">Breakdown</h3>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-surface-2 text-xs text-text-muted">
+                  <tr><th className="px-4 py-2 font-medium">Saver</th><th className="px-4 py-2 font-medium">Requests</th><th className="px-4 py-2 font-medium">Reported tokens</th><th className="px-4 py-2 font-medium">Actual bytes saved</th><th className="px-4 py-2 font-medium">Status</th></tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-border"><td className="px-4 py-3 font-medium">RTK</td><td className="px-4 py-3">{number(rtk.requestsWithHits)} hit requests</td><td className="px-4 py-3">—</td><td className="px-4 py-3">{bytes(rtk.bytesSaved)}</td><td className="px-4 py-3 text-text-muted">{number(rtk.hits)} tool-output hits</td></tr>
+                  <tr><td className="px-4 py-3 font-medium">Headroom</td><td className="px-4 py-3">{number(headroom.compressed)} compressed / {number(headroom.skipped)} skipped</td><td className="px-4 py-3">{number(headroom.tokensSaved)}</td><td className="px-4 py-3">{bytes(Math.max(0, (headroom.bodyBytesBefore || 0) - (headroom.bodyBytesAfter || 0)))}</td><td className="px-4 py-3 text-text-muted">{skipReasons[0] ? `${skipReasons[0][0]}: ${number(skipReasons[0][1])}` : `${number(headroom.disabled)} disabled`}</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </Card>
+          {(headroom.phantomSavings > 0 || headroom.skipped > 0) && <p className="text-xs text-text-muted">Skips are aggregate-safe (counted, not saved). A sub-5% body shrink is phantom savings — Headroom reported a reduction but the provider may bill near the original payload.</p>}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/app/api/token-saver/stats/route.js
+++ b/src/app/api/token-saver/stats/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getTokenSaverStats } from "@/lib/usageDb";
+
+const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "365d"]);
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const period = searchParams.get("period") || "7d";
+
+  if (!VALID_PERIODS.has(period)) {
+    return NextResponse.json({ error: "Invalid period" }, { status: 400 });
+  }
+
+  try {
+    const stats = await getTokenSaverStats(period);
+    return NextResponse.json(stats);
+  } catch (error) {
+    console.error("[API] Failed to get token-saver stats:", error);
+    return NextResponse.json({ error: "Failed to fetch token-saver stats" }, { status: 500 });
+  }
+}

--- a/src/app/api/token-saver/stream/route.js
+++ b/src/app/api/token-saver/stream/route.js
@@ -1,0 +1,55 @@
+import { getTokenSaverStats, statsEmitter } from "@/lib/usageDb";
+
+export const dynamic = "force-dynamic";
+
+const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "365d"]);
+
+export async function GET(request) {
+  const period = new URL(request.url).searchParams.get("period") || "30d";
+  if (!VALID_PERIODS.has(period)) return new Response("Invalid period", { status: 400 });
+
+  const encoder = new TextEncoder();
+  const state = { closed: false, keepalive: null, send: null };
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      state.send = async () => {
+        if (state.closed) return;
+        try {
+          const stats = await getTokenSaverStats(period);
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
+        } catch {
+          state.closed = true;
+          statsEmitter.off("token-saver", state.send);
+          clearInterval(state.keepalive);
+        }
+      };
+
+      await state.send();
+      statsEmitter.on("token-saver", state.send);
+      state.keepalive = setInterval(() => {
+        if (state.closed) return clearInterval(state.keepalive);
+        try {
+          controller.enqueue(encoder.encode(": ping\n\n"));
+        } catch {
+          state.closed = true;
+          clearInterval(state.keepalive);
+        }
+      }, 25000);
+    },
+
+    cancel() {
+      state.closed = true;
+      statsEmitter.off("token-saver", state.send);
+      clearInterval(state.keepalive);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -67,6 +67,11 @@ export {
   saveRequestDetail, getRequestDetails, getRequestDetailById, getDistinctProviders,
 } from "./repos/requestDetailsRepo.js";
 
+// Token Saver telemetry
+export {
+  recordTokenSaverEvent, getTokenSaverStats,
+} from "./repos/tokenSaverRepo.js";
+
 // Export/import full DB
 export async function exportDb() {
   const db = await getAdapter();

--- a/src/lib/db/repos/tokenSaverRepo.js
+++ b/src/lib/db/repos/tokenSaverRepo.js
@@ -6,6 +6,16 @@
 // into the request path.
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+import { statsEmitter } from "./usageRepo.js";
+
+function scheduleTokenSaverStatsEvent() {
+  if (global._tokenSaverStatsTimer) return;
+  global._tokenSaverStatsTimer = setTimeout(() => {
+    global._tokenSaverStatsTimer = null;
+    statsEmitter.emit("token-saver");
+  }, 150);
+  global._tokenSaverStatsTimer.unref?.();
+}
 
 const HEADROOM_STATES = new Set(["disabled", "compressed", "skipped"]);
 
@@ -104,13 +114,8 @@ function normalizeEvent(event) {
   const headroomPhantomSavings = isCompression ? normalizeNonNegativeNum(event.headroomPhantomSavings) : 0;
 
   // Diagnostic category — mapped to a safe enum, never persisted raw.
-  const diag = mapDiagnostic(event.headroomDiagnostic);
-  let skipReasonKey = null;
-  if (diag && diag !== "disabled" && diag !== "other-skip") {
-    skipReasonKey = diag;
-  } else if (diag === "other-skip") {
-    skipReasonKey = "other-skip";
-  }
+  const diag = state === "skipped" ? mapDiagnostic(event.headroomDiagnostic) : null;
+  const skipReasonKey = diag && diag !== "disabled" ? diag : null;
 
   return {
     state,
@@ -164,9 +169,11 @@ function applyToDay(day, norm) {
     h.skipReasons[k] = (h.skipReasons[k] || 0) + 1;
   }
 
-  // actualBytesSaved = rtk.bytesSaved + (bodyBytesBefore - bodyBytesAfter)
-  day.totals.actualBytesSaved =
-    day.rtk.bytesSaved + (day.headroom.bodyBytesBefore - day.headroom.bodyBytesAfter);
+  // actualBytesSaved = RTK bytes plus a non-negative Headroom body reduction.
+  // Guard against NaN from sparse/corrupt data.
+  const rtkSaved = day.rtk.bytesSaved || 0;
+  const bodyDelta = Math.max(0, (day.headroom.bodyBytesBefore || 0) - (day.headroom.bodyBytesAfter || 0));
+  day.totals.actualBytesSaved = rtkSaved + bodyDelta;
   return day;
 }
 
@@ -198,6 +205,7 @@ export async function recordTokenSaverEvent(event) {
       );
       pruneOldDays(db);
     });
+    scheduleTokenSaverStatsEvent();
   } catch {
     // Fail-open: never let telemetry break the caller.
   }
@@ -256,11 +264,26 @@ export async function getTokenSaverStats(period = "7d") {
     }
   }
 
-  // Same body shape from repository
+  const daysByKey = Object.fromEntries(rows.map((r) => [r.dateKey, parseJson(r.data, emptyDay())]));
+  const dailyPoints = Array.from({ length: dayCount }, (_, i) => {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() - (dayCount - 1 - i));
+    const day = daysByKey[localDateKey(date)] || emptyDay();
+    return {
+      dateKey: localDateKey(date),
+      actualBytesSaved: Math.max(0, (day.rtk?.bytesSaved || 0) + ((day.headroom?.bodyBytesBefore || 0) - (day.headroom?.bodyBytesAfter || 0))),
+      rtkBytesSaved: day.rtk?.bytesSaved || 0,
+      headroomBytesSaved: Math.max(0, (day.headroom?.bodyBytesBefore || 0) - (day.headroom?.bodyBytesAfter || 0)),
+      headroomCompressed: day.headroom?.compressed || 0,
+    };
+  });
+
   return {
     requestsObserved: agg.requestsObserved,
     rtk: agg.rtk,
     headroom: agg.headroom,
     totals: agg.totals,
+    dailyPoints,
   };
 }

--- a/src/lib/db/repos/tokenSaverRepo.js
+++ b/src/lib/db/repos/tokenSaverRepo.js
@@ -1,0 +1,266 @@
+// Token Saver telemetry — aggregate-safe daily compression metrics.
+//
+// Stores one normalized daily aggregate per local date (YYYY-MM-DD). Designed
+// to be a pure repository: it normalizes, never trusts diagnostic strings from
+// chat/runtime, and is fail-open so future chat-side recording can never throw
+// into the request path.
+import { getAdapter } from "../driver.js";
+import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+
+const HEADROOM_STATES = new Set(["disabled", "compressed", "skipped"]);
+
+// Safe diagnostic category enum — anything else maps to other-skip.
+const SAFE_DIAGNOSTICS = new Set([
+  "disabled",
+  "missing-proxy-url",
+  "timeout",
+  "http-error",
+  "unsupported-shape",
+  "unsafe-responses-input",
+  "invalid-proxy-response",
+  "translation-failed",
+  "unexpected-error",
+  "other-skip",
+]);
+
+const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "365d"]);
+// 365-day retention: keep current date minus up to 364 days (i.e. 365 rows).
+const RETENTION_DAYS = 365;
+const RETENTION_CUTOFF_DAYS = RETENTION_DAYS - 1; // strictly before (today - 364)
+
+function normalizeNonNegativeNum(v) {
+  const n = typeof v === "string" ? Number(v) : v;
+  if (typeof n !== "number" || !Number.isFinite(n) || n < 0) return 0;
+  return n;
+}
+
+function safeDateKey(date) {
+  const d = date ? new Date(date) : new Date();
+  if (Number.isNaN(d.getTime())) return localDateKey(new Date());
+  return localDateKey(d);
+}
+
+function localDateKey(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+    d.getDate()
+  ).padStart(2, "0")}`;
+}
+
+function emptyDay() {
+  return {
+    requestsObserved: 0,
+    rtk: {
+      requestsWithHits: 0,
+      hits: 0,
+      bytesBefore: 0,
+      bytesAfter: 0,
+      bytesSaved: 0,
+    },
+    headroom: {
+      compressed: 0,
+      skipped: 0,
+      disabled: 0,
+      tokensBefore: 0,
+      tokensAfter: 0,
+      tokensSaved: 0,
+      bodyBytesBefore: 0,
+      bodyBytesAfter: 0,
+      messageBytesBefore: 0,
+      messageBytesAfter: 0,
+      phantomSavings: 0,
+      skipReasons: {},
+    },
+    totals: {
+      actualBytesSaved: 0,
+    },
+  };
+}
+
+function mapDiagnostic(diagnostic) {
+  if (typeof diagnostic !== "string" || diagnostic.length === 0) return null;
+  const d = diagnostic.trim();
+  if (SAFE_DIAGNOSTICS.has(d)) return d;
+  return "other-skip";
+}
+
+// Normalize an event into the pieces we keep. Returns null if the event should
+// be dropped entirely (e.g. no headroom state).
+function normalizeEvent(event) {
+  if (!event || typeof event !== "object") return null;
+
+  if (!event.headroomState || !HEADROOM_STATES.has(event.headroomState)) return null;
+  const state = event.headroomState;
+
+  const isCompression = state === "compressed";
+
+  // For disabled/skipped, Headroom reported token/byte savings are NEVER counted.
+  const headroomTokensBefore = isCompression ? normalizeNonNegativeNum(event.headroomTokensBefore) : 0;
+  const headroomTokensAfter = isCompression ? normalizeNonNegativeNum(event.headroomTokensAfter) : 0;
+  const headroomTokensSaved = isCompression ? normalizeNonNegativeNum(event.headroomTokensSaved) : 0;
+  const headroomBodyBytesBefore = isCompression ? normalizeNonNegativeNum(event.headroomBodyBytesBefore) : 0;
+  const headroomBodyBytesAfter = isCompression ? normalizeNonNegativeNum(event.headroomBodyBytesAfter) : 0;
+  const headroomMessageBytesBefore = isCompression ? normalizeNonNegativeNum(event.headroomMessageBytesBefore) : 0;
+  const headroomMessageBytesAfter = isCompression ? normalizeNonNegativeNum(event.headroomMessageBytesAfter) : 0;
+  const headroomPhantomSavings = isCompression ? normalizeNonNegativeNum(event.headroomPhantomSavings) : 0;
+
+  // Diagnostic category — mapped to a safe enum, never persisted raw.
+  const diag = mapDiagnostic(event.headroomDiagnostic);
+  let skipReasonKey = null;
+  if (diag && diag !== "disabled" && diag !== "other-skip") {
+    skipReasonKey = diag;
+  } else if (diag === "other-skip") {
+    skipReasonKey = "other-skip";
+  }
+
+  return {
+    state,
+    requestsObserved: normalizeNonNegativeNum(event.requestsObserved),
+    rtk: {
+      requestsWithHits: normalizeNonNegativeNum(event.rtkRequestsWithHits),
+      hits: normalizeNonNegativeNum(event.rtkHits),
+      bytesBefore: normalizeNonNegativeNum(event.rtkBytesBefore),
+      bytesAfter: normalizeNonNegativeNum(event.rtkBytesAfter),
+      bytesSaved: normalizeNonNegativeNum(event.rtkBytesSaved),
+    },
+    headroom: {
+      compressed: state === "compressed" ? 1 : 0,
+      skipped: state === "skipped" ? 1 : 0,
+      disabled: state === "disabled" ? 1 : 0,
+      tokensBefore: headroomTokensBefore,
+      tokensAfter: headroomTokensAfter,
+      tokensSaved: headroomTokensSaved,
+      bodyBytesBefore: headroomBodyBytesBefore,
+      bodyBytesAfter: headroomBodyBytesAfter,
+      messageBytesBefore: headroomMessageBytesBefore,
+      messageBytesAfter: headroomMessageBytesAfter,
+      phantomSavings: headroomPhantomSavings,
+      skipReasonKey,
+    },
+  };
+}
+
+function applyToDay(day, norm) {
+  day.requestsObserved += norm.requestsObserved;
+  day.rtk.requestsWithHits += norm.rtk.requestsWithHits;
+  day.rtk.hits += norm.rtk.hits;
+  day.rtk.bytesBefore += norm.rtk.bytesBefore;
+  day.rtk.bytesAfter += norm.rtk.bytesAfter;
+  day.rtk.bytesSaved += norm.rtk.bytesSaved;
+
+  const h = day.headroom;
+  h.compressed += norm.headroom.compressed;
+  h.skipped += norm.headroom.skipped;
+  h.disabled += norm.headroom.disabled;
+  h.tokensBefore += norm.headroom.tokensBefore;
+  h.tokensAfter += norm.headroom.tokensAfter;
+  h.tokensSaved += norm.headroom.tokensSaved;
+  h.bodyBytesBefore += norm.headroom.bodyBytesBefore;
+  h.bodyBytesAfter += norm.headroom.bodyBytesAfter;
+  h.messageBytesBefore += norm.headroom.messageBytesBefore;
+  h.messageBytesAfter += norm.headroom.messageBytesAfter;
+  h.phantomSavings += norm.headroom.phantomSavings;
+  if (norm.headroom.skipReasonKey) {
+    const k = norm.headroom.skipReasonKey;
+    h.skipReasons[k] = (h.skipReasons[k] || 0) + 1;
+  }
+
+  // actualBytesSaved = rtk.bytesSaved + (bodyBytesBefore - bodyBytesAfter)
+  day.totals.actualBytesSaved =
+    day.rtk.bytesSaved + (day.headroom.bodyBytesBefore - day.headroom.bodyBytesAfter);
+  return day;
+}
+
+function pruneOldDays(db) {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - RETENTION_CUTOFF_DAYS);
+  const cutoffKey = localDateKey(cutoff);
+  // strictly before cutoffKey
+  db.run(`DELETE FROM tokenSaverDaily WHERE dateKey < ?`, [cutoffKey]);
+}
+
+// Public: record a normalized Token Saver event into one daily aggregate.
+// Fail-open: catches its own errors so future chat usage cannot fail.
+export async function recordTokenSaverEvent(event) {
+  try {
+    const norm = normalizeEvent(event);
+    if (!norm) return;
+
+    const dateKey = safeDateKey(event?.dateKey);
+    const db = await getAdapter();
+
+    db.transaction(() => {
+      const row = db.get(`SELECT data FROM tokenSaverDaily WHERE dateKey = ?`, [dateKey]);
+      const day = row ? parseJson(row.data, emptyDay()) : emptyDay();
+      applyToDay(day, norm);
+      db.run(
+        `INSERT INTO tokenSaverDaily(dateKey, data) VALUES(?, ?) ON CONFLICT(dateKey) DO UPDATE SET data = excluded.data`,
+        [dateKey, stringifyJson(day)]
+      );
+      pruneOldDays(db);
+    });
+  } catch {
+    // Fail-open: never let telemetry break the caller.
+  }
+}
+
+function daysInRange(db, dayCount) {
+  if (!dayCount) return db.all(`SELECT dateKey, data FROM tokenSaverDaily`);
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - (dayCount - 1));
+  const cutoffKey = localDateKey(cutoff);
+  return db.all(`SELECT dateKey, data FROM tokenSaverDaily WHERE dateKey >= ?`, [cutoffKey]);
+}
+
+// Public: aggregate Token Saver stats for a period.
+// Throws on invalid period (caller/route maps to 400).
+export async function getTokenSaverStats(period = "7d") {
+  if (!VALID_PERIODS.has(period)) {
+    throw new Error(`Invalid period: ${period}`);
+  }
+
+  const db = await getAdapter();
+
+  const periodDays = { today: 1, "24h": 1, "7d": 7, "30d": 30, "60d": 60, "365d": 365 };
+  const dayCount = periodDays[period];
+
+  const rows = daysInRange(db, dayCount);
+
+  const agg = emptyDay();
+  for (const r of rows) {
+    const day = parseJson(r.data, emptyDay());
+    applyToDay(agg, {
+      state: "compressed", // already-aggregated, just sum fields
+      requestsObserved: day.requestsObserved || 0,
+      rtk: day.rtk || {},
+      headroom: {
+        ...day.headroom,
+        compressed: day.headroom?.compressed || 0,
+        skipped: day.headroom?.skipped || 0,
+        disabled: day.headroom?.disabled || 0,
+        tokensBefore: day.headroom?.tokensBefore || 0,
+        tokensAfter: day.headroom?.tokensAfter || 0,
+        tokensSaved: day.headroom?.tokensSaved || 0,
+        bodyBytesBefore: day.headroom?.bodyBytesBefore || 0,
+        bodyBytesAfter: day.headroom?.bodyBytesAfter || 0,
+        messageBytesBefore: day.headroom?.messageBytesBefore || 0,
+        messageBytesAfter: day.headroom?.messageBytesAfter || 0,
+        phantomSavings: day.headroom?.phantomSavings || 0,
+        skipReasonKey: null,
+      },
+    });
+    // Re-apply skipReasons from stored aggregate
+    if (day.headroom?.skipReasons) {
+      for (const [k, v] of Object.entries(day.headroom.skipReasons)) {
+        agg.headroom.skipReasons[k] = (agg.headroom.skipReasons[k] || 0) + (v || 0);
+      }
+    }
+  }
+
+  // Same body shape from repository
+  return {
+    requestsObserved: agg.requestsObserved,
+    rtk: agg.rtk,
+    headroom: agg.headroom,
+    totals: agg.totals,
+  };
+}

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -130,6 +130,12 @@ export const TABLES = {
     ],
   },
   usageDaily: {
+    columns: {
+      dateKey: "TEXT PRIMARY KEY",
+      data: "TEXT NOT NULL",
+    },
+  },
+  tokenSaverDaily: {
     columns: {
       dateKey: "TEXT PRIMARY KEY",
       data: "TEXT NOT NULL",

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -4,4 +4,5 @@ export {
   saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
   saveRequestDetail, getRequestDetails, getRequestDetailById,
+  recordTokenSaverEvent, getTokenSaverStats,
 } from "@/lib/db/index.js";

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -22,6 +22,7 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+import { recordTokenSaverEvent } from "@/lib/usageDb";
 
 /**
  * Handle chat completion request
@@ -134,7 +135,7 @@ export async function handleChat(request, clientRawRequest = null) {
 /**
  * Handle single model chat request
  */
-async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null) {
+export async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null) {
   const modelInfo = await getModelInfo(modelStr);
 
   // If provider is null, this might be a combo name - check and handle
@@ -194,12 +195,19 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   const excludeConnectionIds = new Set();
   let lastError = null;
   let lastStatus = null;
+  // Capture last Token Saver telemetry across fallback attempts;
+  // persist exactly once after the final routing decision.
+  let lastTokenSaverEvent = null;
 
   while (true) {
     const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
 
     // All accounts unavailable
     if (!credentials || credentials.allRateLimited) {
+      if (lastTokenSaverEvent) {
+        try { Promise.resolve(recordTokenSaverEvent(lastTokenSaverEvent)).catch(() => {}); } catch { /* observability must not break requests */ }
+        lastTokenSaverEvent = null;
+      }
       if (credentials?.allRateLimited) {
         const errorMsg = lastError || credentials.lastError || "Unavailable";
         const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
@@ -266,10 +274,17 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       },
       onRequestSuccess: async () => {
         await clearAccountError(credentials.connectionId, credentials, model);
-      }
+      },
+      onTokenSaverEvent: (evt) => { lastTokenSaverEvent = evt; }
     });
 
-    if (result.success) return result.response;
+    if (result.success) {
+      if (lastTokenSaverEvent) {
+        try { Promise.resolve(recordTokenSaverEvent(lastTokenSaverEvent)).catch(() => {}); } catch { /* observability must not break requests */ }
+        lastTokenSaverEvent = null;
+      }
+      return result.response;
+    }
 
     // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise resetsAtMs)
     const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);
@@ -282,6 +297,10 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       continue;
     }
 
+    if (lastTokenSaverEvent) {
+      try { Promise.resolve(recordTokenSaverEvent(lastTokenSaverEvent)).catch(() => {}); } catch { /* observability must not break requests */ }
+      lastTokenSaverEvent = null;
+    }
     return result.response;
   }
 }

--- a/tests/unit/headroom-chat-core.test.js
+++ b/tests/unit/headroom-chat-core.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { executeMock } = vi.hoisted(() => ({
+const { executeMock, recordTokenSaverEventMock } = vi.hoisted(() => ({
   executeMock: vi.fn(),
+  recordTokenSaverEventMock: vi.fn(),
 }));
 
 vi.mock("../../open-sse/executors/index.js", () => ({
@@ -31,6 +32,7 @@ vi.mock("@/lib/usageDb.js", () => ({
   trackPendingRequest: vi.fn(),
   appendRequestLog: vi.fn(async () => {}),
   saveRequestDetail: vi.fn(async () => {}),
+  recordTokenSaverEvent: recordTokenSaverEventMock,
 }));
 
 const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
@@ -207,6 +209,34 @@ describe("handleChatCore Headroom diagnostics", () => {
     const logs = JSON.stringify([...log.info.mock.calls, ...log.warn.mock.calls]);
     expect(logs).not.toContain("saved");
     expect(logs).not.toContain(original);
+  });
+
+  it("invokes onTokenSaverEvent callback with aggregate-safe data without blocking provider dispatch", async () => {
+    const onTokenSaverEvent = vi.fn();
+    onTokenSaverEvent.mockImplementation(() => { throw new Error("telemetry failed"); });
+
+    await handleChatCore({
+      body: { model: "gpt-4o", stream: false, messages: [{ role: "user", content: "hello" }] },
+      modelInfo: { provider: "openai", model: "gpt-4o" },
+      credentials: { apiKey: "test-key", providerSpecificData: {} },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+      connectionId: "test-conn",
+      headroomEnabled: true,
+      headroomUrl: "http://localhost:8787",
+      headroomCompressUserMessages: false,
+      rtkEnabled: false,
+      cavemanEnabled: false,
+      ponytailEnabled: false,
+      clientRawRequest: { endpoint: "/v1/chat/completions", body: {}, headers: { accept: "application/json" } },
+      onTokenSaverEvent,
+    });
+
+    expect(onTokenSaverEvent).toHaveBeenCalledWith(expect.objectContaining({
+      requestsObserved: 1,
+      headroomState: "skipped",
+      headroomDiagnostic: "other-skip",
+    }));
+    expect(executeMock).toHaveBeenCalled();
   });
 
   it("warns when Headroom reports savings but outbound body barely shrinks", async () => {

--- a/tests/unit/headroom.test.js
+++ b/tests/unit/headroom.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { compressWithHeadroom, formatHeadroomLog } from "../../open-sse/rtk/headroom.js";
+import { classifyHeadroomDiagnostic, compressWithHeadroom, formatHeadroomLog } from "../../open-sse/rtk/headroom.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -201,6 +201,21 @@ describe("compressWithHeadroom", () => {
 
     expect(stats).toBeNull();
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("classifyHeadroomDiagnostic", () => {
+  it("maps diagnostics to aggregate-safe categories", () => {
+    expect(classifyHeadroomDiagnostic({}, { tokens_saved: 1 }, true)).toBe("compressed");
+    expect(classifyHeadroomDiagnostic({}, null, false)).toBe("disabled");
+    expect(classifyHeadroomDiagnostic({ reason: "missing proxy URL" }, null, true)).toBe("missing-proxy-url");
+    expect(classifyHeadroomDiagnostic({ reason: "request failed: AbortError" }, null, true)).toBe("timeout");
+    expect(classifyHeadroomDiagnostic({ reason: "proxy returned HTTP 503" }, null, true)).toBe("http-error");
+    expect(classifyHeadroomDiagnostic({ reason: "skipped: openai-responses tool/reasoning input is not safe to compress" }, null, true)).toBe("unsafe-responses-input");
+    expect(classifyHeadroomDiagnostic({ reason: "unsupported gemini request shape" }, null, true)).toBe("unsupported-shape");
+    expect(classifyHeadroomDiagnostic({ reason: "proxy response missing messages[]" }, null, true)).toBe("invalid-proxy-response");
+    expect(classifyHeadroomDiagnostic({ reason: "unexpected error: secret" }, null, true)).toBe("unexpected-error");
+    expect(classifyHeadroomDiagnostic({ reason: "request failed: ECONNREFUSED http://secret.example" }, null, true)).toBe("other-skip");
   });
 });
 

--- a/tests/unit/token-saver-fallback.test.js
+++ b/tests/unit/token-saver-fallback.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+// ---------------------------------------------------------------------------
+// Token Saver fallback double-count test — account retries must fire exactly
+// one recordTokenSaverEvent per request, not per handleChatCore attempt.
+// ---------------------------------------------------------------------------
+
+// Mock a provider that reports (1) successful compression telem then (2) fails
+// so the fallback loop advances. The mock must be set up early via hoisted.
+
+const { executeMock, recordTokenSaverEventMock } = vi.hoisted(() => {
+  // Two calls to executor.execute:
+  // Attempt 1 → non-ok response (triggers fallback)
+  // Attempt 2 → always the same, but loop exhausts accounts
+  const exec = vi.fn().mockResolvedValue({
+    response: { ok: false, status: 502, text: async () => "Bad Gateway" },
+    url: "https://example.com/v1/chat",
+    headers: { "content-type": "application/json" },
+    transformedBody: {},
+  });
+  return {
+    executeMock: exec,
+    recordTokenSaverEventMock: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("../../open-sse/executors/index.js", () => ({
+  getExecutor: () => ({
+    noAuth: true,
+    execute: executeMock,
+    parseError: null,
+  }),
+}));
+
+vi.mock("../../open-sse/utils/requestLogger.js", () => ({
+  createRequestLogger: async () => ({
+    logClientRawRequest: vi.fn(),
+    logRawRequest: vi.fn(),
+    logTargetRequest: vi.fn(),
+    logProviderResponse: vi.fn(),
+    logConvertedResponse: vi.fn(),
+    logError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../open-sse/utils/stream.js", () => ({
+  COLORS: { red: "", reset: "" },
+  createPassthroughStreamWithLogger: vi.fn(() => new TransformStream()),
+}));
+
+// Router-level auth/token mocks
+vi.mock("@/lib/localDb", () => ({
+  getSettings: async () => ({}),
+  getProviderConnections: async () => [],
+}));
+
+// Two accounts: first fails (502), second also fails → loop exhausts
+vi.mock("@/sse/services/auth", () => ({
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: async () => ({ shouldFallback: true, cooldownMs: 1000 }),
+  clearAccountError: async () => {},
+}));
+
+vi.mock("@/sse/services/model", () => ({
+  getModelInfo: async () => ({ provider: "openai", model: "gpt-4o" }),
+}));
+
+vi.mock("@/sse/services/tokenRefresh", () => ({
+  checkAndRefreshToken: async (p, c) => c,
+  updateProviderCredentials: async () => {},
+}));
+
+vi.mock("@/lib/usageDb", () => ({
+  recordTokenSaverEvent: recordTokenSaverEventMock,
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  getUsageStats: vi.fn(),
+}));
+
+vi.mock("@/lib/headroom/detect", () => ({
+  DEFAULT_HEADROOM_URL: "http://localhost:8787",
+}));
+
+vi.mock("@/lib/pxpipe/loader", () => ({
+  getTransform: async () => null,
+}));
+
+vi.mock("@/lib/pxpipe/events", () => ({
+  appendPxpipeEvent: async () => {},
+}));
+
+vi.mock("open-sse/services/projectId", () => ({
+  getProjectIdForConnection: async () => "test-project",
+}));
+
+import { handleSingleModelChat } from "../../src/sse/handlers/chat.js";
+import * as authModule from "../../src/sse/services/auth.js";
+
+describe("Token Saver fallback double-count prevention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authModule.getProviderCredentials)
+      // 1st call → first account
+      .mockResolvedValueOnce({
+        apiKey: "key-1",
+        accessToken: "tok-1",
+        connectionId: "conn-1",
+        connectionName: "Acc01",
+        providerSpecificData: {},
+      })
+      // 2nd call → second account
+      .mockResolvedValueOnce({
+        apiKey: "key-2",
+        accessToken: "tok-2",
+        connectionId: "conn-2",
+        connectionName: "Acc02",
+        providerSpecificData: {},
+      })
+      // 3rd call → exhausted
+      .mockResolvedValueOnce(null);
+  });
+
+  it("fires exactly one recordTokenSaverEvent after multiple fallback attempts", async () => {
+    await handleSingleModelChat(
+      { model: "gpt-4o", stream: false, messages: [{ role: "user", content: "hi" }] },
+      "gpt-4o",
+      null,
+      new Request("http://localhost:3000/v1/chat/completions", {
+        headers: { accept: "application/json" },
+      }),
+      null,
+    );
+
+    // Even though handleChatCore was called twice (two fallback attempts),
+    // recordTokenSaverEvent must be called exactly once.
+    expect(recordTokenSaverEventMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/token-saver-repo.test.js
+++ b/tests/unit/token-saver-repo.test.js
@@ -71,6 +71,12 @@ describe("TokenSaver repository", () => {
     expect(stats.headroom.messageBytesAfter).toBe(80);
     // actualBytesSaved = rtk.bytesSaved + (bodyBytesBefore - bodyBytesAfter)
     expect(stats.totals.actualBytesSaved).toBe(400 + (2000 - 1500));
+    expect(stats.dailyPoints).toEqual([expect.objectContaining({
+      actualBytesSaved: 900,
+      rtkBytesSaved: 400,
+      headroomBytesSaved: 500,
+      headroomCompressed: 1,
+    })]);
   });
 
   it("accumulates two events on same day", async () => {

--- a/tests/unit/token-saver-repo.test.js
+++ b/tests/unit/token-saver-repo.test.js
@@ -1,0 +1,278 @@
+// RED phase: module/functions don't exist yet — these imports fail at call time
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let tempDir;
+const originalDataDir = process.env.DATA_DIR;
+
+// Run against real SQLite test DB (not mocks), same pattern as db-*.test.js
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-ts-"));
+  process.env.DATA_DIR = tempDir;
+  delete global._dbAdapter;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  try { global._dbAdapter?.instance?.close?.(); } catch {}
+  delete global._dbAdapter;
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("TokenSaver repository", () => {
+  /** @type {import("@/lib/db/index.js")} */
+  let db;
+
+  beforeEach(async () => {
+    db = await import("@/lib/db/index.js");
+  });
+
+  it("recordTokenSaverEvent and getTokenSaverStats exist as functions", () => {
+    expect(typeof db.recordTokenSaverEvent).toBe("function");
+    expect(typeof db.getTokenSaverStats).toBe("function");
+  });
+
+  it("records one event into daily aggregate", async () => {
+    await db.recordTokenSaverEvent({
+      requestsObserved: 5,
+      rtkRequestsWithHits: 2,
+      rtkHits: 3,
+      rtkBytesBefore: 1000,
+      rtkBytesAfter: 600,
+      rtkBytesSaved: 400,
+      headroomState: "compressed",
+      headroomTokensBefore: 500,
+      headroomTokensAfter: 300,
+      headroomTokensSaved: 200,
+      headroomBodyBytesBefore: 2000,
+      headroomBodyBytesAfter: 1500,
+      headroomMessageBytesBefore: 100,
+      headroomMessageBytesAfter: 80,
+    });
+
+    const stats = await db.getTokenSaverStats("today");
+    expect(stats.requestsObserved).toBe(5);
+    expect(stats.rtk.requestsWithHits).toBe(2);
+    expect(stats.rtk.hits).toBe(3);
+    expect(stats.rtk.bytesBefore).toBe(1000);
+    expect(stats.rtk.bytesAfter).toBe(600);
+    expect(stats.rtk.bytesSaved).toBe(400);
+    expect(stats.headroom.compressed).toBe(1);
+    expect(stats.headroom.tokensBefore).toBe(500);
+    expect(stats.headroom.tokensAfter).toBe(300);
+    expect(stats.headroom.tokensSaved).toBe(200);
+    expect(stats.headroom.bodyBytesBefore).toBe(2000);
+    expect(stats.headroom.bodyBytesAfter).toBe(1500);
+    expect(stats.headroom.messageBytesBefore).toBe(100);
+    expect(stats.headroom.messageBytesAfter).toBe(80);
+    // actualBytesSaved = rtk.bytesSaved + (bodyBytesBefore - bodyBytesAfter)
+    expect(stats.totals.actualBytesSaved).toBe(400 + (2000 - 1500));
+  });
+
+  it("accumulates two events on same day", async () => {
+    await db.recordTokenSaverEvent({
+      requestsObserved: 3,
+      rtkRequestsWithHits: 1,
+      rtkHits: 2,
+      rtkBytesSaved: 100,
+      headroomState: "compressed",
+      headroomTokensBefore: 200,
+      headroomTokensAfter: 150,
+      headroomTokensSaved: 50,
+      headroomBodyBytesBefore: 500,
+      headroomBodyBytesAfter: 400,
+    });
+    await db.recordTokenSaverEvent({
+      requestsObserved: 7,
+      rtkRequestsWithHits: 3,
+      rtkHits: 5,
+      rtkBytesSaved: 300,
+      headroomState: "compressed",
+      headroomTokensBefore: 800,
+      headroomTokensAfter: 600,
+      headroomTokensSaved: 200,
+      headroomBodyBytesBefore: 1500,
+      headroomBodyBytesAfter: 1200,
+    });
+
+    const stats = await db.getTokenSaverStats("today");
+    expect(stats.requestsObserved).toBe(10);
+    expect(stats.rtk.requestsWithHits).toBe(4);
+    expect(stats.rtk.hits).toBe(7);
+    expect(stats.rtk.bytesSaved).toBe(400);
+    expect(stats.headroom.compressed).toBe(2);
+    expect(stats.headroom.tokensBefore).toBe(1000);
+    expect(stats.headroom.tokensAfter).toBe(750);
+    expect(stats.headroom.tokensSaved).toBe(250);
+    expect(stats.headroom.bodyBytesBefore).toBe(2000);
+    expect(stats.headroom.bodyBytesAfter).toBe(1600);
+  });
+
+  it("disabled/skipped state never increases Headroom reported token savings", async () => {
+    // First event: compressed with real savings
+    await db.recordTokenSaverEvent({
+      requestsObserved: 1,
+      headroomState: "compressed",
+      headroomTokensBefore: 1000,
+      headroomTokensAfter: 700,
+      headroomTokensSaved: 300,
+      headroomBodyBytesBefore: 5000,
+      headroomBodyBytesAfter: 3500,
+    });
+    // Second event: disabled — should NOT add to headroom savings fields
+    await db.recordTokenSaverEvent({
+      requestsObserved: 1,
+      headroomState: "disabled",
+      headroomTokensBefore: 0,
+      headroomTokensAfter: 0,
+      headroomTokensSaved: 0,
+      headroomBodyBytesBefore: 0,
+      headroomBodyBytesAfter: 0,
+    });
+    // Third event: skipped — should NOT add to headroom savings fields
+    await db.recordTokenSaverEvent({
+      requestsObserved: 1,
+      headroomState: "skipped",
+      headroomTokensBefore: 999,  // should be zeroed
+      headroomTokensAfter: 999,   // should be zeroed
+      headroomTokensSaved: 999,   // should be zeroed
+      headroomBodyBytesBefore: 999,
+      headroomBodyBytesAfter: 999,
+      headroomDiagnostic: "timeout",
+    });
+
+    const stats = await db.getTokenSaverStats("today");
+    // Savings from compressed event only
+    expect(stats.headroom.compressed).toBe(1);
+    expect(stats.headroom.disabled).toBe(1);
+    expect(stats.headroom.skipped).toBe(1);
+    expect(stats.headroom.tokensSaved).toBe(300);
+    expect(stats.headroom.tokensBefore).toBe(1000);
+    expect(stats.headroom.tokensAfter).toBe(700);
+    expect(stats.headroom.bodyBytesBefore).toBe(5000);
+    expect(stats.headroom.bodyBytesAfter).toBe(3500);
+    // phantomSavings only from non-compressed events — but disabled/skipped
+    // had 0 phantomSavings, so total remains 0
+    expect(stats.headroom.phantomSavings).toBe(0);
+    // skipReasons: timeout from skipped event
+    expect(stats.headroom.skipReasons.timeout).toBe(1);
+  });
+
+  it("malformed negative/NaN values become zero", async () => {
+    await db.recordTokenSaverEvent({
+      requestsObserved: -5,
+      rtkRequestsWithHits: NaN,
+      rtkHits: -3,
+      rtkBytesSaved: "not-a-number",
+      headroomState: "disabled",
+      headroomTokensSaved: -100,
+    });
+
+    const stats = await db.getTokenSaverStats("today");
+    expect(stats.requestsObserved).toBe(0);
+    expect(stats.rtk.requestsWithHits).toBe(0);
+    expect(stats.rtk.hits).toBe(0);
+    expect(stats.rtk.bytesSaved).toBe(0);
+    expect(stats.headroom.tokensSaved).toBe(0);
+  });
+
+  it("prunes day data older than 365 days after recording", async () => {
+    // Seed a row 400 days in the past directly in DB
+    const pastDate = new Date();
+    pastDate.setDate(pastDate.getDate() - 400);
+    const pastKey = `${pastDate.getFullYear()}-${String(pastDate.getMonth() + 1).padStart(2, "0")}-${String(pastDate.getDate()).padStart(2, "0")}`;
+
+    const { getAdapter } = await import("@/lib/db/driver.js");
+    const adapter = await getAdapter();
+    adapter.run(
+      `INSERT INTO tokenSaverDaily(dateKey, data) VALUES(?, ?)`,
+      [pastKey, JSON.stringify({ requestsObserved: 99, rtk: {}, headroom: {}, totals: {} })]
+    );
+
+    // Record today's event (triggers prune)
+    await db.recordTokenSaverEvent({ requestsObserved: 1, headroomState: "disabled" });
+
+    // Past row should be gone
+    const rows = adapter.all(`SELECT * FROM tokenSaverDaily`);
+    const dateKeys = rows.map((r) => r.dateKey);
+    expect(dateKeys).not.toContain(pastKey);
+    expect(dateKeys.length).toBe(1); // only today's row
+  });
+
+  it("returns data for valid periods", async () => {
+    // Record an event
+    await db.recordTokenSaverEvent({ requestsObserved: 3, headroomState: "disabled" });
+
+    for (const period of ["today", "24h", "7d", "30d", "60d", "365d"]) {
+      const stats = await db.getTokenSaverStats(period);
+      expect(stats.requestsObserved).toBe(3);
+      expect(typeof stats.rtk).toBe("object");
+      expect(typeof stats.headroom).toBe("object");
+      expect(typeof stats.totals).toBe("object");
+      expect(stats.totals.actualBytesSaved).toBeTypeOf("number");
+    }
+  });
+
+  it("throws on invalid period", async () => {
+    await expect(db.getTokenSaverStats("all")).rejects.toThrow();
+    await expect(db.getTokenSaverStats("invalid")).rejects.toThrow();
+  });
+
+  it("data contains no raw diagnostic string/URL", async () => {
+    await db.recordTokenSaverEvent({
+      requestsObserved: 1,
+      headroomState: "skipped",
+      headroomDiagnostic: "http-error",
+    });
+    await db.recordTokenSaverEvent({
+      requestsObserved: 1,
+      headroomState: "skipped",
+      headroomDiagnostic: "something-unexpected-here",
+    });
+
+    const stats = await db.getTokenSaverStats("today");
+    // skipReasons only has safe category keys with counts
+    expect(stats.headroom.skipReasons["http-error"]).toBe(1);
+    expect(stats.headroom.skipReasons["other-skip"]).toBe(1);
+    // No raw string "something-unexpected-here" anywhere in serialized stats
+    const json = JSON.stringify(stats);
+    expect(json).not.toContain("something-unexpected-here");
+    expect(json).not.toContain("http://");
+    expect(json).not.toContain("https://");
+    expect(json).not.toContain(".com");
+  });
+
+  it("unknown/missing headroomState is dropped — no row, no counter inflation", async () => {
+    // Unknown state must NOT default to "skipped" (which would inflate metrics)
+    await db.recordTokenSaverEvent({
+      requestsObserved: 5,
+      headroomState: "bogus-state",
+    });
+    // Missing state entirely — same treatment
+    await db.recordTokenSaverEvent({ requestsObserved: 7 });
+
+    // No daily row recorded at all
+    const { getAdapter } = await import("@/lib/db/driver.js");
+    const adapter = await getAdapter();
+    const rows = adapter.all(`SELECT * FROM tokenSaverDaily`);
+    expect(rows.length).toBe(0);
+
+    // Aggregated stats stay empty — no skipped/requestsObserved inflation
+    const stats = await db.getTokenSaverStats("today");
+    expect(stats.requestsObserved).toBe(0);
+    expect(stats.headroom.skipped).toBe(0);
+    expect(stats.headroom.compressed).toBe(0);
+    expect(stats.headroom.disabled).toBe(0);
+  });
+
+  it("recordTokenSaverEvent catches its own errors (fail-open)", async () => {
+    // Should not throw despite bad args
+    await expect(db.recordTokenSaverEvent(null)).resolves.toBeUndefined();
+    await expect(db.recordTokenSaverEvent(undefined)).resolves.toBeUndefined();
+    await expect(db.recordTokenSaverEvent("bad")).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/token-saver-route.test.js
+++ b/tests/unit/token-saver-route.test.js
@@ -1,0 +1,66 @@
+// RED phase: route file doesn't exist yet
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let tempDir;
+const originalDataDir = process.env.DATA_DIR;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-ts-route-"));
+  process.env.DATA_DIR = tempDir;
+  delete global._dbAdapter;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  try { global._dbAdapter?.instance?.close?.(); } catch {}
+  delete global._dbAdapter;
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+async function loadRoute() {
+  return await import("../../src/app/api/token-saver/stats/route.js");
+}
+
+async function loadDb() {
+  return await import("@/lib/db/index.js");
+}
+
+describe("GET /api/token-saver/stats", () => {
+  it("returns 400 for invalid period", async () => {
+    const route = await loadRoute();
+    const req = new Request("http://localhost/api/token-saver/stats?period=bogus");
+    const res = await route.GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with body shape for valid periods", async () => {
+    const db = await loadDb();
+    await db.recordTokenSaverEvent({ requestsObserved: 2, headroomState: "disabled" });
+    const route = await loadRoute();
+
+    for (const period of ["today", "24h", "7d", "30d", "60d", "365d"]) {
+      const req = new Request(`http://localhost/api/token-saver/stats?period=${period}`);
+      const res = await route.GET(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.requestsObserved).toBe(2);
+      expect(body.rtk).toBeDefined();
+      expect(body.headroom).toBeDefined();
+      expect(body.totals).toBeDefined();
+    }
+  });
+
+  it("defaults to 7d when no period provided", async () => {
+    const db = await loadDb();
+    await db.recordTokenSaverEvent({ requestsObserved: 1, headroomState: "disabled" });
+    const route = await loadRoute();
+    const req = new Request("http://localhost/api/token-saver/stats");
+    const res = await route.GET(req);
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Aggregate Token Saver dashboard extracted from the install build branch as a focused PR. Contains exactly aggregate DB/API, fail-open capture, Overview/Settings UI, privacy-safe diagnostics, and focused tests.

## Changes (17 files)

**Aggregate DB + API:**
- `src/lib/db/repos/tokenSaverRepo.js` — SQLite repo for aggregate compression metrics (total tokens, requests, savings, per-provider breakdown)
- `src/app/api/v1/token-saver/stats/route.js` — GET endpoint returning aggregate stats
- `src/app/api/v1/token-saver/stream/route.js` — SSE endpoint for live token-saver events

**Dashboard UI:**
- `src/app/dashboard/token-saver/TokenSaverOverview.js` — Overview tab with aggregate savings, per-provider breakdown, and trend chart
- `src/app/dashboard/token-saver/TokenSaverClient.js` — Client component wiring Overview + Settings tabs

**Core integration:**
- `open-sse/rtk/headroom.js` — fail-open capture of compression metrics
- `open-sse/handlers/chatCore.js` — pass metrics to token-saver stream
- `open-sse/handlers/responsesHandler.js` — pass metrics for responses endpoint
- `src/lib/db/schema.js` — token_saver_stats table
- `src/lib/db/index.js` — register tokenSaverRepo
- `src/lib/usageDb.js` — wire token-saver stream events
- `src/sse/handlers/chat.js` — wire token-saver stream

**Tests (30 pass, 0 fail):**
- `tests/unit/token-saver-repo.test.js`
- `tests/unit/token-saver-route.test.js`
- `tests/unit/token-saver-fallback.test.js`
- `tests/unit/headroom.test.js`
- `tests/unit/headroom-chat-core.test.js`

## Notes

- Clean cherry-pick from the install build branch — no conflicts, no regressions.
- Fail-open: any error in metrics capture returns null and leaves the body untouched.
- Privacy-safe: only aggregate counts and per-provider summaries are persisted — no request content.
