### PR TITLE
feat(combo): "team" multi-agent strategy (draft — needs help)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Features
+- **Combo**: `team` strategy — one request runs an internal Planner → Worker → Reviewers → Judge → Compressor pipeline with a bounded feedback loop. Single-slot roles (planner/worker/judge/compressor) support fallback chains; reviewers run as a parallel panel. Configured per combo via `comboStrategies[name].team`.
+
 # v0.5.40 (2026-07-20)
 
 ## Features

--- a/docs/superpowers/specs/2026-07-27-team-strategy-design.md
+++ b/docs/superpowers/specs/2026-07-27-team-strategy-design.md
@@ -1,0 +1,209 @@
+# Team Strategy — Design
+
+**Date:** 2026-07-27
+**Status:** Approved (design)
+**Area:** `open-sse/services/` — combo routing engine
+
+## Summary
+
+Add a 5th combo strategy, `"team"`, alongside the existing `fallback`,
+`round-robin`, and `fusion` strategies. A single `/v1/chat/completions` (or
+Claude/Gemini/Responses) request whose model resolves to a `team` combo fans
+out into an internal multi-agent pipeline — Planner → (Plan Reviewer) →
+Worker → Reviewers → Judge/Synthesise → feedback loop → Compressor — and only
+the final compressed answer streams back to the client.
+
+The four routing strategies the feature description mentioned
+(round-robin, fallback, judge, panel) **already exist** in
+`open-sse/services/combo.js`:
+- round-robin → `getRotatedModels`
+- fallback → `handleComboChat`
+- judge + panel → `handleFusionChat` / `buildJudgePrompt`
+
+This spec covers only the new orchestration layer (`team`), which **reuses**
+those existing pieces as primitives (fallback for single-slot roles, panel
+collection for reviewers, judge-style synthesis).
+
+## Goals
+
+- One API call transparently runs a planner/worker/reviewer team and returns
+  one answer. No new public API surface, no client changes.
+- Every role is configurable per combo; sensible defaults when unset.
+- Single-slot roles (planner, worker, judge, compressor) support a **fallback
+  chain** (array of models tried in order until one succeeds).
+- Reviewers run as a **panel** (parallel fan-out).
+- Bounded loop: max iterations + numeric pass threshold.
+- Fail-open at every stage — a failed role degrades the pipeline, never 500s
+  the whole request unless nothing at all could answer.
+
+## Non-Goals (YAGNI)
+
+- **No dashboard UI this pass.** Configuration is via `settings.comboStrategies`
+  (the same object the dashboard already persists). A visual team builder is a
+  later, separate spec.
+- **No interactive human-in-the-loop.** "Send to User" / "Plan feedback" nodes
+  in the original diagram resolve to internal-only stages; the only
+  client-facing output is the final streamed answer.
+- **Chat only.** Image / TTS / fetch / embeddings endpoints keep their existing
+  strategies. `team` is ignored (treated as `fallback`) outside chat.
+- No persistence of intermediate artifacts (plans, critiques) beyond logs.
+
+## Configuration
+
+Extends the existing `settings.comboStrategies[comboName]` object. The combo's
+own `models[]` array remains the canonical model list; `team.*` fields are role
+overrides.
+
+```jsonc
+"comboStrategies": {
+  "my-team": {
+    "fallbackStrategy": "team",
+    "team": {
+      "planner":    ["gpt-5", "claude-opus-4-8"], // string | string[]; [] = fallback chain
+      "worker":     ["claude-sonnet-5", "gpt-5"],  // string | string[]; [] = fallback chain
+      "reviewers":  ["gpt-5", "gemini-3-pro"],     // string[]; panel (parallel)
+      "judge":      "claude-opus-4-8",             // string | string[]; synthesise + score
+      "compressor": "claude-haiku-4-5",            // string | string[]; "turn into haiku"
+      "maxIters":   2,                             // loop cap; default 2
+      "passThreshold": 8,                          // 0-10; default 8
+      "planReview": true                           // vet plan before worker; default true
+    }
+  }
+}
+```
+
+### Defaults when a field is omitted
+
+| Role       | Default                                    |
+|------------|--------------------------------------------|
+| planner    | `models[0]`                                |
+| worker     | `models[0]`                                |
+| reviewers  | `models` (the full combo list)             |
+| judge      | `models[0]`                                |
+| compressor | resolved `judge`                           |
+| maxIters   | `2`                                        |
+| passThreshold | `8`                                     |
+| planReview | `true`                                     |
+
+A role value may be a string (single model) or an array (fallback chain).
+`reviewers` is always treated as a parallel panel, never a fallback chain.
+
+## Pipeline
+
+All stages run **internally, non-streaming, tools stripped** (like fusion's
+panel calls) except the final Compressor call, which keeps the client's
+original `stream` flag and tools so streaming + downstream tool use still work.
+
+```
+Planner ── plan text
+   │  (if planReview) Plan Reviewer vets + revises the plan once   [internal]
+   ▼
+┌─ LOOP (iteration ≤ maxIters) ───────────────────────────────────┐
+│ Worker    ── answer, given (plan + prior consolidated feedback)  │
+│ Reviewers ── critiques, parallel fan-out via collectPanel        │
+│ Judge     ── { score: 0..10, feedback: string }  [synthesise]    │
+│ score ≥ passThreshold ? break : append feedback, next iteration ─┘
+▼  (pass, OR cap reached → keep highest-scored iteration)
+Compressor ── condense the approved answer into tight final form
+   ▼  ← keeps client stream flag + tools = the response "Sent to User"
+```
+
+### Stage details
+
+1. **Planner.** Given the original conversation, produce a short plan/approach.
+   Prompt appended as a synthesised user turn (reuse `appendUserTurn`).
+2. **Plan Reviewer** (optional, `planReview`). Same model chain as planner (or
+   judge — implementation detail, default to planner chain); critiques and
+   returns a revised plan. One pass only, no loop.
+3. **Worker.** Produce the answer, given the plan and (on iterations > 1) the
+   consolidated reviewer feedback from the previous round.
+4. **Reviewers (panel).** Fan out the worker answer to every reviewer in
+   parallel; each returns a critique. Collected with `collectPanel`
+   (quorum-grace + hard timeout), reusing fusion's tuning constants.
+5. **Judge / Synthesise.** Given the worker answer + all critiques, return a
+   JSON `{ score, feedback }`. Score gates the loop; feedback drives the next
+   Worker iteration. Parsing is defensive: unparseable → treat as a fail with
+   the raw text as feedback, but never throw.
+6. **Compressor ("turn into haiku").** Condense the approved answer into a
+   tighter final form. This is the only client-facing call.
+
+### Role invocation — `callRole`
+
+New helper: `callRole(roleModels, body, handleSingleModel, { isPanel })`.
+- `roleModels` normalised to an array.
+- Tries each model in order; returns the first `res.ok`. Uses
+  `checkFallbackError` (from `accountFallback.js`) to decide retry-vs-abort,
+  matching `handleComboChat`'s fallback semantics.
+- Exhausted chain → returns `null` (caller decides degradation).
+
+## Dispatch
+
+Add a `strategy === "team"` branch at **both** combo call sites in
+`src/sse/handlers/chat.js` (the primary path ~line 122 and the
+`handleSingleModelChat` combo-detection path ~line 178), mirroring the existing
+`fusion` branch:
+
+```js
+if (comboStrategy === "team") {
+  log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: team)`);
+  return handleTeamChat({
+    body,
+    models: comboModels,
+    handleSingleModel: (b, m, isInternal) => { /* strip tools when isInternal, like fusion isPanel */ },
+    log,
+    comboName: modelStr,
+    team: comboStrategies[modelStr]?.team,
+  });
+}
+```
+
+`handleTeamChat` lives in a **new file** `open-sse/services/team.js` (keeps the
+already-576-line `combo.js` focused). It imports the shared helpers it needs
+from `combo.js` (`appendUserTurn`, `flattenToolHistory`, `collectPanel`,
+`extractPanelText`, `buildJudgePrompt`) and `checkFallbackError` from
+`accountFallback.js`. Any helper currently module-private in `combo.js` that
+`team.js` needs will be `export`ed from `combo.js` (no behaviour change).
+
+## Error handling / degradation (fail-open)
+
+| Failure                              | Behaviour                                              |
+|--------------------------------------|-------------------------------------------------------|
+| `models.length === 1`                | Direct single-model call; no team.                    |
+| `team` config missing/empty          | Fall back to `handleComboChat` (fallback strategy).   |
+| Planner chain exhausted              | Skip plan; Worker answers the raw prompt.             |
+| Plan Reviewer fails                  | Use the unreviewed plan.                              |
+| Worker chain exhausted, iter 1       | 503 (nothing to return).                              |
+| Worker chain exhausted, iter > 1     | Return best-scored prior iteration.                   |
+| All reviewers fail                   | Skip review; go straight to Compressor with worker's answer. |
+| Judge fails / unparseable score      | Treat as non-pass; if at cap, return best-so-far.     |
+| Compressor chain exhausted           | Stream the approved (uncompressed) answer directly.   |
+
+No stage throws out of `handleTeamChat`; the worst case returns a structured
+503 like `handleFusionChat` does.
+
+## Testing
+
+New `tests/unit/team-strategy.test.js` (vitest), mocking `handleSingleModel`:
+
+- Role routing: correct model chain invoked for each role; defaults applied
+  when fields omitted.
+- Fallback chain: planner/worker first model fails → second model used.
+- Loop: stops early when judge score ≥ threshold; caps at `maxIters` and
+  returns best-scored iteration.
+- Panel: reviewers fan out in parallel; partial reviewer failure tolerated.
+- Degradation: each row of the table above.
+- Single-model bypass; missing-team-config bypass.
+
+Additive only — no changes to existing provider/alias/OAuth baseline snapshots,
+so `tests/__baseline__/verify-*.mjs` remain green.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `open-sse/services/team.js` | **New.** `handleTeamChat`, `callRole`, role-resolution + loop. |
+| `open-sse/services/combo.js` | Export the shared helpers `team.js` needs. No behaviour change. |
+| `src/sse/handlers/chat.js` | Two `strategy === "team"` dispatch branches. |
+| `src/lib/db/repos/settingsRepo.js` | (If needed) document `team` shape; `comboStrategies` already defaults to `{}`. |
+| `tests/unit/team-strategy.test.js` | **New.** Unit coverage. |
+| `CHANGELOG.md` | Feature entry. |

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -18,7 +18,7 @@ const TOOL_RESULT_PREFIX = "[Tool result: ";
 // Flatten tool turns into prose so panel models keep the context but can't loop
 // on tools: drop the request's tools, turn tool/function results into assistant
 // text, and inline assistant tool_calls names instead of the structured field.
-function flattenToolHistory(messages) {
+export function flattenToolHistory(messages) {
   return messages
     .filter((msg) => msg)
     .map((msg) => {
@@ -336,7 +336,7 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
  * Panel responses are already translated to the client format by chatCore, so the
  * leaf content→string step reuses the translator's own extractTextContent.
  */
-function extractPanelText(json) {
+export function extractPanelText(json) {
   if (!json || typeof json !== "object") return "";
 
   // OpenAI chat completion
@@ -374,7 +374,7 @@ function extractPanelText(json) {
  * Append a synthesized user turn to whichever message array the request format uses.
  * Preserves the original conversation + system prompt so the judge has full context.
  */
-function appendUserTurn(body, text) {
+export function appendUserTurn(body, text) {
   const next = { ...body };
   if (Array.isArray(body.messages)) {
     next.messages = [...body.messages, { role: "user", content: text }];
@@ -418,14 +418,14 @@ function buildJudgePrompt(answers) {
 }
 
 // Fusion tuning. Overridable per-combo via settings.comboStrategies[name].
-const FUSION_DEFAULTS = {
+export const FUSION_DEFAULTS = {
   minPanel: 2,             // answers needed before stragglers get a grace window
   stragglerGraceMs: 8000,  // wait this long for laggards once quorum is reached
   panelHardTimeoutMs: 90000, // absolute cap so one hung model can't stall forever
 };
 
 // Resolve a Response (or {__error}) within ms; the loser keeps running but is ignored.
-function withTimeout(promise, ms) {
+export function withTimeout(promise, ms) {
   return new Promise((resolve) => {
     const t = setTimeout(() => resolve({ __timeout: true }), ms);
     Promise.resolve(promise)
@@ -441,7 +441,7 @@ function withTimeout(promise, ms) {
  * still preferring a full panel when everyone is fast. Bounded by a hard timeout.
  * Returns a sparse array aligned to `calls` (undefined = not yet / dropped).
  */
-function collectPanel(calls, { minPanel, stragglerGraceMs, panelHardTimeoutMs }) {
+export function collectPanel(calls, { minPanel, stragglerGraceMs, panelHardTimeoutMs }) {
   return new Promise((resolve) => {
     const out = new Array(calls.length);
     let settled = 0;

--- a/open-sse/services/team.js
+++ b/open-sse/services/team.js
@@ -185,6 +185,149 @@ function jsonResponse(payload, status) {
   });
 }
 
+// Heartbeat cadence for the streaming path (SSE comment lines — ignored by
+// every SSE parser, so they keep the connection warm without corrupting output).
+const HEARTBEAT_MS = 5000;
+
+/**
+ * Run the pipeline up to (not including) the compressor: plan → optional plan
+ * review → worker/reviewers/judge loop. Returns the approved answer, or an error
+ * descriptor. Never throws for a role failure (fail-open); degrades instead.
+ *
+ * @returns {Promise<{ answer: string } | { error: string, status: number }>}
+ */
+async function runToApproved({ internal, roles, cfg, maxIters, passThreshold, handleSingleModel, log }) {
+  // 1. Plan.
+  let plan = "";
+  const plannerRes = await callRole(roles.planner, appendUserTurn(internal, buildPlannerPrompt()), handleSingleModel, log, "planner");
+  plan = await readText(plannerRes);
+  if (!plan) log.warn("TEAM", "Planner produced no plan — worker will answer the raw prompt");
+
+  // 1b. Optional plan review.
+  if (plan && cfg.planReview) {
+    const reviewRes = await callRole(roles.planner, appendUserTurn(internal, buildPlanReviewPrompt(plan)), handleSingleModel, log, "plan-reviewer");
+    const revised = await readText(reviewRes);
+    if (revised) plan = revised;
+  }
+
+  // 2. Worker → Reviewers → Judge loop.
+  let best = null; // { answer, score }
+  let feedback = "";
+  for (let iter = 1; iter <= maxIters; iter++) {
+    const workerRes = await callRole(roles.worker, appendUserTurn(internal, buildWorkerPrompt(plan, feedback)), handleSingleModel, log, "worker");
+    const answer = await readText(workerRes);
+    if (!answer) {
+      log.warn("TEAM", `Worker produced nothing on iteration ${iter}`);
+      if (best) break; // keep the best prior iteration
+      return { error: "Team worker failed to produce an answer", status: 503 };
+    }
+
+    // Reviewers — parallel panel.
+    const tuning = FUSION_DEFAULTS;
+    const reviewCalls = roles.reviewers.map((m) =>
+      withTimeout(handleSingleModel(appendUserTurn(internal, buildReviewerPrompt(answer)), m, true), tuning.panelHardTimeoutMs));
+    const settled = await collectPanel(reviewCalls, { ...tuning, minPanel: Math.min(tuning.minPanel, roles.reviewers.length) });
+    const critiques = [];
+    for (const res of settled) {
+      if (!res || res.__timeout || res.__error || !res.ok) continue;
+      const text = await readText(res);
+      if (text) critiques.push(text);
+    }
+
+    // No usable critiques → accept this answer as-is (nothing to judge/refine).
+    if (critiques.length === 0) {
+      log.warn("TEAM", `No reviewer critiques on iteration ${iter} — accepting worker answer`);
+      best = { answer, score: passThreshold };
+      break;
+    }
+
+    // Judge synthesises a score + actionable feedback.
+    const judgeRes = await callRole(roles.judge, appendUserTurn(internal, buildSynthesisPrompt(answer, critiques)), handleSingleModel, log, "judge");
+    const verdict = parseVerdict(await readText(judgeRes));
+    log.info("TEAM", `Iteration ${iter}: score=${verdict.score} (pass>=${passThreshold})`);
+
+    if (!best || verdict.score > best.score) best = { answer, score: verdict.score };
+    if (verdict.score >= passThreshold) break;
+    feedback = verdict.feedback || "Improve correctness, completeness, and clarity.";
+  }
+
+  if (!best) return { error: "Team produced no answer", status: 503 };
+  return { answer: best.answer };
+}
+
+// Minimal OpenAI-style SSE for the streaming compressor-exhausted fallback.
+function openaiSSE(text) {
+  const chunk = (delta, finish) => `data: ${JSON.stringify({ choices: [{ index: 0, delta, finish_reason: finish }] })}\n\n`;
+  return chunk({ role: "assistant", content: text }, null) + chunk({}, "stop") + "data: [DONE]\n\n";
+}
+
+/**
+ * Streaming team response: open an SSE stream now, heartbeat while the internal
+ * pipeline runs, then pipe the compressor's streamed body (or a fallback chunk).
+ * @returns {Response}
+ */
+function streamTeamResponse({ body, roles, run, handleSingleModel, log }) {
+  const enc = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      let hb = null;
+      const ping = (msg) => { try { controller.enqueue(enc.encode(`: ${msg}\n\n`)); } catch { /* stream closed */ } };
+      ping("9router team: pipeline started");
+      hb = setInterval(() => ping("ping"), HEARTBEAT_MS);
+
+      (async () => {
+        try {
+          const result = await run();
+          if (hb) { clearInterval(hb); hb = null; }
+
+          if (result.error) {
+            ping(`team error: ${result.error}`);
+            controller.enqueue(enc.encode("data: [DONE]\n\n"));
+            controller.close();
+            return;
+          }
+
+          // Compressor — keeps the client's stream flag + tools, so its body is
+          // already correctly formatted SSE for the client's request format.
+          const compBody = { ...appendUserTurn(body, buildCompressorPrompt(result.answer)) };
+          let piped = false;
+          for (const model of roles.compressor) {
+            let res;
+            try {
+              res = await handleSingleModel(compBody, model, false);
+            } catch (e) {
+              log.warn("TEAM", `compressor ${model} threw`, { error: e?.message || String(e) });
+              continue;
+            }
+            if (res && res.ok && res.body) {
+              const reader = res.body.getReader();
+              for (;;) { const { done, value } = await reader.read(); if (done) break; controller.enqueue(value); }
+              piped = true;
+              break;
+            }
+            log.warn("TEAM", `compressor ${model} failed (status ${res?.status ?? 0})`);
+          }
+
+          if (!piped) {
+            log.warn("TEAM", "Compressor exhausted — streaming the approved answer uncompressed");
+            controller.enqueue(enc.encode(openaiSSE(result.answer)));
+          }
+          controller.close();
+        } catch (e) {
+          if (hb) clearInterval(hb);
+          log.warn("TEAM", "Team streaming pipeline crashed", { error: e?.message || String(e) });
+          try { controller.enqueue(enc.encode("data: [DONE]\n\n")); controller.close(); } catch { controller.error(e); }
+        }
+      })();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", "Connection": "keep-alive" },
+  });
+}
+
 /**
  * Handle a team combo. See the file header for the pipeline.
  *
@@ -226,70 +369,22 @@ export async function handleTeamChat({ body, models, handleSingleModel, log, com
   log.info("TEAM", `Combo "${comboName}" | worker=[${roles.worker.join(",")}] reviewers=[${roles.reviewers.join(",")}] judge=[${roles.judge.join(",")}] maxIters=${maxIters} pass>=${passThreshold}`);
 
   const internal = internalBody(body);
+  const run = () => runToApproved({ internal, roles, cfg, maxIters, passThreshold, handleSingleModel, log });
 
-  // 1. Plan.
-  let plan = "";
-  const plannerRes = await callRole(roles.planner, appendUserTurn(internal, buildPlannerPrompt()), handleSingleModel, log, "planner");
-  plan = await readText(plannerRes);
-  if (!plan) log.warn("TEAM", "Planner produced no plan — worker will answer the raw prompt");
-
-  // 1b. Optional plan review.
-  if (plan && cfg.planReview) {
-    const reviewRes = await callRole(roles.planner, appendUserTurn(internal, buildPlanReviewPrompt(plan)), handleSingleModel, log, "plan-reviewer");
-    const revised = await readText(reviewRes);
-    if (revised) plan = revised;
+  // Streaming clients would otherwise see nothing until the compressor (~all
+  // stages are internal/silent) and abort on their first-byte timeout. Open the
+  // SSE stream immediately, heartbeat while the pipeline runs, then pipe the
+  // compressor's output.
+  if (body && body.stream) {
+    return streamTeamResponse({ body, roles, run, handleSingleModel, log });
   }
 
-  // 2. Worker → Reviewers → Judge loop.
-  let best = null; // { answer, score }
-  let feedback = "";
-  for (let iter = 1; iter <= maxIters; iter++) {
-    const workerRes = await callRole(roles.worker, appendUserTurn(internal, buildWorkerPrompt(plan, feedback)), handleSingleModel, log, "worker");
-    const answer = await readText(workerRes);
-    if (!answer) {
-      log.warn("TEAM", `Worker produced nothing on iteration ${iter}`);
-      if (best) break; // keep the best prior iteration
-      return jsonResponse({ error: { message: "Team worker failed to produce an answer" } }, 503);
-    }
+  // Non-streaming: run the pipeline, then the compressor as one blocking call.
+  const result = await run();
+  if (result.error) return jsonResponse({ error: { message: result.error } }, result.status);
 
-    // Reviewers — parallel panel.
-    const tuning = FUSION_DEFAULTS;
-    const reviewCalls = roles.reviewers.map((m) =>
-      withTimeout(handleSingleModel(appendUserTurn(internal, buildReviewerPrompt(answer)), m, true), tuning.panelHardTimeoutMs));
-    const settled = await collectPanel(reviewCalls, { ...tuning, minPanel: Math.min(tuning.minPanel, roles.reviewers.length) });
-    const critiques = [];
-    for (const res of settled) {
-      if (!res || res.__timeout || res.__error || !res.ok) continue;
-      const text = await readText(res);
-      if (text) critiques.push(text);
-    }
-
-    // No usable critiques → accept this answer as-is (nothing to judge/refine).
-    if (critiques.length === 0) {
-      log.warn("TEAM", `No reviewer critiques on iteration ${iter} — accepting worker answer`);
-      best = { answer, score: passThreshold };
-      break;
-    }
-
-    // Judge synthesises a score + actionable feedback.
-    const judgeRes = await callRole(roles.judge, appendUserTurn(internal, buildSynthesisPrompt(answer, critiques)), handleSingleModel, log, "judge");
-    const verdict = parseVerdict(await readText(judgeRes));
-    log.info("TEAM", `Iteration ${iter}: score=${verdict.score} (pass>=${passThreshold})`);
-
-    if (!best || verdict.score > best.score) best = { answer, score: verdict.score };
-    if (verdict.score >= passThreshold) break;
-    feedback = verdict.feedback || "Improve correctness, completeness, and clarity.";
-  }
-
-  if (!best) {
-    return jsonResponse({ error: { message: "Team produced no answer" } }, 503);
-  }
-
-  // 3. Compressor → the only client-facing, streamed call. Falls back to the
-  // approved answer verbatim if the compressor chain is exhausted.
-  const compBody = { ...appendUserTurn(body, buildCompressorPrompt(best.answer)) };
-  const chain = roles.compressor;
-  for (const model of chain) {
+  const compBody = { ...appendUserTurn(body, buildCompressorPrompt(result.answer)) };
+  for (const model of roles.compressor) {
     let res;
     try {
       res = await handleSingleModel(compBody, model, false);
@@ -303,6 +398,6 @@ export async function handleTeamChat({ body, models, handleSingleModel, log, com
 
   log.warn("TEAM", "Compressor exhausted — returning the approved answer uncompressed");
   return jsonResponse({
-    choices: [{ index: 0, message: { role: "assistant", content: best.answer }, finish_reason: "stop" }],
+    choices: [{ index: 0, message: { role: "assistant", content: result.answer }, finish_reason: "stop" }],
   }, 200);
 }

--- a/open-sse/services/team.js
+++ b/open-sse/services/team.js
@@ -187,7 +187,7 @@ function jsonResponse(payload, status) {
 
 // Heartbeat cadence for the streaming path (SSE comment lines — ignored by
 // every SSE parser, so they keep the connection warm without corrupting output).
-const HEARTBEAT_MS = 5000;
+const HEARTBEAT_MS = 2500;
 
 /**
  * Run the pipeline up to (not including) the compressor: plan → optional plan
@@ -261,29 +261,53 @@ function openaiSSE(text) {
   return chunk({ role: "assistant", content: text }, null) + chunk({}, "stop") + "data: [DONE]\n\n";
 }
 
+// Keep-alive as a real OpenAI stream chunk with an empty (or role-only) delta.
+// Strict clients ignore bare ": comment" SSE lines and abort while waiting for a
+// real data event, so the heartbeat must be a data chunk. Empty deltas append
+// nothing to the rendered content.
+function keepAliveChunk(withRole) {
+  return `data: ${JSON.stringify({
+    id: "team-keepalive",
+    object: "chat.completion.chunk",
+    choices: [{ index: 0, delta: withRole ? { role: "assistant" } : {}, finish_reason: null }],
+  })}\n\n`;
+}
+
 /**
- * Streaming team response: open an SSE stream now, heartbeat while the internal
- * pipeline runs, then pipe the compressor's streamed body (or a fallback chunk).
+ * Streaming team response: open an SSE stream now, send real keep-alive data
+ * chunks while the internal pipeline runs, then pipe the compressor's streamed
+ * body (or a fallback chunk). Aborts the upstream and stops work if the client
+ * disconnects.
  * @returns {Response}
  */
 function streamTeamResponse({ body, roles, run, handleSingleModel, log }) {
   const enc = new TextEncoder();
+  let closed = false;      // client gone / stream finished — stop enqueuing
+  let hb = null;
+  let activeReader = null; // current compressor upstream reader, so cancel() can abort it
+
   const stream = new ReadableStream({
     start(controller) {
-      let hb = null;
-      const ping = (msg) => { try { controller.enqueue(enc.encode(`: ${msg}\n\n`)); } catch { /* stream closed */ } };
-      ping("9router team: pipeline started");
-      hb = setInterval(() => ping("ping"), HEARTBEAT_MS);
+      const safeEnqueue = (bytes) => {
+        if (closed) return false;
+        try { controller.enqueue(bytes); return true; }
+        catch { closed = true; return false; }
+      };
+      const finish = () => { if (hb) { clearInterval(hb); hb = null; } if (!closed) { closed = true; try { controller.close(); } catch { /* already closed */ } } };
+
+      // Immediate real data event + periodic empty-delta keep-alives.
+      safeEnqueue(enc.encode(keepAliveChunk(true)));
+      hb = setInterval(() => safeEnqueue(enc.encode(keepAliveChunk(false))), HEARTBEAT_MS);
 
       (async () => {
         try {
           const result = await run();
           if (hb) { clearInterval(hb); hb = null; }
+          if (closed) return; // client disconnected during the pipeline
 
           if (result.error) {
-            ping(`team error: ${result.error}`);
-            controller.enqueue(enc.encode("data: [DONE]\n\n"));
-            controller.close();
+            safeEnqueue(enc.encode("data: [DONE]\n\n"));
+            finish();
             return;
           }
 
@@ -292,6 +316,7 @@ function streamTeamResponse({ body, roles, run, handleSingleModel, log }) {
           const compBody = { ...appendUserTurn(body, buildCompressorPrompt(result.answer)) };
           let piped = false;
           for (const model of roles.compressor) {
+            if (closed) break;
             let res;
             try {
               res = await handleSingleModel(compBody, model, false);
@@ -300,25 +325,36 @@ function streamTeamResponse({ body, roles, run, handleSingleModel, log }) {
               continue;
             }
             if (res && res.ok && res.body) {
-              const reader = res.body.getReader();
-              for (;;) { const { done, value } = await reader.read(); if (done) break; controller.enqueue(value); }
+              activeReader = res.body.getReader();
+              for (;;) {
+                const { done, value } = await activeReader.read();
+                if (done) break;
+                if (!safeEnqueue(value)) break; // client gone — stop pumping
+              }
+              activeReader = null;
               piped = true;
               break;
             }
             log.warn("TEAM", `compressor ${model} failed (status ${res?.status ?? 0})`);
           }
 
-          if (!piped) {
+          if (!piped && !closed) {
             log.warn("TEAM", "Compressor exhausted — streaming the approved answer uncompressed");
-            controller.enqueue(enc.encode(openaiSSE(result.answer)));
+            safeEnqueue(enc.encode(openaiSSE(result.answer)));
           }
-          controller.close();
+          finish();
         } catch (e) {
-          if (hb) clearInterval(hb);
           log.warn("TEAM", "Team streaming pipeline crashed", { error: e?.message || String(e) });
-          try { controller.enqueue(enc.encode("data: [DONE]\n\n")); controller.close(); } catch { controller.error(e); }
+          finish();
         }
       })();
+    },
+    cancel(reason) {
+      // Client disconnected — stop heartbeats, halt the pipeline, drop the upstream.
+      closed = true;
+      if (hb) { clearInterval(hb); hb = null; }
+      if (activeReader) { try { activeReader.cancel(reason); } catch { /* noop */ } activeReader = null; }
+      log.info("TEAM", "Client disconnected — team stream cancelled");
     },
   });
 

--- a/open-sse/services/team.js
+++ b/open-sse/services/team.js
@@ -1,0 +1,308 @@
+/**
+ * Team combo strategy — an internal multi-agent pipeline behind a single API call.
+ *
+ * Pipeline (all stages internal / non-streaming / tools stripped, except the final
+ * compressor call which keeps the client's stream flag + tools):
+ *
+ *   Planner ─► plan
+ *      │ (planReview) Plan Reviewer revises the plan once
+ *      ▼
+ *   ┌─ LOOP (≤ maxIters) ───────────────────────────────────┐
+ *   │ Worker    ─► answer (plan + prior feedback)             │
+ *   │ Reviewers ─► critiques (parallel panel via collectPanel)│
+ *   │ Judge     ─► { score, feedback } (synthesise)           │
+ *   │ score ≥ passThreshold ? break : feed feedback back ─────┘
+ *      ▼ (pass, or cap → best-scored iteration)
+ *   Compressor ("turn into haiku") ─► condense into the final streamed answer
+ *
+ * Fail-open at every stage: a failed role degrades the pipeline; it never throws.
+ * Reuses the fusion primitives (panel collection, prose extraction, turn append)
+ * from combo.js and the fallback-error classifier from accountFallback.js.
+ */
+
+import {
+  appendUserTurn,
+  extractPanelText,
+  collectPanel,
+  withTimeout,
+  flattenToolHistory,
+  FUSION_DEFAULTS,
+} from "./combo.js";
+import { checkFallbackError } from "./accountFallback.js";
+
+// Loop / role defaults. Overridable per-combo via settings.comboStrategies[name].team.
+const TEAM_DEFAULTS = {
+  maxIters: 2,
+  passThreshold: 8,
+  planReview: true,
+};
+
+function toChain(value) {
+  if (Array.isArray(value)) return value.filter(Boolean);
+  return value ? [value] : [];
+}
+
+// Strip tools + force non-streaming for an internal stage, flattening tool turns
+// to prose so internal models keep context without emitting tool_calls.
+function internalBody(body) {
+  const { tools, tool_choice, ...rest } = body;
+  const next = { ...rest, stream: false };
+  if (Array.isArray(next.messages)) next.messages = flattenToolHistory(next.messages);
+  else if (Array.isArray(next.input)) next.input = flattenToolHistory(next.input);
+  return next;
+}
+
+/**
+ * Invoke a single-slot role as a fallback chain: try each model in order, return the
+ * first response that is ok. On a non-ok response, consult checkFallbackError to decide
+ * whether to move on (a non-fallback error short-circuits and returns that response).
+ * A thrown error always falls through to the next model. Returns null if the chain is
+ * fully exhausted with no usable response.
+ *
+ * @returns {Promise<Response|null>}
+ */
+async function callRole(models, body, handleSingleModel, log, roleName) {
+  const chain = toChain(models);
+  let lastRes = null;
+  for (const model of chain) {
+    let res;
+    try {
+      res = await handleSingleModel(body, model, true);
+    } catch (e) {
+      log.warn("TEAM", `${roleName} ${model} threw`, { error: e?.message || String(e) });
+      continue;
+    }
+    if (res && res.ok) return res;
+    lastRes = res;
+    const status = res?.status ?? 0;
+    const { shouldFallback } = checkFallbackError(status, "");
+    log.warn("TEAM", `${roleName} ${model} failed (status ${status})${shouldFallback ? " — falling through" : ""}`);
+    if (!shouldFallback) return res; // non-fallback error: surface it, stop the chain
+  }
+  return lastRes && lastRes.ok ? lastRes : null;
+}
+
+// Read prose out of a role Response, or "" if it can't be parsed.
+async function readText(res) {
+  if (!res) return "";
+  try {
+    return extractPanelText(await res.clone().json()) || "";
+  } catch {
+    return "";
+  }
+}
+
+function buildPlannerPrompt() {
+  return [
+    "You are the PLANNER on an engineering team.",
+    "Produce a concise, ordered plan for how to best answer the user's most recent request.",
+    "Focus on approach, key points to cover, and pitfalls to avoid. Output only the plan.",
+  ].join(" ");
+}
+
+function buildPlanReviewPrompt(plan) {
+  return [
+    "You are the PLAN REVIEWER. A draft plan for answering the user's request is below.",
+    "Tighten it: fix gaps, remove filler, sharpen the approach. Output only the improved plan.",
+    "",
+    "=== DRAFT PLAN ===",
+    plan,
+    "=== END DRAFT PLAN ===",
+  ].join("\n");
+}
+
+function buildWorkerPrompt(plan, feedback) {
+  const parts = ["You are the WORKER. Answer the user's most recent request directly and completely."];
+  if (plan) parts.push("", "Follow this plan:", plan);
+  if (feedback) parts.push("", "Reviewers flagged these issues with your previous attempt — fix them:", feedback);
+  parts.push("", "Output only the answer to the user.");
+  return parts.join("\n");
+}
+
+function buildReviewerPrompt(answer) {
+  return [
+    "You are a REVIEWER. Critique the candidate answer below for correctness, completeness, and clarity.",
+    "List concrete flaws, omissions, and errors. Be specific and terse. Do not rewrite the answer.",
+    "",
+    "=== CANDIDATE ANSWER ===",
+    answer,
+    "=== END CANDIDATE ANSWER ===",
+  ].join("\n");
+}
+
+function buildSynthesisPrompt(answer, critiques) {
+  const panel = critiques.map((c, i) => `[Reviewer ${i + 1}]\n${c}`).join("\n\n");
+  return [
+    "You are the JUDGE synthesising reviewer feedback on a candidate answer.",
+    "Weigh the critiques, discard the wrong ones, and decide how good the answer is.",
+    'Respond with ONLY a JSON object: {"score": <0-10 integer>, "feedback": "<what the worker must fix, empty if none>"}.',
+    "",
+    "=== CANDIDATE ANSWER ===",
+    answer,
+    "=== END CANDIDATE ANSWER ===",
+    "",
+    "=== REVIEWS ===",
+    panel,
+    "=== END REVIEWS ===",
+  ].join("\n");
+}
+
+function buildCompressorPrompt(answer) {
+  return [
+    "Condense the approved answer below into its tightest complete form for the user.",
+    "Preserve every substantive point; drop filler, hedging, and repetition. Keep the user's original language/format.",
+    "Output only the final answer.",
+    "",
+    "=== APPROVED ANSWER ===",
+    answer,
+    "=== END APPROVED ANSWER ===",
+  ].join("\n");
+}
+
+// Parse the judge's JSON verdict defensively. Unparseable → treat as a fail (score 0)
+// and hand the raw text back as feedback, but never throw.
+function parseVerdict(text) {
+  if (!text) return { score: 0, feedback: "" };
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start !== -1 && end > start) {
+    try {
+      const obj = JSON.parse(text.slice(start, end + 1));
+      const score = Number(obj.score);
+      return {
+        score: Number.isFinite(score) ? score : 0,
+        feedback: typeof obj.feedback === "string" ? obj.feedback : "",
+      };
+    } catch { /* fall through */ }
+  }
+  return { score: 0, feedback: text };
+}
+
+function jsonResponse(payload, status) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Handle a team combo. See the file header for the pipeline.
+ *
+ * @param {Object} options
+ * @param {Object} options.body - Request body (client format)
+ * @param {string[]} options.models - Combo model list (role default source)
+ * @param {Function} options.handleSingleModel - (body, modelStr, isInternal) => Promise<Response>
+ * @param {Object} options.log - Logger
+ * @param {string} [options.comboName] - Combo name (logging)
+ * @param {Object} [options.team] - Role + loop config (see TEAM_DEFAULTS / spec)
+ * @returns {Promise<Response>}
+ */
+export async function handleTeamChat({ body, models, handleSingleModel, log, comboName, team }) {
+  const list = Array.isArray(models) ? models.filter(Boolean) : [];
+  if (list.length === 0) {
+    return jsonResponse({ error: { message: "Team combo has no models" } }, 400);
+  }
+
+  const cfg = { ...TEAM_DEFAULTS, ...(team || {}) };
+  const roles = {
+    planner: toChain(cfg.planner).length ? toChain(cfg.planner) : [list[0]],
+    worker: toChain(cfg.worker).length ? toChain(cfg.worker) : [list[0]],
+    reviewers: toChain(cfg.reviewers).length ? toChain(cfg.reviewers) : list,
+    judge: toChain(cfg.judge).length ? toChain(cfg.judge) : [list[0]],
+  };
+  roles.compressor = toChain(cfg.compressor).length ? toChain(cfg.compressor) : roles.judge;
+  const maxIters = Math.max(1, Number(cfg.maxIters) || TEAM_DEFAULTS.maxIters);
+  const passThreshold = Number.isFinite(Number(cfg.passThreshold)) ? Number(cfg.passThreshold) : TEAM_DEFAULTS.passThreshold;
+
+  // Nothing to orchestrate when every role resolves to the same single model.
+  const distinct = new Set([
+    ...roles.planner, ...roles.worker, ...roles.reviewers, ...roles.judge, ...roles.compressor,
+  ]);
+  if (distinct.size <= 1) {
+    log.info("TEAM", `Combo "${comboName}" resolves to a single model — answering directly`);
+    return handleSingleModel(body, [...distinct][0] || list[0]);
+  }
+
+  log.info("TEAM", `Combo "${comboName}" | worker=[${roles.worker.join(",")}] reviewers=[${roles.reviewers.join(",")}] judge=[${roles.judge.join(",")}] maxIters=${maxIters} pass>=${passThreshold}`);
+
+  const internal = internalBody(body);
+
+  // 1. Plan.
+  let plan = "";
+  const plannerRes = await callRole(roles.planner, appendUserTurn(internal, buildPlannerPrompt()), handleSingleModel, log, "planner");
+  plan = await readText(plannerRes);
+  if (!plan) log.warn("TEAM", "Planner produced no plan — worker will answer the raw prompt");
+
+  // 1b. Optional plan review.
+  if (plan && cfg.planReview) {
+    const reviewRes = await callRole(roles.planner, appendUserTurn(internal, buildPlanReviewPrompt(plan)), handleSingleModel, log, "plan-reviewer");
+    const revised = await readText(reviewRes);
+    if (revised) plan = revised;
+  }
+
+  // 2. Worker → Reviewers → Judge loop.
+  let best = null; // { answer, score }
+  let feedback = "";
+  for (let iter = 1; iter <= maxIters; iter++) {
+    const workerRes = await callRole(roles.worker, appendUserTurn(internal, buildWorkerPrompt(plan, feedback)), handleSingleModel, log, "worker");
+    const answer = await readText(workerRes);
+    if (!answer) {
+      log.warn("TEAM", `Worker produced nothing on iteration ${iter}`);
+      if (best) break; // keep the best prior iteration
+      return jsonResponse({ error: { message: "Team worker failed to produce an answer" } }, 503);
+    }
+
+    // Reviewers — parallel panel.
+    const tuning = FUSION_DEFAULTS;
+    const reviewCalls = roles.reviewers.map((m) =>
+      withTimeout(handleSingleModel(appendUserTurn(internal, buildReviewerPrompt(answer)), m, true), tuning.panelHardTimeoutMs));
+    const settled = await collectPanel(reviewCalls, { ...tuning, minPanel: Math.min(tuning.minPanel, roles.reviewers.length) });
+    const critiques = [];
+    for (const res of settled) {
+      if (!res || res.__timeout || res.__error || !res.ok) continue;
+      const text = await readText(res);
+      if (text) critiques.push(text);
+    }
+
+    // No usable critiques → accept this answer as-is (nothing to judge/refine).
+    if (critiques.length === 0) {
+      log.warn("TEAM", `No reviewer critiques on iteration ${iter} — accepting worker answer`);
+      best = { answer, score: passThreshold };
+      break;
+    }
+
+    // Judge synthesises a score + actionable feedback.
+    const judgeRes = await callRole(roles.judge, appendUserTurn(internal, buildSynthesisPrompt(answer, critiques)), handleSingleModel, log, "judge");
+    const verdict = parseVerdict(await readText(judgeRes));
+    log.info("TEAM", `Iteration ${iter}: score=${verdict.score} (pass>=${passThreshold})`);
+
+    if (!best || verdict.score > best.score) best = { answer, score: verdict.score };
+    if (verdict.score >= passThreshold) break;
+    feedback = verdict.feedback || "Improve correctness, completeness, and clarity.";
+  }
+
+  if (!best) {
+    return jsonResponse({ error: { message: "Team produced no answer" } }, 503);
+  }
+
+  // 3. Compressor → the only client-facing, streamed call. Falls back to the
+  // approved answer verbatim if the compressor chain is exhausted.
+  const compBody = { ...appendUserTurn(body, buildCompressorPrompt(best.answer)) };
+  const chain = roles.compressor;
+  for (const model of chain) {
+    let res;
+    try {
+      res = await handleSingleModel(compBody, model, false);
+    } catch (e) {
+      log.warn("TEAM", `compressor ${model} threw`, { error: e?.message || String(e) });
+      continue;
+    }
+    if (res && res.ok) return res;
+    log.warn("TEAM", `compressor ${model} failed (status ${res?.status ?? 0})`);
+  }
+
+  log.warn("TEAM", "Compressor exhausted — returning the approved answer uncompressed");
+  return jsonResponse({
+    choices: [{ index: 0, message: { role: "assistant", content: best.answer }, finish_reason: "stop" }],
+  }, 200);
+}

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -243,6 +243,7 @@ function ComboCard({ combo, getCaps, activeProviders = [], copied, onCopy, onEdi
   const current = strategy.fallbackStrategy || "fallback";
   const judge = strategy.judgeModel || "";
   const isFusion = current === "fusion";
+  const isTeam = current === "team";
 
   return (
     <Card padding="sm" className="group">
@@ -337,6 +338,16 @@ function ComboCard({ combo, getCaps, activeProviders = [], copied, onCopy, onEdi
         </div>
       </div>
 
+      {/* Team: per-role configuration */}
+      {isTeam && (
+        <TeamConfig
+          combo={combo}
+          team={strategy.team || {}}
+          activeProviders={activeProviders}
+          onSetTeam={(patch) => onSetStrategy({ team: { ...(strategy.team || {}), ...patch } })}
+        />
+      )}
+
       {/* Judge model picker (single-select; combo members make natural judges too) */}
       {showJudgeSelect && (
         <ModelSelectModal
@@ -350,6 +361,135 @@ function ComboCard({ combo, getCaps, activeProviders = [], copied, onCopy, onEdi
         />
       )}
     </Card>
+  );
+}
+
+// Single-slot team roles (each resolves to one model; a fallback chain still
+// settable via the comboStrategies JSON). Reviewers are handled separately as a panel.
+const TEAM_ROLES = [
+  { key: "planner", label: "Planner", icon: "map", hint: "Drafts the approach", defaultHint: "first model" },
+  { key: "worker", label: "Worker", icon: "engineering", hint: "Writes the answer", defaultHint: "first model" },
+  { key: "judge", label: "Judge", icon: "gavel", hint: "Scores & gates the loop", defaultHint: "first model" },
+  { key: "compressor", label: "Compressor", icon: "compress", hint: "Condenses the final reply", defaultHint: "judge" },
+];
+
+function TeamConfig({ combo, team, activeProviders = [], onSetTeam }) {
+  const [roleModalFor, setRoleModalFor] = useState(null); // role key or null
+  const models = combo.models || [];
+  const firstModel = models[0] || "first model";
+  // reviewers: array; empty/undefined => Auto (all combo models run as the panel)
+  const reviewers = Array.isArray(team.reviewers) ? team.reviewers : [];
+  const maxIters = team.maxIters ?? 2;
+  const passThreshold = team.passThreshold ?? 8;
+  const planReview = team.planReview ?? true;
+
+  const roleValue = (key) => (typeof team[key] === "string" ? team[key] : (Array.isArray(team[key]) ? team[key][0] : "")) || "";
+  const roleDefault = (role) => (role.key === "compressor" ? (roleValue("judge") || firstModel) : firstModel);
+
+  const toggleReviewer = (model) => {
+    const next = reviewers.includes(model) ? reviewers.filter((m) => m !== model) : [...reviewers, model];
+    onSetTeam({ reviewers: next });
+  };
+
+  return (
+    <div className="mt-3 rounded-lg border border-black/5 bg-black/[0.02] p-3 dark:border-white/5 dark:bg-white/[0.02]">
+      <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-text-muted">Team roles</p>
+
+      {/* Single-slot roles */}
+      <div className="flex flex-wrap gap-2">
+        {TEAM_ROLES.map((role) => {
+          const val = roleValue(role.key);
+          return (
+            <div key={role.key} className="flex items-center gap-1.5">
+              <span className="text-[11px] font-medium text-text-muted" title={role.hint}>{role.label}</span>
+              <button
+                onClick={() => setRoleModalFor(role.key)}
+                className="inline-flex max-w-[180px] items-center gap-1 rounded border border-dashed border-primary/40 px-1.5 py-0.5 font-mono text-[11px] text-primary transition-colors hover:border-primary hover:bg-primary/5"
+                title={role.hint}
+              >
+                <span className="material-symbols-outlined text-[13px]">{role.icon}</span>
+                <span className="truncate">{val || `Auto — ${roleDefault(role)}`}</span>
+              </button>
+              {val && (
+                <button
+                  onClick={() => onSetTeam({ [role.key]: "" })}
+                  className="rounded p-0.5 text-text-muted transition-colors hover:bg-red-500/10 hover:text-red-500"
+                  title={`Reset ${role.label} to Auto`}
+                >
+                  <span className="material-symbols-outlined text-[13px]">close</span>
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Reviewers panel (subset of combo models; empty = all) */}
+      <div className="mt-3">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] font-medium text-text-muted" title="Fan out in parallel to critique the worker">Reviewers</span>
+          {reviewers.length === 0 && <span className="text-[11px] text-text-muted italic">Auto — all models</span>}
+        </div>
+        {models.length === 0 ? (
+          <p className="mt-1 text-[11px] italic text-text-muted">Add models to this combo to pick reviewers.</p>
+        ) : (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {models.map((model) => {
+              const on = reviewers.includes(model);
+              return (
+                <button
+                  key={model}
+                  onClick={() => toggleReviewer(model)}
+                  className={`rounded border px-1.5 py-0.5 font-mono text-[11px] transition-colors ${on ? "border-primary bg-primary/10 text-primary" : "border-black/10 text-text-muted hover:border-primary/40 dark:border-white/10"}`}
+                  title={on ? "Remove from reviewer panel" : "Add to reviewer panel"}
+                >
+                  {model}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Loop controls */}
+      <div className="mt-3 flex flex-wrap items-center gap-4">
+        <label className="flex items-center gap-1.5 text-[11px] font-medium text-text-muted">
+          Max iterations
+          <input
+            type="number" min={1} max={5} value={maxIters}
+            onChange={(e) => onSetTeam({ maxIters: Math.max(1, Number(e.target.value) || 1) })}
+            className="w-14 rounded border border-black/10 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/10"
+          />
+        </label>
+        <label className="flex items-center gap-1.5 text-[11px] font-medium text-text-muted">
+          Pass threshold (0–10)
+          <input
+            type="number" min={0} max={10} value={passThreshold}
+            onChange={(e) => onSetTeam({ passThreshold: Math.min(10, Math.max(0, Number(e.target.value) || 0)) })}
+            className="w-14 rounded border border-black/10 bg-transparent px-1.5 py-0.5 text-xs dark:border-white/10"
+          />
+        </label>
+        <label className="flex items-center gap-1.5 text-[11px] font-medium text-text-muted">
+          <input
+            type="checkbox" checked={planReview}
+            onChange={(e) => onSetTeam({ planReview: e.target.checked })}
+          />
+          Review the plan
+        </label>
+      </div>
+
+      {roleModalFor && (
+        <ModelSelectModal
+          isOpen={!!roleModalFor}
+          onClose={() => setRoleModalFor(null)}
+          onSelect={(m) => { onSetTeam({ [roleModalFor]: m?.value || "" }); setRoleModalFor(null); }}
+          activeProviders={activeProviders}
+          title={`Select ${TEAM_ROLES.find((r) => r.key === roleModalFor)?.label || "Model"}`}
+          addedModelValues={roleValue(roleModalFor) ? [roleValue(roleModalFor)] : []}
+          closeOnSelect={true}
+        />
+      )}
+    </div>
   );
 }
 

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -364,13 +364,14 @@ function ComboCard({ combo, getCaps, activeProviders = [], copied, onCopy, onEdi
   );
 }
 
-// Single-slot team roles (each resolves to one model; a fallback chain still
-// settable via the comboStrategies JSON). Reviewers are handled separately as a panel.
+// Single-slot team roles. Each takes an ordered fallback chain: the pipeline
+// tries the models left-to-right and uses the first that succeeds. Reviewers are
+// handled separately as a parallel panel.
 const TEAM_ROLES = [
-  { key: "planner", label: "Planner", icon: "map", hint: "Drafts the approach", defaultHint: "first model" },
-  { key: "worker", label: "Worker", icon: "engineering", hint: "Writes the answer", defaultHint: "first model" },
-  { key: "judge", label: "Judge", icon: "gavel", hint: "Scores & gates the loop", defaultHint: "first model" },
-  { key: "compressor", label: "Compressor", icon: "compress", hint: "Condenses the final reply", defaultHint: "judge" },
+  { key: "planner", label: "Planner", icon: "map", hint: "Drafts the approach" },
+  { key: "worker", label: "Worker", icon: "engineering", hint: "Writes the answer" },
+  { key: "judge", label: "Judge", icon: "gavel", hint: "Scores & gates the loop" },
+  { key: "compressor", label: "Compressor", icon: "compress", hint: "Condenses the final reply" },
 ];
 
 function TeamConfig({ combo, team, activeProviders = [], onSetTeam }) {
@@ -383,8 +384,11 @@ function TeamConfig({ combo, team, activeProviders = [], onSetTeam }) {
   const passThreshold = team.passThreshold ?? 8;
   const planReview = team.planReview ?? true;
 
-  const roleValue = (key) => (typeof team[key] === "string" ? team[key] : (Array.isArray(team[key]) ? team[key][0] : "")) || "";
-  const roleDefault = (role) => (role.key === "compressor" ? (roleValue("judge") || firstModel) : firstModel);
+  // A role is an ordered fallback chain. Normalise string | string[] | undefined -> array.
+  const roleChain = (key) => (Array.isArray(team[key]) ? team[key] : (typeof team[key] === "string" && team[key] ? [team[key]] : []));
+  const roleDefault = (role) => (role.key === "compressor" ? (roleChain("judge")[0] || firstModel) : firstModel);
+  const addToRole = (key, model) => { const c = roleChain(key); if (!c.includes(model)) onSetTeam({ [key]: [...c, model] }); };
+  const removeFromRole = (key, model) => onSetTeam({ [key]: roleChain(key).filter((m) => m !== model) });
 
   const toggleReviewer = (model) => {
     const next = reviewers.includes(model) ? reviewers.filter((m) => m !== model) : [...reviewers, model];
@@ -393,32 +397,41 @@ function TeamConfig({ combo, team, activeProviders = [], onSetTeam }) {
 
   return (
     <div className="mt-3 rounded-lg border border-black/5 bg-black/[0.02] p-3 dark:border-white/5 dark:bg-white/[0.02]">
-      <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-text-muted">Team roles</p>
+      <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-text-muted">Team roles</p>
+      <p className="mb-2 text-[11px] text-text-muted">Each role is a fallback chain — tried in order, first that works wins. Add a second model as a backup.</p>
 
-      {/* Single-slot roles */}
-      <div className="flex flex-wrap gap-2">
+      {/* Single-slot roles — ordered fallback chains */}
+      <div className="flex flex-col gap-2">
         {TEAM_ROLES.map((role) => {
-          const val = roleValue(role.key);
+          const chain = roleChain(role.key);
           return (
-            <div key={role.key} className="flex items-center gap-1.5">
-              <span className="text-[11px] font-medium text-text-muted" title={role.hint}>{role.label}</span>
+            <div key={role.key} className="flex min-w-0 flex-wrap items-center gap-1.5">
+              <span className="inline-flex items-center gap-1 text-[11px] font-medium text-text-muted" title={role.hint}>
+                <span className="material-symbols-outlined text-[13px]">{role.icon}</span>{role.label}
+              </span>
+              {chain.length === 0 && (
+                <span className="font-mono text-[11px] italic text-text-muted">Auto — {roleDefault(role)}</span>
+              )}
+              {chain.map((model, i) => (
+                <span key={model} className="inline-flex max-w-[180px] items-center gap-1 rounded border border-primary/30 bg-primary/5 px-1.5 py-0.5 font-mono text-[11px] text-primary">
+                  {i > 0 && <span className="text-[9px] text-text-muted">↳</span>}
+                  <span className="truncate">{model}</span>
+                  <button
+                    onClick={() => removeFromRole(role.key, model)}
+                    className="rounded text-text-muted transition-colors hover:text-red-500"
+                    title={`Remove ${model} from ${role.label}`}
+                  >
+                    <span className="material-symbols-outlined text-[13px]">close</span>
+                  </button>
+                </span>
+              ))}
               <button
                 onClick={() => setRoleModalFor(role.key)}
-                className="inline-flex max-w-[180px] items-center gap-1 rounded border border-dashed border-primary/40 px-1.5 py-0.5 font-mono text-[11px] text-primary transition-colors hover:border-primary hover:bg-primary/5"
-                title={role.hint}
+                className="inline-flex items-center gap-0.5 rounded border border-dashed border-primary/40 px-1.5 py-0.5 text-[11px] text-primary transition-colors hover:border-primary hover:bg-primary/5"
+                title={`Add a model to ${role.label}`}
               >
-                <span className="material-symbols-outlined text-[13px]">{role.icon}</span>
-                <span className="truncate">{val || `Auto — ${roleDefault(role)}`}</span>
+                <span className="material-symbols-outlined text-[13px]">add</span>
               </button>
-              {val && (
-                <button
-                  onClick={() => onSetTeam({ [role.key]: "" })}
-                  className="rounded p-0.5 text-text-muted transition-colors hover:bg-red-500/10 hover:text-red-500"
-                  title={`Reset ${role.label} to Auto`}
-                >
-                  <span className="material-symbols-outlined text-[13px]">close</span>
-                </button>
-              )}
             </div>
           );
         })}
@@ -482,11 +495,11 @@ function TeamConfig({ combo, team, activeProviders = [], onSetTeam }) {
         <ModelSelectModal
           isOpen={!!roleModalFor}
           onClose={() => setRoleModalFor(null)}
-          onSelect={(m) => { onSetTeam({ [roleModalFor]: m?.value || "" }); setRoleModalFor(null); }}
+          onSelect={(m) => { if (m?.value) addToRole(roleModalFor, m.value); }}
           activeProviders={activeProviders}
-          title={`Select ${TEAM_ROLES.find((r) => r.key === roleModalFor)?.label || "Model"}`}
-          addedModelValues={roleValue(roleModalFor) ? [roleValue(roleModalFor)] : []}
-          closeOnSelect={true}
+          title={`Add model to ${TEAM_ROLES.find((r) => r.key === roleModalFor)?.label || "role"}`}
+          addedModelValues={roleChain(roleModalFor)}
+          closeOnSelect={false}
         />
       )}
     </div>

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -154,6 +154,7 @@ export default function CombosPage() {
             <li><span className="font-medium text-text-main">Fallback</span> — tries models in order (next on failure)</li>
             <li><span className="font-medium text-text-main">Round Robin</span> — rotates models across requests to spread load</li>
             <li><span className="font-medium text-text-main">Fusion</span> — queries all models in parallel, then a judge synthesizes one answer. Best quality, but costs the most: every request bills all panel models + the judge (N+1 calls)</li>
+            <li><span className="font-medium text-text-main">Team</span> — an internal agent pipeline: a planner drafts an approach, a worker answers, reviewers critique, a judge scores &amp; loops for revisions, then the result is compressed into one reply. Highest cost (many internal calls). Roles default to the combo&apos;s models</li>
             <li><span className="font-medium text-text-main">Capacity auto-switch</span> — sends image/PDF/audio requests to a model that supports them first</li>
           </ul>
         </div>
@@ -234,6 +235,7 @@ const STRATEGY_OPTIONS = [
   { value: "fallback", label: "Fallback — try in order" },
   { value: "round-robin", label: "Round Robin — rotate" },
   { value: "fusion", label: "Fusion — panel + judge" },
+  { value: "team", label: "Team — plan · work · review" },
 ];
 
 function ComboCard({ combo, getCaps, activeProviders = [], copied, onCopy, onEdit, onDelete, strategy = {}, onSetStrategy }) {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -16,6 +16,7 @@ import { getTransform as getPxpipeTransform } from "@/lib/pxpipe/loader.js";
 import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat } from "open-sse/services/combo.js";
+import { handleTeamChat } from "open-sse/services/team.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
@@ -114,6 +115,25 @@ export async function handleChat(request, clientRawRequest = null) {
       });
     }
 
+    if (comboStrategy === "team") {
+      log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: team)`);
+      return handleTeamChat({
+        body,
+        models: comboModels,
+        handleSingleModel: (b, m, isInternal) => {
+          let cleanRawReq = clientRawRequest;
+          if (isInternal && clientRawRequest) {
+            const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
+            cleanRawReq = { ...clientRawRequest, body: cleanBody };
+          }
+          return handleSingleModelChat(b, m, cleanRawReq, request, apiKey);
+        },
+        log,
+        comboName: modelStr,
+        team: comboStrategies[modelStr]?.team,
+      });
+    }
+
     const comboStickyLimit = settings.comboStickyRoundRobinLimit;
     log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: ${comboStrategy}, sticky: ${comboStickyLimit})`);
     return handleComboChat({
@@ -164,6 +184,25 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
           comboName: modelStr,
           judgeModel: comboStrategies[modelStr]?.judgeModel,
           tuning: comboStrategies[modelStr]?.fusionTuning,
+        });
+      }
+
+      if (comboStrategy === "team") {
+        log.info("CHAT", `Combo "${modelStr}" with ${comboModels.length} models (strategy: team)`);
+        return handleTeamChat({
+          body,
+          models: comboModels,
+          handleSingleModel: (b, m, isInternal) => {
+            let cleanRawReq = clientRawRequest;
+            if (isInternal && clientRawRequest) {
+              const { tools, tool_choice, ...cleanBody } = clientRawRequest.body || {};
+              cleanRawReq = { ...clientRawRequest, body: cleanBody };
+            }
+            return handleSingleModelChat(b, m, cleanRawReq, request, apiKey);
+          },
+          log,
+          comboName: modelStr,
+          team: comboStrategies[modelStr]?.team,
         });
       }
 

--- a/tests/unit/team-strategy.test.js
+++ b/tests/unit/team-strategy.test.js
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { handleTeamChat } from "../../open-sse/services/team.js";
+
+const log = { info: () => {}, warn: () => {}, debug: () => {} };
+
+// Minimal OpenAI-chat Response stub with the .ok + .clone().json() surface the engine uses.
+function okResponse(content) {
+  const json = { choices: [{ message: { role: "assistant", content } }] };
+  const make = () => ({ ok: true, status: 200, clone: make, json: async () => json });
+  return make();
+}
+
+function errResponse(status = 500) {
+  const make = () => ({ ok: false, status, clone: make, json: async () => ({ error: { message: "boom" } }) });
+  return make();
+}
+
+// A judge/synthesise response is JSON prose the pipeline parses for {score, feedback}.
+function judgeResponse(score, feedback = "") {
+  return okResponse(JSON.stringify({ score, feedback }));
+}
+
+const base = { messages: [{ role: "user", content: "Q" }], stream: true, tools: [{ name: "x" }] };
+
+describe("team combo strategy", () => {
+  it("answers directly with a single-model combo (nothing to orchestrate)", async () => {
+    const handleSingleModel = vi.fn(async () => okResponse("solo"));
+    await handleTeamChat({
+      body: base,
+      models: ["p/only"],
+      handleSingleModel,
+      log,
+      team: { worker: "p/only" },
+    });
+    expect(handleSingleModel).toHaveBeenCalledTimes(1);
+    expect(handleSingleModel.mock.calls[0][1]).toBe("p/only");
+  });
+
+  it("runs planner -> worker -> reviewers -> judge -> compressor in order", async () => {
+    const seen = [];
+    const handleSingleModel = vi.fn(async (body, model) => {
+      seen.push(model);
+      if (model === "p/judge") return judgeResponse(9, "great");
+      if (model === "p/comp") return okResponse("FINAL");
+      return okResponse(`ans-${model}`);
+    });
+
+    const res = await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: {
+        planner: "p/plan",
+        worker: "p/w",
+        reviewers: ["p/r1", "p/r2"],
+        judge: "p/judge",
+        compressor: "p/comp",
+        planReview: false,
+      },
+    });
+
+    // planner, worker, r1, r2, judge, compressor
+    expect(seen[0]).toBe("p/plan");
+    expect(seen[1]).toBe("p/w");
+    expect(seen.slice(2, 4).sort()).toEqual(["p/r1", "p/r2"]);
+    expect(seen[4]).toBe("p/judge");
+    expect(seen[5]).toBe("p/comp");
+    expect(res.ok).toBe(true);
+  });
+
+  it("forces internal stages non-streaming with tools stripped, but the final compressor streams", async () => {
+    const handleSingleModel = vi.fn(async (body, model, isInternal) => {
+      if (model === "p/judge") return judgeResponse(10);
+      if (model === "p/comp") return okResponse("FINAL");
+      return okResponse("x");
+    });
+
+    await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { planner: "p/plan", worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+
+    for (const [body, model, isInternal] of handleSingleModel.mock.calls) {
+      if (model === "p/comp") {
+        expect(body.stream).toBe(true);
+        expect(body.tools).toEqual([{ name: "x" }]);
+        expect(isInternal).toBeFalsy();
+      } else {
+        expect(body.stream).toBe(false);
+        expect(body.tools).toBeUndefined();
+        expect(isInternal).toBe(true);
+      }
+    }
+  });
+
+  it("vets the plan with a plan-reviewer when planReview is on", async () => {
+    const seen = [];
+    const handleSingleModel = vi.fn(async (body, model) => {
+      seen.push(model);
+      if (model === "p/judge") return judgeResponse(9);
+      if (model === "p/comp") return okResponse("FINAL");
+      return okResponse("x");
+    });
+    await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { planner: "p/plan", worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: true },
+    });
+    // planner runs twice conceptually: draft + review both use the planner chain.
+    expect(seen.filter((m) => m === "p/plan").length).toBe(2);
+  });
+
+  it("falls back to the next model in a role chain when the first fails", async () => {
+    const seen = [];
+    const handleSingleModel = vi.fn(async (body, model) => {
+      seen.push(model);
+      if (model === "p/w1") return errResponse(500);
+      if (model === "p/judge") return judgeResponse(9);
+      if (model === "p/comp") return okResponse("FINAL");
+      return okResponse("x");
+    });
+    await handleTeamChat({
+      body: base,
+      models: ["p/w1"],
+      handleSingleModel,
+      log,
+      team: { worker: ["p/w1", "p/w2"], reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+    expect(seen).toContain("p/w1");
+    expect(seen).toContain("p/w2"); // fell through to the backup worker
+  });
+
+  it("loops until the judge score meets the pass threshold", async () => {
+    let judgeCalls = 0;
+    const workers = [];
+    const handleSingleModel = vi.fn(async (body, model) => {
+      if (model === "p/w") { workers.push(model); return okResponse("draft"); }
+      if (model === "p/judge") { judgeCalls++; return judgeResponse(judgeCalls === 1 ? 4 : 9); }
+      if (model === "p/comp") return okResponse("FINAL");
+      return okResponse("x");
+    });
+    await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { planner: "p/plan", worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", maxIters: 3, passThreshold: 8, planReview: false },
+    });
+    expect(workers.length).toBe(2); // failed once, passed on 2nd
+    expect(judgeCalls).toBe(2);
+  });
+
+  it("caps the loop at maxIters and still returns a compressed answer", async () => {
+    let workerCalls = 0;
+    let compCalled = false;
+    const handleSingleModel = vi.fn(async (body, model) => {
+      if (model === "p/w") { workerCalls++; return okResponse("draft"); }
+      if (model === "p/judge") return judgeResponse(2); // never passes
+      if (model === "p/comp") { compCalled = true; return okResponse("FINAL"); }
+      return okResponse("x");
+    });
+    const res = await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { planner: "p/plan", worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", maxIters: 2, passThreshold: 8, planReview: false },
+    });
+    expect(workerCalls).toBe(2);
+    expect(compCalled).toBe(true);
+    expect(res.ok).toBe(true);
+  });
+
+  it("skips review and compresses the worker answer when all reviewers fail", async () => {
+    let judgeCalls = 0;
+    let compCalled = false;
+    const handleSingleModel = vi.fn(async (body, model) => {
+      if (model === "p/r1" || model === "p/r2") return errResponse(500);
+      if (model === "p/judge") { judgeCalls++; return judgeResponse(9); }
+      if (model === "p/comp") { compCalled = true; return okResponse("FINAL"); }
+      return okResponse("draft");
+    });
+    await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { worker: "p/w", reviewers: ["p/r1", "p/r2"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+    expect(judgeCalls).toBe(0); // no critiques -> nothing to judge
+    expect(compCalled).toBe(true);
+  });
+
+  it("answers raw when the planner chain is exhausted", async () => {
+    const seen = [];
+    const handleSingleModel = vi.fn(async (body, model) => {
+      seen.push(model);
+      if (model === "p/plan") return errResponse(500);
+      if (model === "p/judge") return judgeResponse(9);
+      if (model === "p/comp") return okResponse("FINAL");
+      return okResponse("draft");
+    });
+    const res = await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { planner: "p/plan", worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+    expect(seen).toContain("p/w"); // worker still runs
+    expect(res.ok).toBe(true);
+  });
+
+  it("streams the approved answer directly when the compressor is exhausted", async () => {
+    const handleSingleModel = vi.fn(async (body, model) => {
+      if (model === "p/comp") return errResponse(500);
+      if (model === "p/judge") return judgeResponse(9);
+      return okResponse("APPROVED");
+    });
+    const res = await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+    expect(res.ok).toBe(true);
+    const json = await res.clone().json();
+    expect(json.choices[0].message.content).toBe("APPROVED");
+  });
+
+  it("returns 503 when the worker cannot produce anything on the first iteration", async () => {
+    const handleSingleModel = vi.fn(async (body, model) => {
+      if (model === "p/w") return errResponse(500);
+      return okResponse("x");
+    });
+    const res = await handleTeamChat({
+      body: base,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+    expect(res.status).toBe(503);
+  });
+});

--- a/tests/unit/team-strategy.test.js
+++ b/tests/unit/team-strategy.test.js
@@ -21,7 +21,25 @@ function judgeResponse(score, feedback = "") {
   return okResponse(JSON.stringify({ score, feedback }));
 }
 
-const base = { messages: [{ role: "user", content: "Q" }], stream: true, tools: [{ name: "x" }] };
+// A streaming (SSE) Response stub: real Response whose body streams OpenAI-style chunks.
+function sseResponse(content) {
+  const body = `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\ndata: [DONE]\n\n`;
+  const stream = new ReadableStream({
+    start(c) { c.enqueue(new TextEncoder().encode(body)); c.close(); },
+  });
+  return new Response(stream, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+async function drain(res) {
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let out = "";
+  for (;;) { const { done, value } = await reader.read(); if (done) break; out += dec.decode(value); }
+  return out;
+}
+
+const base = { messages: [{ role: "user", content: "Q" }], stream: false, tools: [{ name: "x" }] };
+const baseStream = { ...base, stream: true };
 
 describe("team combo strategy", () => {
   it("answers directly with a single-model combo (nothing to orchestrate)", async () => {
@@ -70,7 +88,7 @@ describe("team combo strategy", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("forces internal stages non-streaming with tools stripped, but the final compressor streams", async () => {
+  it("forces internal stages non-streaming with tools stripped; the compressor keeps the client's flags", async () => {
     const handleSingleModel = vi.fn(async (body, model, isInternal) => {
       if (model === "p/judge") return judgeResponse(10);
       if (model === "p/comp") return okResponse("FINAL");
@@ -78,7 +96,7 @@ describe("team combo strategy", () => {
     });
 
     await handleTeamChat({
-      body: base,
+      body: base, // non-streaming client request
       models: ["p/w"],
       handleSingleModel,
       log,
@@ -87,8 +105,8 @@ describe("team combo strategy", () => {
 
     for (const [body, model, isInternal] of handleSingleModel.mock.calls) {
       if (model === "p/comp") {
-        expect(body.stream).toBe(true);
-        expect(body.tools).toEqual([{ name: "x" }]);
+        expect(body.stream).toBe(false); // client didn't ask to stream
+        expect(body.tools).toEqual([{ name: "x" }]); // compressor keeps the client's tools
         expect(isInternal).toBeFalsy();
       } else {
         expect(body.stream).toBe(false);
@@ -96,6 +114,49 @@ describe("team combo strategy", () => {
         expect(isInternal).toBe(true);
       }
     }
+  });
+
+  it("streaming: emits an immediate heartbeat, then streams the compressed answer", async () => {
+    const handleSingleModel = vi.fn(async (body, model, isInternal) => {
+      if (model === "p/comp") { expect(body.stream).toBe(true); return sseResponse("FINAL"); }
+      if (model === "p/judge") return judgeResponse(9);
+      return okResponse("draft");
+    });
+
+    const res = await handleTeamChat({
+      body: baseStream,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { planner: "p/plan", worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+
+    // First chunk is an SSE comment (heartbeat) delivered before the pipeline finishes.
+    const reader = res.body.getReader();
+    const first = new TextDecoder().decode((await reader.read()).value);
+    expect(first.startsWith(":")).toBe(true);
+
+    let rest = "";
+    const dec = new TextDecoder();
+    for (;;) { const { done, value } = await reader.read(); if (done) break; rest += dec.decode(value); }
+    expect(rest).toContain("FINAL");
+  });
+
+  it("streaming: falls back to the approved answer when the compressor is exhausted", async () => {
+    const handleSingleModel = vi.fn(async (body, model) => {
+      if (model === "p/comp") return errResponse(500);
+      if (model === "p/judge") return judgeResponse(9);
+      return okResponse("APPROVED");
+    });
+    const res = await handleTeamChat({
+      body: baseStream,
+      models: ["p/w"],
+      handleSingleModel,
+      log,
+      team: { worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
+    });
+    const text = await drain(res);
+    expect(text).toContain("APPROVED");
   });
 
   it("vets the plan with a plan-reviewer when planReview is on", async () => {

--- a/tests/unit/team-strategy.test.js
+++ b/tests/unit/team-strategy.test.js
@@ -131,10 +131,13 @@ describe("team combo strategy", () => {
       team: { planner: "p/plan", worker: "p/w", reviewers: ["p/r1"], judge: "p/judge", compressor: "p/comp", planReview: false },
     });
 
-    // First chunk is an SSE comment (heartbeat) delivered before the pipeline finishes.
+    // First chunk is a real SSE data event (keep-alive) delivered before the
+    // pipeline finishes — strict clients ignore bare ": comment" lines, so the
+    // heartbeat must be a data chunk with an empty/role-only delta.
     const reader = res.body.getReader();
     const first = new TextDecoder().decode((await reader.read()).value);
-    expect(first.startsWith(":")).toBe(true);
+    expect(first).toContain("data:");
+    expect(first).not.toContain("FINAL");
 
     let rest = "";
     const dec = new TextDecoder();


### PR DESCRIPTION
> ⚠️ **Draft — not complete, feedback wanted.** This works end to end but I'm not happy with it yet (latency + defaults + streaming UX). I'm opening it early to get a steer before polishing. See open questions at the bottom. Related: #2860.

## What this adds

A **5th combo strategy, `team`**, alongside `fallback` / `round-robin` / `fusion`. One `/v1/chat/completions` request fans out into an internal multi-agent pipeline and returns a single answer.

```
Planner ─► plan
   │  (optional) Plan Reviewer revises the plan once
   ▼
