### PR TITLE
feat(codex): add transparent native provider transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/custom-server.js ./custom-server.js
+COPY --from=builder /app/server ./server
 COPY --from=builder /app/open-sse ./open-sse
 # Next file tracing can omit sibling files; MITM runs server.js as a separate process.
 COPY --from=builder /app/src/mitm ./src/mitm
@@ -37,6 +38,8 @@ COPY --from=builder /app/src/mitm ./src/mitm
 COPY --from=builder /app/node_modules/node-forge ./node_modules/node-forge
 # Ensure `next` is available at runtime in case tracing did not include it.
 COPY --from=builder /app/node_modules/next ./node_modules/next
+# scripts/prepare-native-standalone.cjs recursively bundles the native WS
+# gateway's direct and transitive runtime dependencies into standalone.
 
 RUN mkdir -p /app/data && chown -R node:node /app && \
   mkdir -p /app/data-home && chown node:node /app/data-home && \

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -67,6 +67,19 @@ const { ensureSqliteRuntime, buildEnvWithRuntime } = require("./hooks/sqliteRunt
 const { ensureTrayRuntime } = require("./hooks/trayRuntime");
 const args = process.argv.slice(2);
 
+// Provider-scoped auth hook used by modern Codex. Stdout must contain only the
+// bearer token because Codex consumes it directly.
+if (args[0] === "codex" && args[1] === "auth-token") {
+  const { run } = require("./src/cli/commands/codexAuthToken");
+  run(args.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err?.message || String(err));
+      process.exit(1);
+    });
+  return;
+}
+
 // Subcommands (`9router xai video …`) run against an already-running gateway
 // and bypass the launcher flow (no runtime self-heal, no server spawn).
 if (args[0] === "xai" && args[1] === "video") {
@@ -154,6 +167,7 @@ Options:
   -v, --version       Show version
 
 Commands:
+  codex auth-token     Print the provider-scoped Codex bridge token
   xai video --prompt "..." --output video.mp4
                       Generate a Grok Imagine video via the running gateway
                       (see: ${APP_NAME} xai video --help)

--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -3,6 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
+const { copyRuntimePackages } = require("../../scripts/copy-runtime-packages.cjs");
 
 const cliDir = path.resolve(__dirname, "..");
 const appDir = path.resolve(cliDir, "..");
@@ -165,6 +166,7 @@ console.log("✅ Copied standalone build\n");
 const customServerSrc = path.join(appDir, "custom-server.js");
 if (fs.existsSync(customServerSrc)) {
   fs.copyFileSync(customServerSrc, path.join(cliAppDir, "custom-server.js"));
+  copyRecursive(path.join(appDir, "server"), path.join(cliAppDir, "server"));
   console.log("✅ Copied custom-server.js\n");
 } else {
   console.warn("⚠️  custom-server.js not found — server will run without real-IP injection\n");
@@ -195,6 +197,19 @@ function ensureModuleInBundle(pkg) {
   console.log(`✅ Bundled ${pkg}`);
 }
 ensureModuleInBundle("sql.js");
+// custom-server.js loads the native gateway outside Next's traced module graph.
+copyRuntimePackages(
+  ["ws", "https-proxy-agent", "socks-proxy-agent"],
+  path.join(cliAppDir, "node_modules"),
+  {
+    searchPaths: [appDir, rootDir],
+    storeDirs: [
+      path.join(appDir, "node_modules", ".pnpm"),
+      path.join(rootDir, "node_modules", ".pnpm"),
+    ],
+    onCopy: (pkg, version) => console.log(`✅ Bundled ${pkg}@${version}`),
+  }
+);
 const betterDir = path.join(cliAppDir, "node_modules", "better-sqlite3");
 if (fs.existsSync(betterDir)) {
   fs.rmSync(betterDir, { recursive: true, force: true });

--- a/cli/src/cli/commands/codexAuthToken.js
+++ b/cli/src/cli/commands/codexAuthToken.js
@@ -1,0 +1,35 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+function defaultDataDir() {
+  if (process.platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), "9router");
+  }
+  return path.join(os.homedir(), ".9router");
+}
+
+function parseDataDir(args) {
+  const index = args.indexOf("--data-dir");
+  if (index >= 0 && args[index + 1]) return path.resolve(args[index + 1]);
+  return process.env.DATA_DIR ? path.resolve(process.env.DATA_DIR) : defaultDataDir();
+}
+
+async function run(args = []) {
+  const secretPath = path.join(parseDataDir(args), "secrets", "codex-bridge-token");
+  let token;
+  try {
+    token = fs.readFileSync(secretPath, "utf8").trim();
+  } catch {
+    console.error("9Router Codex bridge token is not configured. Apply Codex settings in the 9Router dashboard.");
+    return 1;
+  }
+  if (!token) {
+    console.error("9Router Codex bridge token is empty. Re-apply Codex settings in the 9Router dashboard.");
+    return 1;
+  }
+  process.stdout.write(`${token}\n`);
+  return 0;
+}
+
+module.exports = { run };

--- a/custom-server.js
+++ b/custom-server.js
@@ -1,6 +1,24 @@
 const http = require("http");
+const crypto = require("crypto");
+const { attachCodexNativeGateway } = require("./server/codexNativeGateway.cjs");
 
 const origCreate = http.createServer.bind(http);
+process.env.CODEX_NATIVE_INTERNAL_SECRET ||= crypto.randomBytes(32).toString("hex");
+
+function skipClaimedUpgrade(server, gateway) {
+  const originalOn = server.on.bind(server);
+  const originalOnce = server.once.bind(server);
+  const wrap = (listener) => (request, socket, head) => {
+    if (!gateway.handles(request)) return listener(request, socket, head);
+  };
+  server.on = function on(event, listener) {
+    return originalOn(event, event === "upgrade" ? wrap(listener) : listener);
+  };
+  server.addListener = server.on;
+  server.once = function once(event, listener) {
+    return originalOnce(event, event === "upgrade" ? wrap(listener) : listener);
+  };
+}
 
 // Wrap Next standalone HTTP server: derive client IP from the TCP socket
 // (unspoofable) and strip client-supplied forwarding headers so downstream
@@ -26,7 +44,12 @@ http.createServer = (...args) => {
     if (viaProxy) req.headers["x-9r-via-proxy"] = "1";
     return handler(req, res);
   };
-  return origCreate(...rest, wrapped);
+  const server = origCreate(...rest, wrapped);
+  const gateway = attachCodexNativeGateway(server, {
+    secret: process.env.CODEX_NATIVE_INTERNAL_SECRET,
+  });
+  skipClaimedUpgrade(server, gateway);
+  return server;
 };
 
 require("./server.js");

--- a/native-server.cjs
+++ b/native-server.cjs
@@ -1,0 +1,54 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const http = require("node:http");
+const next = require("next");
+const { attachCodexNativeGateway } = require("./server/codexNativeGateway.cjs");
+
+const dev = process.argv.includes("--dev") || process.env.NODE_ENV === "development";
+const port = Number.parseInt(process.env.PORT || "20127", 10);
+const hostname = process.env.HOSTNAME || "0.0.0.0";
+process.env.CODEX_NATIVE_INTERNAL_SECRET ||= crypto.randomBytes(32).toString("hex");
+
+function stampPeer(request) {
+  const socketIp = request.socket?.remoteAddress || "";
+  const forwarded = request.headers["x-forwarded-for"];
+  const realIp = request.headers["x-real-ip"];
+  const viaProxy = !!(forwarded || realIp);
+  const loopback = socketIp === "127.0.0.1"
+    || socketIp === "::1"
+    || socketIp === "::ffff:127.0.0.1";
+  const proxyIp = realIp || (forwarded ? String(forwarded).split(",")[0].trim() : "");
+  delete request.headers["x-forwarded-for"];
+  delete request.headers["x-9r-real-ip"];
+  delete request.headers["x-9r-via-proxy"];
+  request.headers["x-9r-real-ip"] = loopback && proxyIp ? proxyIp : socketIp;
+  if (viaProxy) request.headers["x-9r-via-proxy"] = "1";
+}
+
+async function start() {
+  const app = next({ dev, hostname, port });
+  await app.prepare();
+  const handle = app.getRequestHandler();
+  const handleNextUpgrade = app.getUpgradeHandler();
+  const server = http.createServer((request, response) => {
+    stampPeer(request);
+    handle(request, response);
+  });
+  const gateway = attachCodexNativeGateway(server, {
+    secret: process.env.CODEX_NATIVE_INTERNAL_SECRET,
+    internalBaseUrl: `http://127.0.0.1:${port}`,
+  });
+  server.on("upgrade", (request, socket, head) => {
+    stampPeer(request);
+    if (!gateway.handles(request)) handleNextUpgrade(request, socket, head);
+  });
+  server.listen(port, hostname, () => {
+    console.log(`> 9Router ready on http://${hostname}:${port} (${dev ? "development" : "production"})`);
+  });
+}
+
+start().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/open-sse/config/codexNative.js
+++ b/open-sse/config/codexNative.js
@@ -1,0 +1,98 @@
+export const CODEX_NATIVE_CONFIG = Object.freeze({
+  providerId: "codex",
+  providerConfigId: "9router_codex",
+  upstreamHttpBaseUrl: "https://chatgpt.com/backend-api/codex",
+  upstreamWebSocketUrl: "wss://chatgpt.com/backend-api/codex/responses",
+  catalogTtlMs: 15 * 60 * 1000,
+  catalogStaleMs: 7 * 24 * 60 * 60 * 1000,
+  quotaTtlMs: 60 * 1000,
+  affinityTtlMs: 7 * 24 * 60 * 60 * 1000,
+  affinityMaxEntries: 50_000,
+  leaseTtlMs: 65 * 60 * 1000,
+  quotaThresholds: Object.freeze({
+    drainRemainingPercent: 15,
+    criticalRemainingPercent: 5,
+    recoverRemainingPercent: 20,
+  }),
+  paths: Object.freeze({
+    models: "models",
+    responses: "responses",
+    compact: "responses/compact",
+    memories: "memories/trace_summarize",
+    search: "alpha/search",
+    imageGenerations: "images/generations",
+    imageEdits: "images/edits",
+  }),
+});
+
+// Client credentials and hop-by-hop routing metadata must never reach ChatGPT.
+export const CODEX_NATIVE_BLOCKED_REQUEST_HEADERS = Object.freeze([
+  "authorization",
+  "chatgpt-account-id",
+  "cookie",
+  "host",
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "forwarded",
+  "via",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-port",
+  "x-forwarded-proto",
+  "x-real-ip",
+  "x-9r-real-ip",
+  "x-9r-via-proxy",
+  "x-9r-cli-token",
+  "x-9r-internal-secret",
+]);
+
+export const CODEX_NATIVE_SAFE_REQUEST_HEADERS = Object.freeze([
+  "accept",
+  "accept-encoding",
+  "accept-language",
+  "content-type",
+  "openai-beta",
+  "originator",
+  "session-id",
+  "thread-id",
+  "traceparent",
+  "tracestate",
+  "baggage",
+  "user-agent",
+  "x-client-request-id",
+]);
+
+export const CODEX_NATIVE_SAFE_REQUEST_PREFIXES = Object.freeze([
+  "x-codex-",
+  "x-openai-",
+  "x-stainless-",
+]);
+
+export const CODEX_NATIVE_SAFE_RESPONSE_HEADERS = Object.freeze([
+  "cache-control",
+  "content-encoding",
+  "content-type",
+  "etag",
+  "openai-model",
+  "retry-after",
+  "x-codex-turn-state",
+  "x-models-etag",
+  "x-reasoning-included",
+  "x-request-id",
+]);
+
+export const CODEX_NATIVE_SAFE_RESPONSE_PREFIXES = Object.freeze([
+  "openai-",
+  "x-codex-",
+  "x-openai-",
+  "x-ratelimit-",
+  "x-request-",
+  "x-stainless-",
+]);

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 20127",
+    "dev:native": "node native-server.cjs --dev",
     "dev:webpack": "next dev --webpack --port 20127",
-    "build": "next build --webpack",
-    "start": "next start --port 20127",
+    "build": "next build --webpack && node scripts/prepare-native-standalone.cjs",
+    "start": "node native-server.cjs",
     "dev:bun": "bun --bun next dev --webpack --port 20127",
-    "build:bun": "bun --bun next build --webpack",
-    "start:bun": "bun ./.next/standalone/server.js",
+    "build:bun": "bun --bun next build --webpack && node scripts/prepare-native-standalone.cjs",
+    "start:bun": "bun ./native-server.cjs",
     "cli:pack": "npm --prefix cli run pack:cli",
     "cli:publish": "npm --prefix cli run publish:cli"
   },
@@ -26,6 +27,7 @@
     "confbox": "^0.2.4",
     "express": "^5.2.1",
     "http-proxy-middleware": "^3.0.5",
+    "https-proxy-agent": "^7.0.6",
     "jose": "^6.1.3",
     "marked": "^18.0.1",
     "material-symbols": "^0.44.6",
@@ -44,6 +46,7 @@
     "sql.js": "^1.14.1",
     "undici": "^7.19.2",
     "uuid": "^13.0.0",
