### PR TITLE
fix(huggingface): add sttConfig so HF STT presets are dispatchable

### DIFF
--- a/open-sse/providers/registry/huggingface.js
+++ b/open-sse/providers/registry/huggingface.js
@@ -31,4 +31,10 @@ export default {
   ],
   serviceKinds: ["image", "stt"],
   imageConfig: { baseUrl: "https://api-inference.huggingface.co/models" },
+  sttConfig: {
+    baseUrl: "https://api-inference.huggingface.co/models",
+    authType: "apikey",
+    authHeader: "bearer",
+    format: "huggingface-asr",
+  },
 };

--- a/tests/unit/hf-model-routing.test.js
+++ b/tests/unit/hf-model-routing.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseModel } from "../../open-sse/services/model.js";
+import huggingface from "../../open-sse/providers/registry/huggingface.js";
 
 describe("HuggingFace model alias parsing", () => {
   it("resolves hf alias to huggingface provider", () => {
@@ -8,5 +9,22 @@ describe("HuggingFace model alias parsing", () => {
       model: "black-forest-labs/FLUX.1-schnell",
       providerAlias: "hf",
     });
+  });
+});
+
+describe("HuggingFace STT support (issue #2548)", () => {
+  it("exposes an sttConfig so the STT dispatch layer recognizes the provider", () => {
+    expect(huggingface.serviceKinds).toContain("stt");
+    expect(huggingface.sttConfig).toBeDefined();
+    expect(huggingface.sttConfig.format).toBe("huggingface-asr");
+    expect(huggingface.sttConfig.baseUrl).toContain("api-inference.huggingface.co");
+    expect(huggingface.sttConfig.authType).toBe("apikey");
+  });
+
+  it("advertises the two whisper STT presets", () => {
+    const ids = huggingface.models.filter((m) => m.kind === "stt").map((m) => m.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["openai/whisper-large-v3", "openai/whisper-small"])
+    );
   });
 });


### PR DESCRIPTION
## Fixes #2548

### Bug
The HuggingFace registry advertised two STT models (`openai/whisper-large-v3`, `openai/whisper-small`) with `kind: "stt"` and included `"stt"` in `serviceKinds`, but the entry had **no `sttConfig` block** (only `imageConfig`). Every transcription request then failed at `open-sse/handlers/sttCore.js`:

```js
const cfg = sttConfig;
if (!cfg) return createErrorResult(HTTP_STATUS.BAD_REQUEST, `Provider '${provider}' does not support STT`);
```

Result: `HTTP 400: Provider 'huggingface' does not support STT`, and `GET /v1/models/stt` returned an empty list even after the HF key was configured — even though `sttCore.js` already ships a working `transcribeHuggingFace()` executor (dispatched via `case "huggingface-asr"`) that expects `cfg.baseUrl`.

### Fix (`open-sse/providers/registry/huggingface.js`)
Add the missing `sttConfig`, mirroring the contract the handler already consumes:

```js
sttConfig: {
  baseUrl: "https://api-inference.huggingface.co/models",
  authType: "apikey",
  authHeader: "bearer",
  format: "huggingface-asr",
},
```

`transcribeHuggingFace()` builds `${cfg.baseUrl.replace(/\/+$/, "")}/${model}`, so this yields `https://api-inference.huggingface.co/models/openai/whisper-large-v3` — exactly the HF inference URL. No handler changes needed; the existing executor now actually runs.

### Verification
- Added regression tests in `tests/unit/hf-model-routing.test.js` asserting the registry exposes a valid `sttConfig` (`format: "huggingface-asr"`, HF inference baseUrl, `authType: "apikey"`) and still advertises both whisper STT presets.
- `npx vitest run tests/unit/hf-model-routing.test.js` → **all pass**.
- Confirmed the tests **fail** when `sttConfig` is absent (regression guard is real).
- `node --check` on the edited registry passes.

Co-Authored-By: Hermes Agent <noreply@nousresearch.com>