┌─ LOOP (≤ maxIters) ─────────────────────────────────────┐
│ Worker    ─► answer (given plan + prior feedback)         │
│ Reviewers ─► critiques (parallel panel)                   │
│ Judge     ─► { score 0-10, feedback }  (synthesise)       │
│ score ≥ passThreshold ? break : feed feedback back ───────┘
▼ (pass, or cap → best-scored iteration)
Compressor ─► condense the approved answer = the streamed reply
```

All stages run internally (non-streaming, tools stripped) except the final compressor, which streams to the client.

## Implementation

- **`open-sse/services/team.js`** (new) — `handleTeamChat`, reusing the fusion primitives from `combo.js` (`appendUserTurn`, `collectPanel`, `extractPanelText`, `withTimeout`, `FUSION_DEFAULTS`, now exported).
- **`src/sse/handlers/chat.js`** — dispatch at both combo call sites, mirroring the `fusion` branch (`comboStrategy === "team"`).
- **Config** on `settings.comboStrategies[name].team`:
  - `planner` / `worker` / `judge` / `compressor` — string **or ordered fallback chain** (array; tried in order, first success wins via `checkFallbackError`).
  - `reviewers` — parallel panel via `collectPanel` quorum-grace.
  - `maxIters` (default 2), `passThreshold` (default 8), `planReview` (default true).
  - Defaults: planner/worker/judge = `models[0]`, reviewers = all combo models, compressor = judge.
- **Dashboard** (`combos/page.js`) — `team` in the strategy picker + inline per-role editor: role fallback-chain chips, reviewer toggles, maxIters / threshold / planReview controls.
- **Streaming:** the pipeline is silent until the compressor (~60–90 s), so streaming clients timed out. Added heartbeat streaming — an immediate real `data:` chunk (empty/role-only delta) then periodic keep-alives — plus client-disconnect handling (cancel upstream, halt pipeline). Fixes an observed `Controller is already closed` crash and a 6-minute upstream stall after the client had left.
- **Fail-open** at every stage; 503 only when nothing can answer.

## Tests

`tests/unit/team-strategy.test.js` — 13 tests: role routing + defaults, fallback-chain fallthrough, loop-until-threshold, maxIters cap, reviewer-fail skip, planner/compressor-exhausted degradation, single-model bypass, and both streaming paths (immediate heartbeat, compressor-exhausted fallback). No baseline snapshot changes.

Design doc: `docs/superpowers/specs/2026-07-27-team-strategy-design.md`.

## Results

5-model combo, trivial prompt: ✅ correct answer; loop worked (score 4 → feedback → score 10 → pass). But **~60–90 s total**, and one compressor model (`grok-4.5-high`) stalled once.

## Open questions (where I need help)

1. **Latency** — is the sequential shape right, or should stages be dropped/parallelised by default? Is `planReview` worth the extra round-trip?
2. **Cost** — many upstream calls per request; sane defaults?
3. **Streaming UX** — heartbeat data-chunks keep clients alive, but the user waits in silence. Stream stage progress as reasoning deltas, or does that risk polluting output across client formats?
4. **Config surface** — is `comboStrategies[name].team` the right home, or should roles be first-class combo fields?
5. **Scope** — is multi-agent orchestration in scope for this gateway at all?

I'll finish tests/docs/polish once the direction is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
