### PR TITLE
feat(providers): export/import API keys as JSON and TXT

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/ExportImportKeysModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ExportImportKeysModal.js
@@ -1,0 +1,309 @@
+"use client";
+
+import { useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { Button, Input, Modal } from "@/shared/components";
+import { translate } from "@/i18n/runtime";
+
+const TXT_PLACEHOLDER = `production|sk-key-1
+staging|sk-key-2
+sk-key-only-auto-named`;
+
+const JSON_PLACEHOLDER = `{
+  "version": 1,
+  "provider": "openrouter",
+  "keys": [
+    { "name": "production", "apiKey": "sk-..." },
+    { "name": "staging", "apiKey": "sk-..." }
+  ]
+}`;
+
+function downloadBlob(content, filename, mime) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export default function ExportImportKeysModal({ isOpen, providerId, providerName, onClose, onImportSuccess }) {
+  const fileInputRef = useRef(null);
+  const [tab, setTab] = useState("export"); // export | import
+  const [format, setFormat] = useState("json"); // json | txt
+  const [password, setPassword] = useState("");
+  const [importText, setImportText] = useState("");
+  const [skipDuplicates, setSkipDuplicates] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [status, setStatus] = useState("");
+  const [importResult, setImportResult] = useState(null);
+
+  const resetMessages = () => {
+    setError("");
+    setStatus("");
+    setImportResult(null);
+  };
+
+  const handleClose = () => {
+    if (busy) return;
+    setPassword("");
+    setImportText("");
+    resetMessages();
+    onClose();
+  };
+
+  const handleExport = async () => {
+    resetMessages();
+    if (!password) {
+      setError(translate("Password is required to export keys"));
+      return;
+    }
+    setBusy(true);
+    try {
+      const params = new URLSearchParams({ provider: providerId, format });
+      const res = await fetch(`/api/providers/keys/export?${params}`, {
+        headers: { "x-9r-password": password },
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Export failed (${res.status})`);
+      }
+      const text = await res.text();
+      const stamp = new Date().toISOString().replace(/[.:]/g, "-");
+      const ext = format === "txt" ? "txt" : "json";
+      const mime = format === "txt" ? "text/plain;charset=utf-8" : "application/json;charset=utf-8";
+      downloadBlob(text, `9router-${providerId}-keys-${stamp}.${ext}`, mime);
+      setStatus(translate("Keys exported successfully"));
+      setPassword("");
+    } catch (err) {
+      setError(err.message || translate("Failed to export keys"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleFilePick = async (event) => {
+    const file = event.target.files?.[0];
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (!file) return;
+    try {
+      const text = await file.text();
+      setImportText(text);
+      // Heuristic format from extension / content
+      if (file.name.endsWith(".txt") || (!text.trim().startsWith("{") && !text.trim().startsWith("["))) {
+        setFormat("txt");
+      } else {
+        setFormat("json");
+      }
+      resetMessages();
+    } catch {
+      setError(translate("Failed to read file"));
+    }
+  };
+
+  const handleImport = async () => {
+    resetMessages();
+    const content = importText.trim();
+    if (!content) {
+      setError(translate("Paste keys or choose a file first"));
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/providers/keys/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: providerId,
+          format,
+          content,
+          skipDuplicates,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || `Import failed (${res.status})`);
+      }
+      setImportResult(data);
+      if (data.success > 0 && typeof onImportSuccess === "function") {
+        onImportSuccess();
+      }
+    } catch (err) {
+      setError(err.message || translate("Failed to import keys"));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const failedItems = importResult?.results?.filter((r) => !r.ok) || [];
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={`${translate("Export / Import Keys")} — ${providerName || providerId}`}
+      onClose={handleClose}
+      size="lg"
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant={tab === "export" ? "primary" : "ghost"}
+            onClick={() => { setTab("export"); resetMessages(); }}
+            disabled={busy}
+          >
+            {translate("Export")}
+          </Button>
+          <Button
+            size="sm"
+            variant={tab === "import" ? "primary" : "ghost"}
+            onClick={() => { setTab("import"); resetMessages(); }}
+            disabled={busy}
+          >
+            {translate("Import")}
+          </Button>
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant={format === "json" ? "secondary" : "ghost"}
+            onClick={() => setFormat("json")}
+            disabled={busy}
+          >
+            JSON
+          </Button>
+          <Button
+            size="sm"
+            variant={format === "txt" ? "secondary" : "ghost"}
+            onClick={() => setFormat("txt")}
+            disabled={busy}
+          >
+            TXT
+          </Button>
+        </div>
+
+        {tab === "export" && (
+          <div className="flex flex-col gap-3">
+            <p className="text-xs text-text-muted">
+              {translate(
+                "Download this provider's API keys (and cookie credentials). Password re-auth is required because the file contains secrets."
+              )}
+            </p>
+            <p className="text-xs text-text-muted font-mono">
+              {format === "json"
+                ? '{ "version": 1, "provider": "…", "keys": [ { "name", "apiKey", … } ] }'
+                : "name|apiKey  (one per line)"}
+            </p>
+            <Input
+              label={translate("Dashboard password")}
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={translate("Enter password to confirm")}
+              autoComplete="current-password"
+            />
+            <div className="flex gap-2">
+              <Button onClick={handleExport} fullWidth disabled={busy || !password}>
+                {busy ? translate("Exporting...") : translate("Download")}
+              </Button>
+              <Button onClick={handleClose} variant="ghost" fullWidth disabled={busy}>
+                {translate("Close")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {tab === "import" && (
+          <div className="flex flex-col gap-3">
+            <p className="text-xs text-text-muted">
+              {format === "json"
+                ? translate("Paste a JSON export (or array of { name, apiKey }) for this provider.")
+                : translate("One key per line: name|apiKey — or just apiKey (auto-named).")}
+            </p>
+            <textarea
+              className="w-full rounded border border-accent/30 bg-sidebar p-2 text-sm font-mono resize-y min-h-[180px] focus:outline-none focus:ring-1 focus:ring-primary"
+              placeholder={format === "json" ? JSON_PLACEHOLDER : TXT_PLACEHOLDER}
+              value={importText}
+              onChange={(e) => setImportText(e.target.value)}
+              disabled={busy}
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                size="sm"
+                variant="secondary"
+                icon="upload_file"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={busy}
+              >
+                {translate("Choose file")}
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={format === "json" ? ".json,application/json,text/plain" : ".txt,text/plain,.json"}
+                className="hidden"
+                onChange={handleFilePick}
+              />
+              <label className="flex cursor-pointer items-center gap-1.5 text-xs text-text-muted">
+                <input
+                  type="checkbox"
+                  checked={skipDuplicates}
+                  onChange={(e) => setSkipDuplicates(e.target.checked)}
+                  disabled={busy}
+                  className="h-3.5 w-3.5 rounded border-gray-300 text-primary focus:ring-primary"
+                />
+                {translate("Skip duplicate keys")}
+              </label>
+            </div>
+            {importResult && (
+              <div className="flex flex-col gap-2">
+                <div
+                  className={`text-sm font-medium ${
+                    importResult.failed > 0 ? "text-yellow-400" : "text-green-400"
+                  }`}
+                >
+                  ✓ {importResult.success} {translate("added")}
+                  {importResult.skipped > 0 ? `, ⊘ ${importResult.skipped} ${translate("skipped")}` : ""}
+                  {importResult.failed > 0 ? `, ✗ ${importResult.failed} ${translate("failed")}` : ""}
+                </div>
+                {failedItems.length > 0 && (
+                  <ul className="rounded border border-accent/20 bg-sidebar/50 p-2 text-xs font-mono max-h-32 overflow-y-auto">
+                    {failedItems.map((item) => (
+                      <li key={item.index} className="text-red-400">
+                        [{item.index}] {item.error}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+            <div className="flex gap-2">
+              <Button onClick={handleImport} fullWidth disabled={busy || !importText.trim()}>
+                {busy ? translate("Importing...") : translate("Import All")}
+              </Button>
+              <Button onClick={handleClose} variant="ghost" fullWidth disabled={busy}>
+                {translate("Close")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {error && <p className="text-xs text-red-500 break-words">{error}</p>}
+        {status && !error && <p className="text-xs text-green-500 break-words">{status}</p>}
+      </div>
+    </Modal>
+  );
+}
+
+ExportImportKeysModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  providerId: PropTypes.string.isRequired,
+  providerName: PropTypes.string,
+  onClose: PropTypes.func.isRequired,
+  onImportSuccess: PropTypes.func,
+};

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -21,6 +21,7 @@ import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
 import BulkImportCodexModal from "./BulkImportCodexModal";
+import ExportImportKeysModal from "./ExportImportKeysModal";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
@@ -47,6 +48,7 @@ export default function ProviderDetailPage() {
   const [showAddApiKeyModal, setShowAddApiKeyModal] = useState(false);
   const [addConnectionError, setAddConnectionError] = useState("");
   const [showBulkImportCodex, setShowBulkImportCodex] = useState(false);
+  const [showExportImportKeys, setShowExportImportKeys] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showEditNodeModal, setShowEditNodeModal] = useState(false);
   const [showBulkProxyModal, setShowBulkProxyModal] = useState(false);
@@ -148,6 +150,16 @@ export default function ProviderDetailPage() {
   const isAnthropicCompatible = isAnthropicCompatibleProvider(providerId);
   const isCompatible = isOpenAICompatible || isAnthropicCompatible;
   const hasDualAuthModes = !isCompatible && isOAuth && supportsApiKeyAuth;
+  const isWebCookieProvider = !!WEB_COOKIE_PROVIDERS[providerId];
+  // Export/import applies to API-key and cookie credentials (not OAuth tokens).
+  const canExportImportKeys =
+    !isFreeNoAuth &&
+    (supportsApiKeyAuth ||
+      isCompatible ||
+      isWebCookieProvider ||
+      !!FREE_TIER_PROVIDERS[providerId] ||
+      hasDualAuthModes ||
+      connections.some((c) => c.authType === "apikey" || c.authType === "cookie"));
   const oauthConnectionLabel =
     providerId === "xai" ? "Grok Build OAuth"
     : providerId === "grok-cli" ? "Grok CLI Device Login"
@@ -1381,6 +1393,17 @@ export default function ProviderDetailPage() {
           <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <h2 className="text-lg font-semibold">Connections</h2>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+              {canExportImportKeys && (
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  icon="import_export"
+                  onClick={() => setShowExportImportKeys(true)}
+                  title={translate("Export or import API keys as JSON / TXT")}
+                >
+                  {translate("Export / Import")}
+                </Button>
+              )}
               {connections.length > 0 && proxyPools.length > 0 && (
                 <Button
                   size="sm"
@@ -1731,6 +1754,16 @@ export default function ProviderDetailPage() {
           isOpen={showBulkImportCodex}
           onClose={() => setShowBulkImportCodex(false)}
           onSuccess={fetchConnections}
+        />
+      )}
+
+      {canExportImportKeys && (
+        <ExportImportKeysModal
+          isOpen={showExportImportKeys}
+          providerId={providerId}
+          providerName={providerInfo?.name}
+          onClose={() => setShowExportImportKeys(false)}
+          onImportSuccess={fetchConnections}
         />
       )}
 

--- a/src/app/api/providers/keys/export/route.js
+++ b/src/app/api/providers/keys/export/route.js
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { getProviderConnections } from "@/models";
+import { verifyDashboardPassword } from "@/lib/auth/dashboardSession";
+import { normalizeProviderId } from "@/lib/providerNormalization";
+import { buildExportJson, buildExportTxt } from "@/lib/providerKeysIo";
+
+export const dynamic = "force-dynamic";
+
+const CLI_TOKEN_HEADER = "x-9r-cli-token";
+const PASSWORD_HEADER = "x-9r-password";
+
+function isCliRequest(request) {
+  return Boolean(request.headers.get(CLI_TOKEN_HEADER));
+}
+
+/**
+ * GET /api/providers/keys/export?provider=<id>&format=json|txt
+ *
+ * Returns the provider's API-key / cookie credentials (secrets included).
+ * Requires dashboard password re-auth (or CLI token), same as DB export.
+ */
+export async function GET(request) {
+  try {
+    if (!isCliRequest(request) && !(await verifyDashboardPassword(request.headers.get(PASSWORD_HEADER)))) {
+      return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const providerRaw = searchParams.get("provider") || searchParams.get("providerId") || "";
+    const format = (searchParams.get("format") || "json").toLowerCase();
+
+    if (!providerRaw) {
+      return NextResponse.json({ error: "provider is required" }, { status: 400 });
+    }
+    if (format !== "json" && format !== "txt") {
+      return NextResponse.json({ error: "format must be json or txt" }, { status: 400 });
+    }
+
+    const provider = normalizeProviderId(providerRaw);
+    const connections = await getProviderConnections({ provider });
+
+    if (format === "txt") {
+      const body = buildExportTxt(provider, connections);
+      const filename = `9router-${provider}-keys.txt`;
+      return new NextResponse(body, {
+        status: 200,
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+
+    const payload = buildExportJson(provider, connections);
+    const filename = `9router-${provider}-keys.json`;
+    return new NextResponse(JSON.stringify(payload, null, 2), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    console.log("Error exporting provider keys:", error);
+    return NextResponse.json({ error: "Failed to export provider keys" }, { status: 500 });
+  }
+}

--- a/src/app/api/providers/keys/import/route.js
+++ b/src/app/api/providers/keys/import/route.js
@@ -1,0 +1,204 @@
+import { NextResponse } from "next/server";
+import {
+  createProviderConnection,
+  getProviderConnections,
+  getProviderNodeById,
+  getProxyPoolById,
+} from "@/models";
+import { APIKEY_PROVIDERS } from "@/shared/constants/config";
+import {
+  AI_PROVIDERS,
+  FREE_TIER_PROVIDERS,
+  WEB_COOKIE_PROVIDERS,
+  isOpenAICompatibleProvider,
+  isAnthropicCompatibleProvider,
+  isCustomEmbeddingProvider,
+} from "@/shared/constants/providers";
+import { normalizeProviderId, normalizeProviderSpecificData } from "@/lib/providerNormalization";
+import { ensureKeyNames, parseImportContent } from "@/lib/providerKeysIo";
+
+export const dynamic = "force-dynamic";
+
+function isValidApiKeyProvider(provider) {
+  const supportsApiKeyMode = !!AI_PROVIDERS[provider]?.authModes?.includes("apikey");
+  return !!(
+    APIKEY_PROVIDERS[provider] ||
+    FREE_TIER_PROVIDERS[provider] ||
+    supportsApiKeyMode ||
+    WEB_COOKIE_PROVIDERS[provider] ||
+    isOpenAICompatibleProvider(provider) ||
+    isAnthropicCompatibleProvider(provider) ||
+    isCustomEmbeddingProvider(provider)
+  );
+}
+
+async function buildProviderSpecificData(provider, entry) {
+  let providerSpecificData = normalizeProviderSpecificData(
+    provider,
+    entry,
+    entry.providerSpecificData || null
+  );
+
+  if (isOpenAICompatibleProvider(provider)) {
+    const node = await getProviderNodeById(provider);
+    if (!node) throw new Error("OpenAI Compatible node not found");
+    providerSpecificData = {
+      prefix: node.prefix,
+      apiType: node.apiType,
+      baseUrl: node.baseUrl,
+      nodeName: node.name,
+      ...(providerSpecificData || {}),
+    };
+  } else if (isAnthropicCompatibleProvider(provider)) {
+    const node = await getProviderNodeById(provider);
+    if (!node) throw new Error("Anthropic Compatible node not found");
+    providerSpecificData = {
+      prefix: node.prefix,
+      baseUrl: node.baseUrl,
+      nodeName: node.name,
+      ...(providerSpecificData || {}),
+    };
+  } else if (isCustomEmbeddingProvider(provider)) {
+    const node = await getProviderNodeById(provider);
+    if (!node) throw new Error("Custom Embedding node not found");
+    providerSpecificData = {
+      prefix: node.prefix,
+      baseUrl: node.baseUrl,
+      nodeName: node.name,
+      ...(providerSpecificData || {}),
+    };
+  }
+
+  // Optional proxy pool from import (must already exist)
+  if (entry.proxyPoolId) {
+    const pool = await getProxyPoolById(String(entry.proxyPoolId).trim());
+    if (pool) {
+      providerSpecificData = {
+        ...(providerSpecificData || {}),
+        proxyPoolId: pool.id,
+      };
+    }
+  }
+
+  return providerSpecificData;
+}
+
+/**
+ * POST /api/providers/keys/import
+ *
+ * Body:
+ * {
+ *   provider: string,
+ *   format?: "json" | "txt" | "auto",
+ *   content: string | object,   // raw text, JSON string, or parsed object
+ *   skipDuplicates?: boolean    // skip when same apiKey already exists (default true)
+ * }
+ */
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const provider = normalizeProviderId(body.provider);
+    const format = body.format || "auto";
+    const skipDuplicates = body.skipDuplicates !== false;
+    const content = body.content ?? body.keys ?? body.text ?? body.data;
+
+    if (!provider || !isValidApiKeyProvider(provider)) {
+      return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
+    }
+    if (content === undefined || content === null || content === "") {
+      return NextResponse.json({ error: "content is required" }, { status: 400 });
+    }
+
+    let parsed;
+    try {
+      parsed = parseImportContent(content, format, { provider });
+    } catch (err) {
+      return NextResponse.json({ error: err.message || "Failed to parse content" }, { status: 400 });
+    }
+
+    if (parsed.providerHint && normalizeProviderId(parsed.providerHint) !== provider) {
+      return NextResponse.json(
+        {
+          error: `File is for provider "${parsed.providerHint}", but import target is "${provider}"`,
+        },
+        { status: 400 }
+      );
+    }
+
+    let keys = ensureKeyNames(parsed.keys, "Key");
+    if (keys.length === 0) {
+      return NextResponse.json({ error: "No keys found in input" }, { status: 400 });
+    }
+
+    const isWebCookieProvider = !!WEB_COOKIE_PROVIDERS[provider];
+    const existing = await getProviderConnections({ provider });
+    const existingKeys = new Set(
+      existing
+        .filter((c) => c.authType === "apikey" || c.authType === "cookie")
+        .map((c) => c.apiKey)
+        .filter(Boolean)
+    );
+
+    const results = [];
+    let success = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (let i = 0; i < keys.length; i++) {
+      const entry = keys[i];
+      try {
+        if (!entry.apiKey && provider !== "ollama-local") {
+          results.push({ index: i, ok: false, error: "API key is required" });
+          failed += 1;
+          continue;
+        }
+
+        if (skipDuplicates && entry.apiKey && existingKeys.has(entry.apiKey)) {
+          results.push({ index: i, ok: true, skipped: true, name: entry.name, reason: "duplicate apiKey" });
+          skipped += 1;
+          continue;
+        }
+
+        const providerSpecificData = await buildProviderSpecificData(provider, entry);
+        const authType = isWebCookieProvider
+          ? "cookie"
+          : entry.authType === "cookie"
+            ? "cookie"
+            : "apikey";
+
+        const conn = await createProviderConnection({
+          provider,
+          authType,
+          name: entry.name,
+          apiKey: entry.apiKey || "",
+          priority: entry.priority || 1,
+          globalPriority: entry.globalPriority ?? null,
+          defaultModel: entry.defaultModel || null,
+          providerSpecificData: providerSpecificData || undefined,
+          isActive: entry.isActive !== false,
+          testStatus: "unknown",
+        });
+
+        if (entry.apiKey) existingKeys.add(entry.apiKey);
+        results.push({ index: i, ok: true, id: conn.id, name: conn.name });
+        success += 1;
+      } catch (err) {
+        results.push({ index: i, ok: false, error: err.message || "Failed to import key" });
+        failed += 1;
+      }
+    }
+
+    return NextResponse.json({
+      provider,
+      format: parsed.format,
+      total: keys.length,
+      success,
+      skipped,
+      failed,
+      results,
+    });
+  } catch (error) {
+    console.log("Error importing provider keys:", error);
+    return NextResponse.json({ error: "Failed to import provider keys" }, { status: 500 });
+  }
+}

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -38,6 +38,7 @@ const PUBLIC_PREFIXES = ["/v1", "/v1beta", "/api/v1", "/api/v1beta", "/codex"];
 const ALWAYS_PROTECTED = [
   "/api/shutdown",
   "/api/settings/database",
+  "/api/providers/keys/export",
   "/api/version/shutdown",
   "/api/version/update",
   "/api/oauth/cursor/auto-import",

--- a/src/lib/providerKeysIo.js
+++ b/src/lib/providerKeysIo.js
@@ -1,0 +1,305 @@
+/**
+ * Serialize / parse provider API-key (and cookie) connections for export/import.
+ *
+ * TXT (bulk) format — one key per line (matches AddApiKeyModal bulk add):
+ *   name|apiKey
+ *   name|apiKey|accountId   (cloudflare-ai)
+ *   apiKey                   (auto-named on import)
+ *
+ * JSON format:
+ *   {
+ *     "version": 1,
+ *     "provider": "openrouter",
+ *     "exportedAt": "…",
+ *     "keys": [
+ *       { "name": "…", "apiKey": "…", "priority": 1, "isActive": true, … }
+ *     ]
+ *   }
+ * Also accepts a bare array of key objects, or { accounts: [...] } / { keys: [...] }.
+ */
+
+export const EXPORT_VERSION = 1;
+export const EXPORTABLE_AUTH_TYPES = new Set(["apikey", "cookie"]);
+
+/** Fields from providerSpecificData worth round-tripping across machines. */
+const PSD_EXPORT_KEYS = [
+  "accountId",
+  "region",
+  "baseUrl",
+  "azureEndpoint",
+  "apiVersion",
+  "deployment",
+  "organization",
+];
+
+/**
+ * @param {object} conn - full connection row (may include secrets)
+ * @returns {boolean}
+ */
+export function isExportableConnection(conn) {
+  if (!conn) return false;
+  const authType = conn.authType || "apikey";
+  if (!EXPORTABLE_AUTH_TYPES.has(authType)) return false;
+  // ollama-local may have empty apiKey
+  if (conn.provider === "ollama-local") return true;
+  return typeof conn.apiKey === "string" && conn.apiKey.length > 0;
+}
+
+/**
+ * Pick a portable subset of providerSpecificData for export.
+ * @param {object|null|undefined} psd
+ * @returns {object|undefined}
+ */
+export function pickExportableProviderSpecificData(psd) {
+  if (!psd || typeof psd !== "object") return undefined;
+  const out = {};
+  for (const key of PSD_EXPORT_KEYS) {
+    if (psd[key] !== undefined && psd[key] !== null && psd[key] !== "") {
+      out[key] = psd[key];
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Map a DB connection to a portable export record.
+ * @param {object} conn
+ * @returns {object}
+ */
+export function connectionToExportKey(conn) {
+  const record = {
+    name: conn.name || "",
+    apiKey: conn.apiKey || "",
+    authType: conn.authType === "cookie" ? "cookie" : "apikey",
+    priority: conn.priority ?? 1,
+    isActive: conn.isActive !== false,
+  };
+  if (conn.defaultModel) record.defaultModel = conn.defaultModel;
+  if (conn.globalPriority != null) record.globalPriority = conn.globalPriority;
+  const psd = pickExportableProviderSpecificData(conn.providerSpecificData);
+  if (psd) record.providerSpecificData = psd;
+  return record;
+}
+
+/**
+ * Build JSON export payload for a provider.
+ * @param {string} providerId
+ * @param {object[]} connections - full connection rows
+ * @returns {object}
+ */
+export function buildExportJson(providerId, connections) {
+  const keys = (connections || [])
+    .filter(isExportableConnection)
+    .map(connectionToExportKey);
+  return {
+    version: EXPORT_VERSION,
+    provider: providerId,
+    exportedAt: new Date().toISOString(),
+    count: keys.length,
+    keys,
+  };
+}
+
+/**
+ * Build TXT export content (one key per line).
+ * @param {string} providerId
+ * @param {object[]} connections
+ * @returns {string}
+ */
+export function buildExportTxt(providerId, connections) {
+  const lines = [];
+  for (const conn of (connections || []).filter(isExportableConnection)) {
+    const name = (conn.name || "Key").replace(/\|/g, "_");
+    const apiKey = conn.apiKey || "";
+    const accountId = conn.providerSpecificData?.accountId;
+    if (providerId === "cloudflare-ai" && accountId) {
+      lines.push(`${name}|${apiKey}|${accountId}`);
+    } else {
+      lines.push(`${name}|${apiKey}`);
+    }
+  }
+  return lines.join("\n") + (lines.length ? "\n" : "");
+}
+
+/**
+ * Normalize various JSON shapes into an array of key records.
+ * @param {unknown} parsed
+ * @returns {object[]|null}
+ */
+export function normalizeJsonKeys(parsed) {
+  if (Array.isArray(parsed)) {
+    return parsed.map(normalizeKeyEntry).filter(Boolean);
+  }
+  if (parsed && typeof parsed === "object") {
+    if (Array.isArray(parsed.keys)) {
+      return parsed.keys.map(normalizeKeyEntry).filter(Boolean);
+    }
+    if (Array.isArray(parsed.accounts)) {
+      return parsed.accounts.map(normalizeKeyEntry).filter(Boolean);
+    }
+    // Single object with apiKey
+    const one = normalizeKeyEntry(parsed);
+    return one ? [one] : null;
+  }
+  return null;
+}
+
+/**
+ * @param {unknown} entry
+ * @returns {object|null}
+ */
+function normalizeKeyEntry(entry) {
+  if (typeof entry === "string") {
+    const apiKey = entry.trim();
+    if (!apiKey) return null;
+    return { name: "", apiKey, authType: "apikey", priority: 1, isActive: true };
+  }
+  if (!entry || typeof entry !== "object") return null;
+
+  const apiKey = (
+    entry.apiKey ||
+    entry.key ||
+    entry.token ||
+    entry.cookie ||
+    ""
+  ).toString().trim();
+
+  // Allow empty apiKey only when explicitly named ollama-style (handled by caller validation)
+  const name = (entry.name || entry.displayName || "").toString().trim();
+  const authType = entry.authType === "cookie" ? "cookie" : "apikey";
+
+  const record = {
+    name,
+    apiKey,
+    authType,
+    priority: Number.isFinite(Number(entry.priority)) ? Number(entry.priority) : 1,
+    isActive: entry.isActive !== false,
+  };
+  if (entry.defaultModel) record.defaultModel = String(entry.defaultModel);
+  if (entry.globalPriority != null && entry.globalPriority !== "") {
+    record.globalPriority = Number(entry.globalPriority);
+  }
+  if (entry.providerSpecificData && typeof entry.providerSpecificData === "object") {
+    record.providerSpecificData = pickExportableProviderSpecificData(entry.providerSpecificData)
+      || entry.providerSpecificData;
+  } else {
+    // Flattened accountId / region on the entry itself
+    const flat = {};
+    for (const key of PSD_EXPORT_KEYS) {
+      if (entry[key] !== undefined && entry[key] !== null && entry[key] !== "") {
+        flat[key] = entry[key];
+      }
+    }
+    if (Object.keys(flat).length > 0) record.providerSpecificData = flat;
+  }
+  return record;
+}
+
+/**
+ * Parse TXT bulk content into key records.
+ * @param {string} text
+ * @param {{ provider?: string }} [opts]
+ * @returns {object[]}
+ */
+export function parseTxtKeys(text, opts = {}) {
+  const provider = opts.provider || "";
+  const lines = String(text || "")
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    // skip comments
+    .filter((l) => !l.startsWith("#"));
+
+  const keys = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const parts = line.split("|");
+    let name = "";
+    let apiKey = "";
+    let providerSpecificData;
+
+    if (provider === "cloudflare-ai" && parts.length >= 3) {
+      name = parts[0].trim();
+      apiKey = parts.slice(1, -1).join("|").trim();
+      const accountId = parts[parts.length - 1].trim();
+      if (accountId) providerSpecificData = { accountId };
+    } else if (parts.length >= 2) {
+      name = parts[0].trim();
+      apiKey = parts.slice(1).join("|").trim();
+    } else {
+      apiKey = parts[0].trim();
+      name = "";
+    }
+
+    if (!apiKey && provider !== "ollama-local") continue;
+
+    keys.push({
+      name,
+      apiKey,
+      authType: "apikey",
+      priority: 1,
+      isActive: true,
+      ...(providerSpecificData ? { providerSpecificData } : {}),
+    });
+  }
+  return keys;
+}
+
+/**
+ * Parse import payload (string content or already-parsed object).
+ * @param {string|object} content
+ * @param {"json"|"txt"|"auto"} format
+ * @param {{ provider?: string }} [opts]
+ * @returns {{ keys: object[], format: "json"|"txt", providerHint?: string }}
+ */
+export function parseImportContent(content, format = "auto", opts = {}) {
+  if (format === "txt" || (format === "auto" && typeof content === "string" && !looksLikeJson(content))) {
+    const text = typeof content === "string" ? content : String(content ?? "");
+    return { keys: parseTxtKeys(text, opts), format: "txt" };
+  }
+
+  let parsed = content;
+  if (typeof content === "string") {
+    const trimmed = content.trim();
+    if (!trimmed) return { keys: [], format: "json" };
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      if (format === "json") {
+        throw new Error(`Invalid JSON: ${err.message}`);
+      }
+      // auto-fallback to txt
+      return { keys: parseTxtKeys(content, opts), format: "txt" };
+    }
+  }
+
+  const keys = normalizeJsonKeys(parsed);
+  if (!keys) {
+    throw new Error("No keys found in JSON input");
+  }
+
+  const providerHint =
+    parsed && typeof parsed === "object" && !Array.isArray(parsed) && typeof parsed.provider === "string"
+      ? parsed.provider
+      : undefined;
+
+  return { keys, format: "json", providerHint };
+}
+
+function looksLikeJson(text) {
+  const t = String(text || "").trim();
+  return t.startsWith("{") || t.startsWith("[");
+}
+
+/**
+ * Assign display names for entries missing a name.
+ * @param {object[]} keys
+ * @param {string} [fallbackBase="Key"]
+ * @returns {object[]}
+ */
+export function ensureKeyNames(keys, fallbackBase = "Key") {
+  return keys.map((k, i) => ({
+    ...k,
+    name: (k.name && String(k.name).trim()) || `${fallbackBase} ${i + 1}`,
+  }));
+}

--- a/tests/unit/provider-keys-io.test.js
+++ b/tests/unit/provider-keys-io.test.js
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildExportJson,
+  buildExportTxt,
+  connectionToExportKey,
+  ensureKeyNames,
+  isExportableConnection,
+  parseImportContent,
+  parseTxtKeys,
+  pickExportableProviderSpecificData,
+} from "../../src/lib/providerKeysIo.js";
+
+const sampleConns = [
+  {
+    id: "1",
+    provider: "openrouter",
+    authType: "apikey",
+    name: "prod",
+    apiKey: "sk-prod",
+    priority: 1,
+    isActive: true,
+  },
+  {
+    id: "2",
+    provider: "openrouter",
+    authType: "apikey",
+    name: "stage",
+    apiKey: "sk-stage",
+    priority: 2,
+    isActive: false,
+    defaultModel: "gpt-4o",
+  },
+  {
+    id: "3",
+    provider: "openrouter",
+    authType: "oauth",
+    name: "oauth-user",
+    accessToken: "tok",
+    refreshToken: "rt",
+  },
+  {
+    id: "4",
+    provider: "openrouter",
+    authType: "apikey",
+    name: "empty",
+    apiKey: "",
+  },
+];
+
+describe("providerKeysIo", () => {
+  it("isExportableConnection only allows apikey/cookie with a key", () => {
+    expect(isExportableConnection(sampleConns[0])).toBe(true);
+    expect(isExportableConnection(sampleConns[2])).toBe(false);
+    expect(isExportableConnection(sampleConns[3])).toBe(false);
+    expect(isExportableConnection({ provider: "ollama-local", authType: "apikey", apiKey: "" })).toBe(true);
+  });
+
+  it("buildExportJson excludes oauth and empty keys", () => {
+    const payload = buildExportJson("openrouter", sampleConns);
+    expect(payload.version).toBe(1);
+    expect(payload.provider).toBe("openrouter");
+    expect(payload.count).toBe(2);
+    expect(payload.keys).toHaveLength(2);
+    expect(payload.keys[0]).toMatchObject({ name: "prod", apiKey: "sk-prod" });
+    expect(payload.keys[1].defaultModel).toBe("gpt-4o");
+    expect(payload.keys[1].isActive).toBe(false);
+  });
+
+  it("buildExportTxt uses name|apiKey lines", () => {
+    const txt = buildExportTxt("openrouter", sampleConns);
+    expect(txt).toBe("prod|sk-prod\nstage|sk-stage\n");
+  });
+
+  it("buildExportTxt includes accountId for cloudflare-ai", () => {
+    const txt = buildExportTxt("cloudflare-ai", [
+      {
+        authType: "apikey",
+        name: "cf",
+        apiKey: "sk-cf",
+        providerSpecificData: { accountId: "acc123" },
+      },
+    ]);
+    expect(txt).toBe("cf|sk-cf|acc123\n");
+  });
+
+  it("parseTxtKeys handles name|key and bare key", () => {
+    const keys = parseTxtKeys("a|sk-a\nsk-only\n# comment\n");
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toMatchObject({ name: "a", apiKey: "sk-a" });
+    expect(keys[1]).toMatchObject({ name: "", apiKey: "sk-only" });
+  });
+
+  it("parseTxtKeys handles cloudflare accountId", () => {
+    const keys = parseTxtKeys("n|sk-x|acc9", { provider: "cloudflare-ai" });
+    expect(keys[0].providerSpecificData).toEqual({ accountId: "acc9" });
+  });
+
+  it("parseImportContent accepts JSON envelope and array", () => {
+    const envelope = parseImportContent(
+      JSON.stringify({ provider: "openrouter", keys: [{ name: "a", apiKey: "sk-a" }] }),
+      "json"
+    );
+    expect(envelope.format).toBe("json");
+    expect(envelope.providerHint).toBe("openrouter");
+    expect(envelope.keys).toHaveLength(1);
+
+    const arr = parseImportContent('[{"apiKey":"sk-1"},"sk-2"]', "json");
+    expect(arr.keys).toHaveLength(2);
+    expect(arr.keys[1].apiKey).toBe("sk-2");
+  });
+
+  it("parseImportContent auto-detects txt", () => {
+    const parsed = parseImportContent("n|sk-n\n", "auto");
+    expect(parsed.format).toBe("txt");
+    expect(parsed.keys[0].apiKey).toBe("sk-n");
+  });
+
+  it("ensureKeyNames fills missing names", () => {
+    const named = ensureKeyNames([{ name: "", apiKey: "sk" }, { name: "keep", apiKey: "sk2" }]);
+    expect(named[0].name).toBe("Key 1");
+    expect(named[1].name).toBe("keep");
+  });
+
+  it("pickExportableProviderSpecificData filters unknown fields", () => {
+    expect(
+      pickExportableProviderSpecificData({
+        accountId: "a",
+        proxyPoolId: "p",
+        connectionProxyUrl: "http://x",
+        region: "us",
+      })
+    ).toEqual({ accountId: "a", region: "us" });
+  });
+
+  it("connectionToExportKey maps fields", () => {
+    const rec = connectionToExportKey({
+      name: "n",
+      apiKey: "k",
+      authType: "cookie",
+      priority: 3,
+      isActive: true,
+      providerSpecificData: { region: "eu", junk: 1 },
+    });
+    expect(rec).toEqual({
+      name: "n",
+      apiKey: "k",
+      authType: "cookie",
+      priority: 3,
+      isActive: true,
+      providerSpecificData: { region: "eu" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **export/import** for per-provider API key (and cookie) credentials in **JSON** and **TXT** formats
- Export requires dashboard **password re-auth** (same pattern as DB backup) because the download contains secrets
- Import accepts JSON export files, bare key arrays, or bulk TXT (`name|apiKey`), with optional skip-duplicates
- UI: **Export / Import** button on the provider Connections card

## Formats

**JSON**
```json
{
  "version": 1,
  "provider": "openrouter",
  "keys": [
    { "name": "production", "apiKey": "sk-...", "priority": 1, "isActive": true }
  ]
}
```

**TXT** (matches existing bulk-add lines)
```
production|sk-key-1
staging|sk-key-2
sk-key-only-auto-named
```

Cloudflare AI TXT lines may include `name|apiKey|accountId`.

## API
| Method | Path | Notes |
|--------|------|--------|
| `GET` | `/api/providers/keys/export?provider=<id>&format=json\|txt` | Header `x-9r-password` (or CLI token) |
| `POST` | `/api/providers/keys/import` | Body: `{ provider, format, content, skipDuplicates? }` |

OAuth connections are **not** included (Codex still has its own bulk OAuth import).

## Test plan
- [ ] Open an API-key provider (e.g. OpenRouter) with several keys
- [ ] **Export** as JSON → confirm file downloads after password
- [ ] **Export** as TXT → confirm `name|apiKey` lines
- [ ] Wrong password → 401 / error message
- [ ] **Import** the exported JSON → keys restored (duplicates skipped when enabled)
- [ ] **Import** TXT bulk lines → keys created
- [ ] Compatible OpenAI/Anthropic node: export/import still works
- [ ] OAuth-only connections are not exported
- [ ] `cd tests && npx vitest run unit/provider-keys-io.test.js` passes