### PR TITLE
fix(combo): avoid Anthropic prefill 400 in fusion panel requests

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -16,14 +16,17 @@ const TOOL_CALL_PREFIX = "[Called tools: ";
 const TOOL_RESULT_PREFIX = "[Tool result: ";
 
 // Flatten tool turns into prose so panel models keep the context but can't loop
-// on tools: drop the request's tools, turn tool/function results into assistant
+// on tools: drop the request's tools, turn tool/function results into user
 // text, and inline assistant tool_calls names instead of the structured field.
+// Tool results become user turns (matching the claude-to-openai translator's
+// ROLE.TOOL → USER mapping): a trailing assistant turn is rejected by Anthropic
+// as unsupported prefill on newer Claude models.
 function flattenToolHistory(messages) {
   return messages
     .filter((msg) => msg)
     .map((msg) => {
       if (msg.role === "tool" || msg.role === "function") {
-        return { role: "assistant", content: `${TOOL_RESULT_PREFIX}${extractTextContent(msg.content) || String(msg.content ?? "")}]` };
+        return { role: "user", content: `${TOOL_RESULT_PREFIX}${extractTextContent(msg.content) || String(msg.content ?? "")}]` };
       }
       if (msg.role === "assistant" && Array.isArray(msg.tool_calls)) {
         const { tool_calls, ...rest } = msg;
@@ -56,6 +59,16 @@ function flattenToolHistory(messages) {
       }
       return msg;
     });
+}
+
+// Anthropic rejects conversations that end on an assistant turn ("assistant
+// message prefill") for newer Claude models. Panel bodies are synthesized
+// requests, so close any trailing assistant/model turn (client prefill, or an
+// assistant tool_call inlined by flattenToolHistory) with a user turn.
+function ensureTrailingUserTurn(messages) {
+  const last = messages[messages.length - 1];
+  if (last?.role !== "assistant" && last?.role !== "model") return messages;
+  return [...messages, { role: "user", content: "Continue from where the previous assistant message left off." }];
 }
 
 // Reorder combo models by capability fit. Stable; never drops a model (fallback intact).
@@ -518,9 +531,9 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
 
   // Flatten tool turns to prose so panel models keep context without emitting tool_calls.
   if (Array.isArray(panelBody.messages)) {
-    panelBody.messages = flattenToolHistory(panelBody.messages);
+    panelBody.messages = ensureTrailingUserTurn(flattenToolHistory(panelBody.messages));
   } else if (Array.isArray(panelBody.input)) {
-    panelBody.input = flattenToolHistory(panelBody.input);
+    panelBody.input = ensureTrailingUserTurn(flattenToolHistory(panelBody.input));
   }
 
   const t0 = Date.now();

--- a/tests/unit/combo-fusion.test.js
+++ b/tests/unit/combo-fusion.test.js
@@ -160,7 +160,8 @@ describe("fusion combo", () => {
       judgeModel: "p/judge"
     });
 
-    // Panel calls keep every turn but tool turns are flattened to assistant prose.
+    // Panel calls keep every turn but tool turns are flattened to user prose
+    // (assistant would be rejected as prefill when it ends the conversation).
     const panelCalls = handleSingleModel.mock.calls.filter(([,, isPanel]) => isPanel === true);
     expect(panelCalls.length).toBe(2);
     for (const [panelBody] of panelCalls) {
@@ -169,7 +170,7 @@ describe("fusion combo", () => {
       expect(panelBody.messages[0]).toEqual({ role: "user", content: "find files" });
       expect(panelBody.messages[1].tool_calls).toBeUndefined();
       expect(panelBody.messages[1].content).toContain("find");
-      expect(panelBody.messages[2].role).toBe("assistant");
+      expect(panelBody.messages[2].role).toBe("user");
       expect(panelBody.messages[2].content).toContain("['a.js']");
       expect(panelBody.messages[3]).toEqual({ role: "user", content: "describe it" });
     }
@@ -181,6 +182,29 @@ describe("fusion combo", () => {
     expect(judgeBody.messages.length).toBe(5); // original 4 + judge prompt turn
     expect(judgeBody.messages[1].tool_calls).toBeDefined();
     expect(judgeBody.messages[2].role).toBe("tool");
+  });
+
+  it("closes a trailing assistant turn with a user turn in panel calls (Anthropic prefill 400)", async () => {
+    const handleSingleModel = vi.fn(async () => okResponse("ans"));
+    await handleFusionChat({
+      body: {
+        messages: [
+          { role: "user", content: "Q" },
+          { role: "assistant", content: "partial answer" }
+        ]
+      },
+      models: ["p/a", "p/b"],
+      handleSingleModel,
+      log,
+      judgeModel: "p/judge"
+    });
+
+    const panelCalls = handleSingleModel.mock.calls.filter(([,, isPanel]) => isPanel === true);
+    expect(panelCalls.length).toBe(2);
+    for (const [panelBody] of panelCalls) {
+      expect(panelBody.messages.length).toBe(3);
+      expect(panelBody.messages.at(-1).role).toBe("user");
+    }
   });
 
   it("flattens Anthropic-style tool_use and tool_result blocks in arrays", async () => {


### PR DESCRIPTION
Newer Claude models (claude-sonnet-5, claude-opus-4-8) reject requests whose last message is an assistant turn ("This model does not support assistant message prefill"). Fusion panel bodies could end that way: flattenToolHistory turned trailing tool results into assistant text, and client-sent prefill passed through untouched. Both panel models then 400'd, the account got model-locked, and every fusion request failed with "All fusion panel models failed" until the lock expired.

- flattenToolHistory now maps tool/function results to user turns, matching the claude-to-openai translator's ROLE.TOOL -> USER mapping.
- ensureTrailingUserTurn closes any remaining trailing assistant/model turn with a user turn before the panel fan-out (judge calls already end with a user turn via appendUserTurn).