### PR TITLE
fix(console-log): initialize console log capture at server boot via Next.js instrumentation

### DIFF
--- a/src/app/api/translator/console-logs/stream/route.js
+++ b/src/app/api/translator/console-logs/stream/route.js
@@ -83,8 +83,9 @@ export async function GET(request) {
   return new Response(stream, {
     headers: {
       "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
+      "Cache-Control": "no-cache, no-transform",
       "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
     },
   });
 }

--- a/src/instrumentation.js
+++ b/src/instrumentation.js
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { initConsoleLogCapture } = await import("@/lib/consoleLogBuffer");
+    initConsoleLogCapture();
+  }
+}


### PR DESCRIPTION
### Summary
Fixes an issue where the console log tab (`/dashboard/console-log`) remains blank ("No console logs yet.") on fresh server boots, headless Docker deployments, or when running behind reverse proxies (Nginx / OpenResty / Caddy / Cloudflare).

### Root Causes
1. **Unbuffered Startup Logs in Docker / Standalone Mode:**
   `initConsoleLogCapture()` (which intercepts `console.log/warn/error`) was previously called lazily inside the stream API route (`/api/translator/console-logs/stream/route.js`). 
   In production Docker / standalone environments, 9Router runs headlessly before any user opens the web UI. Because Next.js App Router API routes are lazy-evaluated only when requested, all server logs emitted prior to opening `/dashboard/console-log` were missed and never saved into memory.

2. **Reverse Proxy Response Buffering:**
   The stream route was missing the `X-Accel-Buffering: no` header. When deployed behind reverse proxies (Nginx, OpenResty, Caddy, Cloudflare), the proxy holds back the initial SSE `init` payload in its response buffer on page load/refresh, causing the browser UI to stay blank until the buffer flushes.

### Solution
1. **Added `src/instrumentation.js`**: Uses Next.js `register()` hook to invoke `initConsoleLogCapture()` at server boot so all logs are captured from startup.
2. **Added `X-Accel-Buffering: no` and `Cache-Control: no-cache, no-transform` headers**: Prevents reverse proxies from buffering SSE stream events on page loads and refreshes.