### PR TITLE
fix(kiro): support external_idp token auto-import and CLI proxy routing

### DIFF
--- a/src/app/api/oauth/kiro/auto-import/route.js
+++ b/src/app/api/oauth/kiro/auto-import/route.js
@@ -4,6 +4,19 @@ import { homedir } from "os";
 import { join } from "path";
 
 /**
+ * Check whether an AWS SSO cache entry looks like a Kiro token.
+ * Accepts Builder ID (aorAAAAAG prefix), external_idp (Microsoft Entra),
+ * and organization tokens with codewhisperer scopes.
+ */
+function isKiroToken(data) {
+  if (!data?.refreshToken) return false;
+  if (data.refreshToken.startsWith("aorAAAAAG")) return true;
+  if (data.authMethod === "external_idp") return true;
+  if (Array.isArray(data.scopes) && data.scopes.some(s => s.includes("codewhisperer"))) return true;
+  return false;
+}
+
+/**
  * GET /api/oauth/kiro/auto-import
  * Auto-detect and extract Kiro refresh token from AWS SSO cache.
  * For IDC (organization) tokens, also resolves clientId/clientSecret from the
@@ -33,7 +46,7 @@ export async function GET() {
       try {
         const content = await readFile(join(cachePath, kiroTokenFile), "utf-8");
         const data = JSON.parse(content);
-        if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
+        if (isKiroToken(data)) {
           refreshToken = data.refreshToken;
           foundFile = kiroTokenFile;
           tokenData = data;
@@ -50,7 +63,7 @@ export async function GET() {
         try {
           const content = await readFile(join(cachePath, file), "utf-8");
           const data = JSON.parse(content);
-          if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
+          if (isKiroToken(data)) {
             refreshToken = data.refreshToken;
             foundFile = file;
             tokenData = data;
@@ -112,6 +125,21 @@ export async function GET() {
       }
     }
 
+    // For external_idp tokens, build a minimal payload containing only the
+    // fields the import-cli-proxy normalizer needs — avoids leaking the full
+    // SSO cache (which may include clientSecret, clientIdHash, etc.).
+    const rawAuth = authMethod === "external_idp" ? {
+      auth_method: tokenData.authMethod,
+      access_token: tokenData.accessToken,
+      refresh_token: tokenData.refreshToken,
+      client_id: tokenData.clientId || clientId,
+      token_endpoint: tokenData.tokenEndpoint,
+      scopes: tokenData.scopes,
+      region: tokenData.region,
+      profile_arn: profileArn,
+      ...(tokenData.expiresAt ? { expired: tokenData.expiresAt } : {}),
+    } : undefined;
+
     return NextResponse.json({
       found: true,
       refreshToken,
@@ -121,6 +149,7 @@ export async function GET() {
       region,
       authMethod,
       profileArn,
+      ...(rawAuth ? { rawAuth } : {}),
     });
   } catch (error) {
     console.log("Kiro auto-import error:", error);

--- a/src/lib/updater/updater.js
+++ b/src/lib/updater/updater.js
@@ -176,7 +176,7 @@ function openBrowser(url) {
   const platform = process.platform;
   const cmd = platform === "darwin" ? `open "${url}"`
     : platform === "win32" ? `start "" "${url}"`
-    : `xdg-open "${url}"`;
+      : `xdg-open "${url}"`;
   try { spawn(cmd, { shell: true, detached: true, stdio: "ignore" }).unref(); } catch { /* ignore */ }
 }
 

--- a/src/shared/components/KiroAuthModal.js
+++ b/src/shared/components/KiroAuthModal.js
@@ -40,6 +40,14 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
           setRefreshToken(data.refreshToken);
           setAutoDetected(true);
           // Store IDC/organization credentials if present
+          if (data.authMethod === "external_idp" && data.rawAuth) {
+            // external_idp tokens must go through import-cli-proxy, not the
+            // generic import route (which hits the social endpoint and fails).
+            setCliProxyJson(JSON.stringify(data.rawAuth, null, 2));
+            setSelectedMethod("import-cli-proxy");
+            setAutoDetecting(false);
+            return;
+          }
           if (data.clientId && data.clientSecret) {
             setIdcCredentials({
               clientId: data.clientId,

--- a/src/shared/components/KiroOAuthWrapper.js
+++ b/src/shared/components/KiroOAuthWrapper.js
@@ -27,8 +27,8 @@ export default function KiroOAuthWrapper({ isOpen, providerInfo, onSuccess, onCl
       // Use social login with manual callback
       setAuthMethod("social");
       setSocialProvider(config.provider);
-    } else if (method === "import" || method === "api-key") {
-      // Import / API-key handled in KiroAuthModal, just close
+    } else if (method === "import" || method === "api-key" || method === "import-cli-proxy") {
+      // Import / API-key / CLI-proxy handled in KiroAuthModal, just close
       onSuccess?.();
     }
   }, [onSuccess]);


### PR DESCRIPTION
### What this PR does

This PR fixes a bug where Microsoft Entra ID (`external_idp`) tokens from the AWS SSO cache were silently ignored during auto-import, and subsequently routed to the wrong endpoint if manually pasted.

When an `external_idp` token was manually pasted into the generic import flow, it was incorrectly sent to Kiro's social auth endpoint (`prod.us-east-1.auth.desktop.kiro.dev`), which rejected it with a `"Bad credentials"` error.

This PR ensures these tokens are properly recognized, safely passed to the frontend, and routed to the correct CLI Proxy import flow. It also includes a minor style fix in the updater.

### Key Changes

* **Token Recognition (Auto-Import)**: Extracted an `isKiroToken()` helper in the auto-import route. The endpoint now correctly identifies Builder ID (prefix `aorAAAAAG`), `external_idp`, and `codewhisperer`-scoped organization tokens, rather than just relying on the hardcoded prefix.
* **Safer Payload (Auto-Import)**: For `external_idp` tokens, the backend now constructs and returns a minimal `rawAuth` object containing *only* the fields required by the `import-cli-proxy` normalizer. This prevents leaking the entire SSO cache (which can contain `clientSecret`, `clientIdHash`, etc.) to the browser. The `profile_arn` is also pre-injected server-side.
* **Frontend Routing (KiroAuthModal)**: The auth modal now checks for `data.authMethod === "external_idp"` during auto-detection and automatically routes the user directly to the `import-cli-proxy` tab with the JSON pre-filled.
* **Modal UX (KiroOAuthWrapper)**: Registered `"import-cli-proxy"` as a success-closing condition in the OAuth wrapper, so the modal automatically closes upon a successful import, matching the behavior of other import methods.
* **Style**: Minor ternary indentation alignment in `src/lib/updater/updater.js`.

### Testing

* Tested auto-importing an `external_idp` token from the AWS SSO cache. It successfully detects the token, routes to the CLI proxy tab, and imports it without hitting the generic social auth endpoint.
* Verified that the modal correctly closes after the import succeeds.
* Verified that `rawAuth` in the network response only contains the necessary fields.
