### PR TITLE
feat(oauth): background token keep-alive so idle connections stay valid

### DIFF
--- a/src/app/api/usage/[connectionId]/route.js
+++ b/src/app/api/usage/[connectionId]/route.js
@@ -48,9 +48,11 @@ export async function refreshAndUpdateCredentials(connection, force = false, pro
   const refreshResult = await executor.refreshCredentials(credentials, console, proxyOptions);
 
   if (!refreshResult) {
-    // Refresh failed but we still have an accessToken — try with existing token
+    // Refresh failed but we still have an accessToken — try with existing token.
+    // refreshFailed distinguishes this from "no refresh was due", which otherwise looks
+    // identical to callers and hid every failed refresh.
     if (connection.accessToken) {
-      return { connection, refreshed: false };
+      return { connection, refreshed: false, refreshFailed: true };
     }
     throw new Error("Failed to refresh credentials. Please re-authorize the connection.");
   }
@@ -75,9 +77,9 @@ export async function refreshAndUpdateCredentials(connection, force = false, pro
     updateData.idToken = refreshResult.idToken;
   }
 
-  if (refreshResult.lastRefreshAt) {
-    updateData.lastRefreshAt = refreshResult.lastRefreshAt;
-  }
+  // Stamp when the refresh happened. Most providers do not return this, and without it a
+  // successful refresh leaves no trace, so "has this ever refreshed?" is unanswerable.
+  updateData.lastRefreshAt = refreshResult.lastRefreshAt || now;
 
   // Update token expiry
   if (refreshResult.expiresIn) {

--- a/src/shared/constants/config.js
+++ b/src/shared/constants/config.js
@@ -92,6 +92,14 @@ export const QUOTA_AUTOPING_CONFIG = {
   },
 };
 
+// OAuth token keep-alive: refresh access tokens before they expire so idle connections
+// never need re-authorization. Each tick is a no-op unless a token is inside the refresh
+// window its executor defines, so a healthy install makes no upstream calls.
+export const TOKEN_KEEPALIVE_CONFIG = {
+  tickIntervalMs: 300000,               // 5 min — well inside the shortest refreshLeadMs
+  failureCooldownMs: 1800000,           // 30 min before retrying a connection that failed
+};
+
 // Re-export from providers.js for backward compatibility
 export {
   FREE_PROVIDERS,

--- a/src/shared/services/initializeApp.js
+++ b/src/shared/services/initializeApp.js
@@ -112,6 +112,15 @@ async function runHeavyStartup() {
       .then(({ startQuotaAutoPing }) => startQuotaAutoPing())
       .catch((e) => console.log("[AutoPing] scheduler start failed:", e.message));
   }
+
+  // Always on: without it, a provider with a short-lived access token (xai/grok-cli issues
+  // 6h tokens) expires whenever traffic goes elsewhere for a few hours. The tick only acts
+  // on tokens already inside their refresh window, so an idle install costs nothing.
+  if (settings.tokenKeepAliveEnabled !== false) {
+    import("@/shared/services/tokenKeepAlive")
+      .then(({ startTokenKeepAlive }) => startTokenKeepAlive())
+      .catch((e) => console.log("[KeepAlive] scheduler start failed:", e.message));
+  }
 }
 
 function hasQuotaAutoPingEnabled(settings) {

--- a/src/shared/services/tokenKeepAlive.js
+++ b/src/shared/services/tokenKeepAlive.js
@@ -1,0 +1,140 @@
+// OAuth token keep-alive: refreshes access tokens shortly before they expire so an idle
+// connection never needs re-authorization.
+//
+// Without this, refresh only happens on the request path (getProviderCredentials → the
+// executor's needsRefresh check) or when someone opens the usage page. A provider with a
+// short-lived token — xai/grok-cli issues 6h tokens — therefore expires whenever traffic
+// goes elsewhere for a few hours, and recovery then depends on the refresh token still
+// being accepted much later. Providers that rotate refresh tokens can drop the account
+// entirely, which reads to the user as "I have to re-authorize every day".
+//
+// The tick is cheap: refreshAndUpdateCredentials() no-ops unless the executor says the
+// token is inside its refresh window, so a healthy install makes zero upstream calls.
+import "open-sse/index.js";
+
+import { getProviderConnections, updateProviderConnection } from "@/lib/localDb";
+import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
+import { refreshAndUpdateCredentials } from "@/app/api/usage/[connectionId]/route.js";
+import { TOKEN_KEEPALIVE_CONFIG } from "@/shared/constants/config";
+
+const C = TOKEN_KEEPALIVE_CONFIG;
+
+// Survive Next.js hot reload and keep one scheduler per server process.
+const g = (global.__tokenKeepAlive ??= {
+  interval: null,
+  running: false,
+  failureCache: {},
+});
+
+function isRefreshable(connection) {
+  return connection?.authType === "oauth" && Boolean(connection.refreshToken);
+}
+
+function shouldSkipAfterFailure(state, connectionId, nowMs = Date.now()) {
+  const failedAt = state.failureCache[connectionId];
+  return Boolean(failedAt) && nowMs - failedAt < C.failureCooldownMs;
+}
+
+function buildProxyOptions(cfg) {
+  return {
+    connectionProxyEnabled: cfg.connectionProxyEnabled === true,
+    connectionProxyUrl: cfg.connectionProxyUrl || "",
+    connectionNoProxy: cfg.connectionNoProxy || "",
+    vercelRelayUrl: cfg.vercelRelayUrl || "",
+    strictProxy: false,
+  };
+}
+
+function describe(connection) {
+  const name = connection.displayName || connection.name || connection.email || connection.id.slice(0, 8);
+  return `${connection.provider}:${name}`;
+}
+
+// A failed refresh is the one thing the user must act on, so record it where the dashboard
+// already looks. Deliberately does not touch modelLock_* — the request path owns cooldowns.
+async function recordFailure(deps, connection, reason, state) {
+  state.failureCache[connection.id] = Date.now();
+  try {
+    await deps.updateProviderConnection(connection.id, {
+      lastError: `Token refresh failed: ${String(reason).slice(0, 160)}`,
+      lastErrorAt: new Date().toISOString(),
+    });
+  } catch {
+    /* the console warning below is enough; never let bookkeeping break the tick */
+  }
+  console.warn(`[KeepAlive] ${describe(connection)}: refresh failed: ${reason}`);
+}
+
+export async function keepConnectionAlive(connection, deps, state = g) {
+  if (!isRefreshable(connection)) return { skipped: "not-refreshable" };
+  if (shouldSkipAfterFailure(state, connection.id)) return { skipped: "failure-cooldown" };
+
+  const proxyCfg = await deps.resolveConnectionProxyConfig(connection.providerSpecificData);
+  const proxyOptions = buildProxyOptions(proxyCfg);
+
+  let result;
+  try {
+    result = await deps.refreshAndUpdateCredentials(connection, false, proxyOptions);
+  } catch (e) {
+    await recordFailure(deps, connection, e.message, state);
+    return { failed: true };
+  }
+
+  // refreshAndUpdateCredentials reports refreshFailed when the provider rejected the
+  // refresh but a (stale) access token is still on file. That case used to be silent.
+  if (result?.refreshFailed) {
+    await recordFailure(deps, connection, "provider rejected the refresh token", state);
+    return { failed: true };
+  }
+
+  if (result?.refreshed) {
+    delete state.failureCache[connection.id];
+    console.log(`[KeepAlive] ${describe(connection)}: token refreshed (expires ${result.connection.expiresAt})`);
+    return { refreshed: true };
+  }
+
+  return { skipped: "not-due" };
+}
+
+function createDefaultDeps() {
+  return {
+    getProviderConnections,
+    updateProviderConnection,
+    resolveConnectionProxyConfig,
+    refreshAndUpdateCredentials,
+  };
+}
+
+export async function runTokenKeepAliveTick(deps = createDefaultDeps(), state = g) {
+  if (state.running) return;
+  state.running = true;
+  try {
+    const connections = await deps.getProviderConnections({ isActive: true });
+    for (const connection of connections.filter(isRefreshable)) {
+      try {
+        await keepConnectionAlive(connection, deps, state);
+      } catch (e) {
+        console.warn(`[KeepAlive] ${describe(connection)}: ${e.message}`);
+      }
+    }
+  } catch (e) {
+    console.warn("[KeepAlive] tick error:", e.message);
+  } finally {
+    state.running = false;
+  }
+}
+
+export function startTokenKeepAlive() {
+  if (g.interval) return;
+  console.log("[KeepAlive] scheduler started");
+  runTokenKeepAliveTick().catch(() => {});
+  g.interval = setInterval(() => { runTokenKeepAliveTick().catch(() => {}); }, C.tickIntervalMs);
+  if (g.interval.unref) g.interval.unref();
+}
+
+export function stopTokenKeepAlive() {
+  if (!g.interval) return;
+  clearInterval(g.interval);
+  g.interval = null;
+  console.log("[KeepAlive] scheduler stopped");
+}

--- a/tests/unit/token-keepalive.test.js
+++ b/tests/unit/token-keepalive.test.js
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("open-sse/index.js", () => ({}), { virtual: true });
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: vi.fn(),
+}));
+
+vi.mock("@/app/api/usage/[connectionId]/route.js", () => ({
+  refreshAndUpdateCredentials: vi.fn(),
+}));
+
+vi.mock("@/shared/constants/config", () => ({
+  TOKEN_KEEPALIVE_CONFIG: {
+    tickIntervalMs: 300000,
+    failureCooldownMs: 1800000,
+  },
+}));
+
+function oauthConn(overrides = {}) {
+  return {
+    id: "11111111-2222-3333-4444-555555555555",
+    provider: "grok-cli",
+    email: "user@example.com",
+    authType: "oauth",
+    refreshToken: "rt",
+    accessToken: "at",
+    expiresAt: "2020-01-01T00:00:00.000Z",
+    providerSpecificData: {},
+    ...overrides,
+  };
+}
+
+describe("token keep-alive", () => {
+  let runTokenKeepAliveTick;
+  let keepConnectionAlive;
+  let deps;
+  let state;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete global.__tokenKeepAlive;
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    ({ runTokenKeepAliveTick, keepConnectionAlive } = await import("../../src/shared/services/tokenKeepAlive.js"));
+
+    deps = {
+      getProviderConnections: vi.fn().mockResolvedValue([]),
+      updateProviderConnection: vi.fn(),
+      resolveConnectionProxyConfig: vi.fn().mockResolvedValue({}),
+      refreshAndUpdateCredentials: vi.fn(async (connection) => ({ connection, refreshed: false })),
+    };
+    state = { interval: null, running: false, failureCache: {} };
+  });
+
+  it("only walks active connections", async () => {
+    await runTokenKeepAliveTick(deps, state);
+    expect(deps.getProviderConnections).toHaveBeenCalledWith({ isActive: true });
+  });
+
+  it("skips connections that cannot refresh", async () => {
+    deps.getProviderConnections.mockResolvedValue([
+      oauthConn({ id: "a", authType: "apikey" }),
+      oauthConn({ id: "b", refreshToken: null }),
+    ]);
+    await runTokenKeepAliveTick(deps, state);
+    expect(deps.refreshAndUpdateCredentials).not.toHaveBeenCalled();
+  });
+
+  it("delegates the due check to refreshAndUpdateCredentials (force=false)", async () => {
+    const conn = oauthConn();
+    deps.getProviderConnections.mockResolvedValue([conn]);
+    await runTokenKeepAliveTick(deps, state);
+    expect(deps.refreshAndUpdateCredentials).toHaveBeenCalledWith(conn, false, expect.objectContaining({ strictProxy: false }));
+  });
+
+  it("reports a refresh and clears any previous failure", async () => {
+    const conn = oauthConn();
+    state.failureCache[conn.id] = Date.now() - 3600000; // old enough to retry
+    deps.refreshAndUpdateCredentials.mockResolvedValue({
+      connection: { ...conn, expiresAt: "2030-01-01T00:00:00.000Z" },
+      refreshed: true,
+    });
+    const result = await keepConnectionAlive(conn, deps, state);
+    expect(result).toEqual({ refreshed: true });
+    expect(state.failureCache[conn.id]).toBeUndefined();
+  });
+
+  it("persists a rejected refresh token as lastError", async () => {
+    const conn = oauthConn();
+    deps.refreshAndUpdateCredentials.mockResolvedValue({ connection: conn, refreshed: false, refreshFailed: true });
+    const result = await keepConnectionAlive(conn, deps, state);
+    expect(result).toEqual({ failed: true });
+    expect(deps.updateProviderConnection).toHaveBeenCalledWith(conn.id, expect.objectContaining({
+      lastError: expect.stringContaining("Token refresh failed"),
+    }));
+    expect(state.failureCache[conn.id]).toBeGreaterThan(0);
+  });
+
+  it("persists a thrown refresh error too", async () => {
+    const conn = oauthConn();
+    deps.refreshAndUpdateCredentials.mockRejectedValue(new Error("re-authorize the connection"));
+    const result = await keepConnectionAlive(conn, deps, state);
+    expect(result).toEqual({ failed: true });
+    expect(deps.updateProviderConnection).toHaveBeenCalledWith(conn.id, expect.objectContaining({
+      lastError: expect.stringContaining("re-authorize the connection"),
+    }));
+  });
+
+  it("backs off a failing connection instead of retrying every tick", async () => {
+    const conn = oauthConn();
+    state.failureCache[conn.id] = Date.now();
+    const result = await keepConnectionAlive(conn, deps, state);
+    expect(result).toEqual({ skipped: "failure-cooldown" });
+    expect(deps.refreshAndUpdateCredentials).not.toHaveBeenCalled();
+  });
+
+  it("never writes model locks — cooldowns stay owned by the request path", async () => {
+    const conn = oauthConn();
+    deps.refreshAndUpdateCredentials.mockResolvedValue({ connection: conn, refreshed: false, refreshFailed: true });
+    await keepConnectionAlive(conn, deps, state);
+    const written = deps.updateProviderConnection.mock.calls[0][1];
+    expect(Object.keys(written).some((k) => k.startsWith("modelLock_"))).toBe(false);
+    expect(written).not.toHaveProperty("isActive");
+  });
+
+  it("one failing connection does not stop the rest of the tick", async () => {
+    const bad = oauthConn({ id: "bad" });
+    const good = oauthConn({ id: "good" });
+    deps.getProviderConnections.mockResolvedValue([bad, good]);
+    deps.refreshAndUpdateCredentials.mockImplementation(async (c) => {
+      if (c.id === "bad") throw new Error("boom");
+      return { connection: c, refreshed: true };
+    });
+    await runTokenKeepAliveTick(deps, state);
+    expect(deps.refreshAndUpdateCredentials).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not run two ticks concurrently", async () => {
+    state.running = true;
+    await runTokenKeepAliveTick(deps, state);
+    expect(deps.getProviderConnections).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The problem

Access tokens are only ever refreshed on the request path (`getProviderCredentials` → the
executor's `needsRefresh`) or when someone opens the usage page. Nothing refreshes a token
that is simply sitting idle.

For a provider with a short-lived token that is fatal. xai/grok-cli issues **6h** tokens: if
traffic goes to other providers overnight, the token expires, and recovery then depends on
the refresh token still being accepted many hours later. For providers that rotate or expire
refresh tokens, the account is gone. To the user that reads as *"I have to re-authorize every
day"*.

I grepped every `setInterval` in the server: the only background scheduler is
`quotaAutoPing`, and it is hard-coded to `claude` and `codex`. Nothing keeps credentials
alive.

## The change

A scheduler in the same shape as `quotaAutoPing`, walking every active oauth connection and
calling the **existing**:

```js
await refreshAndUpdateCredentials(connection, false, proxyOptions);
```

That function already returns early unless the executor says the token is inside its refresh
window, so:

- an idle, healthy install makes **zero** upstream calls,
- there is **no per-provider code** — every provider with a refresh path is covered by
  construction,
- the refresh, persistence and proxy handling are all code that already exists and is
  already exercised by the usage route.

The tick deliberately never writes `modelLock_*` or `isActive`. Cooldowns stay owned by the
request path; this only keeps credentials fresh. A connection whose refresh fails is backed
off 30 min instead of retried every tick.

Off switch: `settings.tokenKeepAliveEnabled = false`.

## Two supporting fixes

**A failed refresh was indistinguishable from a healthy no-op.**

```js
if (!refreshResult) {
  if (connection.accessToken) {
    return { connection, refreshed: false };   // ← provider REJECTED the refresh token
  }
  ...
}
```

Callers cannot tell that apart from "nothing was due". It now also reports
`refreshFailed: true` (purely additive), and the keep-alive persists it into `lastError` as
`"Token refresh failed: …"`. Until now a dead refresh token produced only a `console.warn`
somewhere in `open-sse`, so the dashboard showed the *downstream* upstream 401 and the user
had no way to know that re-authorization — not a rate limit — was what they needed.

**`lastRefreshAt` was almost never written.** It was set only when a provider happened to
return it in its token response, which nearly none do. A successful refresh therefore left no
trace at all, and "has this connection ever refreshed?" was unanswerable. It is now stamped
on every successful refresh.

That second one matters for diagnosis: on the install where I found the Windows xAI bug
(#see the companion PR), all 8 grok-cli connections had `lastRefreshAt` absent, which was the
first hard clue that refresh had *never once* succeeded rather than "sometimes fails".

## Tests

`tests/unit/token-keepalive.test.js` — 10 tests: active-only scoping, skipping
non-refreshable connections, `force=false` delegation, failure persistence for both the
`refreshFailed` and thrown-error paths, failure back-off, the "never writes locks or
isActive" invariant, one bad connection not aborting the tick, and no concurrent ticks.

Full suite before and after, same machine, same deps:

| | total | passed | failed |
|---|---|---|---|
| master | 1727 | 1579 | 89 |
| this branch | 1737 | 1589 | 89 |

Same 89 pre-existing failures in both runs, compared per test name — **0 new failures**.
`npx eslint` clean on every changed file.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
