### PR TITLE
feat(combo): add per-model timeout for faster combo fallback

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -58,6 +58,11 @@ export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_M
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
 export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 60 * 1000);
 
+// Per-model timeout for combo fallback. When > 0, each model in a combo
+// gets at most this many ms before the combo falls to the next model.
+// 0 = disabled (use fetch connect timeout + retries). Env: COMBO_MODEL_TIMEOUT_MS.
+export const COMBO_MODEL_TIMEOUT_MS = envMs("COMBO_MODEL_TIMEOUT_MS", 0);
+
 // Gemini native TTS fetch timeout: abort if Google does not return response headers in time.
 export const GEMINI_NATIVE_TTS_FETCH_TIMEOUT_MS = envMs("GEMINI_NATIVE_TTS_FETCH_TIMEOUT_MS", 45 * 1000);
 

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -226,7 +226,7 @@ export function getComboModelsFromData(modelStr, combosData) {
  * @param {number|string} [options.comboStickyLimit=1] - Requests per combo model before switching
  * @returns {Promise<Response>}
  */
-export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true }) {
+export async function handleComboChat({ body, models, handleSingleModel, log, comboName, comboStrategy, comboStickyLimit = 1, autoSwitch = true, comboTimeoutMs = 0 }) {
   // Apply rotation strategy if enabled
   let rotatedModels = getRotatedModels(models, comboName, comboStrategy, comboStickyLimit);
 
@@ -251,7 +251,21 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
     log.info("COMBO", `Trying model ${i + 1}/${rotatedModels.length}: ${modelStr}`);
 
     try {
-      const result = await handleSingleModel(body, modelStr);
+      let resultPromise = handleSingleModel(body, modelStr);
+
+      if (comboTimeoutMs > 0) {
+        resultPromise = Promise.race([
+          resultPromise,
+          new Promise((_, reject) =>
+            setTimeout(() => reject(Object.assign(
+              new Error(`Combo timeout after ${comboTimeoutMs}ms`),
+              { isComboTimeout: true }
+            )), comboTimeoutMs)
+          ),
+        ]);
+      }
+
+      const result = await resultPromise;
       
       // Success (2xx) - return response
       if (result.ok) {
@@ -302,10 +316,17 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       if (!lastStatus) lastStatus = result.status;
       log.warn("COMBO", `Model ${modelStr} failed, trying next`, { status: result.status });
     } catch (error) {
-      // Catch unexpected exceptions to ensure fallback continues
-      lastError = error.message || String(error);
-      if (!lastStatus) lastStatus = 500;
-      log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError });
+      // Catch unexpected exceptions to ensure fallback continues.
+      // When the combo model timeout fires, skip setting lastError so the
+      // "all models failed" message stays accurate (lastError stays on the
+      // most recent genuine failure, not the synthetic timeout).
+      if (error.isComboTimeout) {
+        log.warn("COMBO", `Model ${modelStr} timed out after ${comboTimeoutMs}ms, falling to next`);
+      } else {
+        lastError = error.message || String(error);
+        if (!lastStatus) lastStatus = 500;
+        log.warn("COMBO", `Model ${modelStr} threw error, trying next`, { error: lastError });
+      }
     }
   }
 

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -122,7 +122,11 @@ export default function CombosPage() {
       const updated = { ...comboStrategies };
       const next = { ...(updated[comboName] || {}), ...patch };
       // Prune to keep settings clean: default fallback with no extras = no entry.
-      if (!next.fallbackStrategy || next.fallbackStrategy === "fallback") {
+      // Extras include timeout, sticky limit, fusion config — preserve when any are set.
+      if ((!next.fallbackStrategy || next.fallbackStrategy === "fallback") &&
+          (!next.timeoutMs || next.timeoutMs === 0) &&
+          (!next.stickyLimit) &&
+          (!next.judgeModel)) {
         delete updated[comboName];
       } else {
         updated[comboName] = next;
@@ -307,6 +311,27 @@ function ComboCard({ combo, modelCaps = {}, activeProviders = [], copied, onCopy
               selectClassName="py-1.5 text-xs"
             />
           </div>
+
+          {/* Per-model timeout (fallback / round-robin only; fusion has its own panel timeout) */}
+          {current !== "fusion" && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-[10px] text-text-muted whitespace-nowrap">Timeout</span>
+              <input
+                type="number"
+                min="0"
+                step="1"
+                value={(strategy.timeoutMs || 0) / 1000}
+                onChange={(e) => {
+                  const sec = parseInt(e.target.value, 10) || 0;
+                  onSetStrategy({ timeoutMs: sec * 1000 });
+                }}
+                className="w-10 rounded border border-black/10 dark:border-white/10 bg-transparent px-1 py-0.5 text-[11px] text-text-main text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                placeholder="0"
+                title="Max seconds per model before fallback. 0 = use fetch connect timeout (60s)"
+              />
+              <span className="text-[10px] text-text-muted">s</span>
+            </div>
+          )}
 
           <div className="grid grid-cols-3 gap-1 sm:flex">
             <button

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -17,7 +17,7 @@ import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat } from "open-sse/services/combo.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
-import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+import { HTTP_STATUS, COMBO_MODEL_TIMEOUT_MS } from "open-sse/config/runtimeConfig.js";
 import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
@@ -115,7 +115,10 @@ export async function handleChat(request, clientRawRequest = null) {
     }
 
     const comboStickyLimit = settings.comboStickyRoundRobinLimit;
-    log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: ${comboStrategy}, sticky: ${comboStickyLimit})`);
+    const comboSpecificStrategy = comboStrategies[modelStr];
+    const comboTimeoutMs = comboSpecificStrategy?.timeoutMs || COMBO_MODEL_TIMEOUT_MS || 0;
+
+    log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: ${comboStrategy}, sticky: ${comboStickyLimit}, timeout: ${comboTimeoutMs || "off"})`);
     return handleComboChat({
       body,
       models: comboModels,
@@ -123,7 +126,8 @@ export async function handleChat(request, clientRawRequest = null) {
       log,
       comboName: modelStr,
       comboStrategy,
-      comboStickyLimit
+      comboStickyLimit,
+      comboTimeoutMs,
     });
   }
 


### PR DESCRIPTION
## Summary

Adds configurable per-model timeout to combo fallback, so when a model is busy or timing out, the combo falls back to the next model faster instead of waiting the full 60s fetch connect timeout.

## Changes

### 1. Per-combo timeout config (`timeoutMs` in `comboStrategies`)
- **`src/sse/handlers/chat.js`** — Reads `timeoutMs` from `comboStrategies` (per-combo), falls back to global `COMBO_MODEL_TIMEOUT_MS` env var, then to 0 (disabled). Passes it to `handleComboChat()`.

### 2. Promise.race timeout in `handleComboChat()`
- **`open-sse/services/combo.js`** — Accepts `comboTimeoutMs` parameter. When > 0, wraps each model call in `Promise.race` with a timer. On timeout, the error carries `isComboTimeout: true` — the catch block skips setting `lastError` so the final error message stays accurate. Fallback continues to the next model.

### 3. UI input on combo dashboard
- **`src/app/(dashboard)/dashboard/combos/page.js`** — Adds a small timeout input (in seconds) next to the strategy selector for fallback/round-robin combos. Fusion combos use their own panel timeout and are excluded. Updated pruning logic to preserve `timeoutMs` in `handleSetComboStrategy`.

### 4. Global env override
- **`open-sse/config/runtimeConfig.js`** — Adds `COMBO_MODEL_TIMEOUT_MS` env-controlled default (0 = disabled, use existing 60s fetch connect timeout).

## How it works

```
User sets 15s timeout in dashboard
  -> comboStrategies["my-combo"].timeoutMs = 15000
    -> combo.js wraps each model with Promise.race(handleSingleModel, timer 15s)
      -> 15s without response -> error.isComboTimeout = true
        -> logs warning, falls to next model
```

## Files changed
- `open-sse/services/combo.js`
- `src/sse/handlers/chat.js`
- `open-sse/config/runtimeConfig.js`
- `src/app/(dashboard)/dashboard/combos/page.js`

Made with [Cursor](https://cursor.com)