### PR TITLE
perf(startup): skip inactive background services

### DIFF
--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { getSettings, updateSettings } from "@/lib/localDb";
 import { applyOutboundProxyEnv } from "@/lib/network/outboundProxy";
 import { resetComboRotation } from "open-sse/services/combo.js";
-import { runQuotaAutoPingTick } from "@/shared/services/quotaAutoPing";
 import bcrypt from "bcryptjs";
 
 export const dynamic = "force-dynamic";
@@ -101,10 +100,12 @@ export async function PATCH(request) {
       Object.prototype.hasOwnProperty.call(body, "claudeAutoPing") ||
       Object.prototype.hasOwnProperty.call(body, "codexAutoPing")
     ) {
-      // Run once immediately after opt-in changes so users don't wait for the next scheduler tick.
-      runQuotaAutoPingTick().catch((error) => {
-        console.warn("[AutoPing] settings-triggered tick failed:", error.message);
-      });
+      // Keep the scheduler absent when no account opted in; load its provider graph only on demand.
+      import("@/shared/services/quotaAutoPing")
+        .then(({ configureQuotaAutoPing }) => {
+          configureQuotaAutoPing(settings);
+        })
+        .catch((error) => console.warn("[AutoPing] settings update failed:", error.message));
     }
 
     const { password, oidcClientSecret, ...safeSettings } = settings;

--- a/src/app/api/tunnel/disable/route.js
+++ b/src/app/api/tunnel/disable/route.js
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
 import { disableTunnel } from "@/lib/tunnel";
