### PR TITLE
fix(privacy): disable Google Analytics by default, add opt-in toggle

### DIFF
--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -460,6 +460,21 @@ export default function ProfilePage() {
     }
   };
 
+  const updateAnalyticsEnabled = async (enabled) => {
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ analyticsEnabled: enabled }),
+      });
+      if (res.ok) {
+        setSettings(prev => ({ ...prev, analyticsEnabled: enabled }));
+      }
+    } catch (err) {
+      console.error("Failed to update analyticsEnabled:", err);
+    }
+  };
+
   const reloadSettings = async () => {
     try {
       const res = await fetch("/api/settings");
@@ -551,6 +566,7 @@ export default function ProfilePage() {
   };
 
   const observabilityEnabled = settings.enableObservability === true;
+  const analyticsEnabled = settings.analyticsEnabled === true;
 
   const handleShutdown = async () => {
     setIsShuttingDown(true);
@@ -1096,6 +1112,29 @@ export default function ProfilePage() {
             <Toggle
               checked={observabilityEnabled}
               onChange={updateObservabilityEnabled}
+              disabled={loading}
+            />
+          </div>
+        </Card>
+
+        {/* Privacy Settings */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-orange-500/10 text-orange-500 shrink-0">
+              <span className="material-symbols-outlined text-[20px]">privacy_tip</span>
+            </div>
+            <h3 className="text-base sm:text-lg font-semibold">Privacy</h3>
+          </div>
+          <div className="flex items-start sm:items-center justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-sm sm:text-base">Anonymous Usage Analytics</p>
+              <p className="text-xs sm:text-sm text-text-muted">
+                Send anonymous page-view analytics to Google Analytics. Off by default.
+              </p>
+            </div>
+            <Toggle
+              checked={analyticsEnabled}
+              onChange={updateAnalyticsEnabled}
               disabled={loading}
             />
           </div>

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -7,6 +7,7 @@ import "@/lib/network/initOutboundProxy"; // Auto-initialize outbound proxy env
 import "@/shared/services/bootstrap"; // Auto-run initializeApp (watchdog, auto-resume tunnel)
 import { initConsoleLogCapture } from "@/lib/consoleLogBuffer";
 import { RuntimeI18nProvider } from "@/i18n/RuntimeI18nProvider";
+import { getSettings } from "@/lib/db/index.js";
 
 // Hook console immediately at module load time (server-side only, runs once)
 initConsoleLogCapture();
@@ -28,7 +29,8 @@ export const viewport = {
   themeColor: "#0a0a0a",
 };
 
-export default function RootLayout({ children }) {
+export default async function RootLayout({ children }) {
+  const settings = await getSettings();
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -44,7 +46,7 @@ export default function RootLayout({ children }) {
             {children}
           </RuntimeI18nProvider>
         </ThemeProvider>
-        <GoogleAnalytics gaId={"G-LC959F603F"} />
+        {settings.analyticsEnabled === true && <GoogleAnalytics gaId={"G-LC959F603F"} />}
       </body>
     </html>
   );

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -6,6 +6,7 @@ const DEFAULT_HEADROOM_URL = process.env.HEADROOM_URL || "http://localhost:8787"
 
 const DEFAULT_SETTINGS = {
   cloudEnabled: false,
+  analyticsEnabled: false,
   tunnelEnabled: false,
   tunnelUrl: "",
   tunnelProvider: "cloudflare",


### PR DESCRIPTION
## Summary
- Google Analytics (`GoogleAnalytics` from `@next/third-parties/google`) was rendered unconditionally in `src/app/layout.js` on every dashboard page load, with no setting to disable it.
- Adds `analyticsEnabled: false` as the default in `src/lib/db/repos/settingsRepo.js`, gates the `<GoogleAnalytics>` component on it in `src/app/layout.js`, and adds a "Privacy" toggle card in Dashboard → Profile so users can opt in if they want it.

Flagged as part of a security review for using 9Router with a company-owned provider API key — the concern was an undisclosed background call to a third party from what most people assume is a fully local app. This does not touch LLM traffic or API keys, only the GA page-view telemetry.

## Test plan
- [x] `tests/unit/*` suite run (see PR checks); no new failures introduced by this change.
- [ ] Manual: load dashboard with default settings → confirm no GA script/network call.
- [ ] Manual: toggle "Anonymous Usage Analytics" on in Profile → confirm GA loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)