### PR TITLE
feat(mitm): add Antigravity reasoning effort overrides

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/MitmModelMappingRow.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/MitmModelMappingRow.js
@@ -1,0 +1,84 @@
+const REASONING_OPTIONS = [
+  { value: "", label: "Default" },
+  { value: "none", label: "None" },
+  { value: "minimal", label: "Minimal" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "XHigh" },
+  { value: "max", label: "Max" },
+];
+
+export default function MitmModelMappingRow({
+  model,
+  entry,
+  disabled,
+  canSelectModel,
+  showReasoning,
+  onModelChange,
+  onModelBlur,
+  onModelClear,
+  onModelSelect,
+  onReasoningChange,
+}) {
+  const controlId = model.alias.replace(/[^a-z0-9_-]/gi, "-");
+
+  return (
+    <div className="rounded-lg border border-border/70 bg-surface/40 p-2.5 transition-colors hover:border-primary/30">
+      <div className={`grid grid-cols-1 gap-2 ${showReasoning ? "sm:grid-cols-[9rem_minmax(12rem,1fr)_8rem_auto]" : "sm:grid-cols-[9rem_minmax(12rem,1fr)_auto]"} sm:items-center`}>
+        <label htmlFor={`mitm-model-${controlId}`} className="text-xs font-semibold text-text-main sm:text-right">
+          {model.name}
+        </label>
+        <div className="relative w-full min-w-0">
+          <input
+            id={`mitm-model-${controlId}`}
+            type="text"
+            value={entry.model || ""}
+            onChange={(event) => onModelChange(event.target.value)}
+            onBlur={(event) => onModelBlur(event.target.value)}
+            placeholder="provider/model-id"
+            disabled={disabled}
+            className={`w-full min-w-0 rounded border border-border bg-surface py-2 pl-2 pr-7 text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5 ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+          />
+          {entry.model && (
+            <button
+              id={`mitm-clear-${controlId}`}
+              type="button"
+              onClick={onModelClear}
+              disabled={disabled}
+              className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-0.5 text-text-muted transition-colors hover:text-red-500 disabled:cursor-not-allowed"
+              title={`Clear model mapping for ${model.name}`}
+              aria-label={`Clear model mapping for ${model.name}`}
+            >
+              <span className="material-symbols-outlined text-[14px]">close</span>
+            </button>
+          )}
+        </div>
+        {showReasoning && (
+          <select
+            id={`mitm-reasoning-${controlId}`}
+            value={entry.reasoningEffort || ""}
+            onChange={(event) => onReasoningChange(event.target.value)}
+            disabled={disabled}
+            aria-label={`Reasoning effort for ${model.name}`}
+            title="Default preserves the reasoning effort sent by Antigravity"
+            className={`w-full rounded border border-border bg-surface px-2 py-2 text-xs text-text-main focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5 ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+          >
+            {REASONING_OPTIONS.map((option) => (
+              <option key={option.value || "default"} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        )}
+        <button
+          id={`mitm-select-${controlId}`}
+          type="button"
+          onClick={onModelSelect}
+          disabled={!canSelectModel || disabled}
+          className={`rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 ${canSelectModel && !disabled ? "cursor-pointer border-border bg-surface hover:border-primary" : "cursor-not-allowed border-border opacity-50"}`}
+        >
+          Select
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/cli-tools/components/MitmToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/MitmToolCard.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Card, Button, Badge, Input, ModelSelectModal } from "@/shared/components";
 import { TOOL_HOSTS } from "@/shared/constants/mitmToolHosts";
 import Image from "next/image";
+import MitmModelMappingRow from "./MitmModelMappingRow";
 
 /**
  * Per-tool MITM card — shows DNS status + model mappings.
@@ -41,18 +42,16 @@ export default function MitmToolCard({
   const canRunWithoutPassword = isWin || hasCachedPassword || needsSudoPassword === false;
 
   useEffect(() => {
-    if (isExpanded) loadSavedMappings();
-  }, [isExpanded]);
-
-  const loadSavedMappings = async () => {
-    try {
-      const res = await fetch(`/api/cli-tools/antigravity-mitm/alias?tool=${tool.id}`);
-      if (res.ok) {
-        const data = await res.json();
-        if (Object.keys(data.aliases || {}).length > 0) setModelMappings(data.aliases);
-      }
-    } catch { /* ignore */ }
-  };
+    if (!isExpanded) return;
+    let cancelled = false;
+    fetch(`/api/cli-tools/antigravity-mitm/alias?tool=${tool.id}`)
+      .then((res) => res.ok ? res.json() : null)
+      .then((data) => {
+        if (!cancelled && data) setModelMappings(data.aliases || {});
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [isExpanded, tool.id]);
 
   const saveMappings = useCallback(async (mappings) => {
     try {
@@ -64,12 +63,19 @@ export default function MitmToolCard({
     } catch { /* ignore */ }
   }, [tool.id]);
 
-  const handleMappingBlur = (alias, value) => {
-    saveMappings({ ...modelMappings, [alias]: value });
+  const getMappingEntry = (alias) => modelMappings[alias] || {};
+
+  const updateMapping = (alias, patch, shouldSave = false) => {
+    const updatedEntry = { ...getMappingEntry(alias), ...patch };
+    const updated = { ...modelMappings };
+    if (updatedEntry.model || updatedEntry.reasoningEffort) updated[alias] = updatedEntry;
+    else delete updated[alias];
+    setModelMappings(updated);
+    if (shouldSave) saveMappings(updated);
   };
 
-  const handleModelMappingChange = (alias, value) => {
-    setModelMappings(prev => ({ ...prev, [alias]: value }));
+  const handleMappingBlur = (alias, value) => {
+    updateMapping(alias, { model: value.trim() }, true);
   };
 
   const openModelSelector = (alias) => {
@@ -79,9 +85,7 @@ export default function MitmToolCard({
 
   const handleModelSelect = (model) => {
     if (!currentEditingAlias || model.isPlaceholder) return;
-    const updated = { ...modelMappings, [currentEditingAlias]: model.value };
-    setModelMappings(updated);
-    saveMappings(updated);
+    updateMapping(currentEditingAlias, { model: model.value }, true);
   };
 
   const handleDnsToggle = () => {
@@ -192,41 +196,28 @@ export default function MitmToolCard({
             {/* Model Mappings */}
             {tool.defaultModels?.length > 0 && (
               <div className="flex flex-col gap-2">
-                {tool.defaultModels.map((model) => (
-                  <div key={model.alias} className="grid grid-cols-1 gap-1.5 sm:grid-cols-[9rem_auto_1fr_auto] sm:items-center sm:gap-2">
-                    <span className="text-xs font-semibold text-text-main sm:text-right">{model.name}</span>
-                    <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
-                    <div className="relative w-full min-w-0">
-                      <input
-                        type="text"
-                        value={modelMappings[model.alias] || ""}
-                        onChange={(e) => handleModelMappingChange(model.alias, e.target.value)}
-                        onBlur={(e) => handleMappingBlur(model.alias, e.target.value)}
-                        placeholder="provider/model-id"
-                        disabled={!dnsActive}
-                        className={`w-full min-w-0 pl-2 pr-7 py-2 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5 ${!dnsActive ? "opacity-50 cursor-not-allowed" : ""}`}
-                      />
-                      {modelMappings[model.alias] && (
-                        <button
-                          onClick={() => {
-                            handleModelMappingChange(model.alias, "");
-                            saveMappings({ ...modelMappings, [model.alias]: "" });
-                          }}
-                          className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 text-text-muted hover:text-red-500 rounded transition-colors"
-                          title="Clear"
-                        >
-                          <span className="material-symbols-outlined text-[14px]">close</span>
-                        </button>
-                      )}
-                    </div>
-                    <button
-                      onClick={() => openModelSelector(model.alias)}
-                      disabled={!hasActiveProviders || !dnsActive}
-                      className={`rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 ${hasActiveProviders && dnsActive ? "bg-surface border-border hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}
-                    >
-                      Select
-                    </button>
+                {tool.id === "antigravity" && (
+                  <div className="hidden grid-cols-[9rem_minmax(12rem,1fr)_8rem_auto] gap-2 px-2.5 text-[10px] font-medium uppercase tracking-wide text-text-muted sm:grid">
+                    <span />
+                    <span>Destination model</span>
+                    <span>Reasoning</span>
+                    <span />
                   </div>
+                )}
+                {tool.defaultModels.map((model) => (
+                  <MitmModelMappingRow
+                    key={model.alias}
+                    model={model}
+                    entry={getMappingEntry(model.alias)}
+                    disabled={!dnsActive}
+                    canSelectModel={hasActiveProviders}
+                    showReasoning={tool.id === "antigravity"}
+                    onModelChange={(value) => updateMapping(model.alias, { model: value })}
+                    onModelBlur={(value) => handleMappingBlur(model.alias, value)}
+                    onModelClear={() => updateMapping(model.alias, { model: "" }, true)}
+                    onModelSelect={() => openModelSelector(model.alias)}
+                    onReasoningChange={(value) => updateMapping(model.alias, { reasoningEffort: value }, true)}
+                  />
                 ))}
               </div>
             )}
@@ -308,7 +299,7 @@ export default function MitmToolCard({
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}
         onSelect={handleModelSelect}
-        selectedModel={currentEditingAlias ? modelMappings[currentEditingAlias] : null}
+        selectedModel={currentEditingAlias ? getMappingEntry(currentEditingAlias).model || null : null}
         activeProviders={activeProviders}
         modelAliases={modelAliases}
         title={`Select model for ${currentEditingAlias}`}

--- a/src/app/api/cli-tools/antigravity-mitm/alias/route.js
+++ b/src/app/api/cli-tools/antigravity-mitm/alias/route.js
@@ -4,6 +4,9 @@ import { NextResponse } from "next/server";
 import { getMitmAlias, setMitmAliasAll } from "@/models";
 import { getMitmStatus } from "@/mitm/manager";
 import { writeAliasForTool } from "@/lib/mitmAliasCache";
+import aliasConfig from "@/mitm/aliasConfig";
+
+const { normalizeAliasMappings, hasInvalidReasoningEffort } = aliasConfig;
 
 // GET - Get MITM aliases for a tool
 export async function GET(request) {
@@ -11,7 +14,7 @@ export async function GET(request) {
     const { searchParams } = new URL(request.url);
     const toolName = searchParams.get("tool");
     const aliases = await getMitmAlias(toolName || undefined);
-    return NextResponse.json({ aliases });
+    return NextResponse.json({ aliases: normalizeAliasMappings(aliases) });
   } catch (error) {
     console.log("Error fetching MITM aliases:", error.message);
     return NextResponse.json({ error: "Failed to fetch aliases" }, { status: 500 });
@@ -23,8 +26,11 @@ export async function PUT(request) {
   try {
     const { tool, mappings } = await request.json();
 
-    if (!tool || !mappings || typeof mappings !== "object") {
+    if (!tool || !mappings || typeof mappings !== "object" || Array.isArray(mappings)) {
       return NextResponse.json({ error: "tool and mappings required" }, { status: 400 });
+    }
+    if (hasInvalidReasoningEffort(mappings)) {
+      return NextResponse.json({ error: "Invalid reasoning effort" }, { status: 400 });
     }
 
     // Check if DNS is enabled for this tool
@@ -36,13 +42,7 @@ export async function PUT(request) {
       );
     }
 
-    const filtered = {};
-    for (const [alias, model] of Object.entries(mappings)) {
-      if (model && model.trim()) {
-        filtered[alias] = model.trim();
-      }
-    }
-
+    const filtered = normalizeAliasMappings(mappings);
     await setMitmAliasAll(tool, filtered);
     writeAliasForTool(tool, filtered);
     return NextResponse.json({ success: true, aliases: filtered });

--- a/src/mitm/aliasConfig.js
+++ b/src/mitm/aliasConfig.js
@@ -1,0 +1,56 @@
+const REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+const REASONING_EFFORT_SET = new Set(REASONING_EFFORTS);
+
+function normalizeReasoningEffort(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return REASONING_EFFORT_SET.has(normalized) ? normalized : null;
+}
+
+function normalizeAliasEntry(value) {
+  if (typeof value === "string") {
+    const model = value.trim();
+    return model ? { model } : null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const model = typeof value.model === "string" ? value.model.trim() : "";
+  const reasoningEffort = normalizeReasoningEffort(value.reasoningEffort);
+  if (!model && !reasoningEffort) return null;
+
+  return {
+    ...(model ? { model } : {}),
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+  };
+}
+
+function normalizeAliasMappings(mappings) {
+  if (!mappings || typeof mappings !== "object" || Array.isArray(mappings)) return {};
+  const normalized = {};
+  for (const [alias, value] of Object.entries(mappings)) {
+    if (!alias) continue;
+    const entry = normalizeAliasEntry(value);
+    if (entry) normalized[alias] = entry;
+  }
+  return normalized;
+}
+
+function hasInvalidReasoningEffort(mappings) {
+  if (!mappings || typeof mappings !== "object" || Array.isArray(mappings)) return false;
+  return Object.values(mappings).some((value) => (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    value.reasoningEffort != null &&
+    value.reasoningEffort !== "" &&
+    !normalizeReasoningEffort(value.reasoningEffort)
+  ));
+}
+
+module.exports = {
+  REASONING_EFFORTS,
+  normalizeReasoningEffort,
+  normalizeAliasEntry,
+  normalizeAliasMappings,
+  hasInvalidReasoningEffort,
+};

--- a/src/mitm/dbReader.js
+++ b/src/mitm/dbReader.js
@@ -4,6 +4,7 @@
 const fs = require("fs");
 const path = require("path");
 const { DATA_DIR } = require("./paths");
+const { normalizeAliasMappings } = require("./aliasConfig");
 
 const CACHE_FILE = path.join(DATA_DIR, "mitm", "aliases.json");
 
@@ -16,7 +17,8 @@ function readCache() {
 
 function getMitmAlias(toolName) {
   const all = readCache();
-  return all?.[toolName] || null;
+  if (!all?.[toolName]) return null;
+  return normalizeAliasMappings(all[toolName]);
 }
 
 module.exports = { getMitmAlias };

--- a/src/mitm/handlers/antigravity.js
+++ b/src/mitm/handlers/antigravity.js
@@ -2,17 +2,27 @@ const { err, createResponseDumper } = require("../logger");
 const { IS_DEV } = require("../config");
 const { fetchRouter, pipeSSE } = require("./base");
 
+function applyRequestOverrides(body, override = {}) {
+  if (override.model) body.model = override.model;
+  if (override.reasoningEffort) {
+    body.reasoning_effort = override.reasoningEffort;
+    delete body.thinkingConfig;
+    if (body.generationConfig) delete body.generationConfig.thinkingConfig;
+    if (body.request?.generationConfig) delete body.request.generationConfig.thinkingConfig;
+  }
+  return body;
+}
+
 /**
  * Intercept Antigravity request — forward Gemini body as-is to /v1/chat/completions.
  * Router auto-detects format via body.userAgent==="antigravity" + body.request.contents,
  * runs antigravity→openai→provider→openai→antigravity translators internally.
  */
-async function intercept(req, res, bodyBuffer, mappedModel) {
+async function intercept(req, res, bodyBuffer, override) {
   const dumper = IS_DEV ? createResponseDumper(req, "intercept-antigravity") : null;
   const isStream = req.url.includes(":streamGenerateContent");
   try {
-    const body = JSON.parse(bodyBuffer.toString());
-    if (body.model) body.model = mappedModel;
+    const body = applyRequestOverrides(JSON.parse(bodyBuffer.toString()), override);
 
     const routerRes = await fetchRouter(body, "/v1/chat/completions", req.headers);
     await pipeSSE(routerRes, res, dumper);
@@ -30,4 +40,4 @@ async function intercept(req, res, bodyBuffer, mappedModel) {
   }
 }
 
-module.exports = { intercept };
+module.exports = { intercept, applyRequestOverrides };

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -132,7 +132,7 @@ function isBinaryData(buffer) {
   return (nonPrintable / sample.length) > 0.3;
 }
 
-function getMappedModel(tool, model) {
+function getMappedOverride(tool, model) {
   if (!model) return null;
   try {
     const aliases = getMitmAlias(tool);
@@ -366,12 +366,16 @@ const server = https.createServer(sslOptions, async (req, res) => {
       return passthrough(req, res, bodyBuffer);
     }
 
-    const mappedModel = getMappedModel(tool, model);
-    if (!mappedModel) {
+    const mappedOverride = getMappedOverride(tool, model);
+    if (!mappedOverride) {
       return passthrough(req, res, bodyBuffer);
     }
 
-    return handlers[tool].intercept(req, res, bodyBuffer, mappedModel, passthrough);
+    if (tool === "antigravity") {
+      return handlers[tool].intercept(req, res, bodyBuffer, mappedOverride, passthrough);
+    }
+    if (!mappedOverride.model) return passthrough(req, res, bodyBuffer);
+    return handlers[tool].intercept(req, res, bodyBuffer, mappedOverride.model, passthrough);
   } catch (e) {
     err(`Unhandled error: ${e.message}`);
     if (!res.headersSent) res.writeHead(500, { "Content-Type": "application/json" });

--- a/tests/unit/antigravity-mitm.test.js
+++ b/tests/unit/antigravity-mitm.test.js
@@ -5,6 +5,11 @@ import { MITM_TOOLS } from "../../src/shared/constants/cliTools.js";
 // config.js is the CJS MITM bundle module (dependency-isolated for the runtime copy).
 const require = createRequire(import.meta.url);
 const { MODEL_NO_MAP } = require("../../src/mitm/config.js");
+const {
+  normalizeAliasMappings,
+  hasInvalidReasoningEffort,
+} = require("../../src/mitm/aliasConfig.js");
+const { applyRequestOverrides } = require("../../src/mitm/handlers/antigravity.js");
 
 // All assertions below are grounded in a live MITM dump capture of Antigravity's
 // streamGenerateContent requests (see AI_JOURNAL): the agent loop sends
@@ -36,5 +41,62 @@ describe("Antigravity MITM model handling", () => {
     for (const id of ["gemini-3.5-flash-low", "gemini-3-flash-agent", "claude-sonnet-4-6"]) {
       expect((MODEL_NO_MAP.antigravity || []).some((re) => re.test(id))).toBe(false);
     }
+  });
+});
+
+describe("Antigravity MITM alias configuration", () => {
+  it("normalizes legacy string mappings without a migration", () => {
+    expect(normalizeAliasMappings({ flash: " cx/gpt-5.6-sol " })).toEqual({
+      flash: { model: "cx/gpt-5.6-sol" },
+    });
+  });
+
+  it("keeps a reasoning-only override and canonicalizes its value", () => {
+    expect(normalizeAliasMappings({ flash: { reasoningEffort: " HIGH " } })).toEqual({
+      flash: { reasoningEffort: "high" },
+    });
+  });
+
+  it("detects unsupported reasoning effort values", () => {
+    expect(hasInvalidReasoningEffort({ flash: { model: "p/m", reasoningEffort: "extreme" } })).toBe(true);
+    expect(hasInvalidReasoningEffort({ flash: { model: "p/m", reasoningEffort: "xhigh" } })).toBe(false);
+  });
+});
+
+describe("Antigravity MITM request overrides", () => {
+  it("overrides model and conflicting native thinking intent", () => {
+    const body = {
+      model: "gemini-3-flash-agent",
+      thinkingConfig: { thinkingBudget: 512 },
+      generationConfig: { thinkingConfig: { thinkingBudget: 1024 } },
+      request: { generationConfig: { thinkingConfig: { thinkingBudget: 8192 } } },
+    };
+
+    expect(applyRequestOverrides(body, { model: "cx/gpt-5.6-sol", reasoningEffort: "high" })).toEqual({
+      model: "cx/gpt-5.6-sol",
+      reasoning_effort: "high",
+      generationConfig: {},
+      request: { generationConfig: {} },
+    });
+  });
+
+  it("preserves native reasoning intent when effort is Default", () => {
+    const body = {
+      model: "gemini-3-flash-agent",
+      request: { generationConfig: { thinkingConfig: { thinkingBudget: 8192 } } },
+    };
+
+    expect(applyRequestOverrides(body, { model: "cx/gpt-5.6-sol" })).toEqual({
+      model: "cx/gpt-5.6-sol",
+      request: { generationConfig: { thinkingConfig: { thinkingBudget: 8192 } } },
+    });
+  });
+
+  it("can override reasoning without changing the source model", () => {
+    const body = { model: "gemini-3-flash-agent", request: {} };
+    expect(applyRequestOverrides(body, { reasoningEffort: "none" })).toMatchObject({
+      model: "gemini-3-flash-agent",
+      reasoning_effort: "none",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Add per-source-model reasoning effort overrides to the Antigravity MITM Proxy alongside the existing destination model mappings.

Each Antigravity model row now supports:

- Default
- None
- Minimal
- Low
- Medium
- High
- XHigh
- Max

`Default` preserves the thinking configuration sent by Antigravity. Explicit selections override the request and are translated through 9Router's existing unified thinking pipeline.

## Changes

- Add an accessible reasoning selector beside each Antigravity model mapping.
- Allow model and reasoning overrides to be configured independently.
- Support reasoning-only overrides without changing the source model.
- Store structured `{ model, reasoningEffort }` entries.
- Preserve compatibility with legacy string-based model mappings.
- Normalize cached aliases for the standalone MITM runtime.
- Validate reasoning values at the API boundary.
- Remove conflicting Gemini thinking fields when an explicit effort is selected.
- Keep native Antigravity thinking fields unchanged when effort is `Default`.
- Add focused tests for mapping normalization and request transformation.
- Document persistence, reasoning values, and safety behavior.

## Backward compatibility

Existing mappings remain valid:

```json
{
  "gemini-3-flash-agent": "provider/model-id"
}
```

They are normalized at the API and standalone MITM boundaries into:

```json
{
  "gemini-3-flash-agent": {
    "model": "provider/model-id"
  }
}
```

No database migration is required.

## Verification

- Focused ESLint check passed.
- CommonJS MITM syntax checks passed.
- Mapping and request-transformation smoke assertions passed.
- Next.js development server started successfully.
- Mapping API route compiled successfully.
- `git diff --check` passed.

## Notes

- The repository's root dependencies do not include Vitest, so the focused Vitest file was not executed in the existing workspace.
- Equivalent core normalization and request-transformation assertions were executed directly with Node.
- Antigravity tab-completion models remain excluded from MITM rerouting.