### PR TITLE
feat(kiro): support native external_idp refresh token import and validation

### DIFF
--- a/src/app/api/oauth/kiro/auto-import/route.js
+++ b/src/app/api/oauth/kiro/auto-import/route.js
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { readFile, readdir } from "fs/promises";
-import { homedir } from "os";
-import { join } from "path";
+import { resolveKiroCredentialsFromCache } from "@/lib/oauth/kiroSsoCache";
 
 /**
  * GET /api/oauth/kiro/auto-import
@@ -11,116 +9,18 @@ import { join } from "path";
  */
 export async function GET() {
   try {
-    const cachePath = join(homedir(), ".aws/sso/cache");
-
-    let files;
-    try {
-      files = await readdir(cachePath);
-    } catch (error) {
-      return NextResponse.json({
-        found: false,
-        error: "AWS SSO cache not found. Please login to Kiro IDE first.",
-      });
-    }
-
-    let refreshToken = null;
-    let foundFile = null;
-    let tokenData = null;
-
-    // First try kiro-auth-token.json
-    const kiroTokenFile = "kiro-auth-token.json";
-    if (files.includes(kiroTokenFile)) {
-      try {
-        const content = await readFile(join(cachePath, kiroTokenFile), "utf-8");
-        const data = JSON.parse(content);
-        if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
-          refreshToken = data.refreshToken;
-          foundFile = kiroTokenFile;
-          tokenData = data;
-        }
-      } catch (error) {
-        // Continue to search other files
-      }
-    }
-
-    // If not found, search all .json files
-    if (!refreshToken) {
-      for (const file of files) {
-        if (!file.endsWith(".json")) continue;
-        try {
-          const content = await readFile(join(cachePath, file), "utf-8");
-          const data = JSON.parse(content);
-          if (data.refreshToken && data.refreshToken.startsWith("aorAAAAAG")) {
-            refreshToken = data.refreshToken;
-            foundFile = file;
-            tokenData = data;
-            break;
-          }
-        } catch (error) {
-          continue;
-        }
-      }
-    }
-
-    if (!refreshToken) {
-      return NextResponse.json({
-        found: false,
-        error: "Kiro token not found in AWS SSO cache. Please login to Kiro IDE first.",
-      });
-    }
-
-    // For IDC/organization tokens, resolve clientId and clientSecret from
-    // the linked client registration file (referenced by clientIdHash).
-    let clientId = null;
-    let clientSecret = null;
-    const region = tokenData?.region || null;
-    const authMethod = tokenData?.authMethod || null;
-
-    if (tokenData?.clientIdHash) {
-      const clientFile = `${tokenData.clientIdHash}.json`;
-      try {
-        const clientContent = await readFile(join(cachePath, clientFile), "utf-8");
-        const clientData = JSON.parse(clientContent);
-        if (clientData.clientId && clientData.clientSecret) {
-          clientId = clientData.clientId;
-          clientSecret = clientData.clientSecret;
-        }
-      } catch (error) {
-        // Client registration file not found - continue without it
-      }
-    }
-
-    // Read profileArn from Kiro IDE's profile.json.
-    // Important: the runtime gateway requires us-east-1 in the ARN regardless
-    // of the IDC region, so we normalize the region in the ARN to us-east-1.
-    let profileArn = null;
-    const kiroProfilePaths = [
-      join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
-      join(homedir(), ".config", "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
-    ];
-    for (const profilePath of kiroProfilePaths) {
-      try {
-        const profileContent = await readFile(profilePath, "utf-8");
-        const profileData = JSON.parse(profileContent);
-        if (profileData.arn) {
-          // Normalize region to us-east-1 for the runtime gateway
-          profileArn = profileData.arn.replace(/arn:aws:codewhisperer:[^:]+:/, "arn:aws:codewhisperer:us-east-1:");
-          break;
-        }
-      } catch (error) {
-        continue;
-      }
-    }
+    const credentials = await resolveKiroCredentialsFromCache();
 
     return NextResponse.json({
       found: true,
-      refreshToken,
-      source: foundFile,
-      clientId,
-      clientSecret,
-      region,
-      authMethod,
-      profileArn,
+      refreshToken: credentials.refreshToken,
+      source: credentials.source,
+      clientId: credentials.clientId,
+      clientSecret: credentials.clientSecret,
+      region: credentials.region,
+      authMethod: credentials.authMethod,
+      profileArn: credentials.profileArn,
+      ...(credentials.rawAuth ? { rawAuth: credentials.rawAuth } : {}),
     });
   } catch (error) {
     console.log("Kiro auto-import error:", error);

--- a/src/app/api/oauth/kiro/import/route.js
+++ b/src/app/api/oauth/kiro/import/route.js
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { KiroService } from "@/lib/oauth/services/kiro";
 import { createProviderConnection } from "@/models";
+import { resolveKiroCredentialsFromCache } from "@/lib/oauth/kiroSsoCache";
+import { normalizeKiroExternalIdpAuth } from "@/lib/oauth/kiroExternalIdp";
 
 /**
  * POST /api/oauth/kiro/import
@@ -22,18 +24,30 @@ export async function POST(request) {
     const kiroService = new KiroService();
     const isIdc = !!(clientId && clientSecret);
 
-    // For IDC tokens, refresh via the regional OIDC endpoint with client credentials.
-    // For social/builder-id tokens, use the standard social refresh endpoint.
-    const providerSpecificData = isIdc
+    let resolvedProviderData = isIdc
       ? { clientId, clientSecret, region: region || "us-east-1", authMethod: "idc" }
       : {};
 
-    const tokenData = await kiroService.refreshToken(refreshToken.trim(), providerSpecificData);
+    let resolvedProfileArn = profileArn || null;
+
+    // Try to resolve the token from local SSO cache.
+    try {
+      const cacheResult = await resolveKiroCredentialsFromCache(refreshToken.trim());
+      if (cacheResult.authMethod === "external_idp" && cacheResult.rawAuth) {
+        const tokenData = normalizeKiroExternalIdpAuth(cacheResult.rawAuth);
+        resolvedProviderData = tokenData.providerSpecificData;
+        resolvedProfileArn = tokenData.providerSpecificData.profileArn;
+      }
+    } catch (cacheError) {
+      // Ignore cache errors and proceed with standard flow
+    }
+
+    const tokenData = await kiroService.refreshToken(refreshToken.trim(), resolvedProviderData);
 
     const email = kiroService.extractEmailFromJWT(tokenData.accessToken);
-    const resolvedAuthMethod = isIdc ? "idc" : "imported";
-    const providerLabel = isIdc ? "Enterprise" : "Imported";
-    const resolvedProfileArn = profileArn || tokenData.profileArn || null;
+    const resolvedAuthMethod = tokenData.providerSpecificData?.authMethod || (isIdc ? "idc" : "imported");
+    const providerLabel = tokenData.providerSpecificData?.provider || (isIdc ? "Enterprise" : "Imported");
+    resolvedProfileArn = resolvedProfileArn || tokenData.providerSpecificData?.profileArn || tokenData.profileArn || null;
 
     const connection = await createProviderConnection({
       provider: "kiro",
@@ -47,6 +61,7 @@ export async function POST(request) {
         authMethod: resolvedAuthMethod,
         provider: providerLabel,
         ...(isIdc ? { clientId, clientSecret, region: region || "us-east-1" } : {}),
+        ...(tokenData.providerSpecificData?.authMethod === "external_idp" ? tokenData.providerSpecificData : {})
       },
       testStatus: "active",
     });

--- a/src/lib/oauth/kiroSsoCache.js
+++ b/src/lib/oauth/kiroSsoCache.js
@@ -1,0 +1,132 @@
+import { readFile, readdir } from "fs/promises";
+import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * Check whether an AWS SSO cache entry looks like a Kiro token.
+ * Accepts Builder ID (aorAAAAAG prefix), external_idp (Microsoft Entra),
+ * and organization tokens with codewhisperer scopes.
+ */
+export function isKiroToken(data) {
+  if (!data?.refreshToken) return false;
+  if (data.refreshToken.startsWith("aorAAAAAG")) return true;
+  if (data.authMethod === "external_idp") return true;
+  if (Array.isArray(data.scopes) && data.scopes.some(s => s.includes("codewhisperer"))) return true;
+  return false;
+}
+
+/**
+ * Scan AWS SSO cache and resolve full Kiro credentials.
+ * If targetRefreshToken is provided, it only returns a match for that specific token.
+ * Otherwise, it returns the first found Kiro token.
+ */
+export async function resolveKiroCredentialsFromCache(targetRefreshToken = null) {
+  const cachePath = join(homedir(), ".aws/sso/cache");
+  let files;
+  try {
+    files = await readdir(cachePath);
+  } catch (error) {
+    throw new Error("AWS SSO cache not found. Please login to Kiro IDE first.");
+  }
+
+  let refreshToken = null;
+  let foundFile = null;
+  let tokenData = null;
+
+  const checkData = (data, file) => {
+    if (isKiroToken(data)) {
+      if (targetRefreshToken && data.refreshToken !== targetRefreshToken) {
+        return false;
+      }
+      refreshToken = data.refreshToken;
+      foundFile = file;
+      tokenData = data;
+      return true;
+    }
+    return false;
+  };
+
+  const kiroTokenFile = "kiro-auth-token.json";
+  if (files.includes(kiroTokenFile)) {
+    try {
+      const content = await readFile(join(cachePath, kiroTokenFile), "utf-8");
+      checkData(JSON.parse(content), kiroTokenFile);
+    } catch (error) {}
+  }
+
+  if (!refreshToken) {
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const content = await readFile(join(cachePath, file), "utf-8");
+        if (checkData(JSON.parse(content), file)) break;
+      } catch (error) {
+        continue;
+      }
+    }
+  }
+
+  if (!refreshToken) {
+    throw new Error(targetRefreshToken 
+      ? "Provided refresh token not found in local AWS SSO cache." 
+      : "Kiro token not found in AWS SSO cache. Please login to Kiro IDE first.");
+  }
+
+  let clientId = null;
+  let clientSecret = null;
+  const region = tokenData?.region || null;
+  const authMethod = tokenData?.authMethod || null;
+
+  if (tokenData?.clientIdHash) {
+    const clientFile = `${tokenData.clientIdHash}.json`;
+    try {
+      const clientContent = await readFile(join(cachePath, clientFile), "utf-8");
+      const clientData = JSON.parse(clientContent);
+      if (clientData.clientId && clientData.clientSecret) {
+        clientId = clientData.clientId;
+        clientSecret = clientData.clientSecret;
+      }
+    } catch (error) {}
+  }
+
+  let profileArn = null;
+  const kiroProfilePaths = [
+    join(process.env.APPDATA || join(homedir(), "AppData", "Roaming"), "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
+    join(homedir(), ".config", "Kiro", "User", "globalStorage", "kiro.kiroagent", "profile.json"),
+  ];
+  for (const profilePath of kiroProfilePaths) {
+    try {
+      const profileContent = await readFile(profilePath, "utf-8");
+      const profileData = JSON.parse(profileContent);
+      if (profileData.arn) {
+        profileArn = profileData.arn.replace(/arn:aws:codewhisperer:[^:]+:/, "arn:aws:codewhisperer:us-east-1:");
+        break;
+      }
+    } catch (error) {
+      continue;
+    }
+  }
+
+  const rawAuth = authMethod === "external_idp" ? {
+    auth_method: tokenData.authMethod,
+    access_token: tokenData.accessToken,
+    refresh_token: tokenData.refreshToken,
+    client_id: tokenData.clientId || clientId,
+    token_endpoint: tokenData.tokenEndpoint,
+    scopes: tokenData.scopes,
+    region: tokenData.region,
+    profile_arn: profileArn,
+    ...(tokenData.expiresAt ? { expired: tokenData.expiresAt } : {}),
+  } : undefined;
+
+  return {
+    refreshToken,
+    source: foundFile,
+    clientId,
+    clientSecret,
+    region,
+    authMethod,
+    profileArn,
+    rawAuth
+  };
+}

--- a/src/lib/oauth/services/kiro.js
+++ b/src/lib/oauth/services/kiro.js
@@ -1,4 +1,5 @@
 import { KIRO_CONFIG, assertValidAwsRegion } from "../constants/oauth.js";
+import { buildExternalIdpRefreshParams } from "../kiroExternalIdp.js";
 
 /**
  * Kiro OAuth Service
@@ -176,6 +177,33 @@ export class KiroService {
    */
   async refreshToken(refreshToken, providerSpecificData = {}) {
     const { authMethod, clientId, clientSecret, region } = providerSpecificData;
+
+    // Microsoft Entra ID (external_idp) refresh
+    if (authMethod === "external_idp") {
+      const refreshRequest = buildExternalIdpRefreshParams(refreshToken, providerSpecificData);
+      
+      const response = await fetch(refreshRequest.tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: refreshRequest.body,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Token refresh failed for external_idp: ${errorText}`);
+      }
+
+      const data = await response.json();
+      return {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token || refreshToken,
+        expiresIn: data.expires_in,
+        providerSpecificData: refreshRequest.providerSpecificData,
+      };
+    }
 
     // AWS SSO OIDC refresh (Builder ID or IDC)
     if (clientId && clientSecret) {

--- a/src/shared/components/KiroAuthModal.js
+++ b/src/shared/components/KiroAuthModal.js
@@ -21,7 +21,6 @@ export default function KiroAuthModal({ isOpen, onMethodSelect, onClose }) {
   const [autoDetecting, setAutoDetecting] = useState(false);
   const [autoDetected, setAutoDetected] = useState(false);
   const [idcCredentials, setIdcCredentials] = useState(null);
-
   // Auto-detect token when import method is selected
   useEffect(() => {
     if (selectedMethod !== "import" || !isOpen) return;

--- a/src/shared/components/KiroOAuthWrapper.js
+++ b/src/shared/components/KiroOAuthWrapper.js
@@ -27,8 +27,8 @@ export default function KiroOAuthWrapper({ isOpen, providerInfo, onSuccess, onCl
       // Use social login with manual callback
       setAuthMethod("social");
       setSocialProvider(config.provider);
-    } else if (method === "import" || method === "api-key") {
-      // Import / API-key handled in KiroAuthModal, just close
+    } else if (method === "import" || method === "api-key" || method === "import-cli-proxy") {
+      // Import / API-key / CLI-proxy handled in KiroAuthModal, just close
       onSuccess?.();
     }
   }, [onSuccess]);


### PR DESCRIPTION
Previously, Microsoft Entra ID (external_idp) users lacked a seamless authentication path in Kiro:
- The standard "Import Token" route (POST /api/oauth/kiro/import) strictly validated against AWS OIDC endpoints, rejecting external_idp refresh tokens due to missing enterprise metadata (profile_arn, token_endpoint).
- The fallback import-cli-proxy route bypassed token validation entirely, relying on the user to manually construct a complex JSON payload combining SSO cache data and local IDE state.

This commit resolves these limitations by introducing native backend support for external_idp refresh tokens, fully respecting existing controller patterns:

1. Unified SSO Cache Resolution: Extracted AWS SSO cache discovery logic into a shared utility (kiroSsoCache.js), allowing targeted refresh token lookups.
2. Native Token Validation: Upgraded KiroService.refreshToken to support native external_idp validation by pinging the Microsoft token endpoint directly, matching the architecture of the background refresh worker.
3. Controller Interception: The "Import Token" route now dynamically intercepts external_idp refresh tokens, extracts the hidden enterprise metadata from the local filesystem, and passes it into KiroService.refreshToken for standard validation.

Enterprise users can now submit a refresh token via the Import Token UI. The backend resolves the required metadata, validates the token against the Microsoft endpoint, and establishes the connection without requiring UI redirects or manual JSON construction.

