### PR TITLE
fix(tunnel): bypass worker self-signed TLS via TUNNEL_WORKER_INSECURE

### DIFF
--- a/src/lib/tunnel/cloudflare/config.js
+++ b/src/lib/tunnel/cloudflare/config.js
@@ -7,3 +7,14 @@ export const HEALTH_CHECK = {
 };
 
 export const WORKER_URL = process.env.TUNNEL_WORKER_URL || "https://abc-tunnel.us";
+
+// Opt-in: when the worker's TLS chain ends in a self-signed cert (Cloudflare
+// Access origin, internal proxy), Node's default verifier rejects the
+// handshake and surfaces only "fetch failed". Setting
+// TUNNEL_WORKER_INSECURE=1 disables verification for the worker host only.
+function parseBool(v) {
+  if (v == null) return false;
+  const s = String(v).trim().toLowerCase();
+  return s === "1" || s === "true" || s === "yes" || s === "on";
+}
+export const INSECURE_WORKER = parseBool(process.env.TUNNEL_WORKER_INSECURE);

--- a/src/lib/tunnel/cloudflare/healthCheck.js
+++ b/src/lib/tunnel/cloudflare/healthCheck.js
@@ -1,5 +1,11 @@
 import { resolveDns } from "../shared/dnsResolver.js";
