### PR TITLE
fix(thinking): keep compatible Qwen requests OpenAI-shaped

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -105,6 +105,8 @@ export const captureThinking = extractThinking;
 
 // Resolve thinking format: provider override > capability > derive(targetFormat).
 function resolveFormat(targetFormat, model, provider) {
+  // OpenAI-compatible nodes reject provider-native thinking fields.
+  if (typeof provider === "string" && provider.startsWith("openai-compatible-")) return "openai";
   const providerFmt = provider ? PROVIDERS[provider]?.thinkingFormat : null;
   if (providerFmt) return providerFmt;
   const caps = getCapabilitiesForModel(provider, model);

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -113,6 +113,12 @@ describe("applyThinking per provider format", () => {
     expect(out.enable_thinking).toBe(true);
     expect(out.thinking_budget).toBe(8192);
   });
+  it("OpenAI-compatible Qwen passthrough keeps standard reasoning_effort", () => {
+    const out = apply("openai", "qwen3.7-plus", { reasoning_effort: "medium" }, "openai-compatible-chat-limitrouter");
+    expect(out.reasoning_effort).toBe("medium");
+    expect(out.enable_thinking).toBeUndefined();
+    expect(out.thinking_budget).toBeUndefined();
+  });
   it("QwQ cannot disable → clamp minimal", () => {
     const out = apply("openai", "qwq-32b", { reasoning_effort: "none" }, "qwen");
     expect(out.enable_thinking).toBe(true);


### PR DESCRIPTION
## Summary

Fixes #2752.

Qwen-named models routed through an OpenAI-compatible provider could inherit the global Qwen thinking wire format. That added `enable_thinking` and `thinking_budget` to a standard OpenAI Chat Completions request, which strict compatible upstreams such as LimitRouter reject with HTTP 400.

## Root cause

`resolveFormat()` resolved the thinking format from model capabilities after checking only static provider overrides. Dynamic provider IDs such as `openai-compatible-chat-*` are not entries in `PROVIDERS`, so a model name matching Qwen selected the native `qwen` format even though the downstream transport is OpenAI-compatible.

## Changes

- Prioritize the OpenAI thinking format for dynamic `openai-compatible-*` providers.
- Preserve native Qwen `enable_thinking` / `thinking_budget` behavior for the actual `qwen` provider.
- Add a regression test for `qwen3.7-plus` through `openai-compatible-chat-limitrouter`.

## Result

Compatible Qwen requests now retain the standard field:

```json
{ "reasoning_effort": "medium" }
```

and no longer send provider-native `enable_thinking` or `thinking_budget` fields.

## Verification

```text
npx vitest run --config tests/vitest.config.js tests/translator/thinking-unified.test.js --reporter=dot

Test Files  1 passed (1)
Tests       36 passed (36)
```