### PR TITLE
feat(grok): show current-day request usage

### DIFF
--- a/src/app/api/usage/[connectionId]/route.js
+++ b/src/app/api/usage/[connectionId]/route.js
@@ -1,7 +1,11 @@
 // Ensure proxyFetch is loaded to patch globalThis.fetch
 import "open-sse/index.js";
 
-import { getProviderConnectionById, updateProviderConnection } from "@/lib/localDb";
+import {
+  getDailyConnectionUsage,
+  getProviderConnectionById,
+  updateProviderConnection,
+} from "@/lib/localDb";
 import { getUsageForProvider } from "open-sse/services/usage.js";
 import { getExecutor } from "open-sse/executors/index.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
@@ -180,6 +184,29 @@ export async function GET(request, { params }) {
       } catch (retryError) {
         console.warn(`[Usage] ${connection.provider}: force refresh failed: ${retryError.message}`);
       }
+    }
+
+    if (
+      connection.provider === "grok-cli" &&
+      usage?.message?.includes("does not expose a numeric included quota")
+    ) {
+      const daily = await getDailyConnectionUsage(connection.id);
+      const total = 800;
+      usage = {
+        plan: usage.plan || null,
+        quotas: {
+          "Daily use": {
+            used: daily.requests,
+            total,
+            remainingPercentage: Math.max(
+              0,
+              ((total - daily.requests) / total) * 100,
+            ),
+            resetAt: daily.resetAt,
+            unlimited: false,
+          },
+        },
+      };
     }
 
     return Response.json(usage);

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -59,7 +59,7 @@ export {
 export {
   statsEmitter, trackPendingRequest, getActiveRequests,
   saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
-  appendRequestLog, getRecentLogs,
+  getDailyConnectionUsage, appendRequestLog, getRecentLogs,
 } from "./repos/usageRepo.js";
 
 // Request details

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -313,6 +313,33 @@ export async function saveRequestUsage(entry) {
   }
 }
 
