### PR TITLE
feat(rtk): add X-9Router-Token-Saver header to bypass token savers per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,8 @@ Default URLs:
 | 📊 **Usage Analytics**                                                            | Track tokens, cost, trends over time                                                     | Optimize spending                                 |
 | 🌐 **Deploy Anywhere**                                                            | Localhost, VPS, Docker, Cloudflare Workers                                               | Flexible deployment options                       |
 
+Set `X-9Router-Token-Saver: off` to bypass all token savers for one chat request.
+
 <details>
 <summary><b>📖 Feature Details</b></summary>
 

--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -65,6 +65,8 @@ export const GEMINI_NATIVE_TTS_FETCH_TIMEOUT_MS = envMs("GEMINI_NATIVE_TTS_FETCH
 export const DEFAULT_MAX_TOKENS = 64000;
 export const DEFAULT_MIN_TOKENS = 32000;
 
+export const TOKEN_SAVER_HEADER = "x-9router-token-saver";
+
 // Retry config for 429 responses (legacy - kept for backward compatibility)
 export const RETRY_CONFIG = {
   maxAttempts: 2,

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -9,7 +9,7 @@ import { createRequestLogger } from "../utils/requestLogger.js";
 import { getModelTargetFormat, getModelStrip, getModelUpstreamId, getModelType, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { PROVIDERS } from "../config/providers.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
-import { HTTP_STATUS } from "../config/runtimeConfig.js";
+import { HTTP_STATUS, TOKEN_SAVER_HEADER } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { getExecutor } from "../executors/index.js";
@@ -190,9 +190,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Token-saver summary parts, printed as one "⚙" line at the end (only active ones)
   const xf = [];
+  const tokenSaverEnabled = clientRawRequest?.headers?.[TOKEN_SAVER_HEADER]?.toLowerCase() !== "off";
 
   // RTK: compress tool_result content
-  const rtkStats = compressMessages(translatedBody, rtkEnabled);
+  const rtkStats = compressMessages(translatedBody, tokenSaverEnabled && rtkEnabled);
   if (rtkStats?.hits?.length) {
     const saved = rtkStats.bytesBefore - rtkStats.bytesAfter;
     const pct = rtkStats.bytesBefore > 0 ? ((saved / rtkStats.bytesBefore) * 100).toFixed(0) : "0";
@@ -201,7 +202,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   // Headroom: optional external proxy compression; fail open if proxy is absent.
   const headroomDiagnostics = {};
-  const headroomStats = await compressWithHeadroom(translatedBody, { enabled: headroomEnabled, url: headroomUrl, model: upstreamModel, format: finalFormat, compressUserMessages: headroomCompressUserMessages, diagnostics: headroomDiagnostics });
+  const headroomStats = await compressWithHeadroom(translatedBody, { enabled: tokenSaverEnabled && headroomEnabled, url: headroomUrl, model: upstreamModel, format: finalFormat, compressUserMessages: headroomCompressUserMessages, diagnostics: headroomDiagnostics });
   if (headroomStats) {
     const before = headroomStats.tokens_before || 0;
     const delta = headroomStats.tokens_saved || 0;
@@ -210,25 +211,25 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     if (isHeadroomPhantomSavings(headroomStats, headroomDiagnostics)) {
       log?.warn?.("HEADROOM", `reported token delta, but outbound JSON shrank <5%; provider may bill near-original payload | ${formatHeadroomSizeLog(headroomDiagnostics)}`);
     }
-  } else if (headroomEnabled) {
+  } else if (tokenSaverEnabled && headroomEnabled) {
     log?.warn?.("HEADROOM", `skipped: ${headroomDiagnostics.reason || "compression unavailable"}${headroomDiagnostics.endpoint ? ` (${headroomDiagnostics.endpoint})` : ""}`);
   }
 
   // Caveman: inject terse-style system prompt
-  if (cavemanEnabled && cavemanLevel) {
+  if (tokenSaverEnabled && cavemanEnabled && cavemanLevel) {
     injectCaveman(translatedBody, finalFormat, cavemanLevel);
     xf.push(`CAVEMAN:${cavemanLevel}`);
   }
 
   // Ponytail: inject lazy-senior-dev system prompt
-  if (ponytailEnabled && ponytailLevel) {
+  if (tokenSaverEnabled && ponytailEnabled && ponytailLevel) {
     injectPonytail(translatedBody, finalFormat, ponytailLevel);
     xf.push(`PONYTAIL:${ponytailLevel}`);
   }
 
   // PXPIPE: image bulky context (Claude-format bodies only), last saver before dispatch
   let pxpipeSummary = null;
-  if (pxpipeEnabled) {
+  if (tokenSaverEnabled && pxpipeEnabled) {
     const pxpipeResult = await compressWithPxpipe(translatedBody, {
       enabled: true, format: finalFormat, model: upstreamModel,
       minChars: pxpipeMinChars, timeoutMs: pxpipeTimeoutMs, transform: pxpipeTransform,

--- a/tests/unit/headroom-chat-core.test.js
+++ b/tests/unit/headroom-chat-core.test.js
@@ -250,4 +250,48 @@ describe("handleChatCore Headroom diagnostics", () => {
       expect.stringContaining("reported token delta, but outbound JSON shrank <5%; provider may bill near-original payload")
     );
   });
+
+  it("bypasses token savers when requested by the client", async () => {
+    const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+    const pxpipeTransform = vi.fn();
+    const messages = [{ role: "user", content: "Write polished prose." }];
+
+    global.fetch = vi.fn(async (url) => {
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    await handleChatCore({
+      body: { model: "gpt-4o", stream: false, messages },
+      modelInfo: { provider: "openai", model: "gpt-4o" },
+      credentials: { apiKey: "test-key", providerSpecificData: {} },
+      log,
+      connectionId: "test-conn",
+      headroomEnabled: true,
+      headroomUrl: "http://localhost:8787",
+      headroomCompressUserMessages: true,
+      rtkEnabled: true,
+      cavemanEnabled: true,
+      cavemanLevel: "full",
+      ponytailEnabled: true,
+      ponytailLevel: "full",
+      pxpipeEnabled: true,
+      pxpipeTransform,
+      clientRawRequest: {
+        endpoint: "/v1/chat/completions",
+        body: {},
+        headers: {
+          accept: "application/json",
+          "x-9router-token-saver": "off",
+        },
+      },
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(pxpipeTransform).not.toHaveBeenCalled();
+    expect(executeMock).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.objectContaining({
+        messages: [{ role: "user", content: "Write polished prose." }],
+      }),
+    }));
+  });
 });


### PR DESCRIPTION
## Summary

Adds a per-request opt-out header so a single chat request can bypass **all** token savers without changing global settings.

Send `X-9Router-Token-Saver: off` and RTK, Headroom, Caveman, Ponytail and PXPIPE are all skipped for that request only. Any other value (or no header) keeps current behavior.

## Motivation

Token savers are global on/off settings. Caveman/Ponytail inject terse-style system prompts into **every** request, which degrades output quality for non-coding work such as prose/writing. Today the only workaround is toggling the global setting back and forth (and it needs dashboard auth). A per-request header lets a client mix coding requests (savers on) and writing requests (savers off) against the same endpoint.

## Changes

- `open-sse/handlers/chatCore.js`: compute `tokenSaverEnabled` from the client header and gate RTK, Headroom, Caveman, Ponytail and PXPIPE on it. Fail-open behavior of each saver is unchanged.
- `open-sse/config/runtimeConfig.js`: add `TOKEN_SAVER_HEADER` constant (no hardcoded header string in the handler, per repo conventions).
- `tests/unit/headroom-chat-core.test.js`: add a test asserting all savers are skipped when the header is `off` (no Headroom fetch, no PXPIPE transform, original messages passed through).
- `README.md`: document the header.

## Behavior

- Header absent / any value ≠ `off` → unchanged (savers run per global settings).
- `X-9Router-Token-Saver: off` → all savers skipped for that request.
- Case-insensitive value; header lookup uses the lowercased key already present on `clientRawRequest.headers`.

## Testing

- `npx vitest run unit/headroom-chat-core.test.js` — new bypass test passes; existing Headroom tests unaffected by this change.
- Manual end-to-end against a local 9Router (Caveman enabled globally): a normal request injected the caveman system prompt into the outbound target body; the same request with `X-9Router-Token-Saver: off` contained zero caveman injections.