+    "ws": "^8.21.1",
     "zustand": "^5.0.10"
   },
   "optionalDependencies": {

--- a/scripts/copy-runtime-packages.cjs
+++ b/scripts/copy-runtime-packages.cjs
@@ -1,0 +1,69 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function pnpmPackageRoot(packageName, version, storeDirs) {
+  const prefix = `${packageName.replaceAll("/", "+")}@${version}`;
+  for (const storeDir of storeDirs) {
+    if (!fs.existsSync(storeDir)) continue;
+    const entry = fs.readdirSync(storeDir)
+      .find((name) => name === prefix || name.startsWith(`${prefix}_`));
+    if (!entry) continue;
+    const candidate = path.join(storeDir, entry, "node_modules", packageName);
+    if (fs.existsSync(path.join(candidate, "package.json"))) return candidate;
+  }
+  return null;
+}
+
+function resolvePackage(packageName, searchPaths, storeDirs) {
+  const manifestPath = require.resolve(`${packageName}/package.json`, {
+    paths: searchPaths,
+  });
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const installedRoot = path.dirname(manifestPath);
+  const sourceRoot = pnpmPackageRoot(packageName, manifest.version, storeDirs)
+    || installedRoot;
+  return { manifest, sourceRoot };
+}
+
+function copyRuntimePackages(packageNames, destinationNodeModules, options = {}) {
+  const searchPaths = options.searchPaths || [process.cwd()];
+  const storeDirs = options.storeDirs || [];
+  const copiedVersions = new Map();
+
+  function copyPackage(packageName, dependencySearchPaths) {
+    const { manifest, sourceRoot } = resolvePackage(
+      packageName,
+      dependencySearchPaths,
+      storeDirs
+    );
+    const copiedVersion = copiedVersions.get(packageName);
+    if (copiedVersion) {
+      if (copiedVersion !== manifest.version) {
+        throw new Error(
+          `Cannot flatten ${packageName}@${manifest.version}; ${copiedVersion} is already bundled`
+        );
+      }
+      return;
+    }
+    copiedVersions.set(packageName, manifest.version);
+
+    const destination = path.join(destinationNodeModules, packageName);
+    fs.rmSync(destination, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.cpSync(sourceRoot, destination, { recursive: true, dereference: true });
+    options.onCopy?.(packageName, manifest.version);
+
+    for (const dependency of Object.keys(manifest.dependencies || {})) {
+      copyPackage(dependency, [sourceRoot, ...searchPaths]);
+    }
+  }
+
+  for (const packageName of packageNames) {
+    copyPackage(packageName, searchPaths);
+  }
+  return copiedVersions;
+}
+
+module.exports = { copyRuntimePackages };

--- a/scripts/prepare-native-standalone.cjs
+++ b/scripts/prepare-native-standalone.cjs
@@ -1,0 +1,37 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { copyRuntimePackages } = require("./copy-runtime-packages.cjs");
+
+const appDir = path.resolve(__dirname, "..");
+const distDir = path.join(appDir, process.env.NEXT_DIST_DIR || ".next");
+const standaloneRoot = path.join(distDir, "standalone");
+const packageName = path.basename(appDir);
+const standaloneDir = fs.existsSync(path.join(standaloneRoot, "server.js"))
+  ? standaloneRoot
+  : path.join(standaloneRoot, packageName);
+
+if (!fs.existsSync(path.join(standaloneDir, "server.js"))) {
+  throw new Error(`Next standalone server was not found under ${standaloneRoot}`);
+}
+
+fs.copyFileSync(
+  path.join(appDir, "custom-server.js"),
+  path.join(standaloneDir, "custom-server.js")
+);
+fs.cpSync(path.join(appDir, "server"), path.join(standaloneDir, "server"), {
+  recursive: true,
+  dereference: true,
+});
+
+copyRuntimePackages(
+  ["ws", "https-proxy-agent", "socks-proxy-agent"],
+  path.join(standaloneDir, "node_modules"),
+  {
+    searchPaths: [appDir],
+    storeDirs: [path.join(appDir, "node_modules", ".pnpm")],
+  }
+);
+
+console.log(`Prepared Codex Native standalone gateway in ${standaloneDir}`);

--- a/server/codexNativeGateway.cjs
+++ b/server/codexNativeGateway.cjs
@@ -1,0 +1,452 @@
+"use strict";
+
+const { WebSocket, WebSocketServer } = require("ws");
+const { HttpsProxyAgent } = require("https-proxy-agent");
+const { SocksProxyAgent } = require("socks-proxy-agent");
+
+const NATIVE_PATH = "/v1/codex/responses";
+const UPSTREAM_URL = "wss://chatgpt.com/backend-api/codex/responses";
+const HIGH_WATER_MARK = 1024 * 1024;
+const RESPONSE_HEADERS = new Set([
+  "cache-control",
+  "openai-model",
+  "retry-after",
+  "x-codex-turn-state",
+  "x-models-etag",
+  "x-reasoning-included",
+  "x-request-id",
+]);
+const RESPONSE_PREFIXES = ["openai-", "x-codex-", "x-openai-", "x-ratelimit-", "x-request-", "x-stainless-"];
+
+function isNativeUpgrade(request) {
+  try {
+    return new URL(request.url, "http://127.0.0.1").pathname === NATIVE_PATH;
+  } catch {
+    return false;
+  }
+}
+
+function wsDisabled() {
+  return /^(1|true|yes|on)$/i.test(process.env.CODEX_NATIVE_WS_DISABLED || "");
+}
+
+function clientVersion(request) {
+  const explicit = request.headers["x-codex-client-version"];
+  if (explicit) return String(explicit);
+  const match = String(request.headers["user-agent"] || "").match(/\bcodex(?:_cli_rs)?\/([^\s]+)/i);
+  return match ? match[1] : null;
+}
+
+function requestHeaderObject(request) {
+  const headers = {};
+  for (const [name, value] of Object.entries(request.headers || {})) {
+    if (value != null && name.toLowerCase() !== "x-9r-internal-secret") {
+      headers[name.toLowerCase()] = Array.isArray(value) ? value.join(", ") : String(value);
+    }
+  }
+  return headers;
+}
+
+function noProxyMatches(target, noProxy) {
+  if (!noProxy) return false;
+  const hostname = new URL(target).hostname.toLowerCase();
+  return String(noProxy).split(",").map((entry) => entry.trim().toLowerCase()).some((entry) => {
+    if (!entry) return false;
+    if (entry === "*") return true;
+    if (entry.startsWith(".")) return hostname === entry.slice(1) || hostname.endsWith(entry);
+    return hostname === entry || hostname.endsWith(`.${entry}`);
+  });
+}
+
+function proxyAgent(proxy) {
+  if (!proxy?.enabled || !proxy.url || noProxyMatches(UPSTREAM_URL, proxy.noProxy)) return undefined;
+  const rawUrl = proxy.url.includes("://") ? proxy.url : `http://${proxy.url}`;
+  const protocol = new URL(rawUrl).protocol;
+  if (protocol === "http:" || protocol === "https:") return new HttpsProxyAgent(rawUrl);
+  if (protocol.startsWith("socks")) return new SocksProxyAgent(rawUrl);
+  throw new Error(`Unsupported WebSocket proxy scheme ${protocol}`);
+}
+
+function semanticEvent(event) {
+  const type = event?.type;
+  return typeof type === "string" && (
+    type.startsWith("response.output_")
+    || type.includes("output_text")
+    || type.includes("reasoning")
+    || type.includes("function_call")
+    || type.includes("tool_call")
+    || type.includes("image_generation")
+    || type === "response.completed"
+  );
+}
+
+function safeHandshakeHeaders(upstreamHeaders) {
+  const result = {};
+  for (const [name, value] of Object.entries(upstreamHeaders || {})) {
+    const lower = name.toLowerCase();
+    if (RESPONSE_HEADERS.has(lower) || RESPONSE_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+      result[lower] = Array.isArray(value) ? value.join(", ") : String(value);
+    }
+  }
+  return result;
+}
+
+function sendWithBackpressure(destination, data, options, source) {
+  if (!destination || destination.readyState !== WebSocket.OPEN) return;
+  if (destination.bufferedAmount > HIGH_WATER_MARK) source?._socket?.pause?.();
+  destination.send(data, options, (error) => {
+    if (destination.bufferedAmount <= HIGH_WATER_MARK / 2) source?._socket?.resume?.();
+    if (error && source?.readyState === WebSocket.OPEN) source.close(1011, "WebSocket relay failed");
+  });
+}
+
+function rejectUpgrade(socket, status, message) {
+  const body = JSON.stringify({ error: { code: "codex_websocket_unavailable", message } });
+  const label = status === 401 ? "Unauthorized" : status === 503 ? "Service Unavailable" : "Bad Gateway";
+  socket.end(
+    `HTTP/1.1 ${status} ${label}\r\n`
+    + "Content-Type: application/json\r\n"
+    + `Content-Length: ${Buffer.byteLength(body)}\r\n`
+    + "Connection: close\r\n\r\n"
+    + body
+  );
+}
+
+function relayCloseCode(code, fallback = 1000) {
+  const standard = code >= 1000 && code <= 1014 && ![1004, 1005, 1006].includes(code);
+  return standard || (code >= 3000 && code <= 4999) ? code : fallback;
+}
+
+function attachCodexNativeGateway(server, options = {}) {
+  const secret = options.secret || process.env.CODEX_NATIVE_INTERNAL_SECRET;
+  if (!secret) throw new Error("CODEX_NATIVE_INTERNAL_SECRET is required");
+  const internalBaseUrl = options.internalBaseUrl
+    || `http://127.0.0.1:${process.env.PORT || 20127}`;
+  const fetchImpl = options.fetch || globalThis.fetch;
+  const upstreamUrl = options.upstreamUrl || UPSTREAM_URL;
+  const WebSocketImpl = options.WebSocket || WebSocket;
+  const wss = new WebSocketServer({
+    noServer: true,
+    perMessageDeflate: true,
+    autoPong: false,
+    handleProtocols(protocols) {
+      return protocols.values().next().value || false;
+    },
+  });
+
+  wss.on("headers", (headers, request) => {
+    for (const [name, value] of Object.entries(request.__codexUpstreamHeaders || {})) {
+      headers.push(`${name}: ${value}`);
+    }
+  });
+
+  async function leaseAction(action, payload) {
+    const response = await fetchImpl(`${internalBaseUrl}/api/internal/codex-native/lease/${action}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-9r-internal-secret": secret,
+      },
+      body: JSON.stringify(payload),
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(body.error || `Lease ${action} failed (${response.status})`);
+      error.status = response.status;
+      error.details = body;
+      throw error;
+    }
+    return body;
+  }
+
+  function connectUpstream(lease, request) {
+    return new Promise((resolve, reject) => {
+      let agent;
+      try {
+        agent = proxyAgent(lease.proxy);
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      const protocols = String(request.headers["sec-websocket-protocol"] || "")
+        .split(",").map((value) => value.trim()).filter(Boolean);
+      const upstream = new WebSocketImpl(
+        upstreamUrl,
+        protocols.length ? protocols : undefined,
+        {
+          headers: lease.upstreamHeaders,
+          agent,
+          perMessageDeflate: true,
+          autoPong: false,
+          handshakeTimeout: 10_000,
+        }
+      );
+      let upgradeHeaders = {};
+      upstream.once("upgrade", (response) => {
+        upgradeHeaders = safeHandshakeHeaders(response.headers);
+      });
+      upstream.once("open", () => resolve({ upstream, upgradeHeaders }));
+      upstream.once("unexpected-response", (_request, response) => {
+        const error = new Error(`Codex WebSocket handshake rejected (${response.statusCode})`);
+        error.status = response.statusCode || 502;
+        response.resume();
+        reject(error);
+      });
+      upstream.once("error", reject);
+    });
+  }
+
+  async function acquireConnected(request, excludeConnectionIds = [], model = null) {
+    const lease = await leaseAction("acquire", {
+      requestHeaders: requestHeaderObject(request),
+      clientVersion: clientVersion(request),
+      excludeConnectionIds,
+      model,
+    });
+    try {
+      const connected = await connectUpstream(lease, request);
+      return { lease, ...connected };
+    } catch (error) {
+      await leaseAction("failure", {
+        leaseId: lease.leaseId,
+        status: error.status || 502,
+        error: error.message,
+      }).catch(() => {});
+      await leaseAction("release", { leaseId: lease.leaseId }).catch(() => {});
+      throw Object.assign(error, { connectionId: lease.connectionId });
+    }
+  }
+
+  async function handleUpgrade(request, socket, head) {
+    if (!isNativeUpgrade(request)) return;
+    if (wsDisabled()) {
+      rejectUpgrade(socket, 503, "Codex Native WebSocket is disabled; use HTTP/SSE fallback");
+      return;
+    }
+
+    const excluded = [];
+    let connected;
+    for (;;) {
+      try {
+        connected = await acquireConnected(request, excluded);
+        break;
+      } catch (error) {
+        if (error.connectionId) excluded.push(error.connectionId);
+        if (error.status === 401 || !error.connectionId) {
+          rejectUpgrade(socket, error.status === 401 ? 401 : 503, error.message);
+          return;
+        }
+        // Continue until the pool explicitly reports no eligible account.
+      }
+    }
+
+    request.__codexUpstreamHeaders = connected.upgradeHeaders;
+    wss.handleUpgrade(request, socket, head, (client) => {
+      wss.emit("connection", client, request, connected);
+    });
+  }
+
+  wss.on("connection", (client, request, initial) => {
+    let lease = initial.lease;
+    let upstream = initial.upstream;
+    let model = null;
+    let validating = false;
+    let validated = false;
+    let semanticOutputSeen = false;
+    let closed = false;
+    let failoverInProgress = false;
+    const queued = [];
+    const turnFrames = [];
+    const excluded = [lease.connectionId];
+
+    const cleanupLease = () => leaseAction("release", { leaseId: lease.leaseId }).catch(() => {});
+    const closeBoth = (code = 1000, reason = "") => {
+      if (closed) return;
+      closed = true;
+      const safeCode = relayCloseCode(code, code === 1003 || code === 1008 || code === 1011 ? code : 1000);
+      if (client.readyState === WebSocket.OPEN) client.close(safeCode, reason);
+      if (upstream.readyState === WebSocket.OPEN) upstream.close(safeCode, reason);
+      cleanupLease();
+    };
+
+    const parse = (data) => {
+      try { return JSON.parse(data.toString()); } catch { return null; }
+    };
+
+    async function validateAndFlush(frame) {
+      const event = parse(frame.data);
+      if (!event || event.type !== "response.create" || typeof event.model !== "string") {
+        closeBoth(1008, "First Codex frame must be response.create with a model");
+        return;
+      }
+      model = event.model;
+      validating = true;
+      try {
+        try {
+          await leaseAction("validate-model", { leaseId: lease.leaseId, model });
+        } catch (error) {
+          if (error.status !== 409) {
+            closeBoth(1008, `Model '${model}' is not available on the leased metadata cohort`);
+            return;
+          }
+
+          // The model is only known on response.create. If the handshake lease
+          // belongs to another metadata cohort, replace it before sending bytes.
+          failoverInProgress = true;
+          const previousLeaseId = lease.leaseId;
+          const previousUpstream = upstream;
+          await leaseAction("release", { leaseId: previousLeaseId }).catch(() => {});
+          previousUpstream.removeAllListeners();
+          previousUpstream.terminate();
+          try {
+            const next = await acquireConnected(request, excluded, model);
+            excluded.push(next.lease.connectionId);
+            lease = next.lease;
+            upstream = next.upstream;
+            await leaseAction("validate-model", { leaseId: lease.leaseId, model });
+            bindUpstreamEvents();
+          } catch {
+            closeBoth(1008, `Model '${model}' is not available on a WebSocket-capable metadata cohort`);
+            return;
+          } finally {
+            failoverInProgress = false;
+          }
+        }
+
+        validated = true;
+        turnFrames.push(frame);
+        sendWithBackpressure(upstream, frame.data, { binary: false, compress: frame.compress }, client);
+        for (const pending of queued.splice(0)) {
+          turnFrames.push(pending);
+          sendWithBackpressure(upstream, pending.data, { binary: false, compress: pending.compress }, client);
+        }
+      } finally {
+        validating = false;
+      }
+    }
+
+    function bindUpstreamEvents() {
+      const boundUpstream = upstream;
+      boundUpstream.on("ping", (data) => {
+        if (client.readyState === WebSocket.OPEN) client.ping(data);
+      });
+      boundUpstream.on("pong", (data) => {
+        if (client.readyState === WebSocket.OPEN) client.pong(data);
+      });
+      boundUpstream.on("message", (data, isBinary) => {
+        if (isBinary) {
+          closeBoth(1003, "Binary Codex frames are not supported");
+          return;
+        }
+        const event = parse(data);
+        if (event?.type === "codex.rate_limits") {
+          leaseAction("quota-event", { leaseId: lease.leaseId, event }).catch(() => {});
+        }
+        if (semanticEvent(event)) {
+          semanticOutputSeen = true;
+          turnFrames.length = 0;
+          leaseAction("semantic-output", { leaseId: lease.leaseId }).catch(() => {});
+        }
+        if (event?.type === "response.completed") {
+          leaseAction("success", { leaseId: lease.leaseId }).catch(() => {});
+        }
+        sendWithBackpressure(client, data, { binary: false, compress: true }, upstream);
+      });
+      boundUpstream.on("close", async (code, reason) => {
+        if (closed || failoverInProgress) return;
+        if (!semanticOutputSeen && turnFrames.length > 0) {
+          failoverInProgress = true;
+          await leaseAction("failure", {
+            leaseId: lease.leaseId,
+            status: 502,
+            error: `WebSocket closed before semantic output (${code})`,
+          }).catch(() => {});
+          await cleanupLease();
+          try {
+            const next = await acquireConnected(request, excluded, model);
+            excluded.push(next.lease.connectionId);
+            lease = next.lease;
+            upstream = next.upstream;
+            await leaseAction("validate-model", { leaseId: lease.leaseId, model });
+            bindUpstreamEvents();
+            for (const frame of turnFrames) {
+              sendWithBackpressure(upstream, frame.data, { binary: false, compress: frame.compress }, client);
+            }
+            failoverInProgress = false;
+            return;
+          } catch (error) {
+            failoverInProgress = false;
+          }
+        } else if (semanticOutputSeen) {
+          await leaseAction("failure", {
+            leaseId: lease.leaseId,
+            status: 502,
+            error: `WebSocket closed after semantic output (${code})`,
+          }).catch(() => {});
+        }
+        closeBoth(relayCloseCode(code, 1011), reason?.toString() || "Upstream WebSocket closed");
+      });
+      boundUpstream.on("error", () => {
+        // The close handler owns retry/no-replay decisions.
+      });
+    }
+
+    client.on("message", (data, isBinary) => {
+      if (isBinary) {
+        closeBoth(1003, "Binary Codex frames are not supported");
+        return;
+      }
+      const frame = { data, compress: true };
+      if (!validated) {
+        if (validating) queued.push(frame);
+        else validateAndFlush(frame);
+        return;
+      }
+      const event = parse(data);
+      if (event?.type === "response.create") {
+        semanticOutputSeen = false;
+        turnFrames.length = 0;
+      }
+      turnFrames.push(frame);
+      sendWithBackpressure(upstream, data, { binary: false, compress: true }, client);
+    });
+    client.on("close", (code, reason) => {
+      if (closed) return;
+      closed = true;
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.close(relayCloseCode(code), reason);
+      }
+      cleanupLease();
+    });
+    client.on("error", () => closeBoth(1011, "Client WebSocket failed"));
+    client.on("ping", (data) => {
+      if (upstream.readyState === WebSocket.OPEN) upstream.ping(data);
+    });
+    client.on("pong", (data) => {
+      if (upstream.readyState === WebSocket.OPEN) upstream.pong(data);
+    });
+    bindUpstreamEvents();
+  });
+
+  // Register the gateway first. Callers should wrap later upgrade listeners so
+  // Next.js only receives unclaimed paths.
+  server.on("upgrade", handleUpgrade);
+  return {
+    path: NATIVE_PATH,
+    handles: isNativeUpgrade,
+    close: () => wss.close(),
+    handleUpgrade,
+    wss,
+  };
+}
+
+module.exports = {
+  NATIVE_PATH,
+  attachCodexNativeGateway,
+  isNativeUpgrade,
+  noProxyMatches,
+  proxyAgent,
+  safeHandshakeHeaders,
+  semanticEvent,
+  sendWithBackpressure,
+};

--- a/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
@@ -7,6 +7,14 @@ import BaseUrlSelect from "./BaseUrlSelect";
 import ApiKeySelect from "./ApiKeySelect";
 import { matchKnownEndpoint } from "./cliEndpointMatch";
 
+function readConfiguredModel(status) {
+  return status?.config?.match(/^model\s*=\s*"([^"]+)"/m)?.[1] || "";
+}
+
+function readConfiguredSubagent(status) {
+  return status?.config?.match(/\[agents\.subagent\]\s*\n\s*model\s*=\s*"([^"]+)"/m)?.[1] || "";
+}
+
 export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, apiKeys, activeProviders, cloudEnabled, initialStatus, tunnelEnabled, tunnelPublicUrl, tailscaleEnabled, tailscaleUrl }) {
   const [codexStatus, setCodexStatus] = useState(initialStatus || null);
   const [checkingCodex, setCheckingCodex] = useState(false);
@@ -14,33 +22,25 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
   const [restoring, setRestoring] = useState(false);
   const [message, setMessage] = useState(null);
   const [showInstallGuide, setShowInstallGuide] = useState(false);
-  const [selectedApiKey, setSelectedApiKey] = useState("");
-  const [selectedModel, setSelectedModel] = useState("");
-  const [subagentModel, setSubagentModel] = useState("");
+  const [selectedApiKey, setSelectedApiKey] = useState(apiKeys?.[0]?.key || "");
+  const [selectedModel, setSelectedModel] = useState(readConfiguredModel(initialStatus));
+  const [subagentModel, setSubagentModel] = useState(readConfiguredSubagent(initialStatus));
   const [modalOpen, setModalOpen] = useState(false);
   const [subagentModalOpen, setSubagentModalOpen] = useState(false);
   const [modelAliases, setModelAliases] = useState({});
   const [showManualConfigModal, setShowManualConfigModal] = useState(false);
   const [customBaseUrl, setCustomBaseUrl] = useState("");
+  const [mode, setMode] = useState(initialStatus?.mode || "universal");
+  const [nativeCatalog, setNativeCatalog] = useState({ models: [], accounts: [], catalog: null });
+  const [loadingNativeCatalog, setLoadingNativeCatalog] = useState(false);
+  const [nativeReadiness, setNativeReadiness] = useState(initialStatus?.nativeReadiness || null);
+  const [testingNative, setTestingNative] = useState(false);
+  const [subagentCustomized, setSubagentCustomized] = useState(
+    !!readConfiguredSubagent(initialStatus)
+    && readConfiguredSubagent(initialStatus) !== readConfiguredModel(initialStatus)
+  );
 
-  useEffect(() => {
-    if (apiKeys?.length > 0 && !selectedApiKey) {
-      setSelectedApiKey(apiKeys[0].key);
-    }
-  }, [apiKeys, selectedApiKey]);
-
-  useEffect(() => {
-    if (initialStatus) setCodexStatus(initialStatus);
-  }, [initialStatus]);
-
-  useEffect(() => {
-    if (isExpanded) {
-      if (!codexStatus) checkCodexStatus();
-      fetchModelAliases();
-    }
-  }, [isExpanded]);
-
-  const fetchModelAliases = async () => {
+  async function fetchModelAliases() {
     try {
       const res = await fetch("/api/models/alias");
       const data = await res.json();
@@ -48,19 +48,57 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
     } catch (error) {
       console.log("Error fetching model aliases:", error);
     }
-  };
+  }
 
-  // Parse model and subagent settings from config content
-  useEffect(() => {
-    if (codexStatus?.config) {
-      const modelMatch = codexStatus.config.match(/^model\s*=\s*"([^"]+)"/m);
-      if (modelMatch) setSelectedModel(modelMatch[1]);
-
-      // Parse subagent settings
-      const subagentModelMatch = codexStatus.config.match(/\[agents\.subagent\]\s*\n\s*model\s*=\s*"([^"]+)"/m);
-      if (subagentModelMatch) setSubagentModel(subagentModelMatch[1]);
+  async function fetchNativeCatalog(forceRefresh = false) {
+    setLoadingNativeCatalog(true);
+    try {
+      const res = await fetch(`/api/cli-tools/codex-native/models${forceRefresh ? "?refresh=1" : ""}`);
+      const data = await res.json();
+      if (res.ok) {
+        setNativeCatalog(data);
+        const fallback = data.defaultModel || data.models?.[0]?.slug || "";
+        const slugs = new Set((data.models || []).map((model) => model.slug));
+        setSelectedModel((current) => slugs.has(current) ? current : fallback);
+        setSubagentModel((current) => slugs.has(current) ? current : fallback);
+      }
+    } catch (error) {
+      console.log("Error fetching Codex Native catalog:", error);
+    } finally {
+      setLoadingNativeCatalog(false);
     }
-  }, [codexStatus]);
+  }
+
+  async function checkCodexStatus() {
+    setCheckingCodex(true);
+    try {
+      const res = await fetch("/api/cli-tools/codex-settings");
+      const data = await res.json();
+      setCodexStatus(data);
+      setNativeReadiness(data.nativeReadiness || null);
+      if (data.mode) setMode(data.mode);
+      const configuredModel = readConfiguredModel(data);
+      const configuredSubagent = readConfiguredSubagent(data);
+      if (configuredModel) setSelectedModel(configuredModel);
+      if (configuredSubagent) setSubagentModel(configuredSubagent);
+    } catch (error) {
+      setCodexStatus({ installed: false, error: error.message });
+    } finally {
+      setCheckingCodex(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!isExpanded) return;
+    const timer = setTimeout(() => {
+      if (!codexStatus) checkCodexStatus();
+      fetchModelAliases();
+      fetchNativeCatalog();
+    }, 0);
+    return () => clearTimeout(timer);
+    // Opening the card is the synchronization boundary for external CLI state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isExpanded]);
 
   const getConfigStatus = () => {
     if (!codexStatus?.installed) return null;
@@ -80,19 +118,6 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
 
   const getDisplayUrl = () => customBaseUrl || `${baseUrl}/v1`;
 
-  const checkCodexStatus = async () => {
-    setCheckingCodex(true);
-    try {
-      const res = await fetch("/api/cli-tools/codex-settings");
-      const data = await res.json();
-      setCodexStatus(data);
-    } catch (error) {
-      setCodexStatus({ installed: false, error: error.message });
-    } finally {
-      setCheckingCodex(false);
-    }
-  };
-
   const handleApplySettings = async () => {
     setApplying(true);
     setMessage(null);
@@ -109,7 +134,8 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
           baseUrl: getEffectiveBaseUrl(),
           apiKey: keyToUse,
           model: selectedModel,
-          subagentModel: subagentModel || selectedModel
+          subagentModel: subagentModel || selectedModel,
+          mode,
         }),
       });
       const data = await res.json();
@@ -156,6 +182,56 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
     setModalOpen(false);
   };
 
+  const handleModeChange = (nextMode) => {
+    setMode(nextMode);
+    setMessage(null);
+    if (nextMode === "native") {
+      const slugs = new Set(nativeCatalog.models.map((model) => model.slug));
+      const fallback = nativeCatalog.defaultModel || nativeCatalog.models[0]?.slug || "";
+      setSelectedModel((current) => slugs.has(current) ? current : fallback);
+      setSubagentModel((current) => slugs.has(current) ? current : fallback);
+      setSubagentCustomized(false);
+    } else {
+      setSelectedModel((current) => current.includes("/") ? current : "");
+      setSubagentModel((current) => current.includes("/") ? current : "");
+    }
+  };
+
+  const handleNativeModelChange = (model) => {
+    setSelectedModel(model);
+    if (!subagentCustomized) setSubagentModel(model);
+  };
+
+  const handleRepairNative = async () => {
+    setTestingNative(true);
+    setMessage(null);
+    try {
+      const keyToUse = selectedApiKey?.trim() || (!cloudEnabled ? "sk_9router" : "");
+      const res = await fetch("/api/cli-tools/codex-native/readiness", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          baseUrl: `${getEffectiveBaseUrl()}/codex`,
+          apiKey: keyToUse,
+        }),
+      });
+      const data = await res.json();
+      setNativeReadiness(data);
+      setMessage({
+        type: data.supportsWebSockets ? "success" : "error",
+        text: data.supportsWebSockets
+          ? "Codex Native WebSocket and HTTP fallback are ready."
+          : data.configuredWebSocket?.error || data.models?.error || "Native HTTP works, but WebSocket is not ready.",
+      });
+      await checkCodexStatus();
+      await fetchNativeCatalog();
+    } catch (error) {
+      setMessage({ type: "error", text: error.message });
+    } finally {
+      setTestingNative(false);
+    }
+  };
+
   const getManualConfigs = () => {
     const keyToUse = (selectedApiKey && selectedApiKey.trim())
       ? selectedApiKey
@@ -163,23 +239,28 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
 
     const effectiveSubagentModel = subagentModel || selectedModel;
 
-    const configContent = `# 9Router Configuration for Codex CLI
+    const providerId = mode === "native" ? "9router_codex" : "9router";
+    const providerName = mode === "native" ? "9Router Codex Native" : "9Router Universal";
+    const providerBaseUrl = mode === "native" ? `${getEffectiveBaseUrl()}/codex` : getEffectiveBaseUrl();
+    const dataDir = codexStatus?.dataDir || "~/.9router";
+    const configContent = `# 9Router Configuration for Codex CLI (${mode})
 model = "${selectedModel}"
-model_provider = "9router"
+model_provider = "${providerId}"
 
-[model_providers.9router]
-name = "9Router"
-base_url = "${getEffectiveBaseUrl()}"
+[model_providers.${providerId}]
+name = "${providerName}"
+base_url = "${providerBaseUrl}"
 wire_api = "responses"
+${mode === "native" ? `supports_websockets = ${nativeReadiness?.supportsWebSockets === true}` : ""}
+
+[model_providers.${providerId}.auth]
+command = "9router"
+args = ["codex", "auth-token", "--data-dir", "${dataDir}"]
+refresh_interval_ms = 0
 
 [agents.subagent]
 model = "${effectiveSubagentModel}"
 `;
-
-    const authContent = JSON.stringify({
-      auth_mode: "apikey",
-      OPENAI_API_KEY: keyToUse
-    }, null, 2);
 
     return [
       {
@@ -187,8 +268,8 @@ model = "${effectiveSubagentModel}"
         content: configContent,
       },
       {
-        filename: "~/.codex/auth.json",
-        content: authContent,
+        filename: `${dataDir}/secrets/codex-bridge-token`,
+        content: keyToUse,
       },
     ];
   };
@@ -254,8 +335,9 @@ model = "${effectiveSubagentModel}"
                     <p className="text-text-muted">After installation, run <code className="px-1 bg-black/5 dark:bg-white/5 rounded">codex</code> to verify.</p>
                     <div className="pt-2 border-t border-border">
                       <p className="text-text-muted text-xs">
-                        Codex uses <code className="px-1 bg-black/5 dark:bg-white/5 rounded">~/.codex/auth.json</code> with <code className="px-1 bg-black/5 dark:bg-white/5 rounded">OPENAI_API_KEY</code>.
-                        Click &quot;Apply&quot; to auto-configure.
+                        9Router uses Codex provider-scoped command auth, so your existing
+                        <code className="mx-1 bg-black/5 px-1 dark:bg-white/5 rounded">~/.codex/auth.json</code>
+                        login remains untouched. Click &quot;Apply&quot; to configure it.
                       </p>
                     </div>
                   </div>
@@ -266,6 +348,58 @@ model = "${effectiveSubagentModel}"
 
           {!checkingCodex && codexStatus?.installed && (
             <>
+              <div className="grid grid-cols-2 gap-2 rounded-lg border border-border bg-surface/40 p-1">
+                <button
+                  type="button"
+                  onClick={() => handleModeChange("universal")}
+                  className={`rounded-md px-3 py-2 text-left transition-colors ${mode === "universal" ? "bg-background text-text-main shadow-sm" : "text-text-muted hover:text-text-main"}`}
+                >
+                  <span className="block text-xs font-semibold">Universal Models</span>
+                  <span className="block text-[10px]">All providers and aliases</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleModeChange("native")}
+                  className={`rounded-md px-3 py-2 text-left transition-colors ${mode === "native" ? "bg-primary/10 text-primary shadow-sm" : "text-text-muted hover:text-text-main"}`}
+                >
+                  <span className="block text-xs font-semibold">Codex Native</span>
+                  <span className="block text-[10px]">Native metadata and account pool</span>
+                </button>
+              </div>
+
+              {mode === "native" && (
+                <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-xs">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-medium text-text-main">
+                      {loadingNativeCatalog ? "Refreshing native catalog…" : `${nativeCatalog.models.length} native models · ${nativeCatalog.accounts.length} accounts`}
+                    </span>
+                    <button type="button" onClick={() => fetchNativeCatalog(true)} className="text-primary hover:underline">
+                      Refresh
+                    </button>
+                  </div>
+                  <div className="mt-1 flex flex-wrap gap-2 text-[10px] text-text-muted">
+                    {["healthy", "draining", "critical", "exhausted", "locked"].map((status) => {
+                      const count = nativeCatalog.accounts.filter((account) => account.status === status).length;
+                      return count ? <span key={status}>{status}: {count}</span> : null;
+                    })}
+                    <span>catalog: {nativeCatalog.catalog?.source || "unavailable"}{nativeCatalog.catalog?.stale ? " (stale)" : ""}</span>
+                    {nativeCatalog.catalog?.clientVersion && <span>client: {nativeCatalog.catalog.clientVersion}</span>}
+                    <span>leases: {nativeCatalog.metrics?.activeLeases || 0}</span>
+                    <span>HTTP fallback: {nativeCatalog.metrics?.httpFallbackCount || 0}</span>
+                    <span className={nativeReadiness?.supportsWebSockets ? "text-green-600" : "text-amber-600"}>
+                      WS: {nativeReadiness?.supportsWebSockets ? "ready" : "HTTP fallback"}
+                    </span>
+                  </div>
+                  {nativeCatalog.accounts.some((account) => account.skippedReason) && (
+                    <div className="mt-2 space-y-1 border-t border-primary/10 pt-2 text-[10px] text-text-muted">
+                      {nativeCatalog.accounts.filter((account) => account.skippedReason).slice(0, 3).map((account) => (
+                        <p key={account.connectionId}>{account.name}: {account.skippedReason}</p>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
               <div className="flex flex-col gap-2">
                 {/* Endpoint (selector) */}
                 <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr] sm:items-center sm:gap-2">
@@ -308,18 +442,37 @@ model = "${effectiveSubagentModel}"
                 <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
                   <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Model</span>
                   <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
-                  <div className="relative w-full min-w-0">
-                    <input type="text" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)} placeholder="provider/model-id" className="w-full min-w-0 pl-2 pr-7 py-2 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5" />
-                    {selectedModel && <button onClick={() => setSelectedModel("")} className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 text-text-muted hover:text-red-500 rounded transition-colors" title="Clear"><span className="material-symbols-outlined text-[14px]">close</span></button>}
-                  </div>
-                  <button onClick={() => setModalOpen(true)} disabled={!activeProviders?.length} className={`w-full sm:w-auto rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 whitespace-nowrap sm:shrink-0 ${activeProviders?.length ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>Select Model</button>
+                  {mode === "native" ? (
+                    <>
+                      <select value={selectedModel} onChange={(event) => handleNativeModelChange(event.target.value)} className="w-full min-w-0 rounded border border-border bg-surface px-2 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5">
+                        {nativeCatalog.models.map((model) => (
+                          <option key={model.slug} value={model.slug}>{model.display_name} · {model.eligibleAccountCount} accounts</option>
+                        ))}
+                      </select>
+                      <span className="text-[10px] text-text-muted">Native only</span>
+                    </>
+                  ) : (
+                    <>
+                      <div className="relative w-full min-w-0">
+                        <input type="text" value={selectedModel} onChange={(e) => setSelectedModel(e.target.value)} placeholder="provider/model-id" className="w-full min-w-0 pl-2 pr-7 py-2 bg-surface rounded border border-border text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5" />
+                        {selectedModel && <button onClick={() => setSelectedModel("")} className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 text-text-muted hover:text-red-500 rounded transition-colors" title="Clear"><span className="material-symbols-outlined text-[14px]">close</span></button>}
+                      </div>
+                      <button onClick={() => setModalOpen(true)} disabled={!activeProviders?.length} className={`w-full sm:w-auto rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 whitespace-nowrap sm:shrink-0 ${activeProviders?.length ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}>Select Model</button>
+                    </>
+                  )}
                 </div>
 
                 {/* Subagent Model */}
                 <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-[8rem_auto_1fr_auto] sm:items-center sm:gap-2">
                   <span className="text-xs font-semibold text-text-main sm:text-right sm:text-sm">Subagent Model</span>
                   <span className="material-symbols-outlined hidden text-text-muted text-[14px] sm:inline">arrow_forward</span>
-                  <div className="relative w-full min-w-0">
+                  {mode === "native" ? (
+                    <select value={subagentModel} onChange={(event) => { setSubagentModel(event.target.value); setSubagentCustomized(true); }} className="w-full min-w-0 rounded border border-border bg-surface px-2 py-2 text-xs focus:outline-none focus:ring-1 focus:ring-primary/50 sm:py-1.5">
+                      {nativeCatalog.models.map((model) => (
+                        <option key={model.slug} value={model.slug}>{model.display_name}</option>
+                      ))}
+                    </select>
+                  ) : <div className="relative w-full min-w-0">
                     <input
                       type="text"
                       value={subagentModel}
@@ -336,14 +489,14 @@ model = "${effectiveSubagentModel}"
                         <span className="material-symbols-outlined text-[14px]">close</span>
                       </button>
                     )}
-                  </div>
-                  <button
+                  </div>}
+                  {mode === "universal" && <button
                     onClick={() => setSubagentModalOpen(true)}
                     disabled={!activeProviders?.length}
                     className={`w-full sm:w-auto rounded border px-2 py-2 text-xs transition-colors sm:py-1.5 whitespace-nowrap sm:shrink-0 ${activeProviders?.length ? "bg-surface border-border text-text-main hover:border-primary cursor-pointer" : "opacity-50 cursor-not-allowed border-border"}`}
                   >
                     Select Model
-                  </button>
+                  </button>}
                 </div>
               </div>
 
@@ -361,6 +514,12 @@ model = "${effectiveSubagentModel}"
                 <Button variant="outline" size="sm" onClick={handleResetSettings} disabled={restoring} loading={restoring}>
                   <span className="material-symbols-outlined text-[14px] mr-1">restore</span>Reset
                 </Button>
+                {mode === "native" && (
+                  <Button variant="outline" size="sm" onClick={handleRepairNative} disabled={testingNative} loading={testingNative}>
+                    <span className="material-symbols-outlined text-[14px] mr-1">network_check</span>
+                    {nativeReadiness ? "Test again / Repair Native" : "Test Native"}
+                  </Button>
+                )}
                 <Button variant="ghost" size="sm" onClick={() => setShowManualConfigModal(true)}>
                   <span className="material-symbols-outlined text-[14px] mr-1">content_copy</span>Manual Config
                 </Button>
@@ -370,7 +529,7 @@ model = "${effectiveSubagentModel}"
         </div>
       )}
 
-      {modalOpen && (
+      {mode === "universal" && modalOpen && (
         <ModelSelectModal
           isOpen={modalOpen}
           onClose={() => setModalOpen(false)}
@@ -382,7 +541,7 @@ model = "${effectiveSubagentModel}"
         />
       )}
 
-      {subagentModalOpen && (
+      {mode === "universal" && subagentModalOpen && (
         <ModelSelectModal
           isOpen={subagentModalOpen}
           onClose={() => setSubagentModalOpen(false)}

--- a/src/app/api/cli-tools/codex-native/models/route.js
+++ b/src/app/api/cli-tools/codex-native/models/route.js
@@ -1,0 +1,50 @@
+import { getCodexNativeCatalog, getCodexNativeDefaultModel } from "@/lib/codexNative/catalog.js";
+import { getInstalledCodexClientVersion } from "@/lib/codexNative/clientVersion.js";
+import {
+  getCodexNativeMetrics,
+  getCodexNativePoolSnapshot,
+  refreshCodexNativePoolUsage,
+} from "@/lib/codexNative/pool.js";
+
+export async function GET(request) {
+  try {
+    const url = new URL(request.url);
+    const forceRefresh = url.searchParams.get("refresh") === "1";
+    const requestedVersion = url.searchParams.get("client_version");
+    const installedVersion = requestedVersion
+      ? null
+      : await getInstalledCodexClientVersion({ forceRefresh });
+    const clientVersion = requestedVersion || installedVersion?.version;
+    if (!clientVersion) {
+      return Response.json({
+        error: "Codex client version could not be detected; install Codex CLI or provide client_version",
+      }, { status: 503 });
+    }
+    const catalog = await getCodexNativeCatalog({ forceRefresh, clientVersion });
+    const accounts = forceRefresh
+      ? await refreshCodexNativePoolUsage({ clientVersion })
+      : await getCodexNativePoolSnapshot({ clientVersion });
+    if (!forceRefresh) refreshCodexNativePoolUsage({ clientVersion }).catch(() => {});
+
+    return Response.json({
+      models: catalog.models.map((model) => ({
+        ...model,
+        eligibleAccountCount: catalog.eligibleConnectionIds?.[model.slug]?.length || 0,
+      })),
+      accounts,
+      defaultModel: getCodexNativeDefaultModel(catalog),
+      metrics: getCodexNativeMetrics(),
+      catalog: {
+        source: catalog.source,
+        stale: catalog.stale === true,
+        clientVersion: catalog.clientVersion,
+        fetchedAt: new Date(catalog.fetchedAt).toISOString(),
+        accountCount: catalog.accountCount ?? accounts.length,
+        successfulAccountCount: catalog.successfulAccountCount ?? null,
+        warnings: catalog.warnings || [],
+      },
+    });
+  } catch (error) {
+    return Response.json({ error: error.message }, { status: 503 });
+  }
+}

--- a/src/app/api/cli-tools/codex-native/readiness/route.js
+++ b/src/app/api/cli-tools/codex-native/readiness/route.js
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { WebSocket } from "ws";
+import { parseTOML, stringifyTOML } from "confbox";
+import { DATA_DIR } from "@/lib/dataDir.js";
+import { getInstalledCodexClientVersion } from "@/lib/codexNative/clientVersion.js";
+import {
+  getCodexNativeMetrics,
+  getCodexNativeWebSocketEligibility,
+} from "@/lib/codexNative/pool.js";
+import { getCodexNativeCatalog } from "@/lib/codexNative/catalog.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const STATE_FILE = path.join(DATA_DIR, "codex-native", "readiness.json");
+const SECRET_FILE = path.join(DATA_DIR, "secrets", "codex-bridge-token");
+const CONFIG_FILE = path.join(os.homedir(), ".codex", "config.toml");
+
+async function readJson(file) {
+  try { return JSON.parse(await fs.readFile(file, "utf8")); } catch { return null; }
+}
+
+async function atomicWrite(file, content) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const temporary = `${file}.${process.pid}.tmp`;
+  await fs.writeFile(temporary, content, { mode: 0o600 });
+  await fs.rename(temporary, file);
+  try { await fs.chmod(file, 0o600); } catch { /* Windows */ }
+}
+
+function providerBaseUrl(value) {
+  return String(value || "").trim().replace(/\/+$/, "");
+}
+
+function wsUrl(baseUrl) {
+  const url = new URL(`${providerBaseUrl(baseUrl)}/responses`);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
+async function probeWebSocket(baseUrl, apiKey, clientVersion, timeoutMs = 8_000) {
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    let settled = false;
+    const socket = new WebSocket(wsUrl(baseUrl), {
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        originator: "codex_cli_rs",
+        "user-agent": "9router-readiness",
+        "x-codex-client-version": clientVersion,
+      },
+      handshakeTimeout: timeoutMs,
+      perMessageDeflate: true,
+    });
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (socket.readyState === WebSocket.OPEN) socket.close(1000, "readiness complete");
+      else socket.terminate();
+      resolve({ ...result, latencyMs: Date.now() - startedAt });
+    };
+    const timer = setTimeout(() => finish({ ok: false, error: "WebSocket probe timed out" }), timeoutMs);
+    socket.once("open", () => finish({ ok: true }));
+    socket.once("unexpected-response", (_request, response) => {
+      response.resume();
+      finish({ ok: false, status: response.statusCode, error: `Upgrade returned ${response.statusCode}` });
+    });
+    socket.once("error", (error) => finish({ ok: false, error: error.message }));
+  });
+}
+
+async function probeModels(baseUrl, apiKey, clientVersion) {
+  const url = new URL(`${providerBaseUrl(baseUrl)}/models`);
+  url.searchParams.set("client_version", clientVersion);
+  const response = await fetch(url, {
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "user-agent": "9router-readiness",
+    },
+    signal: AbortSignal.timeout(8_000),
+    cache: "no-store",
+  });
+  const payload = await response.json().catch(() => ({}));
+  return {
+    ok: response.ok && Array.isArray(payload.models) && payload.models.length > 0,
+    status: response.status,
+    modelCount: Array.isArray(payload.models) ? payload.models.length : 0,
+    error: response.ok ? null : payload?.error?.message || `Models returned ${response.status}`,
+  };
+}
+
+async function configuredProviderBaseUrl() {
+  try {
+    const parsed = parseTOML(await fs.readFile(CONFIG_FILE, "utf8")) || {};
+    return parsed?.model_providers?.[CODEX_NATIVE_CONFIG.providerConfigId]?.base_url || null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeSupportsWebSockets(value) {
+  let parsed;
+  try {
+    parsed = parseTOML(await fs.readFile(CONFIG_FILE, "utf8")) || {};
+  } catch {
+    return false;
+  }
+  const provider = parsed?.model_providers?.[CODEX_NATIVE_CONFIG.providerConfigId];
+  if (!provider) return false;
+  provider.supports_websockets = value === true;
+  await atomicWrite(CONFIG_FILE, stringifyTOML(parsed));
+  return true;
+}
+
+export async function GET() {
+  const [last, metrics] = await Promise.all([
+    readJson(STATE_FILE),
+    Promise.resolve(getCodexNativeMetrics()),
+  ]);
+  return Response.json({
+    last,
+    metrics,
+    wsDisabled: /^(1|true|yes|on)$/i.test(process.env.CODEX_NATIVE_WS_DISABLED || ""),
+  });
+}
+
+export async function POST(request) {
+  let input = {};
+  try { input = await request.json(); } catch { /* optional body */ }
+  const origin = new URL(request.url).origin;
+  const localBaseUrl = `${origin}/v1/codex`;
+  const configuredBase = providerBaseUrl(input.baseUrl || await configuredProviderBaseUrl() || localBaseUrl);
+  const installedVersion = await getInstalledCodexClientVersion({ forceRefresh: true });
+  const clientVersion = String(input.clientVersion || installedVersion.version || "").trim();
+  let apiKey;
+  try {
+    apiKey = String(input.apiKey || await fs.readFile(SECRET_FILE, "utf8")).trim();
+  } catch {
+    apiKey = "";
+  }
+
+  const checkedAt = new Date().toISOString();
+  const result = {
+    checkedAt,
+    clientVersion: clientVersion || null,
+    configuredBaseUrl: configuredBase,
+    auth: { ok: !!apiKey },
+    models: { ok: false },
+    localWebSocket: { ok: false },
+    configuredWebSocket: { ok: false },
+    upstreamHandshake: { ok: false },
+    httpFallback: { ok: false },
+    eligibleAccounts: [],
+    supportsWebSockets: false,
+  };
+
+  try {
+    if (!clientVersion) throw new Error("Codex client version could not be detected");
+    const catalog = await getCodexNativeCatalog({ forceRefresh: true, clientVersion });
+    result.catalog = {
+      source: catalog.source,
+      stale: catalog.stale === true,
+      clientVersion: catalog.clientVersion,
+      fetchedAt: new Date(catalog.fetchedAt).toISOString(),
+    };
+    result.eligibleAccounts = await getCodexNativeWebSocketEligibility({ clientVersion });
+  } catch (error) {
+    result.catalog = { error: error.message };
+  }
+
+  if (apiKey) {
+    try {
+      if (!clientVersion) throw new Error("Codex client version could not be detected");
+      result.models = await probeModels(configuredBase, apiKey, clientVersion);
+      result.httpFallback = {
+        ok: result.models.ok,
+        detail: "Models endpoint proves authenticated HTTP fallback without creating a completion",
+      };
+    } catch (error) {
+      result.models = { ok: false, error: error.message };
+      result.httpFallback = { ok: false, error: error.message };
+    }
+
+    const disabled = /^(1|true|yes|on)$/i.test(process.env.CODEX_NATIVE_WS_DISABLED || "");
+    if (!disabled) {
+      result.localWebSocket = await probeWebSocket(localBaseUrl, apiKey, clientVersion);
+      result.configuredWebSocket = configuredBase === localBaseUrl
+        ? result.localWebSocket
+        : await probeWebSocket(configuredBase, apiKey, clientVersion);
+      result.upstreamHandshake = {
+        ...result.configuredWebSocket,
+        detail: "The local gateway only returns 101 after its upstream ChatGPT handshake succeeds",
+      };
+    } else {
+      const error = "Disabled by CODEX_NATIVE_WS_DISABLED";
+      result.localWebSocket = { ok: false, error };
+      result.configuredWebSocket = { ok: false, error };
+      result.upstreamHandshake = { ok: false, error };
+    }
+  }
+
+  const wsEligible = result.eligibleAccounts.some((account) => account.eligible);
+  result.supportsWebSockets = result.auth.ok
+    && result.models.ok
+    && result.configuredWebSocket.ok
+    && result.upstreamHandshake.ok
+    && wsEligible;
+  result.configUpdated = await writeSupportsWebSockets(result.supportsWebSockets);
+  await atomicWrite(STATE_FILE, JSON.stringify(result, null, 2));
+  return Response.json(result, { status: result.models.ok ? 200 : 503 });
+}
+
+export const __test__ = {
+  providerBaseUrl,
+  wsUrl,
+};

--- a/src/app/api/cli-tools/codex-settings/route.js
+++ b/src/app/api/cli-tools/codex-settings/route.js
@@ -1,103 +1,149 @@
 "use server";
 
 import { NextResponse } from "next/server";
-import { exec } from "child_process";
-import { promisify } from "util";
-import fs from "fs/promises";
-import path from "path";
-import os from "os";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
 import { parseTOML, stringifyTOML } from "confbox";
+import { DATA_DIR } from "@/lib/dataDir.js";
+import { getInstalledCodexClientVersion } from "@/lib/codexNative/clientVersion.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
 
-const execAsync = promisify(exec);
+const BRIDGE_SECRET_PATH = path.join(DATA_DIR, "secrets", "codex-bridge-token");
+const BRIDGE_STATE_PATH = path.join(DATA_DIR, "state", "codex-bridge.json");
+const NATIVE_READINESS_PATH = path.join(DATA_DIR, "codex-native", "readiness.json");
 
 const getCodexDir = () => path.join(os.homedir(), ".codex");
 const getCodexConfigPath = () => path.join(getCodexDir(), "config.toml");
 const getCodexAuthPath = () => path.join(getCodexDir(), "auth.json");
 
-// Flatten confbox-parsed TOML into a writable object, preserving nested tables
 const parsedToWritable = (obj) => obj ?? {};
 
-// Set a nested key from a flat dotted path, creating intermediate objects as needed
 const setNestedSection = (obj, dottedKey, value) => {
   const keys = dottedKey.split(".");
-  let cur = obj;
-  for (let i = 0; i < keys.length - 1; i++) {
-    if (cur[keys[i]] == null || typeof cur[keys[i]] !== "object") {
-      cur[keys[i]] = {};
+  let current = obj;
+  for (let index = 0; index < keys.length - 1; index++) {
+    if (current[keys[index]] == null || typeof current[keys[index]] !== "object") {
+      current[keys[index]] = {};
     }
-    cur = cur[keys[i]];
+    current = current[keys[index]];
   }
-  cur[keys[keys.length - 1]] = value;
+  current[keys[keys.length - 1]] = value;
 };
 
-// Delete a nested key from a flat dotted path
+const getNestedSection = (obj, dottedKey) =>
+  dottedKey.split(".").reduce((value, key) => value?.[key], obj);
+
 const deleteNestedSection = (obj, dottedKey) => {
   const keys = dottedKey.split(".");
-  let cur = obj;
-  for (let i = 0; i < keys.length - 1; i++) {
-    cur = cur?.[keys[i]];
-    if (cur == null) return;
+  let current = obj;
+  for (let index = 0; index < keys.length - 1; index++) {
+    current = current?.[keys[index]];
+    if (current == null) return;
   }
-  delete cur[keys[keys.length - 1]];
+  delete current[keys[keys.length - 1]];
 };
 
-// Check if codex CLI is installed (via which/where or config file exists)
-const checkCodexInstalled = async () => {
+async function atomicWrite(filePath, content, mode = 0o600) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  await fs.writeFile(temporaryPath, content, { mode });
+  await fs.rename(temporaryPath, filePath);
+  try { await fs.chmod(filePath, mode); } catch { /* Windows and restricted filesystems */ }
+}
+
+async function readJson(filePath) {
   try {
-    const isWindows = os.platform() === "win32";
-    const command = isWindows ? "where codex" : "which codex";
-    const env = isWindows
-      ? { ...process.env, PATH: `${process.env.APPDATA}\\npm;${process.env.PATH}` }
-      : process.env;
-    await execAsync(command, { windowsHide: true, env });
-    return true;
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
   } catch {
-    try {
-      await fs.access(getCodexConfigPath());
-      return true;
-    } catch {
-      return false;
-    }
+    return null;
   }
-};
+}
 
-// Read current config.toml
-const readConfig = async () => {
+async function readConfig() {
   try {
-    const configPath = getCodexConfigPath();
-    const content = await fs.readFile(configPath, "utf-8");
-    return content;
+    return await fs.readFile(getCodexConfigPath(), "utf8");
   } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;
   }
-};
+}
 
-// Check if config has 9Router settings
-const has9RouterConfig = (config) => {
+function has9RouterConfig(config) {
   if (!config) return false;
-  return config.includes("model_provider = \"9router\"") || config.includes("[model_providers.9router]");
-};
+  return config.includes('model_provider = "9router"')
+    || config.includes('model_provider = "9router_codex"')
+    || config.includes("[model_providers.9router]")
+    || config.includes("[model_providers.9router_codex]");
+}
 
-// GET - Check codex CLI and read current settings
+function normalizeUniversalBaseUrl(baseUrl) {
+  const trimmed = String(baseUrl || "").trim().replace(/\/+$/, "");
+  return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+}
+
+function authConfig() {
+  return {
+    command: "9router",
+    args: ["codex", "auth-token", "--data-dir", DATA_DIR],
+    refresh_interval_ms: 0,
+  };
+}
+
+async function writeBridgeState(parsed, managed) {
+  const existing = await readJson(BRIDGE_STATE_PATH);
+  const previous = existing?.previous || {
+    model: parsed.model ?? null,
+    modelProvider: parsed.model_provider ?? null,
+    subagent: getNestedSection(parsed, "agents.subagent") ?? null,
+  };
+  await atomicWrite(BRIDGE_STATE_PATH, JSON.stringify({
+    version: 1,
+    previous,
+    managed,
+    updatedAt: new Date().toISOString(),
+  }, null, 2));
+}
+
+async function migrateOwnedLegacyAuth(apiKey) {
+  const authPath = getCodexAuthPath();
+  const auth = await readJson(authPath);
+  if (!auth || auth.OPENAI_API_KEY !== apiKey || auth.auth_mode !== "apikey") return false;
+  delete auth.OPENAI_API_KEY;
+  delete auth.auth_mode;
+  if (Object.keys(auth).length === 0) {
+    await fs.unlink(authPath).catch(() => {});
+  } else {
+    await atomicWrite(authPath, JSON.stringify(auth, null, 2));
+  }
+  return true;
+}
+
 export async function GET() {
   try {
-    const isInstalled = await checkCodexInstalled();
-    
-    if (!isInstalled) {
-      return NextResponse.json({
-        installed: false,
-        config: null,
-        message: "Codex CLI is not installed",
-      });
-    }
-
-    const config = await readConfig();
+    const [versionInfo, config, secretConfigured, nativeReadiness] = await Promise.all([
+      getInstalledCodexClientVersion(),
+      readConfig(),
+      fs.access(BRIDGE_SECRET_PATH).then(() => true).catch(() => false),
+      readJson(NATIVE_READINESS_PATH),
+    ]);
+    const parsed = config ? parsedToWritable(parseTOML(config)) : {};
+    const provider = parsed.model_provider || null;
+    const mode = provider === CODEX_NATIVE_CONFIG.providerConfigId
+      ? "native"
+      : (provider === "9router" ? "universal" : null);
 
     return NextResponse.json({
-      installed: true,
+      installed: versionInfo.installed || !!config,
+      codexVersion: versionInfo.version,
+      codexVersionRaw: versionInfo.raw,
+      nativeSupported: nativeReadiness?.supportsWebSockets ?? null,
+      nativeReadiness,
       config,
+      mode,
       has9Router: has9RouterConfig(config),
+      secretConfigured,
+      dataDir: DATA_DIR,
       configPath: getCodexConfigPath(),
     });
   } catch (error) {
@@ -106,67 +152,70 @@ export async function GET() {
   }
 }
 
-// POST - Update 9Router settings (merge with existing config)
 export async function POST(request) {
   try {
-    const { baseUrl, apiKey, model, subagentModel } = await request.json();
-    
+    const {
+      baseUrl,
+      apiKey,
+      model,
+      subagentModel,
+      mode = "universal",
+    } = await request.json();
     if (!baseUrl || !apiKey || !model) {
       return NextResponse.json({ error: "baseUrl, apiKey and model are required" }, { status: 400 });
     }
+    if (!["universal", "native"].includes(mode)) {
+      return NextResponse.json({ error: "mode must be universal or native" }, { status: 400 });
+    }
 
-    const codexDir = getCodexDir();
     const configPath = getCodexConfigPath();
-
-    // Ensure directory exists
-    await fs.mkdir(codexDir, { recursive: true });
-
-    // Read and parse existing config
     let parsed = {};
     try {
-      const existingConfig = await fs.readFile(configPath, "utf-8");
-      parsed = parsedToWritable(parseTOML(existingConfig));
-    } catch { /* No existing config */ }
+      parsed = parsedToWritable(parseTOML(await fs.readFile(configPath, "utf8")));
+    } catch {
+      // First setup.
+    }
 
-    // Update only 9Router related fields (api_key goes to auth.json, not config.toml)
-    parsed.model = model;
-    parsed.model_provider = "9router";
-
-    // Update or create 9router provider section (no api_key - Codex reads from auth.json)
-    // Ensure /v1 suffix is added only once
-    const normalizedBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
-    setNestedSection(parsed, "model_providers.9router", {
-      name: "9Router",
-      base_url: normalizedBaseUrl,
-      wire_api: "responses",
-    });
-
-    // Add subagent configuration
+    const universalBaseUrl = normalizeUniversalBaseUrl(baseUrl);
+    const nativeBaseUrl = `${universalBaseUrl}/codex`;
+    const readiness = await readJson(NATIVE_READINESS_PATH);
+    const wsDisabled = /^(1|true|yes|on)$/i.test(process.env.CODEX_NATIVE_WS_DISABLED || "");
+    const supportsWebSockets = !wsDisabled
+      && readiness?.supportsWebSockets === true
+      && readiness?.configuredBaseUrl === nativeBaseUrl;
     const effectiveSubagentModel = subagentModel || model;
-    setNestedSection(parsed, "agents.subagent", {
-      model: effectiveSubagentModel,
+    const provider = mode === "native" ? CODEX_NATIVE_CONFIG.providerConfigId : "9router";
+    const managed = { model, modelProvider: provider, subagent: { model: effectiveSubagentModel } };
+    await writeBridgeState(parsed, managed);
+
+    parsed.model = model;
+    parsed.model_provider = provider;
+    setNestedSection(parsed, "model_providers.9router", {
+      name: "9Router Universal",
+      base_url: universalBaseUrl,
+      wire_api: "responses",
+      auth: authConfig(),
     });
+    setNestedSection(parsed, `model_providers.${CODEX_NATIVE_CONFIG.providerConfigId}`, {
+      name: "9Router Codex Native",
+      base_url: nativeBaseUrl,
+      wire_api: "responses",
+      supports_websockets: supportsWebSockets,
+      auth: authConfig(),
+    });
+    setNestedSection(parsed, "agents.subagent", { model: effectiveSubagentModel });
 
-    // Write merged config
-    const configContent = stringifyTOML(parsed);
-    await fs.writeFile(configPath, configContent);
-
-    // Update auth.json with OPENAI_API_KEY (Codex reads this first)
-    const authPath = getCodexAuthPath();
-    let authData = {};
-    try {
-      const existingAuth = await fs.readFile(authPath, "utf-8");
-      authData = JSON.parse(existingAuth);
-    } catch { /* No existing auth */ }
-    
-    // Force apikey mode (keep existing tokens untouched for ChatGPT login reuse)
-    authData.OPENAI_API_KEY = apiKey;
-    authData.auth_mode = "apikey";
-    await fs.writeFile(authPath, JSON.stringify(authData, null, 2));
+    await atomicWrite(configPath, stringifyTOML(parsed));
+    await atomicWrite(BRIDGE_SECRET_PATH, `${apiKey.trim()}\n`);
+    const migratedLegacyAuth = await migrateOwnedLegacyAuth(apiKey.trim());
 
     return NextResponse.json({
       success: true,
-      message: "Codex settings applied successfully!",
+      mode,
+      migratedLegacyAuth,
+      message: mode === "native"
+        ? "Codex Native pool configured successfully"
+        : "Codex Universal bridge configured successfully",
       configPath,
     });
   } catch (error) {
@@ -175,61 +224,47 @@ export async function POST(request) {
   }
 }
 
-// DELETE - Remove 9Router settings only (keep other settings)
 export async function DELETE() {
   try {
     const configPath = getCodexConfigPath();
-
-    // Read and parse existing config
     let parsed = {};
     try {
-      const existingConfig = await fs.readFile(configPath, "utf-8");
-      parsed = parsedToWritable(parseTOML(existingConfig));
+      parsed = parsedToWritable(parseTOML(await fs.readFile(configPath, "utf8")));
     } catch (error) {
-      if (error.code === "ENOENT") {
-        return NextResponse.json({
-          success: true,
-          message: "No config file to reset",
-        });
-      }
-      throw error;
+      if (error.code !== "ENOENT") throw error;
     }
 
-    // Remove 9Router related root fields only if they point to 9router
-    if (parsed.model_provider === "9router") {
+    const bridgeState = await readJson(BRIDGE_STATE_PATH);
+    const managed = bridgeState?.managed;
+    const previous = bridgeState?.previous;
+
+    if (managed && parsed.model === managed.model && parsed.model_provider === managed.modelProvider) {
+      if (previous?.model == null) delete parsed.model;
+      else parsed.model = previous.model;
+      if (previous?.modelProvider == null) delete parsed.model_provider;
+      else parsed.model_provider = previous.modelProvider;
+    } else if (parsed.model_provider === "9router" || parsed.model_provider === CODEX_NATIVE_CONFIG.providerConfigId) {
       delete parsed.model;
       delete parsed.model_provider;
     }
 
-    // Remove 9router provider section
+    const currentSubagent = getNestedSection(parsed, "agents.subagent");
+    if (managed && JSON.stringify(currentSubagent) === JSON.stringify(managed.subagent)) {
+      if (previous?.subagent == null) deleteNestedSection(parsed, "agents.subagent");
+      else setNestedSection(parsed, "agents.subagent", previous.subagent);
+    }
+
     deleteNestedSection(parsed, "model_providers.9router");
-
-    // Remove subagent configuration
-    deleteNestedSection(parsed, "agents.subagent");
-
-    // Write updated config
-    const configContent = stringifyTOML(parsed);
-    await fs.writeFile(configPath, configContent);
-
-    // Remove OPENAI_API_KEY from auth.json
-    const authPath = getCodexAuthPath();
-    try {
-      const existingAuth = await fs.readFile(authPath, "utf-8");
-      const authData = JSON.parse(existingAuth);
-      delete authData.OPENAI_API_KEY;
-      delete authData.auth_mode;
-
-      // Write back or delete if empty
-      if (Object.keys(authData).length === 0) {
-        await fs.unlink(authPath);
-      } else {
-        await fs.writeFile(authPath, JSON.stringify(authData, null, 2));
-      }
-    } catch { /* No auth file */ }
+    deleteNestedSection(parsed, `model_providers.${CODEX_NATIVE_CONFIG.providerConfigId}`);
+    await atomicWrite(configPath, stringifyTOML(parsed));
+    await Promise.all([
+      fs.unlink(BRIDGE_SECRET_PATH).catch(() => {}),
+      fs.unlink(BRIDGE_STATE_PATH).catch(() => {}),
+    ]);
 
     return NextResponse.json({
       success: true,
-      message: "9Router settings removed successfully",
+      message: "9Router Codex providers removed; previous Codex defaults restored when unchanged",
     });
   } catch (error) {
     console.log("Error resetting codex settings:", error);

--- a/src/app/api/internal/codex-native/lease/[action]/route.js
+++ b/src/app/api/internal/codex-native/lease/[action]/route.js
@@ -1,0 +1,126 @@
+import {
+  acquireCodexNativeLease,
+  failCodexNativeLease,
+  getCodexNativeLease,
+  getCodexNativeMetrics,
+  ingestCodexNativeQuota,
+  markCodexNativeSemanticOutput,
+  releaseCodexNativeLease,
+  succeedCodexNativeLease,
+  validateCodexNativeLeaseModel,
+} from "@/lib/codexNative/pool.js";
+import { sanitizeCodexNativeRequestHeaders, headersToObject } from "@/lib/codexNative/headers.js";
+import { validateCodexNativeClient } from "@/lib/codexNative/clientAuth.js";
+import { getInstalledCodexClientVersion } from "@/lib/codexNative/clientVersion.js";
+import { getMostRecentCodexClientVersion } from "@/lib/codexNative/catalog.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const LOOPBACK = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
+
+function denied(status = 403) {
+  return Response.json({ error: "Codex Native lease API is process-internal" }, { status });
+}
+
+function internalRequestAllowed(request) {
+  const expected = process.env.CODEX_NATIVE_INTERNAL_SECRET;
+  const supplied = request.headers.get("x-9r-internal-secret");
+  const peer = request.headers.get("x-9r-real-ip");
+  return !!expected && supplied === expected && LOOPBACK.has(peer);
+}
+
+function requestForClientAuth(requestHeaders) {
+  return new Request("http://127.0.0.1/v1/codex/responses", {
+    headers: requestHeaders || {},
+  });
+}
+
+export async function POST(request, context) {
+  if (!internalRequestAllowed(request)) return denied();
+  const { action } = await context.params;
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (action === "acquire") {
+    const clientAuth = await validateCodexNativeClient(requestForClientAuth(payload.requestHeaders));
+    if (!clientAuth.ok) return denied(401);
+    const installedVersion = payload.clientVersion
+      ? null
+      : await getInstalledCodexClientVersion();
+    const clientVersion = payload.clientVersion
+      || installedVersion?.version
+      || await getMostRecentCodexClientVersion();
+    const routed = await acquireCodexNativeLease({
+      headers: payload.requestHeaders || {},
+      body: payload.body || {},
+      model: payload.model || null,
+      transport: "ws",
+      clientVersion,
+      excludeConnectionIds: new Set(payload.excludeConnectionIds || []),
+    });
+    if (!routed.lease) {
+      return Response.json({
+        error: "No WebSocket-capable Codex account is available",
+        skippedReasons: routed.skippedReasons,
+      }, { status: 503 });
+    }
+    const { lease } = routed;
+    const upstreamHeaders = sanitizeCodexNativeRequestHeaders(
+      payload.requestHeaders || {},
+      lease.credentials
+    );
+    return Response.json({
+      leaseId: lease.id,
+      connectionId: lease.connectionId,
+      upstreamHeaders: headersToObject(upstreamHeaders),
+      proxy: {
+        enabled: lease.proxy.connectionProxyEnabled === true,
+        url: lease.proxy.connectionProxyUrl || "",
+        noProxy: lease.proxy.connectionNoProxy || "",
+        strict: lease.proxy.strictProxy === true,
+      },
+    });
+  }
+
+  const lease = getCodexNativeLease(payload.leaseId);
+  if (!lease) return Response.json({ error: "Unknown or expired lease" }, { status: 404 });
+
+  if (action === "validate-model") {
+    const valid = await validateCodexNativeLeaseModel(payload.leaseId, payload.model);
+    return Response.json({ valid }, { status: valid ? 200 : 409 });
+  }
+  if (action === "quota-event") {
+    ingestCodexNativeQuota(lease.connectionId, payload.event, "websocket");
+    return Response.json({ success: true });
+  }
+  if (action === "semantic-output") {
+    markCodexNativeSemanticOutput(payload.leaseId);
+    return Response.json({ success: true });
+  }
+  if (action === "success") {
+    await succeedCodexNativeLease(payload.leaseId);
+    return Response.json({ success: true });
+  }
+  if (action === "failure") {
+    await failCodexNativeLease(payload.leaseId, {
+      status: payload.status,
+      error: payload.error,
+    });
+    return Response.json({ success: true });
+  }
+  if (action === "release") {
+    releaseCodexNativeLease(payload.leaseId);
+    return Response.json({ success: true });
+  }
+  return Response.json({ error: "Unknown lease action" }, { status: 404 });
+}
+
+export async function GET(request) {
+  if (!internalRequestAllowed(request)) return denied();
+  return Response.json(getCodexNativeMetrics());
+}

--- a/src/app/api/v1/codex/alpha/search/route.js
+++ b/src/app/api/v1/codex/alpha/search/route.js
@@ -1,0 +1,12 @@
+import { relayCodexNativeHttp } from "@/lib/codexNative/relay.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  return relayCodexNativeHttp(request, {
+    path: CODEX_NATIVE_CONFIG.paths.search,
+    operation: "search",
+  });
+}

--- a/src/app/api/v1/codex/images/edits/route.js
+++ b/src/app/api/v1/codex/images/edits/route.js
@@ -1,0 +1,12 @@
+import { relayCodexNativeHttp } from "@/lib/codexNative/relay.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  return relayCodexNativeHttp(request, {
+    path: CODEX_NATIVE_CONFIG.paths.imageEdits,
+    operation: "image-edit",
+  });
+}

--- a/src/app/api/v1/codex/images/generations/route.js
+++ b/src/app/api/v1/codex/images/generations/route.js
@@ -1,0 +1,12 @@
+import { relayCodexNativeHttp } from "@/lib/codexNative/relay.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  return relayCodexNativeHttp(request, {
+    path: CODEX_NATIVE_CONFIG.paths.imageGenerations,
+    operation: "image-generation",
+  });
+}

--- a/src/app/api/v1/codex/memories/trace_summarize/route.js
+++ b/src/app/api/v1/codex/memories/trace_summarize/route.js
@@ -1,0 +1,12 @@
+import { relayCodexNativeHttp } from "@/lib/codexNative/relay.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  return relayCodexNativeHttp(request, {
+    path: CODEX_NATIVE_CONFIG.paths.memories,
+    operation: "memories",
+  });
+}

--- a/src/app/api/v1/codex/models/route.js
+++ b/src/app/api/v1/codex/models/route.js
@@ -1,0 +1,65 @@
+import { getCodexNativeCatalog } from "@/lib/codexNative/catalog.js";
+import { refreshCodexNativePoolUsage } from "@/lib/codexNative/pool.js";
+import { codexNativeAuthError, validateCodexNativeClient } from "@/lib/codexNative/clientAuth.js";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
+};
+
+export async function OPTIONS() {
+  return new Response(null, { headers: corsHeaders });
+}
+
+export async function GET(request) {
+  try {
+    const auth = await validateCodexNativeClient(request);
+    if (!auth.ok) return codexNativeAuthError(auth);
+    const url = new URL(request.url);
+    const clientVersion = url.searchParams.has("client_version")
+      ? url.searchParams.get("client_version")
+      : null;
+    if (!clientVersion) {
+      return Response.json({
+        error: {
+          type: "invalid_request_error",
+          code: "missing_client_version",
+          message: "client_version is required",
+        },
+      }, { status: 400, headers: corsHeaders });
+    }
+    const catalog = await getCodexNativeCatalog({ clientVersion });
+    refreshCodexNativePoolUsage().catch(() => {});
+
+    if (request.headers.get("if-none-match") === catalog.etag) {
+      return new Response(null, {
+        status: 304,
+        headers: {
+          ...corsHeaders,
+          ETag: catalog.etag,
+          "x-models-etag": catalog.etag,
+        },
+      });
+    }
+
+    return Response.json({ models: catalog.models }, {
+      headers: {
+        ...corsHeaders,
+        ETag: catalog.etag,
+        "x-models-etag": catalog.etag,
+        "Cache-Control": "private, max-age=60",
+        "X-9Router-Codex-Catalog": catalog.source,
+        "X-9Router-Codex-Catalog-Stale": String(catalog.stale === true),
+      },
+    });
+  } catch (error) {
+    return Response.json({
+      error: {
+        type: "server_error",
+        code: "codex_catalog_unavailable",
+        message: error.message,
+      },
+    }, { status: 503, headers: corsHeaders });
+  }
+}

--- a/src/app/api/v1/codex/responses/compact/route.js
+++ b/src/app/api/v1/codex/responses/compact/route.js
@@ -1,0 +1,12 @@
+import { relayCodexNativeHttp } from "@/lib/codexNative/relay.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  return relayCodexNativeHttp(request, {
+    path: CODEX_NATIVE_CONFIG.paths.compact,
+    operation: "compact",
+  });
+}

