### PR TITLE
feat(providers): allow disabling no-auth providers

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -97,6 +97,7 @@ const APIKEY_INITIAL_VISIBLE = 20;
 export default function ProvidersPage() {
   const [connections, setConnections] = useState([]);
   const [providerNodes, setProviderNodes] = useState([]);
+  const [disabledProviders, setDisabledProviders] = useState({});
   const [loading, setLoading] = useState(true);
   const [showAllApikey, setShowAllApikey] = useState(false);
   const [showAddCompatibleModal, setShowAddCompatibleModal] = useState(false);
@@ -147,15 +148,18 @@ export default function ProvidersPage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [connectionsRes, nodesRes] = await Promise.all([
+        const [connectionsRes, nodesRes, settingsRes] = await Promise.all([
           fetch("/api/providers"),
           fetch("/api/provider-nodes"),
+          fetch("/api/settings"),
         ]);
         const connectionsData = await connectionsRes.json();
         const nodesData = await nodesRes.json();
+        const settingsData = await settingsRes.json();
         if (connectionsRes.ok)
           setConnections(connectionsData.connections || []);
         if (nodesRes.ok) setProviderNodes(nodesData.nodes || []);
+        if (settingsRes.ok) setDisabledProviders(settingsData.disabledProviders || {});
       } catch (error) {
         console.log("Error fetching data:", error);
       } finally {
@@ -228,6 +232,23 @@ export default function ProvidersPage() {
         }),
       ),
     );
