### PR TITLE
fix(ollama): preserve terminal stream message content

### DIFF
--- a/open-sse/translator/response/ollama-to-openai.js
+++ b/open-sse/translator/response/ollama-to-openai.js
@@ -30,34 +30,14 @@ export function ollamaToOpenAIResponse(chunk, state) {
   }
 
   const { id, created, model } = state.ollama;
-
-  // Final chunk with done=true
-  if (chunk.done) {
-    const usage = extractUsage(chunk);
-    
-    // Determine finish_reason: map upstream done_reason, override to tool_calls if tools used
-    let finishReason = toOpenAIFinish(chunk.done_reason, "ollama");
-    if (chunk.done_reason === OPENAI_FINISH.TOOL_CALLS || state.hadToolCalls) {
-      finishReason = OPENAI_FINISH.TOOL_CALLS;
-    }
-
-    const doneChunk = buildChunk({ id, created, model }, {}, finishReason);
-    doneChunk.usage = usage;
-    return doneChunk;
-  }
-
-  // Content chunk
   const message = chunk.message;
-  if (!message) return null;
+  const content = typeof message?.content === "string" ? message.content : "";
+  const thinking = typeof message?.thinking === "string" ? message.thinking : "";
+  const toolCalls = Array.isArray(message?.tool_calls) ? message.tool_calls : null;
 
-  const content = typeof message.content === "string" ? message.content : "";
-  const thinking = typeof message.thinking === "string" ? message.thinking : "";
-  const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : null;
+  // Skip empty non-terminal chunks.
+  if (!chunk.done && !content && !thinking && !toolCalls) return null;
 
-  // Skip empty chunks
-  if (!content && !thinking && !toolCalls) return null;
-
-  // Accumulate content in state
   if (content) {
     state.accumulatedContent = (state.accumulatedContent || "") + content;
   }
@@ -68,11 +48,22 @@ export function ollamaToOpenAIResponse(chunk, state) {
   const delta = {};
   if (content) delta.content = content;
   if (thinking) delta.reasoning_content = thinking;
-  
-  // Convert Ollama tool_calls to OpenAI format
   if (toolCalls) {
     state.hadToolCalls = true;
     delta.tool_calls = convertToolCalls(toolCalls);
+  }
+
+  // Final chunks may carry the last message payload alongside usage and done_reason.
+  if (chunk.done) {
+    const usage = extractUsage(chunk);
+    let finishReason = toOpenAIFinish(chunk.done_reason, "ollama");
+    if (chunk.done_reason === OPENAI_FINISH.TOOL_CALLS || state.hadToolCalls) {
+      finishReason = OPENAI_FINISH.TOOL_CALLS;
+    }
+
+    const doneChunk = buildChunk({ id, created, model }, delta, finishReason);
+    doneChunk.usage = usage;
+    return doneChunk;
   }
 
   return buildChunk({ id, created, model }, delta, null);

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -251,6 +251,16 @@ export function createSSEStream(options = {}) {
           totalContentLength += parsed.delta.thinking.length;
           accumulatedThinking += parsed.delta.thinking;
         }
+
+        // Ollama native format
+        if (typeof parsed.message?.content === "string" && parsed.message.content) {
+          totalContentLength += parsed.message.content.length;
+          accumulatedContent += parsed.message.content;
+        }
+        if (typeof parsed.message?.thinking === "string" && parsed.message.thinking) {
+          totalContentLength += parsed.message.thinking.length;
+          accumulatedThinking += parsed.message.thinking;
+        }
         
         // OpenAI format - content
         if (parsed.choices?.[0]?.delta?.content) {

--- a/tests/unit/ollama-terminal-stream.test.js
+++ b/tests/unit/ollama-terminal-stream.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import "../translator/registerAll.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { initState, translateResponse } from "../../open-sse/translator/index.js";
+import { createSSEStream } from "../../open-sse/utils/stream.js";
+
+const terminalEvent = {
+  model: "qwen3",
+  message: { role: "assistant", content: "final", thinking: "final thought" },
+  done: true,
+  done_reason: "stop",
+  prompt_eval_count: 8,
+  eval_count: 1,
+};
+
+describe("Ollama terminal stream chunks", () => {
+  it("preserves content and thinking when the terminal chunk also carries a message", () => {
+    const out = translateResponse(FORMATS.OLLAMA, FORMATS.OPENAI, terminalEvent, initState(FORMATS.OPENAI));
+    expect(out[0].choices[0]).toMatchObject({
+      delta: { content: "final", reasoning_content: "final thought" },
+      finish_reason: "stop",
+    });
+  });
+
+  it("records terminal native Ollama content for request logging", async () => {
+    const onStreamComplete = vi.fn();
+    const stream = createSSEStream({
+      targetFormat: FORMATS.OLLAMA,
+      sourceFormat: FORMATS.OPENAI,
+      provider: "ollama",
+      body: {},
+      onStreamComplete,
+    });
+    const response = new Response(stream.readable);
+    const consumed = response.text();
+    const writer = stream.writable.getWriter();
+    await writer.write(new TextEncoder().encode(`${JSON.stringify(terminalEvent)}\n`));
+    await writer.close();
+    await consumed;
+
+    expect(onStreamComplete).toHaveBeenCalledWith(
+      { content: "final", thinking: "final thought" },
+      expect.any(Object),
+      expect.any(Number),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2694.

Ollama can place the last assistant payload in the same NDJSON event as `done: true`. 9Router previously translated that terminal event into an OpenAI chunk with an empty delta, silently dropping final content or reasoning. Native Ollama stream content was also omitted from the request-detail accumulator, which could persist `[Empty streaming response]` despite a successful response.

## Root cause

Two paths handled the native Ollama event shape incompletely:

1. `ollamaToOpenAIResponse()` returned as soon as it saw `chunk.done`, before extracting `chunk.message.content`, `chunk.message.thinking`, or terminal tool calls.
2. `createSSEStream()` accumulated Claude, OpenAI, and Gemini fields for request logging, but not Ollama's `message.content` or `message.thinking` fields.

## Changes

- Extract terminal Ollama message fields before handling `done`.
- Include terminal content, reasoning, and tool calls in the final OpenAI SSE delta while preserving usage and `finish_reason`.
- Accumulate native Ollama content and thinking for streaming request details.
- Add focused regression coverage for both client output and completion logging.

## Behavior

A terminal Ollama event such as:

```json
{
  "message": { "content": "final", "thinking": "final thought" },
  "done": true,
  "done_reason": "stop"
}
```

now emits the final OpenAI delta with `content` and `reasoning_content`, then records the same values in request details.

## Verification

```text
npx vitest run --config tests/vitest.config.js tests/unit/ollama-terminal-stream.test.js --reporter=dot

Test Files  1 passed (1)
Tests       2 passed (2)

npx vitest run --config tests/vitest.config.js tests/translator/golden-response-stream.test.js --reporter=dot

Test Files  1 passed (1)
Tests       7 passed (7)
```

Also passed:

```text
git diff --check
node --check open-sse/translator/response/ollama-to-openai.js
node --check open-sse/utils/stream.js
```