### PR TITLE
fix(cli-tools): mark Amp as unsupported

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/DefaultToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/DefaultToolCard.js
@@ -108,7 +108,7 @@ export default function DefaultToolCard({ toolId, tool, isExpanded, onToggle, ba
           if (note.type === "cloudCheck" && (cloudEnabled || tunnelEnabled)) return null;
           
           const isWarning = note.type === "warning";
-          const isError = note.type === "cloudCheck" && !cloudEnabled && !tunnelEnabled;
+          const isError = note.type === "error" || (note.type === "cloudCheck" && !cloudEnabled && !tunnelEnabled);
           
           let bgClass = "bg-blue-500/10 border-blue-500/30";
           let textClass = "text-blue-600 dark:text-blue-400";
@@ -145,7 +145,7 @@ export default function DefaultToolCard({ toolId, tool, isExpanded, onToggle, ba
   };
 
   const renderGuideSteps = () => {
-    if (!tool.guideSteps) return <p className="text-text-muted text-sm">Coming soon...</p>;
+    if (!tool.guideSteps) return renderNotes() || <p className="text-text-muted text-sm">Coming soon...</p>;
 
     return (
       <div className="flex flex-col gap-4">

--- a/src/app/(dashboard)/dashboard/cli-tools/components/ToolSummaryCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/ToolSummaryCard.js
@@ -5,7 +5,8 @@ import Image from "next/image";
 import { Card } from "@/shared/components";
 
 // Derive simple connected/configured/not-installed status from API payload
-function getStatus(status) {
+function getStatus(tool, status) {
+  if (tool.unsupported) return { label: "Unsupported", cls: "bg-red-500/10 text-red-600 dark:text-red-400" };
   if (!status) return { label: "Unknown", cls: "bg-gray-500/10 text-gray-500" };
   if (!status.installed) return { label: "Not installed", cls: "bg-gray-500/10 text-gray-500" };
   if (status.has9Router) return { label: "Connected", cls: "bg-green-500/10 text-green-600 dark:text-green-400" };
@@ -13,7 +14,7 @@ function getStatus(status) {
 }
 
 export default function ToolSummaryCard({ toolId, tool, status }) {
-  const s = getStatus(status);
+  const s = getStatus(tool, status);
   return (
     <Link href={`/dashboard/cli-tools/${toolId}`} className="block">
       <Card padding="sm" className="h-full overflow-hidden hover:border-primary/50 transition-colors cursor-pointer">

--- a/src/shared/constants/cliTools.js
+++ b/src/shared/constants/cliTools.js
@@ -242,31 +242,13 @@ export const CLI_TOOLS = {
     name: "Amp CLI",
     image: "/providers/amp.png",
     color: "#F97316",
-    description: "Sourcegraph Amp coding assistant CLI",
-    docsUrl: "/docs?section=cli-tools&tool=amp",
+    description: "Amp coding agent — custom API endpoints unsupported",
+    docsUrl: "https://ampcode.com/manual",
     configType: "guide",
-    defaultCommand: "amp",
-    modelAliases: ["g25p", "g25f", "cs45", "g54"],
+    unsupported: true,
     notes: [
-      { type: "info", text: "Use 9Router model aliases to keep Amp shorthand mappings stable across provider updates." },
-      { type: "warning", text: "Suggested shorthand examples: g25p → gemini/gemini-2.5-pro, g25f → gemini/gemini-2.5-flash, cs45 → cc/claude-sonnet-4-5-20250929." },
+      { type: "error", text: "Amp does not support custom OpenAI-compatible base URLs. AMP_URL configures the Amp service, not the model inference endpoint, so Amp cannot connect directly to 9Router." },
     ],
-    guideSteps: [
-      { step: 1, title: "Install Amp", desc: "Install the Amp CLI using the package manager supported by your environment." },
-      { step: 2, title: "API Key", type: "apiKeySelector" },
-      { step: 3, title: "Base URL", value: "{{baseUrl}}", copyable: true },
-      { step: 4, title: "Select Model", type: "modelSelector" },
-      { step: 5, title: "Add Shorthands", desc: "Map Amp shorthand names such as g25p or cs45 to 9Router aliases in your local config." },
-    ],
-    codeBlock: {
-      language: "bash",
-      code: `export OPENAI_API_KEY="{{apiKey}}"
-export OPENAI_BASE_URL="{{baseUrl}}"
-amp --model "{{model}}"
-# Example shorthand aliases you can map locally:
-# g25p -> gemini/gemini-2.5-pro
-# cs45 -> cc/claude-sonnet-4-5-20250929`,
-    },
   },
   qwen: {
     id: "qwen",


### PR DESCRIPTION
## Summary

- mark Amp CLI as unsupported in CLI Tools
- remove misleading OpenAI-compatible endpoint and model instructions
- show an Unsupported badge and explain that `AMP_URL` targets the Amp service, not a model inference endpoint

## Verification

- `npx eslint src/shared/constants/cliTools.js src/app/\(dashboard\)/dashboard/cli-tools/components/DefaultToolCard.js src/app/\(dashboard\)/dashboard/cli-tools/components/ToolSummaryCard.js`
- `npm run build`
- config assertion confirming Amp exposes no guide steps, model aliases, or code block