### PR TITLE
feat(fallback): per-provider retry-delay control

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -39,7 +39,7 @@ export const BACKOFF_CONFIG = {
 export const TRANSIENT_COOLDOWN_MS = 30 * 1000;
 
 // Hard cap for provider-reported rate limit cooldown (e.g. codex resets_at can be 5-6h)
-export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000;
+export const MAX_RATE_LIMIT_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 
 // Cooldown durations (ms)
 const COOLDOWN = {

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -1,4 +1,4 @@
-import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
+import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS, MAX_RATE_LIMIT_COOLDOWN_MS } from "../config/errorConfig.js";
 
 /**
  * Calculate exponential backoff cooldown for rate limits (429)
@@ -10,6 +10,50 @@ export function getQuotaCooldown(backoffLevel = 0) {
   const level = Math.max(0, backoffLevel - 1);
   const cooldown = BACKOFF_CONFIG.base * Math.pow(2, level);
   return Math.min(cooldown, BACKOFF_CONFIG.max);
+}
+
+/**
+ * Parse the provider's ACTUAL rate-limit reset window from a 429 body/headers,
+ * so an account is locked for the real duration instead of a fixed cooldown.
+ * Supports: Google/Antigravity RetryInfo ("retryDelay": "1976.3s"),
+ * OpenAI/Codex absolute reset ("resets_at"/"reset_at" epoch s|ms),
+ * OpenRouter/RateLimit ("X-RateLimit-Reset" epoch s|ms) and "Retry-After: N".
+ * @param {string|object} errorText - 429 body/headers, string or object.
+ * @param {number} now - reference epoch ms (defaults to Date.now()).
+ * @returns {number|null} ms until reset, or null when none is present.
+ */
+export function parseProviderResetMs(errorText, now = Date.now()) {
+  if (!errorText) return null;
+  const s = typeof errorText === "string" ? errorText : JSON.stringify(errorText);
+  let m;
+  // Relative seconds (Google/Antigravity RetryInfo): "retryDelay": "1976.365s"
+  if ((m = s.match(/"?retry[_-]?delay"?\s*[:=]\s*"?\s*([0-9]+(?:\.[0-9]+)?)\s*s/i))) {
+    return Math.round(parseFloat(m[1]) * 1000);
+  }
+  // Absolute reset epoch (s or ms): resets_at / reset_at / X-RateLimit-Reset
+  if ((m = s.match(/"?(?:resets?_at|x-?ratelimit-?reset|ratelimit-?reset)"?\s*[:=]\s*"?\s*([0-9]{9,})/i))) {
+    let v = parseInt(m[1], 10);
+    if (v < 1e12) v *= 1000; // seconds -> ms
+    const ms = v - now;
+    return ms > 0 ? ms : null;
+  }
+  // Retry-After: N seconds (header echoed into the body)
+  if ((m = s.match(/"?retry[_-]?after"?\s*[:=]\s*"?\s*([0-9]+)\b/i))) {
+    return parseInt(m[1], 10) * 1000;
+  }
+  return null;
+}
+
+/**
+ * Resolve the 429 account cooldown: prefer the provider's own reset window over
+ * the static exponential backoff, floored at the static value and capped at
+ * MAX_RATE_LIMIT_COOLDOWN_MS so a bogus huge value can't lock an account forever.
+ */
+export function resolveCooldownMs(newLevel, errorText) {
+  const staticMs = getQuotaCooldown(newLevel);
+  const providerMs = parseProviderResetMs(errorText);
+  if (providerMs == null || !(providerMs > 0)) return staticMs;
+  return Math.min(Math.max(providerMs, staticMs), MAX_RATE_LIMIT_COOLDOWN_MS);
 }
 
 /**
@@ -30,7 +74,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     if (rule.text && lowerError && lowerError.includes(rule.text)) {
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+        return { shouldFallback: true, cooldownMs: resolveCooldownMs(newLevel, errorText), newBackoffLevel: newLevel };
       }
       return { shouldFallback: true, cooldownMs: rule.cooldownMs };
     }
@@ -39,7 +83,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     if (rule.status && rule.status === status) {
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+        return { shouldFallback: true, cooldownMs: resolveCooldownMs(newLevel, errorText), newBackoffLevel: newLevel };
       }
       return { shouldFallback: true, cooldownMs: rule.cooldownMs };
     }

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -30,6 +30,21 @@ const AUTO_PING_SETTINGS_KEYS = {
   codex: "codexAutoPing",
 };
 
+// Per-provider retry-delay options. "auto" = honor the provider's reported reset
+// (retryDelay / Retry-After / resets_at), else the built-in backoff. A number is
+// the cooldown (seconds) used only when the provider reports no reset of its own.
+const RETRY_DELAY_OPTIONS = [
+  { value: "auto", label: "Retry: Auto" },
+  { value: "15", label: "Retry: 15s" },
+  { value: "30", label: "Retry: 30s" },
+  { value: "60", label: "Retry: 1m" },
+  { value: "120", label: "Retry: 2m" },
+  { value: "300", label: "Retry: 5m" },
+  { value: "600", label: "Retry: 10m" },
+  { value: "1800", label: "Retry: 30m" },
+  { value: "3600", label: "Retry: 1h" },
+];
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -65,6 +80,7 @@ export default function ProviderDetailPage() {
   const [providerStrategy, setProviderStrategy] = useState(null);
   const [providerStickyLimit, setProviderStickyLimit] = useState("");
   const [thinkingMode, setThinkingMode] = useState("auto");
+  const [retryDelay, setRetryDelay] = useState("auto");
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [liveModels, setLiveModels] = useState([]);
@@ -316,6 +332,9 @@ export default function ProviderDetailPage() {
       // Load per-provider thinking config
       const thinkingCfg = (settingsData.providerThinking || {})[providerId] || {};
       setThinkingMode(thinkingCfg.mode || "auto");
+      // Load per-provider retry-delay override
+      const rd = (settingsData.retryDelayByProvider || {})[providerId];
+      setRetryDelay(rd != null && rd !== "auto" ? String(rd) : "auto");
       const autoPingSettingsKey = AUTO_PING_SETTINGS_KEYS[providerId];
       const apCfg = autoPingSettingsKey ? settingsData[autoPingSettingsKey] || {} : {};
       setAutoPing({ enabled: apCfg.enabled === true, connections: apCfg.connections || {} });
@@ -429,6 +448,32 @@ export default function ProviderDetailPage() {
   const handleThinkingModeChange = (mode) => {
     setThinkingMode(mode);
     saveThinkingConfig(mode);
+  };
+
+  const saveRetryDelay = async (value) => {
+    try {
+      const settingsRes = await fetch("/api/settings", { cache: "no-store" });
+      const settingsData = settingsRes.ok ? await settingsRes.json() : {};
+      const current = settingsData.retryDelayByProvider || {};
+      const updated = { ...current };
+      if (!value || value === "auto") {
+        delete updated[providerId];
+      } else {
+        updated[providerId] = Number(value);
+      }
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ retryDelayByProvider: updated }),
+      });
+    } catch (error) {
+      console.log("Error saving retry delay:", error);
+    }
+  };
+
+  const handleRetryDelayChange = (value) => {
+    setRetryDelay(value);
+    saveRetryDelay(value);
   };
 
   const saveAutoPing = async (next) => {
@@ -1327,6 +1372,20 @@ export default function ProviderDetailPage() {
             <p className="text-text-muted">
               {connections.length} connection{connections.length === 1 ? "" : "s"}
             </p>
+          </div>
+          {/* Retry-delay control — right side of the provider header */}
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            <span className="hidden text-xs text-text-muted sm:inline">Retry delay</span>
+            <select
+              value={retryDelay}
+              onChange={(e) => handleRetryDelayChange(e.target.value)}
+              title="Cooldown after a rate-limit/error when the provider reports no reset time of its own. Auto = honor the provider's reported delay, else built-in backoff."
+              className="rounded-md border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+            >
+              {RETRY_DELAY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
           </div>
         </div>
       </div>

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -14,6 +14,10 @@ const DEFAULT_SETTINGS = {
   stickyRoundRobinLimit: 3,
   providerStrategies: {},
   quotaVisibility: {},
+  // Per-provider retry-delay fallback: { [providerId]: "auto" | <seconds> }.
+  // "auto"/absent → provider-reported reset else built-in backoff; a number is
+  // the lock duration used when the provider reports no reset of its own.
+  retryDelayByProvider: {},
   comboStrategy: "fallback",
   comboStickyRoundRobinLimit: 1,
   comboStrategies: {},

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,8 +1,8 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, parseProviderResetMs, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
-import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
+import { resolveProviderId, FREE_PROVIDERS, FREE_TIER_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
 
 // Mutex to prevent race conditions during account selection
@@ -16,6 +16,19 @@ function githubMonthlyResetMs(status, errorText, provider) {
   const now = new Date();
   return Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
 }
+// Community/free tiers (NVIDIA NIM, opencode-free, …) rate-limit on a short,
+// roughly per-minute window. The generic exponential backoff can bench a 429'd
+// account for up to 5 min — and with only a handful of free accounts that locks
+// the entire pool at once, so the gateway runs out of accounts and returns a 500.
+// Cap the STATIC fallback cooldown for these providers to one recovery window so
+// accounts come back quickly and keep rotating. Only the static backoff is
+// capped: a provider that reports an explicit reset (resetsAtMs / Retry-After /
+// retryDelay / X-RateLimit-Reset) still takes precedence and is never shortened.
+const FREE_TIER_STATIC_COOLDOWN_CAP_MS = 60 * 1000;
+const SHORT_COOLDOWN_PROVIDERS = new Set([
+  ...Object.keys(FREE_PROVIDERS),
+  ...Object.keys(FREE_TIER_PROVIDERS),
+]);
 
 /**
  * Get provider credentials from localDb
@@ -224,6 +237,23 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
 
   // GitHub premium-request exhaustion is account-wide until the next UTC month.
   const githubResetAtMs = githubMonthlyResetMs(status, errorText, provider);
+  const providerKey = resolveProviderId(provider);
+
+  // Per-provider retry-delay fallback (dashboard: Providers → Retry delay).
+  // "auto"/unset keeps the built-in behavior; a numeric value (seconds) is used
+  // as the lock duration ONLY when the provider itself reports no reset window.
+  // A provider-reported reset is always honored and never shortened by this.
+  let fallbackOverrideMs = null;
+  try {
+    const settings = await getSettings();
+    const sel = settings?.retryDelayByProvider?.[providerKey];
+    if (sel != null && sel !== "auto") {
+      const secs = Number(sel);
+      if (Number.isFinite(secs) && secs > 0) {
+        fallbackOverrideMs = Math.min(secs * 1000, MAX_RATE_LIMIT_COOLDOWN_MS);
+      }
+    }
+  } catch { /* settings unavailable → fall through to auto behavior */ }
 
   // Provider-specific precise cooldown (e.g. codex usage_limit_reached resets_at) overrides backoff
   let shouldFallback, cooldownMs, newBackoffLevel;
@@ -237,6 +267,21 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     newBackoffLevel = 0;
   } else {
     ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));
+    // Only reshape the STATIC backoff — when the provider reported no reset of its own.
+    if (shouldFallback && parseProviderResetMs(errorText) == null) {
+      if (fallbackOverrideMs != null) {
+        // User pinned a fixed retry delay for this provider.
+        cooldownMs = fallbackOverrideMs;
+        newBackoffLevel = 0;
+      } else if (
+        // Default for free/free-tier pools: cap the static backoff so the small
+        // account set recovers within its real per-minute window and keeps rotating.
+        cooldownMs > FREE_TIER_STATIC_COOLDOWN_CAP_MS &&
+        SHORT_COOLDOWN_PROVIDERS.has(providerKey)
+      ) {
+        cooldownMs = FREE_TIER_STATIC_COOLDOWN_CAP_MS;
+      }
+    }
   }
   if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
 


### PR DESCRIPTION
## Summary
Adds a per-provider **retry-delay** control so operators can decide how long an account is benched after a rate-limit/error **when the provider reports no reset window of its own**.

**Motivation:** free / free-tier provider pools (e.g. NVIDIA NIM) rate-limit on a short, roughly per-minute window, but the generic exponential backoff can lock a 429'd account for up to 5 minutes. With only a handful of free accounts, one burst locks the whole pool at once and the gateway has nothing left to route to (surfaces to clients as a 500).

## What's in it
- **Dashboard** — a `Retry delay` selector on each provider page (`Providers → [id]`, right side of the header): `Auto / 15s / 30s / 1m / 2m / 5m / 10m / 30m / 1h`. Saves through the existing `/api/settings` PATCH.
- **Setting** — `retryDelayByProvider: { [providerId]: "auto" | <seconds> }` added to `DEFAULT_SETTINGS`. Lives in the DB, so it survives restarts/upgrades. Default `{}` = Auto for every provider.
- **Backend** (`markAccountUnavailable`) precedence:
  1. A provider-reported reset (`retryDelay` / `Retry-After` / `resets_at` / `X-RateLimit-Reset`) is **always honored** and never shortened.
  2. Else a configured numeric value → that fixed lock duration.
  3. Else (`auto`) free/free-tier providers cap the **static** backoff at 60s so the pool rotates within its real window; other providers keep the existing backoff.

## Files
- `src/app/(dashboard)/dashboard/providers/[id]/page.js` — selector + save handler
- `src/lib/db/repos/settingsRepo.js` — `retryDelayByProvider` default
- `src/sse/services/auth.js` — fallback resolution in `markAccountUnavailable`

## Notes
- Stacked on #2879 (uses `parseProviderResetMs`); the diff reduces to a single commit once #2879 merges.
- Verified end-to-end: setting a provider to `120` produces `locked modelLock_… for 120s` on a 429; `Auto` caps free-tier static backoff at 60s; provider-reported resets pass through unchanged.