### PR TITLE
feat(reliability): add provider skip-error rules and retry policy

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -397,6 +397,11 @@ export class AntigravityExecutor extends BaseExecutor {
 
     const errorMessage = this.extractErrorMessage(errorJson, bodyText);
 
+    // NOTE: capacity 503 fail-fast is no longer hardcoded here. It is handled by
+    // the seeded skip-rule ({ provider:"antigravity", status:503, contains:"capacity",
+    // action:"skip" }): a skip-rule resolves attempts=0, so BaseExecutor.tryRetry
+    // short-circuits before ever calling this hook. If the user deletes that rule,
+    // capacity 503 falls through to the transient-retry path below — their choice.
     if (!retryMs) {
       retryMs = this.parseRetryFromErrorMessage(errorMessage);
     }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -1,5 +1,6 @@
 import { HTTP_STATUS, RETRY_CONFIG, DEFAULT_RETRY_CONFIG, resolveRetryEntry, FETCH_CONNECT_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { shouldRefreshCredentials } from "../services/oauthCredentialManager.js";
+import { matchSkipRule } from "../services/accountFallback.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE } from "../providers/shared.js";
@@ -97,19 +98,69 @@ export class BaseExecutor {
     return { status: response.status, message: bodyText || `HTTP ${response.status}` };
   }
 
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null, requestPolicy = null }) {
     const fallbackCount = this.getFallbackCount();
     let lastError = null;
     let lastStatus = 0;
     const retryAttemptsByUrl = {};
 
-    // Merge default retry config with provider-specific config
-    const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
+    // Merge default retry config with provider-specific config (base ceiling per status).
+    // NOTE: never mutate this.config — executors are cached singletons shared across
+    // concurrent requests. All per-request policy lives in local vars derived from requestPolicy.
+    const baseRetry = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
+    const maxTransportAttempts = requestPolicy?.maxTransportAttempts;
+    const skipRules = requestPolicy?.skipRules || null;
+    // Whether any skip-rule for THIS provider matches on response body text
+    // (match.contains). Only then do we pay to read the error body below.
+    const hasContainsRule = Array.isArray(skipRules) &&
+      skipRules.some(r => r && r.provider === this.provider && r.match?.contains != null);
+    // Header/connect timeout: per-request override → provider config → global default.
+    const headerTimeoutMs = requestPolicy?.headerTimeoutMs || this.config?.timeoutMs || FETCH_CONNECT_TIMEOUT_MS;
 
-    // Schedule retry via retryConfig[statusKey]. Returns true when caller should `urlIndex--; continue`
+    // Resolve how many in-place TRANSPORT retries are allowed for a failure.
+    //   rule skip       → 0 (abandon this account now)
+    //   rule retry      → 0 HERE: an account-retry rule is served by the
+    //                     account-selection layer, which re-calls the SAME account
+    //                     retryAttempts times. Spending transport attempts on it too
+    //                     would multiply the two budgets and, worse, tie the user's
+    //                     account-retry count to maxTransportAttempts -- which is what
+    //                     this rule kind previously (and wrongly) did.
+    //   no rule         → min(baseRetry[status].attempts, maxTransportAttempts - 1)
+    //   connect_timeout → 0 unless an explicit retry rule matches it
+    // Transport retry (network/URL-fallback) keeps maxTransportAttempts; account
+    // retry keeps rule.retryAttempts. The two budgets never borrow from each other.
+    const resolveAttempts = ({ statusKey, errorKind, text }) => {
+      const base = resolveRetryEntry(baseRetry[statusKey]);
+      const rule = skipRules
+        ? matchSkipRule(this.provider, { status: statusKey, errorKind, text }, skipRules)
+        : null;
+      const cap = maxTransportAttempts != null ? Math.max(0, maxTransportAttempts - 1) : null;
+
+      if (rule?.action === "skip") return { attempts: 0, delayMs: base.delayMs };
+      if (rule?.action === "retry") return { attempts: 0, delayMs: base.delayMs };
+      // No explicit rule
+      if (errorKind === "connect_timeout") return { attempts: 0, delayMs: base.delayMs };
+      const attempts = cap != null ? Math.min(base.attempts, cap) : base.attempts;
+      return { attempts, delayMs: base.delayMs };
+    };
+
+    // A matched skip-rule means: abandon this account entirely — do NOT cycle the
+    // remaining transport fallback URLs on the same account (which would keep hitting
+    // a stalled/at-capacity upstream). The account-selection layer picks the next
+    // account/model.
+    // A matched RETRY rule returns here too: the account layer is about to re-call
+    // this same account, so exhausting the remaining base URLs first would delay it
+    // and change which URL the retry lands on. Returns the matched rule or null.
+    const matchedSkip = ({ statusKey, errorKind, text }) => {
+      if (!skipRules) return null;
+      const rule = matchSkipRule(this.provider, { status: statusKey, errorKind, text }, skipRules);
+      return (rule?.action === "skip" || rule?.action === "retry") ? rule : null;
+    };
+
+    // Schedule retry. Returns true when caller should `urlIndex--; continue`.
     // response (optional) lets a subclass hook compute a dynamic delay (e.g. antigravity Retry-After).
-    const tryRetry = async (urlIndex, statusKey, reason, response = null) => {
-      const { attempts, delayMs } = resolveRetryEntry(retryConfig[statusKey]);
+    const tryRetry = async (urlIndex, statusKey, reason, response = null, errorKind = null, text = null) => {
+      const { attempts, delayMs } = resolveAttempts({ statusKey, errorKind, text });
       if (attempts <= 0 || retryAttemptsByUrl[urlIndex] >= attempts) return false;
       // Hook: subclass may derive delay from the response (headers/body). null → skip retry, use fallback.
       let waitMs = delayMs;
@@ -131,16 +182,22 @@ export class BaseExecutor {
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
 
-      // Abort if upstream doesn't return response headers within connection timeout
+      // Abort if upstream doesn't return response headers within the connect/header timeout.
+      // Use a closure flag to detect OUR timeout: undici rejects with the exact reason object
+      // we pass to abort(), so error.name stays "Error" (NOT "AbortError") on Node/undici —
+      // the old `error.name === "AbortError"` check never fired. The flag is authoritative.
       const connectCtrl = new AbortController();
-      const timeoutMs = this.config?.timeoutMs || FETCH_CONNECT_TIMEOUT_MS;
-      const connectTimer = setTimeout(() => connectCtrl.abort(new Error("fetch connect timeout")), timeoutMs);
+      let connectTimedOut = false;
+      const connectTimer = setTimeout(() => {
+        connectTimedOut = true;
+        connectCtrl.abort(new Error("fetch connect timeout"));
+      }, headerTimeoutMs);
       const mergedSignal = signal ? AbortSignal.any([signal, connectCtrl.signal]) : connectCtrl.signal;
 
       try {
         const bodyStr = JSON.stringify(transformedBody);
         const fetchT0 = Date.now();
-        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${timeoutMs}ms`);
+        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${headerTimeoutMs}ms`);
         const response = await proxyAwareFetch(url, {
           method: "POST",
           headers,
@@ -152,7 +209,22 @@ export class BaseExecutor {
         const cl = response.headers?.get?.("content-length") || "?";
         dbg("FETCH", `${this.provider.toUpperCase()} ← ${response.status} | ttft=${Date.now() - fetchT0}ms | ct=${ct} | cl=${cl}`);
 
-        if (await tryRetry(urlIndex, response.status, `status ${response.status}`, response)) { urlIndex--; continue; }
+        // Read the error body ONLY when a contains-rule for this provider could fire
+        // (and the status is an error). Clone so the original body stays intact for the
+        // caller/translator. Without this, match.contains never matches at the transport
+        // tier and a status-based retry could run against the user's intent.
+        let errorText = null;
+        if (hasContainsRule && response.status >= 400) {
+          try { errorText = await response.clone().text(); } catch { /* body unreadable → skip contains */ }
+        }
+
+        if (await tryRetry(urlIndex, response.status, `status ${response.status}`, response, `http_${response.status}`, errorText)) { urlIndex--; continue; }
+
+        // A skip-rule matched this HTTP failure → abandon this account now; do NOT
+        // fall through to shouldRetry()/other base URLs on the same account.
+        if (matchedSkip({ statusKey: response.status, errorKind: `http_${response.status}`, text: errorText })) {
+          return { response, url, headers, transformedBody };
+        }
 
         if (this.shouldRetry(response.status, urlIndex)) {
           log?.debug?.("RETRY", `${response.status} on ${url}, trying fallback ${urlIndex + 1}`);
@@ -164,18 +236,31 @@ export class BaseExecutor {
       } catch (error) {
         clearTimeout(connectTimer);
         lastError = error;
-        const isConnectTimeout = connectCtrl.signal.aborted && error.name === "AbortError";
+        const isConnectTimeout = connectTimedOut;
+        // Classify: our header-timeout vs a caller-initiated abort vs a generic network error.
+        const errorKind = isConnectTimeout ? "connect_timeout" : "network";
         dbg("FETCH", `${this.provider.toUpperCase()} ✖ ${error.name}: ${error.message}${isConnectTimeout ? " (connect timeout)" : ""}`);
-        // Connect timeout is internal — convert to retryable network error, don't propagate AbortError
-        if (error.name === "AbortError" && !isConnectTimeout) throw error;
+        // A caller-initiated abort (signal aborted but NOT our connect timer) must propagate.
+        if (!isConnectTimeout && signal?.aborted) {
+          error.errorKind = "aborted";
+          throw error;
+        }
 
-        // Map network/fetch exceptions to 502 retry config
-        if (await tryRetry(urlIndex, HTTP_STATUS.BAD_GATEWAY, `network "${error.message}"`)) { urlIndex--; continue; }
+        // connect_timeout / network → retryable per resolveAttempts (default: connect_timeout=0 retries)
+        if (await tryRetry(urlIndex, HTTP_STATUS.BAD_GATEWAY, `${errorKind} "${error.message}"`, null, errorKind, error.message)) { urlIndex--; continue; }
+
+        // A skip-rule matched this exception → abandon this account now; do NOT cycle
+        // the remaining base URLs on the same account. Let the account layer fall back.
+        if (matchedSkip({ statusKey: HTTP_STATUS.BAD_GATEWAY, errorKind, text: error.message })) {
+          error.errorKind = errorKind;
+          throw error;
+        }
 
         if (urlIndex + 1 < fallbackCount) {
           log?.debug?.("RETRY", `Error on ${url}, trying fallback ${urlIndex + 1}`);
           continue;
         }
+        error.errorKind = errorKind;
         throw error;
       }
     }

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -57,7 +57,7 @@ export function stripContinuityFields(body) {
   return body;
 }
 
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking, requestPolicy = null }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -330,7 +330,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // exception: it is decoded by the executor into OpenAI-compatible output.
   let providerResponseFormat = targetFormat;
   try {
-    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, requestPolicy });
     providerResponse = result.response;
     providerUrl = result.url;
     providerHeaders = result.headers;
@@ -351,15 +351,16 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       status: "error"
     })).catch(() => { });
 
-    if (error.name === "AbortError") {
+    if (error.name === "AbortError" || error.errorKind === "aborted") {
       streamController.handleError(error);
-      return createErrorResult(499, "Request aborted");
+      return createErrorResult(499, "Request aborted", undefined, "aborted");
     }
     const errMsg = formatProviderError(error, provider, model, HTTP_STATUS.BAD_GATEWAY);
     if (log?.errorLine) {
       log.errorLine(reqTag, "✗", `ERROR 502 · ${provider}/${model} · ${Date.now() - requestStartTime}ms\n    ${errMsg}${error.stack ? `\n    ${error.stack}` : ""}`);
     }
-    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg);
+    // errorKind classified by BaseExecutor (connect_timeout | network); default to "network".
+    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg, undefined, error.errorKind || "network");
   }
 
   // Handle 401/403 - try token refresh (skip for noAuth providers)
@@ -421,7 +422,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       log.errorLine(reqTag, "✗", `ERROR ${statusCode} · ${provider}/${model} · ${Date.now() - requestStartTime}ms${urlStr}\n    ${errMsg}`);
     }
     reqLogger.logError(new Error(message), finalBody || translatedBody);
-    return createErrorResult(statusCode, errMsg, resetsAtMs);
+    return createErrorResult(statusCode, errMsg, resetsAtMs, `http_${statusCode}`);
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -44,13 +44,15 @@ export function extractUsageFromResponse(responseBody) {
     };
   }
 
-  // Gemini format
-  if (responseBody.usageMetadata) {
+  // Gemini / Antigravity format. Antigravity wraps the native Gemini response
+  // under `response`, so usage can be either top-level or nested.
+  const usageMetadata = responseBody.usageMetadata || responseBody.response?.usageMetadata;
+  if (usageMetadata) {
     return {
-      prompt_tokens: responseBody.usageMetadata.promptTokenCount || 0,
-      completion_tokens: responseBody.usageMetadata.candidatesTokenCount || 0,
-      cached_tokens: responseBody.usageMetadata.cachedContentTokenCount || 0,
-      reasoning_tokens: responseBody.usageMetadata.thoughtsTokenCount || 0
+      prompt_tokens: usageMetadata.promptTokenCount || 0,
+      completion_tokens: usageMetadata.candidatesTokenCount || 0,
+      cached_tokens: usageMetadata.cachedContentTokenCount || 0,
+      reasoning_tokens: usageMetadata.thoughtsTokenCount || 0
     };
   }
 

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -50,6 +50,120 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
 }
 
 /**
+ * Match a user-configured skip-rule against a failure.
+ *
+ * A rule's `match` may carry any combination of { kind, status, contains }; the
+ * rule matches only when EVERY present condition holds (AND). At least one
+ * condition must be present. Rules are evaluated in ARRAY ORDER — the first rule
+ * (for this provider) whose conditions all match wins. Order is user-controlled
+ * via the settings UI. There is no hardcoded provider default: the legacy
+ * Antigravity capacity skip is now shipped as an ordinary seeded rule
+ * ({ status:503, contains:"capacity", action:"skip" }) the user can edit or delete.
+ *
+ * @param {string} provider   provider id (e.g. "anthropic-compatible-<uuid>", "antigravity")
+ * @param {{status?: number|string, errorKind?: string, text?: string}} failure
+ * @param {Array<{provider, match:{kind?,status?,contains?}, action, headerTimeoutMs?, sweep?}>} skipRules
+ * @returns {{action:"retry"|"skip", headerTimeoutMs?:number, sweep?:boolean}|null}
+ */
+// Minimum for a retry rule's `retryAttempts` (extra calls to the same account).
+// There is no maximum: the user decides how many retries they need, and the
+// abort guard in chat.js terminates the loop immediately on client disconnect
+// regardless of how many budget calls remain.
+export const SKIP_RULE_RETRY_ATTEMPTS_MIN = 1;
+// Rules saved before `retryAttempts` existed default to 1 extra retry.
+export const SKIP_RULE_RETRY_ATTEMPTS_DEFAULT = 1;
+
+/**
+ * Effective extra same-account calls for a retry rule.
+ * Only positive integers are honoured; anything else (absent, 0, negative,
+ * float, string, NaN) falls back to the documented default rather than
+ * silently disabling the rule the user asked for.
+ * @param {object} rule
+ * @returns {number}
+ */
+export function resolveRetryAttempts(rule) {
+  const n = rule?.retryAttempts;
+  if (!Number.isInteger(n) || n < SKIP_RULE_RETRY_ATTEMPTS_MIN) return SKIP_RULE_RETRY_ATTEMPTS_DEFAULT;
+  return n;
+}
+
+export function matchSkipRule(provider, failure = {}, skipRules = []) {
+  const r = findMatchingSkipRule(provider, failure, skipRules);
+  if (!r) return null;
+  const out = { action: r.action };
+  if (r.headerTimeoutMs != null) out.headerTimeoutMs = r.headerTimeoutMs;
+  // `sweep` is only meaningful for skip rules — it asks the account loop to
+  // re-try the whole pool after exhausting it (momentary saturation recovery).
+  if (r.action === "skip" && r.sweep === true) out.sweep = true;
+  // `retryAttempts` is only meaningful for retry rules: it is the number of EXTRA
+  // calls to the SAME account before giving up on it. Resolved here (rather than at
+  // the call site) so every consumer sees the same effective value, including the
+  // backward-compatible default for rules saved before the field existed.
+  if (r.action === "retry") out.retryAttempts = resolveRetryAttempts(r);
+  return out;
+}
+
+/**
+ * Find the FIRST rule (in array order) that matches this failure for `provider`,
+ * and return the rule object itself (not a derived shape) — or null.
+ *
+ * A rule's `match` may carry any combination of { kind, status, contains }; the
+ * rule matches only when EVERY present condition holds (AND). At least one usable
+ * condition must be present (an empty match never matches — avoids skip-all).
+ * Array order is user-controlled via the settings UI (first match wins).
+ *
+ * @param {string} provider
+ * @param {{status?: number|string, errorKind?: string, text?: string}} failure
+ * @param {Array} skipRules
+ * @returns {object|null} the matching rule object, or null
+ */
+export function findMatchingSkipRule(provider, failure = {}, skipRules = []) {
+  const status = failure.status != null ? Number(failure.status) : null;
+  const errorKind = failure.errorKind || null;
+  const text = typeof failure.text === "string" ? failure.text.toLowerCase() : "";
+  const rules = Array.isArray(skipRules) ? skipRules : [];
+
+  const conditionsMatch = (m) => {
+    let has = false;
+    if (m.kind != null) {
+      has = true;
+      if (errorKind == null || m.kind !== errorKind) return false;
+    }
+    if (m.status != null) {
+      has = true;
+      if (status == null || Number(m.status) !== status) return false;
+    }
+    if (m.contains != null && m.contains !== "") {
+      has = true;
+      if (!text.includes(String(m.contains).toLowerCase())) return false;
+    }
+    // A match block with no usable condition never matches (avoids skip-all).
+    return has;
+  };
+
+  for (const r of rules) {
+    if (!r || r.provider !== provider || !r.match || !r.action) continue;
+    if (conditionsMatch(r.match)) return r;
+  }
+  return null;
+}
+
+/**
+ * Resolve the header/connect timeout for a provider from skip-rules.
+ * Scans rules matching this provider with match.kind === "connect_timeout" that
+ * carry a headerTimeoutMs; earlier rule wins. Returns null → caller uses default.
+ */
+export function resolveProviderHeaderTimeout(provider, skipRules = []) {
+  const rules = Array.isArray(skipRules) ? skipRules : [];
+  for (const r of rules) {
+    if (r && r.provider === provider && r.match?.kind === "connect_timeout" && r.headerTimeoutMs != null) {
+      return r.headerTimeoutMs;
+    }
+  }
+  return null;
+}
+
+/**
  * Check if account is currently unavailable (cooldown not expired)
  */
 export function isAccountUnavailable(unavailableUntil) {

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -4,6 +4,7 @@
 
 import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
+import { getRoutingMeta } from "./routingMeta.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
 
@@ -305,10 +306,17 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
         return result;
       }
 
