### PR TITLE
fix(kiro): drop top-level systemPrompt for kiro.dev gateway (unblocks -thinking/-agentic)

### DIFF
--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -304,7 +304,11 @@ export class KiroExecutor extends BaseExecutor {
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {
     const baseUrls = this.getOrderedBaseUrls(credentials);
-    return baseUrls[urlIndex] || baseUrls[0] || this.config.baseUrl;
+    const url = baseUrls[urlIndex] || baseUrls[0] || this.config.baseUrl;
+    // Stash the target URL so transformRequest (called next in the base loop,
+    // without a url arg) can shape the wire body per-surface.
+    this._currentTargetUrl = url;
+    return url;
   }
 
   // Retry only endpoint/auth-surface failures. Payload-invalid HTTP 400 must be
@@ -316,6 +320,17 @@ export class KiroExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body, stream, credentials) {
+    // The Kiro IDE gateway (runtime.*.kiro.dev) rejects a top-level `systemPrompt`
+    // field with 400 REQUEST_BODY_INVALID, breaking every -thinking / -agentic
+    // variant (and any Claude request carrying a `system`). The CodeWhisperer /
+    // Amazon Q surfaces (*.amazonaws.com) accept it. The translator always
+    // duplicates the same prompt into the current message content (contentPrefix),
+    // so dropping the top-level field for the kiro.dev surface preserves behaviour.
+    const url = this._currentTargetUrl || "";
+    if (url.includes(".kiro.dev") && body && typeof body === "object" && body.systemPrompt !== undefined) {
+      const { systemPrompt, ...rest } = body;
+      return rest;
+    }
     return body;
   }
 


### PR DESCRIPTION
## Summary

The Kiro IDE gateway (`runtime.*.kiro.dev/generateAssistantResponse`) rejects any request that carries a top-level `systemPrompt` field, returning `400 { "reason": "REQUEST_BODY_INVALID" }`. This breaks **every** `-thinking` and `-agentic` Kiro variant, plus any Claude request that carries a `system` prompt, because those code paths set `payload.systemPrompt` in the translators.

Base models (no `systemPrompt`) work fine, which is why the failure looks selective.

## Root cause

`openaiToKiroRequest` / `claudeToKiroRequest` build a top-level `systemPrompt` (thinking prefix, agentic chunked-write prompt, and/or the Claude `system` text) and also duplicate the same text into the current message `content` (`contentPrefix`). The `*.amazonaws.com` (CodeWhisperer / Amazon Q) surfaces accept the top-level field, but the `kiro.dev` gateway does not.

## Verification (direct calls to the upstream)

Isolated each payload variable against the live endpoints:

| Payload | `codewhisperer.us-east-1` | `runtime.us-east-1.kiro.dev` |
|---|---|---|
| base (no `systemPrompt`) | 200 | 200 |
| thinking + top-level `systemPrompt` | 200 | **400 REQUEST_BODY_INVALID** |
| thinking content, `systemPrompt` field removed | 200 | 200 |

So the top-level `systemPrompt` field is the sole trigger, and the gateway is happy once it is dropped (the identical prompt still reaches the model via `content`).

## Fix

Strip `systemPrompt` from the wire body **only for the `kiro.dev` surface**, inside `KiroExecutor.transformRequest`. The CodeWhisperer/Q surfaces keep it (they accept it), and behaviour is preserved everywhere because the translator already duplicates the prompt into the message content. The translators are left untouched, so all existing translator tests remain valid.

## Testing

Rebuilt the standalone CLI and ran end-to-end against a live Kiro (IdC) account:

- `kr/claude-opus-4.8` -> ok (base, unchanged)
- `kr/claude-opus-4.8-thinking` -> ok (was 400)
- `kr/claude-sonnet-4.5-agentic` -> ok (was 400)

## Notes

- Follow-up (not in this PR): for IdC/api-key connections, `getOrderedBaseUrls` regionalizes the CodeWhisperer hosts using `providerSpecificData.region` (the OIDC/SSO region, e.g. `ap-southeast-1`), which produces non-existent hosts like `codewhisperer.ap-southeast-1.amazonaws.com`; requests then fall through to `kiro.dev`. Consider deriving the service region from the `profileArn` instead.