--- a/src/app/api/v1/codex/responses/route.js
+++ b/src/app/api/v1/codex/responses/route.js
@@ -1,0 +1,14 @@
+import { relayCodexNativeHttp } from "@/lib/codexNative/relay.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request) {
+  return relayCodexNativeHttp(request, {
+    path: CODEX_NATIVE_CONFIG.paths.responses,
+    operation: "responses",
+    validateModel: true,
+    allowTransportReplay: true,
+  });
+}

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -183,6 +183,17 @@ export const __test__ = {
 export async function proxy(request) {
   const { pathname } = request.nextUrl;
 
+  // Process-local Codex gateway control plane. The secret is generated at
+  // server start and the TCP peer is stamped by custom-server.js.
+  if (
+    pathname.startsWith("/api/internal/codex-native/")
+    && process.env.CODEX_NATIVE_INTERNAL_SECRET
+    && request.headers.get("x-9r-internal-secret") === process.env.CODEX_NATIVE_INTERNAL_SECRET
+    && isLocalRequest(request)
+  ) {
+    return NextResponse.next();
+  }
+
   // Local-only gate for spawn-capable / host-secret routes.
   if (LOCAL_ONLY_PATHS.some((p) => pathname.startsWith(p))) {
     if (!(await canAccessLocalOnlyRoute(request))) {

--- a/src/lib/codexNative/affinity.js
+++ b/src/lib/codexNative/affinity.js
@@ -1,0 +1,149 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DATA_DIR } from "@/lib/dataDir.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+
+const AFFINITY_FILE = path.join(DATA_DIR, "codex-native", "affinity.json");
+const AFFINITY_SECRET_FILE = path.join(DATA_DIR, "codex-native", "affinity.key");
+
+if (!global.__codexNativeAffinityState) {
+  global.__codexNativeAffinityState = {
+    entries: new Map(),
+    loaded: false,
+    persistTimer: null,
+    secret: null,
+  };
+}
+const state = global.__codexNativeAffinityState;
+
+function normalize(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed && trimmed.length <= 512 ? trimmed : null;
+}
+
+function header(headers, name) {
+  return normalize(headers?.[name] ?? headers?.[name.toLowerCase()]);
+}
+
+function rawSessionIdentity(headers, body) {
+  return header(headers, "session-id")
+    || header(headers, "thread-id")
+    || normalize(body?.prompt_cache_key)
+    || null;
+}
+
+async function affinitySecret() {
+  if (state.secret) return state.secret;
+  try {
+    state.secret = await fs.readFile(AFFINITY_SECRET_FILE);
+  } catch {
+    state.secret = crypto.randomBytes(32);
+    await fs.mkdir(path.dirname(AFFINITY_SECRET_FILE), { recursive: true });
+    const tempPath = `${AFFINITY_SECRET_FILE}.${process.pid}.tmp`;
+    await fs.writeFile(tempPath, state.secret, { mode: 0o600 });
+    try {
+      await fs.rename(tempPath, AFFINITY_SECRET_FILE);
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      state.secret = await fs.readFile(AFFINITY_SECRET_FILE);
+    }
+  }
+  return state.secret;
+}
+
+function cleanup() {
+  const now = Date.now();
+  for (const [key, entry] of state.entries) {
+    if (now - entry.lastUsedAt > CODEX_NATIVE_CONFIG.affinityTtlMs) state.entries.delete(key);
+  }
+  while (state.entries.size > CODEX_NATIVE_CONFIG.affinityMaxEntries) {
+    state.entries.delete(state.entries.keys().next().value);
+  }
+}
+
+async function ensureLoaded() {
+  if (state.loaded) return;
+  state.loaded = true;
+  try {
+    const parsed = JSON.parse(await fs.readFile(AFFINITY_FILE, "utf8"));
+    for (const [key, value] of Object.entries(parsed?.entries || {})) {
+      if (value?.connectionId && Number.isFinite(value?.lastUsedAt)) {
+        state.entries.set(key, value);
+      }
+    }
+    cleanup();
+  } catch {
+    // First run.
+  }
+}
+
+function schedulePersist() {
+  if (state.persistTimer) return;
+  state.persistTimer = setTimeout(async () => {
+    state.persistTimer = null;
+    cleanup();
+    try {
+      await fs.mkdir(path.dirname(AFFINITY_FILE), { recursive: true });
+      const tempPath = `${AFFINITY_FILE}.${process.pid}.tmp`;
+      await fs.writeFile(tempPath, JSON.stringify({
+        version: 1,
+        entries: Object.fromEntries(state.entries),
+      }), { mode: 0o600 });
+      await fs.rename(tempPath, AFFINITY_FILE);
+    } catch {
+      // Affinity persistence is an optimization; routing remains correct in memory.
+    }
+  }, 100);
+  state.persistTimer.unref?.();
+}
+
+export async function resolveCodexNativeAffinityKey({ headers, body }) {
+  await ensureLoaded();
+  const raw = rawSessionIdentity(headers, body);
+  if (!raw) return null;
+  return crypto.createHmac("sha256", await affinitySecret())
+    .update(raw)
+    .digest("hex");
+}
+
+export async function getCodexNativeAffinity(key) {
+  await ensureLoaded();
+  cleanup();
+  const entry = key ? state.entries.get(key) : null;
+  if (!entry) return null;
+  entry.lastUsedAt = Date.now();
+  state.entries.delete(key);
+  state.entries.set(key, entry);
+  schedulePersist();
+  return { ...entry };
+}
+
+export async function bindCodexNativeAffinity(key, connectionId) {
+  if (!key || !connectionId) return;
+  await ensureLoaded();
+  state.entries.delete(key);
+  state.entries.set(key, { connectionId, lastUsedAt: Date.now() });
+  cleanup();
+  schedulePersist();
+}
+
+export async function releaseCodexNativeAffinity(key, connectionId) {
+  if (!key) return;
+  await ensureLoaded();
+  const current = state.entries.get(key);
+  if (!current || (connectionId && current.connectionId !== connectionId)) return;
+  state.entries.delete(key);
+  schedulePersist();
+}
+
+export async function getCodexNativeAffinityCounts() {
+  await ensureLoaded();
+  cleanup();
+  const counts = new Map();
+  for (const entry of state.entries.values()) {
+    counts.set(entry.connectionId, (counts.get(entry.connectionId) || 0) + 1);
+  }
+  return counts;
+}

--- a/src/lib/codexNative/catalog.js
+++ b/src/lib/codexNative/catalog.js
@@ -1,0 +1,323 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DATA_DIR } from "@/lib/dataDir.js";
+import { getProviderConnections } from "@/lib/localDb.js";
+import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy.js";
+import { checkAndRefreshToken } from "@/sse/services/tokenRefresh.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+import { proxyAwareFetch } from "open-sse/utils/proxyFetch.js";
+
+const CACHE_FILE = path.join(DATA_DIR, "codex-native", "catalog.json");
+const UNSPECIFIED_VERSION = "__unspecified__";
+
+if (!global.__codexNativeCatalogState) {
+  global.__codexNativeCatalogState = {
+    versions: new Map(),
+    accounts: new Map(),
+    refreshes: new Map(),
+    diskLoaded: false,
+  };
+}
+const state = global.__codexNativeCatalogState;
+
+export function normalizeCodexClientVersion(value) {
+  if (value == null || value === "") return null;
+  const version = String(value);
+  if (version.length > 128 || /[\u0000-\u001f\u007f]/.test(version)) {
+    throw new Error("Invalid Codex client_version");
+  }
+  return version;
+}
+
+function versionKey(version) {
+  return version ?? UNSPECIFIED_VERSION;
+}
+
+function accountKey(version, connectionId) {
+  return `${versionKey(version)}\u0000${connectionId}`;
+}
+
+function accountId(connection) {
+  return connection?.providerSpecificData?.workspaceId
+    || connection?.providerSpecificData?.chatgptAccountId
+    || connection?.providerSpecificData?.accountId
+    || null;
+}
+
+function validModel(model) {
+  return !!model
+    && typeof model === "object"
+    && typeof model.slug === "string"
+    && model.slug.length > 0;
+}
+
+function proxyOptions(proxy) {
+  return {
+    connectionProxyEnabled: proxy.connectionProxyEnabled === true,
+    connectionProxyUrl: proxy.connectionProxyUrl || "",
+    connectionNoProxy: proxy.connectionNoProxy || "",
+    vercelRelayUrl: proxy.vercelRelayUrl || "",
+    strictProxy: proxy.strictProxy === true,
+  };
+}
+
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, stable(value[key])])
+  );
+}
+
+export function hashCodexModelInfo(model) {
+  return crypto.createHash("sha256").update(JSON.stringify(stable(model))).digest("hex");
+}
+
+async function fetchConnectionCatalog(connection, clientVersion, cached) {
+  const credentials = await checkAndRefreshToken("codex", {
+    ...connection,
+    connectionId: connection.id,
+  });
+  if (!credentials?.accessToken) throw new Error("Codex account has no access token");
+
+  const headers = {
+    accept: "application/json",
+    authorization: `Bearer ${credentials.accessToken}`,
+    originator: "codex_cli_rs",
+  };
+  const workspaceId = accountId(credentials);
+  if (workspaceId) headers["chatgpt-account-id"] = workspaceId;
+  if (cached?.upstreamEtag) headers["if-none-match"] = cached.upstreamEtag;
+
+  const proxy = await resolveConnectionProxyConfig(credentials.providerSpecificData || {});
+  const url = new URL(`${CODEX_NATIVE_CONFIG.upstreamHttpBaseUrl}/${CODEX_NATIVE_CONFIG.paths.models}`);
+  if (clientVersion != null) url.searchParams.set("client_version", clientVersion);
+
+  const response = await proxyAwareFetch(url, {
+    method: "GET",
+    headers,
+    signal: AbortSignal.timeout(8_000),
+  }, proxyOptions(proxy));
+
+  if (response.status === 304 && cached) {
+    return { ...cached, fetchedAt: Date.now(), notModified: true };
+  }
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 240);
+    throw new Error(`Codex models ${response.status}${detail ? `: ${detail}` : ""}`);
+  }
+
+  const payload = await response.json();
+  const models = (Array.isArray(payload?.models) ? payload.models : []).filter(validModel);
+  if (models.length === 0) throw new Error("Codex returned an empty native model catalog");
+  return {
+    models,
+    upstreamEtag: response.headers.get("x-models-etag") || response.headers.get("etag"),
+    fetchedAt: Date.now(),
+  };
+}
+
+export function selectCodexModelCohorts(results, connections) {
+  const priorities = new Map(connections.map((connection) => [
+    connection.id,
+    connection.priority ?? 999,
+  ]));
+  const slugs = new Map();
+
+  for (const result of results) {
+    if (!result.ok) continue;
+    for (const model of result.models) {
+      const hash = hashCodexModelInfo(model);
+      if (!slugs.has(model.slug)) slugs.set(model.slug, new Map());
+      const cohorts = slugs.get(model.slug);
+      if (!cohorts.has(hash)) cohorts.set(hash, { hash, model, connectionIds: [] });
+      cohorts.get(hash).connectionIds.push(result.connectionId);
+    }
+  }
+
+  const models = [];
+  const eligibleConnectionIds = {};
+  const cohortHashes = {};
+  for (const [slug, cohorts] of slugs) {
+    const selected = [...cohorts.values()].sort((left, right) => {
+      const size = right.connectionIds.length - left.connectionIds.length;
+      if (size !== 0) return size;
+      const leftPriority = Math.min(...left.connectionIds.map((id) => priorities.get(id) ?? 999));
+      const rightPriority = Math.min(...right.connectionIds.map((id) => priorities.get(id) ?? 999));
+      if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+      return left.hash.localeCompare(right.hash);
+    })[0];
+    selected.connectionIds.sort((left, right) =>
+      (priorities.get(left) ?? 999) - (priorities.get(right) ?? 999)
+      || left.localeCompare(right)
+    );
+    models.push(selected.model);
+    eligibleConnectionIds[slug] = selected.connectionIds;
+    cohortHashes[slug] = selected.hash;
+  }
+
+  models.sort((left, right) =>
+    (left.priority ?? 999) - (right.priority ?? 999)
+    || left.slug.localeCompare(right.slug)
+  );
+  return { models, eligibleConnectionIds, cohortHashes };
+}
+
+function etagFor(models) {
+  return `"${crypto.createHash("sha256").update(JSON.stringify(models)).digest("hex").slice(0, 32)}"`;
+}
+
+async function persistVersions() {
+  await fs.mkdir(path.dirname(CACHE_FILE), { recursive: true });
+  const versions = {};
+  for (const [key, entry] of state.versions) {
+    versions[key] = {
+      clientVersion: entry.clientVersion,
+      fetchedAt: entry.fetchedAt,
+      models: entry.models,
+      eligibleConnectionIds: entry.eligibleConnectionIds,
+      cohortHashes: entry.cohortHashes,
+    };
+  }
+  const tempPath = `${CACHE_FILE}.${process.pid}.tmp`;
+  await fs.writeFile(tempPath, JSON.stringify({ version: 2, versions }), { mode: 0o600 });
+  await fs.rename(tempPath, CACHE_FILE);
+}
+
+async function loadDiskCache() {
+  if (state.diskLoaded) return;
+  state.diskLoaded = true;
+  try {
+    const parsed = JSON.parse(await fs.readFile(CACHE_FILE, "utf8"));
+    if (parsed?.version !== 2 || !parsed.versions) return;
+    for (const [key, saved] of Object.entries(parsed.versions)) {
+      const fetchedAt = Number(saved?.fetchedAt);
+      if (!Number.isFinite(fetchedAt) || Date.now() - fetchedAt > CODEX_NATIVE_CONFIG.catalogStaleMs) continue;
+      const models = (saved.models || []).filter(validModel);
+      if (models.length === 0) continue;
+      state.versions.set(key, {
+        clientVersion: saved.clientVersion ?? null,
+        models,
+        eligibleConnectionIds: saved.eligibleConnectionIds || {},
+        cohortHashes: saved.cohortHashes || {},
+        fetchedAt,
+        etag: etagFor(models),
+        source: "last-known-good",
+        stale: true,
+        accountCount: null,
+        successfulAccountCount: null,
+        warnings: [],
+      });
+    }
+  } catch {
+    // No last-known-good catalog yet.
+  }
+}
+
+async function refreshCatalog(clientVersion) {
+  const connections = await getProviderConnections({ provider: "codex", isActive: true });
+  const settled = await Promise.all(connections.map(async (connection) => {
+    const key = accountKey(clientVersion, connection.id);
+    const cached = state.accounts.get(key);
+    try {
+      const result = await fetchConnectionCatalog(connection, clientVersion, cached);
+      state.accounts.set(key, result);
+      return { ok: true, connectionId: connection.id, ...result };
+    } catch (error) {
+      if (cached && Date.now() - cached.fetchedAt <= CODEX_NATIVE_CONFIG.catalogStaleMs) {
+        return { ok: true, stale: true, connectionId: connection.id, ...cached, warning: error.message };
+      }
+      return { ok: false, connectionId: connection.id, error: error.message };
+    }
+  }));
+
+  const usable = settled.filter((result) => result.ok);
+  if (usable.length === 0) {
+    const previous = state.versions.get(versionKey(clientVersion));
+    if (previous && Date.now() - previous.fetchedAt <= CODEX_NATIVE_CONFIG.catalogStaleMs) {
+      return { ...previous, source: "last-known-good", stale: true };
+    }
+    const error = new Error("No valid native Codex catalog is available");
+    error.code = "codex_catalog_unavailable";
+    throw error;
+  }
+
+  const merged = selectCodexModelCohorts(usable, connections);
+  if (merged.models.length === 0) {
+    const error = new Error("No native Codex model metadata cohort is available");
+    error.code = "codex_catalog_unavailable";
+    throw error;
+  }
+
+  const warnings = settled.flatMap((result) => {
+    const message = result.error || result.warning;
+    return message ? [{ connectionId: result.connectionId, message }] : [];
+  });
+  const entry = {
+    ...merged,
+    clientVersion,
+    fetchedAt: Date.now(),
+    source: usable.some((result) => !result.stale) ? "upstream" : "last-known-good",
+    stale: usable.every((result) => result.stale),
+    accountCount: connections.length,
+    successfulAccountCount: usable.length,
+    upstreamEtags: Object.fromEntries(usable.map((result) => [
+      result.connectionId,
+      result.upstreamEtag || null,
+    ])),
+    warnings,
+  };
+  entry.etag = etagFor(entry.models);
+  state.versions.set(versionKey(clientVersion), entry);
+  persistVersions().catch(() => {});
+  return entry;
+}
+
+export async function getCodexNativeCatalog({ clientVersion, forceRefresh = false } = {}) {
+  await loadDiskCache();
+  const version = normalizeCodexClientVersion(clientVersion);
+  const key = versionKey(version);
+  const cached = state.versions.get(key);
+
+  if (!forceRefresh && cached && Date.now() - cached.fetchedAt < CODEX_NATIVE_CONFIG.catalogTtlMs) {
+    return cached;
+  }
+  if (!state.refreshes.has(key)) {
+    state.refreshes.set(key, refreshCatalog(version).finally(() => state.refreshes.delete(key)));
+  }
+  if (cached && !forceRefresh && Date.now() - cached.fetchedAt <= CODEX_NATIVE_CONFIG.catalogStaleMs) {
+    state.refreshes.get(key).catch(() => {});
+    return { ...cached, source: cached.source === "upstream" ? "cache" : cached.source };
+  }
+  return state.refreshes.get(key);
+}
+
+export async function getMostRecentCodexClientVersion() {
+  await loadDiskCache();
+  return [...state.versions.values()]
+    .filter((entry) => entry.clientVersion)
+    .sort((left, right) => right.fetchedAt - left.fetchedAt)[0]?.clientVersion || null;
+}
+
+export async function invalidateCodexNativeCatalog(connectionId, upstreamEtag, clientVersion = null) {
+  const version = normalizeCodexClientVersion(clientVersion);
+  const key = accountKey(version, connectionId);
+  const cached = state.accounts.get(key);
+  if (!cached || !upstreamEtag || cached.upstreamEtag !== upstreamEtag) {
+    if (cached) cached.fetchedAt = 0;
+    const merged = state.versions.get(versionKey(version));
+    if (merged) merged.fetchedAt = 0;
+    getCodexNativeCatalog({ clientVersion: version, forceRefresh: true }).catch(() => {});
+  }
+}
+
+export function isCodexNativeModel(catalog, model) {
+  return catalog?.models?.some((entry) => entry.slug === model) === true;
+}
+
+export function getCodexNativeDefaultModel(catalog) {
+  return catalog?.models?.find((model) =>
+    model?.supported_in_api !== false && model?.visibility !== "hide"
+  )?.slug || null;
+}

