### PR TITLE
fix(translator): carry Structured Output across the Chat ⇄ Responses hop

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -103,7 +103,7 @@ export class DefaultExecutor extends BaseExecutor {
     if (rf?.type !== "json_schema" || !rf.json_schema?.schema) return body;
 
     const schemaJson = JSON.stringify(rf.json_schema.schema, null, 2);
-    const prompt = `You must respond with valid JSON that strictly follows this JSON schema:\n\`\`\`json\n${schemaJson}\n\`\`\`\nRespond ONLY with the JSON object, no other text.`;
+    const prompt = `You must respond with valid JSON that strictly follows this JSON schema:\n\`\`\`json\n${schemaJson}\n\`\`\`\nRespond ONLY with the JSON object, no other text and no markdown code fences.`;
 
     const messages = Array.isArray(body.messages) ? body.messages.map(m => ({ ...m })) : [];
     const sys = messages.find(m => m.role === "system");

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -9,6 +9,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { unfenceJsonChoices } from "../../utils/jsonFence.js";
 
 function parseToolArguments(value) {
   if (!value) return {};
@@ -281,6 +282,9 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
       }
     }
   }
+
+  // JSON mode: drop a ```json fence the provider added around the object
+  unfenceJsonChoices(body, translatedResponse);
 
   reqLogger.logConvertedResponse(translatedResponse);
 

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -8,6 +8,7 @@ import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLin
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
 import { saveRequestDetail, appendRequestLog } from "@/lib/usageDb.js";
