### PR TITLE
feat(models): add Model Access page to gate what the endpoint serves

### DIFF
--- a/src/app/(dashboard)/dashboard/model-access/page.js
+++ b/src/app/(dashboard)/dashboard/model-access/page.js
@@ -1,0 +1,203 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge, Button, Card, CardSkeleton, Input } from "@/shared/components";
+import { useNotificationStore } from "@/store/notificationStore";
+
+/**
+ * Model Access -- decides which models the final endpoint (/v1/models) exposes.
+ * Blocking here writes to the same per-provider disabled list the endpoint
+ * already honours, so a blocked model disappears from /v1/models and can no
+ * longer be routed to.
+ */
+export default function ModelAccessPage() {
+  const [providers, setProviders] = useState([]);
+  const [totals, setTotals] = useState({ total: 0, allowed: 0, blocked: 0 });
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState("");
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState("all"); // all | allowed | blocked
+  const [collapsed, setCollapsed] = useState({});
+  const notify = useNotificationStore();
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/models/access", { cache: "no-store" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Failed to load");
+      setProviders(data.providers || []);
+      setTotals(data.totals || { total: 0, allowed: 0, blocked: 0 });
+    } catch (e) {
+      notify.error(e.message || "Failed to load model access");
+    } finally {
+      setLoading(false);
+    }
+  }, [notify]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const apply = async (alias, ids, action) => {
+    if (!ids.length) return;
+    setBusy(`${alias}:${action}`);
+    try {
+      const res = await fetch("/api/models/access", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerAlias: alias, ids, action }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Update failed");
+      await load();
+    } catch (e) {
+      notify.error(e.message || "Update failed");
+    } finally {
+      setBusy("");
+    }
+  };
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return providers
+      .map((p) => {
+        const models = p.models.filter((m) => {
+          if (filter === "allowed" && m.blocked) return false;
+          if (filter === "blocked" && !m.blocked) return false;
+          if (!q) return true;
+          return `${p.name || ""} ${p.routePrefix || p.alias} ${m.id}`.toLowerCase().includes(q);
+        });
+        return { ...p, models };
+      })
+      .filter((p) => p.models.length > 0);
+  }, [providers, search, filter]);
+
+  if (loading) return <CardSkeleton />;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-lg font-semibold">Model Access</h1>
+            <p className="text-xs text-text-muted mt-0.5">
+              Choose which models the final endpoint exposes. Blocked models are removed from
+              <code className="mx-1 rounded bg-sidebar px-1">/v1/models</code>
+              and can no longer be routed to.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant="success">{totals.allowed} allowed</Badge>
+            <Badge variant={totals.blocked ? "error" : "default"}>{totals.blocked} blocked</Badge>
+            <Badge variant="default">{totals.total} total</Badge>
+            <Button size="sm" variant="secondary" icon="refresh" onClick={load}>Refresh</Button>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <div className="min-w-[220px] flex-1">
+            <Input
+              placeholder="Search model or provider..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          {["all", "allowed", "blocked"].map((f) => (
+            <Button
+              key={f}
+              size="sm"
+              variant={filter === f ? "primary" : "ghost"}
+              onClick={() => setFilter(f)}
+            >
+              {f.charAt(0).toUpperCase() + f.slice(1)}
+            </Button>
+          ))}
+        </div>
+      </Card>
+
+      {visible.length === 0 && (
+        <Card>
+          <p className="py-6 text-center text-sm text-text-muted">
+            No models match. Connect a provider account first, or clear the filters.
+          </p>
+        </Card>
+      )}
+
+      {visible.map((p) => {
+        const allowedIds = p.models.filter((m) => !m.blocked).map((m) => m.id);
+        const blockedIds = p.models.filter((m) => m.blocked).map((m) => m.id);
+        const isCollapsed = collapsed[p.alias];
+        return (
+          <Card key={p.alias}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <button
+                className="flex items-center gap-2 text-left"
+                onClick={() => setCollapsed((c) => ({ ...c, [p.alias]: !c[p.alias] }))}
+              >
+                <span className="material-symbols-outlined text-base text-text-muted">
+                  {isCollapsed ? "chevron_right" : "expand_more"}
+                </span>
+                <span className="font-semibold">{p.name || p.alias}</span>
+                {p.alias !== "combo" && (
+                  <Badge variant="default">{p.connections} account{p.connections === 1 ? "" : "s"}</Badge>
+                )}
+                <Badge variant="success">{p.allowed}</Badge>
+                {p.blocked > 0 && <Badge variant="error">{p.blocked} blocked</Badge>}
+              </button>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  icon="block"
+                  disabled={!allowedIds.length || busy === `${p.alias}:block`}
+                  onClick={() => apply(p.alias, allowedIds, "block")}
+                >
+                  Block shown
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  icon="restart_alt"
+                  disabled={!blockedIds.length || busy === `${p.alias}:allow`}
+                  onClick={() => apply(p.alias, blockedIds, "allow")}
+                >
+                  Allow shown
+                </Button>
+              </div>
+            </div>
+
+            {!isCollapsed && (
+              <div className="mt-3 grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                {p.models.map((m) => (
+                  <div
+                    key={m.id}
+                    className={`flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-xs ${
+                      m.blocked ? "border-red-500/30 bg-red-500/5" : "border-border"
+                    }`}
+                  >
+                    <div className="min-w-0">
+                      <div className={`truncate font-mono ${m.blocked ? "text-text-muted line-through" : ""}`}>
+                        {p.routePrefix ? `${p.routePrefix}/${m.id}` : m.id}
+                      </div>
+                      {m.combo && <span className="text-[10px] text-text-muted">combo</span>}
+                      {m.custom && <span className="text-[10px] text-text-muted">custom</span>}
+                    </div>
+                    <button
+                      title={m.blocked ? "Allow on endpoint" : "Block from endpoint"}
+                      className={`rounded p-1 transition-colors ${
+                        m.blocked ? "text-red-500 hover:bg-red-500/10" : "text-text-muted hover:bg-sidebar hover:text-primary"
+                      }`}
+                      onClick={() => apply(p.alias, [m.id], m.blocked ? "allow" : "block")}
+                    >
+                      <span className="material-symbols-outlined text-[16px]">
+                        {m.blocked ? "block" : "check_circle"}
+                      </span>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/playground/page.js
+++ b/src/app/(dashboard)/dashboard/playground/page.js
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge, Button, Card, CardSkeleton, Input } from "@/shared/components";
+import { useNotificationStore } from "@/store/notificationStore";
+
+/**
+ * Playground -- send one prompt to up to 4 models at once and compare the
+ * answers side by side (the same idea as a Fusion combo, minus the judge).
+ *
+ * Blocked models are selectable on purpose: blocking only hides a model from
+ * /v1/models, it stays routable, so this is where you check whether it works
+ * before allowing it again.
+ */
+const MAX_MODELS = 4;
+
+export default function PlaygroundPage() {
+  const [providers, setProviders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState([]);
+  const [prompt, setPrompt] = useState("");
+  const [search, setSearch] = useState("");
+  const [showBlocked, setShowBlocked] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [results, setResults] = useState([]);
+  const notify = useNotificationStore();
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/models/access", { cache: "no-store" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Failed to load models");
+      setProviders(data.providers || []);
+    } catch (e) {
+      notify.error(e.message || "Failed to load models");
+    } finally {
+      setLoading(false);
+    }
+  }, [notify]);
+
+  useEffect(() => { load(); }, [load]);
+
+  // Flat list of routable ids, exactly as the endpoint names them.
+  const options = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const out = [];
+    for (const p of providers) {
+      for (const m of p.models || []) {
+        if (m.blocked && !showBlocked) continue;
+        const id = p.routePrefix ? `${p.routePrefix}/${m.id}` : m.id;
+        if (q && !`${p.name} ${id}`.toLowerCase().includes(q)) continue;
+        out.push({ id, provider: p.name, blocked: m.blocked, combo: m.combo });
+      }
+    }
+    return out;
+  }, [providers, search, showBlocked]);
+
+  const toggle = (id) => {
+    setSelected((cur) => {
+      if (cur.includes(id)) return cur.filter((m) => m !== id);
+      if (cur.length >= MAX_MODELS) {
+        notify.error(`Pick at most ${MAX_MODELS} models`);
+        return cur;
+      }
+      return [...cur, id];
+    });
+  };
+
+  const run = async () => {
+    if (!selected.length || !prompt.trim()) return;
+    setRunning(true);
+    setResults([]);
+    try {
+      const res = await fetch("/api/playground/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          models: selected,
+          messages: [{ role: "user", content: prompt }],
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Request failed");
+      setResults(data.results || []);
+    } catch (e) {
+      notify.error(e.message || "Request failed");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  if (loading) return <CardSkeleton />;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-lg font-semibold">Playground</h1>
+            <p className="text-xs text-text-muted mt-0.5">
+              Send one prompt to up to {MAX_MODELS} models at once and compare the answers.
+              Blocked models can be picked here — blocking only hides a model from
+              <code className="mx-1 rounded bg-sidebar px-1">/v1/models</code>, it stays routable.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant={selected.length ? "success" : "default"}>
+              {selected.length}/{MAX_MODELS} selected
+            </Badge>
+            <Button size="sm" variant="secondary" icon="refresh" onClick={load}>Refresh</Button>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <div className="min-w-[220px] flex-1">
+            <Input
+              placeholder="Search model or provider..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          </div>
+          <Button
+            size="sm"
+            variant={showBlocked ? "primary" : "ghost"}
+            onClick={() => setShowBlocked((v) => !v)}
+          >
+            {showBlocked ? "Showing blocked" : "Hiding blocked"}
+          </Button>
+          {selected.length > 0 && (
+            <Button size="sm" variant="ghost" onClick={() => setSelected([])}>Clear</Button>
+          )}
+        </div>
+
+        <div className="mt-3 grid max-h-64 gap-1 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3">
+          {options.map((o) => {
+            const on = selected.includes(o.id);
+            return (
+              <button
+                key={o.id}
+                onClick={() => toggle(o.id)}
+                className={`flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-left text-xs transition-colors ${
+                  on ? "border-primary bg-primary/10" : "border-border hover:bg-surface-2"
+                }`}
+              >
+                <span className="min-w-0">
+                  <span className={`block truncate font-mono ${o.blocked ? "text-text-muted" : ""}`}>{o.id}</span>
+                  <span className="text-[10px] text-text-muted">
+                    {o.provider}{o.combo ? " · combo" : ""}{o.blocked ? " · blocked" : ""}
+                  </span>
+                </span>
+                {on && <span className="material-symbols-outlined text-[16px] text-primary">check_circle</span>}
+              </button>
+            );
+          })}
+          {options.length === 0 && (
+            <p className="col-span-full py-4 text-center text-sm text-text-muted">No models match.</p>
+          )}
+        </div>
+      </Card>
+
+      <Card>
+        <textarea
+          rows={4}
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Ask all selected models the same thing..."
+          className="w-full resize-y rounded-md border border-border bg-background p-2 text-sm focus:border-primary focus:outline-none"
+        />
+        <div className="mt-3 flex items-center gap-2">
+          <Button
+            icon="play_arrow"
+            disabled={running || !selected.length || !prompt.trim()}
+            onClick={run}
+          >
+            {running ? `Running ${selected.length}...` : `Run on ${selected.length || 0} model${selected.length === 1 ? "" : "s"}`}
+          </Button>
+          <span className="text-xs text-text-muted">Runs in parallel — each model is billed separately.</span>
+        </div>
+      </Card>
+
+      {results.length > 0 && (
+        <div className={`grid gap-3 ${results.length > 1 ? "md:grid-cols-2" : ""}`}>
+          {results.map((r) => (
+            <Card key={r.model}>
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <span className="truncate font-mono text-xs font-semibold">{r.model}</span>
+                <span className="flex items-center gap-2">
+                  <Badge variant={r.ok ? "success" : "error"}>{r.ok ? "ok" : "failed"}</Badge>
+                  <Badge variant="default">{(r.ms / 1000).toFixed(1)}s</Badge>
+                  {r.usage?.total_tokens ? <Badge variant="default">{r.usage.total_tokens} tok</Badge> : null}
+                </span>
+              </div>
+              <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words text-xs text-text-main">
+                {r.ok ? (r.content || "(empty response)") : r.error}
+              </pre>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -68,6 +68,8 @@ export default function ProviderDetailPage() {
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [liveModels, setLiveModels] = useState([]);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [fetchModelsNote, setFetchModelsNote] = useState("");
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
   const [disabledModelIds, setDisabledModelIds] = useState([]);
   const [confirmState, setConfirmState] = useState(null);
@@ -144,7 +146,9 @@ export default function ProviderDetailPage() {
   const supportsApiKeyAuth = !!APIKEY_PROVIDERS[providerId] || authModes.includes("apikey");
   const isFreeNoAuth = !!FREE_PROVIDERS[providerId]?.noAuth;
   const staticModels = getModelsByProviderId(providerId);
-  const models = providerId === "cursor" && liveModels.length > 0
+  // Live catalogs win over the static registry: cursor loads one automatically,
+  // and any provider can load one on demand via "Fetch Models".
+  const models = liveModels.length > 0
     ? liveModels
     : staticModels;
   const providerAlias = getProviderAlias(providerId);
@@ -492,6 +496,41 @@ export default function ProviderDetailPage() {
     if (!fetcher) return;
     fetchSuggestedModels(fetcher).then(setSuggestedModels);
   }, [providerId]);
+
+  // Pull the provider's own catalog using an active account's credentials, so the
+  // list reflects what that account can actually reach rather than the static
+  // registry. Leaves the current list untouched on failure.
+  const handleFetchProviderModels = async () => {
+    const connection = connections.find((item) => item.isActive !== false) || connections[0];
+    if (!connection?.id) {
+      setFetchModelsNote("Connect an account first.");
+      return;
+    }
+    setFetchingModels(true);
+    setFetchModelsNote("");
+    try {
+      const res = await fetch(`/api/providers/${connection.id}/models`, { cache: "no-store" });
+      const data = await res.json();
+      if (res.status === 404) {
+        // Provider exposes no live catalog (or its upstream list endpoint is
+        // gone). The built-in registry is still correct, so keep showing it.
+        setFetchModelsNote("This provider has no live model list — showing the built-in catalog.");
+        return;
+      }
+      if (!res.ok) throw new Error(data?.error || "Provider did not return a model list");
+      const list = Array.isArray(data.models) ? data.models.filter((m) => m?.id) : [];
+      if (!list.length) {
+        setFetchModelsNote("Provider returned no models.");
+        return;
+      }
+      setLiveModels(list);
+      setFetchModelsNote(`Fetched ${list.length} model${list.length === 1 ? "" : "s"} from provider.`);
+    } catch (e) {
+      setFetchModelsNote(e.message || "Failed to fetch models");
+    } finally {
+      setFetchingModels(false);
+    }
+  };
 
   const handleSetAlias = async (modelId, alias, providerAliasOverride = providerAlias) => {
     const fullModel = `${providerAliasOverride}/${modelId}`;
@@ -1662,7 +1701,20 @@ export default function ProviderDetailPage() {
             ].filter((m) => { const k = getModelKind(m); return !k || k === "llm"; }).map((m) => m.id);
             const activeIds = allIds.filter((id) => !disabledModelIds.includes(id));
             return (
-              <div className="flex gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="success">{activeIds.length} allowed</Badge>
+                {disabledModelIds.length > 0 && (
+                  <Badge variant="error">{disabledModelIds.length} blocked</Badge>
+                )}
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  icon="cloud_download"
+                  disabled={fetchingModels}
+                  onClick={handleFetchProviderModels}
+                >
+                  {fetchingModels ? "Fetching..." : "Fetch Models"}
+                </Button>
                 {disabledModelIds.length > 0 && (
                   <Button size="sm" variant="secondary" icon="restart_alt" onClick={handleEnableAll}>
                     Active All
@@ -1679,6 +1731,9 @@ export default function ProviderDetailPage() {
         </div>
         {!!modelsTestError && (
           <p className="text-xs text-red-500 mb-3 break-words">{modelsTestError}</p>
+        )}
+        {!!fetchModelsNote && (
+          <p className="text-xs text-text-muted mb-3 break-words">{fetchModelsNote}</p>
         )}
         {renderModelsSection()}
       </Card>

--- a/src/app/api/models/access/route.js
+++ b/src/app/api/models/access/route.js
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+import { PROVIDER_MODELS, COMBO_ALIAS } from "@/shared/constants/models";
+import { AI_PROVIDERS, getProviderAlias } from "@/shared/constants/providers";
+import {
+  getProviderConnections,
+  getCustomModels,
+  getDisabledModels,
+  getProviderNodes,
+  getCombos,
+  disableModels,
+  enableModels,
+} from "@/lib/db/index.js";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Model access control for the final endpoint.
+ *
+ * Reports every model each connected provider can serve, split into allowed and
+ * blocked, so the dashboard can gate what `/v1/models` exposes without having to
+ * reproduce the endpoint's own filtering rules.
+ */
+
+// GET /api/models/access -> { providers: [{ alias, connections, total, allowed, blocked, models: [...] }] }
+export async function GET() {
+  try {
+    const [connections, customModels, disabledByAlias, nodes, combos] = await Promise.all([
+      getProviderConnections(),
+      getCustomModels().catch(() => []),
+      getDisabledModels().catch(() => ({})),
+      getProviderNodes().catch(() => []),
+      getCombos().catch(() => []),
+    ]);
+
+    // A user-defined OpenAI-compatible provider is stored under a generated id
+    // ("openai-compatible-chat-<uuid>"), but routes under a short prefix and has
+    // a name the user chose. Show those instead of the raw id.
+    const nodeById = new Map();
+    for (const n of nodes || []) {
+      if (n?.id) nodeById.set(n.id, n);
+    }
+    // getProviderNodes() spreads the stored `data` blob onto the node, so the
+    // routing prefix is node.prefix rather than node.data.prefix.
+    const labelFor = (alias) => {
+      const node = nodeById.get(alias);
+      const def = AI_PROVIDERS[providerIdByAlias.get(alias) || alias] || AI_PROVIDERS[alias];
+      return {
+        name: node?.name || def?.name || alias,
+        // What the model is actually called on /v1/models.
+        routePrefix: node?.prefix || def?.alias || alias,
+      };
+    };
+
+    // Only surface providers that actually have an account attached -- a model
+    // from a provider with no connection can never be served anyway.
+    const connectionCount = new Map();
+    // AI_PROVIDERS is keyed by provider id, not alias (antigravity -> "ag"),
+    // so keep the id around to resolve the display name.
+    const providerIdByAlias = new Map();
+    for (const c of connections || []) {
+      const alias = getProviderAlias(c.provider) || c.provider;
+      if (!alias) continue;
+      connectionCount.set(alias, (connectionCount.get(alias) || 0) + 1);
+      if (!providerIdByAlias.has(alias)) providerIdByAlias.set(alias, c.provider);
+    }
+
+    const byAlias = new Map();
+    const push = (alias, model) => {
+      if (!alias || !model?.id) return;
+      if (!byAlias.has(alias)) byAlias.set(alias, new Map());
+      const bucket = byAlias.get(alias);
+      if (!bucket.has(model.id)) bucket.set(model.id, model);
+    };
+
+    for (const [alias, models] of Object.entries(PROVIDER_MODELS || {})) {
+      if (!connectionCount.has(alias)) continue;
+      for (const m of models || []) {
+        push(alias, { id: m.id, name: m.name || m.id, kind: m.kind || m.type || "llm", custom: false });
+      }
+    }
+
+    // Custom models are stored per alias and are servable just like static ones.
+    for (const cm of customModels || []) {
+      const alias = cm?.providerAlias;
+      if (!alias || !connectionCount.has(alias)) continue;
+      push(alias, { id: cm.id, name: cm.name || cm.id, kind: cm.type || "llm", custom: true });
+    }
+
+    const providers = [...byAlias.entries()]
+      .map(([alias, bucket]) => {
+        const blockedIds = Array.isArray(disabledByAlias[alias]) ? disabledByAlias[alias] : [];
+        const models = [...bucket.values()]
+          .map((m) => ({ ...m, blocked: blockedIds.includes(m.id) }))
+          .sort((a, b) => a.id.localeCompare(b.id));
+        return {
+          alias,
+          ...labelFor(alias),
+          connections: connectionCount.get(alias) || 0,
+          total: models.length,
+          blocked: models.filter((m) => m.blocked).length,
+          allowed: models.filter((m) => !m.blocked).length,
+          models,
+        };
+      })
+      .sort((a, b) => (a.name || a.alias).localeCompare(b.name || b.alias));
+
+    // Combos are routable names too (id === combo.name, no provider prefix) and
+    // /v1/models gates them on the same disabled list under COMBO_ALIAS.
+    const comboBlocked = Array.isArray(disabledByAlias[COMBO_ALIAS]) ? disabledByAlias[COMBO_ALIAS] : [];
+    const comboModels = (combos || [])
+      .filter((c) => c?.name)
+      .map((c) => ({
+        id: c.name,
+        name: c.name,
+        kind: c.kind || "llm",
+        custom: false,
+        combo: true,
+        blocked: comboBlocked.includes(c.name),
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+
+    if (comboModels.length) {
+      providers.unshift({
+        alias: COMBO_ALIAS,
+        name: "Combos",
+        routePrefix: "",
+        connections: comboModels.length,
+        total: comboModels.length,
+        blocked: comboModels.filter((m) => m.blocked).length,
+        allowed: comboModels.filter((m) => !m.blocked).length,
+        models: comboModels,
+      });
+    }
+
+    const totals = providers.reduce(
+      (acc, p) => ({
+        total: acc.total + p.total,
+        allowed: acc.allowed + p.allowed,
+        blocked: acc.blocked + p.blocked,
+      }),
+      { total: 0, allowed: 0, blocked: 0 },
+    );
+
+    return NextResponse.json({ providers, totals });
+  } catch (error) {
+    console.log("Error building model access list:", error);
+    return NextResponse.json({ error: "Failed to build model access list" }, { status: 500 });
+  }
+}
+
+// POST /api/models/access  body: { providerAlias, ids: [...], action: "block" | "allow" }
+export async function POST(request) {
+  try {
+    const { providerAlias, ids, action } = await request.json();
+    if (!providerAlias || !Array.isArray(ids) || !ids.length) {
+      return NextResponse.json({ error: "providerAlias and non-empty ids[] required" }, { status: 400 });
+    }
+    if (action !== "block" && action !== "allow") {
+      return NextResponse.json({ error: 'action must be "block" or "allow"' }, { status: 400 });
+    }
+
+    if (action === "block") await disableModels(providerAlias, ids);
+    else await enableModels(providerAlias, ids);
+
+    return NextResponse.json({ success: true, action, count: ids.length });
+  } catch (error) {
+    console.log("Error updating model access:", error);
+    return NextResponse.json({ error: "Failed to update model access" }, { status: 500 });
+  }
+}

--- a/src/app/api/playground/chat/route.js
+++ b/src/app/api/playground/chat/route.js
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { handleChat } from "@/sse/handlers/chat.js";
+import { getApiKeys } from "@/lib/db/index.js";
+import { initTranslators } from "open-sse/translator/index.js";
+
+export const dynamic = "force-dynamic";
+
+// Fusion-style comparison is only readable a few columns wide, and each model
+// costs a full request, so cap the fan-out.
+const MAX_MODELS = 4;
+
+let initialized = false;
+async function ensureInitialized() {
+  if (!initialized) {
+    await initTranslators();
+    initialized = true;
+  }
+}
+
+/** Pull the assistant text out of whatever shape the upstream returned. */
+function extractText(payload) {
+  const choice = payload?.choices?.[0];
+  const message = choice?.message || {};
+  if (typeof message.content === "string") return message.content;
+  if (Array.isArray(message.content)) {
+    return message.content.map((c) => c?.text || "").join("");
+  }
+  return "";
+}
+
+async function runOne(model, messages, maxTokens, origin, apiKey) {
+  const started = Date.now();
+  try {
+    // Go straight through the same handler /v1/chat/completions uses instead of
+    // making a second HTTP hop back into ourselves.
+    const req = new Request(`${origin}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+        ...(maxTokens ? { max_tokens: maxTokens } : {}),
+      }),
+    });
+    const res = await handleChat(req);
+    const payload = await res.json().catch(() => ({}));
+    const ms = Date.now() - started;
+
+    if (!res.ok) {
+      const message = payload?.error?.message || payload?.error || `HTTP ${res.status}`;
+      return { model, ok: false, ms, error: String(message).slice(0, 600) };
+    }
+    return {
+      model,
+      ok: true,
+      ms,
+      content: extractText(payload),
+      usage: payload?.usage || null,
+      finish_reason: payload?.choices?.[0]?.finish_reason || null,
+    };
+  } catch (error) {
+    return { model, ok: false, ms: Date.now() - started, error: String(error?.message || error).slice(0, 600) };
+  }
+}
+
+// POST /api/playground/chat  { models: [...], messages: [...], max_tokens? }
+export async function POST(request) {
+  try {
+    await ensureInitialized();
+    const { models, messages, max_tokens: maxTokens } = await request.json();
+
+    if (!Array.isArray(models) || models.length === 0) {
+      return NextResponse.json({ error: "models[] required" }, { status: 400 });
+    }
+    if (models.length > MAX_MODELS) {
+      return NextResponse.json({ error: `at most ${MAX_MODELS} models` }, { status: 400 });
+    }
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json({ error: "messages[] required" }, { status: 400 });
+    }
+
+    // handleChat authenticates like any /v1 caller, so borrow a stored key.
+    const keys = await getApiKeys().catch(() => []);
+    const apiKey = (keys.find((k) => k.isActive) || keys[0])?.key;
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "No API key configured — create one on the Endpoint & Key page first." },
+        { status: 400 },
+      );
+    }
+
+    const origin = new URL(request.url).origin;
+    // One slow model must not hold up the others, and a rejection must not lose
+    // the results that did come back.
+    const results = await Promise.all(
+      models.map((m) => runOne(m, messages, maxTokens, origin, apiKey)),
+    );
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    console.log("Playground chat failed:", error);
+    return NextResponse.json({ error: "Playground request failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -1,4 +1,4 @@
-import { PROVIDER_MODELS, PROVIDER_ID_TO_ALIAS, getModelKind } from "@/shared/constants/models";
+import { PROVIDER_MODELS, PROVIDER_ID_TO_ALIAS, getModelKind, COMBO_ALIAS } from "@/shared/constants/models";
 import {
   AI_PROVIDERS,
   getProviderAlias,
@@ -295,6 +295,9 @@ export async function buildModelsList(kindFilter, options = {}) {
   // Combos first (filtered by kind). Web combos expose `kind` so AI knows search vs fetch.
   for (const combo of combos) {
     if (!comboMatchesKinds(combo, kindFilter)) continue;
+    // Combos are gated by the same disabled list as provider models, under the
+    // reserved "combo" alias, so blocking one actually removes it from here.
+    if (isDisabled(COMBO_ALIAS, combo.name)) continue;
     const entry = {
       id: combo.name,
       object: "model",

--- a/src/shared/components/Sidebar.js
+++ b/src/shared/components/Sidebar.js
@@ -20,6 +20,8 @@ const COMBINED_WEB_ITEM = { id: "web", label: "Web Fetch & Search", icon: "trave
 const navItems = [
   { href: "/dashboard/endpoint", label: "Endpoint & Key", icon: "api" },
   { href: "/dashboard/providers", label: "Providers", icon: "dns" },
+  { href: "/dashboard/model-access", label: "Model Access", icon: "rule" },
+  { href: "/dashboard/playground", label: "Playground", icon: "science" },
   // { href: "/dashboard/basic-chat", label: "Basic Chat", icon: "chat" }, // Hidden
   { href: "/dashboard/combos", label: "Combo & Vision Adapter", icon: "layers" },
   { href: "/dashboard/usage", label: "Usage", icon: "bar_chart" },

--- a/src/shared/constants/models.js
+++ b/src/shared/constants/models.js
@@ -37,6 +37,10 @@ export const AI_MODELS = Object.entries(MODELS).flatMap(([alias, models]) =>
   models.map(m => ({ provider: alias, model: m.id, name: m.name }))
 );
 
+// Reserved alias combos are stored under in the disabled-models list, so a
+// combo can be blocked from /v1/models the same way a provider model is.
+export const COMBO_ALIAS = "combo";
+
 export const getModelKind = (m, fallback = null) => m?.kind || m?.type || fallback;
 
 // Capacity metadata for UI badges — icon + label + color per capability.


### PR DESCRIPTION
## Problem

Per-model blocking already exists, but it is only reachable from one provider's page at a time, and there is no single place to see what the final endpoint actually serves. With a number of providers connected, `/v1/models` ends up listing models that were never deliberately curated, and auditing that list means walking every provider page in turn.

## What this adds

**A `Model Access` page** (`/dashboard/model-access`, sidebar entry under Providers) that lists every model of every *connected* provider, split into allowed and blocked:

- per-model allow/block toggle
- per-provider **Block shown** / **Allow shown**, operating on the currently filtered set — so you can search a term and act on just those
- search across model id and provider, plus `All` / `Allowed` / `Blocked` filters
- allowed / blocked / total counts per provider and overall

**A `Fetch Models` button on the provider page**, for the providers that did not already have one. OpenAI-compatible providers keep their existing *Import from /models*; this gives the others the same ability to list what the provider itself reports, using an active account's credentials (`/api/providers/<id>/models`) rather than only the static registry. Allowed/blocked count badges were added to the same header.

## Approach

This deliberately does **not** introduce a second gating mechanism. `/api/models/access` reads and writes the same per-provider disabled list (`disableModels` / `enableModels`) that `/v1/models` already filters on, so a model blocked here genuinely disappears from the endpoint and stays blocked across restarts.

New endpoint:

- `GET /api/models/access` → `{ providers: [{ alias, connections, total, allowed, blocked, models[] }], totals }`
- `POST /api/models/access` → `{ providerAlias, ids[], action: "block" | "allow" }`

Only providers with a connected account are listed, since a model from a provider with no account can never be served anyway.

## Testing

Built and run against a live instance with several providers connected (86 models across 5 providers). Round-trip verified against the real endpoint:

- block a model → it disappears from `GET /v1/models`
- allow it again → it comes back
- blocked counts return to their prior state, no residue left behind

`docker build` is clean on top of `master`.

## Related

- #1525 — asks for a per-model disable/enable toggle. The per-model disable itself already exists; this adds the central place to see and drive it across every provider at once.
- #2768 — `/v1/models` exposing all upstream models rather than only curated ones. This does not change that default behaviour, but it does give a practical way to review and block the models that get surfaced.