--- a/src/lib/codexNative/clientAuth.js
+++ b/src/lib/codexNative/clientAuth.js
@@ -1,0 +1,26 @@
+import { getSettings } from "@/lib/localDb.js";
+import { extractApiKey, isValidApiKey } from "@/sse/services/auth.js";
+
+export async function validateCodexNativeClient(request) {
+  const settings = await getSettings();
+  const apiKey = extractApiKey(request);
+
+  // Match the authentication semantics used by every existing /v1 endpoint:
+  // local deployments may opt out, while requireApiKey validates the same key store.
+  if (!settings.requireApiKey) return { ok: true, apiKey: apiKey || null };
+  if (!apiKey) return { ok: false, status: 401, message: "Missing API key" };
+  if (!await isValidApiKey(apiKey)) {
+    return { ok: false, status: 401, message: "Invalid API key" };
+  }
+  return { ok: true, apiKey };
+}
+
+export function codexNativeAuthError(auth) {
+  return Response.json({
+    error: {
+      type: "authentication_error",
+      code: "invalid_api_key",
+      message: auth.message,
+    },
+  }, { status: auth.status || 401 });
+}

--- a/src/lib/codexNative/clientVersion.js
+++ b/src/lib/codexNative/clientVersion.js
@@ -1,0 +1,29 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+let cachedVersionInfo = null;
+
+export function parseCodexClientVersion(raw) {
+  if (!raw) return null;
+  return String(raw).match(/\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)\b/)?.[1] || null;
+}
+
+export async function getInstalledCodexClientVersion({ forceRefresh = false } = {}) {
+  if (!forceRefresh && cachedVersionInfo) return cachedVersionInfo;
+  try {
+    const { stdout, stderr } = await execFileAsync("codex", ["--version"], {
+      windowsHide: true,
+      timeout: 5_000,
+    });
+    const raw = `${stdout || ""} ${stderr || ""}`.trim();
+    cachedVersionInfo = {
+      installed: true,
+      raw,
+      version: parseCodexClientVersion(raw),
+    };
+  } catch {
+    cachedVersionInfo = { installed: false, raw: null, version: null };
+  }
+  return cachedVersionInfo;
+}

