### PR TITLE
fix: normalize nested Claude server tool models

### DIFF
--- a/open-sse/translator/formats/claude.js
+++ b/open-sse/translator/formats/claude.js
@@ -84,6 +84,21 @@ export function fixToolUseOrdering(messages) {
 // Models that reject thinking.type "adaptive" + output_config.effort (Opus 4.5+/Sonnet 4.6+ only)
 const ADAPTIVE_THINKING_UNSUPPORTED = /haiku/i;
 
+// 9router provider prefixes are valid for routing the top-level model, but
+// Anthropic server tools expect an upstream model ID in their nested `model`.
+const CLAUDE_PROVIDER_MODEL_PREFIXES = ["cc/", "claude/"];
+
+function normalizeClaudeServerToolModels(tools) {
+  if (!Array.isArray(tools)) return;
+
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object" || typeof tool.model !== "string") continue;
+
+    const prefix = CLAUDE_PROVIDER_MODEL_PREFIXES.find(candidate => tool.model.startsWith(candidate));
+    if (prefix) tool.model = tool.model.slice(prefix.length);
+  }
+}
+
 function handlesThinkingBlocks(provider) {
   return provider === "claude" || provider?.startsWith("anthropic-compatible") || provider === "deepseek";
 }
@@ -108,6 +123,7 @@ function buildThinkingPlaceholder(provider) {
 // 1. thinking.type "adaptive" → unsupported on Haiku
 // 2. output_config.effort → unsupported on Haiku
 // 3. role "system" messages (mid-conversation-system beta) → only top-level system is allowed
+// 4. server tool model IDs must not include 9router's Claude provider prefix
 export function normalizeClaudePassthrough(body, model = "") {
   if (!body || typeof body !== "object") return body;
 
@@ -122,7 +138,7 @@ export function normalizeClaudePassthrough(body, model = "") {
     if (Object.keys(body.output_config).length === 0) delete body.output_config;
   }
 
-  // 2. Hoist mid-conversation system messages into the top-level system field
+  // 3. Hoist mid-conversation system messages into the top-level system field
   if (Array.isArray(body.messages)) {
     const systemBlocks = [];
     const messages = [];
@@ -150,7 +166,10 @@ export function normalizeClaudePassthrough(body, model = "") {
     }
   }
 
-  // 3. Drop thinking blocks whose signature is not Claude's (combo mixes models,
+  // 4. Normalize nested server tool model IDs without changing the routing model
+  normalizeClaudeServerToolModels(body.tools);
+
+  // 5. Drop thinking blocks whose signature is not Claude's (combo mixes models,
   // so foreign signatures leak into history and Anthropic rejects them).
   const thinkingEnabled = body.thinking?.type === "enabled";
   if (Array.isArray(body.messages)) {

--- a/tests/unit/claude-server-tool-passthrough-integration.test.js
+++ b/tests/unit/claude-server-tool-passthrough-integration.test.js
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { executeMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+}));
+
+vi.mock("../../open-sse/executors/index.js", () => ({
+  getExecutor: vi.fn(() => ({
+    execute: executeMock,
+    refreshCredentials: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+vi.mock("../../open-sse/utils/requestLogger.js", () => ({
+  createRequestLogger: vi.fn(async () => ({
+    logClientRawRequest: vi.fn(),
+    logRawRequest: vi.fn(),
+    logTargetRequest: vi.fn(),
+    logError: vi.fn(),
+  })),
+}));
+
+vi.mock("../../open-sse/utils/bypassHandler.js", () => ({
+  handleBypassRequest: vi.fn(() => null),
+}));
+
+vi.mock("../../open-sse/utils/streamHandler.js", () => ({
+  createStreamController: vi.fn(() => ({
+    signal: undefined,
+    handleComplete: vi.fn(),
+    handleError: vi.fn(),
+  })),
+}));
+
+vi.mock("../../open-sse/services/tokenRefresh.js", () => ({
+  refreshWithRetry: vi.fn(),
+}));
+
+vi.mock("../../open-sse/rtk/caveman.js", () => ({
+  injectCaveman: vi.fn(),
+}));
+
+vi.mock("../../open-sse/rtk/ponytail.js", () => ({
+  injectPonytail: vi.fn(),
+}));
+
+vi.mock("../../open-sse/rtk/index.js", () => ({
+  compressMessages: vi.fn(() => null),
+  formatRtkLog: vi.fn(() => ""),
+}));
+
+vi.mock("../../open-sse/rtk/headroom.js", () => ({
+  compressWithHeadroom: vi.fn(async () => null),
+  formatHeadroomLog: vi.fn(() => ""),
+  formatHeadroomSizeLog: vi.fn(() => ""),
+  isHeadroomPhantomSavings: vi.fn(() => false),
+}));
+
+vi.mock("../../open-sse/handlers/chatCore/requestDetail.js", () => ({
+  buildRequestDetail: vi.fn((detail) => detail),
+  extractRequestConfig: vi.fn((body, stream) => ({ body, stream })),
+}));
+
+vi.mock("../../open-sse/utils/error.js", () => ({
+  createErrorResult: vi.fn((status, message) => ({ success: false, status, error: message })),
+  formatProviderError: vi.fn((error) => error.message),
+  parseUpstreamError: vi.fn(),
+}));
+
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+}));
+
+const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
+
+describe("handleChatCore native Claude server-tool passthrough", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executeMock.mockRejectedValue(new Error("stop after outbound body capture"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes the nested Advisor model at the final executor dispatch boundary", async () => {
+    const body = {
+      model: "cc/claude-sonnet-5",
+      max_tokens: 128,
+      stream: false,
+      system: [{ type: "text", text: "Claude Code 2.1.211" }],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Consult the advisor." }] },
+      ],
+      tools: [
+        {
+          name: "Read",
+          description: "Read a file",
+          input_schema: { type: "object", properties: { file_path: { type: "string" } } },
+        },
+        {
+          type: "advisor_20260301",
+          name: "advisor",
+          model: "cc/claude-opus-4-8",
+          input_schema: { type: "object", properties: { question: { type: "string" } } },
+        },
+      ],
+    };
+
+    await handleChatCore({
+      body,
+      modelInfo: { provider: "claude", model: "claude-sonnet-5" },
+      credentials: { accessToken: "test-token", providerSpecificData: {} },
+      connectionId: "test-claude-connection",
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      clientRawRequest: {
+        endpoint: "/v1/messages",
+        body,
+        headers: {
+          accept: "application/json",
+          "user-agent": "claude-cli/2.1.211",
+          "x-app": "cli",
+        },
+      },
+    });
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(executeMock.mock.calls[0][0].body).toEqual({
+      model: "claude-sonnet-5",
+      max_tokens: 128,
+      stream: false,
+      system: [{ type: "text", text: "Claude Code 2.1.211" }],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Consult the advisor." }] },
+      ],
+      tools: [
+        {
+          name: "Read",
+          description: "Read a file",
+          input_schema: { type: "object", properties: { file_path: { type: "string" } } },
+        },
+        {
+          type: "advisor_20260301",
+          name: "advisor",
+          model: "claude-opus-4-8",
+          input_schema: { type: "object", properties: { question: { type: "string" } } },
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/translator-helpers-edge.test.js
+++ b/tests/unit/translator-helpers-edge.test.js
@@ -26,6 +26,84 @@ describe("normalizeClaudePassthrough — haiku adaptive thinking (docs 11 §1)",
   });
 });
 
+describe("normalizeClaudePassthrough — server tool models", () => {
+  it("strips 9router's cc/ prefix from an Advisor server tool only", () => {
+    const body = {
+      model: "cc/claude-opus-4-8",
+      tools: [
+        {
+          type: "advisor_20260301",
+          name: "advisor",
+          model: "cc/claude-opus-4-8",
+          input_schema: { type: "object", properties: { question: { type: "string" } } },
+        },
+      ],
+    };
+
+    expect(normalizeClaudePassthrough(body)).toEqual({
+      model: "cc/claude-opus-4-8",
+      tools: [
+        {
+          type: "advisor_20260301",
+          name: "advisor",
+          model: "claude-opus-4-8",
+          input_schema: { type: "object", properties: { question: { type: "string" } } },
+        },
+      ],
+    });
+  });
+
+  it("normalizes a Task/subagent tool using the canonical claude/ provider prefix", () => {
+    const body = {
+      tools: [
+        {
+          name: "Task",
+          description: "Launch a subagent",
+          model: "claude/claude-sonnet-4-6",
+          input_schema: { type: "object", required: ["prompt"] },
+        },
+      ],
+    };
+
+    expect(normalizeClaudePassthrough(body)).toEqual({
+      tools: [
+        {
+          name: "Task",
+          description: "Launch a subagent",
+          model: "claude-sonnet-4-6",
+          input_schema: { type: "object", required: ["prompt"] },
+        },
+      ],
+    });
+  });
+
+  it("is idempotent and preserves missing, non-string, and unrelated models", () => {
+    const body = {
+      model: "claude-opus-4-8",
+      tools: [
+        { type: "advisor_20260301", model: "claude-opus-4-8", cache_control: { type: "ephemeral" } },
+        { name: "without-model", description: "unchanged" },
+        { name: "numeric-model", model: 42 },
+        { name: "other-provider", model: "openrouter/anthropic/claude-opus-4.1" },
+        null,
+      ],
+    };
+    const expected = {
+      model: "claude-opus-4-8",
+      tools: [
+        { type: "advisor_20260301", model: "claude-opus-4-8", cache_control: { type: "ephemeral" } },
+        { name: "without-model", description: "unchanged" },
+        { name: "numeric-model", model: 42 },
+        { name: "other-provider", model: "openrouter/anthropic/claude-opus-4.1" },
+        null,
+      ],
+    };
+
+    expect(normalizeClaudePassthrough(body)).toEqual(expected);
+    expect(normalizeClaudePassthrough(body)).toEqual(expected);
+  });
+});
+
 describe("parseDataUri / encodeDataUri (docs 11 §4)", () => {
   it("parses a base64 data uri", () => {
     expect(parseDataUri("data:image/png;base64,AAAB")).toEqual({ mimeType: "image/png", base64: "AAAB" });


### PR DESCRIPTION
## Problem

Claude Code can expand ANTHROPIC_DEFAULT_*_MODEL values such as cc/claude-opus-4-8 into Advisor or Task server tools. 9router normalizes the top-level model for routing, but previously forwarded the nested tools[].model unchanged, causing Anthropic to reject the 9router-only prefix with HTTP 400.

## Fix

Normalize only the known cc/ and claude/ prefixes in tools[].model during native Claude passthrough outbound processing. The top-level model remains unchanged so 9router can continue selecting the Claude OAuth provider.

## Why proxy-layer normalization is safer

A settings-only change that writes a bare top-level claude-* model can make 9router infer the anthropic API-key provider instead of the Claude OAuth provider. Normalizing the actual outbound nested values avoids that routing regression and also covers existing settings plus payloads from other clients.

## Regression coverage

- Advisor advisor_20260301 nested model normalization
- Task/subagent nested model normalization
- Idempotency for already-bare models
- Preservation of missing, non-string, unrelated model values, and other tool fields

## Verification

- npx vitest run tests/unit/translator-helpers-edge.test.js — 10/10 passed
- npx eslint open-sse/translator/formats/claude.js tests/unit/translator-helpers-edge.test.js — passed
- git diff --check — passed

Fixes #2642
Related to #2582

This is a proxy-layer alternative to #2645.