### PR TITLE
fix(kiro): retry malformed tool_call wrappers once

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -49,6 +49,7 @@ function isKiroToolCallRepairEnabled(credentials) {
   const configValue = credentials?.providerSpecificData?.kiroToolCallRepair
     ?? credentials?.providerSpecificData?.enableKiroToolCallRepair
     ?? process.env?.[KIRO_TOOL_CALL_REPAIR_ENV];
+  if (configValue == null) return true;
   return isTruthyConfig(configValue);
 }
 

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -6,6 +6,59 @@ import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 
+const KIRO_TOOL_CALL_WRAPPER = "tool_call";
+
+function parseKiroToolInput(toolInput) {
+  if (typeof toolInput === "string") {
+    try {
+      return JSON.parse(toolInput);
+    } catch (error) {
+      throw new Error(`Invalid Kiro tool_call payload: input must be valid JSON (${error.message})`);
+    }
+  }
+  return toolInput;
+}
+
+export function validateKiroToolUse(toolUse) {
+  const toolName = typeof toolUse?.name === "string" ? toolUse.name.trim() : "";
+  if (!toolName) {
+    throw new Error("Invalid Kiro toolUseEvent: missing tool name");
+  }
+
+  if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
+    return;
+  }
+
+  const input = parseKiroToolInput(toolUse.input);
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Invalid Kiro tool_call payload: input must be an object with name and arguments");
+  }
+
+  const nestedName = typeof input.name === "string" ? input.name.trim() : "";
+  if (!nestedName) {
+    throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool name at input.name");
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(input, "arguments")) {
+    throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool arguments at input.arguments");
+  }
+}
+
+function emitKiroToolCallValidationError(controller, state, message) {
+  const error = {
+    error: {
+      message,
+      type: "invalid_request_error",
+      code: "invalid_kiro_tool_call"
+    }
+  };
+  state.invalidToolCall = true;
+  state.finishEmitted = true;
+  state.doneSent = true;
+  controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(error)}\n\n`));
+  controller.enqueue(new TextEncoder().encode(SSE_DONE));
+}
+
 /**
  * KiroExecutor - Executor for Kiro AI (AWS CodeWhisperer)
  * Uses AWS CodeWhisperer streaming API with AWS EventStream binary format
@@ -141,7 +194,8 @@ export class KiroExecutor extends BaseExecutor {
 
     const transformStream = new TransformStream({
       async transform(chunk, controller) {
-             // Track output so we can emit a keepalive if this frame yields no chunk.
+        if (state.invalidToolCall) return;
+        // Track output so we can emit a keepalive if this frame yields no chunk.
         const enqueueCountBefore = chunkIndex;
         // Append to buffer
         const newBuffer = new Uint8Array(buffer.length + chunk.length);
@@ -281,8 +335,16 @@ export class KiroExecutor extends BaseExecutor {
             const toolUses = Array.isArray(toolUse) ? toolUse : [toolUse];
 
             for (const singleToolUse of toolUses) {
+              try {
+                validateKiroToolUse(singleToolUse);
+              } catch (error) {
+                emitKiroToolCallValidationError(controller, state, error.message);
+                buffer = new Uint8Array(0);
+                return;
+              }
+
               const toolCallId = singleToolUse.toolUseId || `call_${Date.now()}`;
-              const toolName = singleToolUse.name || "";
+              const toolName = singleToolUse.name.trim();
               const toolInput = singleToolUse.input;
 
               let toolIndex;
@@ -469,6 +531,7 @@ export class KiroExecutor extends BaseExecutor {
       },
 
       flush(controller) {
+        if (state.invalidToolCall) return;
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;
@@ -487,7 +550,10 @@ export class KiroExecutor extends BaseExecutor {
         }
 
         // Send final done message
-        controller.enqueue(new TextEncoder().encode(SSE_DONE));
+        if (!state.doneSent) {
+          state.doneSent = true;
+          controller.enqueue(new TextEncoder().encode(SSE_DONE));
+        }
       }
     });
 

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -8,7 +8,6 @@ import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { STREAM_FIRST_CHUNK_TIMEOUT_MS } from "../config/runtimeConfig.js";
 
 const KIRO_TOOL_CALL_WRAPPER = "tool_call";
-const KIRO_TOOL_CALL_REPAIR_ENV = "KIRO_TOOL_CALL_REPAIR";
 const KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES_ENV = "KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES";
 const KIRO_TOOL_CALL_REPAIR_TIMEOUT_MS_ENV = "KIRO_TOOL_CALL_REPAIR_TIMEOUT_MS";
 const KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS_ENV = "KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS";
@@ -39,18 +38,6 @@ function envInt(name, fallback) {
   if (raw == null || raw === "") return fallback;
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function isTruthyConfig(value) {
-  return value === true || value === "true" || value === "1" || value === 1;
-}
-
-function isKiroToolCallRepairEnabled(credentials) {
-  const configValue = credentials?.providerSpecificData?.kiroToolCallRepair
-    ?? credentials?.providerSpecificData?.enableKiroToolCallRepair
-    ?? process.env?.[KIRO_TOOL_CALL_REPAIR_ENV];
-  if (configValue == null) return true;
-  return isTruthyConfig(configValue);
 }
 
 function buildKiroToolCallRepairBody(body, invalidMessage) {
@@ -407,7 +394,7 @@ export class KiroExecutor extends BaseExecutor {
   async execute(args) {
     const result = await super.execute(args);
     if (result?.response?.ok) {
-      if (args.stream !== false && isKiroToolCallRepairEnabled(args.credentials)) {
+      if (args.stream !== false) {
         return this.createToolCallRepairResult(result, args);
       }
       result.response = this.transformEventStreamToSSE(result.response, args.model);

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -5,8 +5,20 @@ import { v4 as uuidv4 } from "uuid";
 import { refreshKiroToken } from "../services/tokenRefresh.js";
 import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
+import { STREAM_FIRST_CHUNK_TIMEOUT_MS } from "../config/runtimeConfig.js";
 
 const KIRO_TOOL_CALL_WRAPPER = "tool_call";
+const KIRO_TOOL_CALL_REPAIR_ENV = "KIRO_TOOL_CALL_REPAIR";
+const KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES_ENV = "KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES";
+const KIRO_TOOL_CALL_REPAIR_TIMEOUT_MS_ENV = "KIRO_TOOL_CALL_REPAIR_TIMEOUT_MS";
+const KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS_ENV = "KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS";
+const KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS_ENV = "KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS";
+const KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES = 8 * 1024 * 1024;
+const KIRO_TOOL_CALL_REPAIR_INSTRUCTION = [
+  "Retry the previous response because its Kiro tool_call wrapper was malformed.",
+  "If you use the wrapper tool named tool_call, its input must be a JSON object with a non-empty string name and an arguments field.",
+  "Do not emit a tool_call wrapper without input.name and input.arguments."
+].join(" ");
 const sharedEncoder = new TextEncoder();
 const sharedDecoder = new TextDecoder();
 
@@ -20,6 +32,161 @@ function closeSSEController(controller) {
   } else if (typeof controller.close === "function") {
     controller.close();
   }
+}
+
+function envInt(name, fallback) {
+  const raw = process.env?.[name];
+  if (raw == null || raw === "") return fallback;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isTruthyConfig(value) {
+  return value === true || value === "true" || value === "1" || value === 1;
+}
+
+function isKiroToolCallRepairEnabled(credentials) {
+  const configValue = credentials?.providerSpecificData?.kiroToolCallRepair
+    ?? credentials?.providerSpecificData?.enableKiroToolCallRepair
+    ?? process.env?.[KIRO_TOOL_CALL_REPAIR_ENV];
+  return isTruthyConfig(configValue);
+}
+
+function buildKiroToolCallRepairBody(body, invalidMessage) {
+  const repaired = JSON.parse(JSON.stringify(body || {}));
+  const reason = String(invalidMessage || "invalid tool_call payload").slice(0, 300);
+  const instruction = `${KIRO_TOOL_CALL_REPAIR_INSTRUCTION} Previous validation error: ${reason}`;
+  repaired.systemPrompt = repaired.systemPrompt
+    ? `${repaired.systemPrompt}\n\n${instruction}`
+    : instruction;
+  return repaired;
+}
+
+function makeAbortError(reason) {
+  const error = new Error(reason || "Request aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function combineAbortSignals(signals) {
+  const activeSignals = signals.filter(Boolean);
+  if (activeSignals.length === 0) return { signal: undefined, cleanup: () => {} };
+  if (activeSignals.length === 1) return { signal: activeSignals[0], cleanup: () => {} };
+
+  const controller = new AbortController();
+  const listeners = [];
+  const abortFrom = (signal) => {
+    if (!controller.signal.aborted) {
+      controller.abort(signal.reason || makeAbortError("Request aborted"));
+    }
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+    const listener = () => abortFrom(signal);
+    signal.addEventListener("abort", listener, { once: true });
+    listeners.push([signal, listener]);
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const [signal, listener] of listeners) {
+        signal.removeEventListener("abort", listener);
+      }
+    }
+  };
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) {
+    throw makeAbortError(signal.reason?.message || signal.reason || "Request aborted");
+  }
+}
+
+async function readWithTimeout(reader, signal, timeoutMs, timeoutMessage) {
+  throwIfAborted(signal);
+
+  let abortHandler;
+  let timeoutId;
+  const abortPromise = new Promise((_, reject) => {
+    abortHandler = () => reject(makeAbortError(signal?.reason?.message || signal?.reason || "Request aborted"));
+    signal?.addEventListener?.("abort", abortHandler, { once: true });
+  });
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([reader.read(), abortPromise, timeoutPromise]);
+  } finally {
+    if (abortHandler) signal?.removeEventListener?.("abort", abortHandler);
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+function concatChunks(chunks, totalBytes) {
+  const out = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function hasMeaningfulSSEData(chunk) {
+  const text = sharedDecoder.decode(chunk);
+  return text.split("\n").some((line) => line.startsWith("data: ") && line.slice(6).trim() !== "");
+}
+
+function formatKiroToolCallRepairError(message, code = "kiro_tool_call_repair_failed") {
+  return encodeSSE(`data: ${JSON.stringify({
+    error: {
+      message,
+      type: "invalid_request_error",
+      code
+    }
+  })}\n\ndata: [DONE]\n\n`);
+}
+
+function once(fn) {
+  let called = false;
+  return () => {
+    if (called) return;
+    called = true;
+    fn?.();
+  };
+}
+
+function prependChunkToReader(firstChunk, reader, { onCancel, onDone } = {}) {
+  const finish = once(onDone);
+  return new ReadableStream({
+    async start(controller) {
+      if (firstChunk?.byteLength) controller.enqueue(firstChunk);
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(value);
+        }
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      } finally {
+        finish();
+      }
+    },
+
+    cancel(reason) {
+      onCancel?.(reason);
+      finish();
+      return reader.cancel(reason);
+    }
+  });
 }
 
 function parseKiroToolInput(toolInput) {
@@ -102,19 +269,22 @@ export function validateKiroToolUse(toolUse) {
   validateKiroToolCallWrapperInput(toolUse.input);
 }
 
-function emitKiroToolCallValidationError(controller, state, message) {
+function emitKiroToolCallValidationError(controller, state, message, options = {}) {
   const error = {
     error: {
       message,
       type: "invalid_request_error",
-      code: "invalid_kiro_tool_call"
+      code: options.invalidToolCallErrorCode || "invalid_kiro_tool_call"
     }
   };
   state.invalidToolCall = true;
   state.finishEmitted = true;
   state.doneSent = true;
-  controller.enqueue(encodeSSE(`data: ${JSON.stringify(error)}\n\n`));
-  controller.enqueue(encodeSSE(SSE_DONE));
+  options.onInvalidToolCall?.(message);
+  if (!options.suppressInvalidToolCallError) {
+    controller.enqueue(encodeSSE(`data: ${JSON.stringify(error)}\n\n`));
+    controller.enqueue(encodeSSE(SSE_DONE));
+  }
   closeSSEController(controller);
 }
 
@@ -224,9 +394,198 @@ export class KiroExecutor extends BaseExecutor {
   async execute(args) {
     const result = await super.execute(args);
     if (result?.response?.ok) {
+      if (args.stream !== false && isKiroToolCallRepairEnabled(args.credentials)) {
+        return this.createToolCallRepairResult(result, args);
+      }
       result.response = this.transformEventStreamToSSE(result.response, args.model);
     }
     return result;
+  }
+
+  async createToolCallRepairResult(firstResult, args) {
+    const executeRaw = (nextArgs) => BaseExecutor.prototype.execute.call(this, nextArgs);
+    const repairController = new AbortController();
+    const combined = combineAbortSignals([args.signal, repairController.signal]);
+    let cleanupInFinally = true;
+    const maxBufferBytes = envInt(
+      KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES_ENV,
+      KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES
+    );
+    const legacyTimeoutMs = envInt(KIRO_TOOL_CALL_REPAIR_TIMEOUT_MS_ENV, STREAM_FIRST_CHUNK_TIMEOUT_MS);
+    const ttftTimeoutMs = envInt(KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS_ENV, legacyTimeoutMs);
+    const stallTimeoutMs = envInt(KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS_ENV, legacyTimeoutMs);
+
+    // Repair is intentionally limited to the pre-output gate. Once a real data
+    // chunk is released, streaming TTFT wins and later invalid wrappers surface
+    // as validation errors instead of replaying behind already-visible output.
+    try {
+      const firstAttempt = await this.openToolCallRepairGate(firstResult.response, args, {
+        signal: combined.signal,
+        maxBufferBytes,
+        ttftTimeoutMs,
+        stallTimeoutMs,
+        suppressInvalidToolCallError: true
+      });
+
+      if (firstAttempt.kind === "stream") {
+        cleanupInFinally = false;
+        firstResult.response = new Response(
+          prependChunkToReader(firstAttempt.firstChunk, firstAttempt.reader, {
+            onCancel: (reason) => repairController.abort(reason || "cancelled"),
+            onDone: combined.cleanup
+          }),
+          {
+            status: firstResult.response.status,
+            statusText: firstResult.response.statusText,
+            headers: { ...SSE_HEADERS }
+          }
+        );
+        return firstResult;
+      }
+
+      if (firstAttempt.kind === "complete") {
+        firstResult.response = new Response(firstAttempt.bytes, {
+          status: firstResult.response.status,
+          statusText: firstResult.response.statusText,
+          headers: { ...SSE_HEADERS }
+        });
+        return firstResult;
+      }
+
+      if (firstAttempt.kind === "buffer_exceeded") {
+        firstResult.response = new Response(formatKiroToolCallRepairError(
+          `Kiro tool_call repair buffer exceeded ${maxBufferBytes} bytes`,
+          "kiro_tool_call_repair_buffer_exceeded"
+        ), {
+          status: firstResult.response.status,
+          statusText: firstResult.response.statusText,
+          headers: { ...SSE_HEADERS }
+        });
+        return firstResult;
+      }
+
+      const repairBody = buildKiroToolCallRepairBody(args.body, firstAttempt.invalidToolCall);
+      const retryResult = await executeRaw({
+        ...args,
+        body: repairBody,
+        signal: combined.signal
+      });
+
+      if (!retryResult?.response?.ok) {
+        return retryResult;
+      }
+
+      const retryAttempt = await this.openToolCallRepairGate(retryResult.response, args, {
+        signal: combined.signal,
+        maxBufferBytes,
+        ttftTimeoutMs,
+        stallTimeoutMs,
+        suppressInvalidToolCallError: false,
+        invalidToolCallErrorCode: "kiro_tool_call_repair_retry_failed"
+      });
+
+      if (retryAttempt.kind === "stream") {
+        cleanupInFinally = false;
+        retryResult.response = new Response(
+          prependChunkToReader(retryAttempt.firstChunk, retryAttempt.reader, {
+            onCancel: (reason) => repairController.abort(reason || "cancelled"),
+            onDone: combined.cleanup
+          }),
+          {
+            status: retryResult.response.status,
+            statusText: retryResult.response.statusText,
+            headers: { ...SSE_HEADERS }
+          }
+        );
+        return retryResult;
+      }
+
+      if (retryAttempt.kind === "complete") {
+        retryResult.response = new Response(retryAttempt.bytes, {
+          status: retryResult.response.status,
+          statusText: retryResult.response.statusText,
+          headers: { ...SSE_HEADERS }
+        });
+        return retryResult;
+      }
+
+      retryResult.response = new Response(formatKiroToolCallRepairError(
+        retryAttempt.kind === "buffer_exceeded"
+          ? `Kiro tool_call repair buffer exceeded ${maxBufferBytes} bytes`
+          : retryAttempt.invalidToolCall || "Kiro tool_call repair retry failed",
+        retryAttempt.kind === "buffer_exceeded"
+          ? "kiro_tool_call_repair_buffer_exceeded"
+          : "kiro_tool_call_repair_retry_failed"
+      ), {
+        status: retryResult.response.status,
+        statusText: retryResult.response.statusText,
+        headers: { ...SSE_HEADERS }
+      });
+      return retryResult;
+    } catch (error) {
+      if (error.name === "AbortError") throw error;
+      firstResult.response = new Response(formatKiroToolCallRepairError(
+        error.message || "Kiro tool_call repair failed"
+      ), {
+        status: firstResult.response.status,
+        statusText: firstResult.response.statusText,
+        headers: { ...SSE_HEADERS }
+      });
+      return firstResult;
+    } finally {
+      if (cleanupInFinally) combined.cleanup();
+    }
+  }
+
+  async openToolCallRepairGate(rawResponse, args, options) {
+    let invalidToolCall = null;
+    const transformed = this.transformEventStreamToSSE(rawResponse, args.model, {
+      onInvalidToolCall: (message) => {
+        invalidToolCall = message;
+      },
+      suppressInvalidToolCallError: options.suppressInvalidToolCallError,
+      invalidToolCallErrorCode: options.invalidToolCallErrorCode
+    });
+    const reader = transformed.body.getReader();
+    const bufferedChunks = [];
+    let totalBytes = 0;
+    let sawAnyChunk = false;
+
+    try {
+      while (true) {
+        const timeoutMs = sawAnyChunk ? options.stallTimeoutMs : options.ttftTimeoutMs;
+        const timeoutKind = sawAnyChunk ? "stalled" : "timed out before first chunk";
+        const { done, value } = await readWithTimeout(
+          reader,
+          options.signal,
+          timeoutMs,
+          `Kiro tool_call repair ${timeoutKind}`
+        );
+
+        if (done) {
+          if (invalidToolCall) {
+            return { kind: "invalid", invalidToolCall };
+          }
+          return { kind: "complete", bytes: concatChunks(bufferedChunks, totalBytes) };
+        }
+
+        sawAnyChunk = true;
+        totalBytes += value.byteLength;
+        if (totalBytes > options.maxBufferBytes) {
+          await reader.cancel("kiro_tool_call_repair_buffer_exceeded").catch(() => {});
+          return { kind: "buffer_exceeded" };
+        }
+
+        if (hasMeaningfulSSEData(value)) {
+          return { kind: "stream", firstChunk: value, reader };
+        }
+
+        bufferedChunks.push(value);
+      }
+    } catch (error) {
+      await reader.cancel(error.message || "kiro_tool_call_repair_failed").catch(() => {});
+      throw error;
+    }
   }
 
   /**
@@ -234,7 +593,7 @@ export class KiroExecutor extends BaseExecutor {
    * This pumps the upstream reader directly so a malformed wrapper can emit a
    * clean SSE error and then cancel the upstream HTTP body immediately.
    */
-  transformEventStreamToSSE(response, model) {
+  transformEventStreamToSSE(response, model, options = {}) {
     let buffer = new Uint8Array(0);
     let chunkIndex = 0;
     const responseId = `chatcmpl-${Date.now()}`;
@@ -322,7 +681,7 @@ export class KiroExecutor extends BaseExecutor {
     };
 
     const failInvalidToolCall = (controller, message) => {
-      emitKiroToolCallValidationError(controller, state, message);
+      emitKiroToolCallValidationError(controller, state, message, options);
       buffer = new Uint8Array(0);
     };
 

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -19,17 +19,47 @@ function parseKiroToolInput(toolInput) {
   return toolInput;
 }
 
-export function validateKiroToolUse(toolUse) {
+function validateKiroToolName(toolUse) {
   const toolName = typeof toolUse?.name === "string" ? toolUse.name.trim() : "";
   if (!toolName) {
     throw new Error("Invalid Kiro toolUseEvent: missing tool name");
   }
 
-  if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
+  return toolName;
+}
+
+function getBufferedKiroToolInput(toolCall) {
+  if (toolCall.inputKind === "string") return toolCall.inputText || "";
+  return toolCall.inputObject;
+}
+
+function appendBufferedKiroToolInput(toolCall, toolInput) {
+  if (toolInput === undefined) return;
+
+  if (typeof toolInput === "string") {
+    if (toolCall.inputKind && toolCall.inputKind !== "string") {
+      throw new Error("Invalid Kiro tool_call payload: mixed input fragment types");
+    }
+    toolCall.inputKind = "string";
+    toolCall.inputText = `${toolCall.inputText || ""}${toolInput}`;
     return;
   }
 
-  const input = parseKiroToolInput(toolUse.input);
+  if (toolInput && typeof toolInput === "object" && !Array.isArray(toolInput)) {
+    if (toolCall.inputKind && toolCall.inputKind !== "object") {
+      throw new Error("Invalid Kiro tool_call payload: mixed input fragment types");
+    }
+    toolCall.inputKind = "object";
+    toolCall.inputObject = toolInput;
+  }
+}
+
+function validateKiroToolCallWrapperInput(toolInput) {
+  if (toolInput === undefined) {
+    throw new Error("Invalid Kiro tool_call payload: missing input");
+  }
+
+  const input = parseKiroToolInput(toolInput);
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("Invalid Kiro tool_call payload: input must be an object with name and arguments");
   }
@@ -42,6 +72,15 @@ export function validateKiroToolUse(toolUse) {
   if (!Object.prototype.hasOwnProperty.call(input, "arguments")) {
     throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool arguments at input.arguments");
   }
+}
+
+export function validateKiroToolUse(toolUse) {
+  const toolName = validateKiroToolName(toolUse);
+  if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
+    return;
+  }
+
+  validateKiroToolCallWrapperInput(toolUse.input);
 }
 
 function emitKiroToolCallValidationError(controller, state, message) {
@@ -189,7 +228,86 @@ export class KiroExecutor extends BaseExecutor {
       reasoningChunkCount: 0,
       toolCallIndex: 0,
       seenToolIds: new Map(),
+      pendingWrapperToolCalls: new Map(),
       inThinking: false
+    };
+
+    const emitToolCallStart = (controller, toolCallId, toolName, toolIndex) => {
+      const startChunk = {
+        id: responseId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: {
+            ...(chunkIndex === 0 ? { role: "assistant" } : {}),
+            tool_calls: [{
+              index: toolIndex,
+              id: toolCallId,
+              type: "function",
+              function: {
+                name: toolName,
+                arguments: ""
+              }
+            }]
+          },
+          finish_reason: null
+        }]
+      };
+      chunkIndex++;
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(startChunk)}\n\n`));
+    };
+
+    const emitToolCallArguments = (controller, toolIndex, argumentsStr) => {
+      const argsChunk = {
+        id: responseId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: toolIndex,
+              function: {
+                arguments: argumentsStr
+              }
+            }]
+          },
+          finish_reason: null
+        }]
+      };
+      chunkIndex++;
+      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+    };
+
+    const failInvalidToolCall = (controller, message) => {
+      emitKiroToolCallValidationError(controller, state, message);
+      buffer = new Uint8Array(0);
+    };
+
+    const flushPendingWrapperToolCalls = (controller) => {
+      if (state.pendingWrapperToolCalls.size === 0) return true;
+
+      for (const toolCall of state.pendingWrapperToolCalls.values()) {
+        const toolInput = getBufferedKiroToolInput(toolCall);
+        try {
+          validateKiroToolCallWrapperInput(toolInput);
+        } catch (error) {
+          failInvalidToolCall(controller, error.message);
+          return false;
+        }
+
+        const argumentsStr = typeof toolInput === "string" ? toolInput : JSON.stringify(toolInput);
+        emitToolCallStart(controller, toolCall.toolCallId, toolCall.toolName, toolCall.toolIndex);
+        if (argumentsStr) {
+          emitToolCallArguments(controller, toolCall.toolIndex, argumentsStr);
+        }
+      }
+
+      state.pendingWrapperToolCalls.clear();
+      return true;
     };
 
     const transformStream = new TransformStream({
@@ -335,16 +453,15 @@ export class KiroExecutor extends BaseExecutor {
             const toolUses = Array.isArray(toolUse) ? toolUse : [toolUse];
 
             for (const singleToolUse of toolUses) {
+              let toolName;
               try {
-                validateKiroToolUse(singleToolUse);
+                toolName = validateKiroToolName(singleToolUse);
               } catch (error) {
-                emitKiroToolCallValidationError(controller, state, error.message);
-                buffer = new Uint8Array(0);
+                failInvalidToolCall(controller, error.message);
                 return;
               }
 
               const toolCallId = singleToolUse.toolUseId || `call_${Date.now()}`;
-              const toolName = singleToolUse.name.trim();
               const toolInput = singleToolUse.input;
 
               let toolIndex;
@@ -353,33 +470,27 @@ export class KiroExecutor extends BaseExecutor {
               if (isNewTool) {
                 toolIndex = state.toolCallIndex++;
                 state.seenToolIds.set(toolCallId, toolIndex);
-
-                const startChunk = {
-                  id: responseId,
-                  object: "chat.completion.chunk",
-                  created,
-                  model,
-                  choices: [{
-                    index: 0,
-                    delta: {
-                      ...(chunkIndex === 0 ? { role: "assistant" } : {}),
-                      tool_calls: [{
-                        index: toolIndex,
-                        id: toolCallId,
-                        type: "function",
-                        function: {
-                          name: toolName,
-                          arguments: ""
-                        }
-                      }]
-                    },
-                    finish_reason: null
-                  }]
-                };
-                chunkIndex++;
-                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(startChunk)}\n\n`));
               } else {
                 toolIndex = state.seenToolIds.get(toolCallId);
+              }
+
+              if (toolName === KIRO_TOOL_CALL_WRAPPER) {
+                let toolCall = state.pendingWrapperToolCalls.get(toolCallId);
+                if (!toolCall) {
+                  toolCall = { toolCallId, toolName, toolIndex };
+                  state.pendingWrapperToolCalls.set(toolCallId, toolCall);
+                }
+                try {
+                  appendBufferedKiroToolInput(toolCall, toolInput);
+                } catch (error) {
+                  failInvalidToolCall(controller, error.message);
+                  return;
+                }
+                continue;
+              }
+
+              if (isNewTool) {
+                emitToolCallStart(controller, toolCallId, toolName, toolIndex);
               }
 
               if (toolInput !== undefined) {
@@ -393,32 +504,14 @@ export class KiroExecutor extends BaseExecutor {
                   continue;
                 }
 
-                const argsChunk = {
-                  id: responseId,
-                  object: "chat.completion.chunk",
-                  created,
-                  model,
-                  choices: [{
-                    index: 0,
-                    delta: {
-                      tool_calls: [{
-                        index: toolIndex,
-                        function: {
-                          arguments: argumentsStr
-                        }
-                      }]
-                    },
-                    finish_reason: null
-                  }]
-                };
-                chunkIndex++;
-                controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+                emitToolCallArguments(controller, toolIndex, argumentsStr);
               }
             }
           }
 
           // Handle messageStopEvent
           if (eventType === "messageStopEvent") {
+            if (!flushPendingWrapperToolCalls(controller)) return;
             const chunk = {
               id: responseId,
               object: "chat.completion.chunk",
@@ -477,6 +570,7 @@ export class KiroExecutor extends BaseExecutor {
 
           // Emit final chunk only after receiving BOTH meteringEvent AND contextUsageEvent
           if (state.hasMeteringEvent && state.hasContextUsage && !state.finishEmitted) {
+            if (!flushPendingWrapperToolCalls(controller)) return;
             state.finishEmitted = true;
 
             // Estimate tokens if not available from events
@@ -532,6 +626,7 @@ export class KiroExecutor extends BaseExecutor {
 
       flush(controller) {
         if (state.invalidToolCall) return;
+        if (!flushPendingWrapperToolCalls(controller)) return;
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -7,6 +7,20 @@ import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 
 const KIRO_TOOL_CALL_WRAPPER = "tool_call";
+const sharedEncoder = new TextEncoder();
+const sharedDecoder = new TextDecoder();
+
+function encodeSSE(value) {
+  return sharedEncoder.encode(value);
+}
+
+function closeSSEController(controller) {
+  if (typeof controller.terminate === "function") {
+    controller.terminate();
+  } else if (typeof controller.close === "function") {
+    controller.close();
+  }
+}
 
 function parseKiroToolInput(toolInput) {
   if (typeof toolInput === "string") {
@@ -74,6 +88,11 @@ function validateKiroToolCallWrapperInput(toolInput) {
   }
 }
 
+/**
+ * Validate a complete Kiro toolUseEvent payload. Streaming wrapper tool_call
+ * fragments must be buffered first; otherwise an init/delta fragment without
+ * the final nested input would be rejected as malformed.
+ */
 export function validateKiroToolUse(toolUse) {
   const toolName = validateKiroToolName(toolUse);
   if (toolName !== KIRO_TOOL_CALL_WRAPPER) {
@@ -94,8 +113,9 @@ function emitKiroToolCallValidationError(controller, state, message) {
   state.invalidToolCall = true;
   state.finishEmitted = true;
   state.doneSent = true;
-  controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(error)}\n\n`));
-  controller.enqueue(new TextEncoder().encode(SSE_DONE));
+  controller.enqueue(encodeSSE(`data: ${JSON.stringify(error)}\n\n`));
+  controller.enqueue(encodeSSE(SSE_DONE));
+  closeSSEController(controller);
 }
 
 /**
@@ -210,8 +230,9 @@ export class KiroExecutor extends BaseExecutor {
   }
 
   /**
-   * Transform AWS EventStream binary response to SSE text stream
-   * Using TransformStream instead of ReadableStream.pull() to avoid Workers timeout
+   * Transform AWS EventStream binary response to SSE text stream.
+   * This pumps the upstream reader directly so a malformed wrapper can emit a
+   * clean SSE error and then cancel the upstream HTTP body immediately.
    */
   transformEventStreamToSSE(response, model) {
     let buffer = new Uint8Array(0);
@@ -227,9 +248,27 @@ export class KiroExecutor extends BaseExecutor {
       hasReasoningContent: false,
       reasoningChunkCount: 0,
       toolCallIndex: 0,
+      generatedToolIdCounter: 0,
       seenToolIds: new Map(),
       pendingWrapperToolCalls: new Map(),
       inThinking: false
+    };
+
+    const getToolCallId = (toolUse) => {
+      if (typeof toolUse?.toolUseId === "string" && toolUse.toolUseId) {
+        return toolUse.toolUseId;
+      }
+      state.generatedToolIdCounter++;
+      return `call_${created}_${state.generatedToolIdCounter}`;
+    };
+
+    const getOrAssignToolIndex = (toolCallId) => {
+      if (state.seenToolIds.has(toolCallId)) {
+        return { toolIndex: state.seenToolIds.get(toolCallId), isNewTool: false };
+      }
+      const toolIndex = state.toolCallIndex++;
+      state.seenToolIds.set(toolCallId, toolIndex);
+      return { toolIndex, isNewTool: true };
     };
 
     const emitToolCallStart = (controller, toolCallId, toolName, toolIndex) => {
@@ -256,7 +295,7 @@ export class KiroExecutor extends BaseExecutor {
         }]
       };
       chunkIndex++;
-      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(startChunk)}\n\n`));
+      controller.enqueue(encodeSSE(`data: ${JSON.stringify(startChunk)}\n\n`));
     };
 
     const emitToolCallArguments = (controller, toolIndex, argumentsStr) => {
@@ -279,7 +318,7 @@ export class KiroExecutor extends BaseExecutor {
         }]
       };
       chunkIndex++;
-      controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(argsChunk)}\n\n`));
+      controller.enqueue(encodeSSE(`data: ${JSON.stringify(argsChunk)}\n\n`));
     };
 
     const failInvalidToolCall = (controller, message) => {
@@ -299,10 +338,12 @@ export class KiroExecutor extends BaseExecutor {
           return false;
         }
 
+        const { toolIndex } = getOrAssignToolIndex(toolCall.toolCallId);
         const argumentsStr = typeof toolInput === "string" ? toolInput : JSON.stringify(toolInput);
-        emitToolCallStart(controller, toolCall.toolCallId, toolCall.toolName, toolCall.toolIndex);
+        toolCall.toolIndex = toolIndex;
+        emitToolCallStart(controller, toolCall.toolCallId, toolCall.toolName, toolIndex);
         if (argumentsStr) {
-          emitToolCallArguments(controller, toolCall.toolIndex, argumentsStr);
+          emitToolCallArguments(controller, toolIndex, argumentsStr);
         }
       }
 
