### PR TITLE
Fix OpenAI Responses stream reconstruction

### DIFF
--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -2,6 +2,7 @@ import { convertResponsesStreamToJson } from "../../transformer/streamToJsonConv
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
+import { GEMINI_FINISH, OPENAI_FINISH } from "../../translator/schema/index.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 
@@ -32,6 +33,34 @@ function pickAssistantMessageForChatCompletion(output) {
   }
   const last = messages[messages.length - 1];
   return { msgItem: last, textContent: textFromResponsesMessageItem(last) };
+}
+
+function responsesFinishReason(response, hasToolCalls = false) {
+  if (response?.status === "completed") {
+    return hasToolCalls ? OPENAI_FINISH.TOOL_CALLS : OPENAI_FINISH.STOP;
+  }
+  if (response?.status === "incomplete" && response.incomplete_details?.reason === "max_output_tokens") {
+    return OPENAI_FINISH.LENGTH;
+  }
+  return OPENAI_FINISH.STOP;
+}
+
+function responsesGeminiFinishReason(response) {
+  if (response?.status === "completed") return GEMINI_FINISH.STOP;
+  if (response?.status === "incomplete" && response.incomplete_details?.reason === "max_output_tokens") {
+    return GEMINI_FINISH.MAX_TOKENS;
+  }
+  return null;
+}
+
+function responsesDiagnostic(response) {
+  const error = response?.error;
+  if (error) return `[Error] ${error.message || JSON.stringify(error)}`;
+  const incompleteReason = response?.incomplete_details?.reason;
+  if (response?.status === "incomplete" && incompleteReason && incompleteReason !== "max_output_tokens") {
+    return `[Incomplete] ${incompleteReason}`;
+  }
+  return "";
 }
 
 /**
@@ -127,15 +156,18 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
       if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
-      const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      const { textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      const diagnostic = responsesDiagnostic(jsonResponse);
+      const responseContent = `${textContent || ""}${diagnostic}`;
+      const responseFinish = responsesFinishReason(jsonResponse);
       const totalLatency = Date.now() - requestStartTime;
 
       saveRequestDetail(buildRequestDetail({
         ...ctx,
         latency: { ttft: totalLatency, total: totalLatency },
         tokens: { prompt_tokens: usage.input_tokens || 0, completion_tokens: usage.output_tokens || 0 },
-        response: { content: textContent, thinking: null, finish_reason: jsonResponse.status || "unknown" },
-        status: "success"
+        response: { content: responseContent, thinking: null, finish_reason: responseFinish },
+        status: jsonResponse.status === "completed" ? "success" : "error"
       }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
       // Client is Responses API → return as-is
@@ -161,19 +193,24 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       const hasToolCalls = toolCalls.length > 0;
 
       if (sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI) {
+        const candidate = {
+          content: { role: "model", parts: [{ text: responseContent }] },
+          index: 0
+        };
+        const geminiFinishReason = responsesGeminiFinishReason(jsonResponse);
+        if (geminiFinishReason) candidate.finishReason = geminiFinishReason;
         finalResp = {
           response: {
-            candidates: [{ content: { role: "model", parts: [{ text: textContent || "" }] }, finishReason: "STOP", index: 0 }],
+            candidates: [candidate],
             usageMetadata: { promptTokenCount: inTokens, candidatesTokenCount: outTokens, totalTokenCount: inTokens + outTokens },
             modelVersion: model,
             responseId: jsonResponse.id || `resp_${Date.now()}`
           }
         };
       } else {
-        const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
+        const message = { role: "assistant", content: responseContent || (hasToolCalls ? null : "") };
         if (hasToolCalls) message.tool_calls = toolCalls;
-        const responseDone = jsonResponse.status === "completed" || jsonResponse.status === "done";
-        const finishReason = hasToolCalls ? "tool_calls" : (responseDone ? "stop" : (jsonResponse.status || "stop"));
+        const finishReason = responsesFinishReason(jsonResponse, hasToolCalls);
         finalResp = {
           id: jsonResponse.id || `chatcmpl-${Date.now()}`,
           object: "chat.completion",

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -24,9 +24,10 @@ const CODEX_SOURCE_TO_TARGET = {
  * Determine which SSE transform stream to use based on provider/format.
  */
 function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, responsesAccumulator }) {
+  const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
   // Responses-API providers (e.g. codex) emit Responses SSE → translate into client format
   const isResponsesProvider = PROVIDERS[provider]?.format === FORMATS.OPENAI_RESPONSES;
-  const needsCodexTranslation = isResponsesProvider && targetFormat === FORMATS.OPENAI_RESPONSES;
+  const needsCodexTranslation = isResponsesProvider && targetFormat === FORMATS.OPENAI_RESPONSES && !isDroidCLI;
 
   if (needsCodexTranslation) {
     const codexTarget = CODEX_SOURCE_TO_TARGET[sourceFormat] || FORMATS.OPENAI;

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -5,6 +5,7 @@ import { pipeWithDisconnect } from "../../utils/streamHandler.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
 import { buildAbortedResponsesTerminalBytes } from "../../utils/responsesStreamHelpers.js";
+import { createResponsesAccumulator } from "../../translator/concerns/responsesAccumulator.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
@@ -22,15 +23,14 @@ const CODEX_SOURCE_TO_TARGET = {
 /**
  * Determine which SSE transform stream to use based on provider/format.
  */
-function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey }) {
-  const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
+function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, responsesAccumulator }) {
   // Responses-API providers (e.g. codex) emit Responses SSE → translate into client format
   const isResponsesProvider = PROVIDERS[provider]?.format === FORMATS.OPENAI_RESPONSES;
-  const needsCodexTranslation = isResponsesProvider && targetFormat === FORMATS.OPENAI_RESPONSES && !isDroidCLI;
+  const needsCodexTranslation = isResponsesProvider && targetFormat === FORMATS.OPENAI_RESPONSES;
 
   if (needsCodexTranslation) {
     const codexTarget = CODEX_SOURCE_TO_TARGET[sourceFormat] || FORMATS.OPENAI;
-    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
+    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, responsesAccumulator);
   }
 
   if (needsTranslation(targetFormat, sourceFormat)) {
@@ -79,11 +79,18 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
     };
   }
 
-  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey });
-
   // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
-  const onAbortTerminal = isResponsesPassthrough ? buildAbortedResponsesTerminalBytes : null;
+  const responsesAccumulator = targetFormat === FORMATS.OPENAI_RESPONSES
+    ? createResponsesAccumulator({ model })
+    : null;
+  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, responsesAccumulator });
+  let onAbortTerminal = null;
+  if (isResponsesPassthrough) {
+    onAbortTerminal = () => buildAbortedResponsesTerminalBytes(responsesAccumulator);
+  } else if (targetFormat === FORMATS.OPENAI_RESPONSES && transformStream.buildAbortedTerminalBytes) {
+    onAbortTerminal = () => transformStream.buildAbortedTerminalBytes();
+  }
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
   const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
 

--- a/open-sse/transformer/streamToJsonConverter.js
+++ b/open-sse/transformer/streamToJsonConverter.js
@@ -3,40 +3,32 @@
  * Converts Responses API SSE stream to single JSON response
  * Used when client requests non-streaming but provider forces streaming (e.g., Codex)
  */
+import {
+  createResponsesAccumulator,
+  finalizeResponsesAccumulator,
+  reduceResponsesEvent
+} from "../translator/concerns/responsesAccumulator.js";
 
 /**
- * Process a single SSE message and update state accordingly.
+ * Process a single SSE message through the shared Responses reducer.
  */
