### PR TITLE
fix(translator): stop prompt cache being invalidated every turn

### DIFF
--- a/open-sse/translator/formats/claude.js
+++ b/open-sse/translator/formats/claude.js
@@ -22,6 +22,69 @@ export function hasValidContent(msg) {
   return false;
 }
 
+// Anthropic allows at most 4 cache breakpoints per request. system + tools take
+// one each, leaving two for messages.
+const MAX_MESSAGE_CACHE_BREAKPOINTS = 2;
+
+// thinking/redacted_thinking blocks cannot carry cache_control.
+function canHoldCacheControl(block) {
+  return block?.type !== CLAUDE_BLOCK.THINKING && block?.type !== CLAUDE_BLOCK.REDACTED_THINKING;
+}
+
+// True when a breakpoint can actually be attached to this message. Used to skip
+// messages that would silently waste one of the scarce breakpoint slots.
+function acceptsCacheBreakpoint(msg) {
+  return Array.isArray(msg?.content) && msg.content.some(canHoldCacheControl);
+}
+
+// Attach a cache breakpoint to the last cacheable block of a message.
+function setCacheBreakpoint(msg) {
+  if (!Array.isArray(msg?.content)) return false;
+  for (let j = msg.content.length - 1; j >= 0; j--) {
+    if (canHoldCacheControl(msg.content[j])) {
+      msg.content[j].cache_control = { type: "ephemeral" };
+      return true;
+    }
+  }
+  return false;
+}
+
+// Pick which assistant messages get a cache breakpoint.
+//
+// A single breakpoint on the last assistant message is worst-case for prompt
+// caching: Anthropic only reads cache up to a breakpoint, so when that
+// breakpoint advances each turn there is nothing left at the previous position
+// to read from — the whole prefix is re-written every turn. Observed in
+// production: ~688k cache-creation tokens re-written 29s after the prior
+// request, with the context only growing ~985 tokens.
+//
+// Fix: cascade two breakpoints, positioned relative to the END of the
+// conversation:
+//   anchor = second-to-last assistant → this is exactly where the PREVIOUS turn
+//            put its tail breakpoint, so the cache written last turn is read
+//            back in full.
+//   tail   = last assistant → extends the cache by just this turn's delta.
+//
+// Anthropic checks cache hits at each breakpoint longest-prefix-first, so the
+// anchor absorbs everything up to last turn and only the delta is re-written.
+// Returns a Set of indices into `messages`.
+export function pickCacheBreakpointIndices(messages) {
+  const assistantIdx = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    // Skip messages a breakpoint can't attach to (empty, or thinking-only) —
+    // picking one would waste a slot from the budget of 2.
+    if (msg.role === ROLE.ASSISTANT && acceptsCacheBreakpoint(msg)) {
+      assistantIdx.push(i);
+    }
+  }
+  if (assistantIdx.length === 0) return new Set();
+
+  // Take the last N assistant messages (N = breakpoint budget), tail last.
+  const chosen = assistantIdx.slice(-MAX_MESSAGE_CACHE_BREAKPOINTS);
+  return new Set(chosen);
+}
+
 // Fix tool_use/tool_result ordering for Claude API
 // 1. Assistant message with tool_use: remove text AFTER tool_use (Claude doesn't allow)
 // 2. Merge consecutive same-role messages
@@ -122,31 +185,39 @@ export function normalizeClaudePassthrough(body, model = "") {
     if (Object.keys(body.output_config).length === 0) delete body.output_config;
   }
 
