### PR TITLE
fix(models): populate capabilities for live-catalog LLM models

### DIFF
--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -13,7 +13,7 @@ import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveCopilotModels } from "open-sse/services/copilotModels.js";
 import { resolveClinepassModels } from "open-sse/services/clinepassModels.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
-import { capabilitiesFromServiceKind } from "open-sse/providers/capabilities.js";
+import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -421,7 +421,13 @@ export async function buildModelsList(kindFilter) {
           object: "model",
           owned_by: outputAlias,
         };
-        const caps = liveCapabilitiesById.get(modelId) || capabilitiesFromServiceKind(customKind || liveKind);
+        // Live-catalog resolvers (kiro/qoder/github/clinepass) mostly only return
+        // { id, name } — no per-model capability data. Fall back to the same
+        // pattern-matched capabilities the dashboard uses (useModelCaps.js) so
+        // dynamically-discovered LLM models still surface vision/reasoning/search/tools.
+        const caps = liveCapabilitiesById.get(modelId)
+          || capabilitiesFromServiceKind(customKind || liveKind)
+          || (kind === LLM_KIND ? getCapabilitiesForModel(providerId, modelId) : null);
         if (caps) model.capabilities = caps;
         models.push(model);
       }


### PR DESCRIPTION
## Summary
- `/v1/models` only attached a `capabilities` field from a live resolver's own metadata (only the Kimchi resolver supplies this) or `capabilitiesFromServiceKind()` (non-LLM kinds only). Every plain LLM model discovered through a live catalog (kiro/qoder/github/clinepass) therefore shipped with no `capabilities` field at all, even for models `open-sse/providers/capabilities.js` already has correct entries for (e.g. GitHub Copilot's `claude-sonnet-5`).
- Falls back to `getCapabilitiesForModel(providerId, modelId)` for LLM-kind models when no other capability source is available, mirroring the fallback the dashboard already uses in `src/shared/hooks/useModelCaps.js`.

## Test plan
- [x] `node --check src/app/api/v1/models/route.js`
- [x] `npx eslint src/app/api/v1/models/route.js`
- [x] Manually verified `getCapabilitiesForModel("github", "claude-sonnet-5")` and `getCapabilitiesForModel("github", "claude-fable-5")` both resolve full capabilities (vision/search/reasoning/tools)