### PR TITLE
fix(nvidia): normalize tool names and call IDs

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS, PROVIDER_OAUTH } from "../config/providers.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE } from "../providers/shared.js";
@@ -7,6 +8,19 @@ import { getCachedClaudeHeaders } from "../utils/claudeHeaderCache.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
+
+const nvidiaToolCallId = (id) => /^[a-zA-Z0-9]{9}$/.test(id)
+  ? id
+  : createHash("sha256").update(id).digest("hex").slice(0, 9);
+
+function normalizeNvidiaToolCallIds(body) {
+  for (const message of body.messages || []) {
+    for (const toolCall of message.tool_calls || []) {
+      if (toolCall.id) toolCall.id = nvidiaToolCallId(toolCall.id);
+    }
+    if (message.tool_call_id) message.tool_call_id = nvidiaToolCallId(message.tool_call_id);
+  }
+}
 
 // Auth header descriptors — derived from registry transport.auth, fallback to hardcoded defaults.
 const BEARER = { combined: true, header: "Authorization", scheme: "bearer" };
@@ -86,6 +100,7 @@ export class DefaultExecutor extends BaseExecutor {
     const transformed = this.applyJsonSchemaFallback(body);
 
     if (transformed && typeof transformed === "object") {
+      if (this.provider === "nvidia") normalizeNvidiaToolCallIds(transformed);
       // quirk: some openai-compatible providers reject Anthropic's client_metadata field
       if (this.config.quirks?.dropClientMetadata) {
         delete transformed.client_metadata;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -28,6 +28,7 @@ import { compressWithPxpipe } from "../rtk/pxpipe.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
+import { normalizeOpenAIToolNames } from "../translator/concerns/toolCall.js";
 import { extractThinking } from "../translator/concerns/thinkingUnified.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 
@@ -148,6 +149,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     toolNameMap = translatedBody._toolNameMap;
     delete translatedBody._toolNameMap;
     translatedBody.model = stripThinkingSuffix(upstreamModel);
+  }
+
+  const toolNameMaxLength = PROVIDERS[provider]?.quirks?.toolNameMaxLength;
+  if (toolNameMaxLength && targetFormat === FORMATS.OPENAI) {
+    const aliases = normalizeOpenAIToolNames(translatedBody, toolNameMaxLength);
+    if (aliases.size) toolNameMap = new Map([...(toolNameMap || []), ...aliases]);
   }
 
   // Dedupe duplicate built-in tools when equivalent MCP tools are present (Claude clients only).

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -9,6 +9,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { restoreOpenAIToolNames } from "../../translator/concerns/toolCall.js";
 
 function parseToolArguments(value) {
   if (!value) return {};
@@ -232,6 +233,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   // Decloak tool_use names once on raw Claude body, before any translation (INPUT side)
   responseBody = decloakToolNames(responseBody, toolNameMap);
+  restoreOpenAIToolNames(responseBody, toolNameMap);
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -37,7 +37,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
     return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, toolNameMap);
 }
 
 /**

--- a/open-sse/providers/registry/nvidia.js
+++ b/open-sse/providers/registry/nvidia.js
@@ -18,6 +18,7 @@ export default {
   transport: {
     baseUrl: "https://integrate.api.nvidia.com/v1/chat/completions",
     validateUrl: "https://integrate.api.nvidia.com/v1/models",
+    quirks: { toolNameMaxLength: 64 },
   },
   models: [
     { id: "minimaxai/minimax-m2.7", name: "MiniMax M2.7" },

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -1,11 +1,122 @@
+import { createHash } from "node:crypto";
+
 // Tool call helper functions for translator
 
 // Anthropic tool_use.id must match: ^[a-zA-Z0-9_-]+$
 const TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
+/**
+ * Normalizes OpenAI function/tool names to satisfy provider naming constraints.
+ *
+ * - Replaces unsupported characters with underscores.
+ * - Truncates names that exceed the maximum allowed length.
+ * - Appends a deterministic SHA-256 hash suffix to avoid collisions.
+ * - Returns a map of normalized names back to their original names.
+ *
+ * The request body is mutated in place.
+ */
+export function normalizeOpenAIToolNames(body, maxLength) {
+  // Maps normalized tool names back to their original names.
+  const aliases = new Map();
+
+  /**
+   * Normalizes a single tool/function name.
+   */
+  const alias = (name) => {
+    if (!name || typeof name !== "string") return name;
+
+    // Replace unsupported characters with underscores.
+    const safe = name.replace(/[^a-zA-Z0-9_-]/g, "_");
+
+    // Re-hash the name if it was modified or exceeds the maximum length.
+    const changed = safe !== name || safe.length > maxLength;
+
+    // Preserve uniqueness by appending a deterministic hash suffix.
+    const shortened = changed
+      ? `${safe.slice(0, maxLength - 13)}_${createHash("sha256")
+          .update(name)
+          .digest("hex")
+          .slice(0, 12)}`
+      : safe;
+
+    // Store the original name for reverse lookup.
+    if (shortened !== name) aliases.set(shortened, name);
+
+    return shortened;
+  };
+
+  // Normalize tool definitions.
+  for (const tool of body?.tools || []) {
+    if (tool?.function?.name) {
+      tool.function.name = alias(tool.function.name);
+    }
+  }
+
+  // Normalize explicit tool choice.
+  if (body?.tool_choice?.function?.name) {
+    body.tool_choice.function.name = alias(body.tool_choice.function.name);
+  }
+
+  // Normalize tool calls in conversation history.
+  for (const message of body?.messages || []) {
+    for (const call of message?.tool_calls || []) {
+      if (call?.function?.name) {
+        call.function.name = alias(call.function.name);
+      }
+    }
+
+    // Normalize tool response names.
+    if (message?.role === "tool" && message.name) {
+      message.name = alias(message.name);
+    }
+  }
+
+  return aliases;
+}
+
+/**
+ * Restores original OpenAI tool/function names from their normalized aliases.
+ *
+ * The response body is mutated in place.
+ *
+ * @param {object} body - OpenAI-compatible response body.
+ * @param {Map<string, string>} aliases - Map of normalized names to original names.
+ * @returns {boolean} True if at least one tool name was restored.
+ */
+export function restoreOpenAIToolNames(body, aliases) {
+  // Nothing to restore.
+  if (!aliases?.size) return false;
+
+  let changed = false;
+
+  /**
+   * Restores tool names within a tool call collection.
+   */
+  const restoreCalls = (calls) => {
+    for (const call of calls || []) {
+      const name = call?.function?.name;
+
+      // Replace the normalized alias with the original tool name.
+      if (aliases.has(name)) {
+        call.function.name = aliases.get(name);
+        changed = true;
+      }
+    }
+  };
+
+  // Restore tool names for both streaming deltas and complete responses.
+  for (const choice of body?.choices || []) {
+    restoreCalls(choice?.delta?.tool_calls);
+    restoreCalls(choice?.message?.tool_calls);
+  }
+
+  return changed;
+}
 // Fallback streaming tool_call id when provider omits one (index optional)
 export function fallbackToolCallId(index) {
-  return index === undefined ? `call_${Date.now()}` : `call_${index}_${Date.now()}`;
+  return index === undefined
+    ? `call_${Date.now()}`
+    : `call_${index}_${Date.now()}`;
 }
 
 // Generate deterministic tool call ID from position + tool name (cache-friendly)
@@ -27,7 +138,11 @@ export function ensureToolCallIds(body) {
 
   for (let i = 0; i < body.messages.length; i++) {
     const msg = body.messages[i];
-    if (msg.role === "assistant" && msg.tool_calls && Array.isArray(msg.tool_calls)) {
+    if (
+      msg.role === "assistant" &&
+      msg.tool_calls &&
+      Array.isArray(msg.tool_calls)
+    ) {
       for (let j = 0; j < msg.tool_calls.length; j++) {
         const tc = msg.tool_calls[j];
         // Validate or regenerate ID for Anthropic compatibility
@@ -39,14 +154,21 @@ export function ensureToolCallIds(body) {
           tc.type = "function";
         }
         // Ensure arguments is JSON string, not object
-        if (tc.function?.arguments && typeof tc.function.arguments !== "string") {
+        if (
+          tc.function?.arguments &&
+          typeof tc.function.arguments !== "string"
+        ) {
           tc.function.arguments = JSON.stringify(tc.function.arguments);
         }
       }
     }
 
     // Validate tool_call_id in tool messages (role: "tool")
-    if (msg.role === "tool" && msg.tool_call_id && !TOOL_ID_PATTERN.test(msg.tool_call_id)) {
+    if (
+      msg.role === "tool" &&
+      msg.tool_call_id &&
+      !TOOL_ID_PATTERN.test(msg.tool_call_id)
+    ) {
       const sanitized = sanitizeToolId(msg.tool_call_id);
       msg.tool_call_id = sanitized || generateToolCallId(i, 0);
     }
@@ -55,12 +177,20 @@ export function ensureToolCallIds(body) {
     if (Array.isArray(msg.content)) {
       for (let k = 0; k < msg.content.length; k++) {
         const block = msg.content[k];
-        if (block.type === "tool_use" && block.id && !TOOL_ID_PATTERN.test(block.id)) {
+        if (
+          block.type === "tool_use" &&
+          block.id &&
+          !TOOL_ID_PATTERN.test(block.id)
+        ) {
           const sanitized = sanitizeToolId(block.id);
           block.id = sanitized || generateToolCallId(i, k, block.name);
         }
         // Validate tool_use_id in tool_result blocks
-        if (block.type === "tool_result" && block.tool_use_id && !TOOL_ID_PATTERN.test(block.tool_use_id)) {
+        if (
+          block.type === "tool_result" &&
+          block.tool_use_id &&
+          !TOOL_ID_PATTERN.test(block.tool_use_id)
+        ) {
           const sanitized = sanitizeToolId(block.tool_use_id);
           block.tool_use_id = sanitized || generateToolCallId(i, k);
         }
@@ -108,7 +238,10 @@ export function hasToolResults(msg, toolCallIds) {
   // Claude format: tool_result blocks in user message content
   if (msg.role === "user" && Array.isArray(msg.content)) {
     for (const block of msg.content) {
-      if (block.type === "tool_result" && toolCallIds.includes(block.tool_use_id)) {
+      if (
+        block.type === "tool_result" &&
+        toolCallIds.includes(block.tool_use_id)
+      ) {
         return true;
       }
     }
@@ -141,7 +274,7 @@ export function fixMissingToolResponses(body) {
         newMessages.push({
           role: "tool",
           tool_call_id: id,
-          content: ""
+          content: "",
         });
       }
     }
@@ -150,4 +283,3 @@ export function fixMissingToolResponses(body) {
   body.messages = newMessages;
   return body;
 }
-

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -190,10 +190,12 @@ export function openaiToClaudeResponse(chunk, state) {
         stopTextBlock(state, results);
 
         const toolBlockIndex = state.nextBlockIndex++;
-        state.toolCalls.set(idx, { id: tc.id, name: tc.function?.name || "", blockIndex: toolBlockIndex });
+        const providerToolName = tc.function?.name || "";
+        const originalToolName = state.toolNameMap?.get(providerToolName) || providerToolName;
+        state.toolCalls.set(idx, { id: tc.id, name: originalToolName, blockIndex: toolBlockIndex });
 
         // Strip prefix from tool name for response
-        let toolName = tc.function?.name || "";
+        let toolName = originalToolName;
         if (toolName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)) {
           toolName = toolName.slice(CLAUDE_OAUTH_TOOL_PREFIX.length);
         }

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -5,6 +5,7 @@ import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBu
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
+import { restoreOpenAIToolNames } from "../translator/concerns/toolCall.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
 
@@ -106,6 +107,7 @@ export function createSSEStream(options = {}) {
           if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
               const parsed = JSON.parse(trimmed.slice(5).trim());
+              const toolNameRestored = restoreOpenAIToolNames(parsed, toolNameMap);
 
               const idFixed = fixInvalidId(parsed);
 
@@ -177,7 +179,7 @@ export function createSSEStream(options = {}) {
                 parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
-              } else if (idFixed || fieldsInjected) {
+              } else if (idFixed || fieldsInjected || toolNameRestored) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               }
@@ -480,10 +482,11 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, toolNameMap = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
     provider,
+    toolNameMap,
     reqLogger,
     model,
     connectionId,

--- a/tests/unit/nvidia-tool-call-id.test.js
+++ b/tests/unit/nvidia-tool-call-id.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+
+describe("NVIDIA tool call IDs", () => {
+  it("uses the same 9-character alphanumeric ID for calls and results", () => {
+    const out = new DefaultExecutor("nvidia").transformRequest("mistralai/mistral-medium-3.5-128b", {
+      messages: [
+        { role: "assistant", tool_calls: [{ id: "6075034-0", type: "function", function: { name: "test", arguments: "{}" } }] },
+        { role: "tool", tool_call_id: "6075034-0", content: "ok" },
+      ],
+    });
+
+    expect(out.messages[0].tool_calls[0].id).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(out.messages[1].tool_call_id).toBe(out.messages[0].tool_calls[0].id);
+  });
+});

--- a/tests/unit/nvidia-tool-name.test.js
+++ b/tests/unit/nvidia-tool-name.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { normalizeOpenAIToolNames, restoreOpenAIToolNames } from "../../open-sse/translator/concerns/toolCall.js";
+import { openaiToClaudeResponse } from "../../open-sse/translator/response/openai-to-claude.js";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+
+describe("NVIDIA tool name aliases", () => {
+  it("aliases definitions/history and restores translated responses", () => {
+    const original = "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message";
+    const body = {
+      tools: [{ type: "function", function: { name: original } }],
+      tool_choice: { type: "function", function: { name: original } },
+      messages: [{ role: "assistant", tool_calls: [{ function: { name: original } }] }],
+    };
+
+    const names = normalizeOpenAIToolNames(body, 64);
+    const alias = body.tools[0].function.name;
+    expect(alias).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+    expect(body.tool_choice.function.name).toBe(alias);
+    expect(body.messages[0].tool_calls[0].function.name).toBe(alias);
+
+    const response = { choices: [{ delta: { tool_calls: [{ function: { name: alias } }] } }] };
+    expect(restoreOpenAIToolNames(response, names)).toBe(true);
+    expect(response.choices[0].delta.tool_calls[0].function.name).toBe(original);
+
+    const collisions = { tools: ["a.b", "a?b"].map(name => ({ type: "function", function: { name } })) };
+    normalizeOpenAIToolNames(collisions, 64);
+    expect(collisions.tools[0].function.name).not.toBe(collisions.tools[1].function.name);
+
+    const translated = openaiToClaudeResponse({
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_1", function: { name: alias, arguments: "" } }] } }],
+    }, { toolNameMap: names, toolCalls: new Map(), nextBlockIndex: 0, textBlockIndex: -1, thinkingBlockIndex: -1 });
+    expect(translated.find(x => x.type === "content_block_start").content_block.name).toBe(original);
+  });
+
+  it("reserializes a passthrough SSE chunk with the original MCP name", async () => {
+    const original = "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message";
+    const body = { tools: [{ type: "function", function: { name: original } }] };
+    const names = normalizeOpenAIToolNames(body, 64);
+    const alias = body.tools[0].function.name;
+    const transform = createPassthroughStreamWithLogger("nvidia", null, null, null, null, null, null, names);
+    const writer = transform.writable.getWriter();
+    const reader = transform.readable.getReader();
+    const output = (async () => {
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return text;
+        text += new TextDecoder().decode(value);
+      }
+    })();
+
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify({
+      id: "chatcmpl_1",
+      object: "chat.completion.chunk",
+      created: 1,
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: alias, arguments: "" } }] } }],
+    })}\n\n`));
+    await writer.close();
+
+    const text = await output;
+    expect(text).toContain(original);
+    expect(text).not.toContain(alias);
+  });
+});


### PR DESCRIPTION
## Summary

Fix NVIDIA NIM requests failing with HTTP 400 when tool call IDs or function names do not satisfy NVIDIA’s stricter OpenAI-compatible validation rules.

The fix normalizes identifiers only for NVIDIA requests and restores the original function names before responses are returned to the client.

## Problem

NVIDIA NIM applies stricter constraints than the standard OpenAI-compatible API.

### Tool call IDs

NVIDIA requires every `tool_call.id` and corresponding `tool_call_id` to:

- Contain only `a-z`, `A-Z`, and `0-9`.
- Have exactly 9 characters.

Requests containing IDs such as:

```text
6075034-0
```

were rejected with:

```text
Tool call id was 6075034-0 but must be a-z, A-Z, 0-9,
with a length of 9.
```

### Function names

NVIDIA requires function names to:

- Contain only letters, numbers, underscores, or dashes.
- Have a maximum length of 64 characters.

Long MCP-generated names such as:

```text
mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message
```

were rejected with:

```text
Function name ... must be a-z, A-Z, 0-9, or contain underscores
and dashes, with a maximum length of 64.
```

Reloading plugins does not fix these errors because the identifiers are valid inside the client/plugin ecosystem; the incompatibility occurs at the NVIDIA API boundary.

## Root cause

The router forwarded client-generated tool identifiers directly to NVIDIA.

The existing normalization supported general Anthropic/OpenAI compatibility, but it did not enforce NVIDIA-specific requirements:

- Tool call IDs were not exactly 9 alphanumeric characters.
- Function names could contain unsupported characters.
- MCP function names could exceed NVIDIA’s 64-character limit.
- Shortened names could not safely be returned to the client without restoring their original values.

## Implementation

### 1. Normalize NVIDIA tool call IDs

For NVIDIA requests:

- Valid 9-character alphanumeric IDs are preserved.
- Invalid IDs are converted to the first 9 hexadecimal characters of a SHA-256 digest.
- The same deterministic transformation is applied to both:
  - Assistant `tool_calls[].id`
  - Tool response `tool_call_id`

This keeps the call and result linked while satisfying NVIDIA’s exact format.

Example:

```text
6075034-0
    ↓
<9-character deterministic alphanumeric ID>
```

### 2. Normalize NVIDIA function names

NVIDIA is configured with:

```text
toolNameMaxLength: 64
```

Before sending a request:

- Unsupported characters are replaced with underscores.
- Names already valid and within 64 characters are left unchanged.
- Modified or oversized names receive a deterministic SHA-256 suffix.
- The readable prefix is truncated only as much as needed.
- The final name never exceeds 64 characters.

Conceptually:

```text
<readable sanitized prefix>_<12-character hash>
```

The hash suffix prevents collisions between long names that share the same truncated prefix.

### 3. Normalize every relevant request location

Normalization covers:

- `tools[].function.name`
- `tool_choice.function.name`
- Historical `messages[].tool_calls[].function.name`
- Tool response message names

This prevents follow-up requests from failing when prior tool calls are included in conversation history.

### 4. Restore original names in responses

A per-request alias map records:

```text
normalized NVIDIA name → original client name
```

Original names are restored before returning data to the client in:

- OpenAI-compatible passthrough SSE responses
- Translated streaming responses
- Non-streaming responses
- OpenAI-to-Claude tool-use events

This keeps the NVIDIA-specific alias internal to the router. Clients and plugins continue seeing the exact function names they originally registered.

## Scope

The behavior is enabled through the NVIDIA provider configuration and does not change tool names for other providers.

No plugin reload, plugin configuration change, or client-side workaround is required.

## Compatibility and tradeoffs

### Deterministic aliases

Using a deterministic hash means the same original identifier always produces the same NVIDIA-compatible identifier. This is necessary for matching tool calls with later tool results.

### Hash collision risk

Tool names use a 12-character hexadecimal suffix. A collision is theoretically possible but negligible for the number of tools present in a normal request.

Tool call IDs use 9 hexadecimal characters because NVIDIA requires exactly 9 alphanumeric characters. This provides less collision space, but it is still preferable to random IDs because assistant calls and tool results must independently resolve to the same value.

### Response rewriting

Passthrough SSE chunks must be parsed and reserialized when a tool name is restored. Ordinary text chunks without aliased tool names remain unaffected.

### Provider isolation

The implementation does not globally shorten tool names because other providers may support longer names and clients expect their original identifiers.

## Verification

Added NVIDIA-specific regression coverage for:

1. Invalid tool call IDs are converted to exactly 9 alphanumeric characters.
2. Assistant tool call IDs and tool result IDs remain identical.
3. Long MCP function names are shortened to NVIDIA’s 64-character limit.
4. Normalized names remain unique through deterministic hash suffixes.
5. Tool definitions and conversation history use the same alias.
6. Original names are restored in translated responses.
7. Original names are restored in passthrough SSE responses.

Targeted test result:

```text
Test Files  2 passed
Tests       3 passed
```

## Full-suite status

The full repository suite was also executed:

```text
Test Files  125 passed | 22 failed | 11 skipped
Tests       1391 passed | 82 failed | 18 expected fail | 59 skipped
```

The failures are pre-existing and outside this PR’s scope. Observed causes include:

- Test files resolving source paths relative to `tests/` instead of the repository root.
- `better-sqlite3` compiled for a different Node module ABI.
- Existing OAuth, snapshot, and request-normalization expectation mismatches.

The NVIDIA-specific regression tests pass independently.

## Files changed

- NVIDIA provider constraints.
- Default executor tool call ID normalization.
- Shared tool-name normalization and restoration helpers.
- Chat request normalization.
- Streaming passthrough response restoration.
- Non-streaming response restoration.
- OpenAI-to-Claude response restoration.
- NVIDIA regression tests.

## Out of scope

This PR does not address:

- NVIDIA connection timeouts.
- Stream stall timeouts.
- Provider retry policy.
- NVIDIA model availability or capacity errors.
- Existing unrelated test-suite failures.