### PR TITLE
fix(cli-tools): enable Apply button for dynamic OpenAI/Anthropic-compatible providers

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/[toolId]/ToolDetailClient.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/[toolId]/ToolDetailClient.js
@@ -81,6 +81,33 @@ export default function ToolDetailClient({ toolId, machineId }) {
           models.push({ value: modelValue, label: `${alias}/${m.id}`, provider: conn.provider, alias, connectionName: conn.name, modelId: m.id });
         }
       });
+
+      // openai/anthropic-compatible providers are registered with a random UUID (e.g.
+      // "openai-compatible-chat-<uuid>") that has no entry in the static PROVIDER_MODELS
+      // catalog, so `getModelsByProviderId` returns []. Routing still works because the
+      // request path uses the connection's own model config, but `hasActiveProviders`
+      // below would flip to false and disable the Apply button. Fall back to the
+      // connection's own models so these providers are usable from CLI tool pages.
+      if (providerModels.length === 0) {
+        const prefix = conn.providerSpecificData?.prefix || alias;
+        const fallbackModels = [];
+        if (conn.defaultModel) fallbackModels.push({ id: conn.defaultModel, name: conn.defaultModel });
+        (conn.providerSpecificData?.customModels || []).forEach(m => {
+          if (m?.id && !fallbackModels.some(f => f.id === m.id)) fallbackModels.push({ id: m.id, name: m.name || m.id });
+        });
+        if (fallbackModels.length === 0 && conn.testStatus === "active") {
+          // Provider is confirmed reachable but exposes no model info anywhere;
+          // still let the user apply so they aren't stuck on a permanently disabled button.
+          fallbackModels.push({ id: "model-id", name: `${prefix}/model-id` });
+        }
+        fallbackModels.forEach(m => {
+          const modelValue = `${prefix}/${m.id}`;
+          if (!seenModels.has(modelValue)) {
+            seenModels.add(modelValue);
+            models.push({ value: modelValue, label: `${prefix}/${m.id}`, provider: conn.provider, alias: prefix, connectionName: conn.name, modelId: m.id });
+          }
+        });
+      }
     });
     return models;
   };


### PR DESCRIPTION
## Description

On the CLI Tools detail page (`/dashboard/cli-tools/claude`, `/codex`, …) the **Apply** button is permanently grayed out whenever the only active provider connection is a dynamically-registered OpenAI-compatible / Anthropic-compatible provider (id like `openai-compatible-chat-<uuid>`).

Routing keeps working fine — the connection's `testStatus` is `active` and traffic flows through 9router. Only the dashboard blocks the user from writing `~/.claude/settings.json`, `~/.codex/auth.json`, etc. via the **Apply** button.

## Root Cause

`src/app/(dashboard)/dashboard/cli-tools/[toolId]/ToolDetailClient.js` gates Apply on `hasActiveProviders`, which is derived from `getAllAvailableModels()`. That helper only consults the static `PROVIDER_MODELS` registry via `getModelsByProviderId(conn.provider)`:

| Provider id | In `PROVIDER_MODELS`? | Catalog result | `hasActiveProviders` |
|---|:-:|:-:|:-:|
| `claude`, `groq`, `openrouter`, … | ✅ | model list | `true` (correct) |
| `openai-compatible-chat-<uuid>` | ❌ (random UUID) | `[]` | `false` (wrong) |
| `anthropic-compatible-chat-<uuid>` | ❌ | `[]` | `false` (wrong) |

The actual routing path never reads this catalog for compatible providers — it forwards using the connection's own `defaultModel`, `providerSpecificData.prefix`, and the request body's model name. So 9router happily serves traffic while the UI keeps Apply disabled.

This is the same catalog-miss pattern as #2098 (combo page), which was fixed in `ModelSelectModal.js` by falling back to `modelAliases` + `customModels`. The CLI-tools pages never received the equivalent treatment.

## Changes

In `getAllAvailableModels()` (ToolDetailClient.js), when the static catalog returns no models for a connection, fall back in this order:

1. `conn.defaultModel` — set when the user clicked "Test Connection" on the compatible provider, always present in practice.
2. `conn.providerSpecificData?.customModels` — models registered via the provider detail page's **Add Model** flow (same source `ModelSelectModal` reads).
3. `${prefix}/model-id` placeholder when `conn.testStatus === "active"` — last-resort escape hatch so the button isn't permanently bricked even if the user hasn't registered any model yet. Mirrors the placeholder already used in `ModelSelectModal.js`.

The model value is built with `providerSpecificData.prefix` (e.g. `ixgbe/Kimi-K3`) instead of the raw provider UUID, matching how the router actually routes for these connections — same convention as `ModelSelectModal`.

Built-in providers are untouched: the fallback branch only executes when `getModelsByProviderId()` returned `[]`, and for built-ins that branch never fires.

## Related Issues

- Closes #2994
- Related: #2028, #2098, #1990, #1993, #2013

## Testing

- [x] Reproduced the bug locally on 9router v0.5.45 (macOS): single active connection of type `openai-compatible-chat-d0cd250f-…` with `defaultModel: Kimi-K3`, Apply button disabled.
- [x] Simulated the patched `getAllAvailableModels()` against the real connection record from `~/.9router/db/data.sqlite` (`defaultModel: Kimi-K3`, `providerSpecificData.prefix: ixgbe`): fallback produces `["ixgbe/Kimi-K3"]`, so `hasActiveProviders` flips to `true`.
- [x] Built-in providers unaffected: for `providerModels.length > 0` the new branch is skipped entirely, so Claude / Groq / OpenRouter behavior is unchanged.
