### PR TITLE
fix: freeTier/apikey providers without authModes default to apikey in dualAuthTypes

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -283,7 +283,15 @@ export default function ProvidersPage() {
   const dualAuthTypes = (info, key) => {
     if (key === "kiro") return ["oauth", "apikey", "api_key"];
     const modes = info?.authModes;
-    if (!Array.isArray(modes) || !modes.includes("apikey")) return "oauth";
+    // Free-tier and API-key providers default to supporting apikey even when the
+    // registry entry omits authModes (e.g. cloudflare-ai, byteplus, ollama,
+    // vertex) — otherwise their apikey connections are invisible on the grid card.
+    if (!Array.isArray(modes)) {
+      return key in FREE_TIER_PROVIDERS || key in APIKEY_PROVIDERS
+        ? ["oauth", "apikey", "api_key"]
+        : "oauth";
+    }
+    if (!modes.includes("apikey")) return "oauth";
     return ["oauth", "apikey", "api_key"];
   };
 


### PR DESCRIPTION
## Summary

Fix provider cards showing "No connections" on the **Providers** grid for free-tier providers whose registry entries omit `authModes`.

## Problem

`dualAuthTypes()` in `src/app/(dashboard)/dashboard/providers/page.js` returns `"oauth"` for any provider without `authModes`:

```js
if (!Array.isArray(modes) || !modes.includes("apikey")) return "oauth";
```

Several `category: "freeTier"` providers omit `authType`/`authModes` in the registry (e.g. `cloudflare-ai`, `byteplus`, `ollama`, `vertex`). Their `apikey` connections are then filtered out of the card's connected count → the card shows **"No connections"** even though the provider detail page correctly lists the active connection, and the connection routes fine.

Affected: `cloudflare-ai`, `byteplus`, `ollama`, `vertex` (all `category: "freeTier"`). `category: "apikey"` entries were unaffected because they're counted via the dedicated apikey section.

## Fix

When `authModes` is absent, default to supporting `apikey` for providers that belong to `FREE_TIER_PROVIDERS` or `APIKEY_PROVIDERS`:

```js
if (!Array.isArray(modes)) {
  return key in FREE_TIER_PROVIDERS || key in APIKEY_PROVIDERS
    ? ["oauth", "apikey", "api_key"]
    : "oauth";
}
```

This fixes all affected free-tier cards at once, keeps oauth-only providers (e.g. `kimchi`, which declares `authModes:["oauth"]`) unchanged, and preserves existing behavior for providers that do declare `authModes`.

## Related

- Issue #2969 (original Cloudflare report)
