### PR TITLE
feat(kiro): add Claude Opus 5 models

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -71,7 +71,11 @@ export function capabilitiesFromServiceKind(kind) {
  * otherwise mis-match. Only declare deltas vs DEFAULT.
  */
 export const MODEL_CAPABILITIES = {
-  // Claude 4.6/4.7/4.8 and Kiro Sonnet 5 have 1M context + adaptive thinking (override generic claude pattern)
+  // Claude Opus 5, 4.6/4.7/4.8, and Kiro Sonnet 5 have 1M context + adaptive thinking (override generic claude pattern)
+  "claude-opus-5":     { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-5-thinking": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-5-agentic": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-5-thinking-agentic": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4.6":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4.7":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4-7":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
@@ -180,6 +184,7 @@ export const PROVIDER_CAPABILITIES = {
  */
 export const PATTERN_CAPABILITIES = [
   // ── Claude (4.6+ = adaptive thinking; older/haiku = budget) ──────
+  { pattern: "*claude*opus-5*",     caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 } },
   { pattern: "*claude*opus-4.6*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
   { pattern: "*claude*opus-4.7*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },
   { pattern: "*claude*opus-4.8*",   caps: { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive" } },

--- a/open-sse/providers/registry/kiro.js
+++ b/open-sse/providers/registry/kiro.js
@@ -43,6 +43,10 @@ export default {
   },
   models: [
     // Opus (added per kiro.dev/changelog/models and kiro.dev/docs/models)
+    { id: "claude-opus-5", name: "Claude Opus 5" },
+    { id: "claude-opus-5-thinking", name: "Claude Opus 5 (Thinking)" },
+    { id: "claude-opus-5-agentic", name: "Claude Opus 5 (Agentic)" },
+    { id: "claude-opus-5-thinking-agentic", name: "Claude Opus 5 (Thinking + Agentic)" },
     { id: "claude-opus-4.8", name: "Claude Opus 4.8" },
     { id: "claude-opus-4.8-thinking", name: "Claude Opus 4.8 (Thinking)" },
     { id: "claude-opus-4.8-agentic", name: "Claude Opus 4.8 (Agentic)" },

--- a/tests/unit/capabilities-opus-context.test.js
+++ b/tests/unit/capabilities-opus-context.test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
 
 // Claude Opus 4.6+ ships a 1M-token context window (GA, standard pricing).
-// The registry exposes dashed ids (claude-opus-4-8, claude-opus-4-7), which
+// The registry exposes dashed ids (claude-opus-5, claude-opus-4-8, claude-opus-4-7), which
 // must resolve to the 1M context + adaptive thinking caps rather than falling
 // through to the generic *claude*opus* pattern (200k / budget thinking).
 describe("Claude Opus 1M context capabilities", () => {
@@ -17,6 +17,10 @@ describe("Claude Opus 1M context capabilities", () => {
   };
 
   for (const model of [
+    "claude-opus-5",
+    "claude-opus-5-thinking",
+    "claude-opus-5-agentic",
+    "claude-opus-5-thinking-agentic",
     "claude-opus-4-8",
     "claude-opus-4.8",
     "claude-opus-4-7",

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -20,6 +20,18 @@ describe("getCapabilitiesForModel", () => {
     search: true,
   };
 
+  it("reports Kiro Claude Opus 5 variants as 1M adaptive-thinking models", () => {
+    for (const model of [
+      "claude-opus-5",
+      "anthropic/claude-opus-5",
+      "claude-opus-5-thinking",
+      "claude-opus-5-agentic",
+      "claude-opus-5-thinking-agentic",
+    ]) {
+      expect(getCapabilitiesForModel("kiro", model)).toMatchObject(claudeSonnet5Expected);
+    }
+  });
+
   it("reports Kiro Claude Opus 4.8 as a 1M context model", () => {
     expect(getCapabilitiesForModel("kiro", "claude-opus-4.8").contextWindow).toBe(1000000);
     expect(getCapabilitiesForModel("kiro", "anthropic/claude-opus-4.8").contextWindow).toBe(1000000);


### PR DESCRIPTION
## Description
Add Claude Opus 5 to the Kiro provider model registry.

## Changes
- Add normal, thinking, agentic, and thinking + agentic variants.
- Declare 1M context, 128K output, and adaptive-thinking capabilities.
- Cover all four variants with focused capability tests.

## Verification
- `git diff --check`
- Ran an assert-based registry/capability check for all four model IDs.
- The checkout does not include a Vitest runner, so the full test suite was not run.

## Reference
- https://kiro.dev/blog/opus-5/