-  // 2. Hoist mid-conversation system messages into the top-level system field
+  // 2. Convert mid-conversation system messages to user messages IN PLACE.
+  //
+  // The Messages API rejects role:"system" inside messages, so these have to go
+  // somewhere. Hoisting them into the top-level `system` is the obvious move and
+  // is what this did before — but it wrecks the prompt cache.
+  //
+  // Anthropic caches the prefix in the order tools → system → messages, and a
+  // cache entry only matches an EXACT prefix. Claude Code injects a fresh
+  // reminder every few turns ("The task tools haven't been used recently…",
+  // date-changed notices, hook output), so hoisting grew `system` by one block
+  // each time, invalidating every cached message behind it. Measured over 62
+  // consecutive request pairs in production: `system` grew 7 times and all 7
+  // re-wrote ~133k tokens with cache reads collapsing to the system+tools floor
+  // (39,218), while the 53 turns whose `system` was unchanged wrote 400-1400.
+  //
+  // Keeping them in `messages` means growth only ever APPENDS at the tail, which
+  // is what prompt caching is designed for. Two consecutive user messages are
+  // accepted (verified against the live API), and the translator path's
+  // fixToolUseOrdering merges same-role neighbours anyway.
   if (Array.isArray(body.messages)) {
-    const systemBlocks = [];
-    const messages = [];
     for (const msg of body.messages) {
-      if (msg.role === ROLE.SYSTEM) {
-        const text = typeof msg.content === "string"
-          ? msg.content
-          : Array.isArray(msg.content)
-            ? msg.content.map(b => (typeof b === "string" ? b : b?.text || "")).join("\n")
-            : "";
-        if (text.trim()) systemBlocks.push({ type: CLAUDE_BLOCK.TEXT, text });
-        continue;
-      }
-      messages.push(msg);
-    }
-
-    if (systemBlocks.length > 0) {
-      const existing = Array.isArray(body.system)
-        ? body.system
-        : typeof body.system === "string" && body.system.trim()
-          ? [{ type: "text", text: body.system }]
+      if (msg.role !== ROLE.SYSTEM) continue;
+      const blocks = typeof msg.content === "string"
+        ? [{ type: CLAUDE_BLOCK.TEXT, text: msg.content }]
+        : Array.isArray(msg.content)
+          ? msg.content.map(b => (typeof b === "string" ? { type: CLAUDE_BLOCK.TEXT, text: b } : b))
           : [];
-      body.system = [...existing, ...systemBlocks];
-      body.messages = messages;
+      // Empty text blocks would make the API reject the message outright.
+      const kept = blocks.filter(b => b?.type !== CLAUDE_BLOCK.TEXT || b.text?.trim());
+      msg.role = ROLE.USER;
+      msg.content = kept.length > 0
+        ? kept
+        : [{ type: CLAUDE_BLOCK.TEXT, text: "(system reminder)" }];
     }
   }
 
@@ -260,24 +331,16 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
     const lastMessageIsUser = lastMessage?.role === "user";
     const thinkingEnabled = body.thinking?.type === "enabled" && lastMessageIsUser;
 
