### PR TITLE
fix(translator): flatten multi-block text content parts, preserve multimodal

### DIFF
--- a/open-sse/translator/concerns/message.js
+++ b/open-sse/translator/concerns/message.js
@@ -1,7 +1,17 @@
 import { OPENAI_BLOCK } from "../schema/index.js";
 
-// Collapse an OpenAI content-part array: a lone text part becomes a plain string,
-// otherwise the array is returned as-is. Matches existing translator behavior.
+// Collapse an OpenAI content-part array. A text-only array (one OR more text
+// blocks) is joined into a single plain string; any array containing non-text
+// blocks (image_url, tool_result, …) is returned as-is so multimodal content
+// keeps its structure. This fixes providers that reject repeated
+// [{type:text},{type:text}] arrays and avoids losing content when a single
+// Claude message carries several consecutive text blocks.
 export function collapseTextParts(parts) {
-  return parts.length === 1 && parts[0].type === OPENAI_BLOCK.TEXT ? parts[0].text : parts;
+  if (parts.length === 1 && parts[0].type === OPENAI_BLOCK.TEXT) {
+    return parts[0].text;
+  }
+  if (parts.every((p) => p.type === OPENAI_BLOCK.TEXT)) {
+    return parts.map((p) => p.text).join("\n");
+  }
+  return parts;
 }


### PR DESCRIPTION
## Summary
`collapseTextParts` (shared by the claude / antigravity / gemini translators) only collapsed a **single** text block into a string. Multiple consecutive text blocks were passed through as a `[{type:text},{type:text}]` array, which many OpenAI-compatible backends reject or truncate — silently dropping content.

This change joins any **text-only** content-part array (one *or more* blocks) into a single string, while leaving arrays that contain non-text blocks (`image_url`, `tool_result`, …) untouched so multimodal content keeps its structure.

## Behavior
| input | before | after |
|---|---|---|
| `[{text:"hi"}]` | `"hi"` | `"hi"` |
| `[{text:"a"},{text:"b"}]` | `[{text:"a"},{text:"b"}]` | `"a\nb"` |
| `[{text:"a"},{image_url}]` | preserved | preserved (multimodal) |
| `[]` | `undefined`* | `""` |

\* callers guard with `parts.length > 0` before calling, so no regression.

## Scope
Single-file change in `open-sse/translator/concerns/message.js`. All four callers automatically benefit — no per-translator edits needed.

## Verification
- `collapseTextParts` unit-exercised for all four cases above.
- `node --check` passes on `message.js` and the three translator call sites.