### PR TITLE
fix(codex): current client_version + refresh-aware model sync

### DIFF
--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { getProviderConnectionById } from "@/models";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { GEMINI_CONFIG } from "@/lib/oauth/constants/oauth";
-import { refreshGoogleToken, updateProviderCredentials } from "@/sse/services/tokenRefresh";
+import { refreshGoogleToken, refreshCodexToken, updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveOllamaLocalHost } from "open-sse/config/providers.js";
 import { getModelsByProviderId } from "open-sse/config/providerModels.js";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
@@ -12,6 +12,13 @@ import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
+
+// The /codex/models endpoint gates each entry by minimal_client_version against this
+// value, and codex CLI's own manifest (openai/codex codex-rs/models-manager/models.json)
+// already requires 0.144.0 for its newest models, so a stale client_version here comes
+// back 200 with those entries quietly missing instead of erroring.
+const CODEX_CLIENT_VERSION = "0.144.6";
+const CODEX_MODELS_URL = `https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_CLIENT_VERSION}`;
 
 const parseOpenAIStyleModels = (data) => {
   if (Array.isArray(data)) return data;
@@ -157,12 +164,20 @@ const PROVIDER_MODELS_CONFIG = {
     parseResponse: (data) => data.data || []
   },
   codex: {
-    url: "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0",
-    method: "GET",
-    headers: { "Content-Type": "application/json", "Accept": "application/json" },
-    authHeader: "Authorization",
-    authPrefix: "Bearer ",
-    parseResponse: parseCodexModels
+    customResolver: buildOAuthResolver({
+      refreshFn: (conn) => refreshCodexToken(conn.refreshToken),
+      fetchFn: (token) => fetch(CODEX_MODELS_URL, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+          "Authorization": `Bearer ${token}`,
+          "originator": "codex_cli_rs"
+        }
+      }),
+      parseFn: parseCodexModels,
+      errorLabel: "Failed to fetch Codex models"
+    })
   },
   antigravity: {
     url: "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal:models",


### PR DESCRIPTION
## Problem

Codex model sync calls `https://chatgpt.com/backend-api/codex/models?client_version=1.0.0`. That endpoint filters the returned catalog by `minimal_client_version` against whatever `client_version` the caller sends, and codex CLI's own manifest (`openai/codex` `codex-rs/models-manager/models.json`) already requires `0.144.0` for its newest models. `1.0.0` predates that by a wide margin, so the request can come back a clean 200 with the gated entries just missing, no error to react to.

We hit this in our own implementation of the same call: a real ChatGPT Plus account got a 200 with an empty model list at `client_version=0.21.0`, and the list populated once we bumped to a current release.

There's also no fallback in the generic sync branch this entry runs through (`route.js` ~519-547): a 200 with zero models is returned to the client as-is, with no warning field, nothing to signal that something's off.

## Fix

- Bump `client_version` to `0.144.6` (current stable, comfortably above the `0.144.0` gate) via a named constant with a comment explaining the gating, so it doesn't quietly go stale again.
- Add the `originator: codex_cli_rs` header. Every other codex call site in this codebase already sends it (`open-sse/providers/registry/codex.js`, `open-sse/handlers/imageProviders/codex.js`, `open-sse/services/usage/codex.js`), just not this one.
- Move the codex entry onto the existing `buildOAuthResolver` helper, the same pattern `gemini-cli` and `grok-cli` already use. `refreshCodexToken` was already implemented and used elsewhere (the general provider refresh table in `open-sse/services/tokenRefresh.js`), just never wired into model sync, so codex model listing never retried on an expired token the way the other OAuth providers do. This also means a genuinely empty response now comes back with a `warning` field instead of a silent empty array.

## Scope

Kept this to the codex entry only. I looked at also wiring a static-catalog fallback for a fully-empty result (like `kimchi`/`grok-cli` do), but there's no static codex catalog in `open-sse/config/providerModels.js` to fall back to, and I didn't want to guess at a model list. Happy to follow up separately if that's wanted.

## Checks

- `bunx eslint "src/app/api/providers/[id]/models/route.js"` clean.
- Skipped the test suite: `vitest` isn't a declared dependency and there's no `test` script in `package.json`, even though `tests/unit/*.test.js` exists, so I couldn't run it against a fresh clone.

Reference: https://raw.githubusercontent.com/openai/codex/refs/heads/main/codex-rs/models-manager/models.json
