### PR TITLE
feat(fallback): lock accounts for the provider's real rate-limit reset

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -39,7 +39,7 @@ export const BACKOFF_CONFIG = {
 export const TRANSIENT_COOLDOWN_MS = 30 * 1000;
 
 // Hard cap for provider-reported rate limit cooldown (e.g. codex resets_at can be 5-6h)
-export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000;
+export const MAX_RATE_LIMIT_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 
 // Cooldown durations (ms)
 const COOLDOWN = {

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -1,4 +1,4 @@
-import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
+import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS, MAX_RATE_LIMIT_COOLDOWN_MS } from "../config/errorConfig.js";
 
 /**
  * Calculate exponential backoff cooldown for rate limits (429)
@@ -10,6 +10,50 @@ export function getQuotaCooldown(backoffLevel = 0) {
   const level = Math.max(0, backoffLevel - 1);
   const cooldown = BACKOFF_CONFIG.base * Math.pow(2, level);
   return Math.min(cooldown, BACKOFF_CONFIG.max);
+}
+
+/**
+ * Parse the provider's ACTUAL rate-limit reset window from a 429 body/headers,
+ * so an account is locked for the real duration instead of a fixed cooldown.
+ * Supports: Google/Antigravity RetryInfo ("retryDelay": "1976.3s"),
+ * OpenAI/Codex absolute reset ("resets_at"/"reset_at" epoch s|ms),
+ * OpenRouter/RateLimit ("X-RateLimit-Reset" epoch s|ms) and "Retry-After: N".
+ * @param {string|object} errorText - 429 body/headers, string or object.
+ * @param {number} now - reference epoch ms (defaults to Date.now()).
+ * @returns {number|null} ms until reset, or null when none is present.
+ */
+export function parseProviderResetMs(errorText, now = Date.now()) {
+  if (!errorText) return null;
+  const s = typeof errorText === "string" ? errorText : JSON.stringify(errorText);
+  let m;
+  // Relative seconds (Google/Antigravity RetryInfo): "retryDelay": "1976.365s"
+  if ((m = s.match(/"?retry[_-]?delay"?\s*[:=]\s*"?\s*([0-9]+(?:\.[0-9]+)?)\s*s/i))) {
+    return Math.round(parseFloat(m[1]) * 1000);
+  }
+  // Absolute reset epoch (s or ms): resets_at / reset_at / X-RateLimit-Reset
+  if ((m = s.match(/"?(?:resets?_at|x-?ratelimit-?reset|ratelimit-?reset)"?\s*[:=]\s*"?\s*([0-9]{9,})/i))) {
+    let v = parseInt(m[1], 10);
+    if (v < 1e12) v *= 1000; // seconds -> ms
+    const ms = v - now;
+    return ms > 0 ? ms : null;
+  }
+  // Retry-After: N seconds (header echoed into the body)
+  if ((m = s.match(/"?retry[_-]?after"?\s*[:=]\s*"?\s*([0-9]+)\b/i))) {
+    return parseInt(m[1], 10) * 1000;
+  }
+  return null;
+}
+
+/**
+ * Resolve the 429 account cooldown: prefer the provider's own reset window over
+ * the static exponential backoff, floored at the static value and capped at
+ * MAX_RATE_LIMIT_COOLDOWN_MS so a bogus huge value can't lock an account forever.
+ */
+export function resolveCooldownMs(newLevel, errorText) {
+  const staticMs = getQuotaCooldown(newLevel);
+  const providerMs = parseProviderResetMs(errorText);
+  if (providerMs == null || !(providerMs > 0)) return staticMs;
+  return Math.min(Math.max(providerMs, staticMs), MAX_RATE_LIMIT_COOLDOWN_MS);
 }
 
 /**
@@ -30,7 +74,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     if (rule.text && lowerError && lowerError.includes(rule.text)) {
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+        return { shouldFallback: true, cooldownMs: resolveCooldownMs(newLevel, errorText), newBackoffLevel: newLevel };
       }
       return { shouldFallback: true, cooldownMs: rule.cooldownMs };
     }
@@ -39,7 +83,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     if (rule.status && rule.status === status) {
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+        return { shouldFallback: true, cooldownMs: resolveCooldownMs(newLevel, errorText), newBackoffLevel: newLevel };
       }
       return { shouldFallback: true, cooldownMs: rule.cooldownMs };
     }


### PR DESCRIPTION
## Problem

On a 429 the account is excluded for a **fixed** exponential backoff (`getQuotaCooldown`: base 2s … max 5m) that ignores the reset window the provider actually reports. Consequences:

- An account whose quota resets in ~30m (or hours) is retried every 5m → repeated 429s and needless fallback churn.
- The provider's own reset hint (`retryDelay`, `resets_at`, `X-RateLimit-Reset`, `Retry-After`) is thrown away on the account-exclusion path.

This is the behavior reported in #789 (Antigravity returns a quota reset time, but the account isn't excluded until then). #878 added retry-timestamp parsing for the **executor** path; this brings the same idea to the **account fallback** path.

## Change

`checkFallbackError` now derives the cooldown from the provider's real signal instead of a static value:

| Source | Shape |
|---|---|
| Google / Antigravity `RetryInfo` | `"retryDelay": "1976.365s"` (relative seconds) |
| OpenAI / Codex | `"resets_at"` / `"reset_at"` (epoch s or ms) |
| OpenRouter / RateLimit | `"X-RateLimit-Reset"` (epoch s or ms) |
| generic | `Retry-After: N` (seconds) |

- `parseProviderResetMs(errorText)` — tolerant parse of the above from the 429 body/headers; returns `null` when nothing is present.
- `resolveCooldownMs(newLevel, errorText)` — prefer the parsed reset, **floor** it at the existing static backoff (never retry *sooner* than today), **cap** at `MAX_RATE_LIMIT_COOLDOWN_MS` so a bogus/huge value can't wedge an account.
- `MAX_RATE_LIMIT_COOLDOWN_MS` raised `30m → 6h` to fit real multi-hour resets (e.g. Codex). No signal present → unchanged static backoff.

Behavior is strictly additive: existing rules without a parseable reset behave exactly as before.

## Testing

Parser verified against representative 429 bodies for all four shapes plus the no-signal case, and `resolveCooldownMs` verified for the floor (small reset → static wins) and cap (huge reset → 6h) paths. Built the standalone image and confirmed the logic is bundled and active at runtime.

Closes #789.