### PR TITLE
feat(combo): expose provider-neutral route attribution

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -67,6 +67,19 @@ export const DEFAULT_MIN_TOKENS = 32000;
 
 export const TOKEN_SAVER_HEADER = "x-9router-token-saver";
 
+export const ROUTE_ATTRIBUTION = {
+  maxTokenLength: 160,
+  maxAttempts: 32,
+  headers: {
+    requestedModel: "X-9Router-Requested-Model",
+    routePath: "X-9Router-Route-Path",
+    resolvedProvider: "X-9Router-Resolved-Provider",
+    resolvedModel: "X-9Router-Resolved-Model",
+    fallbackCount: "X-9Router-Fallback-Count",
+    attemptedModels: "X-9Router-Attempted-Models",
+  },
+};
+
 // Retry config for 429 responses (legacy - kept for backward compatibility)
 export const RETRY_CONFIG = {
   maxAttempts: 2,

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -6,6 +6,7 @@ import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
+import { annotateComboResponse } from "./routeAttribution.js";
 
 // Hard capabilities = input modalities; missing one drops request data (e.g. image
 // stripped). Must be prioritized. Soft (e.g. search) only degrades a feature.
@@ -256,7 +257,11 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       // Success (2xx) - return response
       if (result.ok) {
         log.info("COMBO", `Model ${modelStr} succeeded`);
-        return result;
+        return annotateComboResponse({
+          comboName: comboName || body?.model,
+          selectedModel: modelStr,
+          attemptedModels: rotatedModels.slice(0, i + 1),
+        }, result);
       }
 
       // Extract error info from response

--- a/open-sse/services/routeAttribution.js
+++ b/open-sse/services/routeAttribution.js
@@ -1,0 +1,81 @@
+import { ROUTE_ATTRIBUTION } from "../config/runtimeConfig.js";
+
+const EXPOSED_HEADERS = Object.values(ROUTE_ATTRIBUTION.headers);
+
+function safeToken(value) {
+  return String(value || "")
+    .trim()
+    .replace(/[^A-Za-z0-9._:/-]+/g, "-")
+    .slice(0, ROUTE_ATTRIBUTION.maxTokenLength);
+}
+
+function splitModel(value) {
+  const leaf = safeToken(value);
+  const slash = leaf.indexOf("/");
+  return slash > 0
+    ? { leaf, provider: leaf.slice(0, slash), model: leaf.slice(slash + 1) }
+    : { leaf, provider: "", model: leaf };
+}
+
+function list(value) {
+  return String(value || "")
+    .split(",")
+    .map(safeToken)
+    .filter(Boolean);
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))].slice(0, ROUTE_ATTRIBUTION.maxAttempts);
+}
+
+function withHeaders(response, values) {
+  if (!(response instanceof Response)) return response;
+  const headers = new Headers(response.headers);
+  for (const [name, value] of Object.entries(values)) headers.set(name, String(value));
+  headers.set(
+    "Access-Control-Expose-Headers",
+    unique([
+      ...list(headers.get("Access-Control-Expose-Headers")),
+      ...EXPOSED_HEADERS,
+    ]).join(", "),
+  );
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export function annotateDirectResponse({ requestedModel, resolvedModel }, response) {
+  const requested = safeToken(requestedModel);
+  const resolved = splitModel(resolvedModel || requested);
+  return withHeaders(response, {
+    [ROUTE_ATTRIBUTION.headers.requestedModel]: requested || resolved.leaf,
+    [ROUTE_ATTRIBUTION.headers.routePath]: resolved.leaf,
+    [ROUTE_ATTRIBUTION.headers.resolvedProvider]: resolved.provider || "unknown",
+    [ROUTE_ATTRIBUTION.headers.resolvedModel]: resolved.model,
+    [ROUTE_ATTRIBUTION.headers.fallbackCount]: 0,
+    [ROUTE_ATTRIBUTION.headers.attemptedModels]: resolved.leaf,
+  });
+}
+
+export function annotateComboResponse({ comboName, selectedModel, attemptedModels = [] }, response) {
+  if (!(response instanceof Response)) return response;
+  const headers = ROUTE_ATTRIBUTION.headers;
+  const combo = safeToken(comboName);
+  const selected = splitModel(selectedModel);
+  const priorPath = list(response.headers.get(headers.routePath));
+  const resolvedProvider = safeToken(response.headers.get(headers.resolvedProvider)) || selected.provider || "unknown";
+  const resolvedModel = safeToken(response.headers.get(headers.resolvedModel)) || selected.model;
+  const currentAttempts = unique(attemptedModels.map(safeToken));
+  const priorAttempts = list(response.headers.get(headers.attemptedModels));
+  const priorFallbacks = Number.parseInt(response.headers.get(headers.fallbackCount) || "0", 10);
+  return withHeaders(response, {
+    [headers.requestedModel]: combo,
+    [headers.routePath]: unique([combo, ...(priorPath.length ? priorPath : [selected.leaf])]).join(","),
+    [headers.resolvedProvider]: resolvedProvider,
+    [headers.resolvedModel]: resolvedModel,
+    [headers.fallbackCount]: Math.max(0, Number.isFinite(priorFallbacks) ? priorFallbacks : 0) + Math.max(0, currentAttempts.length - 1),
+    [headers.attemptedModels]: unique([...currentAttempts, ...priorAttempts]).join(","),
+  });
+}

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -22,6 +22,7 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+import { annotateDirectResponse } from "open-sse/services/routeAttribution.js";
 
 /**
  * Handle chat completion request
@@ -269,7 +270,12 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       }
     });
 
-    if (result.success) return result.response;
+    if (result.success) {
+      return annotateDirectResponse({
+        requestedModel: modelStr,
+        resolvedModel: `${provider}/${model}`,
+      }, result.response);
+    }
 
     // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise resetsAtMs)
     const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);
@@ -282,6 +288,9 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       continue;
     }
 
-    return result.response;
+    return annotateDirectResponse({
+      requestedModel: modelStr,
+      resolvedModel: `${provider}/${model}`,
+    }, result.response);
   }
 }

--- a/tests/unit/combo-route-attribution.test.js
+++ b/tests/unit/combo-route-attribution.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { handleComboChat } from "../../open-sse/services/combo.js";
+import * as routeAttribution from "../../open-sse/services/routeAttribution.js";
+
+const log = { info() {}, warn() {} };
+
+describe("Combo route attribution", () => {
+  it("annotates a direct stream without exposing private identifiers", async () => {
+    expect(typeof routeAttribution.annotateDirectResponse).toBe("function");
+    let pulls = 0;
+    const body = new ReadableStream({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new TextEncoder().encode("streamed"));
+        controller.close();
+      },
+    });
+
+    const response = routeAttribution.annotateDirectResponse({
+      requestedModel: "alias",
+      resolvedModel: "provider/model",
+      connectionId: "must-not-leak",
+      credentialId: "must-not-leak",
+    }, new Response(body));
+
+    expect(pulls).toBe(0);
+    expect(response.headers.get("x-9router-requested-model")).toBe("alias");
+    expect(response.headers.get("x-9router-resolved-provider")).toBe("provider");
+    expect(response.headers.get("x-9router-resolved-model")).toBe("model");
+    expect([...response.headers].some(([name, value]) => /credential|connection|must-not-leak/i.test(`${name}:${value}`))).toBe(false);
+    expect(response.headers.get("access-control-expose-headers")).toContain("X-9Router-Requested-Model");
+    expect(await response.text()).toBe("streamed");
+    expect(pulls).toBe(1);
+  });
+
+  it("reports the requested Combo, resolved leaf, and attempted fallbacks", async () => {
+    const attempts = [];
+    const response = await handleComboChat({
+      body: { model: "coding-combo", messages: [{ role: "user", content: "ping" }] },
+      models: ["provider/model-a", "provider/model-b"],
+      comboName: "coding-combo",
+      comboStrategy: "fallback",
+      log,
+      handleSingleModel: async (_body, model) => {
+        attempts.push(model);
+        return model.endsWith("model-a")
+          ? new Response("unavailable", { status: 503 })
+          : new Response("ok", { headers: { "content-type": "text/plain" } });
+      },
+    });
+
+    expect(await response.text()).toBe("ok");
+    expect(attempts).toEqual(["provider/model-a", "provider/model-b"]);
+    expect(response.headers.get("x-9router-requested-model")).toBe("coding-combo");
+    expect(response.headers.get("x-9router-resolved-provider")).toBe("provider");
+    expect(response.headers.get("x-9router-resolved-model")).toBe("model-b");
+    expect(response.headers.get("x-9router-route-path")).toBe("coding-combo,provider/model-b");
+    expect(response.headers.get("x-9router-fallback-count")).toBe("1");
+    expect(response.headers.get("x-9router-attempted-models")).toBe("provider/model-a,provider/model-b");
+  });
+
+  it("preserves the complete nested Combo path", async () => {
+    const inner = () => handleComboChat({
+      body: { model: "inner-combo", messages: [] },
+      models: ["provider/model-a", "provider/model-b"],
+      comboName: "inner-combo",
+      comboStrategy: "fallback",
+      log,
+      handleSingleModel: async (_body, model) => model.endsWith("model-a")
+        ? new Response("unavailable", { status: 503 })
+        : new Response("ok"),
+    });
+    const response = await handleComboChat({
+      body: { model: "outer-combo", messages: [] },
+      models: ["inner-combo"],
+      comboName: "outer-combo",
+      comboStrategy: "fallback",
+      log,
+      handleSingleModel: inner,
+    });
+
+    expect(response.headers.get("x-9router-route-path")).toBe("outer-combo,inner-combo,provider/model-b");
+    expect(response.headers.get("x-9router-resolved-provider")).toBe("provider");
+    expect(response.headers.get("x-9router-resolved-model")).toBe("model-b");
+    expect(response.headers.get("x-9router-fallback-count")).toBe("1");
+    expect(response.headers.get("x-9router-attempted-models")).toBe("inner-combo,provider/model-a,provider/model-b");
+  });
+});


### PR DESCRIPTION
## Summary

- expose requested logical model, resolved physical provider/model, nested route path, fallback count, and attempted models as response headers
- annotate direct chat responses and compose nested Combo attribution without reading, cloning, or buffering response bodies
- expose only provider-neutral route identifiers; connection and credential identifiers are not accepted by the API or emitted

This is additive and does not change provider selection, Combo membership/order, fallback policy, credentials, or response payloads. It is distinct from API-key attribution work such as #1681.

## Headers

- `X-9Router-Requested-Model`
- `X-9Router-Route-Path`
- `X-9Router-Resolved-Provider`
- `X-9Router-Resolved-Model`
- `X-9Router-Fallback-Count`
- `X-9Router-Attempted-Models`

The headers are added to `Access-Control-Expose-Headers`. Tokens are sanitized and bounded; attempt lists are deduplicated and capped.

## RED/GREEN evidence

Base: `79918c7830695bbca4a45c9fea4a42c3e9fd73d1` (`v0.5.40`).

Initial RED:

```text
FAIL  combo-route-attribution.test.js
expected null to be 'coding-combo'
```

GREEN:

```bash
npx vitest run --reporter=verbose --config tests/vitest.config.js \
  tests/unit/combo-route-attribution.test.js \
  tests/unit/combo-routing.test.js \
  tests/unit/openai-responses-terminal-event.test.js \
  tests/unit/responses-abort-terminal.test.js
```

Result: 4 files passed, 13 tests passed.

The focused contract covers direct streaming without eager reads, fallback attempts, nested Combo paths, resolved physical leaves, CORS exposure, and absence of private IDs.
