### PR TITLE
fix(translator): don't drop image-only user messages in prepareClaudeRequest

### DIFF
--- a/open-sse/translator/formats/claude.js
+++ b/open-sse/translator/formats/claude.js
@@ -16,7 +16,9 @@ export function hasValidContent(msg) {
     return msg.content.some(block =>
       (block.type === CLAUDE_BLOCK.TEXT && block.text?.trim()) ||
       block.type === CLAUDE_BLOCK.TOOL_USE ||
-      block.type === CLAUDE_BLOCK.TOOL_RESULT
+      block.type === CLAUDE_BLOCK.TOOL_RESULT ||
+      block.type === CLAUDE_BLOCK.IMAGE ||
+      block.type === CLAUDE_BLOCK.DOCUMENT
     );
   }
   return false;

--- a/tests/translator/bugs-toClaude-context.test.js
+++ b/tests/translator/bugs-toClaude-context.test.js
@@ -67,6 +67,27 @@ describe("OpenAI → Claude context mapping", () => {
     expect(JSON.stringify(out), "remote image dropped").toContain("pic.png");
   });
 
+  // claude.js hasValidContent() — a user message whose content is only an
+  // image (no text block) was filtered out by prepareClaudeRequest's
+  // "drop empty messages" pass, so an image-only turn (e.g. a vision
+  // describe request with no accompanying prompt text in the user message)
+  // produced an empty `messages` array and Anthropic rejected the request
+  // with "messages: at least one message is required".
+  it("user message with only an image is not dropped as empty", () => {
+    const out = T({
+      messages: [
+        { role: "system", content: "Describe the image." },
+        { role: "user", content: [
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+        ] },
+      ],
+    });
+    expect(out.messages.length, "image-only user message was dropped").toBeGreaterThan(0);
+    expect(out.messages[0].content).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "image" })])
+    );
+  });
+
   // prepareClaudeRequest reconciles max_tokens vs thinking.budget_tokens.
   // applyThinking runs after adjustMaxTokens caps max_tokens, so a claude-budget
   // model at "max" effort (budget 128000) can exceed the clamped max_tokens and


### PR DESCRIPTION
## What Problem This Solves

`hasValidContent()` in `open-sse/translator/formats/claude.js` only treats
`text` (non-empty), `tool_use`, and `tool_result` blocks as valid content.
`prepareClaudeRequest` uses it to drop "empty" messages before sending the
request upstream.

A `user` message whose content is **only an image** (no text block) —
exactly the shape sent by common vision/image-describe callers, e.g.
OpenClaw's `tools.media.image` pipeline, which sends:

```json
{
  "messages": [
    { "role": "system", "content": "Describe the image." },
    { "role": "user", "content": [
      { "type": "image_url", "image_url": { "url": "data:image/png;base64,..." } }
    ] }
  ]
}
```

— gets filtered out as "empty". When it's the only non-system message,
`messages` ends up `[]`, and Anthropic rejects the request with:

```
messages: at least one message is required
```

...even though the request contains a perfectly valid image.

## Why This Change Was Made

Any OpenAI-compatible client sending an image with no accompanying user
text (a very common shape for image-description use cases) currently
cannot use Claude models through a `cc/*`/anthropic-compatible route at
all — the request fails before it ever reaches Anthropic's API in a
meaningful way.

## User Impact

Vision/image-describe requests routed to Claude that don't include a
user-authored text block alongside the image now work instead of
failing with a 400.

## Fix

Count `image` and `document` blocks as valid content in
`hasValidContent()`, alongside the existing `text`/`tool_use`/`tool_result`
checks.

## Evidence

- Repro'd end-to-end against a running local instance: OpenClaw's
  `tools.media.image` pipeline (provider config pointed at a `cc/claude-*`
  combo) failed with the exact `messages: at least one message is
  required` error before this fix, and succeeded (accurate image
  description returned) after.
- Added a regression test in
  `tests/translator/bugs-toClaude-context.test.js` that reproduces the
  exact system+image-only-user shape and asserts the message is kept
  and translated to an `image` content block.
- `npx vitest run translator/bugs-toClaude-context.test.js` (from `tests/`):
  all tests pass except one pre-existing failure
  (`assistant reasoning_content becomes a thinking block`) that already
  fails identically on a clean `origin/master` checkout, unrelated to
  this change.