### PR TITLE
feat: add provider-scoped input guard rules

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -38,7 +38,7 @@ import { resolveSessionId } from "../utils/sessionManager.js";
  * @param {object} options.credentials - Provider credentials
  * @param {string} options.sourceFormatOverride - Override detected source format (e.g. "openai-responses")
  */
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking, convoy = null }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -241,7 +241,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (xf.length && log?.line) log.line(reqTag, "⚙", xf.join(" · "));
 
   const executor = getExecutor(provider);
-  trackPendingRequest(model, provider, connectionId, true);
+  trackPendingRequest(model, provider, connectionId, true, false, convoy);
   appendRequestLog({ model, provider, connectionId, status: "PENDING" }).catch(() => { });
 
   const msgCount = translatedBody.messages?.length || translatedBody.input?.length || translatedBody.contents?.length || translatedBody.request?.contents?.length || 0;
@@ -313,6 +313,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       providerRequest: translatedBody || null,
       response: { error: error.message || String(error), status: error.name === "AbortError" ? 499 : 502, thinking: null },
       pxpipe: pxpipeSummary,
+      convoy,
       status: "error"
     })).catch(() => { });
 
@@ -366,6 +367,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       providerRequest: finalBody || translatedBody || null,
       response: { error: message, status: statusCode, thinking: null },
       pxpipe: pxpipeSummary,
+      convoy,
       status: "error"
     })).catch(() => { });
 
@@ -378,7 +380,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, convoy, reqTag, log };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -198,7 +198,7 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
 /**
  * Handle non-streaming response from provider.
  */
-export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe, reqTag, log }) {
+export async function handleNonStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, trackDone, appendLog, pxpipe, convoy, reqTag, log }) {
   trackDone();
   const contentType = providerResponse.headers.get("content-type") || "";
   let responseBody;
@@ -235,7 +235,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
-  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
+  saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, convoy, silent: true });
   if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
@@ -298,6 +298,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
       finish_reason: translatedResponse?.choices?.[0]?.finish_reason || "unknown"
     },
     pxpipe,
+    convoy,
     status: "success"
   }, { endpoint: clientRawRequest?.endpoint || null })).catch(err => {
     console.error("[RequestDetail] Failed to save:", err.message);

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -58,6 +58,8 @@ export function extractUsageFromResponse(responseBody) {
 }
 
 export function buildRequestDetail(base, overrides = {}) {
+  const request = base.request ? { ...base.request } : base.request;
+  const convoy = base.convoy;
   return {
     provider: base.provider || "unknown",
     model: base.model || "unknown",
@@ -65,11 +67,12 @@ export function buildRequestDetail(base, overrides = {}) {
     timestamp: new Date().toISOString(),
     latency: base.latency || { ttft: 0, total: 0 },
     tokens: base.tokens || { prompt_tokens: 0, completion_tokens: 0 },
-    request: base.request,
+    request,
     providerRequest: base.providerRequest || null,
     providerResponse: base.providerResponse || null,
     response: base.response || {},
     pxpipe: base.pxpipe || undefined,
+    convoy: convoy || undefined,
     status: base.status || "success",
     ...overrides
   };
@@ -93,7 +96,7 @@ export function formatDoneLine({ usage, latency }) {
   return `DONE ${latency?.total ?? 0}ms${ttftStr} · ${inStr} · OUT ${outTok}`;
 }
 
-export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE", silent = false }) {
+export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, convoy, label = "USAGE", silent = false }) {
   if (!tokens || typeof tokens !== "object") return;
 
   const inTokens = tokens.input_tokens ?? tokens.prompt_tokens ?? 0;
@@ -121,6 +124,7 @@ export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, 
     timestamp: new Date().toISOString(),
     connectionId: connectionId || undefined,
     apiKey: apiKey || undefined,
-    endpoint: endpoint || null
+    endpoint: endpoint || null,
+    meta: convoy ? { convoy } : undefined
   }).catch(() => {});
 }

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -108,7 +108,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
  */
-export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog, reqTag, log }) {
+export async function handleForcedSSEToJson({ providerResponse, sourceFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, trackDone, appendLog, convoy, reqTag, log }) {
   const contentType = providerResponse.headers.get("content-type") || "";
   const isSSE = contentType.includes("text/event-stream") || (contentType === "" && isResponsesProvider(provider));
   if (!isSSE) return null; // not handled here
@@ -130,7 +130,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
       const usage = jsonResponse.usage || {};
       appendLog({ tokens: usage, status: "200 OK" });
-      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
+      saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, convoy, silent: true });
       if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
@@ -141,7 +141,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         latency: { ttft: totalLatency, total: totalLatency },
         tokens: { prompt_tokens: usage.input_tokens || 0, completion_tokens: usage.output_tokens || 0 },
         response: { content: textContent, thinking: null, finish_reason: jsonResponse.status || "unknown" },
-        status: "success"
+        status: "success",
+        convoy
       }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
       // Client is Responses API → return as-is
@@ -213,7 +214,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
 
     const usage = parsed.usage || {};
     appendLog({ tokens: usage, status: "200 OK" });
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
+    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, convoy, silent: true });
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
     const totalLatency = Date.now() - requestStartTime;
@@ -226,7 +227,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         thinking: parsed.choices?.[0]?.message?.reasoning_content || null,
         finish_reason: parsed.choices?.[0]?.finish_reason || "unknown"
       },
