### PR TITLE
fix(kiro): convert letter-dot-digit to letter-dash-digit in Claude model IDs before upstream dispatch

### DIFF
--- a/open-sse/config/kiroConstants.js
+++ b/open-sse/config/kiroConstants.js
@@ -276,6 +276,29 @@ export function stripThinkingSuffix(model) {
 }
 
 /**
+ * Normalize a 9router-registry model id to the wire format the Kiro API
+ * accepts. The Kiro / CodeWhisperer backend uses dashes everywhere except
+ * for dotted version numbers (claude-sonnet-4.5 is fine, claude-sonnet.5 is
+ * not). This function only touches letter-dot-digit runs — the only
+ * transformations that matter for Kiro — and leaves digit-dot-digit
+ * version separators and non-Claude ids untouched.
+ *
+ *   toKiroWireModelId("claude-sonnet-4.5")    // "claude-sonnet-4.5"
+ *   toKiroWireModelId("claude-sonnet.5")      // "claude-sonnet-5"
+ *   toKiroWireModelId("claude-opus-4.8")      // "claude-opus-4.8"
+ *   toKiroWireModelId("deepseek-3.2")         // "deepseek-3.2" (non-Claude)
+ *
+ * @param {string} modelId 9router-registry model id (post-resolveKiroModel)
+ * @returns {string} Kiro wire-format model id
+ */
+export function toKiroWireModelId(modelId) {
+  if (typeof modelId !== "string") return modelId;
+  if (!modelId.startsWith("claude")) return modelId;
+  // sonnet.5 → sonnet-5, opus.4 → opus-4 — but 4.5 stays 4.5
+  return modelId.replace(/([a-z])\.(\d)/g, "$1-$2");
+}
+
+/**
  * Resolve a 9router model id to the real upstream Kiro model id, plus flags
  * describing which behaviours the suffixes implied.
  *

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -28,6 +28,7 @@ import { applyKiroSessionReplay } from "../../utils/kiroSessionReplay.js";
 import { resolveContinuationId, resolveSessionIdentity } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
+  toKiroWireModelId,
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
@@ -389,7 +390,8 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
   const temperature = body.temperature;
   const topP = body.top_p;
 
-  const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
+  const { upstream: rawUpstream, agentic } = resolveKiroModel(model);
+  const upstreamModel = toKiroWireModelId(rawUpstream);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
   const additionalModelRequestFields = buildKiroAdditionalModelRequestFieldsForModel(body, upstreamModel);
   const usesNativeGptEffort = usesKiroNativeGptEffort(body, upstreamModel);

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -9,6 +9,7 @@ import { applyKiroSessionReplay } from "../../utils/kiroSessionReplay.js";
 import { resolveContinuationId, resolveSessionIdentity } from "../../utils/sessionManager.js";
 import {
   resolveKiroModel,
+  toKiroWireModelId,
   resolveKiroThinkingBudget,
   buildThinkingSystemPrefix,
   KIRO_AGENTIC_SYSTEM_PROMPT,
@@ -524,7 +525,8 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
   const temperature = body.temperature;
   const topP = body.top_p;
 
-  const { upstream: upstreamModel, agentic } = resolveKiroModel(model);
+  const { upstream: rawUpstream, agentic } = resolveKiroModel(model);
+  const upstreamModel = toKiroWireModelId(rawUpstream);
   const thinkingBudget = resolveKiroThinkingBudget(body, credentials?.rawHeaders, model);
   const additionalModelRequestFields = buildKiroAdditionalModelRequestFieldsForModel(body, upstreamModel);
   const usesNativeGptEffort = usesKiroNativeGptEffort(body, upstreamModel);


### PR DESCRIPTION
## Problem

The Kiro / CodeWhisperer backend rejects Claude model IDs that contain a dot between a letter and a digit — for example `claude-sonnet.5` — while accepting dot-separated version numbers like `claude-sonnet-4.5`.

The 9router normalizes all dashes to dots during internal routing so the registry lookup works regardless of what the client sends. But that transformed model ID was being forwarded verbatim to the Kiro upstream API:

```
Client sends:    kr/claude-sonnet-5
9router routes:  kr/claude-sonnet.5       ← dot between letter & digit
Kiro receives:   modelId: claude-sonnet.5
Kiro rejects:    HTTP 400 INVALID_MODEL_ID
```

This affects every single-major Claude model in the registry — `claude-sonnet-5`, and any future `claude-haiku-6`, `claude-opus-5`, etc. — because the dash between the family name and the generation number gets normalized to a dot. Models with dotted version numbers like `claude-sonnet-4.5` are unaffected since the dot there is between two digits, which Kiro accepts.

Still reproducible on v0.5.40 (2026-07-29) as reported in #2308.

## Root cause

Both translators (`claude-to-kiro.js` and `openai-to-kiro.js`) call `resolveKiroModel(model)` which returns the registry id as-is after stripping synthetic suffixes. That id — with its letter-dot-digit pattern inherited from global normalization — goes straight into the Kiro payload's `modelId` field.

## Fix

Added `toKiroWireModelId()` in `kiroConstants.js` that converts exactly one pattern: `[letter].[digit]` → `[letter]-[digit]`. Everything else — version dots, non-Claude models — passes through unchanged.

```
toKiroWireModelId("claude-sonnet-4.5")   // "claude-sonnet-4.5"  (unchanged — digits on both sides)
toKiroWireModelId("claude-sonnet.5")     // "claude-sonnet-5"    (fixed — letter before dot)
toKiroWireModelId("claude-opus-4.8")     // "claude-opus-4.8"     (unchanged)
toKiroWireModelId("deepseek-3.2")        // "deepseek-3.2"       (non-Claude, passthrough)
```

Applied in both translators right after `resolveKiroModel()` strips the synthetic suffixes.

## Files changed

- `open-sse/config/kiroConstants.js` — new `toKiroWireModelId()` function
- `open-sse/translator/request/claude-to-kiro.js` — import + apply normalization
- `open-sse/translator/request/openai-to-kiro.js` — import + apply normalization

Fixes #2308