### PR TITLE
fix(v1/messages): reverse-translate OpenAI→Claude for all non-Claude providers + SSE-to-JSON

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -65,7 +65,11 @@ function openAICompletionToClaudeMessage(responseBody) {
  */
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat) {
   if (targetFormat === sourceFormat) return responseBody;
-  if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.CLAUDE) {
+  // After upstream translation, if client sent Claude format and the response
+  // is in OpenAI shape (choices[] array), convert back to Claude message format.
+  // This must catch all non-Claude target formats (combo routing picks Gemini,
+  // Antigravity, etc.) — not just FORMATS.OPENAI.
+  if (sourceFormat === FORMATS.CLAUDE && responseBody?.choices) {
     return openAICompletionToClaudeMessage(responseBody);
   }
   if (targetFormat === FORMATS.OPENAI) return responseBody;

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -4,6 +4,7 @@ import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
+import { openAICompletionToClaudeMessage } from "./nonStreamingHandler.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -169,6 +170,25 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
             responseId: jsonResponse.id || `resp_${Date.now()}`
           }
         };
+      } else if (sourceFormat === FORMATS.CLAUDE) {
+        // Convert to OpenAI chat.completion shape first, then to Claude message format
+        const chatCompletion = {
+          id: jsonResponse.id || `chatcmpl-${Date.now()}`,
+          object: "chat.completion",
+          created: jsonResponse.created_at || Math.floor(Date.now() / 1000),
+          model: jsonResponse.model || model,
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: textContent || (hasToolCalls ? null : "")
+            },
+            finish_reason: hasToolCalls ? "tool_calls" : (jsonResponse.status === "completed" || jsonResponse.status === "done" ? "stop" : (jsonResponse.status || "stop"))
+          }],
+          usage: { prompt_tokens: inTokens, completion_tokens: outTokens, total_tokens: inTokens + outTokens }
+        };
+        if (hasToolCalls) chatCompletion.choices[0].message.tool_calls = toolCalls;
+        finalResp = openAICompletionToClaudeMessage(chatCompletion);
       } else {
         const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
         if (hasToolCalls) message.tool_calls = toolCalls;
@@ -229,7 +249,14 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       }
     }
 
-    return { success: true, response: new Response(JSON.stringify(parsed), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
+    // Reverse translation: OpenAI → Claude when client sent Claude-format request
+    // (relayn provider path: request was translated CLAUDE→OPENAI upstream,
+    //  streaming response was aggregated to OpenAI JSON, must convert back)
+    const finalResponse = (sourceFormat === FORMATS.CLAUDE)
+      ? openAICompletionToClaudeMessage(parsed)
+      : parsed;
+
+    return { success: true, response: new Response(JSON.stringify(finalResponse), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {
     console.error("[ChatCore] Chat Completions SSE→JSON failed:", err);
     return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Failed to convert streaming response to JSON");


### PR DESCRIPTION
## Summary

Same fix as https://github.com/Vanszs/VansRouter/pull/49 but adapted for 9Router v0.5.30 codebase (uses existing `openAICompletionToClaudeMessage` function).

## Changes

**nonStreamingHandler.js** (4 lines net):
- Widen the reverse-translation gate: instead of `targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.CLAUDE`, use `sourceFormat === FORMATS.CLAUDE && responseBody?.choices`. This catches combo routing where the selected provider is Gemini/Antigravity (not just OpenAI) — `translateNonStreamingResponse` always converts to OpenAI shape first, so `choices[]` is the signal.

**sseToJsonHandler.js** (31 lines):
- Import `openAICompletionToClaudeMessage` from nonStreamingHandler
- Claude format reverse translation in:
  - **Responses API path** (codex provider): builds an intermediate `chat.completion` shape, converts to Claude message format
  - **Standard Chat Completions path** (force-stream providers): SSE aggregated to OpenAI JSON → Claude format

## Motivation

Claude Code sends `/v1/messages` with Claude-format requests. When routed through a combo that selects a non-OpenAI provider (Gemini, Antigravity, etc.), the upstream response is translated to OpenAI `chat.completion` shape, but was never converted back to Claude format. The Claude Code client receives a malformed response.

Also, when a provider forces streaming (SSE) despite `stream: false`, the aggregated OpenAI JSON was returned directly even for Claude-format requests — this path now also converts back to Claude format.

## Existing foundation

9Router v0.5.30 already has `openAICompletionToClaudeMessage` in `nonStreamingHandler.js` and uses it when `targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.CLAUDE`. This PR:
1. Fixes the gate to not require FORMATS.OPENAI specifically
2. Adds the same reverse translation to `sseToJsonHandler.js` for streaming providers