### PR TITLE
Prevent stale cloudflared exits from clearing successor PID

### DIFF
--- a/src/lib/tunnel/cloudflare/cloudflared.js
+++ b/src/lib/tunnel/cloudflare/cloudflared.js
@@ -239,8 +239,8 @@ export async function spawnCloudflared(tunnelToken) {
     });
 
     child.on("exit", (code, signal) => {
-      cloudflaredProcess = null;
-      clearPid();
+      if (cloudflaredProcess === child) cloudflaredProcess = null;
+      clearPid(child.pid);
       const wasConnected = resolved; // true = already connected successfully
       if (!resolved) {
         resolved = true;
@@ -372,8 +372,8 @@ export async function spawnQuickTunnel(localPort, onUrlUpdate) {
     });
 
     child.on("exit", (code, signal) => {
-      cloudflaredProcess = null;
-      clearPid();
+      if (cloudflaredProcess === child) cloudflaredProcess = null;
+      clearPid(child.pid);
       // Deliberate kill (restart/disable) — exit silently, no error noise
       if (intentionalKill) {
         intentionalKill = false;

--- a/src/lib/tunnel/cloudflare/pid.js
+++ b/src/lib/tunnel/cloudflare/pid.js
@@ -16,8 +16,12 @@ export function loadPid() {
   return null;
 }
 
-export function clearPid() {
+export function clearPid(expectedPid = null) {
   try {
-    if (fs.existsSync(PID_FILE)) fs.unlinkSync(PID_FILE);
+    if (!fs.existsSync(PID_FILE)) return false;
+    if (expectedPid !== null && loadPid() !== expectedPid) return false;
+    fs.unlinkSync(PID_FILE);
+    return true;
   } catch { /* ignore */ }
+  return false;
 }

--- a/tests/unit/tunnel-pid-ownership.test.js
+++ b/tests/unit/tunnel-pid-ownership.test.js
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("cloudflared PID ownership", () => {
+  let dataDir;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-tunnel-pid-"));
+    process.env.DATA_DIR = dataDir;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.DATA_DIR;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("does not let an old child clear its successor PID", async () => {
+    const { clearPid, loadPid, savePid } = await import("../../src/lib/tunnel/cloudflare/pid.js");
+
+    savePid(100);
+    savePid(200);
+    clearPid(100);
+
+    expect(loadPid()).toBe(200);
+
+    clearPid(200);
+    expect(loadPid()).toBeNull();
+  });
+
+  it("releases PID and process ownership for the exiting child only", () => {
+    const source = fs.readFileSync(new URL("../../src/lib/tunnel/cloudflare/cloudflared.js", import.meta.url), "utf8");
+
+    expect(source.match(/clearPid\(child\.pid\)/g)).toHaveLength(2);
+    expect(source.match(/cloudflaredProcess === child/g)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Concurrent or closely spaced tunnel restarts can spawn a replacement cloudflared process before the previous child emits `exit`. Both exit handlers currently clear global process state and unlink the shared PID file unconditionally. The stale child can therefore erase the replacement PID, causing the watchdog to treat a healthy tunnel as dead and rotate the Quick Tunnel URL repeatedly.

This change:
- makes PID cleanup conditional on the exiting child still owning the PID file
- clears in-memory process ownership only when the exiting child is current
- preserves unconditional cleanup for explicit tunnel disable
- adds regression coverage for stale-child and current-child cleanup

Tested:
- `./tests/node_modules/.bin/vitest run --config tests/vitest.config.js --testTimeout 20000 tests/unit/tunnel-pid-ownership.test.js` (2 passed)
- focused ESLint and `git diff --check`