### PR TITLE
fix(logs): stop writing provider tokens to disk in request logs

### DIFF
--- a/open-sse/utils/requestLogger.js
+++ b/open-sse/utils/requestLogger.js
@@ -69,25 +69,30 @@ function writeJsonFile(sessionPath, filename, data) {
   }
 }
 
-// Mask sensitive data in headers (DISABLED - keep full token for testing)
+// Mask credentials in headers. Request logs are written to disk unredacted
+// otherwise, so an enabled ENABLE_REQUEST_LOGS persists provider OAuth tokens
+// and client API keys in plaintext for as long as the log folder survives.
 function maskSensitiveHeaders(headers) {
   if (!headers) return {};
-  return { ...headers };
-  
-  // Old masking code (disabled):
-  // const masked = { ...headers };
-  // const sensitiveKeys = ["authorization", "x-api-key", "cookie", "token"];
-  // 
-  // for (const key of Object.keys(masked)) {
-  //   const lowerKey = key.toLowerCase();
-  //   if (sensitiveKeys.some(sk => lowerKey.includes(sk))) {
-  //     const value = masked[key];
-  //     if (value && value.length > 20) {
-  //       masked[key] = value.slice(0, 10) + "..." + value.slice(-5);
-  //     }
-  //   }
-  // }
-  // return masked;
+  const masked = { ...headers };
+  const sensitiveKeys = ["authorization", "x-api-key", "api-key", "cookie", "token", "secret"];
+
+  for (const key of Object.keys(masked)) {
+    const lowerKey = key.toLowerCase();
+    if (!sensitiveKeys.some(sk => lowerKey.includes(sk))) continue;
+    const value = masked[key];
+    if (typeof value !== "string" || !value) continue;
+
+    // Keep the auth scheme so logs still show which auth path ran, plus the last
+    // 4 chars to tell two credentials apart — never the secret itself. Short
+    // values are masked too: a 12-char key is no less sensitive than a 40-char one.
+    const parts = value.match(/^(\S+)\s+(.*)$/);
+    const scheme = parts && /^(bearer|basic|token)$/i.test(parts[1]) ? `${parts[1]} ` : "";
+    const secret = scheme ? parts[2] : value;
+    masked[key] = `${scheme}***${secret.length > 4 ? secret.slice(-4) : ""}`;
+  }
+
+  return masked;
 }
 
 // No-op logger when logging is disabled
@@ -170,7 +175,7 @@ export async function createRequestLogger(sourceFormat, targetFormat, model) {
         timestamp: new Date().toISOString(),
         status,
         statusText,
-        headers: headers ? (typeof headers.entries === "function" ? Object.fromEntries(headers.entries()) : headers) : {},
+        headers: maskSensitiveHeaders(headers ? (typeof headers.entries === "function" ? Object.fromEntries(headers.entries()) : headers) : {}),
         body
       });
     },

--- a/tests/unit/request-logger-masking.test.js
+++ b/tests/unit/request-logger-masking.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+
+// requestLogger reads ENABLE_REQUEST_LOGS at module load, and the masking helper is
+// module-private — exercise it through the logger's own file writes instead of
+// reaching in. The point of this suite is a regression gate: masking was once
+// disabled in place ("keep full token for testing") and shipped that way, which
+// wrote provider OAuth tokens to disk verbatim whenever request logging was on.
+let fs, os, path, logsDir, cwdBefore;
+
+beforeAll(async () => {
+  fs = await import("fs");
+  os = await import("os");
+  path = await import("path");
+  // The logger derives LOGS_DIR from process.cwd() at first use.
+  logsDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-logtest-"));
+  cwdBefore = process.cwd();
+  process.chdir(logsDir);
+  process.env.ENABLE_REQUEST_LOGS = "true";
+});
+
+afterAll(() => {
+  if (cwdBefore) process.chdir(cwdBefore);
+  if (logsDir) fs.rmSync(logsDir, { recursive: true, force: true });
+});
+
+function readSessionFile(name) {
+  const root = path.join(logsDir, "logs");
+  const sessions = fs.readdirSync(root);
+  for (const s of sessions) {
+    const f = path.join(root, s, name);
+    if (fs.existsSync(f)) return JSON.parse(fs.readFileSync(f, "utf8"));
+  }
+  return null;
+}
+
+describe("request log header masking", () => {
+  it("never writes a bearer token verbatim", async () => {
+    const { createRequestLogger } = await import("../../open-sse/utils/requestLogger.js");
+    const logger = await createRequestLogger("openai", "claude", "claude-opus-5");
+
+    const secret = "ghu_ThisIsAVeryRealLookingCopilotToken9999";
+    logger.logClientRawRequest("/v1/chat/completions", { model: "x" }, {
+      authorization: `Bearer ${secret}`,
+      "x-api-key": "sk-client-key-abcdef123456",
+      "content-type": "application/json",
+    });
+
+    const written = readSessionFile("1_req_client.json");
+    expect(written).toBeTruthy();
+
+    const serialized = JSON.stringify(written);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain("sk-client-key-abcdef123456");
+
+    // Scheme and a 4-char tail survive so logs stay useful for telling
+    // credentials apart, and non-sensitive headers are untouched.
+    expect(written.headers.authorization).toBe("Bearer ***9999");
+    expect(written.headers["x-api-key"]).toBe("***3456");
+    expect(written.headers["content-type"]).toBe("application/json");
+  });
+
+  it("masks short credential values too", async () => {
+    const { createRequestLogger } = await import("../../open-sse/utils/requestLogger.js");
+    const logger = await createRequestLogger("openai", "claude", "short-secret");
+
+    logger.logTargetRequest("https://api.githubcopilot.com/v1/messages", {
+      authorization: "Bearer abc",
+      cookie: "session=deadbeef",
+    }, { model: "claude-opus-5" });
+
+    const written = readSessionFile("4_req_target.json");
+    expect(written).toBeTruthy();
+    expect(JSON.stringify(written)).not.toContain("deadbeef");
+    expect(written.headers.authorization).toBe("Bearer ***");
+  });
+});


