### PR TITLE
fix(auth): accept valid x-api-key even when an Authorization header is present (Claude Code)

### DIFF
--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -38,6 +38,25 @@ export function errorResponse(statusCode, message) {
 }
 
 /**
+ * Auth error Response in the client's native format. Anthropic endpoints
+ * (/v1/messages*) get the standard Anthropic error envelope so clients like
+ * Claude Code surface the message correctly; everything else keeps the
+ * OpenAI-compatible shape.
+ * @param {string|null} endpoint - Request pathname (e.g. "/v1/messages")
+ * @param {string} message - Error message
+ * @returns {Response}
+ */
+export function authErrorResponse(endpoint, message) {
+  if (endpoint?.includes("/v1/messages")) {
+    return new Response(
+      JSON.stringify({ type: "error", error: { type: "authentication_error", message } }),
+      { status: 401, headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }
+    );
+  }
+  return errorResponse(401, message);
+}
+
+/**
  * Write error to SSE stream (for streaming)
  * @param {WritableStreamDefaultWriter} writer - Stream writer
  * @param {number} statusCode - HTTP status code

--- a/src/app/api/v1beta/models/[...path]/route.js
+++ b/src/app/api/v1beta/models/[...path]/route.js
@@ -123,15 +123,17 @@ export async function POST(request, { params }) {
   }
 }
 
-function extractGeminiClientApiKey(request) {
+// All credentials the client presented, in precedence order — clients can send
+// an unrelated Authorization header alongside a valid x-goog-api-key, so every
+// candidate must be validated (matches src/sse/services/auth.js semantics).
+function extractGeminiClientApiKeyCandidates(request) {
+  const candidates = [];
+  const push = (v) => { if (v && !candidates.includes(v)) candidates.push(v); };
   const authHeader = request.headers.get("Authorization");
-  if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
-
-  const googleApiKey = request.headers.get("x-goog-api-key");
-  if (googleApiKey) return googleApiKey;
-
-  const url = new URL(request.url);
-  return url.searchParams.get("key");
+  if (authHeader?.startsWith("Bearer ")) push(authHeader.slice(7));
+  push(request.headers.get("x-goog-api-key"));
+  push(new URL(request.url).searchParams.get("key"));
+  return candidates;
 }
 
 function normalizeGeminiNativeModel(model) {
@@ -181,17 +183,15 @@ async function validateGeminiNativeClientKey(request) {
   const settings = await getSettings();
   if (!settings.requireApiKey) return null;
 
-  const apiKey = extractGeminiClientApiKey(request);
-  if (!apiKey) {
+  const candidates = extractGeminiClientApiKeyCandidates(request);
+  if (candidates.length === 0) {
     return Response.json({ error: { message: "Missing API key" } }, { status: 401 });
   }
 
-  const valid = await isValidApiKey(apiKey);
-  if (!valid) {
-    return Response.json({ error: { message: "Invalid API key" } }, { status: 401 });
+  for (const apiKey of candidates) {
+    if (await isValidApiKey(apiKey)) return null;
   }
-
-  return null;
+  return Response.json({ error: { message: "Invalid API key" } }, { status: 401 });
 }
 
 function buildGeminiNativeAuthHeaders(credentials) {

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -118,19 +118,30 @@ function isPublicLlmApi(pathname) {
 }
 
 function extractApiKey(request) {
+  return extractApiKeyCandidates(request)[0] || null;
+}
+
+// All credentials the client presented, in precedence order. Anthropic clients
+// (e.g. Claude Code with an active claude.ai session or ANTHROPIC_AUTH_TOKEN)
+// can send an unrelated Authorization header ALONGSIDE a valid x-api-key —
+// api.anthropic.com still authenticates on x-api-key, so we must validate every
+// presented credential, not just the first one found.
+function extractApiKeyCandidates(request) {
+  const candidates = [];
+  const push = (v) => { if (v && !candidates.includes(v)) candidates.push(v); };
   const authHeader = request.headers.get("Authorization");
-  if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
-  const apiKeyHeader = request.headers.get("x-api-key");
-  if (apiKeyHeader) return apiKeyHeader;
-  const googleApiKeyHeader = request.headers.get("x-goog-api-key");
-  if (googleApiKeyHeader) return googleApiKeyHeader;
-  return request.nextUrl.searchParams?.get("key") || null;
+  if (authHeader?.startsWith("Bearer ")) push(authHeader.slice(7));
+  push(request.headers.get("x-api-key"));
+  push(request.headers.get("x-goog-api-key"));
+  push(request.nextUrl.searchParams?.get("key"));
+  return candidates;
 }
 
 async function hasValidApiKey(request) {
-  const apiKey = extractApiKey(request);
-  if (!apiKey) return false;
-  return await validateApiKey(apiKey);
+  for (const apiKey of extractApiKeyCandidates(request)) {
+    if (await validateApiKey(apiKey)) return true;
+  }
+  return false;
 }
 
 async function canAccessPublicLlmApi(request) {
@@ -176,6 +187,7 @@ export const __test__ = {
   isLocalRequest,
   isPublicLlmApi,
   extractApiKey,
+  extractApiKeyCandidates,
   canAccessPublicLlmApi,
   canAccessLocalOnlyRoute,
 };
@@ -199,6 +211,14 @@ export async function proxy(request) {
 
   if (isPublicLlmApi(pathname)) {
     if (await canAccessPublicLlmApi(request)) return NextResponse.next();
+    // Anthropic clients (Claude Code, anthropic SDKs) parse the standard error
+    // envelope; other endpoints keep the legacy flat shape.
+    if (pathname.includes("/v1/messages")) {
+      return NextResponse.json(
+        { type: "error", error: { type: "authentication_error", message: "API key required for remote API access" } },
+        { status: 401 }
+      );
+    }
     return NextResponse.json({ error: "API key required for remote API access" }, { status: 401 });
   }
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -4,8 +4,7 @@ import {
   getProviderCredentials,
   markAccountUnavailable,
   clearAccountError,
-  extractApiKey,
-  isValidApiKey,
+  resolveClientApiKey,
 } from "../services/auth.js";
 import { cacheClaudeHeaders } from "open-sse/utils/claudeHeaderCache.js";
 import { getSettings } from "@/lib/localDb";
@@ -14,7 +13,7 @@ import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
 import { getTransform as getPxpipeTransform } from "@/lib/pxpipe/loader.js";
 import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
-import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
+import { errorResponse, unavailableResponse, authErrorResponse } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat } from "open-sse/services/combo.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
@@ -52,12 +51,11 @@ export async function handleChat(request, clientRawRequest = null) {
 
   // Request summary is emitted as the unified "▶" line in chatCore (has fmt/thinking/account)
 
-  // Log API key (masked)
-  const authHeader = request.headers.get("Authorization");
-  const apiKey = extractApiKey(request);
-  if (authHeader && apiKey) {
-    const masked = log.maskKey(apiKey);
-    log.debug("AUTH", `API Key: ${masked}`);
+  // Resolve client API key across all presented credentials (Authorization +
+  // x-api-key) — attribution uses the credential that actually validated.
+  const { apiKey, valid: apiKeyValid } = await resolveClientApiKey(request);
+  if (apiKey) {
+    log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}${apiKeyValid ? "" : " (not recognized)"}`);
   } else {
     log.debug("AUTH", "No API key provided (local mode)");
   }
@@ -67,12 +65,11 @@ export async function handleChat(request, clientRawRequest = null) {
   if (settings.requireApiKey) {
     if (!apiKey) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
+      return authErrorResponse(clientRawRequest.endpoint, "Missing API key");
     }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
+    if (!apiKeyValid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
-      return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+      return authErrorResponse(clientRawRequest.endpoint, "Invalid API key");
     }
   }
 

--- a/src/sse/handlers/embeddings.js
+++ b/src/sse/handlers/embeddings.js
@@ -2,8 +2,7 @@ import {
   getProviderCredentials,
   markAccountUnavailable,
   clearAccountError,
-  extractApiKey,
-  isValidApiKey,
+  resolveClientApiKey,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
@@ -43,8 +42,8 @@ export async function handleEmbeddings(request) {
 
   log.request("POST", `${url.pathname} | ${modelStr}`);
 
-  // Log API key (masked)
-  const apiKey = extractApiKey(request);
+  // Resolve client API key across all presented credentials (masked log)
+  const { apiKey, valid: apiKeyValid } = await resolveClientApiKey(request);
   if (apiKey) {
     log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
   } else {
@@ -58,8 +57,7 @@ export async function handleEmbeddings(request) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
+    if (!apiKeyValid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
     }

--- a/src/sse/handlers/fetch.js
+++ b/src/sse/handlers/fetch.js
@@ -2,8 +2,7 @@ import {
   getProviderCredentials,
   markAccountUnavailable,
   clearAccountError,
-  extractApiKey,
-  isValidApiKey,
+  resolveClientApiKey,
 } from "../services/auth.js";
 import { getSettings, getCombos } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
@@ -39,8 +38,8 @@ export async function handleFetch(request) {
 
   log.request("POST", `${reqUrl.pathname} | ${providerInput}`);
 
-  // Log API key (masked)
-  const apiKey = extractApiKey(request);
+  // Resolve client API key across all presented credentials (masked log)
+  const { apiKey, valid: apiKeyValid } = await resolveClientApiKey(request);
   if (apiKey) {
     log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
   } else {
@@ -54,8 +53,7 @@ export async function handleFetch(request) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
+    if (!apiKeyValid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
     }

--- a/src/sse/handlers/imageGeneration.js
+++ b/src/sse/handlers/imageGeneration.js
@@ -2,8 +2,7 @@ import {
   getProviderCredentials,
   markAccountUnavailable,
   clearAccountError,
-  extractApiKey,
-  isValidApiKey,
+  resolveClientApiKey,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo, getComboModels } from "../services/model.js";
@@ -35,12 +34,11 @@ export async function handleImageGeneration(request) {
   const binaryOutput = url.searchParams.get("response_format") === "binary";
   const modelStr = body.model;
 
-  const apiKey = extractApiKey(request);
+  const { apiKey, valid: apiKeyValid } = await resolveClientApiKey(request);
   const settings = await getSettings();
   if (settings.requireApiKey) {
     if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+    if (!apiKeyValid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
   }
 
   if (!modelStr) return errorResponse(HTTP_STATUS.BAD_REQUEST, "Missing model");

--- a/src/sse/handlers/search.js
+++ b/src/sse/handlers/search.js
@@ -2,8 +2,7 @@ import {
   getProviderCredentials,
   markAccountUnavailable,
   clearAccountError,
-  extractApiKey,
-  isValidApiKey,
+  resolveClientApiKey,
 } from "../services/auth.js";
 import { getSettings, getCombos } from "@/lib/localDb";
 import { AI_PROVIDERS, resolveProviderId } from "@/shared/constants/providers.js";
@@ -36,8 +35,8 @@ export async function handleSearch(request) {
 
   log.request("POST", `${url.pathname} | ${providerInput}`);
 
-  // Log API key (masked)
-  const apiKey = extractApiKey(request);
+  // Resolve client API key across all presented credentials (masked log)
+  const { apiKey, valid: apiKeyValid } = await resolveClientApiKey(request);
   if (apiKey) {
     log.debug("AUTH", `API Key: ${log.maskKey(apiKey)}`);
   } else {
@@ -51,8 +50,7 @@ export async function handleSearch(request) {
       log.warn("AUTH", "Missing API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
     }
-    const valid = await isValidApiKey(apiKey);
-    if (!valid) {
+    if (!apiKeyValid) {
       log.warn("AUTH", "Invalid API key (requireApiKey=true)");
       return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
     }

--- a/src/sse/handlers/stt.js
+++ b/src/sse/handlers/stt.js
@@ -1,5 +1,5 @@
 import {
-  extractApiKey, isValidApiKey,
+  resolveClientApiKey,
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
@@ -30,9 +30,8 @@ export async function handleStt(request) {
 
   const settings = await getSettings();
   if (settings.requireApiKey) {
-    const apiKey = extractApiKey(request);
+    const { apiKey, valid } = await resolveClientApiKey(request);
     if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    const valid = await isValidApiKey(apiKey);
     if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
   }
 

--- a/src/sse/handlers/tts.js
+++ b/src/sse/handlers/tts.js
@@ -1,5 +1,5 @@
 import {
-  extractApiKey, isValidApiKey,
+  resolveClientApiKey,
   getProviderCredentials, markAccountUnavailable,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
@@ -34,9 +34,8 @@ export async function handleTts(request) {
 
   const settings = await getSettings();
   if (settings.requireApiKey) {
-    const apiKey = extractApiKey(request);
+    const { apiKey, valid } = await resolveClientApiKey(request);
     if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    const valid = await isValidApiKey(apiKey);
     if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
   }
 

--- a/src/sse/handlers/videoGeneration.js
+++ b/src/sse/handlers/videoGeneration.js
@@ -2,8 +2,7 @@ import {
   getProviderCredentials,
   markAccountUnavailable,
   clearAccountError,
-  extractApiKey,
-  isValidApiKey,
+  resolveClientApiKey,
 } from "../services/auth.js";
 import { getSettings } from "@/lib/localDb";
 import { getModelInfo } from "../services/model.js";
@@ -27,11 +26,10 @@ const CREATE_ROTATION_STATUSES = new Set([
 ]);
 
 async function requireValidApiKey(request) {
-  const apiKey = extractApiKey(request);
   const settings = await getSettings();
   if (settings.requireApiKey) {
+    const { apiKey, valid } = await resolveClientApiKey(request);
     if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
-    const valid = await isValidApiKey(apiKey);
     if (!valid) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
   }
   return null;

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -298,22 +298,40 @@ export async function clearAccountError(connectionId, currentConnection, model =
 }
 
 /**
- * Extract API key from request headers
+ * Extract API key from request headers (first presented credential).
  */
 export function extractApiKey(request) {
-  // Check Authorization header first
+  return extractApiKeyCandidates(request)[0] || null;
+}
+
+/**
+ * All credentials the client presented, in precedence order.
+ * Anthropic clients (e.g. Claude Code with an active claude.ai session or
+ * ANTHROPIC_AUTH_TOKEN set) can send an unrelated Authorization header
+ * ALONGSIDE a valid x-api-key — api.anthropic.com still authenticates on
+ * x-api-key, so every presented credential must be checked.
+ */
+export function extractApiKeyCandidates(request) {
+  const candidates = [];
+  const push = (v) => { if (v && !candidates.includes(v)) candidates.push(v); };
   const authHeader = request.headers.get("Authorization");
-  if (authHeader?.startsWith("Bearer ")) {
-    return authHeader.slice(7);
-  }
+  if (authHeader?.startsWith("Bearer ")) push(authHeader.slice(7));
+  push(request.headers.get("x-api-key"));
+  return candidates;
+}
 
