### PR TITLE
fix(cli): default to IPv4-first DNS resolution to avoid undici IPv6 connect timeouts

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -612,7 +612,7 @@ function startServer(updatePromise) {
   function spawnServer() {
     serverStartTime = Date.now();
     crashLog = [];
-    const child = spawn(RUNTIME, ["--max-old-space-size=6144", serverPath], {
+    const child = spawn(RUNTIME, ["--dns-result-order=ipv4first", "--max-old-space-size=6144", serverPath], {
       cwd: standaloneDir,
       stdio: showLog ? "inherit" : ["ignore", "ignore", "pipe"],
       detached: true,
@@ -785,7 +785,7 @@ function startServer(updatePromise) {
           // Windows/Linux: spawn detached bgProcess (systray works fine in child)
           console.log(`\n⏳ Starting background process... (tray icon will appear in ~3s)`);
 
-          const bgProcess = spawn(process.execPath, [__filename, "--tray", "--skip-update", "-p", port.toString()], {
+          const bgProcess = spawn(process.execPath, ["--dns-result-order=ipv4first", __filename, "--tray", "--skip-update", "-p", port.toString()], {
             detached: true,
             stdio: "ignore",
             windowsHide: true,


### PR DESCRIPTION
## Summary
Resolves #2696 — `fetch connect timeout` (502) when proxying upstream requests, caused by Node 18+/undici attempting IPv6 connections that silently drop.

Appends `--dns-result-order=ipv4first` to the spawned processes in `cli/cli.js`:
- the server process (`spawnServer`)
- the tray background process (`bgProcess`)

Forcing IPv4-first DNS resolution makes undici fall back to IPv4 instead of hanging on a dead IPv6 route.

## Validation
- `node --check cli/cli.js` passes (syntax valid).
- Diff is minimal: 2 argument insertions, no logic change.

Closes #2696.