### PR DESCRIPTION
`maskSensitiveHeaders` does not mask. Its body was replaced with a pass-through and the real implementation left commented out beneath it:

```js
// Mask sensitive data in headers (DISABLED - keep full token for testing)
function maskSensitiveHeaders(headers) {
  if (!headers) return {};
  return { ...headers };

  // Old masking code (disabled):
  // const masked = { ...headers };
  // const sensitiveKeys = ["authorization", "x-api-key", "cookie", "token"];
  ...
}
```

The function kept its name and all four call sites still read as if they redact, so nothing at the call site suggests the logs are unredacted.

## Impact

With `ENABLE_REQUEST_LOGS=true`, every request writes a session folder under `logs/`. Two of those files carry credentials, and both go to disk verbatim:

| File | Leaked value |
|---|---|
| `1_req_client.json` | the **client's API key** (`Authorization` / `x-api-key` as sent to 9Router) |
| `4_req_target.json` | the **provider's OAuth token** — e.g. the GitHub Copilot bearer sent to `api.githubcopilot.com/v1/messages` |

These are live credentials, not test fixtures. The Copilot bearer in particular is the same token the gateway refreshes and reuses, so a leaked copy stays valid.

`requestLogger.js` has no rotation, no TTL, and no cleanup path — `createLogSession` only ever creates directories. The tokens therefore persist for as long as the log folder does, which in a container deployment is however long the volume lives. Anyone with read access to that directory (a backup, a mounted volume, a bind mount shared with another service) gets working credentials for every provider the gateway talks to.

Reproduced on `master` against a real GitHub Copilot connection: with logging on, `4_req_target.json` contained the full `Authorization: Bearer <copilot-oauth-token>` in plaintext.

## Fix

Restores masking, with three changes over the commented-out original:

**1. Applies to provider response headers too.** `logProviderResponse` never masked at all — it passed `Object.fromEntries(headers.entries())` straight through. Response headers are a smaller risk than request headers but can carry `set-cookie`, so they now go through the same helper.

**2. Masks short values.** The original only masked when `value.length > 20`, which let a 12-character API key through untouched. Length is not a proxy for sensitivity; the guard is gone.

**3. Keeps the auth scheme and a 4-character tail instead of a 10-character head.** The original emitted `value.slice(0, 10) + "..." + value.slice(-5)`, which for `Bearer ghu_xxx…` exposed part of the secret's leading bytes. Keeping the scheme plus the last four characters preserves what the logs are actually used for — seeing which auth path ran and telling two credentials apart — without exposing a usable prefix:

```
Bearer ghu_ThisIsAVeryRealLookingToken9999  →  Bearer ***9999
sk-client-key-abcdef123456                  →  ***3456
Bearer abc                                  →  Bearer ***
```

Non-sensitive headers are untouched, so the logs stay as readable as before.

The matched-key list also picks up `api-key` and `secret` alongside the original `authorization` / `x-api-key` / `cookie` / `token`.

## Tests

`tests/unit/request-logger-masking.test.js` drives the real logger — it points `process.cwd()` at a temp dir, enables `ENABLE_REQUEST_LOGS`, writes a session, and reads the JSON back off disk. It asserts on the file contents rather than on the helper, because the helper is module-private and because the file is what actually leaks.

Two cases: a bearer token plus a client API key must not appear anywhere in the serialized file, and short credential values must be masked as well. The suite is a regression gate — this code was disabled in place once and shipped that way, so a test that fails the moment a raw token reaches disk is the thing that keeps it from happening again.

Verified live afterwards on a real Copilot request: scanning the whole session folder for `ghu_` / `gho_` / `ghp_` / `sk-` prefixes and for long `Bearer` strings returns nothing, and the two credential fields read `Bearer ***4de4` and `Bearer ***964b`.

## Note on log contents

This PR only addresses headers. Request/response **bodies** are still written in full, which is the point of the feature — but it does mean conversation content lands on disk whenever logging is enabled. That is inherent to a request logger and out of scope here; the credentials were not.

本 PR 由 Claude Code 辅助完成
