### PR TITLE
fix(auth): allow local auto-import without JWT when requireLogin=false

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -190,9 +190,13 @@ export async function proxy(request) {
     }
   }
 
-  // Always protected - require valid JWT or local CLI token (machineId-based)
+  // Always protected - require valid JWT or local CLI token (machineId-based).
+  // Local requests also pass when login is disabled (requireLogin=false) —
+  // otherwise no-login users can never auto-import (issue #115).
   if (ALWAYS_PROTECTED.some((p) => pathname.startsWith(p))) {
     if (await hasValidCliToken(request) || await hasValidToken(request))
+      return NextResponse.next();
+    if (isLocalRequest(request) && (await isAuthenticated(request)))
       return NextResponse.next();
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -188,6 +188,57 @@ describe("dashboard guard public LLM API access", () => {
   });
 });
 
+describe("dashboard guard always-protected auto-import routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({ requireLogin: false });
+    mocks.validateApiKey.mockResolvedValue(false);
+    mocks.getConsistentMachineId.mockResolvedValue("cli-token");
+    mocks.verifyDashboardAuthToken.mockResolvedValue(false);
+  });
+
+  it("allows local auto-import without JWT when requireLogin=false", async () => {
+    const response = await proxy(request("/api/oauth/cursor/auto-import", {
+      host: "localhost:20128",
+      origin: "http://localhost:20128",
+      realIp: "127.0.0.1",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+  });
+
+  it("allows local kiro auto-import without JWT when requireLogin=false", async () => {
+    const response = await proxy(request("/api/oauth/kiro/auto-import", {
+      host: "localhost:20128",
+      origin: "http://localhost:20128",
+      realIp: "127.0.0.1",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+  });
+
+  it("blocks local auto-import without JWT when requireLogin=true", async () => {
+    mocks.getSettings.mockResolvedValue({ requireLogin: true });
+
+    const response = await proxy(request("/api/oauth/cursor/auto-import", {
+      host: "localhost:20128",
+      origin: "http://localhost:20128",
+      realIp: "127.0.0.1",
+    }));
+
+    // local-only gate (403) fires before the always-protected gate (401)
+    expect([401, 403]).toContain(response.status);
+  });
+
+  it("blocks remote auto-import even when requireLogin=false", async () => {
+    const response = await proxy(request("/api/oauth/cursor/auto-import", {
+      host: "router.example.com",
+    }));
+
+    expect([401, 403]).toContain(response.status);
+  });
+});
+
 describe("dashboard guard local-only access", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Problem

`GET /api/oauth/cursor/auto-import` (and `/api/oauth/kiro/auto-import`) return 401 `{"error": "Unauthorized"}` for users running with login disabled (`requireLogin=false`), even from the local dashboard browser on loopback. The dashboard modal shows "Unauthorized" and Cursor/Kiro connect fails entirely.

Root cause: both paths are listed in **both** `LOCAL_ONLY_PATHS` and `ALWAYS_PROTECTED` in `src/dashboardGuard.js`. The `ALWAYS_PROTECTED` gate demands a valid JWT cookie or CLI token **unconditionally** — but with `requireLogin=false` there is no login flow, so no JWT ever exists. The request passes the local-only gate (loopback peer IP + loopback origin) and then dies at the always-protected gate before the handler runs.

Verified on a live instance: `/api/auth/status` reports `requireLogin:false`, and the auto-import request 401s with no `auth_token` cookie set.

## Fix

In the `ALWAYS_PROTECTED` gate, allow requests that are **local** (`isLocalRequest`: loopback real peer IP stamped by custom-server + loopback origin, unspoofable via Host/XFF) **and** authenticated under the current policy (`isAuthenticated`, which already honors `requireLogin=false`):

```js
if (await hasValidCliToken(request) || await hasValidToken(request))
  return NextResponse.next();
if (isLocalRequest(request) && (await isAuthenticated(request)))
  return NextResponse.next();
return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
```

Security posture unchanged:
- Remote/tunnel requests still require JWT or CLI token — `isLocalRequest` returns false behind a reverse proxy (`x-9r-via-proxy`) and for non-loopback peer IPs.
- With `requireLogin=true`, `isAuthenticated` is false without a JWT, so local requests still 401 (or 403 from the local-only gate).

## Tests

Added 4 cases to `tests/unit/dashboard-guard.test.js`:
- local cursor auto-import allowed without JWT when `requireLogin=false` ✅
- local kiro auto-import allowed without JWT when `requireLogin=false` ✅
- local auto-import still blocked when `requireLogin=true` ✅
- remote auto-import still blocked even when `requireLogin=false` ✅

All 26 tests in the file pass; full suite shows no new failures vs baseline.

## Live verification

After rebuilding the CLI bundle and restarting:
```
$ curl http://localhost:20128/api/oauth/cursor/auto-import
{"found":true,"accessToken":"...","machineId":"..."}   # HTTP 200
$ curl -o /dev/null -w '%{http_code}' http://localhost:20128/api/oauth/kiro/auto-import
200
```

Fixes #115