### PR TITLE
fix(thinking): stop claude-adaptive's unlevelled auto intent from 400ing

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -66,6 +66,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const stripList = getModelStrip(alias, model);
   const upstreamModel = getModelUpstreamId(alias, model);
 
+  // Native passthrough: CLI tool and provider are the same ecosystem
+  // Skip all translation/normalization — only model and Bearer are swapped
+  const clientTool = detectClientTool(clientRawRequest?.headers || {}, body);
+  const passthrough = isNativePassthrough(clientTool, provider);
+
   // Inject provider-level thinking config override (only if client hasn't set)
   // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
   if (providerThinking?.mode && providerThinking.mode !== "auto") {
@@ -75,8 +80,25 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       body = { ...body, thinking: { type: "enabled", budget_tokens: 10000 } };
     } else if (mode === "off" && !body.thinking) {
       body = { ...body, thinking: { type: "disabled" } };
-    } else if (!body.reasoning_effort) {
-      body = { ...body, reasoning_effort: mode };
+    } else if (mode !== "on" && mode !== "off") {
+      // A client can say "think, but I'm not naming a level" in a shape that
+      // isn't reasoning_effort — Cherry Studio sends Claude's
+      // thinking:{type:"enabled"} with no budget_tokens for its Auto effort.
+      // extractThinking() reads the thinking field before reasoning_effort, so
+      // testing only for reasoning_effort here let that unlevelled intent
+      // silently outrank this setting. Ask extractThinking() instead: it is the
+      // one reader of client thinking intent, so it agrees with the code that
+      // later decides which field wins.
+      const intent = extractThinking(body);
+      const clientNamedLevel = intent != null && intent.mode !== "auto";
+      if (!clientNamedLevel) {
+        body = { ...body, reasoning_effort: mode };
+        // Translated paths re-emit thinking in the target's native shape from the
+        // winning intent, so the stale unlevelled field has to go or it wins
+        // again. Passthrough forwards the client's body untouched and never reads
+        // reasoning_effort — dropping the field there would just silence thinking.
+        if (!passthrough) delete body.thinking;
+      }
     }
   }
 
@@ -94,8 +116,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // DeepSeek-TUI: interactive TUI panel sends stream:true and needs SSE.
   // Non-interactive mode (-p flag) sends without stream and can't parse SSE.
   // Only force non-streaming when client didn't explicitly request it.
-  const detectedTool = detectClientTool(clientRawRequest?.headers || {}, body);
-  if (detectedTool === "deepseek-tui" && body.stream !== true) stream = false;
+  if (clientTool === "deepseek-tui" && body.stream !== true) stream = false;
 
   // Check client Accept header preference for non-streaming requests
   // This fixes AI SDK compatibility where clients send Accept: application/json
@@ -110,11 +131,6 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (clientRawRequest) reqLogger.logClientRawRequest(clientRawRequest.endpoint, clientRawRequest.body, clientRawRequest.headers);
   reqLogger.logRawRequest(body);
   log?.debug?.("FORMAT", `${sourceFormat} → ${targetFormat} | stream=${stream}`);
-
-  // Native passthrough: CLI tool and provider are the same ecosystem
-  // Skip all translation/normalization — only model and Bearer are swapped
-  const clientTool = detectClientTool(clientRawRequest?.headers || {}, body);
-  const passthrough = isNativePassthrough(clientTool, provider);
 
   // Expose raw client headers to translators/executors for session-id resolution
   if (credentials) credentials.rawHeaders = clientRawRequest?.headers || {};

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -139,6 +139,20 @@ function toGeminiThinkingLevel(cfg) {
   return effortToThinkingLevel(raw);
 }
 
