### PR TITLE
refactor(kiro): keep terminal integrity transport-only

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -9,7 +9,6 @@ import { STREAM_FIRST_CHUNK_TIMEOUT_MS } from "../config/runtimeConfig.js";
 
 const KIRO_REPAIR_BUFFER_MAX_BYTES = 8 * 1024 * 1024;
 const KIRO_REPAIR_HEARTBEAT_MS = 10_000;
-const KIRO_SHORT_FINAL_MAX_CHARS = 800;
 const EVENTSTREAM_MAX_MESSAGE_BYTES = 24 * 1024 * 1024;
 const EVENTSTREAM_MAX_HEADERS_BYTES = 128 * 1024;
 const KIRO_EVENT_TYPES = new Set([
@@ -34,22 +33,7 @@ const CRC32_TABLE = Uint32Array.from({ length: 256 }, (_, index) => {
   return value >>> 0;
 });
 
-const REPAIR_INSTRUCTIONS = Object.freeze({
-  tool: "Retry the previous response because its Kiro tool_call wrapper was malformed. If you use the wrapper tool named tool_call, its input must contain a non-empty name and an arguments field.",
-  ellipsis: "Retry the previous response because it ended with only an ellipsis. Return the complete final answer, not only ... or ….",
-  short_final: "Retry the previous response because its final only announced a future action. Complete the check now and return the result or a concrete blocker."
-});
-const SHORT_FUTURE_ACTION = /^(?:(?:(?:現在|接著|接下來|下一步)[，,:：\s]*(?:我(?:只)?(?:會|要|將|再)?\s*)?|我只再)(?:補|查|確認|驗證|追(?:查|蹤)?|繼續|檢查|測試)|我(?:會|要|將)(?:再|重新)?(?:補(?:齊|查)?|抓取|查(?:詢)?|確認|驗證|追(?:查|蹤)?|繼續|檢查|測試)|(?:(?:next|now|then)\b[\s,:-]*)?(?:i(?:'ll| will| am going to| need to)|let me)\s+(?:verify|check|confirm|validate|investigate|trace|continue|follow up|test)\b)/iu;
-// Keep this tied to the observed whole-response signature. Broader Chinese
-// result/progress heuristics create false positives for completed findings.
-const OBSERVED_TRAILING_FUTURE_ACTION = /^目前證據顯示[\s\S]{1,700}[。.!?；;]\s*最後補查\s+504\s+access\s+log[，,]\s*確認\s+host[／/]路徑與是否為集中流量[。.!]?$/iu;
-const ENGLISH_FUTURE_ACTION = /^(?:(?:next|now|then)\b[\s,:-]*)?(?:i(?:'ll| will| am going to| need to)|let me)\s+(?:verify|check|confirm|validate|investigate|trace|continue|follow up|test)\b/iu;
-const ENGLISH_RESULT_CLAUSE = /(?:[:;\n]|[.!?]\s+\S|\b(?:status|checksum|response|deployment)\s+(?:is|are|was|were|matches?|equals?|returned)\b)/iu;
-const CHINESE_FUTURE_ACTION = /^(?:(?:現在|接著|接下來|下一步)[，,:：\s]*(?:我(?:只)?(?:會|要|將|再)?\s*)?|我只再|我(?:會|要|將)(?:再|重新)?)(?:補|抓取|查|確認|驗證|追|繼續|檢查|測試)/u;
-const CHINESE_RESULT_CLAUSE = /(?:[。！？]\s*\S|(?:版本|狀態|回應|結果|部署|校驗碼)(?:是|為|等於|顯示))/u;
-const USER_WAIT = /(?:請(?:你|先)|你(?:先|需要|可以|提供|確認|批准|允許)|等待(?:你|使用者)|等你|核准|同意|授權|\b(?:after|when|once)\s+you\b|\byour\s+(?:approval|confirmation|permission|input)\b|\bwait(?:ing)?\s+for\s+you\b|\bplease\s+(?:approve|confirm|provide|send)\b)/iu;
-const COMPLETED_FINAL = /(?:已(?:經)?完成|完成(?:了|驗證|確認)|修復完成|確認無誤|驗證(?:完成|通過)|測試(?:均)?通過|結論|總結|\b(?:done|completed|fixed|verified|confirmed|passed|in conclusion|summary)\b|\b(?:is|are) complete\b)/iu;
-const RESULT_EVIDENCE = /(?:顯示|發現|因此|成功|失敗|正常|無錯誤|沒有錯誤|\b(?:found|shows?|showed|because|therefore|succeeded|failed|healthy|green|no errors?)\b)/iu;
+const TOOL_CALL_REPAIR_INSTRUCTION = "Retry the previous response because its Kiro tool_call wrapper was malformed. If you use the wrapper tool named tool_call, its input must contain a non-empty name and an arguments field.";
 
 function crc32(bytes) {
   let crc = 0xffffffff;
@@ -123,12 +107,11 @@ async function readResponsePrefix(response, signal, maxBytes, timeoutMs) {
   return decoder.decode(concatChunks(chunks, totalBytes));
 }
 
-function appendRepairInstruction(body, kind) {
+function appendToolCallRepairInstruction(body) {
   const repaired = structuredClone(body || {});
-  const instruction = REPAIR_INSTRUCTIONS[kind] || "Retry the previous incomplete Kiro response.";
   repaired.systemPrompt = repaired.systemPrompt
-    ? `${repaired.systemPrompt}\n\n${instruction}`
-    : instruction;
+    ? `${repaired.systemPrompt}\n\n${TOOL_CALL_REPAIR_INSTRUCTION}`
+    : TOOL_CALL_REPAIR_INSTRUCTION;
   return repaired;
 }
 
@@ -166,20 +149,6 @@ function mergeStopReason(current, incoming) {
   return severity(incoming) > severity(current) ? incoming : current;
 }
 
-function isEllipsisOnly(value) {
-  return ["...", "…"].includes(String(value || "").trim());
-}
-
-function isShortFutureAction(value) {
-  const text = String(value || "").trim().replaceAll("’", "'");
-  if (OBSERVED_TRAILING_FUTURE_ACTION.test(text)) return true;
-  if (ENGLISH_FUTURE_ACTION.test(text) && ENGLISH_RESULT_CLAUSE.test(text)) return false;
-  if (CHINESE_FUTURE_ACTION.test(text) && CHINESE_RESULT_CLAUSE.test(text)) return false;
-  return text.length > 0 && text.length <= KIRO_SHORT_FINAL_MAX_CHARS &&
-    SHORT_FUTURE_ACTION.test(text) && !USER_WAIT.test(text) &&
-    !COMPLETED_FINAL.test(text) && !RESULT_EVIDENCE.test(text);
-}
-
 function encodeSSEError(code, message, details) {
   return encoder.encode(`data: ${JSON.stringify({ error: {
     message,
@@ -197,12 +166,6 @@ function inspectSSEChunk(chunk, state) {
     try {
       const event = JSON.parse(data);
       if (event.error) state.error = event.error;
-      for (const choice of event.choices || []) {
-        const delta = choice.delta || {};
-        if (typeof delta.content === "string") state.content += delta.content;
-        if (typeof delta.reasoning_content === "string") state.reasoning += delta.reasoning_content;
-        if (delta.tool_calls?.length) state.hasToolCalls = true;
-      }
     } catch { /* a malformed SSE line is diagnosed by the transformer */ }
   }
 }
@@ -398,11 +361,8 @@ export class KiroExecutor extends BaseExecutor {
       return encodeSSEError("invalid_kiro_tool_call", first.message, first.diagnostics);
     }
 
-    const repairKind = ["ellipsis", "short_final", "invalid_tool"].includes(first.kind)
-      ? first.kind
-      : null;
-    const repairBody = repairKind
-      ? appendRepairInstruction(args.body, repairKind === "invalid_tool" ? "tool" : repairKind)
+    const repairBody = first.kind === "invalid_tool"
+      ? appendToolCallRepairInstruction(args.body)
       : structuredClone(args.body || {});
 
     const retry = await BaseExecutor.prototype.execute.call(this, {
@@ -439,13 +399,9 @@ export class KiroExecutor extends BaseExecutor {
     if (second.kind === "terminal_stop" || second.kind === "upstream_error") {
       return this.integrityFailureSSE(second);
     }
-    const code = second.kind === "ellipsis"
-      ? "kiro_ellipsis_retry_failed"
-      : second.kind === "short_final"
-        ? "kiro_short_final_retry_failed"
-        : second.kind === "invalid_tool"
-          ? "kiro_tool_call_repair_retry_failed"
-          : "kiro_missing_terminal_retry_failed";
+    const code = second.kind === "invalid_tool"
+      ? "kiro_tool_call_repair_retry_failed"
+      : "kiro_missing_terminal_retry_failed";
     return encodeSSEError(
       code,
       `Kiro integrity validation failed after one bounded retry: ${second.message || second.kind}`,
@@ -501,7 +457,7 @@ export class KiroExecutor extends BaseExecutor {
     const chunks = [];
     let totalBytes = 0;
     let sawChunk = false;
-    const output = { content: "", reasoning: "", hasToolCalls: false, error: null };
+    const output = { error: null };
 
     try {
       while (true) {
@@ -562,15 +518,6 @@ export class KiroExecutor extends BaseExecutor {
     }
     if (output.error) {
       return { kind: "missing_terminal", message: output.error.message, diagnostics: safeDiagnostics };
-    }
-    if (!output.hasToolCalls) {
-      if (isEllipsisOnly(output.content) ||
-          (!output.content.trim() && isEllipsisOnly(output.reasoning))) {
-        return { kind: "ellipsis", diagnostics: safeDiagnostics };
-      }
-      if (isShortFutureAction(output.content)) {
-        return { kind: "short_final", diagnostics: safeDiagnostics };
-      }
     }
     return { kind: "complete", bytes: concatChunks(chunks, totalBytes), diagnostics: safeDiagnostics };
   }

--- a/tests/unit/kiro-terminal-integrity.test.js
+++ b/tests/unit/kiro-terminal-integrity.test.js
@@ -204,16 +204,15 @@ describe("Kiro terminal integrity recovery", () => {
     expect(body).not.toContain("kiro_missing_terminal");
   });
 
-  it.each(["...", "…"])("repairs exact ellipsis final %s without leaking it", async (ellipsis) => {
-    fetchMock
-      .mockResolvedValueOnce(response([frame("assistantResponseEvent", { content: ellipsis })]))
-      .mockResolvedValueOnce(response([frame("assistantResponseEvent", { content: "Recovered answer." })]));
+  it.each(["...", "…"])("passes exact ellipsis final through unchanged: %s", async (ellipsis) => {
+    fetchMock.mockResolvedValueOnce(response([
+      frame("assistantResponseEvent", { content: ellipsis })
+    ]));
 
     const body = await (await execute()).response.text();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(body).toContain("Recovered answer.");
-    expect(body).not.toContain(`"content":"${ellipsis}"`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(body).toContain(`"content":"${ellipsis}"`);
   });
 
   it.each([
@@ -222,16 +221,15 @@ describe("Kiro terminal integrity recovery", () => {
     "目前證據顯示只在 **03:48:30–03:49:00 TPE** 出現少量 NonKA 504；主池 106/106、副池 50/50，且兩池都沒有重啟。最後補查 504 access log，確認 host／路徑與是否為集中流量。",
     "Next I'll verify the deployment logs.",
     "Let me check the remaining failures."
-  ])("repairs conservative future-action final: %s", async (progress) => {
-    fetchMock
-      .mockResolvedValueOnce(response([frame("assistantResponseEvent", { content: progress })]))
-      .mockResolvedValueOnce(response([frame("assistantResponseEvent", { content: "Verification completed." })]));
+  ])("passes future-action final through unchanged: %s", async (progress) => {
+    fetchMock.mockResolvedValueOnce(response([
+      frame("assistantResponseEvent", { content: progress })
+    ]));
 
     const body = await (await execute()).response.text();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(body).toContain("Verification completed.");
-    expect(body).not.toContain(progress);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(body).toContain(progress);
   });
 
   it.each([
@@ -259,18 +257,6 @@ describe("Kiro terminal integrity recovery", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(body).toContain(finalText);
-  });
-
-  it("bounds incomplete-final repair to one retry", async () => {
-    fetchMock
-      .mockResolvedValueOnce(response([frame("assistantResponseEvent", { content: "..." })]))
-      .mockResolvedValueOnce(response([frame("assistantResponseEvent", { content: "…" })]));
-
-    const body = await (await execute()).response.text();
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(body).toContain("kiro_ellipsis_retry_failed");
-    expect(body).not.toContain('"content":"..."');
   });
 
   it("repairs malformed wrapper tools without leaking the invalid call", async () => {


### PR DESCRIPTION
## Summary

- remove response-text heuristics from the Kiro transport integrity gate
- pass ellipses and future-action/progress prose through unchanged
- preserve EventStream validation, terminal provenance, bounded retry, and malformed nested `tool_call` repair

## Why

PR #2717 added the right transport protections, but it also made the router infer task completeness from answer wording. The router has no user goal or tool history, so those language-specific guesses can retry valid output and encode caller policy in the provider adapter.

This follow-up keeps the boundary strict:

- **9Router:** framing, CRC/header validation, terminal metadata, upstream errors, timeouts/cancellation, bounded protocol retry, malformed tool-call repair
- **caller/agent:** whether the requested task is semantically complete, blocked, or should continue

## Scope

Only the Kiro executor and its terminal-integrity tests change. No credit, auth, affinity, Responses, GPT, cache, pricing, or plugin changes are included.

## Verification

- Kiro-focused tests: 10 files, 161 passed, 2 expected failures
- terminal-integrity suite: 69/69 passed
- touched-file ESLint and Node syntax checks: passed
- production build: passed (130/130 static pages)
- `git diff --check`: passed
- independent Claude Code review: no accepted/actionable findings