+  };
+
+  const handleToggleNoAuthProvider = async (providerId, newActive) => {
+    const previous = disabledProviders;
+    const updated = { ...previous };
+    if (newActive) delete updated[providerId];
+    else updated[providerId] = true;
+    setDisabledProviders(updated);
+    const res = await fetch("/api/settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ disabledProviders: updated }),
+    });
+    if (!res.ok) {
+      setDisabledProviders(previous);
+      notify.error("Failed to update provider");
+    }
   };
 
   const handleBatchTest = async (mode, providerId = null) => {
@@ -471,15 +492,23 @@ export default function ProvidersPage() {
             // while generic apikey providers use "apikey" — include both spellings.
             const freeAuthTypes =
               key === "kiro" ? ["oauth", "apikey", "api_key"] : "oauth";
+            const stats = getProviderStats(key, freeAuthTypes);
             return (
               <ProviderCard
                 key={key}
                 providerId={key}
                 provider={info}
-                stats={getProviderStats(key, freeAuthTypes)}
+                stats={{
+                  ...stats,
+                  allDisabled: info.noAuth
+                    ? disabledProviders[key] === true
+                    : stats.allDisabled,
+                }}
                 authType="free"
                 onToggle={(active) =>
-                  handleToggleProvider(key, freeAuthTypes, active)
+                  info.noAuth
+                    ? handleToggleNoAuthProvider(key, active)
+                    : handleToggleProvider(key, freeAuthTypes, active)
                 }
               />
             );
@@ -687,7 +716,7 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            {stats.total > 0 && (
+            {(stats.total > 0 || isNoAuth) && (
               <div
                 className="opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
                 onClick={(e) => {

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS = {
   tailscaleUrl: "",
   stickyRoundRobinLimit: 3,
   providerStrategies: {},
+  disabledProviders: {},
   quotaVisibility: {},
   comboStrategy: "fallback",
   comboStickyRoundRobinLimit: 1,

--- a/src/shared/components/ModelSelectModal.js
+++ b/src/shared/components/ModelSelectModal.js
@@ -48,6 +48,7 @@ export default function ModelSelectModal({
   const [providerNodes, setProviderNodes] = useState([]);
   const [customModels, setCustomModels] = useState([]);
   const [disabledModels, setDisabledModels] = useState({});
+  const [disabledProviders, setDisabledProviders] = useState({});
 
   const fetchCombos = async () => {
     try {
@@ -113,6 +114,14 @@ export default function ModelSelectModal({
     if (isOpen) fetchDisabledModels();
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    fetch("/api/settings", { cache: "no-store" })
+      .then((res) => res.ok ? res.json() : {})
+      .then((data) => setDisabledProviders(data.disabledProviders || {}))
+      .catch(() => setDisabledProviders({}));
+  }, [isOpen]);
+
   const allProviders = useMemo(() => ({ ...OAUTH_PROVIDERS, ...FREE_PROVIDERS, ...FREE_TIER_PROVIDERS, ...APIKEY_PROVIDERS }), []);
 
   // Group models by provider with priority order
@@ -140,9 +149,10 @@ export default function ModelSelectModal({
     const activeConnectionIds = filteredActiveProviders.map(p => p.provider);
 
     // No-auth providers: filter by kindFilter as well
+    const enabledNoAuthIds = NO_AUTH_PROVIDER_IDS.filter((id) => disabledProviders[id] !== true);
     const noAuthIds = kindFilter
-      ? NO_AUTH_PROVIDER_IDS.filter((id) => (AI_PROVIDERS[id]?.serviceKinds || ["llm"]).includes(kindFilter))
-      : NO_AUTH_PROVIDER_IDS;
+      ? enabledNoAuthIds.filter((id) => (AI_PROVIDERS[id]?.serviceKinds || ["llm"]).includes(kindFilter))
+      : enabledNoAuthIds;
 
     // Only show connected providers (including both standard and custom)
     const providerIdsToShow = new Set([
@@ -349,7 +359,7 @@ export default function ModelSelectModal({
     });
 
     return groups;
-  }, [filteredActiveProviders, modelAliases, allProviders, providerNodes, customModels, disabledModels, kindFilter, activeProviders]);
+  }, [filteredActiveProviders, modelAliases, allProviders, providerNodes, customModels, disabledModels, disabledProviders, kindFilter, activeProviders]);
 
   // Filter combos by search query (and hide combos when kindFilter is set — combos are LLM-only by design)
   const filteredCombos = useMemo(() => {

--- a/src/shared/components/NoAuthProxyCard.js
+++ b/src/shared/components/NoAuthProxyCard.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import Card from "./Card";
 import Select from "./Select";
 import Badge from "./Badge";
+import Toggle from "./Toggle";
 
 const NONE_PROXY_POOL_VALUE = "__none__";
 const STRATEGIES = [
@@ -17,6 +18,7 @@ export default function NoAuthProxyCard({ providerId }) {
   const [proxyPools, setProxyPools] = useState([]);
   const [proxyPoolId, setProxyPoolId] = useState(NONE_PROXY_POOL_VALUE);
   const [rotateStrategy, setRotateStrategy] = useState("none");
+  const [enabled, setEnabled] = useState(true);
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
 
@@ -31,9 +33,36 @@ export default function NoAuthProxyCard({ providerId }) {
       const override = (settingsData.providerStrategies || {})[providerId] || {};
       setProxyPoolId(override.proxyPoolId || NONE_PROXY_POOL_VALUE);
       setRotateStrategy(override.rotateStrategy || "none");
+      setEnabled(settingsData.disabledProviders?.[providerId] !== true);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [providerId]);
+
+  const handleEnabledChange = async (newEnabled) => {
+    const previous = enabled;
+    setEnabled(newEnabled);
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings", { cache: "no-store" });
+      const data = res.ok ? await res.json() : {};
+      const updated = { ...(data.disabledProviders || {}) };
+      if (newEnabled) delete updated[providerId];
+      else updated[providerId] = true;
+      const saveRes = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ disabledProviders: updated }),
+      });
+      if (!saveRes.ok) throw new Error("Failed to update provider");
+      setSavedFlash(true);
+      setTimeout(() => setSavedFlash(false), 1500);
+    } catch (e) {
+      setEnabled(previous);
+      console.log("Save provider status error:", e);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const save = useCallback(async (poolId, strategy) => {
     setSaving(true);
@@ -84,9 +113,10 @@ export default function NoAuthProxyCard({ providerId }) {
         </div>
         <div className="flex-1">
           <p className="text-sm font-medium">No authentication required</p>
-          <p className="text-xs text-text-muted">This provider is ready to use. Optionally route requests through a proxy pool to bypass IP-based limits.</p>
+          <p className="text-xs text-text-muted">{enabled ? "This provider is ready to use." : "This provider is disabled."} Optionally route requests through a proxy pool to bypass IP-based limits.</p>
         </div>
         {savedFlash && <Badge variant="success" size="sm">Saved</Badge>}
+        <Toggle checked={enabled} onChange={handleEnabledChange} disabled={saving} />
       </div>
 
       <Select

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -123,6 +123,10 @@ export function resolveProviderId(aliasOrId) {
   return provider?.id || aliasOrId;
 }
 
+export function isProviderDisabled(settings, providerId) {
+  return settings?.disabledProviders?.[resolveProviderId(providerId)] === true;
+}
+
 // Helper: Get alias from provider ID
 export function getProviderAlias(providerId) {
   const provider = AI_PROVIDERS[providerId];

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -2,7 +2,7 @@ import { getProviderConnections, validateApiKey, updateProviderConnection, getSe
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
-import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
+import { resolveProviderId, FREE_PROVIDERS, isProviderDisabled } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
 
 // Mutex to prevent race conditions during account selection
@@ -35,6 +35,10 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
     // Inject a virtual connection for no-auth free providers (with optional proxy pool from settings)
     if (FREE_PROVIDERS[providerId]?.noAuth) {
       const settings = await getSettings();
+      if (isProviderDisabled(settings, providerId)) {
+        log.warn("AUTH", `Provider ${providerId} is disabled`);
+        return null;
+      }
       const override = (settings.providerStrategies || {})[providerId] || {};
       const strategy = override.rotateStrategy || "none";
       let pickedId = override.proxyPoolId || null;

--- a/tests/unit/noauth-provider-disable.test.js
+++ b/tests/unit/noauth-provider-disable.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getProxyPools: vi.fn(),
+  resolveConnectionProxyConfig: vi.fn(),
+}));
+
+vi.mock("../../src/lib/localDb.js", () => ({
+  getProviderConnections: vi.fn(),
+  validateApiKey: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  getSettings: mocks.getSettings,
+  getProxyPools: mocks.getProxyPools,
+}));
+
+vi.mock("../../src/lib/network/connectionProxy.js", () => ({
+  resolveConnectionProxyConfig: mocks.resolveConnectionProxyConfig,
+  pickProxyPoolId: vi.fn(),
+}));
+
+vi.mock("../../src/sse/utils/logger.js", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+import { getProviderCredentials } from "../../src/sse/services/auth.js";
+
+describe("no-auth provider disabling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({});
+    mocks.resolveConnectionProxyConfig.mockResolvedValue({
+      connectionProxyEnabled: false,
+      connectionProxyUrl: "",
+      connectionNoProxy: "",
+      proxyPoolId: null,
+      vercelRelayUrl: "",
+    });
+  });
+
+  it.each(["opencode", "oc", "mimo-free", "mmf"])("enables %s by default", async (provider) => {
+    await expect(getProviderCredentials(provider)).resolves.toMatchObject({
+      id: "noauth",
+      isActive: true,
+      accessToken: "public",
+    });
+  });
+
+  it.each([
+    ["opencode", "opencode"],
+    ["oc", "opencode"],
+    ["mimo-free", "mimo-free"],
+    ["mmf", "mimo-free"],
+  ])("disables %s using the canonical provider setting", async (provider, providerId) => {
+    mocks.getSettings.mockResolvedValue({ disabledProviders: { [providerId]: true } });
+
+    await expect(getProviderCredentials(provider)).resolves.toBeNull();
+    expect(mocks.resolveConnectionProxyConfig).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add persisted enable/disable controls for connectionless no-auth providers
- enforce disabled state during credential selection, including `oc` and `mmf` aliases
- hide disabled no-auth providers from model selection and expose toggles on provider cards and detail pages
- add focused coverage for OpenCode Free and MiMo Code Free routing

## Testing
- `npx vitest run unit/noauth-provider-disable.test.js unit/mimo-free.test.js`
- `npx eslint src/app/\(dashboard\)/dashboard/providers/page.js src/shared/components/NoAuthProxyCard.js src/shared/constants/providers.js src/sse/services/auth.js src/lib/db/repos/settingsRepo.js tests/unit/noauth-provider-disable.test.js`
- `npm run build`

## Notes
- `ModelSelectModal.js` still has its four existing `react-hooks/set-state-in-effect` lint failures and one existing `sortModels` dependency warning; this change introduces no new lint finding in that file.