### PR TITLE
providers: add Gemini 3.6 Flash and Gemini 3.5 Flash Lite models

### DIFF
--- a/open-sse/providers/pricing.js
+++ b/open-sse/providers/pricing.js
@@ -57,7 +57,13 @@ export const MODEL_PRICING = {
   "o1-mini":                      { input: 3.00,  output: 12.00, cached: 1.50,  reasoning: 18.00,  cache_creation: 3.00  },
 
   // === Gemini ===
-  "gemini-3-flash-preview":       { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
+  "gemini-3.6-flash":              { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
+  "gemini-3.6-flash-high":         { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
+  "gemini-3.6-flash-medium":       { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
+  "gemini-3.6-flash-low":          { input: 1.50,  output: 7.50,  cached: 0.15,  reasoning: 11.25,  cache_creation: 1.875 },
+  "gemini-3.5-flash-lite":         { input: 0.30,  output: 2.50,  cached: 0.03,  reasoning: 3.75,   cache_creation: 0.375 },
+  "gemini-3.5-flash-high":         { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
+  "gemini-3-flash-preview":        { input: 0.50,  output: 3.00,  cached: 0.03,  reasoning: 4.50,   cache_creation: 0.50  },
   "gemini-3-pro-preview":         { input: 2.00,  output: 12.00, cached: 0.25,  reasoning: 18.00,  cache_creation: 2.00  },
   "gemini-3.1-pro-low":           { input: 2.00,  output: 12.00, cached: 0.25,  reasoning: 18.00,  cache_creation: 2.00  },
   "gemini-3.1-pro-high":          { input: 4.00,  output: 18.00, cached: 0.50,  reasoning: 27.00,  cache_creation: 4.00  },

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -44,6 +44,10 @@ export default {
     clientSecret: "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",
   },
   models: [
+    { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash (High)" },
+    { id: "gemini-3.6-flash-medium", name: "Gemini 3.6 Flash (Medium)" },
+    { id: "gemini-3.6-flash-low", name: "Gemini 3.6 Flash (Low)" },
+    { id: "gemini-3.5-flash-high", name: "Gemini 3.5 Flash (High)" },
     { id: "gemini-3-flash-agent", name: "Gemini 3.5 Flash (High)" },
     { id: "gemini-3.5-flash-low", name: "Gemini 3.5 Flash (Medium)" },
     { id: "gemini-3.5-flash-extra-low", name: "Gemini 3.5 Flash (Low)" },

--- a/open-sse/providers/registry/gemini.js
+++ b/open-sse/providers/registry/gemini.js
@@ -34,6 +34,8 @@ export default {
     },
   },
   models: [
+    { id: "gemini-3.6-flash", name: "Gemini 3.6 Flash" },
+    { id: "gemini-3.5-flash-lite", name: "Gemini 3.5 Flash Lite" },
     { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
     { id: "gemini-3.1-flash-lite-preview", name: "Gemini 3.1 Flash Lite Preview" },
     { id: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },


### PR DESCRIPTION
## Summary

Adds Google Gemini 3.6 Flash (`gemini-3.6-flash`) and Gemini 3.5 Flash Lite (`gemini-3.5-flash-lite`) — both GA since 2026-07-21.

## Changes

### `registry/gemini.js` (API Key provider)
- `gemini-3.6-flash` — new default Flash model
- `gemini-3.5-flash-lite` — fastest/cheapest 3.5 model

### `registry/antigravity.js` (OAuth provider)  
- `gemini-3.6-flash-high` / `medium` / `low` — tiered names as surfaced by `agy models`
- `gemini-3.5-flash-high`

### `pricing.js`
| Model | Input | Output | Source |
|-------|-------|--------|--------|
| gemini-3.6-flash* | $1.50 | $7.50 | [Google blog](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/) |
| gemini-3.5-flash-lite | $0.30 | $2.50 | [Models page](https://ai.google.dev/gemini-api/docs/models) |

## Verification

- ✅ `gemini/gemini-3.6-flash` via `generativelanguage.googleapis.com` API key — returns valid content
- ✅ `gemini/gemini-3.5-flash-lite` via API key — returns valid content  
- ✅ `gemini-3.6-flash-medium` via Antigravity CLI `daily-cloudcode-pa` endpoint — returns valid content (model surfaced in `agy models`)