### PR TITLE
fix(antigravity): handle standard-tier accounts gracefully when GCP project is missing

### DIFF
--- a/open-sse/services/projectId.js
+++ b/open-sse/services/projectId.js
@@ -8,6 +8,7 @@
  */
 
 import { CLOUD_CODE_API, LOAD_CODE_ASSIST_HEADERS, LOAD_CODE_ASSIST_METADATA } from "../config/appConstants.js";
+import { generateProjectId } from "../translator/formats/gemini.js";
 
 // ─── Cache ────────────────────────────────────────────────────────────────────
 // connectionId -> { projectId: string, fetchedAt: number }
@@ -236,7 +237,10 @@ async function onboardUser(accessToken, tierID, externalSignal, endpoints) {
                     console.log(`[ProjectId] Successfully onboarded, project ID: ${projectId}`);
                     return projectId;
                 }
-                throw new Error("onboardUser done but no project_id in response");
+                // PR FIX: Google deprecated automatic project creation for standard-tier.
+                // It now requires a user-defined GCP project.
+                console.warn(`[ProjectId] Standard-tier account requires a manual GCP Project ID. Google blocked automatic onboarding.`);
+                return "__REQUIRES_GCP_PROJECT__";
             }
 
             // Server not done yet – wait and retry
@@ -289,9 +293,15 @@ function extractProjectId(data) {
  * Extract project ID from onboardUser response.
  */
 function extractProjectIdFromOnboard(data) {
-    if (!data?.response) return null;
+    if (!data) return null;
 
-    const project = data.response.cloudaicompanionProject;
+    // Check nested in response (Long-Running Operation format)
+    let project = data.response?.cloudaicompanionProject;
+    
+    // Fallback: check directly at root
+    if (!project && data.cloudaicompanionProject) {
+        project = data.cloudaicompanionProject;
+    }
 
     if (typeof project === "string") {
         const id = project.trim();

--- a/src/lib/oauth/services/antigravity.js
+++ b/src/lib/oauth/services/antigravity.js
@@ -163,14 +163,20 @@ export class AntigravityService {
       if (result.done === true) {
         // Extract final project ID from response
         let finalProjectId = projectId;
-        if (result.response?.cloudaicompanionProject) {
-          const respProject = result.response.cloudaicompanionProject;
+        let respProject = result.response?.cloudaicompanionProject;
+        if (!respProject && result.cloudaicompanionProject) {
+          respProject = result.cloudaicompanionProject;
+        }
+
+        if (respProject) {
           if (typeof respProject === 'string') {
             finalProjectId = respProject.trim();
           } else if (respProject.id) {
             finalProjectId = respProject.id.trim();
           }
         }
+        
+        console.log("[Antigravity] Raw completeOnboarding response:", JSON.stringify(result));
         return { success: true, projectId: finalProjectId };
       }
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -220,7 +220,13 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Ensure real project ID is available for providers that need it (P0 fix: cold miss)
     if ((provider === "antigravity" || provider === "gemini-cli") && !refreshedCredentials.projectId) {
       const pid = await getProjectIdForConnection(credentials.connectionId, refreshedCredentials.accessToken, provider);
-      if (pid) {
+      if (pid === "__REQUIRES_GCP_PROJECT__") {
+        log.warn("CHAT", `[${provider}] Google requires a manual GCP Project ID for this account.`);
+        return errorResponse(
+          HTTP_STATUS.FORBIDDEN, 
+          "GCP_PROJECT_REQUIRED: Google Antigravity now requires a free GCP Project ID. Please create one at console.cloud.google.com and enter it in your 9Router Settings."
+        );
+      } else if (pid) {
         refreshedCredentials.projectId = pid;
         // Persist to DB in background so subsequent requests have it immediately
         updateProviderCredentials(credentials.connectionId, { projectId: pid }).catch(() => { });


### PR DESCRIPTION
### Description of the Bug & API Changes

When authenticating or re-authenticating a Google Antigravity account in 9Router v0.5.45, `standard-tier` accounts experience an infinite retry loop during `onboardUser`, followed by a delayed HTTP 429 `RESOURCE_EXHAUSTED` error when attempting to stream chat.

After reverse-engineering the Google Cloud Code / Antigravity API responses, it has been discovered that **Google has deprecated automatic project creation for standard-tier (personal) accounts**. 

The Google API explicitly returns `"userDefinedCloudaicompanionProject": true` for standard-tier, meaning Google now strictly enforces **Bring Your Own Project (BYOP)**. If the `project` ID is omitted or faked (as was done in v0.5.40), Google's backend will perform a quota check, wait ~18 seconds, and then reject the request with `429 RESOURCE_EXHAUSTED`.

Because 9router cannot automatically accept GCP Terms of Service on behalf of users to create a project programmatically, the fallback ID workaround is officially dead on Google's side.

### The Fix in this PR

Instead of letting `projectId.js` loop 5 times trying to find a non-existent project and then failing with a cryptic 429 error, this PR handles the new Google API restriction gracefully:

1. **Graceful UI Error**: If `onboardUser` completes but returns no `project_id`, `projectId.js` now returns a special flag (`__REQUIRES_GCP_PROJECT__`) instead of looping or throwing an unhandled exception.
2. **Fast Failure**: `src/sse/handlers/chat.js` intercepts this flag and immediately returns a fast `HTTP 403 FORBIDDEN` SSE response with a clear, actionable error message for the user: 
   > *"GCP_PROJECT_REQUIRED: Google Antigravity now requires a free GCP Project ID. Please create one at console.cloud.google.com and enter it in your 9Router Settings."*
3. **No More Quota Waste**: By failing fast, we prevent sending invalid requests to Google API that hang for 19 seconds and waste potential rate limits.

---

### Environment Information
- **9Router Version**: `0.5.45`
- **OS**: macOS (ARM64)
- **Provider**: Antigravity (Google OAuth)

### Steps to Test the PR
1. Open 9Router Dashboard (`http://localhost:20128`).
2. Authenticate via Google OAuth for Antigravity using a standard-tier account that HAS NOT defined a default Code Assist project.
3. Observe that 9Router no longer hangs for 5 retries.
4. Attempt a chat in Hermes or your UI. It will instantly return the clear GCP_PROJECT_REQUIRED error instead of a 19-second delayed 429.
