### PR TITLE
feat(kimi): add OAuth subscription quota tracking

### DIFF
--- a/open-sse/providers/registry/kimi.js
+++ b/open-sse/providers/registry/kimi.js
@@ -31,6 +31,9 @@ export default {
     clientId: "17e5f671-d194-4dfb-9706-5516cb48c098",
     tokenUrl: "https://auth.kimi.com/api/oauth/token",
     refreshUrl: "https://auth.kimi.com/api/oauth/token",
+    usage: {
+      url: "https://api.kimi.com/coding/v1/usages",
+    },
     auth: {
       combined: true,
       header: "x-api-key",

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -12,6 +12,7 @@ import { getKiroUsage } from "./usage/kiro.js";
 import { getMiniMaxUsage } from "./usage/minimax.js";
 import { getCodeBuddyCnUsage } from "./usage/codebuddy-cn.js";
 import { getGrokCliUsage } from "./usage/grok-cli.js";
+import { getKimiUsage } from "./usage/kimi.js";
 import {
   getQwenUsage,
   getIflowUsage,
@@ -45,6 +46,7 @@ const USAGE_HANDLERS = {
   "vercel-ai-gateway": (c) => getVercelAiGatewayUsage(c.apiKey, c.proxyOptions),
   "codebuddy-cn": (c) => getCodeBuddyCnUsage(c.accessToken, c.apiKey, c.providerSpecificData, c.proxyOptions),
   "grok-cli": (c) => getGrokCliUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
+  kimi: (c) => getKimiUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null) {

--- a/open-sse/services/usage/kimi.js
+++ b/open-sse/services/usage/kimi.js
@@ -20,14 +20,16 @@ import { proxyAwareFetch } from "../../utils/proxyFetch.js";
 import { U, parseResetTime, toFiniteNumber } from "./shared.js";
 
 // Kimi reports the rolling 5h session allowance as a 300-minute window.
-const SESSION_WINDOW_MINUTES = 300;
-const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+const SESSION_WINDOW_MINUTES = 5 * MINUTES_PER_HOUR;
+const WEEKLY_WINDOW_MINUTES = 7 * MINUTES_PER_DAY;
 const WEEKLY_NAME = "weekly (7d)";
 
 const WINDOW_UNIT_MINUTES = {
   TIME_UNIT_MINUTE: 1,
-  TIME_UNIT_HOUR: 60,
-  TIME_UNIT_DAY: 1440,
+  TIME_UNIT_HOUR: MINUTES_PER_HOUR,
+  TIME_UNIT_DAY: MINUTES_PER_DAY,
 };
 
 function normalizeQuota(detail) {
@@ -48,8 +50,8 @@ function windowMinutes(window) {
 }
 
 function formatSpan(minutes) {
-  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
-  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  if (minutes % MINUTES_PER_DAY === 0) return `${minutes / MINUTES_PER_DAY}d`;
+  if (minutes % MINUTES_PER_HOUR === 0) return `${minutes / MINUTES_PER_HOUR}h`;
   return `${minutes}m`;
 }
 
@@ -109,7 +111,7 @@ export async function getKimiUsage(accessToken, providerSpecificData, proxyOptio
     }
 
     if (Object.keys(quotas).length === 0) {
-      return { message: "Kimi connected. Unable to parse quota data.", quotas };
+      return { message: "Kimi connected. Unable to parse quota data." };
     }
 
     return { plan: "Kimi Code", quotas };

--- a/open-sse/services/usage/kimi.js
+++ b/open-sse/services/usage/kimi.js
@@ -1,0 +1,119 @@
+/**
+ * Kimi Code usage handler
+ *
+ * Source of truth: Kimi CLI OAuth traffic to api.kimi.com
+ *   GET /coding/v1/usages
+ *
+ * Observed shape — a top-level subscription window plus per-window limits,
+ * with numbers sent as strings and durations as a {duration, timeUnit} pair:
+ * {
+ *   usage: { limit: "2048", used: "375", remaining, resetTime },
+ *   limits: [{
+ *     window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+ *     detail: { limit: "200", used: "19", remaining, resetTime }
+ *   }]
+ * }
+ */
+
+import { buildKimiHeaders } from "../../config/appConstants.js";
+import { proxyAwareFetch } from "../../utils/proxyFetch.js";
+import { U, parseResetTime, toFiniteNumber } from "./shared.js";
+
+// Kimi reports the rolling 5h session allowance as a 300-minute window.
+const SESSION_WINDOW_MINUTES = 300;
+const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+const WEEKLY_NAME = "weekly (7d)";
+
+const WINDOW_UNIT_MINUTES = {
+  TIME_UNIT_MINUTE: 1,
+  TIME_UNIT_HOUR: 60,
+  TIME_UNIT_DAY: 1440,
+};
+
+function normalizeQuota(detail) {
+  if (!detail || typeof detail !== "object") return null;
+
+  const total = toFiniteNumber(detail.limit, NaN);
+  const used = toFiniteNumber(detail.used, NaN);
+  if (!Number.isFinite(total) || !Number.isFinite(used) || total < 0 || used < 0) return null;
+
+  return { used, total, resetAt: parseResetTime(detail.resetTime) };
+}
+
+function windowMinutes(window) {
+  const duration = toFiniteNumber(window?.duration, NaN);
+  const unitMinutes = WINDOW_UNIT_MINUTES[window?.timeUnit];
+  if (!Number.isFinite(duration) || duration <= 0 || !unitMinutes) return null;
+  return duration * unitMinutes;
+}
+
+function formatSpan(minutes) {
+  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+}
+
+function getWindowName(window) {
+  const minutes = windowMinutes(window);
+  if (!minutes) return null;
+
+  const span = formatSpan(minutes);
+  if (minutes === SESSION_WINDOW_MINUTES) return `session (${span})`;
+  if (minutes === WEEKLY_WINDOW_MINUTES) return WEEKLY_NAME;
+  return `limit (${span})`;
+}
+
+function parseKimiUsage(data) {
+  const quotas = {};
+  const weekly = normalizeQuota(data?.usage);
+  if (weekly) quotas[WEEKLY_NAME] = weekly;
+
+  // A 7-day window here restates the top-level weekly allowance, so the
+  // first-wins guard keeps `usage` authoritative rather than adding a duplicate row.
+  for (const limit of Array.isArray(data?.limits) ? data.limits : []) {
+    const name = getWindowName(limit?.window);
+    const quota = normalizeQuota(limit?.detail);
+    if (name && quota && !quotas[name]) quotas[name] = quota;
+  }
+
+  return quotas;
+}
+
+export async function getKimiUsage(accessToken, providerSpecificData, proxyOptions = null) {
+  if (!accessToken) return { message: "Kimi access token not available." };
+
+  try {
+    const response = await proxyAwareFetch(U("kimi").url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+        ...buildKimiHeaders(providerSpecificData?.deviceId),
+      },
+    }, proxyOptions);
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        return { message: "Kimi quota API authentication expired." };
+      }
+      return { message: `Kimi connected. Unable to fetch usage (${response.status}).` };
+    }
+
+    // A malformed body is a parse failure, not a transport failure: keep it out
+    // of the outer catch so the JSON error text never reaches the dashboard.
+    let quotas;
+    try {
+      quotas = parseKimiUsage(JSON.parse(await response.text()));
+    } catch {
+      quotas = {};
+    }
+
+    if (Object.keys(quotas).length === 0) {
+      return { message: "Kimi connected. Unable to parse quota data.", quotas };
+    }
+
+    return { plan: "Kimi Code", quotas };
+  } catch (error) {
+    return { message: `Kimi connected. Unable to fetch usage: ${error.message}` };
+  }
+}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -380,6 +380,7 @@ export function parseQuotaData(provider, data) {
         break;
 
       case "kiro":
+      case "kimi":
         if (data.quotas) {
           Object.entries(data.quotas).forEach(([quotaType, quota]) => {
             normalizedQuotas.push({

--- a/tests/unit/kimi-usage.test.js
+++ b/tests/unit/kimi-usage.test.js
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { PROVIDERS } from "../../open-sse/providers/index.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+import { USAGE_SUPPORTED_PROVIDERS } from "../../src/shared/constants/providers.js";
+import { parseQuotaData } from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Mirrors the real coding/v1/usages response: a top-level weekly allowance plus
+// exactly one rolling window in `limits` (the 300-minute session).
+const USAGE_RESPONSE = {
+  usage: {
+    limit: "2048",
+    used: "375",
+    remaining: "1673",
+    resetTime: "2026-08-01T15:23:13.373Z",
+  },
+  limits: [
+    {
+      window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+      detail: {
+        limit: "200",
+        used: "19",
+        remaining: "181",
+        resetTime: "2026-08-01T15:05:24.374Z",
+      },
+    },
+  ],
+};
+
+describe("Kimi usage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("exposes the OAuth subscription usage endpoint", () => {
+    expect(PROVIDERS.kimi.usage?.url).toBe("https://api.kimi.com/coding/v1/usages");
+    expect(USAGE_SUPPORTED_PROVIDERS).toContain("kimi");
+  });
+
+  it("normalizes every valid Kimi quota window and sends identity headers", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(USAGE_RESPONSE));
+
+    const usage = await getUsageForProvider({
+      provider: "kimi",
+      accessToken: "test-token",
+      providerSpecificData: { deviceId: "test-device" },
+    });
+
+    expect(usage).toMatchObject({
+      plan: "Kimi Code",
+      quotas: {
+        "weekly (7d)": {
+          used: 375,
+          total: 2048,
+          resetAt: "2026-08-01T15:23:13.373Z",
+        },
+        "session (5h)": {
+          used: 19,
+          total: 200,
+          resetAt: "2026-08-01T15:05:24.374Z",
+        },
+      },
+    });
+
+    expect(proxyAwareFetch).toHaveBeenCalledWith(
+      "https://api.kimi.com/coding/v1/usages",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+          Accept: "application/json",
+          "X-Msh-Device-Id": "test-device",
+        }),
+      }),
+      null,
+    );
+  });
+
+  it("does not duplicate the weekly row when limits restates the 7-day window", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({
+      ...USAGE_RESPONSE,
+      limits: [
+        ...USAGE_RESPONSE.limits,
+        {
+          window: { duration: 7, timeUnit: "TIME_UNIT_DAY" },
+          detail: { limit: "2048", used: "375", resetTime: "2026-08-01T15:23:13.373Z" },
+        },
+      ],
+    }));
+
+    const usage = await getUsageForProvider({ provider: "kimi", accessToken: "test-token" });
+
+    expect(Object.keys(usage.quotas)).toEqual(["weekly (7d)", "session (5h)"]);
+  });
+
+  it("keeps valid quotas when neighboring records are malformed", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({
+      usage: { limit: "unknown", used: "1", resetTime: "2026-08-01T00:00:00Z" },
+      limits: [
+        {
+          window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+          detail: { limit: "bad", used: "1", resetTime: "2026-08-01T00:00:00Z" },
+        },
+        {
+          window: { duration: 300, timeUnit: "TIME_UNIT_MINUTE" },
+          detail: { limit: "20", used: "1", resetTime: "2026-08-01T00:00:00Z" },
+        },
+      ],
+    }));
+
+    const usage = await getUsageForProvider({ provider: "kimi", accessToken: "test-token" });
+
+    expect(usage.quotas).toEqual({
+      "session (5h)": {
+        used: 1,
+        total: 20,
+        resetAt: "2026-08-01T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("keeps a quota whose reset time is missing", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({
+      usage: { limit: "2048", used: "375" },
+    }));
+
+    const usage = await getUsageForProvider({ provider: "kimi", accessToken: "test-token" });
+
+    expect(usage.quotas).toEqual({
+      "weekly (7d)": { used: 375, total: 2048, resetAt: null },
+    });
+  });
+
+  it("names an hour-expressed session window as session (5h)", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({
+      limits: [
+        {
+          window: { duration: 5, timeUnit: "TIME_UNIT_HOUR" },
+          detail: { limit: "200", used: "19", resetTime: "2026-08-01T15:05:24.374Z" },
+        },
+      ],
+    }));
+
+    const usage = await getUsageForProvider({ provider: "kimi", accessToken: "test-token" });
+
+    expect(Object.keys(usage.quotas)).toEqual(["session (5h)"]);
+  });
+
+  it.each([401, 403])("returns an auth-expiry message on %i", async (status) => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, status));
+
+    const usage = await getUsageForProvider({ provider: "kimi", accessToken: "expired" });
+
+    expect(usage.message).toMatch(/authentication expired/i);
+  });
+
+  it("does not leak parser internals when the body is not JSON", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      new Response("<html>gateway</html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+
+    const usage = await getUsageForProvider({ provider: "kimi", accessToken: "test-token" });
+
+    expect(usage.message).toBe("Kimi connected. Unable to parse quota data.");
+  });
+
+  it("returns the standard failure message for unavailable usage fetches", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ error: "unavailable" }, 503));
+
+    const usage = await getUsageForProvider({ provider: "kimi", accessToken: "test-token" });
+
+    expect(usage.message).toBe("Kimi connected. Unable to fetch usage (503).");
+  });
+
+  it("parses standard Kimi quotas for the dashboard", () => {
+    const rows = parseQuotaData("kimi", {
+      quotas: {
+        "weekly (7d)": { used: 375, total: 2048, resetAt: "2026-08-01T15:23:13.373Z" },
+      },
+    });
+
+    expect(rows).toEqual([
+      {
+        name: "weekly (7d)",
+        used: 375,
+        total: 2048,
+        resetAt: "2026-08-01T15:23:13.373Z",
+      },
+    ]);
+  });
+});

