### PR TITLE
fix(api): decompress Content-Encoding on request JSON bodies

### DIFF
--- a/src/app/api/v1/responses/compact/route.js
+++ b/src/app/api/v1/responses/compact/route.js
@@ -1,5 +1,8 @@
 import { handleChat } from "@/sse/handlers/chat.js";
 import { initTranslators } from "open-sse/translator/index.js";
+import { parseJsonBody } from "@/shared/utils/parseJsonBody.js";
+import { errorResponse } from "open-sse/utils/error.js";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 
 let initialized = false;
 
@@ -26,11 +29,20 @@ export async function OPTIONS() {
  */
 export async function POST(request) {
   await ensureInitialized();
-  const body = await request.json();
+  let body;
+  try {
+    body = await parseJsonBody(request);
+  } catch {
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
+  }
   body._compact = true;
+  // Strip content-encoding: body is already decoded plain JSON
+  const headers = new Headers(request.headers);
+  headers.delete("content-encoding");
+  headers.set("content-type", "application/json");
   const newRequest = new Request(request.url, {
     method: "POST",
-    headers: request.headers,
+    headers,
     body: JSON.stringify(body)
   });
   return await handleChat(newRequest);

--- a/src/shared/utils/parseJsonBody.js
+++ b/src/shared/utils/parseJsonBody.js
@@ -1,0 +1,60 @@
+import { gunzipSync, brotliDecompressSync, inflateSync, zstdDecompressSync } from "node:zlib";
+
+/**
+ * Read a Request body as JSON, honoring Content-Encoding.
+ *
+ * Codex (and other OpenAI-style clients) may zstd-compress large Responses
+ * API payloads when model_provider is treated as official OpenAI/ChatGPT.
+ * Next/undici does not auto-decompress request bodies, so request.json()
+ * fails with SyntaxError → "Invalid JSON body".
+ *
+ * @param {Request} request
+ * @returns {Promise<any>}
+ */
+export async function parseJsonBody(request) {
+  const encoding = (request.headers.get("content-encoding") || "").toLowerCase().trim();
+  // Fast path: no content encoding → native JSON parse
+  if (!encoding || encoding === "identity") {
+    return request.json();
+  }
+
+  const raw = Buffer.from(await request.arrayBuffer());
+  if (raw.length === 0) {
+    throw new SyntaxError("Unexpected end of JSON input");
+  }
+
+  const decoded = decodeBody(raw, encoding);
+  return JSON.parse(decoded.toString("utf8"));
+}
+
+/**
+ * @param {Buffer} buf
+ * @param {string} encoding lowercased Content-Encoding value
+ * @returns {Buffer}
+ */
+export function decodeBody(buf, encoding) {
+  if (!buf || buf.length === 0) return buf;
+  const enc = (encoding || "").toLowerCase();
+
+  // Multi-encoding is rare for request bodies; take the primary token.
+  const primary = enc.split(",")[0].trim();
+
+  if (primary === "zstd" || primary === "zst") {
+    if (typeof zstdDecompressSync !== "function") {
+      throw new Error("Content-Encoding: zstd requires Node.js with zlib.zstdDecompressSync (Node ≥22.15)");
+    }
+    return zstdDecompressSync(buf);
+  }
+  if (primary === "gzip" || primary === "x-gzip") {
+    return gunzipSync(buf);
+  }
+  if (primary === "br") {
+    return brotliDecompressSync(buf);
+  }
+  if (primary === "deflate") {
+    return inflateSync(buf);
+  }
+
+  // Unknown encoding — try raw UTF-8 JSON (may still fail later)
+  return buf;
+}

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -22,6 +22,7 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+import { parseJsonBody } from "@/shared/utils/parseJsonBody.js";
 
 /**
  * Handle chat completion request
@@ -31,9 +32,10 @@ import { getProjectIdForConnection } from "open-sse/services/projectId.js";
 export async function handleChat(request, clientRawRequest = null) {
   let body;
   try {
-    body = await request.json();
-  } catch {
-    log.warn("CHAT", "Invalid JSON body");
+    // Codex OpenAI/ChatGPT mode may send zstd-compressed bodies (Content-Encoding: zstd)
+    body = await parseJsonBody(request);
+  } catch (err) {
+    log.warn("CHAT", "Invalid JSON body", { encoding: request.headers.get("content-encoding"), error: err?.message });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid JSON body");
   }
 

--- a/tests/unit/parse-json-body.test.js
+++ b/tests/unit/parse-json-body.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { brotliCompressSync, gzipSync, zstdCompressSync } from "node:zlib";
+
+import { decodeBody, parseJsonBody } from "../../src/shared/utils/parseJsonBody.js";
+
+function makeRequest(body, { encoding } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (encoding) headers["content-encoding"] = encoding;
+  return new Request("http://localhost/v1/responses", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("parseJsonBody", () => {
+  const payload = { model: "gpt-5.6-sol", input: "hi" };
+  const json = JSON.stringify(payload);
+
+  it("parses plain JSON without Content-Encoding", async () => {
+    const body = await parseJsonBody(makeRequest(json));
+    expect(body).toEqual(payload);
+  });
+
+  it("parses zstd-compressed JSON (Codex OpenAI/ChatGPT mode)", async () => {
+    if (typeof zstdCompressSync !== "function") return;
+    const compressed = zstdCompressSync(Buffer.from(json));
+    const body = await parseJsonBody(makeRequest(compressed, { encoding: "zstd" }));
+    expect(body).toEqual(payload);
+  });
+
+  it("parses gzip-compressed JSON", async () => {
+    const compressed = gzipSync(Buffer.from(json));
+    const body = await parseJsonBody(makeRequest(compressed, { encoding: "gzip" }));
+    expect(body).toEqual(payload);
+  });
+
+  it("parses brotli-compressed JSON", async () => {
+    const compressed = brotliCompressSync(Buffer.from(json));
+    const body = await parseJsonBody(makeRequest(compressed, { encoding: "br" }));
+    expect(body).toEqual(payload);
+  });
+
+  it("decodeBody handles zstd primary token", () => {
+    if (typeof zstdCompressSync !== "function") return;
+    const raw = Buffer.from(json);
+    const compressed = zstdCompressSync(raw);
+    expect(decodeBody(compressed, "zstd").toString("utf8")).toBe(json);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `parseJsonBody` helper that honors `Content-Encoding` (zstd / gzip / br / deflate) before JSON parse
- Use it in chat completions/messages/responses pipeline and `/v1/responses/compact`
- Unit tests for plain + compressed bodies

## Why
Codex in OpenAI/ChatGPT mode compresses large Responses API request bodies with **zstd**. Next/undici does not auto-decompress request bodies, so `request.json()` fails and the gateway returns **Invalid JSON body**.

## Test plan
- [x] `npx vitest run unit/parse-json-body.test.js`
- [ ] Manual: `Content-Encoding: zstd` POST to `/v1/responses` with a valid zstd body returns 200 (not Invalid JSON body)
- [ ] Manual: plain JSON POST still works