### PR TITLE
feat(api-keys): add expiry, token quotas, and model policies

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -38,7 +38,7 @@ import { resolveSessionId } from "../utils/sessionManager.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, apiKeyReservation = 0, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -378,7 +378,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyReservation, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -5,6 +5,7 @@ import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.j
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
+import { settleApiKeyReservation } from "@/sse/services/apiKeyPolicy.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
@@ -198,7 +199,7 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 /**
  * Handle non-streaming response from provider.
  */
-export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe, reqTag, log }) {
+export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyReservation = 0, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe, reqTag, log }) {
   trackDone();
   const contentType = providerResponse.headers.get("content-type") || "";
   let responseBody;
@@ -236,6 +237,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
   saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
+  settleApiKeyReservation(apiKey, apiKeyReservation, usage).catch(() => {});
   if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -108,7 +108,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
  */
-export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog, reqTag, log }) {
+export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, apiKeyReservation = 0, clientRawRequest, onRequestSuccess, trackDone, appendLog, reqTag, log }) {
   const contentType = providerResponse.headers.get("content-type") || "";
   const isSSE = contentType.includes("text/event-stream") || (contentType === "" && isResponsesProvider(provider));
   if (!isSSE) return null; // not handled here
@@ -131,6 +131,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       const usage = jsonResponse.usage || {};
       appendLog({ tokens: usage, status: "200 OK" });
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
+      settleApiKeyReservation(apiKey, apiKeyReservation, usage).catch(() => {});
       if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
@@ -214,6 +215,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
     const usage = parsed.usage || {};
     appendLog({ tokens: usage, status: "200 OK" });
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
+      settleApiKeyReservation(apiKey, apiKeyReservation, usage).catch(() => {});
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
     const totalLatency = Date.now() - requestStartTime;

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -8,6 +8,7 @@ import { buildAbortedResponsesTerminalBytes } from "../../utils/responsesStreamH
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
+import { settleApiKeyReservation } from "@/sse/services/apiKeyPolicy.js";
 
 // Codex returns Responses API SSE → which client format to translate INTO, by request sourceFormat.
 // Gemini-family all map to ANTIGRAVITY decoder; unknown sources fall back to OPENAI.
@@ -110,7 +111,7 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 /**
  * Build onStreamComplete callback for streaming usage tracking.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, apiKeyReservation = 0, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
   const onStreamComplete = (contentObj, usage, ttftAt) => {
@@ -137,6 +138,7 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
 
     // Persist stream usage to DB (no console line; the "📊 done" line below is authoritative)
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE", silent: true });
+    settleApiKeyReservation(apiKey, apiKeyReservation, usage).catch(() => {});
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
   };
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:bun": "bun --bun next dev --webpack --port 20127",
     "build:bun": "bun --bun next build --webpack",
     "start:bun": "bun ./.next/standalone/server.js",
+    "test:policy": "npx vitest run --config tests/vitest.config.js tests/unit/api-key-policies.test.js tests/unit/api-key-edit-route.test.js",
     "cli:pack": "npm --prefix cli run pack:cli",
     "cli:publish": "npm --prefix cli run publish:cli"
   },

--- a/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
+++ b/src/app/(dashboard)/dashboard/endpoint/EndpointPageClient.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
-import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal } from "@/shared/components";
+import { Card, Button, Input, Modal, CardSkeleton, Toggle, ConfirmModal, ModelSelectModal } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
 import {
   TUNNEL_BENEFITS,
@@ -17,12 +17,149 @@ import EndpointRow from "./components/EndpointRow";
 import StatusAlert from "./components/StatusAlert";
 import Tooltip from "./components/Tooltip";
 import SecurityWarning from "./components/SecurityWarning";
+
+const TOKEN_LIMIT_PRESETS = [
+  { label: "100K", value: "100000" },
+  { label: "500K", value: "500000" },
+  { label: "1M", value: "1000000" },
+  { label: "5M", value: "5000000" },
+  { label: "10M", value: "10000000" },
+];
+
+function formatTokenCount(value) {
+  const tokens = Math.max(0, Number(value) || 0);
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(tokens % 1_000_000 === 0 ? 0 : 1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(tokens % 1_000 === 0 ? 0 : 1)}K`;
+  return String(tokens);
+}
+
+function ApiKeyUsageTracker({ used, limit }) {
+  const safeLimit = Math.max(1, Number(limit) || 1);
+  const safeUsed = Math.max(0, Number(used) || 0);
+  const percentage = Math.min(100, Math.round((safeUsed / safeLimit) * 100));
+  const remaining = Math.max(0, safeLimit - safeUsed);
+  const tone = percentage >= 90
+    ? { bar: "bg-red-500", text: "text-red-600 dark:text-red-400" }
+    : percentage >= 75
+      ? { bar: "bg-amber-500", text: "text-amber-600 dark:text-amber-400" }
+      : { bar: "bg-emerald-500", text: "text-text-muted" };
+
+  return (
+    <div className="mt-2 max-w-sm" title={`${formatTokenCount(safeUsed)} of ${formatTokenCount(safeLimit)} tokens used`}>
+      <div className="mb-1 flex items-center justify-between gap-3 text-[11px]">
+        <span className={tone.text}>{percentage}% used</span>
+        <span className="text-text-muted">{formatTokenCount(remaining)} remaining</span>
+      </div>
+      <div
+        className="h-1.5 overflow-hidden rounded-full bg-black/10 dark:bg-white/10"
+        role="progressbar"
+        aria-label={`Token usage: ${percentage}% used, ${formatTokenCount(remaining)} remaining`}
+        aria-valuemin={0}
+        aria-valuemax={safeLimit}
+        aria-valuenow={Math.min(safeUsed, safeLimit)}
+      >
+        <div className={`h-full rounded-full transition-[width] duration-300 ${tone.bar}`} style={{ width: `${percentage}%` }} />
+      </div>
+    </div>
+  );
+}
+
+ApiKeyUsageTracker.propTypes = {
+  used: PropTypes.number,
+  limit: PropTypes.number.isRequired,
+};
+
+function EditApiKeyModal({ apiKey, activeProviders, modelAliases, onClose, onSave }) {
+  const [expiresAt, setExpiresAt] = useState(apiKey.expiresAt ? apiKey.expiresAt.slice(0, 16) : "");
+  const [models, setModels] = useState(apiKey.allowedModels || []);
+  const [tokenAmount, setTokenAmount] = useState("");
+  const [tokenMode, setTokenMode] = useState(apiKey.tokenLimit == null ? "unlimited" : "unchanged");
+  const [showModelSelect, setShowModelSelect] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const hasLimit = apiKey.tokenLimit != null;
+
+  const save = async () => {
+    setSaving(true);
+    await onSave({
+      expiresAt: expiresAt || null,
+      allowedModels: models,
+      ...(tokenMode === "unlimited" ? { tokenLimit: null } : tokenAmount ? { [hasLimit ? "tokenLimitIncrement" : "tokenLimit"]: tokenAmount } : {}),
+    });
+    setSaving(false);
+  };
+
+  return <>
+    <Modal isOpen onClose={onClose} title={`Edit ${apiKey.name}`}>
+      <div className="flex flex-col gap-4">
+        <Input label="Expires at (optional)" type="datetime-local" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} hint="Leave blank for no expiry." />
+        <Input
+          label={hasLimit ? "Add tokens" : "Set token limit"}
+          type="number" min="1" step="1" value={tokenAmount}
+          onChange={(e) => {
+            const value = e.target.value;
+            setTokenAmount(value);
+            setTokenMode(value ? "amount" : hasLimit ? "unchanged" : "unlimited");
+          }}
+          placeholder={hasLimit ? "e.g. 500000" : "e.g. 1000000"}
+          hint={hasLimit ? `Added to the current ${formatTokenCount(apiKey.tokenLimit)} limit; usage is preserved.` : "Choose Unlimited to remove the limit."}
+        />
+        <div className="-mt-2 flex flex-wrap gap-1.5" aria-label="Token limit presets">
+          {TOKEN_LIMIT_PRESETS.map((preset) => {
+            const selected = tokenMode === "amount" && tokenAmount === preset.value;
+            return (
+              <button
+                key={preset.value}
+                type="button"
+                onClick={() => { setTokenAmount(preset.value); setTokenMode("amount"); }}
+                aria-pressed={selected}
+                className={`rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${selected
+                  ? "border-primary bg-primary text-white"
+                  : "border-border bg-surface-2 text-text-muted hover:border-primary/50 hover:text-primary"}`}
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() => { setTokenAmount(""); setTokenMode("unlimited"); }}
+            aria-pressed={tokenMode === "unlimited"}
+            className={`rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${tokenMode === "unlimited"
+              ? "border-primary bg-primary text-white"
+              : "border-border bg-surface-2 text-text-muted hover:border-primary/50 hover:text-primary"}`}
+          >
+            Unlimited
+          </button>
+        </div>
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-text-main">Allowed models</label>
+          <div className="flex min-h-12 flex-wrap gap-1 rounded-lg border border-border bg-surface-2 p-2">
+            {models.length ? models.map((model) => <span key={model} className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-xs text-primary"><span>{model}</span><button type="button" onClick={() => setModels((items) => items.filter((item) => item !== model))} aria-label={`Remove ${model}`} className="material-symbols-outlined text-[14px]">close</button></span>) : <span className="p-1 text-xs text-text-muted">All models allowed</span>}
+          </div>
+          <button type="button" onClick={() => setShowModelSelect(true)} className="mt-2 flex w-full items-center justify-center gap-1 rounded-lg border border-dashed border-black/10 py-2 text-xs font-medium text-primary dark:border-white/10"><span className="material-symbols-outlined text-[16px]">edit</span>Edit model access</button>
+        </div>
+        <div className="flex gap-2"><Button onClick={save} fullWidth disabled={saving}>{saving ? "Saving..." : "Save changes"}</Button><Button onClick={onClose} variant="ghost" fullWidth disabled={saving}>Cancel</Button></div>
+      </div>
+    </Modal>
+    {showModelSelect && <ModelSelectModal isOpen onClose={() => setShowModelSelect(false)} onSelect={(model) => setModels((items) => items.includes(model.value) ? items : [...items, model.value])} onDeselect={(model) => setModels((items) => items.filter((item) => item !== model.value))} activeProviders={activeProviders} modelAliases={modelAliases} addedModelValues={models} closeOnSelect={false} title="Edit allowed models" />}
+  </>;
+}
+
+EditApiKeyModal.propTypes = { apiKey: PropTypes.object.isRequired, activeProviders: PropTypes.array.isRequired, modelAliases: PropTypes.object.isRequired, onClose: PropTypes.func.isRequired, onSave: PropTypes.func.isRequired };
+
 export default function APIPageClient({ machineId }) {
   const [keys, setKeys] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyExpiresAt, setNewKeyExpiresAt] = useState("");
+  const [newKeyTokenLimit, setNewKeyTokenLimit] = useState("");
+  const [newKeyModels, setNewKeyModels] = useState([]);
+  const [showKeyModelSelect, setShowKeyModelSelect] = useState(false);
+  const [activeProviders, setActiveProviders] = useState([]);
+  const [modelAliases, setModelAliases] = useState({});
   const [createdKey, setCreatedKey] = useState(null);
+  const [editingKey, setEditingKey] = useState(null);
   const [confirmState, setConfirmState] = useState(null);
 
   const [requireApiKey, setRequireApiKey] = useState(false);
@@ -101,6 +238,23 @@ export default function APIPageClient({ machineId }) {
     fetchData();
     loadSettings();
   }, []);
+
+  useEffect(() => {
+    if (!showAddModal && !editingKey) return;
+    let cancelled = false;
+    Promise.all([fetch("/api/providers"), fetch("/api/models/alias")])
+      .then(async ([providersRes, aliasesRes]) => {
+        const [providersData, aliasesData] = await Promise.all([
+          providersRes.ok ? providersRes.json() : {},
+          aliasesRes.ok ? aliasesRes.json() : {},
+        ]);
+        if (cancelled) return;
+        setActiveProviders(providersData.connections || []);
+        setModelAliases(aliasesData.aliases || {});
+      })
+      .catch((error) => console.log("Error loading model picker:", error));
+    return () => { cancelled = true; };
+  }, [showAddModal, editingKey]);
 
   // Status poll: only while degraded (not yet reachable). Stop once healthy to avoid spam.
   // Visibility re-check: refresh once when tab becomes visible.
@@ -614,7 +768,12 @@ export default function APIPageClient({ machineId }) {
       const res = await fetch("/api/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newKeyName }),
+        body: JSON.stringify({
+          name: newKeyName,
+          expiresAt: newKeyExpiresAt || null,
+          tokenLimit: newKeyTokenLimit || null,
+          allowedModels: newKeyModels,
+        }),
       });
       const data = await res.json();
 
@@ -622,6 +781,10 @@ export default function APIPageClient({ machineId }) {
         setCreatedKey(data.key);
         await fetchData();
         setNewKeyName("");
+        setNewKeyExpiresAt("");
+        setNewKeyTokenLimit("");
+        setNewKeyModels([]);
+        setShowKeyModelSelect(false);
         setShowAddModal(false);
       }
     } catch (error) {
@@ -665,6 +828,13 @@ export default function APIPageClient({ machineId }) {
     } catch (error) {
       console.log("Error toggling key:", error);
     }
+  };
+
+  const handleUpdateKey = async (id, changes) => {
+    const res = await fetch(`/api/keys/${id}`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(changes) });
+    if (!res.ok) throw new Error((await res.json()).error || "Failed to update key");
+    await fetchData();
+    setEditingKey(null);
   };
 
   const maskKey = (fullKey) => {
@@ -1023,7 +1193,17 @@ export default function APIPageClient({ machineId }) {
                   </div>
                   <p className="text-xs text-text-muted mt-1">
                     Created {new Date(key.createdAt).toLocaleDateString()}
+                    {key.expiresAt ? ` · Expires ${new Date(key.expiresAt).toLocaleString()}` : " · No expiry"}
+                    {key.tokenLimit != null ? ` · ${key.tokensUsed}/${key.tokenLimit} tokens` : " · Unlimited tokens"}
                   </p>
+                  {key.tokenLimit != null && (
+                    <ApiKeyUsageTracker used={key.tokensUsed} limit={key.tokenLimit} />
+                  )}
+                  {Array.isArray(key.allowedModels) && key.allowedModels.length > 0 && (
+                    <p className="text-xs text-text-muted mt-1 truncate" title={key.allowedModels.join(", ")}>
+                      Models: {key.allowedModels.join(", ")}
+                    </p>
+                  )}
                   {key.isActive === false && (
                     <p className="text-xs text-orange-500 mt-1">Paused</p>
                   )}
@@ -1048,6 +1228,7 @@ export default function APIPageClient({ machineId }) {
                     }}
                     title={key.isActive ? "Pause key" : "Resume key"}
                   />
+                  <button onClick={() => setEditingKey(key)} className="p-2 hover:bg-primary/10 rounded text-text-muted hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all" title="Edit key"><span className="material-symbols-outlined text-[18px]">edit</span></button>
                   <button
                     onClick={() => handleDeleteKey(key.id)}
                     className="p-2 hover:bg-red-500/10 rounded text-red-500 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-all"
@@ -1061,6 +1242,8 @@ export default function APIPageClient({ machineId }) {
         )}
       </Card>
 
+      {editingKey && <EditApiKeyModal key={editingKey.id} apiKey={editingKey} activeProviders={activeProviders} modelAliases={modelAliases} onClose={() => setEditingKey(null)} onSave={(changes) => handleUpdateKey(editingKey.id, changes)} />}
+
       {/* Add Key Modal */}
       <Modal
         isOpen={showAddModal}
