### PR TITLE
fix(kiro): restore v0.5.20 payload and enable all effort levels

### DIFF
--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -140,8 +140,7 @@ export function extractKiroEffortLevel(body) {
   if (typeof effort !== "string") return null;
   const normalized = effort.toLowerCase();
   if (normalized === "none" || normalized === "off" || normalized === "disabled") return null;
-  if (normalized === "xhigh" || normalized === "max") return "high";
-  if (["low", "medium", "high"].includes(normalized)) return normalized;
+  if (["low", "medium", "high", "xhigh", "max"].includes(normalized)) return normalized;
   return null;
 }
 

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -96,6 +96,24 @@ export function extractThinking(body) {
     return { mode: "auto" };
   }
 
+  // Kiro shape (post-translation). The kiro translators map thinking intent onto
+  // additionalModelRequestFields rather than a top-level field, so a translated
+  // kiro payload carries no shape any branch above recognizes:
+  //   output_config.effort → modern Claude models
+  //   reasoning.effort     → GPT-5.6
+  // Checked last so a client body that also sets a canonical field keeps its
+  // existing precedence (resolveKiroThinkingBudget reads source bodies too).
+  const amrf = body.additionalModelRequestFields;
+  if (amrf && typeof amrf === "object") {
+    const amrfEffort = amrf.output_config?.effort ?? (typeof amrf.reasoning === "object" ? amrf.reasoning?.effort : null);
+    if (typeof amrfEffort === "string" && amrfEffort) {
+      const e = amrfEffort.toLowerCase();
+      if (e === "none" || e === "off") return { mode: "none" };
+      if (e === "auto") return { mode: "auto" };
+      return { mode: "level", level: e };
+    }
+  }
+
   return null;
 }
 

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -24,8 +24,7 @@
  */
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { applyKiroSessionReplay } from "../../utils/kiroSessionReplay.js";
-import { resolveContinuationId, resolveSessionIdentity } from "../../utils/sessionManager.js";
+import { v4 as uuidv4 } from "uuid";
 import {
   resolveKiroModel,
   resolveKiroThinkingBudget,
@@ -419,73 +418,60 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     ? (credentials?.providerSpecificData?.profileArn || "")
     : (credentials?.providerSpecificData?.profileArn || resolveDefaultProfileArn(authMethod));
 
-  // Kiro CLI/KAS sends system prompt as top-level `systemPrompt`. Keep a
-  // content fallback too because the CodeWhisperer surface does not always
-  // enforce top-level systemPrompt for direct calls.
-  const timestamp = new Date().toISOString();
-  const systemPromptParts = [];
-  if (thinkingBudget !== null && !usesNativeGptEffort) {
-    systemPromptParts.push(buildThinkingSystemPrefix(thinkingBudget));
-  }
-  if (agentic) systemPromptParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
-  const systemInstruction = extractClaudeSystemText(body.system);
-  if (systemInstruction) systemPromptParts.push(systemInstruction);
-  const systemPrompt = systemPromptParts.filter(Boolean).join("\n\n");
-  const currentTimeContext = `[Context: Current time is ${timestamp}]`;
-  const contentPrefix = [systemPrompt, currentTimeContext].filter(Boolean).join("\n\n");
+  let finalContent = currentMessage?.userInputMessage?.content || "";
 
-  const sessionIdentity = resolveSessionIdentity({
-    headers: credentials?.rawHeaders,
-    body,
-    connectionId: credentials?.connectionId,
-    scope: "kiro",
-  });
-  const conversationId = sessionIdentity.sessionId;
-  const continuationId = resolveContinuationId({
-    sessionId: conversationId,
-    connectionId: credentials?.connectionId,
-    scope: "kiro",
-    ephemeral: sessionIdentity.ephemeral,
-  });
-  const replay = applyKiroSessionReplay({
-    conversationId,
-    connectionId: credentials?.connectionId,
-    modelId: upstreamModel,
-    systemPrompt,
-    contentPrefix,
-    currentContentPrefix: currentTimeContext,
-    history,
-    currentMessage,
-  });
-  const replayCurrent = replay.currentMessage?.userInputMessage || {};
+  // System prompt: pass via native systemInstruction field (Kiro/Q API supports it)
+  // and also prepend as <instructions> in user content as fallback for upstreams
+  // that don't support the native field.
+  // ponytail: embed in content (v0.5.20 pattern) — Kiro rejects top-level
+  // `systemPrompt` field with REQUEST_BODY_INVALID. Revert to top-level when
+  // upstream schema accepts it (monitor decolua/9router#2716).
+  let systemInstruction = undefined;
+  if (body.system) {
+    const systemText = extractClaudeSystemText(body.system);
+    if (systemText) {
+      systemInstruction = systemText;
+      finalContent = `<instructions>\n${systemText}\n</instructions>\n\n${finalContent}`;
+    }
+  }
+
+  // Prefix order: thinking_mode tag, timestamp marker, then agentic prompt.
+  const timestamp = new Date().toISOString();
+  const prefixParts = [];
+  if (thinkingBudget !== null && !usesNativeGptEffort) prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
+  prefixParts.push(`[Context: Current time is ${timestamp}]`);
+  if (agentic) prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
+  finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
+
   const userInputMessage = {
-    content: replayCurrent.content || "",
+    content: finalContent,
     modelId: upstreamModel,
     origin: "AI_EDITOR",
-    ...(replayCurrent.userInputMessageContext && {
-      userInputMessageContext: replayCurrent.userInputMessageContext,
+    ...(currentMessage?.userInputMessage?.userInputMessageContext && {
+      userInputMessageContext:
+        currentMessage.userInputMessage.userInputMessageContext,
     }),
-    ...(replayCurrent.images && {
-      images: replayCurrent.images,
+    ...(currentMessage?.userInputMessage?.images && {
+      images: currentMessage.userInputMessage.images,
     }),
   };
+
+  if (systemInstruction) {
+    userInputMessage.systemInstruction = systemInstruction;
+  }
 
   const payload = {
     conversationState: {
       chatTriggerType: "MANUAL",
-      conversationId,
-      agentContinuationId: continuationId,
-      agentTaskType: "vibe",
+      conversationId: uuidv4(),
       currentMessage: {
         userInputMessage,
       },
-      history: replay.history,
+      history,
     },
-    agentMode: "vibe",
   };
 
   if (profileArn) payload.profileArn = profileArn;
-  if (systemPrompt) payload.systemPrompt = systemPrompt;
   if (additionalModelRequestFields) {
     payload.additionalModelRequestFields = additionalModelRequestFields;
   }

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -5,8 +5,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { v4 as uuidv4 } from "uuid";
-import { applyKiroSessionReplay } from "../../utils/kiroSessionReplay.js";
-import { resolveContinuationId, resolveSessionIdentity } from "../../utils/sessionManager.js";
+import { resolveSessionId } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
   resolveKiroThinkingBudget,
@@ -549,70 +548,50 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
     ? (credentials?.providerSpecificData?.profileArn || "")
     : (credentials?.providerSpecificData?.profileArn || resolveDefaultProfileArn(authMethod));
 
+  let finalContent = currentMessage?.userInputMessage?.content || "";
+
   const timestamp = new Date().toISOString();
 
-  // Kiro CLI/KAS sends these as top-level systemPrompt. Keep a content fallback
-  // too because the CodeWhisperer surface does not always enforce top-level
-  // systemPrompt for direct calls.
-  const systemPromptParts = [];
+  // Build the system-prompt prefix that goes ABOVE the user message body.
+  // Order: thinking_mode tag first (so Kiro sees it before any user text),
+  // then context/timestamp marker, then optional agentic chunked-write prompt.
+  // ponytail: embed in content (v0.5.20 pattern) — Kiro rejects top-level
+  // `systemPrompt` field with REQUEST_BODY_INVALID. Revert to top-level when
+  // upstream schema accepts it (monitor decolua/9router#2716).
+  const prefixParts = [];
   if (thinkingBudget !== null && !usesNativeGptEffort) {
-    systemPromptParts.push(buildThinkingSystemPrefix(thinkingBudget));
+    prefixParts.push(buildThinkingSystemPrefix(thinkingBudget));
   }
+  prefixParts.push(`[Context: Current time is ${timestamp}]`);
   if (agentic) {
-    systemPromptParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
+    prefixParts.push(KIRO_AGENTIC_SYSTEM_PROMPT);
   }
-  const systemPrompt = systemPromptParts.filter(Boolean).join("\n\n");
-  const currentTimeContext = `[Context: Current time is ${timestamp}]`;
-  const contentPrefix = [systemPrompt, currentTimeContext].filter(Boolean).join("\n\n");
-
-  const sessionIdentity = resolveSessionIdentity({ headers: credentials?.rawHeaders, body, connectionId: credentials?.connectionId, scope: "kiro" });
-  const conversationId = sessionIdentity.sessionId;
-  const continuationId = resolveContinuationId({
-    sessionId: conversationId,
-    connectionId: credentials?.connectionId,
-    scope: "kiro",
-    ephemeral: sessionIdentity.ephemeral,
-  });
-  const replay = applyKiroSessionReplay({
-    conversationId,
-    connectionId: credentials?.connectionId,
-    modelId: upstreamModel,
-    systemPrompt,
-    contentPrefix,
-    currentContentPrefix: currentTimeContext,
-    history,
-    currentMessage,
-  });
-  const replayCurrent = replay.currentMessage?.userInputMessage || {};
+  finalContent = `${prefixParts.join("\n\n")}\n\n${finalContent}`;
 
   const payload = {
     conversationState: {
       chatTriggerType: "MANUAL",
-      conversationId,
-      agentContinuationId: continuationId,
-      agentTaskType: "vibe",
+      conversationId: resolveSessionId({ headers: credentials?.rawHeaders, body, connectionId: credentials?.connectionId, scope: "kiro" }),
       currentMessage: {
         userInputMessage: {
-          content: replayCurrent.content || "",
+          content: finalContent,
           modelId: upstreamModel,
           origin: "AI_EDITOR",
-          ...(replayCurrent.images?.length > 0 && {
-            images: replayCurrent.images
+          ...(currentMessage?.userInputMessage?.images?.length > 0 && {
+            images: currentMessage.userInputMessage.images
           }),
-          ...(replayCurrent.userInputMessageContext && {
-            userInputMessageContext: replayCurrent.userInputMessageContext
+          ...(currentMessage?.userInputMessage?.userInputMessageContext && {
+            userInputMessageContext: currentMessage.userInputMessage.userInputMessageContext
           })
         }
       },
-      history: replay.history
-    },
-    agentMode: "vibe",
+      history: history
+    }
   };
 
   if (profileArn) {
     payload.profileArn = profileArn;
   }
-  if (systemPrompt) payload.systemPrompt = systemPrompt;
   if (additionalModelRequestFields) {
     payload.additionalModelRequestFields = additionalModelRequestFields;
   }

--- a/tests/translator/__snapshots__/golden-request.test.js.snap
+++ b/tests/translator/__snapshots__/golden-request.test.js.snap
@@ -281,7 +281,9 @@ continue",
     "history": [
       {
         "userInputMessage": {
-          "content": "You are helpful.
+          "content": "<instructions>
+You are helpful.
+</instructions>
 
 What's in this image?",
           "images": [

--- a/tests/translator/claude-kiro-direct.test.js
+++ b/tests/translator/claude-kiro-direct.test.js
@@ -8,6 +8,8 @@ import { FORMATS } from "../../open-sse/translator/formats.js";
 
 const C2K = (body, credentials = null, model = "claude-sonnet-4.5") =>
   translateRequest(FORMATS.CLAUDE, FORMATS.KIRO, model, body, true, credentials, "kiro");
+const contentOf = (out) =>
+  out.conversationState.currentMessage.userInputMessage.content;
 
 describe("Claude → Kiro (direct route)", () => {
   it("produces a Kiro conversationState payload", () => {
@@ -16,7 +18,7 @@ describe("Claude → Kiro (direct route)", () => {
     expect(out.conversationState.currentMessage.userInputMessage.content).toContain("hello");
   });
 
-  it("keeps conversationId stable from client session headers and replays frozen msg0", () => {
+  it("uses independent conversation ids without session-replay fields", () => {
     const credentials = {
       rawHeaders: { "x-session-id": "hermes-session-123-claude-replay" },
       connectionId: "kiro-account-1",
@@ -24,15 +26,11 @@ describe("Claude → Kiro (direct route)", () => {
     const first = C2K({ messages: [{ role: "user", content: "first" }] }, credentials);
     const second = C2K({ messages: [{ role: "user", content: "second" }] }, credentials);
 
-    expect(first.conversationState.conversationId).toBe("hermes-session-123-claude-replay");
-    expect(second.conversationState.conversationId).toBe("hermes-session-123-claude-replay");
-    expect(first.conversationState.agentContinuationId).toBeTruthy();
-    expect(second.conversationState.agentContinuationId).toBe(first.conversationState.agentContinuationId);
-    expect(first.conversationState.agentTaskType).toBe("vibe");
-    expect(second.conversationState.history[0].userInputMessage.content).toBe(
-      first.conversationState.currentMessage.userInputMessage.content
-    );
-    expect(second.conversationState.history[0].userInputMessage.modelId).toBe("claude-sonnet-4.5");
+    expect(first.conversationState.conversationId).toBeTruthy();
+    expect(second.conversationState.conversationId).not.toBe(first.conversationState.conversationId);
+    expect(first.conversationState.agentContinuationId).toBeUndefined();
+    expect(first.conversationState.agentTaskType).toBeUndefined();
+    expect(first.agentMode).toBeUndefined();
     expect(second.conversationState.currentMessage.userInputMessage.content).toContain("Current time");
     expect(second.conversationState.currentMessage.userInputMessage.content).toContain("second");
   });
@@ -81,10 +79,10 @@ describe("Claude → Kiro (direct route)", () => {
       null,
       "kiro"
     );
-    expect(out.systemPrompt).toContain(
+    expect(contentOf(out)).toContain(
       "<thinking_mode>enabled</thinking_mode>"
     );
-    expect(out.agentMode).toBe("vibe");
+    expect(out.agentMode).toBeUndefined();
   });
 
   it("does not send additionalModelRequestFields for Kiro models without effort support", () => {
@@ -95,7 +93,7 @@ describe("Claude → Kiro (direct route)", () => {
 
     expect(out.additionalModelRequestFields).toBeUndefined();
     expect(out.thinking).toBeUndefined();
-    expect(out.systemPrompt).toContain("<max_thinking_length>24576</max_thinking_length>");
+    expect(contentOf(out)).toContain("<max_thinking_length>24576</max_thinking_length>");
   });
 
   it("maps output_config.effort high to Kiro CLI-style additionalModelRequestFields for effort models", () => {
@@ -109,7 +107,7 @@ describe("Claude → Kiro (direct route)", () => {
       output_config: { effort: "high" },
     });
     expect(out.thinking).toBeUndefined();
-    expect(out.systemPrompt).toContain("<max_thinking_length>24576</max_thinking_length>");
+    expect(contentOf(out)).toContain("<max_thinking_length>24576</max_thinking_length>");
   });
 
   it("maps Claude-format effort to GPT-5.6 reasoning fields without legacy prompt tags", () => {
@@ -121,8 +119,8 @@ describe("Claude → Kiro (direct route)", () => {
     expect(out.additionalModelRequestFields).toEqual({
       reasoning: { effort: "low" },
     });
-    expect(out.systemPrompt || "").not.toContain("<thinking_mode>");
-    expect(out.systemPrompt || "").not.toContain("<max_thinking_length>");
+    expect(contentOf(out)).not.toContain("<thinking_mode>");
+    expect(contentOf(out)).not.toContain("<max_thinking_length>");
   });
 
   it.each(["auto", "minimal", "ultra"])(
@@ -134,8 +132,8 @@ describe("Claude → Kiro (direct route)", () => {
       }, null, "gpt-5.6-sol");
 
       expect(out.additionalModelRequestFields).toBeUndefined();
-      expect(out.systemPrompt).toContain("<thinking_mode>enabled</thinking_mode>");
-      expect(out.systemPrompt).toContain("<max_thinking_length>");
+      expect(contentOf(out)).toContain("<thinking_mode>enabled</thinking_mode>");
+      expect(contentOf(out)).toContain("<max_thinking_length>");
     }
   );
 
@@ -148,8 +146,8 @@ describe("Claude → Kiro (direct route)", () => {
       }, null, "gpt-5.6-sol");
 
       expect(out.additionalModelRequestFields).toBeUndefined();
-      expect(out.systemPrompt || "").not.toContain("<thinking_mode>");
-      expect(out.systemPrompt || "").not.toContain("<max_thinking_length>");
+      expect(contentOf(out)).not.toContain("<thinking_mode>");
+      expect(contentOf(out)).not.toContain("<max_thinking_length>");
     }
   );
 
@@ -165,29 +163,15 @@ describe("Claude → Kiro (direct route)", () => {
     });
   });
 
-  it("sends Claude system as top-level systemPrompt and keeps a user-content fallback", () => {
+  it("embeds Claude system in user content without top-level systemPrompt", () => {
     const out = C2K({
       system: "system-only instruction",
       messages: [{ role: "user", content: "hello" }],
     });
 
-    expect(out.systemPrompt).toContain("system-only instruction");
-    expect(out.conversationState.currentMessage.userInputMessage.content).toContain("system-only instruction");
-  });
-
-  it("keeps top-level systemPrompt stable across turns", () => {
-    const first = C2K({
-      system: "stable instruction",
-      messages: [{ role: "user", content: "first" }],
-    });
-    const second = C2K({
-      system: "stable instruction",
-      messages: [{ role: "user", content: "second" }],
-    });
-
-    expect(first.systemPrompt).toBe(second.systemPrompt);
-    expect(first.systemPrompt).not.toContain("Current time");
-    expect(first.conversationState.currentMessage.userInputMessage.content).toContain("Current time");
+    expect(out.systemPrompt).toBeUndefined();
+    expect(contentOf(out)).toContain("<instructions>\nsystem-only instruction\n</instructions>");
+    expect(contentOf(out)).toContain("hello");
   });
 });
 

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -52,6 +52,21 @@ describe("extractThinking", () => {
   it("no intent → null", () => {
     expect(extractThinking({ messages: [] })).toBeNull();
   });
+  it("kiro additionalModelRequestFields.output_config.effort (modern claude)", () => {
+    expect(extractThinking({ additionalModelRequestFields: { thinking: { type: "adaptive", display: "summarized" }, output_config: { effort: "high" } } }))
+      .toEqual({ mode: "level", level: "high" });
+  });
+  it("kiro additionalModelRequestFields.reasoning.effort (gpt-5.6)", () => {
+    expect(extractThinking({ additionalModelRequestFields: { reasoning: { effort: "xhigh" } } }))
+      .toEqual({ mode: "level", level: "xhigh" });
+  });
+  it("kiro additionalModelRequestFields absent → null", () => {
+    expect(extractThinking({ conversationState: { currentMessage: {} } })).toBeNull();
+  });
+  it("canonical client fields win over additionalModelRequestFields", () => {
+    expect(extractThinking({ reasoning_effort: "low", additionalModelRequestFields: { output_config: { effort: "high" } } }))
+      .toEqual({ mode: "level", level: "low" });
+  });
 });
 
 describe("applyThinking per provider format", () => {

--- a/tests/unit/openai-to-kiro.test.js
+++ b/tests/unit/openai-to-kiro.test.js
@@ -11,7 +11,6 @@ import { openaiToKiroRequest } from "../../open-sse/translator/request/openai-to
 
 const contentOf = (result) =>
   result.conversationState.currentMessage.userInputMessage.content;
-const systemPromptOf = (result) => result.systemPrompt || "";
 
 describe("openaiToKiroRequest", () => {
   describe("basic message conversion", () => {
@@ -294,7 +293,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>1024</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>1024</max_thinking_length>");
       expect(result.additionalModelRequestFields).toEqual({
         thinking: { type: "adaptive", display: "summarized" },
         output_config: { effort: "low" },
@@ -309,7 +308,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
       expect(result.additionalModelRequestFields).toEqual({
         thinking: { type: "adaptive", display: "summarized" },
         output_config: { effort: "high" },
@@ -331,8 +330,6 @@ describe("openaiToKiroRequest", () => {
       expect(result.additionalModelRequestFields).toEqual({
         reasoning: { effort },
       });
-      expect(systemPromptOf(result)).not.toContain("<thinking_mode>");
-      expect(systemPromptOf(result)).not.toContain("<max_thinking_length>");
       expect(contentOf(result)).not.toContain("<thinking_mode>");
       expect(contentOf(result)).not.toContain("<max_thinking_length>");
     });
@@ -351,8 +348,8 @@ describe("openaiToKiroRequest", () => {
       expect(result.additionalModelRequestFields).toEqual({
         reasoning: { effort: wireEffort },
       });
-      expect(systemPromptOf(result)).not.toContain("<thinking_mode>");
-      expect(systemPromptOf(result)).not.toContain("<max_thinking_length>");
+      expect(contentOf(result)).not.toContain("<thinking_mode>");
+      expect(contentOf(result)).not.toContain("<max_thinking_length>");
     });
 
     it("omits GPT-5.6 effort fields and legacy prompt tags when effort is absent", () => {
@@ -363,8 +360,8 @@ describe("openaiToKiroRequest", () => {
       const result = openaiToKiroRequest("gpt-5.6-sol", body, true, {});
 
       expect(result.additionalModelRequestFields).toBeUndefined();
-      expect(systemPromptOf(result)).not.toContain("<thinking_mode>");
-      expect(systemPromptOf(result)).not.toContain("<max_thinking_length>");
+      expect(contentOf(result)).not.toContain("<thinking_mode>");
+      expect(contentOf(result)).not.toContain("<max_thinking_length>");
     });
 
     it.each(["auto", "minimal", "ultra"])(
@@ -378,8 +375,8 @@ describe("openaiToKiroRequest", () => {
         const result = openaiToKiroRequest("gpt-5.6-luna", body, true, {});
 
         expect(result.additionalModelRequestFields).toBeUndefined();
-        expect(systemPromptOf(result)).toContain("<thinking_mode>enabled</thinking_mode>");
-        expect(systemPromptOf(result)).toContain("<max_thinking_length>");
+        expect(contentOf(result)).toContain("<thinking_mode>enabled</thinking_mode>");
+        expect(contentOf(result)).toContain("<max_thinking_length>");
       }
     );
 
@@ -394,8 +391,8 @@ describe("openaiToKiroRequest", () => {
         const result = openaiToKiroRequest("gpt-5.6-luna", body, true, {});
 
         expect(result.additionalModelRequestFields).toBeUndefined();
-        expect(systemPromptOf(result)).not.toContain("<thinking_mode>");
-        expect(systemPromptOf(result)).not.toContain("<max_thinking_length>");
+        expect(contentOf(result)).not.toContain("<thinking_mode>");
+        expect(contentOf(result)).not.toContain("<max_thinking_length>");
       }
     );
 
@@ -408,8 +405,8 @@ describe("openaiToKiroRequest", () => {
       const result = openaiToKiroRequest("gpt-5.6-sol-thinking", body, true, {});
 
       expect(result.additionalModelRequestFields).toBeUndefined();
-      expect(systemPromptOf(result)).toContain("<thinking_mode>enabled</thinking_mode>");
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>");
+      expect(contentOf(result)).toContain("<thinking_mode>enabled</thinking_mode>");
+      expect(contentOf(result)).toContain("<max_thinking_length>");
     });
 
     it("does not send additionalModelRequestFields for legacy Kiro model ids", () => {
@@ -420,7 +417,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.5", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
       expect(result.additionalModelRequestFields).toBeUndefined();
     });
 
@@ -432,7 +429,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4-20250514", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
       expect(result.additionalModelRequestFields).toBeUndefined();
     });
 
@@ -444,7 +441,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-3.7", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
       expect(result.additionalModelRequestFields).toBeUndefined();
     });
 
@@ -456,7 +453,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("kiro/claude-3-7-sonnet-20250219", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
       expect(result.additionalModelRequestFields).toBeUndefined();
     });
 
@@ -468,7 +465,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("kiro/gpt-4o", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
       expect(result.additionalModelRequestFields).toBeUndefined();
     });
 
@@ -480,7 +477,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("gpt-4o", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>24576</max_thinking_length>");
       expect(result.additionalModelRequestFields).toBeUndefined();
     });
 
@@ -498,7 +495,7 @@ describe("openaiToKiroRequest", () => {
       });
     });
 
-    it("clamps reasoning_effort max to Kiro max_thinking_length 32000", () => {
+    it("preserves reasoning_effort max with Kiro max_thinking_length 32000", () => {
       const body = {
         reasoning_effort: "max",
         messages: [{ role: "user", content: "Think as much as possible" }]
@@ -506,11 +503,11 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
-      expect(result.additionalModelRequestFields?.output_config?.effort).toBe("high");
+      expect(contentOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
+      expect(result.additionalModelRequestFields?.output_config?.effort).toBe("max");
     });
 
-    it("clamps OpenAI Responses reasoning.effort xhigh to max_thinking_length 32000", () => {
+    it("preserves OpenAI Responses reasoning.effort xhigh with max_thinking_length 32000", () => {
       const body = {
         reasoning: { effort: "xhigh" },
         messages: [{ role: "user", content: "Think extra deeply" }]
@@ -518,8 +515,8 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
-      expect(result.additionalModelRequestFields?.output_config?.effort).toBe("high");
+      expect(contentOf(result)).toContain("<max_thinking_length>32000</max_thinking_length>");
+      expect(result.additionalModelRequestFields?.output_config?.effort).toBe("xhigh");
     });
 
     it("uses Claude thinking.budget_tokens as max_thinking_length", () => {
@@ -530,7 +527,7 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>4096</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>4096</max_thinking_length>");
     });
 
     it("uses the default budget for synthetic -thinking models with no explicit config", () => {
@@ -540,54 +537,41 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6-thinking", body, true, {});
 
-      expect(systemPromptOf(result)).toContain("<max_thinking_length>16000</max_thinking_length>");
+      expect(contentOf(result)).toContain("<max_thinking_length>16000</max_thinking_length>");
     });
 
-    it("keeps top-level systemPrompt stable across turns", () => {
-      const first = openaiToKiroRequest(
+    it("embeds thinking prompt in user content without top-level fields", () => {
+      const result = openaiToKiroRequest(
         "claude-sonnet-4.6-thinking",
         { messages: [{ role: "user", content: "first" }] },
         true,
         {}
       );
-      const second = openaiToKiroRequest(
-        "claude-sonnet-4.6-thinking",
-        { messages: [{ role: "user", content: "second" }] },
-        true,
-        {}
-      );
 
-      expect(first.systemPrompt).toBe(second.systemPrompt);
-      expect(first.systemPrompt).not.toContain("Current time");
-      expect(first.conversationState.currentMessage.userInputMessage.content).toContain("Current time");
+      expect(result.systemPrompt).toBeUndefined();
+      expect(result.agentMode).toBeUndefined();
+      expect(contentOf(result)).toContain("<thinking_mode>enabled</thinking_mode>");
+      expect(contentOf(result)).toContain("Current time");
     });
 
-    it("replays frozen msg0 for explicit Kiro sessions while keeping current time fresh", () => {
+    it("uses the client session id without session-replay fields", () => {
       const credentials = {
         connectionId: "kiro-account-openai-replay",
         rawHeaders: { "x-session-id": "hermes-session-openai-replay" },
       };
-      const first = openaiToKiroRequest(
-        "claude-sonnet-4.6",
-        { messages: [{ role: "user", content: "first turn" }] },
-        true,
-        credentials
-      );
-      const second = openaiToKiroRequest(
+      const result = openaiToKiroRequest(
         "claude-sonnet-4.6",
         { messages: [{ role: "user", content: "second turn" }] },
         true,
         credentials
       );
 
-      expect(second.conversationState.conversationId).toBe("hermes-session-openai-replay");
-      expect(second.conversationState.agentContinuationId).toBe(first.conversationState.agentContinuationId);
-      expect(second.conversationState.history[0].userInputMessage.content).toBe(
-        first.conversationState.currentMessage.userInputMessage.content
-      );
-      expect(second.conversationState.history[0].userInputMessage.modelId).toBe("claude-sonnet-4.6");
-      expect(second.conversationState.currentMessage.userInputMessage.content).toContain("Current time");
-      expect(second.conversationState.currentMessage.userInputMessage.content).toContain("second turn");
+      expect(result.conversationState.conversationId).toBe("hermes-session-openai-replay");
+      expect(result.conversationState.agentContinuationId).toBeUndefined();
+      expect(result.conversationState.agentTaskType).toBeUndefined();
+      expect(result.agentMode).toBeUndefined();
+      expect(contentOf(result)).toContain("Current time");
+      expect(contentOf(result)).toContain("second turn");
     });
 
     it("does not inject thinking prefix for reasoning_effort none", () => {
@@ -598,8 +582,8 @@ describe("openaiToKiroRequest", () => {
 
       const result = openaiToKiroRequest("claude-sonnet-4.6", body, true, {});
 
-      expect(systemPromptOf(result)).not.toContain("<thinking_mode>enabled</thinking_mode>");
-      expect(systemPromptOf(result)).not.toContain("<max_thinking_length>");
+      expect(contentOf(result)).not.toContain("<thinking_mode>enabled</thinking_mode>");
+      expect(contentOf(result)).not.toContain("<max_thinking_length>");
       expect(result.additionalModelRequestFields).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary

- restore the v0.5.20 Kiro payload pattern by embedding system/thinking instructions in user content
- remove top-level `systemPrompt`, `agentMode`, and session-replay fields rejected by Kiro with `REQUEST_BODY_INVALID`
- preserve `low`, `medium`, `high`, `xhigh`, and `max` effort levels in `additionalModelRequestFields`
- recognize translated Kiro effort fields in unified thinking extraction
- align translator tests and golden request snapshot with the restored payload contract

Fixes #2716.
Related: #2739, #2692.

## Verification

- `npx vitest run unit/openai-to-kiro.test.js translator/claude-kiro-direct.test.js translator/thinking-unified.test.js` — 99 passed
- broad Kiro/session suite — 215 passed, 2 expected failures
- full-suite failure-set comparison against `upstream/master` on Windows — 0 new failures (108 upstream failures, 105 PR failures)

> Note: `tests/__baseline__/verify-no-regression.mjs` assumes `/app/` paths and reports every Windows failure as `undefined`, so verification compared test full names from Vitest JSON directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
