### PR TITLE
fix(rtk): preserve non-message Responses items

### DIFF
--- a/open-sse/rtk/systemInject.js
+++ b/open-sse/rtk/systemInject.js
@@ -41,9 +41,18 @@ function injectMessagesSystem(body, prompt) {
     : null;
   if (!arr) return;
 
-  const idx = arr.findIndex(m => m && (m.role === "system" || m.role === "developer"));
+  const responsesInput = !Array.isArray(body.messages) && Array.isArray(body.input);
+  const idx = arr.findIndex(m => m
+    && (m.role === "system" || m.role === "developer")
+    && (!responsesInput || m.type == null || m.type === "message"));
   if (idx >= 0) {
     appendToOpenAIMessage(arr[idx], prompt);
+  } else if (responsesInput) {
+    arr.unshift({
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: prompt }],
+    });
   } else {
     arr.unshift({ role: "system", content: prompt });
   }

--- a/tests/unit/system-inject.test.js
+++ b/tests/unit/system-inject.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { injectSystemPrompt } from "../../open-sse/rtk/systemInject.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("Responses system prompt injection", () => {
+  it("skips Codex additional_tools items and appends to a real developer message", () => {
+    const additionalTools = {
+      type: "additional_tools",
+      role: "developer",
+      tools: [{ type: "function", name: "exec" }],
+    };
+    const body = {
+      input: [
+        additionalTools,
+        {
+          type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "existing" }],
+        },
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+      ],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "injected");
+
+    expect(body.input[0]).toEqual(additionalTools);
+    expect(body.input[0]).not.toHaveProperty("content");
+    expect(body.input[1].content).toEqual([
+      { type: "input_text", text: "existing" },
+      { type: "input_text", text: "injected" },
+    ]);
+  });
+
+  it("creates a typed developer message when Responses input has no instruction message", () => {
+    const additionalTools = {
+      type: "additional_tools",
+      role: "developer",
+      tools: [{ type: "function", name: "exec" }],
+    };
+    const body = { input: [additionalTools] };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "injected");
+
+    expect(body.input).toEqual([
+      {
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: "injected" }],
+      },
+      additionalTools,
+    ]);
+    expect(additionalTools).not.toHaveProperty("content");
+  });
+});


### PR DESCRIPTION
## Summary
- restrict OpenAI Responses prompt injection to message items
- preserve Codex `additional_tools` and other non-message items unchanged
- create a typed developer message when Responses input has no instruction message

## Root cause
`systemInject` selected the first `role: developer` item without checking its Responses item type. New Codex clients send an `additional_tools` item with that role, so Caveman/Ponytail added an unsupported `content` field and ChatGPT Codex rejected the request as `Unknown parameter: input[0].content`.

## Test
- `npx vitest run tests/unit/system-inject.test.js`
- 2 tests passed