### PR TITLE
feat(antigravity): add gemini-3.6 (low/medium/high) models

### DIFF
--- a/cli/src/cli/menus/providers.js
+++ b/cli/src/cli/menus/providers.js
@@ -53,6 +53,9 @@ const PROVIDER_MODELS = {
     { id: "glm-4.7" },
   ],
   ag: [
+    { id: "gemini-3.6-flash-high" },
+    { id: "gemini-3.6-flash-medium" },
+    { id: "gemini-3.6-flash-low" },
     { id: "gemini-3-flash-agent" },
     { id: "gemini-3.5-flash-low" },
     { id: "gemini-3.5-flash-extra-low" },

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -2,16 +2,8 @@ import { PROVIDERS } from "./providers.js";
 import REGISTRY from "../providers/registry/index.js";
 // PROVIDER_MODELS now built from providers/registry (transport + models co-located)
 import { PROVIDER_MODELS } from "../providers/index.js";
-import { modelQuotaFamily, modelStrip, modelTargetFormat, normalizeModelId } from "../providers/models/schema.js";
+import { modelQuotaFamily, modelStrip, modelTargetFormat, modelThinkingLevel, normalizeModelId } from "../providers/models/schema.js";
 import { CODEX_REVIEW_SUFFIX } from "../providers/models/helpers.js";
-
-// Antigravity exposes one Gemini 3.6 wire model; the suffix fixes its thinking tier.
-PROVIDER_MODELS.ag = [
-  { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)", upstreamModelId: "gemini-3.6-flash-tiered(high)" },
-  { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)", upstreamModelId: "gemini-3.6-flash-tiered(medium)" },
-  { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)", upstreamModelId: "gemini-3.6-flash-tiered(low)" },
-  ...(PROVIDER_MODELS.ag || []),
-];
 
 export { PROVIDER_MODELS };
 
@@ -80,10 +72,12 @@ export function getModelUpstreamId(aliasOrId, modelId) {
   const found = findModel(models, baseId, aliasOrId);
   const resolvedId = found?.upstreamModelId || found?.id;
   if (resolvedId) {
-    const presetMatch = resolvedId.match(/\([^()]+\)\s*$/);
-    const presetSuffix = presetMatch?.[0] || "";
-    const resolvedBase = presetSuffix ? resolvedId.slice(0, presetMatch.index).trim() : resolvedId;
-    return resolvedBase + (suffix || presetSuffix);
+    // Picker variants that share one wire model pin their tier via `thinkingLevel`
+    // (see antigravity gemini-3.6-flash-*). Emit it as the same "(level)" suffix a
+    // client can send, so applyThinking resolves both through one path. An explicit
+    // client suffix wins over the pin.
+    const pinned = modelThinkingLevel(found);
+    return resolvedId + (suffix || (pinned ? `(${pinned})` : ""));
   }
   if (aliasOrId === "cx" && typeof baseId === "string" && baseId.endsWith(CODEX_REVIEW_SUFFIX)) {
     return baseId.slice(0, -CODEX_REVIEW_SUFFIX.length) + suffix;

--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -5,6 +5,14 @@ import { PROVIDER_MODELS } from "../providers/index.js";
 import { modelQuotaFamily, modelStrip, modelTargetFormat, normalizeModelId } from "../providers/models/schema.js";
 import { CODEX_REVIEW_SUFFIX } from "../providers/models/helpers.js";
 
+// Antigravity exposes one Gemini 3.6 wire model; the suffix fixes its thinking tier.
+PROVIDER_MODELS.ag = [
+  { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)", upstreamModelId: "gemini-3.6-flash-tiered(high)" },
+  { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)", upstreamModelId: "gemini-3.6-flash-tiered(medium)" },
+  { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)", upstreamModelId: "gemini-3.6-flash-tiered(low)" },
+  ...(PROVIDER_MODELS.ag || []),
+];
+
 export { PROVIDER_MODELS };
 
 
@@ -70,8 +78,13 @@ export function getModelUpstreamId(aliasOrId, modelId) {
   const baseId = suffix ? modelId.slice(0, sufMatch.index).trim() : modelId;
   const models = PROVIDER_MODELS[aliasOrId];
   const found = findModel(models, baseId, aliasOrId);
-  if (found?.upstreamModelId) return found.upstreamModelId + suffix;
-  if (found?.id) return found.id + suffix;
+  const resolvedId = found?.upstreamModelId || found?.id;
+  if (resolvedId) {
+    const presetMatch = resolvedId.match(/\([^()]+\)\s*$/);
+    const presetSuffix = presetMatch?.[0] || "";
+    const resolvedBase = presetSuffix ? resolvedId.slice(0, presetMatch.index).trim() : resolvedId;
+    return resolvedBase + (suffix || presetSuffix);
+  }
   if (aliasOrId === "cx" && typeof baseId === "string" && baseId.endsWith(CODEX_REVIEW_SUFFIX)) {
     return baseId.slice(0, -CODEX_REVIEW_SUFFIX.length) + suffix;
   }

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -264,7 +264,7 @@ export class AntigravityExecutor extends BaseExecutor {
     return {
       ...body,
       project: projectId,
-      model: model,
+      model: body.model || model,
       userAgent: "antigravity",
       requestType: "agent",
       requestId: buildIdeRequestId({ body, request: transformedRequest, credentials, model, requestType: "agent" }),

--- a/open-sse/providers/models/schema.js
+++ b/open-sse/providers/models/schema.js
@@ -14,7 +14,8 @@ export const MODEL_DEFAULTS = {
   kind: "llm",
   quotaFamily: "normal",
   strip: [],
-  targetFormat: null
+  targetFormat: null,
+  thinkingLevel: null
 };
 
 // Normalize a registry model entry: accept terse "id" string, fill name via regex when omitted.
@@ -37,4 +38,9 @@ export function modelStrip(model) {
 }
 export function modelTargetFormat(model) {
   return model?.targetFormat || MODEL_DEFAULTS.targetFormat;
+}
+// Effort tier pinned by the model entry, for picker variants that share one wire
+// model (e.g. antigravity gemini-3.6-flash-*). null = follow the client's request.
+export function modelThinkingLevel(model) {
+  return model?.thinkingLevel || MODEL_DEFAULTS.thinkingLevel;
 }

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -1,5 +1,12 @@
 import { ANTIGRAVITY_IDE_BASE_URL, ANTIGRAVITY_IDE_USER_AGENT, ANTIGRAVITY_OAUTH_CLIENT } from "../shared.js";
 
+// Gemini 3.6 ships as ONE wire model whose effort is chosen per request via
+// generationConfig.thinkingConfig.thinkingLevel — unlike 3.5/3.1, which expose a
+// separate wire id per tier. The three ids below are picker variants over that
+// single model: `upstreamModelId` is what goes on the wire, `thinkingLevel` pins
+// the tier. Sending a tier id (gemini-3.6-flash-medium) upstream 404s.
+const GEMINI_36_FLASH_WIRE_ID = "gemini-3.6-flash-tiered";
+
 export default {
   id: "antigravity",
   priority: 20,
@@ -44,6 +51,9 @@ export default {
     clientSecret: "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",
   },
   models: [
+    { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)", upstreamModelId: GEMINI_36_FLASH_WIRE_ID, thinkingLevel: "high" },
+    { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)", upstreamModelId: GEMINI_36_FLASH_WIRE_ID, thinkingLevel: "medium" },
+    { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)", upstreamModelId: GEMINI_36_FLASH_WIRE_ID, thinkingLevel: "low" },
     { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)" },
     { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium)" },
     { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)" },

--- a/src/mitm/server.js
+++ b/src/mitm/server.js
@@ -99,18 +99,27 @@ function collectBodyRaw(req) {
 // Extract model from URL path (Gemini), body (OpenAI/Anthropic), or Kiro conversationState
 function extractModel(url, body) {
   const urlMatch = url.match(/\/models\/([^/:]+)/);
-  if (urlMatch) return urlMatch[1];
+  const urlModel = urlMatch?.[1] || null;
   
   // Skip parsing if body is binary (AWS EventStream, Protocol Buffers, etc.)
-  if (isBinaryData(body)) return null;
+  if (isBinaryData(body)) return urlModel;
   
   try {
     const parsed = JSON.parse(body.toString());
     if (parsed.conversationState) {
       return parsed.conversationState.currentMessage?.userInputMessage?.modelId || null;
     }
-    return parsed.model || null;
-  } catch { return null; }
+    const model = urlModel || parsed.model || null;
+    if (String(model).replace(/^models\//, "") === "gemini-3.6-flash-tiered") {
+      const rawLevel = parsed.request?.generationConfig?.thinkingConfig?.thinkingLevel
+        || parsed.generationConfig?.thinkingConfig?.thinkingLevel;
+      const level = ["high", "medium", "low"].includes(String(rawLevel).toLowerCase())
+        ? String(rawLevel).toLowerCase()
+        : "medium";
+      return `gemini-3.6-flash-${level}`;
+    }
+    return model;
+  } catch { return urlModel; }
 }
 
 // Detect binary data vs JSON text

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -8,8 +8,11 @@ export const MITM_TOOLS = {
     description: "Google Antigravity IDE with MITM",
     configType: "mitm",
     mitmDomain: "daily-cloudcode-pa.googleapis.com",
-    modelAliases: ["gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
+    modelAliases: ["gemini-3.6-flash-high", "gemini-3.6-flash-medium", "gemini-3.6-flash-low", "gemini-3.5-flash-low", "gemini-3-flash-agent", "gemini-3.5-flash-extra-low", "gemini-3.1-pro-low", "gemini-pro-agent", "claude-sonnet-4-6", "claude-opus-4-6-thinking", "gpt-oss-120b-medium", "gemini-3-flash"],
     defaultModels: [
+      { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)", alias: "gemini-3.6-flash-high" },
+      { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)", alias: "gemini-3.6-flash-medium" },
+      { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)", alias: "gemini-3.6-flash-low" },
       { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium) / Default", alias: "gemini-3.5-flash-low" },
       { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)", alias: "gemini-3-flash-agent" },
       { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)", alias: "gemini-3.5-flash-extra-low" },

--- a/tests/unit/antigravity-model-tiers.test.js
+++ b/tests/unit/antigravity-model-tiers.test.js
@@ -1,0 +1,59 @@
+// Antigravity Gemini 3.6 picker variants share ONE wire model and pin their effort
+// tier. Regression guard for the "404 Requested entity was not found" class: Google
+// rejects any model string that is not a real wire id, so a tier id that reaches the
+// wire (because the registry never mapped it, or because a "(level)" suffix survived)
+// fails with an opaque upstream 404 instead of a routing error.
+import { describe, it, expect } from "vitest";
+import { PROVIDER_MODELS, getModelUpstreamId, isValidModel } from "open-sse/config/providerModels.js";
+import { PROVIDER_MODELS as REGISTRY_MODELS } from "open-sse/providers/index.js";
+import { stripThinkingSuffix, parseSuffix } from "open-sse/translator/concerns/thinkingUnified.js";
+import { MITM_TOOLS } from "@/shared/constants/cliTools.js";
+
+const GEMINI_36_WIRE_ID = "gemini-3.6-flash-tiered";
+const TIERS = [["gemini-3.6-flash-high", "high"], ["gemini-3.6-flash-medium", "medium"], ["gemini-3.6-flash-low", "low"]];
+
+describe("antigravity gemini-3.6 tiers", () => {
+  it.each(TIERS)("%s resolves to the tiered wire model with its pinned level", (id, level) => {
+    const upstream = getModelUpstreamId("ag", id);
+    expect(stripThinkingSuffix(upstream)).toBe(GEMINI_36_WIRE_ID);
+    expect(parseSuffix(upstream).override).toEqual({ mode: "level", level });
+  });
+
+  it("lets an explicit client suffix override the pinned tier", () => {
+    const upstream = getModelUpstreamId("ag", "gemini-3.6-flash-low(high)");
+    expect(stripThinkingSuffix(upstream)).toBe(GEMINI_36_WIRE_ID);
+    expect(parseSuffix(upstream).override).toEqual({ mode: "level", level: "high" });
+  });
+
+  // The models must come from providers/registry/antigravity.js, not be patched onto
+  // PROVIDER_MODELS afterwards: consumers that read the registry directly (CLI package,
+  // providers/index.js importers) would otherwise miss them and pass the tier id upstream.
+  it.each(TIERS)("%s is declared in the provider registry", (id) => {
+    expect(REGISTRY_MODELS.ag.map(m => m.id)).toContain(id);
+  });
+});
+
+describe("model table integrity", () => {
+  // getModelUpstreamId may append a "(level)" thinking suffix, which callers strip via
+  // stripThinkingSuffix. A registry id that already carries parens would survive that
+  // strip only by luck — and reach the provider verbatim.
+  it("no upstreamModelId carries a thinking suffix", () => {
+    const offenders = Object.entries(PROVIDER_MODELS).flatMap(([alias, models]) =>
+      (models || [])
+        .filter(m => /[()]/.test(m?.upstreamModelId || ""))
+        .map(m => `${alias}/${m.id} → ${m.upstreamModelId}`)
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  // Advertising a model the router can't map is what turns a config gap into an
+  // upstream 404: unknown ids are passed through to the provider verbatim.
+  it("every model the Antigravity MITM tool advertises is routable", () => {
+    const advertised = new Set([
+      ...MITM_TOOLS.antigravity.modelAliases,
+      ...MITM_TOOLS.antigravity.defaultModels.map(m => m.id),
+    ]);
+    const unroutable = [...advertised].filter(id => !isValidModel("ag", id));
+    expect(unroutable).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add Gemini 3.6 Flash High, Medium, and Low models to Antigravity.
- Expose all three models through `/v1/models`, the CLI, and the MITM mapping UI.
- Route every variant through `gemini-3.6-flash-tiered` while preserving its distinct thinking level.
- Keep existing Gemini 3.5 models and fallback behavior unchanged.

## Implementation

- Register the following public model IDs:
  - `gemini-3.6-flash-high`
  - `gemini-3.6-flash-medium`
  - `gemini-3.6-flash-low`
- Reuse the existing thinking-suffix normalization to emit `high`, `medium`, or `low` in Antigravity's `thinkingConfig`.
- Preserve the resolved upstream model when the Antigravity executor builds the final request.
- Detect the selected thinking level in native Antigravity MITM requests so each model remains independently mappable.
- Default tiered requests without a valid thinking level to Medium.

## Validation

- Verified all three public models resolve to `gemini-3.6-flash-tiered`.
- Verified High, Medium, and Low produce distinct `thinkingLevel` values.
- Passed 136 focused translator and Antigravity tests.
- Successfully built the Next.js application, CLI package, and bundled MITM server.