--- a/src/lib/codexNative/headers.js
+++ b/src/lib/codexNative/headers.js
@@ -1,0 +1,56 @@
+import {
+  CODEX_NATIVE_BLOCKED_REQUEST_HEADERS,
+  CODEX_NATIVE_SAFE_REQUEST_HEADERS,
+  CODEX_NATIVE_SAFE_REQUEST_PREFIXES,
+  CODEX_NATIVE_SAFE_RESPONSE_HEADERS,
+  CODEX_NATIVE_SAFE_RESPONSE_PREFIXES,
+} from "open-sse/config/codexNative.js";
+
+const blocked = new Set(CODEX_NATIVE_BLOCKED_REQUEST_HEADERS);
+const safeRequest = new Set(CODEX_NATIVE_SAFE_REQUEST_HEADERS);
+const safeResponse = new Set(CODEX_NATIVE_SAFE_RESPONSE_HEADERS);
+
+function entries(headers) {
+  if (!headers) return [];
+  if (typeof headers.entries === "function") return [...headers.entries()];
+  return Object.entries(headers);
+}
+
+function hasPrefix(name, prefixes) {
+  return prefixes.some((prefix) => name.startsWith(prefix));
+}
+
+export function sanitizeCodexNativeRequestHeaders(clientHeaders, credentials) {
+  const result = new Headers();
+  for (const [rawName, rawValue] of entries(clientHeaders)) {
+    const name = String(rawName).toLowerCase();
+    if (blocked.has(name)) continue;
+    if (!safeRequest.has(name) && !hasPrefix(name, CODEX_NATIVE_SAFE_REQUEST_PREFIXES)) continue;
+    if (rawValue != null) result.set(name, String(rawValue));
+  }
+
+  result.set("authorization", `Bearer ${credentials.accessToken}`);
+  const accountId = credentials?.providerSpecificData?.workspaceId
+    || credentials?.providerSpecificData?.chatgptAccountId
+    || credentials?.providerSpecificData?.accountId;
+  if (accountId) result.set("chatgpt-account-id", accountId);
+  if (!result.has("originator")) result.set("originator", "codex_cli_rs");
+  return result;
+}
+
+export function sanitizeCodexNativeResponseHeaders(upstreamHeaders) {
+  const result = new Headers();
+  for (const [rawName, rawValue] of entries(upstreamHeaders)) {
+    const name = String(rawName).toLowerCase();
+    if (!safeResponse.has(name) && !hasPrefix(name, CODEX_NATIVE_SAFE_RESPONSE_PREFIXES)) continue;
+    if (rawValue != null) result.append(name, String(rawValue));
+  }
+  return result;
+}
+
+export function headersToObject(headers) {
+  return Object.fromEntries(entries(headers).map(([name, value]) => [
+    String(name).toLowerCase(),
+    String(value),
+  ]));
+}

