### PR TITLE
feat(dashboard): add bulk enable/disable for provider connections

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -1436,14 +1436,44 @@ export default function ProviderDetailPage() {
               {connections.length > 0 && (
                 <>
                   {selectedConnectionIds.length > 0 && (
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      icon="delete"
-                      onClick={handleBulkDelete}
-                    >
-                      Delete Selected ({selectedConnectionIds.length})
-                    </Button>
+                    <>
+                      {selectedConnections.some((c) => c.isActive !== false) && (
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          icon="block"
+                          onClick={() => {
+                            const ids = [...selectedConnectionIds];
+                            ids.forEach((id) => handleUpdateConnectionStatus(id, false));
+                            setSelectedConnectionIds([]);
+                          }}
+                        >
+                          Disable Selected ({selectedConnectionIds.length})
+                        </Button>
+                      )}
+                      {selectedConnections.some((c) => c.isActive === false) && (
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          icon="check_circle"
+                          onClick={() => {
+                            const ids = [...selectedConnectionIds];
+                            ids.forEach((id) => handleUpdateConnectionStatus(id, true));
+                            setSelectedConnectionIds([]);
+                          }}
+                        >
+                          Enable Selected ({selectedConnectionIds.length})
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        icon="delete"
+                        onClick={handleBulkDelete}
+                      >
+                        Delete Selected ({selectedConnectionIds.length})
+                      </Button>
+                    </>
                   )}
                   <Button
                     size="sm"


### PR DESCRIPTION
## Summary

Adds **Enable Selected** and **Disable Selected** bulk action buttons to the provider connections table header, complementing the existing **Delete Selected** button. This allows users to toggle the active/inactive status of multiple connections at once without editing each connection individually.

## What changed

- wrapped the existing single bulk delete button in a fragment and added two new conditional bulk action buttons:

### Disable Selected
- Renders when **any** selected connection has `isActive !== false` (i.e., at least one selected connection is currently enabled)
- Calls `handleUpdateConnectionStatus(id, false)` for each selected connection ID
- Clears the selection afterward

### Enable Selected
- Renders when **any** selected connection has `isActive === false` (i.e., at least one selected connection is currently disabled)
- Calls `handleUpdateConnectionStatus(id, true)` for each selected connection ID
- Clears the selection afterward

Both buttons use the `secondary` variant with icons (`block` for disable, `check_circle` for enable) to visually distinguish them from the `danger`-variant **Delete Selected** button.

## Why

Previously, users had to open each connection's edit view to toggle its active state, which was tedious when managing many connections. The existing bulk selection UI only supported deletion — a destructive operation with no way to batch-toggle status. These additions give users a non-destructive bulk action that aligns with the existing multi-select pattern.

## Screenshots

<img width="1314" height="713" alt="image" src="https://github.com/user-attachments/assets/50d28367-4cc0-4e17-a504-6e8de1123c53" />

## Related

- Follows the same multi-select pattern as the existing **Delete Selected** button
- Reuses the existing `handleUpdateConnectionStatus` function logic