### PR TITLE
feat(client): broaden Codex client detection

### DIFF
--- a/open-sse/utils/clientDetector.js
+++ b/open-sse/utils/clientDetector.js
@@ -12,19 +12,61 @@ const NATIVE_PAIRS = {
 };
 
 /**
+ * Normalize headers to a lowercase-key object.
+ * @param {Headers|object|null|undefined} headers
+ * @returns {Record<string, string>}
+ */
+export function normalizeHeaders(headers = {}) {
+  if (!headers) return {};
+  if (typeof headers.entries === "function") {
+    const out = {};
+    for (const [k, v] of headers.entries()) {
+      out[String(k).toLowerCase()] = Array.isArray(v) ? String(v[0] ?? "") : String(v ?? "");
+    }
+    return out;
+  }
+  const out = {};
+  for (const [k, v] of Object.entries(headers)) {
+    out[String(k).toLowerCase()] = Array.isArray(v) ? String(v[0] ?? "") : String(v ?? "");
+  }
+  return out;
+}
+
+/**
+ * True when the request is from Codex CLI / Desktop / VS Code extension.
+ * Fail-closed: unknown clients return false.
+ *
+ * Signals (any one is enough):
+ * - User-Agent contains codex markers (codex-cli, codex_cli_rs, codex-tui, codex_vscode, …)
+ * - originator header mentions Codex
+ * - x-openai-product-sku / product headers mention codex
+ *
+ * @param {Headers|object|null|undefined} headers
+ * @param {object} [body]
+ * @returns {boolean}
+ */
+export function isCodexClient(headers = {}, body = {}) {
+  return detectClientTool(headers, body) === "codex";
+}
+
+/**
  * Detect which CLI tool is making the request.
- * Returns one of: "claude" | "gemini-cli" | "antigravity" | "codex" | null
- * @param {object} headers - Lowercase header key/value object
+ * Returns one of: "claude" | "gemini-cli" | "antigravity" | "codex" | "github-copilot" | "deepseek-tui" | null
+ * @param {Headers|object} headers - Header map (any casing) or Fetch Headers
  * @param {object} body    - Parsed request body
  */
 export function detectClientTool(headers = {}, body = {}) {
-  const ua = (headers["user-agent"] || "").toLowerCase();
-  const xApp = (headers["x-app"] || "").toLowerCase();
-  const openaiIntent = (headers["openai-intent"] || "").toLowerCase();
-  const initiator = (headers["x-initiator"] || headers["X-Initiator"] || "").toLowerCase();
+  const h = normalizeHeaders(headers);
+  const ua = (h["user-agent"] || "").toLowerCase();
+  const xApp = (h["x-app"] || "").toLowerCase();
+  const openaiIntent = (h["openai-intent"] || "").toLowerCase();
+  const initiator = (h["x-initiator"] || "").toLowerCase();
+  const originator = (h["originator"] || "").toLowerCase();
+  const productSku = (h["x-openai-product-sku"] || "").toLowerCase();
+  const openAiClient = (h["x-openai-client"] || h["openai-client"] || "").toLowerCase();
 
   // Antigravity: detected via body field (not header)
-  if (body.userAgent === "antigravity") return "antigravity";
+  if (body?.userAgent === "antigravity") return "antigravity";
 
   // GitHub Copilot / OAI compatible extension using Copilot chat headers
   if (ua.includes("githubcopilotchat") || openaiIntent === "conversation-panel" || initiator === "user") {
@@ -37,8 +79,20 @@ export function detectClientTool(headers = {}, body = {}) {
   // Gemini CLI
   if (ua.includes("gemini-cli")) return "gemini-cli";
 
-  // Codex CLI
-  if (ua.includes("codex-cli")) return "codex";
+  // Codex CLI / Desktop / VS Code (UA + originator variants from codex binary)
+  if (
+    ua.includes("codex-cli")
+    || ua.includes("codex_cli_rs")
+    || ua.includes("codex-tui")
+    || ua.includes("codex_vscode")
+    || ua.includes("codex_desktop")
+    || (ua.includes("codex") && !ua.includes("githubcopilot"))
+    || originator.includes("codex")
+    || productSku === "codex"
+    || openAiClient.includes("codex")
+  ) {
+    return "codex";
+  }
 
   // DeepSeek TUI
   if (ua.includes("deepseek-tui")) return "deepseek-tui";

--- a/tests/unit/client-detector-codex.test.js
+++ b/tests/unit/client-detector-codex.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectClientTool,
+  isCodexClient,
+  normalizeHeaders,
+} from "../../open-sse/utils/clientDetector.js";
+
+describe("Codex client detection", () => {
+  it("detects classic codex-cli user-agent", () => {
+    expect(detectClientTool({ "user-agent": "codex-cli/0.145.0" })).toBe("codex");
+    expect(isCodexClient({ "User-Agent": "codex-cli/0.145.0" })).toBe(true);
+  });
+
+  it("detects codex_cli_rs / tui / vscode UA variants", () => {
+    expect(detectClientTool({ "user-agent": "codex_cli_rs/0.145.0" })).toBe("codex");
+    expect(detectClientTool({ "user-agent": "codex-tui/0.1" })).toBe("codex");
+    expect(detectClientTool({ "user-agent": "codex_vscode/1.0" })).toBe("codex");
+  });
+
+  it("detects originator header from Codex Desktop", () => {
+    expect(detectClientTool({ originator: "Codex Desktop" })).toBe("codex");
+    expect(isCodexClient({ Originator: "Codex Desktop" })).toBe(true);
+  });
+
+  it("detects product sku header", () => {
+    expect(detectClientTool({ "x-openai-product-sku": "codex" })).toBe("codex");
+  });
+
+  it("does not treat Claude / OpenCode / unknown as Codex", () => {
+    expect(detectClientTool({ "user-agent": "claude-cli/1.0" })).toBe("claude");
+    expect(isCodexClient({ "user-agent": "claude-cli/1.0" })).toBe(false);
+    expect(detectClientTool({ "user-agent": "opencode/1.0" })).toBe(null);
+    expect(isCodexClient({ "user-agent": "curl/8.0" })).toBe(false);
+    expect(isCodexClient({})).toBe(false);
+  });
+
+  it("normalizeHeaders lowercases Fetch Headers", () => {
+    const h = new Headers({ "User-Agent": "codex-cli/1", Originator: "Codex Desktop" });
+    const n = normalizeHeaders(h);
+    expect(n["user-agent"]).toBe("codex-cli/1");
+    expect(n["originator"]).toBe("Codex Desktop");
+  });
+});


### PR DESCRIPTION
## Summary
- Broaden `detectClientTool` Codex signals (UA variants, `originator`, product sku)
- Export `isCodexClient` and `normalizeHeaders` for gateway gating
- Unit tests for Codex vs Claude/OpenCode/unknown

## Why
Official ChatGPT passthrough must **fail closed** for non-Codex harnesses (Claude Code, OpenCode, curl). Existing detection only matched `codex-cli` in User-Agent.

## Test plan
- [x] `npx vitest run unit/client-detector-codex.test.js`