### PR TITLE
fix(models): compatible-provider discovery + strip cc/ prefix from Claude DEFAULT_MODEL (#2626, #2642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Fixes
+- **Models**: discover OpenAI/Anthropic-compatible provider models in `/v1/models` — `UPSTREAM_CONNECTION_RE` falsely matched the UUID-v4 suffix of compatible node IDs and skipped `fetchCompatibleModelIds` (#2626)
+- **Claude Code**: strip the `cc/` provider prefix from `ANTHROPIC_DEFAULT_*_MODEL` when writing Claude Code settings so the bare model id (e.g. `claude-opus-4-8`) routes through 9router instead of being rejected by Anthropic with a 400 on Task tool / subagent dispatch (#2642)
+
 # v0.5.30 (2026-07-10)
 
 ## Features

--- a/src/app/api/cli-tools/claude-settings/route.js
+++ b/src/app/api/cli-tools/claude-settings/route.js
@@ -112,9 +112,27 @@ export async function POST(request) {
 
     // Normalize ANTHROPIC_BASE_URL to ensure /v1 suffix
     if (env.ANTHROPIC_BASE_URL) {
-      env.ANTHROPIC_BASE_URL = env.ANTHROPIC_BASE_URL.endsWith("/v1") 
-        ? env.ANTHROPIC_BASE_URL 
+      env.ANTHROPIC_BASE_URL = env.ANTHROPIC_BASE_URL.endsWith("/v1")
+        ? env.ANTHROPIC_BASE_URL
         : `${env.ANTHROPIC_BASE_URL}/v1`;
+    }
+
+    // Strip the 9router provider prefix (e.g. "cc/") from the
+    // ANTHROPIC_DEFAULT_*_MODEL values. These vars are read by Claude Code and
+    // embedded verbatim into the Task tool / subagent schema's `model` field,
+    // which is forwarded straight to Anthropic. A "cc/claude-opus-4-8" value is
+    // rejected by Anthropic with a 400 (#2642). The bare model id
+    // ("claude-opus-4-8") still routes correctly through 9router, so the prefix
+    // must not be persisted into Claude Code's settings.
+    for (const key of [
+      "ANTHROPIC_DEFAULT_OPUS_MODEL",
+      "ANTHROPIC_DEFAULT_SONNET_MODEL",
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    ]) {
+      if (typeof env[key] === "string") {
+        env[key] = env[key].replace(/^[^/]+\//, "");
+      }
     }
 
     // Merge new env with existing settings

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -319,7 +319,15 @@ export async function buildModelsList(kindFilter) {
           )
         : providerModels.map((model) => model.id);
 
-      if (isCompatibleProvider && rawModelIds.length === 0 && !UPSTREAM_CONNECTION_RE.test(providerId)) {
+      if (isCompatibleProvider && rawModelIds.length === 0) {
+        // Compatible providers (openai-compatible-*, anthropic-compatible-*) may
+        // carry a UUID-v4 suffix in their node ID, which would falsely match
+        // UPSTREAM_CONNECTION_RE and skip dynamic model discovery (#2626). Always
+        // attempt a live /models fetch for compatible providers.
+        rawModelIds = await fetchCompatibleModelIds(conn);
+      } else if (rawModelIds.length === 0 && !UPSTREAM_CONNECTION_RE.test(providerId)) {
+        // Non-compatible upstream/cross-instance connections keep the guard to
+        // avoid recursive /models fetches between 9router instances.
         rawModelIds = await fetchCompatibleModelIds(conn);
       }
 


### PR DESCRIPTION
## Summary
Two independent bug fixes for issues #2626 and #2642.

### #2626 — OpenAI-compatible provider models missing from `/v1/models`
`UPSTREAM_CONNECTION_RE = /[-_][0-9a-f]{8,}$/i` was meant to skip recursive `/models` fetches between 9router instances (cross-instance connections carry a plain hex suffix). But every OpenAI-compatible / Anthropic-compatible node ID (`openai-compatible-chat-<uuidv4>`) ends in a 12-hex UUID segment that also matches the regex, so `fetchCompatibleModelIds` was **never** called for compatible providers. Local LLM servers (MLX, Ollama, vLLM, LM Studio) were therefore invisible in `/v1/models`.

Fix: compatible providers now always attempt a live `/models` fetch; the upstream-skip guard is retained only for non-compatible cross-instance connections.

### #2642 — `cc/` model prefix causes 400 on Task tool / subagent dispatch
The Claude Code settings writer persisted `ANTHROPIC_DEFAULT_*_MODEL=cc/claude-opus-4-8` verbatim. Claude Code embeds that value into the Task tool / subagent schema's `model` field, which is forwarded straight to Anthropic and rejected with `invalid_request_error` (400). The `cc/` prefix is 9router-internal routing syntax that must not reach Anthropic.

Fix: strip the provider prefix from the four `ANTHROPIC_DEFAULT_*_MODEL` values before persisting them into Claude Code's settings. The bare model id (`claude-opus-4-8`) still routes correctly through 9router.

## Test plan
- [ ] Add an OpenAI-compatible provider (local MLX/Ollama); confirm its models now appear in `GET /v1/models` without manual import.
- [ ] Apply Claude Code CLI Tools config with `cc/` models; confirm `~/.claude/settings.json` contains the bare model id, not the `cc/` prefix.
- [ ] Run Task tool / subagent dispatch with the applied config; confirm no 400 from Anthropic.

## Risk
Low. Both changes are localized to the `/v1/models` route and the Claude settings writer, and preserve existing behaviour for non-compatible providers and bare model ids.
