### PR TITLE
fix(cooldown): honour provider-reported quota reset times instead of re-probing spent accounts

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -28,21 +28,33 @@ export const DEFAULT_ERROR_MESSAGES = {
   504: "Gateway timeout"
 };
 
-// Exponential backoff config for rate limits
+// Exponential backoff config for rate limits.
+// `max` is the blind ceiling used only when the provider reports no reset time. The
+// ladder needs ~9 consecutive failures to reach it, so it applies to accounts that are
+// genuinely spent, not to transient throttles. At the old 5 min an account out of
+// monthly quota was re-probed ~288 times a day, every day, forever.
 export const BACKOFF_CONFIG = {
   base: 2000,
-  max: 5 * 60 * 1000,
+  max: 30 * 60 * 1000,
   maxLevel: 15
 };
 
 // Default cooldown for transient/unknown errors
 export const TRANSIENT_COOLDOWN_MS = 30 * 1000;
 
-// Hard cap for provider-reported rate limit cooldown (e.g. codex resets_at can be 5-6h)
-export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000;
+// Sanity ceiling for a provider-reported reset time (resetsAtMs), NOT a policy cap.
+// Providers report genuinely long resets: codex `resets_at` runs 5-6h out and
+// cloudcode-pa returns `quotaResetTimeStamp` up to ~150h out. Truncating those to
+// 30 min put the account straight back into rotation to fail again. This value exists
+// only to reject nonsense timestamps (some usage APIs return year 9999), so it sits
+// just past the longest legitimate window — a calendar month.
+export const MAX_RATE_LIMIT_COOLDOWN_MS = 31 * 24 * 60 * 60 * 1000;
 
 // Cooldown durations (ms)
 const COOLDOWN = {
+  // Provider says a calendar-month allowance is spent but reports no reset time
+  // (e.g. kiro 402 MONTHLY_REQUEST_COUNT). Re-probe a few times a day, not every 2 min.
+  monthly: 6 * 60 * 60 * 1000,
   long: 2 * 60 * 1000,
   short: 5 * 1000,
 };
