### PR TITLE
fix(antigravity): handle standard-tier accounts gracefully when GCP project is missing

### DIFF
--- a/open-sse/services/projectId.js
+++ b/open-sse/services/projectId.js
@@ -236,7 +236,10 @@ async function onboardUser(accessToken, tierID, externalSignal, endpoints) {
                     console.log(`[ProjectId] Successfully onboarded, project ID: ${projectId}`);
                     return projectId;
                 }
-                throw new Error("onboardUser done but no project_id in response");
+                // Google deprecated automatic project creation for standard-tier.
+                // Return flag so caller can return a clear error instead of retrying.
+                console.warn("[ProjectId] onboardUser completed but no project_id — standard-tier account requires manual GCP Project ID");
+                return "__REQUIRES_GCP_PROJECT__";
             }
 
             // Server not done yet – wait and retry

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -220,7 +220,13 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Ensure real project ID is available for providers that need it (P0 fix: cold miss)
     if ((provider === "antigravity" || provider === "gemini-cli") && !refreshedCredentials.projectId) {
       const pid = await getProjectIdForConnection(credentials.connectionId, refreshedCredentials.accessToken, provider);
-      if (pid) {
+      if (pid === "__REQUIRES_GCP_PROJECT__") {
+        log.warn("CHAT", `[${provider}] Google requires a manual GCP Project ID for this account.`);
+        return errorResponse(
+          HTTP_STATUS.FORBIDDEN,
+          "GCP_PROJECT_REQUIRED: Google Antigravity now requires a free GCP Project ID. Please create one at console.cloud.google.com and enter it in your 9Router Settings."
+        );
+      } else if (pid) {
         refreshedCredentials.projectId = pid;
         // Persist to DB in background so subsequent requests have it immediately
         updateProviderCredentials(credentials.connectionId, { projectId: pid }).catch(() => { });


### PR DESCRIPTION
## Problem

Standard-tier (personal) Google accounts experience an infinite retry loop during `onboardUser`, followed by a delayed HTTP 429 `RESOURCE_EXHAUSTED` error when attempting to stream chat.

Google has deprecated automatic project creation for standard-tier accounts. The API returns `userDefinedCloudaicompanionProject: true` but no `project_id`, causing 9Router to retry 5 times and then fail with a cryptic 429 after ~19 seconds.

## Fix

1. **`projectId.js`**: When `onboardUser` completes but returns no `project_id`, return `__REQUIRES_GCP_PROJECT__` flag instead of throwing an error.
2. **`chat.js`**: Intercept the flag and return a clear HTTP 403 SSE error with actionable instructions.

## Error Message

```
GCP_PROJECT_REQUIRED: Google Antigravity now requires a free GCP Project ID. Please create one at console.cloud.google.com and enter it in your 9Router Settings.
```

## Changes

- `open-sse/services/projectId.js`: +3/-1 (return flag instead of throw)
- `src/sse/handlers/chat.js`: +7/-1 (intercept flag, return 403)

## Testing

1. Authenticate via Google OAuth for Antigravity using a standard-tier account without a GCP project
2. Attempt a chat — should get immediate 403 with clear error message
3. No more 5-retry loop or 19-second delay

---

Closes #2934