### PR TITLE
fix(cursor): bump client version and speak HTTP/2 to AgentService

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -1,8 +1,11 @@
 import { BaseExecutor } from "./base.js";
-import { PROVIDERS } from "../config/providers.js";
+import { PROVIDERS, PROVIDER_OAUTH } from "../config/providers.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import {
   generateCursorBody,
+  encodeField,
+  wrapConnectRPCFrame,
+  decodeMessage,
   parseConnectRPCFrame,
   extractTextFromResponse
 } from "../utils/cursorProtobuf.js";
@@ -13,6 +16,7 @@ import { chatChunkSse } from "../utils/sse.js";
 import { FORMATS } from "../translator/formats.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import zlib from "zlib";
+import crypto from "crypto";
 
 // Detect cloud environment
 const isCloudEnv = () => {
@@ -37,6 +41,130 @@ const COMPRESS_FLAG = {
   TRAILER: 0x02,
   GZIP_TRAILER: 0x03
 };
+
+const AGENT_RUN_PATH = "/agent.v1.AgentService/Run";
+const PROTOBUF_LEN = 2;
+const PROTOBUF_VARINT = 0;
+
+function concatBuffers(...parts) {
+  const length = parts.reduce((total, part) => total + part.length, 0);
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+const agentString = (field, value) => encodeField(field, PROTOBUF_LEN, value);
+const agentMessage = (field, value) => encodeField(field, PROTOBUF_LEN, value);
+const agentBool = (field, value) => encodeField(field, PROTOBUF_VARINT, value ? 1 : 0);
+
+function textFromContent(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function isAgentTextRequest(body) {
+  // Many compatible clients always attach their built-in tool schemas, even
+  // for a normal text turn. Cursor's retired ChatService rejects those
+  // requests; AgentService can still answer the text turn, so ignore schemas
+  // here. A real tool-call/result conversation is kept on the legacy path
+  // until its AgentService tool protocol is implemented.
+  return Array.isArray(body?.messages) && body.messages.every((message) => {
+    if (message?.tool_calls?.length || message?.role === "tool") return false;
+    return typeof message?.content === "string"
+      || Array.isArray(message?.content) && message.content.every((part) => part?.type === "text");
+  });
+}
+
+function encodeHistoryMessage(message) {
+  const content = textFromContent(message?.content);
+  if (!content) return null;
+
+  // ConversationHistoryMessage.user / .assistant -> repeated content -> text.
+  const text = agentString(1, content);
+  if (message.role === "assistant") {
+    return agentMessage(2, agentMessage(1, agentMessage(1, text)));
+  }
+  return agentMessage(1, agentMessage(1, agentMessage(1, text)));
+}
+
+function buildAgentRunFrame(messages, model) {
+  const system = messages
+    .filter((message) => message?.role === "system")
+    .map((message) => textFromContent(message.content))
+    .filter(Boolean)
+    .join("\n\n");
+  const chatMessages = messages.filter((message) => message?.role !== "system");
+  const currentIndex = [...chatMessages].map((message) => message?.role).lastIndexOf("user");
+  const current = currentIndex >= 0 ? chatMessages[currentIndex] : chatMessages.at(-1);
+  const history = chatMessages
+    .slice(0, currentIndex >= 0 ? currentIndex : -1)
+    .map(encodeHistoryMessage)
+    .filter(Boolean);
+  const userText = textFromContent(current?.content) || "Continue.";
+
+  // agent.v1.UserMessageAction.user_message and its optional history.
+  const userMessage = concatBuffers(
+    agentString(1, userText),
+    agentString(2, crypto.randomUUID()),
+  );
+  const conversationHistory = history.length
+    ? concatBuffers(...history.map((entry) => agentMessage(1, entry)))
+    : null;
+  const userAction = concatBuffers(
+    agentMessage(1, userMessage),
+    ...(conversationHistory ? [agentMessage(7, conversationHistory)] : []),
+  );
+  const conversationAction = agentMessage(1, userAction);
+  const requestedModel = concatBuffers(agentString(1, model), agentBool(7, true));
+  const runRequest = concatBuffers(
+    // An empty ConversationStateStructure starts a fresh local agent session.
+    agentMessage(1, new Uint8Array()),
+    agentMessage(2, conversationAction),
+    ...(system ? [agentString(8, system)] : []),
+    agentMessage(9, requestedModel),
+  );
+
+  // agent.v1.AgentClientMessage.run_request.
+  return wrapConnectRPCFrame(agentMessage(1, runRequest));
+}
+
+function extractAgentString(message, field) {
+  const value = message?.get(field)?.[0]?.value;
+  return value ? Buffer.from(value).toString("utf8") : "";
+}
+
+function decodeAgentFrames(buffer, onFrame) {
+  let pending = Buffer.from(buffer || []);
+  while (pending.length >= 5) {
+    const flags = pending[0];
+    const length = pending.readUInt32BE(1);
+    if (pending.length < 5 + length) break;
+    let payload = pending.subarray(5, 5 + length);
+    pending = pending.subarray(5 + length);
+    if (flags & COMPRESS_FLAG.GZIP) {
+      payload = zlib.gunzipSync(payload);
+    }
+    if (!(flags & COMPRESS_FLAG.TRAILER)) onFrame(payload);
+  }
+  return pending;
+}
+
+function createRequestContextResponse() {
+  // AgentService asks every run for client context. 9router has no IDE file
+  // context, so acknowledge with an empty RequestContext.
+  const requestContextSuccess = agentMessage(1, new Uint8Array());
+  const requestContextResult = agentMessage(1, requestContextSuccess);
+  const execClientMessage = agentMessage(10, requestContextResult);
+  return wrapConnectRPCFrame(agentMessage(2, execClientMessage));
+}
 
 const CURSOR_STREAM_DEBUG = process.env.CURSOR_STREAM_DEBUG === "1";
 const debugLog = (...args) => {
@@ -253,7 +381,293 @@ export class CursorExecutor extends BaseExecutor {
     });
   }
 
+  /**
+   * AgentService (agent.api5.cursor.sh) is HTTP/2-only. Node's fetch/undici speaks
+   * HTTP/1.1 and fails with HTTPParserError on the h2 preface — use http2 duplex.
+   */
+  openAgentHttp2Stream(url, headers, signal) {
+    if (!http2) {
+      throw new Error("HTTP/2 is required for Cursor AgentService (endpoint is h2-only)");
+    }
+
+    const urlObj = new URL(url);
+    const client = http2.connect(`https://${urlObj.host}`);
+    const chunkQueue = [];
+    let waiting = null;
+    let ended = false;
+    let streamError = null;
+    let req = null;
+
+    const wake = (result) => {
+      if (!waiting) return;
+      const resolve = waiting;
+      waiting = null;
+      resolve(result);
+    };
+
+    const fail = (error) => {
+      if (streamError) return;
+      streamError = error;
+      ended = true;
+      wake(null);
+    };
+
+    const close = () => {
+      try { req?.destroy(); } catch {}
+      try { client.close(); } catch {}
+    };
+
+    client.on("error", fail);
+
+    req = client.request({
+      ":method": "POST",
+      ":path": urlObj.pathname,
+      ":authority": urlObj.host,
+      ":scheme": "https",
+      ...headers,
+    });
+
+    req.on("error", fail);
+    req.on("data", (chunk) => {
+      if (waiting) wake({ value: chunk, done: false });
+      else chunkQueue.push(chunk);
+    });
+    req.on("end", () => {
+      ended = true;
+      wake({ value: undefined, done: true });
+    });
+
+    if (signal) {
+      const onAbort = () => {
+        fail(new Error("Request aborted"));
+        close();
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    const responseHeaders = new Promise((resolve, reject) => {
+      const onEarlyError = (error) => reject(error);
+      client.once("error", onEarlyError);
+      req.once("error", onEarlyError);
+      req.once("response", (hdrs) => {
+        client.off("error", onEarlyError);
+        req.off("error", onEarlyError);
+        resolve(hdrs);
+      });
+    });
+
+    return {
+      responseHeaders,
+      write(frame) {
+        if (req && !req.destroyed) req.write(Buffer.from(frame));
+      },
+      end() {
+        try { if (req && !req.destroyed) req.end(); } catch {}
+      },
+      close,
+      async read() {
+        if (chunkQueue.length) return { value: chunkQueue.shift(), done: false };
+        if (ended) {
+          if (streamError) throw streamError;
+          return { value: undefined, done: true };
+        }
+        const result = await new Promise((resolve) => { waiting = resolve; });
+        if (streamError) throw streamError;
+        return result || { value: undefined, done: true };
+      },
+    };
+  }
+
+  async executeAgent({ model, body, stream, credentials, signal }) {
+    const agentEndpoint = PROVIDER_OAUTH.cursor?.agentEndpoint;
+    if (!agentEndpoint) throw new Error("Cursor AgentService endpoint is not configured");
+
+    const url = `${agentEndpoint}${AGENT_RUN_PATH}`;
+    const headers = this.buildHeaders(credentials);
+    const requestController = new AbortController();
+    if (signal?.addEventListener) {
+      signal.addEventListener("abort", () => requestController.abort(signal.reason), { once: true });
+    }
+
+    let session;
+    try {
+      session = this.openAgentHttp2Stream(url, headers, requestController.signal);
+      session.write(buildAgentRunFrame(body.messages || [], model));
+    } catch (error) {
+      throw new Error(`Cursor AgentService request failed: ${error.message}`);
+    }
+
+    let responseHeaders;
+    try {
+      responseHeaders = await session.responseHeaders;
+    } catch (error) {
+      session.close();
+      throw new Error(`Cursor AgentService request failed: ${error.message}`);
+    }
+
+    const status = Number(responseHeaders[":status"] || 0);
+    if (status !== 200) {
+      let errorText = "";
+      try {
+        while (true) {
+          const { done, value } = await session.read();
+          if (done) break;
+          errorText += Buffer.from(value).toString("utf8");
+        }
+      } catch {}
+      session.close();
+      return {
+        response: new Response(JSON.stringify({
+          error: { message: `Cursor AgentService ${status}: ${errorText || "request failed"}`, type: "api_error" },
+        }), { status: status || HTTP_STATUS.SERVER_ERROR, headers: { "Content-Type": "application/json" } }),
+        url,
+        headers,
+        transformedBody: body,
+        responseFormat: FORMATS.OPENAI,
+      };
+    }
+
+    // The Claude SSE translator derives Anthropic's message ID by stripping
+    // `chatcmpl-`. Keep the remaining ID in Anthropic's required `msg_` form
+    // so strict clients such as Claude Code accept the completed stream.
+    const responseId = `chatcmpl-msg_${Date.now()}`;
+    const created = Math.floor(Date.now() / 1000);
+    let pending = Buffer.alloc(0);
+    let finished = false;
+
+    const consume = async (onEvent) => {
+      try {
+        while (!finished) {
+          const { done, value } = await session.read();
+          if (done) break;
+          pending = Buffer.concat([pending, Buffer.from(value)]);
+          pending = decodeAgentFrames(pending, (payload) => {
+            const serverMessage = decodeMessage(payload);
+
+            // agent.v1.AgentServerMessage.interaction_update
+            if (serverMessage.has(1)) {
+              const update = decodeMessage(serverMessage.get(1)[0].value);
+              if (update.has(1)) {
+                const textDelta = extractAgentString(decodeMessage(update.get(1)[0].value), 1);
+                if (textDelta) onEvent({ type: "text", value: textDelta });
+              }
+              // Cursor's AgentService emits internal reasoning without the
+              // cryptographic signature required by Anthropic thinking blocks.
+              // Forwarding it makes strict Anthropic clients (Claude Code)
+              // discard or wait on an otherwise complete response. Keep the
+              // reasoning upstream-only and emit the normal answer text.
+              if (update.has(14)) {
+                finished = true;
+                onEvent({ type: "done" });
+              }
+            }
+
+            // AgentService requests IDE context before producing a response.
+            // Return an empty context; 9router is not coupled to an editor.
+            if (serverMessage.has(2)) {
+              const execRequest = decodeMessage(serverMessage.get(2)[0].value);
+              if (execRequest.has(10)) {
+                session.write(createRequestContextResponse());
+              } else {
+                finished = true;
+                onEvent({ type: "error", value: "Cursor AgentService requested an unsupported IDE tool" });
+                onEvent({ type: "done" });
+              }
+            }
+          });
+        }
+      } finally {
+        try { session.end(); } catch {}
+        try { session.close(); } catch {}
+        if (!finished) onEvent({ type: "done" });
+      }
+    };
+
+    if (stream === false) {
+      let content = "";
+      let reasoning = "";
+      let agentError = null;
+      await consume((event) => {
+        if (event.type === "text") content += event.value;
+        else if (event.type === "thinking") reasoning += event.value;
+        else if (event.type === "error") agentError = event.value;
+      });
+      if (agentError) {
+        return {
+          response: new Response(JSON.stringify({ error: { message: agentError, type: "api_error" } }), {
+            status: HTTP_STATUS.BAD_REQUEST,
+            headers: { "Content-Type": "application/json" },
+          }),
+          url,
+          headers,
+          transformedBody: body,
+          responseFormat: FORMATS.OPENAI,
+        };
+      }
+      return {
+        response: new Response(JSON.stringify({
+          id: responseId,
+          object: "chat.completion",
+          created,
+          model,
+          choices: [{ index: 0, message: { role: "assistant", content: content || null, ...(reasoning ? { reasoning_content: reasoning } : {}) }, finish_reason: "stop" }],
+          usage: estimateUsage(body, content.length, FORMATS.OPENAI),
+        }), { headers: { "Content-Type": "application/json" } }),
+        url,
+        headers,
+        transformedBody: body,
+        responseFormat: FORMATS.OPENAI,
+      };
+    }
+
+    const encoder = new TextEncoder();
+    const responseStream = new ReadableStream({
+      start(controller) {
+        consume((event) => {
+          if (event.type === "text") {
+            controller.enqueue(encoder.encode(chatChunkSse({ id: responseId, created, model, delta: { content: event.value } })));
+          } else if (event.type === "thinking") {
+            controller.enqueue(encoder.encode(chatChunkSse({ id: responseId, created, model, delta: { reasoning_content: event.value } })));
+          } else if (event.type === "error") {
+            controller.enqueue(encoder.encode(chatChunkSse({ id: responseId, created, model, delta: { content: `\n[${event.value}]` } })));
+          } else if (event.type === "done") {
+            controller.enqueue(encoder.encode(chatChunkSse({ id: responseId, created, model, delta: {}, finishReason: "stop" })));
+            controller.enqueue(encoder.encode(SSE_DONE));
+            controller.close();
+          }
+        }).catch((error) => controller.error(error));
+      },
+      cancel() {
+        requestController.abort();
+      },
+    });
+
+    return {
+      response: new Response(responseStream, { headers: SSE_HEADERS }),
+      url,
+      headers,
+      transformedBody: body,
+      responseFormat: FORMATS.OPENAI,
+    };
+  }
+
   async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+    if (isAgentTextRequest(body)) {
+      try {
+        return await this.executeAgent({ model, body, stream, credentials, signal });
+      } catch (error) {
+        return {
+          response: new Response(JSON.stringify({
+            error: { message: error.message, type: "connection_error", code: "" },
+          }), { status: HTTP_STATUS.SERVER_ERROR, headers: { "Content-Type": "application/json" } }),
+          url: `${PROVIDER_OAUTH.cursor?.agentEndpoint || ""}${AGENT_RUN_PATH}`,
+          headers: {},
+          transformedBody: body,
+        };
+      }
+    }
+
     const url = this.buildUrl();
     const headers = this.buildHeaders(credentials);
     const transformedBody = this.transformRequest(model, body, stream, credentials);

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -292,12 +292,16 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Execute request
   let providerResponse, providerUrl, providerHeaders, finalBody;
+  // Most executors return their registry format. Cursor AgentService is an
+  // exception: it is decoded by the executor into OpenAI-compatible output.
+  let providerResponseFormat = targetFormat;
   try {
     const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
     providerResponse = result.response;
     providerUrl = result.url;
     providerHeaders = result.headers;
     finalBody = result.transformedBody;
+    providerResponseFormat = result.responseFormat || targetFormat;
     reqLogger.logTargetRequest(providerUrl, providerHeaders, finalBody);
   } catch (error) {
     trackPendingRequest(model, provider, connectionId, false, true);
@@ -336,7 +340,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
         }
         try {
           const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
-          if (retryResult.response.ok) { providerResponse = retryResult.response; providerUrl = retryResult.url; }
+          if (retryResult.response.ok) {
+            providerResponse = retryResult.response;
+            providerUrl = retryResult.url;
+            providerResponseFormat = retryResult.responseFormat || targetFormat;
+          }
         } catch { log?.warn?.("TOKEN", `${provider.toUpperCase()} | retry after refresh failed`); }
       } else {
         log?.warn?.("TOKEN", `${provider.toUpperCase()} | refresh failed`);
@@ -383,14 +391,14 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // True non-streaming response
   if (!stream) {
-    const result = await handleNonStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, reqLogger, toolNameMap, trackDone, appendLog });
+    const result = await handleNonStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, reqLogger, toolNameMap, trackDone, appendLog });
     streamController.handleComplete();
     return result;
   }
 
   // Streaming response
   const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
