### PR TITLE
security: bind dev/start to 127.0.0.1 by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,9 @@ NEXT_PUBLIC_CLOUD_URL=https://9router.com
 
 # Currently unused by application runtime (kept as reference)
 # INSTANCE_NAME=9router
+
+# Network interface to bind to. Defaults to 127.0.0.1 (loopback only).
+# The dashboard exposes privileged endpoints (tunnel install, daemon start) that run
+# system commands, so it must NOT be reachable from the public internet.
+# To expose it deliberately, run: next start --hostname 0.0.0.0 (and put auth in front of it).
+HOSTNAME=127.0.0.1

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "9Router web dashboard",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 20127",
+    "dev": "next dev --hostname 127.0.0.1 --port 20127",
     "dev:webpack": "next dev --webpack --port 20127",
     "build": "next build --webpack",
-    "start": "next start --port 20127",
+    "start": "next start --hostname 127.0.0.1 --port 20127",
     "dev:bun": "bun --bun next dev --webpack --port 20127",
     "build:bun": "bun --bun next build --webpack",
     "start:bun": "bun ./.next/standalone/server.js",


### PR DESCRIPTION
## Summary

`next dev` and `next start` currently bind to `0.0.0.0`, so a default install of the dashboard is reachable from the public internet.

Combined with the routes under `/api/tunnel/*` — which execute privileged system commands and have **no authentication** — a default deployment on a VPS is remotely exploitable. This PR binds both scripts to `127.0.0.1` and documents how to opt in to exposing the dashboard.

## Why: exploited in the wild

A server I help maintain was compromised **twice** through this exposure (2026-07-17 and 2026-07-20):

- 9router was listening on `*:20128` and running as root
- An unauthenticated `POST /api/tunnel/tailscale-install` was used to obtain command execution
- The attacker installed an XMRig miner (`/usr/bin/unicorn/`) with three redundant persistence layers: a systemd unit, a root crontab entry, and a `while true` watchdog built from a renamed copy of `/bin/sh`
- Confirmed by cgroup: both malicious processes belonged to `9router.service` (`0::/system.slice/9router.service`)
- The dropper's cleanup step (`rm -rf /tmp/`, `rm -fr /dev/shm/*`) also took down PostgreSQL on that host twice

The deployed version was 0.4.25, where `installTailscaleLinux()` piped the install script into `sudo -S sh` on the **same stdin as the password**, so a `\n` inside `sudoPassword` executed arbitrary commands as root. That specific bug is already fixed upstream (the script now goes to a temp file passed as an argument) — thank you. But because the routes remain unauthenticated, **network exposure is what decides whether a host is exploitable**, which is what this PR addresses.

Hosts are found by mass internet scanning (Shodan/Censys/masscan) on the fixed port, so any publicly reachable instance is discovered within days.

## Changes

- `package.json`: `dev` and `start` now pass `--hostname 127.0.0.1`
- `.env.example`: documents `HOSTNAME` and why loopback is the safe default

This matches what the dashboard is for (a local control panel) and is what the `dev` script already did in earlier releases.

## Suggested follow-ups (deliberately not in this PR)

1. **Authenticate the privileged routes** — `/api/tunnel/*` and `/api/version/update` have no auth check; a `src/middleware.js` verifying the existing API key would close this properly
2. **Reject `\r` / `\n` in `sudoPassword`** before it reaches any `spawn()` — cheap defence-in-depth for every remaining `sudo -S` call site
3. Document that the dashboard should not be run as root

Happy to open follow-up PRs for any of these if useful.