-      status: "success"
+      status: "success",
+      convoy
     }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
     // Strip reasoning_content only when content is non-empty.

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -43,7 +43,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 /**
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
-export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId, pxpipe, reqTag, log }) {
+export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, streamController, onStreamComplete, streamDetailId, pxpipe, convoy, reqTag, log }) {
   if (onRequestSuccess) {
     Promise.resolve()
       .then(onRequestSuccess)
@@ -96,6 +96,7 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
     providerResponse: "[Streaming - raw response not captured]",
     response: { content: "[Streaming in progress...]", thinking: null, type: "streaming" },
     pxpipe,
+    convoy,
     status: "success"
   }, { id: streamDetailId })).catch(err => {
     console.error("[RequestDetail] Failed to save streaming request:", err.message);
@@ -110,7 +111,7 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 /**
  * Build onStreamComplete callback for streaming usage tracking.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, convoy, reqTag, log }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
   const onStreamComplete = (contentObj, usage, ttftAt) => {
@@ -130,13 +131,14 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
       providerResponse: safeContent,
       response: { content: safeContent, thinking: safeThinking, type: "streaming" },
       pxpipe,
+      convoy,
       status: "success"
     }, { id: streamDetailId })).catch(err => {
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
 
     // Persist stream usage to DB (no console line; the "📊 done" line below is authoritative)
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE", silent: true });
+    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, convoy, label: "STREAM USAGE", silent: true });
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
   };
 

--- a/src/app/(dashboard)/dashboard/convoy/page.js
+++ b/src/app/(dashboard)/dashboard/convoy/page.js
@@ -1,0 +1,325 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, Button, Toggle, Select, Input, Modal } from "@/shared/components";
+
+const MATCH_TYPES = [
+  { value: "literal", label: "Literal" },
+  { value: "regex", label: "Regex" },
+];
+
+const ACTIONS = [
+  { value: "replace", label: "Replace" },
+  { value: "delete", label: "Delete" },
+];
+
+export default function ConvoyPage() {
+  const [rules, setRules] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState(null); // rule being edited, or null
+  const [showForm, setShowForm] = useState(false);
+  const [providers, setProviders] = useState([]);
+  const [error, setError] = useState("");
+
+  // Form state
+  const [form, setForm] = useState({
+    name: "",
+    enabled: true,
+    priority: 1,
+    matchType: "literal",
+    action: "replace",
+    pattern: "",
+    replacement: "",
+    caseSensitive: true,
+    providerIds: [],
+  });
+
+  const refreshRules = async () => {
+    try {
+      const res = await fetch("/api/convoy/rules");
+      const data = await res.json();
+      setRules(data.items || []);
+    } catch (e) {
+      console.error("Failed to fetch rules", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetch("/api/convoy/rules")
+      .then((res) => res.ok ? res.json() : Promise.reject(new Error("Failed to load rules")))
+      .then((data) => setRules(data.items || []))
+      .catch((e) => console.error("Failed to fetch rules", e))
+      .finally(() => setLoading(false));
+  }, []);
+  useEffect(() => {
+    fetch("/api/providers")
+      .then((res) => res.ok ? res.json() : Promise.reject(new Error("Failed to load providers")))
+      .then((data) => {
+        const seen = new Set();
+        setProviders((data.connections || []).filter((item) => {
+          if (!item.provider || seen.has(item.provider)) return false;
+          seen.add(item.provider);
+          return true;
+        }).map((item) => ({ id: item.provider, name: item.name || item.displayName || item.provider })));
+      })
+      .catch(() => setProviders([]));
+  }, []);
+
+  const resetForm = () => {
+    setForm({
+      name: "",
+      enabled: true,
+      priority: rules.length + 1,
+      matchType: "literal",
+      action: "replace",
+      pattern: "",
+      replacement: "",
+      caseSensitive: true,
+      providerIds: [],
+    });
+    setEditing(null);
+    setShowForm(false);
+  };
+
+  const openNew = () => {
+    resetForm();
+    setForm(f => ({ ...f, priority: rules.length + 1 }));
+    setShowForm(true);
+  };
+
+  const openEdit = (rule) => {
+    setEditing(rule.id);
+    setForm({
+      name: rule.name,
+      enabled: rule.enabled,
+      priority: rule.priority,
+      matchType: rule.matchType || "literal",
+      action: rule.action || "replace",
+      pattern: rule.pattern,
+      replacement: rule.replacement || "",
+      caseSensitive: rule.caseSensitive,
+      providerIds: rule.providerIds || [],
+    });
+    setShowForm(true);
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim() || !form.pattern.trim()) return;
+    setSaving(true);
+    setError("");
+    try {
+      const body = editing ? { ...form, id: editing } : form;
+      const res = await fetch("/api/convoy/rules", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        await refreshRules();
+        resetForm();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Failed to save rule");
+      }
+    } catch (e) {
+      console.error("Failed to save rule", e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this rule?")) return;
+    try {
+      await fetch(`/api/convoy/rules?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+      await refreshRules();
+    } catch (e) {
+      console.error("Failed to delete rule", e);
+    }
+  };
+
+  const handleToggle = async (rule) => {
+    try {
+      await fetch("/api/convoy/rules", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...rule, enabled: !rule.enabled }),
+      });
+      await refreshRules();
+    } catch (e) {
+      console.error("Failed to toggle rule", e);
+    }
+  };
+
+  if (loading) return <div className="p-6 text-sm text-zinc-400">Loading...</div>;
+
+  return (
+    <div className="p-6 max-w-4xl">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-100">Input Guard</h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            Text replacement rules applied to chat request bodies before they reach upstream providers.
+          </p>
+        </div>
+        <Button onClick={openNew}>+ Add Rule</Button>
+      </div>
+
+      {rules.length === 0 && !showForm && (
+        <Card className="p-8 text-center text-zinc-500">
+          No rules yet. Add a rule to start filtering request content.
+        </Card>
+      )}
+
+      {rules.map((rule) => (
+        <Card key={rule.id} className="mb-3 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-sm font-medium text-zinc-200">{rule.name}</span>
+                <span className="text-xs text-zinc-500">#{rule.priority}</span>
+              </div>
+              <div className="text-xs text-zinc-400 font-mono truncate">
+                <span className="text-zinc-500">{rule.matchType}:</span>{" "}
+                {rule.pattern.length > 60 ? rule.pattern.slice(0, 60) + "..." : rule.pattern}
+                {rule.action === "replace" && (
+                  <>
+                    {" "}
+                    <span className="text-emerald-500">{"->"}</span>{" "}
+                    {(rule.replacement || "").length > 40
+                      ? (rule.replacement || "").slice(0, 40) + "..."
+                      : rule.replacement || "(empty)"}
+                  </>
+                )}
+                {rule.action === "delete" && (
+                  <>
+                    {" "}
+                    <span className="text-red-500">[delete]</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Toggle checked={rule.enabled} onChange={() => handleToggle(rule)} />
+              <Button variant="ghost" size="sm" onClick={() => openEdit(rule)}>
+                Edit
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => handleDelete(rule.id)}>
+                Delete
+              </Button>
+            </div>
+          </div>
+        </Card>
+      ))}
+
+      {showForm && (
+        <Modal isOpen={showForm} onClose={resetForm} title={editing ? "Edit Rule" : "New Rule"} size="lg">
+          <div className="space-y-4">
+            <Input
+              label="Name"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="e.g. Claude -> CodeBuddy"
+            />
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Match Type</label>
+                <Select
+                  value={form.matchType}
+                  onChange={(e) => setForm({ ...form, matchType: e.target.value })}
+                  options={MATCH_TYPES}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Action</label>
+                <Select
+                  value={form.action}
+                  onChange={(e) => setForm({ ...form, action: e.target.value })}
+                  options={ACTIONS}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-zinc-400 mb-1">Priority</label>
+                <Input
+                  type="number"
+                  value={form.priority}
+                  onChange={(e) => setForm({ ...form, priority: parseInt(e.target.value) || 0 })}
+                />
+              </div>
+            </div>
+            <Input
+              label="Pattern"
+              value={form.pattern}
+              onChange={(e) => setForm({ ...form, pattern: e.target.value })}
+              placeholder={
+                form.matchType === "regex"
+                  ? "e.g. You are \\w+ Code"
+                  : "e.g. You are Claude Code"
+              }
+            />
+            {form.action === "replace" && (
+              <Input
+                label="Replacement"
+                value={form.replacement}
+                onChange={(e) => setForm({ ...form, replacement: e.target.value })}
+                placeholder="e.g. You are CodeBuddy"
+              />
+            )}
+            <div>
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <label className="text-xs text-zinc-400">Providers</label>
+                <span className="text-xs text-zinc-500">None selected means all providers</span>
+              </div>
+              <div className="max-h-40 overflow-y-auto rounded-lg border border-white/10 p-2">
+                {providers.length === 0 ? (
+                  <div className="p-2 text-xs text-zinc-500">No connected providers</div>
+                ) : providers.map((provider) => {
+                  const checked = form.providerIds.includes(provider.id);
+                  return (
+                    <label key={provider.id} className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 hover:bg-white/5">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => setForm({
+                          ...form,
+                          providerIds: checked
+                            ? form.providerIds.filter((id) => id !== provider.id)
+                            : [...form.providerIds, provider.id],
+                        })}
+                      />
+                      <span className="text-sm text-zinc-300">{provider.name}</span>
+                      <span className="ml-auto font-mono text-xs text-zinc-500">{provider.id}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Toggle
+                checked={form.enabled}
+                onChange={(checked) => setForm({ ...form, enabled: checked })}
+              />
+              <span className="text-sm text-zinc-300">Enabled</span>
+              <span className="mx-2 text-zinc-600">|</span>
+              <Toggle
+                checked={form.caseSensitive}
+                onChange={(checked) => setForm({ ...form, caseSensitive: checked })}
+              />
+              <span className="text-sm text-zinc-300">Case Sensitive</span>
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              {error && <div className="mr-auto self-center text-sm text-red-400">{error}</div>}
+              <Button variant="ghost" onClick={resetForm}>Cancel</Button>
+              <Button onClick={handleSave} disabled={saving}>
+                {saving ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderTopology.js
@@ -32,7 +32,7 @@ function getProviderImageUrl(providerId) {
 
 // Custom provider node - rectangle with image + name
 function ProviderNode({ data }) {
-  const { label, color, imageUrl, textIcon, active } = data;
+  const { label, color, imageUrl, textIcon, active, guardEnabled, guardHits } = data;
   const [imgError, setImgError] = useState(false);
   return (
     <div
@@ -84,6 +84,15 @@ function ProviderNode({ data }) {
         <span className="relative flex h-2 w-2 shrink-0">
           <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" style={{ backgroundColor: color }} />
           <span className="relative inline-flex rounded-full h-2 w-2" style={{ backgroundColor: color }} />
+        </span>
+      )}
+      {guardEnabled && (
+        <span
+          className={`ml-auto inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] ${guardHits > 0 ? "bg-emerald-500/20 text-emerald-500" : "bg-primary/10 text-primary"}`}
+          title={guardHits > 0 ? `${guardHits} Input Guard rule(s) applied` : "Input Guard enabled"}
+        >
+          <span className="material-symbols-outlined text-[12px]">filter_alt</span>
+          {guardHits > 0 ? guardHits : "On"}
         </span>
       )}
     </div>
@@ -260,7 +269,7 @@ const nodeTypes = { provider: ProviderNode, router: RouterNode };
 const edgeTypes = { topology: TopologyEdge };
 
 // Place N nodes evenly along an ellipse around the router center.
-function buildLayout(providers, activeSet, lastSet, errorSet) {
+function buildLayout(providers, activeSet, lastSet, errorSet, guardMap) {
   const nodeW = 180;
   const nodeH = 30;
   const routerW = 120;
@@ -310,6 +319,8 @@ function buildLayout(providers, activeSet, lastSet, errorSet) {
       imageUrl: getProviderImageUrl(p.provider),
       textIcon: config.textIcon || (p.provider || "?").slice(0, 2).toUpperCase(),
       active,
+      guardEnabled: !!guardMap[p.provider?.toLowerCase()]?.enabled,
+      guardHits: guardMap[p.provider?.toLowerCase()]?.hits || 0,
     };
 
     // Distribute evenly starting from top (−π/2), clockwise
@@ -354,7 +365,7 @@ function buildLayout(providers, activeSet, lastSet, errorSet) {
   return { nodes, edges };
 }
 
-export default function ProviderTopology({ providers = [], activeRequests = [], lastProvider = "", errorProvider = "" }) {
+export default function ProviderTopology({ providers = [], activeRequests = [], lastProvider = "", errorProvider = "", rules = [] }) {
   // Serialize to stable string keys so useMemo only re-runs when values actually change
   const activeKey = useMemo(
     () => activeRequests.map((r) => r.provider?.toLowerCase()).filter(Boolean).sort().join(","),
@@ -366,6 +377,19 @@ export default function ProviderTopology({ providers = [], activeRequests = [], 
   const rawActiveSet = useMemo(() => new Set(activeKey ? activeKey.split(",") : []), [activeKey]);
   const lastSet = useMemo(() => new Set(lastKey ? [lastKey] : []), [lastKey]);
   const errorSet = useMemo(() => new Set(errorKey ? [errorKey] : []), [errorKey]);
+  const guardMap = useMemo(() => {
+    const map = {};
+    for (const provider of providers) {
+      const id = provider.provider?.toLowerCase();
+      if (!id) continue;
+      const enabled = rules.some((rule) => rule.enabled && (!(rule.providerIds?.length) || rule.providerIds.includes(provider.provider)));
+      const hits = activeRequests
+        .filter((request) => request.provider?.toLowerCase() === id && request.convoy?.applied)
+        .reduce((sum, request) => sum + (request.convoy?.hits?.length || 0), 0);
+      map[id] = { enabled, hits };
+    }
+    return map;
+  }, [providers, rules, activeRequests]);
 
   // Track firstSeen per active provider; drop provider if running too long (BE stuck)
   const firstSeenRef = useRef({});
@@ -399,8 +423,8 @@ export default function ProviderTopology({ providers = [], activeRequests = [], 
   }, [rawActiveSet, tick]);
 
   const { nodes, edges } = useMemo(
-    () => buildLayout(providers, activeSet, lastSet, errorSet),
-    [providers, activeSet, lastSet, errorSet]
+    () => buildLayout(providers, activeSet, lastSet, errorSet, guardMap),
+    [providers, activeSet, lastSet, errorSet, guardMap]
   );
 
   // Stable key — only remount when provider list changes
@@ -484,4 +508,5 @@ ProviderTopology.propTypes = {
   })),
   lastProvider: PropTypes.string,
   errorProvider: PropTypes.string,
+  rules: PropTypes.array,
 };

--- a/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
+++ b/src/app/(dashboard)/dashboard/usage/components/RequestDetailsTab.js
@@ -255,6 +255,7 @@ export default function RequestDetailsTab() {
                 <th className="text-left p-4 text-sm font-semibold text-text-main">Timestamp</th>
                 <th className="text-left p-4 text-sm font-semibold text-text-main">Model</th>
                 <th className="text-left p-4 text-sm font-semibold text-text-main">Provider</th>
+                <th className="text-center p-4 text-sm font-semibold text-text-main">Input Guard</th>
                 <th className="text-right p-4 text-sm font-semibold text-text-main">Input Tokens</th>
                 <th className="text-right p-4 text-sm font-semibold text-text-main">Cached</th>
                 <th className="text-right p-4 text-sm font-semibold text-text-main">Cache Creation</th>
@@ -266,7 +267,7 @@ export default function RequestDetailsTab() {
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan="7" className="p-8 text-center text-text-muted">
+                  <td colSpan="10" className="p-8 text-center text-text-muted">
                     <div className="flex items-center justify-center gap-2">
                       <span className="material-symbols-outlined animate-spin text-[20px]">progress_activity</span>
                       Loading...
@@ -275,7 +276,7 @@ export default function RequestDetailsTab() {
                 </tr>
               ) : details.length === 0 ? (
                 <tr>
-                  <td colSpan="7" className="p-8 text-center text-text-muted">
+                  <td colSpan="10" className="p-8 text-center text-text-muted">
                     No request details found
                   </td>
                 </tr>
@@ -296,6 +297,14 @@ export default function RequestDetailsTab() {
                          {getProviderName(detail.provider, providerNameCache)}
                        </span>
                      </td>
+                    <td className="p-4 text-center">
+                      {detail.convoy?.applied ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-green-500/15 px-2 py-1 text-xs text-green-600">
+                          <span className="material-symbols-outlined text-[14px]">filter_alt</span>
+                          {detail.convoy.hits?.length || 0} applied
+                        </span>
+                      ) : <span className="text-sm text-text-muted">Not applied</span>}
+                    </td>
                     <td className="p-4 text-sm text-text-main text-right font-mono">
                       {getInputTokens(detail.tokens).toLocaleString()}
                     </td>
@@ -451,6 +460,28 @@ export default function RequestDetailsTab() {
                     Reason: <span className="font-mono">{selectedDetail.pxpipe.reason}</span>
                     {selectedDetail.pxpipe.detail ? ` — ${selectedDetail.pxpipe.detail}` : ""}
                   </p>
+                )}
+              </div>
+            )}
+
+            {selectedDetail.convoy && (
+              <div className="rounded-lg border border-black/5 p-4 dark:border-white/5">
+                <div className="mb-2 flex items-center gap-2">
+                  <span className="material-symbols-outlined text-[18px] text-text-muted">filter_alt</span>
+                  <span className="text-sm font-semibold text-text-main">Input Guard</span>
+                  <span className={`rounded px-2 py-0.5 text-xs ${selectedDetail.convoy.applied ? "bg-green-500/15 text-green-600" : "bg-black/5 text-text-muted dark:bg-white/5"}`}>
+                    {selectedDetail.convoy.applied ? "Applied" : "No match"}
+                  </span>
+                </div>
+                {selectedDetail.convoy.applied && (
+                  <div className="space-y-1 text-sm">
+                    {(selectedDetail.convoy.hits || []).map((hit) => (
+                      <div key={hit.ruleId} className="flex items-center justify-between gap-3 rounded bg-black/[0.02] px-3 py-2 dark:bg-white/[0.02]">
+                        <span className="text-text-main">{hit.ruleName}</span>
+                        <span className="font-mono text-xs text-text-muted">{hit.count} match(es)</span>
+                      </div>
+                    ))}
+                  </div>
                 )}
               </div>
             )}

--- a/src/app/api/convoy/rules/route.js
+++ b/src/app/api/convoy/rules/route.js
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { getRules, saveRule, deleteRule } from "@/lib/db/repos/rulesRepo.js";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/convoy/rules - List all rules
+ */
+export async function GET() {
+  try {
+    const rules = await getRules();
+    return NextResponse.json({ items: rules });
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/convoy/rules - Create or update a rule
+ * Body: { id?, name, enabled, priority, matchType, action, pattern, replacement, caseSensitive }
+ * If id is provided and exists, it updates; otherwise creates.
+ */
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    if (!body.name && !body.id) {
+      return NextResponse.json({ error: "name is required" }, { status: 400 });
+    }
+    if (!body.pattern) {
+      return NextResponse.json({ error: "pattern is required" }, { status: 400 });
+    }
+    if (!['literal', 'regex'].includes(body.matchType || 'literal')) {
+      return NextResponse.json({ error: "invalid matchType" }, { status: 400 });
+    }
+    if (!['replace', 'delete'].includes(body.action || 'replace')) {
+      return NextResponse.json({ error: "invalid action" }, { status: 400 });
+    }
+    if (body.matchType === 'regex') {
+      try { new RegExp(body.pattern); } catch (error) {
+        return NextResponse.json({ error: `invalid regex: ${error.message}` }, { status: 400 });
+      }
+    }
+    body.providerIds = Array.isArray(body.providerIds)
+      ? [...new Set(body.providerIds.filter((id) => typeof id === 'string' && id.trim()).map((id) => id.trim()))]
+      : [];
+    const saved = await saveRule(body);
+    return NextResponse.json(saved);
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+}
+
+/**
+ * DELETE /api/convoy/rules - Delete a rule
+ * Query: ?id=xxx
+ */
+export async function DELETE(request) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get("id");
+  if (!id) {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  try {
+    await deleteRule(id);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return NextResponse.json({ error: e.message }, { status: 500 });
+  }
+}

--- a/src/lib/convoy/rulesEngine.js
+++ b/src/lib/convoy/rulesEngine.js
@@ -1,0 +1,81 @@
+/**
+ * Input guard rule engine.
+ * Applies text replacement rules to a JSON request body before it reaches upstream.
+ *
+ * Rules are applied in priority order (lower number = first).
+ * Each rule walks the entire JSON tree and replaces/deletes matching text in all string values.
+ */
+
+/**
+ * Escape regex special characters for literal matching.
+ */
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Apply rules to a request body. Returns { body, hits }.
+ *
+ * @param {object}  body  - Parsed JSON request body
+ * @param {Array}   rules - Array of rule objects: { id, name, enabled, priority, matchType, action, pattern, replacement, caseSensitive }
+ * @returns {{ body: object, hits: Array<{ruleId: string, ruleName: string, count: number}> }}
+ */
+export function applyConvoyRules(body, rules, providerId = null) {
+  const active = rules
+    .filter((r) => {
+      if (!r.enabled) return false;
+      const providerIds = Array.isArray(r.providerIds) ? r.providerIds : [];
+      return providerIds.length === 0 || (providerId && providerIds.includes(providerId));
+    })
+    .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+
+  if (active.length === 0) return { body, hits: [] };
+
+  const hits = [];
+  const cleaned = walk(body, active, hits, "$");
+  return { body: cleaned, hits };
+}
+
+function walk(value, rules, hits, path) {
+  if (typeof value === "string") {
+    let result = value;
+    for (const rule of rules) {
+      const flags = rule.caseSensitive ? "g" : "gi";
+      let re;
+      try {
+        re = rule.matchType === "regex"
+          ? new RegExp(rule.pattern, flags)
+          : new RegExp(escapeRegex(rule.pattern), flags);
+      } catch {
+        continue;
+      }
+
+      const matches = result.match(re);
+      if (matches?.length) {
+        const replacement = rule.action === "delete" ? "" : (rule.replacement ?? "");
+        result = result.replace(re, () => replacement);
+        const existing = hits.find((h) => h.ruleId === rule.id);
+        if (existing) {
+          existing.count += matches.length;
+        } else {
+          hits.push({ ruleId: rule.id, ruleName: rule.name, count: matches.length });
+        }
+      }
+    }
+    return result;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, i) => walk(item, rules, hits, `${path}[${i}]`));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const result = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = walk(val, rules, hits, `${path}.${key}`);
+    }
+    return result;
+  }
+
+  return value;
+}