-function processSSEMessage(msg, state) {
+function processSSEMessage(msg, accumulator) {
   if (!msg.trim()) return;
 
   const eventMatch = msg.match(/^event:\s*(.+)$/m);
   const dataMatch = msg.match(/^data:\s*(.+)$/m);
-  if (!eventMatch || !dataMatch) return;
+  if (!dataMatch) return;
 
-  const eventType = eventMatch[1].trim();
   const dataStr = dataMatch[1].trim();
   if (dataStr === "[DONE]") return;
 
   let parsed;
   try { parsed = JSON.parse(dataStr); }
   catch { return; }
-
-  if (eventType === "response.created") {
-    state.responseId = parsed.response?.id || state.responseId;
-    state.created = parsed.response?.created_at || state.created;
-  } else if (eventType === "response.output_item.done") {
-    state.items.set(parsed.output_index ?? 0, parsed.item);
-  } else if (eventType === "response.completed" || eventType === "response.done") {
-    state.status = "completed";
-    if (parsed.response?.usage) {
-      state.usage.input_tokens = parsed.response.usage.input_tokens || 0;
-      state.usage.output_tokens = parsed.response.usage.output_tokens || 0;
-      state.usage.total_tokens = parsed.response.usage.total_tokens || 0;
-    }
-  } else if (eventType === "response.failed") {
-    state.status = "failed";
-  }
+  reduceResponsesEvent(accumulator, {
+    event: eventMatch?.[1]?.trim() || parsed.type,
+    data: parsed
+  });
 }
 
 const EMPTY_RESPONSE = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
@@ -47,21 +39,18 @@ const EMPTY_RESPONSE = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
  * @returns {Promise<Object>} Final JSON response in Responses API format
  */
 export async function convertResponsesStreamToJson(stream) {
+  const accumulator = createResponsesAccumulator();
   if (!stream || typeof stream.getReader !== "function") {
-    return { id: `resp_${Date.now()}`, object: "response", created_at: Math.floor(Date.now() / 1000), status: "failed", output: [], usage: { ...EMPTY_RESPONSE } };
+    const terminal = finalizeResponsesAccumulator(accumulator, {
+      error: streamFailure("invalid_stream", "response stream is unavailable")
+    });
+    return { ...terminal.response, usage: { ...EMPTY_RESPONSE } };
   }
 
   const reader = stream.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
-
-  const state = {
-    responseId: "",
-    created: Math.floor(Date.now() / 1000),
-    status: "in_progress",
-    usage: { ...EMPTY_RESPONSE },
-    items: new Map()
-  };
+  let readError = null;
 
   try {
     while (true) {
@@ -73,31 +62,33 @@ export async function convertResponsesStreamToJson(stream) {
       buffer = messages.pop() || "";
 
       for (const msg of messages) {
-        processSSEMessage(msg, state);
+        processSSEMessage(msg, accumulator);
       }
     }
 
     // Flush remaining buffer (last event may not end with \n\n)
     if (buffer.trim()) {
-      processSSEMessage(buffer, state);
+      processSSEMessage(buffer, accumulator);
     }
+  } catch (error) {
+    readError = error;
   } finally {
     reader.releaseLock();
   }
 
-  // Build output array from accumulated items (ordered by index)
-  const output = [];
-  const maxIndex = state.items.size > 0 ? Math.max(...state.items.keys()) : -1;
-  for (let i = 0; i <= maxIndex; i++) {
-    output.push(state.items.get(i) || { type: "message", content: [], role: "assistant" });
+  if (!accumulator.finalized) {
+    finalizeResponsesAccumulator(accumulator, {
+      error: streamFailure(
+        readError ? "stream_read_error" : "stream_disconnected",
+        readError?.message || "stream closed before a terminal response event"
+      )
+    });
   }
 
-  return {
-    id: state.responseId || `resp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-    object: "response",
-    created_at: state.created,
-    status: state.status || "completed",
-    output,
-    usage: state.usage
-  };
+  const response = accumulator.terminalResponse;
+  return { ...response, usage: response.usage || { ...EMPTY_RESPONSE } };
+}
+
+function streamFailure(code, message) {
+  return { type: "stream_error", code, message };
 }

--- a/open-sse/translator/concerns/responsesAccumulator.js
+++ b/open-sse/translator/concerns/responsesAccumulator.js
@@ -1,0 +1,557 @@
+const TERMINAL_EVENT_STATUS = {
+  "response.completed": "completed",
+  "response.done": "completed",
+  "response.incomplete": "incomplete",
+  "response.failed": "failed",
+  "response.error": "failed",
+  error: "failed"
+};
+
+const TOOL_ITEM_TYPES = new Set(["function_call", "custom_tool_call"]);
+
+function clone(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function eventPayload(event) {
+  if (!event || typeof event !== "object") return { type: null, data: null };
+  const data = event.data && typeof event.data === "object" ? event.data : event;
+  return { type: data.type || event.type || event.event || null, data };
+}
+
+function numberOrNull(value) {
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function preferComplete(current, incoming) {
+  if (typeof incoming !== "string" || incoming === "") return current || "";
+  if (!current || incoming.startsWith(current)) return incoming;
+  if (current.startsWith(incoming)) return current;
+  return incoming;
+}
+
+function itemIdentifiers(data) {
+  const item = data?.item;
+  return {
+    outputIndex: numberOrNull(data?.output_index),
+    itemId: data?.item_id || item?.id || null,
+    callId: data?.call_id || item?.call_id || null
+  };
+}
+
+function newItem(state, type = null) {
+  const order = state.nextItemOrder++;
+  const item = {
+    order,
+    aliasOrders: new Set([order]),
+    outputIndex: null,
+    id: null,
+    callId: null,
+    type,
+    name: "",
+    role: null,
+    status: null,
+    arguments: "",
+    input: "",
+    argumentFragments: [],
+    inputFragments: [],
+    argumentsSnapshot: "",
+    inputSnapshot: "",
+    content: new Map(),
+    summary: new Map(),
+    contentFragments: new Map(),
+    summaryFragments: new Map(),
+    contentSnapshots: new Map(),
+    summarySnapshots: new Map(),
+    raw: {}
+  };
+  state.items.push(item);
+  return item;
+}
+
+function mergePart(target, incoming, fallbackType) {
+  if (!incoming || typeof incoming !== "object") return target;
+  const merged = { ...(target || {}), ...clone(incoming) };
+  if (fallbackType && !merged.type) merged.type = fallbackType;
+  if (typeof incoming.text === "string") {
+    merged.text = preferComplete(target?.text, incoming.text);
+  }
+  return merged;
+}
+
+function remapItem(state, from, to) {
+  for (const [key, value] of state.itemsByOutputIndex) {
+    if (value === from) state.itemsByOutputIndex.set(key, to);
+  }
+  for (const [key, value] of state.itemsById) {
+    if (value === from) state.itemsById.set(key, to);
+  }
+  for (const [key, value] of state.itemsByCallId) {
+    if (value === from) state.itemsByCallId.set(key, to);
+  }
+  for (const [key, value] of state.implicitItemsByType) {
+    if (value === from) state.implicitItemsByType.set(key, to);
+  }
+}
+
+function mergeFragments(target, source, snapshotKey, fragmentsKey, valueKey) {
+  target[fragmentsKey].push(...source[fragmentsKey]);
+  target[fragmentsKey].sort((a, b) => a.order - b.order);
+  target[snapshotKey] = preferComplete(target[snapshotKey], source[snapshotKey]);
+  const deltas = target[fragmentsKey].map(fragment => fragment.value).join("");
+  target[valueKey] = preferComplete(deltas, target[snapshotKey]);
+}
+
+function recomputePart(item, collectionKey, fragmentsKey, snapshotsKey, index, fallbackType) {
+  const fragments = item[fragmentsKey].get(index) || [];
+  fragments.sort((a, b) => a.order - b.order);
+  const deltaText = fragments.map(fragment => fragment.value).join("");
+  const snapshot = item[snapshotsKey].get(index);
+  const current = mergePart(item[collectionKey].get(index), snapshot, fallbackType) || { type: fallbackType };
+  current.text = preferComplete(deltaText, snapshot?.text);
+  item[collectionKey].set(index, current);
+}
+
+function mergePartState(target, source, collectionKey, fragmentsKey, snapshotsKey, fallbackType) {
+  const indices = new Set([
+    ...target[collectionKey].keys(),
+    ...source[collectionKey].keys(),
+    ...target[fragmentsKey].keys(),
+    ...source[fragmentsKey].keys(),
+    ...target[snapshotsKey].keys(),
+    ...source[snapshotsKey].keys()
+  ]);
+  for (const [index, fragments] of source[fragmentsKey]) {
+    const targetFragments = target[fragmentsKey].get(index) || [];
+    targetFragments.push(...fragments);
+    target[fragmentsKey].set(index, targetFragments);
+  }
+  for (const [index, snapshot] of source[snapshotsKey]) {
+    target[snapshotsKey].set(index, mergePart(target[snapshotsKey].get(index), snapshot, fallbackType));
+  }
+  for (const index of indices) {
+    recomputePart(target, collectionKey, fragmentsKey, snapshotsKey, index, fallbackType);
+  }
+}
+
+function mergeItems(state, target, source) {
+  if (!source || source === target) return target;
+  target.outputIndex ??= source.outputIndex;
+  target.id ||= source.id;
+  target.callId ||= source.callId;
+  target.type ||= source.type;
+  target.name ||= source.name;
+  target.role ||= source.role;
+  target.status ||= source.status;
+  for (const order of source.aliasOrders) target.aliasOrders.add(order);
+  mergeFragments(target, source, "argumentsSnapshot", "argumentFragments", "arguments");
+  mergeFragments(target, source, "inputSnapshot", "inputFragments", "input");
+  target.raw = { ...source.raw, ...target.raw };
+  mergePartState(target, source, "content", "contentFragments", "contentSnapshots", "output_text");
+  mergePartState(target, source, "summary", "summaryFragments", "summarySnapshots", "summary_text");
+  remapItem(state, source, target);
+  state.items = state.items.filter(item => item !== source);
+  return target;
+}
+
+function ensureItem(state, data, typeHint = null) {
+  const ids = itemIdentifiers(data);
+  const candidates = [];
+  const identityCandidates = [];
+  const addCandidate = item => {
+    if (item && !candidates.includes(item)) candidates.push(item);
+  };
+  const addIdentityCandidate = item => {
+    if (item && !identityCandidates.includes(item)) identityCandidates.push(item);
+  };
+  if (ids.itemId) {
+    addIdentityCandidate(state.itemsById.get(ids.itemId));
+    addIdentityCandidate(state.itemsByCallId.get(ids.itemId));
+  }
+  if (ids.callId) {
+    addIdentityCandidate(state.itemsByCallId.get(ids.callId));
+    addIdentityCandidate(state.itemsById.get(ids.callId));
+  }
+  const indexedCandidate = ids.outputIndex !== null
+    ? state.itemsByOutputIndex.get(ids.outputIndex)
+    : null;
+  const indexConflict = indexedCandidate && (
+    (ids.itemId && indexedCandidate.id && ids.itemId !== indexedCandidate.id) ||
+    (ids.callId && indexedCandidate.callId && ids.callId !== indexedCandidate.callId)
+  );
+  if (indexConflict) {
+    state.outputOrderConflict = true;
+  } else {
+    addCandidate(indexedCandidate);
+  }
+  for (const identityCandidate of identityCandidates) addCandidate(identityCandidate);
+  const hasIdentity = ids.outputIndex !== null || ids.itemId || ids.callId;
+  if (candidates.length === 0 && typeHint && !hasIdentity) {
+    addCandidate(state.implicitItemsByType.get(typeHint));
+  }
+
+  let item = candidates[0] || newItem(state, typeHint);
+  for (let i = 1; i < candidates.length; i++) item = mergeItems(state, item, candidates[i]);
+
+  if (ids.outputIndex !== null) {
+    item.outputIndex ??= ids.outputIndex;
+    state.itemsByOutputIndex.set(ids.outputIndex, item);
+  }
+  if (ids.itemId) {
+    item.id ||= ids.itemId;
+    state.itemsById.set(ids.itemId, item);
+  }
+  if (ids.callId) {
+    item.callId ||= ids.callId;
+    state.itemsByCallId.set(ids.callId, item);
+  }
+  item.type ||= typeHint;
+  if (typeHint) state.implicitItemsByType.set(typeHint, item);
+  return item;
+}
+
+function ingestItemSnapshot(state, rawItem, outputIndex = null, envelope = null, positionalIndex = false) {
+  if (!rawItem || typeof rawItem !== "object") return null;
+  const itemId = envelope?.item_id || rawItem.id;
+  const callId = envelope?.call_id || rawItem.call_id;
+  const knownItem = (itemId && (state.itemsById.get(itemId) || state.itemsByCallId.get(itemId))) ||
+    (callId && (state.itemsByCallId.get(callId) || state.itemsById.get(callId))) || null;
+  const suppliedOutputIndex = numberOrNull(outputIndex);
+  const data = {
+    output_index: positionalIndex
+      ? knownItem?.outputIndex ?? suppliedOutputIndex
+      : suppliedOutputIndex,
+    item_id: itemId,
+    call_id: callId,
+    item: rawItem
+  };
+  const item = ensureItem(state, data, rawItem.type || null);
+  const { content, summary, arguments: args, input, ...raw } = clone(rawItem);
+  item.raw = { ...item.raw, ...raw };
+  item.type = rawItem.type || item.type;
+  item.id = rawItem.id || item.id;
+  item.callId = rawItem.call_id || item.callId;
+  item.name = rawItem.name || item.name;
+  item.role = rawItem.role || item.role;
+  item.status = rawItem.status || item.status;
+
+  if (Array.isArray(content)) {
+    content.forEach((part, index) => {
+      applyPartSnapshot(item, item.content, item.contentFragments, item.contentSnapshots, index, part, "output_text");
+    });
+  } else if (typeof content === "string") {
+    applyPartSnapshot(item, item.content, item.contentFragments, item.contentSnapshots, 0, { type: "output_text", text: content }, "output_text");
+  }
+  if (Array.isArray(summary)) {
+    summary.forEach((part, index) => {
+      applyPartSnapshot(item, item.summary, item.summaryFragments, item.summarySnapshots, index, part, "summary_text");
+    });
+  }
+  if (typeof args === "string" && args) {
+    item.argumentsSnapshot = preferComplete(item.argumentsSnapshot, args);
+    item.arguments = preferComplete(item.arguments, item.argumentsSnapshot);
+  }
+  if (typeof input === "string" && input) {
+    item.inputSnapshot = preferComplete(item.inputSnapshot, input);
+    item.input = preferComplete(item.input, item.inputSnapshot);
+  }
+  return item;
+}
+
+function applyResponseMetadata(state, response) {
+  if (!response || typeof response !== "object") return;
+  if (response.id) state.id = response.id;
+  if (response.object) state.object = response.object;
+  if (response.created_at) state.createdAt = response.created_at;
+  if (response.model) state.model = response.model;
+  if (response.usage && typeof response.usage === "object") {
+    state.usage = mergeUsage(state.usage, response.usage);
+  }
+  if (Array.isArray(response.output)) {
+    response.output.forEach((item, index) => ingestItemSnapshot(state, item, index, null, true));
+  }
+}
+
+function mergeUsage(current, incoming) {
+  const merged = { ...(clone(current) || {}) };
+  for (const [key, value] of Object.entries(incoming || {})) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === "object" && !Array.isArray(value)) {
+      merged[key] = { ...(merged[key] || {}), ...clone(value) };
+    } else {
+      merged[key] = value;
+    }
+  }
+  if (typeof merged.input_tokens === "number" && typeof merged.output_tokens === "number" &&
+      incoming.total_tokens === undefined) {
+    merged.total_tokens = merged.input_tokens + merged.output_tokens;
+  }
+  return merged;
+}
+
+function applyPartSnapshot(item, collection, fragments, snapshots, index, incoming, fallbackType) {
+  snapshots.set(index, mergePart(snapshots.get(index), incoming, fallbackType));
+  const deltaText = (fragments.get(index) || []).sort((a, b) => a.order - b.order)
+    .map(fragment => fragment.value).join("");
+  const snapshot = snapshots.get(index);
+  const current = mergePart(collection.get(index), snapshot, fallbackType) || { type: fallbackType };
+  current.text = preferComplete(deltaText, snapshot?.text);
+  collection.set(index, current);
+}
+
+function applyContentPart(item, collection, fragments, snapshots, data, fallbackType) {
+  const index = numberOrNull(data.content_index ?? data.summary_index) ?? 0;
+  const incoming = data.part || { type: fallbackType, text: data.text };
+  applyPartSnapshot(item, collection, fragments, snapshots, index, incoming, fallbackType);
+  return item;
+}
+
+function applyDelta(state, item, collection, fragments, snapshots, data, fallbackType) {
+  const index = numberOrNull(data.content_index ?? data.summary_index) ?? 0;
+  if (typeof data.delta !== "string" || !data.delta) return item;
+  const partFragments = fragments.get(index) || [];
+  partFragments.push({ order: state.nextDeltaOrder++, value: data.delta });
+  fragments.set(index, partFragments);
+  const deltaText = partFragments.sort((a, b) => a.order - b.order).map(fragment => fragment.value).join("");
+  const snapshot = snapshots.get(index);
+  const current = mergePart(collection.get(index), snapshot, fallbackType) || { type: fallbackType };
+  current.text = preferComplete(deltaText, snapshot?.text);
+  collection.set(index, current);
+  return item;
+}
+
+function sortedItems(state) {
+  return [...state.items].sort((a, b) => {
+    if (a.outputIndex !== null && b.outputIndex !== null) return a.outputIndex - b.outputIndex;
+    if (a.outputIndex !== null) return -1;
+    if (b.outputIndex !== null) return 1;
+    return a.order - b.order;
+  });
+}
+
+function sortedParts(parts) {
+  return [...parts.entries()].sort((a, b) => a[0] - b[0]).map(([, part]) => clone(part));
+}
+
+function fallbackToolId(item) {
+  if (item.id) return item.id;
+  if (item.callId) return `fc_${item.callId}`;
+  if (item.outputIndex !== null) return `fc_output_${item.outputIndex}`;
+  return `fc_${item.order}`;
+}
+
+function buildItem(item, terminalStatus = null) {
+  const output = clone(item.raw) || {};
+  if (item.type) output.type = item.type;
+  if (item.id || TOOL_ITEM_TYPES.has(item.type)) output.id = item.id || fallbackToolId(item);
+  if (item.role) output.role = item.role;
+  if (item.status) output.status = item.status;
+  if (terminalStatus && (!output.status || output.status === "in_progress")) {
+    output.status = terminalStatus === "completed" ? "completed" : "incomplete";
+  }
+
+  if (item.type === "message") {
+    output.role ||= "assistant";
+    output.content = sortedParts(item.content);
+  } else if (item.type === "reasoning") {
+    output.summary = sortedParts(item.summary);
+    if (item.content.size > 0) output.content = sortedParts(item.content);
+  } else if (item.type === "function_call") {
+    item.callId ||= output.call_id || item.id || `call_output_${item.outputIndex ?? item.order}`;
+    output.call_id = item.callId;
+    output.name = item.name || output.name || "";
+    output.arguments = item.arguments || output.arguments || "";
+  } else if (item.type === "custom_tool_call") {
+    item.callId ||= output.call_id || item.id || `call_output_${item.outputIndex ?? item.order}`;
+    output.call_id = item.callId;
+    output.name = item.name || output.name || "";
+    output.input = item.input || output.input || "";
+  }
+  return output;
+}
+
+export function createResponsesAccumulator({ id = "", createdAt = 0, model = "" } = {}) {
+  return {
+    id,
+    object: "response",
+    createdAt,
+    model,
+    usage: null,
+    items: [],
+    itemsByOutputIndex: new Map(),
+    itemsById: new Map(),
+    itemsByCallId: new Map(),
+    implicitItemsByType: new Map(),
+    nextItemOrder: 0,
+    nextDeltaOrder: 0,
+    outputOrderConflict: false,
+    sawEvent: false,
+    finalized: false,
+    terminalType: null,
+    terminalResponse: null,
+    doneSent: false
+  };
+}
+
+export function buildResponsesOutput(state, terminalStatus = null) {
+  if (!state) return [];
+  return sortedItems(state).map(item => buildItem(item, terminalStatus));
+}
+
+export function getResponsesItems(state, type = null) {
+  const items = sortedItems(state);
+  return type ? items.filter(item => item.type === type) : items;
+}
+
+export function responsesItemText(item) {
+  if (!item) return "";
+  const parts = item.type === "reasoning" ? item.summary : item.content;
+  return sortedParts(parts).map(part => typeof part.text === "string" ? part.text : "").join("");
+}
+
+export function finalizeResponsesAccumulator(state, {
+  eventType = "response.failed",
+  response = null,
+  status = null,
+  error = null,
+  incompleteDetails = null
+} = {}) {
+  if (!state || state.finalized) {
+    return { accepted: false, type: state?.terminalType || eventType, response: state?.terminalResponse || null };
+  }
+
+  applyResponseMetadata(state, response);
+  const terminalStatus = status || response?.status || TERMINAL_EVENT_STATUS[eventType] || "failed";
+  const finalResponse = {
+    ...(clone(response) || {}),
+    id: response?.id || state.id || `resp_${Date.now()}`,
+    object: response?.object || state.object || "response",
+    created_at: response?.created_at || state.createdAt || Math.floor(Date.now() / 1000),
+    status: terminalStatus,
+    output: buildResponsesOutput(state, terminalStatus)
+  };
+  if (state.model && !finalResponse.model) finalResponse.model = state.model;
+  if (state.usage) finalResponse.usage = clone(state.usage);
+  if (error && !finalResponse.error) finalResponse.error = clone(error);
+  if (terminalStatus === "failed" && !finalResponse.error) {
+    finalResponse.error = {
+      type: "server_error",
+      code: "response_failed",
+      message: "response failed without error details"
+    };
+  }
+  if (incompleteDetails && !finalResponse.incomplete_details) {
+    finalResponse.incomplete_details = clone(incompleteDetails);
+  }
+
+  state.finalized = true;
+  state.terminalType = eventType;
+  state.terminalResponse = finalResponse;
+  return { accepted: true, type: eventType, response: finalResponse };
+}
+
+export function reduceResponsesEvent(state, event) {
+  const { type, data } = eventPayload(event);
+  if (!state || !type || !data) return { accepted: false, type, data };
+  if (state.finalized) return { accepted: false, type, data, response: state.terminalResponse };
+
+  state.sawEvent = true;
+  if (data.response) applyResponseMetadata(state, data.response);
+  let item = null;
+
+  switch (type) {
+    case "response.output_item.added":
+    case "response.output_item.done":
+      item = ingestItemSnapshot(state, data.item, data.output_index, data);
+      break;
+    case "response.content_part.added":
+    case "response.content_part.done":
+      item = ensureItem(state, data, "message");
+      applyContentPart(item, item.content, item.contentFragments, item.contentSnapshots, data, "output_text");
+      break;
+    case "response.output_text.delta":
+      item = ensureItem(state, data, "message");
+      applyDelta(state, item, item.content, item.contentFragments, item.contentSnapshots, data, "output_text");
+      break;
+    case "response.output_text.done":
+      item = ensureItem(state, data, "message");
+      applyContentPart(item, item.content, item.contentFragments, item.contentSnapshots, data, "output_text");
+      break;
+    case "response.reasoning_summary_part.added":
+    case "response.reasoning_summary_part.done":
+      item = ensureItem(state, data, "reasoning");
+      applyContentPart(item, item.summary, item.summaryFragments, item.summarySnapshots, data, "summary_text");
+      break;
+    case "response.reasoning_summary_text.delta":
+      item = ensureItem(state, data, "reasoning");
+      applyDelta(state, item, item.summary, item.summaryFragments, item.summarySnapshots, data, "summary_text");
+      break;
+    case "response.reasoning_summary_text.done":
+      item = ensureItem(state, data, "reasoning");
+      applyContentPart(item, item.summary, item.summaryFragments, item.summarySnapshots, data, "summary_text");
+      break;
+    case "response.reasoning_text.delta":
+      item = ensureItem(state, data, "reasoning");
+      applyDelta(state, item, item.content, item.contentFragments, item.contentSnapshots, data, "reasoning_text");
+      break;
+    case "response.reasoning_text.done":
+      item = ensureItem(state, data, "reasoning");
+      applyContentPart(item, item.content, item.contentFragments, item.contentSnapshots, data, "reasoning_text");
+      break;
+    case "response.function_call_arguments.delta":
+      item = ensureItem(state, data, "function_call");
+      if (typeof data.delta === "string" && data.delta) {
+        item.argumentFragments.push({ order: state.nextDeltaOrder++, value: data.delta });
+        const deltas = item.argumentFragments.map(fragment => fragment.value).join("");
+        item.arguments = preferComplete(deltas, item.argumentsSnapshot);
+      }
+      break;
+    case "response.function_call_arguments.done":
+      item = ensureItem(state, data, "function_call");
+      if (typeof data.name === "string" && data.name) item.name = data.name;
+      item.argumentsSnapshot = preferComplete(item.argumentsSnapshot, data.arguments);
+      item.arguments = preferComplete(item.arguments, item.argumentsSnapshot);
+      break;
+    case "response.custom_tool_call_input.delta":
+      item = ensureItem(state, data, "custom_tool_call");
+      if (typeof data.delta === "string" && data.delta) {
+        item.inputFragments.push({ order: state.nextDeltaOrder++, value: data.delta });
+        const deltas = item.inputFragments.map(fragment => fragment.value).join("");
+        item.input = preferComplete(deltas, item.inputSnapshot);
+      }
+      break;
+    case "response.custom_tool_call_input.done":
+      item = ensureItem(state, data, "custom_tool_call");
+      item.inputSnapshot = preferComplete(item.inputSnapshot, data.input);
+      item.input = preferComplete(item.input, item.inputSnapshot);
+      break;
+    default:
+      break;
+  }
+
+  if (Object.hasOwn(TERMINAL_EVENT_STATUS, type)) {
+    const topLevelError = type === "error" ? {
+      type: "server_error",
+      code: data.code || "response_error",
+      message: data.message || "response stream error",
+      ...(data.param !== undefined ? { param: data.param } : {})
+    } : null;
+    const terminal = finalizeResponsesAccumulator(state, {
+      eventType: type,
+      response: data.response,
+      status: type === "response.done"
+        ? data.response?.status || TERMINAL_EVENT_STATUS[type]
+        : TERMINAL_EVENT_STATUS[type],
+      error: data.error || data.response?.error || topLevelError,
+      incompleteDetails: data.response?.incomplete_details
+    });
+    return {
+      ...terminal,
+      data: terminal.accepted ? { ...clone(data), type, response: terminal.response } : data,
+      item
+    };
+  }
+
+  return { accepted: true, type, data, item };
+}

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -395,6 +395,7 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
 
   const reduced = reduceResponsesEvent(accumulator, chunk);
   if (!reduced.accepted) return null;
+  updateToolStreamingState(state, reduced);
 
   const chunks = [];
   if (reduced.item?.type === RESPONSES_ITEM.MESSAGE) {
@@ -411,7 +412,7 @@ export function openaiResponsesToOpenAIResponse(chunk, state) {
   if (accumulator.finalized) {
     chunks.push(...finalizeResponsesChatStream(state, accumulator));
   } else {
-    chunks.push(...flushReadyTools(state, accumulator));
+    chunks.push(...flushReadyTools(state, accumulator, false, reduced));
   }
   return chunks.length > 0 ? chunks : null;
 }
@@ -440,7 +441,15 @@ function chatItemState(state, item) {
   const existing = [...new Set([...aliases].map(order => state.responsesChatItems.get(order)).filter(Boolean))];
   let chatItem = existing.find(candidate => candidate.announced) || existing[0];
   if (!chatItem) {
-    chatItem = { textFragments: [], argumentFragments: [], announced: false, nameSent: false, index: null };
+    chatItem = {
+      textFragments: [],
+      argumentFragments: [],
+      announced: false,
+      nameSent: false,
+      index: null,
+      canonicalIdentity: false,
+      incrementalSafe: true
+    };
   }
   for (const candidate of existing) {
     if (candidate === chatItem) continue;
@@ -449,7 +458,10 @@ function chatItemState(state, item) {
     chatItem.announced ||= candidate.announced;
     chatItem.nameSent ||= candidate.nameSent;
     chatItem.index ??= candidate.index;
+    chatItem.canonicalIdentity ||= candidate.canonicalIdentity;
+    chatItem.incrementalSafe = chatItem.incrementalSafe !== false && candidate.incrementalSafe !== false;
   }
+  if (existing.length > 1 || aliases.size > 1) chatItem.incrementalSafe = false;
   chatItem.textFragments = uniqueFragments(chatItem.textFragments);
   chatItem.argumentFragments = uniqueFragments(chatItem.argumentFragments);
   for (const order of aliases) state.responsesChatItems.set(order, chatItem);
@@ -495,11 +507,47 @@ function isExecutableToolItem(item) {
   return isToolItem(item) && typeof item.name === "string" && item.name.trim() !== "";
 }
 
+function isToolArgumentDelta(type) {
+  return type === "response.function_call_arguments.delta" ||
+    type === "response.custom_tool_call_input.delta";
+}
+
+function matchesToolIdentity(item, data) {
+  const aliases = new Set([item.id, item.callId].filter(Boolean));
+  const eventAliases = [data?.item_id, data?.call_id].filter(Boolean);
+  return eventAliases.length > 0 && eventAliases.every(alias => aliases.has(alias));
+}
+
+function updateToolStreamingState(state, reduced) {
+  if (!isToolItem(reduced.item)) return;
+  const chatItem = chatItemState(state, reduced.item);
+  const snapshot = reduced.data?.item;
+
+  if (reduced.type === "response.output_item.added" || reduced.type === "response.output_item.done") {
+    const itemId = reduced.data?.item_id || snapshot?.id;
+    const callId = reduced.data?.call_id || snapshot?.call_id;
+    chatItem.canonicalIdentity ||= Number.isInteger(reduced.item.outputIndex) &&
+      Boolean(itemId && callId && snapshot?.name);
+  } else if (isToolArgumentDelta(reduced.type) &&
+      (!chatItem.canonicalIdentity || !matchesToolIdentity(reduced.item, reduced.data))) {
+    // Arguments that cannot yet be tied to canonical metadata may be joined
+    // through a later alias bridge, which can prepend or reorder fragments.
+    chatItem.incrementalSafe = false;
+  }
+}
+
 function hasStableOutputOrder(items) {
   if (items.length === 0) return true;
   const indices = items.map(item => item.outputIndex);
   if (indices.every(index => index === null)) return true;
   if (indices.some(index => index === null)) return false;
+  const unique = [...new Set(indices)].sort((a, b) => a - b);
+  return unique.length === items.length && unique.every((index, position) => index === position);
+}
+
+function hasCanonicalOutputOrder(items) {
+  if (items.length === 0 || items.some(item => item.outputIndex === null)) return false;
+  const indices = items.map(item => item.outputIndex);
   const unique = [...new Set(indices)].sort((a, b) => a - b);
   return unique.length === items.length && unique.every((index, position) => index === position);
 }
@@ -538,15 +586,21 @@ function emitPendingTool(state, accumulator, item, force = false) {
   return [buildChunk(chatMetadata(state, accumulator), { tool_calls: [toolCall] })];
 }
 
-function flushReadyTools(state, accumulator, force = false) {
+function flushReadyTools(state, accumulator, force = false, reduced = null) {
   const items = getResponsesItems(accumulator);
   const tools = items.filter(isToolItem);
   if (tools.length === 0) return [];
 
-  // A currently contiguous prefix can still be invalidated by a later item.
-  // Hold translated tools until the terminal event fixes the complete order.
-  if (!force) return [];
-  if (accumulator.outputOrderConflict || !hasStableOutputOrder(items)) return [];
+  if (accumulator.outputOrderConflict) return [];
+  if (force) {
+    if (!hasStableOutputOrder(items)) return [];
+  } else {
+    if (!isToolArgumentDelta(reduced?.type) || !hasCanonicalOutputOrder(items)) return [];
+    if (tools.some(item => {
+      const chatItem = chatItemState(state, item);
+      return !chatItem.canonicalIdentity || !chatItem.incrementalSafe;
+    })) return [];
+  }
 
   const chunks = [];
   for (const item of tools.filter(isExecutableToolItem)) {

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -8,6 +8,13 @@ import { buildChunk } from "../concerns/chunk.js";
 import { buildUsage } from "../concerns/usage.js";
 import { fallbackToolCallId } from "../concerns/toolCall.js";
 import { reasoningDelta, extractReasoningText } from "../concerns/reasoning.js";
+import {
+  createResponsesAccumulator,
+  finalizeResponsesAccumulator,
+  getResponsesItems,
+  reduceResponsesEvent,
+  responsesItemText
+} from "../concerns/responsesAccumulator.js";
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM, OPENAI_FINISH, MODEL_FALLBACK } from "../schema/index.js";
 
 /**
@@ -361,173 +368,244 @@ function flushEvents(state) {
   return events;
 }
 
-// currentToolCallId is intentionally sticky for the current turn so flush/completion
-  // can still finalize as tool_calls even if the tool call was emitted before stream end.
-function computeFinishReason(state) {
-   return state.toolCallIndex > 0 || state.currentToolCallId
-    ? OPENAI_FINISH.TOOL_CALLS
-    : OPENAI_FINISH.STOP;
-}
-
 /**
  * Translate OpenAI Responses API chunk to OpenAI Chat Completions format
  * This is for when Codex returns data and we need to send it to an OpenAI-compatible client
  */
 export function openaiResponsesToOpenAIResponse(chunk, state) {
+  const accumulator = ensureResponsesAccumulator(state);
+
   if (!chunk) {
-    // Flush: send final chunk with finish_reason
-    if (state.finishReasonSent || !state.started) return null;
-
-    const finishReason = computeFinishReason(state);
-
-    state.finishReasonSent = true;
-    state.finishReason = finishReason;
-
-    const finalChunk = buildChunk(
-      { id: state.chatId || `chatcmpl-${Date.now()}`, created: state.created || Math.floor(Date.now() / 1000), model: state.model || MODEL_FALLBACK },
-      {},
-      finishReason
-    );
-
-    if (state.usage && typeof state.usage === "object") {
-      finalChunk.usage = state.usage;
-    }
-
-    return finalChunk;
+    if (state.finishReasonSent) return null;
+    finalizeResponsesAccumulator(accumulator, {
+      error: {
+        type: "stream_error",
+        code: "stream_disconnected",
+        message: "stream closed before a terminal response event"
+      }
+    });
+    return finalizeResponsesChatStream(state, accumulator);
   }
 
-  // Handle different event types from Responses API
-  const eventType = chunk.type || chunk.event;
-  const data = chunk.data || chunk;
-
-  // Initialize state
   if (!state.started) {
     state.started = true;
     state.chatId = `chatcmpl-${Date.now()}`;
     state.created = Math.floor(Date.now() / 1000);
-    state.toolCallIndex = 0;
-    state.currentToolCallId = null;
   }
 
-  // Text content delta
-  if (eventType === "response.output_text.delta") {
-    const delta = data.delta || "";
-    if (!delta) return null;
+  const reduced = reduceResponsesEvent(accumulator, chunk);
+  if (!reduced.accepted) return null;
 
-    return buildChunk(
-      { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      { content: delta }
-    );
-  }
-
-  // Text content done (ignore, we handle via delta)
-  if (eventType === "response.output_text.done") {
-    return null;
-  }
-
-  // Function call started (standard function_call or custom_tool_call)
-  if (eventType === "response.output_item.added" && (data.item?.type === RESPONSES_ITEM.FUNCTION_CALL || data.item?.type === "custom_tool_call")) {
-    const item = data.item;
-    state.currentToolCallId = item.call_id || fallbackToolCallId();
-
-    return buildChunk(
-      { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      {
-        tool_calls: [{
-          index: state.toolCallIndex,
-          id: state.currentToolCallId,
-          type: OPENAI_BLOCK.FUNCTION,
-          function: { name: item.name || "", arguments: "" }
-        }]
-      }
-    );
-  }
-
-  // Function call arguments delta (standard or custom_tool_call variant)
-  if (eventType === "response.function_call_arguments.delta" || eventType === "response.custom_tool_call_input.delta") {
-    const argsDelta = data.delta || "";
-    if (!argsDelta) return null;
-
-    return buildChunk(
-      { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      { tool_calls: [{ index: state.toolCallIndex, function: { arguments: argsDelta } }] }
-    );
-  }
-
-  // Function call done (standard or custom_tool_call variant)
-  if (eventType === "response.output_item.done" && (data.item?.type === RESPONSES_ITEM.FUNCTION_CALL || data.item?.type === "custom_tool_call")) {
-    state.toolCallIndex++;
-    return null;
-  }
-
-  // Response completed
-  if (eventType === "response.completed" || eventType === "response.done") {
-    // Extract usage from response.completed event
-    const responseUsage = data.response?.usage;
-    if (responseUsage && typeof responseUsage === "object") {
-      const inputTokens = responseUsage.input_tokens || responseUsage.prompt_tokens || 0;
-      const outputTokens = responseUsage.output_tokens || responseUsage.completion_tokens || 0;
-      // OpenAI Responses API: input_tokens already includes cached_tokens
-      // Cache info is in input_tokens_details.cached_tokens
-      const cacheReadTokens = responseUsage.input_tokens_details?.cached_tokens || responseUsage.cache_read_input_tokens || 0;
-      
-      state.usage = buildUsage({ promptTokens: inputTokens, completionTokens: outputTokens, totalTokens: inputTokens + outputTokens, cachedTokens: cacheReadTokens });
+  const chunks = [];
+  if (reduced.item?.type === RESPONSES_ITEM.MESSAGE) {
+    chunks.push(...emitPendingItemText(state, accumulator, reduced.item, false));
+  } else if (reduced.item?.type === RESPONSES_ITEM.REASONING) {
+    // Raw reasoning may be followed by a canonical summary for the same item.
+    // Defer raw text so an already-emitted prefix cannot make that summary
+    // impossible to represent in the Chat reasoning field.
+    if (reduced.type?.startsWith("response.reasoning_summary_")) {
+      chunks.push(...emitPendingItemText(state, accumulator, reduced.item, true));
     }
-    
-    if (!state.finishReasonSent) {
-      const finishReason = computeFinishReason(state);
+  }
 
-      state.finishReasonSent = true;
-      state.finishReason = finishReason; // Mark for usage injection in stream.js
-      
-      const finalChunk = buildChunk(
-        { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-        {},
-        finishReason
-      );
+  if (accumulator.finalized) {
+    chunks.push(...finalizeResponsesChatStream(state, accumulator));
+  } else {
+    chunks.push(...flushReadyTools(state, accumulator));
+  }
+  return chunks.length > 0 ? chunks : null;
+}
 
-      // Include usage in final chunk if available
-      if (state.usage && typeof state.usage === "object") {
-        finalChunk.usage = state.usage;
-      }
-      
-      return finalChunk;
+function ensureResponsesAccumulator(state) {
+  state.responsesAccumulator ??= createResponsesAccumulator({
+    createdAt: state.created,
+    model: state.model
+  });
+  state.responsesChatItems ??= new Map();
+  state.responsesNextToolIndex ??= 0;
+  state.responsesEmissionOrder ??= 0;
+  return state.responsesAccumulator;
+}
+
+function chatMetadata(state, accumulator) {
+  return {
+    id: state.chatId || `chatcmpl-${Date.now()}`,
+    created: accumulator.createdAt || state.created || Math.floor(Date.now() / 1000),
+    model: accumulator.model || state.model || MODEL_FALLBACK
+  };
+}
+
+function chatItemState(state, item) {
+  const aliases = item.aliasOrders || new Set([item.order]);
+  const existing = [...new Set([...aliases].map(order => state.responsesChatItems.get(order)).filter(Boolean))];
+  let chatItem = existing.find(candidate => candidate.announced) || existing[0];
+  if (!chatItem) {
+    chatItem = { textFragments: [], argumentFragments: [], announced: false, nameSent: false, index: null };
+  }
+  for (const candidate of existing) {
+    if (candidate === chatItem) continue;
+    chatItem.textFragments.push(...candidate.textFragments);
+    chatItem.argumentFragments.push(...candidate.argumentFragments);
+    chatItem.announced ||= candidate.announced;
+    chatItem.nameSent ||= candidate.nameSent;
+    chatItem.index ??= candidate.index;
+  }
+  chatItem.textFragments = uniqueFragments(chatItem.textFragments);
+  chatItem.argumentFragments = uniqueFragments(chatItem.argumentFragments);
+  for (const order of aliases) state.responsesChatItems.set(order, chatItem);
+  return chatItem;
+}
+
+function uniqueFragments(fragments) {
+  return [...new Set(fragments)].sort((a, b) => a.order - b.order);
+}
+
+function emittedText(fragments) {
+  return fragments.map(fragment => fragment.value).join("");
+}
+
+function completeReasoningText(item) {
+  const summary = responsesItemText(item);
+  if (summary) return summary;
+  return [...item.content.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, part]) => typeof part.text === "string" ? part.text : "")
+    .join("");
+}
+
+function emitPendingItemText(state, accumulator, item, reasoning) {
+  const chatItem = chatItemState(state, item);
+  const complete = reasoning ? completeReasoningText(item) : responsesItemText(item);
+  const emitted = emittedText(chatItem.textFragments);
+  if (!complete.startsWith(emitted)) return [];
+  const delta = complete.slice(emitted.length);
+  if (!delta) return [];
+  chatItem.textFragments.push({ order: state.responsesEmissionOrder++, value: delta });
+  return [buildChunk(
+    chatMetadata(state, accumulator),
+    reasoning ? reasoningDelta(delta) : { content: delta }
+  )];
+}
+
+function isToolItem(item) {
+  return item?.type === RESPONSES_ITEM.FUNCTION_CALL || item?.type === "custom_tool_call";
+}
+
+function isExecutableToolItem(item) {
+  return isToolItem(item) && typeof item.name === "string" && item.name.trim() !== "";
+}
+
+function hasStableOutputOrder(items) {
+  if (items.length === 0) return true;
+  const indices = items.map(item => item.outputIndex);
+  if (indices.every(index => index === null)) return true;
+  if (indices.some(index => index === null)) return false;
+  const unique = [...new Set(indices)].sort((a, b) => a - b);
+  return unique.length === items.length && unique.every((index, position) => index === position);
+}
+
+function emitPendingTool(state, accumulator, item, force = false) {
+  const chatItem = chatItemState(state, item);
+  const currentArguments = item.type === "custom_tool_call" ? item.input : item.arguments;
+  const hasMetadata = Boolean(item.callId || item.name || (force && item.id));
+  if (!chatItem.announced && !hasMetadata) return [];
+  const emittedArguments = emittedText(chatItem.argumentFragments);
+  if (!currentArguments.startsWith(emittedArguments)) return [];
+
+  const argsDelta = currentArguments.slice(emittedArguments.length);
+  const nameDelta = !chatItem.nameSent && item.name ? item.name : "";
+  if (chatItem.announced && !argsDelta && !nameDelta) return [];
+
+  if (chatItem.index === null) chatItem.index = state.responsesNextToolIndex++;
+  const toolCall = {
+    index: chatItem.index,
+    function: { arguments: argsDelta }
+  };
+  if (!chatItem.announced) {
+    item.callId ||= item.id || fallbackToolCallId(chatItem.index);
+    toolCall.id = item.callId;
+    toolCall.type = OPENAI_BLOCK.FUNCTION;
+  }
+  if (nameDelta) {
+    toolCall.function.name = nameDelta;
+    chatItem.nameSent = true;
+  }
+
+  chatItem.announced = true;
+  if (argsDelta) {
+    chatItem.argumentFragments.push({ order: state.responsesEmissionOrder++, value: argsDelta });
+  }
+  return [buildChunk(chatMetadata(state, accumulator), { tool_calls: [toolCall] })];
+}
+
+function flushReadyTools(state, accumulator, force = false) {
+  const items = getResponsesItems(accumulator);
+  const tools = items.filter(isToolItem);
+  if (tools.length === 0) return [];
+
+  // A currently contiguous prefix can still be invalidated by a later item.
+  // Hold translated tools until the terminal event fixes the complete order.
+  if (!force) return [];
+  if (accumulator.outputOrderConflict || !hasStableOutputOrder(items)) return [];
+
+  const chunks = [];
+  for (const item of tools.filter(isExecutableToolItem)) {
+    chunks.push(...emitPendingTool(state, accumulator, item, force));
+  }
+  return chunks;
+}
+
+function toChatUsage(usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const inputTokens = usage.input_tokens || usage.prompt_tokens || 0;
+  const outputTokens = usage.output_tokens || usage.completion_tokens || 0;
+  const cachedTokens = usage.input_tokens_details?.cached_tokens || usage.cache_read_input_tokens || 0;
+  return buildUsage({
+    promptTokens: inputTokens,
+    completionTokens: outputTokens,
+    totalTokens: usage.total_tokens || inputTokens + outputTokens,
+    cachedTokens
+  });
+}
+
+function responseFinishReason(accumulator) {
+  if (accumulator.terminalResponse?.status === "incomplete" &&
+      accumulator.terminalResponse?.incomplete_details?.reason === "max_output_tokens") {
+    return OPENAI_FINISH.LENGTH;
+  }
+  if (accumulator.terminalResponse?.status !== "completed") return OPENAI_FINISH.STOP;
+  const items = getResponsesItems(accumulator);
+  const tools = items.filter(isToolItem);
+  return !accumulator.outputOrderConflict && hasStableOutputOrder(items) &&
+    tools.length > 0 && tools.every(isExecutableToolItem)
+    ? OPENAI_FINISH.TOOL_CALLS
+    : OPENAI_FINISH.STOP;
+}
+
+function finalizeResponsesChatStream(state, accumulator) {
+  if (state.finishReasonSent) return [];
+  const chunks = [];
+  for (const item of getResponsesItems(accumulator)) {
+    if (item.type === RESPONSES_ITEM.MESSAGE) {
+      chunks.push(...emitPendingItemText(state, accumulator, item, false));
+    } else if (item.type === RESPONSES_ITEM.REASONING) {
+      chunks.push(...emitPendingItemText(state, accumulator, item, true));
     }
-    return null;
   }
+  chunks.push(...flushReadyTools(state, accumulator, true));
 
-  // Error events from Responses API (e.g. model_not_found)
-  if (eventType === "error" || eventType === "response.failed") {
-    // Avoid emitting duplicate errors (error + response.failed arrive back-to-back)
-    if (state.finishReasonSent) return null;
-
-    const error = data.error || data.response?.error;
-    if (error) {
-      state.error = error;
-      state.finishReasonSent = true;
-
-      // Surface the error as an OpenAI-compatible error chunk
-      return buildChunk(
-        { id: state.chatId || `chatcmpl-${Date.now()}`, created: state.created || Math.floor(Date.now() / 1000), model: state.model || MODEL_FALLBACK },
-        { content: `[Error] ${error.message || JSON.stringify(error)}` },
-        OPENAI_FINISH.STOP
-      );
-    }
-    return null;
-  }
-
-  // Reasoning summary delta → emit as reasoning_content for client thinking display
-  if (eventType === "response.reasoning_summary_text.delta") {
-    const delta = data.delta || "";
-    if (!delta) return null;
-    return buildChunk(
-      { id: state.chatId, created: state.created, model: state.model || MODEL_FALLBACK },
-      reasoningDelta(delta)
-    );
-  }
-
-  // Ignore other events
-  return null;
+  const error = accumulator.terminalResponse?.error;
+  const finishReason = responseFinishReason(accumulator);
+  state.finishReasonSent = true;
+  state.finishReason = finishReason;
+  state.usage = toChatUsage(accumulator.terminalResponse?.usage || accumulator.usage);
+  const finalDelta = error
+    ? { content: `[Error] ${error.message || JSON.stringify(error)}` }
+    : {};
+  const finalChunk = buildChunk(chatMetadata(state, accumulator), finalDelta, finishReason);
+  if (state.usage) finalChunk.usage = state.usage;
+  chunks.push(finalChunk);
+  return chunks;
 }
 
 // Register both directions

--- a/open-sse/utils/responsesStreamHelpers.js
+++ b/open-sse/utils/responsesStreamHelpers.js
@@ -1,12 +1,18 @@
 // Helpers for OpenAI Responses API streaming termination + event framing
 import { FORMATS } from "../translator/formats.js";
+import {
+  createResponsesAccumulator,
+  finalizeResponsesAccumulator
+} from "../translator/concerns/responsesAccumulator.js";
 import { formatSSE } from "./streamHelpers.js";
 
 // Responses API events that signal the stream has reached a terminal state
 const OPENAI_RESPONSES_TERMINAL_EVENTS = new Set([
   "response.completed",
   "response.done",
+  "response.incomplete",
   "response.failed",
+  "response.error",
   "error"
 ]);
 
@@ -26,25 +32,35 @@ export function isOpenAIResponsesTerminalEvent(eventName, chunk) {
 const sharedEncoder = new TextEncoder();
 
 // Encoded response.failed + [DONE] payload for aborted/stalled Responses passthrough streams
-export function buildAbortedResponsesTerminalBytes() {
-  return sharedEncoder.encode(`${formatIncompleteOpenAIResponsesStreamFailure()}data: [DONE]\n\n`);
+export function buildAbortedResponsesTerminalBytes(accumulator = null) {
+  const terminal = formatIncompleteOpenAIResponsesStreamFailure(accumulator);
+  if (terminal) {
+    if (accumulator) accumulator.doneSent = true;
+    return sharedEncoder.encode(`${terminal}data: [DONE]\n\n`);
+  }
+  if (accumulator?.finalized && !accumulator.doneSent) {
+    accumulator.doneSent = true;
+    return sharedEncoder.encode("data: [DONE]\n\n");
+  }
+  return null;
 }
 
 // Synthesize a response.failed event for streams that close without a terminal event
-export function formatIncompleteOpenAIResponsesStreamFailure() {
+export function formatIncompleteOpenAIResponsesStreamFailure(accumulator = null) {
+  const state = accumulator || createResponsesAccumulator();
+  const terminal = finalizeResponsesAccumulator(state, {
+    error: {
+      type: "stream_error",
+      code: "stream_disconnected",
+      message: "stream closed before response.completed"
+    }
+  });
+  if (!terminal.accepted) return "";
   return formatSSE({
     event: "response.failed",
     data: {
       type: "response.failed",
-      response: {
-        id: `resp_${Date.now()}`,
-        status: "failed",
-        error: {
-          type: "stream_error",
-          code: "stream_disconnected",
-          message: "stream closed before response.completed"
-        }
-      }
+      response: terminal.response
     }
   }, FORMATS.OPENAI_RESPONSES);
 }

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -4,6 +4,10 @@ import { trackPendingRequest, appendRequestLog } from "@/lib/usageDb.js";
 import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBufferToUsage, filterUsageForFormat, COLORS } from "./usageTracking.js";
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
+import {
+  createResponsesAccumulator,
+  reduceResponsesEvent
+} from "../translator/concerns/responsesAccumulator.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
@@ -48,7 +52,8 @@ export function createSSEStream(options = {}) {
     connectionId = null,
     body = null,
     onStreamComplete = null,
-    apiKey = null
+    apiKey = null,
+    responsesAccumulator = null
   } = options;
 
   let buffer = "";
@@ -72,8 +77,15 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  const openAIResponsesAccumulator = responsesAccumulator ||
+    (targetFormat === FORMATS.OPENAI_RESPONSES
+      ? createResponsesAccumulator({ model })
+      : null);
+  if (state && openAIResponsesAccumulator && targetFormat === FORMATS.OPENAI_RESPONSES) {
+    state.responsesAccumulator = openAIResponsesAccumulator;
+  }
 
-  return new TransformStream({
+  const transformStream = new TransformStream({
     transform(chunk, controller) {
       if (!ttftAt) ttftAt = Date.now();
       const text = decoder.decode(chunk, { stream: true });
@@ -205,17 +217,28 @@ export function createSSEStream(options = {}) {
         // Translate mode
         if (!trimmed) continue;
 
-        const parsed = parseSSELine(trimmed, targetFormat);
+        let parsed = parseSSELine(trimmed, targetFormat);
         if (!parsed) continue;
 
         // Responses API same-format passthrough: preserve event framing + track terminal state
         const isOpenAIResponsesStream = targetFormat === FORMATS.OPENAI_RESPONSES;
         const keepsOpenAIResponsesFormat = isOpenAIResponsesStream && sourceFormat === FORMATS.OPENAI_RESPONSES;
-        const openAIResponsesEventName = isOpenAIResponsesStream
+        let openAIResponsesEventName = isOpenAIResponsesStream
           ? getOpenAIResponsesEventName(currentOpenAIResponsesEvent, parsed)
           : null;
 
-        if (isOpenAIResponsesStream && isOpenAIResponsesTerminalEvent(openAIResponsesEventName, parsed)) {
+        if (keepsOpenAIResponsesFormat && !parsed.done) {
+          const reduced = reduceResponsesEvent(openAIResponsesAccumulator, {
+            event: openAIResponsesEventName,
+            data: parsed
+          });
+          if (!reduced.accepted) continue;
+          parsed = reduced.data;
+          openAIResponsesEventName = reduced.type;
+          if (isOpenAIResponsesTerminalEvent(openAIResponsesEventName, parsed)) {
+            openAIResponsesTerminalSeen = true;
+          }
+        } else if (isOpenAIResponsesStream && isOpenAIResponsesTerminalEvent(openAIResponsesEventName, parsed)) {
           openAIResponsesTerminalSeen = true;
         }
 
@@ -224,7 +247,7 @@ export function createSSEStream(options = {}) {
         if (parsed && parsed.done && targetFormat !== FORMATS.OLLAMA) {
           // Synthesize response.failed if the Responses stream never sent a terminal event
           if (keepsOpenAIResponsesFormat && !openAIResponsesTerminalSeen) {
-            const failedOutput = formatIncompleteOpenAIResponsesStreamFailure();
+            const failedOutput = formatIncompleteOpenAIResponsesStreamFailure(openAIResponsesAccumulator);
             reqLogger?.appendConvertedChunk?.(failedOutput);
             controller.enqueue(sharedEncoder.encode(failedOutput));
             openAIResponsesTerminalSeen = true;
@@ -235,6 +258,7 @@ export function createSSEStream(options = {}) {
             const doneOutput = "data: [DONE]\n\n";
             reqLogger?.appendConvertedChunk?.(doneOutput);
             controller.enqueue(sharedEncoder.encode(doneOutput));
+            openAIResponsesAccumulator.doneSent = true;
           }
           streamDoneSent = true;
           if (keepsOpenAIResponsesFormat) openAIResponsesDoneSent = true;
@@ -384,7 +408,22 @@ export function createSSEStream(options = {}) {
         }
 
         if (buffer.trim()) {
-          const parsed = parseSSELine(buffer.trim());
+          let parsed = parseSSELine(buffer.trim(), targetFormat);
+          if (parsed && !parsed.done) {
+            const keepsOpenAIResponsesFormat = targetFormat === FORMATS.OPENAI_RESPONSES && sourceFormat === FORMATS.OPENAI_RESPONSES;
+            if (keepsOpenAIResponsesFormat) {
+              const eventName = getOpenAIResponsesEventName(currentOpenAIResponsesEvent, parsed);
+              const reduced = reduceResponsesEvent(openAIResponsesAccumulator, { event: eventName, data: parsed });
+              if (reduced.accepted) {
+                parsed = reduced.data;
+                const output = formatSSE({ event: reduced.type, data: parsed }, sourceFormat);
+                reqLogger?.appendConvertedChunk?.(output);
+                controller.enqueue(sharedEncoder.encode(output));
+                if (isOpenAIResponsesTerminalEvent(reduced.type, parsed)) openAIResponsesTerminalSeen = true;
+              }
+              parsed = null;
+            }
+          }
           if (parsed && !parsed.done) {
             const translated = translateResponse(targetFormat, sourceFormat, parsed, state);
 
@@ -427,7 +466,7 @@ export function createSSEStream(options = {}) {
         // Synthesize response.failed if a Responses passthrough stream never reached a terminal event
         const keepsOpenAIResponsesFormat = targetFormat === FORMATS.OPENAI_RESPONSES && sourceFormat === FORMATS.OPENAI_RESPONSES;
         if (keepsOpenAIResponsesFormat && !openAIResponsesTerminalSeen) {
-          const failedOutput = formatIncompleteOpenAIResponsesStreamFailure();
+          const failedOutput = formatIncompleteOpenAIResponsesStreamFailure(openAIResponsesAccumulator);
           reqLogger?.appendConvertedChunk?.(failedOutput);
           controller.enqueue(sharedEncoder.encode(failedOutput));
           openAIResponsesTerminalSeen = true;
@@ -439,6 +478,7 @@ export function createSSEStream(options = {}) {
           controller.enqueue(sharedEncoder.encode(doneOutput));
           openAIResponsesDoneSent = true;
           streamDoneSent = true;
+          openAIResponsesAccumulator.doneSent = true;
         }
 
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
@@ -462,9 +502,22 @@ export function createSSEStream(options = {}) {
       }
     }
   });
+
+  if (targetFormat === FORMATS.OPENAI_RESPONSES && sourceFormat !== FORMATS.OPENAI_RESPONSES) {
+    transformStream.buildAbortedTerminalBytes = () => {
+      const flushed = translateResponse(targetFormat, sourceFormat, null, state);
+      const chunks = Array.isArray(flushed) ? flushed : flushed ? [flushed] : [];
+      const output = chunks.filter(Boolean).map(item => formatSSE(item, sourceFormat)).join("");
+      // Translated streams normally end with their format's final chunk plus EOF;
+      // only same-format Responses streams use the OpenAI `data: [DONE]` sentinel.
+      return output ? sharedEncoder.encode(output) : null;
+    };
+  }
+
+  return transformStream;
 }
 
-export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, responsesAccumulator = null) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
     targetFormat,
@@ -476,7 +529,8 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    responsesAccumulator
   });
 }
 

--- a/tests/translator/__snapshots__/golden-response-stream.test.js.snap
+++ b/tests/translator/__snapshots__/golden-response-stream.test.js.snap
@@ -505,34 +505,12 @@ exports[`GOLDEN response stream: OpenAI-Responses (codex) → OpenAI > text + re
           "tool_calls": [
             {
               "function": {
-                "arguments": "",
+                "arguments": "{"city":"NYC"}",
                 "name": "get_weather",
               },
               "id": "call_1",
               "index": 0,
               "type": "function",
-            },
-          ],
-        },
-        "finish_reason": null,
-        "index": 0,
-      },
-    ],
-    "created": 0,
-    "id": "chatcmpl-<TS>",
-    "model": "unknown",
-    "object": "chat.completion.chunk",
-  },
-  {
-    "choices": [
-      {
-        "delta": {
-          "tool_calls": [
-            {
-              "function": {
-                "arguments": "{"city":"NYC"}",
-              },
-              "index": 0,
             },
           ],
         },

--- a/tests/unit/forced-responses-sse-to-json.test.js
+++ b/tests/unit/forced-responses-sse-to-json.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { handleForcedSSEToJson } = await import("../../open-sse/handlers/chatCore/sseToJsonHandler.js");
+
+function event(type, data = {}) {
+  return { type, ...data };
+}
+
+function streamFromEvents(events) {
+  const encoder = new TextEncoder();
+  const payload = events.map(data => [
+    `event: ${data.type}`,
+    `data: ${JSON.stringify(data)}`,
+    ""
+  ].join("\n")).join("\n") + "data: [DONE]\n\n";
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload));
+      controller.close();
+    }
+  });
+}
+
+async function forceJson(sourceFormat, events) {
+  const result = await handleForcedSSEToJson({
+    providerResponse: new Response(streamFromEvents(events), {
+      headers: { "content-type": "text/event-stream" }
+    }),
+    sourceFormat,
+    provider: "codex",
+    model: "gpt-5.3-codex",
+    body: { model: "gpt-5.3-codex", messages: [] },
+    stream: false,
+    requestStartTime: Date.now(),
+    connectionId: "test-connection",
+    clientRawRequest: { endpoint: "/v1/chat/completions" },
+    trackDone: vi.fn(),
+    appendLog: vi.fn()
+  });
+  return { result, json: await result.response.json() };
+}
+
+function partialEvents(terminal) {
+  return [
+    event("response.created", {
+      response: { id: "resp_forced", model: "gpt-5.3-codex", status: "in_progress", output: [] }
+    }),
+    event("response.output_text.delta", {
+      output_index: 0, item_id: "msg_partial", delta: "partial"
+    }),
+    event("response.output_item.added", {
+      output_index: 1,
+      item: { id: "fc_partial", type: "function_call", call_id: "call_partial", name: "lookup", arguments: "" }
+    }),
+    event("response.function_call_arguments.delta", {
+      output_index: 1, item_id: "fc_partial", call_id: "call_partial", delta: "{}"
+    }),
+    terminal
+  ];
+}
+
+describe("forced Responses SSE to JSON terminal handling", () => {
+  it("retains failed partial output and diagnostics with protocol-valid finishes", async () => {
+    const events = partialEvents(event("response.failed", {
+      response: {
+        id: "resp_forced",
+        status: "failed",
+        output: [],
+        error: { type: "server_error", code: "upstream_failed", message: "upstream failed" },
+        usage: { input_tokens: 8, output_tokens: 3, total_tokens: 11 }
+      }
+    }));
+
+    const chat = (await forceJson(FORMATS.OPENAI, events)).json;
+    expect(chat.choices[0]).toMatchObject({
+      finish_reason: "stop",
+      message: {
+        content: "partial[Error] upstream failed",
+        tool_calls: [{
+          id: "call_partial",
+          function: { name: "lookup", arguments: "{}" }
+        }]
+      }
+    });
+    expect(chat.usage).toEqual({ prompt_tokens: 8, completion_tokens: 3, total_tokens: 11 });
+
+    const gemini = (await forceJson(FORMATS.GEMINI, events)).json.response;
+    expect(gemini.candidates[0].content.parts[0].text).toBe("partial[Error] upstream failed");
+    expect(gemini.candidates[0]).not.toHaveProperty("finishReason");
+    expect(gemini.usageMetadata).toEqual({
+      promptTokenCount: 8,
+      candidatesTokenCount: 3,
+      totalTokenCount: 11
+    });
+  });
+
+  it("maps incomplete max-output diagnostics without discarding partial output", async () => {
+    const events = partialEvents(event("response.incomplete", {
+      response: {
+        id: "resp_forced",
+        status: "incomplete",
+        output: [],
+        incomplete_details: { reason: "max_output_tokens" },
+        usage: { input_tokens: 5, output_tokens: 4, total_tokens: 9 }
+      }
+    }));
+
+    const chat = (await forceJson(FORMATS.OPENAI, events)).json;
+    expect(chat.choices[0].finish_reason).toBe("length");
+    expect(chat.choices[0].message.content).toBe("partial");
+    expect(chat.choices[0].message.tool_calls[0]).toMatchObject({
+      id: "call_partial",
+      function: { name: "lookup", arguments: "{}" }
+    });
+    expect(chat.usage).toEqual({ prompt_tokens: 5, completion_tokens: 4, total_tokens: 9 });
+
+    const gemini = (await forceJson(FORMATS.ANTIGRAVITY, events)).json.response;
+    expect(gemini.candidates[0]).toMatchObject({
+      finishReason: "MAX_TOKENS",
+      content: { parts: [{ text: "partial" }] }
+    });
+    expect(gemini.usageMetadata.totalTokenCount).toBe(9);
+  });
+});

