### PR TITLE
feat(antigravity): show Gemini 3.6 Flash usage bars in quota tracker

### DIFF
--- a/open-sse/services/usage/google.js
+++ b/open-sse/services/usage/google.js
@@ -161,6 +161,9 @@ export async function getAntigravityUsage(accessToken, providerSpecificData, pro
     if (data.models) {
       // Filter only recommended/important models (must match PROVIDER_MODELS ag ids)
       const importantModels = [
+        'gemini-3.6-flash-high',
+        'gemini-3.6-flash-medium',
+        'gemini-3.6-flash-low',
         'gemini-3-flash-agent',
         'gemini-3.5-flash-low',
         'gemini-3.5-flash-extra-low',

--- a/tests/unit/antigravity-quota-gemini-3.6.test.js
+++ b/tests/unit/antigravity-quota-gemini-3.6.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const proxyAwareFetch = vi.fn(async (url) => ({
+  ok: true,
+  status: 200,
+  json: async () => url.includes(":loadCodeAssist")
+    ? { cloudaicompanionProject: "project-1", currentTier: { name: "Pro" } }
+    : {
+        models: {
+          "gemini-3.6-flash-high": {
+            displayName: "Gemini 3.6 Flash (High)",
+            quotaInfo: { remainingFraction: 0.8, resetTime: "2026-07-25T12:00:00Z" },
+          },
+          "gemini-3.6-flash-medium": {
+            displayName: "Gemini 3.6 Flash (Medium)",
+            quotaInfo: { remainingFraction: 0.5, resetTime: "2026-07-25T12:00:00Z" },
+          },
+          "gemini-3.6-flash-low": {
+            displayName: "Gemini 3.6 Flash (Low)",
+            quotaInfo: { remainingFraction: 0.2, resetTime: "2026-07-25T12:00:00Z" },
+          },
+          "gemini-3.5-flash-low": {
+            displayName: "Gemini 3.5 Flash (Medium)",
+            quotaInfo: { remainingFraction: 0.9, resetTime: "2026-07-25T12:00:00Z" },
+          },
+          "internal-model": {
+            displayName: "Internal",
+            isInternal: true,
+            quotaInfo: { remainingFraction: 0.5 },
+          },
+        },
+      },
+  text: async () => "{}",
+}));
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch,
+}));
+
+describe("Antigravity quota tracker: Gemini 3.6 Flash usage bars", () => {
+  beforeEach(() => proxyAwareFetch.mockClear());
+
+  it("returns Gemini 3.6 Flash tier quotas so the dashboard can render usage bars", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    const usage = await getAntigravityUsage("access-token", {});
+
+    expect(usage.quotas["gemini-3.6-flash-high"]).toMatchObject({
+      used: 200,
+      total: 1000,
+      remainingPercentage: 80,
+      displayName: "Gemini 3.6 Flash (High)",
+    });
+    expect(usage.quotas["gemini-3.6-flash-medium"]).toMatchObject({
+      used: 500,
+      total: 1000,
+      remainingPercentage: 50,
+    });
+    expect(usage.quotas["gemini-3.6-flash-low"]).toMatchObject({
+      used: 800,
+      total: 1000,
+      remainingPercentage: 20,
+    });
+  });
+
+  it("still filters out internal and non-important models", async () => {
+    const { getAntigravityUsage } = await import("../../open-sse/services/usage/google.js");
+
+    const usage = await getAntigravityUsage("access-token", {});
+
+    expect(usage.quotas).not.toHaveProperty("internal-model");
+    expect(Object.keys(usage.quotas)).toEqual([
+      "gemini-3.6-flash-high",
+      "gemini-3.6-flash-medium",
+      "gemini-3.6-flash-low",
+      "gemini-3.5-flash-low",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **Gemini 3.6 Flash** tier buckets to the Antigravity quota tracker in the dashboard.

Gemini 3.6 Flash shipped as picker variants (`gemini-3.6-flash-high`/`medium`/`low`) — the provider registry and MITM tool aliases already expose them (see #2779). But `getAntigravityUsage` filters the `fetchAvailableModels` response through a hardcoded `importantModels` list that still only contained 3.5 Flash, so the 3.6 Flash quota buckets were silently dropped and **no usage bar rendered** in the Quota tracker.

## Changes

- `open-sse/services/usage/google.js`: add `gemini-3.6-flash-high`, `gemini-3.6-flash-medium`, `gemini-3.6-flash-low` to the Antigravity `importantModels` filter (keys match `PROVIDER_MODELS` ag ids, same convention as the existing 3.5 Flash tiers).
- `tests/unit/antigravity-quota-gemini-3.6.test.js`: new tests asserting the 3.6 Flash tier quotas (used/total/remainingPercentage/displayName) are returned and that internal/non-important models are still filtered out.

## Testing

- `tests/unit/antigravity-quota-gemini-3.6.test.js` — 2 passed
- Related suites (antigravity-usage-headers, antigravity-mitm, antigravity-retry-hook, antigravity-cache, gemini-usage-projectid, provider-quota-visibility) — 24 passed, 6 skipped (pre-existing)
- ESLint clean on changed files
