### PR TITLE
feat(codebuddy): shared protocol normalization + account profile refresh

### DIFF
--- a/open-sse/executors/codebuddy-cn.js
+++ b/open-sse/executors/codebuddy-cn.js
@@ -1,13 +1,14 @@
 import { DefaultExecutor } from "./default.js";
+import {
+  sanitizeChatBody,
+  createSseNormalizeTransform,
+} from "../protocol/codebuddy/index.js";
 
 /**
- * CodeBuddyExecutor — talks to https://copilot.tencent.com/v2/chat/completions
+ * CodeBuddyExecutor — thin adapter over protocol/codebuddy.
  *
- * CodeBuddy is OpenAI-compatible but rejects non-stream chat requests
- * (HTTP 400, code 11101 "Non-stream chat request is currently not supported").
- * The same-format (openai→openai) translator path leaves body.stream as the
- * client sent it, so we force it true here — 9router still re-aggregates the
- * SSE into a JSON response for non-streaming clients.
+ * Upstream: OpenAI Chat Completions at copilot.tencent.com/v2/chat/completions.
+ * Wire rules (allowlist, reasoning gate, stream force, SSE dirt) live in protocol/.
  */
 export class CodeBuddyExecutor extends DefaultExecutor {
   constructor() {
@@ -15,26 +16,23 @@ export class CodeBuddyExecutor extends DefaultExecutor {
   }
 
   transformRequest(model, body, stream, credentials) {
-    const transformed = super.transformRequest(model, body, stream, credentials);
-    transformed.stream = true;
+    // DefaultExecutor: json_schema fallback + stripUnsupportedParams + injectReasoningContent
+    // (injector is a no-op for this provider). Then protocol allowlist.
+    const base = super.transformRequest(model, body, stream, credentials);
+    return sanitizeChatBody(base && typeof base === "object" ? base : body);
+  }
 
-    // CodeBuddy only surfaces model reasoning when the request carries the CLI's
-    // OpenAI-style params: reasoning_effort + reasoning_summary:"auto". 9router's
-    // thinking pipeline sets reasoning_effort only when the client asks, and never
-    // sets reasoning_summary — so reasoning never shows. Mirror the CLI here.
-    const eff = transformed.reasoning_effort;
-    if (eff === "none" || eff === "off") {
-      delete transformed.reasoning_effort; // gateway has no "none" — just omit
-    } else if (eff) {
-      // Client explicitly asked for reasoning — mirror the CLI's reasoning_summary
-      // so CodeBuddy surfaces the model's reasoning.
-      transformed.reasoning_summary = "auto";
-    }
-    // No reasoning requested: leave both unset. Forcing reasoning_effort:"medium"
-    // + reasoning_summary on plain requests makes CodeBuddy trip its content
-    // filter and return an error (#2071).
-    return transformed;
+  async execute(opts) {
+    const result = await super.execute(opts);
+    if (!result?.response?.ok || !result.response.body) return result;
+
+    const normalized = result.response.body.pipeThrough(createSseNormalizeTransform());
+    const response = new Response(normalized, {
+      status: result.response.status,
+      statusText: result.response.statusText,
+      headers: result.response.headers,
+    });
+    return { ...result, response };
   }
 }
 
-export default CodeBuddyExecutor;

--- a/open-sse/executors/codebuddy-intl.js
+++ b/open-sse/executors/codebuddy-intl.js
@@ -1,12 +1,9 @@
 import { DefaultExecutor } from "./default.js";
+import { sanitizeChatBody } from "../protocol/codebuddy/index.js";
 
 /**
- * CodeBuddyIntlExecutor — talks to https://www.codebuddy.ai/v2/chat/completions
- *
- * Same OpenAI-compatible-but-stream-only gateway behavior as codebuddy-cn:
- * non-stream requests are rejected, and reasoning is surfaced only when the
- * request carries the IDE's OpenAI-style reasoning params. Force stream and
- * mirror reasoning_summary exactly like CodeBuddyExecutor.
+ * CodeBuddy Intl uses the shared stream and reasoning rules while preserving
+ * its broader OpenAI-compatible request body.
  */
 export class CodeBuddyIntlExecutor extends DefaultExecutor {
   constructor() {
@@ -15,16 +12,9 @@ export class CodeBuddyIntlExecutor extends DefaultExecutor {
 
   transformRequest(model, body, stream, credentials) {
     const transformed = super.transformRequest(model, body, stream, credentials);
-    transformed.stream = true;
-
-    const eff = transformed.reasoning_effort;
-    if (eff === "none" || eff === "off") {
-      delete transformed.reasoning_effort;
-    } else if (eff) {
-      transformed.reasoning_summary = "auto";
-    }
-    return transformed;
+    return sanitizeChatBody(transformed && typeof transformed === "object" ? transformed : body, {
+      preserveUnknownFields: true,
+    });
   }
 }
 
-export default CodeBuddyIntlExecutor;

--- a/open-sse/protocol/codebuddy/constants.js
+++ b/open-sse/protocol/codebuddy/constants.js
@@ -1,0 +1,36 @@
+/**
+ * CodeBuddy CN chat wire constants.
+ *
+ * The gateway is OpenAI-shaped, but the CN transport intentionally forwards
+ * only fields verified for its chat contract. Unsupported passthrough fields
+ * remain stripped at the protocol boundary.
+ */
+
+/** Top-level fields forwarded when present. */
+export const CHAT_BODY_ALLOWLIST = Object.freeze([
+  "model",
+  "messages",
+  "stream",
+  "temperature",
+  "top_p",
+  "top_k",
+  "n",
+  "stop",
+  "max_tokens",
+  "max_completion_tokens",
+  "presence_penalty",
+  "frequency_penalty",
+  "logit_bias",
+  "user",
+  "tools",
+  "tool_choice",
+  "parallel_tool_calls",
+  "response_format",
+  "seed",
+  // Conditional — kept only when effort is on (see request.js).
+  "reasoning_effort",
+  "reasoning_summary",
+]);
+
+/** Effort values that mean "do not send reasoning params". */
+export const REASONING_OFF = Object.freeze(new Set(["none", "off", ""]));

--- a/open-sse/protocol/codebuddy/index.js
+++ b/open-sse/protocol/codebuddy/index.js
@@ -1,0 +1,7 @@
+/**
+ * CodeBuddy protocol public surface. Executors stay thin while request and
+ * response wire rules remain centralized here.
+ */
+
+export { sanitizeChatBody } from "./request.js";
+export { createSseNormalizeTransform } from "./response.js";

--- a/open-sse/protocol/codebuddy/request.js
+++ b/open-sse/protocol/codebuddy/request.js
@@ -1,0 +1,48 @@
+/**
+ * Normalize an OpenAI-shaped chat body for CodeBuddy.
+ * CodeBuddy CN uses the verified allowlist; broader gateways may preserve
+ * unknown top-level fields while sharing reasoning, tools, and stream rules.
+ */
+
+import { CHAT_BODY_ALLOWLIST, REASONING_OFF } from "./constants.js";
+
+/**
+ * @param {object} body
+ * @param {{ preserveUnknownFields?: boolean }} [options]
+ * @returns {object}
+ */
+export function sanitizeChatBody(body, { preserveUnknownFields = false } = {}) {
+  if (!body || typeof body !== "object") {
+    return { stream: true, messages: [] };
+  }
+
+  const out = preserveUnknownFields ? { ...body } : {};
+  if (!preserveUnknownFields) {
+    for (const key of CHAT_BODY_ALLOWLIST) {
+      if (body[key] !== undefined) out[key] = body[key];
+    }
+  }
+
+  // Gateway rejects non-stream chat (HTTP 400 code 11101).
+  out.stream = true;
+
+  const effRaw = out.reasoning_effort;
+  const eff =
+    typeof effRaw === "string" ? effRaw.trim().toLowerCase() : effRaw == null ? "" : String(effRaw);
+
+  if (!eff || REASONING_OFF.has(eff)) {
+    delete out.reasoning_effort;
+    delete out.reasoning_summary;
+  } else {
+    // The gateway surfaces model reasoning when summary is "auto" alongside
+    // effort. Only attach it when the client actually requested reasoning.
+    if (out.reasoning_summary == null || out.reasoning_summary === "") {
+      out.reasoning_summary = "auto";
+    }
+  }
+
+  // Empty tools array is useless noise; some gateways reject it.
+  if (Array.isArray(out.tools) && out.tools.length === 0) delete out.tools;
+
+  return out;
+}

--- a/open-sse/protocol/codebuddy/request.test.js
+++ b/open-sse/protocol/codebuddy/request.test.js
@@ -1,0 +1,164 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeChatBody } from "./request.js";
+import { normalizeChatChunk } from "./response.js";
+
+describe("codebuddy sanitizeChatBody", () => {
+  it("forces stream and drops non-minimal top-level keys", () => {
+    const out = sanitizeChatBody({
+      model: "hy3-preview",
+      messages: [{ role: "user", content: "hi" }],
+      stream: false,
+      // Valid hub Chat fields — still dropped here (minimal CodeBuddy proxy)
+      store: true,
+      metadata: { x: 1 },
+      service_tier: "default",
+      stream_options: { include_usage: true },
+      modalities: ["text"],
+      functions: [],
+      function_call: "auto",
+      extra_body: { thinking: { type: "enabled" } },
+      client_metadata: { a: 1 },
+      thinking: { type: "enabled" },
+      temperature: 0.2,
+    });
+    assert.equal(out.stream, true);
+    assert.equal(out.model, "hy3-preview");
+    assert.equal(out.temperature, 0.2);
+    assert.equal(out.store, undefined);
+    assert.equal(out.metadata, undefined);
+    assert.equal(out.service_tier, undefined);
+    assert.equal(out.stream_options, undefined);
+    assert.equal(out.modalities, undefined);
+    assert.equal(out.functions, undefined);
+    assert.equal(out.function_call, undefined);
+    assert.equal(out.extra_body, undefined);
+    assert.equal(out.client_metadata, undefined);
+    assert.equal(out.thinking, undefined);
+  });
+
+  it("keeps multimodal messages and non-empty tools while stripping unknown CN fields", () => {
+    const content = [
+      { type: "text", text: "describe" },
+      { type: "image_url", image_url: { url: "data:image/png;base64,AA==" } },
+    ];
+    const tools = [{ type: "function", function: { name: "lookup", parameters: { type: "object" } } }];
+    const out = sanitizeChatBody({
+      messages: [{ role: "user", content }],
+      tools,
+      unknown_top_level: { keep: false },
+      stream: false,
+    });
+
+    assert.deepEqual(out.messages[0].content, content);
+    assert.deepEqual(out.tools, tools);
+    assert.equal(out.unknown_top_level, undefined);
+    assert.equal(out.stream, true);
+  });
+
+  it("preserves unknown Intl fields when explicitly requested", () => {
+    const body = {
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      tools: [{ type: "function", function: { name: "lookup" } }],
+      unknown_top_level: { keep: true },
+      stream: false,
+    };
+    const out = sanitizeChatBody(body, { preserveUnknownFields: true });
+
+    assert.deepEqual(out.unknown_top_level, { keep: true });
+    assert.deepEqual(out.messages, body.messages);
+    assert.deepEqual(out.tools, body.tools);
+    assert.equal(out.stream, true);
+  });
+
+  it("omits reasoning params on plain chat", () => {
+    const out = sanitizeChatBody({
+      model: "hy3-preview",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    assert.equal(out.reasoning_effort, undefined);
+    assert.equal(out.reasoning_summary, undefined);
+  });
+
+  it("drops empty, none, and off effort and never adds summary", () => {
+    for (const effort of ["", "  ", "none", "off", "NONE"]) {
+      const out = sanitizeChatBody({
+        model: "hy3-preview",
+        messages: [],
+        reasoning_effort: effort,
+        reasoning_summary: "auto",
+      });
+      assert.equal(out.reasoning_effort, undefined, effort);
+      assert.equal(out.reasoning_summary, undefined, effort);
+    }
+  });
+
+  it("keeps effort and defaults reasoning_summary to auto", () => {
+    const out = sanitizeChatBody({
+      model: "hy3-preview",
+      messages: [],
+      reasoning_effort: "medium",
+    });
+    assert.equal(out.reasoning_effort, "medium");
+    assert.equal(out.reasoning_summary, "auto");
+  });
+
+  it("preserves an explicit non-empty reasoning_summary", () => {
+    const out = sanitizeChatBody({
+      model: "hy3-preview",
+      messages: [],
+      reasoning_effort: "high",
+      reasoning_summary: "detailed",
+    });
+    assert.equal(out.reasoning_effort, "high");
+    assert.equal(out.reasoning_summary, "detailed");
+  });
+
+  it("removes empty tools array", () => {
+    const out = sanitizeChatBody({ model: "x", messages: [], tools: [] });
+    assert.equal(out.tools, undefined);
+  });
+});
+
+describe("codebuddy normalizeChatChunk", () => {
+  it("maps empty finish_reason to null", () => {
+    const out = normalizeChatChunk({
+      object: "chat.completion.chunk",
+      choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: "" }],
+    });
+    assert.equal(out.choices[0].finish_reason, null);
+  });
+
+  it("drops empty function_call shells", () => {
+    const out = normalizeChatChunk({
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: "",
+            function_call: { name: "", arguments: "" },
+          },
+          finish_reason: null,
+        },
+      ],
+    });
+    assert.equal(out.choices[0].delta.function_call, undefined);
+    assert.equal(out.choices[0].delta.content, "");
+  });
+
+  it("keeps real finish_reason and tool deltas", () => {
+    const chunk = {
+      choices: [
+        {
+          delta: {
+            tool_calls: [{ index: 0, function: { name: "x", arguments: "{" } }],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    };
+    const out = normalizeChatChunk(chunk);
+    assert.equal(out.choices[0].finish_reason, "tool_calls");
+    assert.ok(out.choices[0].delta.tool_calls);
+  });
+});

--- a/open-sse/protocol/codebuddy/response.js
+++ b/open-sse/protocol/codebuddy/response.js
@@ -1,0 +1,87 @@
+/**
+ * Normalize CodeBuddy chat.completion.chunk dirt to OpenAI mid-stream norms.
+ * - finish_reason:"" → null (not terminal)
+ * - empty function_call shells on delta → drop
+ */
+
+/**
+ * @param {object} chunk
+ * @returns {object}
+ */
+export function normalizeChatChunk(chunk) {
+  if (!chunk || typeof chunk !== "object" || !Array.isArray(chunk.choices)) {
+    return chunk;
+  }
+
+  let changed = false;
+  const choices = chunk.choices.map((choice) => {
+    if (!choice || typeof choice !== "object") return choice;
+    let next = choice;
+
+    if (choice.finish_reason === "") {
+      next = { ...next, finish_reason: null };
+      changed = true;
+    }
+
+    const delta = next.delta;
+    if (delta && typeof delta === "object" && delta.function_call) {
+      const fc = delta.function_call;
+      const name = fc?.name;
+      const args = fc?.arguments;
+      const emptyName = name == null || name === "";
+      const emptyArgs = args == null || args === "";
+      if (emptyName && emptyArgs) {
+        const { function_call: _drop, ...restDelta } = delta;
+        next = { ...next, delta: restDelta };
+        changed = true;
+      }
+    }
+
+    return next;
+  });
+
+  return changed ? { ...chunk, choices } : chunk;
+}
+
+/**
+ * TransformStream: rewrite SSE `data: {...}` JSON lines through normalizeChatChunk.
+ * Pass-through for [DONE], comments, and non-JSON data.
+ * @returns {TransformStream}
+ */
+export function createSseNormalizeTransform() {
+  let buffer = "";
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+
+  return new TransformStream({
+    transform(chunk, controller) {
+      buffer += typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+      const parts = buffer.split("\n");
+      buffer = parts.pop() ?? "";
+
+      for (const line of parts) {
+        controller.enqueue(encoder.encode(`${rewriteSseLine(line)}\n`));
+      }
+    },
+    flush(controller) {
+      if (buffer.length) {
+        controller.enqueue(encoder.encode(rewriteSseLine(buffer)));
+        buffer = "";
+      }
+    },
+  });
+}
+
+function rewriteSseLine(line) {
+  if (!line.startsWith("data:")) return line;
+  const payload = line.slice(5).trimStart();
+  if (!payload || payload === "[DONE]") return line;
+  try {
+    const obj = JSON.parse(payload);
+    const norm = normalizeChatChunk(obj);
+    if (norm === obj) return line;
+    return `data: ${JSON.stringify(norm)}`;
+  } catch {
+    return line;
+  }
+}

--- a/open-sse/providers/registry/codebuddy-cn.js
+++ b/open-sse/providers/registry/codebuddy-cn.js
@@ -43,6 +43,14 @@ export default {
     usage: {
       url: "https://copilot.tencent.com/v2/billing/meter/get-user-resource",
     },
+    modelDiscovery: {
+      urlTemplate: "https://copilot.tencent.com/console/enterprises/{enterpriseId}/models",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "CodeBuddy/5.3.3",
+        "X-Requested-With": "XMLHttpRequest",
+      },
+    },
   },
   models: [
     { id: "glm-5.2", name: "GLM-5.2" },
@@ -73,5 +81,6 @@ export default {
   features: {
     usage: true,
     usageApikey: true,
+    profileRefresh: true,
   },
 };

--- a/open-sse/services/codebuddyCnModels.js
+++ b/open-sse/services/codebuddyCnModels.js
@@ -1,0 +1,68 @@
+// CodeBuddy CN model discovery + capability extraction.
+//
+// This service owns the upstream response contract while the provider registry
+// owns transport endpoints and headers. The route only publishes the resulting
+// model and capability projections.
+
+import { PROVIDERS } from "../providers/index.js";
+
+const PROVIDER_ID = "codebuddy-cn";
+
+/**
+ * Map one raw CodeBuddy model into a capability patch.
+ * Exported so the route can pass it straight to publishDiscoveredCaps without
+ * duplicating field names across providers.
+ */
+export function mapCodebuddyCnCaps(m) {
+  const caps = {};
+  if (typeof m.supportsImages === "boolean") caps.vision = m.supportsImages;
+  if (typeof m.supportsToolCall === "boolean") caps.tools = m.supportsToolCall;
+  if (typeof m.supportsReasoning === "boolean") caps.reasoning = m.supportsReasoning;
+  if (m.maxInputTokens) caps.contextWindow = m.maxInputTokens;
+  if (m.maxOutputTokens) caps.maxOutput = m.maxOutputTokens;
+  return caps;
+}
+
+/**
+ * Fetch the live model list + raw models (for cap publishing).
+ * @returns {Promise<{models?: Array<{id,name}>, rawModels?: object[], error?: string, status?: number}>}
+ */
+export async function resolveCodebuddyCnModels(connection) {
+  const token = connection.accessToken;
+  if (!token) return { error: "No access token", status: 401 };
+
+  const config = PROVIDERS[PROVIDER_ID]?.modelDiscovery;
+  if (!config?.urlTemplate) return { error: "Model discovery not configured", status: 500 };
+
+  const eid = connection.providerSpecificData?.enterpriseId || "personal";
+  const url = config.urlTemplate.replace("{enterpriseId}", eid);
+
+  let response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        ...(config.headers || {}),
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch (e) {
+    return { error: `Fetch failed: ${e.message}`, status: 502 };
+  }
+
+  if (!response.ok) {
+    return { error: `Upstream ${response.status}`, status: response.status };
+  }
+
+  const data = await response.json();
+  const allModels = (data?.data?.models || []).filter(Boolean);
+
+  // Client filters to models the "cli" agent is allowed to use; surface only
+  // those — otherwise we'd show image-only models (hunyuan-image etc.).
+  const cliAgent = (data?.data?.agents || []).find((a) => a.name === "cli");
+  const cliIds = cliAgent?.models ?? [];
+  const rawModels = cliIds.length ? allModels.filter((m) => cliIds.includes(m.id)) : allModels;
+
+  const models = rawModels.filter((m) => m?.id).map((m) => ({ id: m.id, name: m.name || m.id }));
+  return { models, rawModels };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -77,6 +77,7 @@ export default function ProviderDetailPage() {
   const [oneByOneCurrentConnectionId, setOneByOneCurrentConnectionId] = useState(null);
   const [oneByOneResults, setOneByOneResults] = useState({});
   const [oneByOneSummary, setOneByOneSummary] = useState(null);
+  const [refreshingAllProfiles, setRefreshingAllProfiles] = useState(false);
   const stopOneByOneRef = useRef(false);
   const [importingQoderModels, setImportingQoderModels] = useState(false);
   const { copied, copy } = useCopyToClipboard();
@@ -143,6 +144,7 @@ export default function ProviderDetailPage() {
   const isOAuth = !!OAUTH_PROVIDERS[providerId] || !!FREE_PROVIDERS[providerId] || authModes.includes("oauth");
   const supportsApiKeyAuth = !!APIKEY_PROVIDERS[providerId] || authModes.includes("apikey");
   const isFreeNoAuth = !!FREE_PROVIDERS[providerId]?.noAuth;
+  const supportsProfileRefresh = providerInfo?.features?.profileRefresh === true;
   const staticModels = getModelsByProviderId(providerId);
   const models = providerId === "cursor" && liveModels.length > 0
     ? liveModels
@@ -484,6 +486,42 @@ export default function ProviderDetailPage() {
 
     return () => { cancelled = true; };
   }, [providerId, connections]);
+
+  const handleRefreshProfile = async (connectionId) => {
+    try {
+      const res = await fetch(`/api/providers/${connectionId}/refresh-profile`, {
+        method: "POST",
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        console.warn("Profile refresh request failed");
+        return;
+      }
+      if (data.connection) {
+        setConnections((prev) =>
+          prev.map((c) => (c.id === connectionId ? { ...c, ...data.connection } : c)),
+        );
+      } else {
+        await fetchConnections();
+      }
+    } catch {
+      console.warn("Profile refresh request failed");
+    }
+  };
+
+  const handleRefreshAllProfiles = async () => {
+    if (!supportsProfileRefresh || refreshingAllProfiles) return;
+    const targets = connections.filter((c) => c.authType === "oauth");
+    if (targets.length === 0) return;
+    setRefreshingAllProfiles(true);
+    try {
+      for (const conn of targets) {
+        await handleRefreshProfile(conn.id);
+      }
+    } finally {
+      setRefreshingAllProfiles(false);
+    }
+  };
 
   // Fetch suggested models from provider's public API (if configured)
   useEffect(() => {
@@ -1454,6 +1492,17 @@ export default function ProviderDetailPage() {
                   >
                     {oneByOneRunning ? "Testing Connection One-by-One..." : "Test Connection One-by-One"}
                   </Button>
+                  {supportsProfileRefresh && connections.some((c) => c.authType === "oauth") && (
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      icon={refreshingAllProfiles ? "progress_activity" : "sync"}
+                      onClick={handleRefreshAllProfiles}
+                      disabled={refreshingAllProfiles}
+                    >
+                      {refreshingAllProfiles ? "刷新中..." : "全部刷新"}
+                    </Button>
+                  )}
                   {oneByOneRunning && (
                     <Button
                       size="sm"

--- a/src/app/api/providers/[id]/refresh-profile/route.js
+++ b/src/app/api/providers/[id]/refresh-profile/route.js
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server";
+import { getProviderConnectionById, updateProviderConnection } from "@/models";
+import { extractCodebuddyProfileFromToken } from "@/shared/utils/codebuddyProfile";
+import {
+  extractQoderworkProfileFromUserinfo,
+  mergePersistedProfileData,
+} from "@/shared/utils/qoderworkProfile";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/providers/[id]/refresh-profile
+ * - codebuddy-cn: JWT nickname + masked phone
+ * - qoderwork-cn: userinfo name + optional phone-like mask
+ */
+export async function POST(_request, { params }) {
+  try {
+    const { id } = await params;
+    const existing = await getProviderConnectionById(id);
+    if (!existing) {
+      return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+    }
+
+    if (existing.authType !== "oauth") {
+      return NextResponse.json(
+        { error: "Only OAuth connections support profile refresh" },
+        { status: 400 },
+      );
+    }
+
+    const accessToken = existing.accessToken;
+    if (!accessToken || typeof accessToken !== "string") {
+      return NextResponse.json({ error: "Missing access token" }, { status: 401 });
+    }
+
+    if (existing.provider === "codebuddy-cn") {
+      const profile = extractCodebuddyProfileFromToken(accessToken);
+      if (!profile.nickname && !profile.phoneMasked) {
+        return NextResponse.json(
+          { error: "No profile fields found in token" },
+          { status: 422 },
+        );
+      }
+      const updateData = {
+        providerSpecificData: mergePersistedProfileData(
+          existing.providerSpecificData,
+          {
+            ...(profile.phoneMasked ? { phoneMasked: profile.phoneMasked } : {}),
+          },
+        ),
+      };
+      if (profile.nickname) updateData.name = profile.nickname;
+      if (profile.sub) updateData.providerSpecificData.uid = profile.sub;
+      const updated = await updateProviderConnection(id, updateData);
+      if (!updated) {
+        return NextResponse.json({ error: "Failed to update connection" }, { status: 500 });
+      }
+      const result = { ...updated };
+      delete result.apiKey;
+      delete result.accessToken;
+      delete result.refreshToken;
+      delete result.idToken;
+      if (result.providerSpecificData?.phone) {
+        const { phone, ...rest } = result.providerSpecificData;
+        result.providerSpecificData = rest;
+      }
+      return NextResponse.json({ success: true, connection: result });
+    }
+
+    if (existing.provider === "qoderwork-cn") {
+      const { QoderService } = await import("@/lib/oauth/services/qoder");
+      const svc = new QoderService({ profile: "cn-work" });
+      const userinfoRaw = await svc.fetchUserInfo(accessToken);
+      // fetchUserInfo currently returns only name/email/org — call openapi for full body
+      let full = null;
+      try {
+        const res = await fetch("https://openapi.qoder.com.cn/api/v1/userinfo", {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: "application/json",
+            "User-Agent": "QoderWork",
+          },
+        });
+        if (res.ok) full = await res.json();
+      } catch {
+        full = null;
+      }
+      if (!full) {
+        full = {
+          name: userinfoRaw?.name,
+          email: userinfoRaw?.email,
+          id: existing.providerSpecificData?.userId,
+        };
+      }
+      const profile = extractQoderworkProfileFromUserinfo(full);
+
+      const updateData = {
+        providerSpecificData: mergePersistedProfileData(
+          existing.providerSpecificData,
+          {
+            ...(profile.phoneMasked ? { phoneMasked: profile.phoneMasked } : {}),
+          },
+        ),
+      };
+      if (profile.displayName) {
+        updateData.name = profile.displayName;
+        updateData.displayName = profile.displayName;
+      }
+      if (profile.loginSource) {
+        updateData.providerSpecificData.loginSource = profile.loginSource;
+      }
+      if (profile.userId) {
+        updateData.providerSpecificData.userId = profile.userId;
+      }
+
+      const updated = await updateProviderConnection(id, updateData);
+      if (!updated) {
+        return NextResponse.json({ error: "Failed to update connection" }, { status: 500 });
+      }
+      const result = { ...updated };
+      delete result.apiKey;
+      delete result.accessToken;
+      delete result.refreshToken;
+      delete result.idToken;
+      if (result.providerSpecificData?.phone) {
+        const { phone, ...rest } = result.providerSpecificData;
+        result.providerSpecificData = rest;
+      }
+      return NextResponse.json({
+        success: true,
+        connection: result,
+      });
+    }
+
+    return NextResponse.json(
+      { error: `Profile refresh not supported for provider ${existing.provider}` },
+      { status: 400 },
+    );
+  } catch {
+    console.error("Profile refresh failed");
+    return NextResponse.json(
+      { error: "Failed to refresh profile" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -33,6 +33,7 @@ function buildProviderEntry(r) {
     ...(r.passthroughModels ? { passthroughModels: true } : {}),
     ...(r.hasOAuth ? { hasOAuth: true } : {}),
     ...(r.authModes ? { authModes: r.authModes } : {}),
+    ...(r.features ? { features: { ...r.features } } : {}),
     ...(r.authType ? { authType: r.authType } : {}),
     ...(r.authHint ? { authHint: r.authHint } : {}),
   };

--- a/src/shared/utils/codebuddyProfile.js
+++ b/src/shared/utils/codebuddyProfile.js
@@ -1,0 +1,92 @@
+/**
+ * CodeBuddy CN connection profile helpers (local UX).
+ * Mask phone for badges; decode JWT claims for manual profile refresh.
+ */
+
+const BASE64_BLOCK_SIZE = 4;
+
+/**
+ * Mask the middle 4 characters of any string (works for multi-country phone lengths).
+ * @param {string} value
+ * @returns {string}
+ */
+export function maskMiddle4(value) {
+  const s = String(value ?? "").trim();
+  if (!s) return "";
+  if (s.length <= 4) return "*".repeat(s.length);
+  if (s.length === 5) return `${s[0]}***${s[4]}`;
+  if (s.length === 6) return `${s.slice(0, 1)}****${s.slice(5)}`;
+  const start = Math.floor((s.length - 4) / 2);
+  return `${s.slice(0, start)}****${s.slice(start + 4)}`;
+}
+
+/**
+ * Decode a JWT payload without verifying the signature (display / local field only).
+ * Works in Node (Buffer) and browser (atob).
+ * @param {string} jwt
+ * @returns {Record<string, unknown>|null}
+ */
+export function decodeJwtPayloadSafe(jwt) {
+  try {
+    if (!jwt || typeof jwt !== "string") return null;
+    const parts = jwt.split(".");
+    if (parts.length !== 3) return null;
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const missingPadding = (BASE64_BLOCK_SIZE - (base64.length % BASE64_BLOCK_SIZE)) % BASE64_BLOCK_SIZE;
+    const padded = base64 + "=".repeat(missingPadding);
+    let json;
+    if (typeof Buffer !== "undefined") {
+      json = Buffer.from(padded, "base64").toString("utf8");
+    } else if (typeof atob === "function") {
+      json = decodeURIComponent(
+        Array.from(atob(padded), (c) => `%${c.charCodeAt(0).toString(16).padStart(2, "0")}`).join(""),
+      );
+    } else {
+      return null;
+    }
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a string looks like a phone / login id we should mask as a phone badge.
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function looksLikePhone(value) {
+  const s = String(value ?? "").trim();
+  if (!s) return false;
+  // digits with optional leading +, spaces, dashes — strip non-digits for length check
+  const digits = s.replace(/\D/g, "");
+  return digits.length >= 6 && digits.length <= 15;
+}
+
+/**
+ * Extract display name + phone fields from a CodeBuddy access token JWT.
+ * @param {string} accessToken
+ * @returns {{ nickname: string|null, phone: string|null, phoneMasked: string|null, sub: string|null }}
+ */
+export function extractCodebuddyProfileFromToken(accessToken) {
+  const payload = decodeJwtPayloadSafe(accessToken);
+  if (!payload || typeof payload !== "object") {
+    return { nickname: null, phone: null, phoneMasked: null, sub: null };
+  }
+  const nickname =
+    (typeof payload.nickname === "string" && payload.nickname.trim()) ||
+    (typeof payload.name === "string" && payload.name.trim()) ||
+    null;
+  const preferred =
+    typeof payload.preferred_username === "string" ? payload.preferred_username.trim() : "";
+  const digits = preferred.replace(/\D/g, "");
+  const phone = looksLikePhone(preferred) ? digits : null;
+  const phoneMasked = phone ? maskMiddle4(phone) : null;
+  const sub = typeof payload.sub === "string" ? payload.sub : null;
+  return {
+    nickname,
+    phone,
+    phoneMasked,
+    sub,
+  };
+}

--- a/src/shared/utils/qoderworkProfile.js
+++ b/src/shared/utils/qoderworkProfile.js
@@ -1,0 +1,69 @@
+/**
+ * QoderWork CN connection profile helpers (local UX).
+ * Userinfo has no dedicated phone field in current wire; mask only when
+ * name/login looks phone-like. Check-in status maps sash daily-check-in.
+ */
+
+import { maskMiddle4, looksLikePhone } from "./codebuddyProfile.js";
+/**
+ * Merge profile fields into provider-specific data without accepting a newly
+ * fetched raw phone number. A historical phone already present on a connection
+ * is left untouched for backward compatibility and remains response-filtered.
+ */
+export function mergePersistedProfileData(existing, patch) {
+  const safePatch = { ...(patch || {}) };
+  delete safePatch.phone;
+  return { ...(existing || {}), ...safePatch };
+}
+
+/**
+ * @param {object|null|undefined} userinfo - GET openapi /api/v1/userinfo body
+ * @returns {{
+ *   displayName: string|null,
+ *   phone: string|null,
+ *   phoneMasked: string|null,
+ *   loginSource: string|null,
+ *   userId: string|null,
+ * }}
+ */
+export function extractQoderworkProfileFromUserinfo(userinfo) {
+  if (!userinfo || typeof userinfo !== "object") {
+    return {
+      displayName: null,
+      phone: null,
+      phoneMasked: null,
+      loginSource: null,
+      userId: null,
+    };
+  }
+  const displayName =
+    (typeof userinfo.name === "string" && userinfo.name.trim()) ||
+    (typeof userinfo.username === "string" && userinfo.username.trim()) ||
+    null;
+  // Prefer explicit phone fields. Only fall back to name/username when the
+  // entire value is phone-shaped (not aliyun7850... style logins).
+  const explicit = [userinfo.phone, userinfo.mobile, userinfo.telephone]
+    .filter((v) => typeof v === "string" && v.trim())
+    .map((v) => v.trim());
+  const fallback = [userinfo.name, userinfo.username]
+    .filter((v) => typeof v === "string" && v.trim())
+    .map((v) => v.trim())
+    .filter((v) => /^\+?[\d\s-]{6,20}$/.test(v));
+
+  let phone = null;
+  for (const c of [...explicit, ...fallback]) {
+    if (looksLikePhone(c)) {
+      phone = c.replace(/\D/g, "");
+      break;
+    }
+  }
+  const phoneMasked = phone ? maskMiddle4(phone) : null;
+  const loginSource =
+    (typeof userinfo.source === "string" && userinfo.source.trim()) ||
+    (Array.isArray(userinfo.third_party_identities) &&
+      userinfo.third_party_identities[0]?.provider) ||
+    null;
+  const userId = typeof userinfo.id === "string" ? userinfo.id : null;
+  return { displayName, phone, phoneMasked, loginSource, userId };
+}
+

--- a/src/shared/utils/timezone.js
+++ b/src/shared/utils/timezone.js
@@ -1,0 +1,15 @@
+/**
+ * Return a calendar-day key (YYYY-MM-DD) for an instant in an IANA timezone.
+ *
+ * @param {string} timeZone
+ * @param {Date} date
+ * @returns {string}
+ */
+export function dayKeyInTimeZone(timeZone, date = new Date()) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}

--- a/tests/unit/codebuddy-cn-provider-config.test.js
+++ b/tests/unit/codebuddy-cn-provider-config.test.js
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PROVIDERS } from "../../open-sse/providers/index.js";
+import { resolveCodebuddyCnModels } from "../../open-sse/services/codebuddyCnModels.js";
+
+const originalFetch = global.fetch;
+const config = PROVIDERS["codebuddy-cn"];
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("CodeBuddy CN provider-owned service transport", () => {
+  it("uses registry model-discovery endpoint and headers", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            models: [{ id: "glm-5.2", name: "GLM-5.2", supportsReasoning: true }],
+            agents: [{ name: "cli", models: ["glm-5.2"] }],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await expect(
+      resolveCodebuddyCnModels({
+        accessToken: "model-token",
+        providerSpecificData: { enterpriseId: "enterprise-1" },
+      }),
+    ).resolves.toMatchObject({ models: [{ id: "glm-5.2", name: "GLM-5.2" }] });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      config.modelDiscovery.urlTemplate.replace("{enterpriseId}", "enterprise-1"),
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          ...config.modelDiscovery.headers,
+          Authorization: "Bearer model-token",
+        },
+      }),
+    );
+  });
+});

--- a/tests/unit/codebuddy-reasoning-optin.test.js
+++ b/tests/unit/codebuddy-reasoning-optin.test.js
@@ -1,37 +1,64 @@
-// #2071 — CodeBuddy forced reasoning_effort:"medium" + reasoning_summary:"auto"
-// on requests where the client never asked for reasoning, tripping CodeBuddy's
-// content filter ("model return error"). Reasoning params must be opt-in.
 import { describe, it, expect } from "vitest";
 import { CodeBuddyExecutor } from "../../open-sse/executors/codebuddy-cn.js";
+import { CodeBuddyIntlExecutor } from "../../open-sse/executors/codebuddy-intl.js";
 
-describe("CodeBuddyExecutor reasoning params are opt-in (#2071)", () => {
-  const exec = new CodeBuddyExecutor();
+const executors = [
+  { name: "CN", executor: new CodeBuddyExecutor(), preservesUnknownFields: false },
+  { name: "Intl", executor: new CodeBuddyIntlExecutor(), preservesUnknownFields: true },
+];
 
-  it("does NOT force reasoning when the client did not request it", () => {
-    const out = exec.transformRequest("glm-5.2", { messages: [{ role: "user", content: "hi" }] }, false, {});
-    expect(out.reasoning_effort).toBeUndefined();
-    expect(out.reasoning_summary).toBeUndefined();
+describe.each(executors)("CodeBuddy $name request normalization", ({ executor, preservesUnknownFields }) => {
+  const transform = (body) => executor.transformRequest("glm-5.2", body, false, {});
+
+  it("forces stream while preserving multimodal content and non-empty tools", () => {
+    const content = [
+      { type: "text", text: "describe" },
+      { type: "image_url", image_url: { url: "data:image/png;base64,AA==" } },
+    ];
+    const tools = [{ type: "function", function: { name: "lookup", parameters: { type: "object" } } }];
+    const out = transform({
+      messages: [{ role: "user", content }],
+      tools,
+      unknown_top_level: { retainedByIntl: true },
+      stream: false,
+    });
+
+    expect(out.stream).toBe(true);
+    expect(out.messages[0].content).toEqual(content);
+    expect(out.tools).toEqual(tools);
+    if (preservesUnknownFields) {
+      expect(out.unknown_top_level).toEqual({ retainedByIntl: true });
+    } else {
+      expect(out.unknown_top_level).toBeUndefined();
+    }
   });
 
-  it("mirrors reasoning_summary:auto when the client explicitly requested reasoning", () => {
-    const out = exec.transformRequest(
-      "glm-5.2",
-      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
-      false,
-      {}
-    );
+  it("removes empty tools", () => {
+    expect(transform({ messages: [], tools: [] }).tools).toBeUndefined();
+  });
+
+  it.each([undefined, "", "  ", "none", "off"])(
+    "omits disabled reasoning for effort %p",
+    (reasoning_effort) => {
+      const out = transform({ messages: [], reasoning_effort, reasoning_summary: "detailed" });
+      expect(out.reasoning_effort).toBeUndefined();
+      expect(out.reasoning_summary).toBeUndefined();
+    },
+  );
+
+  it("defaults reasoning_summary only for non-empty effort", () => {
+    const out = transform({ messages: [], reasoning_effort: "high" });
     expect(out.reasoning_effort).toBe("high");
     expect(out.reasoning_summary).toBe("auto");
   });
 
-  it("omits reasoning_effort for none/off and adds no reasoning_summary", () => {
-    const out = exec.transformRequest(
-      "glm-5.2",
-      { messages: [{ role: "user", content: "hi" }], reasoning_effort: "none" },
-      false,
-      {}
-    );
-    expect(out.reasoning_effort).toBeUndefined();
-    expect(out.reasoning_summary).toBeUndefined();
+  it("preserves an explicit reasoning_summary", () => {
+    const out = transform({
+      messages: [],
+      reasoning_effort: "high",
+      reasoning_summary: "detailed",
+    });
+    expect(out.reasoning_effort).toBe("high");
+    expect(out.reasoning_summary).toBe("detailed");
   });
 });

--- a/tests/unit/qoderwork-profile.test.js
+++ b/tests/unit/qoderwork-profile.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractQoderworkProfileFromUserinfo,
+  mergePersistedProfileData,
+} from "../../src/shared/utils/qoderworkProfile.js";
+import { dayKeyInTimeZone } from "../../src/shared/utils/timezone.js";
+
+describe("qoderworkProfile", () => {
+  it("extracts display name and login source; no phone when not phone-like", () => {
+    const p = extractQoderworkProfileFromUserinfo({
+      id: "u1",
+      name: "aliyun7850973340",
+      source: "sso.aliyun",
+    });
+    expect(p.displayName).toBe("aliyun7850973340");
+    expect(p.phoneMasked).toBe(null);
+    expect(p.loginSource).toBe("sso.aliyun");
+  });
+
+  it("masks phone-like name", () => {
+    const p = extractQoderworkProfileFromUserinfo({ name: "13812345678" });
+    expect(p.phoneMasked).toMatch(/\*/);
+    expect(p.phone).toBe("13812345678");
+  });
+
+  it("derives calendar days in the requested timezone", () => {
+    const instant = new Date("2026-01-01T16:30:00.000Z");
+    expect(dayKeyInTimeZone("Asia/Shanghai", instant)).toBe("2026-01-02");
+    expect(dayKeyInTimeZone("UTC", instant)).toBe("2026-01-01");
+  });
+
+  it("omits newly fetched raw phone from persisted profile data", () => {
+    const persisted = mergePersistedProfileData(
+      { loginSource: "existing" },
+      { phone: "13812345678", phoneMasked: "138****5678", userId: "u1" },
+    );
+    expect(persisted).toEqual({
+      loginSource: "existing",
+      phoneMasked: "138****5678",
+      userId: "u1",
+    });
+  });
+
+  it("preserves a historical raw phone without replacing it", () => {
+    const persisted = mergePersistedProfileData(
+      { phone: "historical" },
+      { phone: "new-raw", phoneMasked: "new****mask" },
+    );
+    expect(persisted.phone).toBe("historical");
+    expect(persisted.phoneMasked).toBe("new****mask");
+  });
+});


### PR DESCRIPTION
## Summary

Two related improvements for the CodeBuddy providers and a new account-profile refresh capability:

1. **Shared CodeBuddy protocol module** (`open-sse/protocol/codebuddy/`) — request normalization (CN allowlist, Intl preserve-unknown option, reasoning gate, forced stream, empty-tools drop) and SSE dirt normalization now live in one reusable place. The CodeBuddy Intl executor reuses it instead of duplicating reasoning/stream logic.
2. **Provider-owned config** — CodeBuddy CN model-discovery endpoint/headers move into the registry entry; `services/codebuddyCnModels.js` consumes them (no endpoint literals in service code).
3. **Account profile refresh** — `POST /api/providers/[id]/refresh-profile` for codebuddy-cn and qoderwork-cn: fetches display name and masked phone from the token/userinfo. **Raw phone numbers are never persisted** (`mergePersistedProfileData` guards the write; historical raw values remain filtered on read). Dashboard gains a "全部刷新" (refresh all) button driven by `features.profileRefresh` projected through the UI provider builder.

## Changes

- **New** `open-sse/protocol/codebuddy/` — `sanitizeChatBody` (allowlist + `preserveUnknownFields` option), `normalizeChatChunk`, `createSseNormalizeTransform`, constants.
- `open-sse/executors/codebuddy-cn.js` / `codebuddy-intl.js` — both route through the shared normalizer.
- `open-sse/services/codebuddyCnModels.js` — model discovery reading registry-owned endpoint config.
- `open-sse/providers/registry/codebuddy-cn.js` — `modelDiscovery` config + `features.profileRefresh`.
- **New** `src/app/api/providers/[id]/refresh-profile/route.js` + `src/shared/utils/{codebuddyProfile,qoderworkProfile,timezone}.js`.
- `src/shared/constants/providers.js` — project `features` into UI provider entries.
- Dashboard refresh-all button (feature-driven; no hard-coded provider ids).

## Verification

- 26 vitest tests (CodeBuddy CN/Intl normalization, provider-owned config, profile privacy) + 11 node:test protocol tests pass on the v0.5.45 baseline.

## Out of scope

- Check-in / activity features are intentionally not included in this PR.