### PR TITLE
fix(translator): strip `client_metadata` when converting openai-responses to openai

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -201,6 +201,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   delete result.prompt_cache_key;
   delete result.store;
   delete result.reasoning;
+  delete result.client_metadata;
 
   return result;
 }


### PR DESCRIPTION
## Problem

When Codex CLI calls NVIDIA (deepseek-ai/deepseek-v4-pro) through 9router, it returns a 400 error:

```
[nvidia/deepseek-ai/deepseek-v4-pro] [400]: {"message":"Validation: Unsupported parameter(s): \","type":"Bad Request","code":400}
```

However the same model works fine via Claude Code.

## Root Cause

`client_metadata` is an OpenAI Responses API-specific field. Codex sends requests in `openai-responses` format. When 9router translates this to `openai` (Chat Completions) format, the translator in `openai-responses.js` deletes several Responses-specific fields (`input`, `instructions`, `store`, `reasoning`, etc.) but was missing `client_metadata`. This field leaked through to NVIDIA's Chat Completions endpoint, which rejected it as an unsupported parameter.

Claude Code follows the `claude → openai` translation path — the source body never contains `client_metadata`, so it was unaffected.

## Fix

Added one line to the Responses-specific cleanup block in `open-sse/translator/request/openai-responses.js`:

```diff
+  delete result.client_metadata;
```

This is the semantically correct place — `client_metadata` is a Responses format concern and should not survive the conversion to Chat Completions format.

## Context: the other two defense layers

- **Executor layer**: `default.js` has a `dropClientMetadata` quirk, but it only applies when the provider registration explicitly sets `quirks.dropClientMetadata: true` (Cerebras and Mistral have it; NVIDIA does not).
- **paramSupport layer**: no strip rule exists for NVIDIA.

Both layers could be added as defense-in-depth, but the root fix belongs in the translator — the field should never survive format conversion.