### PR TITLE
feat(ollama): add embedding provider adapter and endpoint support for Ollama Local

### DIFF
--- a/open-sse/handlers/embeddingProviders/index.js
+++ b/open-sse/handlers/embeddingProviders/index.js
@@ -2,6 +2,7 @@
 import createOpenAIEmbeddingAdapter from "./openai.js";
 import gemini from "./gemini.js";
 import openaiCompatNode from "./openaiCompatNode.js";
+import ollamaLocal from "./ollamaLocal.js";
 
 const OPENAI_COMPAT_PROVIDERS = [
   "openai", "openrouter", "mistral", "voyage-ai", "fireworks",
@@ -13,6 +14,7 @@ const ADAPTERS = {
   ...Object.fromEntries(OPENAI_COMPAT_PROVIDERS.map((id) => [id, createOpenAIEmbeddingAdapter(id)])),
   gemini,
   google_ai_studio: gemini,
+  "ollama-local": ollamaLocal,
 };
 
 export function getEmbeddingAdapter(provider) {

--- a/open-sse/handlers/embeddingProviders/ollamaLocal.js
+++ b/open-sse/handlers/embeddingProviders/ollamaLocal.js
@@ -1,0 +1,21 @@
+import { resolveOllamaLocalHost } from "../../config/providers.js";
+
+export default {
+  buildUrl: (_model, creds) => {
+    const host = (resolveOllamaLocalHost(creds) || "").replace(/\/+$/, "");
+    return `${host}/v1/embeddings`;
+  },
+  buildHeaders: () => ({
+    "Content-Type": "application/json",
+  }),
+  buildBody: (model, { input, encoding_format, dimensions }) => {
+    const body = { model, input };
+    if (encoding_format) body.encoding_format = encoding_format;
+    if (dimensions != null && dimensions !== "") {
+      const dim = Number(dimensions);
+      if (Number.isFinite(dim) && dim > 0) body.dimensions = dim;
+    }
+    return body;
+  },
+  normalize: (responseBody) => responseBody,
+};

--- a/open-sse/providers/registry/ollama-local.js
+++ b/open-sse/providers/registry/ollama-local.js
@@ -15,5 +15,11 @@ export default {
     baseUrl: "http://localhost:11434/api/chat",
     format: "ollama",
   },
-  serviceKinds: ["llm"],
+  models: [
+    { id: "embeddinggemma", name: "EmbeddingGemma", kind: "embedding" },
+    { id: "nomic-embed-text", name: "Nomic Embed Text", kind: "embedding" },
+    { id: "bge-m3", name: "BGE M3", kind: "embedding" },
+  ],
+  serviceKinds: ["llm", "embedding"],
+  embeddingConfig: { baseUrl: "http://localhost:11434/v1/embeddings", authType: "none" },
 };

--- a/tests/unit/embeddingsCore.test.js
+++ b/tests/unit/embeddingsCore.test.js
@@ -267,6 +267,44 @@ describe("buildEmbeddingsUrl", () => {
     expect(url).toBe("https://myhost.ai/v1/embeddings");
   });
 
+  it("ollama-local default host → http://localhost:11434/v1/embeddings", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
+
+    await handleEmbeddingsCore(makeOptions({
+      modelInfo: { provider: "ollama-local", model: "nomic-embed-text" },
+      credentials: {},
+    }));
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    const sent = JSON.parse(init.body);
+    expect(url).toBe("http://localhost:11434/v1/embeddings");
+    expect(sent.model).toBe("nomic-embed-text");
+  });
+
+  it("ollama-local custom host → respects baseUrl from providerSpecificData", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
+
+    await handleEmbeddingsCore(makeOptions({
+      modelInfo: { provider: "ollama-local", model: "bge-m3" },
+      credentials: { providerSpecificData: { baseUrl: "http://192.168.1.100:11434" } },
+    }));
+
+    const [url] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("http://192.168.1.100:11434/v1/embeddings");
+  });
+
+  it("ollama-local custom host with trailing slashes → strips trailing slashes cleanly", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
+
+    await handleEmbeddingsCore(makeOptions({
+      modelInfo: { provider: "ollama-local", model: "bge-m3" },
+      credentials: { providerSpecificData: { baseUrl: "http://192.168.1.100:11434///" } },
+    }));
+
+    const [url] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("http://192.168.1.100:11434/v1/embeddings");
+  });
+
   it("openai-compatible-* without baseUrl → falls back to api.openai.com", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
 

--- a/tests/unit/embeddingsCore.test.js
+++ b/tests/unit/embeddingsCore.test.js
@@ -275,10 +275,13 @@ describe("buildEmbeddingsUrl", () => {
       credentials: {},
     }));
 
-    const [url, init] = vi.mocked(fetch).mock.calls[0];
-    const sent = JSON.parse(init.body);
-    expect(url).toBe("http://localhost:11434/v1/embeddings");
-    expect(sent.model).toBe("nomic-embed-text");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/embeddings",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ model: "nomic-embed-text", input: "Hello world", encoding_format: "float" }),
+      })
+    );
   });
 
   it("ollama-local custom host → respects baseUrl from providerSpecificData", async () => {
@@ -289,8 +292,10 @@ describe("buildEmbeddingsUrl", () => {
       credentials: { providerSpecificData: { baseUrl: "http://192.168.1.100:11434" } },
     }));
 
-    const [url] = vi.mocked(fetch).mock.calls[0];
-    expect(url).toBe("http://192.168.1.100:11434/v1/embeddings");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://192.168.1.100:11434/v1/embeddings",
+      expect.anything()
+    );
   });
 
   it("ollama-local custom host with trailing slashes → strips trailing slashes cleanly", async () => {
@@ -301,8 +306,10 @@ describe("buildEmbeddingsUrl", () => {
       credentials: { providerSpecificData: { baseUrl: "http://192.168.1.100:11434///" } },
     }));
 
-    const [url] = vi.mocked(fetch).mock.calls[0];
-    expect(url).toBe("http://192.168.1.100:11434/v1/embeddings");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://192.168.1.100:11434/v1/embeddings",
+      expect.anything()
+    );
   });
 
   it("openai-compatible-* without baseUrl → falls back to api.openai.com", async () => {


### PR DESCRIPTION
## Summary
Adds native embedding provider adapter and endpoint support for **Ollama Local** (`ollama-local`) via `/v1/embeddings`.

## Key Changes
- Created `ollamaLocal.js` embedding provider adapter connecting to `http://localhost:11434/v1/embeddings` (or configured custom host with trailing slash normalization).
- Registered `ollama-local` adapter in `open-sse/handlers/embeddingProviders/index.js`.
- Updated `ollama-local` provider registry to include `"embedding"` serviceKind, `embeddingConfig`, and static embedding models catalog (`embeddinggemma`, `nomic-embed-text`, `bge-m3`).
- Added unit tests covering default and custom host routing (including trailing slash stripping) for Ollama Local.

## Testing
- Unit tests added in `tests/unit/embeddingsCore.test.js` (42/42 passing).