### PR TITLE
fix(cursor): implement real PKCE OAuth login

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -288,10 +288,6 @@ export class CursorExecutor extends BaseExecutor {
     const machineId = credentials.providerSpecificData?.machineId;
     const ghostMode = credentials.providerSpecificData?.ghostMode !== false;
 
-    if (!machineId) {
-      throw new Error("Machine ID is required for Cursor API");
-    }
-
     return buildCursorHeaders(accessToken, machineId, ghostMode);
   }
 

--- a/open-sse/providers/registry/cursor.js
+++ b/open-sse/providers/registry/cursor.js
@@ -50,6 +50,10 @@ export default {
     agentNonPrivacyEndpoint: "https://agentn.api5.cursor.sh",
     clientVersion: "3.12.17",
     clientType: "ide",
+    loginUrl: "https://cursor.com/loginDeepControl",
+    pollUrl: "https://api2.cursor.sh/auth/poll",
+    refreshUrl: "https://api2.cursor.sh/auth/exchange_user_api_key",
+    refreshLeadMs: 5 * 60 * 1000,
     dbKeys: {
       accessToken: "cursorAuth/accessToken",
       machineId: "storage.serviceMachineId",

--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -9,6 +9,7 @@ import {
   refreshQwenToken,
   refreshCodexToken,
   refreshKiroToken,
+  refreshCursorToken,
   refreshIflowToken,
   refreshGitHubToken,
   refreshCopilotToken,
@@ -25,6 +26,7 @@ export {
   refreshQwenToken,
   refreshCodexToken,
   refreshKiroToken,
+  refreshCursorToken,
   refreshIflowToken,
   refreshGitHubToken,
   refreshCopilotToken,
@@ -133,6 +135,7 @@ const REFRESH_HANDLERS = {
   iflow: (c, log) => refreshIflowToken(c.refreshToken, log),
   github: (c, log) => refreshGitHubToken(c.refreshToken, log),
   kiro: (c, log) => refreshKiroToken(c.refreshToken, c.providerSpecificData, log),
+  cursor: (c, log) => refreshCursorToken(c.refreshToken, log),
   xai: (c, log) => refreshXaiToken(c.refreshToken, log),
   // Grok CLI shares xAI OAuth client + token endpoint (device-code tokens refresh the same way)
   "grok-cli": (c, log) => refreshXaiToken(c.refreshToken, log),

--- a/open-sse/services/tokenRefresh/providers.js
+++ b/open-sse/services/tokenRefresh/providers.js
@@ -3,8 +3,27 @@ import { OAUTH_ENDPOINTS, GITHUB_COPILOT, buildKimiHeaders } from "../../config/
 import { proxyAwareFetch } from "../../utils/proxyFetch.js";
 import { dedupRefresh } from "./dedup.js";
 import { buildExternalIdpRefreshParams } from "../../../src/lib/oauth/kiroExternalIdp.js";
+import { CursorService } from "../../../src/lib/oauth/services/cursor.js";
 
-let _xaiServiceSingleton = null;
+export async function refreshCursorToken(refreshToken, log) {
+  if (!refreshToken) return null;
+  return dedupRefresh("cursor", refreshToken, async () => {
+    try {
+      const tokens = await new CursorService().refreshToken(refreshToken);
+      log?.info?.("TOKEN_REFRESH", "Successfully refreshed Cursor token", {
+        hasNewAccessToken: !!tokens.accessToken,
+        hasNewRefreshToken: !!tokens.refreshToken,
+        expiresIn: tokens.expiresIn,
+      });
+      return tokens;
+    } catch (error) {
+      log?.warn?.("TOKEN_REFRESH", `Cursor refresh failed: ${error?.message || error}`);
+      return null;
+    }
+  }, log);
+}
+
+
 export async function refreshXaiToken(refreshToken, log) {
   if (!refreshToken) return null;
   return dedupRefresh("xai", refreshToken, async () => {

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { getProviderIconSrc, markProviderIconMissing } from "@/shared/utils/providerIcon";
-import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal } from "@/shared/components";
+import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal } from "@/shared/components";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS } from "@/shared/constants/providers";
 import { getModelsByProviderId, getModelKind } from "@/shared/constants/models";
 import { getThinkingLevels } from "open-sse/providers/thinkingLevels.js";
@@ -1689,12 +1689,6 @@ export default function ProviderDetailPage() {
         <KiroOAuthWrapper
           isOpen={showOAuthModal}
           providerInfo={providerInfo}
-          onSuccess={handleOAuthSuccess}
-          onClose={() => setShowOAuthModal(false)}
-        />
-      ) : providerId === "cursor" ? (
-        <CursorAuthModal
-          isOpen={showOAuthModal}
           onSuccess={handleOAuthSuccess}
           onClose={() => setShowOAuthModal(false)}
         />

--- a/src/app/api/oauth/[provider]/[action]/route.js
+++ b/src/app/api/oauth/[provider]/[action]/route.js
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { NextResponse } from "next/server";
 import { 
   getProvider, 
@@ -7,6 +8,7 @@ import {
   pollForToken 
 } from "@/lib/oauth/providers";
 import { createProviderConnection } from "@/models";
+import { CursorService } from "@/lib/oauth/services/cursor";
 import {
   startCodexProxy,
   stopCodexProxy,
@@ -20,6 +22,18 @@ import {
   clearXaiSession,
 } from "@/lib/oauth/utils/server";
 
+const cursorSessions = new Map();
+const CURSOR_SESSION_LIMIT = 100;
+
+function cleanupCursorSessions() {
+  const cutoff = Date.now() - 5 * 60 * 1000;
+  for (const [state, session] of cursorSessions) {
+    if (session.createdAt < cutoff) cursorSessions.delete(state);
+  }
+  while (cursorSessions.size >= CURSOR_SESSION_LIMIT) {
+    cursorSessions.delete(cursorSessions.keys().next().value);
+  }
+}
 async function completeXaiManualCode(code, state) {
   const session = state ? getXaiSessionStatus(state) : null;
   if (!session) {
@@ -70,6 +84,19 @@ export async function GET(request, { params }) {
   try {
     const { provider, action } = await params;
     const { searchParams } = new URL(request.url);
+
+    if (action === "authorize" && provider === "cursor") {
+      cleanupCursorSessions();
+      const authData = new CursorService().getAuthorizationData(searchParams.get("mode") || "login");
+      const state = crypto.randomUUID();
+      cursorSessions.set(state, { ...authData, createdAt: Date.now() });
+      return NextResponse.json({
+        authUrl: authData.authUrl,
+        state,
+        flowType: "authorization_code_pkce",
+        expiresIn: authData.expiresIn,
+      });
+    }
 
     if (action === "authorize") {
       const redirectUri = searchParams.get("redirect_uri") || "http://localhost:8080/callback";
@@ -194,6 +221,37 @@ export async function POST(request, { params }) {
       body = await request.json();
     } catch {
       return NextResponse.json({ error: "Invalid or empty request body" }, { status: 400 });
+    }
+
+    if (action === "poll" && provider === "cursor") {
+      cleanupCursorSessions();
+      const session = cursorSessions.get(body.state);
+      if (!session) {
+        return NextResponse.json({ success: false, error: "cursor_session_expired" }, { status: 400 });
+      }
+      const cursorService = new CursorService();
+      const result = await cursorService.pollToken(session.uuid, session.verifier);
+      if (!result.success) return NextResponse.json(result);
+      const tokenData = cursorService.mapTokens(
+        result.tokens.accessToken,
+        result.tokens.refreshToken,
+      );
+      const connection = await createProviderConnection({
+        provider: "cursor",
+        authType: "oauth",
+        ...tokenData,
+        testStatus: "active",
+      });
+      cursorSessions.delete(body.state);
+      return NextResponse.json({
+        success: true,
+        connection: {
+          id: connection.id,
+          provider: connection.provider,
+          email: connection.email,
+          displayName: connection.displayName,
+        },
+      });
     }
 
     if (action === "exchange") {

--- a/src/app/api/oauth/cursor/import/route.js
+++ b/src/app/api/oauth/cursor/import/route.js
@@ -45,7 +45,7 @@ export async function POST(request) {
       authType: "oauth",
       accessToken: tokenData.accessToken,
       refreshToken: null, // Cursor doesn't have public refresh endpoint
-      expiresAt: new Date(Date.now() + tokenData.expiresIn * 1000).toISOString(),
+      expiresAt: tokenData.expiresAt,
       email: userInfo?.email || null,
       providerSpecificData: {
         machineId: tokenData.machineId,

--- a/src/lib/oauth/providers.js
+++ b/src/lib/oauth/providers.js
@@ -1067,18 +1067,9 @@ const PROVIDERS = {
 
   cursor: {
     config: CURSOR_CONFIG,
-    flowType: "import_token",
-    // Cursor uses import token flow - tokens are extracted from local SQLite database
-    // No OAuth flow needed, handled by /api/oauth/cursor/import route
-    mapTokens: (tokens) => ({
-      accessToken: tokens.accessToken,
-      refreshToken: null, // Cursor doesn't have public refresh endpoint
-      expiresIn: tokens.expiresIn || 86400,
-      providerSpecificData: {
-        machineId: tokens.machineId,
-        authMethod: "imported",
-      },
-    }),
+    flowType: "authorization_code_pkce",
+    buildAuthUrl: () => null,
+    mapTokens: (tokens) => tokens,
   },
 
   // Kimi Code device flow (CLIProxyAPI internal/auth/kimi). Id is `kimi`;

--- a/src/lib/oauth/services/cursor.js
+++ b/src/lib/oauth/services/cursor.js
@@ -1,178 +1,184 @@
+import crypto from "crypto";
 import { CURSOR_CONFIG } from "../constants/oauth.js";
 
-/**
- * Cursor IDE OAuth Service
- * Supports Import Token method from Cursor IDE's local SQLite database
- *
- * Token Location:
- * - Linux: ~/.config/Cursor/User/globalStorage/state.vscdb
- * - macOS: /Users/<user>/Library/Application Support/Cursor/User/globalStorage/state.vscdb
- * - Windows: %APPDATA%\Cursor\User\globalStorage\state.vscdb
- *
- * Database Keys:
- * - cursorAuth/accessToken: The access token
- * - storage.serviceMachineId: Machine ID for checksum
- */
+const REFRESH_TIMEOUT_MS = 15000;
+const REFRESH_ATTEMPTS = 3;
+const REFRESH_RETRY_BASE_MS = 300;
+const EXPIRY_SKEW_MS = 5 * 60 * 1000;
+const FALLBACK_TTL_MS = 60 * 60 * 1000;
+const CURSOR_USER_AGENT = "Cursor/3.12.29";
+
+function decodeJwtPayload(token) {
+  const parts = typeof token === "string" ? token.split(".") : [];
+  if (parts.length !== 3 || !parts[1]) return null;
+  try {
+    return JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function tokenExpiresAt(token) {
+  const payload = decodeJwtPayload(token);
+  if (typeof payload?.exp === "number") {
+    return payload.exp * 1000 - EXPIRY_SKEW_MS;
+  }
+  return Date.now() + FALLBACK_TTL_MS;
+}
+
+function retryDelay(attempt) {
+  const exponential = REFRESH_RETRY_BASE_MS * 2 ** attempt;
+  return Math.floor(exponential * (0.8 + Math.random() * 0.4));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export class CursorService {
   constructor() {
     this.config = CURSOR_CONFIG;
   }
 
-  /**
-   * Generate Cursor checksum (jyh cipher)
-   * Algorithm: XOR timestamp bytes with rolling key (initial 165), then base64 encode
-   * Format: {encoded_timestamp},{machineId}
-   */
-  generateChecksum(machineId) {
-    const timestamp = Math.floor(Date.now() / 1000).toString();
-    let key = 165;
-    const encoded = [];
-
-    for (let i = 0; i < timestamp.length; i++) {
-      const charCode = timestamp.charCodeAt(i);
-      encoded.push(charCode ^ key);
-      key = (key + charCode) & 0xff; // Rolling key update
-    }
-
-    const base64Encoded = Buffer.from(encoded).toString("base64");
-    return `${base64Encoded},${machineId}`;
-  }
-
-  /**
-   * Build request headers for Cursor API
-   */
-  buildHeaders(accessToken, machineId, ghostMode = false) {
-    const checksum = this.generateChecksum(machineId);
-
+  getAuthorizationData(mode = "login") {
+    const verifier = crypto.randomBytes(32).toString("base64url");
+    const challenge = crypto.createHash("sha256").update(verifier).digest("base64url");
+    const uuid = crypto.randomUUID();
+    const query = new URLSearchParams({
+      challenge,
+      uuid,
+      mode,
+      supportsSelectedTeamLogin: "true",
+    });
     return {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/connect+proto",
-      "Connect-Protocol-Version": "1",
-      "x-cursor-client-version": this.config.clientVersion,
-      "x-cursor-client-type": this.config.clientType,
-      "x-cursor-client-os": this.detectOS(),
-      "x-cursor-client-arch": this.detectArch(),
-      "x-cursor-client-device-type": "desktop",
-      "x-cursor-checksum": checksum,
-      "x-ghost-mode": ghostMode ? "true" : "false",
+      authUrl: `${this.config.loginUrl}?${query.toString()}`,
+      uuid,
+      verifier,
+      expiresIn: 300,
     };
   }
 
-  /**
-   * Detect OS for headers
-   */
-  detectOS() {
-    if (typeof process !== "undefined") {
-      const platform = process.platform;
-      if (platform === "win32") return "windows";
-      if (platform === "darwin") return "macos";
-      return "linux";
+  async pollToken(uuid, verifier, signal) {
+    if (!uuid || !verifier) throw new Error("Cursor OAuth session is incomplete");
+    const query = new URLSearchParams({ uuid, verifier });
+    const response = await fetch(`${this.config.pollUrl}?${query.toString()}`, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": CURSOR_USER_AGENT,
+        "x-cursor-client-type": this.config.clientType,
+        "x-ghost-mode": "implicit-false",
+        "x-new-onboarding-completed": "false",
+        traceparent: `00-${crypto.randomBytes(16).toString("hex")}-${crypto.randomBytes(8).toString("hex")}-01`,
+      },
+      signal,
+    });
+    if (response.status === 404) {
+      return { success: false, pending: true, error: "authorization_pending" };
     }
-    return "linux";
+    if (!response.ok) {
+      throw new Error(`Cursor OAuth polling failed with HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    if (!data.accessToken || !data.refreshToken) {
+      throw new Error("Cursor OAuth response was missing tokens");
+    }
+    return { success: true, tokens: data };
   }
 
-  /**
-   * Detect architecture for headers
-   */
-  detectArch() {
-    if (typeof process !== "undefined") {
-      const arch = process.arch;
-      if (arch === "x64") return "x86_64";
-      if (arch === "arm64") return "aarch64";
-      return arch;
+  async refreshToken(refreshToken) {
+    if (!refreshToken || typeof refreshToken !== "string") {
+      throw new Error("Cursor refresh token is required");
     }
-    return "x86_64";
+    let lastError;
+    for (let attempt = 0; attempt < REFRESH_ATTEMPTS; attempt += 1) {
+      try {
+        const response = await fetch(this.config.refreshUrl, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${refreshToken}`,
+            "Content-Type": "application/json",
+          },
+          body: "{}",
+          signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+        });
+        if (response.ok) {
+          const data = await response.json();
+          if (!data.accessToken) {
+            throw new Error("Cursor refresh response was missing an access token");
+          }
+          return this.mapTokens(data.accessToken, data.refreshToken || refreshToken);
+        }
+        if (response.status !== 429 && response.status < 500) {
+          const error = new Error(`Cursor token refresh failed with HTTP ${response.status}`);
+          error.retryable = false;
+          throw error;
+        }
+        lastError = new Error(`Cursor token refresh failed with HTTP ${response.status}`);
+      } catch (error) {
+        if (error.retryable === false) throw error;
+        lastError = error;
+      }
+      if (attempt < REFRESH_ATTEMPTS - 1) await sleep(retryDelay(attempt));
+    }
+    throw lastError || new Error("Cursor token refresh failed");
   }
 
-  /**
-   * Validate and import token from Cursor IDE
-   * Note: We skip API validation because Cursor API uses complex protobuf format.
-   * Token will be validated when actually used for requests.
-   * @param {string} accessToken - Access token from state.vscdb
-   * @param {string} machineId - Machine ID from state.vscdb
-   */
+  mapTokens(accessToken, refreshToken, machineId = null, authMethod = "oauth") {
+    const expiresAt = tokenExpiresAt(accessToken);
+    const userInfo = this.extractUserInfo(accessToken);
+    return {
+      accessToken,
+      refreshToken,
+      ...(machineId ? { machineId } : {}),
+      expiresAt: new Date(expiresAt).toISOString(),
+      expiresIn: Math.max(1, Math.floor((expiresAt - Date.now()) / 1000)),
+      email: userInfo?.email || null,
+      providerSpecificData: {
+        authMethod,
+        ...(machineId ? { machineId } : {}),
+        ...(userInfo?.userId ? { userId: userInfo.userId } : {}),
+      },
+    };
+  }
+
   async validateImportToken(accessToken, machineId) {
-    // Basic validation
     if (!accessToken || typeof accessToken !== "string") {
       throw new Error("Access token is required");
     }
-
     if (!machineId || typeof machineId !== "string") {
       throw new Error("Machine ID is required");
     }
-
-    // Token format validation (Cursor tokens are typically long strings)
     if (accessToken.length < 50) {
       throw new Error("Invalid token format. Token appears too short.");
     }
-
-    // Machine ID format validation (should be UUID-like)
     const uuidRegex = /^[a-f0-9-]{32,}$/i;
     if (!uuidRegex.test(machineId.replace(/-/g, ""))) {
       throw new Error("Invalid machine ID format. Expected UUID format.");
     }
+    return this.mapTokens(accessToken, null, machineId, "imported");
+  }
 
-    // Note: We don't validate against API because Cursor uses complex protobuf.
-    // Token will be validated when used for actual requests.
-
+  extractUserInfo(accessToken) {
+    const payload = decodeJwtPayload(accessToken);
+    if (!payload) return null;
+    const email = typeof payload.email === "string" && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email)
+      ? payload.email
+      : null;
     return {
-      accessToken,
-      machineId,
-      expiresIn: 86400, // Cursor tokens typically last 24 hours
-      authMethod: "imported",
+      email,
+      userId: payload.sub || payload.user_id || null,
     };
   }
 
-  /**
-   * Extract user info from token if possible
-   * Cursor tokens may contain encoded user info
-   */
-  extractUserInfo(accessToken) {
-    try {
-      // Try to decode as JWT
-      const parts = accessToken.split(".");
-      if (parts.length === 3) {
-        let payload = parts[1];
-        while (payload.length % 4) {
-          payload += "=";
-        }
-        const decoded = JSON.parse(
-          Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString()
-        );
-        return {
-          email: decoded.email || decoded.sub,
-          userId: decoded.sub || decoded.user_id,
-        };
-      }
-    } catch {
-      // Token is not a JWT, that's okay
-    }
-
-    return null;
-  }
-
-  /**
-   * Get token storage path instructions for user
-   */
   getTokenStorageInstructions() {
     return {
-      title: "How to get your Cursor token",
+      title: "How to import your existing Cursor session",
       steps: [
-        "1. Open Cursor IDE and make sure you're logged in",
-        "2. Find the state.vscdb file:",
-        `   - Linux: ${this.config.tokenStoragePaths.linux}`,
-        `   - macOS: ${this.config.tokenStoragePaths.macos}`,
-        `   - Windows: ${this.config.tokenStoragePaths.windows}`,
-        "3. Open the database with SQLite browser or CLI:",
-        "   sqlite3 state.vscdb \"SELECT value FROM itemTable WHERE key='cursorAuth/accessToken'\"",
-        "4. Also get the machine ID:",
-        "   sqlite3 state.vscdb \"SELECT value FROM itemTable WHERE key='storage.serviceMachineId'\"",
-        "5. Paste both values in the form below",
-      ],
-      alternativeMethod: [
-        "Or use this one-liner to get both values:",
-        "sqlite3 state.vscdb \"SELECT key, value FROM itemTable WHERE key IN ('cursorAuth/accessToken', 'storage.serviceMachineId')\"",
+        "Open Cursor IDE and make sure you're logged in",
+        `Linux: ${this.config.tokenStoragePaths.linux}`,
+        `macOS: ${this.config.tokenStoragePaths.macos}`,
+        `Windows: ${this.config.tokenStoragePaths.windows}`,
+        "Read cursorAuth/accessToken and storage.serviceMachineId from itemTable",
       ],
     };
   }

--- a/src/shared/components/OAuthModal.js
+++ b/src/shared/components/OAuthModal.js
@@ -117,7 +117,12 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
         const res = await fetch(`/api/oauth/${provider}/poll`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ deviceCode, codeVerifier, extraData }),
+          body: JSON.stringify({
+            deviceCode,
+            codeVerifier,
+            extraData,
+            ...(provider === "cursor" ? { state: deviceCode } : {}),
+          }),
         });
 
         const data = await res.json();
@@ -156,7 +161,20 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
     try {
       setError(null);
 
-      // Device code flow providers (must match oauth providers with flowType: "device_code")
+      if (provider === "cursor") {
+        setIsDeviceCode(true);
+        setStep("waiting");
+        const res = await fetch(`/api/oauth/cursor/authorize?redirect_uri=${encodeURIComponent(window.location.origin + "/callback")}`);
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error);
+        setAuthData(data);
+        setDeviceData({ verification_uri: data.authUrl, user_code: "" });
+        if (data.authUrl) window.open(data.authUrl, "_blank", "noopener,noreferrer");
+        startPolling(data.state, null, 2, null, (data.expiresIn || 300) * 1000);
+        return;
+      }
+
+      // Device code flow providers
       const deviceCodeProviders = [
         "github",
         "qwen",
@@ -650,18 +668,20 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
                   </Button>
                 </div>
               </div>
-              <div className="bg-primary/10 p-4 rounded-lg">
-                <p className="text-xs text-text-muted mb-1">Your Code</p>
-                <div className="flex items-center justify-center gap-2">
-                  <p className="text-2xl font-mono font-bold text-primary">{deviceData.user_code}</p>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    icon={copied === "user_code" ? "check" : "content_copy"}
-                    onClick={() => copy(deviceData.user_code, "user_code")}
-                  />
+              {deviceData.user_code && (
+                <div className="bg-primary/10 p-4 rounded-lg">
+                  <p className="text-xs text-text-muted mb-1">Your Code</p>
+                  <div className="flex items-center justify-center gap-2">
+                    <p className="text-2xl font-mono font-bold text-primary">{deviceData.user_code}</p>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      icon={copied === "user_code" ? "check" : "content_copy"}
+                      onClick={() => copy(deviceData.user_code, "user_code")}
+                    />
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
             {polling && (
               <div className="flex items-center justify-center gap-2 text-sm text-text-muted">

--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -21,6 +21,7 @@ import {
   formatProviderCredentials as _formatProviderCredentials,
   getAllAccessTokens as _getAllAccessTokens,
   refreshKiroToken as _refreshKiroToken,
+  refreshCursorToken as _refreshCursorToken,
   getRefreshLeadMs as _getRefreshLeadMs
 } from "open-sse/services/tokenRefresh.js";
 import {
@@ -58,6 +59,9 @@ export const refreshCopilotToken = (githubAccessToken) =>
 
 export const refreshKiroToken = (refreshToken, providerSpecificData) =>
   _refreshKiroToken(refreshToken, providerSpecificData, log);
+
+export const refreshCursorToken = (refreshToken) =>
+  _refreshCursorToken(refreshToken, log);
 
 export const getAccessToken = (provider, credentials) =>
   _getAccessToken(provider, credentials, log);

--- a/tests/unit/cursor-oauth.test.js
+++ b/tests/unit/cursor-oauth.test.js
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import crypto from "crypto";
+import { CursorService } from "../../src/lib/oauth/services/cursor.js";
+
+function jwt(payload) {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".");
+}
+
+describe("Cursor OAuth service", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("generates the Cursor PKCE login URL without exposing the verifier", () => {
+    const service = new CursorService();
+    const auth = service.getAuthorizationData();
+    const url = new URL(auth.authUrl);
+    const expectedChallenge = crypto.createHash("sha256").update(auth.verifier).digest("base64url");
+
+    expect(url.origin + url.pathname).toBe("https://cursor.com/loginDeepControl");
+    expect(url.searchParams.get("uuid")).toBe(auth.uuid);
+    expect(url.searchParams.get("challenge")).toBe(expectedChallenge);
+    expect(url.searchParams.get("mode")).toBe("login");
+    expect(url.searchParams.has("verifier")).toBe(false);
+  });
+
+  it("treats a 404 poll response as authorization pending", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("Not found", { status: 404 })));
+    const result = await new CursorService().pollToken("flow-id", "verifier");
+
+    expect(result).toEqual({ success: false, pending: true, error: "authorization_pending" });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api2.cursor.sh/auth/poll?uuid=flow-id&verifier=verifier",
+      expect.objectContaining({ headers: expect.objectContaining({ "x-cursor-client-type": "ide" }) }),
+    );
+  });
+
+  it("maps successful polling tokens to renewable credentials", async () => {
+    const accessToken = jwt({ sub: "auth0|user_123", email: "user@example.com", exp: Math.floor(Date.now() / 1000) + 3600 });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({ accessToken, refreshToken: "refresh-token" })));
+    const service = new CursorService();
+    const result = await service.pollToken("flow-id", "verifier");
+    const credentials = service.mapTokens(result.tokens.accessToken, result.tokens.refreshToken);
+
+    expect(credentials).toMatchObject({
+      accessToken,
+      refreshToken: "refresh-token",
+      email: "user@example.com",
+      providerSpecificData: { authMethod: "oauth", userId: "auth0|user_123" },
+    });
+    expect(credentials.expiresIn).toBeGreaterThan(3000);
+    expect(credentials.providerSpecificData).not.toHaveProperty("machineId");
+  });
+
+  it("refreshes with Cursor's exchange endpoint and preserves an omitted refresh token", async () => {
+    const accessToken = jwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({ accessToken })));
+    const credentials = await new CursorService().refreshToken("old-refresh-token");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api2.cursor.sh/auth/exchange_user_api_key",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer old-refresh-token" }),
+        body: "{}",
+      }),
+    );
+    expect(credentials.refreshToken).toBe("old-refresh-token");
+    expect(credentials.accessToken).toBe(accessToken);
+  });
+});


### PR DESCRIPTION
## Summary

- replace Cursor's token copy/paste-only integration with the real browser PKCE flow
- keep the PKCE verifier server-side and poll `api2.cursor.sh/auth/poll` after browser approval
- persist both access and refresh tokens and refresh access tokens through Cursor's exchange endpoint
- preserve the existing Cursor IDE database import as a compatibility path
- remove the Cursor-specific UI branch so Cursor uses the same OAuth modal as other real OAuth providers

## Implementation details

The login flow follows Cursor's current client flow:

1. Generate a random verifier, S256 challenge, and UUID.
2. Open `https://cursor.com/loginDeepControl` with the challenge and UUID.
3. Poll `https://api2.cursor.sh/auth/poll?uuid=...&verifier=...` until Cursor returns the token pair.
4. Persist the returned access/refresh credentials and JWT-derived identity.
5. Refresh with `POST https://api2.cursor.sh/auth/exchange_user_api_key` using the refresh token as the bearer credential.

The verifier never goes to the browser or client response; it remains in a bounded, expiring server-side session map.

## Validation

- `node --check` on all changed JavaScript files
- targeted Vitest tests: Cursor OAuth and token-refresh dispatch (7 passing)
- ESLint on changed backend/service/test files (0 errors; existing registry warning only)
- `npm run build` passes

## Notes

The existing `/api/oauth/cursor/import` endpoint remains available for users who intentionally want to import an existing Cursor IDE session. It now retains the refresh token when a session token is supplied through the real OAuth flow.