-import { HEALTH_CHECK } from "./config.js";
+import { HEALTH_CHECK, WORKER_URL } from "./config.js";
+import { workerFetch } from "./workerFetch.js";
+
+const WORKER_HOST = (() => {
+  try { return new URL(WORKER_URL).hostname; }
+  catch { return null; }
+})();
 
 export async function probeUrlAlive(url) {
   if (!url) return false;
@@ -8,10 +14,18 @@ export async function probeUrlAlive(url) {
 
   if (!await resolveDns(hostname, HEALTH_CHECK.dnsTimeoutMs)) return false;
 
+  // Worker host may serve a self-signed chain (Cloudflare Access origin).
+  // Use workerFetch so TUNNEL_WORKER_INSECURE is respected; global fetch
+  // would reject the cert silently. Other hosts use plain fetch.
+  const isWorker = WORKER_HOST && hostname === WORKER_HOST;
   try {
-    const res = await fetch(`${url}/api/health`, {
-      signal: AbortSignal.timeout(HEALTH_CHECK.fetchTimeoutMs),
-    });
+    const res = isWorker
+      ? await workerFetch(`${url}/api/health`, {
+          signal: AbortSignal.timeout(HEALTH_CHECK.fetchTimeoutMs),
+        })
+      : await fetch(`${url}/api/health`, {
+          signal: AbortSignal.timeout(HEALTH_CHECK.fetchTimeoutMs),
+        });
     return res.ok;
   } catch {
     return false;

--- a/src/lib/tunnel/cloudflare/manager.js
+++ b/src/lib/tunnel/cloudflare/manager.js
@@ -2,7 +2,8 @@ import { loadState, saveState, generateShortId } from "../shared/state.js";
 import { spawnQuickTunnel, killCloudflared, isCloudflaredRunning, setUnexpectedExitHandler } from "./cloudflared.js";
 import { clearPid } from "./pid.js";
 import { waitForHealth, probeUrlAlive } from "./healthCheck.js";
-import { WORKER_URL } from "./config.js";
+import { WORKER_URL, INSECURE_WORKER } from "./config.js";
+import { workerFetch } from "./workerFetch.js";
 import { getSettings, updateSettings } from "@/lib/localDb";
 
 const svc = {
@@ -20,10 +21,10 @@ let onUnexpectedExit = null;
 export function setTunnelUnexpectedExitCallback(cb) { onUnexpectedExit = cb; }
 
 async function registerTunnelUrl(shortId, tunnelUrl) {
-  await fetch(`${WORKER_URL}/api/tunnel/register`, {
+  await workerFetch(`${WORKER_URL}/api/tunnel/register`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ shortId, tunnelUrl })
+    body: JSON.stringify({ shortId, tunnelUrl }),
   });
 }
 
@@ -103,6 +104,9 @@ export async function enableTunnel(localPort = 20128) {
     // Suppress noise when spawn was deliberately killed (restart/disable superseded it)
     if (!/cloudflared killed|tunnel cancelled/.test(e.message)) {
       console.error(`[Tunnel] enable error: ${e.message}`);
+      if (/fetch failed|self signed|self-signed|certificate/i.test(e.message) && !INSECURE_WORKER) {
+        console.error("[Tunnel] hint: worker TLS rejected. Set TUNNEL_WORKER_INSECURE=1 to bypass cert check for the worker host.");
+      }
     }
     throw e;
   } finally {

--- a/src/lib/tunnel/cloudflare/workerFetch.js
+++ b/src/lib/tunnel/cloudflare/workerFetch.js
@@ -1,0 +1,89 @@
+// Fetch helper for the Cloudflare worker (`WORKER_URL`).
+// Global fetch rejects self-signed certificates, which breaks tunnelling when
+// the worker is fronted by a Cloudflare Access proxy or another TLS origin
+// whose chain includes a self-signed cert (the only error the manager used to
+// surface was the generic "fetch failed"). With TUNNEL_WORKER_INSECURE=1 we
+// fall back to https.request with verification disabled — opt-in only, scoped
+// to the worker host. Default behaviour is unchanged.
+
+import https from "node:https";
+import { URL } from "node:url";
+import { WORKER_URL, INSECURE_WORKER } from "./config.js";
+
+const HOST = (() => {
+  try { return new URL(WORKER_URL).hostname; }
+  catch { return null; }
+})();
+
+const insecureAgent = INSECURE_WORKER && HOST
+  ? new https.Agent({ rejectUnauthorized: false })
+  : null;
+
+function explain(err) {
+  if (!err) return "";
+  const cause = err.cause || err;
+  return cause.code ? ` (cause: ${cause.code})` : "";
+}
+
+async function workerFetch(url, init = {}) {
+  if (!INSECURE_WORKER) {
+    try {
+      return await fetch(url, init);
+    } catch (e) {
+      throw new Error(`${e.message}${explain(e)}`);
+    }
+  }
+
+  // Insecure path: parse + dispatch via https.request with a permissive agent.
+  // Only the WORKER_URL host is allowed to bypass verification.
+  let parsed;
+  try { parsed = new URL(url); }
+  catch (e) { throw new Error(`invalid url: ${url}`); }
+
+  if (!HOST || parsed.hostname !== HOST) {
+    throw new Error(`TUNNEL_WORKER_INSECURE only applies to ${HOST || WORKER_URL}`);
+  }
+
+  const method = (init.method || "GET").toUpperCase();
+  const headers = { ...(init.headers || {}) };
+  const body = init.body == null ? undefined
+    : (typeof init.body === "string" || Buffer.isBuffer(init.body) ? init.body
+       : JSON.stringify(init.body));
+  if (body && !headers["Content-Length"]) headers["Content-Length"] = Buffer.byteLength(body);
+
+  const timeoutMs = init.timeoutMs ?? 10000;
+  const signal = init.signal;
+
+  return new Promise((resolve, reject) => {
+    const req = https.request({
+      hostname: parsed.hostname,
+      port: parsed.port || 443,
+      path: parsed.pathname + parsed.search,
+      method,
+      headers,
+      agent: insecureAgent,
+    }, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        const buf = Buffer.concat(chunks);
+        const response = new Response(buf, {
+          status: res.statusCode || 0,
+          statusText: res.statusMessage || "",
+          headers: res.headers,
+        });
+        resolve(response);
+      });
+    });
+    req.on("error", (e) => reject(new Error(`${e.message}${explain(e)}`)));
+    req.setTimeout(timeoutMs, () => req.destroy(new Error(`request timeout after ${timeoutMs}ms`)));
+    if (signal) {
+      if (signal.aborted) req.destroy(new Error("aborted"));
+      else signal.addEventListener("abort", () => req.destroy(new Error("aborted")), { once: true });
+    }
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+export { workerFetch };

--- a/tests/unit/tunnel-worker-fetch.test.js
+++ b/tests/unit/tunnel-worker-fetch.test.js
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const WORKER = "https://abc-tunnel.us";
+
+describe("tunnel worker fetch (TLS failure)", () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    delete process.env.TUNNEL_WORKER_INSECURE;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.TUNNEL_WORKER_INSECURE;
+    delete process.env.TUNNEL_WORKER_URL;
+  });
+
+  it("annotates fetch failures with the underlying TLS error code", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      const e = new Error("fetch failed");
+      e.cause = Object.assign(new Error("self-signed certificate in certificate chain"), {
+        code: "SELF_SIGNED_CERT_IN_CHAIN",
+      });
+      throw e;
+    });
+
+    const { workerFetch } = await import("../../src/lib/tunnel/cloudflare/workerFetch.js");
+
+    await expect(
+      workerFetch(`${WORKER}/api/tunnel/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shortId: "abc123", tunnelUrl: "https://x.trycloudflare.com" }),
+      })
+    ).rejects.toThrow(/SELF_SIGNED_CERT_IN_CHAIN/);
+  });
+
+  it("respects TUNNEL_WORKER_INSECURE=1 by allowing the worker host", async () => {
+    process.env.TUNNEL_WORKER_INSECURE = "1";
+    globalThis.fetch = vi.fn(async () => ({ ok: true, status: 200 }));
+    const { workerFetch } = await import("../../src/lib/tunnel/cloudflare/workerFetch.js");
+    const res = await workerFetch(`${WORKER}/api/health`);
+    // The worker TLS handshake must complete (no SELF_SIGNED_CERT_IN_CHAIN).
+    // Status code itself is irrelevant — production worker may return 200 or 403.
+    expect(res).toBeDefined();
+    expect(typeof res.status).toBe("number");
+    // insecure path uses https.request, not the global fetch
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  }, 15000);
+
+  it("rejects the insecure path for non-worker hosts", async () => {
+    process.env.TUNNEL_WORKER_INSECURE = "1";
+    const { workerFetch } = await import("../../src/lib/tunnel/cloudflare/workerFetch.js");
+    await expect(
+      workerFetch("https://example.com/api/health")
+    ).rejects.toThrow(/only applies to abc-tunnel\.us/);
+  });
+
+  it("parses common truthy values for the insecure flag", async () => {
+    process.env.TUNNEL_WORKER_INSECURE = "true";
+    const { INSECURE_WORKER } = await import("../../src/lib/tunnel/cloudflare/config.js");
+    expect(INSECURE_WORKER).toBe(true);
+
+    process.env.TUNNEL_WORKER_INSECURE = "off";
+    vi.resetModules();
+    const { INSECURE_WORKER: off } = await import("../../src/lib/tunnel/cloudflare/config.js");
+    expect(off).toBe(false);
+  });
+});
+
+describe("probeUrlAlive uses workerFetch for worker host", () => {
+  beforeEach(() => {
+    delete process.env.TUNNEL_WORKER_INSECURE;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.TUNNEL_WORKER_INSECURE;
+  });
+
+  it("returns false on the worker host when TLS handshake fails", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      const e = new Error("fetch failed");
+      e.cause = Object.assign(new Error("self signed certificate in certificate chain"), {
+        code: "SELF_SIGNED_CERT_IN_CHAIN",
+      });
+      throw e;
+    });
+    const { probeUrlAlive } = await import("../../src/lib/tunnel/cloudflare/healthCheck.js");
+    const alive = await probeUrlAlive("https://rabc123.abc-tunnel.us");
+    expect(alive).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The Cloudflare worker at `WORKER_URL` (default `https://abc-tunnel.us`) terminates TLS with a self-signed certificate in the chain. Node's global `fetch` rejected the handshake and only surfaced the generic `fetch failed` message, so every tunnel enable/restart cycle spun forever:

```
[Tunnel] cloudflared URL: https://...trycloudflare.com
[Tunnel] spawned: https://...trycloudflare.com
[Tunnel] enable error: fetch failed
[Tunnel] restart failed: fetch failed
[Tunnel] disable
[Tunnel] enable start (port=20128)
... (loops)
```

The actual handshake failure was `SELF_SIGNED_CERT_IN_CHAIN` (cause code), which the manager never logged — operators only saw `TypeError: fetch failed`.

## Reproduction (against live worker)

```bash
# Before — fails on TLS
$ node -e "... workerFetch('https://abc-tunnel.us/api/tunnel/register', ...) ..."
UNINSECURE FAIL fetch failed (cause: SELF_SIGNED_CERT_IN_CHAIN) after 206 ms

# After — TLS completes, server returns its real response (e.g. 403 from Cloudflare Access)
$ TUNNEL_WORKER_INSECURE=1 node -e "... workerFetch(...) ..."
INSECURE status 403 in 244 ms
```

## Fix

- New `src/lib/tunnel/cloudflare/workerFetch.js` — wraps `fetch`, annotates errors with `e.cause.code`, and when `TUNNEL_WORKER_INSECURE=1` switches to `https.request` with `rejectUnauthorized: false` (scoped to the worker host only).
- `manager.js` uses `workerFetch` for `registerTunnelUrl`.
- `healthCheck.js` routes worker-host probes through `workerFetch` so `waitForHealth` respects the same flag.
- `manager.js` logs a one-line hint when a fetch/cert error is the cause and the env var is off.
- `config.js` parses common truthy values (`1`, `true`, `yes`, `on`) for the new env var.

## Tests

- New `tests/unit/tunnel-worker-fetch.test.js` (5 cases): error annotation, insecure path, host scoping, env-var parsing, `probeUrlAlive` falls through on TLS failure.
- Existing `tunnel-pid-ownership.test.js` still passes.
- `npx eslint` clean on all changed files.
- No new regressions against `tests/__baseline__/known-fails.txt` (Windsurf/AUDIT/request-normalization entries are pre-existing).

## Operator notes

Two paths to clear the loop in production:

```bash
# 1. Quick path — restart with the env var
TUNNEL_WORKER_INSECURE=1 npm run start

# 2. Preferred — fix the worker side so the cert chain ends at a publicly trusted CA,
#    then no env var is needed and this opt-in becomes a no-op.
```

Default behaviour is unchanged: without `TUNNEL_WORKER_INSECURE=1`, certificate verification is still enforced — only the error log becomes more diagnostic.