### PR TITLE
fix(kiro): validate completed nested tool_call payloads

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -6,6 +6,59 @@ import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 
+const KIRO_TOOL_CALL_WRAPPER = "tool_call";
+
+function parseKiroToolInput(toolInput) {
+  if (typeof toolInput === "string") {
+    try {
+      return JSON.parse(toolInput);
+    } catch (error) {
+      throw new Error(`Invalid Kiro tool_call payload: input must be valid JSON (${error.message})`);
+    }
+  }
+  return toolInput;
+}
+
+export function validateKiroToolUse(toolUse) {
+  const toolName = typeof toolUse?.name === "string" ? toolUse.name.trim() : "";
+  if (!toolName) {
+    throw new Error("Invalid Kiro toolUseEvent: missing tool name");
+  }
+
+  if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
+    return;
+  }
+
+  const input = parseKiroToolInput(toolUse.input);
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Invalid Kiro tool_call payload: input must be an object with name and arguments");
+  }
+
+  const nestedName = typeof input.name === "string" ? input.name.trim() : "";
+  if (!nestedName) {
+    throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool name at input.name");
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(input, "arguments")) {
+    throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool arguments at input.arguments");
+  }
+}
+
+function emitKiroToolCallValidationError(controller, state, message) {
+  const error = {
+    error: {
+      message,
+      type: "invalid_request_error",
+      code: "invalid_kiro_tool_call"
+    }
+  };
+  state.invalidToolCall = true;
+  state.finishEmitted = true;
+  state.doneSent = true;
+  controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(error)}\n\n`));
+  controller.enqueue(new TextEncoder().encode(SSE_DONE));
+}
+
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
  * Uses AWS CodeWhisperer streaming API with AWS EventStream binary format
@@ -141,7 +194,8 @@ export class KiroExecutor extends BaseExecutor {
 
     const transformStream = new TransformStream({
       async transform(chunk, controller) {
-             // Track output so we can emit a keepalive if this frame yields no chunk.
+        if (state.invalidToolCall) return;
+        // Track output so we can emit a keepalive if this frame yields no chunk.
         const enqueueCountBefore = chunkIndex;
         // Append to buffer
         const newBuffer = new Uint8Array(buffer.length + chunk.length);
@@ -281,8 +335,16 @@ export class KiroExecutor extends BaseExecutor {
             const toolUses = Array.isArray(toolUse) ? toolUse : [toolUse];
 
             for (const singleToolUse of toolUses) {
+              try {
+                validateKiroToolUse(singleToolUse);
+              } catch (error) {
+                emitKiroToolCallValidationError(controller, state, error.message);
+                buffer = new Uint8Array(0);
+                return;
+              }
+
               const toolCallId = singleToolUse.toolUseId || `call_${Date.now()}`;
-              const toolName = singleToolUse.name || "";
+              const toolName = singleToolUse.name.trim();
               const toolInput = singleToolUse.input;
 
               let toolIndex;
@@ -469,6 +531,7 @@ export class KiroExecutor extends BaseExecutor {
       },
 
       flush(controller) {
+        if (state.invalidToolCall) return;
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;
@@ -487,7 +550,10 @@ export class KiroExecutor extends BaseExecutor {
         }
 
         // Send final done message
-        controller.enqueue(new TextEncoder().encode(SSE_DONE));
+        if (!state.doneSent) {
+          state.doneSent = true;
+          controller.enqueue(new TextEncoder().encode(SSE_DONE));
+        }
       }
     });
 

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -19,17 +19,47 @@ function parseKiroToolInput(toolInput) {
   return toolInput;
 }
 
-export function validateKiroToolUse(toolUse) {
+function validateKiroToolName(toolUse) {
   const toolName = typeof toolUse?.name === "string" ? toolUse.name.trim() : "";
   if (!toolName) {
     throw new Error("Invalid Kiro toolUseEvent: missing tool name");
   }
 
-  if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
+  return toolName;
+}
+
+function getBufferedKiroToolInput(toolCall) {
+  if (toolCall.inputKind === "string") return toolCall.inputText || "";
+  return toolCall.inputObject;
+}
+
+function appendBufferedKiroToolInput(toolCall, toolInput) {
+  if (toolInput === undefined) return;
+
+  if (typeof toolInput === "string") {
+    if (toolCall.inputKind && toolCall.inputKind !== "string") {
+      throw new Error("Invalid Kiro tool_call payload: mixed input fragment types");
+    }
+    toolCall.inputKind = "string";
+    toolCall.inputText = `${toolCall.inputText || ""}${toolInput}`;
     return;
   }
 
-  const input = parseKiroToolInput(toolUse.input);
+  if (toolInput && typeof toolInput === "object" && !Array.isArray(toolInput)) {
+    if (toolCall.inputKind && toolCall.inputKind !== "object") {
+      throw new Error("Invalid Kiro tool_call payload: mixed input fragment types");
+    }
+    toolCall.inputKind = "object";
+    toolCall.inputObject = toolInput;
+  }
+}
+
+function validateKiroToolCallWrapperInput(toolInput) {
+  if (toolInput === undefined) {
+    throw new Error("Invalid Kiro tool_call payload: missing input");
+  }
+
+  const input = parseKiroToolInput(toolInput);
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("Invalid Kiro tool_call payload: input must be an object with name and arguments");
   }
@@ -42,6 +72,15 @@ export function validateKiroToolUse(toolUse) {
   if (!Object.prototype.hasOwnProperty.call(input, "arguments")) {
     throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool arguments at input.arguments");
   }
+}
+
+export function validateKiroToolUse(toolUse) {
+  const toolName = validateKiroToolName(toolUse);
+  if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
+    return;
+  }
+
+  validateKiroToolCallWrapperInput(toolUse.input);
 }
 
 function emitKiroToolCallValidationError(controller, state, message) {
@@ -189,7 +228,86 @@ export class KiroExecutor extends BaseExecutor {
       reasoningChunkCount: 0,
       toolCallIndex: 0,
       seenToolIds: new Map(),
+      pendingWrapperToolCalls: new Map(),
       inThinking: false
+    };
+
+    const emitToolCallStart = (controller, toolCallId, toolName, toolIndex) => {
+      const startChunk = {
+        id: responseId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: {
+            ...(chunkIndex === 0 ? { role: "assistant" } : {}),
+            tool_calls: [{
+              index: toolIndex,
+              id: toolCallId,
+              type: "function",
+              function: {
+                name: toolName,
+                arguments: ""
+              }
+            }]
+          },
+          finish_reason: null
+        }]
+      };
+      chunkIndex++;
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(startChunk)}\n\n`));
+    };
+
+    const emitToolCallArguments = (controller, toolIndex, argumentsStr) => {
+      const argsChunk = {
+        id: responseId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: toolIndex,
+              function: {
+                arguments: argumentsStr
+              }
+            }]
+          },
+          finish_reason: null
+        }]
+      };
+      chunkIndex++;
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+    };
+
+    const failInvalidToolCall = (controller, message) => {
+      emitKiroToolCallValidationError(controller, state, message);
+      buffer = new Uint8Array(0);
+    };
+
+    const flushPendingWrapperToolCalls = (controller) => {
+      if (state.pendingWrapperToolCalls.size === 0) return true;
+
+      for (const toolCall of state.pendingWrapperToolCalls.values()) {
+        const toolInput = getBufferedKiroToolInput(toolCall);
+        try {
+          validateKiroToolCallWrapperInput(toolInput);
+        } catch (error) {
+          failInvalidToolCall(controller, error.message);
+          return false;
+        }
+
+        const argumentsStr = typeof toolInput === "string" ? toolInput : JSON.stringify(toolInput);
+        emitToolCallStart(controller, toolCall.toolCallId, toolCall.toolName, toolCall.toolIndex);
+        if (argumentsStr) {
+          emitToolCallArguments(controller, toolCall.toolIndex, argumentsStr);
+        }
+      }
+
+      state.pendingWrapperToolCalls.clear();
+      return true;
     };
 
     const transformStream = new TransformStream({
@@ -335,16 +453,15 @@ export class KiroExecutor extends BaseExecutor {
             const toolUses = Array.isArray(toolUse) ? toolUse : [toolUse];
 
             for (const singleToolUse of toolUses) {
+              let toolName;
               try {
-                validateKiroToolUse(singleToolUse);
+                toolName = validateKiroToolName(singleToolUse);
               } catch (error) {
-                emitKiroToolCallValidationError(controller, state, error.message);
-                buffer = new Uint8Array(0);
+                failInvalidToolCall(controller, error.message);
                 return;
               }
 
               const toolCallId = singleToolUse.toolUseId || `call_${Date.now()}`;
-              const toolName = singleToolUse.name.trim();
               const toolInput = singleToolUse.input;
 
               let toolIndex;
@@ -353,33 +470,27 @@ export class KiroExecutor extends BaseExecutor {
               if (isNewTool) {
                 toolIndex = state.toolCallIndex++;
                 state.seenToolIds.set(toolCallId, toolIndex);
-
-                const startChunk = {
-                  id: responseId,
-                  object: "chat.completion.chunk",
-                  created,
-                  model,
-                  choices: [{
-                    index: 0,
-                    delta: {
-                      ...(chunkIndex === 0 ? { role: "assistant" } : {}),
-                      tool_calls: [{
-                        index: toolIndex,
-                        id: toolCallId,
-                        type: "function",
-                        function: {
-                          name: toolName,
-                          arguments: ""
-                        }
-                      }]
-                    },
-                    finish_reason: null
-                  }]
-                };
-                chunkIndex++;
-                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(startChunk)}\n\n`));
               } else {
                 toolIndex = state.seenToolIds.get(toolCallId);
+              }
+
+              if (toolName === KIRO_TOOL_CALL_WRAPPER) {
+                let toolCall = state.pendingWrapperToolCalls.get(toolCallId);
+                if (!toolCall) {
+                  toolCall = { toolCallId, toolName, toolIndex };
+                  state.pendingWrapperToolCalls.set(toolCallId, toolCall);
+                }
+                try {
+                  appendBufferedKiroToolInput(toolCall, toolInput);
+                } catch (error) {
+                  failInvalidToolCall(controller, error.message);
+                  return;
+                }
+                continue;
+              }
+
+              if (isNewTool) {
+                emitToolCallStart(controller, toolCallId, toolName, toolIndex);
               }
 
               if (toolInput !== undefined) {
@@ -393,32 +504,14 @@ export class KiroExecutor extends BaseExecutor {
                   continue;
                 }
 
-                const argsChunk = {
-                  id: responseId,
-                  object: "chat.completion.chunk",
-                  created,
-                  model,
-                  choices: [{
-                    index: 0,
-                    delta: {
-                      tool_calls: [{
-                        index: toolIndex,
-                        function: {
-                          arguments: argumentsStr
-                        }
-                      }]
-                    },
-                    finish_reason: null
-                  }]
-                };
-                chunkIndex++;
-                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+                emitToolCallArguments(controller, toolIndex, argumentsStr);
               }
             }
           }
 
           // Handle messageStopEvent
           if (eventType === "messageStopEvent") {
+            if (!flushPendingWrapperToolCalls(controller)) return;
             const chunk = {
               id: responseId,
               object: "chat.completion.chunk",
@@ -477,6 +570,7 @@ export class KiroExecutor extends BaseExecutor {
 
           // Emit final chunk only after receiving BOTH meteringEvent AND contextUsageEvent
           if (state.hasMeteringEvent && state.hasContextUsage && !state.finishEmitted) {
+            if (!flushPendingWrapperToolCalls(controller)) return;
             state.finishEmitted = true;
 
             // Estimate tokens if not available from events
@@ -532,6 +626,7 @@ export class KiroExecutor extends BaseExecutor {
 
       flush(controller) {
         if (state.invalidToolCall) return;
+        if (!flushPendingWrapperToolCalls(controller)) return;
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -7,6 +7,20 @@ import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 
 const KIRO_TOOL_CALL_WRAPPER = "tool_call";
+const sharedEncoder = new TextEncoder();
+const sharedDecoder = new TextDecoder();
+
+function encodeSSE(value) {
+  return sharedEncoder.encode(value);
+}
+
+function closeSSEController(controller) {
+  if (typeof controller.terminate === "function") {
+    controller.terminate();
+  } else if (typeof controller.close === "function") {
+    controller.close();
+  }
+}
 
 function parseKiroToolInput(toolInput) {
   if (typeof toolInput === "string") {
@@ -74,6 +88,11 @@ function validateKiroToolCallWrapperInput(toolInput) {
   }
 }
 
+/**
+ * Validate a complete Kiro toolUseEvent payload. Streaming wrapper tool_call
+ * fragments must be buffered first; otherwise an init/delta fragment without
+ * the final nested input would be rejected as malformed.
+ */
 export function validateKiroToolUse(toolUse) {
   const toolName = validateKiroToolName(toolUse);
   if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
@@ -94,8 +113,9 @@ function emitKiroToolCallValidationError(controller, state, message) {
   state.invalidToolCall = true;
   state.finishEmitted = true;
   state.doneSent = true;
-  controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(error)}\n\n`));
-  controller.enqueue(new TextEncoder().encode(SSE_DONE));
+  controller.enqueue(encodeSSE(`data: ${JSON.stringify(error)}\n\n`));
+  controller.enqueue(encodeSSE(SSE_DONE));
+  closeSSEController(controller);
 }
 
 /**
@@ -210,8 +230,9 @@ export class KiroExecutor extends BaseExecutor {
   }
 
   /**
-   * Transform AWS EventStream binary response to SSE text stream
-   * Using TransformStream instead of ReadableStream.pull() to avoid Workers timeout
+   * Transform AWS EventStream binary response to SSE text stream.
+   * This pumps the upstream reader directly so a malformed wrapper can emit a
+   * clean SSE error and then cancel the upstream HTTP body immediately.
    */
   transformEventStreamToSSE(response, model) {
     let buffer = new Uint8Array(0);
@@ -227,9 +248,27 @@ export class KiroExecutor extends BaseExecutor {
       hasReasoningContent: false,
       reasoningChunkCount: 0,
       toolCallIndex: 0,
+      generatedToolIdCounter: 0,
       seenToolIds: new Map(),
       pendingWrapperToolCalls: new Map(),
       inThinking: false
+    };
+
+    const getToolCallId = (toolUse) => {
+      if (typeof toolUse?.toolUseId === "string" && toolUse.toolUseId) {
+        return toolUse.toolUseId;
+      }
+      state.generatedToolIdCounter++;
+      return `call_${created}_${state.generatedToolIdCounter}`;
+    };
+
+    const getOrAssignToolIndex = (toolCallId) => {
+      if (state.seenToolIds.has(toolCallId)) {
+        return { toolIndex: state.seenToolIds.get(toolCallId), isNewTool: false };
+      }
+      const toolIndex = state.toolCallIndex++;
+      state.seenToolIds.set(toolCallId, toolIndex);
+      return { toolIndex, isNewTool: true };
     };
 
     const emitToolCallStart = (controller, toolCallId, toolName, toolIndex) => {
@@ -256,7 +295,7 @@ export class KiroExecutor extends BaseExecutor {
         }]
       };
       chunkIndex++;
-      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(startChunk)}\n\n`));
+      controller.enqueue(encodeSSE(`data: ${JSON.stringify(startChunk)}\n\n`));
     };
 
     const emitToolCallArguments = (controller, toolIndex, argumentsStr) => {
@@ -279,7 +318,7 @@ export class KiroExecutor extends BaseExecutor {
         }]
       };
       chunkIndex++;
-      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+      controller.enqueue(encodeSSE(`data: ${JSON.stringify(argsChunk)}\n\n`));
     };
 
     const failInvalidToolCall = (controller, message) => {
@@ -299,10 +338,12 @@ export class KiroExecutor extends BaseExecutor {
           return false;
         }
 
+        const { toolIndex } = getOrAssignToolIndex(toolCall.toolCallId);
         const argumentsStr = typeof toolInput === "string" ? toolInput : JSON.stringify(toolInput);
-        emitToolCallStart(controller, toolCall.toolCallId, toolCall.toolName, toolCall.toolIndex);
+        toolCall.toolIndex = toolIndex;
+        emitToolCallStart(controller, toolCall.toolCallId, toolCall.toolName, toolIndex);
         if (argumentsStr) {
-          emitToolCallArguments(controller, toolCall.toolIndex, argumentsStr);
+          emitToolCallArguments(controller, toolIndex, argumentsStr);
         }
       }
 
@@ -310,8 +351,7 @@ export class KiroExecutor extends BaseExecutor {
       return true;
     };
 
-    const transformStream = new TransformStream({
-      async transform(chunk, controller) {
+    const transformChunk = async (chunk, controller) => {
         if (state.invalidToolCall) return;
         // Track output so we can emit a keepalive if this frame yields no chunk.
         const enqueueCountBefore = chunkIndex;
@@ -391,7 +431,7 @@ export class KiroExecutor extends BaseExecutor {
               }]
             };
             chunkIndex++;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle reasoningContentEvent (Kiro thinking / reasoning)
@@ -425,7 +465,7 @@ export class KiroExecutor extends BaseExecutor {
               };
               chunkIndex++;
               state.reasoningChunkCount++;
-              controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+              controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
             }
           }
 
@@ -443,7 +483,7 @@ export class KiroExecutor extends BaseExecutor {
               }]
             };
             chunkIndex++;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle toolUseEvent
@@ -461,23 +501,17 @@ export class KiroExecutor extends BaseExecutor {
                 return;
               }
 
-              const toolCallId = singleToolUse.toolUseId || `call_${Date.now()}`;
+              const toolCallId = getToolCallId(singleToolUse);
               const toolInput = singleToolUse.input;
-
-              let toolIndex;
-              const isNewTool = !state.seenToolIds.has(toolCallId);
-
-              if (isNewTool) {
-                toolIndex = state.toolCallIndex++;
-                state.seenToolIds.set(toolCallId, toolIndex);
-              } else {
-                toolIndex = state.seenToolIds.get(toolCallId);
-              }
 
               if (toolName === KIRO_TOOL_CALL_WRAPPER) {
                 let toolCall = state.pendingWrapperToolCalls.get(toolCallId);
                 if (!toolCall) {
-                  toolCall = { toolCallId, toolName, toolIndex };
+                  if (state.seenToolIds.has(toolCallId)) {
+                    failInvalidToolCall(controller, "Invalid Kiro tool_call payload: duplicate toolUseId reused by wrapper");
+                    return;
+                  }
+                  toolCall = { toolCallId, toolName };
                   state.pendingWrapperToolCalls.set(toolCallId, toolCall);
                 }
                 try {
@@ -489,6 +523,12 @@ export class KiroExecutor extends BaseExecutor {
                 continue;
               }
 
+              if (state.pendingWrapperToolCalls.has(toolCallId)) {
+                failInvalidToolCall(controller, "Invalid Kiro tool_call payload: mixed wrapper and direct tool fragments");
+                return;
+              }
+
+              const { toolIndex, isNewTool } = getOrAssignToolIndex(toolCallId);
               if (isNewTool) {
                 emitToolCallStart(controller, toolCallId, toolName, toolIndex);
               }
@@ -524,7 +564,7 @@ export class KiroExecutor extends BaseExecutor {
               }]
             };
             state.finishEmitted = true;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle contextUsageEvent to extract contextUsagePercentage
@@ -609,7 +649,7 @@ export class KiroExecutor extends BaseExecutor {
               finishChunk.usage = state.usage;
             }
 
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(finishChunk)}\n\n`));
           }
         }
 
