### PR TITLE
fix(translator): pass service_tier through OpenAI→Responses conversion

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -377,6 +377,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.top_p !== undefined) result.top_p = body.top_p;
   if (body.reasoning !== undefined) result.reasoning = body.reasoning;
   if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
+  if (body.service_tier !== undefined) result.service_tier = body.service_tier;
 
   return result;
 }


### PR DESCRIPTION
## Problem

The `openaiToOpenAIResponsesRequest` translator was not forwarding `service_tier` from Chat Completions to Responses API format, even though the Codex executor already handles it (line 475-476 in `executors/codex.js`):
```js
if (body.service_tier === "fast") body.service_tier = "priority";
if (body.service_tier && body.service_tier !== "priority") delete body.service_tier;
```

This meant `service_tier: "priority"` sent via 9router was **silently dropped** during translation, giving identical performance to `default` tier.

## Benchmark

Direct probe against `https://chatgpt.com/backend-api/codex/responses` (bypassing 9router) confirms priority tier delivers real speedup:

| Model | Tier | TPS p50 | Delta |
|---|---|---|---|
| `gpt-5.6-sol` | default | 45.6 | — |
| `gpt-5.6-sol` | **priority** | **61.8** | **+35.6%** |
| `gpt-5.6-terra` | default | 53.3 | — |
| `gpt-5.6-terra` | **priority** | **73.6** | **+37.9%** |

Via 9router (before fix): no difference between tiers (field dropped).
Via 9router (after fix): priority shows the same ~35-38% TPS improvement.

## Fix

One-line passthrough in the translator's field forwarding block:

```diff
   if (body.reasoning !== undefined) result.reasoning = body.reasoning;
   if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
+  if (body.service_tier !== undefined) result.service_tier = body.service_tier;
```

The executor's existing allowlist (`RESPONSES_API_ALLOWLIST`) already includes `service_tier`, so no additional changes needed there.