### PR TITLE
fix(antigravity): strip stream_options from non-stream requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Dashboard**: ProviderTopology flow animation
 
 ## Fixes
+- **Antigravity**: drop `stream_options` from non-streaming requests before calling Google `generateContent`
 - **DB**: resolve better-sqlite3 parameter binding crash
 - **Translator**: pass `service_tier` through OpenAI → Responses conversion
 - **Kiro**: map GPT-5.6 reasoning effort fields

--- a/docs/bugs/antigravity-nonstream-stream-options.md
+++ b/docs/bugs/antigravity-nonstream-stream-options.md
@@ -1,0 +1,55 @@
+# Antigravity non-streaming request rejected by `stream_options`
+
+## Status
+
+Fixed in source and covered by regression tests. Not deployed to production as of 2026-07-28.
+
+## Symptom
+
+A non-streaming request routed to Antigravity could fail upstream with HTTP 400:
+
+```text
+stream_options can only be set if stream is true
+```
+
+The issue was observed with `antigravity/gpt-oss-120b-medium`. Combo fallback kept the overall request available, but added an avoidable provider error and extra latency.
+
+## Root cause
+
+OpenAI-compatible clients may include:
+
+```json
+{
+  "stream": false,
+  "stream_options": { "include_usage": true }
+}
+```
+
+`AntigravityExecutor.transformRequest()` preserved the top-level `stream_options` field while selecting Google's non-streaming `generateContent` endpoint. That upstream endpoint rejects `stream_options` when streaming is disabled.
+
+## Fix
+
+`AntigravityExecutor.transformRequest()` now removes top-level `stream_options` whenever the effective `stream` argument is not exactly `true`. Streaming requests retain their existing `stream_options` value.
+
+## Regression coverage
+
+`tests/unit/antigravity-stream-options.test.js` verifies both boundaries:
+
+1. `stream=false` removes `stream_options`.
+2. `stream=true` preserves `stream_options`.
+
+## Verification
+
+Run:
+
+```bash
+npx vitest run --config tests/vitest.config.js tests/unit/antigravity-stream-options.test.js
+```
+
+Expected result: two tests pass.
+
+Full unit suite and application build must also pass before release.
+
+## Deployment
+
+No production container, database, service, or routing configuration was changed by this source fix. Production activation requires a separately approved image build, container replacement, restart, and smoke test with rollback available.

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -136,6 +136,10 @@ export class AntigravityExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     const projectId = credentials?.projectId || this.generateProjectId();
 
+    // OpenAI clients may include stream_options even for non-streaming calls.
+    // Google generateContent rejects that combination before processing the request.
+    if (stream !== true) delete body.stream_options;
+
     // ─── Image generation: completely different request structure ───
     if (isImageModel(model)) {
       const imageConfig = parseImageConfig(model);

--- a/tests/unit/antigravity-stream-options.test.js
+++ b/tests/unit/antigravity-stream-options.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
+
+const credentials = {
+  projectId: "synthetic-project",
+  connectionId: "synthetic-connection",
+};
+
+function requestBody(stream) {
+  return {
+    stream,
+    stream_options: { include_usage: true },
+    request: {
+      contents: [{ role: "user", parts: [{ text: "Reply only OK" }] }],
+    },
+  };
+}
+
+describe("AntigravityExecutor stream_options normalization", () => {
+  it("removes stream_options from a non-streaming request", () => {
+    const executor = new AntigravityExecutor();
+    const output = executor.transformRequest(
+      "gpt-oss-120b-medium",
+      requestBody(false),
+      false,
+      credentials,
+    );
+
+    expect(output.stream).toBe(false);
+    expect(output.stream_options).toBeUndefined();
+  });
+
+  it("preserves stream_options for a streaming request", () => {
+    const executor = new AntigravityExecutor();
+    const output = executor.transformRequest(
+      "gpt-oss-120b-medium",
+      requestBody(true),
+      true,
+      credentials,
+    );
+
+    expect(output.stream).toBe(true);
+    expect(output.stream_options).toEqual({ include_usage: true });
+  });
+});


### PR DESCRIPTION
## Summary

- remove top-level `stream_options` before Antigravity non-streaming `generateContent` requests
- preserve `stream_options` for streaming requests
- add regression tests for both boundaries
- document symptom, root cause, impact, fix, verification, and deployment status

## Bug

OpenAI-compatible clients may send:

```json
{
  "stream": false,
  "stream_options": { "include_usage": true }
}
```

Antigravity preserved that field while using Google's non-streaming `generateContent` endpoint. Upstream rejected the request with:

```text
stream_options can only be set if stream is true
```

## Verification

- TDD RED: non-stream regression test failed before fix (`expected undefined`, received `{ include_usage: true }`)
- targeted GREEN: `2/2` tests passed
- production build: `npm run build` exited `0`
- full unit comparison:
  - branch: `1119 passed`, `63 failed`, `24 skipped`
  - clean baseline `79918c7`: `1119 passed`, `63 failed`, `24 skipped`
  - new failures: `0`
- `git diff --check`: passed
- added-line secret/security scan: `0` findings

## Scope

No production container, service, database, credentials, or buyer data were changed. Deployment remains separate.

## Documentation

See `docs/bugs/antigravity-nonstream-stream-options.md`.