### PR TITLE
fix(github): route Claude models to Copilot's native format via chatCore

### DIFF
--- a/open-sse/executors/github.js
+++ b/open-sse/executors/github.js
@@ -4,8 +4,7 @@ import { OAUTH_ENDPOINTS, GITHUB_COPILOT } from "../config/appConstants.js";
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { openaiToOpenAIResponsesRequest } from "../translator/request/openai-responses.js";
 import { openaiResponsesToOpenAIResponse } from "../translator/response/openai-responses.js";
-import { initState, translateRequest, translateResponse } from "../translator/index.js";
-import { FORMATS } from "../translator/formats.js";
+import { initState } from "../translator/index.js";
 import { parseSSELine, formatSSE } from "../utils/streamHelpers.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
@@ -19,17 +18,18 @@ export class GithubExecutor extends BaseExecutor {
     this.knownCodexModels = new Set();
   }
 
-  // Claude models get routed to Copilot's Anthropic-native /v1/messages shim (see
-  // executeWithMessagesEndpoint below) — the only Copilot endpoint that surfaces
-  // prompt-cache token counts. gpt/gemini/grok models stay on /chat/completions
-  // (or /responses). Name-pattern check, not a registry field: Copilot's live model
-  // catalog (services/copilotModels.js) regularly exposes claude-* variants ahead
-  // of the static registry (registry/github.js).
+  // Single source of truth for "is this model served by the Anthropic-native shim":
+  // the registry hook chatCore also uses to pick the target format, so the body shape
+  // the executor receives and the endpoint it posts to can never disagree.
   isClaudeModel(model) {
-    return /claude/i.test(model || "");
+    return this.config.resolveTargetFormat?.(model) === "claude";
   }
 
   buildUrl(model, stream, urlIndex = 0) {
+    // Claude models arrive already Anthropic-native (chatCore translated to the
+    // "claude" target format) — post them to Copilot's /v1/messages shim, the only
+    // Copilot endpoint that surfaces prompt-cache token counts.
+    if (this.isClaudeModel(model)) return this.config.messagesUrl;
     return this.config.baseUrl;
   }
 