@@ -620,13 +660,13 @@ export class KiroExecutor extends BaseExecutor {
         // No client chunk produced this frame — emit an SSE comment keepalive
                 // so the stall watchdog sees upstream activity (ignored by parser/client).
                 if (chunkIndex === enqueueCountBefore && !state.finishEmitted) {
-                  controller.enqueue(new TextEncoder().encode(": ka\n\n"));
+                  controller.enqueue(encodeSSE(": ka\n\n"));
                 }
-      },
+      };
 
-      flush(controller) {
-        if (state.invalidToolCall) return;
-        if (!flushPendingWrapperToolCalls(controller)) return;
+      const flushOutput = (controller) => {
+        if (state.invalidToolCall) return false;
+        if (!flushPendingWrapperToolCalls(controller)) return false;
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;
@@ -641,22 +681,49 @@ export class KiroExecutor extends BaseExecutor {
               finish_reason: state.hasToolCalls ? "tool_calls" : "stop"
             }]
           };
-          controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
+          controller.enqueue(encodeSSE(`data: ${JSON.stringify(finishChunk)}\n\n`));
         }
 
         // Send final done message
         if (!state.doneSent) {
           state.doneSent = true;
-          controller.enqueue(new TextEncoder().encode(SSE_DONE));
+          controller.enqueue(encodeSSE(SSE_DONE));
         }
