### PR TITLE
fix(codex): preserve GPT-5.6 max reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Fixes
+- **Codex/OpenAI**: preserve GPT-5.6 `max` reasoning effort instead of downgrading it to `xhigh`
+
+
 # v0.5.40 (2026-07-20)
 
 ## Features

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -11,6 +11,7 @@ import { getModelUpstreamId } from "../config/providerModels.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import { supportsThinkingLevel } from "../providers/thinkingLevels.js";
 
 // SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
 const CODEX_SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
@@ -124,8 +125,8 @@ function resolveCacheSessionId(body, credentials) {
   });
 }
 
-function normalizeReasoningEffort(value) {
-  return value === "max" ? "xhigh" : value;
+function normalizeReasoningEffort(value, model) {
+  return value === "max" && !supportsThinkingLevel("codex", model, "max") ? "xhigh" : value;
 }
 
 function findNestedMessage(value, depth = 0) {
@@ -427,7 +428,7 @@ export class CodexExecutor extends BaseExecutor {
 
     // Extract thinking level from model name suffix
     // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → medium (default)
-    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
     let modelEffort = null;
     for (const level of effortLevels) {
       if (body.model.endsWith(`-${level}`)) {
@@ -440,10 +441,10 @@ export class CodexExecutor extends BaseExecutor {
 
     // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (medium)
     if (!body.reasoning) {
-      const effort = normalizeReasoningEffort(body.reasoning_effort || modelEffort || 'low');
+      const effort = normalizeReasoningEffort(body.reasoning_effort || modelEffort || 'low', body.model);
       body.reasoning = { effort, summary: "auto" };
     } else {
-      body.reasoning.effort = normalizeReasoningEffort(body.reasoning.effort);
+      body.reasoning.effort = normalizeReasoningEffort(body.reasoning.effort, body.model);
       if (!body.reasoning.summary) body.reasoning.summary = "auto";
     }
     delete body.reasoning_effort;

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -30,10 +30,13 @@ const FORMAT_LEVELS = {
   step: L.base,
 };
 
+const GPT_56_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
 // Model-name pattern overrides (glob, first match wins) — more precise than format default.
 const PATTERN_THINKING = [
-  // gpt-5.6-sol accepts max (maps to xhigh on wire); live probe rejected ultra.
-  { pattern: "*gpt-5.6-sol*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max"] },
+  // OpenAI API and Codex GPT-5.6 models accept max directly; older models cap at xhigh.
+  { providers: ["openai", "codex"], pattern: "*gpt-5.6", levels: GPT_56_LEVELS },
+  { providers: ["openai", "codex"], pattern: "*gpt-5.6-*", levels: GPT_56_LEVELS },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
 ];
 
@@ -41,8 +44,14 @@ const PATTERN_THINKING = [
 export function getThinkingLevels(provider, model) {
   const caps = getCapabilitiesForModel(provider, model);
   if (!caps.reasoning) return null;
-  const hit = PATTERN_THINKING.find((p) => matchPattern(p.pattern, model));
+  const hit = PATTERN_THINKING.find((p) =>
+    (!p.providers || p.providers.includes(provider)) && matchPattern(p.pattern, model)
+  );
   let levels = hit?.levels || FORMAT_LEVELS[caps.thinkingFormat] || L.base;
   if (caps.thinkingCanDisable === false) levels = levels.filter((l) => l !== "none");
   return levels;
+}
+
+export function supportsThinkingLevel(provider, model, level) {
+  return getThinkingLevels(provider, model)?.includes(level) === true;
 }

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -4,6 +4,7 @@
 
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { PROVIDERS } from "../../providers/index.js";
+import { supportsThinkingLevel } from "../../providers/thinkingLevels.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
@@ -213,7 +214,7 @@ function stripAll(body) {
 }
 
 // Apply unified thinking config to body in the resolved provider-native format.
-function applyFormat(fmt, body, cfg, caps) {
+function applyFormat(fmt, body, cfg, caps, provider, model) {
   const none = cfg.mode === "none";
   const canDisable = caps.thinkingCanDisable !== false;
   // Model cannot disable thinking → clamp "none" to minimal effort instead.
@@ -223,8 +224,8 @@ function applyFormat(fmt, body, cfg, caps) {
     case "openai": {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
       const level = toLevel(eff);
-      // OpenAI reasoning_effort enum caps at "xhigh" (no "max"); clamp Claude Code's "max".
-      if (level) body.reasoning_effort = level === "max" ? "xhigh" : level;
+      // OpenAI-format support is model-specific; older models still reject max.
+      if (level) body.reasoning_effort = level === "max" && !supportsThinkingLevel(provider, model, "max") ? "xhigh" : level;
       break;
     }
     case "claude-adaptive": {
@@ -330,6 +331,6 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
 
   const fmt = resolveFormat(targetFormat, cleanModel, provider);
   stripAll(body);
-  applyFormat(fmt, body, cfg, caps);
+  applyFormat(fmt, body, cfg, caps, provider, cleanModel);
   return body;
 }

--- a/tests/unit/codex-fast-capacity.test.js
+++ b/tests/unit/codex-fast-capacity.test.js
@@ -25,6 +25,31 @@ describe("Codex fast tier and capacity handling", () => {
     expect(body.reasoning.effort).toBe("xhigh");
   });
 
+  it.each(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])(
+    "preserves max reasoning for %s",
+    (model) => {
+      const executor = new CodexExecutor();
+      const body = executor.transformRequest(model, {
+        model,
+        input: "hi",
+        reasoning_effort: "max",
+      }, true, {});
+
+      expect(body.reasoning.effort).toBe("max");
+    },
+  );
+
+  it("parses and preserves the GPT-5.6 max model suffix", () => {
+    const executor = new CodexExecutor();
+    const body = executor.transformRequest("gpt-5.6-sol-max", {
+      model: "gpt-5.6-sol-max",
+      input: "hi",
+    }, true, {});
+
+    expect(body.model).toBe("gpt-5.6-sol");
+    expect(body.reasoning.effort).toBe("max");
+  });
+
   it("uses ChatGPT workspace header fallback", () => {
     const executor = new CodexExecutor();
     const headers = executor.buildHeaders({

--- a/tests/unit/thinking-effort-openai-max-clamp.test.js
+++ b/tests/unit/thinking-effort-openai-max-clamp.test.js
@@ -2,11 +2,8 @@ import { describe, expect, it } from "vitest";
 import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 
-// Regression: Claude Code sends thinking effort "max" (its top level). When
-// 9router routes to an OpenAI-format provider, applyThinking() case "openai"
-// must clamp "max"→"xhigh" because OpenAI's reasoning_effort enum has no "max"
-// (L.openai caps at "xhigh"). Without the clamp, upstream returns HTTP 400
-// "max effort not support". See open-sse/providers/thinkingLevels.js:10.
+// Regression: Claude Code sends thinking effort "max" (its top level). Older
+// OpenAI-format models reject it, while GPT-5.6 accepts it as a distinct level.
 describe("applyThinking (openai): clamp max effort to xhigh", () => {
   it("client output_config.effort:\"max\" → reasoning_effort:\"xhigh\" (not \"max\")", () => {
     const body = { output_config: { effort: "max" } };
@@ -19,6 +16,20 @@ describe("applyThinking (openai): clamp max effort to xhigh", () => {
     const out = applyThinking(FORMATS.OPENAI, "gpt-5", body, "openai");
     expect(out.reasoning_effort).toBe("xhigh");
   });
+
+  it.each([
+    ["openai", "gpt-5.6"],
+    ["openai", "gpt-5.6-sol"],
+    ["codex", "gpt-5.6-sol"],
+    ["codex", "gpt-5.6-terra"],
+    ["codex", "gpt-5.6-luna"],
+  ])(
+    "%s/%s preserves max directly",
+    (provider, model) => {
+      const out = applyThinking(FORMATS.OPENAI, model, { reasoning_effort: "max" }, provider);
+      expect(out.reasoning_effort).toBe("max");
+    },
+  );
 
   it("\"xhigh\" passes through unchanged (highest valid OpenAI level)", () => {
     const body = { reasoning_effort: "xhigh" };

--- a/tests/unit/thinking-levels-gpt56-sol.test.js
+++ b/tests/unit/thinking-levels-gpt56-sol.test.js
@@ -1,12 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
+import { getThinkingLevels, supportsThinkingLevel } from "../../open-sse/providers/thinkingLevels.js";
 
 describe("getThinkingLevels", () => {
-  it("adds max for gpt-5.6-sol on codex", () => {
-    const levels = getThinkingLevels("codex", "gpt-5.6-sol");
+  it.each(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])("adds max for %s on codex", (model) => {
+    const levels = getThinkingLevels("codex", model);
     expect(levels).toContain("max");
     expect(levels).toContain("xhigh");
     expect(levels).not.toContain("ultra");
+  });
+
+  it.each(["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])("adds max for %s on OpenAI", (model) => {
+    expect(supportsThinkingLevel("openai", model, "max")).toBe(true);
   });
 
   it("does not add max for other codex models", () => {
@@ -14,8 +18,11 @@ describe("getThinkingLevels", () => {
     expect(levels).toEqual(["low", "medium", "high", "xhigh"]);
   });
 
-  it("does not add max for other gpt-5.6 models", () => {
-    const levels = getThinkingLevels("codex", "gpt-5.5");
-    expect(levels || []).not.toContain("max");
+  it.each([
+    ["codex", "gpt-5.5"],
+    ["openai", "gpt-5.5"],
+    ["kiro", "gpt-5.6-sol"],
+  ])("does not add max for %s/%s", (provider, model) => {
+    expect(supportsThinkingLevel(provider, model, "max")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- preserve reasoning effort `max` for OpenAI API and Codex GPT-5.6 models
- retain `max` to `xhigh` compatibility for older OpenAI-format models
- parse and preserve the GPT-5.6 `max` model suffix in the Codex executor
- centralize model-level support in `thinkingLevels.js` so the picker and wire normalization agree

## Root cause

PR #2466 introduced a global `max` to `xhigh` clamp after an older OpenAI-format upstream rejected `max`. PR #2500 later exposed `max` for GPT-5.6 Sol, but its live probe passed through that clamp, so the upstream only received `xhigh`.

Current OpenAI documentation lists `none`, `low`, `medium`, `high`, `xhigh`, and `max` as distinct supported reasoning efforts for GPT-5.6 models:
https://developers.openai.com/api/docs/guides/deployment-checklist#set-up-reasoningeffort

## Verification

- reasoning-focused Vitest suite: 72 passed
- focused ESLint: passed
- `git diff --check`: passed
- production `npm run build`: passed
- local routed request confirmed `THINK:max`

## Related work

- restores GPT-5.6 behavior narrowed by #2466
- completes the end-to-end behavior intended by #2500
- overlaps only the GPT-5.6 `max` portion of #2452; this PR intentionally excludes its Fast/Priority and context-estimator changes
