### PR TITLE
fix(kiro): preserve credit metering cost

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -382,6 +382,27 @@ export class KiroExecutor extends BaseExecutor {
           // Handle meteringEvent - mark that we received it
           if (eventType === "meteringEvent") {
             state.hasMeteringEvent = true;
+            const metering = event.payload?.meteringEvent || event.payload || {};
+            const credits = Number(metering.usage);
+            if (Number.isFinite(credits)) {
+              state.usage = {
+                ...(state.usage || {}),
+                kiro_credits: credits,
+                kiro_credit_unit: typeof metering.unit === "string" ? metering.unit : "credit"
+              };
+
+              if (state.finishEmitted) {
+                const usageChunk = {
+                  id: responseId,
+                  object: "chat.completion.chunk",
+                  created,
+                  model,
+                  choices: [],
+                  usage: state.usage
+                };
+                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(usageChunk)}\n\n`));
+              }
+            }
           }
 
           // Handle metricsEvent for token usage
@@ -399,6 +420,7 @@ export class KiroExecutor extends BaseExecutor {
 
               if (inputTokens > 0 || outputTokens > 0) {
                 state.usage = {
+                  ...(state.usage || {}),
                   prompt_tokens: inputTokens,
                   completion_tokens: outputTokens,
                   total_tokens: inputTokens + outputTokens
@@ -418,7 +440,9 @@ export class KiroExecutor extends BaseExecutor {
             state.finishEmitted = true;
 
             // Estimate tokens if not available from events
-            if (!state.usage) {
+            const hasTokenUsage = Number.isFinite(Number(state.usage?.prompt_tokens)) ||
+              Number.isFinite(Number(state.usage?.completion_tokens));
+            if (!hasTokenUsage) {
               // Estimate output tokens from content length
               const estimatedOutputTokens = state.totalContentLength > 0
                 ? Math.max(1, Math.floor(state.totalContentLength / 4))
@@ -430,6 +454,7 @@ export class KiroExecutor extends BaseExecutor {
                 : 0;
 
               state.usage = {
+                ...(state.usage || {}),
                 prompt_tokens: estimatedInputTokens,
                 completion_tokens: estimatedOutputTokens,
                 total_tokens: estimatedInputTokens + estimatedOutputTokens

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -2,7 +2,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { needsTranslation } from "../../translator/index.js";
 import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
-import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
+import { addBufferToUsage, estimateUsage, filterUsageForFormat, hasValidUsage, mergeUsage } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
@@ -233,7 +233,13 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   // Decloak tool_use names once on raw Claude body, before any translation (INPUT side)
   responseBody = decloakToolNames(responseBody, toolNameMap);
 
-  const usage = responseBody._internalUsage || extractUsageFromResponse(responseBody);
+  let usage = responseBody._internalUsage || extractUsageFromResponse(responseBody);
+  if (!hasValidUsage(usage)) {
+    const contentLength = responseBody?.choices?.[0]?.message?.content?.length || responseBody?.content?.length || 0;
+    if (contentLength > 0) {
+      usage = mergeUsage(usage, estimateUsage(body, contentLength, sourceFormat));
+    }
+  }
   appendLog({ tokens: usage, status: "200 OK" });
   saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
   if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -233,7 +233,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   // Decloak tool_use names once on raw Claude body, before any translation (INPUT side)
   responseBody = decloakToolNames(responseBody, toolNameMap);
 
-  const usage = extractUsageFromResponse(responseBody);
+  const usage = responseBody._internalUsage || extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
   saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
   if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -98,8 +98,10 @@ export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, 
 
   const inTokens = tokens.input_tokens ?? tokens.prompt_tokens ?? 0;
   const outTokens = tokens.output_tokens ?? tokens.completion_tokens ?? 0;
+  const kiroCredits = Number(tokens.kiro_credits);
+  const hasKiroCreditUsage = Number.isFinite(kiroCredits) && kiroCredits >= 0;
 
-  if (inTokens === 0 && outTokens === 0) return;
+  if (inTokens === 0 && outTokens === 0 && !hasKiroCreditUsage) return;
 
   if (!silent) {
     const time = new Date().toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -3,6 +3,7 @@ import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
+import { extractUsage, filterUsageForFormat, mergeUsage } from "../../utils/usageTracking.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
@@ -57,6 +58,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
   const toolCallMap = new Map(); // index -> { id, type, function: { name, arguments } }
   let finishReason = "stop";
   let usage = null;
+  let internalUsage = null;
 
   for (const chunk of chunks) {
     const choice = chunk?.choices?.[0];
@@ -64,7 +66,11 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
     if (typeof delta.content === "string" && delta.content.length > 0) contentParts.push(delta.content);
     if (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) reasoningParts.push(delta.reasoning_content);
     if (choice?.finish_reason) finishReason = choice.finish_reason;
-    if (chunk?.usage && typeof chunk.usage === "object") usage = chunk.usage;
+    if (chunk?.usage && typeof chunk.usage === "object") {
+      usage = chunk.usage;
+      const extracted = extractUsage(chunk);
+      if (extracted) internalUsage = mergeUsage(internalUsage, extracted);
+    }
 
     // Accumulate tool_calls from streaming deltas
     if (Array.isArray(delta.tool_calls)) {
@@ -94,7 +100,14 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
     model: first.model || fallbackModel || "unknown",
     choices: [{ index: 0, message, finish_reason: finishReason }]
   };
-  if (usage) result.usage = usage;
+  if (usage) result.usage = filterUsageForFormat(usage, FORMATS.OPENAI);
+  if (internalUsage) {
+    Object.defineProperty(result, "_internalUsage", {
+      value: internalUsage,
+      enumerable: false,
+      configurable: true,
+    });
+  }
   return result;
 }
 
@@ -199,7 +212,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
     if (onRequestSuccess) await onRequestSuccess();
 
-    const usage = parsed.usage || {};
+    const usage = parsed._internalUsage || parsed.usage || {};
     appendLog({ tokens: usage, status: "200 OK" });
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -3,7 +3,7 @@ import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
-import { extractUsage, filterUsageForFormat, mergeUsage } from "../../utils/usageTracking.js";
+import { estimateUsage, extractUsage, filterUsageForFormat, hasValidUsage, mergeUsage } from "../../utils/usageTracking.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
@@ -212,7 +212,13 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
     if (onRequestSuccess) await onRequestSuccess();
 
-    const usage = parsed._internalUsage || parsed.usage || {};
+    let usage = parsed._internalUsage || parsed.usage || {};
+    if (!hasValidUsage(usage)) {
+      const contentLength = parsed.choices?.[0]?.message?.content?.length || 0;
+      if (contentLength > 0) {
+        usage = mergeUsage(usage, estimateUsage(body, contentLength, sourceFormat));
+      }
+    }
     appendLog({ tokens: usage, status: "200 OK" });
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));

--- a/open-sse/providers/pricing.js
+++ b/open-sse/providers/pricing.js
@@ -277,6 +277,11 @@ export function formatCost(cost) {
 export function calculateCostFromTokens(tokens, pricing) {
   if (!tokens || !pricing) return 0;
 
+  // Kiro reports actual billable usage as credits through metering events.
+  // Prefer that over token-list pricing so cost alerting reflects what was charged.
+  const kiroCredits = Number(tokens.kiro_credits);
+  if (Number.isFinite(kiroCredits) && kiroCredits >= 0) return kiroCredits;
+
   let cost = 0;
 
   const inputTokens = tokens.prompt_tokens || tokens.input_tokens || 0;

--- a/open-sse/providers/pricing.js
+++ b/open-sse/providers/pricing.js
@@ -277,11 +277,6 @@ export function formatCost(cost) {
 export function calculateCostFromTokens(tokens, pricing) {
   if (!tokens || !pricing) return 0;
 
-  // Kiro reports actual billable usage as credits through metering events.
-  // Prefer that over token-list pricing so cost alerting reflects what was charged.
-  const kiroCredits = Number(tokens.kiro_credits);
-  if (Number.isFinite(kiroCredits) && kiroCredits >= 0) return kiroCredits;
-
   let cost = 0;
 
   const inputTokens = tokens.prompt_tokens || tokens.input_tokens || 0;

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -170,7 +170,7 @@ export function createSSEStream(options = {}) {
                 const estimated = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
                 parsed.usage = filterUsageForFormat(estimated, FORMATS.OPENAI);
                 output = `data: ${JSON.stringify(parsed)}\n`;
-                usage = estimated;
+                usage = mergeUsage(usage, estimated);
                 injectedUsage = true;
               } else if (isFinishChunk && usage) {
                 const buffered = addBufferToUsage(usage);
@@ -318,7 +318,7 @@ export function createSSEStream(options = {}) {
             if (state.finishReason && isFinishChunk && !hasValidUsage(item.usage) && totalContentLength > 0) {
               const estimated = estimateUsage(body, totalContentLength, sourceFormat);
               item.usage = filterUsageForFormat(estimated, sourceFormat); // Filter + already has buffer
-              state.usage = estimated;
+              state.usage = mergeUsage(state.usage, estimated);
             } else if (state.finishReason && isFinishChunk && state.usage) {
               // Add buffer and filter usage for client (but keep original in state.usage for logging)
               const buffered = addBufferToUsage(state.usage);
@@ -353,7 +353,7 @@ export function createSSEStream(options = {}) {
           }
 
           if (!hasValidUsage(usage) && totalContentLength > 0) {
-            usage = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
+            usage = mergeUsage(usage, estimateUsage(body, totalContentLength, FORMATS.OPENAI));
           }
 
           if (hasValidUsage(usage)) {
@@ -442,7 +442,7 @@ export function createSSEStream(options = {}) {
         }
 
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
-          state.usage = estimateUsage(body, totalContentLength, sourceFormat);
+          state.usage = mergeUsage(state?.usage, estimateUsage(body, totalContentLength, sourceFormat));
         }
 
         if (hasValidUsage(state?.usage)) {

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -131,6 +131,10 @@ export function normalizeUsage(usage) {
   assignNumber("cache_creation_input_tokens", usage?.cache_creation_input_tokens);
   assignNumber("cached_tokens", usage?.cached_tokens);
   assignNumber("reasoning_tokens", usage?.reasoning_tokens);
+  assignNumber("kiro_credits", usage?.kiro_credits);
+  if (typeof usage?.kiro_credit_unit === "string") {
+    normalized.kiro_credit_unit = usage.kiro_credit_unit;
+  }
 
   // Preserve nested details objects for OpenAI format forwarding
   if (usage?.prompt_tokens_details && typeof usage.prompt_tokens_details === "object") {
@@ -203,6 +207,11 @@ export function canonicalizeUsage(usage) {
     cache_creation_input_tokens: cacheCreation,
   };
   if (reasoning > 0) result.reasoning_tokens = reasoning;
+  const kiroCredits = Number(usage.kiro_credits);
+  if (Number.isFinite(kiroCredits) && kiroCredits >= 0) {
+    result.kiro_credits = kiroCredits;
+    if (typeof usage.kiro_credit_unit === "string") result.kiro_credit_unit = usage.kiro_credit_unit;
+  }
   return result;
 }
 
@@ -225,6 +234,11 @@ export function hasValidUsage(usage) {
     if (typeof usage[field] === "number" && usage[field] > 0) {
       return true;
     }
+  }
+
+  const kiroCredits = Number(usage.kiro_credits);
+  if (Number.isFinite(kiroCredits) && kiroCredits >= 0) {
+    return true;
   }
 
   return false;
@@ -272,15 +286,20 @@ export function extractUsage(chunk) {
     });
   }
 
-  // OpenAI format (also covers DeepSeek which uses prompt_cache_hit_tokens)
-  if (chunk.usage && typeof chunk.usage === "object" && chunk.usage.prompt_tokens !== undefined) {
+  // OpenAI format (also covers DeepSeek which uses prompt_cache_hit_tokens).
+  // Kiro can attach credit-only metering without token counts.
+  if (chunk.usage && typeof chunk.usage === "object" &&
+      (chunk.usage.prompt_tokens !== undefined || chunk.usage.kiro_credits !== undefined)) {
+    const hasPromptTokens = chunk.usage.prompt_tokens !== undefined;
     return normalizeUsage({
       prompt_tokens: chunk.usage.prompt_tokens,
-      completion_tokens: chunk.usage.completion_tokens || 0,
+      completion_tokens: hasPromptTokens ? (chunk.usage.completion_tokens || 0) : chunk.usage.completion_tokens,
       cached_tokens: chunk.usage.prompt_tokens_details?.cached_tokens || chunk.usage.prompt_cache_hit_tokens,
       reasoning_tokens: chunk.usage.completion_tokens_details?.reasoning_tokens,
       prompt_tokens_details: chunk.usage.prompt_tokens_details,
-      completion_tokens_details: chunk.usage.completion_tokens_details
+      completion_tokens_details: chunk.usage.completion_tokens_details,
+      kiro_credits: chunk.usage.kiro_credits,
+      kiro_credit_unit: chunk.usage.kiro_credit_unit
     });
   }
 

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -236,11 +236,6 @@ export function hasValidUsage(usage) {
     }
   }
 
-  const kiroCredits = Number(usage.kiro_credits);
-  if (Number.isFinite(kiroCredits) && kiroCredits >= 0) {
-    return true;
-  }
-
   return false;
 }
 

--- a/tests/unit/cached-token-usage.test.js
+++ b/tests/unit/cached-token-usage.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { canonicalizeUsage, extractUsage, mergeUsage } from "../../open-sse/utils/usageTracking.js";
+import { canonicalizeUsage, extractUsage, hasValidUsage, mergeUsage } from "../../open-sse/utils/usageTracking.js";
 import { calculateCostFromTokens } from "../../open-sse/providers/pricing.js";
 import { toOpenAIUsage } from "../../open-sse/translator/concerns/usage.js";
 
@@ -88,6 +88,17 @@ describe("canonicalizeUsage", () => {
     expect(out.cached_tokens).toBe(0);
     expect(out.cache_creation_input_tokens).toBe(500);
   });
+
+  it("preserves Kiro credit metering alongside token counts", () => {
+    const out = canonicalizeUsage({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      kiro_credits: 0.0123,
+      kiro_credit_unit: "credit",
+    });
+    expect(out.kiro_credits).toBe(0.0123);
+    expect(out.kiro_credit_unit).toBe("credit");
+  });
 });
 
 describe("calculateCostFromTokens (canonical inclusive convention)", () => {
@@ -117,6 +128,40 @@ describe("calculateCostFromTokens (canonical inclusive convention)", () => {
   it("matches plain input pricing when no cache present", () => {
     const cost = calculateCostFromTokens({ prompt_tokens: 100, completion_tokens: 50 }, pricing);
     expect(cost).toBeCloseTo((100 * 3 + 50 * 15) / 1_000_000, 12);
+  });
+
+  it("uses Kiro credits as actual billable cost when present", () => {
+    const cost = calculateCostFromTokens(
+      { prompt_tokens: 1_000_000, completion_tokens: 50_000, kiro_credits: 0.42 },
+      pricing
+    );
+    expect(cost).toBe(0.42);
+  });
+});
+
+describe("Kiro credit metering", () => {
+  it("extracts credit-only Kiro usage for internal persistence", () => {
+    const usage = extractUsage({
+      usage: {
+        kiro_credits: 0.003,
+        kiro_credit_unit: "credit",
+      },
+    });
+
+    expect(usage.kiro_credits).toBe(0.003);
+    expect(usage.kiro_credit_unit).toBe("credit");
+    expect(usage.prompt_tokens).toBeUndefined();
+    expect(hasValidUsage(usage)).toBe(true);
+  });
+
+  it("keeps prompt-only OpenAI usage complete while credit-only Kiro usage stays tokenless", () => {
+    const promptOnly = extractUsage({ usage: { prompt_tokens: 123 } });
+    expect(promptOnly.prompt_tokens).toBe(123);
+    expect(promptOnly.completion_tokens).toBe(0);
+
+    const creditOnly = extractUsage({ usage: { kiro_credits: 0.001, kiro_credit_unit: "credit" } });
+    expect(creditOnly.kiro_credits).toBe(0.001);
+    expect(creditOnly.completion_tokens).toBeUndefined();
   });
 });
 

--- a/tests/unit/cached-token-usage.test.js
+++ b/tests/unit/cached-token-usage.test.js
@@ -130,12 +130,12 @@ describe("calculateCostFromTokens (canonical inclusive convention)", () => {
     expect(cost).toBeCloseTo((100 * 3 + 50 * 15) / 1_000_000, 12);
   });
 
-  it("uses Kiro credits as actual billable cost when present", () => {
+  it("keeps Kiro credits separate from USD token cost", () => {
     const cost = calculateCostFromTokens(
       { prompt_tokens: 1_000_000, completion_tokens: 50_000, kiro_credits: 0.42 },
       pricing
     );
-    expect(cost).toBe(0.42);
+    expect(cost).toBeCloseTo((1_000_000 * 3 + 50_000 * 15) / 1_000_000, 12);
   });
 });
 
@@ -151,7 +151,7 @@ describe("Kiro credit metering", () => {
     expect(usage.kiro_credits).toBe(0.003);
     expect(usage.kiro_credit_unit).toBe("credit");
     expect(usage.prompt_tokens).toBeUndefined();
-    expect(hasValidUsage(usage)).toBe(true);
+    expect(hasValidUsage(usage)).toBe(false);
   });
 
   it("keeps prompt-only OpenAI usage complete while credit-only Kiro usage stays tokenless", () => {

--- a/tests/unit/kiro-thinking-strip.test.js
+++ b/tests/unit/kiro-thinking-strip.test.js
@@ -47,6 +47,13 @@ async function readAllSSE(stream) {
   return result;
 }
 
+async function readNextWithTimeout(reader) {
+  return Promise.race([
+    reader.read(),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("timed out waiting for SSE chunk")), 100)),
+  ]);
+}
+
 describe("KiroExecutor thinking tag stripping", () => {
   it("strips <thinking> tags from assistantResponseEvent", async () => {
     const executor = new KiroExecutor();
@@ -120,5 +127,108 @@ describe("KiroExecutor thinking tag stripping", () => {
     // We shouldn't get an empty content chunk from f1 since it was entirely stripped and reasoning was present
     const contentChunks = objects.filter(obj => obj.choices[0].delta.content !== undefined);
     expect(contentChunks.length).toBe(0);
+  });
+
+  it("preserves Kiro meteringEvent usage on the final token-usage chunk", async () => {
+    const executor = new KiroExecutor();
+
+    const f1 = createMockFrame("assistantResponseEvent", { content: "OK" });
+    const f2 = createMockFrame("meteringEvent", { usage: 0.0097, unit: "credit", unitPlural: "credits" });
+    const f3 = createMockFrame("contextUsageEvent", { contextUsagePercentage: 1 });
+
+    const readableStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(f1);
+        controller.enqueue(f2);
+        controller.enqueue(f3);
+        controller.close();
+      }
+    });
+
+    const output = await readAllSSE(executor.transformEventStreamToSSE({ body: readableStream }, "claude-test").body);
+    const objects = output
+      .split("\n")
+      .filter(line => line.startsWith("data: ") && !line.includes("[DONE]"))
+      .map(line => JSON.parse(line.slice(6)));
+
+    const usageChunk = objects.find(obj => obj.usage?.kiro_credits !== undefined);
+    expect(usageChunk.usage.kiro_credits).toBe(0.0097);
+    expect(usageChunk.usage.kiro_credit_unit).toBe("credit");
+    expect(usageChunk.usage.prompt_tokens).toBeGreaterThan(0);
+  });
+
+  it("emits Kiro metering usage even when messageStop arrives first", async () => {
+    const executor = new KiroExecutor();
+
+    const f1 = createMockFrame("assistantResponseEvent", { content: "OK" });
+    const f2 = createMockFrame("messageStopEvent", {});
+    const f3 = createMockFrame("meteringEvent", { usage: 0.0061, unit: "credit", unitPlural: "credits" });
+
+    const readableStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(f1);
+        controller.enqueue(f2);
+        controller.enqueue(f3);
+        controller.close();
+      }
+    });
+
+    const output = await readAllSSE(executor.transformEventStreamToSSE({ body: readableStream }, "claude-test").body);
+    const objects = output
+      .split("\n")
+      .filter(line => line.startsWith("data: ") && !line.includes("[DONE]"))
+      .map(line => JSON.parse(line.slice(6)));
+
+    const usageChunk = objects.find(obj => obj.usage?.kiro_credits !== undefined);
+    expect(usageChunk.usage.kiro_credits).toBe(0.0061);
+  });
+
+  it("emits a terminal chunk at messageStop before the upstream stream closes", async () => {
+    const executor = new KiroExecutor();
+
+    const f1 = createMockFrame("assistantResponseEvent", { content: "OK" });
+    const f2 = createMockFrame("messageStopEvent", {});
+
+    const readableStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(f1);
+        controller.enqueue(f2);
+      }
+    });
+
+    const transformedResponse = executor.transformEventStreamToSSE({ body: readableStream }, "claude-test");
+    const reader = transformedResponse.body.getReader();
+    const decoder = new TextDecoder();
+    let output = "";
+    for (let i = 0; i < 4 && !output.includes("\"finish_reason\":\"stop\""); i++) {
+      const { value } = await readNextWithTimeout(reader);
+      output += decoder.decode(value, { stream: true });
+    }
+    await reader.cancel();
+
+    expect(output).toContain("\"finish_reason\":\"stop\"");
+  });
+
+  it("uses tool_calls finish reason for tool streams without messageStop", async () => {
+    const executor = new KiroExecutor();
+
+    const f1 = createMockFrame("toolUseEvent", { toolUseId: "tool-1", name: "read_file", input: { path: "a.txt" } });
+
+    const readableStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(f1);
+        controller.close();
+      }
+    });
+
+    const transformedResponse = executor.transformEventStreamToSSE({ body: readableStream }, "claude-test");
+    const output = await readAllSSE(transformedResponse.body);
+    const objects = output
+      .split("\n")
+      .filter(line => line.startsWith("data: ") && !line.includes("[DONE]"))
+      .map(line => JSON.parse(line.slice(6)));
+
+    const finalChunk = objects.at(-1);
+    expect(finalChunk.choices[0].finish_reason).toBe("tool_calls");
   });
 });

--- a/tests/unit/sse-to-json-usage.test.js
+++ b/tests/unit/sse-to-json-usage.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseSSEToOpenAIResponse } from "../../open-sse/handlers/chatCore/sseToJsonHandler.js";
+
+describe("parseSSEToOpenAIResponse usage", () => {
+  it("keeps Kiro credit-only usage internal while hiding private fields from clients", () => {
+    const raw = [
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"OK"},"finish_reason":null}]}',
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"kiro_credits":0.0123,"kiro_credit_unit":"credit"}}',
+      'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+      "data: [DONE]",
+    ].join("\n\n");
+
+    const parsed = parseSSEToOpenAIResponse(raw, "m");
+
+    expect(parsed.choices[0].message.content).toBe("OK");
+    expect(parsed.usage).toEqual({});
+    expect(parsed._internalUsage).toEqual({
+      kiro_credits: 0.0123,
+      kiro_credit_unit: "credit",
+    });
+    expect(JSON.stringify(parsed)).not.toContain("kiro_credits");
+  });
+});


### PR DESCRIPTION
## Summary
- preserve `kiro_credits` through usage normalization/canonicalization
- preserve Kiro credit-only SSE usage internally while hiding private credit fields from client responses
- keep `usageHistory.cost` on the existing USD/token-pricing basis instead of treating Kiro credits as USD
- when Kiro only returns credits, keep token estimation active so USD/token-cost reporting does not become zero

## Notes
This only changes the usage persistence path. It does not change Kiro continuation/session behavior.

Kiro credits are stored for future analysis, but they are not converted into USD here because the credit-to-USD exchange rate is not guaranteed to be 1:1.

## Tests
- `npx vitest run --config tests/vitest.config.js tests/unit/cached-token-usage.test.js tests/unit/sse-to-json-usage.test.js tests/translator/claude-kiro-direct.test.js`
- local combined deploy tests: `session-manager`, `claude-kiro-direct`, `cached-token-usage`, `sse-to-json-usage` passed, 54 tests total
- local combined deploy smoke: Kiro JSON + stream requests persisted `kiro_credits`, while `usageHistory.cost` stayed on token-pricing USD and did not equal credits
