### PR TITLE
fix(codex): normalize replayed call item IDs

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -55,13 +55,15 @@ function convertSystemToDeveloperRole(body) {
   }
 }
 
-// Strip server-generated item IDs (rs_/fc_/resp_/msg_) from input — avoids 404 with store=false
+// Strip invalid or stored item IDs before sending a store=false request.
 function stripStoredItemReferences(body) {
   if (!Array.isArray(body.input)) return;
   body.input = body.input.filter((item) => {
     if (typeof item === "string" && SERVER_ID_PATTERN.test(item)) return false;
     if (item && typeof item === "object" && !Array.isArray(item)) {
       if (item.type === "item_reference") return false;
+      // function_call.id is optional input metadata; call_id carries tool-result correlation.
+      if (item.type === "function_call") delete item.id;
       if (typeof item.id === "string" && SERVER_ID_PATTERN.test(item.id)) delete item.id;
     }
     return true;
@@ -406,7 +408,7 @@ export class CodexExecutor extends BaseExecutor {
 
     // Keep system prompts in body.input as role=developer so they stay in the cacheable prefix
     convertSystemToDeveloperRole(body);
-    // Strip server-generated item IDs (rs_/fc_/resp_/msg_) — Codex /responses can't resolve when store=false
+    // Strip invalid function-call IDs and stored references that Codex cannot resolve with store=false
     stripStoredItemReferences(body);
     // Flatten function tools + drop unsupported types
     normalizeCodexTools(body);

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -5,7 +5,7 @@ import {
   refreshProviderCredentials,
   shouldRefreshCredentials,
 } from "../services/oauthCredentialManager.js";
-import { normalizeResponsesInput } from "../translator/formats/responsesApi.js";
+import { normalizeResponsesInput, normalizeStatelessResponseInput } from "../translator/formats/responsesApi.js";
 import { fetchImageAsBase64 } from "../translator/concerns/image.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { getThinkingLevels } from "../providers/thinkingLevels.js";
@@ -24,9 +24,6 @@ const CODEX_SSE_USER_OUTPUT_PATTERNS = [
 ];
 const CODEX_SSE_PEEK_BYTES = 256 * 1024;
 const CODEX_MODEL_CAPACITY_MESSAGE = "Selected model is at capacity. Please try a different model.";
-
-// Server-generated item id prefixes that Codex /responses cannot resolve when store=false
-const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
 
 // Hosted tool types that Codex/OpenAI Responses executes server-side
 const CODEX_HOSTED_TOOL_TYPES = new Set([
@@ -53,21 +50,6 @@ function convertSystemToDeveloperRole(body) {
     const isSystemMsg = item.role === "system" && (!item.type || item.type === "message");
     if (isSystemMsg) item.role = "developer";
   }
-}
-
-// Strip invalid or stored item IDs before sending a store=false request.
-function stripStoredItemReferences(body) {
-  if (!Array.isArray(body.input)) return;
-  body.input = body.input.filter((item) => {
-    if (typeof item === "string" && SERVER_ID_PATTERN.test(item)) return false;
-    if (item && typeof item === "object" && !Array.isArray(item)) {
-      if (item.type === "item_reference") return false;
-      // function_call.id is optional input metadata; call_id carries tool-result correlation.
-      if (item.type === "function_call") delete item.id;
-      if (typeof item.id === "string" && SERVER_ID_PATTERN.test(item.id)) delete item.id;
-    }
-    return true;
-  });
 }
 
 // Flatten Chat-Completions tool shape into Responses flat format + filter unsupported tools
@@ -408,8 +390,8 @@ export class CodexExecutor extends BaseExecutor {
 
     // Keep system prompts in body.input as role=developer so they stay in the cacheable prefix
     convertSystemToDeveloperRole(body);
-    // Strip invalid function-call IDs and stored references that Codex cannot resolve with store=false
-    stripStoredItemReferences(body);
+    // Strip optional call item IDs and stored references that store=false cannot resolve.
+    body.input = normalizeStatelessResponseInput(body.input);
     // Flatten function tools + drop unsupported types
     normalizeCodexTools(body);
 

--- a/open-sse/translator/formats/responsesApi.js
+++ b/open-sse/translator/formats/responsesApi.js
@@ -1,5 +1,32 @@
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM } from "../schema/index.js";
 
+const STORED_ITEM_REFERENCE_PATTERN = /^(?:at|msg|amsg|rs|lsh|fc|tsc|fco|ctc|ctco|tso|ws|ig|cmp|resp)_/;
+const STATELESS_CALL_ITEM_TYPES = new Set([
+  RESPONSES_ITEM.FUNCTION_CALL,
+  RESPONSES_ITEM.FUNCTION_CALL_OUTPUT,
+  RESPONSES_ITEM.CUSTOM_TOOL_CALL,
+  RESPONSES_ITEM.CUSTOM_TOOL_CALL_OUTPUT,
+]);
+
+/**
+ * Remove stored references and optional call item IDs from a stateless Responses replay.
+ * call_id remains the correlation key; IDs on every other item type are preserved.
+ */
+export function normalizeStatelessResponseInput(input) {
+  if (!Array.isArray(input)) return input;
+
+  return input.flatMap((item) => {
+    if (typeof item === "string" && STORED_ITEM_REFERENCE_PATTERN.test(item)) return [];
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [item];
+    if (item.type === RESPONSES_ITEM.ITEM_REFERENCE) return [];
+    if (!STATELESS_CALL_ITEM_TYPES.has(item.type) || !Object.hasOwn(item, "id")) return [item];
+
+    const normalizedItem = { ...item };
+    delete normalizedItem.id;
+    return [normalizedItem];
+  });
+}
+
 /**
  * Normalize Responses API input to array format.
  * Accepts string or array, returns array of message items.

--- a/open-sse/translator/schema/blocks.js
+++ b/open-sse/translator/schema/blocks.js
@@ -30,6 +30,7 @@ export const RESPONSES_ITEM = {
   CUSTOM_TOOL_CALL: "custom_tool_call",
   CUSTOM_TOOL_CALL_OUTPUT: "custom_tool_call_output",
   ADDITIONAL_TOOLS: "additional_tools",
+  ITEM_REFERENCE: "item_reference",
   REASONING: "reasoning",
   OUTPUT_TEXT: "output_text",
   INPUT_TEXT: "input_text",

--- a/tests/unit/codex-function-call-item-id.test.js
+++ b/tests/unit/codex-function-call-item-id.test.js
@@ -11,84 +11,117 @@ function transformInput(input) {
   };
 
   executor.transformRequest("gpt-5.6-sol", body, true, {
-    connectionId: "test-codex-function-call-item-id",
+    connectionId: "test-codex-stateless-item-id",
     providerSpecificData: {},
   });
 
   return body.input;
 }
 
-describe("CodexExecutor function-call item ids", () => {
-  it("strips replayed item ids without changing the tool correlation id", () => {
-    const input = transformInput([
-      {
-        type: "function_call",
-        id: "item_a80a215e158de93e3e66cd2c",
-        call_id: "call_shell_1",
-        name: "shell",
-        arguments: "{}",
-      },
-      {
-        type: "function_call_output",
-        id: "item_output_1",
-        call_id: "call_shell_1",
-        output: "done",
-      },
-    ]);
+const TARGET_ITEMS = {
+  function_call: {
+    legalId: "fc_valid_1",
+    payload: { call_id: "call_function", name: "shell", arguments: "{\"cmd\":\"pwd\"}", status: "completed" },
+  },
+  function_call_output: {
+    legalId: "fco_valid_1",
+    payload: { call_id: "call_function", output: "done", status: "completed" },
+  },
+  custom_tool_call: {
+    legalId: "ctc_valid_1",
+    payload: { call_id: "call_custom", name: "codex_app", input: "PAYLOAD", status: "completed" },
+  },
+  custom_tool_call_output: {
+    legalId: "ctco_valid_1",
+    payload: { call_id: "call_custom", output: "RESULT", status: "completed" },
+  },
+};
 
-    expect(input[0]).toEqual({
-      type: "function_call",
-      call_id: "call_shell_1",
-      name: "shell",
-      arguments: "{}",
+describe("CodexExecutor stateless item IDs", () => {
+  it.each(Object.entries(TARGET_ITEMS))("removes every optional %s id and preserves its payload", (type, fixture) => {
+    const ids = ["item_replayed_1", fixture.legalId, 42, null];
+    const source = [
+      ...ids.map((id, sequence) => ({ type, id, ...fixture.payload, sequence })),
+      { type, ...fixture.payload, sequence: ids.length },
+    ];
+
+    const input = transformInput(source);
+
+    expect(input).toHaveLength(source.length);
+    input.forEach((item, sequence) => {
+      expect(item).toEqual({ type, ...fixture.payload, sequence });
     });
-    expect(input[1].id).toBe("item_output_1");
-    expect(input[1].call_id).toBe("call_shell_1");
   });
 
-  it("cleans an invalid function-call id at the reported history index", () => {
-    const history = Array.from({ length: 59 }, (_, index) => ({
+  it("preserves IDs and payloads on non-call items", () => {
+    const source = [
+      { type: "message", id: "msg_history_1", role: "assistant", content: [{ type: "output_text", text: "continue" }] },
+      { type: "message", id: "item_message_1", role: "user", content: [{ type: "input_text", text: "again" }] },
+      { type: "reasoning", id: "rs_history_1", encrypted_content: "ENCRYPTED_REASONING" },
+      { type: "reasoning", id: "item_reasoning_1", summary: [{ type: "summary_text", text: "summary" }] },
+      { type: "future_response_item", id: "item_future_1", payload: "PAYLOAD" },
+      { id: "item_implicit_message_1", role: "user", content: "hello" },
+    ];
+
+    expect(transformInput(source)).toEqual(source);
+  });
+
+  it("removes stored item references while preserving ordinary input", () => {
+    const storedReferences = [
+      "at_stored", "msg_stored", "amsg_stored", "rs_stored", "lsh_stored",
+      "fc_stored", "tsc_stored", "fco_stored", "ctc_stored", "ctco_stored",
+      "tso_stored", "ws_stored", "ig_stored", "cmp_stored", "resp_stored",
+    ];
+
+    const input = transformInput([
+      ...storedReferences,
+      { type: "item_reference", id: "item_stored" },
+      "ordinary text",
+      { type: "message", id: "msg_kept", role: "user", content: "continue" },
+    ]);
+
+    expect(input).toEqual([
+      "ordinary text",
+      { type: "message", id: "msg_kept", role: "user", content: "continue" },
+    ]);
+  });
+
+  it("preserves function and custom call/output pairing through call_id", () => {
+    const input = transformInput([
+      { type: "function_call", id: "item_fc", call_id: "call_function", name: "shell", arguments: "{}" },
+      { type: "function_call_output", id: "item_fco", call_id: "call_function", output: "done" },
+      { type: "custom_tool_call", id: "item_ctc", call_id: "call_custom", name: "codex_app", input: "PAYLOAD" },
+      { type: "custom_tool_call_output", id: "item_ctco", call_id: "call_custom", output: "RESULT" },
+    ]);
+
+    expect(input).toEqual([
+      { type: "function_call", call_id: "call_function", name: "shell", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_function", output: "done" },
+      { type: "custom_tool_call", call_id: "call_custom", name: "codex_app", input: "PAYLOAD" },
+      { type: "custom_tool_call_output", call_id: "call_custom", output: "RESULT" },
+    ]);
+  });
+
+  it.each([
+    [58, "function_call", "function_call_output", { name: "shell", arguments: "{}" }],
+    [434, "custom_tool_call", "custom_tool_call_output", { name: "codex_app", input: "PAYLOAD" }],
+  ])("normalizes a call/output pair after %i replayed history items", (targetIndex, callType, outputType, callPayload) => {
+    const callId = `call_reported_${targetIndex}`;
+    const history = Array.from({ length: targetIndex }, (_, index) => ({
       type: "message",
-      id: `item_message_${index}`,
+      id: `msg_history_${index}`,
       role: "user",
       content: [{ type: "input_text", text: `step ${index}` }],
     }));
-    history.push({
-      type: "function_call",
-      id: "item_6a5f72cd0d444378d96b2841",
-      call_id: "call_reported_59",
-      name: "local_tool",
-      arguments: "{}",
-    });
+    history.push(
+      { type: callType, id: `item_call_${targetIndex}`, call_id: callId, ...callPayload },
+      { type: outputType, id: `item_output_${targetIndex}`, call_id: callId, output: "RESULT" },
+    );
 
     const input = transformInput(history);
 
-    expect(input[59].id).toBeUndefined();
-    expect(input[59].call_id).toBe("call_reported_59");
+    expect(input[targetIndex - 1].id).toBe(`msg_history_${targetIndex - 1}`);
+    expect(input[targetIndex]).toEqual({ type: callType, call_id: callId, ...callPayload });
+    expect(input[targetIndex + 1]).toEqual({ type: outputType, call_id: callId, output: "RESULT" });
   });
-
-  it("removes every function-call item id when store is disabled", () => {
-    const input = transformInput([
-      {
-        type: "function_call",
-        id: "fc_valid_1",
-        call_id: "call_valid_1",
-        name: "shell",
-        arguments: "{}",
-      },
-      {
-        type: "function_call",
-        id: 42,
-        call_id: "call_numeric_1",
-        name: "shell",
-        arguments: "{}",
-      },
-    ]);
-
-    expect(input[0].id).toBeUndefined();
-    expect(input[0].call_id).toBe("call_valid_1");
-    expect(input[1].id).toBeUndefined();
-    expect(input[1].call_id).toBe("call_numeric_1");
-  });
-
 });

--- a/tests/unit/codex-function-call-item-id.test.js
+++ b/tests/unit/codex-function-call-item-id.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+function transformInput(input) {
+  const executor = new CodexExecutor();
+  const body = {
+    model: "gpt-5.6-sol",
+    input,
+    stream: true,
+  };
+
+  executor.transformRequest("gpt-5.6-sol", body, true, {
+    connectionId: "test-codex-function-call-item-id",
+    providerSpecificData: {},
+  });
+
+  return body.input;
+}
+
+describe("CodexExecutor function-call item ids", () => {
+  it("strips replayed item ids without changing the tool correlation id", () => {
+    const input = transformInput([
+      {
+        type: "function_call",
+        id: "item_a80a215e158de93e3e66cd2c",
+        call_id: "call_shell_1",
+        name: "shell",
+        arguments: "{}",
+      },
+      {
+        type: "function_call_output",
+        id: "item_output_1",
+        call_id: "call_shell_1",
+        output: "done",
+      },
+    ]);
+
+    expect(input[0]).toEqual({
+      type: "function_call",
+      call_id: "call_shell_1",
+      name: "shell",
+      arguments: "{}",
+    });
+    expect(input[1].id).toBe("item_output_1");
+    expect(input[1].call_id).toBe("call_shell_1");
+  });
+
+  it("cleans an invalid function-call id at the reported history index", () => {
+    const history = Array.from({ length: 59 }, (_, index) => ({
+      type: "message",
+      id: `item_message_${index}`,
+      role: "user",
+      content: [{ type: "input_text", text: `step ${index}` }],
+    }));
+    history.push({
+      type: "function_call",
+      id: "item_6a5f72cd0d444378d96b2841",
+      call_id: "call_reported_59",
+      name: "local_tool",
+      arguments: "{}",
+    });
+
+    const input = transformInput(history);
+
+    expect(input[59].id).toBeUndefined();
+    expect(input[59].call_id).toBe("call_reported_59");
+  });
+
+  it("removes every function-call item id when store is disabled", () => {
+    const input = transformInput([
+      {
+        type: "function_call",
+        id: "fc_valid_1",
+        call_id: "call_valid_1",
+        name: "shell",
+        arguments: "{}",
+      },
+      {
+        type: "function_call",
+        id: 42,
+        call_id: "call_numeric_1",
+        name: "shell",
+        arguments: "{}",
+      },
+    ]);
+
+    expect(input[0].id).toBeUndefined();
+    expect(input[0].call_id).toBe("call_valid_1");
+    expect(input[1].id).toBeUndefined();
+    expect(input[1].call_id).toBe("call_numeric_1");
+  });
+
+});


### PR DESCRIPTION
## Problem

Codex Responses rejects replayed history when function or custom tool call items include item IDs.

## Fix

When forwarding stateless requests, remove the optional `id` from `function_call`, `function_call_output`, `custom_tool_call`, and `custom_tool_call_output`. Preserve `call_id` and all payload fields.

## Validation

Covers function and custom tool call/output pairs, long replay histories, and non-call item ID invariance.