### PR TITLE
feat(docker): comprehensive Docker Compose overhaul with monitoring and CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,13 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+
+# Docker compose files
+docker-compose*.yml
+Dockerfile*
+
+# Documentation and tests
+README.md
+tests/
+docs/
+cli/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,82 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main, master]
+    tags: ["v*"]
+  pull_request:
+    branches: [main, master]
+
+env:
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          load: true
+          tags: ${{ env.GHCR_IMAGE }}:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.GHCR_IMAGE }}:scan
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          sbom: false

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+:80 {
+    reverse_proxy 9router:20128
+}

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -115,6 +115,73 @@ docker run --rm -p 20128:20128 \
   9router
 ```
 
+## Docker Compose (Production)
+
+Run all services with:
+
+```bash
+docker compose up -d
+```
+
+Services included:
+- **9router**: Main application (port 20128)
+- **headroom**: Token saver sidecar
+- **caddy**: Reverse proxy with automatic HTTPS (ports 80, 443)
+- **prometheus**: Metrics collection (port 9090)
+- **grafana**: Monitoring dashboards (port 3000, default password: admin)
+
+## Docker Compose (Development)
+
+For hot reload development:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+Development mode:
+- Mounts source code for hot reload
+- Exposes debugger port (9229)
+- Disables Caddy, Prometheus, Grafana
+- Runs `npm run dev` instead of production build
+
+## Caddy Reverse Proxy
+
+Caddy provides automatic HTTPS and reverse proxying. Edit `Caddyfile` to configure:
+
+```caddyfile
+# Default: reverse proxy on port 80
+:80 {
+    reverse_proxy 9router:20128
+}
+
+# With domain (uncomment and configure)
+# example.com {
+#     reverse_proxy 9router:20128
+# }
+```
+
+## Prometheus + Grafana Monitoring
+
+Prometheus scrapes 9router metrics at `/api/metrics` every 10 seconds. Grafana provides dashboards for visualization.
+
+Access:
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3000 (default password: admin)
+
+Configure `prometheus.yml` to adjust scrape intervals or targets.
+
+## CI/CD Pipeline
+
+GitHub Actions workflow (`.github/workflows/docker.yml`) builds and pushes images:
+
+- **Triggers**: Push to main/master, tags `v*`, pull requests
+- **Registry**: GHCR (`ghcr.io/${{ github.repository }}`)
+- **Security**: Trivy scans for CRITICAL/HIGH vulnerabilities before push
+- **Platforms**: linux/amd64 + linux/arm64
+- **Caching**: GitHub Actions cache for faster builds
+
+Fork-aware: Images push to `ghcr.io/<your-fork>/<repo>` automatically.
+
 ## Publish (automatic via CI)
 
 Push a git tag `v*` → GitHub Actions builds multi-platform (amd64+arm64) and pushes to:
@@ -129,4 +196,4 @@ node scripts/release.js "Release title" "Notes"
 git tag v0.4.x && git push origin v0.4.x
 ```
 
-Workflow: `app/.github/workflows/docker-publish.yml`
+Workflow: `.github/workflows/docker-publish.yml`

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,30 @@ ARG NODE_IMAGE=node:22-alpine
 FROM ${NODE_IMAGE} AS base
 WORKDIR /app
 
-FROM base AS builder
-
+# Stage: dependencies (cached layer — only rebuilds when package.json changes)
+FROM base AS deps
 RUN apk --no-cache upgrade && apk --no-cache add python3 make g++ linux-headers
-
-COPY package.json ./
+COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm \
-  npm install
+  --mount=type=cache,target=/app/node_modules \
+  npm ci
 
-COPY . ./
+# Stage: development (hot reload, debug tools)
+FROM base AS dev
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+EXPOSE 20128 9229
+CMD ["npm", "run", "dev"]
+
+# Stage: build
+FROM base AS build
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm run build
+RUN --mount=type=cache,target=/app/.next/cache npm run build
 
-FROM ${NODE_IMAGE} AS runner
+# Stage: production (minimal image)
+FROM ${NODE_IMAGE} AS production
 WORKDIR /app
 
 LABEL org.opencontainers.image.title="9router"
@@ -26,17 +37,17 @@ ENV HOSTNAME=0.0.0.0
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV DATA_DIR=/app/data
 
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/custom-server.js ./custom-server.js
-COPY --from=builder /app/open-sse ./open-sse
+COPY --from=build /app/public ./public
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/custom-server.js ./custom-server.js
+COPY --from=build /app/open-sse ./open-sse
 # Next file tracing can omit sibling files; MITM runs server.js as a separate process.
-COPY --from=builder /app/src/mitm ./src/mitm
+COPY --from=build /app/src/mitm ./src/mitm
 # Standalone node_modules may omit deps only required by the MITM child process.