+// Unified level → Anthropic's output_config.effort enum [low medium high xhigh max].
+// "auto" (think, level unspecified) and "minimal" are valid unified intents with no
+// value in that enum, and an unmapped value is not ignored — Anthropic rejects the
+// whole request (400 invalid_reasoning_effort) — so they resolve to the nearest
+// supported level, as the gemini-level and kimi branches already do for auto.
+function toClaudeAdaptiveEffort(cfg) {
+  const level = toLevel(cfg);
+  if (level === "auto") return "high";
+  if (level === "minimal") return "low";
+  // Pre-existing downgrade: kept until xhigh is verified across the 4.6+ line.
+  if (level === "xhigh") return "high";
+  return level;
+}
+
 function toKimiReasoningEffort(cfg) {
   const level = toLevel(cfg);
   if (level === "auto") return "high";
@@ -235,8 +249,7 @@ function applyFormat(fmt, body, cfg, caps) {
       // shims (e.g. GitHub Copilot /v1/messages) default thinking off even for
       // Sonnet 5. Send both fields — the documented adaptive-thinking shape.
       body.thinking = { type: "adaptive" };
-      const level = toLevel(eff);
-      body.output_config = { effort: level === "xhigh" ? "high" : level };
+      body.output_config = { effort: toClaudeAdaptiveEffort(eff) };
       break;
     }
     case "claude-budget": {

--- a/tests/translator/golden-request.test.js
+++ b/tests/translator/golden-request.test.js
@@ -47,6 +47,51 @@ describe("GOLDEN request: OpenAI → Claude", () => {
     const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-opus-4-6", body, true, { apiKey: "sk-x" }, "anthropic");
     expect(clean(out)).toMatchSnapshot();
   });
+
+  // Regression: an unlevelled thinking intent (client asked to think without
+  // naming a level — Cherry Studio's Auto effort) used to reach the wire as
+  // output_config.effort:"auto", which Anthropic rejects with 400
+  // invalid_reasoning_effort ("supported values: [low medium high xhigh max]").
+  it("unlevelled thinking intent → a real effort level, never the literal auto", () => {
+    for (const body of [
+      { messages: [{ role: "user", content: "hi" }], thinking: { type: "enabled" } },
+      { messages: [{ role: "user", content: "hi" }], thinking: { type: "adaptive" } },
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "auto" },
+    ]) {
+      const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-opus-4-6", body, true, { apiKey: "sk-x" }, "github");
+      expect(out.thinking).toEqual({ type: "adaptive" });
+      expect(["low", "medium", "high", "xhigh", "max"]).toContain(out.output_config.effort);
+    }
+  });
+
+  // A model-name suffix reaches the same branch via parseSuffix → mode:"auto".
+  it("model(auto) suffix does not put auto on the wire", () => {
+    const body = { messages: [{ role: "user", content: "hi" }] };
+    const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-opus-4-6(auto)", body, true, { apiKey: "sk-x" }, "github");
+    expect(out.output_config.effort).not.toBe("auto");
+  });
+
+  // Same class as "auto": a unified level with no value in Anthropic's enum.
+  // "minimal" comes from OpenAI-style clients and from tiny thinking budgets.
+  it("minimal effort maps into Anthropic's enum instead of 400ing", () => {
+    for (const body of [
+      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "minimal" },
+      { messages: [{ role: "user", content: "hi" }], thinking: { type: "enabled", budget_tokens: 512 } },
+    ]) {
+      const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-opus-4-6", body, true, { apiKey: "sk-x" }, "github");
+      expect(["low", "medium", "high", "xhigh", "max"]).toContain(out.output_config.effort);
+    }
+  });
+
+  // Concrete levels must still pass through untouched — the mapping only rewrites
+  // values Anthropic has no enum entry for.
+  it("concrete levels reach the wire unchanged", () => {
+    for (const [asked, expected] of [["low", "low"], ["medium", "medium"], ["high", "high"], ["max", "max"]]) {
+      const body = { messages: [{ role: "user", content: "hi" }], reasoning_effort: asked };
+      const out = translateRequest(FORMATS.OPENAI, FORMATS.CLAUDE, "claude-opus-4-6", body, true, { apiKey: "sk-x" }, "github");
+      expect(out.output_config.effort, asked).toBe(expected);
+    }
+  });
 });
 
 describe("GOLDEN request: OpenAI → Gemini", () => {

--- a/tests/unit/provider-thinking-injection.test.js
+++ b/tests/unit/provider-thinking-injection.test.js
@@ -1,0 +1,231 @@
+// Guards the provider-level thinking default (dashboard "Thinking: <level>" picker)
+// against being outranked by a client's unlevelled thinking intent.
+// Cherry Studio's Auto effort sends Claude's thinking:{type:"enabled"} with no
+// budget_tokens; extractThinking() reads that field before reasoning_effort, so a
+// guard that only tested reasoning_effort let the setting be silently dropped.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { executeMock, detectClientToolMock, isNativePassthroughMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  detectClientToolMock: vi.fn(() => null),
+  isNativePassthroughMock: vi.fn(() => false),
+}));
+
+vi.mock("../../open-sse/executors/index.js", () => ({
+  getExecutor: vi.fn(() => ({
+    execute: executeMock,
+    refreshCredentials: vi.fn().mockResolvedValue(null),
+  })),
+}));
+
+vi.mock("../../open-sse/utils/requestLogger.js", () => ({
+  createRequestLogger: vi.fn(async () => ({
+    logClientRawRequest: vi.fn(),
+    logRawRequest: vi.fn(),
+    logTargetRequest: vi.fn(),
+    logError: vi.fn(),
+  })),
+}));
+
+vi.mock("../../open-sse/utils/clientDetector.js", () => ({
+  detectClientTool: detectClientToolMock,
+  isNativePassthrough: isNativePassthroughMock,
+}));
+
+vi.mock("../../open-sse/utils/bypassHandler.js", () => ({
+  handleBypassRequest: vi.fn(() => null),
+}));
+
+vi.mock("../../open-sse/utils/streamHandler.js", () => ({
+  createStreamController: vi.fn(() => ({
+    signal: undefined,
+    handleComplete: vi.fn(),
+    handleError: vi.fn(),
+  })),
+}));
+
+vi.mock("../../open-sse/services/tokenRefresh.js", () => ({
+  refreshWithRetry: vi.fn(),
+}));
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  default: vi.fn(),
+  proxyAwareFetch: vi.fn(),
+}));
+
+vi.mock("../../open-sse/utils/toolDeduper.js", () => ({
+  dedupeTools: vi.fn((tools) => ({ tools, stripped: [] })),
+}));
+
+vi.mock("../../open-sse/rtk/caveman.js", () => ({
+  injectCaveman: vi.fn(),
+}));
+
+vi.mock("../../open-sse/rtk/ponytail.js", () => ({
+  injectPonytail: vi.fn(),
+}));
+
+vi.mock("../../open-sse/rtk/index.js", () => ({
+  compressMessages: vi.fn(() => null),
+  formatRtkLog: vi.fn(() => ""),
+}));
+
+vi.mock("../../open-sse/rtk/headroom.js", () => ({
+  compressWithHeadroom: vi.fn(async () => null),
+  formatHeadroomLog: vi.fn(() => ""),
+  formatHeadroomSizeLog: vi.fn(() => ""),
+  isHeadroomPhantomSavings: vi.fn(() => false),
+}));
+
+vi.mock("../../open-sse/translator/concerns/modality.js", () => ({
+  stripUnsupportedModalities: vi.fn(() => false),
+}));
+
+vi.mock("../../open-sse/translator/concerns/prefetch.js", () => ({
+  prefetchRemoteImages: vi.fn(async () => 0),
+}));
+
+vi.mock("../../open-sse/handlers/chatCore/requestDetail.js", () => ({
+  buildRequestDetail: vi.fn((detail) => detail),
+  extractRequestConfig: vi.fn((body, stream) => ({ body, stream })),
+}));
+
+vi.mock("../../open-sse/utils/error.js", () => ({
+  createErrorResult: vi.fn((status, message) => ({ success: false, status, error: message })),
+  formatProviderError: vi.fn((error) => error.message),
+  parseUpstreamError: vi.fn(),
+}));
+
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(() => Promise.resolve()),
+  saveRequestDetail: vi.fn(() => Promise.resolve()),
+}));
+
+// capabilities.js is deliberately NOT mocked: the assertions are about the effort
+// that reaches the wire, which the real claude-adaptive capability decides.
+
+const MODEL = "claude-opus-4-6";
+
+// Runs one request through chatCore and returns the body handed to the executor.
+async function dispatch({ clientBody, providerThinking }) {
+  const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
+  const body = { model: MODEL, messages: [{ role: "user", content: "hi" }], ...clientBody };
+
+  await handleChatCore({
+    body,
+    modelInfo: { provider: "github", model: MODEL },
+    credentials: { apiKey: "sk-test" },
+    providerThinking,
+    clientRawRequest: { endpoint: "/v1/chat/completions", body, headers: {} },
+    connectionId: "test-connection",
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  });
+
+  expect(executeMock).toHaveBeenCalledTimes(1);
+  return executeMock.mock.calls[0][0].body;
+}
+
+describe("provider-level thinking default vs client intent", () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    executeMock.mockRejectedValue(new Error("boom"));
+    detectClientToolMock.mockReset();
+    detectClientToolMock.mockReturnValue(null);
+    isNativePassthroughMock.mockReset();
+    isNativePassthroughMock.mockReturnValue(false);
+  });
+
+  // The reported failure: dashboard set to High, Cherry Studio sent Auto, and the
+  // request 400'd with output_config.effort "auto" instead of using High.
+  it("fills in the configured level when the client names none", async () => {
+    const sent = await dispatch({
+      clientBody: { thinking: { type: "enabled" } },
+      providerThinking: { mode: "high" },
+    });
+
+    expect(sent.output_config.effort).toBe("high");
+  });
+
+  // Distinguishes "the setting was honoured" from "auto happened to fall back to
+  // high": every configured level must reach the wire verbatim.
+  it.each(["low", "medium", "high", "max"])("honours the configured level %s", async (mode) => {
+    const sent = await dispatch({
+      clientBody: { thinking: { type: "enabled" } },
+      providerThinking: { mode },
+    });
+
+    expect(sent.output_config.effort).toBe(mode);
+  });
+
+  it("leaves no unlevelled thinking field behind to outrank the injected level", async () => {
+    const sent = await dispatch({
+      clientBody: { thinking: { type: "enabled" } },
+      providerThinking: { mode: "low" },
+    });
+
+    // applyThinking re-emits the field from the winning intent; the stale one is gone.
+    expect(sent.thinking).toEqual({ type: "adaptive" });
+    expect(sent.output_config.effort).toBe("low");
+  });
+
+  it("does not override a level the client asked for", async () => {
+    const viaEffort = await dispatch({
+      clientBody: { reasoning_effort: "low" },
+      providerThinking: { mode: "high" },
+    });
+    expect(viaEffort.output_config.effort).toBe("low");
+
+    executeMock.mockReset();
+    executeMock.mockRejectedValue(new Error("boom"));
+
+    // A concrete budget is a named level too (1024 → "low"), not an auto intent.
+    const viaBudget = await dispatch({
+      clientBody: { thinking: { type: "enabled", budget_tokens: 1024 } },
+      providerThinking: { mode: "high" },
+    });
+    expect(viaBudget.output_config.effort).toBe("low");
+  });
+
+  it("respects a client that asked for no thinking at all", async () => {
+    const sent = await dispatch({
+      clientBody: { thinking: { type: "disabled" } },
+      providerThinking: { mode: "high" },
+    });
+
+    expect(sent.thinking).toEqual({ type: "disabled" });
+    expect(sent.output_config).toBeUndefined();
+  });
+
+  it("still injects when the client sends no thinking intent", async () => {
+    const sent = await dispatch({ clientBody: {}, providerThinking: { mode: "medium" } });
+
+    expect(sent.output_config.effort).toBe("medium");
+  });
+
+  it("leaves the body alone when the provider default is auto", async () => {
+    const sent = await dispatch({
+      clientBody: { thinking: { type: "enabled" } },
+      providerThinking: { mode: "auto" },
+    });
+
+    // No configured level to inject — the unlevelled intent resolves in the
+    // translator instead, which must still not put "auto" on the wire.
+    expect(sent.output_config.effort).not.toBe("auto");
+  });
+
+  // Passthrough forwards the client's body untouched and never reads
+  // reasoning_effort, so stripping the client's thinking field there would turn
+  // thinking off instead of raising it to the configured level.
+  it("keeps the client's thinking field on the native passthrough path", async () => {
+    detectClientToolMock.mockReturnValue("claude");
+    isNativePassthroughMock.mockReturnValue(true);
+
+    const sent = await dispatch({
+      clientBody: { thinking: { type: "enabled" } },
+      providerThinking: { mode: "high" },
+    });
+
+    expect(sent.thinking).toEqual({ type: "enabled" });
+  });
+});