@@ -310,8 +351,7 @@ export class KiroExecutor extends BaseExecutor {
       return true;
     };
 
-    const transformStream = new TransformStream({
-      async transform(chunk, controller) {
+    const transformChunk = async (chunk, controller) => {
         if (state.invalidToolCall) return;
         // Track output so we can emit a keepalive if this frame yields no chunk.
         const enqueueCountBefore = chunkIndex;
@@ -391,7 +431,7 @@ export class KiroExecutor extends BaseExecutor {
               }]
             };
             chunkIndex++;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle reasoningContentEvent (Kiro thinking / reasoning)
@@ -425,7 +465,7 @@ export class KiroExecutor extends BaseExecutor {
               };
               chunkIndex++;
               state.reasoningChunkCount++;
-              controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+              controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
             }
           }
 
@@ -443,7 +483,7 @@ export class KiroExecutor extends BaseExecutor {
               }]
             };
             chunkIndex++;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle toolUseEvent
@@ -461,23 +501,17 @@ export class KiroExecutor extends BaseExecutor {
                 return;
               }
 
-              const toolCallId = singleToolUse.toolUseId || `call_${Date.now()}`;
+              const toolCallId = getToolCallId(singleToolUse);
               const toolInput = singleToolUse.input;
-
-              let toolIndex;
-              const isNewTool = !state.seenToolIds.has(toolCallId);
-
-              if (isNewTool) {
-                toolIndex = state.toolCallIndex++;
-                state.seenToolIds.set(toolCallId, toolIndex);
-              } else {
-                toolIndex = state.seenToolIds.get(toolCallId);
-              }
 
               if (toolName === KIRO_TOOL_CALL_WRAPPER) {
                 let toolCall = state.pendingWrapperToolCalls.get(toolCallId);
                 if (!toolCall) {
-                  toolCall = { toolCallId, toolName, toolIndex };
+                  if (state.seenToolIds.has(toolCallId)) {
+                    failInvalidToolCall(controller, "Invalid Kiro tool_call payload: duplicate toolUseId reused by wrapper");
+                    return;
+                  }
+                  toolCall = { toolCallId, toolName };
                   state.pendingWrapperToolCalls.set(toolCallId, toolCall);
                 }
                 try {
@@ -489,6 +523,12 @@ export class KiroExecutor extends BaseExecutor {
                 continue;
               }
 
+              if (state.pendingWrapperToolCalls.has(toolCallId)) {
+                failInvalidToolCall(controller, "Invalid Kiro tool_call payload: mixed wrapper and direct tool fragments");
+                return;
+              }
+
+              const { toolIndex, isNewTool } = getOrAssignToolIndex(toolCallId);
               if (isNewTool) {
                 emitToolCallStart(controller, toolCallId, toolName, toolIndex);
               }
@@ -524,7 +564,7 @@ export class KiroExecutor extends BaseExecutor {
               }]
             };
             state.finishEmitted = true;
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(chunk)}\n\n`));
           }
 
           // Handle contextUsageEvent to extract contextUsagePercentage
@@ -609,7 +649,7 @@ export class KiroExecutor extends BaseExecutor {
               finishChunk.usage = state.usage;
             }
 
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
+            controller.enqueue(encodeSSE(`data: ${JSON.stringify(finishChunk)}\n\n`));
           }
         }
 
@@ -620,13 +660,13 @@ export class KiroExecutor extends BaseExecutor {
         // No client chunk produced this frame — emit an SSE comment keepalive
                 // so the stall watchdog sees upstream activity (ignored by parser/client).
                 if (chunkIndex === enqueueCountBefore && !state.finishEmitted) {
-                  controller.enqueue(new TextEncoder().encode(": ka\n\n"));
+                  controller.enqueue(encodeSSE(": ka\n\n"));
                 }
-      },
+      };
 
-      flush(controller) {
-        if (state.invalidToolCall) return;
-        if (!flushPendingWrapperToolCalls(controller)) return;
+      const flushOutput = (controller) => {
+        if (state.invalidToolCall) return false;
+        if (!flushPendingWrapperToolCalls(controller)) return false;
         // Emit finish chunk if not already sent
         if (!state.finishEmitted) {
           state.finishEmitted = true;
@@ -641,22 +681,49 @@ export class KiroExecutor extends BaseExecutor {
               finish_reason: state.hasToolCalls ? "tool_calls" : "stop"
             }]
           };
-          controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(finishChunk)}\n\n`));
+          controller.enqueue(encodeSSE(`data: ${JSON.stringify(finishChunk)}\n\n`));
         }
 
         // Send final done message
         if (!state.doneSent) {
           state.doneSent = true;
-          controller.enqueue(new TextEncoder().encode(SSE_DONE));
+          controller.enqueue(encodeSSE(SSE_DONE));
         }
