### PR TITLE
fix(non-streaming): keep reasoning_content by default, make stripping opt-in

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -67,6 +67,12 @@ export const DEFAULT_MIN_TOKENS = 32000;
 
 export const TOKEN_SAVER_HEADER = "x-9router-token-saver";
 
+// Opt-out for reasoning_content on non-streaming responses. Send "off" to get the
+// pre-#517 behaviour (field dropped whenever content is non-empty) for clients whose
+// JSON parser rejects the non-standard field. Env STRIP_REASONING_CONTENT flips the
+// default for a whole deployment. See utils/reasoningVisibility.js.
+export const REASONING_HEADER = "x-9router-reasoning";
+
 // Retry config for 429 responses (legacy - kept for backward compatibility)
 export const RETRY_CONFIG = {
   maxAttempts: 2,

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -9,6 +9,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { applyReasoningVisibility } from "../../utils/reasoningVisibility.js";
 
 function parseToolArguments(value) {
   if (!value) return {};
@@ -271,15 +272,10 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     translatedResponse.usage = filterUsageForFormat(addBufferToUsage(translatedResponse.usage), sourceFormat);
   }
 
-  // Strip reasoning_content only when content is non-empty.
-  // When content is empty (e.g. thinking models that used all tokens for reasoning),
-  // reasoning_content is the only useful output and must be preserved.
-  if (!isClaudeMessageResponse && translatedResponse?.choices) {
-    for (const choice of translatedResponse.choices) {
-      if (choice?.message?.reasoning_content && choice.message.content) {
-        delete choice.message.reasoning_content;
-      }
-    }
+  // reasoning_content is kept by default; only an explicit opt-out drops it.
+  // Claude-format responses carry thinking as a content block and are untouched.
+  if (!isClaudeMessageResponse) {
+    applyReasoningVisibility(translatedResponse, clientRawRequest);
   }
 
   reqLogger.logConvertedResponse(translatedResponse);

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -4,6 +4,7 @@ import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
+import { applyReasoningVisibility } from "../../utils/reasoningVisibility.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -229,17 +230,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       status: "success"
     }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
-    // Strip reasoning_content only when content is non-empty.
-    // When content is empty (e.g. thinking models that used all tokens for reasoning),
-    // reasoning_content is the only useful output and must be preserved.
-    // Previously this was unconditional, which broke Qwen3.5, Claude extended thinking, etc.
-    if (parsed?.choices) {
-      for (const choice of parsed.choices) {
-        if (choice?.message?.reasoning_content && choice.message.content) {
-          delete choice.message.reasoning_content;
-        }
-      }
-    }
+    // reasoning_content is kept by default; only an explicit opt-out drops it.
+    applyReasoningVisibility(parsed, clientRawRequest);
 
     return { success: true, response: new Response(JSON.stringify(parsed), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {

--- a/open-sse/utils/reasoningVisibility.js
+++ b/open-sse/utils/reasoningVisibility.js
@@ -1,0 +1,37 @@
+import { REASONING_HEADER } from "../config/runtimeConfig.js";
+
+// Whether reasoning_content should be dropped from a non-streaming OpenAI-format
+// response.
+//
+// History: #517 stripped it unconditionally because one client (Firecrawl's AI SDK)
+// had a JSON parser that rejected the non-standard field. That cost every other
+// non-streaming client its thinking output, and #1836 already walked it back once by
+// only stripping when `content` was non-empty. It is still a lossy default: the field
+// is what DeepSeek/GLM/Qwen/Kimi/Hunyuan/Ollama all return natively, our own streaming
+// path emits it, and Claude-format responses keep their thinking blocks — so an
+// OpenAI-format client was the only one silently losing data.
+//
+// Default is now "keep". Clients that genuinely cannot parse it send
+// `x-9router-reasoning: off`; a deployment fronting only such clients sets
+// STRIP_REASONING_CONTENT=1.
+export function shouldStripReasoningContent(clientRawRequest) {
+  const header = clientRawRequest?.headers?.[REASONING_HEADER];
+  if (typeof header === "string" && header.toLowerCase() === "off") return true;
+  // Read at call time, not module load, so the env is honoured under test and after
+  // a config reload.
+  const env = process.env.STRIP_REASONING_CONTENT?.trim().toLowerCase();
+  return env === "1" || env === "true" || env === "on" || env === "yes";
+}
+
+// Apply the opt-out in place. Never strips when `content` is empty — for a model that
+// spent its whole budget on reasoning, reasoning_content is the only output there is.
+export function applyReasoningVisibility(response, clientRawRequest) {
+  if (!response?.choices) return response;
+  if (!shouldStripReasoningContent(clientRawRequest)) return response;
+  for (const choice of response.choices) {
+    if (choice?.message?.reasoning_content && choice.message.content) {
+      delete choice.message.reasoning_content;
+    }
+  }
+  return response;
+}

--- a/tests/unit/reasoning-visibility.test.js
+++ b/tests/unit/reasoning-visibility.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  shouldStripReasoningContent,
+  applyReasoningVisibility
+} from "open-sse/utils/reasoningVisibility.js";
+import { REASONING_HEADER } from "open-sse/config/runtimeConfig.js";
+
+const req = (headers) => ({ headers });
+
+const response = () => ({
+  choices: [{
+    index: 0,
+    message: { role: "assistant", content: "42", reasoning_content: "let me count" },
+    finish_reason: "stop"
+  }]
+});
+
+afterEach(() => {
+  delete process.env.STRIP_REASONING_CONTENT;
+});
+
+describe("shouldStripReasoningContent", () => {
+  it("keeps reasoning by default", () => {
+    expect(shouldStripReasoningContent(undefined)).toBe(false);
+    expect(shouldStripReasoningContent(req({}))).toBe(false);
+  });
+
+  it("strips when the client opts out via header", () => {
+    expect(shouldStripReasoningContent(req({ [REASONING_HEADER]: "off" }))).toBe(true);
+    expect(shouldStripReasoningContent(req({ [REASONING_HEADER]: "OFF" }))).toBe(true);
+  });
+
+  it("ignores any other header value", () => {
+    expect(shouldStripReasoningContent(req({ [REASONING_HEADER]: "on" }))).toBe(false);
+    expect(shouldStripReasoningContent(req({ [REASONING_HEADER]: "" }))).toBe(false);
+    expect(shouldStripReasoningContent(req({ [REASONING_HEADER]: "offf" }))).toBe(false);
+  });
+
+  it("honours the env default flip", () => {
+    for (const value of ["1", "true", "on", "YES", " true "]) {
+      process.env.STRIP_REASONING_CONTENT = value;
+      expect(shouldStripReasoningContent(undefined)).toBe(true);
+    }
+    for (const value of ["0", "false", "off", ""]) {
+      process.env.STRIP_REASONING_CONTENT = value;
+      expect(shouldStripReasoningContent(undefined)).toBe(false);
+    }
+  });
+});
+
+describe("applyReasoningVisibility", () => {
+  it("leaves reasoning_content in place by default", () => {
+    const res = applyReasoningVisibility(response(), req({}));
+    expect(res.choices[0].message.reasoning_content).toBe("let me count");
+  });
+
+  it("drops reasoning_content when the client opts out", () => {
+    const res = applyReasoningVisibility(response(), req({ [REASONING_HEADER]: "off" }));
+    expect(res.choices[0].message).not.toHaveProperty("reasoning_content");
+    expect(res.choices[0].message.content).toBe("42");
+  });
+
+  it("never drops reasoning_content when content is empty", () => {
+    // A model that spent its whole budget reasoning has no other output to return.
+    const res = {
+      choices: [{ message: { role: "assistant", content: "", reasoning_content: "thinking..." } }]
+    };
+    applyReasoningVisibility(res, req({ [REASONING_HEADER]: "off" }));
+    expect(res.choices[0].message.reasoning_content).toBe("thinking...");
+  });
+
+  it("applies to every choice", () => {
+    const res = {
+      choices: [
+        { message: { content: "a", reasoning_content: "ra" } },
+        { message: { content: "b", reasoning_content: "rb" } }
+      ]
+    };
+    applyReasoningVisibility(res, req({ [REASONING_HEADER]: "off" }));
+    expect(res.choices[0].message).not.toHaveProperty("reasoning_content");
+    expect(res.choices[1].message).not.toHaveProperty("reasoning_content");
+  });
+
+  it("is a no-op on non-choices payloads (Claude message shape)", () => {
+    const claude = { type: "message", content: [{ type: "thinking", thinking: "hi" }] };
+    expect(applyReasoningVisibility(claude, req({ [REASONING_HEADER]: "off" }))).toBe(claude);
+    expect(claude.content[0].thinking).toBe("hi");
+    expect(applyReasoningVisibility(null, req({}))).toBe(null);
+  });
+});


### PR DESCRIPTION
## Problem

Non-streaming OpenAI-format responses drop `reasoning_content` whenever `content` is non-empty, so the **same request returns different data depending only on `stream`**:

```
gh/claude-sonnet-4.6, identical prompt
  stream: true   -> reasoning_content = 300 chars
  stream: false  -> reasoning_content = 0 chars
```

Clients that render the field (Cherry Studio, Chatbox, …) simply never see the model's thinking unless they stream.

## Why the strip exists, and why the default is wrong now

It came from #517 (closing #509), where **one** client — Firecrawl's AI SDK — had a JSON parser that rejected the non-standard field. The fix was a global, unconditional delete on every provider's non-streaming response.

#1836 already walked it back once, adding the `&& choice.message.content` guard so thinking-only responses keep their only output. This PR finishes that direction:

- `reasoning_content` is what DeepSeek / GLM / Qwen / Kimi / Hunyuan / Ollama return **natively** — stripping it makes 9router lossier than the upstreams it proxies.
- Our own streaming path emits it, and Claude-format responses keep their `thinking` blocks. An OpenAI-format non-streaming client was the only consumer silently losing data.
- The dashboard already stores it (`buildRequestDetail`'s `thinking` field) — the server has the content and just declines to hand it over.

## Change

Default flips to **keep**. The original reporter gets an explicit escape hatch:

| escape hatch | scope |
| --- | --- |
| `x-9router-reasoning: off` | per request |
| `STRIP_REASONING_CONTENT=1` | whole deployment |

Both strip sites (`nonStreamingHandler` and the forced-SSE→JSON path in `sseToJsonHandler`) now share `applyReasoningVisibility`, which preserves the "never strip when `content` is empty" rule #1836 added.

The header follows the existing `x-9router-token-saver` convention in `runtimeConfig.js`.

## Verification

- New `tests/unit/reasoning-visibility.test.js` — 9 tests: default keeps, header opts out, header is case-insensitive, unrelated values ignored, env flip accepted in `1/true/on/yes`, empty-content never stripped, applies to every choice, no-op on Claude message shape.
- Full suite on this branch vs. `v0.5.40`: **82 failures → 82 failures, identical sets** (worktree diff of failure sets, not name matching).
- Live against a deployed instance, `gh/claude-sonnet-4.6`, same prompt:

```
PASS  A non-stream, default              reasoning=  284ch  content=  449ch
PASS  B non-stream, x-9router-reasoning: off  reasoning=    0ch  content=  321ch
PASS  C stream (control)                 reasoning=  300ch  content=  365ch
```

本 PR 由 Claude Code 辅助完成