### PR TITLE
feat: drop temperature for all Claude models

### DIFF
--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -6,8 +6,8 @@ import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 // Each rule: optional provider, regex match on model, list of params to drop.
 // A param is removed only when it is present (!== undefined).
 const STRIP_RULES = [
-  // claude-opus-4 series: temperature is deprecated (Anthropic 400). #1748
-  { match: /claude-opus-4/i, drop: ["temperature"] },
+  // All Claude models: temperature deprecated/rejected upstream (Anthropic 400). #1748
+  { match: /claude/i, drop: ["temperature"] },
   // GitHub Copilot gpt-5.4: temperature unsupported.
   { provider: "github", match: /gpt-5\.4/i, drop: ["temperature"] },
   // GitHub Copilot Claude (except opus/sonnet 4.6): thinking + reasoning_effort rejected. #713


### PR DESCRIPTION
Dropped `temperature` from all Claude requests to fix Anthropic 400 errors:

- paramSupport.js — Broadened the strip rule from `/claude-opus-4/i` to `/claude/i`, so `temperature` is removed for every Claude model (not just opus-4). Applies on all OpenAI-compatible routes via default.js and the GitHub executor.