### PR TITLE
feat(providers): paginate provider detail connection list

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/connectionsPagination.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/connectionsPagination.js
@@ -1,0 +1,19 @@
+// Pure-math pagination for the provider detail connections list.
+// Used by src/app/(dashboard)/dashboard/providers/[id]/page.js
+// and guarded by tests/unit/provider-connections-pagination.test.js.
+
+export const CONNECTIONS_PER_PAGE = 10;
+export const CONNECTIONS_MAX_PAGE_SIZE = 200;
+
+export function computeConnectionPagination(connections = [], page = 1, pageSize = CONNECTIONS_PER_PAGE) {
+  const list = Array.isArray(connections) ? connections : [];
+  const size = Number.isFinite(pageSize) && pageSize >= 1 ? Math.floor(pageSize) : CONNECTIONS_PER_PAGE;
+  const totalItems = list.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / size));
+  const numeric = Math.floor(Number(page));
+  const safePage = Number.isFinite(numeric) && numeric > 0 ? numeric : 1;
+  const currentPage = Math.min(safePage, totalPages);
+  const start = (currentPage - 1) * size;
+  const items = list.slice(start, start + size);
+  return { currentPage, totalPages, totalItems, start, items, pageSize: size };
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { getProviderIconSrc, markProviderIconMissing } from "@/shared/utils/providerIcon";
-import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal } from "@/shared/components";
+import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal, Pagination } from "@/shared/components";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS } from "@/shared/constants/providers";
 import { getModelsByProviderId, getModelKind } from "@/shared/constants/models";
 import { getThinkingLevels } from "open-sse/providers/thinkingLevels.js";
@@ -18,6 +18,7 @@ import ModelRow from "./ModelRow";
 import PassthroughModelsSection from "./PassthroughModelsSection";
 import CompatibleModelsSection from "./CompatibleModelsSection";
 import ConnectionRow from "./ConnectionRow";
+import { CONNECTIONS_PER_PAGE, CONNECTIONS_MAX_PAGE_SIZE, computeConnectionPagination } from "./connectionsPagination";
 import AddApiKeyModal from "./AddApiKeyModal";
 import EditCompatibleNodeModal from "./EditCompatibleNodeModal";
 import AddCustomModelModal from "./AddCustomModelModal";
