### PR TITLE
fix(translator): resolve model validation response format for Claude Code CLI

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -51,7 +51,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   })();
   const reqTag = log?.tagForSession ? log.tagForSession(sessionSeed) : (log?.nextTag ? log.nextTag() : "");
 
-  const sourceFormat = sourceFormatOverride || detectFormat(body);
+  // Format resolution: Override > Endpoint > Body-based
+  const sourceFormat = sourceFormatOverride || (clientRawRequest?.endpoint?.includes("/messages") ? FORMATS.CLAUDE : detectFormat(body));
 
   // Check for bypass patterns (warmup, skip, cc naming)
   const bypassResponse = handleBypassRequest(body, model, userAgent, ccFilterNaming);

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -95,7 +95,7 @@ export function detectFormat(body) {
     
     // If content is string, it's likely OpenAI (Claude also supports this)
     // Check for other Claude-specific indicators
-    if (body.system !== undefined || body.anthropic_version) {
+    if (body.system !== undefined || body.anthropic_version || body['anthropic-version']) {
       return "claude";
     }
   }

--- a/open-sse/translator/formats.js
+++ b/open-sse/translator/formats.js
@@ -20,11 +20,12 @@ export const FORMATS = {
  * Returns null to fall back to body-based detection.
  */
 export function detectFormatByEndpoint(pathname, body) {
+  if (!pathname) return null;
   // /v1/responses is always openai-responses
   if (pathname.includes("/v1/responses")) return FORMATS.OPENAI_RESPONSES;
 
-  // /v1/messages is always Claude
-  if (pathname.includes("/v1/messages")) return FORMATS.CLAUDE;
+  // /v1/messages or /messages is always Claude
+  if (pathname.includes("/v1/messages") || pathname.includes("/messages")) return FORMATS.CLAUDE;
 
   // /v1/chat/completions + input[] → treat as openai (Cursor CLI sends Responses body via chat endpoint)
   if (pathname.includes("/v1/chat/completions") && Array.isArray(body?.input)) {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -255,8 +255,9 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       pxpipeTransform: chatSettings.pxpipeEnabled ? await getPxpipeTransform() : null,
       onPxpipeEvent: appendPxpipeEvent,
       providerThinking,
-      // Detect source format by endpoint + body
-      sourceFormatOverride: request?.url ? detectFormatByEndpoint(new URL(request.url).pathname, body) : null,
+      sourceFormatOverride: (clientRawRequest?.endpoint || request?.url)
+        ? detectFormatByEndpoint(clientRawRequest?.endpoint || (request?.url?.startsWith("http") ? new URL(request.url).pathname : request?.url || ""), body)
+        : null,
       onCredentialsRefreshed: async (newCreds) => {
         await updateProviderCredentials(credentials.connectionId, {
           ...newCreds,


### PR DESCRIPTION
## Problem

When validating custom models in Claude Code CLI (e.g. `/model cbai/glm-5.2`), Claude Code sends a non-streaming (`stream: false`) POST request to `/v1/messages`.

Upstream OpenAI-compatible providers return standard OpenAI JSON (`{"choices": [...], "usage": {"prompt_tokens": 751}}`). 9router's format resolution defaulted to `openai` because:
1. `detectFormatByEndpoint` was attempting `new URL(request.url)` on relative endpoints, throwing an unhandled `TypeError: Invalid URL`.
2. `detectFormat(body)` did not inspect the endpoint or `anthropic-version` header, falling back to `openai`.

As a result, 9router returned raw OpenAI format JSON without converting it to Anthropic format (`{"type": "message", "usage": {"input_tokens": 751}}`), causing Claude Code CLI to crash with:
`Unable to validate model: undefined is not an object (evaluating 'z.usage.input_tokens')`

## Fix

- **`open-sse/translator/formats.js`**: Update `detectFormatByEndpoint` to match `/messages` endpoints and safely handle null/relative paths.
- **`src/sse/handlers/chat.js`**: Extract endpoint safely from `clientRawRequest?.endpoint` before trying `request?.url` to avoid `Invalid URL` parsing errors.
- **`open-sse/handlers/chatCore.js`**: Set fallback `sourceFormat` to `FORMATS.CLAUDE` whenever the endpoint contains `/messages`.
- **`open-sse/services/provider.js`**: Add support for `anthropic-version` header in format detector.

## Tests

- Verified via non-streaming `POST http://127.0.0.1:20128/v1/messages` with `cbai/glm-5.2`:
  - Returns HTTP 200 OK with `type: "message"` and `usage: { input_tokens, output_tokens }`.
- Verified model validation in Claude Code CLI passes cleanly.