@@ -1068,6 +1251,10 @@ export default function APIPageClient({ machineId }) {
         onClose={() => {
           setShowAddModal(false);
           setNewKeyName("");
+          setNewKeyExpiresAt("");
+          setNewKeyTokenLimit("");
+          setNewKeyModels([]);
+          setShowKeyModelSelect(false);
         }}
       >
         <div className="flex flex-col gap-4">
@@ -1077,6 +1264,85 @@ export default function APIPageClient({ machineId }) {
             onChange={(e) => setNewKeyName(e.target.value)}
             placeholder="Production Key"
           />
+          <Input
+            label="Expires at (optional)"
+            type="datetime-local"
+            value={newKeyExpiresAt}
+            onChange={(e) => setNewKeyExpiresAt(e.target.value)}
+            hint="Leave blank for no expiry."
+          />
+          <Input
+            label="Token limit (optional)"
+            type="number"
+            min="1"
+            step="1"
+            value={newKeyTokenLimit}
+            onChange={(e) => setNewKeyTokenLimit(e.target.value)}
+            placeholder="Unlimited"
+            hint="Total input and output tokens. Strictly enforced."
+          />
+          <div className="-mt-2 flex flex-wrap gap-1.5" aria-label="Token limit presets">
+            {TOKEN_LIMIT_PRESETS.map((preset) => {
+              const selected = newKeyTokenLimit === preset.value;
+              return (
+                <button
+                  key={preset.value}
+                  type="button"
+                  onClick={() => setNewKeyTokenLimit(preset.value)}
+                  aria-pressed={selected}
+                  className={`rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${selected
+                    ? "border-primary bg-primary text-white"
+                    : "border-border bg-surface-2 text-text-muted hover:border-primary/50 hover:text-primary"}`}
+                >
+                  {preset.label}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() => setNewKeyTokenLimit("")}
+              aria-pressed={!newKeyTokenLimit}
+              className={`rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ${!newKeyTokenLimit
+                ? "border-primary bg-primary text-white"
+                : "border-border bg-surface-2 text-text-muted hover:border-primary/50 hover:text-primary"}`}
+            >
+              Unlimited
+            </button>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Allowed models (optional)</label>
+            {newKeyModels.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-black/10 bg-black/[0.01] px-3 py-4 text-center dark:border-white/10 dark:bg-white/[0.01]">
+                <span className="material-symbols-outlined mb-1 text-xl text-text-muted">layers</span>
+                <p className="text-xs text-text-muted">All models are allowed</p>
+              </div>
+            ) : (
+              <div className="flex max-h-28 flex-wrap gap-1 overflow-y-auto rounded-lg border border-border bg-surface-2 p-2">
+                {newKeyModels.map((model) => (
+                  <span key={model} className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-xs text-primary">
+                    <span className="max-w-48 truncate">{model}</span>
+                    <button
+                      type="button"
+                      onClick={() => setNewKeyModels((models) => models.filter((value) => value !== model))}
+                      aria-label={`Remove ${model}`}
+                      className="material-symbols-outlined text-[14px] hover:text-red-500"
+                    >
+                      close
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={() => setShowKeyModelSelect(true)}
+              className="flex w-full items-center justify-center gap-1 rounded-lg border border-dashed border-black/10 py-2 text-xs font-medium text-primary transition-colors hover:border-primary/50 dark:border-white/10"
+            >
+              <span className="material-symbols-outlined text-[16px]">add</span>
+              {newKeyModels.length ? "Add another model" : "Choose models"}
+            </button>
+            <p className="text-xs text-text-muted">Leave empty to allow every model.</p>
+          </div>
           <div className="flex gap-2">
             <Button onClick={handleCreateKey} fullWidth disabled={!newKeyName.trim()}>
               Create
@@ -1085,6 +1351,10 @@ export default function APIPageClient({ machineId }) {
               onClick={() => {
                 setShowAddModal(false);
                 setNewKeyName("");
+                setNewKeyExpiresAt("");
+                setNewKeyTokenLimit("");
+                setNewKeyModels([]);
+                setShowKeyModelSelect(false);
               }}
               variant="ghost"
               fullWidth
@@ -1094,6 +1364,20 @@ export default function APIPageClient({ machineId }) {
           </div>
         </div>
       </Modal>
+
+      {showKeyModelSelect && (
+        <ModelSelectModal
+          isOpen={showKeyModelSelect}
+          onClose={() => setShowKeyModelSelect(false)}
+          onSelect={(model) => setNewKeyModels((models) => models.includes(model.value) ? models : [...models, model.value])}
+          onDeselect={(model) => setNewKeyModels((models) => models.filter((value) => value !== model.value))}
+          activeProviders={activeProviders}
+          modelAliases={modelAliases}
+          addedModelValues={newKeyModels}
+          closeOnSelect={false}
+          title="Choose models for this API key"
+        />
+      )}
 
       {/* Created Key Modal */}
       <Modal

--- a/src/app/api/keys/[id]/route.js
+++ b/src/app/api/keys/[id]/route.js
@@ -1,14 +1,34 @@
 import { NextResponse } from "next/server";
 import { deleteApiKey, getApiKeyById, updateApiKey } from "@/lib/localDb";
 
-// GET /api/keys/[id] - Get single key
+function parsePolicy(body) {
+  const data = {};
+  if (body.isActive !== undefined) data.isActive = body.isActive === true;
+  if (body.expiresAt !== undefined) {
+    if (body.expiresAt && Number.isNaN(new Date(body.expiresAt).getTime())) throw new Error("Expiration must be a valid date");
+    data.expiresAt = body.expiresAt || null;
+  }
+  if (body.tokenLimit !== undefined) {
+    const tokenLimit = body.tokenLimit === "" || body.tokenLimit == null ? null : Number(body.tokenLimit);
+    if (tokenLimit != null && (!Number.isSafeInteger(tokenLimit) || tokenLimit < 1)) throw new Error("Token limit must be a positive whole number");
+    data.tokenLimit = tokenLimit;
+  }
+  if (body.tokenLimitIncrement !== undefined) {
+    const increment = Number(body.tokenLimitIncrement);
+    if (!Number.isSafeInteger(increment) || increment < 1) throw new Error("Token addition must be a positive whole number");
+    data.tokenLimitIncrement = increment;
+  }
+  if (body.allowedModels !== undefined) {
+    if (!Array.isArray(body.allowedModels)) throw new Error("Allowed models must be an array");
+    data.allowedModels = body.allowedModels;
+  }
+  return data;
+}
+
 export async function GET(request, { params }) {
   try {
-    const { id } = await params;
-    const key = await getApiKeyById(id);
-    if (!key) {
-      return NextResponse.json({ error: "Key not found" }, { status: 404 });
-    }
+    const key = await getApiKeyById((await params).id);
+    if (!key) return NextResponse.json({ error: "Key not found" }, { status: 404 });
     return NextResponse.json({ key });
   } catch (error) {
     console.log("Error fetching key:", error);
@@ -16,40 +36,23 @@ export async function GET(request, { params }) {
   }
 }
 
-// PUT /api/keys/[id] - Update key
 export async function PUT(request, { params }) {
   try {
-    const { id } = await params;
-    const body = await request.json();
-    const { isActive } = body;
-
-    const existing = await getApiKeyById(id);
-    if (!existing) {
-      return NextResponse.json({ error: "Key not found" }, { status: 404 });
-    }
-
-    const updateData = {};
-    if (isActive !== undefined) updateData.isActive = isActive;
-
-    const updated = await updateApiKey(id, updateData);
-
+    const id = (await params).id;
+    if (!await getApiKeyById(id)) return NextResponse.json({ error: "Key not found" }, { status: 404 });
+    const updated = await updateApiKey(id, parsePolicy(await request.json()));
     return NextResponse.json({ key: updated });
   } catch (error) {
+    const status = /Token limit|Token addition|Cannot add tokens|Expiration|Allowed models/.test(error.message) ? 400 : 500;
     console.log("Error updating key:", error);
-    return NextResponse.json({ error: "Failed to update key" }, { status: 500 });
+    return NextResponse.json({ error: status === 400 ? error.message : "Failed to update key" }, { status });
   }
 }
 
-// DELETE /api/keys/[id] - Delete API key
 export async function DELETE(request, { params }) {
   try {
-    const { id } = await params;
-
-    const deleted = await deleteApiKey(id);
-    if (!deleted) {
-      return NextResponse.json({ error: "Key not found" }, { status: 404 });
-    }
-
+    const deleted = await deleteApiKey((await params).id);
+    if (!deleted) return NextResponse.json({ error: "Key not found" }, { status: 404 });
     return NextResponse.json({ message: "Key deleted successfully" });
   } catch (error) {
     console.log("Error deleting key:", error);

--- a/src/app/api/keys/route.js
+++ b/src/app/api/keys/route.js
@@ -4,7 +4,15 @@ import { getConsistentMachineId } from "@/shared/utils/machineId";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/keys - List API keys
+function parsePolicy(body) {
+  const expiresAt = body.expiresAt || null;
+  const tokenLimit = body.tokenLimit === "" || body.tokenLimit == null ? null : Number(body.tokenLimit);
+  if (tokenLimit != null && (!Number.isSafeInteger(tokenLimit) || tokenLimit < 1)) throw new Error("Token limit must be a positive whole number");
+  if (expiresAt && Number.isNaN(new Date(expiresAt).getTime())) throw new Error("Expiration must be a valid date");
+  if (body.allowedModels != null && !Array.isArray(body.allowedModels)) throw new Error("Allowed models must be an array");
+  return { expiresAt, tokenLimit, allowedModels: body.allowedModels };
+}
+
 export async function GET() {
   try {
     const keys = await getApiKeys();
@@ -15,28 +23,16 @@ export async function GET() {
   }
 }
 
-// POST /api/keys - Create new API key
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { name } = body;
-
-    if (!name) {
-      return NextResponse.json({ error: "Name is required" }, { status: 400 });
-    }
-
-    // Always get machineId from server
+    if (!body.name?.trim()) return NextResponse.json({ error: "Name is required" }, { status: 400 });
     const machineId = await getConsistentMachineId();
-    const apiKey = await createApiKey(name, machineId);
-
-    return NextResponse.json({
-      key: apiKey.key,
-      name: apiKey.name,
-      id: apiKey.id,
-      machineId: apiKey.machineId,
-    }, { status: 201 });
+    const apiKey = await createApiKey(body.name.trim(), machineId, parsePolicy(body));
+    return NextResponse.json({ key: apiKey.key, name: apiKey.name, id: apiKey.id, machineId: apiKey.machineId }, { status: 201 });
   } catch (error) {
+    const status = /Token limit|Expiration|Allowed models/.test(error.message) ? 400 : 500;
     console.log("Error creating key:", error);
-    return NextResponse.json({ error: "Failed to create key" }, { status: 500 });
+    return NextResponse.json({ error: status === 400 ? error.message : "Failed to create key" }, { status });
   }
 }

--- a/src/app/api/v1/models/[kind]/route.js
+++ b/src/app/api/v1/models/[kind]/route.js
@@ -1,4 +1,4 @@
-import { buildModelsList } from "../route.js";
+import { buildModelsList, getModelListPolicy } from "../route.js";
 
 // URL slug → service kind(s). `web` covers both webSearch and webFetch.
 const KIND_SLUG_MAP = {
@@ -24,7 +24,7 @@ export async function OPTIONS() {
  * GET /v1/models/{kind} - OpenAI-compatible models list filtered by capability.
  * Supported kinds: image, tts, stt, embedding, image-to-text, web.
  */
-export async function GET(_request, { params }) {
+export async function GET(request, { params }) {
   try {
     const { kind } = await params;
     const kindFilter = KIND_SLUG_MAP[kind];
@@ -41,7 +41,9 @@ export async function GET(_request, { params }) {
       );
     }
 
-    const data = await buildModelsList(kindFilter);
+    const policy = await getModelListPolicy(request);
+    if (policy.error) return Response.json({ error: { message: "Invalid API key", type: "authentication_error" } }, { status: 401, headers: { "Access-Control-Allow-Origin": "*" } });
+    const data = await buildModelsList(kindFilter, { apiKey: policy.key });
     return Response.json({ object: "list", data }, {
       headers: { "Access-Control-Allow-Origin": "*" },
     });

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -5,7 +5,8 @@ import {
   isAnthropicCompatibleProvider,
   isOpenAICompatibleProvider,
 } from "@/shared/constants/providers";
-import { getProviderConnections, getCombos, getCustomModels, getModelAliases } from "@/lib/localDb";
+import { getProviderConnections, getCombos, getCustomModels, getModelAliases, getApiKeyByValue, getSettings } from "@/lib/localDb";
+import { extractApiKey } from "@/sse/services/auth.js";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 import { resolveKimchiModels } from "open-sse/services/kimchiModels.js";
@@ -500,7 +501,10 @@ export async function buildModelsList(kindFilter, options = {}) {
     dedupedModels.push(model);
   }
 
-  return dedupedModels;
+  const apiKey = options.apiKey;
+  const allowedModels = apiKey?.allowedModels;
+  if (!Array.isArray(allowedModels) || allowedModels.length === 0) return dedupedModels;
+  return dedupedModels.filter((model) => allowedModels.includes(model.id));
 }
 
 /**
@@ -524,7 +528,9 @@ export async function GET(request) {
   try {
     // Detect cross-instance recursive /models fetch (another 9router fetching our /models)
     const skipDynamicFetch = request?.headers?.get(INTERNAL_MODELS_FETCH_HEADER) === "1";
-    const data = await buildModelsList([LLM_KIND], { skipDynamicFetch });
+    const policy = await getModelListPolicy(request);
+    if (policy.error) return Response.json({ error: { message: "Invalid API key", type: "authentication_error" } }, { status: 401, headers: { "Access-Control-Allow-Origin": "*" } });
+    const data = await buildModelsList([LLM_KIND], { skipDynamicFetch, apiKey: policy.key });
     return Response.json({ object: "list", data }, {
       headers: { "Access-Control-Allow-Origin": "*" },
     });
@@ -535,4 +541,19 @@ export async function GET(request) {
       { status: 500 }
     );
   }
+}
+
+async function getModelListKey(request) {
+  const keyValue = extractApiKey(request);
+  if (!keyValue) return { present: false, key: null };
+  const key = await getApiKeyByValue(keyValue);
+  const expired = key?.expiresAt && new Date(key.expiresAt).getTime() <= Date.now();
+  return { present: true, key: key?.isActive && !expired ? key : null };
+}
+
+export async function getModelListPolicy(request) {
+  const settings = await getSettings();
+  const result = await getModelListKey(request);
+  if ((settings.requireApiKey && !result.key) || (result.present && !result.key)) return { error: true };
+  return { key: result.key };
 }

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -29,7 +29,7 @@ export {
 
 // API keys
 export {
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByValue, createApiKey, updateApiKey, deleteApiKey, validateApiKey, reserveApiKeyTokens, settleApiKeyTokens,
 } from "./repos/apiKeysRepo.js";
 
 // Combos
@@ -77,7 +77,7 @@ export async function exportDb() {
     providerConnections: db.all(`SELECT * FROM providerConnections`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, provider: r.provider, authType: r.authType, name: r.name, email: r.email, priority: r.priority, isActive: r.isActive === 1, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     providerNodes: db.all(`SELECT * FROM providerNodes`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, type: r.type, name: r.name, createdAt: r.createdAt, updatedAt: r.updatedAt })),
     proxyPools: db.all(`SELECT * FROM proxyPools`).map((r) => ({ ...parseJson(r.data, {}), id: r.id, isActive: r.isActive === 1, testStatus: r.testStatus, createdAt: r.createdAt, updatedAt: r.updatedAt })),
-    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, createdAt: r.createdAt })),
+    apiKeys: db.all(`SELECT * FROM apiKeys`).map((r) => ({ id: r.id, key: r.key, name: r.name, machineId: r.machineId, isActive: r.isActive === 1, expiresAt: r.expiresAt || null, tokenLimit: r.tokenLimit == null ? null : Number(r.tokenLimit), tokensUsed: Number(r.tokensUsed || 0), tokensReserved: Number(r.tokensReserved || 0), allowedModels: parseJson(r.allowedModels, null), createdAt: r.createdAt })),
     combos: db.all(`SELECT * FROM combos`).map((r) => ({ id: r.id, name: r.name, kind: r.kind, models: parseJson(r.models, []), createdAt: r.createdAt, updatedAt: r.updatedAt })),
     modelAliases: {},
     customModels: [],
@@ -137,8 +137,8 @@ export async function importDb(payload) {
     }
     for (const k of payload.apiKeys || []) {
       db.run(
-        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.createdAt || new Date().toISOString()]
+        `INSERT OR REPLACE INTO apiKeys(id, key, name, machineId, isActive, expiresAt, tokenLimit, tokensUsed, tokensReserved, allowedModels, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [k.id, k.key, k.name || null, k.machineId || null, k.isActive === false ? 0 : 1, k.expiresAt || null, k.tokenLimit == null ? null : Number(k.tokenLimit), Number(k.tokensUsed || 0), Number(k.tokensReserved || 0), stringifyJson(k.allowedModels || null), k.createdAt || new Date().toISOString()]
       );
     }
     for (const c of payload.combos || []) {

--- a/src/lib/db/migrations/002-api-key-policies.js
+++ b/src/lib/db/migrations/002-api-key-policies.js
@@ -1,0 +1,17 @@
+export default {
+  version: 2,
+  name: "api-key-policies",
+  up(db) {
+    const columns = new Set(db.all("PRAGMA table_info(apiKeys)").map((column) => column.name));
+    const additions = {
+      expiresAt: "TEXT",
+      tokenLimit: "INTEGER",
+      tokensUsed: "INTEGER NOT NULL DEFAULT 0",
+      tokensReserved: "INTEGER NOT NULL DEFAULT 0",
+      allowedModels: "TEXT",
+    };
+    for (const [name, definition] of Object.entries(additions)) {
+      if (!columns.has(name)) db.exec(`ALTER TABLE apiKeys ADD COLUMN ${name} ${definition}`);
+    }
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-api-key-policies.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/apiKeysRepo.js
+++ b/src/lib/db/repos/apiKeysRepo.js
@@ -1,6 +1,26 @@
 import { v4 as uuidv4 } from "uuid";
 import { getAdapter } from "../driver.js";
 
+function normalizeAllowedModels(value) {
+  if (!Array.isArray(value)) return null;
+  const models = [...new Set(value.filter((model) => typeof model === "string" && model.trim()).map((model) => model.trim()))];
+  return models.length ? models : null;
+}
+
+function normalizeTokenLimit(value) {
+  if (value === undefined || value === null || value === "") return null;
+  const limit = Number(value);
+  if (!Number.isSafeInteger(limit) || limit < 1) throw new Error("tokenLimit must be a positive integer");
+  return limit;
+}
+
+function normalizeExpiry(value) {
+  if (value === undefined || value === null || value === "") return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) throw new Error("expiresAt must be a valid date");
+  return date.toISOString();
+}
+
 function rowToKey(row) {
   if (!row) return null;
   return {
@@ -9,38 +29,49 @@ function rowToKey(row) {
     name: row.name,
     machineId: row.machineId,
     isActive: row.isActive === 1 || row.isActive === true,
+    expiresAt: row.expiresAt || null,
+    tokenLimit: row.tokenLimit == null ? null : Number(row.tokenLimit),
+    tokensUsed: Number(row.tokensUsed || 0),
+    tokensReserved: Number(row.tokensReserved || 0),
+    allowedModels: (() => {
+      try { return row.allowedModels ? JSON.parse(row.allowedModels) : null; }
+      catch { return null; }
+    })(),
     createdAt: row.createdAt,
   };
 }
 
 export async function getApiKeys() {
   const db = await getAdapter();
-  const rows = db.all(`SELECT * FROM apiKeys ORDER BY createdAt ASC`);
-  return rows.map(rowToKey);
+  return db.all(`SELECT * FROM apiKeys ORDER BY createdAt ASC`).map(rowToKey);
 }
 
 export async function getApiKeyById(id) {
   const db = await getAdapter();
-  const row = db.get(`SELECT * FROM apiKeys WHERE id = ?`, [id]);
-  return rowToKey(row);
+  return rowToKey(db.get(`SELECT * FROM apiKeys WHERE id = ?`, [id]));
 }
 
-export async function createApiKey(name, machineId) {
+export async function getApiKeyByValue(key) {
+  const db = await getAdapter();
+  return rowToKey(db.get(`SELECT * FROM apiKeys WHERE key = ?`, [key]));
+}
+
+export async function createApiKey(name, machineId, policy = {}) {
   if (!machineId) throw new Error("machineId is required");
   const db = await getAdapter();
   const { generateApiKeyWithMachine } = await import("@/shared/utils/apiKey");
   const result = generateApiKeyWithMachine(machineId);
   const apiKey = {
-    id: uuidv4(),
-    name,
-    key: result.key,
-    machineId,
-    isActive: true,
+    id: uuidv4(), name, key: result.key, machineId, isActive: true,
+    expiresAt: normalizeExpiry(policy.expiresAt),
+    tokenLimit: normalizeTokenLimit(policy.tokenLimit),
+    tokensUsed: 0, tokensReserved: 0,
+    allowedModels: normalizeAllowedModels(policy.allowedModels),
     createdAt: new Date().toISOString(),
   };
   db.run(
-    `INSERT INTO apiKeys(id, key, name, machineId, isActive, createdAt) VALUES(?, ?, ?, ?, ?, ?)`,
-    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.createdAt]
+    `INSERT INTO apiKeys(id, key, name, machineId, isActive, expiresAt, tokenLimit, tokensUsed, tokensReserved, allowedModels, createdAt) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [apiKey.id, apiKey.key, apiKey.name, apiKey.machineId, 1, apiKey.expiresAt, apiKey.tokenLimit, 0, 0, apiKey.allowedModels ? JSON.stringify(apiKey.allowedModels) : null, apiKey.createdAt]
   );
   return apiKey;
 }
@@ -52,9 +83,17 @@ export async function updateApiKey(id, data) {
     const row = db.get(`SELECT * FROM apiKeys WHERE id = ?`, [id]);
     if (!row) return;
     const merged = { ...rowToKey(row), ...data };
+    if (data.allowedModels !== undefined) merged.allowedModels = normalizeAllowedModels(data.allowedModels);
+    if (data.expiresAt !== undefined) merged.expiresAt = normalizeExpiry(data.expiresAt);
+    if (data.tokenLimit !== undefined) merged.tokenLimit = normalizeTokenLimit(data.tokenLimit);
+    if (data.tokenLimitIncrement !== undefined) {
+      const increment = normalizeTokenLimit(data.tokenLimitIncrement);
+      if (merged.tokenLimit == null) throw new Error("Cannot add tokens to an unlimited key; set a token limit first");
+      merged.tokenLimit += increment;
+    }
     db.run(
-      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ? WHERE id = ?`,
-      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, id]
+      `UPDATE apiKeys SET key = ?, name = ?, machineId = ?, isActive = ?, expiresAt = ?, tokenLimit = ?, tokensUsed = ?, tokensReserved = ?, allowedModels = ? WHERE id = ?`,
+      [merged.key, merged.name, merged.machineId, merged.isActive ? 1 : 0, merged.expiresAt || null, merged.tokenLimit == null ? null : Number(merged.tokenLimit), Number(merged.tokensUsed || 0), Number(merged.tokensReserved || 0), merged.allowedModels ? JSON.stringify(merged.allowedModels) : null, id]
     );
     result = merged;
   });
@@ -63,13 +102,34 @@ export async function updateApiKey(id, data) {
 
 export async function deleteApiKey(id) {
   const db = await getAdapter();
-  const res = db.run(`DELETE FROM apiKeys WHERE id = ?`, [id]);
-  return (res?.changes ?? 0) > 0;
+  return (db.run(`DELETE FROM apiKeys WHERE id = ?`, [id])?.changes ?? 0) > 0;
 }
 
 export async function validateApiKey(key) {
+  const apiKey = await getApiKeyByValue(key);
+  return !!apiKey && apiKey.isActive && (!apiKey.expiresAt || new Date(apiKey.expiresAt).getTime() > Date.now());
+}
+
+export async function reserveApiKeyTokens(key, requestedTokens) {
+  const apiKey = await getApiKeyByValue(key);
+  if (apiKey?.tokenLimit == null) return { ok: true, reserved: 0 };
+  const reserve = Math.max(0, Math.floor(Number(requestedTokens) || 0));
   const db = await getAdapter();
-  const row = db.get(`SELECT isActive FROM apiKeys WHERE key = ?`, [key]);
-  if (!row) return false;
-  return row.isActive === 1 || row.isActive === true;
+  let ok = false;
+  db.transaction(() => {
+    const row = db.get(`SELECT tokenLimit, tokensUsed, tokensReserved FROM apiKeys WHERE key = ? AND isActive = 1`, [key]);
+    if (!row || row.tokenLimit == null || Number(row.tokensUsed || 0) + Number(row.tokensReserved || 0) + reserve > Number(row.tokenLimit)) return;
+    db.run(`UPDATE apiKeys SET tokensReserved = tokensReserved + ? WHERE key = ?`, [reserve, key]);
+    ok = true;
+  });
+  return ok ? { ok: true, reserved: reserve } : { ok: false, error: "API key token quota exceeded" };
+}
+
+export async function settleApiKeyTokens(key, reservedTokens, actualTokens) {
+  if (!reservedTokens) return;
+  const used = Math.min(reservedTokens, Math.max(0, Math.floor(Number(actualTokens) || 0)));
+  const db = await getAdapter();
+  db.transaction(() => {
+    db.run(`UPDATE apiKeys SET tokensReserved = MAX(0, tokensReserved - ?), tokensUsed = tokensUsed + ? WHERE key = ?`, [reservedTokens, used, key]);
+  });
 }

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -82,6 +82,11 @@ export const TABLES = {
       name: "TEXT",
       machineId: "TEXT",
       isActive: "INTEGER DEFAULT 1",
+      expiresAt: "TEXT",
+      tokenLimit: "INTEGER",
+      tokensUsed: "INTEGER NOT NULL DEFAULT 0",
+      tokensReserved: "INTEGER NOT NULL DEFAULT 0",
+      allowedModels: "TEXT",
       createdAt: "TEXT NOT NULL",
     },
     indexes: ["CREATE INDEX IF NOT EXISTS idx_ak_key ON apiKeys(key)"],

--- a/src/lib/localDb.js
+++ b/src/lib/localDb.js
@@ -10,7 +10,7 @@ export {
   createProviderNode, updateProviderNode, deleteProviderNode,
   getProxyPools, getProxyPoolById,
   createProxyPool, updateProxyPool, deleteProxyPool,
-  getApiKeys, getApiKeyById, createApiKey, updateApiKey, deleteApiKey, validateApiKey,
+  getApiKeys, getApiKeyById, getApiKeyByValue, createApiKey, updateApiKey, deleteApiKey, validateApiKey, reserveApiKeyTokens, settleApiKeyTokens,
   getCombos, getComboById, getComboByName,
   createCombo, updateCombo, deleteCombo,
   getModelAliases, setModelAlias, deleteModelAlias,

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -5,10 +5,10 @@ import {
   markAccountUnavailable,
   clearAccountError,
   extractApiKey,
-  isValidApiKey,
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
 import { getSettings } from "@/lib/localDb";
+import { authorizeApiKeyRequest, settleApiKeyReservation } from "../services/apiKeyPolicy.js";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
@@ -62,24 +62,14 @@ export async function handleChat(request, clientRawRequest = null) {
     log.debug("AUTH", "No API key provided (local mode)");
   }
 
-  // Enforce API key if enabled in settings
-  const settings = await getSettings();
-  if (settings.requireApiKey) {
-    if (!apiKey) {
-      log.warn("AUTH", "Missing API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
-      log.warn("AUTH", "Invalid API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
-    }
-  }
-
   if (!modelStr) {
     log.warn("CHAT", "Missing model");
     return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   }
+
+  const policy = await authorizeApiKeyRequest(request, { model: modelStr.includes("/") ? modelStr : null, body });
+  if (policy.error) return policy.error;
+  const settings = await getSettings();
 
   // Bypass naming/warmup requests before combo rotation to avoid wasting rotation slots
   const userAgent = request?.headers?.get("user-agent") || "";
@@ -134,7 +124,7 @@ export async function handleChat(request, clientRawRequest = null) {
 /**
  * Handle single model chat request
  */
-async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null) {
+async function handleSingleModelChat(body, modelStr, clientRawRequest = null, request = null, apiKey = null, apiKeyReservation = 0) {
   const modelInfo = await getModelInfo(modelStr);
 
   // If provider is null, this might be a combo name - check and handle
@@ -184,6 +174,10 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   }
 
   const { provider, model } = modelInfo;
+  const policy = await authorizeApiKeyRequest(request, { model: `${provider}/${model}`, body, reserveTokens: true });
+  if (policy.error) return policy.error;
+  body = policy.body;
+  apiKeyReservation = policy.reservation || 0;
 
   // Routing shown in the unified "▶" line (client model → provider/model)
 
@@ -204,13 +198,16 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         const errorMsg = lastError || credentials.lastError || "Unavailable";
         const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
         log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
+        await settleApiKeyReservation(apiKey, apiKeyReservation, null);
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }
       if (excludeConnectionIds.size === 0) {
         log.warn("AUTH", `No active credentials for provider: ${provider}`);
+        await settleApiKeyReservation(apiKey, apiKeyReservation, null);
         return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
       }
       log.warn("CHAT", "No more accounts available", { provider });
+      await settleApiKeyReservation(apiKey, apiKeyReservation, null);
       return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
     }
 
@@ -239,6 +236,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       connectionId: credentials.connectionId,
       userAgent,
       apiKey,
+      apiKeyReservation,
       ccFilterNaming: !!chatSettings.ccFilterNaming,
       rtkEnabled: !!chatSettings.rtkEnabled,
       headroomEnabled: !!chatSettings.headroomEnabled,
@@ -282,6 +280,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       continue;
     }
 
+    await settleApiKeyReservation(apiKey, apiKeyReservation, null);
     return result.response;
   }
 }

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -5,6 +5,7 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth.js";
+import { authorizeApiKeyRequest } from "../services/apiKeyPolicy.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
 import { handleEmbeddingsCore } from "open-sse/handlers/embeddingsCore.js";
@@ -72,6 +73,8 @@ export async function handleEmbeddings(request) {
   }
 
   const { provider, model } = modelInfo;
+  const policy = await authorizeApiKeyRequest(request, { model: `${provider}/${model}`, body });
+  if (policy.error) return policy.error;
 
   if (modelStr !== `${provider}/${model}`) {
     log.info("ROUTING", `${modelStr} → ${provider}/${model}`);

--- a/src/sse/handlers/fetch.js
+++ b/src/sse/handlers/fetch.js
@@ -5,6 +5,7 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth.js";
+import { authorizeApiKeyRequest } from "../services/apiKeyPolicy.js";
 import { getSettings, getCombos } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
 import { handleFetchCore } from "open-sse/handlers/fetch/index.js";
@@ -120,6 +121,9 @@ async function handleSingleProviderFetch(body, providerInput, request, apiKey, s
     log.warn("FETCH", "Unknown provider", { provider: providerInput });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, `Unknown provider: ${providerInput}`);
   }
+
+  const policy = await authorizeApiKeyRequest(request, { model: `${resolvedProvider.alias || providerId}/fetch`, body });
+  if (policy.error) return policy.error;
 
   const providerConfig = resolvedProvider.fetchConfig;
   if (!providerConfig) {

--- a/src/sse/handlers/imageGeneration.js
+++ b/src/sse/handlers/imageGeneration.js
@@ -5,6 +5,7 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth.js";
+import { authorizeApiKeyRequest } from "../services/apiKeyPolicy.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleImageGenerationCore } from "open-sse/handlers/imageGenerationCore.js";
@@ -45,7 +46,6 @@ export async function handleImageGeneration(request) {
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   if (!body.prompt) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: prompt");
-
   // Combo expansion: model may be a combo name → run fallback/round-robin across models
   const comboModels = await getComboModels(modelStr);
   if (comboModels) {
@@ -56,7 +56,7 @@ export async function handleImageGeneration(request) {
     return handleComboChat({
       body,
       models: comboModels,
-      handleSingleModel: (b, m) => handleSingleModelImage(b, m, { wantsStream, binaryOutput, preferredConnectionId }),
+      handleSingleModel: (b, m) => handleSingleModelImage(b, m, request, { wantsStream, binaryOutput, preferredConnectionId }),
       log,
       comboName: modelStr,
       comboStrategy,
@@ -64,14 +64,16 @@ export async function handleImageGeneration(request) {
     });
   }
 
-  return handleSingleModelImage(body, modelStr, { wantsStream, binaryOutput, preferredConnectionId });
+  return handleSingleModelImage(body, modelStr, request, { wantsStream, binaryOutput, preferredConnectionId });
 }
 
-async function handleSingleModelImage(body, modelStr, { wantsStream, binaryOutput, preferredConnectionId } = {}) {
+async function handleSingleModelImage(body, modelStr, request, { wantsStream, binaryOutput, preferredConnectionId } = {}) {
   const modelInfo = await getModelInfo(modelStr);
   if (!modelInfo.provider) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");
 
   const { provider, model } = modelInfo;
+  const policy = await authorizeApiKeyRequest(request, { model: `${provider}/${model}`, body });
+  if (policy.error) return policy.error;
 
   // noAuth providers — no credential needed
   if (NO_AUTH_PROVIDERS.has(provider)) {

--- a/src/sse/handlers/search.js
+++ b/src/sse/handlers/search.js
@@ -5,6 +5,7 @@ import {
   extractApiKey,
   isValidApiKey,
 } from "../services/auth.js";
+import { authorizeApiKeyRequest } from "../services/apiKeyPolicy.js";
 import { getSettings, getCombos } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
 import { handleSearchCore } from "open-sse/handlers/search/index.js";
@@ -99,6 +100,9 @@ async function handleSingleProviderSearch(body, providerInput, request, apiKey, 
     log.warn("SEARCH", "Unknown provider", { provider: providerInput });
     return errorResponse(HTTP_STATUS.BAD_REQUEST, `Unknown provider: ${providerInput}`);
   }
+
+  const policy = await authorizeApiKeyRequest(request, { model: `${resolvedProvider.alias || providerId}/search`, body });
+  if (policy.error) return policy.error;
 
   const providerConfig = resolvedProvider.searchConfig;
   const supportsSearch = !!providerConfig || !!resolvedProvider.searchViaChat;

--- a/src/sse/handlers/stt.js
+++ b/src/sse/handlers/stt.js
@@ -3,6 +3,7 @@ import {
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
+import { authorizeApiKeyRequest } from "../services/apiKeyPolicy.js";
 import { getModelInfo } from "../services/model.js";
 import { handleSttCore } from "open-sse/handlers/sttCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -38,11 +39,12 @@ export async function handleStt(request) {
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   if (!formData.get("file")) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: file");
-
   const modelInfo = await getModelInfo(modelStr);
   if (!modelInfo.provider) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");
 
   const { provider, model } = modelInfo;
+  const policy = await authorizeApiKeyRequest(request, { model: `${provider}/${model}` });
+  if (policy.error) return policy.error;
   log.info("ROUTING", `Provider: ${provider}, Model: ${model}`);
 
   // noAuth providers

--- a/src/sse/handlers/tts.js
+++ b/src/sse/handlers/tts.js
@@ -2,6 +2,7 @@ import {
   extractApiKey, isValidApiKey,
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
+import { authorizeApiKeyRequest } from "../services/apiKeyPolicy.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleTtsCore } from "open-sse/handlers/ttsCore.js";
@@ -42,7 +43,6 @@ export async function handleTts(request) {
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");
   if (!body.input) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing required field: input");
-
   // Combo expansion: model may be a combo name → run fallback/round-robin across models
   const comboModels = await getComboModels(modelStr);
   if (comboModels) {
@@ -53,7 +53,7 @@ export async function handleTts(request) {
     return handleComboChat({
       body,
       models: comboModels,
-      handleSingleModel: (b, m) => handleSingleModelTts(b, m, responseFormat, language),
+      handleSingleModel: (b, m) => handleSingleModelTts(b, m, request, responseFormat, language),
       log,
       comboName: modelStr,
       comboStrategy,
@@ -61,14 +61,16 @@ export async function handleTts(request) {
     });
   }
 
-  return handleSingleModelTts(body, modelStr, responseFormat, language);
+  return handleSingleModelTts(body, modelStr, request, responseFormat, language);
 }
 
-async function handleSingleModelTts(body, modelStr, responseFormat, language) {
+async function handleSingleModelTts(body, modelStr, request, responseFormat, language) {
   const modelInfo = await getModelInfo(modelStr);
   if (!modelInfo.provider) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Invalid model format");
 
   const { provider, model } = modelInfo;
+  const policy = await authorizeApiKeyRequest(request, { model: `${provider}/${model}`, body });
+  if (policy.error) return policy.error;
   log.info("ROUTING", `Provider: ${provider}, Voice: ${model}`);
 
   // noAuth providers — no credential needed

--- a/src/sse/handlers/videoGeneration.js
+++ b/src/sse/handlers/videoGeneration.js
@@ -6,6 +6,7 @@ import {
   isValidApiKey,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
+import { authorizeApiKeyRequest } from "../services/apiKeyPolicy.js";
 import { getModelInfo } from "../services/model.js";
 import { handleVideoProxyCore, getVideoConfig, sanitizeSecrets } from "open-sse/handlers/videoCore.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
@@ -101,6 +102,8 @@ export async function handleVideoCreate(request, action) {
   const resolved = await resolveVideoProvider(bodyInfo.parsed);
   if (resolved.error) return resolved.error;
   const { provider, model } = resolved;
+  const policy = await authorizeApiKeyRequest(request, { model: model ? `${provider}/${model}` : "__implicit_video_model__" });
+  if (policy.error) return policy.error;
 
   // Strip the provider prefix (e.g. "xai/grok-imagine-video") before forwarding;
   // otherwise forward the original bytes untouched.

--- a/src/sse/services/apiKeyPolicy.js
+++ b/src/sse/services/apiKeyPolicy.js
@@ -1,0 +1,56 @@
+import { getApiKeyByValue, getSettings, reserveApiKeyTokens, settleApiKeyTokens } from "@/lib/localDb";
+import { extractApiKey } from "./auth.js";
+import { errorResponse } from "open-sse/utils/error.js";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+
+function tokenEstimate(body) {
+  const text = JSON.stringify(body?.messages || body?.input || body?.prompt || body?.query || "");
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function requestedOutputTokens(body, remaining) {
+  const requested = body?.max_completion_tokens ?? body?.max_tokens ?? body?.max_output_tokens;
+  if (requested == null) return remaining;
+  return Math.min(remaining, Math.max(1, Number(requested) || 1));
+}
+
+function cappedBody(body, outputTokens) {
+  if (body?.max_completion_tokens != null) return { ...body, max_completion_tokens: outputTokens };
+  if (body?.max_output_tokens != null) return { ...body, max_output_tokens: outputTokens };
+  return { ...body, max_tokens: outputTokens };
+}
+
+export async function authorizeApiKeyRequest(request, { model, body, reserveTokens = false } = {}) {
+  const settings = await getSettings();
+  const apiKey = extractApiKey(request);
+  if (!apiKey) {
+    if (settings.requireApiKey) return { error: errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key") };
+    return { apiKey: null, body };
+  }
+
+  const key = await getApiKeyByValue(apiKey);
+  const expired = key?.expiresAt && new Date(key.expiresAt).getTime() <= Date.now();
+  if (!key?.isActive || expired) return { error: errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key") };
+  if (Array.isArray(key.allowedModels) && key.allowedModels.length && model) {
+    const requestedModel = typeof body?.model === "string" ? body.model : null;
+    if (!key.allowedModels.includes(model) && !key.allowedModels.includes(requestedModel)) {
+      return { error: errorResponse(HTTP_STATUS.FORBIDDEN, "This API key is not allowed to use the selected model") };
+    }
+  }
+  if (!reserveTokens || key.tokenLimit == null) return { apiKey, key, body };
+
+  const remaining = key.tokenLimit - key.tokensUsed - key.tokensReserved;
+  const inputTokens = tokenEstimate(body);
+  if (remaining <= inputTokens) return { error: errorResponse(HTTP_STATUS.FORBIDDEN, "API key token quota exceeded") };
+  const outputTokens = requestedOutputTokens(body, Math.max(0, remaining - inputTokens));
+  const reservation = await reserveApiKeyTokens(apiKey, inputTokens + outputTokens);
+  if (!reservation.ok) return { error: errorResponse(HTTP_STATUS.FORBIDDEN, reservation.error) };
+  return { apiKey, key, body: cappedBody(body, outputTokens), reservation: reservation.reserved };
+}
+
+export async function settleApiKeyReservation(apiKey, reservation, usage) {
+  if (!apiKey || !reservation) return;
+  const total = Number(usage?.total_tokens ?? usage?.totalTokens)
+    || Number(usage?.prompt_tokens ?? usage?.input_tokens ?? 0) + Number(usage?.completion_tokens ?? usage?.output_tokens ?? 0);
+  await settleApiKeyTokens(apiKey, reservation, total);
+}

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -303,11 +303,13 @@ export function extractApiKey(request) {
 
   // Check Anthropic x-api-key header
   const xApiKey = request.headers.get("x-api-key");
-  if (xApiKey) {
-    return xApiKey;
-  }
+  if (xApiKey) return xApiKey;
 
-  return null;
+  const googleApiKey = request.headers.get("x-goog-api-key");
+  if (googleApiKey) return googleApiKey;
+
+  try { return new URL(request.url).searchParams.get("key") || null; }
+  catch { return null; }
 }
 
 /**

--- a/tests/unit/api-key-edit-route.test.js
+++ b/tests/unit/api-key-edit-route.test.js
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const db = vi.hoisted(() => ({
+  key: { id: "key-1", tokenLimit: 100, tokensUsed: 40, allowedModels: ["ag/gemini-3-flash-agent"] },
+  get: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (body, init = {}) => new Response(JSON.stringify(body), { status: init.status || 200 }),
+  },
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getApiKeyById: (...args) => db.get(...args),
+  updateApiKey: (...args) => db.update(...args),
+  deleteApiKey: vi.fn(),
+}));
+
+const { PUT } = await import("@/app/api/keys/[id]/route.js");
+const context = { params: Promise.resolve({ id: "key-1" }) };
+
+describe("API key edit route", () => {
+  beforeEach(() => {
+    db.get.mockResolvedValue(db.key);
+    db.update.mockResolvedValue({ ...db.key, tokenLimit: 150, expiresAt: "2026-12-01T00:00:00.000Z", allowedModels: ["ag/gemini-3-flash-agent", "zd/claude-sonnet-4.6"] });
+    db.update.mockClear();
+  });
+
+  it("passes expiry, models, and a token top-up without accepting client usage changes", async () => {
+    const response = await PUT(new Request("http://router.test/api/keys/key-1", {
+      method: "PUT",
+      body: JSON.stringify({
+        expiresAt: "2026-12-01T00:00:00Z",
+        allowedModels: ["ag/gemini-3-flash-agent", "zd/claude-sonnet-4.6"],
+        tokenLimitIncrement: 50,
+        tokensUsed: 0,
+      }),
+    }), context);
+    expect(response.status).toBe(200);
+    expect(db.update).toHaveBeenCalledWith("key-1", {
+      expiresAt: "2026-12-01T00:00:00Z",
+      allowedModels: ["ag/gemini-3-flash-agent", "zd/claude-sonnet-4.6"],
+      tokenLimitIncrement: 50,
+    });
+  });
+
+  it("returns 400 when adding tokens to an unlimited key is rejected", async () => {
+    db.update.mockRejectedValueOnce(new Error("Cannot add tokens to an unlimited key; set a token limit first"));
+    const response = await PUT(new Request("http://router.test/api/keys/key-1", {
+      method: "PUT", body: JSON.stringify({ tokenLimitIncrement: 50 }),
+    }), context);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Cannot add tokens to an unlimited key; set a token limit first" });
+  });
+});

--- a/tests/unit/api-key-policies.test.js
+++ b/tests/unit/api-key-policies.test.js
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getAdapter } from "../../src/lib/db/driver.js";
+import { createApiKey, getApiKeyByValue, reserveApiKeyTokens, settleApiKeyTokens, updateApiKey, validateApiKey } from "../../src/lib/db/repos/apiKeysRepo.js";
+
+const prefix = `policy-test-${Date.now()}`;
+
+beforeAll(async () => {
+  const db = await getAdapter();
+  db.run("DELETE FROM apiKeys WHERE name LIKE ?", [`${prefix}%`]);
+});
+
+afterAll(async () => {
+  const db = await getAdapter();
+  db.run("DELETE FROM apiKeys WHERE name LIKE ?", [`${prefix}%`]);
+  expect(db.get("SELECT COUNT(*) AS count FROM apiKeys WHERE name LIKE ?", [`${prefix}%`]).count).toBe(0);
+});
+
+describe("API key policies", () => {
+  it("keeps policy fields optional for new keys", async () => {
+    const key = await createApiKey(`${prefix}-unrestricted`, "test-machine");
+    expect(key.expiresAt).toBeNull();
+    expect(key.tokenLimit).toBeNull();
+    expect(key.allowedModels).toBeNull();
+    expect(await validateApiKey(key.key)).toBe(true);
+  });
+
+  it("reserves quota atomically and settles against actual usage", async () => {
+    const key = await createApiKey(`${prefix}-limited`, "test-machine", { tokenLimit: 10 });
+    expect(await reserveApiKeyTokens(key.key, 8)).toMatchObject({ ok: true, reserved: 8 });
+    expect(await reserveApiKeyTokens(key.key, 3)).toMatchObject({ ok: false });
+    await settleApiKeyTokens(key.key, 8, 5);
+    const after = await getApiKeyByValue(key.key);
+    expect(after.tokensUsed).toBe(5);
+    expect(after.tokensReserved).toBe(0);
+  });
+
+  it("reserves concurrent quota only once", async () => {
+    const key = await createApiKey(`${prefix}-atomic`, "test-machine", { tokenLimit: 10 });
+    const reservations = await Promise.all(Array.from({ length: 4 }, () => reserveApiKeyTokens(key.key, 5)));
+    expect(reservations.filter((result) => result.ok)).toHaveLength(2);
+    const after = await getApiKeyByValue(key.key);
+    expect(after.tokensReserved).toBe(10);
+  });
+
+  it("adds quota without resetting recorded usage", async () => {
+    const key = await createApiKey(`${prefix}-top-up`, "test-machine", { tokenLimit: 100 });
+    await reserveApiKeyTokens(key.key, 40);
+    await settleApiKeyTokens(key.key, 40, 40);
+    await updateApiKey(key.id, { tokenLimitIncrement: 50 });
+    const after = await getApiKeyByValue(key.key);
+    expect(after.tokenLimit).toBe(150);
+    expect(after.tokensUsed).toBe(40);
+    expect(await reserveApiKeyTokens(key.key, 110)).toMatchObject({ ok: true, reserved: 110 });
+  });
+
+  it("invalidates an expired key while allowing a future expiry", async () => {
+    const key = await createApiKey(`${prefix}-expiring`, "test-machine");
+    await updateApiKey(key.id, { expiresAt: new Date(Date.now() - 1000).toISOString() });
+    expect(await validateApiKey(key.key)).toBe(false);
+    await updateApiKey(key.id, { expiresAt: new Date(Date.now() + 60_000).toISOString() });
+    expect(await validateApiKey(key.key)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds optional per-API-key policies for expiry, total token quotas, and model allowlists. Existing keys remain unrestricted until a policy is configured.

## What changed

### API key policy storage and API
- Adds a forward-only SQLite migration for `expiresAt`, `tokenLimit`, `tokensUsed`, `tokensReserved`, and `allowedModels`.
- Extends create and update key APIs with validated policy fields.
- Supports quota top-ups through `tokenLimitIncrement` without accepting client-controlled usage values.
- Keeps `null` / an empty allowlist as unlimited tokens / all models, preserving legacy behavior.

### Request enforcement
- Rejects expired or inactive keys.
- Rejects model requests outside a key's allowlist.
- Applies policy checks across chat, embeddings, image generation, TTS, STT, video generation, web fetch, and search handlers.
- Filters `/v1/models` and `/v1/models/:kind` to the authenticated key's allowlist.
- For chat requests with a limited key, atomically reserves estimated input plus bounded output tokens before provider dispatch, caps requested output to remaining quota, then settles the reservation against reported usage for both streaming and non-streaming responses.
- Releases reservations when routing fails before a provider response is returned.

### Dashboard
- Adds expiry, token-limit presets (`100K`, `500K`, `1M`, `5M`, `10M`, `Unlimited`), and model selection when creating a key.
- Adds an Edit Key flow for expiry, allowlist changes, quota removal, and quota top-ups.
- Shows expiry, model restrictions, token usage, remaining quota, and an accessible usage progress bar.

## Compatibility and safety

- Existing rows receive nullable policy columns, so legacy keys continue with no expiry, unlimited token usage, and access to all models.
- Empty `allowedModels` remains unrestricted rather than denying all models.
- Usage fields are server-owned; the edit route ignores client-supplied usage changes.
- Quota reservation is transactional to prevent concurrent requests from exceeding the configured cap.

## Validation

- `npm run test:policy` — 2 test files, 7 tests passed.
  - optional/unrestricted key behavior
  - atomic quota reservation and settlement
  - concurrent reservation protection
  - quota top-up without resetting usage
  - API edit validation and client usage-field rejection
- `npm run build` — passed.
- `git diff --check upstream/master...HEAD` — passed.

## Commits

1. `feat(api-keys): enforce expiry quota and model policies`
2. `feat(dashboard): manage API key policies`