--- a/tests/unit/usage-dispatch.test.js
+++ b/tests/unit/usage-dispatch.test.js
@@ -15,7 +15,7 @@ const load = () => import("../../open-sse/services/usage.js");
 const SUPPORTED = [
   "github", "gemini-cli", "antigravity", "claude", "codex", "kiro",
   "qoder", "qwen", "iflow", "ollama", "glm", "glm-cn",
-  "minimax", "minimax-cn", "vercel-ai-gateway", "grok-cli",
+  "minimax", "minimax-cn", "vercel-ai-gateway", "grok-cli", "kimi",
 ];
 
 describe("usage dispatch", () => {


### PR DESCRIPTION
Adds Kimi CLI OAuth subscription quota to the existing Quota Tracker, via the established usage pipeline (registry `transport.usage` → `USAGE_HANDLERS` → `GET /api/usage/[connectionId]` → `parseQuotaData` → generic quota cards). No OAuth-flow, refresh-route, dashboard-layout, or chart changes.

## What

- `open-sse/services/usage/kimi.js` — calls `GET https://api.kimi.com/coding/v1/usages` with `Authorization: Bearer <accessToken>`, `Accept: application/json`, and the persisted `X-Msh-*` identity headers (`buildKimiHeaders(providerSpecificData.deviceId)`).
- Normalizes the top-level weekly allowance plus per-window `limits` to the shared quota contract: `weekly (7d)` and `session (5h)` (the 300-minute window), matching Claude's label convention. Other windows name deterministically from duration (`limit (Nd/Nh/Nm)`); a restated 7-day window dedupes first-wins so the top-level allowance stays authoritative.
- Emits only `{ used, total, resetAt }` rows; malformed/incomplete entries are dropped. 401/403 return the auth-expiry-compatible message (existing route force-refreshes and retries once); other failures return the temporarily-unavailable message.
- Explicit `case "kimi"` in `parseQuotaData`; handler registered in `USAGE_HANDLERS` with `providerSpecificData` + `proxyOptions`.



## Tests

13 focused tests: both windows + headers, dedup of a restated 7-day window, malformed neighbors, missing `resetTime`, hour-expressed session window, 401/403, 503, non-JSON body, dashboard mapping, dispatch registration.

## Screenshots

<img width="2480" height="2200" alt="01-quota-page-full" src="https://github.com/user-attachments/assets/18493cf1-5f22-40a9-9e3a-09baf97ffe19" />


Local review gate: /code-review passed — 2 findings fixed, 1 accepted (first-wins dedup discards a differing restated 7-day row; user-directed behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)