--- a/src/lib/db/migrations/002-convoy-provider-scope.js
+++ b/src/lib/db/migrations/002-convoy-provider-scope.js
@@ -1,0 +1,12 @@
+const migration = {
+  version: 2,
+  name: "convoy-provider-scope",
+  up(db) {
+    const columns = db.all("PRAGMA table_info(convoyRules)");
+    if (!columns.some((column) => column.name === "providerIds")) {
+      db.exec("ALTER TABLE convoyRules ADD COLUMN providerIds TEXT DEFAULT '[]'");
+    }
+  },
+};
+
+export default migration;

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-convoy-provider-scope.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/requestDetailsRepo.js
+++ b/src/lib/db/repos/requestDetailsRepo.js
@@ -99,6 +99,7 @@ async function flushToDatabase() {
             providerResponse: truncateField(item.providerResponse, config.maxJsonSize),
             response: truncateField(item.response, config.maxJsonSize),
             pxpipe: item.pxpipe || undefined,
+            convoy: item.convoy || undefined,
           };
 
           db.run(

--- a/src/lib/db/repos/rulesRepo.js
+++ b/src/lib/db/repos/rulesRepo.js
@@ -1,0 +1,78 @@
+import { v4 as uuidv4 } from "uuid";
+import { getAdapter } from "../driver.js";
+import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+
+function rowToRule(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    enabled: row.enabled === 1 || row.enabled === true,
+    priority: row.priority ?? 0,
+    matchType: row.matchType || "literal",
+    action: row.action || "replace",
+    pattern: row.pattern,
+    replacement: row.replacement || "",
+    caseSensitive: row.caseSensitive === 1 || row.caseSensitive === true,
+    providerIds: parseJson(row.providerIds, []),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export async function getRules() {
+  const db = await getAdapter();
+  const rows = db.all(`SELECT * FROM convoyRules ORDER BY priority ASC, createdAt ASC`);
+  return rows.map(rowToRule);
+}
+
+export async function getRuleById(id) {
+  const db = await getAdapter();
+  const row = db.get(`SELECT * FROM convoyRules WHERE id = ?`, [id]);
+  return rowToRule(row);
+}
+
+export async function saveRule(rule) {
+  const db = await getAdapter();
+  const now = new Date().toISOString();
+  const id = rule.id || uuidv4();
+
+  const existing = db.get(`SELECT id FROM convoyRules WHERE id = ?`, [id]);
+  if (existing) {
+    db.run(
+      `UPDATE convoyRules SET name=?, enabled=?, priority=?, matchType=?, action=?, pattern=?, replacement=?, caseSensitive=?, providerIds=?, updatedAt=? WHERE id=?`,
+      [
+        rule.name, rule.enabled ? 1 : 0, rule.priority ?? 0,
+        rule.matchType || "literal", rule.action || "replace",
+        rule.pattern, rule.replacement || "",
+        rule.caseSensitive ? 1 : 0, stringifyJson(rule.providerIds || []), now, id,
+      ]
+    );
+  } else {
+    db.run(
+      `INSERT INTO convoyRules(id, name, enabled, priority, matchType, action, pattern, replacement, caseSensitive, providerIds, createdAt, updatedAt) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)`,
+      [
+        id, rule.name, rule.enabled ? 1 : 0, rule.priority ?? 0,
+        rule.matchType || "literal", rule.action || "replace",
+        rule.pattern, rule.replacement || "",
+        rule.caseSensitive ? 1 : 0, stringifyJson(rule.providerIds || []), now, now,
+      ]
+    );
+  }
+  return getRuleById(id);
+}
+
+export async function deleteRule(id) {
+  const db = await getAdapter();
+  const res = db.run(`DELETE FROM convoyRules WHERE id = ?`, [id]);
+  return (res?.changes ?? 0) > 0;
+}
+
+export async function reorderRules(ids) {
+  const db = await getAdapter();
+  db.transaction(() => {
+    for (let i = 0; i < ids.length; i++) {
+      db.run(`UPDATE convoyRules SET priority = ? WHERE id = ?`, [i + 1, ids[i]]);
+    }
+  });
+}

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -15,7 +15,8 @@ const CONN_CACHE_TTL_MS = 30 * 1000;
 const PERIOD_MS = { "24h": 86400000, "7d": 604800000, "30d": 2592000000, "60d": 5184000000 };
 
 // In-memory state shared across Next.js modules
-if (!global._pendingRequests) global._pendingRequests = { byModel: {}, byAccount: {} };
+if (!global._pendingRequests) global._pendingRequests = { byModel: {}, byAccount: {}, meta: {} };
+if (!global._pendingRequests.meta) global._pendingRequests.meta = {};
 if (!global._lastErrorProvider) global._lastErrorProvider = { provider: "", ts: 0 };
 if (!global._statsEmitter) {
   global._statsEmitter = new EventEmitter();
@@ -122,11 +123,11 @@ async function ensureRingInitialized() {
   recentRing.initialized = true;
   try {
     const db = await getAdapter();
-    const rows = db.all(`SELECT timestamp, provider, model, connectionId, apiKey, endpoint, cost, status, tokens FROM usageHistory ORDER BY id DESC LIMIT ?`, [RING_CAP]);
+    const rows = db.all(`SELECT timestamp, provider, model, connectionId, apiKey, endpoint, cost, status, tokens, meta FROM usageHistory ORDER BY id DESC LIMIT ?`, [RING_CAP]);
     recentRing.items = rows.reverse().map((r) => ({
       timestamp: r.timestamp, provider: r.provider, model: r.model, connectionId: r.connectionId,
       apiKey: r.apiKey, endpoint: r.endpoint, cost: r.cost, status: r.status,
-      tokens: parseJson(r.tokens, {}),
+      tokens: parseJson(r.tokens, {}), meta: parseJson(r.meta, {}),
     }));
   } catch {}
 }
@@ -149,7 +150,7 @@ async function calculateCost(provider, model, tokens) {
   }
 }
 
-export function trackPendingRequest(model, provider, connectionId, started, error = false) {
+export function trackPendingRequest(model, provider, connectionId, started, error = false, meta = null) {
   const modelKey = provider ? `${model} (${provider})` : model;
   const timerKey = `${connectionId}|${modelKey}`;
 
@@ -170,6 +171,7 @@ export function trackPendingRequest(model, provider, connectionId, started, erro
   }
 
   if (started) {
+    if (meta) pendingRequests.meta[timerKey] = meta;
     clearTimeout(pendingTimers[timerKey]);
     pendingTimers[timerKey] = setTimeout(() => {
       delete pendingTimers[timerKey];
@@ -177,11 +179,13 @@ export function trackPendingRequest(model, provider, connectionId, started, erro
       if (connectionId && pendingRequests.byAccount[connectionId]?.[modelKey] > 0) {
         pendingRequests.byAccount[connectionId][modelKey] = 0;
       }
+      delete pendingRequests.meta[timerKey];
       scheduleStatsEvent("pending");
     }, PENDING_TIMEOUT_MS);
   } else {
     clearTimeout(pendingTimers[timerKey]);
     delete pendingTimers[timerKey];
+    if (!pendingRequests.byAccount[connectionId]?.[modelKey]) delete pendingRequests.meta[timerKey];
   }
 
   if (!started && error && provider) {
@@ -206,6 +210,7 @@ export async function getActiveRequests() {
           model: match ? match[1] : modelKey,
           provider: match ? match[2] : "unknown",
           account: accountName, count,
+          convoy: pendingRequests.meta[`${connectionId}|${modelKey}`] || null,
         });
       }
     }
@@ -222,6 +227,7 @@ export async function getActiveRequests() {
         promptTokens: t.prompt_tokens || t.input_tokens || 0,
         completionTokens: t.completion_tokens || t.output_tokens || 0,
         status: e.status || "ok",
+        convoy: e.meta?.convoy || null,
       };
     })
     .filter((e) => {
@@ -284,7 +290,7 @@ export async function saveRequestUsage(entry) {
           entry.timestamp, entry.provider || null, entry.model || null,
           entry.connectionId || null, entry.apiKey || null, entry.endpoint || null,
           promptTokens, completionTokens, entry.cost || 0, entry.status || "ok",
-          stringifyJson(tokens), stringifyJson({}),
+          stringifyJson(tokens), stringifyJson(entry.meta || {}),
         ]
       );
 
@@ -369,7 +375,7 @@ export async function getUsageStats(period = "all") {
   for (const k of allApiKeys) apiKeyMap[k.key] = { name: k.name, id: k.id, createdAt: k.createdAt };
 
   // recentRequests from live history (last 100 entries enough for 20 deduped)
-  const recentRows = db.all(`SELECT timestamp, provider, model, tokens, status FROM usageHistory ORDER BY id DESC LIMIT 100`);
+  const recentRows = db.all(`SELECT timestamp, provider, model, tokens, status, meta FROM usageHistory ORDER BY id DESC LIMIT 100`);
   const seen = new Set();
   const recentRequests = recentRows
     .map((r) => {
@@ -380,6 +386,7 @@ export async function getUsageStats(period = "all") {
         completionTokens: t.completion_tokens || t.output_tokens || 0,
         cachedTokens: t.cached_tokens || t.cache_read_input_tokens || 0,
         status: r.status || "ok",
+        convoy: parseJson(r.meta, {})?.convoy || null,
       };
     })
     .filter((e) => {

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 3;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -152,6 +152,26 @@ export const TABLES = {
       "CREATE INDEX IF NOT EXISTS idx_rd_conn ON requestDetails(connectionId)",
     ],
   },
+  convoyRules: {
+    columns: {
+      id: "TEXT PRIMARY KEY",
+      name: "TEXT NOT NULL",
+      enabled: "INTEGER DEFAULT 1",
+      priority: "INTEGER DEFAULT 0",
+      matchType: "TEXT NOT NULL DEFAULT 'literal'",
+      action: "TEXT NOT NULL DEFAULT 'replace'",
+      pattern: "TEXT NOT NULL",
+      replacement: "TEXT DEFAULT ''",
+      caseSensitive: "INTEGER DEFAULT 1",
+      providerIds: "TEXT DEFAULT '[]'",
+      createdAt: "TEXT NOT NULL",
+      updatedAt: "TEXT NOT NULL",
+    },
+    indexes: [
+      "CREATE INDEX IF NOT EXISTS idx_cr_enabled ON convoyRules(enabled)",
+      "CREATE INDEX IF NOT EXISTS idx_cr_priority ON convoyRules(enabled, priority)",
+    ],
+  }
 };
 
 export function buildCreateTableSql(name, def) {

--- a/src/shared/components/Sidebar.js
+++ b/src/shared/components/Sidebar.js
@@ -25,6 +25,7 @@ const navItems = [
   { href: "/dashboard/usage", label: "Usage", icon: "bar_chart" },
   { href: "/dashboard/quota", label: "Quota Tracker", icon: "data_usage" },
   { href: "/dashboard/token-saver", label: "Token Saver", icon: "savings" },
+  { href: "/dashboard/convoy", label: "Input Guard", icon: "filter_alt" },
   // { href: "/dashboard/pxpipe", label: "PXPIPE", icon: "image" },
   { href: "/dashboard/cli-tools", label: "CLI Tools", icon: "terminal" },
 ];

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -56,6 +56,7 @@ function RecentRequests({ requests = [] }) {
               <tr className="border-b border-border">
                 <th className="py-1.5 text-left font-semibold text-text-muted w-2"></th>
                 <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
+                <th className="py-1.5 text-center font-semibold text-text-muted">Guard</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
                 <th className="py-1.5 text-right font-semibold text-text-muted">When</th>
               </tr>
@@ -69,6 +70,14 @@ function RecentRequests({ requests = [] }) {
                       <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} />
                     </td>
                     <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
+                    <td className="py-1.5 text-center">
+                      {r.convoy?.applied ? (
+                        <span className="inline-flex items-center gap-1 rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] text-emerald-500" title={r.convoy.hits?.map((hit) => hit.ruleName).join(", ")}>
+                          <span className="material-symbols-outlined text-[12px]">filter_alt</span>
+                          {r.convoy.hits?.length || 0}
+                        </span>
+                      ) : <span className="text-text-muted">-</span>}
+                    </td>
                     <td className="py-1.5 text-right whitespace-nowrap">
                       <span className="text-primary">{fmt(r.promptTokens)}↑</span>
                       {" "}
@@ -213,6 +222,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
   const [tableView, setTableView] = useState("model");
   const [viewMode, setViewMode] = useState("costs");
   const [providers, setProviders] = useState([]);
+  const [convoyRules, setConvoyRules] = useState([]);
   const [periodLocal, setPeriodLocal] = useState("today");
   const isInitialLoad = useRef(true);
   const hasLoadedStats = useRef(false);
@@ -249,6 +259,13 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
         setProviders([...unique, ...noAuthProviders]);
       })
       .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/convoy/rules")
+      .then((response) => response.ok ? response.json() : null)
+      .then((data) => setConvoyRules(data?.items || []))
+      .catch(() => setConvoyRules([]));
   }, []);
 
   // Fetch filtered stats via REST when period changes
@@ -475,6 +492,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
             activeRequests={stats.activeRequests || []}
             lastProvider={stats.recentRequests?.[0]?.provider || ""}
             errorProvider={stats.errorProvider || ""}
+            rules={convoyRules}
           />
           <RecentRequests requests={stats.recentRequests || []} />
         </div>

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -13,6 +13,9 @@ import { getModelInfo, getComboModels } from "../services/model.js";
 import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
 import { getTransform as getPxpipeTransform } from "@/lib/pxpipe/loader.js";
+import { applyConvoyRules } from "@/lib/convoy/rulesEngine.js";
+import { getRules } from "@/lib/db/repos/rulesRepo.js";
+
 import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
 import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat } from "open-sse/services/combo.js";
