### PR TITLE
fix(byteplus): use standard ModelArk endpoint, not Coding Plan endpoint

### DIFF
--- a/open-sse/providers/registry/byteplus.js
+++ b/open-sse/providers/registry/byteplus.js
@@ -19,7 +19,7 @@ export default {
   },
   category: "freeTier",
   transport: {
-    baseUrl: "https://ark.ap-southeast.bytepluses.com/api/coding/v3/chat/completions",
+    baseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3/chat/completions",
     headers: {},
   },
   models: [


### PR DESCRIPTION
## Summary
- The `byteplus` provider registry entry (`open-sse/providers/registry/byteplus.js`) is tagged `category: "freeTier"`, but its `transport.baseUrl` points at `/api/coding/v3/chat/completions` — an endpoint gated behind a separate paid **Coding Plan** subscription (Lite $10/mo or Pro $50/mo).
- Accounts on the genuinely free "Free Credits Only Mode" (500k tokens/model) without a Coding Plan subscription get every request rejected: `400 InvalidSubscription`, regardless of free quota remaining.
- The sibling `volcengine-ark.js` entry uses the same `/api/coding/v3` path but is correctly tagged `category: "apikey"` — this file looks copy-pasted from it without updating the endpoint for the free tier.

## Fix
Switch to `/api/v3/chat/completions` — the standard ModelArk Chat/inference endpoint, same host, same auth (Bearer API key). This makes the free per-model token pool actually usable with no Coding Plan subscription required.

## Verification
Tested against a live BytePlus account on Free Credits Only Mode with no Coding Plan subscription, same API key and model IDs (`seed-2-0-pro-260328`):
- Old endpoint (`/api/coding/v3/chat/completions`): `400 {"error":{"code":"InvalidSubscription",...}}`
- New endpoint (`/api/v3/chat/completions`): request succeeds end-to-end (verified via a duplicate custom OpenAI-compatible connector pointed at the fixed URL, before applying this change to the registry file directly).