### PR DESCRIPTION
## Summary

Cherry Studio's Auto thinking effort sends Claude's `thinking:{type:"enabled"}` with no `budget_tokens` (an unlevelled intent, not a specific budget). For any 4.6+/5-gen Claude model, that intent reaches `output_config.effort` as the **literal string `"auto"`**, which Anthropic rejects outright:

```
400 invalid_reasoning_effort: output_config.effort "auto" is not supported by
model claude-fable-5; supported values: [low medium high xhigh max]
```

Two bugs compound to produce this, fixed in two commits:

1. **`toLevel()` never resolves `"auto"`/`"minimal"` into Anthropic's enum.** The `claude-adaptive` branch of `applyFormat()` passed the unified level straight through. `"auto"` (think, level unspecified) and `"minimal"` (from OpenAI-style clients, or budgets ≤768) both have no value in `[low medium high xhigh max]` — an unmapped value isn't ignored, it 400s the whole request. Resolved through a new `toClaudeAdaptiveEffort()`, mirroring how the `gemini-level` and `kimi` branches already resolve `auto`.

2. **The dashboard's per-provider "Thinking: `<level>`" default gets silently dropped when the client sends this shape.** `chatCore.js`'s injection only checked `!body.reasoning_effort` before filling in the configured level — it didn't know the client had *already* said something, just in the `thinking` shape rather than `reasoning_effort`. `extractThinking()` (which decides what actually reaches the wire) checks `thinking` before `reasoning_effort`, so the injected level landed in the body but was outranked by the client's unlevelled field, and the panel's configured default never took effect — not even to fall back to a fixed default, it just silently reverted to (1)'s `"auto"` bug. Fixed by asking `extractThinking()` whether the client named a level, and clearing the stale unlevelled field when injecting — except on the native-passthrough path, which forwards the client's body untouched and never reads `reasoning_effort`, so clearing `thinking` there would silence thinking instead of raising it.

Both were live-verified against GitHub Copilot's Claude endpoint (`gh/claude-fable-5`) after deploying, including the case where the client sends nothing (`THINK:high` from the panel default lands correctly in `output_config.effort`).

## Test plan

- [x] `tests/translator/golden-request.test.js`: 4 new cases (unlevelled intent via `thinking`/`reasoning_effort:"auto"`, `model(auto)` suffix, `minimal`, concrete levels pass through unchanged)
- [x] `tests/unit/provider-thinking-injection.test.js` (new file): 11 cases through `handleChatCore` — configured level fills in when client is unlevelled, every configured level (low/medium/high/max) reaches the wire, explicit client choice (via `reasoning_effort` or a concrete `thinking.budget_tokens`) is never overridden, explicit "no thinking" is respected, native passthrough keeps the client's `thinking` field untouched
- [x] All 15 new tests fail against pre-fix code, pass after
- [x] Full suite diffed against `upstream/master` via stash/branch comparison (not `known-fails.txt`, which doesn't run outside the Docker build context): 124 failed both before and after, 0 regressions, 0 new failures among the 15 added tests
- [x] `npx eslint` clean on all changed files

由 Claude Code 辅助完成