### PR TITLE
fix(capabilities): support bare Kimi K3 upstream id

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -222,6 +222,9 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*qwen*",          caps: { reasoning: true, thinkingFormat: "qwen", contextWindow: 262144 } },
 
   // ── Kimi (enabled→reasoning_effort; K2.7-code cannot disable) ─────
+  // K3 routes through bare upstream id `k3`; keep this before generic Kimi.
+  { pattern: "*kimi*k3*",       caps: { vision: true, videoInput: true, reasoning: true, thinkingFormat: "kimi", contextWindow: 1048576, maxOutput: 131072 } },
+  { pattern: "k3",              caps: { vision: true, videoInput: true, reasoning: true, thinkingFormat: "kimi", contextWindow: 1048576, maxOutput: 131072 } },
   { pattern: "*kimi*k2.7*code*", caps: { vision: true, reasoning: true, thinkingFormat: "kimi", thinkingCanDisable: false, contextWindow: 262144, maxOutput: 262144 } },
   { pattern: "*kimi*k2*",       caps: { vision: true, reasoning: true, thinkingFormat: "kimi", contextWindow: 262144, maxOutput: 262144 } },
   { pattern: "*kimi*",          caps: { reasoning: true, thinkingFormat: "kimi", contextWindow: 262144 } },

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -126,6 +126,10 @@ describe("applyThinking per provider format", () => {
     const out = apply("openai", "kimi-k2.6", { reasoning_effort: "high" }, "kimi");
     expect(out.reasoning_effort).toBe("high");
   });
+  it("Kimi K3 keeps reasoning_effort after its alias resolves to bare k3", () => {
+    const out = apply("openai", "k3", { reasoning_effort: "high" }, "kimi");
+    expect(out.reasoning_effort).toBe("high");
+  });
   it("Kimi auto → supported reasoning_effort", () => {
     const out = apply("openai", "kimi-k2.7", { reasoning_effort: "auto" }, "kimchi");
     expect(out.reasoning_effort).toBe("high");

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -43,4 +43,19 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-luna-agentic")).toMatchObject(kiroGpt56Expected);
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-sol-thinking-agentic")).toMatchObject(kiroGpt56Expected);
   });
+
+  it("keeps Kimi K3 capabilities after its alias resolves to bare k3", () => {
+    const expected = {
+      vision: true,
+      videoInput: true,
+      reasoning: true,
+      thinkingFormat: "kimi",
+      contextWindow: 1048576,
+      maxOutput: 131072,
+    };
+
+    expect(getCapabilitiesForModel("kimi", "kimi-k3")).toMatchObject(expected);
+    expect(getCapabilitiesForModel("kimi", "k3")).toMatchObject(expected);
+    expect(getCapabilitiesForModel("kimi", "k3.5").reasoning).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #2690.

## Problem

Kimi K3 can be selected through aliases such as `kimi/k3` and `kimi-k3`, but the upstream receives the bare model ID `k3`.

Capability resolution runs after that alias resolution:

```text
kimi/k3 → k3 → getCapabilitiesForModel(provider, "k3")
```

Before this change, Kimi capability rules only matched model IDs containing `kimi`. Bare `k3` therefore reached the default capability floor:

```js
{ reasoning: false, vision: false, videoInput: false }
```

That has two user-visible effects:

1. `applyThinking()` treats K3 as non-reasoning and removes client `reasoning_effort` before the upstream request is sent.
2. Modality filtering treats K3 as text-only and removes image/video input before translation.

## Fix

Add K3-specific capability entries before generic `*kimi*` matching:

```js
{ pattern: "*kimi*k3*", caps: K3_CAPABILITIES },
{ pattern: "k3",        caps: K3_CAPABILITIES },
```

`K3_CAPABILITIES` is represented inline and declares:

- `reasoning: true`
- `thinkingFormat: "kimi"`
- `vision: true`
- `videoInput: true`
- `contextWindow: 1048576`
- `maxOutput: 131072`

The pattern matcher is anchored. Exact `"k3"` matches only the bare upstream ID, so unrelated IDs such as `k3.5` do not inherit K3 capabilities.

## Why capability metadata is the right layer

The alias itself is working: it correctly routes to upstream `k3`. The regression occurs because later capability checks re-infer support from the rewritten ID. Adding the explicit upstream ID preserves existing alias behavior and keeps capability decisions consistent for both original (`kimi-k3`) and resolved (`k3`) IDs, without expanding alias-resolution scope.

K3 metadata is based on [models.dev](https://models.dev/api.json) entries `moonshotai/kimi-k3` and `kimi-for-coding/k3`, plus [Kimi Code model documentation](https://www.kimi.com/code/docs/kimi-code/models): image/video input, reasoning, 1M context window, and 131072 output tokens.

## Regression coverage

- `getCapabilitiesForModel("kimi", "kimi-k3")` receives K3 capability metadata.
- `getCapabilitiesForModel("kimi", "k3")` receives identical metadata after alias resolution.
- `k3.5` remains unmatched by exact `k3`.
- `applyThinking(..., "k3", { reasoning_effort: "high" }, "kimi")` preserves `reasoning_effort`.

## Verification

```text
npx vitest run --config tests/vitest.config.js tests/unit/capabilities.test.js tests/translator/thinking-unified.test.js

2 test files passed
40 tests passed
```

## Scope

No router or alias-resolution refactor. This is a narrowly scoped capability correction for Kimi K3's documented bare upstream ID.
