### PR TITLE
Include commandcode cache reads in usage statistics

### DIFF
--- a/open-sse/translator/concerns/usage.js
+++ b/open-sse/translator/concerns/usage.js
@@ -57,7 +57,10 @@ const USAGE_EXTRACTORS = {
   commandcode(raw) {
     const input = n(raw.inputTokens), output = n(raw.outputTokens);
     const total = typeof raw.totalTokens === "number" ? raw.totalTokens : input + output;
-    return { promptTokens: input, completionTokens: output, totalTokens: total };
+    const cached = n(raw.cachedInputTokens);
+    const out = { promptTokens: input, completionTokens: output, totalTokens: total };
+    if (cached > 0) out.cachedTokens = cached;
+    return out;
   },
 };
 


### PR DESCRIPTION
Small change to include cache reads in the usage statistics from the commandcode provider.

As far as I can tell, there is currently no way to retrieve cache write stats.