@@ -96,6 +96,9 @@ export class GithubExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body, stream, credentials) {
+    // Anthropic-native body — none of the OpenAI-shape fixups below apply.
+    if (this.isClaudeModel(model)) return body;
+
     const transformed = { ...body };
     if (this.requiresMaxCompletionTokens(model) && transformed.max_tokens !== undefined) {
       transformed.max_completion_tokens = transformed.max_tokens;
@@ -123,25 +126,23 @@ export class GithubExecutor extends BaseExecutor {
   async execute(options) {
     const { model, log } = options;
 
-    // Claude models: route to Copilot's Anthropic-native /v1/messages shim — the only
-    // Copilot endpoint that surfaces prompt-cache token counts for Claude. Detected by
-    // model NAME (not a registry field): Copilot's live model catalog regularly exposes
-    // claude-* variants the static registry hasn't caught up with yet (see registry/github.js).
-    if (this.isClaudeModel(model)) {
-      log?.debug("GITHUB", `Using /v1/messages route for ${model}`);
-      return this.executeWithMessagesEndpoint(options);
-    }
+    // Claude models fall straight through to BaseExecutor.execute(): the body is
+    // already Anthropic-native and buildUrl() targets /v1/messages, so there is
+    // nothing left to translate here (chatCore handles both directions).
+    const isClaude = this.isClaudeModel(model);
+    if (isClaude) log?.debug("GITHUB", `Using /v1/messages route for ${model}`);
 
     // Only use /responses for models that are explicitly known to need it (e.g. gpt codex models)
     // and that the /responses endpoint actually serves (excludes Gemini/Claude, see #1062).
-    if (this.knownCodexModels.has(model) && this.supportsResponsesEndpoint(model)) {
+    if (!isClaude && this.knownCodexModels.has(model) && this.supportsResponsesEndpoint(model)) {
       log?.debug("GITHUB", `Using cached /responses route for ${model}`);
       return this.executeWithResponsesEndpoint(options);
     }
 
     // Sanitize messages before sending to /chat/completions (gpt/gemini/grok — the
-    // endpoint rejects non-text/image_url content parts).
-    const sanitizedOptions = {
+    // endpoint rejects non-text/image_url content parts). Claude bodies are Anthropic
+    // shape and must not be touched.
+    const sanitizedOptions = isClaude ? options : {
       ...options,
       body: this.sanitizeMessagesForChatCompletions(options.body)
     };
@@ -223,101 +224,6 @@ export class GithubExecutor extends BaseExecutor {
             if (converted) {
               controller.enqueue(new TextEncoder().encode(formatSSE(converted, "openai")));
             }
-          }
-        }
-      }
-    });
-
-    if (!response.body) {
-      return { response: new Response("", { status: response.status, headers: response.headers }), url, headers, transformedBody };
-    }
-    const convertedStream = response.body.pipeThrough(transformStream);
-
-    return {
-      response: new Response(convertedStream, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers
-      }),
-      url,
-      headers,
-      transformedBody
-    };
-  }
-
-  // Claude models arrive here OpenAI-shape (chatCore.js targets "openai" for github —
-  // see the note in execute() above), so we translate to Anthropic-native ourselves.
-  // This is what makes prepareClaudeRequest() (translator/formats/claude.js) inject
-  // cache_control — /chat/completions never gets there, so it never sees cache tokens.
-  async executeWithMessagesEndpoint({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
-    const url = this.config.messagesUrl;
-    const headers = this.buildHeaders(credentials, stream);
-
-    // Force stream:true upstream regardless of client preference, same as
-    // executeWithResponsesEndpoint below — chatCore.js's non-streaming handler already
-    // knows how to buffer an SSE response into a single JSON reply when the client
-    // asked for stream:false.
-    const transformedBody = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, model, body, true, credentials, "github");
-    // _toolNameMap is internal bookkeeping (see openai-to-claude.js) — chatCore.js
-    // normally strips it before dispatch and threads it into the response state to
-    // restore original tool names; we must do the same here, or Anthropic's strict
-    // schema rejects the extra field with a 400.
-    const toolNameMap = transformedBody._toolNameMap;
-    delete transformedBody._toolNameMap;
-
-    log?.debug("GITHUB", "Sending translated request to /v1/messages");
-
-    const response = await proxyAwareFetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(transformedBody),
-      signal
-    }, proxyOptions);
-
-    if (!response.ok) {
-      return { response, url, headers, transformedBody };
-    }
-
-    const state = initState(FORMATS.CLAUDE);
-    state.model = model;
-    if (toolNameMap) state.toolNameMap = toolNameMap;
-
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    const emitAll = (controller, chunks) => {
-      for (const c of chunks) {
-        controller.enqueue(new TextEncoder().encode(formatSSE(c, "openai")));
-      }
-    };
-
-    const transformStream = new TransformStream({
-      async transform(chunk, controller) {
-        buffer += decoder.decode(chunk, { stream: true });
-        const lines = buffer.split("\n");
-
-        buffer = lines.pop() || "";
-
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (!trimmed) continue;
-
-          const parsed = parseSSELine(trimmed);
-          if (!parsed) continue;
-
-          if (parsed.done && stream === true) {
-            controller.enqueue(new TextEncoder().encode(SSE_DONE));
-            continue;
-          }
-
-          emitAll(controller, translateResponse(FORMATS.CLAUDE, FORMATS.OPENAI, parsed, state));
-        }
-      },
-      flush(controller) {
-        if (buffer.trim()) {
-          const parsed = parseSSELine(buffer.trim());
-          if (parsed && !parsed.done) {
-            emitAll(controller, translateResponse(FORMATS.CLAUDE, FORMATS.OPENAI, parsed, state));
           }
         }
       }

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -1,4 +1,4 @@
-import { detectFormat, getTargetFormat, resolveTransport } from "../services/provider.js";
+import { detectFormat, getTargetFormat, resolveTransport, resolveDynamicTargetFormat } from "../services/provider.js";
 import { translateRequest } from "../translator/index.js";
 import { stripThinkingSuffix } from "../translator/concerns/thinkingUnified.js";
 import { FORMATS } from "../translator/formats.js";
@@ -58,7 +58,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (bypassResponse) return bypassResponse;
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
-  const modelTargetFormat = getModelTargetFormat(alias, model);
+  // Static per-model targetFormat first (explicit registry entries win), then the
+  // provider's runtime name-pattern hook for catalogs that outrun the static list.
+  const modelTargetFormat = getModelTargetFormat(alias, model)
+    || resolveDynamicTargetFormat(provider, model);
   // Multi-endpoint providers: pick transport matching sourceFormat → zero translation
   const runtimeTransport = resolveTransport(provider, sourceFormat);
   const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider);

--- a/open-sse/providers/registry/github.js
+++ b/open-sse/providers/registry/github.js
@@ -37,6 +37,14 @@ export default {
       userAgent: "GitHubCopilotChat/0.38.0",
       apiVersion: "2025-04-01",
     },