+export async function getDailyConnectionUsage(connectionId, now = new Date()) {
+  if (!connectionId) {
+    return { requests: 0, tokens: 0, resetAt: null };
+  }
+
+  const current = now instanceof Date ? now : new Date(now);
+  const startOfDay = new Date(current);
+  startOfDay.setHours(0, 0, 0, 0);
+  const nextDay = new Date(startOfDay);
+  nextDay.setDate(nextDay.getDate() + 1);
+
+  const db = await getAdapter();
+  const row = db.get(
+    `SELECT COUNT(*) AS requests,
+            COALESCE(SUM(promptTokens + completionTokens), 0) AS tokens
+       FROM usageHistory
+      WHERE timestamp >= ? AND timestamp < ? AND connectionId = ?`,
+    [startOfDay.toISOString(), nextDay.toISOString(), String(connectionId)],
+  );
+
+  return {
+    requests: Number(row?.requests) || 0,
+    tokens: Number(row?.tokens) || 0,
+    resetAt: nextDay.toISOString(),
+  };
+}
+
 export async function getUsageHistory(filter = {}) {
   const db = await getAdapter();
   const conds = [];

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -17,5 +17,6 @@ export {
   getCustomModels, addCustomModel, deleteCustomModel,
   getMitmAlias, setMitmAliasAll,
   getPricing, getPricingForModel, updatePricing, resetPricing, resetAllPricing,
+  getDailyConnectionUsage,
   exportDb, importDb,
 } from "@/lib/db/index.js";

--- a/tests/unit/grok-daily-usage-route.test.js
+++ b/tests/unit/grok-daily-usage-route.test.js
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getDailyConnectionUsage: vi.fn(),
+  getProviderConnectionById: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  getUsageForProvider: vi.fn(),
+  getExecutor: vi.fn(),
+  resolveConnectionProxyConfig: vi.fn(),
+}));
+
+vi.mock("open-sse/index.js", () => ({}));
+
+vi.mock("@/lib/localDb", () => ({
+  getDailyConnectionUsage: mocks.getDailyConnectionUsage,
+  getProviderConnectionById: mocks.getProviderConnectionById,
+  updateProviderConnection: mocks.updateProviderConnection,
+}));
+
+vi.mock("open-sse/services/usage.js", () => ({
+  getUsageForProvider: mocks.getUsageForProvider,
+}));
+
+vi.mock("open-sse/executors/index.js", () => ({
+  getExecutor: mocks.getExecutor,
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: mocks.resolveConnectionProxyConfig,
+}));
+
+describe("Grok daily usage route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.resolveConnectionProxyConfig.mockResolvedValue({});
+    mocks.getExecutor.mockReturnValue({
+      needsRefresh: () => false,
+      refreshCredentials: vi.fn(),
+    });
+  });
+
+  it("replaces the no-numeric-quota text with today's request meter", async () => {
+    const connection = {
+      id: "grok-1",
+      provider: "grok-cli",
+      authType: "oauth",
+      accessToken: "token",
+      providerSpecificData: {},
+    };
+    mocks.getProviderConnectionById.mockResolvedValue(connection);
+    mocks.getUsageForProvider.mockResolvedValue({
+      plan: "XPremiumPlus",
+      message:
+        "Subscription access is active; Grok does not expose a numeric included quota.",
+      quotas: {},
+    });
+    mocks.getDailyConnectionUsage.mockResolvedValue({
+      requests: 37,
+      tokens: 123456,
+      resetAt: "2026-07-21T00:00:00.000Z",
+    });
+
+    const { GET } = await import(
+      "../../src/app/api/usage/[connectionId]/route.js"
+    );
+    const response = await GET(
+      new Request("http://localhost/api/usage/grok-1"),
+      { params: Promise.resolve({ connectionId: "grok-1" }) },
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mocks.getDailyConnectionUsage).toHaveBeenCalledWith("grok-1");
+    expect(body.message).toBeUndefined();
+    expect(body.quotas["Daily use"]).toMatchObject({
+      used: 37,
+      total: 800,
+      resetAt: "2026-07-21T00:00:00.000Z",
+      unlimited: false,
+    });
+    expect(body.quotas["Daily use"].remainingPercentage).toBeCloseTo(95.375);
+  });
+
+  it("preserves owner text when Grok does not report subscribed access", async () => {
+    const connection = {
+      id: "grok-2",
+      provider: "grok-cli",
+      authType: "oauth",
+      accessToken: "token",
+      providerSpecificData: {},
+    };
+    const usage = {
+      plan: "Grok Build",
+      message:
+        "Grok Build connected, but no credit allotment was returned. Free promo may be exhausted.",
+      quotas: {},
+    };
+    mocks.getProviderConnectionById.mockResolvedValue(connection);
+    mocks.getUsageForProvider.mockResolvedValue(usage);
+
+    const { GET } = await import(
+      "../../src/app/api/usage/[connectionId]/route.js"
+    );
+    const response = await GET(
+      new Request("http://localhost/api/usage/grok-2"),
+      { params: Promise.resolve({ connectionId: "grok-2" }) },
+    );
+
+    expect(await response.json()).toEqual(usage);
+    expect(mocks.getDailyConnectionUsage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- keep the provider's existing owner-repo text response unchanged
- at the dashboard usage route, replace only the subscribed/no-numeric-quota Grok message with a **Daily use** meter
- count real requests for the current connection since local midnight
- reset the meter at the next local midnight
- keep exhausted promo/free-account text and API-provided numeric quotas unchanged

## Daily semantics
This is a current local calendar-day request counter. It does not use the 7-day chart endpoint or aggregate seven days of history.

## Test plan
- [x] `vitest run unit/grok-daily-usage-route.test.js unit/grok-cli-usage.test.js`
- [x] ESLint on changed files
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)