+import { getSettings } from "@/lib/localDb";
+import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
 
 export async function POST() {
   try {
     const result = await disableTunnel();
+    getSettings()
+      .then(configureTunnelMonitoring)
+      .catch((error) => console.warn("Tunnel monitor update failed:", error.message));
     return NextResponse.json(result);
   } catch (error) {
     console.error("Tunnel disable error:", error);

--- a/src/app/api/tunnel/enable/route.js
+++ b/src/app/api/tunnel/enable/route.js
@@ -1,11 +1,16 @@
 import { NextResponse } from "next/server";
 import { enableTunnel } from "@/lib/tunnel";
+import { getSettings } from "@/lib/localDb";
+import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
 
 const DNS_WARMUP_DELAY_MS = 8000;
 
 export async function POST() {
   try {
     const result = await enableTunnel();
+    getSettings()
+      .then(configureTunnelMonitoring)
+      .catch((error) => console.warn("Tunnel monitor start failed:", error.message));
     // Wait for DNS warmup to propagate at Cloudflare edge after tunnel registered
     await new Promise((r) => setTimeout(r, DNS_WARMUP_DELAY_MS));
     return NextResponse.json(result);

--- a/src/app/api/tunnel/tailscale-disable/route.js
+++ b/src/app/api/tunnel/tailscale-disable/route.js
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
 import { disableTailscale } from "@/lib/tunnel";
+import { getSettings } from "@/lib/localDb";
+import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
 
 export async function POST() {
   try {
     const result = await disableTailscale();
+    getSettings()
+      .then(configureTunnelMonitoring)
+      .catch((error) => console.warn("Tailscale monitor update failed:", error.message));
     return NextResponse.json(result);
   } catch (error) {
     console.error("Tailscale disable error:", error);

--- a/src/app/api/tunnel/tailscale-enable/route.js
+++ b/src/app/api/tunnel/tailscale-enable/route.js
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
 import { enableTailscale } from "@/lib/tunnel";
+import { getSettings } from "@/lib/localDb";
+import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
 
 export async function POST() {
   try {
     const result = await enableTailscale();
+    getSettings()
+      .then(configureTunnelMonitoring)
+      .catch((error) => console.warn("Tailscale monitor start failed:", error.message));
     return NextResponse.json(result);
   } catch (error) {
     console.error("Tailscale enable error:", error.message);

--- a/src/shared/services/initializeApp.js
+++ b/src/shared/services/initializeApp.js
@@ -14,7 +14,6 @@ import {
   WATCHDOG_INTERVAL_MS, NETWORK_CHECK_INTERVAL_MS, VIRTUAL_IFACE_REGEX,
 } from "@/lib/tunnel";
 import { getMitmStatus, startMitm, loadEncryptedPassword, initDbHooks, restoreToolDNS, removeAllDNSEntriesSync } from "@/mitm/manager";
-import { startQuotaAutoPing } from "@/shared/services/quotaAutoPing";
 import { syncToJson as syncMitmAliasCache } from "@/lib/mitmAliasCache";
 import { killAllBridges } from "@/lib/mcp/stdioSseBridge";
 
@@ -98,22 +97,32 @@ async function runHeavyStartup() {
     safeRestartTailscale("startup").catch((e) => console.log("[InitApp] Tailscale resume failed:", e.message));
   }
 
-  ensureCloudflared().catch(() => {});
+  if (settings.tunnelEnabled) ensureCloudflared().catch(() => {});
 
-  // Sync mitmAlias DB → JSON cache so standalone MITM server can read it
-  syncMitmAliasCache().catch(() => {});
+  if (settings.mitmEnabled) {
+    // Sync mitmAlias DB → JSON cache so standalone MITM server can read it.
+    syncMitmAliasCache().catch(() => {});
+    autoStartMitm(settings);
+  }
 
-  startWatchdog();
-  startNetworkMonitor();
-  autoStartMitm();
-  startQuotaAutoPing();
+  configureTunnelMonitoring(settings);
+
+  if (hasQuotaAutoPingEnabled(settings)) {
+    import("@/shared/services/quotaAutoPing")
+      .then(({ startQuotaAutoPing }) => startQuotaAutoPing())
+      .catch((e) => console.log("[AutoPing] scheduler start failed:", e.message));
+  }
 }
 
-async function autoStartMitm() {
+function hasQuotaAutoPingEnabled(settings) {
+  return [settings?.claudeAutoPing, settings?.codexAutoPing]
+    .some((config) => Object.values(config?.connections || {}).some(Boolean));
+}
+
+async function autoStartMitm(settings) {
   if (g.mitmStartInProgress) return;
   g.mitmStartInProgress = true;
   try {
-    const settings = await getSettings();
     if (!settings.mitmEnabled) return;
     const mitmStatus = await getMitmStatus();
     if (mitmStatus.running) return;
@@ -232,6 +241,12 @@ function startWatchdog() {
   if (g.watchdogInterval.unref) g.watchdogInterval.unref();
 }
 
+function stopWatchdog() {
+  if (!g.watchdogInterval) return;
+  clearInterval(g.watchdogInterval);
+  g.watchdogInterval = null;
+}
+
 // ─── Network monitor: detect IPv4 fingerprint change + sleep/wake ────────────
 
 function getNetworkFingerprint() {
@@ -291,6 +306,25 @@ function startNetworkMonitor() {
   }, NETWORK_CHECK_INTERVAL_MS);
 
   if (g.networkMonitorInterval.unref) g.networkMonitorInterval.unref();
+}
+
+
+function stopNetworkMonitor() {
+  if (!g.networkMonitorInterval) return;
+  clearInterval(g.networkMonitorInterval);
+  g.networkMonitorInterval = null;
+  g.lastNetworkFingerprint = null;
+  g.lastOnline = null;
+}
+
+export function configureTunnelMonitoring(settings) {
+  if (settings?.tunnelEnabled || settings?.tailscaleEnabled) {
+    startWatchdog();
+    startNetworkMonitor();
+    return;
+  }
+  stopWatchdog();
+  stopNetworkMonitor();
 }
 
 export default initializeApp;

--- a/src/shared/services/quotaAutoPing.js
+++ b/src/shared/services/quotaAutoPing.js
@@ -296,3 +296,18 @@ export function startQuotaAutoPing() {
   g.interval = setInterval(() => { runQuotaAutoPingTick().catch(() => {}); }, C.tickIntervalMs);
   if (g.interval.unref) g.interval.unref();
 }
+
+export function stopQuotaAutoPing() {
+  if (!g.interval) return;
+  clearInterval(g.interval);
+  g.interval = null;
+  console.log("[AutoPing] scheduler stopped");
+}
+
+export function configureQuotaAutoPing(settings) {
+  const enabled = Object.values(C.providers).some((providerConfig) =>
+    Object.values(settings?.[providerConfig.settingsKey]?.connections || {}).some(Boolean)
+  );
+  if (enabled) startQuotaAutoPing();
+  else stopQuotaAutoPing();
+}

--- a/tests/unit/quota-auto-ping.test.js
+++ b/tests/unit/quota-auto-ping.test.js
@@ -72,6 +72,7 @@ vi.mock("open-sse/executors/index.js", () => ({
 
 describe("quota auto-ping", () => {
   let runQuotaAutoPingTick;
+  let configureQuotaAutoPing;
   let deps;
   let state;
   let getCodexUsage;
@@ -83,11 +84,12 @@ describe("quota auto-ping", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.useRealTimers();
+    delete global.__quotaAutoPing;
 
     ({ getCodexUsage } = await import("open-sse/services/usage/codex.js"));
     ({ getClaudeUsage } = await import("open-sse/services/usage/claude.js"));
     ({ getExecutor } = await import("open-sse/executors/index.js"));
-    ({ runQuotaAutoPingTick } = await import("../../src/shared/services/quotaAutoPing.js"));
+    ({ runQuotaAutoPingTick, configureQuotaAutoPing } = await import("../../src/shared/services/quotaAutoPing.js"));
 
     deps = {
       getSettings: vi.fn(),
@@ -115,6 +117,25 @@ describe("quota auto-ping", () => {
 
     expect(deps.getProviderConnections).not.toHaveBeenCalled();
     expect(deps.proxyAwareFetch).not.toHaveBeenCalled();
+  });
+
+  it("starts the scheduler only when an account opts in", () => {
+    vi.useFakeTimers();
+
+    configureQuotaAutoPing({ codexAutoPing: { connections: {} } });
+    expect(vi.getTimerCount()).toBe(0);
+
+    configureQuotaAutoPing({ codexAutoPing: { connections: { "codex-1": true } } });
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it("stops the scheduler when the last account opts out", () => {
+    vi.useFakeTimers();
+    configureQuotaAutoPing({ claudeAutoPing: { connections: { "claude-1": true } } });
+
+    configureQuotaAutoPing({ claudeAutoPing: { connections: { "claude-1": false } } });
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("does not ping Codex on the first resetAt observation", async () => {


### PR DESCRIPTION
## Summary

This PR reduces unnecessary startup and background activity by only initializing optional services when their related features are enabled.

Previously, several background services were started even when unused. This included tunnel network monitoring, periodic watchdog checks, Cloudflared installation checks, MITM cache synchronization, and the quota auto-ping scheduler.

## Changes

- Only check or install `cloudflared` when Cloudflare Tunnel is enabled.
- Only run the tunnel watchdog and network monitor when Cloudflare Tunnel or Tailscale is enabled.
- Stop tunnel monitoring when the last active tunnel service is disabled.
- Start tunnel monitoring immediately when Tunnel or Tailscale is enabled at runtime.
- Only synchronize the MITM alias cache and attempt MITM auto-start when MITM is enabled.
- Lazy-load the quota auto-ping service when at least one account has opted in.
- Stop the quota auto-ping scheduler when the last account opts out.
- Avoid loading the quota provider/executor dependency graph from the settings route unless needed.
- Add tests for quota scheduler startup and shutdown behavior.

## Motivation

When optional services were disabled, the application could still:

- Open a TCP connection to `1.1.1.1:443` every few seconds.
- Run tunnel and Tailscale watchdog checks every minute.
- Check or download the Cloudflared binary.
- Read and write the MITM alias cache.
- Keep the quota auto-ping scheduler active.
- Eagerly load provider and executor modules through the quota scheduler.

These operations added unnecessary network, disk, timer, memory, and event-loop activity. They could also introduce latency jitter while chat streams were active.

## Behavior After This Change

When Tunnel, Tailscale, MITM, and quota auto-ping are disabled:

- No tunnel network reachability probes are scheduled.
- No tunnel watchdog timer is active.
- Cloudflared is not checked or downloaded.
- The MITM alias cache is not synchronized at startup.
- The quota auto-ping scheduler is not loaded or started.

Runtime enable and disable operations continue to work without requiring a server restart.

## Testing

- `npx vitest run unit/quota-auto-ping.test.js`
  - 15 tests passed.
- ESLint passed for all changed files.
- `git diff --check` passed.

A production build was also attempted, but the local Windows environment prevented Next.js/Webpack from scanning legacy user-directory junctions:

```text
EPERM: operation not permitted, scandir 'C:\Users\hungt\Application Data'
This failure occurs outside the repository and is unrelated to the changed source files.