+    // Copilot serves Claude models on its Anthropic-native /v1/messages shim (the only
+    // endpoint that surfaces prompt-cache token counts) and everything else on
+    // /chat/completions. Decided by model NAME at request time rather than a static
+    // per-entry targetFormat in models[] below: Copilot's live catalog
+    // (services/copilotModels.js) ships claude-* variants long before the static list
+    // catches up — it currently serves claude-sonnet-5, claude-opus-4.8,
+    // claude-opus-4.8-fast and claude-fable-5, none of which are listed here.
+    resolveTargetFormat: (model) => (/claude/i.test(model || "") ? "claude" : null),
     usage: {
       url: "https://api.github.com/copilot_internal/user",
     },
@@ -47,14 +55,7 @@ export default {
     { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
     { id: "gpt-5.4", name: "GPT-5.4" },
     { id: "gpt-5.4-mini", name: "GPT-5.4 Mini" },
-    // Note: routing to Copilot's Anthropic-native /v1/messages shim (see
-    // executors/github.js) is decided by model-NAME pattern at request time, not by
-    // a static targetFormat field here — Copilot's live model catalog (see
-    // services/copilotModels.js) regularly exposes claude-* models this static list
-    // hasn't caught up with yet (e.g. claude-opus-4.8), and a static per-entry
-    // targetFormat would silently miss those while also double-translating requests
-    // for models that ARE listed here (chatCore.js would pre-translate to Claude
-    // shape, then the executor would translate again). Keep these as plain entries.
+    // Claude entries stay plain — transport.resolveTargetFormat above routes them.
     { id: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
     { id: "claude-opus-4.5", name: "Claude Opus 4.5" },
     { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -146,6 +146,24 @@ export function resolveTransport(provider, sourceFormat) {
   return transports.find(t => t.format === sourceFormat) || null;
 }
 
+// Per-model target format resolved at request time from the model NAME.
+// For providers that serve different wire formats per model AND whose live model
+// catalog outruns their static models[] list, a static per-entry `targetFormat`
+// silently misses the newcomers (github/Copilot: claude-* go to the Anthropic-native
+// /v1/messages shim, and the catalog ships claude-* variants well before the registry
+// lists them). Providers opt in by exporting transport.resolveTargetFormat(model).
+// Returns null when the provider has no hook or the model isn't special-cased.
+export function resolveDynamicTargetFormat(provider, model) {
+  const fn = PROVIDERS[provider]?.resolveTargetFormat;
+  if (typeof fn !== "function") return null;
+  try {
+    return fn(model) || null;
+  } catch {
+    // Registry data must never be able to break routing.
+    return null;
+  }
+}
+
 // Check if last message is from user
 export function isLastMessageFromUser(body) {
   const messages = body.messages || body.contents;

--- a/tests/unit/github-claude-native-route.test.js
+++ b/tests/unit/github-claude-native-route.test.js
@@ -1,0 +1,159 @@
+/**
+ * GitHub Copilot serves Claude models on its Anthropic-native /v1/messages shim.
+ * chatCore must resolve those models to the "claude" target format so a Claude-source
+ * request (Claude Code / Zed, directly or via a downstream Anthropic proxy) reaches
+ * the shim with zero translation.
+ *
+ * Before this route existed the request went claude -> openai -> claude, and
+ * request/claude-to-openai.js has no case for thinking blocks: the assistant turn's
+ * thinking block (and its signature) was silently dropped on the way in, so the model
+ * never saw its own prior reasoning on the next turn.
+ */
+
+import { describe, it, expect } from "vitest";
+import { GithubExecutor } from "../../open-sse/executors/github.js";
+import { resolveDynamicTargetFormat, getTargetFormat } from "../../open-sse/services/provider.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+// A real Copilot thinking signature (E-form, truncated) — must survive verbatim.
+const SIGNATURE = "EpwGCkYIChgCKkCzVUuRrg7CcglSUWEef4rH6o35g9UYS8ZPe0/VomQTBsFx6sttYNj5";
+
+function claudeMultiTurnBody() {
+  return {
+    model: "claude-sonnet-4.6",
+    max_tokens: 2048,
+    thinking: { type: "adaptive" },
+    output_config: { effort: "high" },
+    tools: [{ name: "get_weather", description: "w", input_schema: { type: "object", properties: {} } }],
+    messages: [
+      { role: "user", content: "weather?" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "I should call the weather tool.", signature: SIGNATURE },
+          { type: "tool_use", id: "toolu_01", name: "get_weather", input: { city: "Beijing" } },
+        ],
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_01", content: "sunny" }] },
+    ],
+  };
+}
+
+describe("github dynamic target format", () => {
+  it("routes claude-* to the Anthropic-native format", () => {
+    for (const model of ["claude-sonnet-4.6", "claude-opus-4.7", "claude-haiku-4.5"]) {
+      expect(resolveDynamicTargetFormat("github", model)).toBe("claude");
+    }
+  });
+
+  // The whole reason this is a name pattern and not a static per-model registry field.
+  it("covers live-catalog models the static registry list has not caught up with", () => {
+    for (const model of ["claude-sonnet-5", "claude-opus-4.8", "claude-opus-4.8-fast", "claude-fable-5"]) {
+      expect(resolveDynamicTargetFormat("github", model)).toBe("claude");
+    }
+  });
+
+  it("leaves every other Copilot model on the provider default", () => {
+    for (const model of ["gpt-5.4", "gpt-5.2-codex", "gemini-3-flash-preview", "grok-code-fast-1"]) {
+      expect(resolveDynamicTargetFormat("github", model)).toBeNull();
+    }
+    expect(getTargetFormat("github")).toBe("openai");
+  });
+
+  it("is inert for providers that declare no hook, and null-safe", () => {
+    expect(resolveDynamicTargetFormat("openai", "gpt-4")).toBeNull();
+    expect(resolveDynamicTargetFormat("anthropic", "claude-sonnet-4.6")).toBeNull();
+    expect(resolveDynamicTargetFormat("github", null)).toBeNull();
+    expect(resolveDynamicTargetFormat("no-such-provider", "x")).toBeNull();
+  });
+});
+
+describe("GithubExecutor.buildUrl", () => {
+  const exec = new GithubExecutor();
+
+  it("posts Claude models to /v1/messages", () => {
+    expect(exec.buildUrl("claude-sonnet-4.6", true)).toBe("https://api.githubcopilot.com/v1/messages");
+    expect(exec.buildUrl("claude-fable-5", true)).toBe("https://api.githubcopilot.com/v1/messages");
+  });
+
+  it("posts everything else to /chat/completions", () => {
+    expect(exec.buildUrl("gpt-5.4", true)).toBe("https://api.githubcopilot.com/chat/completions");
+    expect(exec.buildUrl("gemini-3-flash-preview", true)).toBe("https://api.githubcopilot.com/chat/completions");
+  });
+
+  it("leaves an Anthropic-native body untouched in transformRequest", () => {
+    const body = { model: "claude-sonnet-4.6", max_tokens: 10, thinking: { type: "adaptive" } };
+    expect(exec.transformRequest("claude-sonnet-4.6", body, true, {})).toBe(body);
+  });
+});
+
+describe("claude -> claude passthrough for github", () => {
+  it("preserves the assistant thinking block and its signature verbatim", () => {
+    const out = translateRequest(
+      FORMATS.CLAUDE, FORMATS.CLAUDE, "claude-sonnet-4.6",
+      claudeMultiTurnBody(), true, {}, "github"
+    );
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    const thinking = assistant.content.find((b) => b.type === "thinking");
+
+    expect(thinking).toBeDefined();
+    expect(thinking.thinking).toBe("I should call the weather tool.");
+    expect(thinking.signature).toBe(SIGNATURE);
+    // thinking must stay first — Anthropic rejects a thinking block after content
+    expect(assistant.content[0].type).toBe("thinking");
+  });
+
+  it("still injects cache_control (the reason Claude models use /v1/messages at all)", () => {
+    const out = translateRequest(
+      FORMATS.CLAUDE, FORMATS.CLAUDE, "claude-sonnet-4.6",
+      claudeMultiTurnBody(), true, {}, "github"
+    );
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    const cached = assistant.content.filter((b) => b.cache_control);
+    expect(cached.length).toBeGreaterThan(0);
+    // never on a thinking block — Anthropic rejects cache_control there
+    expect(cached.every((b) => b.type !== "thinking")).toBe(true);
+  });
+
+  it("leaves the thinking config untouched", () => {
+    const out = translateRequest(
+      FORMATS.CLAUDE, FORMATS.CLAUDE, "claude-sonnet-4.6",
+      claudeMultiTurnBody(), true, {}, "github"
+    );
+    expect(out.thinking).toEqual({ type: "adaptive" });
+    expect(out.output_config).toEqual({ effort: "high" });
+  });
+
+  // Guards the old behaviour so a future refactor cannot quietly reintroduce it.
+  it("documents that the claude -> openai hop drops thinking blocks", () => {
+    const out = translateRequest(
+      FORMATS.CLAUDE, FORMATS.OPENAI, "claude-sonnet-4.6",
+      claudeMultiTurnBody(), true, {}, "github"
+    );
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.content).toBeUndefined();
+    expect(assistant.tool_calls).toHaveLength(1);
+  });
+});
+
+describe("openai -> claude for github (OpenAI-format clients)", () => {
+  it("still translates and injects cache_control", () => {
+    const out = translateRequest(
+      FORMATS.OPENAI, FORMATS.CLAUDE, "claude-sonnet-4.6",
+      {
+        model: "claude-sonnet-4.6", max_tokens: 2048, reasoning_effort: "high",
+        messages: [
+          { role: "user", content: "weather?" },
+          { role: "assistant", tool_calls: [{ id: "call_1", type: "function", function: { name: "get_weather", arguments: "{}" } }] },
+          { role: "tool", tool_call_id: "call_1", content: "sunny" },
+        ],
+      },
+      true, {}, "github"
+    );
+    expect(out.thinking).toEqual({ type: "adaptive" });
+    expect(out.output_config).toEqual({ effort: "high" });
+    const assistant = out.messages.find((m) => m.role === "assistant");
+    expect(assistant.content.some((b) => b.cache_control)).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #2608 (same author). That PR sent Claude models to Copilot's Anthropic-native `/v1/messages` shim by branching **inside the executor**: `chatCore` still resolved github's target format to `"openai"`, and `executeWithMessagesEndpoint` translated openai → claude on the way out and claude → openai on the way back.

That made `targetFormat` a lie, and Claude-format clients paid for it.

## The bug

A request from Claude Code / Zed (directly, or through a downstream Anthropic proxy) went **claude → openai → claude**. `translator/request/claude-to-openai.js` has no case for thinking blocks — its `switch` handles `text`, `image`, `tool_use` and `tool_result` only. The assistant turn's thinking block and its signature were therefore dropped on the way in, so on every follow-up turn the model lost its own prior reasoning.

It failed **silently**: Copilot accepts a history with no thinking block (verified), it only rejects a thinking block whose signature is missing. Same body, two routes:

```
claude → claude   assistant blocks: ['thinking', 'tool_use']   signature: preserved verbatim
claude → openai   assistant keys:   ['role', 'tool_calls']     thinking: gone
```

## The fix

The provider now declares the routing decision where `chatCore` can see it:

```js
transport.resolveTargetFormat(model) -> "claude" | null
```

Resolved at request time from the model **name**, because Copilot's live catalog ships `claude-*` variants long before the static `models[]` list catches up — it currently serves `claude-sonnet-5`, `claude-opus-4.8`, `claude-opus-4.8-fast` and `claude-fable-5`, **none of them listed**. A static per-entry `targetFormat` would miss exactly those, which is why #2608 avoided one; a runtime hook does not have that problem.

Providers without the hook are unaffected — the helper returns `null` and the existing precedence chain is untouched.

With the target format honest:

- A claude-source request short-circuits in `translateRequest` (`sourceFormat === targetFormat`) and reaches the shim untouched — thinking blocks and real signatures survive verbatim.
- `prepareClaudeRequest` still runs — it is gated on `targetFormat === CLAUDE`, *outside* the short-circuit — so #2608's `cache_control` injection and its prompt-cache token counts are preserved. There is a test pinning this.
- OpenAI-format clients still translate once, now in `chatCore` rather than the executor.

`executeWithMessagesEndpoint` goes away entirely (**-90 lines**), along with its hand-rolled SSE transform and its duplicate `_toolNameMap` threading: the generic streaming handler already does both, keyed off the same target format. Net **-72 lines**.

## Verification

- Live end-to-end against Copilot: the exact body 9router now produces for a claude-source multi-turn request — thinking block with a real 400-char signature, `tool_use`, `tool_result` — returns 200.
- Deployed smoke test through the running gateway: multi-turn thinking replay, single-turn thinking text, and OpenAI-format clients all pass.
- Full suite: failure set identical to the `master` baseline, zero regression.
- 13 new tests, including a reverse guard that explicitly asserts the claude → openai hop drops thinking blocks, so a future refactor cannot quietly route back through it.

## Scope

Deliberately does **not** touch `request/claude-to-openai.js` or `openai-to-claude.js` — patching those would affect every provider that pivots through OpenAI, for a benefit this routing fix already delivers. Note that `tests/translator/bugs-toClaude-context.test.js` already has a red test (`assistant reasoning_content becomes a thinking block`) documenting that separate gap.

OpenAI-format clients still cannot round-trip thinking — that format has nowhere to carry a signature. Inherent, not addressed here.

本 PR 由 Claude Code 辅助完成