### PR TITLE
feat(xai): add Grok Imagine video generation (/v1/videos) + CLI

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -67,6 +67,19 @@ const { ensureSqliteRuntime, buildEnvWithRuntime } = require("./hooks/sqliteRunt
 const { ensureTrayRuntime } = require("./hooks/trayRuntime");
 const args = process.argv.slice(2);
 
+// Subcommands (`9router xai video …`) run against an already-running gateway
+// and bypass the launcher flow (no runtime self-heal, no server spawn).
+if (args[0] === "xai" && args[1] === "video") {
+  const { run } = require("./src/cli/commands/xaiVideo");
+  run(args.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(`❌ ${err?.message || err}`);
+      process.exit(1);
+    });
+  return;
+}
+
 // Self-heal SQLite runtime deps (sql.js + better-sqlite3) into ~/.9router/runtime
 // so the server can resolve them via NODE_PATH. Best-effort — sql.js is required,
 // better-sqlite3 is optional. Logs to stderr only on failure.
@@ -139,6 +152,11 @@ Options:
   --skip-update       Skip auto-update check
   -h, --help          Show this help message
   -v, --version       Show version
+
+Commands:
+  xai video --prompt "..." --output video.mp4
+                      Generate a Grok Imagine video via the running gateway
+                      (see: ${APP_NAME} xai video --help)
 `);
     process.exit(0);
   } else if (args[i] === "--version" || args[i] === "-v") {

--- a/cli/src/cli/commands/xaiVideo.js
+++ b/cli/src/cli/commands/xaiVideo.js
@@ -1,0 +1,300 @@
+/**
+ * `9router xai video` — generate a Grok Imagine video through the local
+ * 9router gateway and save the result as an MP4 file.
+ *
+ * Flow: POST /v1/videos/generations → poll GET /v1/videos/{request_id}
+ * until done/failed/timeout → download video.url → atomic rename.
+ *
+ * No OAuth tokens or Authorization headers are ever printed.
+ */
+
+const http = require("http");
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+
+const DEFAULT_PORT = 20128;
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_MODEL = "xai/grok-imagine-video";
+const DEFAULT_TIMEOUT_SEC = 600;
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+
+const TERMINAL_STATUSES = new Set(["done", "failed", "completed", "error", "expired", "cancelled"]);
+const FAILED_STATUSES = new Set(["failed", "error", "expired", "cancelled"]);
+
+const HELP = `
+Usage: 9router xai video --prompt "..." [options]
+
+Generate a Grok Imagine video via your local 9router gateway
+(requires a connected xAI account — Grok Build OAuth or API key).
+
+Options:
+  --prompt <text>         Video description (required)
+  --output <file>         Output MP4 path (default: video.mp4)
+  --model <id>            Model (default: ${DEFAULT_MODEL})
+  --duration <seconds>    Video duration
+  --aspect-ratio <ratio>  e.g. 16:9, 9:16, 1:1
+  --resolution <res>      480p | 720p | 1080p
+  --image <path-or-url>   Image input for image-to-video
+  --timeout <seconds>     Max wait for the job (default: ${DEFAULT_TIMEOUT_SEC})
+  --port <port>           Gateway port (default: ${DEFAULT_PORT})
+  --host <host>           Gateway host (default: ${DEFAULT_HOST})
+  --api-key <key>         9router API key (or env NINE_ROUTER_API_KEY)
+  -h, --help              Show this help
+`;
+
+function sanitizeText(text) {
+  return String(text ?? "").replace(/Bearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [redacted]");
+}
+
+function parseArgs(argv) {
+  const opts = {
+    model: DEFAULT_MODEL,
+    output: "video.mp4",
+    timeoutSec: DEFAULT_TIMEOUT_SEC,
+    port: DEFAULT_PORT,
+    host: DEFAULT_HOST,
+    apiKey: process.env.NINE_ROUTER_API_KEY || null,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    if (a === "--prompt") opts.prompt = next();
+    else if (a === "--output" || a === "-o") opts.output = next();
+    else if (a === "--model") opts.model = next();
+    else if (a === "--duration") opts.duration = parseInt(next(), 10);
+    else if (a === "--aspect-ratio") opts.aspectRatio = next();
+    else if (a === "--resolution") opts.resolution = next();
+    else if (a === "--image") opts.image = next();
+    else if (a === "--timeout") opts.timeoutSec = parseInt(next(), 10) || DEFAULT_TIMEOUT_SEC;
+    else if (a === "--port" || a === "-p") opts.port = parseInt(next(), 10) || DEFAULT_PORT;
+    else if (a === "--host" || a === "-H") opts.host = next() || DEFAULT_HOST;
+    else if (a === "--api-key") opts.apiKey = next();
+    else if (a === "--poll-interval-ms") opts.pollIntervalMs = parseInt(next(), 10) || DEFAULT_POLL_INTERVAL_MS;
+    else if (a === "-h" || a === "--help") opts.help = true;
+    else {
+      throw new Error(`Unknown option: ${a}`);
+    }
+  }
+  return opts;
+}
+
+/** Local file path → base64 data URL; URLs pass through untouched. */
+function imageInputToUrl(input) {
+  if (/^(https?:|data:)/i.test(input)) return input;
+  const buf = fs.readFileSync(input);
+  const ext = path.extname(input).toLowerCase();
+  const mime = ext === ".png" ? "image/png" : ext === ".webp" ? "image/webp" : "image/jpeg";
+  return `data:${mime};base64,${buf.toString("base64")}`;
+}
+
+/** Minimal JSON request against the local gateway. Returns { status, headers, body }. */
+function gatewayRequest({ host, port, apiKey, method, reqPath, body, signal }) {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : null;
+    const headers = { Accept: "application/json" };
+    if (payload) {
+      headers["Content-Type"] = "application/json";
+      headers["Content-Length"] = Buffer.byteLength(payload);
+    }
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+    const req = http.request({ hostname: host, port, path: reqPath, method, headers, signal }, (res) => {
+      let data = "";
+      res.on("data", (c) => (data += c));
+      res.on("end", () => {
+        let parsed = null;
+        try { parsed = data ? JSON.parse(data) : null; } catch { /* keep raw */ }
+        resolve({ status: res.statusCode, headers: res.headers, body: parsed, raw: data });
+      });
+    });
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+const sleep = (ms, signal) =>
+  new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener?.("abort", () => { clearTimeout(t); reject(new Error("aborted")); }, { once: true });
+  });
+
+/**
+ * Poll GET /v1/videos/{id} until a terminal status or deadline.
+ * @returns {Promise<object>} final poll body (status done) — throws on failed/timeout.
+ */
+async function pollUntilDone({ host, port, apiKey, requestId, connectionId, timeoutSec, pollIntervalMs, signal, onProgress }) {
+  const deadline = Date.now() + timeoutSec * 1000;
+  while (true) {
+    if (signal?.aborted) throw new Error("aborted");
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out after ${timeoutSec}s waiting for video job ${requestId}`);
+    }
+
+    const res = await gatewayRequestWithConnection({ host, port, apiKey, requestId, connectionId, signal });
+    if (res.status === 200 && res.body) {
+      const status = String(res.body.status || "").toLowerCase();
+      onProgress?.(status || "pending", res.body.progress);
+      if (FAILED_STATUSES.has(status)) {
+        const msg = res.body.error?.message || res.body.error || "video generation failed";
+        throw new Error(`Job ${requestId} failed: ${sanitizeText(typeof msg === "string" ? msg : JSON.stringify(msg))}`);
+      }
+      if (TERMINAL_STATUSES.has(status)) return res.body;
+    } else if (res.status >= 400 && res.status !== 429 && res.status !== 503) {
+      throw new Error(`Polling failed (HTTP ${res.status}): ${sanitizeText(res.raw?.slice(0, 300))}`);
+    }
+    await sleep(pollIntervalMs, signal);
+  }
+}
+
+function gatewayRequestWithConnection({ host, port, apiKey, requestId, connectionId, signal }) {
+  return new Promise((resolve, reject) => {
+    const headers = { Accept: "application/json" };
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+    if (connectionId) headers["x-connection-id"] = connectionId;
+    const req = http.request(
+      { hostname: host, port, path: `/v1/videos/${encodeURIComponent(requestId)}`, method: "GET", headers, signal },
+      (res) => {
+        let data = "";
+        res.on("data", (c) => (data += c));
+        res.on("end", () => {
+          let parsed = null;
+          try { parsed = data ? JSON.parse(data) : null; } catch { /* keep raw */ }
+          resolve({ status: res.statusCode, body: parsed, raw: data });
+        });
+      }
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/**
+ * Download a URL to `outputPath` via a `.part` temp file with atomic rename.
+ * The temp file is removed on any failure.
+ */
+async function downloadToFile(url, outputPath, { signal } = {}) {
+  const partPath = `${outputPath}.part`;
+  await new Promise((resolve, reject) => {
+    const cleanupAnd = (fn) => (err) => {
+      try { fs.unlinkSync(partPath); } catch { /* not created yet */ }
+      fn(err);
+    };
+    const get = (target, redirectsLeft) => {
+      const mod = target.startsWith("https:") ? https : http;
+      const req = mod.get(target, { signal }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location && redirectsLeft > 0) {
+          res.resume();
+          return get(new URL(res.headers.location, target).toString(), redirectsLeft - 1);
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          return cleanupAnd(reject)(new Error(`Download failed: HTTP ${res.statusCode}`));
+        }
+        const out = fs.createWriteStream(partPath);
+        res.pipe(out);
+        out.on("finish", () => out.close(resolve));
+        out.on("error", cleanupAnd(reject));
+        res.on("error", cleanupAnd(reject));
+      });
+      req.on("error", cleanupAnd(reject));
+    };
+    get(url, 5);
+  });
+  fs.renameSync(partPath, outputPath);
+}
+
+async function run(argv) {
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (err) {
+    console.error(`❌ ${err.message}`);
+    console.log(HELP);
+    return 1;
+  }
+  if (opts.help) {
+    console.log(HELP);
+    return 0;
+  }
+  if (!opts.prompt) {
+    console.error("❌ --prompt is required");
+    console.log(HELP);
+    return 1;
+  }
+
+  const controller = new AbortController();
+  const partPath = `${opts.output}.part`;
+  const onSigint = () => {
+    controller.abort();
+    try { fs.unlinkSync(partPath); } catch { /* absent */ }
+    console.error("\n✋ Cancelled");
+    process.exit(130);
+  };
+  process.on("SIGINT", onSigint);
+
+  try {
+    const body = { model: opts.model, prompt: opts.prompt };
+    if (opts.duration) body.duration = opts.duration;
+    if (opts.aspectRatio) body.aspect_ratio = opts.aspectRatio;
+    if (opts.resolution) body.resolution = opts.resolution;
+    if (opts.image) body.image = { url: imageInputToUrl(opts.image) };
+
+    console.log(`🎬 Requesting video (${opts.model})…`);
+    const create = await gatewayRequest({
+      host: opts.host, port: opts.port, apiKey: opts.apiKey,
+      method: "POST", reqPath: "/v1/videos/generations", body, signal: controller.signal,
+    });
+
+    if (create.status !== 200 || !create.body?.request_id) {
+      const detail = create.body?.error?.message || create.body?.error || create.raw || `HTTP ${create.status}`;
+      console.error(`❌ Create failed: ${sanitizeText(typeof detail === "string" ? detail : JSON.stringify(detail)).slice(0, 500)}`);
+      if (create.status === 400 && /No credentials/i.test(String(detail))) {
+        console.error("   Connect an xAI account first: dashboard → Providers → xAI (Grok).");
+      }
+      return 1;
+    }
+
+    const requestId = create.body.request_id;
+    const connectionId = create.headers["x-9router-connection-id"] || null;
+    console.log(`📋 Job accepted: ${requestId}`);
+
+    let lastLine = "";
+    const result = await pollUntilDone({
+      host: opts.host, port: opts.port, apiKey: opts.apiKey,
+      requestId, connectionId,
+      timeoutSec: opts.timeoutSec, pollIntervalMs: opts.pollIntervalMs,
+      signal: controller.signal,
+      onProgress: (status, progress) => {
+        const line = `⏳ ${status}${Number.isFinite(progress) ? ` ${progress}%` : ""}`;
+        if (line !== lastLine) {
+          lastLine = line;
+          if (process.stdout.isTTY) process.stdout.write(`\r\x1b[K${line}`);
+          else console.log(line);
+        }
+      },
+    });
+    if (process.stdout.isTTY) process.stdout.write("\n");
+
+    const videoUrl = result.video?.url || result.video?.file_output?.public_url;
+    if (!videoUrl) {
+      console.error("❌ Job finished but no video URL was returned");
+      return 1;
+    }
+
+    console.log("⬇️  Downloading…");
+    await downloadToFile(videoUrl, opts.output, { signal: controller.signal });
+    console.log(`✅ Saved ${opts.output}`);
+    return 0;
+  } catch (err) {
+    if (process.stdout.isTTY) process.stdout.write("\n");
+    console.error(`❌ ${sanitizeText(err?.message || String(err))}`);
+    return 1;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+  }
+}
+
+module.exports = { run, parseArgs, pollUntilDone, downloadToFile, imageInputToUrl, sanitizeText };

--- a/open-sse/handlers/videoCore.js
+++ b/open-sse/handlers/videoCore.js
@@ -1,0 +1,166 @@
+import { createErrorResult } from "../utils/error.js";
+import { HTTP_STATUS } from "../config/runtimeConfig.js";
+import { refreshTokenByProvider } from "../services/tokenRefresh.js";
+import { PROVIDER_MEDIA } from "../providers/index.js";
+
+// Upstream fetch deadline for video job submission/polling (the job itself is
+// async upstream — this only bounds the HTTP round-trip, not video rendering).
+const VIDEO_FETCH_TIMEOUT_MS = Number(process.env.VIDEO_FETCH_TIMEOUT_MS || 120000);
+
+// POST /videos/* creates a billable upstream job. A network error after the
+// request left the socket may still have created the job, so creation is NEVER
+// auto-retried (the only re-send is the auth retry after a 401/403 refresh,
+// which upstream rejects before job creation).
+export const VIDEO_ACTIONS = new Set(["generations", "edits", "extensions"]);
+
+export function getVideoConfig(provider) {
+  return PROVIDER_MEDIA[provider]?.videoConfig || null;
+}
+
+/** Strip bearer tokens / obvious secrets from text destined for clients or logs. */
+export function sanitizeSecrets(text, credentials = null) {
+  if (!text) return text;
+  let out = String(text).replace(/Bearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, "Bearer [redacted]");
+  for (const key of ["accessToken", "refreshToken", "apiKey"]) {
+    const secret = credentials?.[key];
+    if (typeof secret === "string" && secret.length >= 8) {
+      out = out.split(secret).join("[redacted]");
+    }
+  }
+  return out;
+}
+
+function buildUpstreamUrl(config, action, requestId) {
+  const base = config.baseUrl.replace(/\/$/, "");
+  return requestId ? `${base}/${encodeURIComponent(requestId)}` : `${base}/${action}`;
+}
+
+function buildHeaders({ token, contentType, idempotencyKey }) {
+  const headers = { Accept: "application/json" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (contentType) headers["Content-Type"] = contentType;
+  if (idempotencyKey) headers["Idempotency-Key"] = idempotencyKey;
+  return headers;
+}
+
+function combineSignals(signal, timeoutMs) {
+  const timeoutSignal = typeof AbortSignal?.timeout === "function" ? AbortSignal.timeout(timeoutMs) : null;
+  if (signal && timeoutSignal && typeof AbortSignal.any === "function") {
+    return AbortSignal.any([signal, timeoutSignal]);
+  }
+  return signal || timeoutSignal || undefined;
+}
+
+/**
+ * Transparent proxy for async video jobs (xAI Grok Imagine shape).
+ *
+ * - Forwards the raw body byte-for-byte (JSON or multipart) — no reshaping.
+ * - Passes upstream JSON (request_id, status, video.url, error) back verbatim.
+ * - 401/403 with a refresh token: refresh ONCE, retry ONCE. No other retry.
+ * - Upstream error text is sanitized before it reaches the client.
+ *
+ * @param {object} options
+ * @param {string} options.provider - Provider id (must have registry videoConfig)
+ * @param {"generations"|"edits"|"extensions"|null} options.action - Creation action (POST)
+ * @param {string|null} [options.requestId] - Poll target (GET /videos/{id})
+ * @param {Buffer|string|null} [options.rawBody] - Exact body to forward
+ * @param {string|null} [options.contentType] - Original Content-Type header
+ * @param {string|null} [options.idempotencyKey] - Forwarded Idempotency-Key
+ * @param {object} options.credentials - { accessToken?, apiKey?, refreshToken?, authType? }
+ * @param {AbortSignal} [options.signal] - Client cancellation signal
+ * @param {number} [options.timeoutMs]
+ * @param {object} [options.log]
+ * @param {function} [options.onCredentialsRefreshed]
+ * @returns {Promise<{ success: boolean, response: Response, status?: number, error?: string }>}
+ */
+export async function handleVideoProxyCore({
+  provider,
+  action = null,
+  requestId = null,
+  rawBody = null,
+  contentType = null,
+  idempotencyKey = null,
+  credentials,
+  signal,
+  timeoutMs = VIDEO_FETCH_TIMEOUT_MS,
+  log,
+  onCredentialsRefreshed,
+}) {
+  const config = getVideoConfig(provider);
+  if (!config) {
+    return createErrorResult(HTTP_STATUS.BAD_REQUEST, `Provider '${provider}' does not support video generation`);
+  }
+  if (!requestId && !VIDEO_ACTIONS.has(action)) {
+    return createErrorResult(HTTP_STATUS.BAD_REQUEST, `Unknown video action: ${action}`);
+  }
+
+  const method = requestId ? "GET" : "POST";
+  const url = buildUpstreamUrl(config, action, requestId);
+  const fetchSignal = combineSignals(signal, timeoutMs);
+
+  const doFetch = (token) =>
+    fetch(url, {
+      method,
+      headers: buildHeaders({ token, contentType: method === "POST" ? contentType : null, idempotencyKey: method === "POST" ? idempotencyKey : null }),
+      body: method === "POST" ? rawBody : undefined,
+      signal: fetchSignal,
+    });
+
+  let upstream;
+  try {
+    upstream = await doFetch(credentials?.accessToken || credentials?.apiKey);
+  } catch (error) {
+    if (error?.name === "AbortError" || error?.name === "TimeoutError") {
+      return createErrorResult(HTTP_STATUS.REQUEST_TIMEOUT, `[${provider}] video ${method} aborted: ${error.message}`);
+    }
+    // Never re-send a creation POST on network error — the job may already exist upstream.
+    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, sanitizeSecrets(`[${provider}] video upstream fetch failed: ${error.message}`, credentials));
+  }
+
+  // 401/403 → refresh once → retry once (OAuth accounts only; API keys can't refresh)
+  if (
+    (upstream.status === HTTP_STATUS.UNAUTHORIZED || upstream.status === HTTP_STATUS.FORBIDDEN) &&
+    credentials?.refreshToken
+  ) {
+    let refreshed = null;
+    try {
+      refreshed = await refreshTokenByProvider(provider, credentials, log);
+    } catch (error) {
+      log?.warn?.("TOKEN", `${provider} | video refresh error: ${sanitizeSecrets(error.message, credentials)}`);
+    }
+    if (refreshed?.accessToken) {
+      log?.info?.("TOKEN", `${provider.toUpperCase()} | refreshed for video ${method}`);
+      Object.assign(credentials, refreshed);
+      if (onCredentialsRefreshed) await onCredentialsRefreshed(refreshed);
+      try {
+        await upstream.body?.cancel?.();
+      } catch { /* noop */ }
+      try {
+        upstream = await doFetch(credentials.accessToken || credentials.apiKey);
+      } catch (error) {
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, sanitizeSecrets(`[${provider}] video retry after refresh failed: ${error.message}`, credentials));
+      }
+    } else {
+      log?.warn?.("TOKEN", `${provider.toUpperCase()} | video refresh failed — account needs re-auth`);
+    }
+  }
+
+  const bodyText = await upstream.text().catch(() => "");
+
+  if (!upstream.ok) {
+    const message = sanitizeSecrets(bodyText || `HTTP ${upstream.status}`, credentials);
+    return createErrorResult(upstream.status, `[${provider}] ${message.slice(0, 2000)}`);
+  }
+
+  // Success: pass the upstream JSON through untouched (request_id / status / video.url).
+  return {
+    success: true,
+    response: new Response(bodyText, {
+      status: upstream.status,
+      headers: {
+        "Content-Type": upstream.headers.get("content-type") || "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    }),
+  };
+}

--- a/open-sse/providers/registry/xai.js
+++ b/open-sse/providers/registry/xai.js
@@ -32,9 +32,13 @@ export default {
     { id: "grok-code-fast-1", name: "Grok Code Fast" },
     { id: "grok-3", name: "Grok 3" },
     { id: "grok-2-image-1212", name: "Grok 2 Image", params: ["n","response_format"], kind: "image" },
+    { id: "grok-imagine-video", name: "Grok Imagine Video", params: ["duration","aspect_ratio","resolution"], kind: "video" },
   ],
-  serviceKinds: ["llm","imageToText","webSearch","image"],
+  serviceKinds: ["llm","imageToText","webSearch","image","video"],
   imageConfig: { baseUrl: "https://api.x.ai/v1/images/generations", bodyFields: ["model","prompt","n","response_format"] },
+  // Async video jobs (POST returns { request_id }, GET polls until done/failed).
+  // Docs: https://docs.x.ai/developers/rest-api-reference/inference/videos
+  videoConfig: { baseUrl: "https://api.x.ai/v1/videos" },
   searchViaChat: {
     defaultModel: "grok-4.20-reasoning",
     endpoint: "https://api.x.ai/v1/responses",

--- a/skills/9router-video/SKILL.md
+++ b/skills/9router-video/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: 9router-video
+description: Generate videos via 9Router /v1/videos/generations using xAI Grok Imagine (grok-imagine-video). Async job flow - submit, poll request_id until done, download MP4. Use when the user wants to create, generate, or render a video, text-to-video (txt2vid), or image-to-video.
+---
+
+# 9Router — Video Generation (xAI Grok Imagine)
+
+Requires `NINEROUTER_URL` (and `NINEROUTER_KEY` if auth enabled). See https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router/SKILL.md for setup.
+
+Requires a connected **xAI account** in the 9Router dashboard — either **Grok Build OAuth** (SuperGrok / X Premium+ subscription sign-in) or a direct **xAI API key** from console.x.ai. The two are separate auth types with separate billing; the dashboard shows which one each connection uses.
+
+## Endpoints (async job flow)
+
+Video generation is **asynchronous**: the POST returns a `request_id` immediately, then you poll until the job is `done` or `failed`.
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /v1/videos/generations` | text-to-video / image-to-video |
+| `POST /v1/videos/edits` | edit an existing video |
+| `POST /v1/videos/extensions` | extend an existing video |
+| `GET /v1/videos/{request_id}` | poll job status |
+
+Request fields (passed through to xAI unchanged — see https://docs.x.ai/developers/rest-api-reference/inference/videos):
+
+| Field | Required | Notes |
+|---|---|---|
+| `model` | no | `xai/grok-imagine-video` (prefix is stripped before upstream) |
+| `prompt` | yes for T2V | video description |
+| `duration` | no | seconds |
+| `aspect_ratio` | no | `16:9`, `9:16`, `1:1`, `4:3`, `3:4`, `3:2`, `2:3` |
+| `resolution` | no | `480p`, `720p`, `1080p` |
+| `image` | no | `{ "url": "https://… or data:image/…;base64,…" }` for image-to-video |
+| `video` | edits/extensions | `{ "url": "…mp4" }` or `{ "file_id": "…" }` |
+
+## Examples
+
+Submit a job:
+
+```bash
+curl -X POST "$NINEROUTER_URL/v1/videos/generations" \
+  -H "Authorization: Bearer $NINEROUTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"xai/grok-imagine-video","prompt":"A cinematic tracking shot through a neon city at night","duration":8,"aspect_ratio":"16:9","resolution":"720p"}'
+# → {"request_id":"abc123"}   (response header x-9router-connection-id: <id>)
+```
+
+Poll until done (echo the connection header back so the same account polls the job):
+
+```bash
+curl "$NINEROUTER_URL/v1/videos/abc123" \
+  -H "Authorization: Bearer $NINEROUTER_KEY" \
+  -H "x-connection-id: <id from create response>"
+# → {"status":"pending","progress":42}
+# → {"status":"done","video":{"url":"https://…mp4","duration":8},"model":"grok-imagine-video"}
+# → {"status":"failed","error":{"code":"…","message":"…"}}
+```
+
+Download: fetch `video.url` from the `done` response.
+
+## CLI one-shot
+
+```bash
+9router xai video \
+  --prompt "A cinematic tracking shot through a neon city at night" \
+  --output video.mp4
+# options: --model --duration --aspect-ratio --resolution --image --timeout --port --api-key
+```
+
+Submits, polls with progress, downloads to `video.mp4.part`, atomically renames on success. Ctrl+C cancels cleanly; non-zero exit on failure.
+
+## Notes & limits
+
+- Jobs are **account-bound** upstream: poll with the same connection that created the job (`x-connection-id` header, value from the create response's `x-9router-connection-id`).
+- Creation POSTs are **never auto-retried** (a retry could create and bill two videos). Only a 401→token-refresh→single-retry is performed, which upstream rejects before job creation.
+- Video models are tagged `kind: "video"` and are excluded from chat model lists and chat fallback combos.
+- Grok Build **subscription OAuth** tokens are sent to the same `api.x.ai/v1/videos` endpoints as API keys; whether a given subscription tier includes video-generation quota is controlled by xAI and is not verified by 9Router — a `403`/`permission_denied` from upstream means the connected account has no video access.

--- a/skills/README.md
+++ b/skills/README.md
@@ -11,6 +11,7 @@ Drop-in skills for any AI agent (Claude, Cursor, ChatGPT, custom SDK). Just **co
 | **Entry / Setup** (start here) | https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router/SKILL.md |
 | Chat / code-gen | https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router-chat/SKILL.md |
 | Image generation | https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router-image/SKILL.md |
+| Video generation (xAI Grok Imagine) | https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router-video/SKILL.md |
 | Text-to-speech | https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router-tts/SKILL.md |
 | Speech-to-text | https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router-stt/SKILL.md |
 | Embeddings | https://raw.githubusercontent.com/decolua/9router/refs/heads/master/skills/9router-embeddings/SKILL.md |

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -93,6 +93,7 @@ const MODEL_TYPE_TO_KIND = {
   embedding: "embedding",
   stt: "stt",
   imageToText: "imageToText",
+  video: "video",
 };
 
 function modelKind(model) {

--- a/src/app/api/v1/videos/[id]/route.js
+++ b/src/app/api/v1/videos/[id]/route.js
@@ -1,0 +1,17 @@
+import { handleVideoGet } from "@/sse/handlers/videoGeneration.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+/** GET /v1/videos/{request_id} - poll async video job status (xAI Grok Imagine) */
+export async function GET(request, { params }) {
+  const { id } = await params;
+  return await handleVideoGet(request, id);
+}

--- a/src/app/api/v1/videos/edits/route.js
+++ b/src/app/api/v1/videos/edits/route.js
@@ -1,0 +1,16 @@
+import { handleVideoCreate } from "@/sse/handlers/videoGeneration.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+/** POST /v1/videos/edits - async video edit (xAI Grok Imagine) */
+export async function POST(request) {
+  return await handleVideoCreate(request, "edits");
+}

--- a/src/app/api/v1/videos/extensions/route.js
+++ b/src/app/api/v1/videos/extensions/route.js
@@ -1,0 +1,16 @@
+import { handleVideoCreate } from "@/sse/handlers/videoGeneration.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+/** POST /v1/videos/extensions - async video extension (xAI Grok Imagine) */
+export async function POST(request) {
+  return await handleVideoCreate(request, "extensions");
+}

--- a/src/app/api/v1/videos/generations/route.js
+++ b/src/app/api/v1/videos/generations/route.js
@@ -1,0 +1,16 @@
+import { handleVideoCreate } from "@/sse/handlers/videoGeneration.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+/** POST /v1/videos/generations - async video generation (xAI Grok Imagine) */
+export async function POST(request) {
+  return await handleVideoCreate(request, "generations");
+}

--- a/src/shared/components/Sidebar.js
+++ b/src/shared/components/Sidebar.js
@@ -13,7 +13,7 @@ import { ConfirmModal } from "./Modal";
 import NineRemotePromoModal from "./NineRemotePromoModal";
 
 // const VISIBLE_MEDIA_KINDS = ["embedding", "image", "imageToText", "tts", "stt", "webSearch", "webFetch", "video", "music"];
-const VISIBLE_MEDIA_KINDS = ["embedding", "image", "tts", "stt"];
+const VISIBLE_MEDIA_KINDS = ["embedding", "image", "video", "tts", "stt"];
 // Combined entry: webSearch + webFetch share one page at /dashboard/media-providers/web
 const COMBINED_WEB_ITEM = { id: "web", label: "Web Fetch & Search", icon: "travel_explore", href: "/dashboard/media-providers/web" };
 

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -77,7 +77,7 @@ export const MEDIA_PROVIDER_KINDS = [
   { id: "stt",         label: "Speech To Text", icon: "mic",               endpoint: { method: "POST", path: "/v1/audio/transcriptions" } },
   { id: "webSearch",   label: "Web Search",     icon: "travel_explore",    endpoint: { method: "POST", path: "/v1/search" } },
   { id: "webFetch",    label: "Web Fetch",      icon: "language",          endpoint: { method: "POST", path: "/v1/web/fetch" } },
-  { id: "video",       label: "Video",          icon: "movie",             endpoint: { method: "POST", path: "/v1/video/generations" } },
+  { id: "video",       label: "Video",          icon: "movie",             endpoint: { method: "POST", path: "/v1/videos/generations" } },
   { id: "music",       label: "Music",          icon: "music_note",        endpoint: { method: "POST", path: "/v1/audio/music" } },
 ];
 

--- a/src/sse/handlers/videoGeneration.js
+++ b/src/sse/handlers/videoGeneration.js
@@ -1,0 +1,223 @@
+import {
+  getProviderCredentials,
+  markAccountUnavailable,
+  clearAccountError,
+  extractApiKey,
+  isValidApiKey,
+} from "../services/auth.js";
+import { getSettings } from "@/lib/localDb";
+import { getModelInfo } from "../services/model.js";
+import { handleVideoProxyCore, getVideoConfig, sanitizeSecrets } from "open-sse/handlers/videoCore.js";
+import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
+import * as log from "../utils/logger.js";
+
+// Video generation is xAI-only today; requests without a provider prefix
+// (bare model id, or multipart bodies we deliberately don't parse) land here.
+const DEFAULT_VIDEO_PROVIDER = "xai";
+
+// Creation POSTs are billable jobs — only rotate to another account for
+// errors that upstream rejects BEFORE creating a job (auth/quota). A 5xx may
+// have created the job, so it is returned to the caller instead of re-sent.
+const CREATE_ROTATION_STATUSES = new Set([
+  HTTP_STATUS.UNAUTHORIZED,
+  HTTP_STATUS.FORBIDDEN,
+  HTTP_STATUS.RATE_LIMITED,
+]);
+
+async function requireValidApiKey(request) {
+  const apiKey = extractApiKey(request);
+  const settings = await getSettings();
+  if (settings.requireApiKey) {
+    if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
+    const valid = await isValidApiKey(apiKey);
+    if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  }
+  return null;
+}
+
+/**
+ * Read the request body once, byte-preserving.
+ * JSON bodies are additionally parsed so the `model` provider prefix can be
+ * resolved (and stripped) — everything else is forwarded exactly as received.
+ */
+async function readForwardableBody(request) {
+  const contentType = request.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    const raw = await request.text();
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { error: errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body") };
+    }
+    return { raw, parsed, contentType };
+  }
+  // Multipart (or any other content type): forward the exact bytes — parsing
+  // and re-encoding FormData would change the multipart boundary.
+  const buf = Buffer.from(await request.arrayBuffer());
+  return { raw: buf, parsed: null, contentType };
+}
+
+async function resolveVideoProvider(parsedBody) {
+  if (!parsedBody?.model) return { provider: DEFAULT_VIDEO_PROVIDER, model: null };
+
+  const modelStr = String(parsedBody.model);
+  const modelInfo = await getModelInfo(modelStr);
+  if (!modelInfo.provider) {
+    return { error: errorResponse(HTTP_STATUS.BAD_REQUEST, "Combos are not supported for video generation") };
+  }
+  if (!getVideoConfig(modelInfo.provider)) {
+    // Bare model ids (no explicit "provider/" prefix) fall back to the default
+    // video provider — the prefix-less inference targets chat providers only.
+    if (!modelStr.includes("/")) {
+      return { provider: DEFAULT_VIDEO_PROVIDER, model: modelStr };
+    }
+    return { error: errorResponse(HTTP_STATUS.BAD_REQUEST, `Provider '${modelInfo.provider}' does not support video generation`) };
+  }
+  return { provider: modelInfo.provider, model: modelInfo.model };
+}
+
+function withConnectionHeader(response, connectionId) {
+  if (!connectionId) return response;
+  const headers = new Headers(response.headers);
+  // Video jobs are account-bound upstream — clients echo this back as
+  // `x-connection-id` on GET polls so the same account is used.
+  headers.set("x-9router-connection-id", String(connectionId));
+  return new Response(response.body, { status: response.status, headers });
+}
+
+/**
+ * POST /v1/videos/{generations|edits|extensions} — async job creation proxy.
+ */
+export async function handleVideoCreate(request, action) {
+  const authError = await requireValidApiKey(request);
+  if (authError) return authError;
+
+  const bodyInfo = await readForwardableBody(request);
+  if (bodyInfo.error) return bodyInfo.error;
+
+  const resolved = await resolveVideoProvider(bodyInfo.parsed);
+  if (resolved.error) return resolved.error;
+  const { provider, model } = resolved;
+
+  // Strip the provider prefix (e.g. "xai/grok-imagine-video") before forwarding;
+  // otherwise forward the original bytes untouched.
+  let forwardBody = bodyInfo.raw;
+  if (bodyInfo.parsed && model && bodyInfo.parsed.model !== model) {
+    forwardBody = JSON.stringify({ ...bodyInfo.parsed, model });
+  }
+
+  const preferredConnectionId = request.headers.get("x-connection-id") || null;
+  const idempotencyKey = request.headers.get("idempotency-key") || null;
+
+  const excludeConnectionIds = new Set();
+  let lastError = null;
+  let lastStatus = null;
+
+  while (true) {
+    const credentials = await getProviderCredentials(provider, excludeConnectionIds, model, { preferredConnectionId });
+
+    if (!credentials || credentials.allRateLimited) {
+      if (credentials?.allRateLimited) {
+        const errorMsg = lastError || credentials.lastError || "Unavailable";
+        const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
+        return unavailableResponse(status, `[${provider}/${model || "video"}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
+      }
+      if (excludeConnectionIds.size === 0) {
+        return errorResponse(HTTP_STATUS.BAD_REQUEST, `No credentials for provider: ${provider}`);
+      }
+      return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+    }
+
+    const refreshedCredentials = await checkAndRefreshToken(provider, credentials);
+
+    const result = await handleVideoProxyCore({
+      provider,
+      action,
+      rawBody: forwardBody,
+      contentType: bodyInfo.contentType || null,
+      idempotencyKey,
+      credentials: refreshedCredentials,
+      signal: request.signal,
+      log,
+      onCredentialsRefreshed: async (newCreds) => {
+        await updateProviderCredentials(credentials.connectionId, {
+          accessToken: newCreds.accessToken,
+          refreshToken: newCreds.refreshToken,
+          providerSpecificData: newCreds.providerSpecificData,
+          testStatus: "active",
+        });
+      },
+    });
+
+    if (result.success) {
+      await clearAccountError(credentials.connectionId, credentials, model);
+      log.info("VIDEO", `${provider.toUpperCase()} | ${action} accepted (connection ${credentials.connectionId})`);
+      return withConnectionHeader(result.response, credentials.connectionId);
+    }
+
+    // Record the failure (dashboard shows lastError/errorCode → user sees re-auth is needed)
+    const { shouldFallback } = await markAccountUnavailable(
+      credentials.connectionId, result.status, sanitizeSecrets(result.error, refreshedCredentials), provider, model
+    );
+
+    if (shouldFallback && CREATE_ROTATION_STATUSES.has(result.status)) {
+      excludeConnectionIds.add(credentials.connectionId);
+      lastError = result.error;
+      lastStatus = result.status;
+      continue;
+    }
+
+    return result.response;
+  }
+}
+
+/**
+ * GET /v1/videos/{request_id} — poll job status.
+ * Jobs are account-bound upstream, so no cross-account rotation here: the
+ * caller pins the creating account via `x-connection-id` (returned on create).
+ */
+export async function handleVideoGet(request, requestId) {
+  const authError = await requireValidApiKey(request);
+  if (authError) return authError;
+
+  if (!requestId) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing video request id");
+
+  const provider = DEFAULT_VIDEO_PROVIDER;
+  const preferredConnectionId = request.headers.get("x-connection-id") || null;
+
+  const credentials = await getProviderCredentials(provider, null, null, { preferredConnectionId });
+  if (!credentials || credentials.allRateLimited) {
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, `No credentials for provider: ${provider}`);
+  }
+
+  const refreshedCredentials = await checkAndRefreshToken(provider, credentials);
+
+  const result = await handleVideoProxyCore({
+    provider,
+    requestId,
+    credentials: refreshedCredentials,
+    signal: request.signal,
+    log,
+    onCredentialsRefreshed: async (newCreds) => {
+      await updateProviderCredentials(credentials.connectionId, {
+        accessToken: newCreds.accessToken,
+        refreshToken: newCreds.refreshToken,
+        providerSpecificData: newCreds.providerSpecificData,
+        testStatus: "active",
+      });
+    },
+  });
+
+  if (result.success) {
+    await clearAccountError(credentials.connectionId, credentials, null);
+    return withConnectionHeader(result.response, credentials.connectionId);
+  }
+
+  await markAccountUnavailable(
+    credentials.connectionId, result.status, sanitizeSecrets(result.error, refreshedCredentials), provider, null
+  );
+  return result.response;
+}

--- a/tests/unit/cli-xai-video.test.js
+++ b/tests/unit/cli-xai-video.test.js
@@ -1,0 +1,273 @@
+/**
+ * Tests for the `9router xai video` CLI command (cli/src/cli/commands/xaiVideo.js)
+ *
+ * Uses a real local HTTP server standing in for the 9router gateway + video CDN.
+ * No real credentials or upstream calls.
+ *
+ * Covers:
+ *  - arg parsing (defaults, flags, unknown flag rejection)
+ *  - full happy path: create → poll (pending → done) → MP4 download → atomic rename
+ *  - x-connection-id pinning from the create response header
+ *  - failed job → non-zero exit, no output file, no stray .part
+ *  - poll timeout → non-zero exit
+ *  - download failure cleans up the .part file
+ *  - no Authorization/token material in output
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import http from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { run, parseArgs, downloadToFile, sanitizeText, imageInputToUrl } = require("../../cli/src/cli/commands/xaiVideo.js");
+
+const MP4_BYTES = Buffer.from("FAKE-MP4-DATA-0123456789");
+
+function startServer(handler) {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port }));
+  });
+}
+
+const closeServer = (server) => new Promise((r) => server.close(r));
+
+let tmpDir;
+let server;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xai-video-test-"));
+});
+
+afterEach(async () => {
+  if (server) {
+    await closeServer(server);
+    server = null;
+  }
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("parseArgs", () => {
+  it("applies defaults", () => {
+    const opts = parseArgs(["--prompt", "hi"]);
+    expect(opts.prompt).toBe("hi");
+    expect(opts.model).toBe("xai/grok-imagine-video");
+    expect(opts.output).toBe("video.mp4");
+    expect(opts.port).toBe(20128);
+  });
+
+  it("parses all documented flags", () => {
+    const opts = parseArgs([
+      "--prompt", "p", "--output", "o.mp4", "--model", "m",
+      "--duration", "10", "--aspect-ratio", "16:9", "--resolution", "720p",
+      "--image", "https://x/img.png", "--timeout", "30", "--port", "1234", "--api-key", "k",
+    ]);
+    expect(opts).toMatchObject({
+      prompt: "p", output: "o.mp4", model: "m", duration: 10,
+      aspectRatio: "16:9", resolution: "720p", image: "https://x/img.png",
+      timeoutSec: 30, port: 1234, apiKey: "k",
+    });
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseArgs(["--bogus"])).toThrow(/Unknown option/);
+  });
+});
+
+describe("imageInputToUrl", () => {
+  it("passes URLs and data URLs through", () => {
+    expect(imageInputToUrl("https://example.com/a.png")).toBe("https://example.com/a.png");
+    expect(imageInputToUrl("data:image/png;base64,AAA")).toBe("data:image/png;base64,AAA");
+  });
+
+  it("converts a local file to a base64 data URL", () => {
+    const p = path.join(tmpDir, "in.png");
+    fs.writeFileSync(p, Buffer.from([1, 2, 3]));
+    expect(imageInputToUrl(p)).toBe(`data:image/png;base64,${Buffer.from([1, 2, 3]).toString("base64")}`);
+  });
+});
+
+describe("sanitizeText", () => {
+  it("redacts bearer tokens from error output", () => {
+    expect(sanitizeText("boom Bearer abcdefghijklmnop!")).toBe("boom Bearer [redacted]!");
+  });
+});
+
+describe("run (against a mock gateway)", () => {
+  it("creates, polls to done, downloads the MP4, and exits 0", async () => {
+    let pollCount = 0;
+    const seen = { createAuth: null, pollConnectionIds: [] };
+
+    ({ server } = await startServer((req, res) => {
+      if (req.method === "POST" && req.url === "/v1/videos/generations") {
+        seen.createAuth = req.headers.authorization || null;
+        let body = "";
+        req.on("data", (c) => (body += c));
+        req.on("end", () => {
+          seen.createBody = JSON.parse(body);
+          res.writeHead(200, { "Content-Type": "application/json", "x-9router-connection-id": "conn-42" });
+          res.end(JSON.stringify({ request_id: "job-1" }));
+        });
+        return;
+      }
+      if (req.method === "GET" && req.url === "/v1/videos/job-1") {
+        seen.pollConnectionIds.push(req.headers["x-connection-id"] || null);
+        pollCount++;
+        const port = server.address().port;
+        const payload = pollCount < 3
+          ? { status: "pending", progress: pollCount * 30 }
+          : { status: "done", video: { url: `http://127.0.0.1:${port}/files/out.mp4`, duration: 8 } };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(payload));
+        return;
+      }
+      if (req.method === "GET" && req.url === "/files/out.mp4") {
+        res.writeHead(200, { "Content-Type": "video/mp4" });
+        res.end(MP4_BYTES);
+        return;
+      }
+      res.writeHead(404).end();
+    }));
+
+    const output = path.join(tmpDir, "result.mp4");
+    const logs = [];
+    vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
+    vi.spyOn(console, "error").mockImplementation((...a) => logs.push(a.join(" ")));
+
+    const code = await run([
+      "--prompt", "a neon city",
+      "--output", output,
+      "--port", String(server.address().port),
+      "--api-key", "local-key-secret",
+      "--timeout", "10",
+      "--poll-interval-ms", "20",
+    ]);
+
+    expect(code).toBe(0);
+    expect(fs.readFileSync(output)).toEqual(MP4_BYTES);
+    expect(fs.existsSync(`${output}.part`)).toBe(false);
+
+    // Model prefix forwarded as-is to the gateway (gateway strips it)
+    expect(seen.createBody.model).toBe("xai/grok-imagine-video");
+    expect(seen.createBody.prompt).toBe("a neon city");
+    // Polls pinned to the connection that created the job
+    expect(seen.pollConnectionIds.every((id) => id === "conn-42")).toBe(true);
+    // No token material in user-facing output
+    expect(logs.join("\n")).not.toContain("local-key-secret");
+    expect(logs.join("\n")).not.toContain("Authorization");
+  });
+
+  it("exits non-zero when the job fails, without leaving files", async () => {
+    ({ server } = await startServer((req, res) => {
+      if (req.method === "POST") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ request_id: "job-f" }));
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "failed", error: { code: "invalid_argument", message: "bad prompt" } }));
+    }));
+
+    const output = path.join(tmpDir, "nope.mp4");
+    const errors = [];
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation((...a) => errors.push(a.join(" ")));
+
+    const code = await run([
+      "--prompt", "x", "--output", output,
+      "--port", String(server.address().port),
+      "--timeout", "10", "--poll-interval-ms", "10",
+    ]);
+
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain("bad prompt");
+    expect(fs.existsSync(output)).toBe(false);
+    expect(fs.existsSync(`${output}.part`)).toBe(false);
+  });
+
+  it("exits non-zero when polling exceeds the timeout", async () => {
+    ({ server } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(req.method === "POST" ? JSON.stringify({ request_id: "job-slow" }) : JSON.stringify({ status: "pending", progress: 1 }));
+    }));
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errors = [];
+    vi.spyOn(console, "error").mockImplementation((...a) => errors.push(a.join(" ")));
+
+    const code = await run([
+      "--prompt", "x", "--output", path.join(tmpDir, "slow.mp4"),
+      "--port", String(server.address().port),
+      "--timeout", "1", "--poll-interval-ms", "50",
+    ]);
+
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toMatch(/Timed out/i);
+  }, 15000);
+
+  it("reports a helpful error when no xAI account is connected", async () => {
+    ({ server } = await startServer((req, res) => {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: { message: "No credentials for provider: xai", type: "invalid_request_error" } }));
+    }));
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errors = [];
+    vi.spyOn(console, "error").mockImplementation((...a) => errors.push(a.join(" ")));
+
+    const code = await run([
+      "--prompt", "x", "--output", path.join(tmpDir, "n.mp4"),
+      "--port", String(server.address().port),
+    ]);
+
+    expect(code).toBe(1);
+    expect(errors.join("\n")).toContain("No credentials");
+    expect(errors.join("\n")).toContain("Connect an xAI account");
+  });
+});
+
+describe("downloadToFile", () => {
+  it("downloads via .part and renames atomically", async () => {
+    ({ server } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "video/mp4" });
+      res.end(MP4_BYTES);
+    }));
+
+    const out = path.join(tmpDir, "dl.mp4");
+    await downloadToFile(`http://127.0.0.1:${server.address().port}/f.mp4`, out);
+    expect(fs.readFileSync(out)).toEqual(MP4_BYTES);
+    expect(fs.existsSync(`${out}.part`)).toBe(false);
+  });
+
+  it("follows redirects", async () => {
+    ({ server } = await startServer((req, res) => {
+      if (req.url === "/start") {
+        res.writeHead(302, { Location: `/final` });
+        res.end();
+        return;
+      }
+      res.writeHead(200);
+      res.end(MP4_BYTES);
+    }));
+
+    const out = path.join(tmpDir, "redir.mp4");
+    await downloadToFile(`http://127.0.0.1:${server.address().port}/start`, out);
+    expect(fs.readFileSync(out)).toEqual(MP4_BYTES);
+  });
+
+  it("removes the .part file when the download fails", async () => {
+    ({ server } = await startServer((req, res) => {
+      res.writeHead(500);
+      res.end("nope");
+    }));
+
+    const out = path.join(tmpDir, "fail.mp4");
+    await expect(downloadToFile(`http://127.0.0.1:${server.address().port}/f.mp4`, out)).rejects.toThrow(/HTTP 500/);
+    expect(fs.existsSync(out)).toBe(false);
+    expect(fs.existsSync(`${out}.part`)).toBe(false);
+  });
+});

--- a/tests/unit/xai-video-core.test.js
+++ b/tests/unit/xai-video-core.test.js
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for the xAI video proxy core (open-sse/handlers/videoCore.js)
+ *
+ * Covers:
+ *  - registry wiring (videoConfig, grok-imagine-video kind)
+ *  - byte-exact body forwarding (JSON + multipart)
+ *  - request_id / polling-status passthrough (pending, processing, done, failed)
+ *  - 401 → refresh once → retry once; refresh failure → no retry loop
+ *  - no auto-retry of creation POSTs on network error
+ *  - upstream error propagation with secret sanitization
+ *  - abort/cancellation
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("open-sse/services/tokenRefresh.js", () => ({
+  refreshTokenByProvider: vi.fn(),
+}));
+
+import { handleVideoProxyCore, getVideoConfig, sanitizeSecrets, VIDEO_ACTIONS } from "open-sse/handlers/videoCore.js";
+import { refreshTokenByProvider } from "open-sse/services/tokenRefresh.js";
+import { PROVIDER_MEDIA, PROVIDER_MODELS } from "open-sse/providers/index.js";
+
+const originalFetch = global.fetch;
+
+const jsonResponse = (body, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+describe("registry wiring", () => {
+  it("exposes videoConfig for xai", () => {
+    expect(getVideoConfig("xai")).toEqual({ baseUrl: "https://api.x.ai/v1/videos" });
+    expect(PROVIDER_MEDIA.xai.serviceKinds).toContain("video");
+  });
+
+  it("registers grok-imagine-video with kind video (kept out of LLM lists)", () => {
+    const model = PROVIDER_MODELS.xai.find((m) => m.id === "grok-imagine-video");
+    expect(model).toBeTruthy();
+    expect(model.kind || model.type).toBe("video");
+  });
+
+  it("supports exactly the three creation actions", () => {
+    expect([...VIDEO_ACTIONS].sort()).toEqual(["edits", "extensions", "generations"]);
+  });
+});
+
+describe("handleVideoProxyCore", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+    refreshTokenByProvider.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("rejects providers without videoConfig", async () => {
+    const result = await handleVideoProxyCore({
+      provider: "openai",
+      action: "generations",
+      rawBody: "{}",
+      credentials: { apiKey: "k" },
+    });
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.error).toContain("does not support video generation");
+  });
+
+  it("forwards a creation POST byte-for-byte and passes request_id through", async () => {
+    global.fetch.mockResolvedValueOnce(jsonResponse({ request_id: "req-123" }));
+
+    const raw = '{"model":"grok-imagine-video","prompt":"neon city","duration":8}';
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: raw,
+      contentType: "application/json",
+      idempotencyKey: "idem-1",
+      credentials: { accessToken: "tok-A", refreshToken: "ref-A" },
+    });
+
+    expect(result.success).toBe(true);
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe("https://api.x.ai/v1/videos/generations");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(raw); // byte-exact, no reshaping
+    expect(init.headers.Authorization).toBe("Bearer tok-A");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers["Idempotency-Key"]).toBe("idem-1");
+
+    expect(await result.response.json()).toEqual({ request_id: "req-123" });
+  });
+
+  it("forwards multipart bodies untouched with the original boundary header", async () => {
+    global.fetch.mockResolvedValueOnce(jsonResponse({ request_id: "req-mp" }));
+
+    const boundary = "----vitestBoundary42";
+    const multipartBody = Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="prompt"\r\n\r\nextend it\r\n--${boundary}--\r\n`
+    );
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "extensions",
+      rawBody: multipartBody,
+      contentType: `multipart/form-data; boundary=${boundary}`,
+      credentials: { apiKey: "xai-key" },
+    });
+
+    expect(result.success).toBe(true);
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe("https://api.x.ai/v1/videos/extensions");
+    expect(init.body).toBe(multipartBody); // same Buffer, no re-encode
+    expect(init.headers["Content-Type"]).toBe(`multipart/form-data; boundary=${boundary}`);
+  });
+
+  it.each([
+    ["pending", { status: "pending", progress: 10 }],
+    ["processing", { status: "processing", progress: 55 }],
+    ["done", { status: "done", video: { url: "https://cdn.x.ai/v.mp4", duration: 8 } }],
+  ])("passes %s polling payload through verbatim", async (_label, payload) => {
+    global.fetch.mockResolvedValueOnce(jsonResponse(payload));
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      requestId: "req-123",
+      credentials: { accessToken: "tok" },
+    });
+
+    expect(result.success).toBe(true);
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe("https://api.x.ai/v1/videos/req-123");
+    expect(init.method).toBe("GET");
+    expect(await result.response.json()).toEqual(payload);
+  });
+
+  it("passes a failed job (HTTP 200, status failed) through without translating", async () => {
+    const payload = { status: "failed", error: { code: "internal_error", message: "render crashed" } };
+    global.fetch.mockResolvedValueOnce(jsonResponse(payload));
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      requestId: "req-bad",
+      credentials: { accessToken: "tok" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(await result.response.json()).toEqual(payload);
+  });
+
+  it("url-encodes the request id when polling", async () => {
+    global.fetch.mockResolvedValueOnce(jsonResponse({ status: "pending" }));
+    await handleVideoProxyCore({
+      provider: "xai",
+      requestId: "id with/slash",
+      credentials: { accessToken: "tok" },
+    });
+    expect(global.fetch.mock.calls[0][0]).toBe("https://api.x.ai/v1/videos/id%20with%2Fslash");
+  });
+
+  it("401 → refreshes once and retries once with the new token", async () => {
+    global.fetch
+      .mockResolvedValueOnce(jsonResponse({ error: "expired" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ request_id: "req-after-refresh" }));
+    refreshTokenByProvider.mockResolvedValueOnce({ accessToken: "tok-NEW", refreshToken: "ref-NEW" });
+
+    const credentials = { accessToken: "tok-OLD", refreshToken: "ref-OLD" };
+    const onCredentialsRefreshed = vi.fn();
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: '{"prompt":"x"}',
+      contentType: "application/json",
+      credentials,
+      onCredentialsRefreshed,
+    });
+
+    expect(result.success).toBe(true);
+    expect(refreshTokenByProvider).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch.mock.calls[1][1].headers.Authorization).toBe("Bearer tok-NEW");
+    expect(onCredentialsRefreshed).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "tok-NEW" }));
+    expect(await result.response.json()).toEqual({ request_id: "req-after-refresh" });
+  });
+
+  it("401 twice → still only one refresh and one retry (no loop)", async () => {
+    global.fetch
+      .mockResolvedValueOnce(jsonResponse({ error: "expired" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ error: "still expired" }, 401));
+    refreshTokenByProvider.mockResolvedValueOnce({ accessToken: "tok-NEW" });
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: "{}",
+      credentials: { accessToken: "tok-OLD", refreshToken: "ref" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+    expect(refreshTokenByProvider).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("failed refresh → 401 propagates with a single upstream call (account flagged for re-auth upstream)", async () => {
+    global.fetch.mockResolvedValueOnce(jsonResponse({ error: "expired" }, 401));
+    refreshTokenByProvider.mockResolvedValueOnce(null);
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: "{}",
+      credentials: { accessToken: "tok-OLD", refreshToken: "ref" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("API-key accounts (no refreshToken) never attempt refresh on 401", async () => {
+    global.fetch.mockResolvedValueOnce(jsonResponse({ error: "bad key" }, 401));
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: "{}",
+      credentials: { apiKey: "xai-key" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(refreshTokenByProvider).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("never re-sends a creation POST after a network error", async () => {
+    global.fetch.mockRejectedValueOnce(new Error("socket hang up"));
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: "{}",
+      credentials: { accessToken: "tok", refreshToken: "ref" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(502);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("sanitizes bearer tokens and credential values out of upstream errors", async () => {
+    global.fetch.mockResolvedValueOnce(
+      jsonResponse({ error: "denied for Bearer sk-secret-token-value-123456 (token tok-SECRETSECRET)" }, 403)
+    );
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: "{}",
+      credentials: { apiKey: "tok-SECRETSECRET" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).not.toContain("sk-secret-token-value-123456");
+    expect(result.error).not.toContain("tok-SECRETSECRET");
+    expect(result.error).toContain("[redacted]");
+  });
+
+  it("maps client aborts to 408 without retrying", async () => {
+    const abortError = new Error("This operation was aborted");
+    abortError.name = "AbortError";
+    global.fetch.mockRejectedValueOnce(abortError);
+
+    const result = await handleVideoProxyCore({
+      provider: "xai",
+      action: "generations",
+      rawBody: "{}",
+      credentials: { accessToken: "tok" },
+      signal: new AbortController().signal,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(408);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sanitizeSecrets", () => {
+  it("redacts bearer tokens", () => {
+    expect(sanitizeSecrets("Authorization: Bearer abc.def-ghi_jkl")).not.toContain("abc.def-ghi_jkl");
+  });
+
+  it("redacts explicit credential values", () => {
+    const creds = { accessToken: "supersecretaccess", refreshToken: "supersecretrefresh" };
+    const out = sanitizeSecrets("leak supersecretaccess and supersecretrefresh", creds);
+    expect(out).toBe("leak [redacted] and [redacted]");
+  });
+
+  it("leaves normal text untouched", () => {
+    expect(sanitizeSecrets("video render failed: invalid_argument")).toBe("video render failed: invalid_argument");
+  });
+});

--- a/tests/unit/xai-video-handler.test.js
+++ b/tests/unit/xai-video-handler.test.js
@@ -1,0 +1,221 @@
+/**
+ * Unit tests for the app-side video handler (src/sse/handlers/videoGeneration.js)
+ *
+ * Covers:
+ *  - `xai/` model prefix stripping before the body is forwarded upstream
+ *  - byte-exact forwarding when no prefix rewrite is needed
+ *  - multi-account selection (preferred connection id, rotation on 401)
+ *  - NO rotation on 5xx creation errors (a job may already exist upstream)
+ *  - connection id surfaced via x-9router-connection-id
+ *  - GET polling pinned to x-connection-id, no rotation
+ *  - refresh failure recorded via markAccountUnavailable (dashboard re-auth signal)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const authMocks = vi.hoisted(() => ({
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(async () => ({ shouldFallback: true, cooldownMs: 0 })),
+  clearAccountError: vi.fn(async () => {}),
+  extractApiKey: vi.fn(() => null),
+  isValidApiKey: vi.fn(async () => true),
+}));
+const tokenMocks = vi.hoisted(() => ({
+  checkAndRefreshToken: vi.fn(async (_p, creds) => creds),
+  updateProviderCredentials: vi.fn(async () => {}),
+}));
+
+vi.mock("@/sse/services/auth.js", () => authMocks);
+vi.mock("@/sse/services/tokenRefresh.js", () => tokenMocks);
+vi.mock("@/lib/localDb", () => ({
+  getSettings: vi.fn(async () => ({ requireApiKey: false })),
+  getComboByName: vi.fn(async () => null),
+  getModelAliases: vi.fn(async () => ({})),
+  getProviderNodes: vi.fn(async () => []),
+}));
+vi.mock("@/sse/utils/logger.js", () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }));
+
+import { handleVideoCreate, handleVideoGet } from "@/sse/handlers/videoGeneration.js";
+
+const originalFetch = global.fetch;
+
+const jsonResponse = (body, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+const makeRequest = (body, { headers = {}, contentType = "application/json" } = {}) =>
+  new Request("http://localhost/v1/videos/generations", {
+    method: "POST",
+    headers: { "Content-Type": contentType, ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+
+const account = (overrides = {}) => ({
+  connectionId: "conn-1",
+  accessToken: "tok-1",
+  refreshToken: "ref-1",
+  authType: "oauth",
+  ...overrides,
+});
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  authMocks.getProviderCredentials.mockReset();
+  authMocks.markAccountUnavailable.mockClear();
+  authMocks.clearAccountError.mockClear();
+  tokenMocks.checkAndRefreshToken.mockClear();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("handleVideoCreate", () => {
+  it("strips the xai/ prefix from model before forwarding", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account());
+    global.fetch.mockResolvedValueOnce(jsonResponse({ request_id: "r1" }));
+
+    const res = await handleVideoCreate(
+      makeRequest({ model: "xai/grok-imagine-video", prompt: "a cat" }),
+      "generations"
+    );
+
+    expect(res.status).toBe(200);
+    const forwarded = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(forwarded.model).toBe("grok-imagine-video");
+    expect(forwarded.prompt).toBe("a cat");
+  });
+
+  it("forwards the original raw JSON bytes when no rewrite is needed", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account());
+    global.fetch.mockResolvedValueOnce(jsonResponse({ request_id: "r1" }));
+
+    // Odd spacing survives only if we forward the raw string untouched
+    const raw = '{ "model" : "grok-imagine-video",  "prompt" : "spaced" }';
+    await handleVideoCreate(makeRequest(raw), "generations");
+
+    expect(global.fetch.mock.calls[0][1].body).toBe(raw);
+  });
+
+  it("rejects providers without video support", async () => {
+    const res = await handleVideoCreate(
+      makeRequest({ model: "openai/sora-alike", prompt: "x" }),
+      "generations"
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("does not support video generation");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns the serving connection id in x-9router-connection-id", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account({ connectionId: "conn-77" }));
+    global.fetch.mockResolvedValueOnce(jsonResponse({ request_id: "r1" }));
+
+    const res = await handleVideoCreate(makeRequest({ prompt: "x" }), "generations");
+    expect(res.headers.get("x-9router-connection-id")).toBe("conn-77");
+    expect(await res.json()).toEqual({ request_id: "r1" });
+  });
+
+  it("honors preferred x-connection-id when selecting the account", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account());
+    global.fetch.mockResolvedValueOnce(jsonResponse({ request_id: "r1" }));
+
+    await handleVideoCreate(
+      makeRequest({ prompt: "x" }, { headers: { "x-connection-id": "conn-9" } }),
+      "generations"
+    );
+
+    expect(authMocks.getProviderCredentials).toHaveBeenCalledWith(
+      "xai", expect.anything(), null, expect.objectContaining({ preferredConnectionId: "conn-9" })
+    );
+  });
+
+  it("rotates to the next account on 401 (auth errors cannot have created a job)", async () => {
+    authMocks.getProviderCredentials
+      .mockResolvedValueOnce(account({ connectionId: "conn-1", refreshToken: null }))
+      .mockResolvedValueOnce(account({ connectionId: "conn-2", accessToken: "tok-2", refreshToken: null }));
+    global.fetch
+      .mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ request_id: "r2" }));
+
+    const res = await handleVideoCreate(makeRequest({ prompt: "x" }), "generations");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-9router-connection-id")).toBe("conn-2");
+    expect(authMocks.markAccountUnavailable).toHaveBeenCalledWith(
+      "conn-1", 401, expect.any(String), "xai", null
+    );
+  });
+
+  it("does NOT rotate accounts on a 500 creation error (job may exist upstream)", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account({ refreshToken: null }));
+    global.fetch.mockResolvedValueOnce(jsonResponse({ error: "boom" }, 500));
+
+    const res = await handleVideoCreate(makeRequest({ prompt: "x" }), "generations");
+
+    expect(res.status).toBe(500);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(authMocks.getProviderCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards multipart bodies byte-exact with default xai provider", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account());
+    global.fetch.mockResolvedValueOnce(jsonResponse({ request_id: "r-mp" }));
+
+    const boundary = "----handlerBoundary";
+    const raw = `--${boundary}\r\nContent-Disposition: form-data; name="prompt"\r\n\r\nedit\r\n--${boundary}--\r\n`;
+    const req = new Request("http://localhost/v1/videos/edits", {
+      method: "POST",
+      headers: { "Content-Type": `multipart/form-data; boundary=${boundary}` },
+      body: raw,
+    });
+
+    const res = await handleVideoCreate(req, "edits");
+    expect(res.status).toBe(200);
+
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe("https://api.x.ai/v1/videos/edits");
+    expect(Buffer.from(init.body).toString()).toBe(raw);
+    expect(init.headers["Content-Type"]).toContain(boundary);
+  });
+
+  it("returns 400 when no credentials are connected", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(null);
+    const res = await handleVideoCreate(makeRequest({ prompt: "x" }), "generations");
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("No credentials for provider: xai");
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const res = await handleVideoCreate(makeRequest("{not json"), "generations");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("handleVideoGet", () => {
+  it("polls upstream pinned to the x-connection-id account and passes status through", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account({ connectionId: "conn-5" }));
+    global.fetch.mockResolvedValueOnce(jsonResponse({ status: "pending", progress: 42 }));
+
+    const req = new Request("http://localhost/v1/videos/req-1", {
+      headers: { "x-connection-id": "conn-5" },
+    });
+    const res = await handleVideoGet(req, "req-1");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "pending", progress: 42 });
+    expect(authMocks.getProviderCredentials).toHaveBeenCalledWith(
+      "xai", null, null, expect.objectContaining({ preferredConnectionId: "conn-5" })
+    );
+    expect(global.fetch.mock.calls[0][0]).toBe("https://api.x.ai/v1/videos/req-1");
+  });
+
+  it("records the failure when polling hits a terminal auth error", async () => {
+    authMocks.getProviderCredentials.mockResolvedValueOnce(account({ refreshToken: null }));
+    global.fetch.mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401));
+
+    const res = await handleVideoGet(new Request("http://localhost/v1/videos/req-1"), "req-1");
+
+    expect(res.status).toBe(401);
+    expect(authMocks.markAccountUnavailable).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

xAI Grok Imagine video generation (issue #1285, acceptance criterion 8) is the last piece of the xAI provider that never landed. `master` already ships Grok OAuth (PKCE + manual-code fallback in `OAuthModal`), token refresh (`tokenRefresh/providers.js` xai branch), per-connection auth-type display (`ConnectionRow`), and the `grok-cli` / `grok-web` subscription paths — but there is **no video subsystem**: no `/v1/videos/*` routes, no handler, and the `video` media kind in `src/shared/constants/providers.js` pointed at an endpoint that didn't exist.

## Relationship to #1285 / #1286 — why this is not a duplicate

Huge credit to @mugnimaestra — #1286 pioneered the xAI OAuth constants and the video-endpoint semantics (401 → refresh once → retry once, Idempotency-Key forwarding, verbatim polling), and this PR reuses those semantics. However #1286 has been stale since May, is in conflict with `master`, and most of its scope has since been implemented natively on `master` (OAuth service, dashboard flows, token refresh, auth-type display). What remains unique in #1286 is the video part — but it lives in a parallel `src/lib/providers/xai/` executor/translator tree that diverges from the `open-sse` engine architecture `master` uses.

This PR takes the **narrow remaining gap only** — the video subsystem + CLI — built on current `master` conventions (mirrors the existing image-generation handler split), so it stays small and reviewable (~9 source files). It intentionally does **not** claim to replace #1286; if maintainers prefer, the two can be reconciled, but nothing here conflicts with `master`.

## Architecture

Follows the existing image pipeline split 1:1:

```
src/app/api/v1/videos/*             thin Next routes (POST x3 + GET)
  → src/sse/handlers/videoGeneration.js    app glue: auth gate, model prefix strip,
                                            account selection loop, refresh persistence
    → open-sse/handlers/videoCore.js        engine core: transparent upstream proxy,
                                            401 refresh-once/retry-once, sanitization
```

Registry: `open-sse/providers/registry/xai.js` gains `grok-imagine-video` (`kind: "video"`), `videoConfig: { baseUrl: "https://api.x.ai/v1/videos" }`, and `"video"` in `serviceKinds`.

## Endpoints

| Endpoint | Behavior |
|---|---|
| `POST /v1/videos/generations` | async job create → `{ request_id }` passthrough |
| `POST /v1/videos/edits` | same, JSON or multipart body forwarded **byte-exact** |
| `POST /v1/videos/extensions` | same |
| `GET /v1/videos/{request_id}` | upstream `status`/`progress`/`video.url`/`error` passthrough, no reshaping |

Key behaviors (per https://docs.x.ai/developers/rest-api-reference/inference/videos):

- `xai/grok-imagine-video` → prefix stripped before upstream (existing `getModelInfo` convention); bare `grok-imagine-video` defaults to xAI.
- **No auto-retry of creation POSTs** — a blind retry could create and bill two videos. The only re-send is the 401/403 → single-refresh → single-retry, which upstream rejects before job creation. Account rotation happens only on 401/403/429.
- Jobs are account-bound upstream: the create response carries `x-9router-connection-id`, and clients echo it back as `x-connection-id` on polls so the same account polls the job.
- Failed refresh → `markAccountUnavailable` records `errorCode`/`lastError` on the connection (master's re-auth signal, shown by the dashboard).
- Upstream error text is sanitized (`Bearer …` + exact credential values redacted). Tokens are never logged.
- `kind: "video"` is now mapped in the `/v1/models` kind filter, so video models stay **out of chat model lists and chat fallback combos** (this also fixes the pre-existing leak where runwayml's `kind: "video"` models fell through to the LLM list).

## CLI

```bash
9router xai video \
  --prompt "A cinematic tracking shot through a neon city at night" \
  --output video.mp4
# --model --duration --aspect-ratio --resolution --image --timeout --port --host --api-key
```

Submit → poll with progress → download to `video.mp4.part` → atomic rename. `.part` removed on any failure, clean Ctrl+C (exit 130), non-zero exit on failure, friendly hint when no xAI account is connected. No `grok-cli` binary name is introduced.

## Authentication & security notes

- Reuses master's existing account resolution (`getProviderCredentials` → `checkAndRefreshToken` → persist refreshed tokens) — both **Grok Build OAuth** and **xAI API-key** connections work, distinguished by the existing `authType` plumbing.
- No cookie scraping, no quota/payment bypass, no automatic credential import.
- **Unverified subscription capability (honest limitation):** the official docs document `/v1/videos/*` on `api.x.ai` with Bearer auth. Whether a given SuperGrok / X Premium+ **subscription OAuth** token carries video quota on those endpoints is controlled by xAI and cannot be verified without a live subscription; an upstream `403 permission_denied` is surfaced as-is. Documented in the skill doc.

## Tests (46 new, all green)

`tests/unit/xai-video-core.test.js` (21) · `xai-video-handler.test.js` (12) · `cli-xai-video.test.js` (13, real local HTTP mock server — no live credentials needed):

byte-exact JSON + multipart forwarding · request_id passthrough · polling states pending/processing/done/failed · 401 → refresh once → retry once (exactly 2 fetches) · failed refresh → single fetch + recorded error · API-key accounts never refresh · no retry on network error · secret sanitization · abort → 408 · model prefix strip · preferred/pinned connection id · rotation on 401 but **not** on 5xx · CLI happy path (MP4 downloaded, `.part` gone) · failed job / timeout → exit 1 · `.part` cleanup on download failure · redirects.

Quality gates on this branch:

- `npx eslint <changed files>` — 0 errors (1 pre-existing `import/no-anonymous-default-export` warning shared by every registry file).
- `npm run build` — passes; `/api/v1/videos/{generations,edits,extensions,[id]}` emitted.
- Full vitest suite vs a clean `master` run on the same machine: **43 failures on master, 43 on this branch, identical sets — zero new failures** (the suite is documented as not-all-green in CLAUDE.md).
- `tests/__baseline__/verify-{providers,alias,oauth-urls}.mjs` — output byte-identical to master (no registry drift).

## Manual verification

```bash
npm run build && npm run start
# no account connected → clean 400, proves routing + account resolution wiring:
curl -s -X POST localhost:20128/v1/videos/generations -H 'Content-Type: application/json' \
  -d '{"model":"xai/grok-imagine-video","prompt":"neon city"}'
# → {"error":{"message":"No credentials for provider: xai",...}}

node cli/cli.js xai video --prompt test --output t.mp4
# → "❌ Create failed: No credentials…  Connect an xAI account first…" (exit 1)
```

With a connected xAI account (dashboard → Providers → xAI (Grok) → Connect OAuth or Add API key), the same POST returns `{ "request_id": … }` and `GET /v1/videos/{id}` polls to `done` with `video.url`.

## Remaining limitations

- Video generation is **async-only** (as upstream); no synchronous convenience wrapper.
- Subscription-OAuth video quota unverified (see above).
- Multipart creation bodies skip model-prefix rewriting (forwarded byte-exact; provider defaults to xAI).
- Dashboard gets the Video media page + model kind wiring; no bespoke video playground UI in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
