### PR TITLE
fix(thinking): send explicit thinking:{type:adaptive} alongside output_config.effort

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -229,6 +229,12 @@ function applyFormat(fmt, body, cfg, caps) {
     }
     case "claude-adaptive": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
+      // output_config.effort alone does NOT turn thinking on: Anthropic requires
+      // an explicit thinking:{type:"adaptive"} on Opus 4.6/4.7/4.8 and Sonnet 4.6
+      // ("thinking is off unless you explicitly set it"), and Anthropic-compatible
+      // shims (e.g. GitHub Copilot /v1/messages) default thinking off even for
+      // Sonnet 5. Send both fields — the documented adaptive-thinking shape.
+      body.thinking = { type: "adaptive" };
       const level = toLevel(eff);
       body.output_config = { effort: level === "xhigh" ? "high" : level };
       break;

--- a/tests/translator/__snapshots__/golden-request.test.js.snap
+++ b/tests/translator/__snapshots__/golden-request.test.js.snap
@@ -118,6 +118,9 @@ exports[`GOLDEN request: OpenAI → Claude > reasoning_effort → adaptive outpu
       "type": "text",
     },
   ],
+  "thinking": {
+    "type": "adaptive",
+  },
 }
 `;
 

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -55,10 +55,14 @@ describe("extractThinking", () => {
 });
 
 describe("applyThinking per provider format", () => {
-  it("claude 4.6+ → adaptive output_config (no budget_tokens)", () => {
+  it("claude 4.6+ → adaptive thinking + output_config (no budget_tokens)", () => {
     const out = apply("claude", "claude-opus-4.7", { reasoning_effort: "high" }, "claude");
     expect(out.output_config).toEqual({ effort: "high" });
-    expect(out.thinking).toBeUndefined();
+    // Anthropic: on Opus 4.6/4.7/4.8 and Sonnet 4.6 thinking stays OFF unless
+    // thinking:{type:"adaptive"} is sent explicitly; output_config alone is not
+    // enough (and Anthropic-compatible shims like Copilot default off even on
+    // Sonnet 5). Both fields together are the documented adaptive shape.
+    expect(out.thinking).toEqual({ type: "adaptive" });
   });
   it("claude haiku → enabled+budget", () => {
     const out = apply("claude", "claude-haiku-4.5", { reasoning_effort: "high" }, "claude");


### PR DESCRIPTION
## Problem

The `claude-adaptive` thinking format (`thinkingUnified.js → applyFormat`) sets only `output_config: { effort }` and never a `thinking` field. Per [Anthropic's adaptive-thinking docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking), that leaves thinking **completely off** on most adaptive models:

> - Claude Opus 4.8 / 4.7: "Thinking is off unless you explicitly set `thinking: {type: \"adaptive\"}` in your request"
> - Claude Opus 4.6 / Sonnet 4.6: "adaptive thinking is off unless you explicitly set `thinking: {type: \"adaptive\"}`"
> - Claude Sonnet 5: on by default on the first-party API — but Anthropic-compatible shims (e.g. GitHub Copilot `/v1/messages`) default thinking off there too.

Net effect: every adaptive-thinking Claude model routed through the `claude-adaptive` path silently runs with thinking disabled, while the request logs happily show `THINK:high`.

## Live verification (GitHub Copilot /v1/messages, raw non-streaming responses)

| request shape | result |
|---|---|
| `claude-sonnet-5`, `output_config` only (current behavior) | no thinking at all — `text` block only, 168 output tokens |
| `claude-sonnet-5`, `thinking:{type:"adaptive"}` + `output_config` | thinking block present (signed), 1190 output tokens |
| `claude-sonnet-5`, `thinking:{type:"enabled"}` | 400: `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort"` |
| `claude-sonnet-4.6`, `thinking:{type:"adaptive"}` + `output_config` | 2.5k chars of thinking text streamed back |

Same account, same endpoint, same prompt — the only variable is whether the request actually turns thinking on. Also confirmed end-to-end through the router: `claude-sonnet-4.6` went from zero thinking output to full thinking text with this one change.

## Change

`claude-adaptive` now sends both fields together — the documented adaptive shape:

```json
{ "thinking": { "type": "adaptive" }, "output_config": { "effort": "high" } }
```

- `thinking-unified.test.js` had a test asserting `thinking` must stay `undefined` for opus-4.7 — precisely the model the docs call out as needing the explicit field. Updated, with the doc reference inline.
- `golden-request.test.js.snap`: the claude entry gains the `thinking: {type:"adaptive"}` field (+3 lines; no other snapshot touched).
- Full suite vs clean base: zero new failures.

本 PR 由 Claude Code 辅助完成