--- a/src/lib/codexNative/pool.js
+++ b/src/lib/codexNative/pool.js
@@ -1,0 +1,463 @@
+import crypto from "node:crypto";
+import { getProviderConnections } from "@/lib/localDb.js";
+import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy.js";
+import { checkAndRefreshToken } from "@/sse/services/tokenRefresh.js";
+import { markAccountUnavailable, clearAccountError } from "@/sse/services/auth.js";
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+import { isModelLockActive } from "open-sse/services/accountFallback.js";
+import { getCodexUsage } from "open-sse/services/usage/codex.js";
+import {
+  bindCodexNativeAffinity,
+  getCodexNativeAffinity,
+  getCodexNativeAffinityCounts,
+  releaseCodexNativeAffinity,
+  resolveCodexNativeAffinityKey,
+} from "./affinity.js";
+import { getCodexNativeCatalog, invalidateCodexNativeCatalog } from "./catalog.js";
+
+if (!global.__codexNativePoolState) {
+  global.__codexNativePoolState = {
+    quotas: new Map(),
+    quotaRefreshes: new Map(),
+    activeTurns: new Map(),
+    activeSockets: new Map(),
+    leases: new Map(),
+    failures: new Map(),
+    httpFallbackCount: 0,
+  };
+}
+const state = global.__codexNativePoolState;
+
+function increment(map, key, delta) {
+  const next = Math.max(0, (map.get(key) || 0) + delta);
+  if (next === 0) map.delete(key);
+  else map.set(key, next);
+}
+
+function minRemaining(usage) {
+  const windows = [usage?.quotas?.session, usage?.quotas?.weekly].filter(Boolean);
+  const values = windows.map((quota) => Number(quota.remaining)).filter(Number.isFinite);
+  return values.length ? Math.min(...values) : null;
+}
+
+function earliestReset(usage) {
+  const resets = [usage?.quotas?.session?.resetAt, usage?.quotas?.weekly?.resetAt]
+    .filter(Boolean)
+    .map((value) => new Date(value).getTime())
+    .filter(Number.isFinite);
+  return resets.length ? new Date(Math.min(...resets)).toISOString() : null;
+}
+
+export function codexQuotaStatus(remaining, previousStatus) {
+  const thresholds = CODEX_NATIVE_CONFIG.quotaThresholds;
+  if (remaining === null || !Number.isFinite(remaining)) return "unknown";
+  if (remaining <= 0) return "exhausted";
+  if (previousStatus && previousStatus !== "healthy" && remaining < thresholds.recoverRemainingPercent) {
+    return remaining < thresholds.criticalRemainingPercent ? "critical" : "draining";
+  }
+  if (remaining < thresholds.criticalRemainingPercent) return "critical";
+  if (remaining < thresholds.drainRemainingPercent) return "draining";
+  return "healthy";
+}
+
+function proxyOptions(proxy) {
+  return {
+    connectionProxyEnabled: proxy.connectionProxyEnabled === true,
+    connectionProxyUrl: proxy.connectionProxyUrl || "",
+    connectionNoProxy: proxy.connectionNoProxy || "",
+    vercelRelayUrl: proxy.vercelRelayUrl || "",
+    strictProxy: proxy.strictProxy === true,
+  };
+}
+
+export function codexWebSocketProxyCapability(proxy) {
+  if (proxy?.vercelRelayUrl) return { capable: false, reason: "relay-only proxy has no WebSocket transport" };
+  if (!proxy?.connectionProxyEnabled || !proxy?.connectionProxyUrl) {
+    return { capable: true, reason: null };
+  }
+  let protocol;
+  try {
+    protocol = new URL(proxy.connectionProxyUrl.includes("://")
+      ? proxy.connectionProxyUrl
+      : `http://${proxy.connectionProxyUrl}`).protocol;
+  } catch {
+    return { capable: false, reason: "invalid proxy URL" };
+  }
+  if (!["http:", "https:", "socks:", "socks4:", "socks4a:", "socks5:", "socks5h:"].includes(protocol)) {
+    return { capable: false, reason: `unsupported WebSocket proxy scheme ${protocol}` };
+  }
+  return { capable: true, reason: null };
+}
+
+async function refreshConnectionQuota(connection) {
+  const existing = state.quotas.get(connection.id);
+  if (existing && Date.now() - existing.fetchedAt < CODEX_NATIVE_CONFIG.quotaTtlMs) return existing;
+  if (state.quotaRefreshes.has(connection.id)) return state.quotaRefreshes.get(connection.id);
+
+  const pending = (async () => {
+    try {
+      const credentials = await checkAndRefreshToken("codex", {
+        ...connection,
+        connectionId: connection.id,
+      });
+      const proxy = await resolveConnectionProxyConfig(credentials.providerSpecificData || {});
+      const usage = await getCodexUsage(credentials.accessToken, proxyOptions(proxy));
+      const remaining = minRemaining(usage);
+      const snapshot = {
+        remaining,
+        status: codexQuotaStatus(remaining, existing?.status),
+        resetAt: earliestReset(usage),
+        fetchedAt: Date.now(),
+        source: "poll",
+      };
+      state.quotas.set(connection.id, snapshot);
+      return snapshot;
+    } catch (error) {
+      const snapshot = existing || {
+        remaining: null,
+        status: "unknown",
+        resetAt: null,
+        fetchedAt: Date.now(),
+        source: "poll-error",
+      };
+      return { ...snapshot, error: error.message };
+    }
+  })().finally(() => state.quotaRefreshes.delete(connection.id));
+
+  state.quotaRefreshes.set(connection.id, pending);
+  return pending;
+}
+
+function cachedQuota(connectionId) {
+  return state.quotas.get(connectionId)
+    || { remaining: null, status: "unknown", resetAt: null, fetchedAt: null, source: null };
+}
+
+function remainingFromRateLimitPayload(payload) {
+  const details = payload?.rate_limits || payload?.rate_limit || payload;
+  const windows = [
+    details?.primary,
+    details?.primary_window,
+    details?.secondary,
+    details?.secondary_window,
+  ].filter(Boolean);
+  const remaining = windows
+    .map((window) => Number(window.remaining ?? (100 - Number(window.used_percent ?? window.percent_used))))
+    .filter(Number.isFinite);
+  return remaining.length ? Math.max(0, Math.min(...remaining)) : null;
+}
+
+export function ingestCodexNativeQuota(connectionId, payload, source = "event") {
+  if (!connectionId || !payload) return null;
+  let remaining = null;
+  let resetAt = null;
+  if (typeof payload?.get === "function") {
+    const used = [
+      payload.get("x-codex-primary-used-percent"),
+      payload.get("x-codex-secondary-used-percent"),
+    ].map(Number).filter(Number.isFinite);
+    if (used.length) remaining = Math.max(0, 100 - Math.max(...used));
+    const resets = [
+      payload.get("x-codex-primary-reset-at"),
+      payload.get("x-codex-secondary-reset-at"),
+    ].map(Number).filter(Number.isFinite);
+    if (resets.length) resetAt = new Date(Math.min(...resets) * 1000).toISOString();
+  } else {
+    remaining = remainingFromRateLimitPayload(payload);
+  }
+  if (remaining === null) return null;
+  const existing = state.quotas.get(connectionId);
+  const snapshot = {
+    remaining,
+    status: codexQuotaStatus(remaining, existing?.status),
+    resetAt: resetAt || existing?.resetAt || null,
+    fetchedAt: Date.now(),
+    source,
+  };
+  state.quotas.set(connectionId, snapshot);
+  return snapshot;
+}
+
+function rankCandidates(candidates, counts, transport) {
+  const statusRank = { healthy: 0, unknown: 1, draining: 2, critical: 3, exhausted: 4 };
+  return [...candidates].sort((a, b) => {
+    const aQuota = cachedQuota(a.id);
+    const bQuota = cachedQuota(b.id);
+    const statusDiff = (statusRank[aQuota.status] ?? 1) - (statusRank[bQuota.status] ?? 1);
+    if (statusDiff !== 0) return statusDiff;
+    const remainingDiff = (bQuota.remaining ?? -1) - (aQuota.remaining ?? -1);
+    if (remainingDiff !== 0) return remainingDiff;
+    const activeMap = transport === "ws" ? state.activeSockets : state.activeTurns;
+    const activeDiff = (activeMap.get(a.id) || 0) - (activeMap.get(b.id) || 0);
+    if (activeDiff !== 0) return activeDiff;
+    const affinityDiff = (counts.get(a.id) || 0) - (counts.get(b.id) || 0);
+    if (affinityDiff !== 0) return affinityDiff;
+    const priorityDiff = (a.priority ?? 999) - (b.priority ?? 999);
+    if (priorityDiff !== 0) return priorityDiff;
+    return new Date(a.lastUsedAt || 0) - new Date(b.lastUsedAt || 0);
+  });
+}
+
+async function candidatesFor({ model, transport, excludeConnectionIds, clientVersion }) {
+  const [connections, catalog, counts] = await Promise.all([
+    getProviderConnections({ provider: "codex", isActive: true }),
+    getCodexNativeCatalog({ clientVersion }),
+    getCodexNativeAffinityCounts(),
+  ]);
+  const advertised = model ? new Set(catalog.eligibleConnectionIds?.[model] || []) : null;
+  const skipped = new Map();
+  const candidates = [];
+
+  for (const connection of connections) {
+    let reason = null;
+    if (excludeConnectionIds.has(connection.id)) reason = "excluded after failure";
+    else if (advertised && !advertised.has(connection.id)) reason = "different model metadata cohort";
+    else if (model && isModelLockActive(connection, model)) reason = "model temporarily locked";
+    else if (cachedQuota(connection.id).status === "exhausted") reason = "quota exhausted";
+    if (!reason && transport === "ws") {
+      const proxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});
+      const capability = codexWebSocketProxyCapability(proxy);
+      if (!capability.capable) reason = capability.reason;
+    }
+    if (reason) skipped.set(connection.id, reason);
+    else candidates.push(connection);
+  }
+  return { connections, catalog, counts, candidates, skipped };
+}
+
+export async function refreshCodexNativePoolUsage(options = {}) {
+  const connections = await getProviderConnections({ provider: "codex", isActive: true });
+  await Promise.all(connections.map(refreshConnectionQuota));
+  return getCodexNativePoolSnapshot(options);
+}
+
+export async function getCodexNativePoolSnapshot({ model = null, clientVersion } = {}) {
+  const { connections, catalog, counts, candidates, skipped } = await candidatesFor({
+    model,
+    transport: "http",
+    excludeConnectionIds: new Set(),
+    clientVersion,
+  });
+  const candidateIds = new Set(candidates.map((connection) => connection.id));
+  return connections.map((connection) => {
+    const quota = cachedQuota(connection.id);
+    return {
+      connectionId: connection.id,
+      name: connection.displayName || connection.name || connection.email || connection.id.slice(0, 8),
+      priority: connection.priority ?? 999,
+      eligible: candidateIds.has(connection.id),
+      skippedReason: skipped.get(connection.id) || null,
+      affinityCount: counts.get(connection.id) || 0,
+      activeTurns: state.activeTurns.get(connection.id) || 0,
+      activeSockets: state.activeSockets.get(connection.id) || 0,
+      remaining: quota.remaining,
+      status: isModelLockActive(connection, model) ? "locked" : quota.status,
+      resetAt: quota.resetAt,
+      quotaFetchedAt: quota.fetchedAt,
+      quotaSource: quota.source,
+      catalogEtag: catalog.upstreamEtags?.[connection.id] || null,
+    };
+  });
+}
+
+export async function resolveCodexNativeRouting({
+  headers,
+  body,
+  model,
+  transport = "http",
+  clientVersion,
+  excludeConnectionIds = new Set(),
+}) {
+  const { counts, candidates, skipped, catalog } = await candidatesFor({
+    model,
+    transport,
+    excludeConnectionIds,
+    clientVersion,
+  });
+  for (const connection of candidates) refreshConnectionQuota(connection).catch(() => {});
+
+  const affinityKey = await resolveCodexNativeAffinityKey({ headers, body, model });
+  const affinity = affinityKey ? await getCodexNativeAffinity(affinityKey) : null;
+  const preferred = affinity
+    ? candidates.find((connection) => connection.id === affinity.connectionId)
+    : null;
+  if (preferred) {
+    const status = cachedQuota(preferred.id).status;
+    if (status !== "critical" && status !== "exhausted") {
+      return {
+        affinityKey,
+        preferredConnectionId: preferred.id,
+        eligibleConnectionIds: candidates.map((connection) => connection.id),
+        skippedReasons: Object.fromEntries(skipped),
+        catalog,
+      };
+    }
+  }
+
+  const ranked = rankCandidates(candidates, counts, transport);
+  const selected = ranked.find((connection) => {
+    const status = cachedQuota(connection.id).status;
+    return status === "healthy" || status === "unknown";
+  }) || null;
+
+  if (affinityKey && selected) await bindCodexNativeAffinity(affinityKey, selected.id);
+  return {
+    affinityKey,
+    preferredConnectionId: selected?.id || null,
+    eligibleConnectionIds: candidates.map((connection) => connection.id),
+    skippedReasons: Object.fromEntries(skipped),
+    catalog,
+  };
+}
+
+export async function acquireCodexNativeLease({
+  headers,
+  body,
+  model,
+  transport = "http",
+  clientVersion,
+  excludeConnectionIds = new Set(),
+}) {
+  const routing = await resolveCodexNativeRouting({
+    headers,
+    body,
+    model,
+    transport,
+    clientVersion,
+    excludeConnectionIds,
+  });
+  if (!routing.preferredConnectionId) return { ...routing, lease: null };
+  const connections = await getProviderConnections({ provider: "codex", isActive: true });
+  const connection = connections.find((entry) => entry.id === routing.preferredConnectionId);
+  if (!connection) return { ...routing, lease: null };
+  const credentials = await checkAndRefreshToken("codex", {
+    ...connection,
+    connectionId: connection.id,
+  });
+  const proxy = await resolveConnectionProxyConfig(credentials.providerSpecificData || {});
+  if (transport === "ws" && !codexWebSocketProxyCapability(proxy).capable) {
+    return { ...routing, lease: null };
+  }
+  const lease = {
+    id: crypto.randomUUID(),
+    connectionId: connection.id,
+    connection,
+    credentials,
+    proxy,
+    affinityKey: routing.affinityKey,
+    model: model || null,
+    transport,
+    clientVersion: clientVersion ?? null,
+    createdAt: Date.now(),
+    semanticOutput: false,
+  };
+  state.leases.set(lease.id, lease);
+  increment(transport === "ws" ? state.activeSockets : state.activeTurns, connection.id, 1);
+  return { ...routing, lease };
+}
+
+export function getCodexNativeLease(leaseId) {
+  const lease = state.leases.get(leaseId);
+  if (!lease) return null;
+  if (Date.now() - lease.createdAt > CODEX_NATIVE_CONFIG.leaseTtlMs) {
+    releaseCodexNativeLease(leaseId);
+    return null;
+  }
+  return lease;
+}
+
+export async function validateCodexNativeLeaseModel(leaseId, model) {
+  const lease = getCodexNativeLease(leaseId);
+  if (!lease || !model) return false;
+  const catalog = await getCodexNativeCatalog({ clientVersion: lease.clientVersion });
+  const eligible = catalog.eligibleConnectionIds?.[model] || [];
+  if (!eligible.includes(lease.connectionId)) return false;
+  lease.model = model;
+  if (lease.affinityKey) await bindCodexNativeAffinity(lease.affinityKey, lease.connectionId);
+  return true;
+}
+
+export function markCodexNativeSemanticOutput(leaseId) {
+  const lease = getCodexNativeLease(leaseId);
+  if (lease) lease.semanticOutput = true;
+}
+
+export async function succeedCodexNativeLease(leaseId, { headers } = {}) {
+  const lease = getCodexNativeLease(leaseId);
+  if (!lease) return;
+  if (headers) {
+    ingestCodexNativeQuota(lease.connectionId, headers, "headers");
+    const modelsEtag = headers.get?.("x-models-etag");
+    if (modelsEtag) invalidateCodexNativeCatalog(lease.connectionId, modelsEtag, lease.clientVersion);
+  }
+  await clearAccountError(lease.connectionId, lease.connection, lease.model).catch(() => {});
+  if (lease.affinityKey) await bindCodexNativeAffinity(lease.affinityKey, lease.connectionId);
+}
+
+export async function failCodexNativeLease(leaseId, { status = 503, error = "Codex Native failure" } = {}) {
+  const lease = getCodexNativeLease(leaseId);
+  if (!lease) return;
+  state.failures.set(lease.connectionId, {
+    status,
+    message: String(error).slice(0, 160),
+    at: Date.now(),
+  });
+  if (lease.affinityKey) await releaseCodexNativeAffinity(lease.affinityKey, lease.connectionId);
+  if ([401, 429].includes(Number(status)) || Number(status) >= 500) {
+    await markAccountUnavailable(
+      lease.connectionId,
+      Number(status),
+      String(error),
+      "codex",
+      lease.model
+    ).catch(() => {});
+  }
+}
+
+export function releaseCodexNativeLease(leaseId) {
+  const lease = state.leases.get(leaseId);
+  if (!lease) return;
+  state.leases.delete(leaseId);
+  increment(lease.transport === "ws" ? state.activeSockets : state.activeTurns, lease.connectionId, -1);
+}
+
+export function incrementCodexNativeHttpFallback() {
+  state.httpFallbackCount += 1;
+}
+
+export function getCodexNativeMetrics() {
+  return {
+    activeLeases: state.leases.size,
+    activeSockets: [...state.activeSockets.values()].reduce((sum, count) => sum + count, 0),
+    activeTurns: [...state.activeTurns.values()].reduce((sum, count) => sum + count, 0),
+    httpFallbackCount: state.httpFallbackCount,
+  };
+}
+
+export async function getCodexNativeWebSocketEligibility({ model = null, clientVersion } = {}) {
+  const connections = await getProviderConnections({ provider: "codex", isActive: true });
+  const catalog = await getCodexNativeCatalog({ clientVersion });
+  const advertised = model ? new Set(catalog.eligibleConnectionIds?.[model] || []) : null;
+  return Promise.all(connections.map(async (connection) => {
+    let reason = null;
+    if (advertised && !advertised.has(connection.id)) reason = "different model metadata cohort";
+    else if (cachedQuota(connection.id).status === "exhausted") reason = "quota exhausted";
+    const proxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});
+    const capability = codexWebSocketProxyCapability(proxy);
+    if (!reason && !capability.capable) reason = capability.reason;
+    return {
+      connectionId: connection.id,
+      eligible: !reason,
+      reason,
+    };
+  }));
+}
+
+// Compatibility exports used by phase-1 Universal glue.
+export async function confirmCodexNativeRouting(affinityKey, connectionId) {
+  await bindCodexNativeAffinity(affinityKey, connectionId);
+}
+
+export async function failCodexNativeRouting(affinityKey, connectionId) {
+  await releaseCodexNativeAffinity(affinityKey, connectionId);
+}