@@ -185,6 +188,27 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
 
   const { provider, model } = modelInfo;
 
+  let routedBody = body;
+  let routedRawRequest = clientRawRequest;
+  let convoy = { applied: false, provider, hits: [] };
+  try {
+    const rules = await getRules();
+    const result = applyConvoyRules(body, rules, provider);
+    routedBody = result.body;
+    convoy = {
+      applied: result.hits.length > 0,
+      provider,
+      hits: result.hits,
+    };
+    if (clientRawRequest) routedRawRequest = { ...clientRawRequest, body: routedBody, convoy };
+    if (result.hits.length > 0) {
+      const hitInfo = result.hits.map((hit) => `${hit.ruleName}(${hit.count})`).join(", ");
+      log.info("CONVOY", `[${provider}] Rules applied: ${hitInfo}`);
+    }
+  } catch (error) {
+    log.warn("CONVOY", `[${provider}] Rule engine error: ${error.message}`);
+  }
+
   // Routing shown in the unified "▶" line (client model → provider/model)
 
   // Extract userAgent from request
@@ -231,11 +255,12 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     const chatSettings = await getSettings();
     const providerThinking = (chatSettings.providerThinking || {})[provider] || null;
     const result = await handleChatCore({
-      body: { ...body, model: `${provider}/${model}` },
+      body: { ...routedBody, model: `${provider}/${model}` },
       modelInfo: { provider, model },
       credentials: refreshedCredentials,
       log,
-      clientRawRequest,
+      clientRawRequest: routedRawRequest,
+      convoy,
       connectionId: credentials.connectionId,
       userAgent,
       apiKey,

--- a/tests/unit/convoy-rules.test.js
+++ b/tests/unit/convoy-rules.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { applyConvoyRules } from "@/lib/convoy/rulesEngine.js";
+
+const baseRule = {
+  id: "rule-1",
+  name: "Claude to CodeBuddy",
+  enabled: true,
+  priority: 1,
+  matchType: "literal",
+  action: "replace",
+  pattern: "Claude Code",
+  replacement: "CodeBuddy",
+  caseSensitive: true,
+  providerIds: [],
+};
+
+describe("Input Guard rules", () => {
+  it("applies a global rule to every provider", () => {
+    const result = applyConvoyRules({ messages: [{ content: "Claude Code" }] }, [baseRule], "codex");
+    expect(result.body.messages[0].content).toBe("CodeBuddy");
+    expect(result.hits).toHaveLength(1);
+  });
+
+  it("only applies scoped rules to selected providers", () => {
+    const rule = { ...baseRule, providerIds: ["codebuddy-cn"] };
+    expect(applyConvoyRules({ text: "Claude Code" }, [rule], "codebuddy-cn").body.text).toBe("CodeBuddy");
+    expect(applyConvoyRules({ text: "Claude Code" }, [rule], "codex").body.text).toBe("Claude Code");
+  });
+
+  it("supports case-insensitive regex replacement and counts every match", () => {
+    const rule = {
+      ...baseRule,
+      matchType: "regex",
+      pattern: "claude\\s+code",
+      replacement: "CodeBuddy",
+      caseSensitive: false,
+    };
+    const result = applyConvoyRules({ text: "Claude Code and CLAUDE CODE" }, [rule], "codex");
+    expect(result.body.text).toBe("CodeBuddy and CodeBuddy");
+    expect(result.hits[0].count).toBe(2);
+  });
+
+  it("deletes matches and leaves the original request unchanged", () => {
+    const request = { messages: [{ content: "remove secret remove" }] };
+    const rule = { ...baseRule, action: "delete", pattern: "remove", replacement: "ignored" };
+    const result = applyConvoyRules(request, [rule], "codex");
+    expect(result.body.messages[0].content).toBe(" secret ");
+    expect(result.hits[0].count).toBe(2);
+    expect(request.messages[0].content).toBe("remove secret remove");
+  });
+
+  it("treats dollar signs in literal replacements as plain text", () => {
+    const rule = { ...baseRule, replacement: "$&-$1-$$" };
+    const result = applyConvoyRules({ text: "Claude Code" }, [rule], "codex");
+    expect(result.body.text).toBe("$&-$1-$$");
+  });
+
+  it("skips an invalid regex without blocking valid rules", () => {
+    const invalid = { ...baseRule, id: "bad", matchType: "regex", pattern: "[" };
+    const valid = { ...baseRule, id: "good", priority: 2 };
+    const result = applyConvoyRules({ text: "Claude Code" }, [invalid, valid], "codex");
+    expect(result.body.text).toBe("CodeBuddy");
+    expect(result.hits.map((hit) => hit.ruleId)).toEqual(["good"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add an Input Guard dashboard and CRUD API for literal or regex request-body replacement rules.
- Allow each rule to apply globally or only to selected providers.
- Apply enabled rules before provider request translation.
- Preserve match metadata through streaming and non-streaming request paths.
- Show rule status and matches in active requests, provider topology, usage history, and request details.

## Details

Rules support:

- Literal or regular-expression matching
- Replace or delete actions
- Case-sensitive or case-insensitive matching
- Explicit priority ordering
- Global or provider-scoped activation

Rule definitions are stored in SQLite. Applied rule metadata is recorded alongside request details and usage entries so operators can see whether Input Guard was active and which rules matched.

## Validation

- `vitest run unit/convoy-rules.test.js`: 6 tests passed
- ESLint passed for all changed Input Guard and request-pipeline files
- Production Docker/Linux build completed successfully (`9router-pr-check:latest`)
