### PR TITLE
fix(cloudflare-ai): declare API key authentication

### DIFF
--- a/open-sse/providers/registry/cloudflare-ai.js
+++ b/open-sse/providers/registry/cloudflare-ai.js
@@ -19,6 +19,8 @@ export default {
     },
   },
   category: "freeTier",
+  authType: "apikey",
+  authModes: ["apikey"],
   hasProviderSpecificData: true,
   transport: {
     baseUrl: "https://api.cloudflare.com/client/v4/accounts/{accountId}/ai/v1/chat/completions",

--- a/tests/unit/provider-display-split.test.js
+++ b/tests/unit/provider-display-split.test.js
@@ -31,4 +31,10 @@ describe("provider display split (E1)", () => {
     expect(m.ALIAS_TO_ID.kr).toBe("kiro");
     expect(m.getProvidersByKind("tts").length).toBeGreaterThan(0);
   });
+
+  it("Cloudflare exposes API-key authentication on its free-tier card", async () => {
+    const { FREE_TIER_PROVIDERS } = await import("../../src/shared/constants/providers.js");
+    expect(FREE_TIER_PROVIDERS["cloudflare-ai"].authType).toBe("apikey");
+    expect(FREE_TIER_PROVIDERS["cloudflare-ai"].authModes).toEqual(["apikey"]);
+  });
 });


### PR DESCRIPTION
## Description
Fixes the Cloudflare provider card reporting "No connections" when it has an active API-key connection.

## Changes
- declare `authType: "apikey"` and `authModes: ["apikey"]` in the Cloudflare provider registry entry
- add a regression test for the free-tier provider metadata exposed to the dashboard

## Verification
- `./tests/node_modules/.bin/vitest run --config tests/vitest.config.js tests/unit/provider-display-split.test.js --reporter=verbose`
- `git diff --check`

Closes #2969