### PR TITLE
fix(kiro): convert dots back to dashes in Claude model ids before upstream dispatch

### DIFF
--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -276,6 +276,27 @@ export function stripThinkingSuffix(model) {
 }
 
 /**
+ * Convert a 9router-registry model id to the format the Kiro API expects
+ * on the wire. The registry stores Claude version numbers with dots
+ * ("claude-sonnet-4.5", "claude-opus-4.8") but the Kiro / CodeWhisperer
+ * backend only accepts dashes ("claude-sonnet-4-5", "claude-opus-4-8").
+ * Non-Claude ids and already-correct ids pass through unchanged.
+ *
+ *   toKiroModelId("claude-sonnet-4.5")    // => "claude-sonnet-4-5"
+ *   toKiroModelId("claude-opus-4.8")      // => "claude-opus-4-8"
+ *   toKiroModelId("claude-sonnet-5")      // => "claude-sonnet-5"  (unchanged)
+ *   toKiroModelId("deepseek-3.2")         // => "deepseek-3.2"     (non-Claude)
+ *
+ * @param {string} modelId 9router-registry model id (post-resolveKiroModel)
+ * @returns {string} Kiro-upstream-ready model id
+ */
+export function toKiroModelId(modelId) {
+  if (typeof modelId !== "string") return modelId;
+  if (!modelId.startsWith("claude")) return modelId;
+  return modelId.replace(/(\d)\.(\d)/g, "$1-$2");
+}
+
+/**
  * Resolve a 9router model id to the real upstream Kiro model id, plus flags
  * describing which behaviours the suffixes implied.
  *

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -28,6 +28,7 @@ import { applyKiroSessionReplay } from "../../utils/kiroSessionReplay.js";
 import { resolveContinuationId, resolveSessionIdentity } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
+  toKiroModelId,
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
@@ -389,7 +390,8 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   const temperature = body.temperature;
   const topP = body.top_p;
 
-  const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
+  const { upstream: rawUpstream, agentic } = resolveKiroModel(model);
+  const upstreamModel = toKiroModelId(rawUpstream);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
   const additionalModelRequestFields = buildKiroAdditionalModelRequestFieldsForModel(body, upstreamModel);
   const usesNativeGptEffort = usesKiroNativeGptEffort(body, upstreamModel);

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -9,6 +9,7 @@ import { applyKiroSessionReplay } from "../../utils/kiroSessionReplay.js";
 import { resolveContinuationId, resolveSessionIdentity } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
+  toKiroModelId,
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
@@ -524,7 +525,8 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   const temperature = body.temperature;
   const topP = body.top_p;
 
-  const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
+  const { upstream: rawUpstream, agentic } = resolveKiroModel(model);
+  const upstreamModel = toKiroModelId(rawUpstream);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
   const additionalModelRequestFields = buildKiroAdditionalModelRequestFieldsForModel(body, upstreamModel);
   const usesNativeGptEffort = usesKiroNativeGptEffort(body, upstreamModel);


### PR DESCRIPTION
## Problem

The Kiro / CodeWhisperer backend rejects Claude model ids with dots in the version number (e.g. `claude-sonnet-4.5`) and only accepts dash notation (`claude-sonnet-4-5`).

When the client sends `kr/claude-sonnet-4-5`, the 9router's `normalizeModelId` in `providerModels.js` converts dashes to dots for registry lookup (`claude-sonnet-4.5`), which matches correctly — but that dot-format id then gets forwarded verbatim as the `modelId` in the upstream request payload. The Kiro API rejects it:

```json
{ "message": "Invalid model ID. Please select a different model to continue.", "reason": "INVALID_MODEL_ID" }
```

Reported in #2308 and still reproducible on v0.5.40 with `kr/claude-sonnet-5`.

## Root cause

Both translators (`claude-to-kiro.js` and `openai-to-kiro.js`) call `resolveKiroModel(model)` which returns the registry id as-is — with dots for version numbers. That id goes straight into the Kiro payload's `modelId` field without any reverse conversion.

## Fix

Added `toKiroModelId()` in `kiroConstants.js` that converts digit-dot-digit back to digit-dash-digit for Claude models only, and applied it in both translators right after `resolveKiroModel()` strips the synthetic suffixes.

```
toKiroModelId("claude-sonnet-4.5")   // => "claude-sonnet-4-5"
toKiroModelId("claude-opus-4.8")     // => "claude-opus-4-8"
toKiroModelId("claude-sonnet-5")     // => "claude-sonnet-5"   (unchanged)
toKiroModelId("deepseek-3.2")        // => "deepseek-3.2"      (non-Claude)
```

This covers every Claude model in the registry regardless of version format — single major (`claude-sonnet-5`), dotted (`claude-sonnet-4.5`), or multi-segment (`claude-opus-4.8`). Non-Claude models pass through unchanged.

## Files changed

- `open-sse/config/kiroConstants.js` — new `toKiroModelId()` function
- `open-sse/translator/request/claude-to-kiro.js` — import + apply conversion
- `open-sse/translator/request/openai-to-kiro.js` — import + apply conversion

Fixes #2308