--- a/tests/unit/openai-responses-terminal-event.test.js
+++ b/tests/unit/openai-responses-terminal-event.test.js
@@ -50,6 +50,7 @@ describe("OpenAI Responses streaming termination", () => {
 
     expect(output).toContain("event: response.failed");
     expect(output).toContain('"type":"response.failed"');
+    expect(output).toContain('"text":"partial"');
     expect(output).not.toContain("data: null");
     expect(output).toContain("data: [DONE]");
   });
@@ -65,6 +66,25 @@ describe("OpenAI Responses streaming termination", () => {
     expect(output).not.toContain("event: response.failed");
     expect(output).not.toContain("data: null");
     expect(output).toContain("data: [DONE]");
+  });
+
+  it("repairs a completed response whose output is missing and emits one terminal", async () => {
+    const output = await runTransform([
+      `event: response.output_text.delta`,
+      `data: ${JSON.stringify({ type: "response.output_text.delta", output_index: 0, item_id: "msg_1", delta: "repaired" })}`,
+      "",
+      `event: response.completed`,
+      `data: ${JSON.stringify({ type: "response.completed", response: { id: "resp_test", status: "completed", output: [], usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 } } })}`,
+      "",
+      `event: response.failed`,
+      `data: ${JSON.stringify({ type: "response.failed", response: { id: "resp_test", status: "failed" } })}`,
+      "",
+    ].join("\n"));
+
+    expect(output.match(/event: response\.completed/g)).toHaveLength(1);
+    expect(output).not.toContain("event: response.failed");
+    expect(output).toContain('"text":"repaired"');
+    expect(output).toContain('"total_tokens":3');
   });
 
   it("does not add response.failed when a Responses stream sends response.done", async () => {

--- a/tests/unit/responses-abort-terminal.test.js
+++ b/tests/unit/responses-abort-terminal.test.js
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { createDisconnectAwareStream } from "../../open-sse/utils/streamHandler.js";
 import { buildAbortedResponsesTerminalBytes } from "../../open-sse/utils/responsesStreamHelpers.js";
+import {
+  createResponsesAccumulator,
+  reduceResponsesEvent
+} from "../../open-sse/translator/concerns/responsesAccumulator.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
 
 // Minimal stream controller stub
 function makeController() {
@@ -68,5 +74,82 @@ describe("Responses abort terminal synthesis", () => {
     const text = await readAll(out);
     expect(text).not.toContain("response.failed");
     expect(text).not.toContain("[DONE]");
+  });
+
+  it("includes reconstructed partial output in the synthesized abort terminal", async () => {
+    const accumulator = createResponsesAccumulator({ id: "resp_abort" });
+    reduceResponsesEvent(accumulator, {
+      type: "response.output_text.delta",
+      output_index: 0,
+      item_id: "msg_abort",
+      delta: "partial before stall"
+    });
+    const upstream = new ReadableStream({
+      start(controller) {
+        controller.error(new Error("stream stall timeout"));
+      },
+    });
+
+    const out = createDisconnectAwareStream(
+      { readable: upstream, writable: { getWriter: () => ({ abort: () => Promise.resolve() }) } },
+      makeController(),
+      () => buildAbortedResponsesTerminalBytes(accumulator)
+    );
+
+    const text = await readAll(out);
+    expect(text).toContain('"id":"resp_abort"');
+    expect(text).toContain('"text":"partial before stall"');
+    expect(text.match(/event: response\.failed/g)).toHaveLength(1);
+    expect(buildAbortedResponsesTerminalBytes(accumulator)).toBeNull();
+  });
+
+  it("emits only DONE when abort follows an accepted Responses terminal", () => {
+    const accumulator = createResponsesAccumulator({ id: "resp_terminal" });
+    reduceResponsesEvent(accumulator, {
+      type: "response.completed",
+      response: { id: "resp_terminal", status: "completed", output: [] }
+    });
+
+    const first = new TextDecoder().decode(buildAbortedResponsesTerminalBytes(accumulator));
+    expect(first).toBe("data: [DONE]\n\n");
+    expect(buildAbortedResponsesTerminalBytes(accumulator)).toBeNull();
+  });
+
+  it("finalizes a Responses-to-Chat translation when upstream aborts", async () => {
+    const transform = createSSETransformStreamWithLogger(
+      FORMATS.OPENAI_RESPONSES,
+      FORMATS.OPENAI,
+      "codex",
+      null,
+      null,
+      "gpt-p0"
+    );
+    const encoder = new TextEncoder();
+    let sentPartial = false;
+    const upstream = new ReadableStream({
+      pull(controller) {
+        if (!sentPartial) {
+          sentPartial = true;
+          controller.enqueue(encoder.encode([
+            "event: response.output_text.delta",
+            `data: ${JSON.stringify({ type: "response.output_text.delta", output_index: 0, item_id: "msg_abort", delta: "partial" })}`,
+            ""
+          ].join("\n")));
+          return;
+        }
+        controller.error(new Error("stream stall timeout"));
+      }
+    }).pipeThrough(transform);
+
+    const out = createDisconnectAwareStream(
+      { readable: upstream, writable: { getWriter: () => ({ abort: () => Promise.resolve() }) } },
+      makeController(),
+      () => transform.buildAbortedTerminalBytes()
+    );
+
+    const text = await readAll(out);
+    expect(text).toContain('"partial"');
+    expect(text).toContain('"finish_reason":"stop"');
+    expect(text).toContain("stream closed before a terminal response event");
   });
 });

--- a/tests/unit/responses-accumulator.test.js
+++ b/tests/unit/responses-accumulator.test.js
@@ -1,0 +1,600 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createResponsesAccumulator,
+  finalizeResponsesAccumulator,
+  reduceResponsesEvent
+} from "../../open-sse/translator/concerns/responsesAccumulator.js";
+import { convertResponsesStreamToJson } from "../../open-sse/transformer/streamToJsonConverter.js";
+import { openaiResponsesToOpenAIResponse } from "../../open-sse/translator/response/openai-responses.js";
+
+function event(type, data = {}) {
+  return { type, ...data };
+}
+
+function streamFromEvents(events, includeDone = true) {
+  const encoder = new TextEncoder();
+  const payload = events.map(data => [
+    `event: ${data.type}`,
+    `data: ${JSON.stringify(data)}`,
+    ""
+  ].join("\n")).join("\n") + (includeDone ? "data: [DONE]\n\n" : "");
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload));
+      controller.close();
+    }
+  });
+}
+
+function p0Events(terminalType = "response.completed") {
+  return [
+    event("response.created", {
+      response: { id: "resp_p0", object: "response", created_at: 123, model: "gpt-p0", status: "in_progress", output: [] }
+    }),
+    event("response.output_item.added", {
+      output_index: 0,
+      item: { id: "rs_1", type: "reasoning", encrypted_content: "ENC_KEEP_ME", summary: [] }
+    }),
+    event("response.reasoning_summary_text.delta", {
+      output_index: 0, item_id: "rs_1", summary_index: 0, delta: "think"
+    }),
+    event("response.output_text.delta", {
+      output_index: 1, item_id: "msg_1", content_index: 0, delta: "Hello "
+    }),
+    event("response.function_call_arguments.delta", {
+      output_index: 3, item_id: "fc_b", delta: "{\"b\":"
+    }),
+    event("response.function_call_arguments.delta", {
+      output_index: 2, item_id: "fc_a", delta: "{\"a\":"
+    }),
+    event("response.output_item.added", {
+      output_index: 3,
+      item: { id: "fc_b", type: "function_call", call_id: "call_b", name: "tool_b", arguments: "" }
+    }),
+    event("response.output_item.added", {
+      output_index: 2,
+      item: { id: "fc_a", type: "function_call", call_id: "call_a", name: "tool_a", arguments: "" }
+    }),
+    event("response.function_call_arguments.delta", {
+      output_index: 2, call_id: "call_a", delta: "1}"
+    }),
+    event("response.output_text.delta", {
+      output_index: 1, item_id: "msg_1", content_index: 0, delta: "world"
+    }),
+    event("response.function_call_arguments.delta", {
+      output_index: 3, call_id: "call_b", delta: "2}"
+    }),
+    event(terminalType, {
+      response: {
+        id: "resp_p0",
+        object: "response",
+        created_at: 123,
+        model: "gpt-p0",
+        status: terminalType === "response.incomplete" ? "incomplete" : terminalType === "response.failed" ? "failed" : "completed",
+        output: [],
+        usage: { input_tokens: 7, output_tokens: 5, total_tokens: 12 }
+      }
+    })
+  ];
+}
+
+function reduceAll(events) {
+  const accumulator = createResponsesAccumulator();
+  const results = events.map(item => reduceResponsesEvent(accumulator, item));
+  return { accumulator, results };
+}
+
+function collectChat(events) {
+  const state = { model: "gpt-p0", created: 123 };
+  const chunks = [];
+  for (const item of events) {
+    const converted = openaiResponsesToOpenAIResponse(item, state);
+    if (Array.isArray(converted)) chunks.push(...converted);
+    else if (converted) chunks.push(converted);
+  }
+  const text = chunks.map(chunk => chunk.choices?.[0]?.delta?.content || "").join("");
+  const reasoning = chunks.map(chunk => chunk.choices?.[0]?.delta?.reasoning_content || "").join("");
+  const tools = new Map();
+  for (const chunk of chunks) {
+    for (const tool of chunk.choices?.[0]?.delta?.tool_calls || []) {
+      const stored = tools.get(tool.index) || { id: "", name: "", arguments: "" };
+      if (tool.id) stored.id = tool.id;
+      if (tool.function?.name) stored.name += tool.function.name;
+      if (tool.function?.arguments) stored.arguments += tool.function.arguments;
+      tools.set(tool.index, stored);
+    }
+  }
+  return { chunks, text, reasoning, tools: [...tools.values()], state };
+}
+
+describe("Responses accumulator P0 reconstruction", () => {
+  it("correlates interleaved tools and arguments that arrive before metadata", () => {
+    const { accumulator } = reduceAll(p0Events());
+
+    expect(accumulator.terminalResponse.output).toEqual([
+      {
+        id: "rs_1",
+        type: "reasoning",
+        encrypted_content: "ENC_KEEP_ME",
+        status: "completed",
+        summary: [{ type: "summary_text", text: "think" }]
+      },
+      {
+        type: "message",
+        id: "msg_1",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "Hello world" }]
+      },
+      {
+        id: "fc_a",
+        type: "function_call",
+        call_id: "call_a",
+        name: "tool_a",
+        arguments: "{\"a\":1}",
+        status: "completed"
+      },
+      {
+        id: "fc_b",
+        type: "function_call",
+        call_id: "call_b",
+        name: "tool_b",
+        arguments: "{\"b\":2}",
+        status: "completed"
+      }
+    ]);
+    expect(accumulator.terminalResponse.usage).toEqual({ input_tokens: 7, output_tokens: 5, total_tokens: 12 });
+  });
+
+  it("merges pre-metadata fragments discovered through separate aliases in arrival order", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, event("response.function_call_arguments.delta", {
+      output_index: 4, delta: "{\"x\":"
+    }));
+    reduceResponsesEvent(accumulator, event("response.function_call_arguments.delta", {
+      item_id: "fc_bridge", delta: "true}"
+    }));
+    reduceResponsesEvent(accumulator, event("response.output_item.added", {
+      output_index: 4,
+      item_id: "fc_bridge",
+      item: { id: "fc_bridge", type: "function_call", call_id: "call_bridge", name: "bridge" }
+    }));
+    reduceResponsesEvent(accumulator, event("response.completed", {
+      response: { status: "completed", output: [] }
+    }));
+
+    expect(accumulator.terminalResponse.output[0].arguments).toBe("{\"x\":true}");
+  });
+
+  it("merges text and reasoning fragments discovered through separate aliases", () => {
+    const events = [
+      event("response.output_text.delta", { output_index: 0, delta: "Hello " }),
+      event("response.output_text.delta", { item_id: "msg_bridge", delta: "world" }),
+      event("response.output_item.added", {
+        output_index: 0,
+        item_id: "msg_bridge",
+        item: { id: "msg_bridge", type: "message", role: "assistant", content: [] }
+      }),
+      event("response.reasoning_summary_text.delta", { output_index: 1, delta: "first " }),
+      event("response.reasoning_summary_text.delta", { item_id: "rs_bridge", delta: "second" }),
+      event("response.output_item.added", {
+        output_index: 1,
+        item_id: "rs_bridge",
+        item: { id: "rs_bridge", type: "reasoning", summary: [] }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ];
+    const accumulator = createResponsesAccumulator();
+    for (const item of events) reduceResponsesEvent(accumulator, item);
+
+    expect(accumulator.terminalResponse.output[0].content[0].text).toBe("Hello world");
+    expect(accumulator.terminalResponse.output[1].summary[0].text).toBe("first second");
+    expect(collectChat(events)).toMatchObject({ text: "Hello world", reasoning: "first second" });
+  });
+
+  it("preserves diagnostics from top-level error events", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, event("error", {
+      code: "model_not_found", message: "missing model", param: "model"
+    }));
+
+    expect(accumulator.terminalResponse.error).toEqual({
+      type: "server_error", code: "model_not_found", message: "missing model", param: "model"
+    });
+  });
+
+  it("accepts wrapped events whose type is outside data", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, {
+      type: "response.output_text.delta",
+      data: { output_index: 0, item_id: "msg_wrapped", delta: "wrapped" }
+    });
+    reduceResponsesEvent(accumulator, {
+      type: "response.completed",
+      data: { response: { status: "completed", output: [] } }
+    });
+
+    expect(accumulator.terminalResponse.output[0].content[0].text).toBe("wrapped");
+  });
+
+  it("uses output-item envelope aliases when nested metadata omits them", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, event("response.function_call_arguments.delta", {
+      item_id: "fc_envelope", delta: "{\"ok\":true}"
+    }));
+    reduceResponsesEvent(accumulator, event("response.output_item.added", {
+      output_index: 0,
+      item_id: "fc_envelope",
+      call_id: "call_envelope",
+      item: { type: "function_call", name: "envelope" }
+    }));
+    reduceResponsesEvent(accumulator, event("response.completed", {
+      response: { status: "completed", output: [] }
+    }));
+
+    expect(accumulator.terminalResponse.output).toHaveLength(1);
+    expect(accumulator.terminalResponse.output[0]).toMatchObject({
+      call_id: "call_envelope", name: "envelope", arguments: "{\"ok\":true}"
+    });
+  });
+
+  it("does not merge unrelated items when terminal output is partial", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, event("response.output_text.delta", {
+      output_index: 0, item_id: "msg_partial", delta: "answer"
+    }));
+    reduceResponsesEvent(accumulator, event("response.output_item.added", {
+      output_index: 2,
+      item: { id: "fc_partial", type: "function_call", call_id: "call_partial", name: "tool" }
+    }));
+    reduceResponsesEvent(accumulator, event("response.function_call_arguments.delta", {
+      output_index: 2, item_id: "fc_partial", delta: "{}"
+    }));
+    reduceResponsesEvent(accumulator, event("response.completed", {
+      response: {
+        status: "completed",
+        output: [{ id: "fc_partial", type: "function_call", call_id: "call_partial", name: "tool", arguments: "{}" }]
+      }
+    }));
+
+    expect(accumulator.terminalResponse.output.map(item => item.type)).toEqual(["message", "function_call"]);
+    expect(accumulator.terminalResponse.output[0].content[0].text).toBe("answer");
+  });
+
+  it("cross-resolves equivalent item_id and fallback call_id aliases", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, event("response.output_item.added", {
+      output_index: 0,
+      item: { id: "fc_equivalent", type: "function_call", name: "equivalent" }
+    }));
+    reduceResponsesEvent(accumulator, event("response.function_call_arguments.delta", {
+      call_id: "fc_equivalent", delta: "{\"ok\":true}"
+    }));
+    reduceResponsesEvent(accumulator, event("response.completed", {
+      response: { status: "completed", output: [] }
+    }));
+
+    expect(accumulator.terminalResponse.output).toHaveLength(1);
+    expect(accumulator.terminalResponse.output[0].arguments).toBe("{\"ok\":true}");
+  });
+
+  it("retains usage when a terminal snapshot is empty", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, event("response.in_progress", {
+      response: { usage: { input_tokens: 3, output_tokens: 2, total_tokens: 5 } }
+    }));
+    reduceResponsesEvent(accumulator, event("response.completed", {
+      response: { status: "completed", output: [], usage: {} }
+    }));
+
+    expect(accumulator.terminalResponse.usage).toEqual({ input_tokens: 3, output_tokens: 2, total_tokens: 5 });
+  });
+
+  it.each([
+    ["response.completed", "completed"],
+    ["response.done", "completed"],
+    ["response.incomplete", "incomplete"],
+    ["response.failed", "failed"]
+  ])("finalizes %s exactly once with status %s", (terminalType, status) => {
+    const { accumulator, results } = reduceAll(p0Events(terminalType));
+    const duplicate = reduceResponsesEvent(accumulator, event("response.failed", { response: { status: "failed" } }));
+
+    expect(accumulator.terminalResponse.status).toBe(status);
+    expect(results.at(-1).accepted).toBe(true);
+    expect(duplicate.accepted).toBe(false);
+    expect(accumulator.terminalType).toBe(terminalType);
+  });
+
+  it("preserves a failed status carried by response.done", () => {
+    const accumulator = createResponsesAccumulator();
+    reduceResponsesEvent(accumulator, event("response.done", {
+      response: { id: "resp_done_failed", status: "failed", output: [] }
+    }));
+
+    expect(accumulator.terminalResponse).toMatchObject({
+      id: "resp_done_failed",
+      status: "failed",
+      error: { code: "response_failed" }
+    });
+  });
+
+  it("repairs a metadata-light arguments.done tool with stream/non-stream ID parity", () => {
+    const events = [
+      event("response.function_call_arguments.done", {
+        output_index: 0,
+        item_id: "fc_done_only",
+        name: "done_only",
+        arguments: "{\"ok\":true}"
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ];
+    const { accumulator } = reduceAll(events);
+    const chat = collectChat(events);
+    const tool = accumulator.terminalResponse.output[0];
+
+    expect(tool).toMatchObject({
+      type: "function_call",
+      id: "fc_done_only",
+      call_id: "fc_done_only",
+      name: "done_only",
+      arguments: "{\"ok\":true}"
+    });
+    expect(chat.tools).toEqual([{
+      id: "fc_done_only",
+      name: "done_only",
+      arguments: "{\"ok\":true}"
+    }]);
+  });
+
+  it("persists one fallback call ID for custom-tool stream/non-stream parity", () => {
+    const events = [
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { id: "ct_1", type: "custom_tool_call", name: "custom", input: "payload" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ];
+    const { accumulator } = reduceAll(events);
+    const chat = collectChat(events);
+
+    expect(accumulator.terminalResponse.output[0].call_id).toBe("ct_1");
+    expect(chat.tools[0].id).toBe("ct_1");
+  });
+
+  it("reuses a generated metadata-light tool ID in the streaming terminal", () => {
+    const chat = collectChat([
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { type: "function_call", name: "fallback", arguments: "{}" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    const terminalTool = chat.state.responsesAccumulator.terminalResponse.output[0];
+    expect(chat.tools[0].id).toBe(terminalTool.call_id);
+  });
+
+  it("synthesizes a failed terminal with partial output on EOF", () => {
+    const accumulator = createResponsesAccumulator({ id: "resp_eof" });
+    reduceResponsesEvent(accumulator, event("response.output_text.delta", { delta: "partial" }));
+    const terminal = finalizeResponsesAccumulator(accumulator, {
+      error: { type: "stream_error", code: "stream_disconnected", message: "EOF" }
+    });
+
+    expect(terminal.response).toMatchObject({
+      id: "resp_eof",
+      status: "failed",
+      error: { code: "stream_disconnected" },
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "partial" }] }]
+    });
+  });
+});
+
+describe("Responses stream and forced non-stream parity", () => {
+  it("reconstructs the same text, reasoning, tools, status, and usage", async () => {
+    const events = p0Events();
+    const json = await convertResponsesStreamToJson(streamFromEvents(events));
+    const chat = collectChat(events);
+
+    expect(json.status).toBe("completed");
+    expect(json.usage).toEqual({ input_tokens: 7, output_tokens: 5, total_tokens: 12 });
+    expect(json.output.find(item => item.type === "message")?.content[0].text).toBe(chat.text);
+    expect(json.output.find(item => item.type === "reasoning")?.summary[0].text).toBe(chat.reasoning);
+    const jsonTools = json.output.filter(item => item.type === "function_call").map(item => ({
+      id: item.call_id,
+      name: item.name,
+      arguments: item.arguments
+    }));
+    expect(jsonTools).toEqual(chat.tools);
+    expect(chat.chunks.filter(chunk => chunk.choices?.[0]?.finish_reason)).toHaveLength(1);
+    expect(chat.chunks.at(-1).usage).toEqual({
+      prompt_tokens: 7,
+      completion_tokens: 5,
+      total_tokens: 12
+    });
+  });
+
+  it("returns a failed Responses object with reconstructed partial output on EOF", async () => {
+    const json = await convertResponsesStreamToJson(streamFromEvents([
+      event("response.created", { response: { id: "resp_eof", status: "in_progress" } }),
+      event("response.output_text.delta", { output_index: 0, item_id: "msg_eof", delta: "partial" })
+    ], false));
+
+    expect(json.status).toBe("failed");
+    expect(json.error).toMatchObject({ type: "stream_error", code: "stream_disconnected" });
+    expect(json.output[0].content[0].text).toBe("partial");
+  });
+
+  it("emits a failed terminal chunk for an empty translated stream", () => {
+    const chunks = openaiResponsesToOpenAIResponse(null, { model: "gpt-p0", created: 123 });
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].choices[0]).toMatchObject({
+      delta: { content: expect.stringContaining("stream closed") },
+      finish_reason: "stop"
+    });
+  });
+
+  it("does not advertise a partial failed tool call as executable", () => {
+    const chat = collectChat([
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { id: "fc_partial", type: "function_call", call_id: "call_partial", name: "unsafe" }
+      }),
+      event("response.function_call_arguments.delta", {
+        output_index: 0, item_id: "fc_partial", delta: "{\"partial\":"
+      }),
+      event("response.failed", {
+        response: { status: "failed", error: { type: "server_error", message: "upstream failed" } }
+      })
+    ]);
+
+    expect(chat.chunks.at(-1).choices[0].finish_reason).toBe("stop");
+  });
+
+  it("waits for call_id aliases to bridge before emitting arguments", () => {
+    const chat = collectChat([
+      event("response.function_call_arguments.delta", {
+        output_index: 0, delta: "{\"x\":"
+      }),
+      event("response.function_call_arguments.delta", {
+        call_id: "call_bridge", delta: "true}"
+      }),
+      event("response.output_item.added", {
+        output_index: 0,
+        call_id: "call_bridge",
+        item: { id: "fc_bridge", type: "function_call", call_id: "call_bridge", name: "bridge" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.tools).toEqual([{
+      id: "call_bridge",
+      name: "bridge",
+      arguments: "{\"x\":true}"
+    }]);
+  });
+
+  it("waits for an unindexed tool to receive its final output order", () => {
+    const chat = collectChat([
+      event("response.output_item.added", {
+        item_id: "fc_late",
+        item: { id: "fc_late", type: "function_call", call_id: "call_late", name: "late", arguments: "{}" }
+      }),
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { id: "fc_first", type: "function_call", call_id: "call_first", name: "first", arguments: "{}" }
+      }),
+      event("response.output_item.done", {
+        output_index: 1,
+        item_id: "fc_late",
+        item: { id: "fc_late", type: "function_call", call_id: "call_late", name: "late", arguments: "{}" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.tools.map(tool => tool.id)).toEqual(["call_first", "call_late"]);
+  });
+
+  it("does not advertise a reconstructed nameless tool as executable", () => {
+    const chat = collectChat([
+      event("response.function_call_arguments.delta", {
+        output_index: 0, delta: "{\"unsafe\":true}"
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.tools).toEqual([]);
+    expect(chat.chunks.at(-1).choices[0].finish_reason).toBe("stop");
+  });
+
+  it("does not force-emit tools with mixed unresolved output order", () => {
+    const chat = collectChat([
+      event("response.output_item.added", {
+        output_index: 2,
+        item: { id: "fc_indexed", type: "function_call", call_id: "call_indexed", name: "indexed", arguments: "{}" }
+      }),
+      event("response.output_item.added", {
+        item_id: "fc_unknown",
+        item: { id: "fc_unknown", type: "function_call", call_id: "call_unknown", name: "unknown", arguments: "{}" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.tools).toEqual([]);
+    expect(chat.chunks.at(-1).choices[0].finish_reason).toBe("stop");
+  });
+
+  it("does not emit a contiguous tool prefix before a later gap appears", () => {
+    const chat = collectChat([
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { id: "fc_zero", type: "function_call", call_id: "call_zero", name: "zero", arguments: "{}" }
+      }),
+      event("response.output_item.added", {
+        output_index: 2,
+        item: { id: "fc_two", type: "function_call", call_id: "call_two", name: "two", arguments: "{}" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.tools).toEqual([]);
+    expect(chat.chunks.at(-1).choices[0].finish_reason).toBe("stop");
+  });
+
+  it("keeps conflicting duplicate output indexes detectable", () => {
+    const chat = collectChat([
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { id: "fc_a", type: "function_call", call_id: "call_a", name: "a", arguments: "{}" }
+      }),
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { id: "fc_b", type: "function_call", call_id: "call_b", name: "b", arguments: "{}" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.state.responsesAccumulator.terminalResponse.output).toHaveLength(2);
+    expect(chat.tools).toEqual([]);
+    expect(chat.chunks.at(-1).choices[0].finish_reason).toBe("stop");
+  });
+
+  it("rejects a recorded index conflict even when final indexes look contiguous", () => {
+    const chat = collectChat([
+      event("response.output_item.added", {
+        output_index: 0,
+        item: { id: "fc_a", type: "function_call", call_id: "call_a", name: "a", arguments: "{}" }
+      }),
+      event("response.output_item.added", {
+        output_index: 1,
+        item: { id: "fc_b", type: "function_call", call_id: "call_b", name: "b", arguments: "{}" }
+      }),
+      event("response.output_item.done", {
+        output_index: 0,
+        item_id: "fc_b",
+        item: { id: "fc_b", type: "function_call", call_id: "call_b", name: "b", arguments: "{}" }
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.state.responsesAccumulator.outputOrderConflict).toBe(true);
+    expect(chat.tools).toEqual([]);
+    expect(chat.chunks.at(-1).choices[0].finish_reason).toBe("stop");
+  });
+
+  it("prefers a later reasoning summary over deferred raw reasoning text", () => {
+    const chat = collectChat([
+      event("response.reasoning_text.delta", {
+        output_index: 0, item_id: "rs_summary", delta: "raw chain"
+      }),
+      event("response.reasoning_summary_text.delta", {
+        output_index: 0, item_id: "rs_summary", delta: "safe summary"
+      }),
+      event("response.completed", { response: { status: "completed", output: [] } })
+    ]);
+
+    expect(chat.reasoning).toBe("safe summary");
+  });
+});

--- a/tests/unit/responses-accumulator.test.js
+++ b/tests/unit/responses-accumulator.test.js
@@ -392,6 +392,79 @@ describe("Responses accumulator P0 reconstruction", () => {
 });
 
 describe("Responses stream and forced non-stream parity", () => {
+  it("streams a canonical single tool's argument deltas without terminal replay", () => {
+    const state = { model: "gpt-p0", created: 123 };
+    const metadata = openaiResponsesToOpenAIResponse(event("response.output_item.added", {
+      output_index: 0,
+      item: { id: "fc_stream", type: "function_call", call_id: "call_stream", name: "search", arguments: "" }
+    }), state);
+    const first = openaiResponsesToOpenAIResponse(event("response.function_call_arguments.delta", {
+      output_index: 0, item_id: "fc_stream", call_id: "call_stream", delta: "{\"q\":"
+    }), state);
+    const second = openaiResponsesToOpenAIResponse(event("response.function_call_arguments.delta", {
+      output_index: 0, item_id: "fc_stream", call_id: "call_stream", delta: "\"router\"}"
+    }), state);
+    const terminal = openaiResponsesToOpenAIResponse(event("response.completed", {
+      response: { status: "completed", output: [] }
+    }), state);
+
+    expect(metadata).toBeNull();
+    expect(first[0].choices[0].delta.tool_calls[0]).toEqual({
+      index: 0,
+      id: "call_stream",
+      type: "function",
+      function: { name: "search", arguments: "{\"q\":" }
+    });
+    expect(second[0].choices[0].delta.tool_calls[0]).toEqual({
+      index: 0,
+      function: { arguments: "\"router\"}" }
+    });
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0].choices[0].delta.tool_calls).toBeUndefined();
+    expect(terminal[0].choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("buffers an interleaved arguments-before-metadata turn until identities are final", () => {
+    const state = { model: "gpt-p0", created: 123 };
+    const beforeMetadata = openaiResponsesToOpenAIResponse(event("response.function_call_arguments.delta", {
+      output_index: 1, item_id: "fc_b", call_id: "call_b", delta: "{\"b\":"
+    }), state);
+    const metadataA = openaiResponsesToOpenAIResponse(event("response.output_item.added", {
+      output_index: 0,
+      item: { id: "fc_a", type: "function_call", call_id: "call_a", name: "a", arguments: "" }
+    }), state);
+    const deltaA = openaiResponsesToOpenAIResponse(event("response.function_call_arguments.delta", {
+      output_index: 0, item_id: "fc_a", call_id: "call_a", delta: "{}"
+    }), state);
+    const metadataB = openaiResponsesToOpenAIResponse(event("response.output_item.added", {
+      output_index: 1,
+      item: { id: "fc_b", type: "function_call", call_id: "call_b", name: "b", arguments: "" }
+    }), state);
+    const deltaB = openaiResponsesToOpenAIResponse(event("response.function_call_arguments.delta", {
+      output_index: 1, item_id: "fc_b", call_id: "call_b", delta: "2}"
+    }), state);
+    const terminal = openaiResponsesToOpenAIResponse(event("response.completed", {
+      response: { status: "completed", output: [] }
+    }), state);
+
+    expect([beforeMetadata, metadataA, deltaA, metadataB, deltaB]).toEqual([null, null, null, null, null]);
+    expect(terminal.slice(0, -1).map(chunk => chunk.choices[0].delta.tool_calls[0])).toEqual([
+      {
+        index: 0,
+        id: "call_a",
+        type: "function",
+        function: { name: "a", arguments: "{}" }
+      },
+      {
+        index: 1,
+        id: "call_b",
+        type: "function",
+        function: { name: "b", arguments: "{\"b\":2}" }
+      }
+    ]);
+    expect(terminal.at(-1).choices[0].finish_reason).toBe("tool_calls");
+  });
+
   it("reconstructs the same text, reasoning, tools, status, and usage", async () => {
     const events = p0Events();
     const json = await convertResponsesStreamToJson(streamFromEvents(events));

--- a/tests/unit/streaming-handler-responses-passthrough.test.js
+++ b/tests/unit/streaming-handler-responses-passthrough.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { passthroughMock, translateMock } = vi.hoisted(() => ({
+  passthroughMock: vi.fn(() => new TransformStream()),
+  translateMock: vi.fn(() => new TransformStream())
+}));
+
+vi.mock("../../open-sse/utils/stream.js", () => ({
+  COLORS: { green: "", reset: "" },
+  createPassthroughStreamWithLogger: passthroughMock,
+  createSSETransformStreamWithLogger: translateMock
+}));
+
+vi.mock("../../open-sse/utils/streamHandler.js", () => ({
+  pipeWithDisconnect: vi.fn(providerResponse => providerResponse.body)
+}));
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { handleStreamingResponse } = await import("../../open-sse/handlers/chatCore/streamingHandler.js");
+
+function responsesProviderResponse() {
+  return new Response("event: response.completed\ndata: {}\n\n", {
+    headers: { "content-type": "text/event-stream" }
+  });
+}
+
+async function handleWithUserAgent(userAgent) {
+  return handleStreamingResponse({
+    providerResponse: responsesProviderResponse(),
+    provider: "codex",
+    model: "gpt-5.3-codex",
+    sourceFormat: FORMATS.OPENAI_RESPONSES,
+    targetFormat: FORMATS.OPENAI_RESPONSES,
+    userAgent,
+    body: { model: "gpt-5.3-codex", stream: true },
+    stream: true,
+    requestStartTime: Date.now(),
+    connectionId: "test-connection",
+    clientRawRequest: { endpoint: "/v1/responses" },
+    streamController: {}
+  });
+}
+
+describe("Responses streaming handler CLI passthrough", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(["Droid/1.2.3", "codex-cli/0.42.0"])(
+    "keeps the raw Responses-to-Responses path for %s",
+    async userAgent => {
+      const result = await handleWithUserAgent(userAgent);
+
+      expect(result.success).toBe(true);
+      expect(passthroughMock).toHaveBeenCalledOnce();
+      expect(translateMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("continues repairing the Responses path for non-CLI clients", async () => {
+    const result = await handleWithUserAgent("9router-test-client/1.0");
+
+    expect(result.success).toBe(true);
+    expect(translateMock).toHaveBeenCalledOnce();
+    expect(passthroughMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a per-request Responses accumulator shared by streaming and forced non-stream conversion
- correlate fragmented and interleaved tool calls by output index, item id, and call id
- reconstruct complete terminal output and usage while preserving exactly-once completed, failed, incomplete, cancelled, abort, and EOF semantics
- keep simple unambiguous tool calls incremental while buffering ambiguous ordering without replay or duplication
- preserve Droid/codex-cli raw Responses passthrough and protocol-valid forced non-stream error mapping

## Why

The previous translators assembled Responses state independently and tracked only one current tool call. Parallel or interleaved calls could attach argument fragments to the wrong call, while terminal events or forced non-stream responses could lose output, tools, usage, or failure diagnostics.

## Tests

- focused accumulator, terminal, abort, golden-stream, forced-non-stream, and passthrough suite: 54 passed in parent verification
- independent Claude Code final review: 60 targeted tests passed
- changed-file ESLint passed
- `git diff --check` and `git show --check` passed
- production build passed

## Review

Independent Claude Code review found three regressions in the first revision. Follow-up commit `8817537` fixes all three. Final review verdict: **SHIP**, with no P0 findings remaining.
