### PR TITLE
fix(proxy-pools): increase relay test timeout to 30s and use reliable test endpoint

### DIFF
--- a/src/app/api/proxy-pools/[id]/test/route.js
+++ b/src/app/api/proxy-pools/[id]/test/route.js
@@ -3,7 +3,7 @@ import { getProxyPoolById, updateProxyPool } from "@/models";
 import { testProxyUrl } from "@/lib/network/proxyTest";
 import { fetch as undiciFetch } from "undici";
 
-async function testVercelRelay(relayUrl, timeoutMs = 10000) {
+async function testVercelRelay(relayUrl, timeoutMs = 30000) {
   const controller = new AbortController();
   const startedAt = Date.now();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -11,8 +11,8 @@ async function testVercelRelay(relayUrl, timeoutMs = 10000) {
     const res = await undiciFetch(relayUrl, {
       method: "GET",
       headers: {
-        "x-relay-target": "https://httpbin.org",
-        "x-relay-path": "/get",
+        "x-relay-target": "https://api.ipify.org",
+        "x-relay-path": "/?format=json",
       },
       signal: controller.signal,
     });


### PR DESCRIPTION
Increase testVercelRelay default timeout from 10s to 30s to accommodate Vercel/Cloudflare/Deno cold starts on free plans.

Replace httpbin.org/get (currently returning 503) with api.ipify.org/?format=json as the relay test target.