+import { stripJsonFence, unfenceJsonChoices, wantsJsonOutput } from "../../utils/jsonFence.js";
 
 function textFromResponsesMessageItem(item) {
   if (!item?.content || !Array.isArray(item.content)) return "";
@@ -133,7 +134,9 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
       if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
-      const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      const { msgItem, textContent: rawTextContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      // JSON mode: drop a ```json fence the provider added around the object
+      const textContent = wantsJsonOutput(body) ? stripJsonFence(rawTextContent) : rawTextContent;
       const totalLatency = Date.now() - requestStartTime;
 
       saveRequestDetail(buildRequestDetail({
@@ -240,6 +243,9 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         }
       }
     }
+
+    // JSON mode: drop a ```json fence the provider added around the object
+    unfenceJsonChoices(body, parsed);
 
     return { success: true, response: new Response(JSON.stringify(parsed), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -195,6 +195,13 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
     delete result.max_output_tokens;
   }
 
+  // Structured Output: Responses `text.format` → Chat `response_format` (`text` is not a Chat field)
+  if (result.text !== undefined) {
+    const responseFormat = textFormatToResponseFormat(result.text);
+    if (responseFormat && result.response_format === undefined) result.response_format = responseFormat;
+    delete result.text;
+  }
+
   delete result.input;
   delete result.instructions;
   delete result.include;
@@ -382,7 +389,37 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
   if (body.service_tier !== undefined) result.service_tier = body.service_tier;
 
+  // Structured Output: Chat `response_format` → Responses `text.format` (#dropped otherwise)
+  const textFormat = responseFormatToTextFormat(body.response_format);
+  if (textFormat) result.text = { format: textFormat };
+
   return result;
+}
+
+/**
+ * Chat Completions `response_format` → Responses API `text.format`.
+ * Responses nests the schema one level up and flattens json_schema.{name,schema,strict}.
+ */
+function responseFormatToTextFormat(responseFormat) {
+  if (responseFormat?.type === "json_schema") {
+    const js = responseFormat.json_schema;
+    if (!js?.schema) return null;
+    return { type: "json_schema", name: js.name || "response", schema: js.schema, strict: js.strict ?? true };
+  }
+  if (responseFormat?.type === "json_object") return { type: "json_object" };
+  return null;
+}
+
+/**
+ * Responses API `text.format` → Chat Completions `response_format` (inverse of the above).
+ */
+function textFormatToResponseFormat(text) {
+  const fmt = text?.format;
+  if (fmt?.type === "json_schema" && fmt.schema) {
+    return { type: "json_schema", json_schema: { name: fmt.name || "response", schema: fmt.schema, strict: fmt.strict ?? true } };
+  }
+  if (fmt?.type === "json_object") return { type: "json_object" };
+  return null;
 }
 
 // Register both directions

--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -123,9 +123,9 @@ export function openaiToClaudeRequest(model, body, stream) {
 \`\`\`json
 ${schemaJson}
 \`\`\`
-Respond ONLY with the JSON object, no other text.`);
+Respond ONLY with the JSON object, no other text and no markdown code fences.`);
     } else if (responseFormat.type === "json_object") {
-      systemParts.push("You must respond with valid JSON. Respond ONLY with a JSON object, no other text.");
+      systemParts.push("You must respond with valid JSON. Respond ONLY with a JSON object, no other text and no markdown code fences.");
     }
   }
 

--- a/open-sse/utils/jsonFence.js
+++ b/open-sse/utils/jsonFence.js
@@ -1,0 +1,34 @@
+/**
+ * Providers that get Structured Output as a prompt instruction (Claude-backed ones
+ * especially) tend to answer with the JSON wrapped in a ```json fence. Clients that
+ * JSON.parse the content — anything using schema-parsed calls — choke on it.
+ * Strip the fence, but only when the request actually asked for JSON output.
+ */
+
+// Whole content is one fenced block: ```json\n{...}\n```
+const FENCED_JSON = /^\s*```(?:json|JSON)?\s*\r?\n([\s\S]*?)\r?\n?\s*```\s*$/;
+
+export function wantsJsonOutput(body) {
+  const type = body?.response_format?.type;
+  return type === "json_schema" || type === "json_object";
+}
+
+export function stripJsonFence(content) {
+  if (typeof content !== "string") return content;
+  const match = content.match(FENCED_JSON);
+  return match ? match[1].trim() : content;
+}
+
+/**
+ * Unfence the assistant content of an OpenAI-shaped response, in place.
+ * ponytail: non-streaming only — a streaming client would need the fence stripped
+ * across chunk boundaries; add a stateful transform if that ever comes up.
+ */
+export function unfenceJsonChoices(body, response) {
+  if (!wantsJsonOutput(body) || !Array.isArray(response?.choices)) return response;
+  for (const choice of response.choices) {
+    const message = choice?.message;
+    if (message) message.content = stripJsonFence(message.content);
+  }
+  return response;
+}

--- a/tests/translator/structured-output.test.js
+++ b/tests/translator/structured-output.test.js
@@ -1,0 +1,39 @@
+// Structured Output must survive the Chat ⇄ Responses translation (Codex/cx path).
+// Regression: response_format was silently dropped, so json_schema never reached the provider.
+import { describe, it, expect } from "vitest";
+import "./registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const R2O = (body) => translateRequest(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI, "m", body, true, null, null);
+const O2R = (body) => translateRequest(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, "m", body, true, null, null);
+
+const SCHEMA = { type: "object", properties: { facts: { type: "array", items: { type: "string" } } }, required: ["facts"], additionalProperties: false };
+const chatBody = (response_format) => ({ messages: [{ role: "user", content: "hi" }], response_format });
+
+describe("OpenAI Chat → Responses", () => {
+  it("maps response_format json_schema to text.format", () => {
+    const out = O2R(chatBody({ type: "json_schema", json_schema: { name: "Facts", strict: true, schema: SCHEMA } }));
+    expect(out.text?.format).toEqual({ type: "json_schema", name: "Facts", schema: SCHEMA, strict: true });
+  });
+
+  it("maps response_format json_object to text.format", () => {
+    const out = O2R(chatBody({ type: "json_object" }));
+    expect(out.text?.format).toEqual({ type: "json_object" });
+  });
+
+  it("leaves text unset when no response_format is requested", () => {
+    expect(O2R(chatBody(undefined)).text).toBeUndefined();
+  });
+});
+
+describe("OpenAI Responses → Chat", () => {
+  it("maps text.format back to response_format and drops the Responses-only field", () => {
+    const out = R2O({
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      text: { format: { type: "json_schema", name: "Facts", strict: true, schema: SCHEMA } },
+    });
+    expect(out.response_format).toEqual({ type: "json_schema", json_schema: { name: "Facts", schema: SCHEMA, strict: true } });
+    expect(out.text).toBeUndefined();
+  });
+});

--- a/tests/unit/jsonFence.test.js
+++ b/tests/unit/jsonFence.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { stripJsonFence, wantsJsonOutput, unfenceJsonChoices } from "../../open-sse/utils/jsonFence.js";
+
+const JSON_MODE = { response_format: { type: "json_schema", json_schema: { name: "x", schema: {} } } };
+const wrap = (content) => ({ choices: [{ message: { role: "assistant", content } }] });
+
+describe("stripJsonFence", () => {
+  it("unwraps a ```json fence", () => {
+    expect(stripJsonFence('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it("unwraps a bare ``` fence", () => {
+    expect(stripJsonFence('```\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it("leaves unfenced JSON untouched", () => {
+    expect(stripJsonFence('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it("leaves prose containing a fence untouched", () => {
+    const prose = 'Here you go:\n```json\n{"a":1}\n```\nHope that helps.';
+    expect(stripJsonFence(prose)).toBe(prose);
+  });
+
+  it("passes through non-strings", () => {
+    expect(stripJsonFence(null)).toBe(null);
+  });
+});
+
+describe("wantsJsonOutput", () => {
+  it("is true for json_schema and json_object", () => {
+    expect(wantsJsonOutput(JSON_MODE)).toBe(true);
+    expect(wantsJsonOutput({ response_format: { type: "json_object" } })).toBe(true);
+  });
+
+  it("is false without response_format", () => {
+    expect(wantsJsonOutput({})).toBe(false);
+    expect(wantsJsonOutput({ response_format: { type: "text" } })).toBe(false);
+  });
+});
+
+describe("unfenceJsonChoices", () => {
+  it("unfences assistant content in JSON mode", () => {
+    const out = unfenceJsonChoices(JSON_MODE, wrap('```json\n{"a":1}\n```'));
+    expect(out.choices[0].message.content).toBe('{"a":1}');
+  });
+
+  it("leaves content alone when JSON was not requested", () => {
+    const fenced = '```json\n{"a":1}\n```';
+    expect(unfenceJsonChoices({}, wrap(fenced)).choices[0].message.content).toBe(fenced);
+  });
+
+  it("tolerates a tool-call message with null content", () => {
+    const out = unfenceJsonChoices(JSON_MODE, wrap(null));
+    expect(out.choices[0].message.content).toBe(null);
+  });
+});


### PR DESCRIPTION
## Problem

`response_format` is silently dropped whenever a Chat Completions request is translated to the OpenAI Responses API, so Structured Output never reaches Codex-family providers. They answer in prose, and any client that parses the content as JSON fails.

Reproduction against a `cx`/codex-backed model:

```bash
curl $GATEWAY/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{
  "model": "<codex-backed-model>",
  "messages": [{"role": "user", "content": "Two facts about the number 7."}],
  "response_format": {"type": "json_schema", "json_schema": {
    "name": "Facts", "strict": true,
    "schema": {"type": "object", "properties": {"facts": {"type": "array", "items": {"type": "string"}}},
               "required": ["facts"], "additionalProperties": false}}}
}'
```

Before: `"content": "- 7 is a prime number.\n- 7 is the number of days in a week."`
After: `"content": "{\"facts\":[\"7 is a prime number...\",\"A standard week has 7 days.\"]}"`

This surfaced through a self-hosted [Honcho](https://github.com/plastic-labs/honcho) deriver, which uses schema-parsed calls: every derivation failed with `pydantic ValidationError ... Invalid JSON` for ~4 hours after a combo fell back onto a codex provider, and the memory queue stalled at 200+ items.

## Cause

`openaiToOpenAIResponsesRequest` (`open-sse/translator/request/openai-responses.js`) builds the Responses body field by field — `messages` → `input`, system → `instructions`, `tools`, `temperature`, `max_tokens`, `top_p`, `reasoning`, `service_tier` — and `response_format` is not among them, so it is dropped.

Nothing downstream compensates:

- `RESPONSES_API_ALLOWLIST` in `open-sse/executors/codex.js` already permits `text`, so the field would pass through if anything set it — nothing does.
- `applyJsonSchemaFallback` in `open-sse/executors/default.js` is gated on `provider.startsWith("openai-compatible-")`, so codex never reaches it.

The reverse direction has the mirror bug: `openaiResponsesToOpenAIRequest` starts from `{...body}` and deletes the Responses-only fields, but not `text` — so `text` leaks into Chat Completions requests as an unknown field.

## Changes

**1. Map Structured Output across both directions of the hop** (`openai-responses.js`)

Chat `response_format` → Responses `text.format` on the way out, `text.format` → `response_format` (and `delete text`) on the way back. `json_schema` flattens to `{type, name, schema, strict}`; `json_object` maps straight across.

**2. Unwrap ```json fences when the client asked for JSON** (`open-sse/utils/jsonFence.js`, wired into `chatCore`'s non-streaming paths)

Providers that receive Structured Output as a prompt instruction rather than a native schema — Claude-backed ones especially — answer with the object inside a markdown fence, which breaks the same clients for a different reason. Instructing them not to fence is unreliable in practice, so the fence is stripped on the way out instead. Guarded by `response_format`, and only when the whole content is a single fenced block, so an ordinary answer containing a code block is untouched.

Non-streaming paths only; a streaming client would need a stateful transform across chunk boundaries, which is noted in the code and left out.

The second change is independent of the first — happy to split it into its own PR if you'd prefer to review them separately.

## Tests

- `tests/translator/structured-output.test.js` — round-trip mapping in both directions, and that `text` stays unset when no `response_format` was requested (4 tests)
- `tests/unit/jsonFence.test.js` — fence variants, prose containing a fence left alone, non-JSON-mode requests untouched, null content (10 tests)

Full suite (excluding `real/`) on this branch: 1299 passing vs 1288 on `master`, with one previously failing case now green and no new failures.

Verified end to end against a live gateway: the codex path returns unfenced JSON, and the Honcho deriver drained its backlog with zero validation errors.