-      }
-    });
+        return true;
+      };
 
-    // Pipe response body through transform stream
     if (!response.body) {
       return new Response(SSE_DONE, { status: response.status, headers: { "Content-Type": "text/event-stream" } });
     }
-    const transformedStream = response.body.pipeThrough(transformStream);
+    let reader;
+    const transformedStream = new ReadableStream({
+      async start(controller) {
+        reader = response.body.getReader();
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            await transformChunk(value, controller);
+            if (state.invalidToolCall) {
+              await reader.cancel("invalid_kiro_tool_call").catch(() => {});
+              return;
+            }
+          }
+
+          if (flushOutput(controller)) {
+            closeSSEController(controller);
+          }
+        } catch (error) {
+          if (state.invalidToolCall) return;
+          controller.error(error);
+        }
+      },
+
+      cancel(reason) {
+        return reader?.cancel(reason);
+      }
+    });
 
     return new Response(transformedStream, {
       status: response.status,
@@ -703,7 +770,7 @@ function parseEventFrame(data) {
       offset++;
       if (offset + nameLen > data.length) break;
 
-      const name = new TextDecoder().decode(data.slice(offset, offset + nameLen));
+      const name = sharedDecoder.decode(data.slice(offset, offset + nameLen));
       offset += nameLen;
 
       const headerType = data[offset];
@@ -714,7 +781,7 @@ function parseEventFrame(data) {
         offset += 2;
         if (offset + valueLen > data.length) break;
 
-        const value = new TextDecoder().decode(data.slice(offset, offset + valueLen));
+        const value = sharedDecoder.decode(data.slice(offset, offset + valueLen));
         offset += valueLen;
         headers[name] = value;
       } else {
@@ -728,7 +795,7 @@ function parseEventFrame(data) {
 
     let payload = null;
     if (payloadEnd > payloadStart) {
-      const payloadStr = new TextDecoder().decode(data.slice(payloadStart, payloadEnd));
+      const payloadStr = sharedDecoder.decode(data.slice(payloadStart, payloadEnd));
 
       // Skip empty or whitespace-only payloads
       if (!payloadStr || !payloadStr.trim()) {

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -140,7 +140,11 @@ function concatChunks(chunks, totalBytes) {
 
 function hasMeaningfulSSEData(chunk) {
   const text = sharedDecoder.decode(chunk);
-  return text.split("\n").some((line) => line.startsWith("data: ") && line.slice(6).trim() !== "");
+  return text.split("\n").some((line) => {
+    if (!line.startsWith("data: ")) return false;
+    const data = line.slice(6).trim();
+    return data !== "" && data !== "[DONE]";
+  });
 }
 
 function formatKiroToolCallRepairError(message, code = "kiro_tool_call_repair_failed") {
@@ -163,28 +167,36 @@ function once(fn) {
 }
 
 function prependChunkToReader(firstChunk, reader, { onCancel, onDone } = {}) {
+  let cancelled = false;
   const finish = once(onDone);
   return new ReadableStream({
     async start(controller) {
-      if (firstChunk?.byteLength) controller.enqueue(firstChunk);
       try {
-        while (true) {
+        if (firstChunk?.byteLength) controller.enqueue(firstChunk);
+        while (!cancelled) {
           const { done, value } = await reader.read();
           if (done) break;
-          controller.enqueue(value);
+          if (!cancelled) controller.enqueue(value);
         }
-        controller.close();
+        if (!cancelled) controller.close();
       } catch (error) {
-        controller.error(error);
+        if (!cancelled) controller.error(error);
       } finally {
         finish();
       }
     },
 
-    cancel(reason) {
-      onCancel?.(reason);
-      finish();
-      return reader.cancel(reason);
+    async cancel(reason) {
+      cancelled = true;
+      try {
+        onCancel?.(reason);
+      } finally {
+        try {
+          await reader.cancel(reason);
+        } finally {
+          finish();
+        }
+      }
     }
   });
 }
@@ -570,6 +582,11 @@ export class KiroExecutor extends BaseExecutor {
         }
 
         sawAnyChunk = true;
+        if (invalidToolCall) {
+          await reader.cancel("invalid_kiro_tool_call").catch(() => {});
+          return { kind: "invalid", invalidToolCall };
+        }
+
         totalBytes += value.byteLength;
         if (totalBytes > options.maxBufferBytes) {
           await reader.cancel("kiro_tool_call_repair_buffer_exceeded").catch(() => {});

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -22,6 +22,49 @@ const STREAM_MODE = {
   PASSTHROUGH: "passthrough" // No translation, normalize output, extract usage
 };
 
+function normalizeStreamError(error) {
+  if (!error || typeof error !== "object") {
+    return {
+      message: String(error || "Upstream stream error"),
+      type: "server_error",
+      code: "stream_error"
+    };
+  }
+  return {
+    message: String(error.message || "Upstream stream error"),
+    type: String(error.type || "server_error"),
+    code: String(error.code || "stream_error")
+  };
+}
+
+function formatTranslatedStreamError(error, sourceFormat) {
+  const normalized = normalizeStreamError(error);
+
+  if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+    const now = Math.floor(Date.now() / 1000);
+    const failed = {
+      type: "response.failed",
+      response: {
+        id: `resp_error_${Date.now()}`,
+        object: "response",
+        created_at: now,
+        status: "failed",
+        background: false,
+        error: normalized,
+        output: []
+      },
+      sequence_number: 0
+    };
+    return `event: response.failed\ndata: ${JSON.stringify(failed)}\n\ndata: [DONE]\n\n`;
+  }
+
+  if (sourceFormat === FORMATS.CLAUDE) {
+    return `event: error\ndata: ${JSON.stringify({ type: "error", error: normalized })}\n\ndata: [DONE]\n\n`;
+  }
+
+  return `data: ${JSON.stringify({ error: normalized })}\n\ndata: [DONE]\n\n`;
+}
+
 /**
  * Create unified SSE transform stream
  * @param {object} options
@@ -72,6 +115,7 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  let upstreamErrorForwarded = false;
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -207,6 +251,18 @@ export function createSSEStream(options = {}) {
 
         const parsed = parseSSELine(trimmed, targetFormat);
         if (!parsed) continue;
+
+        if (upstreamErrorForwarded) continue;
+
+        if (parsed.error) {
+          const output = formatTranslatedStreamError(parsed.error, sourceFormat);
+          reqLogger?.appendConvertedChunk?.(output);
+          controller.enqueue(sharedEncoder.encode(output));
+          upstreamErrorForwarded = true;
+          streamDoneSent = true;
+          if (sourceFormat === FORMATS.OPENAI_RESPONSES) openAIResponsesDoneSent = true;
+          continue;
+        }
 
         // Responses API same-format passthrough: preserve event framing + track terminal state
         const isOpenAIResponsesStream = targetFormat === FORMATS.OPENAI_RESPONSES;
@@ -380,6 +436,11 @@ export function createSSEStream(options = {}) {
               thinking: accumulatedThinking
             }, usage, ttftAt);
           }
+          return;
+        }
+
+        if (upstreamErrorForwarded) {
+          appendRequestLog({ model, provider, connectionId, tokens: null, status: "FAILED STREAM_ERROR" }).catch(() => { });
           return;
         }
 

--- a/tests/unit/kiro-one-shot-tool-call-repair.test.js
+++ b/tests/unit/kiro-one-shot-tool-call-repair.test.js
@@ -90,19 +90,15 @@ function collectDataChunks(text) {
 
 const credentials = {
   accessToken: "test-token",
-  providerSpecificData: {
-    kiroToolCallRepair: true
-  }
+  providerSpecificData: {}
 };
 
 beforeEach(() => {
   fetchMock.mockReset();
-  delete process.env.KIRO_TOOL_CALL_REPAIR;
   delete process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES;
 });
 
 afterEach(() => {
-  delete process.env.KIRO_TOOL_CALL_REPAIR;
   delete process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES;
   delete process.env.KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS;
   delete process.env.KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS;
@@ -321,33 +317,6 @@ describe("Kiro one-shot tool_call repair", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(result.response.status).toBe(429);
     expect(await result.response.text()).toBe("rate limited");
-  });
-
-  it("allows repair to be explicitly disabled", async () => {
-    const executor = new KiroExecutor();
-    fetchMock.mockResolvedValueOnce(eventStreamResponse([
-      encodeEventFrame("toolUseEvent", {
-        toolUseId: "call_1",
-        name: "tool_call",
-        input: { arguments: { q: "router" } }
-      }),
-      encodeEventFrame("messageStopEvent", {})
-    ]));
-
-    const result = await executor.execute({
-      model: "kr/claude-opus-4.8",
-      body: { conversationState: {} },
-      stream: true,
-      credentials: {
-        accessToken: "test-token",
-        providerSpecificData: { kiroToolCallRepair: false }
-      }
-    });
-    const text = await collectText(result.response.body);
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(text).toContain("invalid_kiro_tool_call");
-    expect(text).not.toContain("\"tool_calls\"");
   });
 
   it("fails cleanly if the private repair gate buffer exceeds its configured cap", async () => {

--- a/tests/unit/kiro-one-shot-tool-call-repair.test.js
+++ b/tests/unit/kiro-one-shot-tool-call-repair.test.js
@@ -132,6 +132,35 @@ describe("Kiro one-shot tool_call repair", () => {
     await reader.cancel("test complete").catch(() => {});
   });
 
+  it("propagates client cancellation after the happy-path gate opens", async () => {
+    const executor = new KiroExecutor();
+    let cancelCount = 0;
+    let cancelReason;
+    fetchMock.mockResolvedValueOnce(new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encodeEventFrame("assistantResponseEvent", { content: "hello" }));
+      },
+      cancel(reason) {
+        cancelCount++;
+        cancelReason = reason;
+      }
+    }), { status: 200, statusText: "OK" }));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials
+    });
+    const reader = result.response.body.getReader();
+    const firstRead = await reader.read();
+
+    expect(firstRead.done).toBe(false);
+    await reader.cancel("client cancelled");
+    await vi.waitFor(() => expect(cancelCount).toBe(1));
+    expect(cancelReason).toBe("client cancelled");
+  });
+
   it("retries once on pre-output malformed wrapper output and does not leak fake tool calls", async () => {
     const executor = new KiroExecutor();
     fetchMock
@@ -205,6 +234,31 @@ describe("Kiro one-shot tool_call repair", () => {
     expect(text).not.toContain("\"tool_calls\"");
   });
 
+  it("classifies invalid transformed output before treating its SSE error as stream data", async () => {
+    const executor = new KiroExecutor();
+    const gate = await executor.openToolCallRepairGate(eventStreamResponse([
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ]), {
+      model: "kr/claude-opus-4.8"
+    }, {
+      signal: undefined,
+      maxBufferBytes: 1024 * 1024,
+      ttftTimeoutMs: 1000,
+      stallTimeoutMs: 1000,
+      suppressInvalidToolCallError: false,
+      invalidToolCallErrorCode: "kiro_tool_call_repair_retry_failed"
+    });
+
+    expect(gate.kind).toBe("invalid");
+    expect(gate.invalidToolCall).toContain("missing nested MCP tool name");
+    expect(gate.firstChunk).toBeUndefined();
+  });
+
   it("propagates retry HTTP 429 instead of hiding it in a 200 SSE error", async () => {
     const executor = new KiroExecutor();
     executor.config = { ...executor.config, baseUrls: [executor.config.baseUrls[0]] };
@@ -259,8 +313,7 @@ describe("Kiro one-shot tool_call repair", () => {
     process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES = "8";
     const executor = new KiroExecutor();
     fetchMock.mockResolvedValueOnce(eventStreamResponse([
-      encodeEventFrame("toolUseEvent", { toolUseId: "call_1", name: "tool_call" }),
-      encodeEventFrame("toolUseEvent", { toolUseId: "call_1", name: "tool_call" })
+      encodeEventFrame("assistantResponseEvent", { content: "hello" })
     ]));
 
     const result = await executor.execute({

--- a/tests/unit/kiro-one-shot-tool-call-repair.test.js
+++ b/tests/unit/kiro-one-shot-tool-call-repair.test.js
@@ -1,0 +1,349 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args),
+}));
+
+const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+
+function encodeHeader(name, value) {
+  const nameBytes = new TextEncoder().encode(name);
+  const valueBytes = new TextEncoder().encode(value);
+  const out = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
+  let offset = 0;
+  out[offset++] = nameBytes.length;
+  out.set(nameBytes, offset);
+  offset += nameBytes.length;
+  out[offset++] = 7;
+  out[offset++] = (valueBytes.length >> 8) & 0xff;
+  out[offset++] = valueBytes.length & 0xff;
+  out.set(valueBytes, offset);
+  return out;
+}
+
+function encodeEventFrame(eventType, payload) {
+  const headers = encodeHeader(":event-type", eventType);
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(payload));
+  const totalLength = 12 + headers.length + payloadBytes.length + 4;
+  const frame = new Uint8Array(totalLength);
+  const view = new DataView(frame.buffer);
+  view.setUint32(0, totalLength, false);
+  view.setUint32(4, headers.length, false);
+  view.setUint32(8, 0, false);
+  frame.set(headers, 12);
+  frame.set(payloadBytes, 12 + headers.length);
+  view.setUint32(totalLength - 4, 0, false);
+  return frame;
+}
+
+function eventStreamResponse(frames, status = 200) {
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(frame);
+      controller.close();
+    }
+  }), { status, statusText: status === 200 ? "OK" : "Bad Gateway" });
+}
+
+function controlledEventStreamResponse(initialFrames = []) {
+  let controllerRef;
+  const response = new Response(new ReadableStream({
+    start(controller) {
+      controllerRef = controller;
+      for (const frame of initialFrames) controller.enqueue(frame);
+    }
+  }), { status: 200, statusText: "OK" });
+
+  return {
+    response,
+    enqueue(frame) {
+      controllerRef.enqueue(frame);
+    },
+    close() {
+      controllerRef.close();
+    }
+  };
+}
+
+async function collectText(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+function collectDataChunks(text) {
+  return text
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice(6).trim())
+    .filter((data) => data && data !== "[DONE]")
+    .map((data) => JSON.parse(data));
+}
+
+const credentials = {
+  accessToken: "test-token",
+  providerSpecificData: {
+    kiroToolCallRepair: true
+  }
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  delete process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES;
+});
+
+afterEach(() => {
+  delete process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES;
+  delete process.env.KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS;
+  delete process.env.KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS;
+});
+
+describe("Kiro one-shot tool_call repair", () => {
+  it("preserves happy-path streaming and returns the first chunk before upstream completion", async () => {
+    const executor = new KiroExecutor();
+    const upstream = controlledEventStreamResponse([
+      encodeEventFrame("assistantResponseEvent", { content: "hello" })
+    ]);
+    fetchMock.mockResolvedValueOnce(upstream.response);
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials
+    });
+    const reader = result.response.body.getReader();
+    const decoder = new TextDecoder();
+    const firstRead = await reader.read();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(firstRead.done).toBe(false);
+    expect(decoder.decode(firstRead.value)).toContain("hello");
+
+    upstream.enqueue(encodeEventFrame("messageStopEvent", {}));
+    upstream.close();
+    await reader.cancel("test complete").catch(() => {});
+  });
+
+  it("retries once on pre-output malformed wrapper output and does not leak fake tool calls", async () => {
+    const executor = new KiroExecutor();
+    fetchMock
+      .mockResolvedValueOnce(eventStreamResponse([
+        encodeEventFrame("toolUseEvent", {
+          toolUseId: "call_1",
+          name: "tool_call",
+          input: { arguments: { q: "router" } }
+        }),
+        encodeEventFrame("messageStopEvent", {})
+      ]))
+      .mockResolvedValueOnce(eventStreamResponse([
+        encodeEventFrame("toolUseEvent", {
+          toolUseId: "call_2",
+          name: "tool_call",
+          input: { name: "mcp_search", arguments: { q: "router" } }
+        }),
+        encodeEventFrame("messageStopEvent", {})
+      ]));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { systemPrompt: "base", conversationState: {} },
+      stream: true,
+      credentials
+    });
+    const text = await collectText(result.response.body);
+    const chunks = collectDataChunks(text);
+    const toolChunks = chunks.flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || []);
+    const args = toolChunks.map((toolCall) => toolCall.function?.arguments || "").join("");
+    const retryBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(JSON.parse(args)).toEqual({ name: "mcp_search", arguments: { q: "router" } });
+    expect(retryBody.systemPrompt).toContain("Previous validation error");
+  });
+
+  it("emits repair retry failure code when the single repair retry is still malformed", async () => {
+    const executor = new KiroExecutor();
+    fetchMock
+      .mockResolvedValueOnce(eventStreamResponse([
+        encodeEventFrame("toolUseEvent", {
+          toolUseId: "call_1",
+          name: "tool_call",
+          input: { arguments: { q: "router" } }
+        }),
+        encodeEventFrame("messageStopEvent", {})
+      ]))
+      .mockResolvedValueOnce(eventStreamResponse([
+        encodeEventFrame("toolUseEvent", {
+          toolUseId: "call_2",
+          name: "tool_call",
+          input: { arguments: { q: "router" } }
+        }),
+        encodeEventFrame("messageStopEvent", {})
+      ]));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials
+    });
+    const text = await collectText(result.response.body);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(text).toContain("kiro_tool_call_repair_retry_failed");
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(text).toContain("missing nested MCP tool name");
+    expect(text).not.toContain("\"tool_calls\"");
+  });
+
+  it("propagates retry HTTP 429 instead of hiding it in a 200 SSE error", async () => {
+    const executor = new KiroExecutor();
+    executor.config = { ...executor.config, baseUrls: [executor.config.baseUrls[0]] };
+    fetchMock
+      .mockResolvedValueOnce(eventStreamResponse([
+        encodeEventFrame("toolUseEvent", {
+          toolUseId: "call_1",
+          name: "tool_call",
+          input: { arguments: { q: "router" } }
+        }),
+        encodeEventFrame("messageStopEvent", {})
+      ]))
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429, statusText: "Too Many Requests" }));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.response.status).toBe(429);
+    expect(await result.response.text()).toBe("rate limited");
+  });
+
+  it("does not retry unless repair is explicitly enabled", async () => {
+    const executor = new KiroExecutor();
+    fetchMock.mockResolvedValueOnce(eventStreamResponse([
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ]));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials: { accessToken: "test-token", providerSpecificData: {} }
+    });
+    const text = await collectText(result.response.body);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(text).toContain("invalid_kiro_tool_call");
+    expect(text).not.toContain("\"tool_calls\"");
+  });
+
+  it("fails cleanly if the private repair gate buffer exceeds its configured cap", async () => {
+    process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES = "8";
+    const executor = new KiroExecutor();
+    fetchMock.mockResolvedValueOnce(eventStreamResponse([
+      encodeEventFrame("toolUseEvent", { toolUseId: "call_1", name: "tool_call" }),
+      encodeEventFrame("toolUseEvent", { toolUseId: "call_1", name: "tool_call" })
+    ]));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials
+    });
+    const text = await collectText(result.response.body);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(text).toContain("kiro_tool_call_repair_buffer_exceeded");
+  });
+
+  it("aborts a gated first attempt and cancels its upstream reader", async () => {
+    process.env.KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS = "1000";
+    const executor = new KiroExecutor();
+    let cancelReason;
+    fetchMock.mockResolvedValueOnce(new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encodeEventFrame("toolUseEvent", { toolUseId: "call_1", name: "tool_call" }));
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      }
+    }), { status: 200, statusText: "OK" }));
+    const abortController = new AbortController();
+
+    const executePromise = executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials,
+      signal: abortController.signal
+    });
+    abortController.abort("client aborted");
+
+    await expect(executePromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(cancelReason).toBeDefined();
+  });
+
+  it("uses separate TTFT and inter-chunk stall timeouts for the repair gate", async () => {
+    process.env.KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS = "1000";
+    process.env.KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS = "1";
+    const executor = new KiroExecutor();
+    fetchMock.mockResolvedValueOnce(new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encodeEventFrame("toolUseEvent", { toolUseId: "call_1", name: "tool_call" }));
+      }
+    }), { status: 200, statusText: "OK" }));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials
+    });
+    const text = await collectText(result.response.body);
+
+    expect(text).toContain("Kiro tool_call repair stalled");
+  });
+
+  it("does not retry valid wrapper output and calls upstream exactly once", async () => {
+    const executor = new KiroExecutor();
+    fetchMock.mockResolvedValueOnce(eventStreamResponse([
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { name: "mcp_search", arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ]));
+
+    const result = await executor.execute({
+      model: "kr/claude-opus-4.8",
+      body: { conversationState: {} },
+      stream: true,
+      credentials
+    });
+    const text = await collectText(result.response.body);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(text).not.toContain("kiro_tool_call_repair");
+    expect(text).toContain("\"tool_calls\"");
+  });
+});

--- a/tests/unit/kiro-one-shot-tool-call-repair.test.js
+++ b/tests/unit/kiro-one-shot-tool-call-repair.test.js
@@ -6,6 +6,7 @@ vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
 }));
 
 const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+const { getExecutor } = await import("../../open-sse/executors/index.js");
 
 function encodeHeader(name, value) {
   const nameBytes = new TextEncoder().encode(name);
@@ -96,16 +97,53 @@ const credentials = {
 
 beforeEach(() => {
   fetchMock.mockReset();
+  delete process.env.KIRO_TOOL_CALL_REPAIR;
   delete process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES;
 });
 
 afterEach(() => {
+  delete process.env.KIRO_TOOL_CALL_REPAIR;
   delete process.env.KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES;
   delete process.env.KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS;
   delete process.env.KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS;
 });
 
 describe("Kiro one-shot tool_call repair", () => {
+  it("repairs malformed wrapper output by default through the exported live executor", async () => {
+    fetchMock
+      .mockResolvedValueOnce(eventStreamResponse([
+        encodeEventFrame("toolUseEvent", {
+          toolUseId: "call_1",
+          name: "tool_call",
+          input: { arguments: { q: "router" } }
+        }),
+        encodeEventFrame("messageStopEvent", {})
+      ]))
+      .mockResolvedValueOnce(eventStreamResponse([
+        encodeEventFrame("toolUseEvent", {
+          toolUseId: "call_2",
+          name: "tool_call",
+          input: { name: "mcp_search", arguments: { q: "router" } }
+        }),
+        encodeEventFrame("messageStopEvent", {})
+      ]));
+
+    const result = await getExecutor("kiro").execute({
+      model: "kr/gpt-5.6-sol",
+      body: { systemPrompt: "base", conversationState: {} },
+      stream: true,
+      credentials: { accessToken: "test-token", providerSpecificData: {} }
+    });
+    const text = await collectText(result.response.body);
+    const chunks = collectDataChunks(text);
+    const toolChunks = chunks.flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || []);
+    const args = toolChunks.map((toolCall) => toolCall.function?.arguments || "").join("");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(JSON.parse(args)).toEqual({ name: "mcp_search", arguments: { q: "router" } });
+  });
+
   it("preserves happy-path streaming and returns the first chunk before upstream completion", async () => {
     const executor = new KiroExecutor();
     const upstream = controlledEventStreamResponse([
@@ -285,7 +323,7 @@ describe("Kiro one-shot tool_call repair", () => {
     expect(await result.response.text()).toBe("rate limited");
   });
 
-  it("does not retry unless repair is explicitly enabled", async () => {
+  it("allows repair to be explicitly disabled", async () => {
     const executor = new KiroExecutor();
     fetchMock.mockResolvedValueOnce(eventStreamResponse([
       encodeEventFrame("toolUseEvent", {
@@ -300,7 +338,10 @@ describe("Kiro one-shot tool_call repair", () => {
       model: "kr/claude-opus-4.8",
       body: { conversationState: {} },
       stream: true,
-      credentials: { accessToken: "test-token", providerSpecificData: {} }
+      credentials: {
+        accessToken: "test-token",
+        providerSpecificData: { kiroToolCallRepair: false }
+      }
     });
     const text = await collectText(result.response.body);
 

--- a/tests/unit/kiro-tool-call-validation.test.js
+++ b/tests/unit/kiro-tool-call-validation.test.js
@@ -109,14 +109,17 @@ describe("Kiro nested tool_call validation", () => {
 
   it("emits an actionable stream error instead of a fake legal tool call", async () => {
     const executor = new KiroExecutor();
-    const frame = encodeEventFrame("toolUseEvent", {
-      toolUseId: "call_1",
-      name: "tool_call",
-      input: { arguments: { q: "router" } }
-    });
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
     const response = new Response(new ReadableStream({
       start(controller) {
-        controller.enqueue(frame);
+        for (const frame of frames) controller.enqueue(frame);
         controller.close();
       }
     }), { status: 200, statusText: "OK" });
@@ -202,6 +205,40 @@ describe("Kiro nested tool_call validation", () => {
     expect(chunks.at(-1).usage).toBeDefined();
   });
 
+  it("preserves monotonic emitted tool indices when a wrapper is buffered before a direct tool", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "wrapper_1",
+        name: "tool_call",
+        input: { name: "mcp_search", arguments: { q: "router" } }
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "direct_1",
+        name: "read_file",
+        input: { path: "README.md" }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+    const chunks = collectDataChunks(text);
+    const toolStarts = chunks
+      .flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || [])
+      .filter((toolCall) => toolCall.id);
+
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(toolStarts.map((toolCall) => toolCall.function.name)).toEqual(["read_file", "tool_call"]);
+    expect(toolStarts.map((toolCall) => toolCall.index)).toEqual([0, 1]);
+  });
+
   it("fails malformed final wrapper payloads without emitting a legal tool_call", async () => {
     const executor = new KiroExecutor();
     const frames = [
@@ -230,6 +267,41 @@ describe("Kiro nested tool_call validation", () => {
     expect(text).toContain("missing nested MCP tool name");
     expect(text).not.toContain("\"tool_calls\"");
     expect(text).toContain("data: [DONE]");
+  });
+
+  it("cancels the upstream response body after an invalid wrapper payload", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    let cancelReason;
+    const cancelPromise = new Promise((resolve) => {
+      const response = new Response(new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(frame);
+        },
+        cancel(reason) {
+          cancelReason = reason;
+          resolve(reason);
+        }
+      }), { status: 200, statusText: "OK" });
+
+      const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+      collectText(transformed.body).catch(resolve);
+    });
+
+    const result = await Promise.race([
+      cancelPromise,
+      new Promise((resolve) => setTimeout(() => resolve("timeout"), 250))
+    ]);
+
+    expect(result).not.toBe("timeout");
+    expect(cancelReason).toBeDefined();
   });
 
   it("translates Kiro stream errors into Responses response.failed events", async () => {

--- a/tests/unit/kiro-tool-call-validation.test.js
+++ b/tests/unit/kiro-tool-call-validation.test.js
@@ -46,6 +46,15 @@ async function collectText(stream) {
   return text + decoder.decode();
 }
 
+function collectDataChunks(text) {
+  return text
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => line.slice(6).trim())
+    .filter((data) => data && data !== "[DONE]")
+    .map((data) => JSON.parse(data));
+}
+
 describe("Kiro nested tool_call validation", () => {
   it("accepts a valid wrapper tool_call with nested name and arguments", () => {
     expect(() => validateKiroToolUse({
@@ -108,6 +117,108 @@ describe("Kiro nested tool_call validation", () => {
     const response = new Response(new ReadableStream({
       start(controller) {
         controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+
+    expect(text).toContain("invalid_kiro_tool_call");
+    expect(text).toContain("missing nested MCP tool name");
+    expect(text).not.toContain("\"tool_calls\"");
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("allows a wrapper init frame without input and validates after string fragments", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call"
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: "{\"name\":\"mcp_search\","
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: "\"arguments\":{\"q\":\"router\"}}"
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+    const chunks = collectDataChunks(text);
+    const toolChunks = chunks.flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || []);
+    const args = toolChunks.map((toolCall) => toolCall.function?.arguments || "").join("");
+
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(toolChunks[0].function.name).toBe("tool_call");
+    expect(JSON.parse(args)).toEqual({ name: "mcp_search", arguments: { q: "router" } });
+    expect(chunks.at(-1).choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("waits for the final growing object payload before validating wrapper fields", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { name: "mcp_search", arguments: { q: "router" } }
+      }),
+      encodeEventFrame("meteringEvent", {}),
+      encodeEventFrame("contextUsageEvent", { contextUsagePercentage: 1 })
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+    const chunks = collectDataChunks(text);
+    const toolChunks = chunks.flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls || []);
+    const args = toolChunks.map((toolCall) => toolCall.function?.arguments || "").join("");
+
+    expect(text).not.toContain("invalid_kiro_tool_call");
+    expect(JSON.parse(args)).toEqual({ name: "mcp_search", arguments: { q: "router" } });
+    expect(chunks.at(-1).usage).toBeDefined();
+  });
+
+  it("fails malformed final wrapper payloads without emitting a legal tool_call", async () => {
+    const executor = new KiroExecutor();
+    const frames = [
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call"
+      }),
+      encodeEventFrame("toolUseEvent", {
+        toolUseId: "call_1",
+        name: "tool_call",
+        input: { arguments: { q: "router" } }
+      }),
+      encodeEventFrame("messageStopEvent", {})
+    ];
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(frame);
         controller.close();
       }
     }), { status: 200, statusText: "OK" });

--- a/tests/unit/kiro-tool-call-validation.test.js
+++ b/tests/unit/kiro-tool-call-validation.test.js
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { KiroExecutor, validateKiroToolUse } from "../../open-sse/executors/kiro.js";
+import { openaiToOpenAIResponsesResponse } from "../../open-sse/translator/response/openai-responses.js";
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+function encodeHeader(name, value) {
+  const nameBytes = new TextEncoder().encode(name);
+  const valueBytes = new TextEncoder().encode(value);
+  const out = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
+  let offset = 0;
+  out[offset++] = nameBytes.length;
+  out.set(nameBytes, offset);
+  offset += nameBytes.length;
+  out[offset++] = 7;
+  out[offset++] = (valueBytes.length >> 8) & 0xff;
+  out[offset++] = valueBytes.length & 0xff;
+  out.set(valueBytes, offset);
+  return out;
+}
+
+function encodeEventFrame(eventType, payload) {
+  const headers = encodeHeader(":event-type", eventType);
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(payload));
+  const totalLength = 12 + headers.length + payloadBytes.length + 4;
+  const frame = new Uint8Array(totalLength);
+  const view = new DataView(frame.buffer);
+  view.setUint32(0, totalLength, false);
+  view.setUint32(4, headers.length, false);
+  view.setUint32(8, 0, false);
+  frame.set(headers, 12);
+  frame.set(payloadBytes, 12 + headers.length);
+  view.setUint32(totalLength - 4, 0, false);
+  return frame;
+}
+
+async function collectText(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+describe("Kiro nested tool_call validation", () => {
+  it("accepts a valid wrapper tool_call with nested name and arguments", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { name: "mcp_search", arguments: { q: "router" } }
+    })).not.toThrow();
+  });
+
+  it("accepts ordinary provider tool calls without requiring wrapper fields", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "get_weather",
+      input: { city: "Taipei" }
+    })).not.toThrow();
+  });
+
+  it("rejects missing or empty Kiro tool names", () => {
+    expect(() => validateKiroToolUse({ toolUseId: "call_1", input: {} }))
+      .toThrow(/missing tool name/);
+    expect(() => validateKiroToolUse({ toolUseId: "call_1", name: "   ", input: {} }))
+      .toThrow(/missing tool name/);
+  });
+
+  it("rejects wrapper tool_call payloads without the real MCP tool name", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { arguments: { q: "router" } }
+    })).toThrow(/missing nested MCP tool name/);
+
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { name: "  ", arguments: {} }
+    })).toThrow(/missing nested MCP tool name/);
+  });
+
+  it("rejects malformed wrapper JSON and missing nested arguments", () => {
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: "{\"name\":\"mcp_search\","
+    })).toThrow(/valid JSON/);
+
+    expect(() => validateKiroToolUse({
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { name: "mcp_search" }
+    })).toThrow(/missing nested MCP tool arguments/);
+  });
+
+  it("emits an actionable stream error instead of a fake legal tool call", async () => {
+    const executor = new KiroExecutor();
+    const frame = encodeEventFrame("toolUseEvent", {
+      toolUseId: "call_1",
+      name: "tool_call",
+      input: { arguments: { q: "router" } }
+    });
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(frame);
+        controller.close();
+      }
+    }), { status: 200, statusText: "OK" });
+
+    const transformed = executor.transformEventStreamToSSE(response, "kr/claude-opus-4.8");
+    const text = await collectText(transformed.body);
+
+    expect(text).toContain("invalid_kiro_tool_call");
+    expect(text).toContain("missing nested MCP tool name");
+    expect(text).not.toContain("\"tool_calls\"");
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("translates Kiro stream errors into Responses response.failed events", async () => {
+    const transform = createSSETransformStreamWithLogger(
+      FORMATS.KIRO,
+      FORMATS.OPENAI_RESPONSES,
+      "kiro",
+      null,
+      null,
+      "kr/claude-opus-4.8"
+    );
+    const writer = transform.writable.getWriter();
+    const readPromise = collectText(transform.readable);
+    await writer.write(new TextEncoder().encode(
+      "data: {\"error\":{\"message\":\"Invalid Kiro tool_call payload: missing nested MCP tool name at input.name\",\"type\":\"invalid_request_error\",\"code\":\"invalid_kiro_tool_call\"}}\n\n"
+    ));
+    await writer.close();
+
+    const text = await readPromise;
+
+    expect(text).toContain("event: response.failed");
+    expect(text).toContain("invalid_kiro_tool_call");
+    expect(text).toContain("missing nested MCP tool name");
+    expect(text).not.toContain("response.output_item.added");
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("does not change non-Kiro OpenAI function_call translation", () => {
+    const state = {
+      seq: 0,
+      responseId: "resp_test",
+      created: 1,
+      started: false,
+      msgTextBuf: {},
+      msgItemAdded: {},
+      msgContentAdded: {},
+      msgItemDone: {},
+      reasoningId: "",
+      reasoningIndex: -1,
+      reasoningBuf: "",
+      funcArgsBuf: {},
+      funcNames: {},
+      funcCallIds: {},
+      funcArgsDone: {},
+      funcItemDone: {},
+      completedSent: false
+    };
+    const events = openaiToOpenAIResponsesResponse({
+      id: "chatcmpl_test",
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            index: 0,
+            id: "call_1",
+            type: "function",
+            function: { name: "tool_call", arguments: "{\"arguments\":{}}" }
+          }]
+        },
+        finish_reason: null
+      }]
+    }, state);
+
+    expect(events.some((event) => event.data?.item?.name === "tool_call")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add a guarded, one-shot repair path for malformed Kiro `tool_call` wrappers
- run the repair gate unconditionally for every successful streaming Kiro response — there is no feature toggle or provider option
- preserve normal streaming TTFT by opening the gate on the first meaningful valid SSE chunk
- retry only when a malformed wrapper is detected before visible output
- suppress the failed first attempt, append a corrective instruction, and retry at most once
- propagate retry HTTP errors such as `429` to existing account rotation/fallback logic
- add Node 18-compatible abort-signal handling, separate TTFT/stall timeouts, buffer limits, and cancellation cleanup

## Root cause confirmed in production

The first implementation made the repair path opt-in. AWS live Kiro credentials did not set the option, so the real path was:

```text
chatCore → getExecutor("kiro") → KiroExecutor.execute() → transformEventStreamToSSE()
```

The malformed wrapper was validated and returned as `invalid_kiro_tool_call` without entering the one-shot repair gate. This matched the live failure:

```text
Invalid Kiro tool_call payload: missing nested MCP tool name at input.name
```

This PR now removes that option entirely. Successful streaming Kiro responses always enter the bounded one-shot repair gate. Non-streaming and unsuccessful HTTP responses remain unchanged.

## Dependency

Depends on #2681. This is intentionally a stacked PR; until #2681 merges, the GitHub diff also contains its commits. The repair-only diff is:

```bash
git diff fa842ae..4bbba26
```

After #2681 merges, this branch can be rebased onto `master` so only the repair commits remain.

## Behavior

The repair gate:

- releases normal text/valid wrapper streams on the first meaningful valid SSE chunk
- never treats keepalives or `[DONE]` as meaningful output
- classifies malformed output before opening the stream
- never leaks a failed first-attempt tool call
- performs exactly one retry
- returns `kiro_tool_call_repair_retry_failed` if the retry is also malformed
- does not invent or silently drop ambiguous nested tool names

Operational safety limits remain configurable; these are bounds, not enable/disable switches:

- `KIRO_TOOL_CALL_REPAIR_BUFFER_MAX_BYTES`
- `KIRO_TOOL_CALL_REPAIR_TTFT_TIMEOUT_MS`
- `KIRO_TOOL_CALL_REPAIR_STALL_TIMEOUT_MS`

## Tests

- exported live path regression via `getExecutor("kiro").execute()` with empty provider-specific data
- malformed → repaired valid wrapper, with no first-attempt leakage
- malformed → malformed retry returns the repair failure code
- valid streaming opens before upstream completion and does not retry
- retry `429` remains a non-OK response for existing account rotation
- buffer cap, TTFT/stall timeout, abort, client cancellation, and ordering
- related Kiro/base suites: 9 files / 83 tests passed
- changed-file ESLint
- `git diff --check`
- `npm run build`

The branch was deployed to AWS internal 9Router before the toggle removal and passed direct Kiro text and real terminal tool-call smoke tests; post-deploy logs showed zero `invalid_kiro_tool_call`, `kiro_tool_call_repair_retry_failed`, or `response.failed` markers during the smoke window. The final toggle-removal commit does not change the already-active live behavior when no option is set; it removes the ability to bypass it.
