### PR TITLE
fix(responses): preserve namespace tools across chat translation

### DIFF
--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -257,6 +257,7 @@ export function initState(sourceFormat) {
       inThinking: false,
       funcArgsBuf: {},
       funcNames: {},
+      funcNamespaces: {},
       funcCallIds: {},
       funcItemAdded: {},
       funcArgsDone: {},

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -181,7 +181,22 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   ];
   if (responseTools.length > 0) {
     result.tools = responseTools
-      .map(tool => {
+      .flatMap(tool => {
+        // Chat Completions has no namespace tool type. Expose each nested
+        // Responses function directly so providers can call it by name.
+        if (tool.type === "namespace" && Array.isArray(tool.tools)) {
+          return tool.tools
+            .filter(nestedTool => nestedTool?.type === OPENAI_BLOCK.FUNCTION && nestedTool.name)
+            .map(nestedTool => ({
+              type: OPENAI_BLOCK.FUNCTION,
+              function: {
+                name: nestedTool.name,
+                description: String(nestedTool.description || tool.description || ""),
+                parameters: normalizeToolParameters(nestedTool.parameters),
+                strict: nestedTool.strict
+              }
+            }));
+        }
         // Already in Chat Completions format: { type: "function", function: { name, ... } }
         if (tool.function) return tool;
         // Responses API function/custom tool: { type, name, description, parameters|format }.

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -276,7 +276,11 @@ function emitToolCall(state, emit, tc) {
   const newCallId = tc.id;
   const funcName = tc.function?.name;
 
-  if (funcName) state.funcNames[tcIdx] = funcName;
+  if (funcName) {
+    state.funcNames[tcIdx] = funcName;
+    const namespace = state.toolNamespaces?.get(funcName);
+    if (namespace) state.funcNamespaces[tcIdx] = namespace;
+  }
   if (newCallId) state.funcCallIds[tcIdx] = newCallId;
 
   // Some compatible providers split the call id and function name across
@@ -295,7 +299,8 @@ function emitToolCall(state, emit, tc) {
         type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
         ...(custom ? { input: "" } : { arguments: "" }),
         call_id: callId,
-        name: state.funcNames[tcIdx] || ""
+        name: state.funcNames[tcIdx] || "",
+        ...(state.funcNamespaces[tcIdx] && { namespace: state.funcNamespaces[tcIdx] })
       }
     });
   }
@@ -356,7 +361,8 @@ function closeToolCall(state, emit, idx) {
         type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
         ...(custom ? { input: extractCustomToolInput(args) } : { arguments: args }),
         call_id: callId,
-        name: state.funcNames[idx] || ""
+        name: state.funcNames[idx] || "",
+        ...(state.funcNamespaces[idx] && { namespace: state.funcNamespaces[idx] })
       }
     });
 

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -14,6 +14,17 @@ export { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER };
 // sharedEncoder is stateless — safe to share across streams
 const sharedEncoder = new TextEncoder();
 
+function collectToolNamespaces(tools) {
+  const namespaces = new Map();
+  for (const namespaceTool of tools || []) {
+    if (namespaceTool?.type !== "namespace" || !namespaceTool.name || !Array.isArray(namespaceTool.tools)) continue;
+    for (const tool of namespaceTool.tools) {
+      if (tool?.type === "function" && tool.name) namespaces.set(tool.name, namespaceTool.name);
+    }
+  }
+  return namespaces;
+}
+
 /**
  * Stream modes
  */
@@ -59,7 +70,14 @@ export function createSSEStream(options = {}) {
   const decoder = new TextDecoder("utf-8", { fatal: false });
 
   const state = mode === STREAM_MODE.TRANSLATE
-    ? { ...initState(sourceFormat), provider, toolNameMap, customToolNames: new Set(customToolNames || []), model }
+    ? {
+        ...initState(sourceFormat),
+        provider,
+        toolNameMap,
+        toolNamespaces: collectToolNamespaces(body?.tools),
+        customToolNames: new Set(customToolNames || []),
+        model
+      }
     : null;
 
   let totalContentLength = 0;

--- a/tests/translator/bugs-codexCli-responses.test.js
+++ b/tests/translator/bugs-codexCli-responses.test.js
@@ -1,13 +1,55 @@
 // Real Codex CLI requests (OpenAI Responses API: { input:[], instructions }) → providers.
 import { describe, it, expect } from "vitest";
 import "./registerAll.js";
-import { translateRequest } from "../../open-sse/translator/index.js";
+import { initState, translateRequest, translateResponse } from "../../open-sse/translator/index.js";
 import { FORMATS } from "../../open-sse/translator/formats.js";
 
 const R2O = (body) => translateRequest(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI, "m", body, true, null, null);
 const O2R = (body) => translateRequest(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, "m", body, true, null, null);
 
 describe("Codex CLI Responses → OpenAI", () => {
+  it("round-trips Responses namespace functions through Chat Completions", () => {
+    const out = R2O({
+      input: "Review SQL",
+      tools: [{
+        type: "namespace",
+        name: "ai_audit",
+        tools: [{ type: "function", name: "get_table_metadata", parameters: { type: "object", properties: {} } }],
+      }],
+    });
+    expect(out.tools[0]).toMatchObject({ type: "function", function: { name: "get_table_metadata" } });
+
+    const state = initState(FORMATS.OPENAI_RESPONSES);
+    state.toolNamespaces = new Map([["get_table_metadata", "ai_audit"]]);
+    const events = [
+      ...translateResponse(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, {
+        id: "chatcmpl-1",
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: "call_1",
+              type: "function",
+              function: { name: "get_table_metadata", arguments: '{"table":"pg_tables"}' },
+            }],
+          },
+        }],
+      }, state),
+      ...translateResponse(FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, {
+        id: "chatcmpl-1",
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+      }, state),
+    ];
+    for (const eventName of ["response.output_item.added", "response.output_item.done"]) {
+      expect(events.find(event => event.event === eventName).data.item).toMatchObject({
+        type: "function_call",
+        name: "get_table_metadata",
+        namespace: "ai_audit",
+      });
+    }
+  });
+
   // openai-responses.js:103 — function_call with empty name skipped, can leave tool_calls: []
   // KNOWN BUG: empty tool_calls array is rejected by OpenAI/Codex
   it.fails("assistant has no empty tool_calls array when all names are empty", () => {


### PR DESCRIPTION
## Summary
- flatten Responses namespace tools into Chat Completions function declarations
- restore the original namespace on translated streaming function-call items
- keep the change scoped to namespace request/response translation

## Validation
- direct Node namespace translation smoke test
- `npm run build`