### PR TITLE
fix(oauth): resolve ReferenceError searchParams is not defined in POST handler

### DIFF
--- a/src/app/api/oauth/[provider]/[action]/route.js
+++ b/src/app/api/oauth/[provider]/[action]/route.js
@@ -254,6 +254,7 @@ export async function POST(request, { params }) {
     if (action === "register-session") {
       // Register proxy session out of URL query (state) + body (codeVerifier).
       // Zed's codeVerifier encodes the RSA private key — must stay out of URL/logs.
+      const searchParams = new URL(request.url).searchParams;
       const state = searchParams.get("state") || body?.state;
       if (!state) return NextResponse.json({ error: "Missing state" }, { status: 400 });
       let ok = false;


### PR DESCRIPTION
### Summary
This PR fixes a `ReferenceError: searchParams is not defined` in `POST /api/oauth/[provider]/[action]`.

### Details
In `src/app/api/oauth/[provider]/[action]/route.js`, under the `action === "register-session"` block in the `POST` handler, `searchParams.get("state")` was called without declaring `const searchParams = new URL(request.url).searchParams;`.

This caused a runtime `500 Internal Server Error` returning an HTML error response (`Internal Server Error...`), leading to `SyntaxError: Unexpected token 'I', "Internal S"... is not valid JSON` in the frontend UI modal when attempting to parse the response.

### Solution
Initialized `const searchParams = new URL(request.url).searchParams;` inside the `register-session` block.