-COPY --from=builder /app/node_modules/node-forge ./node_modules/node-forge
+COPY --from=build /app/node_modules/node-forge ./node_modules/node-forge
 # Ensure `next` is available at runtime in case tracing did not include it.
-COPY --from=builder /app/node_modules/next ./node_modules/next
+COPY --from=build /app/node_modules/next ./node_modules/next
 
 RUN mkdir -p /app/data && chown -R node:node /app && \
   mkdir -p /app/data-home && chown node:node /app/data-home && \
@@ -48,6 +59,8 @@ RUN apk --no-cache upgrade && apk --no-cache add su-exec && \
   chmod +x /entrypoint.sh
 
 EXPOSE 20128
+HEALTHCHECK --interval=30s --timeout=3s \
+  CMD wget -qO- http://localhost:20128/dashboard || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["node", "custom-server.js"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,30 @@
+services:
+  9router:
+    build:
+      context: .
+      target: dev
+    image: ghcr.io/${GITHUB_REPOSITORY:-decolua/9router}:dev
+    container_name: 9router-dev
+    volumes:
+      - .:/app
+      - /app/node_modules
+      - /app/.next
+    environment:
+      NODE_ENV: development
+      DEBUG: "app:*"
+    ports:
+      - "20128:20128"
+      - "9229:9229"
+    networks:
+      - frontend
+      - backend
+
+  caddy:
+    profiles:
+      - disabled
+  prometheus:
+    profiles:
+      - disabled
+  grafana:
+    profiles:
+      - disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   9router:
-    image: decolua/9router:latest
+    build:
+      context: .
+      target: production
+    image: ghcr.io/${GITHUB_REPOSITORY:-decolua/9router}:latest
     container_name: 9router
     restart: always
     ports:
@@ -14,17 +17,68 @@ services:
       PORT: "20128"
       HOSTNAME: "0.0.0.0"
       NODE_ENV: production
-      HEADROOM_URL: http://headroom:8787
     depends_on:
-      - headroom
+      headroom:
+        condition: service_started
+    networks:
+      - frontend
+      - backend
 
   headroom:
     image: ghcr.io/chopratejas/headroom:latest
     container_name: headroom
     restart: always
+    networks:
+      - backend
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: caddy
+    restart: always
     ports:
-      - "8787:8787"
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    networks:
+      - frontend
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    networks:
+      - backend
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_PASSWORD:-admin}"
+    networks:
+      - backend
 
 volumes:
   9router-data:
     name: 9router-data
+  caddy-data:
+  caddy-config:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  frontend:
+  backend:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "9router"
+    static_configs:
+      - targets: ["9router:20128"]
+    metrics_path: "/api/metrics"
+    scrape_interval: 10s


### PR DESCRIPTION
## Summary

Full overhaul of the Docker infrastructure: better layer caching, Caddy reverse proxy, Prometheus + Grafana monitoring, dev/prod separation via Compose overrides, and a fork-aware GitHub Actions CI/CD pipeline with Trivy security scanning.

Closes #2828

## Changes

### Dockerfile
- **deps stage** — `npm ci` with `--mount=type=cache` for deterministic, cached installs
- **dev stage** — hot-reload with debugger port 9229
- **build stage** — `--mount=type=cache` on `.next/cache` for incremental rebuilds
- **production stage** — unchanged runtime; add `HEALTHCHECK`

### Docker Compose

| File | Purpose |
|------|---------|
| `docker-compose.yml` | Production base — 9router, headroom, caddy, prometheus, grafana |
| `docker-compose.dev.yml` | Dev override — bind-mount source, `npm run dev`, disable optional services |

### New files

| File | Purpose |
|------|---------|
| `Caddyfile` | Reverse proxy `:80` → `9router:20128` |
| `.github/workflows/docker.yml` | Fork-aware build + Trivy scan + multi-platform push |

### Updated files

| File | Change |
|------|--------|
| `.dockerignore` | Exclude `cli/`, `docs/`, `tests/`, compose files |
| `DOCKER.md` | Document Caddy, monitoring, dev mode, CI/CD pipeline |

## Usage

```bash
# Production (all services)
docker compose up -d

# Development (hot reload)
docker compose -f docker-compose.yml -f docker-compose.dev.yml up
```

## CI/CD

- Triggers on push to main/master and `v*` tags
- `ghcr.io/${{ github.repository }}` — pushes to the fork's own registry
- Trivy blocks push on CRITICAL/HIGH vulnerabilities
- Multi-platform: linux/amd64 + linux/arm64
- GHA build cache

## Testing

- [ ] `docker build --target production` succeeds
- [ ] `docker compose up -d` starts all services
- [ ] 9router responds on :20128
- [ ] Caddy proxies on :80
- [ ] Prometheus reachable on :9090
- [ ] Grafana reachable on :3000
- [ ] Dev mode hot-reloads on source change