### PR TITLE
fix(translator): stop leaking literal <think>/</think> markers into OpenAI content

### DIFF
--- a/open-sse/translator/response/claude-to-openai.js
+++ b/open-sse/translator/response/claude-to-openai.js
@@ -60,9 +60,14 @@ export function claudeToOpenAIResponse(chunk, state) {
       if (block?.type === CLAUDE_BLOCK.TEXT) {
         state.textBlockStarted = true;
       } else if (block?.type === CLAUDE_BLOCK.THINKING) {
+        // Track the thinking block internally only. Thinking text flows through
+        // reasoning_content (see thinking_delta below) — never inject literal
+        // <think>/</think> markers into content: they leak as visible text to
+        // any external OpenAI consumer (Claude Code / Zed via a downstream
+        // proxy render them verbatim) and displace the thinking block from
+        // first position when a downstream proxy rebuilds a Claude message.
         state.inThinkingBlock = true;
         state.currentBlockIndex = chunk.index;
-        results.push(createChunk(state, { content: "<think>" }));
       } else if (block?.type === CLAUDE_BLOCK.TOOL_USE) {
         const toolCallIndex = state.toolCallIndex++;
         // Restore original tool name from mapping (Claude OAuth)
@@ -113,7 +118,10 @@ export function claudeToOpenAIResponse(chunk, state) {
         break;
       }
       if (state.inThinkingBlock && chunk.index === state.currentBlockIndex) {
-        results.push(createChunk(state, { content: "</think>" }));
+        // End of thinking is signaled by state, not by a literal </think> text
+        // chunk (see content_block_start above). Consumers that need an explicit
+        // "reasoning ended" event (#454) detect the reasoning_content → content
+        // transition instead (see openai-responses.js).
         state.inThinkingBlock = false;
       }
       state.textBlockStarted = false;

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -73,6 +73,15 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
   if (delta.content) {
     let content = delta.content;
 
+    // Reasoning arrived via reasoning_content (not inline <think> tags) and now
+    // normal text begins → the reasoning section is over. Close it here on the
+    // state transition, so consumers get an explicit "reasoning ended" event
+    // before the first output_text.delta (#454) without translators having to
+    // inject literal tag markers into content.
+    if (state.reasoningId && !state.reasoningDone && !state.inThinking) {
+      closeReasoning(state, emit);
+    }
+
     if (content.includes("<think>")) {
       state.inThinking = true;
       content = content.replace("<think>", "");

--- a/tests/translator/__snapshots__/golden-response-stream.test.js.snap
+++ b/tests/translator/__snapshots__/golden-response-stream.test.js.snap
@@ -21,37 +21,7 @@ exports[`GOLDEN response stream: Claude → OpenAI > text + thinking + tool_use 
     "choices": [
       {
         "delta": {
-          "content": "<think>",
-        },
-        "finish_reason": null,
-        "index": 0,
-      },
-    ],
-    "created": 0,
-    "id": "chatcmpl-msg_1",
-    "model": "claude-opus-4-6",
-    "object": "chat.completion.chunk",
-  },
-  {
-    "choices": [
-      {
-        "delta": {
           "reasoning_content": "let me think",
-        },
-        "finish_reason": null,
-        "index": 0,
-      },
-    ],
-    "created": 0,
-    "id": "chatcmpl-msg_1",
-    "model": "claude-opus-4-6",
-    "object": "chat.completion.chunk",
-  },
-  {
-    "choices": [
-      {
-        "delta": {
-          "content": "</think>",
         },
         "finish_reason": null,
         "index": 0,

--- a/tests/translator/bugs-claude-thinking-tags.test.js
+++ b/tests/translator/bugs-claude-thinking-tags.test.js
@@ -1,0 +1,133 @@
+// Regression: Claude thinking must NOT leak literal <think>/</think> markers
+// into OpenAI delta.content.
+//
+// History (the tug-of-war this test ends):
+//   85b7a0b  moved thinking text to reasoning_content ("mixed with actual
+//            response" fix) but left the literal "<think>" start marker behind.
+//   #454     re-added a literal "</think>" close marker because the Responses
+//            pipeline needed an explicit "reasoning ended" signal.
+// The markers are a private convention — only openai-responses.js understood
+// them. Any EXTERNAL OpenAI consumer (Claude Code / Zed behind a downstream
+// proxy, plain OpenAI SDK) renders them as visible text, and a downstream
+// proxy rebuilding a Claude message puts a text block before the thinking
+// block, which makes clients silently drop the thinking content entirely.
+//
+// The fix: claude-to-openai.js emits NO content for thinking block boundaries
+// (text flows via reasoning_content), and openai-responses.js closes the
+// reasoning section on the reasoning_content → content state transition —
+// satisfying #454 without literal markers on the wire.
+import { describe, it, expect } from "vitest";
+import "./registerAll.js";
+import { translateResponse, initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+function runStream(targetFormat, sourceFormat, events) {
+  const state = initState(sourceFormat);
+  const all = [];
+  for (const ev of events) {
+    const out = translateResponse(targetFormat, sourceFormat, ev, state);
+    if (Array.isArray(out)) all.push(...out);
+    else if (out) all.push(out);
+  }
+  return all;
+}
+
+const claudeThinkingThenText = [
+  { type: "message_start", message: { id: "msg_1", model: "claude-sonnet-5" } },
+  { type: "content_block_start", index: 0, content_block: { type: "thinking" } },
+  { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "let me think" } },
+  { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: " harder" } },
+  { type: "content_block_stop", index: 0 },
+  { type: "content_block_start", index: 1, content_block: { type: "text" } },
+  { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Hello" } },
+  { type: "content_block_stop", index: 1 },
+  { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 10, output_tokens: 5 } },
+  { type: "message_stop" },
+];
+
+describe("Claude → OpenAI: thinking block boundaries", () => {
+  it("never emits literal <think>/</think> in delta.content", () => {
+    const chunks = runStream(FORMATS.CLAUDE, FORMATS.OPENAI, claudeThinkingThenText);
+    for (const chunk of chunks) {
+      const content = chunk?.choices?.[0]?.delta?.content;
+      if (typeof content === "string") {
+        expect(content).not.toContain("<think>");
+        expect(content).not.toContain("</think>");
+      }
+    }
+  });
+
+  it("delivers thinking text via reasoning_content and answer via content", () => {
+    const chunks = runStream(FORMATS.CLAUDE, FORMATS.OPENAI, claudeThinkingThenText);
+    const reasoning = chunks.map(c => c?.choices?.[0]?.delta?.reasoning_content || "").join("");
+    const content = chunks.map(c => c?.choices?.[0]?.delta?.content || "").join("");
+    expect(reasoning).toBe("let me think harder");
+    expect(content).toBe("Hello");
+  });
+});
+
+describe("OpenAI → Responses: reasoning closes on reasoning→content transition (#454)", () => {
+  const openaiChunk = (delta, finish = null) => ({
+    id: "chatcmpl-x",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "claude-sonnet-5",
+    choices: [{ index: 0, delta, finish_reason: finish }],
+  });
+
+  it("emits reasoning done events before the first output_text.delta", () => {
+    const events = runStream(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, [
+      openaiChunk({ role: "assistant" }),
+      openaiChunk({ reasoning_content: "let me think" }),
+      openaiChunk({ content: "Hello" }),
+      openaiChunk({}, "stop"),
+    ]);
+    const types = events.map(e => e?.data?.type || e?.event);
+    const reasoningDoneIdx = types.indexOf("response.reasoning_summary_text.done");
+    const firstTextIdx = types.indexOf("response.output_text.delta");
+    expect(reasoningDoneIdx).toBeGreaterThan(-1);
+    expect(firstTextIdx).toBeGreaterThan(-1);
+    expect(reasoningDoneIdx).toBeLessThan(firstTextIdx);
+  });
+
+  it("keeps inline <think> tag parsing working for providers that emit tags in content", () => {
+    const events = runStream(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, [
+      openaiChunk({ role: "assistant" }),
+      openaiChunk({ content: "<think>raw reasoning" }),
+      openaiChunk({ content: "</think>Answer" }),
+      openaiChunk({}, "stop"),
+    ]);
+    const reasoning = events
+      .filter(e => e?.data?.type === "response.reasoning_summary_text.delta")
+      .map(e => e.data.delta).join("");
+    const text = events
+      .filter(e => e?.data?.type === "response.output_text.delta")
+      .map(e => e.data.delta).join("");
+    expect(reasoning).toBe("raw reasoning");
+    expect(text).toBe("Answer");
+  });
+});
+
+describe("Claude → Responses full pivot (the #454 end-to-end scenario)", () => {
+  it("reasoning section closes before text, no literal tags anywhere", () => {
+    const events = runStream(FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES, claudeThinkingThenText);
+    const types = events.map(e => e?.data?.type || e?.event);
+
+    const reasoningDoneIdx = types.indexOf("response.reasoning_summary_text.done");
+    const firstTextIdx = types.indexOf("response.output_text.delta");
+    expect(reasoningDoneIdx).toBeGreaterThan(-1);
+    expect(firstTextIdx).toBeGreaterThan(-1);
+    expect(reasoningDoneIdx).toBeLessThan(firstTextIdx);
+
+    const reasoning = events
+      .filter(e => e?.data?.type === "response.reasoning_summary_text.delta")
+      .map(e => e.data.delta).join("");
+    const text = events
+      .filter(e => e?.data?.type === "response.output_text.delta")
+      .map(e => e.data.delta).join("");
+    expect(reasoning).toBe("let me think harder");
+    expect(text).toBe("Hello");
+    expect(text).not.toContain("<think>");
+    expect(text).not.toContain("</think>");
+  });
+});


### PR DESCRIPTION
## Problem

`claude-to-openai.js` marks thinking block boundaries by emitting literal `"<think>"` / `"</think>"` text chunks in `delta.content`, while the thinking text itself already flows through `reasoning_content`. These markers are a private convention that only `openai-responses.js` understands — **any external OpenAI consumer renders them as visible text**.

It gets worse behind a downstream proxy. When a proxy (e.g. CLIProxyAPI) rebuilds an Anthropic message from this stream, the `"<think>"` text chunk becomes a `text` content block placed **before** the real `thinking` block:

```
content: [
  { type: "text", text: "<think>" },        ← displaces thinking from first position
  { type: "thinking", thinking: "..." },    ← silently dropped by Anthropic clients
  { type: "text", text: "</think>answer" }
]
```

Anthropic clients (Claude Code, Zed) expect the thinking block first; with this shape they silently drop the thinking content, and users see a bare, empty `<think></think>` pair glued to the answer. Verified end-to-end with `gh/claude-sonnet-5` via Copilot's `/v1/messages`.

**Affected: every Claude-protocol provider** routed through this translator — anthropic, claude, github/copilot, deepseek, kimi, kimi-coding, minimax, minimax-cn, glm, xiaomi-tokenplan, xiaomi-mimo.

## Why the markers existed — and why this PR doesn't just delete them

This code has been back and forth before:

- `85b7a0b` moved thinking text to `reasoning_content` ("thinking was sent as content, mixed with actual response") but left the `"<think>"` start marker behind.
- #454 deliberately re-added a literal `"</think>"` because the Responses pipeline needed an explicit *"reasoning ended"* signal — an empty-string `reasoning_content` delta gets dropped by truthiness checks.

That need is legitimate, so this PR **re-implements it instead of reverting it**: `openai-responses.js` now closes the reasoning section on the `reasoning_content` → `content` state transition. The reasoning done events still fire before the first `output_text.delta`, exactly as #454 intended — just without leaking markers onto the wire. Inline `<think>` tag parsing is kept untouched for providers that genuinely emit tags inside `content`.

## Changes

- `claude-to-openai.js`: thinking `content_block_start`/`content_block_stop` only track internal state (same as text blocks); no content chunks emitted.
- `openai-responses.js`: close reasoning when normal content begins (state-based #454 semantics).
- `tests/translator/bugs-claude-thinking-tags.test.js` (new): locks ① no literal tags in `delta.content`, ② reasoning-done ordering before first text delta on both the direct and the full claude→responses pivot path, ③ the tag-parsing fallback still works. These tests are the guardrail that ends the tug-of-war.
- Golden snapshot refreshed: the **entire diff** is the two literal-tag chunks disappearing — no other output changes.

## Verification

- New suite: 5/5 pass; `golden-response-stream` 7/7; `golden-translator-concerns` 6/6; `unit/github-responses-routing` 5/5.
- Full `vitest run` compared against a clean checkout of the same base: identical failure set (documented known-fails + network/live tests only) — zero regressions.
- `eslint` clean on all touched files.

本 PR 由 Claude Code 辅助完成