### PR TITLE
feat(updater): one-click dashboard update with manual fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Perplexity**: add Agent API provider (#2492)
 - **Grok CLI**: add Grok CLI / Grok Build provider with OAuth device-code flow (#2502)
 - **Updater**: one-click Update in dashboard (auto install + restart, manual fallback)
+- **Updater**: show What's new (changelog) before update + soft post-update banner
 - **Featherless**: add OpenAI-compatible provider presets
 - **SearXNG**: configure endpoint via SEARXNG_URL env (#2499)
 - **Providers**: add max thinking level for gpt-5.6-sol (#2500)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 - **Perplexity**: add Agent API provider (#2492)
 - **Grok CLI**: add Grok CLI / Grok Build provider with OAuth device-code flow (#2502)
+- **Updater**: one-click Update in dashboard (auto install + restart, manual fallback)
 - **Featherless**: add OpenAI-compatible provider presets
 - **SearXNG**: configure endpoint via SEARXNG_URL env (#2499)
 - **Providers**: add max thinking level for gpt-5.6-sol (#2500)

--- a/src/app/api/version/update/route.js
+++ b/src/app/api/version/update/route.js
@@ -1,10 +1,15 @@
 import { NextResponse } from "next/server";
 import { killAppProcesses, spawnUpdaterAndExit } from "@/lib/appUpdater";
+import { UPDATER_CONFIG } from "@/shared/constants/config";
 
 export async function POST() {
   if (process.env.NODE_ENV !== "production") {
     return NextResponse.json(
-      { success: false, message: "Update is only available in production build (9router CLI)" },
+      {
+        success: false,
+        message:
+          "Auto-update only works with the production 9router CLI install (not npm run dev). Use the manual install command instead.",
+      },
       { status: 403 }
     );
   }
@@ -14,8 +19,13 @@ export async function POST() {
     await killAppProcesses();
   } catch { /* best effort */ }
 
-  // Schedule detached updater then exit current server process
-  spawnUpdaterAndExit();
+  // Schedule detached updater then exit current server process.
+  // Pin @latest so npm always prefers the registry tip (matches installCmdLatest).
+  spawnUpdaterAndExit(`${UPDATER_CONFIG.npmPackageName}@latest`);
 
-  return NextResponse.json({ success: true, message: "Updater started. This app will exit shortly." });
+  return NextResponse.json({
+    success: true,
+    message: "Updater started. This app will exit shortly.",
+    statusUrl: `http://127.0.0.1:${UPDATER_CONFIG.statusPort}/update/status`,
+  });
 }

--- a/src/lib/appUpdater.js
+++ b/src/lib/appUpdater.js
@@ -189,7 +189,8 @@ export function spawnUpdaterAndExit(packageName = UPDATER_CONFIG.npmPackageName)
       UPDATER_WAIT_MIN_MS: String(UPDATER_CONFIG.waitForExitMinMs),
       UPDATER_WAIT_MAX_MS: String(UPDATER_CONFIG.waitForExitMaxMs),
       UPDATER_WAIT_CHECK_MS: String(UPDATER_CONFIG.waitForExitCheckMs),
-      UPDATER_APP_PORT: String(UPDATER_CONFIG.appPort),
+      // Prefer the live server port so wait/relaunch match this instance (not a hardcoded default)
+      UPDATER_APP_PORT: String(process.env.PORT || UPDATER_CONFIG.appPort),
       UPDATER_RELAUNCH: "1",
       UPDATER_RELAUNCH_CMD: relaunch.cmd,
       UPDATER_RELAUNCH_ARGS: JSON.stringify(relaunchArgs),

--- a/src/shared/components/PostUpdateBanner.js
+++ b/src/shared/components/PostUpdateBanner.js
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { APP_CONFIG, GITHUB_CONFIG } from "@/shared/constants/config";
+import {
+  collectChangelogHighlights,
+  detectPostUpdate,
+  dismissPostUpdate,
+  getChangelogSectionsBetween,
+} from "@/shared/utils/changelog";
+import ChangelogModal from "./ChangelogModal";
+
+/**
+ * Soft banner after an upgrade: "Updated to vX — see what changed".
+ * Shown once per version bump (localStorage).
+ */
+export default function PostUpdateBanner() {
+  const [visible, setVisible] = useState(false);
+  const [fromVersion, setFromVersion] = useState(null);
+  const [toVersion, setToVersion] = useState(null);
+  const [highlights, setHighlights] = useState([]);
+  const [truncated, setTruncated] = useState(false);
+  const [changelogOpen, setChangelogOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    const detected = detectPostUpdate(APP_CONFIG.version);
+    if (!detected.show) return;
+    setVisible(true);
+    setFromVersion(detected.fromVersion);
+    setToVersion(detected.toVersion);
+
+    let cancelled = false;
+    fetch(GITHUB_CONFIG.changelogUrl, { cache: "no-store" })
+      .then((res) => (res.ok ? res.text() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((md) => {
+        if (cancelled) return;
+        const sections = getChangelogSectionsBetween(md, detected.fromVersion, detected.toVersion);
+        // If range empty (changelog not yet published on master), fall back to latest section
+        const effective =
+          sections.length > 0
+            ? sections
+            : getChangelogSectionsBetween(md, null, detected.toVersion);
+        const { bullets, truncated: trunc } = collectChangelogHighlights(
+          effective.length ? effective : [],
+          { maxBullets: 6 },
+        );
+        setHighlights(bullets);
+        setTruncated(trunc);
+      })
+      .catch(() => {
+        /* banner still useful without bullets */
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleDismiss = () => {
+    dismissPostUpdate(APP_CONFIG.version);
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <>
+      <div className="pointer-events-auto w-full rounded-lg border border-green-500/30 bg-green-500/10 text-green-800 dark:text-green-200 shadow-lg backdrop-blur-sm px-3 py-2.5">
+        <div className="flex items-start gap-2">
+          <span className="material-symbols-outlined text-[18px] leading-5 text-green-600 dark:text-green-400 shrink-0">
+            celebration
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold">
+              Updated to v{toVersion}
+              {fromVersion ? (
+                <span className="font-normal opacity-80"> (from v{fromVersion})</span>
+              ) : null}
+            </p>
+            {!expanded && highlights.length === 0 && (
+              <p className="text-[11px] opacity-80 mt-0.5">You&apos;re on the latest install.</p>
+            )}
+            {expanded && highlights.length > 0 && (
+              <ul className="mt-1.5 space-y-0.5 text-[11px] opacity-90 list-disc list-inside">
+                {highlights.map((b, i) => (
+                  <li key={`${b.version}-${i}`} className="truncate" title={b.text}>
+                    {b.text}
+                  </li>
+                ))}
+                {truncated && (
+                  <li className="list-none opacity-70 pl-0">…and more</li>
+                )}
+              </ul>
+            )}
+            <div className="mt-1.5 flex flex-wrap items-center gap-2">
+              {highlights.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setExpanded((v) => !v)}
+                  className="text-[11px] font-medium underline-offset-2 hover:underline"
+                >
+                  {expanded ? "Hide changes" : "See what changed"}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setChangelogOpen(true)}
+                className="text-[11px] font-medium underline-offset-2 hover:underline opacity-80"
+              >
+                Full changelog
+              </button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="text-current/70 hover:text-current shrink-0"
+            aria-label="Dismiss"
+          >
+            <span className="material-symbols-outlined text-[16px]">close</span>
+          </button>
+        </div>
+      </div>
+
+      <ChangelogModal isOpen={changelogOpen} onClose={() => setChangelogOpen(false)} />
+    </>
+  );
+}
+
+PostUpdateBanner.propTypes = {};

--- a/src/shared/components/Sidebar.js
+++ b/src/shared/components/Sidebar.js
@@ -8,9 +8,8 @@ import { cn } from "@/shared/utils/cn";
 import { APP_CONFIG, UPDATER_CONFIG } from "@/shared/constants/config";
 import { MEDIA_PROVIDER_KINDS } from "@/shared/constants/providers";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
-import Button from "./Button";
-import { ConfirmModal } from "./Modal";
 import NineRemotePromoModal from "./NineRemotePromoModal";
+import UpdatePanel from "./UpdatePanel";
 
 // const VISIBLE_MEDIA_KINDS = ["embedding", "image", "imageToText", "tts", "stt", "webSearch", "webFetch", "video", "music"];
 const VISIBLE_MEDIA_KINDS = ["embedding", "image", "tts", "stt"];
@@ -43,11 +42,8 @@ export default function Sidebar({ onClose }) {
   const pathname = usePathname();
   const [mediaOpen, setMediaOpen] = useState(false);
   const [showRemoteModal, setShowRemoteModal] = useState(false);
-  const [isDisconnected, setIsDisconnected] = useState(false);
   const [updateInfo, setUpdateInfo] = useState(null);
-  const [showUpdateModal, setShowUpdateModal] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
-  const [shutdownCountdown, setShutdownCountdown] = useState(0);
   const [enableTranslator, setEnableTranslator] = useState(false);
   const { copied, copy } = useCopyToClipboard(2000);
 
@@ -74,37 +70,6 @@ export default function Sidebar({ onClose }) {
     }
     return pathname.startsWith(href);
   };
-
-  // Open manual update panel (no countdown yet — user must click Copy to trigger shutdown)
-  const handleUpdate = () => {
-    setShowUpdateModal(false);
-    setIsUpdating(true);
-  };
-
-  // Triggered by Copy button inside ManualUpdatePanel: copy + countdown + shutdown
-  const handleCopyAndShutdown = async () => {
-    try { await navigator.clipboard.writeText(INSTALL_CMD); } catch { /* clipboard blocked */ }
-    copy(INSTALL_CMD);
-    let remaining = UPDATER_CONFIG.shutdownCountdownSec;
-    setShutdownCountdown(remaining);
-    const timer = setInterval(() => {
-      remaining -= 1;
-      setShutdownCountdown(remaining);
-      if (remaining <= 0) {
-        clearInterval(timer);
-        fetch("/api/version/shutdown", { method: "POST" }).catch(() => {});
-        setIsDisconnected(true);
-      }
-    }, 1000);
-  };
-
-  const handleCancelUpdate = () => {
-    setIsUpdating(false);
-    setShutdownCountdown(0);
-  };
-
-  // Note: legacy updater poll removed. New flow: copy install cmd + shutdown server,
-  // user runs the command manually in another terminal.
 
 
   return (
@@ -137,7 +102,7 @@ export default function Sidebar({ onClose }) {
               </span>
               <div className="flex items-center gap-2">
                 <button
-                  onClick={() => setShowUpdateModal(true)}
+                  onClick={() => setIsUpdating(true)}
                   className="px-2 py-1 rounded bg-green-600 hover:bg-green-700 dark:bg-amber-500 dark:hover:bg-amber-600 text-white text-[11px] font-semibold transition-colors cursor-pointer"
                 >
                   Update now
@@ -334,43 +299,14 @@ export default function Sidebar({ onClose }) {
       {/* Remote Promo Modal */}
       <NineRemotePromoModal isOpen={showRemoteModal} onClose={() => setShowRemoteModal(false)} />
 
-      {/* Update Confirmation Modal */}
-      <ConfirmModal
-        isOpen={showUpdateModal}
-        onClose={() => setShowUpdateModal(false)}
-        onConfirm={handleUpdate}
-        title="Update 9Router"
-        message={`Show install command for v${updateInfo?.latestVersion || ""}? You can copy it and shutdown to install manually.`}
-        confirmText="Show Command"
-        cancelText="Cancel"
-        variant="primary"
-      />
-
-      {/* Disconnected / Updating Overlay */}
-      {(isDisconnected || isUpdating) && (
+      {/* One-click update overlay (auto install + manual fallback) */}
+      {isUpdating && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-6">
-          {isUpdating ? (
-            <ManualUpdatePanel
-              latestVersion={updateInfo?.latestVersion}
-              installCmd={INSTALL_CMD}
-              copied={copied}
-              onCopyAndShutdown={handleCopyAndShutdown}
-              onCancel={handleCancelUpdate}
-              countdown={shutdownCountdown}
-              isDisconnected={isDisconnected}
-            />
-          ) : (
-            <div className="text-center p-8">
-              <div className="flex items-center justify-center size-16 rounded-full bg-red-500/20 text-red-500 mx-auto mb-4">
-                <span className="material-symbols-outlined text-[32px]">power_off</span>
-              </div>
-              <h2 className="text-xl font-semibold text-white mb-2">Server Disconnected</h2>
-              <p className="text-text-muted mb-6">The proxy server has been stopped.</p>
-              <Button variant="secondary" onClick={() => globalThis.location.reload()}>
-                Reload Page
-              </Button>
-            </div>
-          )}
+          <UpdatePanel
+            latestVersion={updateInfo?.latestVersion}
+            installCmd={INSTALL_CMD}
+            onClose={() => setIsUpdating(false)}
+          />
         </div>
       )}
     </>
@@ -379,63 +315,4 @@ export default function Sidebar({ onClose }) {
 
 Sidebar.propTypes = {
   onClose: PropTypes.func,
-};
-
-function ManualUpdatePanel({ latestVersion, installCmd, copied, onCopyAndShutdown, onCancel, countdown, isDisconnected }) {
-  const isCountingDown = countdown > 0;
-  return (
-    <div className="w-full max-w-lg rounded-xl bg-neutral-900/95 border border-white/10 p-6 text-white">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="flex items-center justify-center size-11 rounded-full bg-amber-500/20 text-amber-400">
-          <span className="material-symbols-outlined text-[24px]">content_copy</span>
-        </div>
-        <div>
-          <h2 className="text-lg font-semibold">Update 9Router{latestVersion ? ` to v${latestVersion}` : ""}</h2>
-          <p className="text-xs text-white/60">
-            {isDisconnected
-              ? "Server stopped. Paste the command into a terminal to install."
-              : isCountingDown
-                ? `Command copied. Server will stop in ${countdown}s...`
-                : "Click the button below to copy the install command and shutdown."}
-          </p>
-        </div>
-      </div>
-
-      <p className="text-sm text-white/80 mb-2">Install command:</p>
-      <div className="w-full px-3 py-2 rounded bg-white/5 mb-4">
-        <code className="text-xs font-mono text-amber-400 break-all">{installCmd}</code>
-      </div>
-
-      <ol className="text-xs text-white/70 space-y-1 list-decimal list-inside mb-4">
-        <li>Click <strong>Copy & Shutdown</strong> below.</li>
-        <li>Paste the command into your terminal and press Enter.</li>
-        <li>Run <code className="px-1 rounded bg-white/10 text-green-400">9router</code> again after install.</li>
-      </ol>
-
-      {isDisconnected ? (
-        <Button variant="secondary" fullWidth onClick={() => globalThis.location.reload()}>
-          Reload Page
-        </Button>
-      ) : (
-        <div className="flex gap-2">
-          <Button variant="secondary" onClick={onCancel} disabled={isCountingDown}>
-            Cancel
-          </Button>
-          <Button variant="primary" fullWidth onClick={onCopyAndShutdown} disabled={isCountingDown}>
-            {copied ? "✓ Copied — shutting down..." : isCountingDown ? `Shutting down in ${countdown}s` : "Copy & Shutdown"}
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-ManualUpdatePanel.propTypes = {
-  latestVersion: PropTypes.string,
-  installCmd: PropTypes.string.isRequired,
-  copied: PropTypes.bool,
-  onCopyAndShutdown: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  countdown: PropTypes.number,
-  isDisconnected: PropTypes.bool,
 };

--- a/src/shared/components/Sidebar.js
+++ b/src/shared/components/Sidebar.js
@@ -303,6 +303,7 @@ export default function Sidebar({ onClose }) {
       {isUpdating && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-6">
           <UpdatePanel
+            currentVersion={updateInfo?.currentVersion || APP_CONFIG.version}
             latestVersion={updateInfo?.latestVersion}
             installCmd={INSTALL_CMD}
             onClose={() => setIsUpdating(false)}

--- a/src/shared/components/UpdatePanel.js
+++ b/src/shared/components/UpdatePanel.js
@@ -3,7 +3,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import Button from "./Button";
-import { UPDATER_CONFIG } from "@/shared/constants/config";
+import ChangelogModal from "./ChangelogModal";
+import { GITHUB_CONFIG, UPDATER_CONFIG } from "@/shared/constants/config";
+import {
+  collectChangelogHighlights,
+  getChangelogSectionsBetween,
+  markUpdateStarting,
+  parseChangelogSections,
+} from "@/shared/utils/changelog";
 import {
   getUpdaterPhaseLabel,
   getUpdaterProgressPercent,
@@ -18,6 +25,7 @@ import {
  * - manual: copy install cmd + optional shutdown (fallback / user choice)
  */
 export default function UpdatePanel({
+  currentVersion,
   latestVersion,
   installCmd,
   onClose,
@@ -29,6 +37,8 @@ export default function UpdatePanel({
   const [copied, setCopied] = useState(false);
   const [countdown, setCountdown] = useState(0);
   const [isDisconnected, setIsDisconnected] = useState(false);
+  const [whatsNew, setWhatsNew] = useState({ bullets: [], truncated: false, loading: true, error: null, versions: [] });
+  const [changelogOpen, setChangelogOpen] = useState(false);
   const pollRef = useRef(null);
   const reloadRef = useRef(null);
   const cancelledRef = useRef(false);
@@ -48,6 +58,53 @@ export default function UpdatePanel({
     cancelledRef.current = true;
     clearTimers();
   }, [clearTimers]);
+
+  // Prefetch release notes for the upgrade range (current → latest)
+  useEffect(() => {
+    let cancelled = false;
+    setWhatsNew((prev) => ({ ...prev, loading: true, error: null }));
+    fetch(GITHUB_CONFIG.changelogUrl, { cache: "no-store" })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.text();
+      })
+      .then((md) => {
+        if (cancelled) return;
+        let sections = getChangelogSectionsBetween(md, currentVersion, latestVersion);
+        // Changelog on master may lag npm latest — fall back to newest published section
+        if (sections.length === 0 && latestVersion) {
+          sections = getChangelogSectionsBetween(md, null, latestVersion);
+        }
+        if (sections.length === 0 && currentVersion) {
+          sections = getChangelogSectionsBetween(md, currentVersion, null).slice(0, 2);
+        }
+        if (sections.length === 0) {
+          const all = parseChangelogSections(md);
+          if (all.length > 0) sections = [all[0]];
+        }
+        const { bullets, truncated, versions } = collectChangelogHighlights(sections, {
+          maxBullets: 10,
+        });
+        setWhatsNew({ bullets, truncated, loading: false, error: null, versions });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setWhatsNew({
+          bullets: [],
+          truncated: false,
+          loading: false,
+          error: err.message || "Failed to load release notes",
+          versions: [],
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVersion, latestVersion]);
+
+  const rememberUpdateFrom = useCallback(() => {
+    markUpdateStarting(currentVersion);
+  }, [currentVersion]);
 
   const startStatusPoll = useCallback(() => {
     clearTimers();
@@ -100,6 +157,7 @@ export default function UpdatePanel({
     setStatus(null);
     setPhase("starting");
     cancelledRef.current = false;
+    rememberUpdateFrom();
 
     try {
       const res = await fetch("/api/version/update", { method: "POST" });
@@ -125,9 +183,10 @@ export default function UpdatePanel({
         setError(null);
       }
     }
-  }, [startStatusPoll]);
+  }, [startStatusPoll, rememberUpdateFrom]);
 
   const handleCopyAndShutdown = async () => {
+    rememberUpdateFrom();
     try {
       await navigator.clipboard.writeText(installCmd);
     } catch { /* clipboard blocked */ }
@@ -159,10 +218,63 @@ export default function UpdatePanel({
   const busy = phase === "starting" || phase === "running" || phase === "success";
   const title = `Update 9Router${latestVersion ? ` to v${latestVersion}` : ""}`;
 
+  const whatsNewBlock = (
+    <div className="mb-4 rounded-lg border border-white/10 bg-white/5 p-3">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <p className="text-xs font-semibold text-white/90">
+          What&apos;s new
+          {latestVersion ? (
+            <span className="font-normal text-white/50">
+              {" "}
+              {currentVersion ? `v${currentVersion} → ` : ""}v{latestVersion}
+            </span>
+          ) : null}
+        </p>
+        <button
+          type="button"
+          onClick={() => setChangelogOpen(true)}
+          className="text-[10px] text-white/50 hover:text-white/80 transition-colors shrink-0"
+        >
+          Full changelog
+        </button>
+      </div>
+      {whatsNew.loading && (
+        <p className="text-[11px] text-white/50 flex items-center gap-1.5">
+          <span className="material-symbols-outlined text-[14px] animate-spin">progress_activity</span>
+          Loading release notes…
+        </p>
+      )}
+      {!whatsNew.loading && whatsNew.error && (
+        <p className="text-[11px] text-white/50">
+          Couldn&apos;t load release notes ({whatsNew.error}). You can still update.
+        </p>
+      )}
+      {!whatsNew.loading && !whatsNew.error && whatsNew.bullets.length === 0 && (
+        <p className="text-[11px] text-white/50">
+          No release notes found for this range yet. Check the full changelog after updating.
+        </p>
+      )}
+      {!whatsNew.loading && whatsNew.bullets.length > 0 && (
+        <ul className="max-h-40 overflow-y-auto space-y-1 text-[11px] text-white/75 list-disc list-inside">
+          {whatsNew.bullets.map((b, i) => (
+            <li key={`${b.version}-${i}`} className="leading-snug" title={b.text}>
+              <span className="text-white/40 mr-1">v{b.version}</span>
+              {b.text}
+            </li>
+          ))}
+          {whatsNew.truncated && (
+            <li className="list-none text-white/40 pl-0">…more in full changelog</li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+
   // ── Auto mode (default) ──────────────────────────────────────────────────
   if (mode === "auto") {
     return (
-      <div className="w-full max-w-lg rounded-xl bg-neutral-900/95 border border-white/10 p-6 text-white">
+      <>
+      <div className="w-full max-w-xl rounded-xl bg-neutral-900/95 border border-white/10 p-6 text-white">
         <div className="flex items-center gap-3 mb-4">
           <div className="flex items-center justify-center size-11 rounded-full bg-green-500/20 text-green-400">
             <span className="material-symbols-outlined text-[24px]">
@@ -179,6 +291,7 @@ export default function UpdatePanel({
 
         {phase === "idle" && (
           <>
+            {whatsNewBlock}
             <ul className="text-xs text-white/70 space-y-1.5 list-disc list-inside mb-4">
               <li>Works with the production <code className="px-1 rounded bg-white/10">9router</code> CLI install</li>
               <li>Takes about 1–2 minutes (npm global install + restart)</li>
@@ -262,13 +375,16 @@ export default function UpdatePanel({
           </>
         )}
       </div>
+      <ChangelogModal isOpen={changelogOpen} onClose={() => setChangelogOpen(false)} />
+      </>
     );
   }
 
   // ── Manual fallback ──────────────────────────────────────────────────────
   const isCountingDown = countdown > 0;
   return (
-    <div className="w-full max-w-lg rounded-xl bg-neutral-900/95 border border-white/10 p-6 text-white">
+    <>
+    <div className="w-full max-w-xl rounded-xl bg-neutral-900/95 border border-white/10 p-6 text-white">
       <div className="flex items-center gap-3 mb-4">
         <div className="flex items-center justify-center size-11 rounded-full bg-amber-500/20 text-amber-400">
           <span className="material-symbols-outlined text-[24px]">content_copy</span>
@@ -286,6 +402,8 @@ export default function UpdatePanel({
           </p>
         </div>
       </div>
+
+      {!isDisconnected && !isCountingDown && whatsNewBlock}
 
       {error && (
         <div className="mb-3 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
@@ -341,10 +459,13 @@ export default function UpdatePanel({
         </button>
       )}
     </div>
+    <ChangelogModal isOpen={changelogOpen} onClose={() => setChangelogOpen(false)} />
+    </>
   );
 }
 
 UpdatePanel.propTypes = {
+  currentVersion: PropTypes.string,
   latestVersion: PropTypes.string,
   installCmd: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/shared/components/UpdatePanel.js
+++ b/src/shared/components/UpdatePanel.js
@@ -1,0 +1,351 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import Button from "./Button";
+import { UPDATER_CONFIG } from "@/shared/constants/config";
+import {
+  getUpdaterPhaseLabel,
+  getUpdaterProgressPercent,
+  getUpdaterStatusUrl,
+  isUpdaterFailure,
+  isUpdaterSuccess,
+} from "@/shared/utils/updaterStatus";
+
+/**
+ * Modes:
+ * - auto: POST /api/version/update → poll detached status server → reload
+ * - manual: copy install cmd + optional shutdown (fallback / user choice)
+ */
+export default function UpdatePanel({
+  latestVersion,
+  installCmd,
+  onClose,
+}) {
+  const [mode, setMode] = useState("auto"); // "auto" | "manual"
+  const [phase, setPhase] = useState("idle"); // idle | confirming | starting | running | success | failed
+  const [status, setStatus] = useState(null);
+  const [error, setError] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const [isDisconnected, setIsDisconnected] = useState(false);
+  const pollRef = useRef(null);
+  const reloadRef = useRef(null);
+  const cancelledRef = useRef(false);
+
+  const clearTimers = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    if (reloadRef.current) {
+      clearInterval(reloadRef.current);
+      reloadRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => {
+    cancelledRef.current = true;
+    clearTimers();
+  }, [clearTimers]);
+
+  const startStatusPoll = useCallback(() => {
+    clearTimers();
+    const url = getUpdaterStatusUrl();
+    const poll = async () => {
+      if (cancelledRef.current) return;
+      try {
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelledRef.current) return;
+        setStatus(data);
+        setPhase("running");
+
+        if (isUpdaterSuccess(data)) {
+          setPhase("success");
+          // App relaunches itself; keep trying reload until dashboard is back.
+          if (!reloadRef.current) {
+            reloadRef.current = setInterval(() => {
+              globalThis.location.reload();
+            }, 2000);
+            // First attempt slightly delayed so relaunch can bind the port
+            setTimeout(() => {
+              try { globalThis.location.reload(); } catch { /* ignore */ }
+            }, 2500);
+          }
+          if (pollRef.current) {
+            clearInterval(pollRef.current);
+            pollRef.current = null;
+          }
+        } else if (isUpdaterFailure(data)) {
+          setPhase("failed");
+          setError(data.error || "Install failed");
+          setMode("manual");
+          if (pollRef.current) {
+            clearInterval(pollRef.current);
+            pollRef.current = null;
+          }
+        }
+      } catch {
+        // Status server not up yet, or transient network blip after parent exit — keep polling
+      }
+    };
+    poll();
+    pollRef.current = setInterval(poll, UPDATER_CONFIG.statusPollIntervalMs);
+  }, [clearTimers]);
+
+  const startAutoUpdate = useCallback(async () => {
+    setError(null);
+    setStatus(null);
+    setPhase("starting");
+    cancelledRef.current = false;
+
+    try {
+      const res = await fetch("/api/version/update", { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        // Dev / non-CLI install: auto path disabled — fall back to manual
+        setError(data.message || `Auto-update unavailable (${res.status})`);
+        setPhase("failed");
+        setMode("manual");
+        return;
+      }
+
+      // Parent Next server will exit shortly; poll detached updater status
+      setPhase("running");
+      startStatusPoll();
+    } catch (e) {
+      // POST may fail if the server already exited after scheduling the updater — still poll
+      setPhase("running");
+      startStatusPoll();
+      if (e?.message) {
+        // Keep a soft note; polling may still succeed
+        setError(null);
+      }
+    }
+  }, [startStatusPoll]);
+
+  const handleCopyAndShutdown = async () => {
+    try {
+      await navigator.clipboard.writeText(installCmd);
+    } catch { /* clipboard blocked */ }
+    setCopied(true);
+    let remaining = UPDATER_CONFIG.shutdownCountdownSec;
+    setCountdown(remaining);
+    const timer = setInterval(() => {
+      remaining -= 1;
+      setCountdown(remaining);
+      if (remaining <= 0) {
+        clearInterval(timer);
+        fetch("/api/version/shutdown", { method: "POST" }).catch(() => {});
+        setIsDisconnected(true);
+      }
+    }, 1000);
+  };
+
+  const progress = getUpdaterProgressPercent(status || { phase: phase === "starting" ? "starting" : null });
+  const phaseLabel =
+    phase === "starting"
+      ? "Contacting updater…"
+      : phase === "success"
+        ? "Update complete — reloading when app is ready…"
+        : getUpdaterPhaseLabel(status?.phase, {
+            attempt: status?.attempt,
+            maxRetries: status?.maxRetries,
+          });
+  const logTail = Array.isArray(status?.logTail) ? status.logTail : [];
+  const busy = phase === "starting" || phase === "running" || phase === "success";
+  const title = `Update 9Router${latestVersion ? ` to v${latestVersion}` : ""}`;
+
+  // ── Auto mode (default) ──────────────────────────────────────────────────
+  if (mode === "auto") {
+    return (
+      <div className="w-full max-w-lg rounded-xl bg-neutral-900/95 border border-white/10 p-6 text-white">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="flex items-center justify-center size-11 rounded-full bg-green-500/20 text-green-400">
+            <span className="material-symbols-outlined text-[24px]">
+              {phase === "success" ? "check_circle" : "system_update"}
+            </span>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold">{title}</h2>
+            <p className="text-xs text-white/60">
+              One-click install. The app will stop, update, and restart automatically.
+            </p>
+          </div>
+        </div>
+
+        {phase === "idle" && (
+          <>
+            <ul className="text-xs text-white/70 space-y-1.5 list-disc list-inside mb-4">
+              <li>Works with the production <code className="px-1 rounded bg-white/10">9router</code> CLI install</li>
+              <li>Takes about 1–2 minutes (npm global install + restart)</li>
+              <li>You can switch to manual install if auto fails</li>
+            </ul>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Button variant="secondary" onClick={onClose} className="sm:w-auto">
+                Cancel
+              </Button>
+              <Button variant="primary" fullWidth onClick={startAutoUpdate}>
+                Update & Restart
+              </Button>
+            </div>
+            <button
+              type="button"
+              onClick={() => setMode("manual")}
+              className="mt-3 w-full text-center text-[11px] text-white/50 hover:text-white/80 transition-colors"
+            >
+              Prefer manual install instead?
+            </button>
+          </>
+        )}
+
+        {busy && (
+          <>
+            <div className="mb-3">
+              <div className="flex items-center justify-between text-xs mb-1.5">
+                <span className="text-white/80">{phaseLabel}</span>
+                <span className="text-white/50 tabular-nums">{progress}%</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-white/10 overflow-hidden">
+                <div
+                  className="h-full bg-green-500 transition-all duration-500"
+                  style={{ width: `${Math.min(100, progress)}%` }}
+                />
+              </div>
+            </div>
+
+            {logTail.length > 0 && (
+              <div className="mb-3 max-h-32 overflow-y-auto rounded bg-black/40 px-2 py-1.5 font-mono text-[10px] text-white/60 space-y-0.5">
+                {logTail.map((line, i) => (
+                  <div key={`${i}-${line.slice(0, 24)}`} className="truncate">{line}</div>
+                ))}
+              </div>
+            )}
+
+            {phase === "success" ? (
+              <p className="text-xs text-green-400/90 mb-3">
+                Install succeeded. Waiting for the app to come back, then reloading…
+              </p>
+            ) : (
+              <p className="text-xs text-white/50 mb-3">
+                Keep this tab open. Do not close the browser until the update finishes.
+              </p>
+            )}
+
+            {phase !== "success" && (
+              <button
+                type="button"
+                onClick={() => {
+                  clearTimers();
+                  setMode("manual");
+                  setPhase("failed");
+                }}
+                className="w-full text-center text-[11px] text-white/50 hover:text-white/80 transition-colors"
+              >
+                Stuck? Switch to manual install
+              </button>
+            )}
+          </>
+        )}
+
+        {phase === "failed" && mode === "auto" && (
+          <>
+            <div className="mb-3 rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+              {error || "Auto-update failed."}
+            </div>
+            <Button variant="primary" fullWidth onClick={() => setMode("manual")}>
+              Open manual install
+            </Button>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // ── Manual fallback ──────────────────────────────────────────────────────
+  const isCountingDown = countdown > 0;
+  return (
+    <div className="w-full max-w-lg rounded-xl bg-neutral-900/95 border border-white/10 p-6 text-white">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex items-center justify-center size-11 rounded-full bg-amber-500/20 text-amber-400">
+          <span className="material-symbols-outlined text-[24px]">content_copy</span>
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <p className="text-xs text-white/60">
+            {isDisconnected
+              ? "Server stopped. Paste the command into a terminal to install."
+              : isCountingDown
+                ? `Command copied. Server will stop in ${countdown}s...`
+                : error
+                  ? "Auto-update unavailable — install manually."
+                  : "Copy the install command, stop the server, then re-run 9router."}
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-3 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          {error}
+        </div>
+      )}
+
+      <p className="text-sm text-white/80 mb-2">Install command:</p>
+      <div className="w-full px-3 py-2 rounded bg-white/5 mb-4">
+        <code className="text-xs font-mono text-amber-400 break-all">{installCmd}</code>
+      </div>
+
+      <ol className="text-xs text-white/70 space-y-1 list-decimal list-inside mb-4">
+        <li>Click <strong>Copy & Shutdown</strong> below.</li>
+        <li>Paste the command into your terminal and press Enter.</li>
+        <li>Run <code className="px-1 rounded bg-white/10 text-green-400">9router</code> again after install.</li>
+      </ol>
+
+      {isDisconnected ? (
+        <Button variant="secondary" fullWidth onClick={() => globalThis.location.reload()}>
+          Reload Page
+        </Button>
+      ) : (
+        <div className="flex flex-col sm:flex-row gap-2">
+          <Button
+            variant="secondary"
+            onClick={() => {
+              if (!busy) onClose();
+            }}
+            disabled={isCountingDown}
+            className="sm:w-auto"
+          >
+            Cancel
+          </Button>
+          <Button variant="primary" fullWidth onClick={handleCopyAndShutdown} disabled={isCountingDown}>
+            {copied ? "✓ Copied — shutting down..." : isCountingDown ? `Shutting down in ${countdown}s` : "Copy & Shutdown"}
+          </Button>
+        </div>
+      )}
+
+      {!isDisconnected && !isCountingDown && (
+        <button
+          type="button"
+          onClick={() => {
+            setMode("auto");
+            setPhase("idle");
+            setError(null);
+            setStatus(null);
+          }}
+          className="mt-3 w-full text-center text-[11px] text-white/50 hover:text-white/80 transition-colors"
+        >
+          Try automatic update instead
+        </button>
+      )}
+    </div>
+  );
+}
+
+UpdatePanel.propTypes = {
+  latestVersion: PropTypes.string,
+  installCmd: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -11,6 +11,7 @@ export { default as Toggle } from "./Toggle";
 export { default as ThemeToggle } from "./ThemeToggle";
 export { ThemeProvider } from "./ThemeProvider";
 export { default as Sidebar } from "./Sidebar";
+export { default as UpdatePanel } from "./UpdatePanel";
 export { default as Header } from "./Header";
 export { default as Footer } from "./Footer";
 export { default as OAuthModal } from "./OAuthModal";

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -12,6 +12,7 @@ export { default as ThemeToggle } from "./ThemeToggle";
 export { ThemeProvider } from "./ThemeProvider";
 export { default as Sidebar } from "./Sidebar";
 export { default as UpdatePanel } from "./UpdatePanel";
+export { default as PostUpdateBanner } from "./PostUpdateBanner";
 export { default as Header } from "./Header";
 export { default as Footer } from "./Footer";
 export { default as OAuthModal } from "./OAuthModal";

--- a/src/shared/components/layouts/DashboardLayout.js
+++ b/src/shared/components/layouts/DashboardLayout.js
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useNotificationStore } from "@/store/notificationStore";
 import Sidebar from "../Sidebar";
 import Header from "../Header";
+import PostUpdateBanner from "../PostUpdateBanner";
 
 function getToastStyle(type) {
   if (type === "success") {
@@ -40,6 +41,7 @@ export default function DashboardLayout({ children }) {
   return (
     <div className="flex h-screen w-full overflow-hidden bg-bg">
       <div className="fixed top-4 right-4 z-[80] flex w-[min(92vw,380px)] flex-col gap-2">
+        <PostUpdateBanner />
         {notifications.map((n) => {
           const style = getToastStyle(n.type);
           return (

--- a/src/shared/utils/changelog.js
+++ b/src/shared/utils/changelog.js
@@ -1,0 +1,199 @@
+/**
+ * CHANGELOG.md helpers for update UX.
+ *
+ * Expected section headers (this repo):
+ *   # v0.5.30 (2026-07-10)
+ *   # v0.5.20 (2026-07-07)
+ */
+
+export const CHANGELOG_STORAGE = {
+  lastSeenVersion: "9router:lastSeenVersion",
+  updateFromVersion: "9router:updateFromVersion",
+};
+
+/** Compare dotted semver-ish strings. Returns 1 / 0 / -1. */
+export function compareSemver(a, b) {
+  if (!a && !b) return 0;
+  if (!a) return -1;
+  if (!b) return 1;
+  const normalize = (v) =>
+    String(v)
+      .trim()
+      .replace(/^v/i, "")
+      .split(/[.+-]/)
+      .map((p) => {
+        const n = parseInt(p, 10);
+        return Number.isFinite(n) ? n : 0;
+      });
+  const pa = normalize(a);
+  const pb = normalize(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+  return 0;
+}
+
+/**
+ * Parse full CHANGELOG markdown into ordered sections (newest first, as in file).
+ * @param {string} markdown
+ * @returns {Array<{ version: string, heading: string, body: string, bullets: string[] }>}
+ */
+export function parseChangelogSections(markdown) {
+  if (!markdown || typeof markdown !== "string") return [];
+
+  const headerRe = /^#\s+v?(\d+\.\d+\.\d+[^\s)]*)\s*([^\n]*)/gm;
+  const headers = [];
+  let m;
+  while ((m = headerRe.exec(markdown)) !== null) {
+    headers.push({
+      version: m[1].trim(),
+      heading: m[0].replace(/^#\s+/, "").trim(),
+      index: m.index,
+      headerEnd: m.index + m[0].length,
+    });
+  }
+  if (headers.length === 0) return [];
+
+  return headers.map((h, i) => {
+    const bodyStart = h.headerEnd;
+    const bodyEnd = i + 1 < headers.length ? headers[i + 1].index : markdown.length;
+    const body = markdown.slice(bodyStart, bodyEnd).trim();
+    const bullets = body
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^[-*]\s+/.test(line))
+      .map((line) => line.replace(/^[-*]\s+/, "").trim())
+      .filter(Boolean);
+    return {
+      version: h.version,
+      heading: h.heading,
+      body,
+      bullets,
+    };
+  });
+}
+
+/**
+ * Sections with version in (fromVersion, toVersion] — i.e. what you get by upgrading.
+ * If `toVersion` is null/empty, include everything newer than `fromVersion`.
+ * If `fromVersion` is empty, only the top section (or up to `toVersion`) is returned.
+ */
+export function getChangelogSectionsBetween(markdown, fromVersion, toVersion = null) {
+  const sections = parseChangelogSections(markdown);
+  if (sections.length === 0) return [];
+
+  return sections.filter((s) => {
+    if (toVersion && compareSemver(s.version, toVersion) > 0) return false;
+    if (fromVersion && compareSemver(s.version, fromVersion) <= 0) return false;
+    // No fromVersion: prefer only the latest matching toVersion, else first section
+    if (!fromVersion) {
+      if (toVersion) return compareSemver(s.version, toVersion) === 0;
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Flatten bullets for UI preview.
+ * @returns {{ bullets: Array<{ text: string, version: string }>, truncated: boolean, versions: string[] }}
+ */
+export function collectChangelogHighlights(sections, { maxBullets = 10 } = {}) {
+  const versions = [];
+  const bullets = [];
+  for (const s of sections) {
+    if (!versions.includes(s.version)) versions.push(s.version);
+    for (const b of s.bullets) {
+      bullets.push({ text: stripInlineMarkdown(b), version: s.version });
+    }
+  }
+  const truncated = bullets.length > maxBullets;
+  return {
+    bullets: bullets.slice(0, maxBullets),
+    truncated,
+    versions,
+  };
+}
+
+/** Light strip of **bold** / `code` for plain list display */
+export function stripInlineMarkdown(text) {
+  if (!text) return "";
+  return String(text)
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .trim();
+}
+
+// ── localStorage helpers (SSR-safe) ────────────────────────────────────────
+
+function storageGet(key) {
+  try {
+    if (typeof localStorage === "undefined") return null;
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function storageSet(key, value) {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(key, value);
+  } catch { /* private mode */ }
+}
+
+function storageRemove(key) {
+  try {
+    if (typeof localStorage === "undefined") return;
+    localStorage.removeItem(key);
+  } catch { /* private mode */ }
+}
+
+/** Call right before starting an update so post-restart banner knows the range. */
+export function markUpdateStarting(fromVersion) {
+  if (fromVersion) storageSet(CHANGELOG_STORAGE.updateFromVersion, String(fromVersion).replace(/^v/i, ""));
+}
+
+/**
+ * Detect a just-completed upgrade for the soft "Updated to vX" banner.
+ * @returns {{ show: boolean, fromVersion: string|null, toVersion: string }}
+ */
+export function detectPostUpdate(currentVersion) {
+  const current = String(currentVersion || "").replace(/^v/i, "");
+  if (!current) return { show: false, fromVersion: null, toVersion: current };
+
+  const fromFlag = storageGet(CHANGELOG_STORAGE.updateFromVersion);
+  const lastSeen = storageGet(CHANGELOG_STORAGE.lastSeenVersion);
+
+  // First ever visit — seed lastSeen, no banner
+  if (!lastSeen && !fromFlag) {
+    storageSet(CHANGELOG_STORAGE.lastSeenVersion, current);
+    return { show: false, fromVersion: null, toVersion: current };
+  }
+
+  if (fromFlag && compareSemver(current, fromFlag) > 0) {
+    return { show: true, fromVersion: fromFlag, toVersion: current };
+  }
+
+  if (lastSeen && compareSemver(current, lastSeen) > 0) {
+    return { show: true, fromVersion: lastSeen, toVersion: current };
+  }
+
+  // Already on this version — keep lastSeen in sync
+  if (!lastSeen || compareSemver(current, lastSeen) !== 0) {
+    storageSet(CHANGELOG_STORAGE.lastSeenVersion, current);
+  }
+  return { show: false, fromVersion: null, toVersion: current };
+}
+
+/** Dismiss post-update banner and clear pending flags. */
+export function dismissPostUpdate(currentVersion) {
+  const current = String(currentVersion || "").replace(/^v/i, "");
+  if (current) storageSet(CHANGELOG_STORAGE.lastSeenVersion, current);
+  storageRemove(CHANGELOG_STORAGE.updateFromVersion);
+}

--- a/src/shared/utils/updaterStatus.js
+++ b/src/shared/utils/updaterStatus.js
@@ -1,0 +1,76 @@
+import { UPDATER_CONFIG } from "@/shared/constants/config";
+
+/** Status endpoint exposed by the detached updater process (survives Next exit). */
+export function getUpdaterStatusUrl(port = UPDATER_CONFIG.statusPort) {
+  return `http://127.0.0.1:${port}/update/status`;
+}
+
+/**
+ * Human-readable label for updater phase.
+ * @param {string|null|undefined} phase
+ * @param {{ attempt?: number, maxRetries?: number }} [meta]
+ */
+export function getUpdaterPhaseLabel(phase, meta = {}) {
+  const attempt = meta.attempt || 0;
+  const maxRetries = meta.maxRetries || UPDATER_CONFIG.installRetries;
+  switch (phase) {
+    case "starting":
+      return "Starting updater…";
+    case "waitingForExit":
+      return "Stopping current app (releasing file locks)…";
+    case "installing":
+      return attempt > 0
+        ? `Installing package (attempt ${attempt}/${maxRetries})…`
+        : "Installing package…";
+    case "done":
+      return "Update complete — restarting app…";
+    case "error":
+      return "Update failed";
+    default:
+      return phase ? String(phase) : "Preparing…";
+  }
+}
+
+/**
+ * Coarse progress % for the overlay bar (not exact npm progress).
+ * @param {{ phase?: string, attempt?: number, maxRetries?: number, done?: boolean, success?: boolean }} status
+ */
+export function getUpdaterProgressPercent(status) {
+  if (!status || typeof status !== "object") return 5;
+  const { phase, attempt = 0, maxRetries = UPDATER_CONFIG.installRetries, done, success } = status;
+  if (done && success) return 100;
+  if (phase === "error" || (done && !success)) return 90;
+  switch (phase) {
+    case "starting":
+      return 8;
+    case "waitingForExit":
+      return 22;
+    case "installing": {
+      const safeMax = Math.max(1, maxRetries);
+      const base = 35;
+      const span = 50;
+      const step = Math.min(attempt, safeMax) / safeMax;
+      return Math.round(base + span * step);
+    }
+    case "done":
+      return 100;
+    default:
+      return 5;
+  }
+}
+
+/**
+ * Whether auto-update finished successfully.
+ * @param {object|null|undefined} status
+ */
+export function isUpdaterSuccess(status) {
+  return !!(status && status.done && status.success);
+}
+
+/**
+ * Whether auto-update finished with failure.
+ * @param {object|null|undefined} status
+ */
+export function isUpdaterFailure(status) {
+  return !!(status && (status.phase === "error" || (status.done && !status.success)));
+}

--- a/tests/unit/changelog.test.js
+++ b/tests/unit/changelog.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  collectChangelogHighlights,
+  compareSemver,
+  detectPostUpdate,
+  dismissPostUpdate,
+  getChangelogSectionsBetween,
+  markUpdateStarting,
+  parseChangelogSections,
+  stripInlineMarkdown,
+  CHANGELOG_STORAGE,
+} from "../../src/shared/utils/changelog.js";
+
+const SAMPLE = `# v0.5.31 (2026-07-13)
+
+## Features
+- **Updater**: one-click Update in dashboard
+- **CLI tools**: add Grok Build setup
+
+## Fixes
+- **Grok CLI**: parse SuperGrok percent-based billing
+
+# v0.5.30 (2026-07-10)
+
+## Features
+- **Perplexity**: add Agent API provider (#2492)
+- **Grok CLI**: add Grok CLI / Grok Build provider with OAuth device-code flow (#2502)
+
+## Fixes
+- **Codex**: avoid bare-email OAuth dedup (#2477)
+
+# v0.5.20 (2026-07-07)
+
+## Features
+- **Thinking**: per-model thinking level picker
+`;
+
+describe("compareSemver", () => {
+  it("orders versions", () => {
+    expect(compareSemver("0.5.31", "0.5.30")).toBe(1);
+    expect(compareSemver("0.5.30", "0.5.31")).toBe(-1);
+    expect(compareSemver("0.5.30", "v0.5.30")).toBe(0);
+  });
+});
+
+describe("parseChangelogSections", () => {
+  it("parses version sections and bullets", () => {
+    const sections = parseChangelogSections(SAMPLE);
+    expect(sections).toHaveLength(3);
+    expect(sections[0].version).toBe("0.5.31");
+    expect(sections[0].bullets.length).toBeGreaterThanOrEqual(3);
+    expect(sections[1].version).toBe("0.5.30");
+  });
+});
+
+describe("getChangelogSectionsBetween", () => {
+  it("returns only versions after from and up to to", () => {
+    const range = getChangelogSectionsBetween(SAMPLE, "0.5.30", "0.5.31");
+    expect(range.map((s) => s.version)).toEqual(["0.5.31"]);
+  });
+
+  it("includes multiple hops", () => {
+    const range = getChangelogSectionsBetween(SAMPLE, "0.5.20", "0.5.31");
+    expect(range.map((s) => s.version)).toEqual(["0.5.31", "0.5.30"]);
+  });
+
+  it("returns empty when already on version", () => {
+    const range = getChangelogSectionsBetween(SAMPLE, "0.5.31", "0.5.31");
+    expect(range).toEqual([]);
+  });
+});
+
+describe("collectChangelogHighlights", () => {
+  it("flattens and truncates bullets", () => {
+    const sections = getChangelogSectionsBetween(SAMPLE, "0.5.20", "0.5.31");
+    const { bullets, truncated, versions } = collectChangelogHighlights(sections, {
+      maxBullets: 2,
+    });
+    expect(bullets).toHaveLength(2);
+    expect(truncated).toBe(true);
+    expect(versions).toContain("0.5.31");
+    expect(bullets[0].text).not.toMatch(/\*\*/);
+  });
+});
+
+describe("stripInlineMarkdown", () => {
+  it("strips bold and code", () => {
+    expect(stripInlineMarkdown("**Grok CLI**: `fix`")).toBe("Grok CLI: fix");
+  });
+});
+
+describe("post-update storage", () => {
+  beforeEach(() => {
+    const store = new Map();
+    vi.stubGlobal("localStorage", {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+    });
+  });
+
+  it("seeds lastSeen on first visit without banner", () => {
+    const d = detectPostUpdate("0.5.30");
+    expect(d.show).toBe(false);
+    expect(localStorage.getItem(CHANGELOG_STORAGE.lastSeenVersion)).toBe("0.5.30");
+  });
+
+  it("shows banner after markUpdateStarting + version bump", () => {
+    markUpdateStarting("0.5.30");
+    const d = detectPostUpdate("0.5.31");
+    expect(d.show).toBe(true);
+    expect(d.fromVersion).toBe("0.5.30");
+    expect(d.toVersion).toBe("0.5.31");
+    dismissPostUpdate("0.5.31");
+    expect(detectPostUpdate("0.5.31").show).toBe(false);
+  });
+});

--- a/tests/unit/updater-status.test.js
+++ b/tests/unit/updater-status.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  getUpdaterPhaseLabel,
+  getUpdaterProgressPercent,
+  getUpdaterStatusUrl,
+  isUpdaterFailure,
+  isUpdaterSuccess,
+} from "../../src/shared/utils/updaterStatus.js";
+
+describe("updaterStatus helpers", () => {
+  it("builds local status URL on the configured port", () => {
+    expect(getUpdaterStatusUrl(20129)).toBe("http://127.0.0.1:20129/update/status");
+    expect(getUpdaterStatusUrl()).toContain("127.0.0.1");
+    expect(getUpdaterStatusUrl()).toContain("/update/status");
+  });
+
+  it("labels known phases", () => {
+    expect(getUpdaterPhaseLabel("starting")).toMatch(/starting/i);
+    expect(getUpdaterPhaseLabel("waitingForExit")).toMatch(/stopping/i);
+    expect(getUpdaterPhaseLabel("installing", { attempt: 2, maxRetries: 3 })).toMatch(/2\/3/);
+    expect(getUpdaterPhaseLabel("done")).toMatch(/complete|restart/i);
+    expect(getUpdaterPhaseLabel("error")).toMatch(/failed/i);
+  });
+
+  it("maps phases to increasing progress", () => {
+    const start = getUpdaterProgressPercent({ phase: "starting" });
+    const wait = getUpdaterProgressPercent({ phase: "waitingForExit" });
+    const install = getUpdaterProgressPercent({ phase: "installing", attempt: 1, maxRetries: 3 });
+    const done = getUpdaterProgressPercent({ phase: "done", done: true, success: true });
+    expect(start).toBeLessThan(wait);
+    expect(wait).toBeLessThan(install);
+    expect(install).toBeLessThan(done);
+    expect(done).toBe(100);
+  });
+
+  it("detects success and failure terminal states", () => {
+    expect(isUpdaterSuccess({ done: true, success: true })).toBe(true);
+    expect(isUpdaterSuccess({ done: true, success: false })).toBe(false);
+    expect(isUpdaterFailure({ phase: "error" })).toBe(true);
+    expect(isUpdaterFailure({ done: true, success: false })).toBe(true);
+    expect(isUpdaterFailure({ phase: "installing" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Restores **one-click update** in the dashboard so users no longer need to stop the app, copy `npm i -g 9router@latest`, and restart manually.

**Flow**
1. Banner **Update now** opens `UpdatePanel`
2. **Update & Restart** → `POST /api/version/update` (existing detached updater)
3. UI polls `http://127.0.0.1:20129/update/status` for progress + log tail
4. On success: auto-reload when the app comes back
5. On failure / non-production: fall back to **manual** copy + shutdown

**Also**
- Pass live `PORT` into the updater (wait/relaunch match this instance)
- Install `9router@latest` for registry tip parity
- Keep manual install as an explicit escape hatch

## Test plan

- [x] `cd tests && npx vitest run unit/updater-status.test.js` (4/4)
- [x] Detached updater **success** with fake `npm` (status `done` / `success: true`)
- [x] Detached updater **failure** + retries (status `error` after max attempts)
- [x] Wait-for-exit while app port busy, then install
- [x] Runtime updater path copy under `~/.9router/runtime/updater/`
- [ ] Browser E2E: production CLI + `hasUpdate: true` → Update & Restart → version bumps (blocked today: npm latest already equals installed `0.5.30`)
- [ ] Windows smoke: auto path under file locks
- [ ] Tray mode: relaunch keeps `--tray`

## Notes for reviewers

Backend auto-update (`spawnUpdaterAndExit` + `updater.js`) already existed; UI had been demoted to copy-command-only. This PR re-wires auto as primary and keeps manual fallback for dev (`NODE_ENV !== production`) and install failures.