### PR TITLE
fix(openrouter): opt into provider fallback for `openrouter/fusion` e…

### DIFF
--- a/open-sse/executors/index.js
+++ b/open-sse/executors/index.js
@@ -12,6 +12,7 @@ import { VertexExecutor } from "./vertex.js";
 import { QwenExecutor } from "./qwen.js";
 import { OpenCodeExecutor } from "./opencode.js";
 import { OpenCodeGoExecutor } from "./opencode-go.js";
+import { OpenRouterExecutor } from "./openrouter.js";
 import { GrokWebExecutor } from "./grok-web.js";
 import { GrokCliExecutor } from "./grok-cli.js";
 import { PerplexityWebExecutor } from "./perplexity-web.js";
@@ -39,6 +40,7 @@ const executors = {
   qwen: new QwenExecutor(),
   opencode: new OpenCodeExecutor(),
   "opencode-go": new OpenCodeGoExecutor(),
+  openrouter: new OpenRouterExecutor(),
   "grok-web": new GrokWebExecutor(),
   "grok-cli": new GrokCliExecutor(),
   gcli: new GrokCliExecutor(), // Alias
@@ -80,6 +82,7 @@ export { DefaultExecutor } from "./default.js";
 export { QwenExecutor } from "./qwen.js";
 export { OpenCodeExecutor } from "./opencode.js";
 export { OpenCodeGoExecutor } from "./opencode-go.js";
+export { OpenRouterExecutor } from "./openrouter.js";
 export { GrokWebExecutor } from "./grok-web.js";
 export { GrokCliExecutor } from "./grok-cli.js";
 export { PerplexityWebExecutor } from "./perplexity-web.js";

--- a/open-sse/executors/openrouter.js
+++ b/open-sse/executors/openrouter.js
@@ -1,0 +1,71 @@
+import { DefaultExecutor } from "./default.js";
+import { PROVIDERS } from "../config/providers.js";
+
+/**
+ * OpenRouterExecutor — specialized for the OpenRouter gateway.
+ *
+ * Why this exists (see PR for full root-cause analysis):
+ *
+ * OpenRouter auto-routes every `model` lookup to one of its internal upstream
+ * providers. For some models — e.g. `openrouter/fusion` — its primary upstream is
+ * branded "Stealth", and OpenRouter's Stealth provider is configured (upstream
+ * of 9router) with an empty `url` field. When 9router forwards a request for
+ * such a model OpenRouter responds with HTTP 502:
+ *
+ *   {
+ *     "error": {
+ *       "message": "Invalid URL: ",
+ *       "code": 502,
+ *       "metadata": { "provider_name": "Stealth" }
+ *     },
+ *     "user_id": "user_..."
+ *   }
+ *
+ * Plain retries against the same body never clear this — Stealth stays broken.
+ * The minimal, side-effect-free mitigation 9router can apply is to set
+ * `provider: { allow_fallbacks: true }` on every outbound request, which lets
+ * OpenRouter route to an alternate upstream if the primary's route is broken.
+ *
+ * The executor is registered in `executors/index.js` so `getExecutor("openrouter")`
+ * returns this instance instead of the generic `DefaultExecutor` fallback.
+ */
+export class OpenRouterExecutor extends DefaultExecutor {
+  constructor() {
+    super("openrouter", PROVIDERS.openrouter);
+  }
+
+  /**
+   * Request OpenRouter's provider-fallback routing on chat calls.
+   * `allow_fallbacks: true` is a no-op when the only configured provider is
+   * healthy, but recovers the request whenever the model's primary upstream
+   * (e.g. OpenRouter's "Stealth") is misconfigured upstream of 9router.
+   *
+   * Translation layer already normalises the body shape; we only mutate the
+   * root key `provider`, which is OpenRouter's documented routing object.
+   *
+   * Three input shapes, ordered by how cautiously we mutate:
+   *  - missing   → inject `{ allow_fallbacks: true }` (default opt-in).
+   *  - object    → shallow-merge `allow_fallbacks: true` only when the caller
+   *                hasn't already set it (preserve user intent).
+   *  - non-object (string name `provider: "Azure"`, array) → leave untouched;
+   *                the caller has explicitly pinned a provider / opt-out set.
+   */
+  transformRequest(model, body) {
+    const transformed = super.transformRequest(model, body);
+    if (!transformed || typeof transformed !== "object") return transformed;
+
+    const existing = transformed.provider;
+    if (existing === undefined || existing === null) {
+      transformed.provider = { allow_fallbacks: true };
+    } else if (typeof existing === "object" && !Array.isArray(existing)) {
+      if (existing.allow_fallbacks === undefined) {
+        transformed.provider = { ...existing, allow_fallbacks: true };
+      }
+    }
+    // Non-object provider values (string, array) are intentionally preserved
+    // as-is — the caller has opted into a specific routing identity.
+    return transformed;
+  }
+}
+
+export default OpenRouterExecutor;

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -1,4 +1,5 @@
 import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
+import { HTTP_STATUS } from "../config/runtimeConfig.js";
 
 /**
  * Build OpenAI-compatible error response body
@@ -75,15 +76,39 @@ export async function parseUpstreamError(response, executor = null) {
   }
 
   let message = "";
+  let providerName = null;
+  let invalidUrlEmpty = false;
   try {
     const json = JSON.parse(bodyText);
     message = json.error?.message || json.message || json.error || bodyText;
+    providerName = json.error?.metadata?.provider_name || null;
+    // OpenRouter's internal "Stealth" upstream returns a malformed message
+    // like "Invalid URL: " with the URL value left empty (the upstream's
+    // url field in OpenRouter's routing table is unset). Detect the
+    // signature so we can surface a friendlier hint to the user instead of
+    // the opaque 502 + empty message they would otherwise see.
+    if (typeof message === "string") {
+      const m = /^Invalid URL:\s*(.*)$/.exec(message);
+      if (m) invalidUrlEmpty = m[1].trim() === "";
+    }
   } catch {
     message = bodyText;
   }
 
   const messageStr = typeof message === "string" ? message : JSON.stringify(message);
-  const finalMessage = messageStr || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
+  let finalMessage = messageStr || DEFAULT_ERROR_MESSAGES[response.status] || `Upstream error: ${response.status}`;
+
+  // Annotate OpenRouter "Stealth" (or any upstream whose routing table has an
+  // empty url field) with a hint explaining the failure mode. The 9router
+  // OpenRouterExecutor now sets `provider.allow_fallbacks = true` on retries;
+  // this annotation gives the user a legible reason when no alternate upstream
+  // is configured upstream of 9router.
+  if ((providerName || invalidUrlEmpty) && (response.status === HTTP_STATUS.BAD_GATEWAY || response.status === HTTP_STATUS.SERVER_ERROR)) {
+    const hint = providerName
+      ? `OpenRouter upstream "${providerName}" returned an invalid routing URL — its endpoint is misconfigured on OpenRouter's side`
+      : "Upstream returned an invalid (empty) routing URL";
+    finalMessage = `${finalMessage} — ${hint}. Try a different model, or set \`provider: { allow_fallbacks: true }\` to opt into OpenRouter's automatic upstream fallback.`;
+  }
 
   return { statusCode: response.status, message: finalMessage };
 }

--- a/tests/unit/openrouter-stealth-fallback.test.js
+++ b/tests/unit/openrouter-stealth-fallback.test.js
@@ -1,0 +1,149 @@
+// Locks two narrow behaviors added to mitigate OpenRouter's internal "Stealth"
+// upstream returning an opaque 502 with message "Invalid URL: " for models
+// like `openrouter/fusion` whose primary route is misconfigured upstream of
+// 9router.
+//
+// 1. OpenRouterExecutor.transformRequest injects `provider.allow_fallbacks =
+//    true` so OpenRouter can route to an alternate upstream when the primary
+//    (e.g. "Stealth") is broken.
+// 2. parseUpstreamError annotates 5xx responses whose body matches the OpenRouter
+//    Stealth signature with a human-readable hint, so users no longer see an
+//    opaque `[502]: Invalid URL:` error.
+import { describe, it, expect } from "vitest";
+
+import { OpenRouterExecutor } from "../../open-sse/executors/openrouter.js";
+import { getExecutor } from "../../open-sse/executors/index.js";
+import { parseUpstreamError } from "../../open-sse/utils/error.js";
+
+describe("OpenRouterExecutor — body transform for provider fallback routing", () => {
+  // Use getExecutor("openrouter") via the public registry so we exercise the
+  // exact wiring that runs at request-time.
+
+  it("registers a specialized executor for the openrouter provider id", () => {
+    const ex = getExecutor("openrouter");
+    expect(ex).toBeInstanceOf(OpenRouterExecutor);
+  });
+
+  it("injectReasoningContent is preserved (parent hook order unchanged)", () => {
+    const ex = getExecutor("openrouter");
+    // OpenRouterExecutor extends DefaultExecutor; reasoning injection must
+    // still run AFTER allow_fallbacks is injected (parent.transformRequest
+    // → injectReasoningContent).
+    const body = { model: "fusion", messages: [{ role: "user", content: "hi" }], reasoning_effort: "low" };
+    const out = ex.transformRequest("fusion", body);
+    // reasoning_effort is a top-level OpenRouter-recognised field — verify it
+    // survived the transform (caught a regression where a naive overwrite of
+    // body.provider would wipe unrelated top-level keys — sanity guard).
+    expect(out.reasoning_effort).toBe("low");
+  });
+
+  it("injects provider.allow_fallbacks = true on a bare body", () => {
+    const ex = new OpenRouterExecutor();
+    const out = ex.transformRequest("fusion", {
+      model: "fusion",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(out.provider).toEqual({ allow_fallbacks: true });
+  });
+
+  it("preserves a caller-supplied provider object and only adds allow_fallbacks when missing", () => {
+    const ex = new OpenRouterExecutor();
+    const out = ex.transformRequest("fusion", {
+      model: "fusion",
+      provider: { sort: "price", quantizations: ["fp16"] },
+    });
+    expect(out.provider).toEqual({
+      sort: "price",
+      quantizations: ["fp16"],
+      allow_fallbacks: true,
+    });
+  });
+
+  it("respects a caller-supplied allow_fallbacks = false (does not overwrite)", () => {
+    const ex = new OpenRouterExecutor();
+    const out = ex.transformRequest("fusion", {
+      model: "fusion",
+      provider: { allow_fallbacks: false },
+    });
+    expect(out.provider).toEqual({ allow_fallbacks: false });
+  });
+
+  it("does not coerce a non-object provider value into an object", () => {
+    const ex = new OpenRouterExecutor();
+    // Some OpenRouter SDKs accept provider as a string id — guard against
+    // accidental mutation that would break those SDKs.
+    const out = ex.transformRequest("fusion", {
+      model: "fusion",
+      provider: "Azure",
+    });
+    expect(out.provider).toBe("Azure");
+  });
+});
+
+describe("parseUpstreamError — annotate OpenRouter Stealth signature", () => {
+  // Minimal Response stub exposing the surface parseUpstreamError uses:
+  // .status + .text().
+  function makeResponse(status, body) {
+    return {
+      status,
+      text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+    };
+  }
+
+  it("annotates 502 with provider_name=Stealth and Invalid URL: empty value", async () => {
+    const payload = {
+      error: {
+        message: "Invalid URL: ",
+        code: 502,
+        metadata: { provider_name: "Stealth" },
+      },
+      user_id: "user_test",
+    };
+    const { message } = await parseUpstreamError(
+      makeResponse(502, payload),
+    );
+    // Original message preserved.
+    expect(message).toContain("Invalid URL: ");
+    // Hint explains the failure mode.
+    expect(message).toContain("Stealth");
+    expect(message).toContain("misconfigured on OpenRouter's side");
+    // Suggests the new opt-in fallback flag.
+    expect(message).toContain("allow_fallbacks");
+  });
+
+  it("annotates when only message matches Invalid URL: <empty> (no provider_name)", async () => {
+    const payload = { error: { message: "Invalid URL:   " } };
+    const { message } = await parseUpstreamError(
+      makeResponse(500, payload),
+    );
+    expect(message).toContain("invalid (empty) routing URL");
+    expect(message).toContain("allow_fallbacks");
+  });
+
+  it("does not annotate unrelated 502 errors", async () => {
+    const payload = { error: { message: "Upstream unavailable" } };
+    const { message } = await parseUpstreamError(
+      makeResponse(502, payload),
+    );
+    expect(message).toBe("Upstream unavailable");
+    expect(message).not.toContain("allow_fallbacks");
+  });
+
+  it("does not annotate a 4xx (e.g. 401) even if message starts with Invalid URL", async () => {
+    const payload = {
+      error: { message: "Invalid URL: ", metadata: { provider_name: "Stealth" } },
+    };
+    const { message } = await parseUpstreamError(
+      makeResponse(401, payload),
+    );
+    expect(message).toBe("Invalid URL: ");
+  });
+
+  it("falls back to raw body when JSON parsing fails", async () => {
+    const { message } = await parseUpstreamError(
+      makeResponse(502, "not-json"),
+    );
+    expect(message).toBe("not-json");
+    expect(message).not.toContain("allow_fallbacks");
+  });
+});


### PR DESCRIPTION
…t al.

User-side repro: configuring `openrouter/fusion` returns `[502]: Invalid URL: ` with metadata `provider_name: "Stealth"`. 9router forwards the chat to OpenRouter (`https://openrouter.ai/api/v1/chat/completions`) and OpenRouter's internal auto-routing picks the "Stealth" upstream provider, whose URL field in OpenRouter's routing table is unset — OpenRouter then returns 502 because nothing matches the empty URL.

Two non-overlapping mitigations:

1. Specialized OpenRouterExecutor that injects `provider: { allow_fallbacks: true }` on every chat request, ordered strict-to-lax for typing safety:
   - missing/null → inject `{ allow_fallbacks: true }`
   - object      → shallow-merge only when `allow_fallbacks` is undefined
   - non-object (string `"Azure"` etc.) → leave untouched — caller has
     explicitly pinned a provider, so we never coerce it into an object
   This is a no-op on healthy upstreams and lets OpenRouter swap in a sane
   alternate whenever a model's primary upstream (e.g. "Stealth") is broken.

2. `parseUpstreamError` annotates 5xx responses whose body matches the OpenRouter Stealth signature (metadata.provider_name, or message matches `^Invalid URL:\s*$`) with a human-readable hint + an opt-in `allow_fallbacks` pointer, so users no longer see an opaque 502 + empty message.

Tests: 11/11 in `tests/unit/openrouter-stealth-fallback.test.js`, covering getExecutor wiring, transformRequest for all four input shapes, reasoning preservation, message annotation, non-5xx skip, and JSON-parse fallback.

Files:
- open-sse/executors/openrouter.js  (new)
- open-sse/executors/index.js       (register OpenRouterExecutor)
- open-sse/utils/error.js           (parseUpstreamError Stealth signature)
- tests/unit/openrouter-stealth-fallback.test.js (new)