### PR TITLE
fix(codex): strip orphaned tool outputs

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -67,6 +67,42 @@ function stripStoredItemReferences(body) {
   });
 }
 
+// Strip function_call_output items whose call_id has no matching function_call in input.
+// Prevents Codex 400: "No tool call found for function call output with call_id ..."
+// Orphaned outputs occur when conversation compaction removes original tool calls
+// but leaves their results (e.g., multiple image attachments, compacted tool loops).
+function stripOrphanedToolOutputs(body) {
+  if (!Array.isArray(body.input)) return;
+  const callIds = new Set();
+  let outputCount = 0;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    if (item.type === "function_call" && typeof item.call_id === "string") {
+      callIds.add(item.call_id);
+    }
+    // Chat Completions format: assistant message with embedded tool_calls
+    if (Array.isArray(item.tool_calls)) {
+      for (const tc of item.tool_calls) {
+        if (tc && typeof tc.id === "string") callIds.add(tc.id);
+      }
+    }
+    if (item.type === "function_call_output") outputCount++;
+  }
+  if (outputCount === 0) return;
+  const before = body.input.length;
+  body.input = body.input.filter((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return true;
+    if (item.type === "function_call_output" && typeof item.call_id === "string") {
+      return callIds.has(item.call_id);
+    }
+    return true;
+  });
+  const removed = before - body.input.length;
+  if (removed > 0) {
+    dbg("CODEX", `stripOrphanedToolOutputs | removed ${removed} orphaned function_call_output(s) | call_ids=${callIds.size} outputs=${outputCount}`);
+  }
+}
+
 // Flatten Chat-Completions tool shape into Responses flat format + filter unsupported tools
 function normalizeCodexTools(body) {
   if (!Array.isArray(body.tools)) return;
@@ -403,6 +439,8 @@ export class CodexExecutor extends BaseExecutor {
     convertSystemToDeveloperRole(body);
     // Strip server-generated item IDs (rs_/fc_/resp_/msg_) — Codex /responses can't resolve when store=false
     stripStoredItemReferences(body);
+    // Strip orphaned function_call_output items (no matching function_call) — prevents 400 error
+    stripOrphanedToolOutputs(body);
     // Flatten function tools + drop unsupported types
     normalizeCodexTools(body);
 

--- a/tests/unit/codex-orphaned-tool-outputs.test.js
+++ b/tests/unit/codex-orphaned-tool-outputs.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+function transform(input) {
+  const executor = new CodexExecutor();
+  const body = {
+    model: "gpt-5.6-sol",
+    input,
+    stream: true,
+    tools: [{
+      type: "function",
+      function: { name: "read_file", description: "Read a file", parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] } },
+    }],
+  };
+  executor.transformRequest("gpt-5.6-sol", body, true, {
+    connectionId: "test-orphaned-outputs",
+    providerSpecificData: {},
+  });
+  return body.input;
+}
+
+describe("CodexExecutor stripOrphanedToolOutputs", () => {
+  it("removes function_call_output with no matching function_call", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call_output", call_id: "call_orphan1", output: "result1" },
+      { type: "function_call_output", call_id: "call_orphan2", output: "result2" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toEqual([]);
+  });
+
+  it("keeps function_call_output when matching function_call exists", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call", call_id: "call_valid", name: "read_file", arguments: '{"path":"a.txt"}' },
+      { type: "function_call_output", call_id: "call_valid", output: "file contents" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0].call_id).toBe("call_valid");
+  });
+
+  it("keeps matched, removes orphaned in mixed input", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call", call_id: "call_keep", name: "read_file", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_keep", output: "ok" },
+      { type: "function_call_output", call_id: "call_orphan", output: "orphaned" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0].call_id).toBe("call_keep");
+  });
+
+  it("handles Chat Completions tool_calls format in assistant message", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { role: "assistant", content: null, tool_calls: [{ id: "call_cc1", function: { name: "read_file", arguments: "{}" } }] },
+      { type: "function_call_output", call_id: "call_cc1", output: "ok" },
+      { type: "function_call_output", call_id: "call_cc2", output: "orphaned" },
+    ];
+    const result = transform(input);
+    const outputs = result.filter((i) => i.type === "function_call_output");
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0].call_id).toBe("call_cc1");
+  });
+
+  it("no-op when no function_call_output items", () => {
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
+    ];
+    const result = transform(input);
+    expect(result).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- remove Responses `function_call_output` items when their matching `function_call` was removed from history
- recognize both Responses and embedded Chat Completions tool-call shapes
- add focused regression coverage for matched, orphaned, mixed, and no-op inputs

## Problem
Compacted conversations can retain tool outputs after the originating tool call has been removed. Codex rejects those requests with `No tool call found for function call output with call_id ...`.

## Test plan
- `cd tests && npx vitest run unit/codex-orphaned-tool-outputs.test.js unit/codex-tool-normalization.test.js`
- `npx eslint open-sse/executors/codex.js tests/unit/codex-orphaned-tool-outputs.test.js`