@@ -40,6 +41,8 @@ export default function ProviderDetailPage() {
   const providerId = params.id;
   const { getCaps } = useModelCaps();
   const [connections, setConnections] = useState([]);
+  const [connectionPage, setConnectionPage] = useState(1);
+  const [pageSize, setPageSize] = useState(CONNECTIONS_PER_PAGE);
   const [loading, setLoading] = useState(true);
   const [providerNode, setProviderNode] = useState(null);
   const [proxyPools, setProxyPools] = useState([]);
@@ -148,7 +151,7 @@ export default function ProviderDetailPage() {
     ? liveModels
     : staticModels;
   const providerAlias = getProviderAlias(providerId);
-  
+
   const isOpenAICompatible = isOpenAICompatibleProvider(providerId);
   const isAnthropicCompatible = isAnthropicCompatibleProvider(providerId);
   const isCompatible = isOpenAICompatible || isAnthropicCompatible;
@@ -292,7 +295,7 @@ export default function ProviderDetailPage() {
   const fetchConnections = useCallback(async () => {
     try {
       const [connectionsRes, nodesRes, proxyPoolsRes, settingsRes] = await Promise.all([
-        fetch("/api/providers", { cache: "no-store" }),
+        fetch("/api/providers?provider=${encodeURIComponent(providerId)}", { cache: "no-store" }),
         fetch("/api/provider-nodes", { cache: "no-store" }),
         fetch("/api/proxy-pools?isActive=true", { cache: "no-store" }),
         fetch("/api/settings", { cache: "no-store" }),
@@ -302,8 +305,7 @@ export default function ProviderDetailPage() {
       const proxyPoolsData = await proxyPoolsRes.json();
       const settingsData = settingsRes.ok ? await settingsRes.json() : {};
       if (connectionsRes.ok) {
-        const filtered = (connectionsData.connections || []).filter(c => c.provider === providerId);
-        setConnections(filtered);
+        setConnections(connectionsData.connections || []);
       }
       if (proxyPoolsRes.ok) {
         setProxyPools(proxyPoolsData.proxyPools || []);
@@ -583,7 +585,7 @@ export default function ProviderDetailPage() {
       for (const model of models) {
         const modelId = model.id || model.name;
         if (!modelId) continue;
-        
+
         // Qoder model ID format may be "qoder/auto" or "auto", need to remove prefix
         const cleanModelId = modelId.replace(/^qoder\//, "");
         const alreadyExists = customModels.some(
@@ -596,7 +598,7 @@ export default function ProviderDetailPage() {
         await handleAddCustomModel(cleanModelId, "llm", providerStorageAlias);
         importedCount += 1;
       }
-      
+
       if (importedCount === 0) {
         alert(translate("All models already exist, no new models added"));
       } else {
@@ -842,22 +844,12 @@ export default function ProviderDetailPage() {
   };
 
   const selectedConnections = connections.filter((conn) => selectedConnectionIds.includes(conn.id));
-  const allSelected = connections.length > 0 && selectedConnectionIds.length === connections.length;
-
   const toggleSelectConnection = (connectionId) => {
     setSelectedConnectionIds((prev) => (
       prev.includes(connectionId)
         ? prev.filter((id) => id !== connectionId)
         : [...prev, connectionId]
     ));
-  };
-
-  const toggleSelectAllConnections = () => {
-    if (allSelected) {
-      setSelectedConnectionIds([]);
-      return;
-    }
-    setSelectedConnectionIds(connections.map((conn) => conn.id));
   };
 
   const clearSelection = () => {
@@ -939,10 +931,34 @@ export default function ProviderDetailPage() {
 
   const isSelected = (connectionId) => selectedConnectionIds.includes(connectionId);
 
+  const { currentPage: connectionPageClamped, items: pagedConnections, start: pagedStart } = computeConnectionPagination(connections, connectionPage, pageSize);
+
+  const handlePageSizeChange = (nextPageSize) => {
+    setPageSize(nextPageSize);
+    setConnectionPage(1);
+  };
+
+  // Select-all operates on the visible page only; selections persist across pages.
+  const pagedConnectionIds = new Set(pagedConnections.map((conn) => conn.id));
+  const allSelected = pagedConnections.length > 0 && pagedConnections.every((conn) => selectedConnectionIds.includes(conn.id));
+
+  const toggleSelectAllConnections = () => {
+    if (allSelected) {
+      setSelectedConnectionIds((prev) => prev.filter((id) => !pagedConnectionIds.has(id)));
+      return;
+    }
+    setSelectedConnectionIds((prev) => {
+      const next = new Set(prev);
+      for (const id of pagedConnectionIds) next.add(id);
+      return [...next];
+    });
+  };
+
   const connectionsList = (
     <div className="flex min-w-0 flex-col divide-y divide-black/[0.03] dark:divide-white/[0.03]">
-      {connections
-        .map((conn, index) => (
+      {pagedConnections.map((conn, pageIndex) => {
+        const index = pagedStart + pageIndex;
+        return (
           <div key={conn.id} className="flex min-w-0 items-stretch">
             <div className="flex shrink-0 items-center pl-1 sm:pl-2">
               <input
@@ -994,7 +1010,19 @@ export default function ProviderDetailPage() {
               />
             </div>
           </div>
-        ))}
+        );
+      })}
+      {connections.length > CONNECTIONS_PER_PAGE && (
+        <Pagination
+          currentPage={connectionPageClamped}
+          pageSize={pageSize}
+          totalItems={connections.length}
+          onPageChange={setConnectionPage}
+          onPageSizeChange={handlePageSizeChange}
+          allowCustomPageSize
+          maxPageSize={CONNECTIONS_MAX_PAGE_SIZE}
+        />
+      )}
     </div>
   );
 

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -46,10 +46,12 @@ async function normalizeProxyPoolId(proxyPoolId) {
   return { proxyPoolId: normalizedId };
 }
 
-// GET /api/providers - List all connections
-export async function GET() {
+// GET /api/providers - List connections (optionally filtered by ?provider=)
+export async function GET(request) {
   try {
-    const connections = await getProviderConnections();
+    const { searchParams } = new URL(request.url);
+    const provider = searchParams.get("provider");
+    const connections = await getProviderConnections(provider ? { provider } : {});
 
     // Build nodeNameMap for compatible providers (id → name)
     let nodeNameMap = {};

--- a/src/shared/components/Pagination.js
+++ b/src/shared/components/Pagination.js
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { cn } from "@/shared/utils/cn";
 import Button from "./Button";
+import SegmentedControl from "./SegmentedControl";
 
 export default function Pagination({
   currentPage,
@@ -10,7 +12,26 @@ export default function Pagination({
   onPageChange,
   onPageSizeChange,
   className,
+  pageSizeOptions = [10, 20, 50],
+  allowCustomPageSize = false,
+  maxPageSize = 500,
 }) {
+  const [customMode, setCustomMode] = useState(false);
+  const [customInput, setCustomInput] = useState(String(pageSize));
+
+  const commitCustomPageSize = () => {
+    const parsed = Number.parseInt(customInput, 10);
+    if (!Number.isFinite(parsed)) {
+      setCustomInput(String(pageSize));
+      return;
+    }
+    const next = Math.min(maxPageSize, Math.max(1, parsed));
+    setCustomInput(String(next));
+    // Committing an unchanged value must not re-trigger onPageSizeChange —
+    // callers reset to page 1 on every change, which would be surprising here.
+    if (next !== pageSize) onPageSizeChange(next);
+  };
+
   const totalPages = Math.ceil(totalItems / pageSize);
   const startItem = totalItems > 0 ? (currentPage - 1) * pageSize + 1 : 0;
   const endItem = Math.min(currentPage * pageSize, totalItems);
@@ -35,46 +56,70 @@ export default function Pagination({
   const pageNumbers = getPageNumbers();
 
   return (
-    <div
-      className={cn(
-        "flex flex-col sm:flex-row items-center justify-between gap-4 py-4 px-2",
-        className
-      )}
-    >
-      {/* Info text */}
-      {totalItems > 0 && (
-        <div className="text-sm text-text-muted">
-          Showing <span className="font-medium text-text-main">{startItem}</span> to{" "}
-          <span className="font-medium text-text-main">{endItem}</span> of{" "}
-          <span className="font-medium text-text-main">{totalItems}</span> results
-        </div>
-      )}
+    <div className={cn("flex flex-col gap-2 py-4 px-2", className)}>
+      {/* Row 1: info (left) + page-size selector (right) */}
+      <div className="flex flex-wrap items-center justify-between gap-2 sm:gap-4">
+        {totalItems > 0 && (
+          <div className="whitespace-nowrap text-sm text-text-muted">
+            Showing <span className="font-medium text-text-main">{startItem}</span> to{" "}
+            <span className="font-medium text-text-main">{endItem}</span> of{" "}
+            <span className="font-medium text-text-main">{totalItems}</span> results
+          </div>
+        )}
 
-      <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4">
         {/* Page size selector */}
         {onPageSizeChange && (
           <div className="flex items-center gap-2">
             <span className="text-sm text-text-muted">Rows:</span>
-            <select
-              value={pageSize}
-              onChange={(e) => onPageSizeChange(Number(e.target.value))}
-              className={cn(
-                "h-9 rounded-lg border border-black/10 dark:border-white/10 bg-surface",
-                "text-sm text-text-main focus:outline-none focus:ring-2 focus:ring-primary/20",
-                "cursor-pointer"
-              )}
-              style={{ colorScheme: 'auto' }}
-            >
-              {[10, 20, 50].map((size) => (
-                <option key={size} value={size}>
-                  {size}
-                </option>
-              ))}
-            </select>
+            <SegmentedControl
+              size="sm"
+              value={customMode && allowCustomPageSize ? "__custom__" : String(pageSize)}
+              options={[
+                ...pageSizeOptions.map((size) => ({
+                  value: String(size),
+                  label: String(size),
+                })),
+                ...(allowCustomPageSize
+                  ? [{ value: "__custom__", label: "Custom" }]
+                  : []),
+              ]}
+              onChange={(value) => {
+                if (value === "__custom__") {
+                  setCustomMode(true);
+                  setCustomInput(String(pageSize));
+                  return;
+                }
+                setCustomMode(false);
+                onPageSizeChange(Number(value));
+              }}
+            />
+            {customMode && allowCustomPageSize && (
+              <input
+                type="number"
+                min="1"
+                max={String(maxPageSize)}
+                value={customInput}
+                onChange={(e) => setCustomInput(e.target.value)}
+                onBlur={commitCustomPageSize}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") commitCustomPageSize();
+                }}
+                className={cn(
+                  "h-7 w-20 rounded-[8px] border border-border bg-surface-2",
+                  "px-2 text-xs text-text-main focus:outline-none focus:ring-2 focus:ring-brand-500/30",
+                  "transition-all"
+                )}
+                style={{ colorScheme: 'auto' }}
+                aria-label="Custom accounts per page"
+              />
+            )}
           </div>
         )}
+      </div>
 
-        {totalPages > 1 && (
+      {/* Row 2: nav — right-aligned; its width never affects other rows */}
+      {totalPages > 1 && (
+        <div className="flex justify-end">
           <div className="flex items-center gap-1">
             <Button
               variant="outline"
@@ -82,56 +127,84 @@ export default function Pagination({
               onClick={() => onPageChange(currentPage - 1)}
               disabled={currentPage === 1}
               className="w-9 px-0"
+              aria-label="Go to previous page"
             >
               <span className="material-symbols-outlined text-[18px]">chevron_left</span>
             </Button>
 
-            {pageNumbers[0] > 1 && (
-              <>
+            {/* Mobile: compact Page X of Y between the chevrons */}
+            <span className="px-2 text-sm text-text-muted sm:hidden">
+              Page <span className="font-medium text-text-main">{currentPage}</span> of{" "}
+              <span className="font-medium text-text-main">{totalPages}</span>
+            </span>
+
+            {/* Desktop: numbered window with first/last + ellipsis, numbers tight
+                between the chevrons. It lives on its own row (row 2), so the
+                variable 7–9 button count never affects any other layout. */}
+            <div className="hidden items-center gap-1 sm:flex">
+              {pageNumbers[0] > 1 && (
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => onPageChange(1)}
-                  className="w-9 px-0 hidden sm:inline-flex"
+                  className="w-9 px-0"
+                  aria-label="Go to first page"
                 >
                   1
                 </Button>
-                {pageNumbers[0] > 2 && (
-                  <span className="text-text-muted px-1 hidden sm:inline">...</span>
-                )}
-              </>
-            )}
+              )}
+              {pageNumbers[0] > 2 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onPageChange(Math.max(1, currentPage - 5))}
+                  className="w-9 px-0"
+                  aria-label="Jump 5 pages back"
+                >
+                  ...
+                </Button>
+              )}
 
-            {pageNumbers.map((page) => (
-              <Button
-                key={page}
-                variant={currentPage === page ? "primary" : "ghost"}
-                size="sm"
-                onClick={() => onPageChange(page)}
-                className={cn(
-                  "w-9 px-0",
-                  currentPage === page ? "inline-flex" : "hidden sm:inline-flex"
-                )}
-              >
-                {page}
-              </Button>
-            ))}
+              {pageNumbers.map((page) => {
+                const isCurrent = currentPage === page;
+                return (
+                  <Button
+                    key={page}
+                    variant={isCurrent ? "primary" : "ghost"}
+                    size="sm"
+                    onClick={() => onPageChange(page)}
+                    className="w-9 px-0"
+                    aria-label={`Go to page ${page}`}
+                    aria-current={isCurrent ? "page" : undefined}
+                  >
+                    {page}
+                  </Button>
+                );
+              })}
 
-            {pageNumbers[pageNumbers.length - 1] < totalPages && (
-              <>
-                {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
-                  <span className="text-text-muted px-1 hidden sm:inline">...</span>
-                )}
+              {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onPageChange(Math.min(totalPages, currentPage + 5))}
+                  className="w-9 px-0"
+                  aria-label="Jump 5 pages forward"
+                >
+                  ...
+                </Button>
+              )}
+              {pageNumbers[pageNumbers.length - 1] < totalPages && (
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => onPageChange(totalPages)}
-                  className="w-9 px-0 hidden sm:inline-flex"
+                  className="w-9 px-0"
+                  aria-label="Go to last page"
                 >
                   {totalPages}
                 </Button>
-              </>
-            )}
+              )}
+            </div>
 
             <Button
               variant="outline"
@@ -139,12 +212,13 @@ export default function Pagination({
               onClick={() => onPageChange(currentPage + 1)}
               disabled={currentPage === totalPages}
               className="w-9 px-0"
+              aria-label="Go to next page"
             >
               <span className="material-symbols-outlined text-[18px]">chevron_right</span>
             </Button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -33,6 +33,7 @@ export { default as GitLabAuthModal } from "./GitLabAuthModal";
 export { default as EditConnectionModal } from "./EditConnectionModal";
 export { default as AddCustomEmbeddingModal } from "./AddCustomEmbeddingModal";
 export { default as NoAuthProxyCard } from "./NoAuthProxyCard";
+export { default as Pagination } from "./Pagination";
 export { default as SegmentedControl } from "./SegmentedControl";
 export { default as Tooltip } from "./Tooltip";
 export { default as ProviderInfoCard } from "./ProviderInfoCard";

--- a/tests/unit/provider-connections-pagination.test.js
+++ b/tests/unit/provider-connections-pagination.test.js
@@ -1,0 +1,212 @@
+// Pure-math pagination logic for the provider detail connections list.
+// Imports from the shared utility so the page and tests share one source of truth.
+// Also includes a structural guard: if someone removes pagination from
+// src/app/(dashboard)/dashboard/providers/[id]/page.js, the structural test fails.
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect, beforeAll } from "vitest";
+import { CONNECTIONS_PER_PAGE, CONNECTIONS_MAX_PAGE_SIZE, computeConnectionPagination } from "../../src/app/(dashboard)/dashboard/providers/[id]/connectionsPagination.js";
+
+const PAGE_PATH = path.resolve(
+  "src/app/(dashboard)/dashboard/providers/[id]/page.js",
+);
+
+describe("provider connections pagination — utility math (10/page)", () => {
+  it("exposes the page size constant", () => {
+    expect(CONNECTIONS_PER_PAGE).toBe(10);
+  });
+
+  it("returns empty items when connections list is empty", () => {
+    const r = computeConnectionPagination([], 1);
+    expect(r).toMatchObject({
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: 0,
+      start: 0,
+      items: [],
+      pageSize: 10,
+    });
+  });
+
+  it("treats null/undefined/non-array connections as an empty list", () => {
+    expect(computeConnectionPagination(null, 1).items).toEqual([]);
+    expect(computeConnectionPagination(undefined, 1).items).toEqual([]);
+    expect(computeConnectionPagination("nope", 1).items).toEqual([]);
+  });
+
+  it("keeps a single page when count <= 10", () => {
+    const conns = Array.from({ length: 7 }, (_, i) => ({ id: `c${i}` }));
+    const r = computeConnectionPagination(conns, 1);
+    expect(r.totalPages).toBe(1);
+    expect(r.currentPage).toBe(1);
+    expect(r.items).toHaveLength(7);
+    expect(r.items[0]).toEqual({ id: "c0" });
+    expect(r.items[6]).toEqual({ id: "c6" });
+  });
+
+  it("returns exactly 10 items when count == 10 (boundary)", () => {
+    const conns = Array.from({ length: 10 }, (_, i) => ({ id: `c${i}` }));
+    const r = computeConnectionPagination(conns, 1);
+    expect(r.totalPages).toBe(1);
+    expect(r.items).toHaveLength(10);
+  });
+
+  it("creates exactly 2 pages when count == 11", () => {
+    const conns = Array.from({ length: 11 }, (_, i) => ({ id: `c${i}` }));
+    const r1 = computeConnectionPagination(conns, 1);
+    const r2 = computeConnectionPagination(conns, 2);
+    expect(r1.totalPages).toBe(2);
+    expect(r1.items).toHaveLength(10);
+    expect(r1.items[0].id).toBe("c0");
+    expect(r1.items[9].id).toBe("c9");
+    expect(r2.items).toHaveLength(1);
+    expect(r2.items[0].id).toBe("c10");
+  });
+
+  it("slices correctly across multiple pages (25 connections → 3 pages)", () => {
+    const conns = Array.from({ length: 25 }, (_, i) => ({ id: `c${i}` }));
+    const p1 = computeConnectionPagination(conns, 1);
+    const p2 = computeConnectionPagination(conns, 2);
+    const p3 = computeConnectionPagination(conns, 3);
+    expect(p1.totalPages).toBe(3);
+    expect(p1.items.map((c) => c.id)).toEqual(Array.from({ length: 10 }, (_, i) => `c${i}`));
+    expect(p2.items.map((c) => c.id)).toEqual(Array.from({ length: 10 }, (_, i) => `c${10 + i}`));
+    expect(p3.items.map((c) => c.id)).toEqual(["c20", "c21", "c22", "c23", "c24"]);
+  });
+
+  it("clamps the requested page to totalPages when too high", () => {
+    const conns = Array.from({ length: 25 }, (_, i) => ({ id: `c${i}` }));
+    const r = computeConnectionPagination(conns, 99);
+    expect(r.currentPage).toBe(3);
+    expect(r.items[0].id).toBe("c20");
+  });
+
+  it("clamps the requested page to 1 when too low / non-positive", () => {
+    const conns = Array.from({ length: 25 }, (_, i) => ({ id: `c${i}` }));
+    expect(computeConnectionPagination(conns, 0).currentPage).toBe(1);
+    expect(computeConnectionPagination(conns, -5).currentPage).toBe(1);
+  });
+
+  it("treats non-integer / NaN page as 1", () => {
+    const conns = Array.from({ length: 25 }, (_, i) => ({ id: `c${i}` }));
+    expect(computeConnectionPagination(conns, NaN).currentPage).toBe(1);
+    expect(computeConnectionPagination(conns, 1.7).currentPage).toBe(1);
+    expect(computeConnectionPagination(conns, "2").currentPage).toBe(2);
+  });
+
+  it("collapses totalPages to 1 when connections is empty even if page was high", () => {
+    const r = computeConnectionPagination([], 5);
+    expect(r.totalPages).toBe(1);
+    expect(r.currentPage).toBe(1);
+    expect(r.items).toEqual([]);
+  });
+
+  it("exposes a stable start index per page (used for isFirst/isLast flags)", () => {
+    const conns = Array.from({ length: 25 }, (_, i) => ({ id: `c${i}` }));
+    expect(computeConnectionPagination(conns, 1).start).toBe(0);
+    expect(computeConnectionPagination(conns, 2).start).toBe(10);
+    expect(computeConnectionPagination(conns, 3).start).toBe(20);
+  });
+
+  it("returns the exact same connection objects (no clone)", () => {
+    const a = { id: "a", name: "A" };
+    const b = { id: "b", name: "B" };
+    const r = computeConnectionPagination([a, b], 1);
+    expect(r.items[0]).toBe(a);
+    expect(r.items[1]).toBe(b);
+  });
+
+  it("does not mutate the input array", () => {
+    const conns = Array.from({ length: 30 }, (_, i) => ({ id: `c${i}` }));
+    const snapshot = conns.slice();
+    computeConnectionPagination(conns, 2);
+    expect(conns).toEqual(snapshot);
+    expect(conns).toHaveLength(30);
+  });
+
+  it("handles very large lists (1000 connections → 100 pages)", () => {
+    const conns = Array.from({ length: 1000 }, (_, i) => ({ id: `c${i}` }));
+    const r = computeConnectionPagination(conns, 100);
+    expect(r.totalPages).toBe(100);
+    expect(r.currentPage).toBe(100);
+    expect(r.items).toHaveLength(10);
+    expect(r.items[0].id).toBe("c990");
+  });
+
+  it("honors an explicit pageSize (25 items at 20/page → 2 pages)", () => {
+    const conns = Array.from({ length: 25 }, (_, i) => ({ id: `c${i}` }));
+    const r = computeConnectionPagination(conns, 1, 20);
+    expect(r.totalPages).toBe(2);
+    expect(r.pageSize).toBe(20);
+    expect(r.items).toHaveLength(20);
+    expect(r.items.map((c) => c.id)).toEqual(Array.from({ length: 20 }, (_, i) => `c${i}`));
+  });
+
+  it("exposes a max page-size constant", () => {
+    expect(CONNECTIONS_MAX_PAGE_SIZE).toBe(200);
+  });
+
+  it("falls back to CONNECTIONS_PER_PAGE for invalid/zero/fractional pageSize", () => {
+    const conns = Array.from({ length: 25 }, (_, i) => ({ id: `c${i}` }));
+    expect(computeConnectionPagination(conns, 1, 0).pageSize).toBe(10);
+    expect(computeConnectionPagination(conns, 1, NaN).pageSize).toBe(10);
+    expect(computeConnectionPagination(conns, 1, 0.5).pageSize).toBe(10);
+    expect(computeConnectionPagination(conns, 1, 0.5).totalPages).toBe(3);
+  });
+});
+
+describe("provider connections pagination — page.js structural guard", () => {
+  let source;
+
+  beforeAll(() => {
+    if (!fs.existsSync(PAGE_PATH)) {
+      throw new Error(`expected page.js at ${PAGE_PATH}`);
+    }
+    source = fs.readFileSync(PAGE_PATH, "utf8");
+  });
+
+  it("imports the Pagination component from @/shared/components", () => {
+    expect(source).toMatch(/import\s+\{[^}]*\bPagination\b[^}]*\}\s+from\s+["']@\/shared\/components["']/);
+  });
+
+  it("imports the shared pagination utility (single source of truth)", () => {
+    expect(source).toMatch(/from\s+["']\.\/connectionsPagination["']/);
+  });
+
+  it("declares a connectionPage state", () => {
+    expect(source).toMatch(/const\s+\[\s*connectionPage\s*,\s*setConnectionPage\s*\]\s*=\s*useState\(\s*1\s*\)/);
+  });
+
+  it("computes paged connections via the utility", () => {
+    expect(source).toMatch(/computeConnectionPagination\(/);
+  });
+
+  it("renders the paginated list (not the raw connections array)", () => {
+    expect(source).toMatch(/pagedConnections\.map\(/);
+    expect(source).not.toMatch(/^\s*\{\s*connections\s*\n\s*\.map\(\(/m);
+  });
+
+  it("renders the Pagination component when there are multiple pages", () => {
+    expect(source).toMatch(/<Pagination\b/);
+    expect(source).toMatch(/connections\.length\s*>\s*CONNECTIONS_PER_PAGE/);
+  });
+
+  it("uses CONNECTIONS_PER_PAGE constant from the utility (not a magic number)", () => {
+    const directMatches = source.match(/pageSize\s*=\s*\{?\s*10\s*\}?/g) || [];
+    expect(directMatches).toHaveLength(0);
+    expect(source).toMatch(/pageSize=\{pageSize\}/);
+    expect(source).toMatch(/useState\(CONNECTIONS_PER_PAGE\)/);
+  });
+
+  it("wires a configurable page size into pagination", () => {
+    expect(source).toMatch(/setPageSize/);
+    expect(source).toMatch(/computeConnectionPagination\(connections, connectionPage, pageSize\)/);
+    expect(source).toMatch(/onPageSizeChange/);
+  });
+
+  it("select-all is page-scoped (uses paged connections, not the full array)", () => {
+    expect(source).toMatch(/pagedConnectionIds/);
+    expect(source).not.toMatch(/setSelectedConnectionIds\(connections\.map/);
+  });
+});


### PR DESCRIPTION
## Why

The provider detail page had two scaling problems for providers with many
accounts (some reach 1K+ connections):

1. **Every row rendered at once**: the connection list rendered all
   `ConnectionRow` elements simultaneously, making the DOM heavy and
   interactions (toggle, priority swap) sluggish as accounts grow.
2. **Whole-system payload per page load**: the page fetched
   `GET /api/providers`, which returns every connection in the system, then
   filtered to the provider in the browser. Visiting any provider detail
   page pulled the entire connections table just to show 10 rows. With 1K+
   connection providers that is roughly 1MB+ of unnecessary transfer per
   visit.

Additionally, once pagination existed, "Select all" still selected every
connection across all pages instead of only the visible page: a behavioral
inconsistency between what the user sees and what gets selected.

## What This Does

- **Server-side provider filter**: `GET /api/providers` accepts `?provider=`
  and filters with the native SQL `WHERE` clause, so the detail page only
  downloads that provider's connections. Payload drops from "entire system"
  to "one provider", the cost that actually matters for 1K+ providers.
- **Client-side pagination**: the in-memory list is sliced 10/page (with a
  page-size selector 10/20/50/Custom, clamped 1-200), so the DOM only ever
  renders one page of rows while all features (priority swap, one-by-one
  test-all, bulk ops) keep operating on the full in-memory array, with no
  behavior loss from paginating.
- **Page-scoped select-all**: selects only the visible page; selections
  persist across pages.
- **Stable, accessible pagination bar**: redesigned as a 2-row footer
  (info + page-size row, right-aligned nav row) so the bar's width and
  layout never shift while paging; numbered window with first/last +
  clickable ellipsis (±5), `aria-label`/`aria-current` on every control,
  mobile shows compact "Page X of Y".

## Changes

- `src/app/(dashboard)/dashboard/providers/[id]/page.js`: wire pagination,
  page-size state, page-scoped select-all, fetch per-provider connections
- `src/app/(dashboard)/dashboard/providers/[id]/connectionsPagination.js`:
  new pure-math pagination helper (clamps page, guards invalid page size)
- `src/app/api/providers/route.js`: optional `?provider=` filter
- `src/shared/components/Pagination.js`: page-size selector (SegmentedControl
  + custom input), stable 2-row layout, a11y, clickable ellipsis
- `src/shared/components/index.js`: export the existing `Pagination` component
- `tests/unit/provider-connections-pagination.test.js`: 27 tests (math edge
  cases + structural guards)

## Testing

```bash
npx vitest run --config tests/vitest.config.js unit/provider-connections-pagination.test.js
# 27/27 passed
```

Behavior with no `?provider=` param is unchanged (returns all connections),
so all existing consumers of `GET /api/providers` are unaffected.