-      }
-    });
+        return true;
+      };
 
-    // Pipe response body through transform stream
     if (!response.body) {
       return new Response(SSE_DONE, { status: response.status, headers: { "Content-Type": "text/event-stream" } });
     }
-    const transformedStream = response.body.pipeThrough(transformStream);
+    let reader;
+    const transformedStream = new ReadableStream({
+      async start(controller) {
+        reader = response.body.getReader();
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            await transformChunk(value, controller);
+            if (state.invalidToolCall) {
+              await reader.cancel("invalid_kiro_tool_call").catch(() => {});
+              return;
+            }
+          }
+
+          if (flushOutput(controller)) {
+            closeSSEController(controller);
+          }
+        } catch (error) {
+          if (state.invalidToolCall) return;
+          controller.error(error);
+        }
+      },
+
+      cancel(reason) {
+        return reader?.cancel(reason);
+      }
+    });
 
     return new Response(transformedStream, {
       status: response.status,
@@ -703,7 +770,7 @@ function parseEventFrame(data) {
       offset++;
       if (offset + nameLen > data.length) break;
 
-      const name = new TextDecoder().decode(data.slice(offset, offset + nameLen));
+      const name = sharedDecoder.decode(data.slice(offset, offset + nameLen));
       offset += nameLen;
 
       const headerType = data[offset];
@@ -714,7 +781,7 @@ function parseEventFrame(data) {
         offset += 2;
         if (offset + valueLen > data.length) break;
 
-        const value = new TextDecoder().decode(data.slice(offset, offset + valueLen));
+        const value = sharedDecoder.decode(data.slice(offset, offset + valueLen));
         offset += valueLen;
         headers[name] = value;
       } else {
@@ -728,7 +795,7 @@ function parseEventFrame(data) {
 
     let payload = null;
     if (payloadEnd > payloadStart) {
-      const payloadStr = new TextDecoder().decode(data.slice(payloadStart, payloadEnd));
+      const payloadStr = sharedDecoder.decode(data.slice(payloadStart, payloadEnd));
 
       // Skip empty or whitespace-only payloads
       if (!payloadStr || !payloadStr.trim()) {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -22,6 +22,49 @@ const STREAM_MODE = {
   PASSTHROUGH: "passthrough" // No translation, normalize output, extract usage
 };
 
+function normalizeStreamError(error) {
+  if (!error || typeof error !== "object") {
+    return {
+      message: String(error || "Upstream stream error"),
+      type: "server_error",
+      code: "stream_error"
+    };
+  }
+  return {
+    message: String(error.message || "Upstream stream error"),
+    type: String(error.type || "server_error"),
+    code: String(error.code || "stream_error")
+  };
+}
+
+function formatTranslatedStreamError(error, sourceFormat) {
+  const normalized = normalizeStreamError(error);
+
+  if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+    const now = Math.floor(Date.now() / 1000);
+    const failed = {
+      type: "response.failed",
+      response: {
+        id: `resp_error_${Date.now()}`,
+        object: "response",
+        created_at: now,
+        status: "failed",
+        background: false,
+        error: normalized,
+        output: []
+      },
+      sequence_number: 0
+    };
+    return `event: response.failed\ndata: ${JSON.stringify(failed)}\n\ndata: [DONE]\n\n`;
+  }
+
+  if (sourceFormat === FORMATS.CLAUDE) {
+    return `event: error\ndata: ${JSON.stringify({ type: "error", error: normalized })}\n\ndata: [DONE]\n\n`;
+  }
+
+  return `data: ${JSON.stringify({ error: normalized })}\n\ndata: [DONE]\n\n`;
+}
+
 /**
  * Create unified SSE transform stream
  * @param {object} options
@@ -72,6 +115,7 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  let upstreamErrorForwarded = false;
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -207,6 +251,18 @@ export function createSSEStream(options = {}) {
 
         const parsed = parseSSELine(trimmed, targetFormat);
         if (!parsed) continue;
+
+        if (upstreamErrorForwarded) continue;
+
+        if (parsed.error) {
+          const output = formatTranslatedStreamError(parsed.error, sourceFormat);
+          reqLogger?.appendConvertedChunk?.(output);
+          controller.enqueue(sharedEncoder.encode(output));
+          upstreamErrorForwarded = true;
+          streamDoneSent = true;
+          if (sourceFormat === FORMATS.OPENAI_RESPONSES) openAIResponsesDoneSent = true;
+          continue;
+        }
 
         // Responses API same-format passthrough: preserve event framing + track terminal state
         const isOpenAIResponsesStream = targetFormat === FORMATS.OPENAI_RESPONSES;
@@ -380,6 +436,11 @@ export function createSSEStream(options = {}) {
               thinking: accumulatedThinking
             }, usage, ttftAt);
           }
+          return;
+        }
+
+        if (upstreamErrorForwarded) {
+          appendRequestLog({ model, provider, connectionId, tokens: null, status: "FAILED STREAM_ERROR" }).catch(() => { });
           return;
         }
 

--- a/tests/unit/kiro-tool-call-validation.test.js
+++ b/tests/unit/kiro-tool-call-validation.test.js
@@ -109,14 +109,17 @@ describe("Kiro nested tool_call validation", () => {
 
   it("emits an actionable stream error instead of a fake legal tool call", async () => {
     const executor = new KiroExecutor();
-    const frame = encodeEventFrame("toolUseEvent", {
-      toolUseId: "call_1",
-      name: "tool_call",
-      input: { arguments: { q: "router" } }
-    });
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
     const response = new Response(new ReadableStream({
       start(controller) {
-        controller.enqueue(frame);
+        for (const frame of frames) controller.enqueue(frame);
         controller.close();
       }
     }), { status: 200, statusText: "OK" });
@@ -202,6 +205,40 @@ describe("Kiro nested tool_call validation", () => {
     expect(chunks.at(-1).usage).toBeDefined();
   });
 
+  it("preserves monotonic emitted tool indices when a wrapper is buffered before a direct tool", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "wrapper_1",
+        name: "tool_call",
+        input: { name: "mcp_search", arguments: { q: "router" } }
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "direct_1",
+        name: "read_file",
+        input: { path: "README.md" }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+    const chunks = collectDataChunks(text);
+    const toolStarts = chunks
+      .flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || [])
+      .filter((toolCall) => toolCall.id);
+
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(toolStarts.map((toolCall) => toolCall.function.name)).toEqual(["read_file", "tool_call"]);
+    expect(toolStarts.map((toolCall) => toolCall.index)).toEqual([0, 1]);
+  });
+
   it("fails malformed final wrapper payloads without emitting a legal tool_call", async () => {
     const executor = new KiroExecutor();
     const frames = [
@@ -230,6 +267,41 @@ describe("Kiro nested tool_call validation", () => {
     expect(text).toContain("missing nested MCP tool name");
     expect(text).not.toContain("\"tool_calls\"");
     expect(text).toContain("data: [DONE]");
+  });
+
+  it("cancels the upstream response body after an invalid wrapper payload", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    let cancelReason;
+    const cancelPromise = new Promise((resolve) => {
+      const response = new Response(new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(frame);
+        },
+        cancel(reason) {
+          cancelReason = reason;
+          resolve(reason);
+        }
+      }), { status: 200, statusText: "OK" });
+
+      const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+      collectText(transformed.body).catch(resolve);
+    });
+
+    const result = await Promise.race([
+      cancelPromise,
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 250))
+    ]);
+
+    expect(result).not.toBe("timeout");
+    expect(cancelReason).toBeDefined();
   });
 
   it("translates Kiro stream errors into Responses response.failed events", async () => {

--- a/tests/unit/kiro-tool-call-validation.test.js
+++ b/tests/unit/kiro-tool-call-validation.test.js
@@ -46,6 +46,15 @@ async function collectText(stream) {
   return text + decoder.decode();
 }
 
+function collectDataChunks(text) {
+  return text
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice(6).trim())
+    .filter((data) => data && data !== "[DONE]")
+    .map((data) => JSON.parse(data));
+}
+
 describe("Kiro nested tool_call validation", () => {
   it("accepts a valid wrapper tool_call with nested name and arguments", () => {
     expect(() => validateKiroToolUse({
@@ -108,6 +117,108 @@ describe("Kiro nested tool_call validation", () => {
     const response = new Response(new ReadableStream({
       start(controller) {
         controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+
+    expect(text).toContain("invalid_kiro_tool_call");
+    expect(text).toContain("missing nested MCP tool name");
+    expect(text).not.toContain("\"tool_calls\"");
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("allows a wrapper init frame without input and validates after string fragments", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call"
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: "{\"name\":\"mcp_search\","
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: "\"arguments\":{\"q\":\"router\"}}"
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+    const chunks = collectDataChunks(text);
+    const toolChunks = chunks.flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || []);
+    const args = toolChunks.map((toolCall) => toolCall.function?.arguments || "").join("");
+
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(toolChunks[0].function.name).toBe("tool_call");
+    expect(JSON.parse(args)).toEqual({ name: "mcp_search", arguments: { q: "router" } });
+    expect(chunks.at(-1).choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("waits for the final growing object payload before validating wrapper fields", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { name: "mcp_search", arguments: { q: "router" } }
+      }),
+      encodeEventFrame("meteringEvent", {}),
+      encodeEventFrame("contextUsageEvent", { contextUsagePercentage: 1 })
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+    const chunks = collectDataChunks(text);
+    const toolChunks = chunks.flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || []);
+    const args = toolChunks.map((toolCall) => toolCall.function?.arguments || "").join("");
+
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(JSON.parse(args)).toEqual({ name: "mcp_search", arguments: { q: "router" } });
+    expect(chunks.at(-1).usage).toBeDefined();
+  });
+
+  it("fails malformed final wrapper payloads without emitting a legal tool_call", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call"
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
         controller.close();
       }
     }), { status: 200, statusText: "OK" });

--- a/tests/unit/kiro-tool-call-validation.test.js
+++ b/tests/unit/kiro-tool-call-validation.test.js
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { KiroExecutor, validateKiroToolUse } from "../../open-sse/executors/kiro.js";
+import { openaiToOpenAIResponsesResponse } from "../../open-sse/translator/response/openai-responses.js";
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+function encodeHeader(name, value) {
+  const nameBytes = new TextEncoder().encode(name);
+  const valueBytes = new TextEncoder().encode(value);
+  const out = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
+  let offset = 0;
+  out[offset++] = nameBytes.length;
+  out.set(nameBytes, offset);
+  offset += nameBytes.length;
+  out[offset++] = 7;
+  out[offset++] = (valueBytes.length >> 8) & 0xff;
+  out[offset++] = valueBytes.length & 0xff;
+  out.set(valueBytes, offset);
+  return out;
+}
+
+function encodeEventFrame(eventType, payload) {
+  const headers = encodeHeader(":event-type", eventType);
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(payload));
+  const totalLength = 12 + headers.length + payloadBytes.length + 4;
+  const frame = new Uint8Array(totalLength);
+  const view = new DataView(frame.buffer);
+  view.setUint32(0, totalLength, false);
+  view.setUint32(4, headers.length, false);
+  view.setUint32(8, 0, false);
+  frame.set(headers, 12);
+  frame.set(payloadBytes, 12 + headers.length);
+  view.setUint32(totalLength - 4, 0, false);
+  return frame;
+}
+
+async function collectText(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+describe("Kiro nested tool_call validation", () => {
+  it("accepts a valid wrapper tool_call with nested name and arguments", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { name: "mcp_search", arguments: { q: "router" } }
+    })).not.toThrow();
+  });
+
+  it("accepts ordinary provider tool calls without requiring wrapper fields", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "get_weather",
+      input: { city: "Taipei" }
+    })).not.toThrow();
+  });
+
+  it("rejects missing or empty Kiro tool names", () => {
+    expect(() => validateKiroToolUse({ toolUseId: "call_1", input: {} }))
+      .toThrow(/missing tool name/);
+    expect(() => validateKiroToolUse({ toolUseId: "call_1", name: "   ", input: {} }))
+      .toThrow(/missing tool name/);
+  });
+
+  it("rejects wrapper tool_call payloads without the real MCP tool name", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { arguments: { q: "router" } }
+    })).toThrow(/missing nested MCP tool name/);
+
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { name: "  ", arguments: {} }
+    })).toThrow(/missing nested MCP tool name/);
+  });
+
+  it("rejects malformed wrapper JSON and missing nested arguments", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: "{\"name\":\"mcp_search\","
+    })).toThrow(/valid JSON/);
+
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { name: "mcp_search" }
+    })).toThrow(/missing nested MCP tool arguments/);
+  });
+
+  it("emits an actionable stream error instead of a fake legal tool call", async () => {
+    const executor = new KiroExecutor();
+    const frame = encodeEventFrame("toolUseEvent", {
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { arguments: { q: "router" } }
+    });
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+
+    expect(text).toContain("invalid_kiro_tool_call");
+    expect(text).toContain("missing nested MCP tool name");
+    expect(text).not.toContain("\"tool_calls\"");
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("translates Kiro stream errors into Responses response.failed events", async () => {
+    const transform = createSSETransformStreamWithLogger(
+      FORMATS.KIRO,
+      FORMATS.OPENAI_RESPONSES,
+      "kiro",
+      null,
+      null,
+      "kr/claude-opus-4.8"
+    );
+    const writer = transform.writable.getWriter();
+    const readPromise = collectText(transform.readable);
+    await writer.write(new TextEncoder().encode(
+      "data: {\"error\":{\"message\":\"Invalid Kiro tool_call payload: missing nested MCP tool name at input.name\",\"type\":\"invalid_request_error\",\"code\":\"invalid_kiro_tool_call\"}}\n\n"
+    ));
+    await writer.close();
+
+    const text = await readPromise;
+
+    expect(text).toContain("event: response.failed");
+    expect(text).toContain("invalid_kiro_tool_call");
+    expect(text).toContain("missing nested MCP tool name");
+    expect(text).not.toContain("response.output_item.added");
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("does not change non-Kiro OpenAI function_call translation", () => {
+    const state = {
+      seq: 0,
+      responseId: "resp_test",
+      created: 1,
+      started: false,
+      msgTextBuf: {},
+      msgItemAdded: {},
+      msgContentAdded: {},
+      msgItemDone: {},
+      reasoningId: "",
+      reasoningIndex: -1,
+      reasoningBuf: "",
+      funcArgsBuf: {},
+      funcNames: {},
+      funcCallIds: {},
+      funcArgsDone: {},
+      funcItemDone: {},
+      completedSent: false
+    };
+    const events = openaiToOpenAIResponsesResponse({
+      id: "chatcmpl_test",
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            index: 0,
+            id: "call_1",
+            type: "function",
+            function: { name: "tool_call", arguments: "{\"arguments\":{}}" }
+          }]
+        },
+        finish_reason: null
+      }]
+    }, state);
+
+    expect(events.some((event) => event.data?.item?.name === "tool_call")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- validate Kiro's nested `tool_call` wrapper only after its streamed input is complete
- accumulate phased `toolUseEvent` input by `toolUseId` instead of rejecting the init frame when it has no `input` yet
- preserve emitted OpenAI tool-call index ordering when wrapper and direct tools are interleaved
- emit a clean `invalid_kiro_tool_call` stream error without producing a fake legal function call, then cancel the upstream reader

## Why

Kiro may stream a wrapper tool call in phases:

1. an init event containing `name: "tool_call"` and `toolUseId`
2. one or more input fragments
3. a terminal event

Validating the init frame immediately creates false failures because the nested `{ name, arguments }` payload is not present yet. Conversely, forwarding a truly malformed final wrapper as a normal function call hides the provider error and leaves downstream agents with an unusable tool name.

This change buffers only wrapper metadata/input until a terminal boundary, validates the completed payload, and keeps normal non-wrapper tools streaming as before.

## Tests

- focused Kiro wrapper validation tests, including phased input, mixed wrapper/direct ordering, duplicate IDs, malformed terminal payloads, clean SSE failure, and upstream cancellation
- related Kiro translator and OpenAI Responses tests
- changed-file ESLint
- `git diff --check`
- `npm run build`

Claude Code reviewed the final branch and approved it for push.
