### PR TITLE
fix(models): sync discovered catalogs with configured models

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -27,6 +27,18 @@ import BulkImportGrokCliModal from "./BulkImportGrokCliModal";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
+// These providers use an account-specific catalog in /v1/models. Keep their
+// dashboard model controls on the same catalog so Disable All remains complete.
+const LIVE_CATALOG_PROVIDER_IDS = new Set([
+  "cursor",
+  "github",
+  "kiro",
+  "qoder",
+  "kimchi",
+  "clinepass",
+  "grok-cli",
+]);
+
 const AUTO_PING_SETTINGS_KEYS = {
   claude: "claudeAutoPing",
   codex: "codexAutoPing",
@@ -147,9 +159,9 @@ export default function ProviderDetailPage() {
   const supportsApiKeyAuth = !!APIKEY_PROVIDERS[providerId] || authModes.includes("apikey");
   const isFreeNoAuth = !!FREE_PROVIDERS[providerId]?.noAuth;
   const staticModels = getModelsByProviderId(providerId);
-  const models = providerId === "cursor" && liveModels.length > 0
-    ? liveModels
-    : providerId === "github"
+  const models = providerId === "cursor"
+    ? (liveModels.length > 0 ? liveModels : staticModels)
+    : LIVE_CATALOG_PROVIDER_IDS.has(providerId)
       ? mergeModelCatalogs(staticModels, liveModels)
       : staticModels;
   const providerAlias = getProviderAlias(providerId);
@@ -463,11 +475,11 @@ export default function ProviderDetailPage() {
     fetchDisabledModels();
   }, [fetchConnections, fetchAliases, fetchCustomModels, fetchDisabledModels]);
 
-  // Cursor and GitHub Copilot model availability is account-specific and changes frequently.
-  // Load the active account's live catalog for the dashboard; Copilot merges it with
-  // its static catalog so every model that /v1/models can expose is manageable here.
+  // Account-specific catalog providers can expose models outside the static
+  // registry. Fetch the same active-connection catalog used for discovery so
+  // model controls and Disable All can manage every exposed model.
   useEffect(() => {
-    if (providerId !== "cursor" && providerId !== "github") {
+    if (!LIVE_CATALOG_PROVIDER_IDS.has(providerId)) {
       setLiveModels([]);
       return;
     }

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -14,6 +14,7 @@ import { useModelCaps } from "@/shared/hooks/useModelCaps";
 import { translate } from "@/i18n/runtime";
 import { fetchSuggestedModels } from "@/shared/utils/providerModelsFetcher";
 import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
+import { mergeModelCatalogs } from "@/shared/utils/mergeModelCatalogs";
 import ModelRow from "./ModelRow";
 import PassthroughModelsSection from "./PassthroughModelsSection";
 import CompatibleModelsSection from "./CompatibleModelsSection";
@@ -148,7 +149,9 @@ export default function ProviderDetailPage() {
   const staticModels = getModelsByProviderId(providerId);
   const models = providerId === "cursor" && liveModels.length > 0
     ? liveModels
-    : staticModels;
+    : providerId === "github"
+      ? mergeModelCatalogs(staticModels, liveModels)
+      : staticModels;
   const providerAlias = getProviderAlias(providerId);
   
   const isOpenAICompatible = isOpenAICompatibleProvider(providerId);
@@ -460,11 +463,11 @@ export default function ProviderDetailPage() {
     fetchDisabledModels();
   }, [fetchConnections, fetchAliases, fetchCustomModels, fetchDisabledModels]);
 
-  // Cursor's model availability is account-specific and changes frequently.
-  // Load the active account's live catalog for the dashboard; the static
-  // registry remains the fallback while the request is pending or unavailable.
+  // Cursor and GitHub Copilot model availability is account-specific and changes frequently.
+  // Load the active account's live catalog for the dashboard; Copilot merges it with
+  // its static catalog so every model that /v1/models can expose is manageable here.
   useEffect(() => {
-    if (providerId !== "cursor") {
+    if (providerId !== "cursor" && providerId !== "github") {
       setLiveModels([]);
       return;
     }
@@ -1104,7 +1107,7 @@ export default function ProviderDetailPage() {
       customModels,
       modelAliases,
       providerAlias: providerStorageAlias,
-      builtInModels: models,
+      builtInModels: allModels,
       type: "llm",
     });
 

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -26,6 +26,18 @@ import BulkImportCodexModal from "./BulkImportCodexModal";
 
 const ONE_BY_ONE_DELAY_MS = 1000;
 
+// These providers use an account-specific catalog in /v1/models. Keep their
+// dashboard model controls on the same catalog so Disable All remains complete.
+const LIVE_CATALOG_PROVIDER_IDS = new Set([
+  "cursor",
+  "github",
+  "kiro",
+  "qoder",
+  "kimchi",
+  "clinepass",
+  "grok-cli",
+]);
+
 const AUTO_PING_SETTINGS_KEYS = {
   claude: "claudeAutoPing",
   codex: "codexAutoPing",
@@ -145,9 +157,9 @@ export default function ProviderDetailPage() {
   const supportsApiKeyAuth = !!APIKEY_PROVIDERS[providerId] || authModes.includes("apikey");
   const isFreeNoAuth = !!FREE_PROVIDERS[providerId]?.noAuth;
   const staticModels = getModelsByProviderId(providerId);
-  const models = providerId === "cursor" && liveModels.length > 0
-    ? liveModels
-    : providerId === "github"
+  const models = providerId === "cursor"
+    ? (liveModels.length > 0 ? liveModels : staticModels)
+    : LIVE_CATALOG_PROVIDER_IDS.has(providerId)
       ? mergeModelCatalogs(staticModels, liveModels)
       : staticModels;
   const providerAlias = getProviderAlias(providerId);
@@ -460,11 +472,11 @@ export default function ProviderDetailPage() {
     fetchDisabledModels();
   }, [fetchConnections, fetchAliases, fetchCustomModels, fetchDisabledModels]);
 
-  // Cursor and GitHub Copilot model availability is account-specific and changes frequently.
-  // Load the active account's live catalog for the dashboard; Copilot merges it with
-  // its static catalog so every model that /v1/models can expose is manageable here.
+  // Account-specific catalog providers can expose models outside the static
+  // registry. Fetch the same active-connection catalog used for discovery so
+  // model controls and Disable All can manage every exposed model.
   useEffect(() => {
-    if (providerId !== "cursor" && providerId !== "github") {
+    if (!LIVE_CATALOG_PROVIDER_IDS.has(providerId)) {
       setLiveModels([]);
       return;
     }

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -14,6 +14,7 @@ import { useModelCaps } from "@/shared/hooks/useModelCaps";
 import { translate } from "@/i18n/runtime";
 import { fetchSuggestedModels } from "@/shared/utils/providerModelsFetcher";
 import { getProviderCustomModelRows } from "@/shared/utils/providerCustomModels";
+import { mergeModelCatalogs } from "@/shared/utils/mergeModelCatalogs";
 import ModelRow from "./ModelRow";
 import PassthroughModelsSection from "./PassthroughModelsSection";
 import CompatibleModelsSection from "./CompatibleModelsSection";
@@ -146,7 +147,9 @@ export default function ProviderDetailPage() {
   const staticModels = getModelsByProviderId(providerId);
   const models = providerId === "cursor" && liveModels.length > 0
     ? liveModels
-    : staticModels;
+    : providerId === "github"
+      ? mergeModelCatalogs(staticModels, liveModels)
+      : staticModels;
   const providerAlias = getProviderAlias(providerId);
   
   const isOpenAICompatible = isOpenAICompatibleProvider(providerId);
@@ -457,11 +460,11 @@ export default function ProviderDetailPage() {
     fetchDisabledModels();
   }, [fetchConnections, fetchAliases, fetchCustomModels, fetchDisabledModels]);
 
-  // Cursor's model availability is account-specific and changes frequently.
-  // Load the active account's live catalog for the dashboard; the static
-  // registry remains the fallback while the request is pending or unavailable.
+  // Cursor and GitHub Copilot model availability is account-specific and changes frequently.
+  // Load the active account's live catalog for the dashboard; Copilot merges it with
+  // its static catalog so every model that /v1/models can expose is manageable here.
   useEffect(() => {
-    if (providerId !== "cursor") {
+    if (providerId !== "cursor" && providerId !== "github") {
       setLiveModels([]);
       return;
     }
@@ -1101,7 +1104,7 @@ export default function ProviderDetailPage() {
       customModels,
       modelAliases,
       providerAlias: providerStorageAlias,
-      builtInModels: models,
+      builtInModels: allModels,
       type: "llm",
     });
 

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -18,6 +18,7 @@ import { resolveZedModels } from "open-sse/shared/zedAuth.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { shouldFetchCompatibleModels } from "@/shared/utils/compatibleModelDiscovery";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -375,7 +376,17 @@ export async function buildModelsList(kindFilter, options = {}) {
           )
         : providerModels.map((model) => model.id);
 
-      if (isCompatibleProvider && rawModelIds.length === 0 && !skipDynamicFetch) {
+      const hasConfiguredCustomModels = customModels.some((model) => {
+        const alias = model?.providerAlias;
+        return alias === staticAlias || alias === outputAlias || alias === providerId;
+      });
+
+      if (shouldFetchCompatibleModels({
+        isCompatibleProvider,
+        hasExplicitEnabledModels,
+        hasConfiguredCustomModels,
+        skipDynamicFetch,
+      })) {
         rawModelIds = await fetchCompatibleModelIds(conn);
       }
 

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -17,6 +17,7 @@ import { resolveCursorModels } from "open-sse/services/cursorModels.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { shouldFetchCompatibleModels } from "@/shared/utils/compatibleModelDiscovery";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -358,7 +359,17 @@ export async function buildModelsList(kindFilter, options = {}) {
           )
         : providerModels.map((model) => model.id);
 
-      if (isCompatibleProvider && rawModelIds.length === 0 && !skipDynamicFetch) {
+      const hasConfiguredCustomModels = customModels.some((model) => {
+        const alias = model?.providerAlias;
+        return alias === staticAlias || alias === outputAlias || alias === providerId;
+      });
+
+      if (shouldFetchCompatibleModels({
+        isCompatibleProvider,
+        hasExplicitEnabledModels,
+        hasConfiguredCustomModels,
+        skipDynamicFetch,
+      })) {
         rawModelIds = await fetchCompatibleModelIds(conn);
       }
 

--- a/src/shared/utils/compatibleModelDiscovery.js
+++ b/src/shared/utils/compatibleModelDiscovery.js
@@ -1,0 +1,11 @@
+export function shouldFetchCompatibleModels({
+  isCompatibleProvider,
+  hasExplicitEnabledModels,
+  hasConfiguredCustomModels,
+  skipDynamicFetch,
+}) {
+  return isCompatibleProvider
+    && !hasExplicitEnabledModels
+    && !hasConfiguredCustomModels
+    && !skipDynamicFetch;
+}

--- a/src/shared/utils/mergeModelCatalogs.js
+++ b/src/shared/utils/mergeModelCatalogs.js
@@ -1,0 +1,15 @@
+export function mergeModelCatalogs(...catalogs) {
+  const seen = new Set();
+  const merged = [];
+
+  for (const catalog of catalogs) {
+    for (const model of catalog || []) {
+      const id = typeof model?.id === "string" ? model.id.trim() : "";
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      merged.push(model);
+    }
+  }
+
+  return merged;
+}

--- a/tests/unit/compatible-model-discovery.test.js
+++ b/tests/unit/compatible-model-discovery.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { shouldFetchCompatibleModels } from "../../src/shared/utils/compatibleModelDiscovery.js";
+
+describe("shouldFetchCompatibleModels", () => {
+  it("does not auto-discover upstream models when custom models define a compatible provider whitelist", () => {
+    expect(shouldFetchCompatibleModels({
+      isCompatibleProvider: true,
+      hasExplicitEnabledModels: false,
+      hasConfiguredCustomModels: true,
+      skipDynamicFetch: false,
+    })).toBe(false);
+  });
+
+  it("auto-discovers upstream models when a compatible provider has no configured model list", () => {
+    expect(shouldFetchCompatibleModels({
+      isCompatibleProvider: true,
+      hasExplicitEnabledModels: false,
+      hasConfiguredCustomModels: false,
+      skipDynamicFetch: false,
+    })).toBe(true);
+  });
+
+  it("does not auto-discover when a configured enabled-model list or internal fetch disables discovery", () => {
+    expect(shouldFetchCompatibleModels({
+      isCompatibleProvider: true,
+      hasExplicitEnabledModels: true,
+      hasConfiguredCustomModels: false,
+      skipDynamicFetch: false,
+    })).toBe(false);
+    expect(shouldFetchCompatibleModels({
+      isCompatibleProvider: true,
+      hasExplicitEnabledModels: false,
+      hasConfiguredCustomModels: false,
+      skipDynamicFetch: true,
+    })).toBe(false);
+  });
+});

--- a/tests/unit/merge-model-catalogs.test.js
+++ b/tests/unit/merge-model-catalogs.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { mergeModelCatalogs } from "../../src/shared/utils/mergeModelCatalogs.js";
+
+describe("mergeModelCatalogs", () => {
+  it("keeps static models and adds Copilot live-only models once", () => {
+    const staticModels = [
+      { id: "gpt-5.2", name: "GPT 5.2" },
+      { id: "gpt-4o", name: "Static GPT-4o" },
+    ];
+    const liveModels = [
+      { id: "gpt-4o", name: "Live GPT-4o" },
+      { id: "copilot-search-a", name: "Copilot Search A" },
+    ];
+
+    expect(mergeModelCatalogs(staticModels, liveModels)).toEqual([
+      { id: "gpt-5.2", name: "GPT 5.2" },
+      { id: "gpt-4o", name: "Static GPT-4o" },
+      { id: "copilot-search-a", name: "Copilot Search A" },
+    ]);
+  });
+
+  it("ignores catalog rows without a usable model ID", () => {
+    expect(mergeModelCatalogs([{ id: "gpt-5.2" }], [{ name: "Missing ID" }, null])).toEqual([
+      { id: "gpt-5.2" },
+    ]);
+  });
+});

--- a/tests/unit/merge-model-catalogs.test.js
+++ b/tests/unit/merge-model-catalogs.test.js
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mergeModelCatalogs } from "../../src/shared/utils/mergeModelCatalogs.js";
 
 describe("mergeModelCatalogs", () => {
-  it("keeps static models and adds Copilot live-only models once", () => {
+  it("keeps static models and adds any provider's live-only models once", () => {
     const staticModels = [
       { id: "gpt-5.2", name: "GPT 5.2" },
       { id: "gpt-4o", name: "Static GPT-4o" },
@@ -16,6 +16,12 @@ describe("mergeModelCatalogs", () => {
       { id: "gpt-5.2", name: "GPT 5.2" },
       { id: "gpt-4o", name: "Static GPT-4o" },
       { id: "copilot-search-a", name: "Copilot Search A" },
+    ]);
+  });
+
+  it("keeps entries from a live catalog when the static catalog is empty", () => {
+    expect(mergeModelCatalogs([], [{ id: "account-only-model", name: "Account Only" }])).toEqual([
+      { id: "account-only-model", name: "Account Only" },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Load account-specific live catalogs into provider controls for Cursor, GitHub Copilot, Kiro, Qoder, Kimchi, ClinePass, and Grok CLI.
- Ensure **Disable All** can manage every dynamically discoverable model.
- Treat configured custom models on OpenAI/Anthropic Compatible nodes as an explicit whitelist: when such a list exists, `/v1/models` no longer auto-adds every model returned by the upstream `/models` endpoint.
- Add regression coverage for live-only catalogs and compatible-node whitelist discovery.

## Problems fixed
1. The gateway could expose dynamic provider models that were absent from provider-page controls.
2. A compatible node with four manually configured models could still expose the full upstream catalog through `/v1/models`.

## Test plan
- `npx vitest run unit/compatible-model-discovery.test.js unit/merge-model-catalogs.test.js`
- `npm run build`
- Live verification: disabling the full Copilot catalog yields zero `gh/` models; a dex compatible node configured with four custom models now returns exactly those four `dex/` models.