-  // Check Anthropic x-api-key header
-  const xApiKey = request.headers.get("x-api-key");
-  if (xApiKey) {
-    return xApiKey;
+/**
+ * Resolve the client's API key against the apiKeys table.
+ * Returns { apiKey, valid }: when valid, apiKey is the credential that
+ * actually validated (use it for usage attribution); otherwise apiKey is the
+ * first presented credential (or null if none).
+ */
+export async function resolveClientApiKey(request) {
+  const candidates = extractApiKeyCandidates(request);
+  for (const key of candidates) {
+    if (await validateApiKey(key)) return { apiKey: key, valid: true };
   }
-
-  return null;
+  return { apiKey: candidates[0] || null, valid: false };
 }
 
 /**

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -276,4 +276,70 @@ describe("dashboard guard helpers", () => {
 
     expect(__test__.extractApiKey(apiRequest)).toBe("header-key");
   });
+
+  it("collects every presented credential in precedence order", () => {
+    const apiRequest = request("/v1beta/models?key=query-key", {
+      authorization: "Bearer bearer-key",
+      "x-api-key": "header-key",
+      "x-goog-api-key": "google-key",
+    });
+
+    expect(__test__.extractApiKeyCandidates(apiRequest)).toEqual([
+      "bearer-key", "header-key", "google-key", "query-key",
+    ]);
+  });
+});
+
+describe("dashboard guard multi-credential validation (Anthropic clients)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({ requireLogin: true });
+    mocks.verifyDashboardAuthToken.mockResolvedValue(false);
+  });
+
+  it("accepts valid x-api-key even when a stale Authorization header is present", async () => {
+    // Claude Code with an active claude.ai session (or ANTHROPIC_AUTH_TOKEN)
+    // sends both headers; api.anthropic.com still authenticates on x-api-key.
+    mocks.validateApiKey.mockImplementation(async (key) => key === "sk-valid");
+
+    const response = await proxy(request("/v1/messages", {
+      host: "router.example.com",
+      authorization: "Bearer sk-ant-oat01-stale-session-token",
+      "x-api-key": "sk-valid",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-valid");
+  });
+
+  it("rejects when no presented credential validates", async () => {
+    mocks.validateApiKey.mockResolvedValue(false);
+
+    const response = await proxy(request("/v1/messages", {
+      host: "router.example.com",
+      authorization: "Bearer sk-bad",
+      "x-api-key": "sk-also-bad",
+    }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns the Anthropic error envelope on /v1/messages 401", async () => {
+    mocks.validateApiKey.mockResolvedValue(false);
+
+    const response = await proxy(request("/v1/messages", { host: "router.example.com" }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.type).toBe("error");
+    expect(response.body.error.type).toBe("authentication_error");
+  });
+
+  it("keeps the legacy error shape on non-Anthropic endpoints", async () => {
+    mocks.validateApiKey.mockResolvedValue(false);
+
+    const response = await proxy(request("/v1/chat/completions", { host: "router.example.com" }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("API key required for remote API access");
+  });
 });


### PR DESCRIPTION
## Problem

Anthropic clients can send an `Authorization: Bearer …` header **alongside** `x-api-key`. Claude Code does this whenever the user has an active claude.ai session or `ANTHROPIC_AUTH_TOKEN` set while `ANTHROPIC_API_KEY` points at 9router. The real Anthropic API authenticates on `x-api-key` regardless of other headers — but 9router's `extractApiKey` (both in `dashboardGuard.js` and `src/sse/services/auth.js`) picks the Authorization bearer first and never falls back, so a **valid** client API key gets 401 whenever any bearer is present.

Reproduction against a 9router instance with `requireApiKey` enabled:

```bash
# works
curl -X POST $BASE/v1/messages -H 'x-api-key: <valid-9router-key>' ...
# 401 — same valid key, plus the stale bearer Claude Code sends
curl -X POST $BASE/v1/messages \
  -H 'Authorization: Bearer sk-ant-oat01-…' \
  -H 'x-api-key: <valid-9router-key>' ...
```

## Fix

- The guard and the SSE auth service now collect **all** presented credentials (`Authorization` bearer, `x-api-key`, `x-goog-api-key`, `?key=`) in precedence order and accept the request if **any** of them validates.
- New `resolveClientApiKey()` returns the credential that actually validated, so per-key usage attribution records the real key instead of a stale bearer.
- All `/v1` handlers (chat/messages, embeddings, search, fetch, stt, tts, image, video) and the Gemini-native `/v1beta` route use the multi-credential check.
- 401s on `/v1/messages` now return the standard Anthropic error envelope (`{"type":"error","error":{"type":"authentication_error",…}}`) so Claude Code and anthropic SDKs surface the message instead of an opaque body. Other endpoints keep their existing error shape.

## Tests

- New unit tests cover the both-headers case, candidate collection order, and the Anthropic 401 envelope (`tests/unit/dashboard-guard.test.js`).
- `unit/dashboard-guard`, `unit/embeddingsCore`, `unit/image-generation`, `unit/gemini-native-endpoint`, `unit/gemini-tts`, `unit/xai-video-handler`, `unit/minimax-tts`, `unit/kiro-nonstream-error`: 112/112 passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)