### PR TITLE
fix(github): enforce Claude prompt limits

### DIFF
--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -11,6 +11,8 @@ import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
 import { SSE_DONE } from "../utils/sseConstants.js";
 import { ANTHROPIC_API_VERSION } from "../providers/shared.js";
+import { getCapabilitiesForModel } from "../providers/capabilities.js";
+import { estimateInputTokens } from "../utils/usageTracking.js";
 import crypto from "crypto";
 
 export class GithubExecutor extends BaseExecutor {
@@ -264,6 +266,50 @@ export class GithubExecutor extends BaseExecutor {
     // schema rejects the extra field with a 400.
     const toolNameMap = transformedBody._toolNameMap;
     delete transformedBody._toolNameMap;
+
+    const maxPrompt = getCapabilitiesForModel("github", model).maxPrompt;
+    const preflightThreshold = maxPrompt * (this.config.countTokensPreflightRatio || 0);
+    if (Number.isFinite(maxPrompt)
+      && maxPrompt > 0
+      && estimateInputTokens(transformedBody) >= preflightThreshold) {
+      try {
+        const timeoutSignal = AbortSignal.timeout(this.config.countTokensTimeoutMs);
+        const countSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+        const countResponse = await proxyAwareFetch(this.config.countTokensUrl, {
+          method: "POST",
+          headers: this.buildHeaders(credentials, false),
+          body: JSON.stringify(transformedBody),
+          signal: countSignal,
+        }, proxyOptions);
+        if (countResponse.ok) {
+          const inputTokens = Number((await countResponse.json())?.input_tokens);
+          if (Number.isFinite(inputTokens) && inputTokens > maxPrompt) {
+            const errorBody = {
+              error: {
+                message: `Prompt is ${inputTokens} tokens; maximum for ${model} is ${maxPrompt}.`,
+                type: "invalid_request_error",
+                param: "messages",
+                code: "context_length_exceeded",
+              },
+            };
+            return {
+              response: new Response(JSON.stringify(errorBody), {
+                status: HTTP_STATUS.BAD_REQUEST,
+                headers: { "Content-Type": "application/json" },
+              }),
+              url: this.config.countTokensUrl,
+              headers,
+              transformedBody,
+            };
+          }
+        } else {
+          log?.warn?.("GITHUB", `Prompt token preflight returned ${countResponse.status}; continuing`);
+        }
+      } catch (error) {
+        if (signal?.aborted) throw error;
+        log?.warn?.("GITHUB", `Prompt token preflight failed: ${error?.message || error}; continuing`);
+      }
+    }
 
     log?.debug("GITHUB", "Sending translated request to /v1/messages");
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -367,7 +367,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // Provider returned error
   if (!providerResponse.ok) {
     trackPendingRequest(model, provider, connectionId, false, true);
-    const { statusCode, message, resetsAtMs } = await parseUpstreamError(providerResponse, executor);
+    const { statusCode, message, resetsAtMs, code } = await parseUpstreamError(providerResponse, executor);
     appendRequestLog({ model, provider, connectionId, status: `FAILED ${statusCode}` }).catch(() => { });
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
@@ -386,7 +386,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       log.errorLine(reqTag, "✗", `ERROR ${statusCode} · ${provider}/${model} · ${Date.now() - requestStartTime}ms${urlStr}\n    ${errMsg}`);
     }
     reqLogger.logError(new Error(message), finalBody || translatedBody);
-    return createErrorResult(statusCode, errMsg, resetsAtMs);
+    return createErrorResult(statusCode, errMsg, resetsAtMs, code);
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -125,6 +125,7 @@ export const PROVIDER_CAPABILITIES = {
   "github": {
     "claude-fable-5": GITHUB_CLAUDE_200K_CAPS,
     "claude-opus-4.8": GITHUB_CLAUDE_200K_CAPS,
+    "claude-opus-5": GITHUB_CLAUDE_200K_CAPS,
   },
   // NVIDIA NIM is OpenAI-compatible → rejects MiniMax/GLM native `thinking` field.
   // Force openai reasoning_effort format for its reasoning models. #issue

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -116,11 +116,16 @@ const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true,
 // (lower than OpenAI API's 1.05M). Sol differs from Terra/Luna. #2720
 const CODEX_GPT_56_SOL_CAPS  = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 372000, maxOutput: 128000 };
 const CODEX_GPT_56_DEFAULT_CAPS = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
+const GITHUB_CLAUDE_200K_CAPS = { vision: true, pdf: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 264000, maxPrompt: 200000, maxOutput: 64000 };
 
 /**
  * Provider-specific capability overrides. Keyed by provider alias/id.
  */
 export const PROVIDER_CAPABILITIES = {
+  "github": {
+    "claude-fable-5": GITHUB_CLAUDE_200K_CAPS,
+    "claude-opus-4.8": GITHUB_CLAUDE_200K_CAPS,
+  },
   // NVIDIA NIM is OpenAI-compatible → rejects MiniMax/GLM native `thinking` field.
   // Force openai reasoning_effort format for its reasoning models. #issue
   "nvidia": {

--- a/open-sse/providers/registry/github.js
+++ b/open-sse/providers/registry/github.js
@@ -19,6 +19,9 @@ export default {
     baseUrl: "https://api.githubcopilot.com/chat/completions",
     responsesUrl: "https://api.githubcopilot.com/responses",
     messagesUrl: "https://api.githubcopilot.com/v1/messages",
+    countTokensUrl: "https://api.githubcopilot.com/v1/messages/count_tokens",
+    countTokensPreflightRatio: 0.5,
+    countTokensTimeoutMs: 10000,
     headers: {
       "copilot-integration-id": "vscode-chat",
       "editor-version": "vscode/1.110.0",

--- a/open-sse/providers/registry/github.js
+++ b/open-sse/providers/registry/github.js
@@ -53,8 +53,8 @@ export default {
     // Note: routing to Copilot's Anthropic-native /v1/messages shim (see
     // executors/github.js) is decided by model-NAME pattern at request time, not by
     // a static targetFormat field here — Copilot's live model catalog (see
-    // services/copilotModels.js) regularly exposes claude-* models this static list
-    // hasn't caught up with yet (e.g. claude-opus-4.8), and a static per-entry
+    // services/copilotModels.js) can expose claude-* models before this static list
+    // catches up, and a static per-entry
     // targetFormat would silently miss those while also double-translating requests
     // for models that ARE listed here (chatCore.js would pre-translate to Claude
     // shape, then the executor would translate again). Keep these as plain entries.
@@ -64,6 +64,9 @@ export default {
     { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
     { id: "claude-opus-4.6", name: "Claude Opus 4.6" },
     { id: "claude-opus-4.7", name: "Claude Opus 4.7" },
+    { id: "claude-opus-4.8", name: "Claude Opus 4.8" },
+    { id: "claude-opus-5", name: "Claude Opus 5" },
+    { id: "claude-fable-5", name: "Claude Fable 5" },
     { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
     { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" },

--- a/open-sse/services/copilotModels.js
+++ b/open-sse/services/copilotModels.js
@@ -13,6 +13,7 @@
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { GITHUB_COPILOT } from "../config/appConstants.js";
 import { refreshCopilotToken } from "./tokenRefresh.js";
+import { getCapabilitiesForModel } from "../providers/capabilities.js";
 
 const MODELS_URL = "https://api.githubcopilot.com/models";
 const FETCH_TIMEOUT_MS = 10_000;
@@ -73,7 +74,27 @@ function expandCatalog(raw) {
     const id = m.id;
     if (!id || seen.has(id)) continue;
     seen.add(id);
-    models.push({ id, name: m.name || id });
+    const upstream = m.capabilities || {};
+    const limits = upstream.limits || {};
+    const supports = upstream.supports || {};
+    const capabilities = {
+      ...getCapabilitiesForModel("github", id),
+      ...(Number.isFinite(limits.max_context_window_tokens)
+        ? { contextWindow: limits.max_context_window_tokens }
+        : {}),
+      ...(Number.isFinite(limits.max_prompt_tokens)
+        ? { maxPrompt: limits.max_prompt_tokens }
+        : {}),
+      ...(Number.isFinite(limits.max_output_tokens)
+        ? { maxOutput: limits.max_output_tokens }
+        : {}),
+      ...(typeof supports.vision === "boolean" ? { vision: supports.vision } : {}),
+      ...(typeof supports.tool_calls === "boolean" ? { tools: supports.tool_calls } : {}),
+      ...(supports.adaptive_thinking === true || Array.isArray(supports.reasoning_effort)
+        ? { reasoning: true }
+        : {}),
+    };
+    models.push({ id, name: m.name || id, capabilities });
   }
   return models;
 }

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -4,9 +4,10 @@ import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
  * Build OpenAI-compatible error response body
  * @param {number} statusCode - HTTP status code
  * @param {string} message - Error message
+ * @param {string} [code] - Upstream error code
  * @returns {object} Error response object
  */
-export function buildErrorBody(statusCode, message) {
+export function buildErrorBody(statusCode, message, code) {
   const errorInfo = ERROR_TYPES[statusCode] || 
     (statusCode >= 500 
       ? { type: "server_error", code: "internal_server_error" }
@@ -16,7 +17,7 @@ export function buildErrorBody(statusCode, message) {
     error: {
       message: message || DEFAULT_ERROR_MESSAGES[statusCode] || "An error occurred",
       type: errorInfo.type,
-      code: errorInfo.code
+      code: code ?? errorInfo.code
     }
   };
 }
@@ -25,10 +26,11 @@ export function buildErrorBody(statusCode, message) {
  * Create error Response object (for non-streaming)
  * @param {number} statusCode - HTTP status code
  * @param {string} message - Error message
+ * @param {string} [code] - Upstream error code
  * @returns {Response} HTTP Response object
  */
-export function errorResponse(statusCode, message) {
-  return new Response(JSON.stringify(buildErrorBody(statusCode, message)), {
+export function errorResponse(statusCode, message, code) {
+  return new Response(JSON.stringify(buildErrorBody(statusCode, message, code)), {
     status: statusCode,
     headers: {
       "Content-Type": "application/json",
@@ -53,7 +55,7 @@ export async function writeStreamError(writer, statusCode, message) {
  * Parse upstream provider error response
  * @param {Response} response - Fetch response from provider
  * @param {object} [executor] - Optional executor with parseError() override for provider-specific parsing
- * @returns {Promise<{statusCode: number, message: string, resetsAtMs?: number}>}
+ * @returns {Promise<{statusCode: number, message: string, resetsAtMs?: number, code?: string}>}
  */
 export async function parseUpstreamError(response, executor = null) {
   let bodyText = "";
@@ -63,29 +65,39 @@ export async function parseUpstreamError(response, executor = null) {
     bodyText = "";
   }
 
+  let structuredMessage = "";
+  let structuredCode;
+  try {
+    const json = JSON.parse(bodyText);
+    structuredMessage = json.error?.message || json.message || json.error || bodyText;
+    structuredCode = json.error?.code || json.code;
+  } catch {
+    structuredMessage = bodyText;
+  }
+  const messageStr = typeof structuredMessage === "string"
+    ? structuredMessage
+    : JSON.stringify(structuredMessage);
+  const fallbackMessage = messageStr || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
+
   // Let executor-specific parser extract provider-specific fields (e.g. codex resetsAtMs)
   if (executor && typeof executor.parseError === "function") {
     try {
       const parsed = executor.parseError(response, bodyText);
       if (parsed && typeof parsed === "object") {
-        const msg = parsed.message || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
-        return { statusCode: parsed.status || response.status, message: msg, resetsAtMs: parsed.resetsAtMs };
+        const message = parsed.message && parsed.message !== bodyText
+          ? parsed.message
+          : fallbackMessage;
+        return {
+          statusCode: parsed.status || response.status,
+          message,
+          resetsAtMs: parsed.resetsAtMs,
+          code: parsed.code ?? structuredCode,
+        };
       }
     } catch { /* fall through to default parsing */ }
   }
 
-  let message = "";
-  try {
-    const json = JSON.parse(bodyText);
-    message = json.error?.message || json.message || json.error || bodyText;
-  } catch {
-    message = bodyText;
-  }
-
-  const messageStr = typeof message === "string" ? message : JSON.stringify(message);
-  const finalMessage = messageStr || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
-
-  return { statusCode: response.status, message: finalMessage };
+  return { statusCode: response.status, message: fallbackMessage, code: structuredCode };
 }
 
 /**
@@ -93,15 +105,16 @@ export async function parseUpstreamError(response, executor = null) {
  * @param {number} statusCode - HTTP status code
  * @param {string} message - Error message
  * @param {number} [resetsAtMs] - Optional precise cooldown expiry (ms epoch) for provider-specific quota errors
+ * @param {string} [code] - Upstream error code
  * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number }}
  */
-export function createErrorResult(statusCode, message, resetsAtMs) {
+export function createErrorResult(statusCode, message, resetsAtMs, code) {
   return {
     success: false,
     status: statusCode,
     error: message,
     resetsAtMs,
-    response: errorResponse(statusCode, message)
+    response: errorResponse(statusCode, message, code)
   };
 }
 

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import github from "../../open-sse/providers/registry/github.js";
 
 describe("getCapabilitiesForModel", () => {
   const claudeSonnet5Expected = {
@@ -49,7 +50,7 @@ describe("getCapabilitiesForModel", () => {
   });
 
   it("keeps Copilot Claude prompt and output limits provider-specific", () => {
-    for (const model of ["claude-fable-5", "claude-opus-4.8"]) {
+    for (const model of ["claude-fable-5", "claude-opus-4.8", "claude-opus-5"]) {
       expect(getCapabilitiesForModel("github", model)).toMatchObject({
         contextWindow: 264000,
         maxPrompt: 200000,
@@ -62,6 +63,12 @@ describe("getCapabilitiesForModel", () => {
       contextWindow: 1000000,
       maxOutput: 128000,
     });
+  });
+
+  it("keeps current Copilot Claude models in the static fallback catalog", () => {
+    for (const model of ["claude-fable-5", "claude-opus-4.8", "claude-opus-5"]) {
+      expect(github.models.some(({ id }) => id === model)).toBe(true);
+    }
   });
 
   it("reports Kiro GPT 5.6 models with the Kiro 272k context window", () => {

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -48,6 +48,22 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("kiro", "claude-sonnet-5-thinking-agentic")).toMatchObject(claudeSonnet5Expected);
   });
 
+  it("keeps Copilot Claude prompt and output limits provider-specific", () => {
+    for (const model of ["claude-fable-5", "claude-opus-4.8"]) {
+      expect(getCapabilitiesForModel("github", model)).toMatchObject({
+        contextWindow: 264000,
+        maxPrompt: 200000,
+        maxOutput: 64000,
+        thinkingFormat: "claude-adaptive",
+        reasoning: true,
+      });
+    }
+    expect(getCapabilitiesForModel("kiro", "claude-opus-4.8")).toMatchObject({
+      contextWindow: 1000000,
+      maxOutput: 128000,
+    });
+  });
+
   it("reports Kiro GPT 5.6 models with the Kiro 272k context window", () => {
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-sol")).toMatchObject(kiroGpt56Expected);
     expect(getCapabilitiesForModel("kiro", "openai/gpt-5.6-sol")).toMatchObject(kiroGpt56Expected);

--- a/tests/unit/copilot-model-capabilities.test.js
+++ b/tests/unit/copilot-model-capabilities.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  proxyAwareFetch: vi.fn(),
+  refreshCopilotToken: vi.fn(),
+}));
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: mocks.proxyAwareFetch,
+}));
+vi.mock("../../open-sse/services/tokenRefresh.js", () => ({
+  refreshCopilotToken: mocks.refreshCopilotToken,
+}));
+
+import { clearCopilotModelCache, resolveCopilotModels } from "../../open-sse/services/copilotModels.js";
+
+beforeEach(() => {
+  mocks.proxyAwareFetch.mockReset();
+  mocks.refreshCopilotToken.mockReset();
+  clearCopilotModelCache();
+});
+
+describe("Copilot live model capabilities", () => {
+  it("normalizes upstream limits and supported features", async () => {
+    mocks.proxyAwareFetch.mockResolvedValueOnce(new Response(JSON.stringify({
+      data: [{
+        id: "claude-fable-5",
+        name: "Claude Fable 5",
+        capabilities: {
+          type: "chat",
+          limits: {
+            max_context_window_tokens: 264000,
+            max_prompt_tokens: 200000,
+            max_output_tokens: 64000,
+          },
+          supports: {
+            adaptive_thinking: true,
+            reasoning_effort: ["low", "medium", "high", "xhigh", "max"],
+            tool_calls: true,
+            vision: true,
+          },
+        },
+        policy: { state: "enabled" },
+      }],
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+
+    const result = await resolveCopilotModels({
+      providerSpecificData: { copilotToken: "test-token" },
+    }, { forceRefresh: true });
+
+    expect(result.models).toEqual([{
+      id: "claude-fable-5",
+      name: "Claude Fable 5",
+      capabilities: expect.objectContaining({
+        contextWindow: 264000,
+        maxPrompt: 200000,
+        maxOutput: 64000,
+        reasoning: true,
+        tools: true,
+        vision: true,
+      }),
+    }]);
+  });
+});

--- a/tests/unit/github-responses-routing.test.js
+++ b/tests/unit/github-responses-routing.test.js
@@ -7,6 +7,13 @@
 
 import { describe, it, expect, vi } from "vitest";
 import { GithubExecutor } from "../../open-sse/executors/github.js";
+import { createErrorResult, parseUpstreamError } from "../../open-sse/utils/error.js";
+
+const { proxyFetchMock } = vi.hoisted(() => ({ proxyFetchMock: vi.fn() }));
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: proxyFetchMock,
+}));
 
 describe("GithubExecutor.supportsResponsesEndpoint", () => {
   const exec = new GithubExecutor();
@@ -52,5 +59,115 @@ describe("GithubExecutor.execute cached-route guard (#1062)", () => {
     expect(respSpy).not.toHaveBeenCalled();
     expect(baseSpy).toHaveBeenCalled();
     expect(result.via).toBe("chat");
+  });
+});
+
+describe("GitHub Claude prompt-limit preflight", () => {
+  it("rejects an oversized prompt before creating a message", async () => {
+    proxyFetchMock.mockReset();
+    proxyFetchMock.mockResolvedValueOnce(new Response(
+      JSON.stringify({ input_tokens: 200001 }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ));
+    const exec = new GithubExecutor();
+
+    const result = await exec.executeWithMessagesEndpoint({
+      model: "claude-fable-5",
+      body: { messages: [{ role: "user", content: "x".repeat(400000) }] },
+      stream: true,
+      credentials: { copilotToken: "test-token" },
+      log: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(proxyFetchMock).toHaveBeenCalledTimes(1);
+    expect(proxyFetchMock.mock.calls[0][0]).toBe("https://api.githubcopilot.com/v1/messages/count_tokens");
+    expect(result.response.status).toBe(400);
+    expect(await result.response.json()).toMatchObject({
+      error: { code: "context_length_exceeded" },
+    });
+  });
+
+  it("does not add token-count latency to small prompts", async () => {
+    proxyFetchMock.mockReset();
+    proxyFetchMock.mockResolvedValueOnce(new Response("bad request", { status: 400 }));
+    const exec = new GithubExecutor();
+
+    await exec.executeWithMessagesEndpoint({
+      model: "claude-fable-5",
+      body: { messages: [{ role: "user", content: "hello" }] },
+      stream: true,
+      credentials: { copilotToken: "test-token" },
+      log: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(proxyFetchMock).toHaveBeenCalledTimes(1);
+    expect(proxyFetchMock.mock.calls[0][0]).toBe("https://api.githubcopilot.com/v1/messages");
+  });
+
+  it("allows a prompt exactly at the upstream limit", async () => {
+    proxyFetchMock.mockReset();
+    proxyFetchMock
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ input_tokens: 200000 }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ))
+      .mockResolvedValueOnce(new Response("generated", { status: 200 }));
+    const exec = new GithubExecutor();
+
+    await exec.executeWithMessagesEndpoint({
+      model: "claude-fable-5",
+      body: { messages: [{ role: "user", content: "x".repeat(400000) }] },
+      stream: true,
+      credentials: { copilotToken: "test-token" },
+      log: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(proxyFetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://api.githubcopilot.com/v1/messages/count_tokens",
+      "https://api.githubcopilot.com/v1/messages",
+    ]);
+  });
+
+  it("continues when the token-count endpoint is unavailable", async () => {
+    proxyFetchMock.mockReset();
+    proxyFetchMock
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response("generated", { status: 200 }));
+    const warn = vi.fn();
+    const exec = new GithubExecutor();
+
+    await exec.executeWithMessagesEndpoint({
+      model: "claude-fable-5",
+      body: { messages: [{ role: "user", content: "x".repeat(400000) }] },
+      stream: true,
+      credentials: { copilotToken: "test-token" },
+      log: { debug: vi.fn(), warn },
+    });
+
+    expect(proxyFetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://api.githubcopilot.com/v1/messages/count_tokens",
+      "https://api.githubcopilot.com/v1/messages",
+    ]);
+    expect(warn).toHaveBeenCalledWith("GITHUB", "Prompt token preflight returned 503; continuing");
+  });
+
+  it("preserves context_length_exceeded through default executor parsing", async () => {
+    const upstream = new Response(JSON.stringify({
+      error: {
+        message: "Prompt is 200001 tokens; maximum is 200000.",
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+      },
+    }), { status: 400, headers: { "content-type": "application/json" } });
+
+    const parsed = await parseUpstreamError(upstream, new GithubExecutor());
+    const result = createErrorResult(parsed.statusCode, parsed.message, undefined, parsed.code);
+
+    expect(await result.response.json()).toMatchObject({
+      error: {
+        message: "Prompt is 200001 tokens; maximum is 200000.",
+        code: "context_length_exceeded",
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- applies GitHub Copilot-specific Claude limits: 264K total context, 200K prompt, 64K output
- covers Fable 5, Opus 4.8, and Opus 5 without lowering direct Claude limits
- prefers live Copilot capability values over static fallbacks
- exact-counts only likely-large Anthropic requests through Copilot's token-count endpoint
- rejects proven over-limit prompts with `context_length_exceeded`; count service failures remain fail-open
- preserves structured synchronous error codes through chat handling

## Compatibility

- supersedes global Fable metadata PR #2652 with provider-specific behavior
- #2927 owns adaptive `auto`/`minimal` effort normalization
- #2666 owns delayed streaming error framing after headers start

## Verification

- capabilities/catalog/routing suite: 17/17 passed
- changed-file ESLint: 0 errors; one unchanged registry warning also exists on pristine v0.5.45
- `git diff --check`: passed
- both commits are range-diff equivalent after rebase
- Gitleaks: no leaks

Base: `v0.5.45` (`6fcd2733`).