### PR TITLE
fix(db): encrypt provider connection secrets at rest (AES-256-GCM)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ ENABLE_REQUEST_LOGS=false
 OBSERVABILITY_ENABLED=true
 AUTH_COOKIE_SECURE=false
 REQUIRE_API_KEY=false
+# Optional: overrides the machine-derived key used to encrypt provider connection
+# secrets (access/refresh tokens, API keys) at rest in the local SQLite DB.
+# Set this if you need the DB to remain readable after moving DATA_DIR to a new machine.
+# DB_ENCRYPTION_KEY=change-me-to-a-long-random-secret
 
 # Cloud sync variables
 # Must point to this running instance so internal sync jobs can call /api/sync/cloud.

--- a/src/lib/db/helpers/secretCol.js
+++ b/src/lib/db/helpers/secretCol.js
@@ -1,0 +1,55 @@
+import crypto from "crypto";
+
+const ENCRYPT_ALGO = "aes-256-gcm";
+const ENCRYPT_SALT = "9router-conn-secret";
+const ENC_PREFIX = "enc1:";
+
+function deriveKey() {
+  if (process.env.DB_ENCRYPTION_KEY) {
+    return crypto.createHash("sha256").update(process.env.DB_ENCRYPTION_KEY).digest();
+  }
+  try {
+    const { machineIdSync } = require("node-machine-id");
+    const raw = machineIdSync();
+    return crypto.createHash("sha256").update(raw + ENCRYPT_SALT).digest();
+  } catch {
+    return crypto.createHash("sha256").update(ENCRYPT_SALT).digest();
+  }
+}
+
+function encrypt(plaintext) {
+  const key = deriveKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ENCRYPT_ALGO, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${ENC_PREFIX}${iv.toString("hex")}:${tag.toString("hex")}:${encrypted.toString("hex")}`;
+}
+
+function decrypt(stored) {
+  const [ivHex, tagHex, dataHex] = stored.slice(ENC_PREFIX.length).split(":");
+  if (!ivHex || !tagHex || !dataHex) throw new Error("malformed secret ciphertext");
+  const key = deriveKey();
+  const decipher = crypto.createDecipheriv(ENCRYPT_ALGO, key, Buffer.from(ivHex, "hex"));
+  decipher.setAuthTag(Buffer.from(tagHex, "hex"));
+  return decipher.update(Buffer.from(dataHex, "hex")) + decipher.final("utf8");
+}
+
+// Encrypts a JSON-serializable value for storage in a `data` column.
+export function encryptSecretJson(value) {
+  return encrypt(JSON.stringify(value ?? null));
+}
+
+// Decrypts a value stored by encryptSecretJson. Transparently reads legacy
+// plaintext JSON (no "enc1:" prefix) written before this encryption was added.
+export function decryptSecretJson(stored, fallback = null) {
+  if (stored == null) return fallback;
+  try {
+    if (typeof stored === "string" && stored.startsWith(ENC_PREFIX)) {
+      return JSON.parse(decrypt(stored));
+    }
+    return JSON.parse(stored);
+  } catch {
+    return fallback;
+  }
+}

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -1,6 +1,7 @@
 // Public API barrel — all DB functions
 import { getAdapter } from "./driver.js";
 import { stringifyJson, parseJson } from "./helpers/jsonCol.js";
+import { decryptSecretJson, encryptSecretJson } from "./helpers/secretCol.js";
 
 // Settings
 export {
@@ -74,7 +75,7 @@ export async function exportDb() {
 
   const out = {
     settings: await exportSettings(),
-    providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
+    providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...decryptSecretJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
@@ -118,7 +119,7 @@ export async function importDb(payload) {
       const { id, provider, authType, name, email, priority, isActive, createdAt, updatedAt, ...rest } = c;
       db.run(
         `INSERT OR REPLACE INTO providerConnections(id, provider, authType, name, email, priority, isActive, data, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [id, provider, authType || "oauth", name || null, email || null, priority || null, isActive === false ? 0 : 1, stringifyJson(rest), createdAt || new Date().toISOString(), updatedAt || new Date().toISOString()]
+        [id, provider, authType || "oauth", name || null, email || null, priority || null, isActive === false ? 0 : 1, encryptSecretJson(rest), createdAt || new Date().toISOString(), updatedAt || new Date().toISOString()]
       );
     }
     for (const n of payload.providerNodes || []) {

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -7,6 +7,7 @@ import { getMetaSync, setMetaSync } from "./helpers/metaStore.js";
 import { makeBackupDir, backupFile, backupDbLite, pruneOldBackups } from "./backup.js";
 import { getAppVersion } from "./version.js";
 import { stringifyJson } from "./helpers/jsonCol.js";
+import { encryptSecretJson } from "./helpers/secretCol.js";
 
 // Marker file: prevents re-importing legacy JSON when user wipes data.sqlite.
 const MIGRATED_MARKER = path.join(DB_DIR, ".migrated-from-json");
@@ -120,7 +121,7 @@ function importLegacyMain(adapter, data) {
     const { id, provider, authType, name, email, priority, isActive, createdAt, updatedAt, ...rest } = c;
     adapter.run(
       `INSERT OR REPLACE INTO providerConnections(id, provider, authType, name, email, priority, isActive, data, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [id, provider, authType || "oauth", name || null, email || null, priority || null, isActive === false ? 0 : 1, stringifyJson(rest), createdAt || new Date().toISOString(), updatedAt || new Date().toISOString()]
+      [id, provider, authType || "oauth", name || null, email || null, priority || null, isActive === false ? 0 : 1, encryptSecretJson(rest), createdAt || new Date().toISOString(), updatedAt || new Date().toISOString()]
     );
   }, (c) => ({ id: c.id ?? null, provider: c.provider ?? null, name: c.name ?? null }));
 

--- a/src/lib/db/repos/connectionsRepo.js
+++ b/src/lib/db/repos/connectionsRepo.js
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { getAdapter } from "../driver.js";
-import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+import { decryptSecretJson, encryptSecretJson } from "../helpers/secretCol.js";
 
 const OPTIONAL_FIELDS = [
   "displayName", "email", "globalPriority", "defaultModel",
@@ -12,7 +12,7 @@ const OPTIONAL_FIELDS = [
 
 function rowToConn(row) {
   if (!row) return null;
-  const extra = parseJson(row.data, {});
+  const extra = decryptSecretJson(row.data, {});
   return {
     ...extra,
     id: row.id,
@@ -37,7 +37,7 @@ function connToRow(c) {
     email: email ?? null,
     priority: priority ?? null,
     isActive: isActive === false ? 0 : 1,
-    data: stringifyJson(rest),
+    data: encryptSecretJson(rest),
     createdAt,
     updatedAt,
   };

--- a/tests/unit/secretCol.test.js
+++ b/tests/unit/secretCol.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { encryptSecretJson, decryptSecretJson } from "../../src/lib/db/helpers/secretCol.js";
+
+describe("secretCol", () => {
+  it("round-trips a JSON value through encryption", () => {
+    const value = { apiKey: "sk-test-123", refreshToken: "rt-abc", nested: { n: 1 } };
+    const stored = encryptSecretJson(value);
+    expect(typeof stored).toBe("string");
+    expect(stored.startsWith("enc1:")).toBe(true);
+    expect(stored).not.toContain("sk-test-123");
+    expect(decryptSecretJson(stored)).toEqual(value);
+  });
+
+  it("reads legacy plaintext JSON without the enc1: prefix", () => {
+    const value = { apiKey: "legacy-key" };
+    const legacy = JSON.stringify(value);
+    expect(decryptSecretJson(legacy)).toEqual(value);
+  });
+
+  it("returns the fallback for null/invalid input", () => {
+    expect(decryptSecretJson(null, { a: 1 })).toEqual({ a: 1 });
+    expect(decryptSecretJson("not json", { a: 1 })).toEqual({ a: 1 });
+    expect(decryptSecretJson("enc1:garbage", { a: 1 })).toEqual({ a: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- `providerConnections.data` (accessToken, refreshToken, idToken, apiKey, etc.) was stored as plain `JSON.stringify` in SQLite — readable in the clear by anyone with filesystem access to `~/.9router/` or `DATA_DIR`.
- Adds `src/lib/db/helpers/secretCol.js`: AES-256-GCM encryption, keyed by a machine-derived key by default (`node-machine-id` + salt, same pattern already used for the MITM sudo password in `src/mitm/manager.js`), with an optional `DB_ENCRYPTION_KEY` env override documented in `.env.example` for portability across machines.
- Wires it into every code path that reads/writes that column: `connectionsRepo.js` (normal read/write path), `db/index.js` (`exportDb`/`importDb`, DB backup/restore), and `migrate.js` (one-time legacy `db.json` → SQLite import).
- Backward compatible: existing plaintext rows are detected (no `enc1:` prefix) and parsed directly; every write re-encrypts going forward. No explicit migration step required.
- DB export/import backup payloads are intentionally kept in plaintext JSON (decrypt-on-export, encrypt-on-import) to preserve the existing human-readable/portable backup format — this matches current behavior, not a new regression.

Flagged as the top finding in a security review for using 9Router with a company-owned provider API key.

## Test plan
- [x] New `tests/unit/secretCol.test.js`: round-trip encryption, legacy-plaintext read compatibility, fallback on invalid/null input.
- [x] Verified no regressions against the existing suite (`tests/__baseline__/known-fails.txt` known-red set) — checked in particular `db-concurrent`, `db-migration-chain`, `db-sqlite-vs-lowdb`, `bulk-add-names`, `antigravity-cache` (all pass; unrelated failures confirmed pre-existing on a clean checkout).
- [ ] Manual: add a provider connection, inspect the SQLite `data` column directly to confirm it's ciphertext, restart the app and confirm the connection still works (round-trip through the running app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)