### PR TITLE
fix(usage): include Claude cache tokens in prompt totals

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -2,7 +2,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { needsTranslation } from "../../translator/index.js";
 import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
-import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
+import { addBufferToUsage, claudeUsageToOpenAI, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
@@ -178,11 +178,7 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
     };
 
     if (responseBody.usage) {
-      result.usage = {
-        prompt_tokens: responseBody.usage.input_tokens || 0,
-        completion_tokens: responseBody.usage.output_tokens || 0,
-        total_tokens: (responseBody.usage.input_tokens || 0) + (responseBody.usage.output_tokens || 0)
-      };
+      result.usage = claudeUsageToOpenAI(responseBody.usage);
     }
     return result;
   }

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -207,6 +207,36 @@ export function canonicalizeUsage(usage) {
 }
 
 /**
+ * Convert Claude's cache-exclusive input accounting to OpenAI's convention,
+ * where prompt_tokens includes cached and newly cached input tokens.
+ */
+export function claudeUsageToOpenAI(usage) {
+  const canonical = canonicalizeUsage({
+    prompt_tokens: usage?.input_tokens,
+    completion_tokens: usage?.output_tokens,
+    cache_read_input_tokens: usage?.cache_read_input_tokens,
+    cache_creation_input_tokens: usage?.cache_creation_input_tokens,
+  });
+  if (!canonical) return null;
+
+  const result = {
+    prompt_tokens: canonical.prompt_tokens,
+    completion_tokens: canonical.completion_tokens,
+    total_tokens: canonical.total_tokens,
+  };
+  if (canonical.cached_tokens > 0 || canonical.cache_creation_input_tokens > 0) {
+    result.prompt_tokens_details = {};
+    if (canonical.cached_tokens > 0) {
+      result.prompt_tokens_details.cached_tokens = canonical.cached_tokens;
+    }
+    if (canonical.cache_creation_input_tokens > 0) {
+      result.prompt_tokens_details.cache_creation_tokens = canonical.cache_creation_input_tokens;
+    }
+  }
+  return result;
+}
+
+/**
  * Check if usage has valid token data
  * Valid = has at least one token field with value > 0
  * Invalid = empty object {}, null, undefined, no token fields, or all zeros

--- a/tests/unit/claude-nonstreaming-usage.test.js
+++ b/tests/unit/claude-nonstreaming-usage.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { claudeUsageToOpenAI } from "../../open-sse/utils/usageTracking.js";
+
+describe("Claude non-streaming usage translation", () => {
+  it("includes cache reads and cache writes in OpenAI prompt totals", () => {
+    const translated = claudeUsageToOpenAI({
+      input_tokens: 11,
+      output_tokens: 3,
+      cache_read_input_tokens: 7,
+      cache_creation_input_tokens: 5,
+    });
+
+    expect(translated).toEqual({
+      prompt_tokens: 23,
+      completion_tokens: 3,
+      total_tokens: 26,
+      prompt_tokens_details: {
+        cached_tokens: 7,
+        cache_creation_tokens: 5,
+      },
+    });
+  });
+
+  it("does not add empty prompt details when Claude reports no cache usage", () => {
+    const translated = claudeUsageToOpenAI({ input_tokens: 11, output_tokens: 3 });
+
+    expect(translated).toEqual({
+      prompt_tokens: 11,
+      completion_tokens: 3,
+      total_tokens: 14,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- translate Claude non-streaming usage to OpenAI cache-inclusive prompt totals
- preserve cache-read and cache-creation detail fields
- reuse the existing canonical usage convention so client responses match the usage ledger

## Why

Claude reports input tokens separately from cache-read and cache-creation tokens. The current OpenAI response translation exposes only input_tokens as prompt_tokens, while the ledger correctly folds cache tokens into its canonical prompt total. This makes the response usage disagree with the persisted usage row.

## Tests

- claude-nonstreaming-usage.test.js
- cached-token-usage.test.js
- cached-token-e2e.test.js

19 tests passed.