-  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId });
+  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, userAgent, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId });
 }
 
 export function isTokenExpiringSoon(expiresAt, bufferMs = 5 * 60 * 1000) {

--- a/open-sse/providers/registry/cursor.js
+++ b/open-sse/providers/registry/cursor.js
@@ -23,7 +23,7 @@ export default {
       "Content-Type": "application/connect+proto",
       "User-Agent": "connect-es/1.6.1",
     },
-    clientVersion: "3.1.0",
+    clientVersion: "3.11.13",
   },
   models: [
     { id: "default", name: "Auto (Server Picks)" },
@@ -44,11 +44,11 @@ export default {
   oauth: {
     apiEndpoint: "https://api2.cursor.sh",
     chatEndpoint: "/aiserver.v1.ChatService/StreamUnifiedChatWithTools",
-    modelsEndpoint: "/aiserver.v1.AiService/GetDefaultModelNudgeData",
+    modelsEndpoint: "/agent.v1.AgentService/GetUsableModels",
     api3Endpoint: "https://api3.cursor.sh",
     agentEndpoint: "https://agent.api5.cursor.sh",
     agentNonPrivacyEndpoint: "https://agentn.api5.cursor.sh",
-    clientVersion: "3.1.0",
+    clientVersion: "3.11.13",
     clientType: "ide",
     dbKeys: {
       accessToken: "cursorAuth/accessToken",

--- a/open-sse/services/cursorModels.js
+++ b/open-sse/services/cursorModels.js
@@ -1,0 +1,187 @@
+/**
+ * Cursor live model catalog fetcher.
+ *
+ * Cursor exposes the account-specific model picker through the AgentService
+ * `GetUsableModels` Connect RPC. Unlike the static provider registry, this
+ * includes models newly enabled for the account and omits unavailable ones.
+ */
+
+import crypto from "crypto";
+import http2 from "http2";
+import { PROVIDER_OAUTH } from "../providers/index.js";
+import { buildCursorHeaders } from "../utils/cursorChecksum.js";
+import { decodeMessage } from "../utils/cursorProtobuf.js";
+
+const FETCH_TIMEOUT_MS = 10_000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+// agent.v1.ModelDetails protobuf field numbers.
+const MODEL_ID_FIELD = 1;
+const DISPLAY_MODEL_ID_FIELD = 3;
+const DISPLAY_NAME_FIELD = 4;
+const DISPLAY_NAME_SHORT_FIELD = 5;
+const RESPONSE_MODELS_FIELD = 1;
+
+/** @type {Map<string, { expiresAt: number, models: { id: string, name: string }[] }>} */
+const catalogCache = new Map();
+
+function getCursorModelsUrl() {
+  const config = PROVIDER_OAUTH.cursor;
+  if (!config?.agentEndpoint || !config?.modelsEndpoint) return null;
+  return `${config.agentEndpoint.replace(/\/$/, "")}${config.modelsEndpoint}`;
+}
+
+function cacheKey(credentials) {
+  const seed = [
+    credentials?.providerSpecificData?.machineId,
+    credentials?.accessToken,
+  ].filter(Boolean).join(":");
+  if (!seed) return "cursor-anonymous";
+  return crypto.createHash("sha256").update(`cursor:${seed}`).digest("hex");
+}
+
+function firstString(fields, fieldNumber) {
+  const value = fields.get(fieldNumber)?.[0]?.value;
+  if (!value || typeof value === "number") return "";
+  return Buffer.from(value).toString("utf8");
+}
+
+/**
+ * Decode Cursor's `agent.v1.GetUsableModelsResponse` protobuf payload.
+ * The response contains repeated `agent.v1.ModelDetails` messages in field 1.
+ */
+export function parseCursorUsableModels(payload) {
+  const response = decodeMessage(payload);
+  const seen = new Set();
+  const models = [];
+
+  for (const entry of response.get(RESPONSE_MODELS_FIELD) || []) {
+    if (!entry?.value || typeof entry.value === "number") continue;
+    const detail = decodeMessage(entry.value);
+    const id = firstString(detail, MODEL_ID_FIELD).trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+
+    const name = (
+      firstString(detail, DISPLAY_NAME_FIELD)
+      || firstString(detail, DISPLAY_NAME_SHORT_FIELD)
+      || firstString(detail, DISPLAY_MODEL_ID_FIELD)
+      || id
+    ).trim();
+    models.push({ id, name });
+  }
+
+  return models;
+}
+
+/**
+ * agent.api5.cursor.sh is HTTP/2-only; Node fetch/undici cannot speak h2.
+ * Unary GetUsableModels uses an unframed protobuf body (application/proto).
+ */
+function http2PostProto(url, headers, body, signal, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const client = http2.connect(`https://${urlObj.host}`);
+    const chunks = [];
+    let responseHeaders = {};
+    let settled = false;
+
+    const finish = (fn) => (...args) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      try { client.close(); } catch {}
+      fn(...args);
+    };
+
+    const timeoutId = setTimeout(finish(() => {
+      reject(new Error("Cursor GetUsableModels timed out"));
+    }), timeoutMs);
+
+    client.on("error", finish(reject));
+
+    const req = client.request({
+      ":method": "POST",
+      ":path": urlObj.pathname,
+      ":authority": urlObj.host,
+      ":scheme": "https",
+      ...headers,
+    });
+
+    req.on("response", (hdrs) => { responseHeaders = hdrs; });
+    req.on("data", (chunk) => { chunks.push(chunk); });
+    req.on("end", finish(() => {
+      resolve({
+        status: Number(responseHeaders[":status"] || 0),
+        body: Buffer.concat(chunks),
+      });
+    }));
+    req.on("error", finish(reject));
+
+    if (signal) {
+      const onAbort = finish(() => reject(new Error("Request aborted")));
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    req.end(body && body.length ? Buffer.from(body) : undefined);
+  });
+}
+
+async function fetchCursorCatalog(credentials, signal) {
+  const accessToken = credentials?.accessToken;
+  const machineId = credentials?.providerSpecificData?.machineId;
+  const url = getCursorModelsUrl();
+  if (!accessToken || !machineId || !url) return null;
+
+  const headers = {
+    ...buildCursorHeaders(accessToken, machineId, credentials?.providerSpecificData?.ghostMode !== false),
+    // Connect unary calls use an unframed protobuf body, unlike Cursor chat's
+    // streaming `application/connect+proto` endpoint.
+    accept: "application/proto",
+    "content-type": "application/proto",
+  };
+  delete headers["connect-accept-encoding"];
+  delete headers["connect-protocol-version"];
+
+  const response = await http2PostProto(url, headers, new Uint8Array(), signal, FETCH_TIMEOUT_MS);
+  if (response.status !== 200) {
+    const error = new Error(`Cursor GetUsableModels returned ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+
+  return parseCursorUsableModels(new Uint8Array(response.body));
+}
+
+/**
+ * Resolve the live Cursor catalog for the authenticated account.
+ * Returns null on any failure so callers can fall back to static models.
+ */
+export async function resolveCursorModels(credentials, options = {}) {
+  if (!credentials?.accessToken || !credentials?.providerSpecificData?.machineId) {
+    options.log?.debug?.("CURSOR_MODELS", "No Cursor access token or machine ID; skipping live fetch");
+    return null;
+  }
+
+  const key = cacheKey(credentials);
+  const now = Date.now();
+  if (!options.forceRefresh) {
+    const cached = catalogCache.get(key);
+    if (cached?.expiresAt > now) return { models: cached.models };
+  }
+
+  try {
+    const models = await fetchCursorCatalog(credentials, options.signal);
+    if (!models?.length) return null;
+    catalogCache.set(key, { expiresAt: now + CACHE_TTL_MS, models });
+    return { models };
+  } catch (error) {
+    options.log?.warn?.("CURSOR_MODELS", `Live model fetch failed: ${error?.message || error}`);
+    return null;
+  }
+}
+
+export function clearCursorModelCache() {
+  catalogCache.clear();
+}

--- a/open-sse/utils/cursorChecksum.js
+++ b/open-sse/utils/cursorChecksum.js
@@ -128,7 +128,7 @@ export function buildCursorHeaders(accessToken, machineId = null, ghostMode = tr
     "x-amzn-trace-id": `Root=${crypto.randomUUID()}`,
     "x-client-key": clientKey,
     "x-cursor-checksum": checksum,
-    "x-cursor-client-version": "3.1.0",
+    "x-cursor-client-version": "3.11.13",
     "x-cursor-client-type": "ide",
     "x-cursor-client-os": os,
     "x-cursor-client-arch": arch,

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -66,6 +66,7 @@ export default function ProviderDetailPage() {
   const [thinkingMode, setThinkingMode] = useState("auto");
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
+  const [liveModels, setLiveModels] = useState([]);
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
   const [disabledModelIds, setDisabledModelIds] = useState([]);
   const [confirmState, setConfirmState] = useState(null);
@@ -141,7 +142,10 @@ export default function ProviderDetailPage() {
   const isOAuth = !!OAUTH_PROVIDERS[providerId] || !!FREE_PROVIDERS[providerId] || authModes.includes("oauth");
   const supportsApiKeyAuth = !!APIKEY_PROVIDERS[providerId] || authModes.includes("apikey");
   const isFreeNoAuth = !!FREE_PROVIDERS[providerId]?.noAuth;
-  const models = getModelsByProviderId(providerId);
+  const staticModels = getModelsByProviderId(providerId);
+  const models = providerId === "cursor" && liveModels.length > 0
+    ? liveModels
+    : staticModels;
   const providerAlias = getProviderAlias(providerId);
   
   const isOpenAICompatible = isOpenAICompatibleProvider(providerId);
@@ -447,6 +451,34 @@ export default function ProviderDetailPage() {
     fetchCustomModels();
     fetchDisabledModels();
   }, [fetchConnections, fetchAliases, fetchCustomModels, fetchDisabledModels]);
+
+  // Cursor's model availability is account-specific and changes frequently.
+  // Load the active account's live catalog for the dashboard; the static
+  // registry remains the fallback while the request is pending or unavailable.
+  useEffect(() => {
+    if (providerId !== "cursor") {
+      setLiveModels([]);
+      return;
+    }
+
+    const connection = connections.find((item) => item.isActive !== false);
+    if (!connection?.id) {
+      setLiveModels([]);
+      return;
+    }
+
+    let cancelled = false;
+    fetch(`/api/providers/${connection.id}/models`, { cache: "no-store" })
+      .then(async (res) => ({ ok: res.ok, data: await res.json() }))
+      .then(({ ok, data }) => {
+        if (!cancelled && ok && Array.isArray(data.models) && data.models.length > 0) {
+          setLiveModels(data.models);
+        }
+      })
+      .catch(() => {});
+
+    return () => { cancelled = true; };
+  }, [providerId, connections]);
 
   // Fetch suggested models from provider's public API (if configured)
   useEffect(() => {

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -8,6 +8,7 @@ import { getModelsByProviderId } from "open-sse/config/providerModels.js";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 import { resolveKimchiModels } from "open-sse/services/kimchiModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
+import { resolveCursorModels } from "open-sse/services/cursorModels.js";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
@@ -266,6 +267,19 @@ const PROVIDER_MODELS_CONFIG = {
         warning: "Kimchi returned no live models; falling back to static catalog.",
       };
     }
+  },
+  cursor: {
+    customResolver: async (connection) => {
+      const result = await resolveCursorModels({
+        accessToken: connection.accessToken,
+        providerSpecificData: connection.providerSpecificData || {},
+      }, { forceRefresh: true, log: console });
+      if (result?.models?.length) return { models: result.models };
+      return {
+        models: getStaticProviderModels("cursor"),
+        warning: "Cursor returned no live models; falling back to static catalog.",
+      };
+    },
   },
 
   // Custom resolvers (non-OpenAI-shaped APIs / token-refresh flows)

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -12,6 +12,7 @@ import { resolveKimchiModels } from "open-sse/services/kimchiModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveCopilotModels } from "open-sse/services/copilotModels.js";
 import { resolveClinepassModels } from "open-sse/services/clinepassModels.js";
+import { resolveCursorModels } from "open-sse/services/cursorModels.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { capabilitiesFromServiceKind } from "open-sse/providers/capabilities.js";
 
@@ -70,6 +71,13 @@ const LIVE_MODEL_RESOLVERS = {
       accessToken: conn.accessToken,
       apiKey: conn.apiKey,
     });
+    return result?.models?.length ? { models: result.models } : null;
+  },
+  cursor: async (conn) => {
+    const result = await resolveCursorModels({
+      accessToken: conn.accessToken,
+      providerSpecificData: conn.providerSpecificData || {},
+    }, { log: console });
     return result?.models?.length ? { models: result.models } : null;
   }
 };

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -48,6 +48,48 @@ export default function ModelSelectModal({
   const [providerNodes, setProviderNodes] = useState([]);
   const [customModels, setCustomModels] = useState([]);
   const [disabledModels, setDisabledModels] = useState({});
+  const [cursorModels, setCursorModels] = useState([]);
+
+  // Cursor exposes the usable catalog per account. Keep the static catalog only
+  // as a fallback, since it quickly becomes stale and different accounts can
+  // have different model entitlements.
+  const cursorConnectionIds = useMemo(
+    () => activeProviders
+      .filter((provider) => provider.provider === "cursor" && provider.id)
+      .map((provider) => provider.id),
+    [activeProviders],
+  );
+
+  useEffect(() => {
+    if (!isOpen || cursorConnectionIds.length === 0) {
+      setCursorModels([]);
+      return undefined;
+    }
+
+    let cancelled = false;
+    Promise.all(cursorConnectionIds.map(async (connectionId) => {
+      const response = await fetch(`/api/providers/${connectionId}/models`, { cache: "no-store" });
+      if (!response.ok) return [];
+      const data = await response.json();
+      return Array.isArray(data.models) ? data.models : [];
+    }))
+      .then((modelLists) => {
+        if (cancelled) return;
+        const seen = new Set();
+        setCursorModels(modelLists.flat().filter((model) => {
+          if (!model?.id || seen.has(model.id)) return false;
+          seen.add(model.id);
+          return true;
+        }));
+      })
+      .catch((error) => {
+        // Do not hide the static fallback when the account catalog is unavailable.
+        console.warn("Unable to load Cursor models for selector:", error);
+        if (!cancelled) setCursorModels([]);
+      });
+
+    return () => { cancelled = true; };
+  }, [isOpen, cursorConnectionIds]);
 
   const fetchCombos = async () => {
     try {
@@ -280,7 +322,9 @@ export default function ModelSelectModal({
           hasModels: mergedModels.length > 0,
         };
       } else {
-        const hardcodedModels = getModelsByProviderId(providerId);
+        const hardcodedModels = providerId === "cursor" && cursorModels.length > 0
+          ? cursorModels
+          : getModelsByProviderId(providerId);
         const hardcodedIds = new Set(hardcodedModels.map((m) => m.id));
 
         // Custom models: if no hardcoded models (e.g. openrouter), show all aliases for this provider
@@ -349,7 +393,7 @@ export default function ModelSelectModal({
     });
 
     return groups;
-  }, [filteredActiveProviders, modelAliases, allProviders, providerNodes, customModels, disabledModels, kindFilter, activeProviders]);
+  }, [filteredActiveProviders, modelAliases, allProviders, providerNodes, customModels, disabledModels, kindFilter, activeProviders, cursorModels]);
 
   // Filter combos by search query (and hide combos when kindFilter is set — combos are LLM-only by design)
   const filteredCombos = useMemo(() => {

--- a/tests/__baseline__/providers-baseline.json
+++ b/tests/__baseline__/providers-baseline.json
@@ -232,7 +232,7 @@
       "Content-Type": "application/connect+proto",
       "User-Agent": "connect-es/1.6.1"
     },
-    "clientVersion": "3.1.0"
+    "clientVersion": "3.11.13"
   },
   "deepgram": {
     "baseUrl": "https://api.deepgram.com/v1/listen",

--- a/tests/unit/cursor-models.test.js
+++ b/tests/unit/cursor-models.test.js
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearCursorModelCache,
+  parseCursorUsableModels,
+  resolveCursorModels,
+} from "../../open-sse/services/cursorModels.js";
+
+const originalFetch = global.fetch;
+
+function varint(value) {
+  const bytes = [];
+  while (value >= 0x80) {
+    bytes.push((value & 0x7f) | 0x80);
+    value >>>= 7;
+  }
+  bytes.push(value);
+  return Uint8Array.from(bytes);
+}
+
+function field(fieldNumber, value) {
+  return Uint8Array.from([(fieldNumber << 3) | 2, ...varint(value.length), ...value]);
+}
+
+function text(value) {
+  return new TextEncoder().encode(value);
+}
+
+function concat(...parts) {
+  const size = parts.reduce((sum, part) => sum + part.length, 0);
+  const result = new Uint8Array(size);
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+function model(id, name) {
+  return field(1, concat(field(1, text(id)), field(4, text(name))));
+}
+
+describe("Cursor live model catalog", () => {
+  beforeEach(() => {
+    clearCursorModelCache();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    clearCursorModelCache();
+  });
+
+  it("decodes the GetUsableModels protobuf response", () => {
+    const payload = concat(
+      model("default", "Auto"),
+      model("gpt-5.3-codex", "GPT 5.3 Codex"),
+      model("gpt-5.3-codex", "Duplicate"),
+    );
+
+    expect(parseCursorUsableModels(payload)).toEqual([
+      { id: "default", name: "Auto" },
+      { id: "gpt-5.3-codex", name: "GPT 5.3 Codex" },
+    ]);
+  });
+
+  it("fetches the account-specific catalog and caches it", async () => {
+    const payload = concat(model("claude-4.6-opus", "Claude 4.6 Opus"));
+    global.fetch = vi.fn().mockResolvedValue(new Response(payload, { status: 200 }));
+    const credentials = {
+      accessToken: "cursor-token",
+      providerSpecificData: { machineId: "machine-id" },
+    };
+
+    await expect(resolveCursorModels(credentials)).resolves.toEqual({
+      models: [{ id: "claude-4.6-opus", name: "Claude 4.6 Opus" }],
+    });
+    await expect(resolveCursorModels(credentials)).resolves.toEqual({
+      models: [{ id: "claude-4.6-opus", name: "Claude 4.6 Opus" }],
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://agent.api5.cursor.sh/agent.v1.AgentService/GetUsableModels",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(Uint8Array),
+        headers: expect.objectContaining({
+          "content-type": "application/proto",
+          accept: "application/proto",
+        }),
+      }),
+    );
+  });
+
+  it("fails open when the Cursor catalog request fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response("no", { status: 403 }));
+
+    await expect(resolveCursorModels({
+      accessToken: "cursor-token",
+      providerSpecificData: { machineId: "machine-id" },
+    })).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Bump `x-cursor-client-version` from `3.1.0` → `3.11.13` so Cursor stops rejecting requests with `ERROR_GPT_4_VISION_PREVIEW_RATE_LIMIT` / "Update Required" (fixes #2487).
- Route Cursor **AgentService** (`agent.api5.cursor.sh`, HTTP/2-only) through Node `http2` duplex instead of `fetch`/undici, which only speaks HTTP/1.1 and fails with `fetch failed`.
- Teach `chatCore` to honor executor `responseFormat` when AgentService already decodes to OpenAI-compatible SSE.
- Fetch the live `GetUsableModels` catalog (also over HTTP/2) for account-specific model lists in the dashboard / `/v1/models`.

## Test plan
- [ ] Import Cursor OAuth credentials; provider test / chat with `cu/default` no longer returns 429 `Update Required`
- [ ] Claude Code (or any client that always sends tool schemas) against `cu/default` streams a normal reply instead of hanging / `AgentService request failed: fetch failed`
- [ ] Dashboard Cursor model picker loads live models (or falls back to static catalog on failure)
- [ ] `tests/__baseline__/providers-baseline.json` clientVersion matches registry (`3.11.13`)