### PR TITLE
fix(alicode-intl): use DashScope compatible-mode endpoint so standard keys work

### DIFF
--- a/tests/unit/alicode-intl-endpoint-2591.test.js
+++ b/tests/unit/alicode-intl-endpoint-2591.test.js
@@ -1,0 +1,24 @@
+// #2591 — Alibaba Intl (alicode-intl) must use the OpenAI-compatible-mode
+// DashScope endpoint so standard DashScope API keys work. The previous
+// coding-intl host only accepted Alibaba Coding Plan keys and rejected
+// ordinary DashScope keys with "Invalid API key".
+import { describe, it, expect } from "vitest";
+import alicodeIntl from "../../open-sse/providers/registry/alicode-intl.js";
+
+describe("alicode-intl endpoint (issue #2591)", () => {
+  it("routes to the compatible-mode DashScope endpoint", () => {
+    expect(alicodeIntl.id).toBe("alicode-intl");
+    expect(alicodeIntl.transport.baseUrl).toBe(
+      "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions"
+    );
+  });
+
+  it("does not use the coding-intl host that rejects standard keys", () => {
+    expect(alicodeIntl.transport.baseUrl).not.toContain("coding-intl.dashscope.aliyuncs.com");
+  });
+
+  it("keeps the chat/completions path and preserveCacheControl quirk", () => {
+    expect(alicodeIntl.transport.baseUrl).toContain("/v1/chat/completions");
+    expect(alicodeIntl.transport.quirks.preserveCacheControl).toBe(true);
+  });
+});


### PR DESCRIPTION
## Fixes #2591

### Bug
The built-in `alicode-intl` provider hardcoded its chat endpoint to `https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions`, which only accepts Alibaba **Coding Plan** keys. Standard DashScope API keys are rejected with `Invalid API key`.

### Fix (`open-sse/providers/registry/alicode-intl.js`)
Point `transport.baseUrl` at the OpenAI-compatible-mode host:

```js
baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
```

so ordinary DashScope API keys authenticate. The `/v1/chat/completions` path and the `preserveCacheControl` quirk are unchanged.

### Verification
- New `tests/unit/alicode-intl-endpoint-2591.test.js` asserts the registry routes to the compatible-mode endpoint and no longer uses the `coding-intl` host.
- `npx vitest run tests/unit/alicode-intl-endpoint-2591.test.js` → all pass.
- Reverting the URL makes 2 of 3 assertions fail (regression guard confirmed).
- `node --check` clean.

Co-Authored-By: Hermes Agent <noreply@nousresearch.com>