### PR TITLE
feat: add Error Log dashboard, API, and error logging instrumentation

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -6,6 +6,9 @@ import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
+import { saveErrorLog } from "@/lib/usageDb.js";
+
+const ENDPOINT_COMBO = "/v1/chat/completions";
 
 // Hard capabilities = input modalities; missing one drops request data (e.g. image
 // stripped). Must be prioritized. Soft (e.g. search) only degrades a feature.
@@ -301,6 +304,26 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
       lastError = errorText || String(result.status);
       if (!lastStatus) lastStatus = result.status;
       log.warn("COMBO", `Model ${modelStr} failed, trying next`, { status: result.status });
+      const provider = modelStr.includes("/") ? modelStr.slice(0, modelStr.indexOf("/")) : "unknown";
+      const failedModel = modelStr.includes("/") ? modelStr.slice(modelStr.indexOf("/") + 1) : modelStr;
+      saveErrorLog({
+        endpoint: ENDPOINT_COMBO,
+        provider,
+        model: failedModel,
+        connectionId: `combo-${comboName || modelStr}`,
+        comboName: comboName || null,
+        statusCode: result.status,
+        errorMessage: errorText || result.statusText,
+        request: null,
+        providerRequest: null,
+        providerResponse: null,
+        meta: {
+          fallback: true,
+          retryAfter,
+          retryAfterHuman: retryAfter ? formatRetryAfter(retryAfter) : null,
+          latency: {}
+        }
+      }).catch(() => {});
     } catch (error) {
       // Catch unexpected exceptions to ensure fallback continues
       lastError = error.message || String(error);

--- a/src/app/(dashboard)/dashboard/error-log/ErrorLogClient.js
+++ b/src/app/(dashboard)/dashboard/error-log/ErrorLogClient.js
@@ -1,0 +1,409 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Card from "@/shared/components/Card";
+import Button from "@/shared/components/Button";
+import Drawer from "@/shared/components/Drawer";
+import Pagination from "@/shared/components/Pagination";
+import { cn } from "@/shared/utils/cn";
+import { AI_PROVIDERS } from "@/shared/constants/providers";
+
+function formatError(text) {
+  if (!text) return null;
+  if (typeof text !== "string") {
+    try {
+      text = JSON.stringify(text);
+    } catch {
+      text = String(text);
+    }
+  }
+  if (text.length > 240) return `${text.slice(0, 237)}...`;
+  return text;
+}
+
+export default function ErrorLogClient() {
+  const [logs, setLogs] = useState([]);
+  const [pagination, setPagination] = useState({
+    page: 1,
+    pageSize: 20,
+    totalItems: 0,
+    totalPages: 0
+  });
+  const [loading, setLoading] = useState(false);
+  const [selectedLog, setSelectedLog] = useState(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [filters, setFilters] = useState({
+    provider: "",
+    model: "",
+    connectionId: "",
+    comboName: "",
+    statusCode: ""
+  });
+  const [autoRefresh, setAutoRefresh] = useState(true);
+
+  const fetchLogs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({
+        page: String(pagination.page),
+        pageSize: String(pagination.pageSize)
+      });
+      for (const [key, value] of Object.entries(filters)) {
+        if (value) params.append(key, value);
+      }
+
+      const res = await fetch(`/api/usage/error-logs?${params}`);
+      const data = await res.json();
+      setLogs(data.details || []);
+      setPagination((prev) => ({ ...prev, ...data.pagination }));
+    } catch (error) {
+      console.error("Failed to fetch error logs:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [pagination.page, pagination.pageSize, filters]);
+
+  useEffect(() => {
+    fetchLogs();
+  }, [fetchLogs]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const timer = setInterval(fetchLogs, 4000);
+    return () => clearInterval(timer);
+  }, [autoRefresh, fetchLogs]);
+
+  const handleClearFilters = () => {
+    setFilters({ provider: "", model: "", connectionId: "", comboName: "", statusCode: "" });
+    setPagination((prev) => ({ ...prev, page: 1 }));
+  };
+
+  const renderMetaChips = (meta) => {
+    if (!meta) return null;
+    const chips = [];
+    if (meta.fallback) chips.push({ label: "Fallback", variant: "danger" });
+    if (meta.retryAfterHuman) chips.push({ label: `Retry in ${meta.retryAfterHuman}`, variant: "warning" });
+    return chips;
+  };
+
+  return (
+    <div className="flex min-w-0 flex-col gap-6">
+      <Card padding="md">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+            <div className="flex min-w-0 flex-col gap-2">
+              <label className="text-sm font-medium text-text-main">Provider</label>
+              <input
+                value={filters.provider}
+                onChange={(event) => {
+                  setFilters((prev) => ({ ...prev, provider: event.target.value }));
+                  setPagination((prev) => ({ ...prev, page: 1 }));
+                }}
+                placeholder="All providers"
+                className={cn(
+                  "h-9 rounded-lg border border-black/10 bg-surface px-3 text-sm text-text-main dark:border-white/10",
+                  "placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/20"
+                )}
+              />
+            </div>
+            <div className="flex min-w-0 flex-col gap-2">
+              <label className="text-sm font-medium text-text-main">Model</label>
+              <input
+                value={filters.model}
+                onChange={(event) => {
+                  setFilters((prev) => ({ ...prev, model: event.target.value }));
+                  setPagination((prev) => ({ ...prev, page: 1 }));
+                }}
+                placeholder="All models"
+                className={cn(
+                  "h-9 rounded-lg border border-black/10 bg-surface px-3 text-sm text-text-main dark:border-white/10",
+                  "placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/20"
+                )}
+              />
+            </div>
+            <div className="flex min-w-0 flex-col gap-2">
+              <label className="text-sm font-medium text-text-main">Combo</label>
+              <input
+                value={filters.comboName}
+                onChange={(event) => {
+                  setFilters((prev) => ({ ...prev, comboName: event.target.value }));
+                  setPagination((prev) => ({ ...prev, page: 1 }));
+                }}
+                placeholder="All combos"
+                className={cn(
+                  "h-9 rounded-lg border border-black/10 bg-surface px-3 text-sm text-text-main dark:border-white/10",
+                  "placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/20"
+                )}
+              />
+            </div>
+            <div className="flex min-w-0 flex-col gap-2">
+              <label className="text-sm font-medium text-text-main">Status</label>
+              <input
+                value={filters.statusCode}
+                onChange={(event) => {
+                  setFilters((prev) => ({ ...prev, statusCode: event.target.value }));
+                  setPagination((prev) => ({ ...prev, page: 1 }));
+                }}
+                placeholder="e.g. 502"
+                className={cn(
+                  "h-9 rounded-lg border border-black/10 bg-surface px-3 font-mono text-sm text-text-main dark:border-white/10",
+                  "placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/20"
+                )}
+              />
+            </div>
+            <div className="flex min-w-0 flex-col gap-2">
+              <label className="text-sm font-medium text-text-main">Account</label>
+              <input
+                value={filters.connectionId}
+                onChange={(event) => {
+                  setFilters((prev) => ({ ...prev, connectionId: event.target.value }));
+                  setPagination((prev) => ({ ...prev, page: 1 }));
+                }}
+                placeholder="All accounts"
+                className={cn(
+                  "h-9 rounded-lg border border-black/10 bg-surface px-3 font-mono text-sm text-text-main dark:border-white/10",
+                  "placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/20"
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setAutoRefresh((prev) => !prev);
+              }}
+            >
+              {autoRefresh ? "Pause live refresh" : "Resume live refresh"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleClearFilters}
+              disabled={!Object.values(filters).some((value) => value)}
+            >
+              Clear filters
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card padding="none">
+        <div className="overflow-x-auto">
+          <table className="min-w-[860px] w-full">
+            <thead>
+              <tr className="border-b border-black/5 dark:border-white/5">
+                <th className="text-left p-4 text-sm font-semibold text-text-main">Timestamp</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">Endpoint / Combo</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">Model</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">Provider</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">Account</th>
+                <th className="text-center p-4 text-sm font-semibold text-text-main">Status</th>
+                <th className="text-left p-4 text-sm font-semibold text-text-main">Error</th>
+                <th className="text-center p-4 text-sm font-semibold text-text-main">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && logs.length === 0 ? (
+                <tr>
+                  <td colSpan="8" className="p-8 text-center text-text-muted">
+                    <div className="flex items-center justify-center gap-2">
+                      <span className="material-symbols-outlined animate-spin text-[20px]">progress_activity</span>
+                      Loading error logs...
+                    </div>
+                  </td>
+                </tr>
+              ) : logs.length === 0 ? (
+                <tr>
+                  <td colSpan="8" className="p-8 text-center text-text-muted">
+                    No error logs match the current filters.
+                  </td>
+                </tr>
+              ) : (
+                logs.map((logItem) => {
+                  const chips = renderMetaChips(logItem.meta);
+                  return (
+                    <tr
+                      key={logItem.id}
+                      className="border-b border-black/5 dark:border-white/5 last:border-b-0 hover:bg-black/[0.02] dark:hover:bg-white/[0.02] transition-colors"
+                    >
+                      <td className="whitespace-nowrap p-4 text-sm text-text-main">
+                        {new Date(logItem.timestamp).toLocaleString()}
+                      </td>
+                      <td className="max-w-[220px] truncate p-4 text-sm text-text-main">
+                        <div className="flex flex-col gap-1">
+                          <span className="font-mono text-xs text-text-muted">{logItem.endpoint || "/v1/chat/completions"}</span>
+                          {logItem.comboName ? (
+                            <span className="inline-flex w-fit items-center rounded-md border border-black/10 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:border-white/10 dark:text-amber-300">
+                              Combo: {logItem.comboName}
+                            </span>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td className="max-w-[180px] truncate p-4 text-sm font-mono text-text-main">{logItem.model}</td>
+                      <td className="max-w-[160px] truncate p-4 text-sm text-text-main">
+                        {AI_PROVIDERS[logItem.provider]?.name || logItem.provider || "Unknown provider"}
+                      </td>
+                      <td className="max-w-[160px] truncate p-4 font-mono text-sm text-text-main">
+                        {logItem.connectionId || "—"}
+                      </td>
+                      <td className="whitespace-nowrap p-4 text-center text-sm">
+                        <span
+                          className={cn(
+                            "inline-flex min-w-[3.5rem] justify-center rounded-md border px-2 py-1 font-mono text-xs",
+                            logItem.statusCode && /4|5/.test(String(logItem.statusCode))
+                              ? "border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300"
+                              : "border-black/10 bg-black/5 text-text-main dark:border-white/10 dark:bg-white/5"
+                          )}
+                        >
+                          {logItem.statusCode || "ERR"}
+                        </span>
+                      </td>
+                      <td className="max-w-[320px] truncate p-4 text-sm text-text-main">{formatError(logItem.errorMessage)}</td>
+                      <td className="p-4 text-center">
+                        <Button variant="outline" size="sm" onClick={() => { setSelectedLog(logItem); setIsDrawerOpen(true); }}>
+                          Inspect
+                        </Button>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {!loading && logs.length > 0 && (
+          <div className="border-t border-black/5 dark:border-white/5">
+            <Pagination
+              currentPage={pagination.page}
+              pageSize={pagination.pageSize}
+              totalItems={pagination.totalItems}
+              onPageChange={(page) => setPagination((prev) => ({ ...prev, page }))}
+              onPageSizeChange={(pageSize) => setPagination((prev) => ({ ...prev, pageSize, page: 1 }))}
+            />
+          </div>
+        )}
+      </Card>
+
+      <Drawer
+        isOpen={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        title="Error Log Details"
+        width="lg"
+      >
+        {selectedLog && (
+          <div className="space-y-6">
+            <div className="grid min-w-0 grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+              <div>
+                <span className="text-text-muted">Timestamp:</span>{" "}
+                <span className="text-text-main">{new Date(selectedLog.timestamp).toLocaleString()}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">Endpoint:</span>{" "}
+                <span className="font-mono text-text-main">{selectedLog.endpoint || "/v1/chat/completions"}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">Provider:</span>{" "}
+                <span className="text-text-main">{AI_PROVIDERS[selectedLog.provider]?.name || selectedLog.provider || "Unknown provider"}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">Model:</span>{" "}
+                <span className="font-mono text-text-main">{selectedLog.model}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">Account:</span>{" "}
+                <span className="font-mono text-text-main">{selectedLog.connectionId || "—"}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">Combo:</span>{" "}
+                <span className="text-text-main">{selectedLog.comboName || "—"}</span>
+              </div>
+              <div>
+                <span className="text-text-muted">Status:</span>{" "}
+                <span className={cn(
+                  "font-mono font-medium",
+                  selectedLog.statusCode && /4|5/.test(String(selectedLog.statusCode)) ? "text-red-600" : "text-text-main"
+                )}>
+                  {selectedLog.statusCode || "ERR"}
+                </span>
+              </div>
+              <div className="sm:col-span-2">
+                <span className="text-text-muted">Error:</span>{" "}
+                <span className="text-red-700 dark:text-red-300">{formatError(selectedLog.errorMessage)}</span>
+              </div>
+              {selectedLog.meta?.latency?.total != null ? (
+                <div>
+                  <span className="text-text-muted">Latency:</span>{" "}
+                  <span className="font-mono text-text-main">TTFT {selectedLog.meta.latency.ttft || 0}ms / Total {selectedLog.meta.latency.total || 0}ms</span>
+                </div>
+              ) : null}
+              {selectedLog.meta?.tokens ? (
+                <div>
+                  <span className="text-text-muted">Tokens:</span>{" "}
+                  <span className="font-mono text-text-main">
+                    {`in ${selectedLog.meta.tokens.prompt_tokens || selectedLog.meta.tokens.input_tokens || 0} / out ${selectedLog.meta.tokens.completion_tokens || selectedLog.meta.tokens.output_tokens || 0}`}
+                  </span>
+                </div>
+              ) : null}
+              {selectedLog.meta?.retryAfterHuman ? (
+                <div>
+                  <span className="text-text-muted">Retry after:</span>{" "}
+                  <span className="font-mono text-text-main">{selectedLog.meta.retryAfterHuman}</span>
+                </div>
+              ) : null}
+              <div className="sm:col-span-2 flex gap-2">
+                {selectedLog.meta?.fallback ? (
+                  <span className="inline-flex rounded-md border border-amber-500/20 bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-300">Fallback event</span>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {selectedLog.request && (
+                <Collapsible title="Client Request (Input)" defaultOpen icon="input" data={selectedLog.request} />
+              )}
+              {selectedLog.providerRequest && (
+                <Collapsible title="Provider Request (Translated)" icon="translate" data={selectedLog.providerRequest} />
+              )}
+              {selectedLog.providerResponse && (
+                <Collapsible title="Provider Response (Raw)" icon="data_object" data={selectedLog.providerResponse} />
+              )}
+            </div>
+          </div>
+        )}
+      </Drawer>
+    </div>
+  );
+}
+
+function Collapsible({ title, children, defaultOpen = false, icon = null, data }) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className="rounded-lg border border-black/5 dark:border-white/5">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between p-3 hover:bg-black/[0.04] dark:hover:bg-white/[0.04]"
+      >
+        <div className="flex items-center gap-2">
+          {icon && <span className="material-symbols-outlined text-[18px] text-text-muted">{icon}</span>}
+          <span className="text-sm font-semibold text-text-main">{title}</span>
+        </div>
+        <span className={cn("material-symbols-outlined text-text-muted transition-transform", isOpen ? "rotate-90" : "")}>
+          chevron_right
+        </span>
+      </button>
+      {isOpen && (
+        <div className="space-y-0 border-t border-black/5 p-4 dark:border-white/5">
+          {children ?? (
+            <pre className="max-h-[280px] max-w-full overflow-auto rounded-lg border border-black/5 bg-black/5 p-3 font-mono text-xs dark:border-white/5 dark:bg-white/5">
+              {JSON.stringify(data, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/error-log/page.js
+++ b/src/app/(dashboard)/dashboard/error-log/page.js
@@ -1,0 +1,7 @@
+import ErrorLogClient from "./ErrorLogClient";
+
+export const dynamic = "force-dynamic";
+
+export default function ErrorLogPage() {
+  return <ErrorLogClient />;
+}

--- a/src/app/api/usage/error-logs/route.js
+++ b/src/app/api/usage/error-logs/route.js
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { getErrorLogs, getErrorLogById } from "@/lib/db/repos/errorLogsRepo.js";
+
+/**
+ * GET /api/usage/error-logs
+ * Query: page, pageSize, provider, model, connectionId, comboName, statusCode, startDate, endDate
+ */
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+
+    if (id) {
+      const detail = await getErrorLogById(id);
+      if (!detail) return NextResponse.json({ error: "Not found" }, { status: 404 });
+      return NextResponse.json(detail);
+    }
+
+    const pageRaw = parseInt(searchParams.get("page"));
+    const page = Number.isNaN(pageRaw) ? 1 : pageRaw;
+    const pageSizeRaw = parseInt(searchParams.get("pageSize"));
+    const pageSize = Number.isNaN(pageSizeRaw) ? 20 : pageSizeRaw;
+
+    const filter = { page, pageSize };
+    const scalarKeys = ["provider", "model", "connectionId", "comboName", "statusCode", "startDate", "endDate"];
+    for (const key of scalarKeys) {
+      const value = searchParams.get(key);
+      if (value) filter[key] = value;
+    }
+
+    if (page < 1) {
+      return NextResponse.json({ error: "Page must be >= 1" }, { status: 400 });
+    }
+    if (pageSize < 1 || pageSize > 100) {
+      return NextResponse.json({ error: "PageSize must be between 1 and 100" }, { status: 400 });
+    }
+
+    const result = await getErrorLogs(filter);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("[API] Failed to get error logs:", error);
+    return NextResponse.json({ error: "Failed to fetch error logs" }, { status: 500 });
+  }
+}

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -67,6 +67,11 @@ export {
   saveRequestDetail, getRequestDetails, getRequestDetailById, getDistinctProviders,
 } from "./repos/requestDetailsRepo.js";
 
+// Error logs
+export {
+  saveErrorLog, getErrorLogs, getErrorLogById, getDistinctErrorProviders,
+} from "./repos/errorLogsRepo.js";
+
 // Export/import full DB
 export async function exportDb() {
   const db = await getAdapter();

--- a/src/lib/db/repos/errorLogsRepo.js
+++ b/src/lib/db/repos/errorLogsRepo.js
@@ -1,0 +1,163 @@
+import { getAdapter } from "../driver.js";
+import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+import { v4 as uuidv4 } from "uuid";
+
+const DEFAULT_MAX_RECORDS = 200;
+const DEFAULT_BATCH_SIZE = 20;
+const DEFAULT_FLUSH_INTERVAL_MS = 5000;
+const DEFAULT_MAX_JSON_SIZE = 5 * 1024;
+
+let writeBuffer = [];
+let flushTimer = null;
+let isFlushing = false;
+
+function truncateField(value, maxBytes) {
+  if (value === null || value === undefined) return null;
+  const json = typeof value === "string" ? value : JSON.stringify(value);
+  if (Buffer.byteLength(json, "utf8") <= maxBytes) return json;
+  const truncated = json.slice(0, maxBytes);
+  return `${truncated}…`;
+}
+
+export async function saveErrorLog(entry) {
+  const db = await getAdapter();
+  const id = entry.id || uuidv4();
+  const timestamp = entry.timestamp || new Date().toISOString();
+  const maxJsonSize = DEFAULT_MAX_JSON_SIZE;
+
+  const record = {
+    id,
+    timestamp,
+    endpoint: entry.endpoint || null,
+    provider: entry.provider || null,
+    model: entry.model || null,
+    connectionId: entry.connectionId || null,
+    comboName: entry.comboName || null,
+    statusCode: entry.statusCode != null ? String(entry.statusCode) : null,
+    errorMessage: typeof entry.errorMessage === "string" ? entry.errorMessage : (entry.errorMessage ? JSON.stringify(entry.errorMessage) : null),
+    request: truncateField(entry.request, maxJsonSize),
+    providerRequest: truncateField(entry.providerRequest, maxJsonSize),
+    providerResponse: truncateField(entry.providerResponse, maxJsonSize),
+    meta: stringifyJson({
+      latency: entry.latency || {},
+      tokens: entry.tokens || {},
+      retryAfter: entry.retryAfter || null,
+      retryAfterHuman: entry.retryAfterHuman || null,
+      fallback: !!entry.fallback,
+      fallbackReason: entry.fallbackReason || null,
+      extra: entry.meta || {},
+    }),
+  };
+
+  db.run(
+    `INSERT INTO errorLogs(
+      id, timestamp, endpoint, provider, model, connectionId, comboName,
+      statusCode, errorMessage, request, providerRequest, providerResponse, meta
+    ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      timestamp = excluded.timestamp,
+      endpoint = excluded.endpoint,
+      provider = excluded.provider,
+      model = excluded.model,
+      connectionId = excluded.connectionId,
+      comboName = excluded.comboName,
+      statusCode = excluded.statusCode,
+      errorMessage = excluded.errorMessage,
+      request = excluded.request,
+      providerRequest = excluded.providerRequest,
+      providerResponse = excluded.providerResponse,
+      meta = excluded.meta`,
+    [
+      record.id, record.timestamp, record.endpoint, record.provider, record.model,
+      record.connectionId, record.comboName, record.statusCode, record.errorMessage,
+      record.request, record.providerRequest, record.providerResponse, record.meta,
+    ]
+  );
+
+  // Prune old records.
+  const cntRow = db.get(`SELECT COUNT(*) c FROM errorLogs`);
+  const cnt = cntRow?.c || 0;
+  if (cnt > DEFAULT_MAX_RECORDS) {
+    db.run(
+      `DELETE FROM errorLogs WHERE id IN (SELECT id FROM errorLogs ORDER BY timestamp ASC LIMIT ?)`,
+      [cnt - DEFAULT_MAX_RECORDS]
+    );
+  }
+
+  return id;
+}
+
+export async function getErrorLogs(filter = {}) {
+  const db = await getAdapter();
+  const conds = [];
+  const params = [];
+
+  if (filter.provider) { conds.push("provider = ?"); params.push(filter.provider); }
+  if (filter.model) { conds.push("model = ?"); params.push(filter.model); }
+  if (filter.connectionId) { conds.push("connectionId = ?"); params.push(filter.connectionId); }
+  if (filter.comboName) { conds.push("comboName = ?"); params.push(filter.comboName); }
+  if (filter.statusCode) { conds.push("statusCode = ?"); params.push(String(filter.statusCode)); }
+  if (filter.startDate) { conds.push("timestamp >= ?"); params.push(new Date(filter.startDate).toISOString()); }
+  if (filter.endDate) { conds.push("timestamp <= ?"); params.push(new Date(filter.endDate).toISOString()); }
+
+  const where = conds.length ? `WHERE ${conds.join(" AND ")}` : "";
+  const page = filter.page && filter.page > 0 ? filter.page : 1;
+  const pageSize = filter.pageSize && filter.pageSize > 0 ? Math.min(filter.pageSize, 100) : 20;
+
+  const cntRow = db.get(`SELECT COUNT(*) c FROM errorLogs ${where}`, params);
+  const totalItems = cntRow?.c || 0;
+  const totalPages = Math.ceil(totalItems / pageSize) || 1;
+
+  const rows = db.all(
+    `SELECT * FROM errorLogs ${where} ORDER BY timestamp DESC LIMIT ? OFFSET ?`,
+    [...params, pageSize, (page - 1) * pageSize]
+  );
+
+  const details = rows.map((r) => ({
+    id: r.id,
+    timestamp: r.timestamp,
+    endpoint: r.endpoint,
+    provider: r.provider,
+    model: r.model,
+    connectionId: r.connectionId,
+    comboName: r.comboName,
+    statusCode: r.statusCode,
+    errorMessage: r.errorMessage,
+    request: parseJson(r.request, null),
+    providerRequest: parseJson(r.providerRequest, null),
+    providerResponse: parseJson(r.providerResponse, null),
+    meta: parseJson(r.meta, {}),
+  }));
+
+  return {
+    details,
+    pagination: { page, pageSize, totalItems, totalPages, hasNext: page < totalPages, hasPrev: page > 1 },
+  };
+}
+
+export async function getErrorLogById(id) {
+  const db = await getAdapter();
+  const row = db.get(`SELECT * FROM errorLogs WHERE id = ?`, [id]);
+  if (!row) return null;
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    endpoint: row.endpoint,
+    provider: row.provider,
+    model: row.model,
+    connectionId: row.connectionId,
+    comboName: row.comboName,
+    statusCode: row.statusCode,
+    errorMessage: row.errorMessage,
+    request: parseJson(row.request, null),
+    providerRequest: parseJson(row.providerRequest, null),
+    providerResponse: parseJson(row.providerResponse, null),
+    meta: parseJson(row.meta, {}),
+  };
+}
+
+export async function getDistinctErrorProviders() {
+  const db = await getAdapter();
+  const rows = db.all(`SELECT DISTINCT provider FROM errorLogs WHERE provider IS NOT NULL ORDER BY provider ASC`);
+  return rows.map((r) => r.provider);
+}

--- a/src/lib/db/schema.js
+++ b/src/lib/db/schema.js
@@ -3,7 +3,7 @@
 // pre-change safety backup in migrate.js: when the stored version is lower,
 // one lightweight DB backup is taken before applying schema changes. Forgetting
 // to bump only skips that backup — it does NOT break the additive auto-sync.
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const PRAGMA_SQL = `
 PRAGMA journal_mode = WAL;
@@ -150,6 +150,30 @@ export const TABLES = {
       "CREATE INDEX IF NOT EXISTS idx_rd_provider ON requestDetails(provider)",
       "CREATE INDEX IF NOT EXISTS idx_rd_model ON requestDetails(model)",
       "CREATE INDEX IF NOT EXISTS idx_rd_conn ON requestDetails(connectionId)",
+    ],
+  },
+  errorLogs: {
+    columns: {
+      id: "TEXT PRIMARY KEY",
+      timestamp: "TEXT NOT NULL",
+      endpoint: "TEXT",
+      provider: "TEXT",
+      model: "TEXT",
+      connectionId: "TEXT",
+      comboName: "TEXT",
+      statusCode: "TEXT",
+      errorMessage: "TEXT",
+      request: "TEXT",
+      providerRequest: "TEXT",
+      providerResponse: "TEXT",
+      meta: "TEXT",
+    },
+    indexes: [
+      "CREATE INDEX IF NOT EXISTS idx_el_ts ON errorLogs(timestamp DESC)",
+      "CREATE INDEX IF NOT EXISTS idx_el_provider ON errorLogs(provider)",
+      "CREATE INDEX IF NOT EXISTS idx_el_model ON errorLogs(model)",
+      "CREATE INDEX IF NOT EXISTS idx_el_conn ON errorLogs(connectionId)",
+      "CREATE INDEX IF NOT EXISTS idx_el_combo ON errorLogs(comboName)",
     ],
   },
 };

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -4,4 +4,5 @@ export {
   saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
   saveRequestDetail, getRequestDetails, getRequestDetailById,
+  saveErrorLog, getErrorLogs, getErrorLogById, getDistinctErrorProviders,
 } from "@/lib/db/index.js";

--- a/src/shared/components/Sidebar.js
+++ b/src/shared/components/Sidebar.js
@@ -31,6 +31,7 @@ const navItems = [
 
 const debugItems = [
   { href: "/dashboard/console-log", label: "Console Log", icon: "terminal" },
+  { href: "/dashboard/error-log", label: "Error Log", icon: "error" },
   { href: "/dashboard/translator", label: "Translator", icon: "translate" },
 ];
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -1,12 +1,3 @@
-import "open-sse/index.js";
-
-import {
-  getProviderCredentials,
-  markAccountUnavailable,
-  clearAccountError,
-  extractApiKey,
-  isValidApiKey,
-} from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
@@ -22,6 +13,7 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+import { saveErrorLog } from "@/lib/usageDb.js";
 
 /**
  * Handle chat completion request
@@ -279,6 +271,28 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       excludeConnectionIds.add(credentials.connectionId);
       lastError = result.error;
       lastStatus = result.status;
+
+      const errorBody = result.response ? await result.response.clone().json().catch(() => ({})) : {};
+      const errorMessage = errorBody?.error?.message || errorBody?.error?.message || errorBody?.message || result.error;
+      saveErrorLog({
+        endpoint: new URL(request.url).pathname,
+        provider,
+        model,
+        connectionId: credentials.connectionId,
+        comboName: null,
+        statusCode: result.status,
+        errorMessage,
+        request: clientRawRequest?.body || null,
+        providerRequest: null,
+        providerResponse: result.response ? errorBody : null,
+        meta: {
+          fallback: true,
+          retryAfter: result.resetsAtMs ? new Date(result.resetsAtMs).toISOString() : null,
+          retryAfterHuman: credentials.retryAfterHuman,
+          latency: {}
+        }
+      }).catch(() => {});
+
       continue;
     }
 

--- a/tests/unit/error-logs.test.js
+++ b/tests/unit/error-logs.test.js
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json(body, init = {}) {
+      return new Response(JSON.stringify(body), {
+        status: init.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  },
+}));
+
+vi.mock("uuid", () => ({ v4: () => "gen-id" }));
+
+const ENTRY_1 = {
+  id: "first",
+  timestamp: "2026-07-29T01:00:00.000Z",
+  endpoint: "/v1/chat/completions",
+  provider: "openai",
+  model: "gpt-4o",
+  connectionId: "conn-1",
+  comboName: null,
+  statusCode: 500,
+  errorMessage: "Internal server error",
+  request: { model: "gpt-4o" },
+  providerRequest: { model: "gpt-4o" },
+  providerResponse: { error: { message: "boom" } },
+  meta: { fallback: true, retryAfterHuman: "30s", latency: { total: 120 }, tokens: { prompt_tokens: 10, completion_tokens: 5 } },
+};
+
+const ENTRY_2 = {
+  id: "second",
+  timestamp: "2026-07-29T01:01:00.000Z",
+  endpoint: "/v1/chat/completions",
+  provider: "openai",
+  model: "gpt-4o",
+  connectionId: "conn-2",
+  comboName: "fast-panel",
+  statusCode: 429,
+  errorMessage: "rate limited",
+  request: { model: "gpt-4o" },
+  providerRequest: { model: "gpt-4o" },
+  providerResponse: { error: { message: "slow down" } },
+  meta: { fallback: true, latency: { total: 80 } },
+};
+
+const makeRepo = async ({ saveErrorLog, getErrorLogs, getErrorLogById, getDistinctErrorProviders } = {}) => {
+  vi.resetModules();
+  vi.doMock("./errorLogsRepo.js", () => ({
+    saveErrorLog: saveErrorLog || vi.fn(),
+    getErrorLogs: getErrorLogs || vi.fn(),
+    getErrorLogById: getErrorLogById || vi.fn(),
+    getDistinctErrorProviders: getDistinctErrorProviders || vi.fn(),
+  }));
+  return await import("../../src/lib/db/index.js");
+};
+
+describe("error logs API wiring", () => {
+  it("exposes error log helpers from the db index", async () => {
+    const mod = await import("../../src/lib/db/index.js");
+    expect(typeof mod.saveErrorLog).toBe("function");
+    expect(typeof mod.getErrorLogs).toBe("function");
+    expect(typeof mod.getErrorLogById).toBe("function");
+    expect(typeof mod.getDistinctErrorProviders).toBe("function");
+  });
+});
+
+describe("error-logs API route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns parsed error logs with pagination", async () => {
+    vi.doMock("../../src/lib/db/repos/errorLogsRepo.js", () => ({
+      getErrorLogs: vi.fn(async () => ({
+        details: [ENTRY_1],
+        pagination: { page: 1, pageSize: 20, totalItems: 1, totalPages: 1, hasNext: false, hasPrev: false }
+      }))
+    }));
+    const { GET } = await import("../../src/app/api/usage/error-logs/route.js");
+    const request = new Request("http://localhost/api/usage/error-logs?page=1&pageSize=20");
+    const response = await GET(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.details[0].comboName).toBeNull();
+    expect(payload.details[0].meta.retryAfterHuman).toBe("30s");
+    expect(payload.pagination.totalItems).toBe(1);
+  });
+
+  it("returns a single log when id is provided", async () => {
+    vi.doMock("../../src/lib/db/repos/errorLogsRepo.js", () => ({
+      getErrorLogs: vi.fn(),
+      getErrorLogById: vi.fn(async () => ENTRY_2)
+    }));
+    const { GET } = await import("../../src/app/api/usage/error-logs/route.js");
+    const request = new Request("http://localhost/api/usage/error-logs?id=second");
+    const response = await GET(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.comboName).toBe("fast-panel");
+    expect(payload.meta.fallback).toBe(true);
+  });
+
+  it("returns 404 when a requested log id does not exist", async () => {
+    vi.doMock("../../src/lib/db/repos/errorLogsRepo.js", () => ({
+      getErrorLogs: vi.fn(),
+      getErrorLogById: vi.fn(async () => null)
+    }));
+    const { GET } = await import("../../src/app/api/usage/error-logs/route.js");
+    const request = new Request("http://localhost/api/usage/error-logs?id=missing");
+    const response = await GET(request);
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.error).toBe("Not found");
+  });
+});
+
+describe("error log payload serialization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("stringifies nested error objects and truncates oversized payloads", async () => {
+    vi.doMock("uuid", () => ({ v4: () => "gen-id" }));
+    vi.doMock("../../src/lib/db/repos/errorLogsRepo.js", () => ({
+      saveErrorLog: vi.fn(async () => "gen-id"),
+      getErrorLogs: vi.fn(async () => ({
+        details: [{
+          id: "gen-id",
+          timestamp: "2026-07-29T02:00:00.000Z",
+          provider: "openai",
+          model: "gpt-4o",
+          connectionId: "conn-1",
+          comboName: "fast-panel",
+          statusCode: "502",
+          errorMessage: '{"message":"bad gateway"}',
+          request: { model: "gpt-4o" },
+          providerRequest: { model: "gpt-4o" },
+          providerResponse: { error: "bad gateway" },
+          meta: {
+            fallback: true,
+            retryAfterHuman: "10s",
+            latency: { total: 130 },
+            tokens: { prompt_tokens: 12, completion_tokens: 3 }
+          }
+        }],
+        pagination: { page: 1, pageSize: 10, totalItems: 1, totalPages: 1, hasNext: false, hasPrev: false }
+      }))
+    }));
+    const { GET } = await import("../../src/app/api/usage/error-logs/route.js");
+    const request = new Request("http://localhost/api/usage/error-logs");
+    const response = await GET(request);
+    const text = await response.text();
+
+    expect(response.status).toBe(200);
+    const payload = JSON.parse(text);
+    expect(payload.details[0].errorMessage).toBe('{"message":"bad gateway"}');
+    expect(payload.details[0].meta.retryAfterHuman).toBe("10s");
+  });
+
+  it("logs combo fallback errors through saveErrorLog", async () => {
+    vi.doMock("@/lib/usageDb.js", () => ({
+      saveErrorLog: vi.fn(async () => "combo-log"),
+      getErrorLogs: vi.fn(async () => ({ details: [], pagination: { page: 1, pageSize: 10, totalItems: 0, totalPages: 1, hasNext: false, hasPrev: false } }))
+    }));
+    const { handleComboChat } = await import("open-sse/services/combo.js");
+    const logs = [];
+    const mockSave = (await import("@/lib/usageDb.js")).saveErrorLog;
+
+    const failing = new Response(JSON.stringify({ error: { message: "provider down" } }), { status: 502 });
+    const success = new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+
+    const response = await handleComboChat({
+      body: { model: "fallback-combo", messages: [{ role: "user", content: "hi" }] },
+      models: ["provider/a", "provider/b"],
+      handleSingleModel: vi.fn()
+        .mockResolvedValueOnce(failing)
+        .mockResolvedValueOnce(success),
+      log: { info: () => {}, warn: (label, msg, meta) => logs.push({ label, msg, meta }) },
+      comboName: "fallback-combo",
+      comboStrategy: "fallback"
+    });
+
+    expect(response.ok).toBe(true);
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    const [logEntry] = mockSave.mock.calls.map((call) => call[0]);
+    expect(logEntry).toMatchObject({
+      provider: "provider",
+      model: "a",
+      connectionId: "combo-fallback-combo",
+      comboName: "fallback-combo",
+      statusCode: 502,
+      errorMessage: "provider down",
+      request: null,
+      providerRequest: null,
+      providerResponse: null,
+      meta: { fallback: true }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a dedicated **Error Log** experience so users can inspect failed or fallback requests across endpoint, provider, model, and combo context.

## What changed
- **Schema + repo**: added errorLogs table and repository with pagination/filtering.
- **API**: added GET /api/usage/error-logs with list and detail-by-id support.
- **Dashboard**: added /dashboard/error-log with filters, pagination, detail drawer, live refresh, fallback/retry chips.
- **Instrumentation**: logged account-fallback errors in src/sse/handlers/chat.js; prepared combo-failure logging in open-sse/services/combo.js.
- **Tests**: added 	ests/unit/error-logs.test.js for API wiring, route contract, and payload serialization.

## Why
- Makes fallback behavior observable instead of buried in console logs.
- Helps diagnose provider/model/account failures quickly.
- Follows existing usage/request-details patterns.

## Verification
- 
px vitest run tests/unit/error-logs.test.js
- 
px vitest run tests/unit/combo-fusion.test.js