--- a/src/lib/codexNative/relay.js
+++ b/src/lib/codexNative/relay.js
@@ -1,0 +1,265 @@
+import { CODEX_NATIVE_CONFIG } from "open-sse/config/codexNative.js";
+import { proxyAwareFetch } from "open-sse/utils/proxyFetch.js";
+import {
+  getCodexNativeCatalog,
+  getMostRecentCodexClientVersion,
+  invalidateCodexNativeCatalog,
+  isCodexNativeModel,
+} from "./catalog.js";
+import { getInstalledCodexClientVersion } from "./clientVersion.js";
+import {
+  acquireCodexNativeLease,
+  failCodexNativeLease,
+  ingestCodexNativeQuota,
+  incrementCodexNativeHttpFallback,
+  markCodexNativeSemanticOutput,
+  releaseCodexNativeLease,
+  succeedCodexNativeLease,
+} from "./pool.js";
+import {
+  sanitizeCodexNativeRequestHeaders,
+  sanitizeCodexNativeResponseHeaders,
+} from "./headers.js";
+import { codexNativeAuthError, validateCodexNativeClient } from "./clientAuth.js";
+
+const DEFINITIVE_REJECTION = new Set([401, 429]);
+
+function proxyOptions(proxy) {
+  return {
+    connectionProxyEnabled: proxy.connectionProxyEnabled === true,
+    connectionProxyUrl: proxy.connectionProxyUrl || "",
+    connectionNoProxy: proxy.connectionNoProxy || "",
+    vercelRelayUrl: proxy.vercelRelayUrl || "",
+    strictProxy: proxy.strictProxy === true,
+  };
+}
+
+function errorResponse(status, code, message) {
+  return Response.json({
+    error: { type: "server_error", code, message },
+  }, { status });
+}
+
+export function codexClientVersionFromRequest(request) {
+  const url = new URL(request.url);
+  const queryVersion = url.searchParams.get("client_version");
+  if (queryVersion != null) return queryVersion;
+  const explicit = request.headers.get("x-codex-client-version");
+  if (explicit) return explicit;
+  const userAgent = request.headers.get("user-agent") || "";
+  const match = userAgent.match(/\bcodex(?:_cli_rs)?\/([^\s]+)/i);
+  return match?.[1] || null;
+}
+
+async function resolveCodexClientVersion(request) {
+  const requestVersion = codexClientVersionFromRequest(request);
+  if (requestVersion) return requestVersion;
+  const installed = await getInstalledCodexClientVersion();
+  return installed.version || await getMostRecentCodexClientVersion();
+}
+
+export function isCodexSemanticEvent(event) {
+  const type = typeof event === "string" ? event : event?.type;
+  if (!type) return false;
+  return type.startsWith("response.output_")
+    || type.includes("output_text")
+    || type.includes("reasoning")
+    || type.includes("function_call")
+    || type.includes("tool_call")
+    || type.includes("image_generation")
+    || type === "response.completed";
+}
+
+function inspectSseText(text, leaseId, connectionId) {
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const raw = line.slice(5).trim();
+    if (!raw || raw === "[DONE]") continue;
+    try {
+      const event = JSON.parse(raw);
+      if (event.type === "codex.rate_limits") {
+        ingestCodexNativeQuota(connectionId, event, "sse");
+      }
+      if (isCodexSemanticEvent(event)) markCodexNativeSemanticOutput(leaseId);
+    } catch {
+      // Partial SSE records are inspected again after the next chunk.
+    }
+  }
+}
+
+function monitoredBody(upstream, lease) {
+  if (!upstream.body) return null;
+  const reader = upstream.body.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  return new ReadableStream({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          if (pending) inspectSseText(pending, lease.id, lease.connectionId);
+          await succeedCodexNativeLease(lease.id, { headers: upstream.headers });
+          releaseCodexNativeLease(lease.id);
+          controller.close();
+          return;
+        }
+        const text = pending + decoder.decode(value, { stream: true });
+        const boundary = text.lastIndexOf("\n\n");
+        if (boundary >= 0) {
+          inspectSseText(text.slice(0, boundary + 2), lease.id, lease.connectionId);
+          pending = text.slice(boundary + 2);
+        } else {
+          pending = text.slice(-16_384);
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        await failCodexNativeLease(lease.id, { status: 502, error: error.message });
+        releaseCodexNativeLease(lease.id);
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      reader.cancel(reason).catch(() => {});
+      releaseCodexNativeLease(lease.id);
+    },
+  });
+}
+
+function shouldRetryStatus(status, operation) {
+  if (DEFINITIVE_REJECTION.has(status)) return true;
+  return operation === "responses" && status >= 500;
+}
+
+function upstreamUrl(path) {
+  return `${CODEX_NATIVE_CONFIG.upstreamHttpBaseUrl}/${path}`;
+}
+
+async function parseRoutingCopy(rawBody, contentType) {
+  if (!rawBody.byteLength || !String(contentType || "").toLowerCase().includes("json")) return {};
+  try {
+    return JSON.parse(new TextDecoder().decode(rawBody));
+  } catch {
+    return null;
+  }
+}
+
+export async function relayCodexNativeHttp(request, {
+  path,
+  operation,
+  validateModel = false,
+  allowTransportReplay = false,
+} = {}) {
+  const auth = await validateCodexNativeClient(request);
+  if (!auth.ok) return codexNativeAuthError(auth);
+  if (operation === "responses") incrementCodexNativeHttpFallback();
+
+  const rawBody = await request.arrayBuffer();
+  const routingBody = await parseRoutingCopy(rawBody, request.headers.get("content-type"));
+  if (routingBody === null) return errorResponse(400, "invalid_json", "Invalid JSON body");
+  const model = typeof routingBody?.model === "string" ? routingBody.model.trim() : null;
+  const clientVersion = await resolveCodexClientVersion(request);
+
+  if (validateModel) {
+    if (!model || model.includes("/")) {
+      return errorResponse(400, "model_not_in_codex_native_catalog", "A bare native Codex model slug is required");
+    }
+    let catalog;
+    try {
+      catalog = await getCodexNativeCatalog({ clientVersion });
+    } catch (error) {
+      return errorResponse(503, "codex_catalog_unavailable", error.message);
+    }
+    if (!isCodexNativeModel(catalog, model)) {
+      return errorResponse(
+        400,
+        "model_not_in_codex_native_catalog",
+        `Model '${model}' is not available in the selected native metadata cohort`
+      );
+    }
+  }
+
+  const excludeConnectionIds = new Set();
+  let lastError = null;
+  while (true) {
+    const routed = await acquireCodexNativeLease({
+      headers: Object.fromEntries(request.headers.entries()),
+      body: routingBody || {},
+      model,
+      transport: "http",
+      clientVersion,
+      excludeConnectionIds,
+    });
+    const lease = routed.lease;
+    if (!lease) {
+      return errorResponse(
+        503,
+        "codex_native_accounts_unavailable",
+        lastError || "No eligible Codex account is available for this model"
+      );
+    }
+
+    const headers = sanitizeCodexNativeRequestHeaders(request.headers, lease.credentials);
+    let upstream;
+    try {
+      upstream = await proxyAwareFetch(upstreamUrl(path), {
+        method: request.method,
+        headers,
+        body: rawBody.byteLength ? rawBody.slice(0) : undefined,
+        signal: request.signal,
+      }, proxyOptions(lease.proxy));
+    } catch (error) {
+      await failCodexNativeLease(lease.id, { status: 502, error: error.message });
+      releaseCodexNativeLease(lease.id);
+      excludeConnectionIds.add(lease.connectionId);
+      lastError = error.message;
+      if (allowTransportReplay) continue;
+      return errorResponse(502, "codex_upstream_transport_error", error.message);
+    }
+
+    ingestCodexNativeQuota(lease.connectionId, upstream.headers, "headers");
+    const modelsEtag = upstream.headers.get("x-models-etag");
+    if (modelsEtag) {
+      invalidateCodexNativeCatalog(lease.connectionId, modelsEtag, clientVersion);
+    }
+
+    if (!upstream.ok && shouldRetryStatus(upstream.status, operation)) {
+      const bodyBytes = new Uint8Array(await upstream.arrayBuffer());
+      const detail = new TextDecoder().decode(bodyBytes).slice(0, 512);
+      await failCodexNativeLease(lease.id, { status: upstream.status, error: detail });
+      releaseCodexNativeLease(lease.id);
+      excludeConnectionIds.add(lease.connectionId);
+      lastError = detail || `Codex upstream returned ${upstream.status}`;
+      continue;
+    }
+
+    const responseHeaders = sanitizeCodexNativeResponseHeaders(upstream.headers);
+    if (!upstream.ok) {
+      const bodyBytes = await upstream.arrayBuffer();
+      await failCodexNativeLease(lease.id, {
+        status: upstream.status,
+        error: new TextDecoder().decode(bodyBytes).slice(0, 512),
+      });
+      releaseCodexNativeLease(lease.id);
+      return new Response(bodyBytes, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: responseHeaders,
+      });
+    }
+
+    if (!upstream.body) {
+      await succeedCodexNativeLease(lease.id, { headers: upstream.headers });
+      releaseCodexNativeLease(lease.id);
+      return new Response(null, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: responseHeaders,
+      });
+    }
+    return new Response(monitoredBody(upstream, lease), {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders,
+    });
+  }
+}

--- a/tests/unit/codex-native-catalog.test.js
+++ b/tests/unit/codex-native-catalog.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/localDb.js", () => ({ getProviderConnections: vi.fn(async () => []) }));
+vi.mock("@/lib/network/connectionProxy.js", () => ({
+  resolveConnectionProxyConfig: vi.fn(async () => ({})),
+}));
+vi.mock("@/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_provider, connection) => connection),
+}));
+
+describe("Codex Native model metadata cohorts", () => {
+  it("keeps one complete ModelInfo cohort and deterministically prefers account count then priority", async () => {
+    const { hashCodexModelInfo, selectCodexModelCohorts } = await import("@/lib/codexNative/catalog.js");
+    const rich = {
+      slug: "gpt-native",
+      display_name: "Native",
+      priority: 2,
+      base_instructions: "cohort-rich",
+      context_window: 300_000,
+      supported_reasoning_levels: [{ effort: "high" }],
+      experimental_supported_tools: ["shell", "search"],
+    };
+    const different = {
+      ...rich,
+      base_instructions: "cohort-other",
+      context_window: 200_000,
+      experimental_supported_tools: [],
+    };
+    const result = selectCodexModelCohorts([
+      { ok: true, connectionId: "a", models: [rich] },
+      { ok: true, connectionId: "b", models: [rich] },
+      { ok: true, connectionId: "priority-first", models: [different] },
+    ], [
+      { id: "priority-first", priority: 1 },
+      { id: "a", priority: 2 },
+      { id: "b", priority: 3 },
+    ]);
+
+    expect(result.models).toEqual([rich]);
+    expect(result.eligibleConnectionIds["gpt-native"]).toEqual(["a", "b"]);
+    expect(result.cohortHashes["gpt-native"]).toBe(hashCodexModelInfo(rich));
+  });
+
+  it("uses account priority as the tie breaker without merging fields", async () => {
+    const { selectCodexModelCohorts } = await import("@/lib/codexNative/catalog.js");
+    const first = { slug: "gpt-native", display_name: "First", context_window: 100 };
+    const second = { slug: "gpt-native", display_name: "Second", context_window: 200 };
+    const result = selectCodexModelCohorts([
+      { ok: true, connectionId: "low-priority", models: [first] },
+      { ok: true, connectionId: "high-priority", models: [second] },
+    ], [
+      { id: "high-priority", priority: 1 },
+      { id: "low-priority", priority: 2 },
+    ]);
+    expect(result.models[0]).toEqual(second);
+    expect(result.models[0]).not.toHaveProperty("context_window", 100);
+  });
+
+  it("hashes the whole ModelInfo independent of object key order", async () => {
+    const { hashCodexModelInfo } = await import("@/lib/codexNative/catalog.js");
+    expect(hashCodexModelInfo({ slug: "a", nested: { z: 1, a: 2 } }))
+      .toBe(hashCodexModelInfo({ nested: { a: 2, z: 1 }, slug: "a" }));
+  });
+});

--- a/tests/unit/codex-native-client-version.test.js
+++ b/tests/unit/codex-native-client-version.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexClientVersion } from "@/lib/codexNative/clientVersion.js";
+
+describe("Codex Native client version detection", () => {
+  it("parses stable and prerelease versions without a hard-coded current version", () => {
+    expect(parseCodexClientVersion("codex-cli 0.146.0")).toBe("0.146.0");
+    expect(parseCodexClientVersion("codex 0.147.0-beta.2+ws")).toBe("0.147.0-beta.2+ws");
+    expect(parseCodexClientVersion("unknown")).toBeNull();
+  });
+});

--- a/tests/unit/codex-native-executor.test.js
+++ b/tests/unit/codex-native-executor.test.js
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sanitizeCodexNativeRequestHeaders } from "@/lib/codexNative/headers.js";
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  acquire: vi.fn(),
+  success: vi.fn(),
+  failure: vi.fn(),
+  release: vi.fn(),
+  semantic: vi.fn(),
+  quota: vi.fn(),
+  invalidate: vi.fn(),
+  getCatalog: vi.fn(),
+  getInstalledVersion: vi.fn(),
+}));
+
+vi.mock("open-sse/utils/proxyFetch.js", () => ({ proxyAwareFetch: mocks.fetch }));
+vi.mock("@/lib/codexNative/clientAuth.js", () => ({
+  validateCodexNativeClient: vi.fn(async () => ({ ok: true })),
+  codexNativeAuthError: vi.fn(),
+}));
+vi.mock("@/lib/codexNative/catalog.js", () => ({
+  getCodexNativeCatalog: (...args) => mocks.getCatalog(...args),
+  getMostRecentCodexClientVersion: vi.fn(async () => "0.145.0"),
+  isCodexNativeModel: (_catalog, model) => model === "gpt-native",
+  invalidateCodexNativeCatalog: (...args) => mocks.invalidate(...args),
+}));
+vi.mock("@/lib/codexNative/clientVersion.js", () => ({
+  getInstalledCodexClientVersion: (...args) => mocks.getInstalledVersion(...args),
+}));
+vi.mock("@/lib/codexNative/pool.js", () => ({
+  acquireCodexNativeLease: (...args) => mocks.acquire(...args),
+  failCodexNativeLease: (...args) => mocks.failure(...args),
+  ingestCodexNativeQuota: (...args) => mocks.quota(...args),
+  incrementCodexNativeHttpFallback: vi.fn(),
+  markCodexNativeSemanticOutput: (...args) => mocks.semantic(...args),
+  releaseCodexNativeLease: (...args) => mocks.release(...args),
+  succeedCodexNativeLease: (...args) => mocks.success(...args),
+}));
+
+describe("Codex Native transparent HTTP transport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.acquire.mockResolvedValue({
+      lease: {
+        id: "lease-1",
+        connectionId: "account-1",
+        credentials: {
+          accessToken: "upstream-token",
+          providerSpecificData: { chatgptAccountId: "upstream-account" },
+        },
+        proxy: {},
+      },
+    });
+    mocks.getCatalog.mockResolvedValue({ models: [{ slug: "gpt-native" }] });
+    mocks.getInstalledVersion.mockResolvedValue({
+      installed: true,
+      version: "0.146.0",
+      raw: "codex-cli 0.146.0",
+    });
+  });
+
+  it("forwards semantic headers but always rebuilds credentials", () => {
+    const headers = sanitizeCodexNativeRequestHeaders(new Headers({
+      authorization: "Bearer client-key",
+      "chatgpt-account-id": "client-account",
+      cookie: "secret=1",
+      host: "attacker.invalid",
+      "x-forwarded-for": "203.0.113.4",
+      "session-id": "session-1",
+      "thread-id": "thread-1",
+      "x-codex-future-protocol": "v3",
+      "x-openai-subagent": "collab_spawn",
+      "user-agent": "codex/next",
+    }), {
+      accessToken: "upstream-token",
+      providerSpecificData: { chatgptAccountId: "upstream-account" },
+    });
+
+    expect(headers.get("authorization")).toBe("Bearer upstream-token");
+    expect(headers.get("chatgpt-account-id")).toBe("upstream-account");
+    expect(headers.get("session-id")).toBe("session-1");
+    expect(headers.get("thread-id")).toBe("thread-1");
+    expect(headers.get("x-codex-future-protocol")).toBe("v3");
+    expect(headers.get("x-openai-subagent")).toBe("collab_spawn");
+    expect(headers.get("cookie")).toBeNull();
+    expect(headers.get("host")).toBeNull();
+    expect(headers.get("x-forwarded-for")).toBeNull();
+  });
+
+  it("relays the exact request bytes, unknown fields, SSE bytes, status, and native response headers", async () => {
+    const original = '{"model":"gpt-native","input":[],"future_field":{"kept":true},"stream":true}';
+    const upstreamSse = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n";
+    mocks.fetch.mockResolvedValue(new Response(upstreamSse, {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "x-codex-turn-state": "turn-state",
+        "x-models-etag": "models-v2",
+        "set-cookie": "upstream-secret=1",
+      },
+    }));
+    const { relayCodexNativeHttp } = await import("@/lib/codexNative/relay.js");
+    const response = await relayCodexNativeHttp(new Request("http://localhost/v1/codex/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer client-key",
+        "session-id": "session-1",
+      },
+      body: original,
+    }), {
+      path: "responses",
+      operation: "responses",
+      validateModel: true,
+      allowTransportReplay: true,
+    });
+
+    const [url, options] = mocks.fetch.mock.calls[0];
+    expect(url).toBe("https://chatgpt.com/backend-api/codex/responses");
+    expect(new TextDecoder().decode(options.body)).toBe(original);
+    expect(options.headers.get("authorization")).toBe("Bearer upstream-token");
+    expect(options.headers.get("session-id")).toBe("session-1");
+    expect(mocks.getCatalog).toHaveBeenCalledWith({ clientVersion: "0.146.0" });
+    expect(mocks.acquire).toHaveBeenCalledWith(expect.objectContaining({
+      clientVersion: "0.146.0",
+    }));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-codex-turn-state")).toBe("turn-state");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    await expect(response.text()).resolves.toBe(upstreamSse);
+    expect(mocks.semantic).toHaveBeenCalledWith("lease-1");
+    expect(mocks.success).toHaveBeenCalled();
+    expect(mocks.release).toHaveBeenCalledWith("lease-1");
+  });
+
+  it("does not replay an ambiguous image-generation transport failure", async () => {
+    mocks.fetch.mockRejectedValue(new Error("socket reset"));
+    const { relayCodexNativeHttp } = await import("@/lib/codexNative/relay.js");
+    const response = await relayCodexNativeHttp(new Request("http://localhost/v1/codex/images/generations", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"prompt":"draw"}',
+    }), {
+      path: "images/generations",
+      operation: "image-generation",
+    });
+    expect(response.status).toBe(502);
+    expect(mocks.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/codex-native-internal-api.test.js
+++ b/tests/unit/codex-native-internal-api.test.js
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  acquire: vi.fn(),
+}));
+
+vi.mock("@/lib/codexNative/pool.js", () => ({
+  acquireCodexNativeLease: (...args) => mocks.acquire(...args),
+  failCodexNativeLease: vi.fn(),
+  getCodexNativeLease: vi.fn(),
+  getCodexNativeMetrics: vi.fn(() => ({})),
+  ingestCodexNativeQuota: vi.fn(),
+  markCodexNativeSemanticOutput: vi.fn(),
+  releaseCodexNativeLease: vi.fn(),
+  succeedCodexNativeLease: vi.fn(),
+  validateCodexNativeLeaseModel: vi.fn(),
+}));
+vi.mock("@/lib/codexNative/clientAuth.js", () => ({
+  validateCodexNativeClient: vi.fn(async () => ({ ok: true })),
+}));
+vi.mock("@/lib/codexNative/clientVersion.js", () => ({
+  getInstalledCodexClientVersion: vi.fn(async () => ({
+    installed: true,
+    version: "0.146.0",
+  })),
+}));
+vi.mock("@/lib/codexNative/catalog.js", () => ({
+  getMostRecentCodexClientVersion: vi.fn(async () => "0.145.0"),
+}));
+
+describe("Codex Native process-internal lease API", () => {
+  beforeEach(() => {
+    process.env.CODEX_NATIVE_INTERNAL_SECRET = "process-secret";
+    mocks.acquire.mockResolvedValue({
+      lease: {
+        id: "lease-1",
+        connectionId: "account-1",
+        credentials: {
+          accessToken: "upstream-token",
+          providerSpecificData: { chatgptAccountId: "account-binding" },
+        },
+        proxy: {},
+      },
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.CODEX_NATIVE_INTERNAL_SECRET;
+    vi.clearAllMocks();
+  });
+
+  it("rejects the correct secret when the TCP peer is not loopback", async () => {
+    const { POST } = await import("@/app/api/internal/codex-native/lease/[action]/route.js");
+    const response = await POST(new Request("http://router/api/internal/codex-native/lease/acquire", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-9r-internal-secret": "process-secret",
+        "x-9r-real-ip": "203.0.113.8",
+      },
+      body: JSON.stringify({ requestHeaders: { authorization: "Bearer client-key" } }),
+    }), { params: Promise.resolve({ action: "acquire" }) });
+    expect(response.status).toBe(403);
+    expect(mocks.acquire).not.toHaveBeenCalled();
+  });
+
+  it("returns rebuilt upstream credentials only to a secret-authenticated loopback peer", async () => {
+    const { POST } = await import("@/app/api/internal/codex-native/lease/[action]/route.js");
+    const response = await POST(new Request("http://router/api/internal/codex-native/lease/acquire", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-9r-internal-secret": "process-secret",
+        "x-9r-real-ip": "::ffff:127.0.0.1",
+      },
+      body: JSON.stringify({
+        requestHeaders: {
+          authorization: "Bearer client-key",
+          cookie: "client-secret=1",
+          "session-id": "session-1",
+        },
+      }),
+    }), { params: Promise.resolve({ action: "acquire" }) });
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.upstreamHeaders.authorization).toBe("Bearer upstream-token");
+    expect(payload.upstreamHeaders["chatgpt-account-id"]).toBe("account-binding");
+    expect(payload.upstreamHeaders.cookie).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain("client-key");
+    expect(mocks.acquire).toHaveBeenCalledWith(expect.objectContaining({
+      clientVersion: "0.146.0",
+    }));
+  });
+});

