### PR TITLE
fix(capabilities): correct thinking format and limits for the 4.6+ Claude generation

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -113,6 +113,13 @@ const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true,
 const CODEX_GPT_56_SOL_CAPS  = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 372000, maxOutput: 128000 };
 const CODEX_GPT_56_DEFAULT_CAPS = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
 
+// The 4.6+ Claude generation: adaptive thinking, 1M context, 128k output. Shared by the
+// patterns below so an unlisted variant (claude-opus-4.8-fast, anthropic/claude-sonnet-5,
+// …) inherits the family's real limits instead of dropping to the 200k/64k floor —
+// maxOutput is a clamp ceiling (translator/formats/claude.js), so a stale value silently
+// caps these models at half their output budget.
+const CLAUDE_4_6_PLUS_CAPABILITIES = { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 };
+
 /**
  * Provider-specific capability overrides. Keyed by provider alias/id.
  */
@@ -180,18 +187,18 @@ export const PROVIDER_CAPABILITIES = {
  */
 export const PATTERN_CAPABILITIES = [
   // ── Claude (4.6+ = adaptive thinking; older/haiku = budget) ──────
-  { pattern: "*claude*opus-4.6*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
-  { pattern: "*claude*opus-4.7*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
-  { pattern: "*claude*opus-4.8*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
-  { pattern: "*claude*sonnet-4.6*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
-  { pattern: "*claude*sonnet-4.7*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
-  { pattern: "*claude*sonnet-5*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
+  { pattern: "*claude*opus-4.6*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },
+  { pattern: "*claude*opus-4.7*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },
+  { pattern: "*claude*opus-4.8*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },
+  { pattern: "*claude*sonnet-4.6*", caps: CLAUDE_4_6_PLUS_CAPABILITIES },
+  { pattern: "*claude*sonnet-4.7*", caps: CLAUDE_4_6_PLUS_CAPABILITIES },
+  { pattern: "*claude*sonnet-5*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },
   // fable / mythos are newer than 4.6, so they follow the 4.6+ adaptive rule above.
   // Anthropic rejects thinking.type "enabled" on them outright ("... is not supported
   // for this model. Use thinking.type.adaptive and output_config.effort"), so a budget
   // format makes every thinking request 400.
-  { pattern: "*claude*fable*",  caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 } },
-  { pattern: "*claude*mythos*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 } },
+  { pattern: "*claude*fable*",  caps: CLAUDE_4_6_PLUS_CAPABILITIES },
+  { pattern: "*claude*mythos*", caps: CLAUDE_4_6_PLUS_CAPABILITIES },
   { pattern: "*claude*haiku*",  caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget" } },
   { pattern: "*claude*opus*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget" } },
   { pattern: "*claude*sonnet*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget" } },

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -185,11 +185,16 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*claude*opus-4.8*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
   { pattern: "*claude*sonnet-4.6*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
   { pattern: "*claude*sonnet-4.7*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
+  { pattern: "*claude*sonnet-5*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
+  // fable / mythos are newer than 4.6, so they follow the 4.6+ adaptive rule above.
+  // Anthropic rejects thinking.type "enabled" on them outright ("... is not supported
+  // for this model. Use thinking.type.adaptive and output_config.effort"), so a budget
+  // format makes every thinking request 400.
+  { pattern: "*claude*fable*",  caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 } },
+  { pattern: "*claude*mythos*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 } },
   { pattern: "*claude*haiku*",  caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget" } },
   { pattern: "*claude*opus*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget" } },
   { pattern: "*claude*sonnet*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget" } },
-  { pattern: "*claude*fable*",  caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget", contextWindow: 1000000, maxOutput: 128000 } },
-  { pattern: "*claude*mythos*", caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget", contextWindow: 1000000, maxOutput: 128000 } },
   { pattern: "*claude-3*",      caps: { vision: true } },
   { pattern: "*claude*",        caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-budget" } },
 

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -190,6 +190,7 @@ export const PATTERN_CAPABILITIES = [
   { pattern: "*claude*opus-4.6*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },
   { pattern: "*claude*opus-4.7*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },
   { pattern: "*claude*opus-4.8*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },
+  { pattern: "*claude*opus-5*",     caps: CLAUDE_4_6_PLUS_CAPABILITIES },
   { pattern: "*claude*sonnet-4.6*", caps: CLAUDE_4_6_PLUS_CAPABILITIES },
   { pattern: "*claude*sonnet-4.7*", caps: CLAUDE_4_6_PLUS_CAPABILITIES },
   { pattern: "*claude*sonnet-5*",   caps: CLAUDE_4_6_PLUS_CAPABILITIES },

--- a/tests/unit/capabilities-opus-context.test.js
+++ b/tests/unit/capabilities-opus-context.test.js
@@ -22,6 +22,9 @@ describe("Claude Opus 1M context capabilities", () => {
     "claude-opus-4-7",
     "claude-opus-4.7",
     "claude-opus-4-6",
+    // serving-speed variant, present in Copilot's live catalog but in no static list —
+    // upstream reports the same limits and even resolves it to claude-opus-4-8
+    "claude-opus-4.8-fast",
   ]) {
     it(`resolves ${model} to a 1M context window`, () => {
       expect(getCapabilitiesForModel("cc", model)).toMatchObject(expected);

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -36,6 +36,18 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("kiro", "claude-sonnet-5-thinking-agentic")).toMatchObject(claudeSonnet5Expected);
   });
 
+  // Opus 5 shipped after the 4.8 patterns were written and fell through to the generic
+  // "*claude*opus*" entry, so every thinking request 400'd on the budget shape and
+  // max_tokens was clamped to the 64k floor.
+  it("reports Claude Opus 5 as a 1M adaptive-thinking model", () => {
+    for (const model of [
+      "claude-opus-5", "anthropic/claude-opus-5", "claude-opus-5-thinking",
+      "claude-opus-5-agentic", "claude-opus-5-20260724",
+    ]) {
+      expect(getCapabilitiesForModel("github", model)).toMatchObject(claudeSonnet5Expected);
+    }
+  });
+
   it("reports Kiro GPT 5.6 models with the Kiro 272k context window", () => {
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-sol")).toMatchObject(kiroGpt56Expected);
     expect(getCapabilitiesForModel("kiro", "openai/gpt-5.6-sol")).toMatchObject(kiroGpt56Expected);
@@ -85,7 +97,7 @@ describe("4.6+ Claude limits reach unlisted variants", () => {
   it("covers variants of every 4.6+ family", () => {
     for (const model of [
       "claude-sonnet-5.1", "claude-sonnet-4.6-preview", "claude-opus-4.7-fast",
-      "anthropic/claude-opus-4.6", "claude-fable-5-preview",
+      "anthropic/claude-opus-4.6", "claude-fable-5-preview", "claude-opus-5-fast",
     ]) {
       expect(getCapabilitiesForModel("github", model)).toMatchObject(family);
     }

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -69,3 +69,39 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("github", "claude-opus-4.5").thinkingFormat).toBe("claude-budget");
   });
 });
+
+// maxOutput is a clamp ceiling (translator/formats/claude.js, openai-to-claude.js), and
+// contextWindow drives context accounting — a variant that drops to the 200k/64k floor
+// is silently capped at half its real output budget. Limits verified upstream:
+// "max_tokens: 999999 > 128000" / "prompt is too long: ... > 1000000 maximum".
+describe("4.6+ Claude limits reach unlisted variants", () => {
+  const family = { contextWindow: 1000000, maxOutput: 128000, thinkingFormat: "claude-adaptive" };
+
+  it("gives claude-opus-4.8-fast the same limits as claude-opus-4.8", () => {
+    expect(getCapabilitiesForModel("github", "claude-opus-4.8-fast")).toMatchObject(family);
+    expect(getCapabilitiesForModel("github", "claude-opus-4.8")).toMatchObject(family);
+  });
+
+  it("covers variants of every 4.6+ family", () => {
+    for (const model of [
+      "claude-sonnet-5.1", "claude-sonnet-4.6-preview", "claude-opus-4.7-fast",
+      "anthropic/claude-opus-4.6", "claude-fable-5-preview",
+    ]) {
+      expect(getCapabilitiesForModel("github", model)).toMatchObject(family);
+    }
+  });
+
+  it("leaves 4.5 and older on the conservative floor", () => {
+    for (const model of ["claude-haiku-4.5", "claude-sonnet-4.5", "claude-opus-4.5"]) {
+      const caps = getCapabilitiesForModel("github", model);
+      expect(caps.contextWindow).toBe(200000);
+      expect(caps.maxOutput).toBe(64000);
+    }
+  });
+
+  it("does not let the shared caps object leak mutations between lookups", () => {
+    const first = getCapabilitiesForModel("github", "claude-opus-4.8-fast");
+    first.maxOutput = 1;
+    expect(getCapabilitiesForModel("github", "claude-opus-4.8").maxOutput).toBe(128000);
+  });
+});

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -43,4 +43,29 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-luna-agentic")).toMatchObject(kiroGpt56Expected);
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-sol-thinking-agentic")).toMatchObject(kiroGpt56Expected);
   });
+
+  // Anthropic rejects thinking.type "enabled" on 4.6+ generation models outright, so a
+  // budget format turns every thinking request into a 400. Fable/Mythos are newer than
+  // 4.6 and must follow the adaptive rule.
+  it("reports Claude Fable / Mythos as adaptive-thinking models", () => {
+    for (const provider of ["github", "claude"]) {
+      expect(getCapabilitiesForModel(provider, "claude-fable-5").thinkingFormat).toBe("claude-adaptive");
+      expect(getCapabilitiesForModel(provider, "claude-mythos-1").thinkingFormat).toBe("claude-adaptive");
+    }
+  });
+
+  // Live provider catalogs ship claude-* variants ahead of the static model lists;
+  // anything falling through to the generic "*claude*sonnet*" pattern gets the 4.5-era
+  // budget format and breaks.
+  it("keeps unlisted Sonnet 5 variants on the adaptive format", () => {
+    expect(getCapabilitiesForModel("github", "claude-sonnet-5.1").thinkingFormat).toBe("claude-adaptive");
+    expect(getCapabilitiesForModel("github", "claude-sonnet-5-preview").thinkingFormat).toBe("claude-adaptive");
+  });
+
+  // 4.5 and older stay on the budget format — they reject output_config.effort.
+  it("keeps pre-4.6 Claude models on the budget format", () => {
+    expect(getCapabilitiesForModel("github", "claude-haiku-4.5").thinkingFormat).toBe("claude-budget");
+    expect(getCapabilitiesForModel("github", "claude-sonnet-4.5").thinkingFormat).toBe("claude-budget");
+    expect(getCapabilitiesForModel("github", "claude-opus-4.5").thinkingFormat).toBe("claude-budget");
+  });
 });


### PR DESCRIPTION
Two related gaps in the Claude entries of `PATTERN_CAPABILITIES`: models newer than 4.6 that are not in the exact `MODEL_CAPABILITIES` table fall through to entries that are stale in two different ways.

## 1. Fable / Mythos get a thinking format Anthropic rejects

`claude-fable-5` matched `*claude*fable*`, which declared `thinkingFormat: "claude-budget"`. That emits `thinking:{type:"enabled", budget_tokens:N}`, and Anthropic rejects it outright on the 4.6+ generation:

```
400 "thinking.type.enabled" is not supported for this model.
    Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

So **every thinking request to a Fable model failed**. Verified live against GitHub Copilot's `/v1/messages` shim — the budget shape 400s, the adaptive shape returns 200. Fable and Mythos are newer than 4.6 and belong to the adaptive group the section header already describes; they were simply left behind when that group was introduced.

Also adds a `*claude*sonnet-5*` pattern. Live provider catalogs ship `claude-*` variants ahead of the static model lists, and anything falling through to the generic `*claude*sonnet*` pattern inherits the 4.5-era budget format and breaks the same way. This mirrors the existing forward-looking `*claude*sonnet-4.7*` entry.

Providers that pin a thinking format at the provider level (`blackbox` declares `thinkingFormat: "openai"`) take precedence in `resolveFormat` and are unaffected.

## 2. Unlisted 4.6+ variants drop to the 200k/64k floor

The 1M context / 128k output figures lived only in the `MODEL_CAPABILITIES` exact table. The matching pattern entries carried `thinkingFormat` and nothing else, so any 4.6+ model whose exact id is not listed fell through to `DEFAULT_CAPABILITIES`.

`claude-opus-4.8-fast` is the live example — Copilot serves it today, no static list mentions it, and upstream enforces exactly the same limits as `claude-opus-4.8`, even resolving the id back in its error text:

```
max_tokens: 999999 > 128000, which is the maximum allowed number of output tokens for claude-opus-4-8
prompt is too long: 1500032 tokens > 1000000 maximum
```

`maxOutput` is a clamp ceiling, not documentation: `translator/formats/claude.js` and `openai-to-claude.js` both cap `max_tokens` with it, and their comments name *"Opus 4.8 / Sonnet 4.6 = 128000"* as the case they exist to serve. A stale value silently halved the output budget of the very models that motivated that code.

The six 4.6+ patterns now share one `CLAUDE_4_6_PLUS_CAPABILITIES` object — the same idiom `KIRO_GPT_5_6_CAPABILITIES` already uses — so the family cannot drift apart again. `getCapabilitiesForModel` always returns a fresh spread, so sharing the object cannot leak mutations (covered by a test).

4.5 and older keep the conservative floor, which upstream confirms is correct for them (`haiku-4.5: prompt is too long: 200038 tokens > 200000 maximum`).

## 3. Claude Opus 5 lands in the same gap

Opus 5 shipped after the patterns above were written and matched none of them, so it fell through to the generic `*claude*opus*` entry and inherited the 4.5-era budget format — the exact failure this PR describes, reproduced on a model released days later:

```
POST /v1/messages  model=claude-opus-5
{"thinking":{"type":"enabled","budget_tokens":24576}}
400 "thinking.type.enabled" is not supported for this model.
    Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

The same fallthrough dropped it to the 200k/64k floor, so `max_tokens` went upstream as `64000` instead of the family's `128000`.

Adding `*claude*opus-5*` alongside the existing per-version entries fixes both, since they now share one caps object.

## Verification

- Live-verified against Copilot for every limit and error message quoted above.
- Full suite: failure set identical to the `master` baseline, zero regression.
- New tests cover Fable/Mythos, Opus 5 (including `anthropic/` prefixed, `-thinking`, `-agentic` and dated ids), unlisted Sonnet 5 variants, `opus-4.8-fast` limits, the pre-4.6 floor, and shared-object mutation safety.
- The Opus 5 `400` above is a captured real request, not a synthetic one. After the fix the translator emits `thinking:{type:"adaptive"}` + `output_config:{effort:"high"}` for the same input, and caps resolve to 1M/128k.

本 PR 由 Claude Code 辅助完成
