### PR TITLE
fix(kiro): distinguish confirmed credit exhaustion from ambiguous 402s

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -41,6 +41,19 @@ export const TRANSIENT_COOLDOWN_MS = 30 * 1000;
 // Hard cap for provider-reported rate limit cooldown (e.g. codex resets_at can be 5-6h)
 export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000;
 
+// Confirmed Kiro credit exhaustion (monthly quota, `resetAt` from GetUsageLimits) can be
+// weeks away. Capping it at the generic 30-min rate-limit window would mean re-probing an
+// account we already know is exhausted every 30 minutes; instead cap it at a low-frequency
+// daily probe so the account is retried roughly once a day — enough to notice an early
+// reset (manual top-up, plan change) without hammering a known-dead account.
+export const KIRO_CREDIT_EXHAUSTION_PROBE_MS = 24 * 60 * 60 * 1000;
+
+// Per-provider override for the max resetsAtMs-derived cooldown (see markAccountUnavailable).
+// Any provider not listed here falls back to MAX_RATE_LIMIT_COOLDOWN_MS.
+export const RESET_COOLDOWN_CAP_MS = {
+  kiro: KIRO_CREDIT_EXHAUSTION_PROBE_MS,
+};
+
 // Cooldown durations (ms)
 const COOLDOWN = {
   long: 2 * 60 * 1000,

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -5,6 +5,56 @@ import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
+import { getKiroUsage } from "../services/usage/kiro.js";
+import { KIRO_CREDIT_EXHAUSTION_PROBE_MS } from "../config/errorConfig.js";
+
+/**
+ * Confirmed-exhaustion signal for Kiro's monthly credit quota. Verified against a real
+ * CodeWhisperer GenerateAssistantResponse 402 body (AWS ServiceQuotaExceededException):
+ *   { "message": "You have reached the limit.",
+ *     "cause": { "$metadata": { "httpStatusCode": 402 }, "name": "ServiceQuotaExceededException",
+ *                "reason": "MONTHLY_REQUEST_COUNT" } }
+ * Some surfaces flatten `cause.name`/`cause.reason` onto the top-level object instead, so both
+ * shapes are checked. Any other 402 (bad payment method, suspended account, unrecognized shape)
+ * is left ambiguous and keeps the existing generic 402 cooldown (open-sse/config/errorConfig.js).
+ */
+const KIRO_QUOTA_EXCEEDED_EXCEPTION = "ServiceQuotaExceededException";
+const KIRO_QUOTA_EXCEEDED_REASON = "MONTHLY_REQUEST_COUNT";
+
+/** Follow-up quota-lookup timeout — bounds how long a confirmed-402 error response can wait. */
+const KIRO_RESET_LOOKUP_TIMEOUT_MS = 8000;
+
+function isConfirmedKiroCreditExhaustion(bodyText) {
+  if (!bodyText) return false;
+  try {
+    const json = JSON.parse(bodyText);
+    const name = json?.name ?? json?.cause?.name;
+    const reason = json?.reason ?? json?.cause?.reason;
+    if (name === KIRO_QUOTA_EXCEEDED_EXCEPTION && reason === KIRO_QUOTA_EXCEEDED_REASON) return true;
+  } catch { /* not JSON — fall through to the text-based check below */ }
+  const lower = bodyText.toLowerCase();
+  return lower.includes(KIRO_QUOTA_EXCEEDED_EXCEPTION.toLowerCase())
+    && lower.includes(KIRO_QUOTA_EXCEEDED_REASON.toLowerCase());
+}
+
+/** Earliest resetAt (ms epoch) among fully-depleted quota buckets, or null if none/unknown. */
+function earliestDepletedResetMs(quotas) {
+  let earliest = null;
+  for (const quota of Object.values(quotas || {})) {
+    if (!quota || quota.unlimited || !(quota.total > 0) || quota.remaining > 0 || !quota.resetAt) continue;
+    const ms = new Date(quota.resetAt).getTime();
+    if (!Number.isFinite(ms)) continue;
+    if (earliest === null || ms < earliest) earliest = ms;
+  }
+  return earliest;
+}
+
+function withTimeout(promise, ms) {
+  return Promise.race([
+    promise,
+    new Promise((resolve) => setTimeout(() => resolve(null), ms)),
+  ]);
+}
 
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
@@ -91,6 +141,42 @@ export class KiroExecutor extends BaseExecutor {
 
   transformRequest(model, body, stream, credentials) {
     return body;
+  }
+
+  /**
+   * Classify a Kiro 402 as confirmed monthly-credit exhaustion vs. ambiguous (bad payment
+   * method, suspended account, unrecognized upstream shape — see isConfirmedKiroCreditExhaustion
+   * doc above). Only a confirmed match gets a precise cooldown; everything else falls through
+   * to the base classifier and keeps the existing generic 402 cooldown unchanged.
+   *
+   * The 402 body itself never carries a reset time, so on a confirmed match this makes a
+   * best-effort follow-up call to Kiro's own quota API (GetUsageLimits) for the trustworthy
+   * `resetAt` already surfaced there (services/usage/kiro.js). If that lookup is unreachable,
+   * times out, or shows nothing depleted, resetsAtMs falls back to a bounded daily-probe
+   * window rather than guessing a date — markAccountUnavailable caps either case at
+   * KIRO_CREDIT_EXHAUSTION_PROBE_MS (see errorConfig.js) so the account is retried at most
+   * about once a day until it recovers.
+   */
+  async parseError(response, bodyText, credentials, proxyOptions) {
+    if (response.status !== 402 || !isConfirmedKiroCreditExhaustion(bodyText)) {
+      return super.parseError(response, bodyText);
+    }
+
+    let resetsAtMs = null;
+    try {
+      const accessToken = credentials?.apiKey || credentials?.accessToken;
+      const usage = await withTimeout(
+        getKiroUsage(accessToken, credentials?.providerSpecificData, proxyOptions),
+        KIRO_RESET_LOOKUP_TIMEOUT_MS
+      );
+      resetsAtMs = earliestDepletedResetMs(usage?.quotas);
+    } catch { /* best-effort only — fall back to the daily probe below */ }
+
+    if (!resetsAtMs || resetsAtMs <= Date.now()) {
+      resetsAtMs = Date.now() + KIRO_CREDIT_EXHAUSTION_PROBE_MS;
+    }
+
+    return { status: 402, message: "Kiro monthly credit limit reached", resetsAtMs };
   }
 
   /**

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -349,7 +349,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Provider returned error
   if (!providerResponse.ok) {
     trackPendingRequest(model, provider, connectionId, false, true);
-    const { statusCode, message, resetsAtMs } = await parseUpstreamError(providerResponse, executor);
+    const { statusCode, message, resetsAtMs } = await parseUpstreamError(providerResponse, executor, credentials, proxyOptions);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${statusCode}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -114,15 +114,18 @@ export function getModelLockKey(model) {
 }
 
 /**
- * Get the active lock expiry for a specific model on one connection.
+ * Get when one connection becomes available for a specific model.
+ * Both model-specific and account-wide locks apply, so the later active expiry wins.
  */
 export function getModelLockUntil(connection, model) {
   if (!connection) return null;
-  const key = getModelLockKey(model);
-  const expiry = connection[key] || connection[MODEL_LOCK_ALL];
-  const expiryMs = expiry ? new Date(expiry).getTime() : NaN;
-  if (!Number.isFinite(expiryMs) || expiryMs <= Date.now()) return null;
-  return new Date(expiryMs).toISOString();
+  const now = Date.now();
+  const lockKeys = model ? [getModelLockKey(model), MODEL_LOCK_ALL] : [MODEL_LOCK_ALL];
+  const activeExpiries = lockKeys
+    .map(key => new Date(connection[key]).getTime())
+    .filter(expiryMs => Number.isFinite(expiryMs) && expiryMs > now);
+  if (activeExpiries.length === 0) return null;
+  return new Date(Math.max(...activeExpiries)).toISOString();
 }
 
 /**

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -114,14 +114,23 @@ export function getModelLockKey(model) {
 }
 
 /**
+ * Get the active lock expiry for a specific model on one connection.
+ */
+export function getModelLockUntil(connection, model) {
+  if (!connection) return null;
+  const key = getModelLockKey(model);
+  const expiry = connection[key] || connection[MODEL_LOCK_ALL];
+  const expiryMs = expiry ? new Date(expiry).getTime() : NaN;
+  if (!Number.isFinite(expiryMs) || expiryMs <= Date.now()) return null;
+  return new Date(expiryMs).toISOString();
+}
+
+/**
  * Check if a model lock on a connection is still active.
  * Reads flat field `modelLock_${model}` (or `modelLock___all` when model=null).
  */
 export function isModelLockActive(connection, model) {
-  const key = getModelLockKey(model);
-  const expiry = connection[key] || connection[MODEL_LOCK_ALL];
-  if (!expiry) return false;
-  return new Date(expiry).getTime() > Date.now();
+  return getModelLockUntil(connection, model) !== null;
 }
 
 /**

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -53,9 +53,12 @@ export async function writeStreamError(writer, statusCode, message) {
  * Parse upstream provider error response
  * @param {Response} response - Fetch response from provider
  * @param {object} [executor] - Optional executor with parseError() override for provider-specific parsing
+ * @param {object} [credentials] - Request credentials, passed through for parsers that need a follow-up
+ *   lookup (e.g. kiro confirming a credit-exhaustion reset time via the quota API)
+ * @param {object} [proxyOptions] - Proxy options to reuse for any such follow-up lookup
  * @returns {Promise<{statusCode: number, message: string, resetsAtMs?: number}>}
  */
-export async function parseUpstreamError(response, executor = null) {
+export async function parseUpstreamError(response, executor = null, credentials = null, proxyOptions = null) {
   let bodyText = "";
   try {
     bodyText = await response.text();
@@ -63,10 +66,12 @@ export async function parseUpstreamError(response, executor = null) {
     bodyText = "";
   }
 
-  // Let executor-specific parser extract provider-specific fields (e.g. codex resetsAtMs)
+  // Let executor-specific parser extract provider-specific fields (e.g. codex resetsAtMs).
+  // parseError may be sync (codex) or async (kiro, which may issue a follow-up quota lookup) —
+  // awaiting a plain value is a no-op, so both shapes work here.
   if (executor && typeof executor.parseError === "function") {
     try {
-      const parsed = executor.parseError(response, bodyText);
+      const parsed = await executor.parseError(response, bodyText, credentials, proxyOptions);
       if (parsed && typeof parsed === "object") {
         const msg = parsed.message || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
         return { statusCode: parsed.status || response.status, message: msg, resetsAtMs: parsed.resetsAtMs };

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -201,8 +201,8 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // All accounts unavailable
     if (!credentials || credentials.allRateLimited) {
       if (credentials?.allRateLimited) {
-        const errorMsg = lastError || credentials.lastError || "Unavailable";
-        const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
+        const errorMsg = credentials.lastError || "Unavailable";
+        const status = Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
         log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,7 +1,7 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
-import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
+import { MAX_RATE_LIMIT_COOLDOWN_MS, RESET_COOLDOWN_CAP_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
 
@@ -213,11 +213,15 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   const conn = connections.find(c => c.id === connectionId);
   const backoffLevel = conn?.backoffLevel || 0;
 
-  // Provider-specific precise cooldown (e.g. codex usage_limit_reached resets_at) overrides backoff
+  // Provider-specific precise cooldown (e.g. codex usage_limit_reached resets_at, kiro
+  // confirmed credit exhaustion) overrides backoff. Each provider's resetsAtMs is capped
+  // at a provider-appropriate max so a far-future reset doesn't lock the account past its
+  // next low-frequency recheck (see RESET_COOLDOWN_CAP_MS).
   let shouldFallback, cooldownMs, newBackoffLevel;
   if (resetsAtMs && resetsAtMs > Date.now()) {
     shouldFallback = true;
-    cooldownMs = Math.min(resetsAtMs - Date.now(), MAX_RATE_LIMIT_COOLDOWN_MS);
+    const cooldownCapMs = RESET_COOLDOWN_CAP_MS[provider] ?? MAX_RATE_LIMIT_COOLDOWN_MS;
+    cooldownMs = Math.min(resetsAtMs - Date.now(), cooldownCapMs);
     newBackoffLevel = 0;
   } else {
     ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,6 +1,6 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS, RESET_COOLDOWN_CAP_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
@@ -79,25 +79,26 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       const excluded = excludeSet.has(c.id);
       const locked = isModelLockActive(c, model);
       if (excluded || locked) {
-        const lockUntil = getEarliestModelLockUntil(c);
+        const lockUntil = getModelLockUntil(c, model);
         log.debug("AUTH", `  → ${c.id?.slice(0, 8)} | ${excluded ? "excluded" : ""} ${locked ? `modelLocked(${model}) until ${lockUntil}` : ""}`);
       }
     });
 
     if (availableConnections.length === 0) {
-      // Find earliest lock expiry across all connections for retry timing
-      const lockedConns = connections.filter(c => isModelLockActive(c, model));
-      const expiries = lockedConns.map(c => getEarliestModelLockUntil(c)).filter(Boolean);
-      const earliest = expiries.sort()[0] || null;
-      if (earliest) {
-        const earliestConn = lockedConns[0];
-        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(earliest)}) | lastError=${earliestConn?.lastError?.slice(0, 50)}`);
+      // Keep retry timing and error metadata paired to the same locked account.
+      const earliestLock = connections
+        .map(connection => ({ connection, retryAfter: getModelLockUntil(connection, model) }))
+        .filter(lock => lock.retryAfter)
+        .sort((a, b) => new Date(a.retryAfter) - new Date(b.retryAfter))[0];
+      if (earliestLock) {
+        const { connection: earliestConn, retryAfter } = earliestLock;
+        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(retryAfter)}) | lastError=${earliestConn?.lastError?.slice(0, 50)}`);
         return {
           allRateLimited: true,
-          retryAfter: earliest,
-          retryAfterHuman: formatRetryAfter(earliest),
+          retryAfter,
+          retryAfterHuman: formatRetryAfter(retryAfter),
           lastError: earliestConn?.lastError || null,
-          lastErrorCode: earliestConn?.errorCode || null
+          lastErrorCode: earliestConn?.errorCode ?? null
         };
       }
       log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`);
@@ -266,7 +267,7 @@ export async function clearAccountError(connectionId, currentConnection, model =
   const now = Date.now();
   const allLockKeys = Object.keys(conn).filter(k => k.startsWith("modelLock_"));
 
-  if (!conn.testStatus && !conn.lastError && allLockKeys.length === 0) return;
+  if (!conn.testStatus && !conn.lastError && !conn.errorCode && allLockKeys.length === 0) return;
 
   // Keys to clear: current model's lock + all expired locks
   const keysToClear = allLockKeys.filter(k => {
@@ -276,7 +277,7 @@ export async function clearAccountError(connectionId, currentConnection, model =
     return expiry && new Date(expiry).getTime() <= now;   // expired
   });
 
-  if (keysToClear.length === 0 && conn.testStatus !== "unavailable" && !conn.lastError) return;
+  if (keysToClear.length === 0 && conn.testStatus !== "unavailable" && !conn.lastError && !conn.errorCode) return;
 
   // Check if any active locks remain after clearing
   const remainingActiveLocks = allLockKeys.filter(k => {
@@ -289,7 +290,7 @@ export async function clearAccountError(connectionId, currentConnection, model =
 
   // Only reset error state if no active locks remain
   if (remainingActiveLocks.length === 0) {
-    Object.assign(clearObj, { testStatus: "active", lastError: null, lastErrorAt: null, backoffLevel: 0 });
+    Object.assign(clearObj, { testStatus: "active", lastError: null, lastErrorAt: null, errorCode: null, backoffLevel: 0 });
   }
 
   await updateProviderConnection(connectionId, clearObj);

--- a/tests/unit/account-lock-aggregation.test.js
+++ b/tests/unit/account-lock-aggregation.test.js
@@ -73,6 +73,27 @@ describe("account lock aggregation", () => {
     expect(getModelLockUntil({ modelLock___all: accountLock }, MODEL)).toBe(accountLock);
   });
 
+  it("uses an active account-wide lock when the requested model lock has expired", () => {
+    const accountLock = lockAt(45_000);
+    const connection = {
+      [`modelLock_${MODEL}`]: lockAt(-1_000),
+      modelLock___all: accountLock,
+    };
+
+    expect(getModelLockUntil(connection, MODEL)).toBe(accountLock);
+  });
+
+  it("waits for both model-specific and account-wide locks to expire", () => {
+    const modelLock = lockAt(45_000);
+    const accountLock = lockAt(60_000);
+    const connection = {
+      [`modelLock_${MODEL}`]: modelLock,
+      modelLock___all: accountLock,
+    };
+
+    expect(getModelLockUntil(connection, MODEL)).toBe(accountLock);
+  });
+
   it("keeps the earliest lock expiry, status, and error paired to one account", async () => {
     const quotaLock = lockAt(120_000);
     const transientLock = lockAt(30_000);

--- a/tests/unit/account-lock-aggregation.test.js
+++ b/tests/unit/account-lock-aggregation.test.js
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  getSettings: vi.fn(),
+  updateProviderConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  getSettings: mocks.getSettings,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: vi.fn(),
+  getProxyPools: vi.fn(),
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: vi.fn().mockResolvedValue({}),
+  pickProxyPoolId: vi.fn(),
+}));
+
+const MODEL = "gpt-5.6-sol";
+const NOW = new Date("2026-07-20T16:00:00.000Z");
+let connections;
+
+const lockAt = (offsetMs) => new Date(NOW.getTime() + offsetMs).toISOString();
+const lockedConnection = (id, offsetMs, errorCode, lastError) => ({
+  id,
+  priority: Number(id.match(/\d+/)?.[0] || 1),
+  isActive: true,
+  accessToken: `token-${id}`,
+  [`modelLock_${MODEL}`]: lockAt(offsetMs),
+  testStatus: "unavailable",
+  errorCode,
+  lastError,
+});
+
+const { getModelLockUntil } = await import("../../open-sse/services/accountFallback.js");
+const { clearAccountError, getProviderCredentials } = await import("../../src/sse/services/auth.js");
+
+describe("account lock aggregation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    connections = [];
+    mocks.getProviderConnections.mockImplementation(async () => connections);
+    mocks.getSettings.mockResolvedValue({ fallbackStrategy: "fill-first", providerStrategies: {} });
+    mocks.updateProviderConnection.mockImplementation(async (id, update) => {
+      const connection = connections.find((candidate) => candidate.id === id);
+      if (connection) Object.assign(connection, update);
+      return connection;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("gets the active lock expiry for the requested model", () => {
+    const requestedModelLock = lockAt(60_000);
+    const connection = {
+      [`modelLock_${MODEL}`]: requestedModelLock,
+      "modelLock_other-model": lockAt(10_000),
+    };
+
+    expect(getModelLockUntil(connection, MODEL)).toBe(requestedModelLock);
+  });
+
+  it("uses an account-wide lock when the requested model has no lock", () => {
+    const accountLock = lockAt(45_000);
+
+    expect(getModelLockUntil({ modelLock___all: accountLock }, MODEL)).toBe(accountLock);
+  });
+
+  it("keeps the earliest lock expiry, status, and error paired to one account", async () => {
+    const quotaLock = lockAt(120_000);
+    const transientLock = lockAt(30_000);
+    connections = [
+      ...[1, 2, 3].map((index) => lockedConnection(`quota-${index}`, 120_000, 402, "MONTHLY_REQUEST_COUNT")),
+      lockedConnection("funded-4", 30_000, 502, "Funded account bad gateway"),
+      lockedConnection("funded-5", 30_000, 503, "Funded account temporarily unavailable"),
+    ];
+
+    const unavailable = await getProviderCredentials("kiro", null, MODEL);
+
+    expect(connections.slice(0, 3).every((connection) => connection[`modelLock_${MODEL}`] === quotaLock)).toBe(true);
+    expect(connections.slice(3).every((connection) => connection[`modelLock_${MODEL}`] === transientLock)).toBe(true);
+    expect(unavailable).toMatchObject({
+      allRateLimited: true,
+      retryAfter: transientLock,
+      lastError: "Funded account bad gateway",
+      lastErrorCode: 502,
+    });
+  });
+
+  it("preserves a genuine all-quota-exhausted result", async () => {
+    connections = [1, 2, 3].map((index) => lockedConnection(
+      `quota-${index}`,
+      120_000,
+      402,
+      "MONTHLY_REQUEST_COUNT"
+    ));
+
+    const unavailable = await getProviderCredentials("kiro", null, MODEL);
+
+    expect(unavailable).toMatchObject({
+      allRateLimited: true,
+      retryAfter: lockAt(120_000),
+      lastError: "MONTHLY_REQUEST_COUNT",
+      lastErrorCode: 402,
+    });
+  });
+
+  it("selects a funded account after cooldown and clears its stale error code on success", async () => {
+    connections = [lockedConnection("funded-1", 30_000, 502, "Funded account bad gateway")];
+    connections[0].lastErrorAt = NOW.toISOString();
+    connections[0].backoffLevel = 2;
+
+    vi.advanceTimersByTime(31_000);
+    const credentials = await getProviderCredentials("kiro", null, MODEL);
+    await clearAccountError(credentials.connectionId, credentials, MODEL);
+
+    expect(credentials.connectionId).toBe("funded-1");
+    expect(connections[0]).toMatchObject({
+      [`modelLock_${MODEL}`]: null,
+      testStatus: "active",
+      lastError: null,
+      lastErrorAt: null,
+      errorCode: null,
+      backoffLevel: 0,
+    });
+  });
+
+  it("clears errorCode even when it is the only stale error state", async () => {
+    connections = [{ id: "funded-1", isActive: true, testStatus: "active", errorCode: 502 }];
+
+    await clearAccountError("funded-1", connections[0], MODEL);
+
+    expect(mocks.updateProviderConnection).toHaveBeenCalledWith("funded-1", expect.objectContaining({ errorCode: null }));
+  });
+});

--- a/tests/unit/chat-all-accounts-locked.test.js
+++ b/tests/unit/chat-all-accounts-locked.test.js
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  getModelInfo: vi.fn(),
+  getComboModels: vi.fn(),
+  handleChatCore: vi.fn(),
+  checkAndRefreshToken: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({ getSettings: mocks.getSettings }));
+
+vi.mock("../../src/sse/services/auth.js", () => ({
+  getProviderCredentials: mocks.getProviderCredentials,
+  markAccountUnavailable: mocks.markAccountUnavailable,
+  clearAccountError: mocks.clearAccountError,
+  extractApiKey: vi.fn(() => null),
+  isValidApiKey: vi.fn(),
+}));
+
+vi.mock("../../src/sse/services/model.js", () => ({
+  getModelInfo: mocks.getModelInfo,
+  getComboModels: mocks.getComboModels,
+}));
+
+vi.mock("open-sse/handlers/chatCore.js", () => ({ handleChatCore: mocks.handleChatCore }));
+
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: mocks.checkAndRefreshToken,
+  updateProviderCredentials: vi.fn(),
+}));
+
+vi.mock("../../src/sse/utils/logger.js", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  maskKey: vi.fn(),
+}));
+
+const { handleChat } = await import("../../src/sse/handlers/chat.js");
+
+const request = () => new Request("https://router.test/v1/chat/completions", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ model: "kiro/gpt-5.6-sol", messages: [{ role: "user", content: "ping" }] }),
+});
+
+describe("chat aggregate account locks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-20T16:00:00.000Z"));
+    mocks.getSettings.mockResolvedValue({ requireApiKey: false, providerStrategies: {} });
+    mocks.getComboModels.mockResolvedValue(null);
+    mocks.getModelInfo.mockResolvedValue({ provider: "kiro", model: "gpt-5.6-sol" });
+    mocks.checkAndRefreshToken.mockImplementation(async (_provider, credentials) => credentials);
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 120_000 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the earliest transient lock metadata instead of the last attempted quota error", async () => {
+    const retryAfter = new Date(Date.now() + 30_000).toISOString();
+    mocks.getProviderCredentials
+      .mockResolvedValueOnce({
+        connectionId: "quota-account",
+        connectionName: "Quota account",
+        providerSpecificData: {},
+      })
+      .mockResolvedValueOnce({
+        allRateLimited: true,
+        retryAfter,
+        retryAfterHuman: "reset after 30s",
+        lastError: "Funded account bad gateway",
+        lastErrorCode: 502,
+      });
+    mocks.handleChatCore.mockResolvedValue({
+      success: false,
+      status: 402,
+      error: "MONTHLY_REQUEST_COUNT",
+      response: Response.json({ error: { message: "MONTHLY_REQUEST_COUNT" } }, { status: 402 }),
+    });
+
+    const response = await handleChat(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(body.error.message).toContain("Funded account bad gateway");
+    expect(body.error.message).not.toContain("MONTHLY_REQUEST_COUNT");
+  });
+
+  it("does not borrow prior account metadata when the earliest lock owner has none", async () => {
+    const retryAfter = new Date(Date.now() + 30_000).toISOString();
+    mocks.getProviderCredentials
+      .mockResolvedValueOnce({
+        connectionId: "quota-account",
+        connectionName: "Quota account",
+        providerSpecificData: {},
+      })
+      .mockResolvedValueOnce({
+        allRateLimited: true,
+        retryAfter,
+        retryAfterHuman: "reset after 30s",
+        lastError: null,
+        lastErrorCode: null,
+      });
+    mocks.handleChatCore.mockResolvedValue({
+      success: false,
+      status: 402,
+      error: "MONTHLY_REQUEST_COUNT",
+      response: Response.json({ error: { message: "MONTHLY_REQUEST_COUNT" } }, { status: 402 }),
+    });
+
+    const response = await handleChat(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(body.error.message).toContain("Unavailable");
+    expect(body.error.message).not.toContain("MONTHLY_REQUEST_COUNT");
+  });
+
+  it("keeps a genuine aggregate quota exhaustion as 402", async () => {
+    const retryAfter = new Date(Date.now() + 120_000).toISOString();
+    mocks.getProviderCredentials.mockResolvedValue({
+      allRateLimited: true,
+      retryAfter,
+      retryAfterHuman: "reset after 2m",
+      lastError: "MONTHLY_REQUEST_COUNT",
+      lastErrorCode: 402,
+    });
+
+    const response = await handleChat(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(402);
+    expect(response.headers.get("Retry-After")).toBe("120");
+    expect(body.error.message).toContain("MONTHLY_REQUEST_COUNT");
+    expect(mocks.handleChatCore).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/kiro-credit-cooldown.test.js
+++ b/tests/unit/kiro-credit-cooldown.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: vi.fn(),
+  getSettings: vi.fn(),
+  getProxyPools: vi.fn(),
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: vi.fn().mockResolvedValue({}),
+  pickProxyPoolId: vi.fn(),
+}));
+
+describe("markAccountUnavailable — Kiro confirmed credit-exhaustion cooldown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateProviderConnection.mockResolvedValue({});
+  });
+
+  it("caps a far-future Kiro reset at the daily-probe interval, not the full reset window", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const { KIRO_CREDIT_EXHAUSTION_PROBE_MS } = await import("../../open-sse/config/errorConfig.js");
+    mocks.getProviderConnections.mockResolvedValue([{ id: "acc-1", backoffLevel: 0 }]);
+
+    const now = Date.now();
+    const resetsAtMs = now + 20 * 24 * 60 * 60 * 1000; // 20 days away
+    const { shouldFallback, cooldownMs } = await markAccountUnavailable(
+      "acc-1", 402, "Kiro monthly credit limit reached", "kiro", "claude-sonnet-4.5", resetsAtMs
+    );
+
+    expect(shouldFallback).toBe(true);
+    expect(cooldownMs).toBe(KIRO_CREDIT_EXHAUSTION_PROBE_MS);
+    expect(cooldownMs).toBeLessThan(resetsAtMs - now);
+
+    const [, update] = mocks.updateProviderConnection.mock.calls[0];
+    expect(update.testStatus).toBe("unavailable");
+  });
+
+  it("respects a near-term reset instead of waiting the full probe window", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    mocks.getProviderConnections.mockResolvedValue([{ id: "acc-1", backoffLevel: 0 }]);
+
+    const now = Date.now();
+    const resetsAtMs = now + 3 * 60 * 60 * 1000; // 3h away
+    const { cooldownMs } = await markAccountUnavailable("acc-1", 402, "err", "kiro", "model-x", resetsAtMs);
+
+    expect(cooldownMs).toBeGreaterThan(2.9 * 60 * 60 * 1000);
+    expect(cooldownMs).toBeLessThanOrEqual(3 * 60 * 60 * 1000);
+  });
+
+  it("keeps the existing short cooldown for an ambiguous Kiro 402 (no resetsAtMs)", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    mocks.getProviderConnections.mockResolvedValue([{ id: "acc-1", backoffLevel: 0 }]);
+
+    const { cooldownMs } = await markAccountUnavailable("acc-1", 402, "Payment required", "kiro", "model-x", null);
+    expect(cooldownMs).toBe(2 * 60 * 1000); // unchanged generic 402 cooldown
+  });
+
+  it("does not change the cooldown cap for other providers' resetsAtMs (e.g. codex)", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const { MAX_RATE_LIMIT_COOLDOWN_MS } = await import("../../open-sse/config/errorConfig.js");
+    mocks.getProviderConnections.mockResolvedValue([{ id: "acc-2", backoffLevel: 0 }]);
+
+    const resetsAtMs = Date.now() + 6 * 60 * 60 * 1000; // 6h away, like codex resets_at
+    const { cooldownMs } = await markAccountUnavailable("acc-2", 429, "usage_limit_reached", "codex", "gpt-5", resetsAtMs);
+    expect(cooldownMs).toBe(MAX_RATE_LIMIT_COOLDOWN_MS);
+  });
+
+  it("clears the lock and allows selection again once the capped cooldown expires", async () => {
+    const { buildModelLockUpdate, isModelLockActive } = await import("../../open-sse/services/accountFallback.js");
+    const cooldownMs = 50;
+    const lock = buildModelLockUpdate("model-x", cooldownMs);
+    const conn = { id: "acc-1", ...lock };
+
+    expect(isModelLockActive(conn, "model-x")).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, cooldownMs + 20));
+    expect(isModelLockActive(conn, "model-x")).toBe(false);
+  });
+
+  it("multi-account fallback: a locked Kiro account is skipped while a sibling account stays available", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const { isModelLockActive } = await import("../../open-sse/services/accountFallback.js");
+
+    const connA = { id: "acc-A", backoffLevel: 0 };
+    const connB = { id: "acc-B", backoffLevel: 0 };
+    mocks.getProviderConnections.mockResolvedValue([connA, connB]);
+    let capturedUpdate = null;
+    mocks.updateProviderConnection.mockImplementation((id, update) => {
+      capturedUpdate = update;
+      return Promise.resolve({});
+    });
+
+    const resetsAtMs = Date.now() + 20 * 24 * 60 * 60 * 1000;
+    await markAccountUnavailable("acc-A", 402, "Kiro monthly credit limit reached", "kiro", "model-x", resetsAtMs);
+
+    // Mirrors what getProviderCredentials' availableConnections filter does (src/sse/services/auth.js)
+    const updatedConnA = { ...connA, ...capturedUpdate };
+    const available = [updatedConnA, connB].filter((c) => !isModelLockActive(c, "model-x"));
+
+    expect(isModelLockActive(updatedConnA, "model-x")).toBe(true);
+    expect(isModelLockActive(connB, "model-x")).toBe(false);
+    expect(available.map((c) => c.id)).toEqual(["acc-B"]);
+  });
+});

--- a/tests/unit/kiro-credit-exhaustion.test.js
+++ b/tests/unit/kiro-credit-exhaustion.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getKiroUsage: vi.fn(),
+}));
+
+vi.mock("../../open-sse/services/usage/kiro.js", () => ({
+  getKiroUsage: mocks.getKiroUsage,
+}));
+
+// Verified shape of a real CodeWhisperer GenerateAssistantResponse 402 body
+// (AWS ServiceQuotaExceededException, reason MONTHLY_REQUEST_COUNT).
+const CONFIRMED_BODY = JSON.stringify({
+  code: "QModelResponse",
+  requestId: "d8a9e87f-2cbb-4cc5-8085-c3336cd8bf98",
+  name: "Error",
+  message: "You have reached the limit.",
+  cause: {
+    $fault: "client",
+    $metadata: { httpStatusCode: 402, requestId: "d8a9e87f-2cbb-4cc5-8085-c3336cd8bf98", attempts: 1, totalRetryDelay: 0 },
+    name: "ServiceQuotaExceededException",
+    reason: "MONTHLY_REQUEST_COUNT",
+  },
+});
+
+describe("Kiro executor — 402 credit-exhaustion classification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("derives resetsAtMs from Kiro's own quota API on confirmed exhaustion", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    const resetAtIso = new Date(Date.now() + 9 * 24 * 60 * 60 * 1000).toISOString();
+    mocks.getKiroUsage.mockResolvedValue({
+      plan: "Kiro Free",
+      quotas: {
+        agentic_request: { used: 50, total: 50, remaining: 0, resetAt: resetAtIso, unlimited: false },
+      },
+    });
+
+    const executor = new KiroExecutor();
+    const credentials = { accessToken: "token-1", providerSpecificData: { authMethod: "builder-id" } };
+    const result = await executor.parseError({ status: 402 }, CONFIRMED_BODY, credentials, {});
+
+    expect(mocks.getKiroUsage).toHaveBeenCalledWith("token-1", credentials.providerSpecificData, {});
+    expect(result.status).toBe(402);
+    expect(result.resetsAtMs).toBe(new Date(resetAtIso).getTime());
+  });
+
+  it("prefers the api-key credential over accessToken when both are present", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    mocks.getKiroUsage.mockResolvedValue({ quotas: {} });
+    const executor = new KiroExecutor();
+    const credentials = { accessToken: "oidc-token", apiKey: "raw-api-key", providerSpecificData: { authMethod: "api_key" } };
+    await executor.parseError({ status: 402 }, CONFIRMED_BODY, credentials, {});
+    expect(mocks.getKiroUsage).toHaveBeenCalledWith("raw-api-key", credentials.providerSpecificData, {});
+  });
+
+  it("falls back to the daily-probe window when the quota lookup has nothing depleted", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    const { KIRO_CREDIT_EXHAUSTION_PROBE_MS } = await import("../../open-sse/config/errorConfig.js");
+    mocks.getKiroUsage.mockResolvedValue({ plan: "Kiro Free", quotas: {} });
+
+    const executor = new KiroExecutor();
+    const before = Date.now();
+    const result = await executor.parseError({ status: 402 }, CONFIRMED_BODY, { accessToken: "t" }, {});
+    const after = Date.now();
+
+    expect(result.resetsAtMs).toBeGreaterThanOrEqual(before + KIRO_CREDIT_EXHAUSTION_PROBE_MS);
+    expect(result.resetsAtMs).toBeLessThanOrEqual(after + KIRO_CREDIT_EXHAUSTION_PROBE_MS);
+  });
+
+  it("falls back to the daily-probe window when the quota lookup fails", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    const { KIRO_CREDIT_EXHAUSTION_PROBE_MS } = await import("../../open-sse/config/errorConfig.js");
+    mocks.getKiroUsage.mockRejectedValue(new Error("network down"));
+
+    const executor = new KiroExecutor();
+    const result = await executor.parseError({ status: 402 }, CONFIRMED_BODY, { accessToken: "t" }, {});
+    expect(result.resetsAtMs).toBeGreaterThan(Date.now());
+    expect(result.resetsAtMs).toBeLessThanOrEqual(Date.now() + KIRO_CREDIT_EXHAUSTION_PROBE_MS + 1000);
+  });
+
+  it("leaves an ambiguous 402 unclassified, preserving the existing generic cooldown", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    const executor = new KiroExecutor();
+    const result = await executor.parseError(
+      { status: 402 },
+      JSON.stringify({ message: "Payment method declined" }),
+      { accessToken: "t" },
+      {}
+    );
+    expect(result.resetsAtMs).toBeUndefined();
+    expect(mocks.getKiroUsage).not.toHaveBeenCalled();
+  });
+
+  it("does not classify non-402 statuses", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    const executor = new KiroExecutor();
+    const result = await executor.parseError({ status: 429 }, "Too many requests", { accessToken: "t" }, {});
+    expect(result.resetsAtMs).toBeUndefined();
+    expect(mocks.getKiroUsage).not.toHaveBeenCalled();
+  });
+
+  it("also recognizes the confirmed signal when cause fields are flattened to the top level", async () => {
+    const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+    mocks.getKiroUsage.mockResolvedValue({ quotas: {} });
+    const flatBody = JSON.stringify({
+      name: "ServiceQuotaExceededException",
+      reason: "MONTHLY_REQUEST_COUNT",
+      message: "You have reached the limit.",
+    });
+    const executor = new KiroExecutor();
+    const result = await executor.parseError({ status: 402 }, flatBody, { accessToken: "t" }, {});
+    expect(mocks.getKiroUsage).toHaveBeenCalled();
+    expect(result.resetsAtMs).toBeGreaterThan(Date.now());
+  });
+});


### PR DESCRIPTION
## Summary

Today every Kiro 402 gets the same flat 2-minute cooldown (`open-sse/config/errorConfig.js` `ERROR_RULES`, `status: 402`). That's a reasonable default for an *ambiguous* 402 (bad payment method, suspended account), but wrong for a **confirmed monthly credit-limit exhaustion**: the account keeps getting re-tried and re-402ing every 2 minutes until the real reset, burning requests and cycling needlessly through account/combo fallback — sometimes for weeks.

This PR adds a narrow, backward-compatible path: only a *recognized* exhaustion signal gets special handling; everything else keeps today's behavior exactly as-is.

## Is a Kiro 402 distinguishable from "really out of credits"? Yes — for one well-known shape

A CodeWhisperer `GenerateAssistantResponse` 402 for monthly-quota exhaustion has a documented, reproducible shape (AWS `ServiceQuotaExceededException`), confirmed via public reports (e.g. [aws/aws-toolkit-vscode#8577](https://github.com/aws/aws-toolkit-vscode/issues/8577)):

```json
{
  "code": "QModelResponse",
  "name": "Error",
  "message": "You have reached the limit.",
  "cause": {
    "$metadata": { "httpStatusCode": 402 },
    "name": "ServiceQuotaExceededException",
    "reason": "MONTHLY_REQUEST_COUNT"
  }
}
```

`KiroExecutor.parseError()` (`open-sse/executors/kiro.js`) now matches this shape — and a flattened variant some surfaces use (`name`/`reason` at the top level instead of nested under `cause`) — to classify a 402 as **confirmed** vs. **ambiguous**. Anything that doesn't match (unrecognized body, non-JSON, a different `reason`) is left ambiguous and keeps the exact current 2-minute cooldown.

I also checked the related credits/quota reports in this repo (#1328, #1854, #1901, #2374) and the recent Kiro PRs #2580/#2618/#2639 — none of them touch 402 classification or the reactive cooldown path; #1854 (open) adds a complementary **proactive** pre-flight quota check that skips known-depleted Kiro accounts before dispatch. This PR is the **reactive** fallback for when that pre-flight either isn't present or is stale — the two aren't in conflict.

## Where does the reset time come from?

The 402 body itself never carries a reset date (confirmed against the real-world shape above). The only trustworthy source is Kiro's own quota endpoint, `GetUsageLimits`, which 9router already parses (`open-sse/services/usage/kiro.js`, `nextDateReset`/`resetDate`). So on a **confirmed** match, `parseError` makes a best-effort follow-up call to that endpoint (8s timeout) and takes the earliest `resetAt` among fully-depleted quota buckets.

If that lookup is unreachable, times out, or nothing comes back depleted, it does **not** guess a date — it falls back to a fixed default (see below) rather than fabricating provider semantics.

## Why the existing `resetsAtMs` cap needed a per-provider override

`resetsAtMs` already flows through the pipeline (`parseUpstreamError` → `createErrorResult` → `markAccountUnavailable`), and was previously capped at a single shared `MAX_RATE_LIMIT_COOLDOWN_MS` (30 min) — sized for short-window resets like Codex's `resets_at` (hours). Applying that cap to a month-scale Kiro reset would mean re-probing a known-exhausted account **every 30 minutes**.

`markAccountUnavailable` (`src/sse/services/auth.js`) now looks up a per-provider cap via `RESET_COOLDOWN_CAP_MS` (`open-sse/config/errorConfig.js`), with Kiro set to 24h:

```js
const cooldownCapMs = RESET_COOLDOWN_CAP_MS[provider] ?? MAX_RATE_LIMIT_COOLDOWN_MS;
cooldownMs = Math.min(resetsAtMs - Date.now(), cooldownCapMs);
```

Other providers (Codex, etc.) are untouched — they still resolve to `MAX_RATE_LIMIT_COOLDOWN_MS`.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Ambiguous 402 (unrecognized body) | 2-min cooldown | **unchanged** — 2-min cooldown |
| Confirmed exhaustion, quota API says reset in 3h | 2-min cooldown, retried every 2 min for 3h | locked ~3h (real reset honored) |
| Confirmed exhaustion, quota API says reset in 20 days | 2-min cooldown, retried every 2 min for 20 days | locked in ≤24h increments; re-probed roughly once/day until it recovers or the real reset passes |
| Confirmed exhaustion, quota lookup fails/times out/nothing depleted | 2-min cooldown | locked 24h (safe default, not fabricated), then re-probed |
| Multi-account | account cycles fallback every 2 min | locked account is skipped; sibling accounts keep serving normally |

## Tests

New: `tests/unit/kiro-credit-exhaustion.test.js`, `tests/unit/kiro-credit-cooldown.test.js`
- confirmed exhaustion → `resetsAtMs` derived from the quota API
- api-key credential precedence for the quota lookup
- quota lookup returns nothing depleted → daily-probe fallback
- quota lookup fails/rejects → daily-probe fallback
- ambiguous 402 → unclassified, no `resetsAtMs` (old cooldown preserved)
- non-402 statuses untouched
- flattened-shape (top-level `name`/`reason`) also recognized
- far-future reset capped at the daily-probe interval, not the full window
- near-term reset respected (not stretched to 24h)
- ambiguous Kiro 402 still gets the old 2-minute cooldown
- other providers' `resetsAtMs` cap (Codex) unchanged
- lock expiry — account becomes selectable again once the cooldown elapses
- multi-account fallback — a locked account is skipped while a sibling stays available

```
npx vitest run unit/kiro-credit-exhaustion.test.js unit/kiro-credit-cooldown.test.js
# 2 files, 13 passed

npx vitest run unit/openai-to-kiro.test.js unit/cached-token-usage.test.js unit/kiro-external-idp.test.js \
  unit/kiro-model-slots.test.js unit/kiro-profile-arn.test.js unit/kiro-thinking-strip.test.js unit/rtkKiro.test.js \
  unit/codex-reset-credits.test.js unit/codex-fast-capacity.test.js translator/claude-kiro-direct.test.js translator/bugs-kiro.test.js
# 11 files, 72 passed | 2 expected fail (pre-existing, unrelated)
```

Full suite: ran on a clean `master` checkout before and after this change — identical set of unrelated failures both times (environment-dependent: live-network tests, CWD-relative `fs.readFileSync` in `security-audit.test.js`, SQLite concurrency timing, golden snapshot drift). No new failures introduced.

`npx eslint` clean on all changed files.

## Limitations

- The lock is still per `(account, model)`, like every other error type in this file — an account rotating through several Kiro model aliases can independently probe each alias within the cap window. Making confirmed credit exhaustion an account-wide lock is a natural follow-up, but changing that shared locking mechanism felt out of scope for a focused fix — happy to do it here if maintainers would rather have it bundled.
- The quota-lookup follow-up call adds a bit of latency to the (already-failed) 402 response — bounded to 8s worst case, and only on a confirmed match, not on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Account-lock aggregation hardening

This branch now also keeps retry timing, HTTP status, and error text paired to the same locked account when every account is unavailable. A transient 502/503 account with the earliest 30-second retry can no longer inherit MONTHLY_REQUEST_COUNT from a different 402 account. Genuine all-account quota exhaustion remains 402.

The follow-up also clears stale errorCode after a successful cooldown recovery and makes model-specific plus account-wide locks compose by waiting for the later active expiry on each account before selecting the earliest account across the pool.

Regression coverage adds the mixed 3x402/120s plus 2x502/503/30s case, genuine all-402 preservation, cooldown recovery, stale error cleanup, and overlapping model/account lock expiry. Focused verification: 4 files, 24 tests; ESLint and production build pass. Independent Claude Code review verdict: SHIP.