+      // Fail-fast when the router flagged this failure as such: connect_timeout
+      // (upstream stalled before headers) OR a user skip-rule fired (status/contains/
+      // kind + action:"skip"). Both mean waiting a cooldown just delays the jump to
+      // the next backup model. Read the in-process routing metadata (never serialized).
+      const meta = getRoutingMeta(result);
+      const failFast = meta?.failFast === true || meta?.errorKind === "connect_timeout";
+
       // For transient errors (503/502/504), wait for cooldown before falling through
       // so a briefly-overloaded provider gets a chance to recover rather than being
       // skipped immediately (fixes: combo falls through on transient 503)
-      if (cooldownMs && cooldownMs > 0 && cooldownMs <= 5000 &&
+      if (!failFast && cooldownMs && cooldownMs > 0 && cooldownMs <= 5000 &&
           (result.status === 503 || result.status === 502 || result.status === 504)) {
         log.info("COMBO", `Model ${modelStr} transient ${result.status}, waiting ${cooldownMs}ms before next`);
         await new Promise(r => setTimeout(r, cooldownMs));

--- a/open-sse/services/routingMeta.js
+++ b/open-sse/services/routingMeta.js
@@ -1,0 +1,16 @@
+// In-process routing metadata attached to Response objects.
+// Kept in a WeakMap so it never leaks into the response headers/body sent to
+// clients, yet downstream routing code (combo fallback) can read the error
+// classification of a failed single-model Response.
+
+const _meta = new WeakMap(); // Response → { errorKind, status, failFast? }
+
+export function setRoutingMeta(response, metadata) {
+  if (response && typeof response === "object") _meta.set(response, metadata);
+  return response;
+}
+
+export function getRoutingMeta(response) {
+  if (!response || typeof response !== "object") return null;
+  return _meta.get(response) || null;
+}

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -1,4 +1,5 @@
 import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
+import { setRoutingMeta } from "../services/routingMeta.js";
 
 /**
  * Build OpenAI-compatible error response body
@@ -95,13 +96,18 @@ export async function parseUpstreamError(response, executor = null) {
  * @param {number} [resetsAtMs] - Optional precise cooldown expiry (ms epoch) for provider-specific quota errors
  * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number }}
  */
-export function createErrorResult(statusCode, message, resetsAtMs) {
+export function createErrorResult(statusCode, message, resetsAtMs, errorKind = null) {
+  const response = errorResponse(statusCode, message);
+  // Attach internal routing metadata (in-process WeakMap only — never serialized
+  // into headers/body) so combo fallback can read the error kind off the Response.
+  if (errorKind != null) setRoutingMeta(response, { errorKind, status: statusCode });
   return {
     success: false,
     status: statusCode,
     error: message,
     resetsAtMs,
-    response: errorResponse(statusCode, message)
+    errorKind,
+    response
   };
 }
 

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -22,6 +22,24 @@ const STREAM_MODE = {
   PASSTHROUGH: "passthrough" // No translation, normalize output, extract usage
 };
 
+function getGeminiFamilyParts(chunk) {
+  const parts = chunk?.response?.candidates?.[0]?.content?.parts
+    || chunk?.candidates?.[0]?.content?.parts;
+  return Array.isArray(parts) ? parts : [];
+}
+
+function accumulateGeminiFamilyParts(parts, accumulate) {
+  for (const part of parts) {
+    if (part.text && typeof part.text === "string") {
+      accumulate(part.text, part.thought === true);
+    }
+  }
+}
+
+function hasGeminiFamilyFinishReason(chunk) {
+  return !!(chunk?.response?.candidates?.[0]?.finishReason || chunk?.candidates?.[0]?.finishReason);
+}
+
 /**
  * Create unified SSE transform stream
  * @param {object} options
@@ -75,6 +93,32 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  let completionRecorded = false;
+
+  const recordStreamCompletion = (currentUsage) => {
+    if (completionRecorded) return currentUsage;
+    let finalUsage = currentUsage;
+
+    if (!hasValidUsage(finalUsage) && totalContentLength > 0) {
+      finalUsage = estimateUsage(body, totalContentLength, mode === STREAM_MODE.PASSTHROUGH ? FORMATS.OPENAI : sourceFormat);
+    }
+
+    if (hasValidUsage(finalUsage)) {
+      logUsage(mode === STREAM_MODE.TRANSLATE ? (state?.provider || targetFormat) : provider, finalUsage, model, connectionId, apiKey);
+    } else {
+      appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
+    }
+
+    if (onStreamComplete) {
+      onStreamComplete({
+        content: accumulatedContent,
+        thinking: accumulatedThinking
+      }, finalUsage, ttftAt);
+    }
+
+    completionRecorded = true;
+    return finalUsage;
+  };
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -163,6 +207,15 @@ export function createSSEStream(options = {}) {
                 accumulatedThinking += reasoning;
               }
 
+              accumulateGeminiFamilyParts(getGeminiFamilyParts(parsed), (text, isThought) => {
+                totalContentLength += text.length;
+                if (isThought) {
+                  accumulatedThinking += text;
+                } else {
+                  accumulatedContent += text;
+                }
+              });
+
               const extracted = extractUsage(parsed);
               if (extracted) {
                 usage = mergeUsage(usage, extracted);
@@ -183,6 +236,10 @@ export function createSSEStream(options = {}) {
               } else if (idFixed || fieldsInjected) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
+              }
+
+              if (isFinishChunk || hasGeminiFamilyFinishReason(parsed)) {
+                usage = recordStreamCompletion(usage);
               }
             } catch {
               // Skip non-JSON data lines silently — don't forward garbage to clients.
@@ -266,24 +323,23 @@ export function createSSEStream(options = {}) {
           accumulatedThinking += parsed.choices[0].delta.reasoning_content;
         }
         
-        // Gemini format
-        if (parsed.candidates?.[0]?.content?.parts) {
-          for (const part of parsed.candidates[0].content.parts) {
-            if (part.text && typeof part.text === "string") {
-              totalContentLength += part.text.length;
-              // Check if this is thinking content
-              if (part.thought === true) {
-                accumulatedThinking += part.text;
-              } else {
-                accumulatedContent += part.text;
-              }
-            }
+        // Gemini-family format (Gemini/Vertex direct and Antigravity wrapped)
+        accumulateGeminiFamilyParts(getGeminiFamilyParts(parsed), (text, isThought) => {
+          totalContentLength += text.length;
+          if (isThought) {
+            accumulatedThinking += text;
+          } else {
+            accumulatedContent += text;
           }
-        }
+        });
 
         // Extract usage
         const extracted = extractUsage(parsed);
         if (extracted) state.usage = mergeUsage(state.usage, extracted); // Keep original usage for logging
+
+        if (hasGeminiFamilyFinishReason(parsed)) {
+          state.usage = recordStreamCompletion(state.usage);
+        }
 
         // Responses same-format passthrough: re-emit with original event framing
         if (keepsOpenAIResponsesFormat && openAIResponsesEventName) {
@@ -359,11 +415,7 @@ export function createSSEStream(options = {}) {
             usage = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
           }
 
-          if (hasValidUsage(usage)) {
-            logUsage(provider, usage, model, connectionId, apiKey);
-          } else {
-            appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
-          }
+          usage = recordStreamCompletion(usage);
           
           // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
@@ -377,12 +429,6 @@ export function createSSEStream(options = {}) {
             controller.enqueue(sharedEncoder.encode(doneOutput));
           }
 
-          if (onStreamComplete) {
-            onStreamComplete({
-              content: accumulatedContent,
-              thinking: accumulatedThinking
-            }, usage, ttftAt);
-          }
           return;
         }
 
@@ -448,18 +494,7 @@ export function createSSEStream(options = {}) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);
         }
 
-        if (hasValidUsage(state?.usage)) {
-          logUsage(state.provider || targetFormat, state.usage, model, connectionId, apiKey);
-        } else {
-          appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
-        }
-        
-        if (onStreamComplete) {
-          onStreamComplete({
-            content: accumulatedContent,
-            thinking: accumulatedThinking
-          }, state?.usage, ttftAt);
-        }
+        state.usage = recordStreamCompletion(state?.usage);
       } catch (error) {
         console.log("Error in flush:", error);
       }

--- a/src/app/(dashboard)/dashboard/profile/SkipRulesModal.js
+++ b/src/app/(dashboard)/dashboard/profile/SkipRulesModal.js
@@ -1,0 +1,329 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button, Select, Input, SegmentedControl, Toggle } from "@/shared/components";
+import Modal from "@/shared/components/Modal";
+import { cn } from "@/shared/utils/cn";
+import { AI_PROVIDERS } from "@/shared/constants/config";
+import { ruleToRow, rowToRule, mergeProviderOptions } from "./skipRulesLogic.js";
+
+// Suggested error codes for the datalist (from open-sse errorConfig status map).
+const SUGGESTED_STATUSES = [400, 401, 402, 403, 404, 406, 408, 429, 500, 502, 503, 504];
+
+// How to match: an HTTP failure (status and/or body text) or a transport error kind.
+const MATCH_MODES = [
+  { value: "http", label: "HTTP" },
+  { value: "kind", label: "Transport" },
+];
+
+const KIND_OPTIONS = [
+  { value: "connect_timeout", label: "connect_timeout" },
+  { value: "network", label: "network" },
+];
+
+// Short labels so the two segments never clip inside the control.
+const ACTION_OPTIONS = [
+  { value: "skip", label: "Skip" },
+  { value: "retry", label: "Retry" },
+];
+
+// Turn the shared Input/Select into a *real* field on the card. The shared
+// components hardcode `bg-surface-2 border-transparent rounded-[10px] py-2.5`
+// and cn() is a plain string-join (NOT tailwind-merge), so overriding those
+// exact props needs `!` to win. Only the overridden props carry `!`:
+//   bg-surface-2 → !bg-bg   (bg-bg = var(--color-bg), the real contrasting token;
+//                            `bg-background` does NOT exist in this theme)
+//   border-transparent → !border-border   (resting border)
+//   rounded-[10px] → !rounded-lg           (app-standard radius)
+//   py-2.5 → !py-0 + h-10                  (fixed 40px height; h-10 not set by
+//                                           the component so it needs no `!`)
+// hover carries `!` because it must beat the `!border-border` base on hover.
+// Focus ring is already provided by the shared component (focus:ring-2).
+const FIELD_CLS = "h-10 !py-0 !bg-bg !border-border !rounded-lg hover:!border-brand-500/60";
+
+// Small fixed label above each field (12px), so placeholders aren't the only label.
+function Field({ label, children, className }) {
+  return (
+    <div className={cn("flex flex-col gap-1 min-w-0", className)}>
+      {label && <span className="text-xs text-text-muted leading-none">{label}</span>}
+      {children}
+    </div>
+  );
+}
+
+function emptyRule() {
+  return { provider: "", matchMode: "http", status: "", contains: "", kind: "connect_timeout", action: "skip", headerTimeoutMs: "", sweep: false, retryAttempts: "" };
+}
+
+export default function SkipRulesModal({ open, onClose, onSaved }) {
+  const [rows, setRows] = useState([]);
+  const [providerOpts, setProviderOpts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [rowErrors, setRowErrors] = useState({});
+  const [expanded, setExpanded] = useState({}); // UI-only: which rows show advanced options
+
+  // Provider dropdown = static registry (AI_PROVIDERS) + dynamic compatible nodes
+  // (/api/provider-nodes) so user-created providers like anthropic-compatible-<uuid> appear.
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError("");
+    Promise.all([
+      fetch("/api/settings", { cache: "no-store" }).then(r => r.ok ? r.json() : {}),
+      fetch("/api/provider-nodes", { cache: "no-store" }).then(r => r.ok ? r.json() : { nodes: [] }).catch(() => ({ nodes: [] })),
+    ]).then(([settings, nodesData]) => {
+      const rules = Array.isArray(settings.providerSkipRules) ? settings.providerSkipRules : [];
+      setRows(rules.map(ruleToRow));
+      setProviderOpts(mergeProviderOptions(AI_PROVIDERS, nodesData.nodes));
+    }).finally(() => setLoading(false));
+  }, [open]);
+
+  const updateRow = (i, patch) => {
+    setRows(rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+    setRowErrors(prev => { const next = { ...prev }; delete next[i]; return next; });
+  };
+  const addRow = () => setRows([...rows, emptyRule()]);
+  const removeRow = (i) => setRows(rows.filter((_, idx) => idx !== i));
+  const toggleExpanded = (i) => setExpanded(prev => ({ ...prev, [i]: !prev[i] }));
+
+  const save = async () => {
+    setError("");
+    // Validate every row up front. Flag the exact rows that fail instead of
+    // silently dropping incomplete/invalid ones on save.
+    const providerSkipRules = [];
+    const errs = {};
+    rows.forEach((row, i) => {
+      const { rule, error: rowErr } = rowToRule(row);
+      if (rowErr) errs[i] = rowErr;
+      else providerSkipRules.push(rule);
+    });
+    if (Object.keys(errs).length > 0) {
+      setRowErrors(errs);
+      setError(`${Object.keys(errs).length} invalid row(s) — fix the highlighted rows.`);
+      return;
+    }
+    setRowErrors({});
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerSkipRules }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Failed to save");
+        return;
+      }
+      onSaved?.(providerSkipRules);
+      onClose?.();
+    } catch (e) {
+      setError(e.message || "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Compact footer: the Modal footer bar is a separate flow row below the
+  // scrollable body (single scroll region, never overlaps a rule). -my-2.5
+  // trims the bar's hardcoded p-6 to ~14px vertical without touching Modal.
+  const footer = (
+    <div className="flex items-center gap-3 w-full -my-2.5">
+      {error && <div className="mr-auto text-xs text-red-500">{error}</div>}
+      <div className="ml-auto flex items-center gap-2">
+        <Button size="sm" variant="ghost" onClick={onClose} disabled={saving}>Cancel</Button>
+        <Button size="sm" variant="primary" onClick={save} loading={saving}>Save</Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      title="Skip-error rules"
+      size="lg"
+      className="!max-w-[800px] w-full"
+      footer={footer}
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-xs text-text-muted leading-relaxed">
+          When a provider returns an error matching a rule: <b>Skip</b> = drop the account and jump to the backup immediately (no cooldown) ·
+          <b> Retry</b> = call the same account N more times. If it still fails, move to the next account with no cooldown.
+          Fill in a status and/or matching text (when both are set, both must match).
+        </p>
+
+        {loading ? (
+          <div className="text-sm text-text-muted">Loading…</div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {/* Shared suggestions for every HTTP-status input (list="skip-rule-status-suggestions"). */}
+            <datalist id="skip-rule-status-suggestions">
+              {SUGGESTED_STATUSES.map(s => (
+                <option key={s} value={s} />
+              ))}
+            </datalist>
+            {rows.length === 0 && (
+              <div className="text-sm text-text-muted italic py-2">No rules yet. Click &quot;Add rule&quot; to get started.</div>
+            )}
+            {rows.map((row, i) => {
+              const showAdvanced = row.action === "skip" || row.action === "retry" || (row.matchMode === "kind" && row.kind === "connect_timeout");
+              return (
+              <div key={i} className={cn("px-3 py-2.5 border rounded-lg bg-surface-2", rowErrors[i] ? "border-red-500" : "border-border")}>
+                {/* Responsive main row:
+                    mobile  → 1 col, everything stacked
+                    md      → 2 cols × 2 rows  (Provider | Condition  /  Action | Delete)
+                    lg      → 1 row: Provider | Condition | Action | Delete */}
+                <div className="grid gap-2 items-end grid-cols-1 md:grid-cols-[140px_minmax(0,1fr)] lg:grid-cols-[minmax(120px,150px)_minmax(280px,1fr)_auto_auto]">
+                  {/* 1 · Provider */}
+                  <Field label="Provider">
+                    <Select
+                      options={providerOpts}
+                      value={row.provider}
+                      onChange={(e) => updateRow(i, { provider: e.target.value })}
+                      placeholder="Select provider"
+                      selectClassName={FIELD_CLS}
+                      aria-label="Provider"
+                    />
+                  </Field>
+
+                  {/* 2 · Condition: Error kind + (Status + Text) | (Transport kind) */}
+                  <div className="flex flex-wrap gap-2 items-end min-w-0">
+                    <Field label="Error kind" className="w-[104px] shrink-0">
+                      <Select
+                        options={MATCH_MODES}
+                        value={row.matchMode}
+                        onChange={(e) => updateRow(i, { matchMode: e.target.value })}
+                        selectClassName={FIELD_CLS}
+                        aria-label="Error kind"
+                      />
+                    </Field>
+                    {row.matchMode === "http" ? (
+                      <>
+                        <Field label="HTTP status" className="w-[92px] shrink-0">
+                          <Input
+                            type="number"
+                            list="skip-rule-status-suggestions"
+                            value={row.status}
+                            onChange={(e) => updateRow(i, { status: e.target.value })}
+                            placeholder="any code"
+                            inputClassName={FIELD_CLS}
+                            title="HTTP status — leave blank to match any error code"
+                            aria-label="HTTP status"
+                          />
+                        </Field>
+                        <Field label="Contains text" className="flex-1 min-w-[120px]">
+                          <Input
+                            value={row.contains}
+                            onChange={(e) => updateRow(i, { contains: e.target.value })}
+                            placeholder="optional — e.g. overloaded"
+                            inputClassName={FIELD_CLS}
+                            title="Text inside the error body — set it to narrow the match (both code and text must match)"
+                            aria-label="Contains text"
+                          />
+                        </Field>
+                      </>
+                    ) : (
+                      <Field label="Transport kind" className="flex-1 min-w-[140px]">
+                        <Select
+                          options={KIND_OPTIONS}
+                          value={row.kind}
+                          onChange={(e) => updateRow(i, { kind: e.target.value })}
+                          selectClassName={FIELD_CLS}
+                          aria-label="Transport error kind"
+                        />
+                      </Field>
+                    )}
+                  </div>
+
+                  {/* 3 · Action — one segmented control; contrast root vs card via !bg-bg + border */}
+                  <SegmentedControl
+                    size="md"
+                    options={ACTION_OPTIONS}
+                    value={row.action}
+                    onChange={(v) => updateRow(i, v === "retry"
+                      ? { action: v, sweep: false }
+                      : { action: v, retryAttempts: "" })}
+                    className="!bg-bg border border-border"
+                  />
+
+                  {/* 4 · Delete */}
+                  <div className="flex justify-start md:justify-end lg:justify-start">
+                    <Button size="sm" variant="ghost" icon="delete" onClick={() => removeRow(i)} title="Delete rule" aria-label="Delete rule" />
+                  </div>
+                </div>
+
+                {rowErrors[i] && (
+                  <div className="mt-1.5 text-xs text-red-500">{rowErrors[i]}</div>
+                )}
+
+                {/* Advanced options — collapsed by default; only when relevant */}
+                {showAdvanced && (
+                  <div className="mt-1.5">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(i)}
+                      className="flex items-center gap-1 text-xs text-text-muted hover:text-text-main transition-colors"
+                    >
+                      <span className={cn("material-symbols-outlined text-[16px] transition-transform", expanded[i] && "rotate-180")}>expand_more</span>
+                      Advanced options
+                    </button>
+                    {expanded[i] && (
+                      <div className="mt-2 flex flex-col gap-2.5 pl-1">
+                        {row.action === "skip" && (
+                          <Toggle
+                            checked={!!row.sweep}
+                            onChange={(v) => updateRow(i, { sweep: v })}
+                            label="Re-sweep the whole pool when accounts run out"
+                            description="For momentary capacity errors — retry every account for a few more rounds."
+                          />
+                        )}
+                        {row.action === "retry" && (
+                          <div className="w-[200px]">
+                            <Field label="Extra retries">
+                              <Input
+                                type="number"
+                                value={row.retryAttempts}
+                                onChange={(e) => updateRow(i, { retryAttempts: e.target.value })}
+                                placeholder="1"
+                                inputClassName={FIELD_CLS}
+                                title="Call the same account N more times. Leave blank for 1."
+                                aria-label="Extra retries"
+                              />
+                            </Field>
+                          </div>
+                        )}
+                        {row.matchMode === "kind" && row.kind === "connect_timeout" && (
+                          <div className="w-[200px]">
+                            <Field label="Header timeout (ms)">
+                              <Input
+                                type="number"
+                                value={row.headerTimeoutMs}
+                                onChange={(e) => updateRow(i, { headerTimeoutMs: e.target.value })}
+                                placeholder="25000"
+                                inputClassName={FIELD_CLS}
+                                title="Defaults to 60000"
+                                aria-label="Header timeout (ms)"
+                              />
+                            </Field>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+              );
+            })}
+
+            <div className="mt-0.5">
+              <Button size="sm" variant="ghost" icon="add" onClick={addRow}>Add rule</Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Card, Button, Toggle, Input } from "@/shared/components";
 import Modal, { ConfirmModal } from "@/shared/components/Modal";
 import LanguageSwitcher from "@/shared/components/LanguageSwitcher";
+import SkipRulesModal from "./SkipRulesModal";
 import { useTheme } from "@/shared/hooks/useTheme";
 import { cn } from "@/shared/utils/cn";
 import { APP_CONFIG } from "@/shared/constants/config";
@@ -48,6 +49,7 @@ export default function ProfilePage() {
   const [oidcTestStatus, setOidcTestStatus] = useState({ type: "", message: "" });
   const [oidcRedirectUri, setOidcRedirectUri] = useState("/api/auth/oidc/callback");
   const [oidcExpanded, setOidcExpanded] = useState(false);
+  const [skipRulesOpen, setSkipRulesOpen] = useState(false);
   const importFileRef = useRef(null);
   const [proxyForm, setProxyForm] = useState({
     outboundProxyEnabled: false,
@@ -237,6 +239,21 @@ export default function ProfilePage() {
       if (res.ok) {
         setSettings(prev => ({ ...prev, fallbackStrategy: strategy }));
       }
+    } catch (err) {
+      console.error("Failed to update settings:", err);
+    }
+  };
+
+  const updateMaxTransportAttempts = async (value) => {
+    const n = parseInt(value, 10);
+    if (!Number.isInteger(n) || n < 1 || n > 5) return;
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxTransportAttempts: n }),
+      });
+      if (res.ok) setSettings(prev => ({ ...prev, maxTransportAttempts: n }));
     } catch (err) {
       console.error("Failed to update settings:", err);
     }
@@ -1006,6 +1023,45 @@ export default function ProfilePage() {
           </div>
         </Card>
 
+        {/* Reliability: retries + skip-error rules */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-amber-500/10 text-amber-500 shrink-0">
+              <span className="material-symbols-outlined text-[20px]">bolt</span>
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-text-main">Reliability & Fail-fast</h2>
+              <p className="text-sm text-text-muted">Maximum call attempts and per-provider error handling.</p>
+            </div>
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-3 flex-wrap">
+              <span className="text-sm text-text-main font-medium">Max transport attempts</span>
+              <input
+                type="number"
+                min={1}
+                max={5}
+                value={settings.maxTransportAttempts ?? 2}
+                onChange={(e) => setSettings(prev => ({ ...prev, maxTransportAttempts: e.target.value }))}
+                onBlur={(e) => updateMaxTransportAttempts(e.target.value)}
+                className="w-16 px-2 py-1 text-sm border border-border rounded-md bg-background focus:outline-none focus:border-primary"
+              />
+              <span className="text-xs text-text-muted">Maximum calls per account (including the first). Defaults to 2.</span>
+            </div>
+            <div className="flex items-center justify-between gap-3 pt-3 border-t border-border">
+              <div>
+                <div className="text-sm text-text-main font-medium">Skip-error rules</div>
+                <div className="text-xs text-text-muted">
+                  Declare provider + error code pairs to skip fast or retry the same account.
+                </div>
+              </div>
+              <Button size="sm" variant="secondary" icon="tune" onClick={() => setSkipRulesOpen(true)}>
+                Configure
+              </Button>
+            </div>
+          </div>
+        </Card>
+
         {/* Network */}
         <Card>
           <div className="flex items-center gap-3 mb-4">
@@ -1177,6 +1233,12 @@ export default function ProfilePage() {
           autoFocus
         />
       </Modal>
+
+      <SkipRulesModal
+        open={skipRulesOpen}
+        onClose={() => setSkipRulesOpen(false)}
+        onSaved={(rules) => setSettings(prev => ({ ...prev, providerSkipRules: rules }))}
+      />
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/profile/skipRulesLogic.js
+++ b/src/app/(dashboard)/dashboard/profile/skipRulesLogic.js
@@ -1,0 +1,99 @@
+import { SKIP_RULE_RETRY_ATTEMPTS_MIN } from "open-sse/services/accountFallback.js";
+
+// Pure, framework-free helpers for the Skip-rules modal. Extracted from
+// SkipRulesModal.js so they can be unit-tested without a JSX/React harness
+// (the vitest env is "node" and cannot parse JSX imported from a .js file).
+
+// Row model (editable form state):
+//   { provider, matchMode: "http" | "kind",
+//     status, contains,          // used when matchMode === "http" (either/both)
+//     kind,                      // used when matchMode === "kind"
+//     action, headerTimeoutMs, sweep, retryAttempts }
+// Stored rule: { provider, match: { status?, contains?, kind? }, action, headerTimeoutMs?, sweep?, retryAttempts? }
+// retryAttempts (retry only) = extra calls to the SAME account before moving on.
+// A rule's match may carry any combination of status/contains/kind (AND at runtime).
+// sweep (skip only) asks the account loop to re-try the whole pool after exhaustion.
+
+// Convert stored rule → editable row.
+export function ruleToRow(rule) {
+  const m = rule.match || {};
+  const matchMode = m.kind != null ? "kind" : "http";
+  return {
+    provider: rule.provider || "",
+    matchMode,
+    status: m.status != null ? String(m.status) : "",
+    contains: m.contains != null ? String(m.contains) : "",
+    kind: m.kind != null ? String(m.kind) : "connect_timeout",
+    action: rule.action === "retry" ? "retry" : "skip",
+    headerTimeoutMs: rule.headerTimeoutMs != null ? String(rule.headerTimeoutMs) : "",
+    sweep: rule.sweep === true,
+    // Blank for a retry rule saved before the field existed; rowToRule() then omits
+    // it and accountFallback.resolveRetryAttempts() applies the documented default.
+    retryAttempts: rule.retryAttempts != null ? String(rule.retryAttempts) : "",
+  };
+}
+
+// Convert an editable row → stored rule. Returns { rule } when valid, or
+// { error } with a human-readable reason so the caller can flag the exact row
+// instead of silently dropping it.
+export function rowToRule(row) {
+  if (!row.provider) return { error: "Select a provider" };
+  const match = {};
+
+  if (row.matchMode === "kind") {
+    if (!row.kind) return { error: "Select an error kind" };
+    match.kind = row.kind;
+  } else {
+    // HTTP mode: status and/or contains — at least one required.
+    const hasStatus = row.status != null && String(row.status).trim() !== "";
+    const hasContains = row.contains != null && String(row.contains).trim() !== "";
+    if (!hasStatus && !hasContains) {
+      return { error: "Enter an HTTP status or matching text (at least one)" };
+    }
+    if (hasStatus) {
+      const n = parseInt(row.status, 10);
+      if (!Number.isInteger(n) || n < 100 || n > 599) return { error: "HTTP status must be an integer 100-599" };
+      match.status = n;
+    }
+    if (hasContains) {
+      const c = String(row.contains).trim();
+      if (c.length > 200) return { error: "Matching text is too long (200 characters max)" };
+      match.contains = c;
+    }
+  }
+
+  const rule = { provider: row.provider, match, action: row.action === "retry" ? "retry" : "skip" };
+  if (row.matchMode === "kind" && row.kind === "connect_timeout" && row.headerTimeoutMs) {
+    const t = parseInt(row.headerTimeoutMs, 10);
+    if (!Number.isInteger(t) || t < 1000 || t > 120000) return { error: "Header timeout must be an integer 1000-120000 ms" };
+    rule.headerTimeoutMs = t;
+  }
+  // sweep (re-try whole pool after exhaustion) is only meaningful for skip.
+  if (rule.action === "skip" && row.sweep === true) rule.sweep = true;
+  // retryAttempts is only meaningful for retry. Switching a row Retry → Skip
+  // therefore drops it, which is what the UI promises.
+  if (rule.action === "retry" && row.retryAttempts != null && String(row.retryAttempts).trim() !== "") {
+    const n = parseInt(row.retryAttempts, 10);
+    if (!Number.isInteger(n) || n < SKIP_RULE_RETRY_ATTEMPTS_MIN) {
+      return { error: `Retry count must be an integer >= ${SKIP_RULE_RETRY_ATTEMPTS_MIN}` };
+    }
+    rule.retryAttempts = n;
+  }
+  return { rule };
+}
+
+// Merge the static provider registry (AI_PROVIDERS) with dynamic compatible
+// nodes from /api/provider-nodes so user-created providers (anthropic-compatible-<uuid>)
+// appear in the dropdown. Deduped by id, static entries win.
+export function mergeProviderOptions(aiProviders, nodes) {
+  const staticOpts = Object.values(aiProviders || {})
+    .filter(p => p && !p.hidden)
+    .map(p => ({ value: p.id, label: p.name || p.id }));
+  const nodeOpts = (nodes || []).map(n => ({ value: n.id, label: `${n.name || n.id} (${n.type || "custom"})` }));
+  const seen = new Set();
+  return [...staticOpts, ...nodeOpts].filter(o => {
+    if (seen.has(o.value)) return false;
+    seen.add(o.value);
+    return true;
+  });
+}

--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -3,6 +3,7 @@ import { getSettings, updateSettings } from "@/lib/localDb";
 import { applyOutboundProxyEnv } from "@/lib/network/outboundProxy";
 import { resetComboRotation } from "open-sse/services/combo.js";
 import bcrypt from "bcryptjs";
+import { SKIP_RULE_RETRY_ATTEMPTS_MIN } from "open-sse/services/accountFallback.js";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -13,6 +14,67 @@ const SETTINGS_RESPONSE_HEADERS = {
 
 // Secrets must never be mass-assigned from request body (CWE-915)
 const PROTECTED_SETTING_KEYS = ["password", "mitmSudoEncrypted"];
+
+const SKIP_RULE_KINDS = new Set(["connect_timeout", "network"]);
+const SKIP_RULE_ACTIONS = new Set(["retry", "skip"]);
+
+// Validate maxTransportAttempts + providerSkipRules when present in the PATCH body.
+// Returns an error string (→ 400) or null when valid / absent.
+function validateSkipRuleSettings(body) {
+  if (Object.prototype.hasOwnProperty.call(body, "maxTransportAttempts")) {
+    const n = body.maxTransportAttempts;
+    if (!Number.isInteger(n) || n < 1 || n > 5) return "maxTransportAttempts must be an integer 1-5";
+  }
+  if (!Object.prototype.hasOwnProperty.call(body, "providerSkipRules")) return null;
+
+  const rules = body.providerSkipRules;
+  if (!Array.isArray(rules)) return "providerSkipRules must be an array";
+  if (rules.length > 100) return "providerSkipRules cannot exceed 100 rules";
+
+  for (let i = 0; i < rules.length; i++) {
+    const r = rules[i];
+    const at = `providerSkipRules[${i}]`;
+    if (!r || typeof r !== "object") return `${at} must be an object`;
+    if (typeof r.provider !== "string" || !r.provider.trim() || r.provider.length > 128) {
+      return `${at}.provider must be a non-empty string ≤128 chars`;
+    }
+    if (!SKIP_RULE_ACTIONS.has(r.action)) return `${at}.action must be "retry" or "skip"`;
+    const m = r.match;
+    if (!m || typeof m !== "object") return `${at}.match is required`;
+    // Match may carry any combination of kind|status|contains; at least one is
+    // required, and every present condition must be valid (AND semantics at runtime).
+    const present = ["kind", "status", "contains"].filter(k => m[k] != null && m[k] !== "");
+    if (present.length < 1) return `${at}.match must have at least one of kind|status|contains`;
+    if (m.kind != null && !SKIP_RULE_KINDS.has(m.kind)) return `${at}.match.kind invalid`;
+    if (m.status != null && (!Number.isInteger(m.status) || m.status < 100 || m.status > 599)) {
+      return `${at}.match.status must be an integer 100-599`;
+    }
+    if (m.contains != null && m.contains !== "" && (typeof m.contains !== "string" || m.contains.length > 200)) {
+      return `${at}.match.contains must be a string ≤200 chars`;
+    }
+    if (r.headerTimeoutMs != null) {
+      if (m.kind !== "connect_timeout") return `${at}.headerTimeoutMs only allowed when match.kind is "connect_timeout"`;
+      if (!Number.isInteger(r.headerTimeoutMs) || r.headerTimeoutMs < 1000 || r.headerTimeoutMs > 120000) {
+        return `${at}.headerTimeoutMs must be an integer 1000-120000`;
+      }
+    }
+    if (r.sweep != null) {
+      if (typeof r.sweep !== "boolean") return `${at}.sweep must be a boolean`;
+      if (r.sweep === true && r.action !== "skip") return `${at}.sweep is only allowed when action is "skip"`;
+    }
+    // retryAttempts = extra calls to the SAME account before giving up on it.
+    // Rejected outright on a skip rule so the stored shape cannot imply a budget
+    // that nothing reads. Floats/strings/NaN fail Number.isInteger.
+    if (r.retryAttempts != null) {
+      if (r.action !== "retry") return `${at}.retryAttempts is only allowed when action is "retry"`;
+      if (!Number.isInteger(r.retryAttempts) ||
+          r.retryAttempts < SKIP_RULE_RETRY_ATTEMPTS_MIN) {
+        return `${at}.retryAttempts must be a positive integer (>= ${SKIP_RULE_RETRY_ATTEMPTS_MIN})`;
+      }
+    }
+  }
+  return null;
+}
 
 export async function GET() {
   try {
@@ -74,6 +136,12 @@ export async function PATCH(request) {
       if (!body.oidcClientSecret || !String(body.oidcClientSecret).trim()) {
         delete body.oidcClientSecret;
       }
+    }
+
+    // Validate skip-rules feature settings (reject invalid rather than mass-assign blindly)
+    const skipRulesError = validateSkipRuleSettings(body);
+    if (skipRulesError) {
+      return NextResponse.json({ error: skipRulesError }, { status: 400 });
     }
 
     const settings = await updateSettings(body);

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -7,6 +7,7 @@ import { getMetaSync, setMetaSync } from "./helpers/metaStore.js";
 import { makeBackupDir, backupFile, backupDbLite, pruneOldBackups } from "./backup.js";
 import { getAppVersion } from "./version.js";
 import { stringifyJson } from "./helpers/jsonCol.js";
+import { seedAntigravityRule } from "./repos/settingsRepo.js";
 
 // Marker file: prevents re-importing legacy JSON when user wipes data.sqlite.
 const MIGRATED_MARKER = path.join(DB_DIR, ".migrated-from-json");
@@ -113,7 +114,13 @@ function importLegacyMain(adapter, data) {
   if (!data || typeof data !== "object") return;
 
   if (data.settings) {
-    adapter.run(`INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`, [stringifyJson(data.settings)]);
+    // Seed the default Antigravity capacity skip-rule onto imported legacy settings.
+    // The versioned migration (#2) runs while the DB is still fresh (no settings row
+    // yet) and returns early, so the legacy-JSON path must seed here — otherwise a
+    // direct upgrade from db.json would lose the capacity fail-fast after the hardcode
+    // removal. Uses the SAME helper as migration #2 (idempotent, respects the flag).
+    const settingsToStore = seedAntigravityRule({ ...data.settings });
+    adapter.run(`INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`, [stringifyJson(settingsToStore)]);
   }
 
   importWithAssertion(adapter, "providerConnections", data.providerConnections || [], (c) => {

--- a/src/lib/db/migrations/002-seed-antigravity-skip-rule.js
+++ b/src/lib/db/migrations/002-seed-antigravity-skip-rule.js
@@ -1,0 +1,38 @@
+// One-time seed of the default Antigravity capacity skip-rule for EXISTING installs.
+//
+// Fresh DBs get the rule from DEFAULT_SETTINGS. Installs created before this feature
+// have a settings row with providerSkipRules:[] (or absent) and no skipRulesSeeded
+// flag — and mergeWithDefaults only fills keys that are `undefined`, so it would never
+// backfill the rule. This migration seeds it exactly once via the shared helper.
+//
+// The seeding logic lives in settingsRepo.seedAntigravityRule so this migration and
+// the legacy-db.json import path (migrate.js) behave identically. It is idempotent,
+// only adds the rule when no capacity-equivalent antigravity rule exists (an unrelated
+// antigravity rule like 429→retry does NOT block it), and respects a user who later
+// deletes the rule (the flag stays set).
+import { seedAntigravityRule } from "../repos/settingsRepo.js";
+
+export default {
+  version: 2,
+  name: "seed-antigravity-skip-rule",
+  up(db) {
+    const row = db.get(`SELECT data FROM settings WHERE id = 1`);
+    if (!row) return; // no settings row yet → DEFAULT_SETTINGS covers fresh installs
+
+    let data;
+    try {
+      data = JSON.parse(row.data) || {};
+    } catch {
+      return; // unreadable settings blob → leave untouched
+    }
+
+    if (data.skipRulesSeeded) return; // already seeded (or fresh) → respect user state
+
+    seedAntigravityRule(data);
+
+    db.run(
+      `INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`,
+      [JSON.stringify(data)]
+    );
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-seed-antigravity-skip-rule.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -1,8 +1,61 @@
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+import { findMatchingSkipRule } from "open-sse/services/accountFallback.js";
 
 const DEFAULT_MITM_ROUTER_BASE = "http://localhost:20128";
 const DEFAULT_HEADROOM_URL = process.env.HEADROOM_URL || "http://localhost:8787";
+
+// Seeded skip-rule: the former hardcoded Antigravity capacity fail-fast, now shipped
+// as an ordinary, user-editable rule. Matches 503 AND body text containing "capacity"
+// (covers both MODEL_CAPACITY_EXHAUSTED and "No capacity available for model").
+// sweep:true preserves the legacy full-pool resweep on momentary capacity saturation.
+export const DEFAULT_ANTIGRAVITY_CAPACITY_RULE = {
+  provider: "antigravity",
+  match: { status: 503, contains: "capacity" },
+  action: "skip",
+  sweep: true,
+};
+
+// The two canonical Antigravity capacity-503 error shapes the legacy hardcode caught.
+// We probe the user's rules with these (via the REAL match logic) to decide whether a
+// rule already covers capacity — rather than guessing from rule shape, which breaks
+// with first-match ordering and partial matches (e.g. contains-only / status-only).
+const ANTIGRAVITY_CAPACITY_PROBES = [
+  { status: 503, errorKind: "http_503", text: "MODEL_CAPACITY_EXHAUSTED" },
+  { status: 503, errorKind: "http_503", text: "No capacity available for model x" },
+];
+
+// Pure seed of the default Antigravity capacity rule into a settings object.
+// Idempotent + respects the user's array-order intent. Runs only when skipRulesSeeded
+// is falsy. For each canonical capacity-503 probe, we find the FIRST rule that fires:
+//   - no rule fires        → that pattern is uncovered → append the default at the end
+//   - a "retry" rule fires → user's deliberate choice; leave it, treat probe as handled
+//   - a "skip" rule fires  → ensure sweep:true on it (restores the legacy pool resweep)
+// Existing user rules keep their order/priority; the default is only appended when at
+// least one capacity pattern is matched by no rule. Always stamps the flag.
+// Shared by migration #2 and the legacy-JSON import so both upgrade paths agree (DRY).
+export function seedAntigravityRule(data) {
+  if (!data || typeof data !== "object") return data;
+  if (data.skipRulesSeeded) return data;
+  const rules = Array.isArray(data.providerSkipRules) ? data.providerSkipRules : [];
+
+  let allCovered = true;
+  for (const probe of ANTIGRAVITY_CAPACITY_PROBES) {
+    const rule = findMatchingSkipRule("antigravity", probe, rules);
+    if (rule == null) {
+      allCovered = false; // this capacity pattern is caught by no rule → need default
+    } else if (rule.action === "skip" && rule.sweep !== true) {
+      rule.sweep = true; // restore legacy full-pool resweep for the rule that catches it
+    }
+    // rule.action === "retry" → deliberate user choice; leave untouched.
+  }
+  if (!allCovered) {
+    rules.push({ ...DEFAULT_ANTIGRAVITY_CAPACITY_RULE });
+  }
+  data.providerSkipRules = rules;
+  data.skipRulesSeeded = true;
+  return data;
+}
 
 const DEFAULT_SETTINGS = {
   cloudEnabled: false,
@@ -54,6 +107,9 @@ const DEFAULT_SETTINGS = {
   pxpipeAutoInstall: true,
   pxpipeMinChars: 25000,
   pxpipeTimeoutMs: 15000,
+  maxTransportAttempts: 2,
+  providerSkipRules: [DEFAULT_ANTIGRAVITY_CAPACITY_RULE],
+  skipRulesSeeded: true,
 };
 
 async function readRaw() {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -19,9 +19,15 @@ import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActi
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
+import { resolveProviderHeaderTimeout } from "open-sse/services/accountFallback.js";
+import { setRoutingMeta } from "open-sse/services/routingMeta.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+
+// How many times to re-sweep the whole account pool when a matched skip-rule opts
+// in via sweep:true (momentary capacity/saturation recovery). Not provider-specific.
+const POOL_RESWEEP_RETRIES = 2;
 
 /**
  * Handle chat completion request
@@ -223,9 +229,28 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   const excludeConnectionIds = new Set();
   let lastError = null;
   let lastStatus = null;
+  let lastErrorKind = null;
+  let lastFailFast = false;
+  let lastResweep = false;
+  let poolResweeps = 0;
+  // Request-scoped account-retry budget: how many EXTRA calls each
+  // (connectionId, rule) pair has already consumed. Deliberately a local Map and
+  // never persisted -- a durable counter would leak across unrelated requests and
+  // silently disable the rule for the next caller. Cleared with the request.
+  const accountRetryUsed = new Map();
+
+  // Set while an account-retry rule still has budget on this connection, so the
+  // next getProviderCredentials() call returns the SAME account instead of letting
+  // the selection strategy hand us a different one.
+  let pinnedConnectionId = null;
 
   while (true) {
-    const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
+    const credentials = await getProviderCredentials(
+      provider,
+      excludeConnectionIds,
+      model,
+      pinnedConnectionId ? { preferredConnectionId: pinnedConnectionId } : {}
+    );
 
     // All accounts unavailable
     if (!credentials || credentials.allRateLimited) {
@@ -233,14 +258,36 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         const errorMsg = lastError || credentials.lastError || "Unavailable";
         const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
         log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
-        return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
+        // Carry the fail-fast classification of the last account failure onto the
+        // terminal response so combo can jump to the next model without a cooldown wait.
+        const resp = unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
+        setRoutingMeta(resp, { errorKind: lastErrorKind, status, failFast: lastFailFast });
+        return resp;
       }
       if (excludeConnectionIds.size === 0) {
         log.warn("AUTH", `No active credentials for provider: ${provider}`);
         return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
       }
+      // Pool resweep: a matched skip-rule with sweep:true asks us to re-try the whole
+      // account pool a few times before giving up (momentary capacity/saturation
+      // recovery). Gated ONLY on the rule's opt-in resweep signal — NOT on failFast
+      // (which fires for every skip / connect_timeout) and NOT hardcoded to any
+      // provider. lastResweep reflects the most recent account failure's rule.
+      if (
+        lastResweep &&
+        poolResweeps < POOL_RESWEEP_RETRIES
+      ) {
+        poolResweeps += 1;
+        log.warn("CHAT", `[${provider}/${model}] pool exhausted with resweep rule; restarting account sweep ${poolResweeps}/${POOL_RESWEEP_RETRIES}`);
+        excludeConnectionIds.clear();
+        continue;
+      }
       log.warn("CHAT", "No more accounts available", { provider });
-      return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+      // Skip-loop terminal: all accounts exhausted. Attach the last failure's
+      // fail-fast signal so combo reads it off THIS response (the object it receives).
+      const resp = errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+      setRoutingMeta(resp, { errorKind: lastErrorKind, status: lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, failFast: lastFailFast });
+      return resp;
     }
 
     // Account selection shown in the unified "▶" line (acc:...)
@@ -259,10 +306,20 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Use shared chatCore
     const chatSettings = await getSettings();
     const providerThinking = (chatSettings.providerThinking || {})[provider] || null;
+    // Request-scoped transport policy (never mutate the cached executor's this.config).
+    const skipRules = chatSettings.providerSkipRules || [];
+    const resolvedHeaderTimeout = resolveProviderHeaderTimeout(provider, skipRules);
+    const requestPolicy = {
+      providerId: provider,
+      maxTransportAttempts: chatSettings.maxTransportAttempts,
+      skipRules,
+      ...(resolvedHeaderTimeout != null ? { headerTimeoutMs: resolvedHeaderTimeout } : {})
+    };
     const result = await handleChatCore({
       body: { ...body, model: `${provider}/${model}` },
       modelInfo: { provider, model },
       credentials: refreshedCredentials,
+      requestPolicy,
       log,
       clientRawRequest,
       connectionId: credentials.connectionId,
@@ -300,17 +357,79 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
 
     if (result.success) return result.response;
 
-    // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise resetsAtMs)
-    const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);
+    // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise
+    // resetsAtMs). Pass the request-scoped skipRules so the fallback tier matches on the SAME
+    // rules the transport tier used — no second getSettings() read that could drift mid-request.
+    const { shouldFallback, failFast, resweep, accountRetry, retryAttempts, ruleKey } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs, result.errorKind, skipRules);
 
-    if (shouldFallback) {
-      log.warn("FALLBACK", `⇄ ACC:${credentials.connectionName} UNAVAILABLE (${result.status}) → NEXT ACCOUNT`);
+    // Account-retry rule: call the SAME account again, up to retryAttempts EXTRA
+    // times. This budget is the rule's own and is independent of
+    // maxTransportAttempts, which governs transport/URL-fallback retries inside the
+    // executor. Nothing is written to the DB on this path -- the account is not what
+    // failed. A client abort ends the request instead of consuming budget, and a
+    // request that already streamed bytes is never retried.
+    if (accountRetry) {
+      const aborted = request?.signal?.aborted || result.errorKind === "aborted" || result.status === 499;
+      if (aborted) {
+        log.warn("CHAT", `[${provider}/${model}] client aborted; not retrying account`);
+        setRoutingMeta(result.response, { errorKind: result.errorKind, status: result.status, failFast: !!failFast });
+        return result.response;
+      }
+      // noauth providers expose a single virtual connection whose connectionId is
+      // undefined; key it explicitly so the budget is still counted, and terminate
+      // below instead of excluding an id that would filter nothing.
+      const retryConnKey = credentials.connectionId || "noauth";
+      const key = `${retryConnKey}|${ruleKey}`;
+      const used = accountRetryUsed.get(key) || 0;
+      if (used < retryAttempts) {
+        accountRetryUsed.set(key, used + 1);
+        pinnedConnectionId = credentials.connectionId;
+        log.warn("RETRY", `↻ ACC:${credentials.connectionName} retry ${used + 1}/${retryAttempts} (${result.status}) — same account, no cooldown`);
+        lastError = result.error;
+        lastStatus = result.status;
+        lastErrorKind = result.errorKind || lastErrorKind;
+        continue;
+      }
+      // Budget exhausted. There is no next account for a no-auth provider (one
+      // virtual connection, and its id is undefined so excluding it would filter
+      // nothing) -- return the terminal error and let combo pick the next model.
+      if (!credentials.connectionId) {
+        log.warn("RETRY", `[${provider}/${model}] retry budget spent (${retryAttempts}) on no-auth connection; no further account`);
+        setRoutingMeta(result.response, { errorKind: result.errorKind, status: result.status, failFast: true });
+        return result.response;
+      }
+      // Move to the next account WITHOUT marking this one unavailable -- no
+      // cooldown, no model lock, no backoff, no lastError write.
+      log.warn("RETRY", `⇄ ACC:${credentials.connectionName} retry budget spent (${retryAttempts}) → NEXT ACCOUNT (no cooldown)`);
+      pinnedConnectionId = null;
       excludeConnectionIds.add(credentials.connectionId);
       lastError = result.error;
       lastStatus = result.status;
+      lastErrorKind = result.errorKind || lastErrorKind;
+      lastFailFast = true;
       continue;
     }
 
+    if (shouldFallback) {
+      log.warn("FALLBACK", `⇄ ACC:${credentials.connectionName} UNAVAILABLE (${result.status}) → NEXT ACCOUNT`);
+      pinnedConnectionId = null;
+      excludeConnectionIds.add(credentials.connectionId);
+      lastError = result.error;
+      lastStatus = result.status;
+      // Preserve the last failure's classification so the terminal response (built
+      // when accounts run out) can signal fail-fast to combo, and resweep to gate
+      // the pool-resweep loop.
+      lastErrorKind = result.errorKind || lastErrorKind;
+      lastFailFast = !!failFast;
+      lastResweep = !!resweep;
+      continue;
+    }
+
+    // Terminal: this account failed but is NOT eligible for fallback (e.g. no-auth
+    // provider, or a non-fallback error). Attach the fail-fast classification onto
+    // the response combo receives so a skip-rule / connect_timeout still skips the
+    // cooldown wait even when there is no next account to try.
+    setRoutingMeta(result.response, { errorKind: result.errorKind, status: result.status, failFast: !!failFast });
     return result.response;
   }
 }

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,6 +1,6 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, matchSkipRule, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
@@ -214,13 +214,73 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
  * @param {string} errorText
  * @param {string|null} provider
  * @param {string|null} model - The specific model that triggered the error
- * @returns {{ shouldFallback: boolean, cooldownMs: number }}
+ * @param {number|null} resetsAtMs - Precise cooldown expiry (overrides backoff) if known
+ * @param {string|null} errorKind - Classified error kind from the executor (connect_timeout | network | http_<status>)
+ * @param {Array|null} skipRules - Request-scoped skip-rules captured for THIS attempt. When
+ *   provided, they are authoritative (same rules the transport tier used); when null we fall
+ *   back to reading settings so non-chat callers (image/search/stt/tts) keep working.
+ * @returns {{ shouldFallback: boolean, cooldownMs: number, failFast?: boolean, resweep?: boolean,
+ *   accountRetry?: boolean, retryAttempts?: number, ruleKey?: string }}
+ *   accountRetry:true asks the caller to re-invoke the SAME account. No DB write happens
+ *   on that path: the caller owns the per-request attempt counter, because a durable count
+ *   would leak between unrelated requests.
  */
-export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null) {
-  if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 };
+export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null, errorKind = null, skipRules = null) {
+  // connect_timeout is always fail-fast: the upstream stalled before returning
+  // headers, so a cooldown wait just delays the jump to the next backup model.
+  const connectTimeoutFailFast = errorKind === "connect_timeout";
+
+  // Match skip-rules using the request-scoped rules when passed (authoritative — the
+  // same set the BaseExecutor retry tier saw). Only read settings as a fallback for
+  // callers that don't thread a policy through. Compute BEFORE the noauth early-return
+  // so a skip signal is not lost for no-auth providers.
+  const effectiveSkipRules = Array.isArray(skipRules)
+    ? skipRules
+    : ((await getSettings()) || {}).providerSkipRules || [];
+  const skipRule = matchSkipRule(provider, { status, errorKind, text: errorText }, effectiveSkipRules);
+  const failFast = skipRule?.action === "skip" || connectTimeoutFailFast;
+  // resweep is a SEPARATE, opt-in signal (rule.sweep:true) — NOT every failFast.
+  // It asks the account loop to re-try the whole pool after exhausting it. Kept
+  // distinct so a plain skip / connect_timeout does NOT trigger a full-pool sweep.
+  const resweep = skipRule?.action === "skip" && skipRule?.sweep === true;
+
+  // A "retry" rule means: call the SAME account again. Return before ANY DB read or
+  // write -- this path must never mark the account unavailable, write a model lock, or
+  // touch backoffLevel, because the account is not the thing that failed. The caller
+  // holds the request-scoped attempt counter and decides whether budget remains; when
+  // it runs out it moves to the next account, still without a DB write. ruleKey lets
+  // the caller keep one counter per (connection, rule) pair. Placed before the noauth
+  // early-return so a no-auth provider retries its virtual connection too.
+  if (skipRule?.action === "retry") {
+    return {
+      shouldFallback: false,
+      cooldownMs: 0,
+      failFast: connectTimeoutFailFast,
+      accountRetry: true,
+      retryAttempts: skipRule.retryAttempts,
+      ruleKey: `${provider || "?"}|${status ?? ""}|${errorKind || ""}`
+    };
+  }
+
+  // No-auth / no-connection: there is a single virtual connection, so we must NOT
+  // ask the account loop to fall back (it would re-select the same virtual connection
+  // forever). Return shouldFallback:false, but still surface the fail-fast
+  // classification so combo can route to the next model without a cooldown wait.
+  if (!connectionId || connectionId === "noauth") {
+    return { shouldFallback: false, cooldownMs: 0, failFast, resweep };
+  }
+
   const connections = await getProviderConnections({ provider });
   const conn = connections.find(c => c.id === connectionId);
   const backoffLevel = conn?.backoffLevel || 0;
+
+  // A "skip" rule means: transient/busy signal — fall back WITHOUT writing a DB
+  // cooldown lock, so the next request can use this account again immediately.
+  if (skipRule?.action === "skip") {
+    const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8);
+    log.warn("AUTH", `${connName} skip-rule (${errorKind || status}) for ${model || "unknown model"}; fallback without cooldown`);
+    return { shouldFallback: true, cooldownMs: 0, failFast: true, resweep };
+  }
 
   // GitHub premium-request exhaustion is account-wide until the next UTC month.
   const githubResetAtMs = githubMonthlyResetMs(status, errorText, provider);
@@ -238,7 +298,7 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   } else {
     ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));
   }
-  if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
+  if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0, failFast: connectTimeoutFailFast };
 
   const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
   const lockUpdate = buildModelLockUpdate(githubResetAtMs ? null : model, cooldownMs);
@@ -260,7 +320,7 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     console.error(`❌ ${provider} [${status}]: ${reason}`);
   }
 
-  return { shouldFallback: true, cooldownMs };
+  return { shouldFallback: true, cooldownMs, failFast: connectTimeoutFailFast };
 }
 
 /**

--- a/tests/unit/account-retry-semantics.test.js
+++ b/tests/unit/account-retry-semantics.test.js
@@ -1,0 +1,279 @@
+/**
+ * Account-retry semantics for skip-rules with action:"retry".
+ *
+ * The original implementation served a retry rule inside BaseExecutor: it set the
+ * transport attempt count to maxTransportAttempts - 1 and, once those were spent,
+ * let the failure fall through to the ordinary account-fallback path -- which
+ * marked the account unavailable and wrote a model-lock cooldown. So the UI
+ * promise ("call the account again") was wrong twice over: the retry count was really a
+ * transport setting the user never associated with the rule, and the account was
+ * punished anyway.
+ *
+ * Correct semantics, locked here:
+ *   - rule.retryAttempts = extra calls to the SAME account, owned by the
+ *     account-selection layer in chat.js, counted per request.
+ *   - Exhausting it moves to the next account with NO DB write at all: no
+ *     unavailable status, no model lock, no backoff, no lastError.
+ *   - It is independent of maxTransportAttempts in both directions.
+ *   - A client abort stops retrying immediately.
+ *   - Skip rules and unmatched errors keep their existing behaviour.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRoutingMeta } from "../../open-sse/services/routingMeta.js";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  getComboModels: vi.fn(),
+  getModelInfo: vi.fn(),
+  handleChatCore: vi.fn(),
+}));
+
+// The real chat.js account loop and the real auth.js run; only DB deps are stubbed.
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: vi.fn(),
+  getProxyPools: vi.fn(async () => []),
+}));
+vi.mock("../../src/sse/services/model.js", () => ({
+  getComboModels: mocks.getComboModels,
+  getModelInfo: mocks.getModelInfo,
+}));
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_p, c) => c),
+  updateProviderCredentials: vi.fn(),
+}));
+vi.mock("../../open-sse/handlers/chatCore.js", () => ({ handleChatCore: mocks.handleChatCore }));
+vi.mock("../../open-sse/services/projectId.js", () => ({ getProjectIdForConnection: vi.fn() }));
+
+function makeRequest(model) {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, messages: [{ role: "user", content: "hi" }] }),
+  });
+}
+
+const fail502 = () => ({
+  success: false, status: 502, error: "[502]: upstream busy", errorKind: "http_502",
+  response: new Response("err", { status: 502 }),
+});
+const ok = () => ({ success: true, response: new Response("ok", { status: 200 }) });
+
+// Which connection each handleChatCore call ran against, in order.
+const calledConnections = () => mocks.handleChatCore.mock.calls.map(c => c[0].connectionId);
+
+function settings(rules, maxTransportAttempts = 2) {
+  mocks.getSettings.mockResolvedValue({
+    requireApiKey: false,
+    providerSkipRules: rules,
+    maxTransportAttempts,
+  });
+}
+
+const RETRY_RULE = (extra) => ({
+  provider: "kr-ac", match: { status: 502 }, action: "retry",
+  ...(extra != null ? { retryAttempts: extra } : {}),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getComboModels.mockResolvedValue(null);
+  mocks.getModelInfo.mockResolvedValue({ provider: "kr-ac", model: "m1" });
+});
+
+describe("account retry calls the same account retryAttempts extra times", () => {
+  it("retryAttempts:3 → 4 calls on the same connection before moving on", async () => {
+    settings([RETRY_RULE(3)]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    // 1 initial + 3 retries, all on kr-1; then the pool is exhausted.
+    expect(calledConnections()).toEqual(["kr-1", "kr-1", "kr-1", "kr-1"]);
+  });
+
+  it("does not move to the next account until the budget is spent", async () => {
+    settings([RETRY_RULE(2)]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, priority: 1, backoffLevel: 0 },
+      { id: "kr-2", provider: "kr-ac", isActive: true, priority: 2, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    // kr-1 three times (1 + 2), then kr-2 three times, then exhausted.
+    expect(calledConnections()).toEqual(["kr-1", "kr-1", "kr-1", "kr-2", "kr-2", "kr-2"]);
+  });
+
+  it("honours a budget far above any built-in ceiling", async () => {
+    // The user decides how many retries they want; there is no upper bound. 25 is
+    // chosen only because it is comfortably past the 10 that used to be enforced,
+    // and a value over that ceiling used to collapse to 1 extra call in silence.
+    settings([RETRY_RULE(25)]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(calledConnections()).toEqual(Array(26).fill("kr-1"));
+  });
+
+  it("a retry rule with no retryAttempts defaults to one extra call", async () => {
+    // Backward compatibility for rules saved before the field existed.
+    settings([RETRY_RULE(null)]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(calledConnections()).toEqual(["kr-1", "kr-1"]);
+  });
+});
+
+describe("a retry that succeeds stops immediately", () => {
+  it("returns the success and never touches the next account", async () => {
+    settings([RETRY_RULE(3)]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, priority: 1, backoffLevel: 0 },
+      { id: "kr-2", provider: "kr-ac", isActive: true, priority: 2, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore
+      .mockResolvedValueOnce(fail502())
+      .mockResolvedValueOnce(fail502())
+      .mockResolvedValueOnce(ok());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const resp = await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(resp.status).toBe(200);
+    expect(calledConnections()).toEqual(["kr-1", "kr-1", "kr-1"]);
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe("account retry never writes account state", () => {
+  it("writes no cooldown, lock, backoff or lastError even after the budget is spent", async () => {
+    settings([RETRY_RULE(2)]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, priority: 1, backoffLevel: 0 },
+      { id: "kr-2", provider: "kr-ac", isActive: true, priority: 2, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    // The whole point: the account is not what failed, so nothing is persisted.
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("an unmatched error still cools the account down (unchanged behaviour)", async () => {
+    settings([RETRY_RULE(2)]); // rule matches 502 only
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue({
+      success: false, status: 500, error: "boom", errorKind: "http_500",
+      response: new Response("err", { status: 500 }),
+    });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(mocks.updateProviderConnection).toHaveBeenCalledWith(
+      "kr-1",
+      expect.objectContaining({ testStatus: "unavailable" })
+    );
+  });
+});
+
+describe("account retry is independent of maxTransportAttempts", () => {
+  it.each([1, 5])("maxTransportAttempts=%i does not change the account retry count", async (maxTransportAttempts) => {
+    settings([RETRY_RULE(3)], maxTransportAttempts);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(calledConnections()).toEqual(["kr-1", "kr-1", "kr-1", "kr-1"]);
+  });
+});
+
+describe("skip rules are unaffected", () => {
+  it("skip moves on after one call and writes no cooldown", async () => {
+    settings([{ provider: "kr-ac", match: { status: 502 }, action: "skip" }]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, priority: 1, backoffLevel: 0 },
+      { id: "kr-2", provider: "kr-ac", isActive: true, priority: 2, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(calledConnections()).toEqual(["kr-1", "kr-2"]);
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe("client abort stops the retry loop", () => {
+  it("returns the aborted response instead of consuming budget", async () => {
+    settings([{ provider: "kr-ac", match: { status: 499 }, action: "retry", retryAttempts: 5 }]);
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue({
+      success: false, status: 499, error: "Request aborted", errorKind: "aborted",
+      response: new Response("aborted", { status: 499 }),
+    });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const resp = await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(resp.status).toBe(499);
+    expect(calledConnections()).toEqual(["kr-1"]); // no retry after an abort
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+});
+
+describe("no-auth providers retry the virtual connection without looping", () => {
+  it("retries retryAttempts times then terminates", async () => {
+    mocks.getModelInfo.mockResolvedValue({ provider: "mimo-free", model: "mimo-auto" });
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      providerSkipRules: [{ provider: "mimo-free", match: { status: 502 }, action: "retry", retryAttempts: 2 }],
+      maxTransportAttempts: 2,
+    });
+    mocks.getProviderConnections.mockResolvedValue([]); // unused on the noAuth path
+    mocks.handleChatCore.mockResolvedValue(fail502());
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const resp = await handleChat(makeRequest("mimo-free/mimo-auto"));
+
+    // 1 + 2 retries against the single virtual connection, then a terminal return
+    // rather than an endless re-select of the same virtual account.
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(3);
+    expect(resp.status).toBe(502);
+    expect(getRoutingMeta(resp)?.failFast).toBe(true);
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/antigravity-capacity-fallback.test.js
+++ b/tests/unit/antigravity-capacity-fallback.test.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  validateApiKey: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: mocks.validateApiKey,
+  getSettings: mocks.getSettings,
+}));
+
+describe("Antigravity capacity fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "ag-1", provider: "antigravity", email: "ag@example.com", backoffLevel: 4 },
+    ]);
+    // Capacity fail-fast is no longer hardcoded — it is the seeded skip-rule
+    // (which ships with sweep:true). markAccountUnavailable reads it from settings
+    // when no request-scoped rules are passed.
+    mocks.getSettings.mockResolvedValue({
+      providerSkipRules: [
+        { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+      ],
+    });
+  });
+
+  it("falls back without writing model cooldown for MODEL_CAPACITY_EXHAUSTED", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "ag-1",
+      503,
+      '{"reason":"MODEL_CAPACITY_EXHAUSTED","message":"No capacity available for model claude-opus-4-6-thinking on the server"}',
+      "antigravity",
+      "claude-opus-4-6-thinking",
+    );
+
+    // failFast: combo skips its cooldown wait. resweep:true: seeded rule opts into
+    // the full-pool resweep (cooldownMs was already 0 — no DB lock written).
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: true });
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("keeps normal cooldown behavior for non-Antigravity capacity text", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "ag-1",
+      503,
+      "No capacity available for model x",
+      "anthropic",
+      "some-model",
+    );
+
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(0);
+    expect(mocks.updateProviderConnection).toHaveBeenCalledWith(
+      "ag-1",
+      expect.objectContaining({
+        testStatus: "unavailable",
+        errorCode: 503,
+      }),
+    );
+  });
+});

--- a/tests/unit/antigravity-combo-capacity-cycle.test.js
+++ b/tests/unit/antigravity-combo-capacity-cycle.test.js
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getComboModels: vi.fn(),
+  getModelInfo: vi.fn(),
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  extractApiKey: vi.fn(),
+  isValidApiKey: vi.fn(),
+  handleChatCore: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+}));
+
+vi.mock("../../src/sse/services/model.js", () => ({
+  getComboModels: mocks.getComboModels,
+  getModelInfo: mocks.getModelInfo,
+}));
+
+vi.mock("../../src/sse/services/auth.js", () => ({
+  getProviderCredentials: mocks.getProviderCredentials,
+  markAccountUnavailable: mocks.markAccountUnavailable,
+  clearAccountError: mocks.clearAccountError,
+  extractApiKey: mocks.extractApiKey,
+  isValidApiKey: mocks.isValidApiKey,
+}));
+
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_provider, credentials) => credentials),
+  updateProviderCredentials: vi.fn(),
+}));
+
+vi.mock("../../open-sse/handlers/chatCore.js", () => ({
+  handleChatCore: mocks.handleChatCore,
+}));
+
+vi.mock("../../open-sse/services/projectId.js", () => ({
+  getProjectIdForConnection: vi.fn(),
+}));
+
+function makeRequest(model = "combo-ag") {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+}
+
+function capacityError(model = "claude-opus-4-6-thinking") {
+  return JSON.stringify({
+    error: {
+      code: 503,
+      message: `No capacity available for model ${model} on the server`,
+      status: "UNAVAILABLE",
+      details: [{
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        reason: "MODEL_CAPACITY_EXHAUSTED",
+        domain: "cloudcode-pa.googleapis.com",
+        metadata: { model },
+      }],
+    },
+  });
+}
+
+describe("Antigravity combo capacity cycling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      comboStrategy: "fallback",
+      comboStickyRoundRobinLimit: 1,
+      rtkEnabled: false,
+      headroomEnabled: false,
+      cavemanEnabled: false,
+      ponytailEnabled: false,
+    });
+    mocks.getComboModels.mockImplementation(async (model) => (
+      model === "combo-ag"
+        ? ["ag/claude-opus-4-6-thinking", "anthropic/claude-sonnet-4.5"]
+        : null
+    ));
+    mocks.getModelInfo.mockImplementation(async (modelStr) => {
+      if (modelStr === "ag/claude-opus-4-6-thinking") {
+        return { provider: "antigravity", model: "claude-opus-4-6-thinking" };
+      }
+      if (modelStr === "anthropic/claude-sonnet-4.5") {
+        return { provider: "anthropic", model: "claude-sonnet-4.5" };
+      }
+      return { provider: null, model: modelStr };
+    });
+    // Pool resweep gates on the rule's opt-in resweep signal (sweep:true), not a
+    // hardcoded capacity check — so markAccountUnavailable must report resweep:true.
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: true });
+  });
+
+  it("restarts the Antigravity account sweep after all accounts report model capacity before trying the next combo model", async () => {
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+
+    const excludeSnapshots = [];
+    let antigravityEmptySweepCount = 0;
+    mocks.getProviderCredentials.mockImplementation(async (provider, excludeConnectionIds) => {
+      const excluded = [...(excludeConnectionIds || [])];
+      excludeSnapshots.push({ provider, excluded });
+
+      if (provider === "anthropic") {
+        return { connectionId: "anthropic-1", connectionName: "Anthropic 1" };
+      }
+
+      if (excluded.length === 0) {
+        antigravityEmptySweepCount += 1;
+        return { connectionId: "ag-1", connectionName: `AG 1 sweep ${antigravityEmptySweepCount}` };
+      }
+
+      if (excluded.length === 1 && excluded[0] === "ag-1") {
+        return { connectionId: "ag-2", connectionName: "AG 2" };
+      }
+
+      return null;
+    });
+
+    mocks.handleChatCore.mockImplementation(async ({ modelInfo }) => {
+      if (modelInfo.provider === "anthropic") {
+        return { success: true, response: new Response("anthropic-ok", { status: 200 }) };
+      }
+      if (antigravityEmptySweepCount >= 2) {
+        return { success: true, response: new Response("ag-ok", { status: 200 }) };
+      }
+      return { success: false, status: 503, error: capacityError() };
+    });
+
+    const response = await handleChat(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ag-ok");
+    expect(excludeSnapshots).toEqual([
+      { provider: "antigravity", excluded: [] },
+      { provider: "antigravity", excluded: ["ag-1"] },
+      { provider: "antigravity", excluded: ["ag-1", "ag-2"] },
+      { provider: "antigravity", excluded: [] },
+    ]);
+    expect(mocks.handleChatCore).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelInfo: expect.objectContaining({ provider: "anthropic" }),
+      }),
+    );
+  });
+
+  it("does NOT resweep the pool when resweep:false → each account tried once, combo moves to next model", async () => {
+    // Negative control for the chat.js gate (the exact site of the prior regression):
+    // a plain skip (resweep:false) must try each Antigravity account exactly once and
+    // then let combo advance to the next model — NOT restart the account sweep.
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: false });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const excludeSnapshots = [];
+    mocks.getProviderCredentials.mockImplementation(async (provider, excludeConnectionIds) => {
+      const excluded = [...(excludeConnectionIds || [])];
+      excludeSnapshots.push({ provider, excluded });
+      if (provider === "anthropic") return { connectionId: "anthropic-1", connectionName: "Anthropic 1" };
+      if (excluded.length === 0) return { connectionId: "ag-1", connectionName: "AG 1" };
+      if (excluded.length === 1 && excluded[0] === "ag-1") return { connectionId: "ag-2", connectionName: "AG 2" };
+      return null; // pool exhausted, no resweep
+    });
+    mocks.handleChatCore.mockImplementation(async ({ modelInfo }) => {
+      if (modelInfo.provider === "anthropic") {
+        return { success: true, response: new Response("anthropic-ok", { status: 200 }) };
+      }
+      return { success: false, status: 503, error: capacityError() };
+    });
+
+    const response = await handleChat(makeRequest());
+
+    // Antigravity: each of the two accounts tried exactly once (no resweep loop).
+    const agCalls = mocks.handleChatCore.mock.calls.filter(
+      ([arg]) => arg?.modelInfo?.provider === "antigravity"
+    );
+    expect(agCalls).toHaveLength(2);
+    // Anthropic: tried once and succeeded → combo actually advanced to the next model.
+    const anthropicCalls = mocks.handleChatCore.mock.calls.filter(
+      ([arg]) => arg?.modelInfo?.provider === "anthropic"
+    );
+    expect(anthropicCalls).toHaveLength(1);
+    // Antigravity account selection never restarts (no second excluded:[] for antigravity).
+    const agEmptySweeps = excludeSnapshots.filter(s => s.provider === "antigravity" && s.excluded.length === 0);
+    expect(agEmptySweeps).toHaveLength(1);
+    // Final response is Anthropic's success.
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("anthropic-ok");
+  });
+});

--- a/tests/unit/antigravity-recent-requests.test.js
+++ b/tests/unit/antigravity-recent-requests.test.js
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import {
+  createPassthroughStreamWithLogger,
+  createSSETransformStreamWithLogger,
+} from "../../open-sse/utils/stream.js";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(() => Promise.resolve()),
+}));
+
+async function writeAndCollect(transform, chunks) {
+  const writer = transform.writable.getWriter();
+  const reader = transform.readable.getReader();
+  const readAll = (async () => {
+    const out = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(value);
+    }
+    return out;
+  })();
+
+  for (const chunk of chunks) {
+    await writer.write(new TextEncoder().encode(chunk));
+  }
+  await writer.close();
+  return await readAll;
+}
+
+describe("Antigravity Recent Requests usage", () => {
+  it("finalizes native Antigravity usage when the final chunk arrives before stream close", async () => {
+    let completed = null;
+    const stream = createPassthroughStreamWithLogger(
+      "antigravity",
+      null,
+      "claude-opus-4-6-thinking",
+      "conn-1",
+      { request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] } },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+    const readOne = reader.read();
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "AG_NATIVE_USAGE_OK" }],
+          },
+          finishReason: "STOP",
+        }],
+        usageMetadata: {
+          promptTokenCount: 18,
+          candidatesTokenCount: 12,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+    await readOne;
+
+    expect(completed?.content?.content).toBe("AG_NATIVE_USAGE_OK");
+    expect(completed?.usage).toMatchObject({
+      prompt_tokens: 18,
+      completion_tokens: 12,
+      total_tokens: 30,
+    });
+
+    await writer.abort();
+    await reader.cancel().catch(() => {});
+  });
+
+  it("finalizes translated Responses API Antigravity usage when the final chunk arrives before stream close", async () => {
+    let completed = null;
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.ANTIGRAVITY,
+      FORMATS.OPENAI_RESPONSES,
+      "antigravity",
+      null,
+      null,
+      "gemini-pro-agent",
+      "conn-1",
+      { input: "hello", stream: true },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+    const readOne = reader.read();
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "AG_RESPONSES_USAGE_OK" }],
+          },
+          finishReason: "STOP",
+        }],
+        usageMetadata: {
+          promptTokenCount: 21,
+          candidatesTokenCount: 13,
+          totalTokenCount: 34,
+        },
+      },
+    };
+
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+    await readOne;
+
+    expect(completed?.content?.content).toBe("AG_RESPONSES_USAGE_OK");
+    expect(completed?.usage).toMatchObject({
+      prompt_tokens: 21,
+      completion_tokens: 13,
+      total_tokens: 34,
+    });
+
+    await writer.abort();
+    await reader.cancel().catch(() => {});
+  });
+
+  it("estimates usage for Antigravity passthrough content when upstream omits usageMetadata", async () => {
+    let completed = null;
+    const stream = createPassthroughStreamWithLogger(
+      "antigravity",
+      null,
+      "gemini-pro-agent",
+      "conn-1",
+      { request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] } },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "A useful Antigravity response." }],
+          },
+          finishReason: "STOP",
+        }],
+      },
+    };
+
+    await writeAndCollect(stream, [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(completed?.content?.content).toBe("A useful Antigravity response.");
+    expect(completed?.usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.completion_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.estimated).toBe(true);
+  });
+
+  it("estimates usage for translated Antigravity wrapped content when upstream omits usageMetadata", async () => {
+    let completed = null;
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.ANTIGRAVITY,
+      FORMATS.OPENAI,
+      "antigravity",
+      null,
+      null,
+      "claude-opus-4-6-thinking",
+      "conn-1",
+      { messages: [{ role: "user", content: "hello" }] },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "Translated Antigravity response." }],
+          },
+          finishReason: "STOP",
+        }],
+      },
+    };
+
+    await writeAndCollect(stream, [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(completed?.content?.content).toBe("Translated Antigravity response.");
+    expect(completed?.usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.completion_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.estimated).toBe(true);
+  });
+});

--- a/tests/unit/antigravity-retry-hook.test.js
+++ b/tests/unit/antigravity-retry-hook.test.js
@@ -37,6 +37,20 @@ describe("antigravity computeRetryDelay hook (D3)", () => {
     expect(await ag.computeRetryDelay(res(503), 1)).toBe(2000);
   });
 
+  it("capacity 503 no longer vetoed at the hook — fail-fast is a skip-rule now", async () => {
+    // The hardcoded capacity veto was removed. In isolation the hook treats a
+    // capacity 503 as a transient error (backoff). Fail-fast is enforced upstream:
+    // the seeded skip-rule resolves attempts=0, so BaseExecutor never calls this hook
+    // for capacity 503. This test locks the hook's post-removal behavior.
+    const r = res(503, {}, {
+      error: {
+        reason: "MODEL_CAPACITY_EXHAUSTED",
+        message: "No capacity available for model claude-opus-4-6-thinking on the server",
+      },
+    });
+    expect(await ag.computeRetryDelay(r, 1)).toBe(2000); // transient backoff, not false
+  });
+
   it("retries Antigravity agent terminated body even when status is not 429", async () => {
     const r = res(500, {}, { error: { message: "Agent execution terminated due to error" } });
     expect(await ag.computeRetryDelay(r, 1)).toBe(2000);

--- a/tests/unit/base-executor-connect-timeout.test.js
+++ b/tests/unit/base-executor-connect-timeout.test.js
@@ -1,0 +1,282 @@
+// Locks the connect-timeout classification + retry policy in BaseExecutor.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args),
+}));
+
+const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+
+const creds = { apiKey: "k" };
+
+// Upstream that never returns headers: settles ONLY when the merged abort signal
+// fires (our connect timer). undici rejects with the abort REASON object, so
+// error.name stays "Error" — the whole point of the closure-flag fix.
+// base.js ALWAYS passes a signal (connectCtrl.signal, or AbortSignal.any([...])),
+// so a call with no signal is a genuine anomaly — throw loudly instead of
+// swallowing it, so a stray/background request would fail the test rather than hide.
+function hangingFetch(url, opts) {
+  const sig = opts?.signal;
+  if (!sig) throw new Error("proxyAwareFetch called without a signal — base.js must always pass one");
+  return new Promise((_resolve, reject) => {
+    const onAbort = () => reject(sig.reason || new Error("aborted"));
+    if (sig.aborted) return onAbort();
+    sig.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+// NOTE: block body (not `() => fetchMock.mockReset()`). mockReset() returns the
+// mock, and an arrow that returns a function hands it to vitest as a teardown
+// callback — vitest then invokes it after the test with zero args, producing a
+// phantom no-signal fetch call during cleanup. Returning undefined avoids that.
+beforeEach(() => { fetchMock.mockReset(); });
+
+describe("BaseExecutor connect timeout", () => {
+  it("classifies header-timeout via closure flag (NOT error.name); 0 in-place retries by default", async () => {
+    fetchMock.mockImplementation(hangingFetch);
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr-ac", maxTransportAttempts: 2, skipRules: [], headerTimeoutMs: 40 },
+    }).catch(e => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errorKind).toBe("connect_timeout");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  }, 8000);
+
+  it("a connect_timeout retry rule does not retry at the transport tier", async () => {
+    // A retry rule is served by the account layer (same account, rule.retryAttempts
+    // times). The transport tier used to spend maxTransportAttempts-1 here, which
+    // made the effective count depend on an unrelated setting.
+    fetchMock.mockImplementation(hangingFetch);
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr-ac",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "retry" }],
+        headerTimeoutMs: 25,
+      },
+    }).catch(e => e);
+
+    expect(err.errorKind).toBe("connect_timeout");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  }, 8000);
+
+  it("does not classify a real HTTP 502 as connect_timeout", async () => {
+    fetchMock.mockResolvedValue({ status: 502, headers: { get: () => "" } });
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr-ac", maxTransportAttempts: 1, skipRules: [], headerTimeoutMs: 5000 },
+    });
+    expect(out.response.status).toBe(502);
+  }, 8000);
+});
+
+// An HTTP error whose body carries text a `contains` rule matches. The mock's
+// clone().text() returns that body; base.js must read it and drive retry policy.
+function httpErrorWithBody(status, bodyText) {
+  return () => Promise.resolve({
+    status,
+    headers: { get: () => "application/json" },
+    clone: () => ({ text: () => Promise.resolve(bodyText) }),
+  });
+}
+
+describe("BaseExecutor contains-rule drives transport retry", () => {
+  it("action:retry does NOT spend transport attempts (account layer owns that budget)", async () => {
+    // This used to retry maxTransportAttempts-1 times here, which tied the user's
+    // account-retry count to a transport setting and still let the failure fall
+    // through to the account-cooldown path afterwards. A retry rule is now served
+    // entirely by the account-selection layer, so the transport tier returns after
+    // a single call and does not cycle the remaining base URLs either.
+    fetchMock.mockImplementation(httpErrorWithBody(500, '{"error":"Server OVERLOADED, try later"}'));
+    const ex = new BaseExecutor("prov-x", { baseUrl: "https://x/api", retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "prov-x",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "prov-x", match: { contains: "overloaded" }, action: "retry" }],
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(out.response.status).toBe(500);
+  }, 8000);
+
+  it("account-retry count is independent of maxTransportAttempts at the transport tier", async () => {
+    // Same rule, a much larger transport budget: still one transport call.
+    fetchMock.mockImplementation(httpErrorWithBody(500, "upstream OVERLOADED"));
+    const ex = new BaseExecutor("prov-x", { baseUrl: "https://x/api", retry: {} });
+
+    await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "prov-x",
+        maxTransportAttempts: 5,
+        skipRules: [{ provider: "prov-x", match: { contains: "overloaded" }, action: "retry", retryAttempts: 3 }],
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  }, 8000);
+
+  it("leaves transport retry alone when no rule matches", async () => {
+    // Regression guard for the untouched path: 429 has a default retry entry, so
+    // the transport tier must still honour maxTransportAttempts - 1 extra calls.
+    fetchMock.mockImplementation(httpErrorWithBody(429, "slow down"));
+    const ex = new BaseExecutor("prov-y", { baseUrl: "https://y/api", retry: { 429: { attempts: 4, delayMs: 0 } } });
+
+    await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "prov-y", maxTransportAttempts: 3, skipRules: [] },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 + min(4, 3-1)
+  }, 8000);
+
+  it("action:skip on a matching body substring does NOT retry (0 in-place)", async () => {
+    fetchMock.mockImplementation(httpErrorWithBody(500, "upstream is overloaded right now"));
+    const ex = new BaseExecutor("prov-x", { baseUrl: "https://x/api", retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "prov-x",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "prov-x", match: { contains: "overloaded" }, action: "skip" }],
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // skip → jump to fallback, no in-place retry
+    expect(out.response.status).toBe(500);
+  }, 8000);
+
+  it("does NOT read the body when no contains-rule applies to this provider", async () => {
+    let cloned = 0;
+    fetchMock.mockImplementation(() => Promise.resolve({
+      status: 500,
+      headers: { get: () => "application/json" },
+      clone: () => { cloned++; return { text: () => Promise.resolve("overloaded") }; },
+    }));
+    const ex = new BaseExecutor("prov-y", { baseUrl: "https://x/api", retry: {} });
+
+    await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "prov-y",
+        maxTransportAttempts: 2,
+        // contains rule is for a DIFFERENT provider → must not trigger a body read here
+        skipRules: [{ provider: "other", match: { contains: "overloaded" }, action: "retry" }],
+      },
+    });
+    expect(cloned).toBe(0);
+  }, 8000);
+});
+
+describe("BaseExecutor error classification + policy isolation", () => {
+  it("classifies a generic fetch failure (ECONNRESET) as network, not connect_timeout", async () => {
+    fetchMock.mockImplementation(() => {
+      const e = new Error("read ECONNRESET");
+      e.code = "ECONNRESET";
+      return Promise.reject(e);
+    });
+    const ex = new BaseExecutor("prov-x", { baseUrl: "https://x/api", retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "prov-x", maxTransportAttempts: 1, skipRules: [], headerTimeoutMs: 5000 },
+    }).catch(e => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errorKind).toBe("network");
+  }, 8000);
+
+  it("two concurrent executes with different policies do not bleed timeouts/retries", async () => {
+    // A: 30ms header timeout, no rule → 1 call, connect_timeout.
+    // B: 200ms header timeout + a 429 retry rule that this failure does NOT match,
+    //    so B keeps its own transport budget → 3 calls, connect_timeout.
+    // Shared singleton executor; policy must be per-call (never on this.config).
+    fetchMock.mockImplementation(hangingFetch);
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const callsBefore = () => fetchMock.mock.calls.length;
+    const pA = ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr-ac", maxTransportAttempts: 2, skipRules: [], headerTimeoutMs: 30 },
+    }).catch(e => e);
+    const pB = ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr-ac",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "kr-ac", match: { status: 429 }, action: "retry" }],
+        headerTimeoutMs: 200,
+      },
+    }).catch(e => e);
+
+    const [errA, errB] = await Promise.all([pA, pB]);
+    expect(errA.errorKind).toBe("connect_timeout");
+    expect(errB.errorKind).toBe("connect_timeout");
+    // Both take the no-rule connect_timeout path (0 in-place retries), so 1 call
+    // each. What this guards is that A's 30ms timeout never truncates B's 200ms
+    // one: B must outlive A rather than share its policy.
+    expect(callsBefore()).toBe(2);
+  }, 8000);
+});
+
+describe("BaseExecutor skip-rule abandons account without cycling base URLs", () => {
+  const THREE_URLS = ["https://a/api", "https://b/api", "https://c/api"];
+
+  it("HTTP skip: does NOT cycle the remaining base URLs on the same account", async () => {
+    // 429 that WITHOUT a skip rule would cycle all 3 URLs (shouldRetry on 429).
+    fetchMock.mockImplementation(httpErrorWithBody(429, "rate limited"));
+    const ex = new BaseExecutor("kr", { baseUrls: THREE_URLS, retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr",
+        maxTransportAttempts: 2,
+        skipRules: [{ provider: "kr", match: { status: 429 }, action: "skip" }],
+      },
+    });
+    expect(out.response.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // one URL only, then abandon account
+  }, 8000);
+
+  it("exception skip: does NOT cycle the remaining base URLs on the same account", async () => {
+    // network error that WITHOUT a skip rule would fall through all 3 base URLs.
+    fetchMock.mockImplementation(() => Promise.reject(new Error("read ECONNRESET")));
+    const ex = new BaseExecutor("kr", { baseUrls: THREE_URLS, retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr",
+        maxTransportAttempts: 2,
+        skipRules: [{ provider: "kr", match: { kind: "network" }, action: "skip" }],
+      },
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errorKind).toBe("network");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // abandoned after the first URL
+  }, 8000);
+
+  it("no skip rule → still cycles all base URLs (unchanged default behavior)", async () => {
+    // Guards against over-reach: only a matched skip rule short-circuits URL cycling.
+    fetchMock.mockImplementation(() => Promise.reject(new Error("read ECONNRESET")));
+    const ex = new BaseExecutor("kr", { baseUrls: THREE_URLS, retry: {} });
+
+    await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr", maxTransportAttempts: 1, skipRules: [] },
+    }).catch(e => e);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // all three URLs tried
+  }, 8000);
+});

--- a/tests/unit/chat-skip-terminal-meta.test.js
+++ b/tests/unit/chat-skip-terminal-meta.test.js
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRoutingMeta } from "../../open-sse/services/routingMeta.js";
+
+// Drive the REAL account-selection loop in chat.js AND the real auth.js
+// (getProviderCredentials + markAccountUnavailable) so we lock the terminal-branch
+// reattach that was silently dropping fail-fast metadata:
+//   1. keyed provider: single account fails with a skip-rule → excluded → accounts
+//      run out → chat.js builds a NEW errorResponse and must reattach { failFast:true }.
+//   2. no-auth provider (FREE_PROVIDERS[*].noAuth): getProviderCredentials returns the
+//      virtual "noauth" connection (no connectionId) → markAccountUnavailable takes the
+//      noauth early-return (shouldFallback:false, NO infinite re-select) → chat.js hits
+//      the terminal `return result.response`, which must still carry failFast.
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getProviderConnections: vi.fn(),
+  getComboModels: vi.fn(),
+  getModelInfo: vi.fn(),
+  handleChatCore: vi.fn(),
+}));
+
+// Real auth.js is used (the code under test); only its DB-backed deps are stubbed.
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: vi.fn(),
+  validateApiKey: vi.fn(),
+  getProxyPools: vi.fn(async () => []),
+}));
+vi.mock("../../src/sse/services/model.js", () => ({
+  getComboModels: mocks.getComboModels,
+  getModelInfo: mocks.getModelInfo,
+}));
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_p, c) => c),
+  updateProviderCredentials: vi.fn(),
+}));
+vi.mock("../../open-sse/handlers/chatCore.js", () => ({ handleChatCore: mocks.handleChatCore }));
+vi.mock("../../open-sse/services/projectId.js", () => ({ getProjectIdForConnection: vi.fn() }));
+
+function makeRequest(model) {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, messages: [{ role: "user", content: "hi" }] }),
+  });
+}
+
+describe("chat.js terminal-branch routing metadata (real account loop)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getComboModels.mockResolvedValue(null);
+  });
+
+  it("reattaches failFast onto the terminal errorResponse when keyed accounts run out", async () => {
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      providerSkipRules: [{ provider: "kr-ac", match: { status: 502 }, action: "skip" }],
+      maxTransportAttempts: 2,
+    });
+    mocks.getModelInfo.mockResolvedValue({ provider: "kr-ac", model: "m1" });
+    // One keyed connection; once excluded, the next lookup finds nothing available.
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue({
+      success: false, status: 502, error: "[502]: connect timeout", errorKind: "http_502",
+    });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const resp = await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(1); // one account tried, then exhausted
+    const meta = getRoutingMeta(resp);
+    expect(meta).not.toBeNull();
+    expect(meta.failFast).toBe(true); // survived skip → exhaust → freshly-built Response
+  });
+
+  it("carries failFast on the no-auth terminal return without looping", async () => {
+    // mimo-free is a real FREE_PROVIDERS entry with noAuth:true → virtual connection.
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      providerSkipRules: [{ provider: "mimo-free", match: { status: 502 }, action: "skip" }],
+      maxTransportAttempts: 2,
+    });
+    mocks.getModelInfo.mockResolvedValue({ provider: "mimo-free", model: "mimo-auto" });
+    mocks.getProviderConnections.mockResolvedValue([]); // unused on the noAuth path
+    mocks.handleChatCore.mockResolvedValue({
+      success: false, status: 502, error: "[502]: connect timeout", errorKind: "http_502",
+      response: new Response("err", { status: 502 }),
+    });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const resp = await handleChat(makeRequest("mimo-free/mimo-auto"));
+
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(1); // no infinite re-select of noauth
+    expect(getRoutingMeta(resp)?.failFast).toBe(true);
+  });
+});

--- a/tests/unit/combo-failfast-meta.test.js
+++ b/tests/unit/combo-failfast-meta.test.js
@@ -1,0 +1,64 @@
+// Integration: routing metadata (failFast) must survive to the Response combo
+// receives, so combo skips the cooldown wait and jumps to the next model fast.
+// This is the #1/#3 fix — the skip→exhaust path builds a NEW errorResponse, so the
+// meta has to be re-attached there (not just on the direct-return object).
+import { describe, expect, it, vi } from "vitest";
+import { handleComboChat } from "../../open-sse/services/combo.js";
+import { setRoutingMeta } from "../../open-sse/services/routingMeta.js";
+import { errorResponse } from "../../open-sse/utils/error.js";
+
+const log = { info: () => {}, warn: () => {}, error: () => {} };
+
+// A 503 whose text hits the "request not allowed" rule → cooldownMs 5000 (≤5000),
+// which is exactly the branch combo would WAIT on unless fail-fast is signalled.
+function transientResponse({ failFast }) {
+  const resp = errorResponse(503, "request not allowed");
+  if (failFast != null) setRoutingMeta(resp, { errorKind: failFast ? "connect_timeout" : null, status: 503, failFast });
+  return resp;
+}
+
+describe("combo fail-fast honors routing metadata", () => {
+  it("skips the cooldown wait when the failed Response is flagged failFast", async () => {
+    let waited = 0;
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((fn, ms) => {
+      waited += ms || 0;
+      return realSetTimeout(fn, 0); // fire immediately so the test stays fast
+    });
+
+    const models = ["prov/m1", "prov/m2"];
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce(transientResponse({ failFast: true }))  // model 1 fails, fail-fast
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));   // model 2 succeeds
+
+    const out = await handleComboChat({ body: {}, models, handleSingleModel, log, comboName: "c" });
+    // Snapshot before restoring: vi.restoreAllMocks() also clears vi.fn() call
+    // history, so the assertion has to read the count captured here.
+    const modelCalls = handleSingleModel.mock.calls.length;
+    vi.restoreAllMocks();
+
+    expect(out.status).toBe(200);
+    expect(modelCalls).toBe(2);
+    expect(waited).toBe(0); // fail-fast → no cooldown delay before the next model
+  });
+
+  it("waits the cooldown when the failure is NOT flagged fail-fast", async () => {
+    let waited = 0;
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((fn, ms) => {
+      waited += ms || 0;
+      return realSetTimeout(fn, 0);
+    });
+
+    const models = ["prov/m1", "prov/m2"];
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce(transientResponse({ failFast: false })) // model 1 fails, normal
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const out = await handleComboChat({ body: {}, models, handleSingleModel, log, comboName: "c" });
+    vi.restoreAllMocks();
+
+    expect(out.status).toBe(200);
+    expect(waited).toBe(5000); // transient 503 → combo waited the cooldown
+  });
+});

--- a/tests/unit/db-migration-chain.test.js
+++ b/tests/unit/db-migration-chain.test.js
@@ -57,7 +57,14 @@ describe("Schema migrations", () => {
     expect(parseInt(row.value, 10)).toBe(latestVersion());
 
     const settings = db2.get(`SELECT data FROM settings WHERE id=1`);
-    expect(JSON.parse(settings.data)).toEqual({ foo: "bar" });
+    // Migration #1 preserves the row; migration #2 (seed-antigravity-skip-rule)
+    // then augments it — proving the FULL pending chain re-applied, not just #1.
+    const parsed = JSON.parse(settings.data);
+    expect(parsed.foo).toBe("bar"); // existing data preserved
+    expect(parsed.skipRulesSeeded).toBe(true); // migration #2 ran
+    expect(parsed.providerSkipRules).toEqual([
+      { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+    ]);
   });
 
   it("fresh DB + legacy db.json → imports data automatically", async () => {
@@ -73,7 +80,14 @@ describe("Schema migrations", () => {
     const db = await getAdapter();
 
     const settings = db.get(`SELECT data FROM settings WHERE id=1`);
-    expect(JSON.parse(settings.data)).toEqual({ foo: "legacy-value" });
+    // Legacy import now seeds the Antigravity capacity rule (Fix #3) so a direct
+    // upgrade from db.json keeps capacity fail-fast after the hardcode removal.
+    const parsed = JSON.parse(settings.data);
+    expect(parsed.foo).toBe("legacy-value"); // legacy settings preserved
+    expect(parsed.skipRulesSeeded).toBe(true);
+    expect(parsed.providerSkipRules).toEqual([
+      { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+    ]);
 
     const keys = db.all(`SELECT * FROM apiKeys`);
     expect(keys).toHaveLength(1);

--- a/tests/unit/github-monthly-usage-lock.test.js
+++ b/tests/unit/github-monthly-usage-lock.test.js
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const dbMocks = vi.hoisted(() => ({
   getProviderConnections: vi.fn(),
   updateProviderConnection: vi.fn(),
+  // markAccountUnavailable now falls back to settings when the caller does not
+  // thread request-scoped skip rules through. No rules here -> stock behaviour.
+  getSettings: vi.fn(),
 }));
 
 vi.mock("@/lib/localDb", () => dbMocks);
@@ -20,6 +23,7 @@ const { markAccountUnavailable } = await import("../../src/sse/services/auth.js"
 
 beforeEach(() => {
   vi.clearAllMocks();
+  dbMocks.getSettings.mockResolvedValue({});
   dbMocks.getProviderConnections.mockResolvedValue([{
     id: "github-a",
     provider: "github",

--- a/tests/unit/request-detail-usage.test.js
+++ b/tests/unit/request-detail-usage.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { extractUsageFromResponse } from "../../open-sse/handlers/chatCore/requestDetail.js";
+
+describe("request detail usage extraction", () => {
+  it("extracts usage from Antigravity wrapped response usageMetadata", () => {
+    const usage = extractUsageFromResponse({
+      response: {
+        usageMetadata: {
+          promptTokenCount: 77187,
+          candidatesTokenCount: 236,
+          totalTokenCount: 77423,
+          cachedContentTokenCount: 69387,
+          thoughtsTokenCount: 12,
+        },
+      },
+    });
+
+    expect(usage).toEqual({
+      prompt_tokens: 77187,
+      completion_tokens: 236,
+      cached_tokens: 69387,
+      reasoning_tokens: 12,
+    });
+  });
+});

--- a/tests/unit/routing-meta.test.js
+++ b/tests/unit/routing-meta.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { setRoutingMeta, getRoutingMeta } from "../../open-sse/services/routingMeta.js";
+
+describe("routingMeta", () => {
+  it("stores and reads metadata on the same Response object", () => {
+    const resp = new Response("err", { status: 502 });
+    setRoutingMeta(resp, { errorKind: "connect_timeout", status: 502 });
+    expect(getRoutingMeta(resp)).toEqual({ errorKind: "connect_timeout", status: 502 });
+  });
+
+  it("does NOT leak metadata into headers or body", async () => {
+    const resp = new Response(JSON.stringify({ error: "boom" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+    setRoutingMeta(resp, { errorKind: "connect_timeout", status: 502 });
+
+    // No header carries the kind
+    for (const [, value] of resp.headers.entries()) {
+      expect(String(value)).not.toContain("connect_timeout");
+    }
+    const text = await resp.clone().text();
+    expect(text).not.toContain("connect_timeout");
+  });
+
+  it("returns null for an unknown Response", () => {
+    expect(getRoutingMeta(new Response("x"))).toBeNull();
+    expect(getRoutingMeta(null)).toBeNull();
+  });
+});

--- a/tests/unit/seed-antigravity-skip-rule.test.js
+++ b/tests/unit/seed-antigravity-skip-rule.test.js
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import m002 from "../../src/lib/db/migrations/002-seed-antigravity-skip-rule.js";
+import { DEFAULT_ANTIGRAVITY_CAPACITY_RULE } from "../../src/lib/db/repos/settingsRepo.js";
+
+// Fake adapter: only the settings id=1 row is exercised by the migration.
+function makeDb(initialData) {
+  let store = initialData == null ? null : JSON.stringify(initialData);
+  return {
+    get: () => (store == null ? null : { data: store }),
+    run: (_sql, params) => { store = params[0]; },
+    dump: () => (store == null ? null : JSON.parse(store)),
+  };
+}
+
+// Seeding is probe-based: it checks whether the two canonical Antigravity capacity-503
+// error shapes (MODEL_CAPACITY_EXHAUSTED / "No capacity available for model") are caught
+// by the user's rules via the REAL match logic, appends the default only for uncovered
+// patterns, and raises sweep:true on a skip rule that catches capacity.
+describe("migration 002: seed Antigravity capacity skip-rule (probe-based)", () => {
+  it("seeds the default (sweep:true) for legacy installs (empty rules, no flag)", () => {
+    const db = makeDb({ providerSkipRules: [], other: 1 });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toEqual([DEFAULT_ANTIGRAVITY_CAPACITY_RULE]);
+    expect(d.skipRulesSeeded).toBe(true);
+    expect(d.other).toBe(1); // preserves unrelated keys
+  });
+
+  it("is idempotent — re-running does not duplicate", () => {
+    const db = makeDb({ providerSkipRules: [] });
+    m002.up(db);
+    m002.up(db);
+    expect(db.dump().providerSkipRules).toHaveLength(1);
+  });
+
+  it("500+capacity skip does NOT cover 503 → keeps rule 500 and appends default", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 500, contains: "capacity" }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(2);
+    expect(d.providerSkipRules[0].match.status).toBe(500); // user rule kept, unchanged
+    expect(d.providerSkipRules[1]).toEqual(DEFAULT_ANTIGRAVITY_CAPACITY_RULE);
+    expect(d.skipRulesSeeded).toBe(true);
+  });
+
+  it("contains-only capacity skip (no status) covers both patterns → raise sweep, no append", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { contains: "capacity" }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(1);
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { contains: "capacity" }, action: "skip", sweep: true });
+  });
+
+  it("status-only 503 skip (no contains) covers both patterns → raise sweep, no append", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 503 }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(1);
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { status: 503 }, action: "skip", sweep: true });
+  });
+
+  it("503+model_capacity_exhausted skip covers only ONE pattern → raise sweep AND append default", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 503, contains: "model_capacity_exhausted" }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(2);
+    // partial rule caught MODEL_CAPACITY_EXHAUSTED → sweep raised
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { status: 503, contains: "model_capacity_exhausted" }, action: "skip", sweep: true });
+    // "No capacity available for model" still uncovered → default appended to catch it
+    expect(d.providerSkipRules[1]).toEqual(DEFAULT_ANTIGRAVITY_CAPACITY_RULE);
+  });
+
+  it("503+capacity RETRY (deliberate user choice) → NOT mutated to skip, no sweep, no append", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "retry" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(1); // array-order: retry wins, covers both probes
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "retry" });
+    expect(d.providerSkipRules[0].sweep).toBeUndefined();
+    expect(d.skipRulesSeeded).toBe(true);
+  });
+
+  it("full default already present (sweep:true) → unchanged, no duplicate", () => {
+    const db = makeDb({ providerSkipRules: [{ ...DEFAULT_ANTIGRAVITY_CAPACITY_RULE }] });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toEqual([DEFAULT_ANTIGRAVITY_CAPACITY_RULE]);
+  });
+
+  it("respects a user who deleted the rule after seeding (flag already set)", () => {
+    const db = makeDb({ providerSkipRules: [], skipRulesSeeded: true });
+    m002.up(db);
+    expect(db.dump().providerSkipRules).toHaveLength(0); // not re-seeded
+  });
+
+  it("is a no-op when there is no settings row (DEFAULT_SETTINGS covers fresh DB)", () => {
+    const db = makeDb(null);
+    m002.up(db);
+    expect(db.dump()).toBeNull();
+  });
+});

--- a/tests/unit/settings-retry-attempts-validation.test.js
+++ b/tests/unit/settings-retry-attempts-validation.test.js
@@ -1,0 +1,76 @@
+/**
+ * PATCH /api/settings validation for skip-rule `retryAttempts`.
+ *
+ * The field only makes sense on a retry rule (extra calls to the SAME account), so
+ * the API refuses it on a skip rule rather than storing a shape nothing reads.
+ * Range and integer-ness are enforced here as well as in the modal, because the
+ * modal is not the only writer.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(async () => ({})),
+  updateSettings: vi.fn(async (v) => v),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+  updateSettings: mocks.updateSettings,
+}));
+vi.mock("@/lib/network/outboundProxy", () => ({ applyOutboundProxyEnv: vi.fn() }));
+
+const { PATCH } = await import("../../src/app/api/settings/route.js");
+
+function patch(body) {
+  return PATCH(new Request("http://localhost/api/settings", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }));
+}
+
+const rule = (over) => ({ provider: "kr-ac", match: { status: 502 }, action: "retry", ...over });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("retryAttempts validation", () => {
+  it("accepts any positive integer on a retry rule (no upper bound)", async () => {
+    for (const n of [1, 5, 10, 11, 50, 1000]) {
+      const res = await patch({ providerSkipRules: [rule({ retryAttempts: n })] });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("accepts a retry rule that omits the field", async () => {
+    const res = await patch({ providerSkipRules: [rule()] });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects it on a skip rule", async () => {
+    const res = await patch({
+      providerSkipRules: [{ provider: "kr-ac", match: { status: 502 }, action: "skip", retryAttempts: 2 }],
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/retryAttempts/);
+  });
+
+  it.each([0, -1, 2.5, "3", true, [], {}])("rejects %p", async (bad) => {
+    const res = await patch({ providerSkipRules: [rule({ retryAttempts: bad })] });
+    expect(res.status).toBe(400);
+  });
+
+  it.each([null, undefined, NaN])("treats %p as absent, not as a bad value", async (blank) => {
+    // JSON.stringify turns undefined and NaN into absent/null on the wire, so the
+    // server can never observe them as values; asserting a 400 here would be
+    // testing the serializer, not the validator.
+    const res = await patch({ providerSkipRules: [rule({ retryAttempts: blank })] });
+    expect(res.status).toBe(200);
+  });
+
+  it("keeps existing skip-rule validation intact", async () => {
+    const bad = await patch({ providerSkipRules: [{ provider: "kr-ac", match: {}, action: "retry" }] });
+    expect(bad.status).toBe(400);
+    const sweepOnRetry = await patch({ providerSkipRules: [rule({ sweep: true })] });
+    expect(sweepOnRetry.status).toBe(400);
+  });
+});

--- a/tests/unit/skip-rule-fallback.test.js
+++ b/tests/unit/skip-rule-fallback.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  validateApiKey: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: mocks.validateApiKey,
+  getSettings: mocks.getSettings,
+}));
+
+describe("skip-rule fallback (generalized, non-Antigravity)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", email: "k@example.com", backoffLevel: 0 },
+    ]);
+  });
+
+  it("connect_timeout with action:skip → fallback without DB cooldown", async () => {
+    mocks.getSettings.mockResolvedValue({
+      providerSkipRules: [{ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip" }],
+    });
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "kr-1", 502, "[502]: fetch connect timeout", "kr-ac", "claude-sonnet-5", null, "connect_timeout",
+    );
+    // resweep:false — the connect_timeout skip rule has no sweep:true opt-in.
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: false });
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled(); // no lock written
+  });
+
+  it("skip rule with sweep:true → resweep:true (separate from failFast)", async () => {
+    mocks.getSettings.mockResolvedValue({
+      providerSkipRules: [{ provider: "kr-ac", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true }],
+    });
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "kr-1", 503, "MODEL_CAPACITY_EXHAUSTED", "kr-ac", "claude-sonnet-5", null, "http_503",
+    );
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: true });
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("no matching rule → normal cooldown + DB lock", async () => {
+    mocks.getSettings.mockResolvedValue({ providerSkipRules: [] });
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "kr-1", 502, "[502]: fetch connect timeout", "kr-ac", "claude-sonnet-5", null, "connect_timeout",
+    );
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(0);
+    expect(mocks.updateProviderConnection).toHaveBeenCalledWith(
+      "kr-1",
+      expect.objectContaining({ testStatus: "unavailable", errorCode: 502 }),
+    );
+  });
+});

--- a/tests/unit/skip-rules-match.test.js
+++ b/tests/unit/skip-rules-match.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { matchSkipRule, findMatchingSkipRule, resolveProviderHeaderTimeout, resolveRetryAttempts, SKIP_RULE_RETRY_ATTEMPTS_DEFAULT } from "../../open-sse/services/accountFallback.js";
+
+describe("matchSkipRule", () => {
+  const rules = [
+    { provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 },
+    { provider: "kr-ac", match: { status: 429 }, action: "retry" },
+    { provider: "foo", match: { contains: "overloaded" }, action: "skip" },
+  ];
+
+  it("matches by error kind", () => {
+    const r = matchSkipRule("kr-ac", { errorKind: "connect_timeout" }, rules);
+    expect(r).toEqual({ action: "skip", headerTimeoutMs: 25000 });
+  });
+
+  it("matches by status (string/number normalized)", () => {
+    expect(matchSkipRule("kr-ac", { status: 429 }, rules)?.action).toBe("retry");
+    expect(matchSkipRule("kr-ac", { status: "429" }, rules)?.action).toBe("retry");
+  });
+
+  it("matches by substring (case-insensitive)", () => {
+    expect(matchSkipRule("foo", { text: "Server OVERLOADED now" }, rules)?.action).toBe("skip");
+  });
+
+  it("returns null when provider does not match", () => {
+    expect(matchSkipRule("other", { status: 429 }, rules)).toBeNull();
+  });
+
+  it("AND-matches when a rule carries both status and contains", () => {
+    const mixed = [
+      { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip" },
+    ];
+    // both conditions hold → match
+    expect(matchSkipRule("antigravity", { status: 503, text: "MODEL_CAPACITY_EXHAUSTED" }, mixed)?.action).toBe("skip");
+    expect(matchSkipRule("antigravity", { status: 503, text: "No capacity available for model x" }, mixed)?.action).toBe("skip");
+    // status matches but text does not → NO match
+    expect(matchSkipRule("antigravity", { status: 503, text: "gateway boom" }, mixed)).toBeNull();
+    // text matches but status does not → NO match
+    expect(matchSkipRule("antigravity", { status: 500, text: "capacity" }, mixed)).toBeNull();
+  });
+
+  it("uses array order — first fully-matching rule wins", () => {
+    const ordered = [
+      { provider: "p", match: { status: 503 }, action: "retry" },
+      { provider: "p", match: { status: 503, contains: "capacity" }, action: "skip" },
+    ];
+    // first rule (status:503 only) matches first → retry, even though the 2nd also would
+    const r = matchSkipRule("p", { status: 503, text: "capacity" }, ordered);
+    expect(r.action).toBe("retry");
+  });
+
+  it("a match block with no usable condition never matches (no skip-all)", () => {
+    expect(matchSkipRule("p", { status: 503 }, [{ provider: "p", match: {}, action: "skip" }])).toBeNull();
+  });
+
+  it("returns sweep:true only when a matched skip rule opts in", () => {
+    const withSweep = [{ provider: "ag", match: { status: 503 }, action: "skip", sweep: true }];
+    expect(matchSkipRule("ag", { status: 503 }, withSweep)).toEqual({ action: "skip", sweep: true });
+
+    const noSweep = [{ provider: "ag", match: { status: 503 }, action: "skip" }];
+    expect(matchSkipRule("ag", { status: 503 }, noSweep)).toEqual({ action: "skip" });
+
+    // sweep is ignored on retry rules (not a skip); retryAttempts is resolved instead.
+    const retrySweep = [{ provider: "ag", match: { status: 429 }, action: "retry", sweep: true }];
+    expect(matchSkipRule("ag", { status: 429 }, retrySweep))
+      .toEqual({ action: "retry", retryAttempts: SKIP_RULE_RETRY_ATTEMPTS_DEFAULT });
+  });
+});
+
+describe("findMatchingSkipRule", () => {
+  const rules = [
+    { provider: "ag", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+    { provider: "ag", match: { status: 429 }, action: "retry" },
+  ];
+
+  it("returns the ACTUAL matching rule object (first match), not a derived shape", () => {
+    const r = findMatchingSkipRule("ag", { status: 503, text: "MODEL_CAPACITY_EXHAUSTED" }, rules);
+    expect(r).toBe(rules[0]); // same object reference → callers can mutate (e.g. raise sweep)
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(findMatchingSkipRule("ag", { status: 500, text: "boom" }, rules)).toBeNull();
+    expect(findMatchingSkipRule("other", { status: 503, text: "capacity" }, rules)).toBeNull();
+  });
+
+  it("matchSkipRule is a thin wrapper — derives {action,sweep,retryAttempts} from the found rule", () => {
+    expect(matchSkipRule("ag", { status: 503, text: "capacity" }, rules)).toEqual({ action: "skip", sweep: true });
+    expect(matchSkipRule("ag", { status: 429 }, rules))
+      .toEqual({ action: "retry", retryAttempts: SKIP_RULE_RETRY_ATTEMPTS_DEFAULT });
+  });
+});
+
+describe("resolveProviderHeaderTimeout", () => {
+  it("returns configured timeout for connect_timeout rule", () => {
+    const rules = [{ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 }];
+    expect(resolveProviderHeaderTimeout("kr-ac", rules)).toBe(25000);
+  });
+
+  it("returns null for a different provider (no cross-provider leak)", () => {
+    const rules = [{ provider: "A", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 }];
+    expect(resolveProviderHeaderTimeout("B", rules)).toBeNull();
+  });
+
+  it("earlier rule wins when multiple connect_timeout rules exist", () => {
+    const rules = [
+      { provider: "A", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 10000 },
+      { provider: "A", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 30000 },
+    ];
+    expect(resolveProviderHeaderTimeout("A", rules)).toBe(10000);
+  });
+});
+
+describe("resolveRetryAttempts", () => {
+  it("honours any positive integer, with no upper bound", () => {
+    expect(resolveRetryAttempts({ retryAttempts: 1 })).toBe(1);
+    expect(resolveRetryAttempts({ retryAttempts: 3 })).toBe(3);
+    expect(resolveRetryAttempts({ retryAttempts: 10 })).toBe(10);
+    // 11 is the first value the removed ceiling rejected -- guard the boundary.
+    expect(resolveRetryAttempts({ retryAttempts: 11 })).toBe(11);
+    expect(resolveRetryAttempts({ retryAttempts: 50 })).toBe(50);
+    expect(resolveRetryAttempts({ retryAttempts: 1000 })).toBe(1000);
+  });
+
+  it("falls back to the default rather than disabling the rule", () => {
+    // A rule the user explicitly created should still retry once even if the
+    // stored value is junk; 0/negative must not silently mean "never retry".
+    for (const bad of [undefined, null, 0, -2, 2.5, "3", NaN]) {
+      expect(resolveRetryAttempts({ retryAttempts: bad })).toBe(SKIP_RULE_RETRY_ATTEMPTS_DEFAULT);
+    }
+    expect(resolveRetryAttempts({})).toBe(SKIP_RULE_RETRY_ATTEMPTS_DEFAULT);
+    expect(resolveRetryAttempts(null)).toBe(SKIP_RULE_RETRY_ATTEMPTS_DEFAULT);
+  });
+
+  it("matchSkipRule surfaces it only for retry rules", () => {
+    const rules = [
+      { provider: "p", match: { status: 502 }, action: "retry", retryAttempts: 4 },
+      { provider: "p", match: { status: 503 }, action: "skip" },
+    ];
+    expect(matchSkipRule("p", { status: 502 }, rules).retryAttempts).toBe(4);
+    expect("retryAttempts" in matchSkipRule("p", { status: 503 }, rules)).toBe(false);
+  });
+});

--- a/tests/unit/skip-rules-modal-merge.test.js
+++ b/tests/unit/skip-rules-modal-merge.test.js
@@ -1,0 +1,138 @@
+// Skip-rules modal pure logic: provider dropdown merge + row↔rule validation.
+// These live in skipRulesLogic.js (no JSX) so the "node" vitest env can import them.
+import { describe, expect, it } from "vitest";
+import { mergeProviderOptions, rowToRule, ruleToRow } from "../../src/app/(dashboard)/dashboard/profile/skipRulesLogic.js";
+
+describe("mergeProviderOptions", () => {
+  const AI = {
+    anthropic: { id: "anthropic", name: "Anthropic" },
+    antigravity: { id: "antigravity", name: "Antigravity" },
+    secret: { id: "secret", name: "Secret", hidden: true },
+  };
+
+  it("includes dynamic compatible nodes so kr-ac appears", () => {
+    const nodes = [{ id: "anthropic-compatible-5edf", name: "kr-ac", type: "anthropic-compatible" }];
+    const opts = mergeProviderOptions(AI, nodes);
+    expect(opts.map(o => o.value)).toContain("anthropic-compatible-5edf");
+    expect(opts.find(o => o.value === "anthropic-compatible-5edf").label).toBe("kr-ac (anthropic-compatible)");
+  });
+
+  it("hides providers flagged hidden", () => {
+    expect(mergeProviderOptions(AI, []).map(o => o.value)).not.toContain("secret");
+  });
+
+  it("dedupes by id (static wins over node)", () => {
+    const opts = mergeProviderOptions(AI, [{ id: "anthropic", name: "Anthropic Node", type: "custom" }]);
+    expect(opts.filter(o => o.value === "anthropic")).toHaveLength(1);
+    expect(opts.find(o => o.value === "anthropic").label).toBe("Anthropic");
+  });
+
+  it("tolerates null/undefined inputs", () => {
+    expect(mergeProviderOptions(null, null)).toEqual([]);
+    expect(mergeProviderOptions(AI, undefined).length).toBeGreaterThan(0);
+  });
+});
+
+describe("rowToRule validation (no silent drop, multi-condition)", () => {
+  const httpRow = (o) => ({ provider: "anthropic", matchMode: "http", status: "", contains: "", action: "skip", ...o });
+  const kindRow = (o) => ({ provider: "kr-ac", matchMode: "kind", kind: "connect_timeout", action: "skip", ...o });
+
+  it("flags a row missing provider", () => {
+    expect(rowToRule(httpRow({ provider: "", status: "429" })).error).toBeTruthy();
+  });
+
+  it("flags an http row with neither status nor contains", () => {
+    expect(rowToRule(httpRow({ status: "", contains: "" })).error).toBeTruthy();
+  });
+
+  it("flags an out-of-range status", () => {
+    expect(rowToRule(httpRow({ status: "99" })).error).toBeTruthy();
+    expect(rowToRule(httpRow({ status: "700" })).error).toBeTruthy();
+  });
+
+  it("flags a bad headerTimeoutMs on a connect_timeout rule", () => {
+    expect(rowToRule(kindRow({ headerTimeoutMs: "50" })).error).toBeTruthy();
+  });
+
+  it("builds a valid status-only rule", () => {
+    const { rule, error } = rowToRule(httpRow({ status: "429", action: "retry" }));
+    expect(error).toBeUndefined();
+    expect(rule).toEqual({ provider: "anthropic", match: { status: 429 }, action: "retry" });
+  });
+
+  it("builds a valid status+contains rule (AND)", () => {
+    const { rule, error } = rowToRule(httpRow({ provider: "antigravity", status: "503", contains: "capacity" }));
+    expect(error).toBeUndefined();
+    expect(rule).toEqual({ provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip" });
+  });
+
+  it("builds a valid contains-only rule", () => {
+    const { rule } = rowToRule(httpRow({ provider: "some", contains: "overloaded" }));
+    expect(rule).toEqual({ provider: "some", match: { contains: "overloaded" }, action: "skip" });
+  });
+
+  it("builds a valid connect_timeout rule with headerTimeoutMs", () => {
+    const { rule } = rowToRule(kindRow({ headerTimeoutMs: "25000" }));
+    expect(rule).toEqual({ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 });
+  });
+
+  it("round-trips a combined rule: rule → row → rule", () => {
+    const original = { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip" };
+    const { rule } = rowToRule(ruleToRow(original));
+    expect(rule).toEqual(original);
+  });
+
+  it("round-trips sweep:true through row and back", () => {
+    const original = { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true };
+    const { rule } = rowToRule(ruleToRow(original));
+    expect(rule).toEqual(original);
+  });
+
+  it("drops sweep when action is retry (sweep only meaningful for skip)", () => {
+    const { rule } = rowToRule({ provider: "anthropic", matchMode: "http", status: "429", contains: "", action: "retry", sweep: true });
+    expect(rule).toEqual({ provider: "anthropic", match: { status: 429 }, action: "retry" });
+  });
+});
+
+describe("retryAttempts round-trips through the modal", () => {
+  it("keeps the value across rule → row → rule", () => {
+    const rule = { provider: "kr-ac", match: { status: 502 }, action: "retry", retryAttempts: 4 };
+    const row = ruleToRow(rule);
+    expect(row.retryAttempts).toBe("4");
+    expect(rowToRule(row).rule).toEqual(rule);
+  });
+
+  it("omits retryAttempts for a retry rule saved before the field existed", () => {
+    // Absent → blank row → omitted again, so accountFallback applies its default
+    // rather than the modal silently inventing a number.
+    const row = ruleToRow({ provider: "kr-ac", match: { status: 502 }, action: "retry" });
+    expect(row.retryAttempts).toBe("");
+    expect("retryAttempts" in rowToRule(row).rule).toBe(false);
+  });
+
+  it("drops retryAttempts when the row switches to skip", () => {
+    const row = { ...ruleToRow({ provider: "kr-ac", match: { status: 502 }, action: "retry", retryAttempts: 3 }), action: "skip" };
+    const { rule } = rowToRule(row);
+    expect(rule.action).toBe("skip");
+    expect("retryAttempts" in rule).toBe(false);
+  });
+
+  it("rejects non-positive and non-integer values (no upper bound)", () => {
+    const base = ruleToRow({ provider: "kr-ac", match: { status: 502 }, action: "retry" });
+    for (const bad of ["0", "-1", "abc"]) {
+      expect(rowToRule({ ...base, retryAttempts: bad }).error).toBeTruthy();
+    }
+    expect(rowToRule({ ...base, retryAttempts: "1" }).rule.retryAttempts).toBe(1);
+    expect(rowToRule({ ...base, retryAttempts: "10" }).rule.retryAttempts).toBe(10);
+    // Just past the removed ceiling: the modal must not silently clamp it.
+    expect(rowToRule({ ...base, retryAttempts: "11" }).rule.retryAttempts).toBe(11);
+    expect(rowToRule({ ...base, retryAttempts: "50" }).rule.retryAttempts).toBe(50);
+    expect(rowToRule({ ...base, retryAttempts: "1000" }).rule.retryAttempts).toBe(1000);
+  });
+
+  it("does not attach retryAttempts to a sweep-carrying skip rule", () => {
+    const { rule } = rowToRule({ ...ruleToRow({ provider: "kr-ac", match: { status: 502 }, action: "skip", sweep: true }), retryAttempts: "3" });
+    expect(rule.sweep).toBe(true);
+    expect("retryAttempts" in rule).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Supersedes #2370 while preserving its Antigravity capacity fallback, stream usage, and Recent Requests fixes.
- Adds request-scoped transport retry policy and configurable provider skip-error rules.
- Adds a compact Settings UI, strict API validation, and an idempotent migration for the legacy Antigravity capacity behavior.

## Behavior

- `maxTransportAttempts` caps in-place transport attempts per request without mutating cached executor config.
- `providerSkipRules` supports `kind`, `status`, and `contains` conditions with AND semantics and first-match ordering.
- Rules can `retry` the current transport or `skip` to the next account/model; `headerTimeoutMs` customizes connect/header timeout and `sweep` opts a skip rule into a full account-pool resweep.
- Connect timeout classification uses an attempt-local closure flag, so caller aborts, network failures, and real HTTP errors remain distinct.
- Combo fail-fast metadata is kept in an in-process `WeakMap`; it is never serialized into response headers or bodies.
- Transport retry policy does not change Codex SSE-overload retry, namespace compatibility retry, token refresh, or other higher-level retry loops.

## Migration and UI

- Schema migration v2 seeds the former Antigravity `503 + capacity` behavior as an editable `skip + sweep` rule when it is not already covered, while respecting existing user rules.
- Settings validation limits attempts to `1..5`, rules to 100, and validates match/action/timeout/sweep combinations before writing.
- The responsive Skip-error rules modal uses compact, clearly separated fields in light and dark themes and merges static providers with dynamic compatible provider nodes.

## Test plan

- 41 targeted skip-rule, fail-fast, routing metadata, no-auth, concurrency, modal, and Antigravity capacity tests passed with `--unhandled-rejections=warn`.
- 32 inherited Antigravity Recent Requests, retry-hook, request-detail usage, migration-chain, and seed tests passed.
- `git diff --check` passed.
- `npm run build` passed.

## Notes

- No production patch, database, screenshot helper, or generated snapshot is included in this PR.