-    // Pass 2 (reverse): add cache_control to last assistant + handle thinking for Anthropic
-    let lastAssistantProcessed = false;
+    // Cascading cache breakpoints: a stride-pinned anchor to READ from plus the
+    // tail to extend. See pickCacheBreakpointIndices.
+    const cacheBreakpointIdx = pickCacheBreakpointIndices(filtered);
+
+    // Pass 2 (reverse): add cache_control breakpoints + handle thinking for Anthropic
     for (let i = filtered.length - 1; i >= 0; i--) {
       const msg = filtered[i];
 
       if (msg.role === "assistant" && Array.isArray(msg.content)) {
-        // Add cache_control to last non-thinking block of first (from end) assistant with content
-        // thinking/redacted_thinking blocks do not support cache_control
-        if (!lastAssistantProcessed && msg.content.length > 0) {
-          for (let j = msg.content.length - 1; j >= 0; j--) {
-            const block = msg.content[j];
-            if (block.type !== CLAUDE_BLOCK.THINKING && block.type !== CLAUDE_BLOCK.REDACTED_THINKING) {
-              block.cache_control = { type: "ephemeral" };
-              break;
-            }
-          }
-          lastAssistantProcessed = true;
-        }
+        if (cacheBreakpointIdx.has(i)) setCacheBreakpoint(msg);
 
         // Handle thinking blocks for Anthropic-compatible endpoints.
         if (handlesThinkingBlocks(provider)) {

--- a/tests/translator/cache-breakpoints.test.js
+++ b/tests/translator/cache-breakpoints.test.js
@@ -1,0 +1,220 @@
+// Prompt-cache breakpoint placement on the claude request path.
+//
+// Regression guard for a production incident: a single breakpoint pinned to the
+// LAST assistant message meant the breakpoint advanced every turn, leaving
+// nothing at the previous position for Anthropic to read cache from. Result was
+// ~688k cache-creation tokens re-written 29s after the prior request while the
+// context had only grown ~985 tokens — cache writes became 52% of spend.
+import { describe, it, expect } from "vitest";
+import "./registerAll.js";
+import { prepareClaudeRequest, pickCacheBreakpointIndices, normalizeClaudePassthrough } from "../../open-sse/translator/formats/claude.js";
+
+const U = (t) => ({ role: "user", content: [{ type: "text", text: t }] });
+const A = (t) => ({ role: "assistant", content: [{ type: "text", text: t }] });
+const THINK = () => ({ role: "assistant", content: [{ type: "thinking", thinking: "x", signature: "s" }] });
+
+// Collect message indices carrying a cache_control breakpoint.
+const msgBreakpoints = (body) => {
+  const idx = [];
+  body.messages.forEach((msg, i) => {
+    if (Array.isArray(msg.content) && msg.content.some((b) => b.cache_control)) idx.push(i);
+  });
+  return idx;
+};
+
+const run = (messages) =>
+  prepareClaudeRequest(
+    {
+      model: "claude-opus-5",
+      max_tokens: 1024,
+      system: [{ type: "text", text: "sys" }],
+      tools: [{ name: "t1", description: "d", input_schema: { type: "object" } }],
+      messages: structuredClone(messages),
+    },
+    "claude", "k", null, {}, null
+  );
+
+describe("pickCacheBreakpointIndices", () => {
+  it("never exceeds the 2-slot message budget", () => {
+    const messages = [];
+    for (let i = 0; i < 20; i++) messages.push(U("u" + i), A("a" + i));
+    expect(pickCacheBreakpointIndices(messages).size).toBeLessThanOrEqual(2);
+  });
+
+  // The whole point of the fix: this turn's anchor must sit exactly where the
+  // previous turn's tail was, so the cache written then is read back now.
+  it("anchors on the position the previous turn used as its tail", () => {
+    let messages = [];
+    let prevTail = null;
+    for (let turn = 1; turn <= 6; turn++) {
+      messages = [...messages, U("u" + turn), A("a" + turn)];
+      const picked = [...pickCacheBreakpointIndices(messages)].sort((a, b) => a - b);
+      if (prevTail !== null) {
+        expect(picked.length, `turn ${turn} should have anchor + tail`).toBe(2);
+        expect(picked[0], `turn ${turn} anchor must equal turn ${turn - 1} tail`).toBe(prevTail);
+      }
+      prevTail = picked[picked.length - 1];
+    }
+  });
+
+  it("skips messages a breakpoint cannot attach to", () => {
+    // thinking-only assistant: cache_control is illegal on thinking blocks, so
+    // picking it would burn a slot and emit nothing.
+    expect(pickCacheBreakpointIndices([U("u"), THINK()]).size).toBe(0);
+    expect(pickCacheBreakpointIndices([U("u"), { role: "assistant", content: [] }]).size).toBe(0);
+    // ...but skip past it to reach real assistants.
+    expect([...pickCacheBreakpointIndices([U("u1"), A("a1"), U("u2"), THINK(), U("u3"), A("a3")])].sort((a, b) => a - b))
+      .toEqual([1, 5]);
+  });
+
+  it("returns nothing when there is no assistant turn yet", () => {
+    expect(pickCacheBreakpointIndices([]).size).toBe(0);
+    expect(pickCacheBreakpointIndices([U("only user")]).size).toBe(0);
+  });
+});
+
+describe("prepareClaudeRequest cache breakpoints", () => {
+  // Anthropic rejects requests carrying more than 4 breakpoints, and system +
+  // tools already claim one each.
+  it("stays within Anthropic's 4-breakpoint limit as the conversation grows", () => {
+    let messages = [];
+    for (let turn = 1; turn <= 8; turn++) {
+      messages = [...messages, U("u" + turn), A("a" + turn)];
+      const out = run(messages);
+      const total =
+        msgBreakpoints(out).length +
+        (out.system || []).filter((b) => b.cache_control).length +
+        (out.tools || []).filter((t) => t.cache_control).length;
+      expect(total, `turn ${turn} breakpoint count`).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it("emits two message breakpoints once a second assistant turn exists", () => {
+    const single = run([U("u1"), A("a1")]);
+    expect(msgBreakpoints(single)).toHaveLength(1);
+
+    const multi = run([U("u1"), A("a1"), U("u2"), A("a2")]);
+    expect(msgBreakpoints(multi)).toHaveLength(2);
+  });
+
+  it("keeps the long-lived 1h breakpoints on system and tools", () => {
+    const out = run([U("u1"), A("a1")]);
+    expect(out.system.at(-1).cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(out.tools.at(-1).cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+  });
+
+  // Messages churn far more than system/tools, and 1h writes cost 2x base input
+  // vs 1.25x for 5m. With 99% of observed turns under 5 minutes apart, the
+  // default TTL is both sufficient and cheaper here.
+  it("leaves message breakpoints at the default 5m TTL", () => {
+    const out = run([U("u1"), A("a1"), U("u2"), A("a2")]);
+    for (const i of msgBreakpoints(out)) {
+      const block = out.messages[i].content.find((b) => b.cache_control);
+      expect(block.cache_control).toEqual({ type: "ephemeral" });
+    }
+  });
+
+  it("drops cache_control the client sent so the budget stays predictable", () => {
+    const noisy = [
+      { role: "user", content: [{ type: "text", text: "u1", cache_control: { type: "ephemeral" } }] },
+      { role: "assistant", content: [{ type: "text", text: "a1", cache_control: { type: "ephemeral" } }] },
+      { role: "user", content: [{ type: "text", text: "u2", cache_control: { type: "ephemeral" } }] },
+      { role: "assistant", content: [{ type: "text", text: "a2", cache_control: { type: "ephemeral" } }] },
+    ];
+    const out = run(noisy);
+    // User turns must not keep client-supplied breakpoints.
+    for (const msg of out.messages.filter((m) => m.role === "user")) {
+      expect(msg.content.some((b) => b.cache_control)).toBe(false);
+    }
+    expect(msgBreakpoints(out)).toHaveLength(2);
+  });
+});
+
+// Native passthrough (Claude Code → claude provider) skips prepareClaudeRequest
+// entirely — 21k of 21.5k observed requests took this path — so breakpoint
+// handling here matters far more than in the translator.
+describe("normalizeClaudePassthrough mid-conversation system messages", () => {
+  const norm = (messages, extra = {}) =>
+    normalizeClaudePassthrough({ messages: structuredClone(messages), ...extra }, "claude-opus-5");
+
+  const countMsgBreakpoints = (body) => {
+    let n = 0;
+    (body.messages || []).forEach((m) => {
+      if (Array.isArray(m.content)) m.content.forEach((b) => { if (b.cache_control) n++; });
+    });
+    return n;
+  };
+
+  it("rewrites role system to user without moving it", () => {
+    const out = norm([
+      { role: "user", content: [{ type: "text", text: "u1" }] },
+      { role: "assistant", content: [{ type: "text", text: "a1" }] },
+      { role: "system", content: [{ type: "text", text: "reminder" }] },
+    ]);
+    expect(out.messages.map((m) => m.role)).toEqual(["user", "assistant", "user"]);
+    expect(out.messages[2].content[0].text).toBe("reminder");
+    // The API rejects role:"system" inside messages — none may survive.
+    expect(out.messages.some((m) => m.role === "system")).toBe(false);
+  });
+
+  // The whole point of the change: `system` must not grow, because it sits
+  // BEFORE messages in the cached prefix. Growth there invalidated every
+  // cached message behind it and re-wrote ~133k tokens per occurrence.
+  it("does not grow the top-level system as reminders accumulate", () => {
+    const base = [
+      { role: "user", content: [{ type: "text", text: "u1" }] },
+      { role: "assistant", content: [{ type: "text", text: "a1" }] },
+    ];
+    const turn1 = norm([...base, { role: "system", content: [{ type: "text", text: "r1" }] }],
+      { system: [{ type: "text", text: "fixed prompt" }] });
+    const turn2 = norm([...base,
+      { role: "system", content: [{ type: "text", text: "r1" }] },
+      { role: "assistant", content: [{ type: "text", text: "a2" }] },
+      { role: "system", content: [{ type: "text", text: "r2" }] },
+    ], { system: [{ type: "text", text: "fixed prompt" }] });
+
+    expect(turn2.system).toEqual(turn1.system);
+    expect(turn2.system).toHaveLength(1);
+  });
+
+  // Cache hits require a byte-exact prefix, so everything the previous turn
+  // already sent must be untouched — new content may only append at the tail.
+  it("keeps the previous turn's prefix byte-identical", () => {
+    const base = [
+      { role: "user", content: [{ type: "text", text: "u1" }] },
+      { role: "assistant", content: [{ type: "text", text: "a1" }] },
+      { role: "system", content: [{ type: "text", text: "r1" }] },
+    ];
+    const turn1 = norm(base);
+    const turn2 = norm([...base,
+      { role: "assistant", content: [{ type: "text", text: "a2" }] },
+      { role: "system", content: [{ type: "text", text: "r2" }] },
+    ]);
+
+    expect(turn2.messages.slice(0, turn1.messages.length)).toEqual(turn1.messages);
+  });
+
+  it("preserves a cache_control the client put on a system message", () => {
+    const out = norm([
+      { role: "user", content: [{ type: "text", text: "u1" }] },
+      { role: "system", content: [{ type: "text", text: "r", cache_control: { type: "ephemeral" } }] },
+    ]);
+    expect(countMsgBreakpoints(out)).toBe(1);
+  });
+
+  it("accepts string content and never emits an empty message", () => {
+    const out = norm([
+      { role: "system", content: "plain string" },
+      { role: "system", content: [{ type: "text", text: "   " }] },
+    ]);
+    expect(out.messages[0].content).toEqual([{ type: "text", text: "plain string" }]);
+    expect(out.messages[1].content.length).toBeGreaterThan(0);
+    expect(out.messages[1].content[0].text.trim()).not.toBe("");
+  });
+
+  it("leaves conversations without system messages alone", () => {
+    const out = norm([{ role: "user", content: [{ type: "text", text: "u", cache_control: { type: "ephemeral" } }] }]);
+    expect(countMsgBreakpoints(out)).toBe(1);
+    expect(out.messages).toHaveLength(1);
+  });
+});

--- a/tests/unit/translator-helpers-edge.test.js
+++ b/tests/unit/translator-helpers-edge.test.js
@@ -14,15 +14,21 @@ describe("normalizeClaudePassthrough — haiku adaptive thinking (docs 11 §1)",
     expect(out.thinking).toEqual({ type: "adaptive" });
   });
 
-  it("hoists mid-conversation system messages into top-level system", () => {
+  // Used to hoist these into top-level `system`. That grew the cached prefix by a
+  // block every time Claude Code injected a reminder, invalidating every cached
+  // message behind it (~133k tokens re-written per occurrence in production), so
+  // they are now converted in place. The invariant that matters is unchanged:
+  // no role:"system" may reach the API inside messages.
+  it("converts mid-conversation system messages to user in place", () => {
     const out = normalizeClaudePassthrough({
       messages: [
         { role: "user", content: "hi" },
         { role: "system", content: "be brief" },
       ],
     });
-    expect(out.system).toEqual([{ type: "text", text: "be brief" }]);
+    expect(out.system).toBeUndefined();
     expect(out.messages.every((m) => m.role !== "system")).toBe(true);
+    expect(out.messages[1]).toEqual({ role: "user", content: [{ type: "text", text: "be brief" }] });
   });
 });
 


### PR DESCRIPTION
## Problem

Anthropic matches a cached prefix in the order `tools` → `system` → `messages`, and only up to a breakpoint. Two things broke that invariant, so on most turns the **entire context was re-billed as `cache_creation`** instead of being read back.

Measured on production traffic before the fix — ~688k tokens re-written 29 seconds after the previous request, while the context had grown only 985 tokens:

```
cacheW=688,619  gap=29s  contextGrowth=985     totalIn=770,831
cacheW=687,090  gap=49s  contextGrowth=-1,529  totalIn=769,302
cacheW=681,795  gap=28s  contextGrowth=318     totalIn=764,007
```

Ruled out first: retry amplification (0 duplicate requests), TTL expiry (99% of requests were <5 min apart), and the `extended-cache-ttl` beta header (`ttl:"1h"` is GA).

## Cause 1 — the single breakpoint moved every turn

`prepareClaudeRequest` deleted all client `cache_control`, then re-added exactly **one** breakpoint on the last assistant message. That position advances each turn, so nothing was left at the previous position to read from:

```
turn N:   [system][tools][msg 1..40][BP @ 40]  → writes cache up to 40
turn N+1: [system][tools][msg 1..42][BP @ 42]  → no BP at 40 to read from
                                               → rewrites the whole prefix
```

Anthropic allows 4 breakpoints precisely so a **fixed** one can be kept at the old position to read from while a new one at the tail extends the cache.

**Fix:** cascade two breakpoints within the budget (`system` and `tools` take one each) — an anchor on the second-to-last assistant message, which is exactly where the previous turn put its tail, plus the tail itself. The anchor absorbs everything up to last turn, so only this turn's delta is written. Messages that cannot hold a breakpoint (empty, or thinking-only) are skipped, since `thinking` blocks reject `cache_control` and a wasted slot costs a full rewrite.

## Cause 2 — mid-conversation system messages were hoisted into `system`

The Messages API rejects `role:"system"` inside `messages`, so `normalizeClaudePassthrough` moved them into the top-level `system`. But `system` sits in front of every message in the cached prefix, and clients inject reminders mid-conversation — so each one grew `system` by a block and invalidated every cached message behind it.

Over 62 consecutive production request pairs, `system` grew 7 times. All 7 re-wrote ~133k tokens with cache reads collapsing to the system+tools floor (exactly 39,218), while the 53 turns with an unchanged `system` wrote 400–1,400:

| `system` | requests | cache write | cache read |
|---|---|---|---|
| grew | 7 | ~133,000 | 39,218 (floor) |
| unchanged | 53 | 400–1,400 | full prefix |

**Fix:** convert them to `role:"user"` in place, so growth only ever appends at the tail — which is what prompt caching is designed for. Two consecutive `user` messages are accepted by the API (verified against the live endpoint), and `fixToolUseOrdering` merges same-role neighbours on the translator path anyway.

Verified on live traffic after deploy: upstream `system` went from `array[21]` to a fixed `array[3]`.

## Result

Production traffic, same API key, priced with one fixed rate card so the model switch we happened to make cannot distort the comparison:

| | requests | wasteful rewrites | cache write/req | cache hit | $/1M ctx |
|---|---|---|---|---|---|
| before | 957 | **17.3%** | 44,736 | 81.6% | 1.558 |
| after | 68 | **0%** | 13,089 | 88.5% | **1.158 (−25%)** |

"Wasteful rewrite" = re-writing >20k tokens when the context grew only a few hundred and the 5-minute TTL was still alive. The remaining large writes after the fix are all new sessions or genuine TTL expiry.

⚠️ The "after" sample is 68 requests against 957 — the direction is consistent and the mechanism is confirmed on captured payloads, but the exact −25% figure deserves more data.

## Tests

Adds `tests/translator/cache-breakpoints.test.js` (15 tests): breakpoint cascade positions, the 4-breakpoint budget, thinking-block skipping, and prefix stability as reminders accumulate.

Full `translator/` + `unit/` suite: **1582 → 1597 passing, failure list unchanged** (86 pre-existing failures on a clean v0.5.45 checkout — verified the same set fails before and after with `comm -13` on sorted test names, so nothing new broke and nothing suspiciously "fixed itself").

The one existing test asserting the hoist behaviour is updated to assert in-place conversion. Its actual invariant — no `role:"system"` reaches the API inside `messages` — is unchanged.

## Not included

This branch is scoped to the cache fix. Unrelated local changes (cost guards, a `updateApiKey` column bug, a missing PXPIPE token-saver guard) are held back for separate PRs if you want them.
