### PR TITLE
feat(providers): add Poolside provider (OpenAI-compatible)

### DIFF
--- a/open-sse/providers/registry/index.js
+++ b/open-sse/providers/registry/index.js
@@ -99,6 +99,7 @@ import p96 from "./xiaomi-mimo.js";
 import p97 from "./xiaomi-tokenplan.js";
 import p98 from "./youcom.js";
 import p99 from "./alims-intl.js";
+import p100 from "./poolside.js";
 
 export default [
   p0,
@@ -201,4 +202,5 @@ export default [
   p97,
   p98,
   p99,
+  p100,
 ];

--- a/open-sse/providers/registry/poolside.js
+++ b/open-sse/providers/registry/poolside.js
@@ -1,0 +1,30 @@
+export default {
+  id: "poolside",
+  priority: 60,
+  alias: "poolside",
+  aliases: [
+    "ps",
+  ],
+  uiAlias: "ps",
+  display: {
+    name: "Poolside",
+    icon: "pool",
+    color: "#0EA5E9",
+    textIcon: "PS",
+    website: "https://poolside.ai",
+    notice: {
+      apiKeyUrl: "https://inference.poolside.ai",
+    },
+  },
+  category: "apikey",
+  authType: "apikey",
+  transport: {
+    baseUrl: "https://inference.poolside.ai/v1/chat/completions",
+    validateUrl: "https://inference.poolside.ai/v1/models",
+  },
+  models: [
+    { id: "poolside/laguna-s-2.1", name: "Laguna S 2.1" },
+    { id: "poolside/laguna-xs-2.1", name: "Laguna XS 2.1" },
+    { id: "poolside/laguna-m.1", name: "Laguna M.1" },
+  ],
+};


### PR DESCRIPTION
## Summary
Adds [Poolside](https://poolside.ai) as an API-key provider. Poolside exposes an OpenAI-compatible Responses/Chat API at `https://inference.poolside.ai/v1`, so this uses the standard registry pattern with the default OpenAI transport — no custom executor or translator required.

## Changes
- `open-sse/providers/registry/poolside.js` — new registry entry (`category: "apikey"`, `format: "openai"`, alias `poolside` / `ps`).
- `open-sse/providers/registry/index.js` — register the entry (`p100`), appended the same way as prior additions.

## Models
All three are currently free, 262K context, 32K max completion, with `tools` + `reasoning`:

| id | note |
|----|------|
| `poolside/laguna-s-2.1` | 2nd-gen S class — set as default |
| `poolside/laguna-xs-2.1` | 2nd-gen XS class |
| `poolside/laguna-m.1` | most-capable flagship, but carries `deprecation_date: 2026-07-28`, so it is listed last rather than defaulted |

## Verification
- `GET /v1/models` and `POST /v1/chat/completions` confirmed working against the live API with a key (OpenAI-shaped responses, including `reasoning_content`).
- Loaded the registry locally: `PROVIDERS.poolside` builds as `{ baseUrl, validateUrl, format: "openai" }` and `PROVIDER_MODELS.poolside` resolves all three models; `ps` alias wires through the standard alias mechanism.
- Follows the same two-file footprint as the previously merged Featherless provider PR (#2491).