### PR TITLE
docs: add Vietnamese OpenClaw Zalo video guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ Default URLs:
       <b>🇮🇷 Persian-فارسی</b><br/>
       <sub dir="rtl">این شکلی از هر API ای استفاده کن برای هوش مصنوعی<br/>by <a href="https://www.youtube.com/@Matin_SenPai">Matin SenPai</a></sub>
     </td>
+    <td align="center" width="320">
+      <a href="https://www.youtube.com/watch?v=hPusYX-5Pmw">
+        <img src="https://img.youtube.com/vi/hPusYX-5Pmw/maxresdefault.jpg" alt="Hướng Dẫn Setup OpenClaw + 9Router: Tạo Bot Zalo AI Tự Động Từ A-Z" width="300"/>
+      </a><br/>
+      <b>🇻🇳 Tiếng Việt</b><br/>
+      <sub>Hướng Dẫn Setup OpenClaw + 9Router: Tạo Bot Zalo AI Tự Động Từ A-Z<br/>by <a href="https://github.com/tuanminhhole">tuanminhhole</a></sub>
+    </td>
   </tr>
 
 </table>


### PR DESCRIPTION
## Summary

Adds a Vietnamese community video to the README Video Guides section:

- **Language:** 🇻🇳 Tiếng Việt
- **Title:** Hướng Dẫn Setup OpenClaw + 9Router: Tạo Bot Zalo AI Tự Động Từ A-Z
- **Author:** [tuanminhhole](https://github.com/tuanminhhole)
- **Video:** https://www.youtube.com/watch?v=hPusYX-5Pmw

## Why

This gives Vietnamese users another practical OpenClaw and 9Router setup guide, focused on building an automated Zalo AI bot from start to finish.

## Validation

- Followed the existing three-column HTML table structure.
- Used the YouTube thumbnail and direct watch URL.
- `git diff --check` passes.