--- a/tests/unit/codex-native-pool.test.js
+++ b/tests/unit/codex-native-pool.test.js
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connections: [],
+  usageByToken: new Map(),
+  affinity: null,
+  bind: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb.js", () => ({
+  getProviderConnections: vi.fn(async () => mocks.connections),
+}));
+vi.mock("@/lib/network/connectionProxy.js", () => ({
+  resolveConnectionProxyConfig: vi.fn(async () => ({})),
+}));
+vi.mock("@/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_provider, credentials) => credentials),
+}));
+vi.mock("open-sse/services/usage/codex.js", () => ({
+  getCodexUsage: vi.fn(async (token) => mocks.usageByToken.get(token)),
+}));
+vi.mock("@/lib/codexNative/catalog.js", () => ({
+  getCodexNativeCatalog: vi.fn(async () => ({
+    models: [{ slug: "gpt-5.6-sol" }],
+    eligibleConnectionIds: {
+      "gpt-5.6-sol": ["account-low", "account-healthy", "account-exhausted"],
+    },
+  })),
+}));
+vi.mock("@/lib/codexNative/affinity.js", () => ({
+  resolveCodexNativeAffinityKey: vi.fn(async () => "affinity-key"),
+  getCodexNativeAffinity: vi.fn(async () => mocks.affinity),
+  getCodexNativeAffinityCounts: vi.fn(async () => new Map()),
+  bindCodexNativeAffinity: (...args) => mocks.bind(...args),
+  releaseCodexNativeAffinity: (...args) => mocks.release(...args),
+}));
+
+function usage(remaining) {
+  return {
+    quotas: {
+      session: { remaining, resetAt: "2026-08-01T00:00:00.000Z" },
+      weekly: { remaining: Math.max(remaining, 50), resetAt: "2026-08-02T00:00:00.000Z" },
+    },
+  };
+}
+
+describe("Codex Native account pool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.connections = [
+      { id: "account-low", accessToken: "low-token", provider: "codex", isActive: true, priority: 1 },
+      { id: "account-healthy", accessToken: "healthy-token", provider: "codex", isActive: true, priority: 2 },
+      { id: "account-exhausted", accessToken: "exhausted-token", provider: "codex", isActive: true, priority: 3 },
+    ];
+    mocks.usageByToken = new Map([
+      ["low-token", usage(4)],
+      ["healthy-token", usage(80)],
+      ["exhausted-token", usage(0)],
+    ]);
+    mocks.affinity = { connectionId: "account-low", lastUsedAt: Date.now() };
+  });
+
+  it("moves a critical session to a healthy eligible account at the next turn", async () => {
+    const pool = await import("@/lib/codexNative/pool.js");
+    await pool.refreshCodexNativePoolUsage();
+    const routing = await pool.resolveCodexNativeRouting({
+      headers: { "session-id": "session-1" },
+      body: { prompt_cache_key: "session-1" },
+      model: "gpt-5.6-sol",
+    });
+
+    expect(routing.preferredConnectionId).toBe("account-healthy");
+    expect(routing.eligibleConnectionIds).toEqual(["account-low", "account-healthy"]);
+    expect(mocks.bind).toHaveBeenCalledWith("affinity-key", "account-healthy");
+  });
+
+  it("applies quota hysteresis at healthy, draining, critical, and exhausted thresholds", async () => {
+    const { codexQuotaStatus } = await import("@/lib/codexNative/pool.js");
+    expect(codexQuotaStatus(20, "draining")).toBe("healthy");
+    expect(codexQuotaStatus(14.9, "healthy")).toBe("draining");
+    expect(codexQuotaStatus(19.9, "draining")).toBe("draining");
+    expect(codexQuotaStatus(4.9, "healthy")).toBe("critical");
+    expect(codexQuotaStatus(0, "healthy")).toBe("exhausted");
+  });
+
+  it("does not assign a new session to draining or critical accounts", async () => {
+    const pool = await import("@/lib/codexNative/pool.js");
+    mocks.affinity = null;
+    pool.ingestCodexNativeQuota("account-low", {
+      rate_limits: { primary: { remaining: 10 } },
+    });
+    pool.ingestCodexNativeQuota("account-healthy", {
+      rate_limits: { primary: { remaining: 4 } },
+    });
+    pool.ingestCodexNativeQuota("account-exhausted", {
+      rate_limits: { primary: { remaining: 0 } },
+    });
+
+    const routing = await pool.resolveCodexNativeRouting({
+      headers: {},
+      body: {},
+      model: "gpt-5.6-sol",
+    });
+
+    expect(routing.preferredConnectionId).toBeNull();
+    expect(mocks.bind).not.toHaveBeenCalled();
+  });
+
+  it("excludes relay-only accounts from WebSocket without excluding HTTP", async () => {
+    const { codexWebSocketProxyCapability } = await import("@/lib/codexNative/pool.js");
+    expect(codexWebSocketProxyCapability({ vercelRelayUrl: "https://relay.example" }))
+      .toEqual({ capable: false, reason: "relay-only proxy has no WebSocket transport" });
+    expect(codexWebSocketProxyCapability({
+      connectionProxyEnabled: true,
+      connectionProxyUrl: "socks5://127.0.0.1:1080",
+    }).capable).toBe(true);
+  });
+});

--- a/tests/unit/codex-native-routes.test.js
+++ b/tests/unit/codex-native-routes.test.js
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  relay: vi.fn(),
+  getCatalog: vi.fn(),
+  refreshUsage: vi.fn(),
+  getPoolSnapshot: vi.fn(),
+  detectVersion: vi.fn(),
+}));
+
+vi.mock("@/lib/codexNative/relay.js", () => ({ relayCodexNativeHttp: mocks.relay }));
+vi.mock("@/lib/codexNative/catalog.js", () => ({
+  getCodexNativeCatalog: mocks.getCatalog,
+  getCodexNativeDefaultModel: vi.fn((catalog) => catalog.models[0]?.slug || null),
+}));
+vi.mock("@/lib/codexNative/pool.js", () => ({
+  refreshCodexNativePoolUsage: mocks.refreshUsage,
+  getCodexNativePoolSnapshot: mocks.getPoolSnapshot,
+  getCodexNativeMetrics: vi.fn(() => ({ activeLeases: 0 })),
+}));
+vi.mock("@/lib/codexNative/clientVersion.js", () => ({
+  getInstalledCodexClientVersion: mocks.detectVersion,
+}));
+vi.mock("@/lib/codexNative/clientAuth.js", () => ({
+  validateCodexNativeClient: vi.fn(async () => ({ ok: true })),
+  codexNativeAuthError: vi.fn(),
+}));
+
+describe("Codex Native routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getCatalog.mockResolvedValue({
+      models: [{ slug: "gpt-native", display_name: "GPT Native" }],
+      etag: '"catalog-etag"',
+      source: "upstream",
+      stale: false,
+      clientVersion: "0.146.0",
+      fetchedAt: Date.parse("2026-07-31T00:00:00.000Z"),
+    });
+    mocks.refreshUsage.mockResolvedValue([]);
+    mocks.getPoolSnapshot.mockResolvedValue([]);
+    mocks.detectVersion.mockResolvedValue({
+      installed: true,
+      version: "0.146.0",
+      raw: "codex-cli 0.146.0",
+    });
+    mocks.relay.mockResolvedValue(new Response("ok"));
+  });
+
+  it("serves the native ModelsResponse and preserves the exact client_version", async () => {
+    const { GET } = await import("@/app/api/v1/codex/models/route.js");
+    const response = await GET(new Request("http://localhost/v1/codex/models?client_version=next-canary%2Bws"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("etag")).toBe('"catalog-etag"');
+    expect(response.headers.get("x-models-etag")).toBe('"catalog-etag"');
+    expect(mocks.getCatalog).toHaveBeenCalledWith({ clientVersion: "next-canary+ws" });
+    await expect(response.json()).resolves.toEqual({
+      models: [{ slug: "gpt-native", display_name: "GPT Native" }],
+    });
+  });
+
+  it("honors If-None-Match", async () => {
+    const { GET } = await import("@/app/api/v1/codex/models/route.js");
+    const response = await GET(new Request("http://localhost/v1/codex/models?client_version=0.146.0", {
+      headers: { "If-None-Match": '"catalog-etag"' },
+    }));
+    expect(response.status).toBe(304);
+    expect(response.headers.get("x-models-etag")).toBe('"catalog-etag"');
+  });
+
+  it("returns a clear client error when client_version is missing", async () => {
+    const { GET } = await import("@/app/api/v1/codex/models/route.js");
+    const response = await GET(new Request("http://localhost/v1/codex/models"));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        type: "invalid_request_error",
+        code: "missing_client_version",
+        message: "client_version is required",
+      },
+    });
+  });
+
+  it("uses the dynamically detected Codex version for the dashboard catalog", async () => {
+    const { GET } = await import("@/app/api/cli-tools/codex-native/models/route.js");
+    const response = await GET(new Request("http://localhost/api/cli-tools/codex-native/models"));
+    expect(response.status).toBe(200);
+    expect(mocks.detectVersion).toHaveBeenCalledWith({ forceRefresh: false });
+    expect(mocks.getCatalog).toHaveBeenCalledWith({
+      forceRefresh: false,
+      clientVersion: "0.146.0",
+    });
+    expect(mocks.getPoolSnapshot).toHaveBeenCalledWith({ clientVersion: "0.146.0" });
+    await expect(response.json()).resolves.toMatchObject({
+      defaultModel: "gpt-native",
+      models: [{ slug: "gpt-native", eligibleAccountCount: 0 }],
+      catalog: { clientVersion: "0.146.0" },
+    });
+  });
+
+  it.each([
+    ["@/app/api/v1/codex/responses/route.js", "responses", "responses"],
+    ["@/app/api/v1/codex/responses/compact/route.js", "responses/compact", "compact"],
+    ["@/app/api/v1/codex/memories/trace_summarize/route.js", "memories/trace_summarize", "memories"],
+    ["@/app/api/v1/codex/alpha/search/route.js", "alpha/search", "search"],
+    ["@/app/api/v1/codex/images/generations/route.js", "images/generations", "image-generation"],
+    ["@/app/api/v1/codex/images/edits/route.js", "images/edits", "image-edit"],
+  ])("maps %s to the native upstream path", async (moduleId, path, operation) => {
+    const { POST } = await import(moduleId);
+    const request = new Request("http://localhost/native", { method: "POST", body: "{}" });
+    await POST(request);
+    expect(mocks.relay).toHaveBeenCalledWith(request, expect.objectContaining({ path, operation }));
+  });
+});

--- a/tests/unit/codex-native-websocket.test.js
+++ b/tests/unit/codex-native-websocket.test.js
@@ -1,0 +1,251 @@
+import http from "node:http";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+
+const require = createRequire(import.meta.url);
+const {
+  attachCodexNativeGateway,
+  isNativeUpgrade,
+  safeHandshakeHeaders,
+  semanticEvent,
+} = require("../../server/codexNativeGateway.cjs");
+
+const servers = [];
+const listen = (server) => new Promise((resolve) => {
+  server.listen(0, "127.0.0.1", () => {
+    servers.push(server);
+    resolve(server.address().port);
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) =>
+    new Promise((resolve) => server.close(() => resolve()))
+  ));
+});
+
+describe("Codex Native WebSocket gateway", () => {
+  it("relays text frames, compression, handshake metadata, ping/pong, and rebuilt credentials", async () => {
+    const upstreamHttp = http.createServer();
+    const upstreamWss = new WebSocketServer({ server: upstreamHttp, perMessageDeflate: true });
+    upstreamWss.on("headers", (headers) => {
+      headers.push("x-models-etag: upstream-models-v2");
+      headers.push("x-reasoning-included: true");
+      headers.push("set-cookie: do-not-relay=1");
+    });
+    const upstreamPort = await listen(upstreamHttp);
+
+    let capturedHeaders;
+    let capturedFrame;
+    let upstreamPong;
+    upstreamWss.on("connection", (socket, request) => {
+      capturedHeaders = request.headers;
+      socket.on("message", (data) => {
+        capturedFrame = data.toString();
+        socket.send(data.toString());
+        socket.ping("health");
+      });
+      upstreamPong = new Promise((resolve) => socket.once("pong", resolve));
+    });
+
+    let leaseCounter = 0;
+    const actions = [];
+    const fakeFetch = async (url, options) => {
+      const action = new URL(url).pathname.split("/").pop();
+      const payload = JSON.parse(options.body);
+      actions.push({ action, payload });
+      if (action === "acquire") {
+        leaseCounter += 1;
+        return Response.json({
+          leaseId: `lease-${leaseCounter}`,
+          connectionId: "account-1",
+          upstreamHeaders: {
+            authorization: "Bearer upstream-token",
+            "chatgpt-account-id": "upstream-account",
+            "session-id": payload.requestHeaders["session-id"],
+            "x-codex-future": payload.requestHeaders["x-codex-future"],
+          },
+          proxy: { enabled: false, url: "", strict: false },
+        });
+      }
+      if (action === "validate-model") return Response.json({ valid: true });
+      return Response.json({ success: true });
+    };
+
+    const gatewayHttp = http.createServer((_request, response) => response.end("ok"));
+    attachCodexNativeGateway(gatewayHttp, {
+      secret: "process-secret",
+      fetch: fakeFetch,
+      upstreamUrl: `ws://127.0.0.1:${upstreamPort}`,
+    });
+    const gatewayPort = await listen(gatewayHttp);
+
+    const frame = JSON.stringify({
+      type: "response.create",
+      model: "gpt-native",
+      input: [],
+      generate: false,
+      previous_response_id: "resp-1",
+      future_field: { untouched: true },
+    });
+    let upgradeHeaders;
+    let clientSocket;
+    const responseFrame = await new Promise((resolve, reject) => {
+      clientSocket = new WebSocket(`ws://127.0.0.1:${gatewayPort}/v1/codex/responses`, {
+        headers: {
+          authorization: "Bearer client-api-key",
+          "session-id": "session-1",
+          "x-codex-future": "v2",
+        },
+        perMessageDeflate: true,
+      });
+      clientSocket.on("upgrade", (response) => { upgradeHeaders = response.headers; });
+      clientSocket.on("open", () => clientSocket.send(frame));
+      clientSocket.on("message", (data) => {
+        resolve({ value: data.toString(), extensions: clientSocket.extensions });
+      });
+      clientSocket.on("error", reject);
+    });
+
+    await upstreamPong;
+    const clientClosed = new Promise((resolve) => clientSocket.once("close", resolve));
+    clientSocket.close(1000, "test complete");
+    await clientClosed;
+    expect(responseFrame.value).toBe(frame);
+    expect(responseFrame.extensions).toContain("permessage-deflate");
+    expect(capturedFrame).toBe(frame);
+    expect(capturedHeaders.authorization).toBe("Bearer upstream-token");
+    expect(capturedHeaders.authorization).not.toContain("client-api-key");
+    expect(capturedHeaders["chatgpt-account-id"]).toBe("upstream-account");
+    expect(capturedHeaders["session-id"]).toBe("session-1");
+    expect(capturedHeaders["x-codex-future"]).toBe("v2");
+    expect(upgradeHeaders["x-models-etag"]).toBe("upstream-models-v2");
+    expect(upgradeHeaders["x-reasoning-included"]).toBe("true");
+    expect(upgradeHeaders["set-cookie"]).toBeUndefined();
+    expect(actions.some(({ action }) => action === "validate-model")).toBe(true);
+  });
+
+  it("switches to a model-compatible metadata cohort before sending the first frame", async () => {
+    const upstreamHttp = http.createServer();
+    const upstreamWss = new WebSocketServer({ server: upstreamHttp });
+    const upstreamPort = await listen(upstreamHttp);
+    const upstreamConnections = [];
+    upstreamWss.on("connection", (socket, request) => {
+      const record = { authorization: request.headers.authorization, frames: [] };
+      upstreamConnections.push(record);
+      socket.on("message", (data) => {
+        record.frames.push(data.toString());
+        socket.send(data.toString());
+      });
+    });
+
+    const actions = [];
+    const fakeFetch = async (url, options) => {
+      const action = new URL(url).pathname.split("/").pop();
+      const payload = JSON.parse(options.body);
+      actions.push({ action, payload });
+      if (action === "acquire") {
+        const compatible = payload.model === "gpt-cohort";
+        return Response.json({
+          leaseId: compatible ? "lease-compatible" : "lease-handshake",
+          connectionId: compatible ? "account-compatible" : "account-handshake",
+          upstreamHeaders: {
+            authorization: `Bearer ${compatible ? "compatible" : "handshake"}`,
+          },
+          proxy: { enabled: false },
+        });
+      }
+      if (action === "validate-model" && payload.leaseId === "lease-handshake") {
+        return Response.json({ valid: false }, { status: 409 });
+      }
+      return Response.json({ success: true, valid: true });
+    };
+
+    const gatewayHttp = http.createServer();
+    attachCodexNativeGateway(gatewayHttp, {
+      secret: "secret",
+      fetch: fakeFetch,
+      upstreamUrl: `ws://127.0.0.1:${upstreamPort}`,
+    });
+    const port = await listen(gatewayHttp);
+    const frame = JSON.stringify({
+      type: "response.create",
+      model: "gpt-cohort",
+      input: [],
+    });
+
+    const socket = new WebSocket(`ws://127.0.0.1:${port}/v1/codex/responses`);
+    const echoed = await new Promise((resolve, reject) => {
+      socket.on("open", () => socket.send(frame));
+      socket.on("message", (data) => resolve(data.toString()));
+      socket.on("error", reject);
+    });
+    const closed = new Promise((resolve) => socket.once("close", resolve));
+    socket.close(1000, "done");
+    await closed;
+
+    expect(echoed).toBe(frame);
+    expect(actions.filter(({ action }) => action === "acquire")).toHaveLength(2);
+    expect(actions.find(({ action, payload }) =>
+      action === "acquire" && payload.model === "gpt-cohort"
+    )).toBeTruthy();
+    expect(upstreamConnections.find(({ authorization }) =>
+      authorization === "Bearer handshake"
+    )?.frames).toEqual([]);
+    expect(upstreamConnections.find(({ authorization }) =>
+      authorization === "Bearer compatible"
+    )?.frames).toEqual([frame]);
+  });
+
+  it("rejects binary client frames with the Codex-compatible unsupported-data close code", async () => {
+    const upstreamHttp = http.createServer();
+    const upstreamWss = new WebSocketServer({ server: upstreamHttp });
+    const upstreamPort = await listen(upstreamHttp);
+    upstreamWss.on("connection", () => {});
+
+    const gatewayHttp = http.createServer();
+    attachCodexNativeGateway(gatewayHttp, {
+      secret: "secret",
+      upstreamUrl: `ws://127.0.0.1:${upstreamPort}`,
+      fetch: async (url) => {
+        const action = new URL(url).pathname.split("/").pop();
+        if (action === "acquire") {
+          return Response.json({
+            leaseId: "lease-binary",
+            connectionId: "account-1",
+            upstreamHeaders: {},
+            proxy: { enabled: false },
+          });
+        }
+        return Response.json({ success: true });
+      },
+    });
+    const port = await listen(gatewayHttp);
+
+    const close = await new Promise((resolve, reject) => {
+      const socket = new WebSocket(`ws://127.0.0.1:${port}/v1/codex/responses`);
+      socket.on("open", () => socket.send(Buffer.from([1, 2, 3])));
+      socket.on("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+      socket.on("error", reject);
+    });
+    expect(close.code).toBe(1003);
+    expect(close.reason).toContain("Binary");
+  });
+
+  it("claims only the native responses path and recognizes semantic output", () => {
+    expect(isNativeUpgrade({ url: "/v1/codex/responses?transport=v2" })).toBe(true);
+    expect(isNativeUpgrade({ url: "/_next/webpack-hmr" })).toBe(false);
+    expect(semanticEvent({ type: "response.function_call_arguments.delta" })).toBe(true);
+    expect(semanticEvent({ type: "response.created" })).toBe(false);
+    expect(safeHandshakeHeaders({
+      "x-codex-turn-state": "turn",
+      "x-models-etag": "etag",
+      "set-cookie": "secret",
+      authorization: "secret",
+    })).toEqual({
+      "x-codex-turn-state": "turn",
+      "x-models-etag": "etag",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add a dedicated Codex Native provider path that keeps Codex CLI in control of
agent behavior, sessions, tools, compaction, and model metadata. 9Router only
handles client authentication, account selection, quota-aware failover, proxy
selection, and protocol relay.

- relay native request bodies, SSE bytes, WebSocket text frames, and unknown
  future fields without passing through the Universal translator
- sanitize client credentials and hop-by-hop headers, then rebuild OAuth bearer
  and ChatGPT account headers from the selected 9Router Codex account
- expose native models, responses, compact, memory trace, search, and image
  endpoints under `/v1/codex`
- add a one-port WebSocket gateway with compression, ping/pong, close-code,
  backpressure, HTTP CONNECT, SOCKS, and strict-proxy handling
- group full `ModelInfo` metadata into deterministic account cohorts and cache
  catalogs per client version/account/ETag
- add HMAC session affinity, quota hysteresis, model/proxy capability ranking,
  lease lifecycle tracking, and safe pre-output failover
- prevent replay after semantic output and avoid replaying ambiguous image or
  auxiliary-operation transport failures
- add provider-scoped Codex command auth without overwriting the user's global
  `~/.codex/auth.json`
- add native readiness/repair controls and account/catalog/lease visibility to
  the Codex dashboard card
- package the gateway and its recursive runtime dependency tree for standalone,
  CLI, Docker, and the native development launcher

## Motivation

Codex CLI's native model metadata and reasoning levels (including `max` and
`ultra`) must be handled as a provider protocol, not translated as Universal
chat traffic. Responses requests do not always repeat `client_version`, so the
native relay resolves it from the request, installed Codex CLI, or the most
recent valid catalog instead of returning a false
`codex_catalog_unavailable` 503.

## Safety properties

- client Authorization, account ID, cookies, forwarding, proxy, host, and
  hop-by-hop headers never reach the upstream
- internal lease APIs require both a process-local secret and a loopback peer
- tokens, raw prompts, and raw session IDs are not exposed in dashboard state
- an account can be retried only before semantic output; partial text,
  reasoning, tool calls, images, or output items disable replay for that turn
- no fabricated model catalog is returned; a last-known-good catalog is marked
  stale and absence of any valid catalog is explicit
- realtime voice/WebRTC remains out of scope

## Verification

- ESLint passed for all added and modified Codex Native files
- 27/27 focused unit and contract tests passed:
  - raw body/header/SSE passthrough and credential rebuilding
  - client-version fallback and versioned catalog behavior
  - metadata cohorts, affinity, quota hysteresis, and proxy eligibility
  - internal lease API loopback protection
  - WebSocket compression, ping/pong, close behavior, binary rejection, model
    cohort switching, and handshake header filtering
  - auxiliary endpoint mapping and image no-replay behavior
- `pnpm build` passed from an isolated worktree based on current
  `origin/master`, including all 133 routes, build traces, and standalone
  gateway dependency packaging