@@ -58,6 +70,9 @@ const COOLDOWN = {
  */
 export const ERROR_RULES = [
   // --- Text-based rules (checked first, order = priority) ---
+  // Monthly allowance spent — must be matched before the generic 402/429 rules.
+  { text: "monthly_request_count",    cooldownMs: COOLDOWN.monthly },
+  { text: "monthly limit",            cooldownMs: COOLDOWN.monthly },
   { text: "no credentials",           cooldownMs: COOLDOWN.long },
   { text: "request not allowed",      cooldownMs: COOLDOWN.short },
   { text: "improperly formed request", cooldownMs: COOLDOWN.long },
@@ -79,6 +94,7 @@ export const ERROR_RULES = [
 export const COOLDOWN_MS = {
   unauthorized: COOLDOWN.long,
   paymentRequired: COOLDOWN.long,
+  monthlyQuota: COOLDOWN.monthly,
   notFound: COOLDOWN.long,
   transient: TRANSIENT_COOLDOWN_MS,
   requestNotAllowed: COOLDOWN.short,

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -5,6 +5,7 @@ import { OAUTH_ENDPOINTS, ANTIGRAVITY_HEADERS, AG_DEFAULT_TOOLS, AG_TOOL_SUFFIX 
 import { HTTP_STATUS } from "../config/runtimeConfig.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
+import { parseGoogleQuotaReset } from "../utils/googleQuota.js";
 import { cleanJSONSchemaForAntigravity } from "../translator/formats/gemini.js";
 import { DEFAULT_THINKING_AG_SIGNATURE } from "../config/defaultThinkingSignature.js";
 
@@ -121,6 +122,24 @@ export class AntigravityExecutor extends BaseExecutor {
     const forceNonStream = isImageModel(model);
     const action = (stream && !forceNonStream) ? "streamGenerateContent?alt=sse" : "generateContent";
     return `${baseUrl}/v1internal:${action}`;
+  }
+
+  // cloudcode-pa reports exactly when an exhausted quota returns — a real 429 carries
+  // `quotaResetTimeStamp` up to ~150h out. Surface it as resetsAtMs so the model lock
+  // lasts that long instead of expiring on the blind backoff ladder and failing again.
+  // Quotas are per model here, so only the model that ran dry gets locked.
+  parseError(response, bodyText) {
+    if (response.status === 429 && bodyText) {
+      const { resetsAtMs } = parseGoogleQuotaReset(bodyText);
+      if (resetsAtMs) {
+        let message = bodyText;
+        try {
+          message = JSON.parse(bodyText)?.error?.message || bodyText;
+        } catch { /* keep raw body */ }
+        return { status: 429, message, resetsAtMs };
+      }
+    }
+    return super.parseError(response, bodyText);
   }
 
   // sessionId comes from transformRequest output; base.execute runs transformRequest before

--- a/open-sse/executors/gemini-cli.js
+++ b/open-sse/executors/gemini-cli.js
@@ -1,6 +1,7 @@
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
 import { OAUTH_ENDPOINTS, GEMINI_CLI_API_CLIENT, geminiCLIUserAgent } from "../config/appConstants.js";
+import { parseGoogleQuotaReset } from "../utils/googleQuota.js";
 
 export class GeminiCLIExecutor extends BaseExecutor {
   constructor() {
@@ -34,22 +35,14 @@ export class GeminiCLIExecutor extends BaseExecutor {
     };
   }
 
-  // Parse RetryInfo.retryDelay from Google API 429 body to surface upstream retry hint
+  // Surface the upstream retry hint and the precise quota reset moment from a
+  // Google API 429 body, so the account lock lasts until the quota actually returns.
   parseError(response, bodyText) {
     const base = super.parseError(response, bodyText);
     if (response.status !== 429 || !bodyText) return base;
-    try {
-      const parsed = JSON.parse(bodyText);
-      const details = parsed?.error?.details;
-      if (Array.isArray(details)) {
-        for (const d of details) {
-          if (d?.["@type"] === "type.googleapis.com/google.rpc.RetryInfo" && d?.retryDelay) {
-            base.retryAfter = d.retryDelay;
-            break;
-          }
-        }
-      }
-    } catch {}
+    const { resetsAtMs, retryAfter } = parseGoogleQuotaReset(bodyText);
+    if (retryAfter) base.retryAfter = retryAfter;
+    if (resetsAtMs) base.resetsAtMs = resetsAtMs;
     return base;
   }
 

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -220,6 +220,25 @@ export class KiroExecutor extends BaseExecutor {
     super("kiro", PROVIDERS.kiro);
   }
 
+  // Kiro splits its errors into a human `message` plus a machine `reason`, and the
+  // reason is the only part that says which allowance ran out — a spent monthly quota
+  // is `402 {"message":"You have reached the limit.","reason":"MONTHLY_REQUEST_COUNT"}`.
+  // Default parsing keeps only `message`, so the reason never reached the cooldown
+  // rules and a month-long outage was treated as a generic 2 min 402.
+  parseError(response, bodyText) {
+    if (bodyText) {
+      try {
+        const json = JSON.parse(bodyText);
+        const message = json?.message || json?.error || "";
+        const reason = typeof json?.reason === "string" ? json.reason : "";
+        if (message && reason) {
+          return { status: response.status, message: `${message} (${reason})` };
+        }
+      } catch { /* fall through to default */ }
+    }
+    return super.parseError(response, bodyText);
+  }
+
   buildHeaders(credentials, stream = true, url = "") {
     const headers = {
       ...this.config.headers,

--- a/open-sse/utils/googleQuota.js
+++ b/open-sse/utils/googleQuota.js
@@ -1,0 +1,105 @@
+/**
+ * Extract the precise quota reset moment from a Google Cloud Code Assist error body.
+ *
+ * Both antigravity and gemini-cli talk to cloudcode-pa.googleapis.com, which reports
+ * exactly when an exhausted quota comes back. A real 429 body looks like:
+ *
+ *   { "error": { "code": 429, "status": "RESOURCE_EXHAUSTED",
+ *       "message": "Individual quota reached. ... Resets in 149h50m20s.",
+ *       "details": [
+ *         { "@type": ".../google.rpc.ErrorInfo", "reason": "QUOTA_EXHAUSTED",
+ *           "metadata": { "quotaResetDelay": "149h50m20.179078308s",
+ *                         "quotaResetTimeStamp": "2026-08-08T17:54:07Z" } },
+ *         { "@type": ".../google.rpc.RetryInfo", "retryDelay": "539420.179078308s" } ] } }
+ *
+ * Preference order: absolute timestamp, then quota delay, then RetryInfo delay.
+ */
+
+const ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
+const RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
+
+/**
+ * Parse a duration string into milliseconds.
+ * Handles protobuf Duration JSON ("539420.179078308s") and Go's unit form
+ * ("149h50m20.179078308s"). Returns null when nothing parses.
+ * @param {string} value
+ * @returns {number|null}
+ */
+export function parseDurationMs(value) {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!text) return null;
+
+  // Protobuf Duration JSON: a bare seconds value with an "s" suffix.
+  if (/^\d+(\.\d+)?s$/.test(text)) {
+    return Math.round(parseFloat(text) * 1000);
+  }
+
+  // Go duration: any combination of h / m / s parts.
+  const parts = text.match(/(\d+(?:\.\d+)?)(h|m|s|ms)/g);
+  if (!parts) return null;
+  const unitMs = { h: 3600000, m: 60000, s: 1000, ms: 1 };
+  let total = 0;
+  for (const part of parts) {
+    const [, num, unit] = part.match(/(\d+(?:\.\d+)?)(h|m|s|ms)/);
+    total += parseFloat(num) * unitMs[unit];
+  }
+  return Math.round(total);
+}
+
+/**
+ * Pull the quota reset moment out of a Google API error body.
+ * @param {string|object} body - Raw response text or already-parsed JSON
+ * @param {number} [now] - Epoch ms to resolve relative delays against
+ * @returns {{ resetsAtMs: number|null, reason: string|null, model: string|null, retryAfter: string|null }}
+ */
+export function parseGoogleQuotaReset(body, now = Date.now()) {
+  const empty = { resetsAtMs: null, reason: null, model: null, retryAfter: null };
+  if (!body) return empty;
+
+  let parsed = body;
+  if (typeof body === "string") {
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      return empty;
+    }
+  }
+
+  const details = parsed?.error?.details;
+  if (!Array.isArray(details)) return empty;
+
+  let resetsAtMs = null;
+  let reason = null;
+  let model = null;
+  let retryAfter = null;
+
+  for (const detail of details) {
+    if (detail?.["@type"] === ERROR_INFO_TYPE) {
+      reason = detail.reason || reason;
+      model = detail.metadata?.model || model;
+
+      const stamp = detail.metadata?.quotaResetTimeStamp;
+      if (!resetsAtMs && stamp) {
+        const ms = new Date(stamp).getTime();
+        if (Number.isFinite(ms) && ms > now) resetsAtMs = ms;
+      }
+
+      if (!resetsAtMs) {
+        const delayMs = parseDurationMs(detail.metadata?.quotaResetDelay);
+        if (delayMs > 0) resetsAtMs = now + delayMs;
+      }
+    } else if (detail?.["@type"] === RETRY_INFO_TYPE && detail?.retryDelay) {
+      retryAfter = detail.retryDelay;
+    }
+  }
+
+  // RetryInfo is the last resort: it repeats the quota delay when a quota is spent,
+  // but is also present on short server-side throttles.
+  if (!resetsAtMs && retryAfter) {
+    const delayMs = parseDurationMs(retryAfter);
+    if (delayMs > 0) resetsAtMs = now + delayMs;
+  }
+
+  return { resetsAtMs, reason, model, retryAfter };
+}

--- a/tests/unit/quota-reset-cooldown.test.js
+++ b/tests/unit/quota-reset-cooldown.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { parseDurationMs, parseGoogleQuotaReset } from "../../open-sse/utils/googleQuota.js";
+import { checkFallbackError } from "../../open-sse/services/accountFallback.js";
+import { BACKOFF_CONFIG, COOLDOWN_MS, MAX_RATE_LIMIT_COOLDOWN_MS } from "../../open-sse/config/errorConfig.js";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
+import { GeminiCLIExecutor } from "../../open-sse/executors/gemini-cli.js";
+import { KiroExecutor } from "../../open-sse/executors/kiro.js";
+
+// Verbatim 429 body captured from cloudcode-pa.googleapis.com via the antigravity executor.
+const AG_QUOTA_BODY = JSON.stringify({
+  error: {
+    code: 429,
+    message: "Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 149h50m20s.",
+    status: "RESOURCE_EXHAUSTED",
+    details: [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        reason: "QUOTA_EXHAUSTED",
+        domain: "cloudcode-pa.googleapis.com",
+        metadata: {
+          uiMessage: "true",
+          model: "gemini-3-flash-agent",
+          quotaResetDelay: "149h50m20.179078308s",
+          quotaResetTimeStamp: "2026-08-08T17:54:07Z",
+        },
+      },
+      { "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "539420.179078308s" },
+    ],
+  },
+});
+
+// Verbatim 402 body captured from kiro when the monthly allowance is spent.
+const KIRO_MONTHLY_BODY = JSON.stringify({
+  message: "You have reached the limit.",
+  reason: "MONTHLY_REQUEST_COUNT",
+});
+
+describe("parseDurationMs", () => {
+  it("parses protobuf Duration JSON", () => {
+    expect(parseDurationMs("539420.179078308s")).toBe(539420179);
+  });
+
+  it("parses Go unit durations", () => {
+    expect(parseDurationMs("149h50m20.179078308s")).toBe(539420179);
+    expect(parseDurationMs("90m")).toBe(5400000);
+  });
+
+  it("returns null for junk", () => {
+    expect(parseDurationMs("")).toBeNull();
+    expect(parseDurationMs("soon")).toBeNull();
+    expect(parseDurationMs(undefined)).toBeNull();
+  });
+});
+
+describe("parseGoogleQuotaReset", () => {
+  it("prefers the absolute quotaResetTimeStamp", () => {
+    const now = Date.parse("2026-08-02T12:03:46Z");
+    const out = parseGoogleQuotaReset(AG_QUOTA_BODY, now);
+    expect(out.resetsAtMs).toBe(Date.parse("2026-08-08T17:54:07Z"));
+    expect(out.reason).toBe("QUOTA_EXHAUSTED");
+    expect(out.model).toBe("gemini-3-flash-agent");
+    expect(out.retryAfter).toBe("539420.179078308s");
+  });
+
+  it("falls back to quotaResetDelay when the timestamp is stale", () => {
+    const now = Date.parse("2027-01-01T00:00:00Z"); // timestamp already in the past
+    const out = parseGoogleQuotaReset(AG_QUOTA_BODY, now);
+    expect(out.resetsAtMs).toBe(now + 539420179);
+  });
+
+  it("falls back to RetryInfo when no quota metadata is present", () => {
+    const now = 1000;
+    const body = JSON.stringify({
+      error: { details: [{ "@type": "type.googleapis.com/google.rpc.RetryInfo", retryDelay: "30s" }] },
+    });
+    expect(parseGoogleQuotaReset(body, now).resetsAtMs).toBe(now + 30000);
+  });
+
+  it("returns nulls for unrelated or unparseable bodies", () => {
+    expect(parseGoogleQuotaReset("not json").resetsAtMs).toBeNull();
+    expect(parseGoogleQuotaReset(JSON.stringify({ error: { code: 500 } })).resetsAtMs).toBeNull();
+    expect(parseGoogleQuotaReset("").resetsAtMs).toBeNull();
+  });
+});
+
+describe("antigravity executor parseError", () => {
+  it("surfaces resetsAtMs and keeps the human message", () => {
+    const out = new AntigravityExecutor().parseError({ status: 429 }, AG_QUOTA_BODY);
+    expect(out.status).toBe(429);
+    expect(out.resetsAtMs).toBe(Date.parse("2026-08-08T17:54:07Z"));
+    expect(out.message).toContain("Individual quota reached");
+  });
+
+  it("leaves non-quota errors to the base parser", () => {
+    const out = new AntigravityExecutor().parseError({ status: 500 }, "boom");
+    expect(out.resetsAtMs).toBeUndefined();
+    expect(out.message).toBe("boom");
+  });
+});
+
+describe("gemini-cli executor parseError", () => {
+  it("reports both the retry hint and the quota reset", () => {
+    const out = new GeminiCLIExecutor().parseError({ status: 429 }, AG_QUOTA_BODY);
+    expect(out.retryAfter).toBe("539420.179078308s");
+    expect(out.resetsAtMs).toBe(Date.parse("2026-08-08T17:54:07Z"));
+  });
+});
+
+describe("kiro executor parseError", () => {
+  it("keeps the machine reason in the message so cooldown rules can see it", () => {
+    const out = new KiroExecutor().parseError({ status: 402 }, KIRO_MONTHLY_BODY);
+    expect(out.message).toBe("You have reached the limit. (MONTHLY_REQUEST_COUNT)");
+  });
+
+  it("falls back to the base parser without a reason", () => {
+    const out = new KiroExecutor().parseError({ status: 403 }, "HTTP 403");
+    expect(out.message).toBe("HTTP 403");
+  });
+});
+
+describe("cooldown policy", () => {
+  it("classifies a spent monthly allowance as a multi-hour cooldown", () => {
+    const { cooldownMs } = checkFallbackError(402, "You have reached the limit. (MONTHLY_REQUEST_COUNT)");
+    expect(cooldownMs).toBe(COOLDOWN_MS.monthlyQuota);
+    expect(cooldownMs).toBeGreaterThan(60 * 60 * 1000);
+  });
+
+  it("still treats a bare 402 as a short cooldown", () => {
+    const { cooldownMs } = checkFallbackError(402, "Payment required");
+    expect(cooldownMs).toBe(2 * 60 * 1000);
+  });
+
+  it("does not truncate a provider-reported multi-day reset", () => {
+    // The antigravity body above is ~150h out; the ceiling must not clip it.
+    expect(MAX_RATE_LIMIT_COOLDOWN_MS).toBeGreaterThan(150 * 60 * 60 * 1000);
+  });
+
+  it("still rejects nonsense reset timestamps", () => {
+    const absurd = Date.parse("9999-12-31T00:00:00Z") - Date.now();
+    expect(MAX_RATE_LIMIT_COOLDOWN_MS).toBeLessThan(absurd);
+  });
+
+  it("keeps the blind backoff ladder short at the low levels", () => {
+    expect(checkFallbackError(429, "rate limit", 0).cooldownMs).toBe(2000);
+    expect(checkFallbackError(429, "rate limit", 1).cooldownMs).toBe(4000);
+    expect(checkFallbackError(429, "rate limit", 14).cooldownMs).toBe(BACKOFF_CONFIG.max);
+  });
+});


### PR DESCRIPTION
## The problem

An account whose quota is spent for hours or for the rest of the month goes back into
rotation minutes later, fails, and keeps failing until the quota really returns. Every
failed probe costs a full upstream round trip and a fallback hop.

Measured on one install over 22h: **233 antigravity 429s at ~16.4 s each** — about 70
minutes of dead wall-clock, all of it re-probing accounts that had told 9router exactly
when they would be back.

Three ceilings cause it.

**1. `MAX_RATE_LIMIT_COOLDOWN_MS` truncates every provider-reported reset to 30 min.**

`markAccountUnavailable()` already accepts a precise `resetsAtMs`, then clamps it:

```js
cooldownMs = Math.min(resetsAtMs - Date.now(), MAX_RATE_LIMIT_COOLDOWN_MS);
```

The comment on the constant says codex `resets_at` runs 5–6h out — so the clamp is known
to be discarding the very number it was given. It is now a sanity ceiling (31 days) whose
only job is rejecting nonsense timestamps, not a policy cap. 31 days is just past the
longest legitimate window, a calendar month. (Nonsense values are real: at least one usage
API reports `9999-12-31`.)

**2. `BACKOFF_CONFIG.max` capped the blind ladder at 5 min**, so an account out of monthly
quota was re-probed ~288 times a day, every day, forever. Raised to 30 min. The ladder
needs ~9 consecutive failures to reach the ceiling, so transient throttles are unaffected —
levels 1-5 are still 2 s → 32 s.

**3. A 402 fell into the generic 2 min rule** even when the body said the monthly
allowance was gone. Added a `monthly` cooldown class (6h) for providers that report a
monthly quota but no reset time.

## Reporting the reset time providers already send

**antigravity** — a real 429 from `cloudcode-pa.googleapis.com`:

```json
{ "error": { "code": 429, "status": "RESOURCE_EXHAUSTED",
  "message": "Individual quota reached. ... Resets in 149h50m20s.",
  "details": [
    { "@type": ".../google.rpc.ErrorInfo", "reason": "QUOTA_EXHAUSTED",
      "metadata": { "model": "gemini-3-flash-agent",
                    "quotaResetDelay": "149h50m20.179078308s",
                    "quotaResetTimeStamp": "2026-08-08T17:54:07Z" } },
    { "@type": ".../google.rpc.RetryInfo", "retryDelay": "539420.179078308s" } ] } }
```

The quota is back in **6.2 days** and says so three different ways. Before this patch the
lock lasted at most 5 minutes. Now `quotaResetTimeStamp` becomes `resetsAtMs`. Quotas there
are per model, so `modelLock_gemini-3-flash-agent` is set and the account's other pools
(Claude models, other Gemini tiers) stay usable — no new mechanism needed, that is what
`buildModelLockUpdate` already does.

**gemini-cli** — same Cloud Code Assist API. It already walked `error.details` for
`RetryInfo.retryDelay` but only used it as a display hint. It now shares the parser and
reports `resetsAtMs` too.

**kiro** — a spent monthly allowance is
`402 {"message":"You have reached the limit.","reason":"MONTHLY_REQUEST_COUNT"}`.
`parseUpstreamError` keeps only `message`, so the reason — the only part naming the
exhausted allowance — never reached the cooldown rules, and a month-long outage was treated
as a generic 2 min 402. `KiroExecutor.parseError` now keeps it, which also makes
`lastError` in the dashboard say which limit was hit.

## Notes

- Google duration/timestamp parsing lives in one place, `open-sse/utils/googleQuota.js`,
  because both Google-backed executors need it. Handles protobuf Duration JSON
  (`"539420.179078308s"`) and Go's unit form (`"149h50m20.179078308s"`).
- No new config surface, no schema change, no behaviour change for providers that report
  nothing.
- `CHANGELOG.md` deliberately untouched to avoid a version conflict — happy to add an entry
  in whatever form you prefer.

## Tests

`tests/unit/quota-reset-cooldown.test.js` — 17 tests, fixtures are response bodies captured
verbatim from live antigravity and kiro accounts.

Full suite before and after, same machine, same deps:

| | total | passed | failed |
|---|---|---|---|
| master | 1727 | 1579 | 89 |
| this branch | 1744 | 1596 | 89 |

Same 89 pre-existing failures in both runs, compared per test name — **0 new failures, 0
newly passing** besides the 17 added here. `npx eslint` clean on every changed file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
