### PR TITLE
fix(codex): preserve quota window duration

### DIFF
--- a/open-sse/services/usage/codex.js
+++ b/open-sse/services/usage/codex.js
@@ -39,6 +39,7 @@ function formatCodexWindow(window) {
     total: 100,
     remaining: Math.max(0, 100 - used),
     resetAt: parseResetTime(window?.reset_at ?? window?.resets_at ?? window?.resetAt ?? null),
+    windowSeconds: toFiniteNumber(window?.limit_window_seconds ?? window?.window_seconds ?? window?.windowSeconds, null),
     unlimited: false,
   };
 }

--- a/tests/unit/codex-usage-windows.test.js
+++ b/tests/unit/codex-usage-windows.test.js
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const proxyAwareFetch = vi.fn();
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch }));
+
+describe("Codex usage windows", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("preserves upstream window duration so consumers can label 5h and 7d correctly", async () => {
+    proxyAwareFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        plan_type: "team",
+        rate_limit: {
+          primary_window: {
+            used_percent: 7,
+            limit_window_seconds: 18000,
+            reset_at: 1785623016,
+          },
+          secondary_window: {
+            used_percent: 19,
+            limit_window_seconds: 604800,
+            reset_at: 1785678428,
+          },
+        },
+      }),
+    });
+
+    const { getCodexUsage } = await import("../../open-sse/services/usage/codex.js");
+
+    await expect(getCodexUsage("token")).resolves.toMatchObject({
+      quotas: {
+        session: { used: 7, windowSeconds: 18000 },
+        weekly: { used: 19, windowSeconds: 604800 },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- preserve Codex `limit_window_seconds` as normalized `windowSeconds`
- support snake_case and camelCase upstream variants
- add regression coverage for 5-hour and 7-day windows

## Why

Codex usage responses include actual window duration, but 9Router discarded it while normalizing quota data. Consumers then had to infer labels from `primary_window` / `secondary_window`, which is wrong for plans that expose only a weekly primary window.

## Test plan

- `NODE_PATH=/tmp/node_modules /tmp/node_modules/.bin/vitest run unit/codex-usage-windows.test.js --reporter=verbose`
- `npm run build`

Both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)