### PR TITLE
fix(translator): drop JSON Schema keywords Gemini has no field for

### DIFF
--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -7,7 +7,13 @@ import { OPENAI_BLOCK } from "../schema/index.js";
 export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
   // Basic constraints (not supported by Gemini API)
   "minLength", "maxLength", "exclusiveMinimum", "exclusiveMaximum",
-  "minItems", "maxItems", "format",
+  "minItems", "maxItems", "format", "multipleOf",
+  // Array keywords the Gemini schema proto has no field for. Agent tool
+  // schemas set these routinely, and one occurrence rejects the whole request
+  // with "Unknown name ...: Cannot find field".
+  "uniqueItems", "contains",
+  // 2020-12 keywords with no Gemini equivalent
+  "unevaluatedProperties", "unevaluatedItems", "contentSchema",
   // Claude rejects these in VALIDATED mode
   "default", "examples",
   // JSON Schema meta keywords


### PR DESCRIPTION
## Problem

Any client whose tool schemas carry `uniqueItems` — which agent/CLI tooling sets routinely on array parameters — cannot use an Antigravity/Gemini model at all. Every request fails before the model is reached:

```
400 INVALID_ARGUMENT
Invalid JSON payload received. Unknown name "uniqueItems" at
'request.tools[0].function_declarations[83].parameters.properties[0].value.items.properties[3].value':
Cannot find field.
```

One occurrence anywhere in a tool definition rejects the whole request, so with a large tool set this fires on literally every call. The model looks broken while models on other providers work fine from the same client, which makes it easy to misdiagnose as an account or quota problem.

`UNSUPPORTED_SCHEMA_CONSTRAINTS` in `open-sse/translator/formats/gemini.js` already strips the neighbouring array constraints (`minItems`, `maxItems`, `format`, …) for exactly this reason — `uniqueItems` and a few 2020-12 keywords were simply missing from the list.

## Change

Adds to `UNSUPPORTED_SCHEMA_CONSTRAINTS`:

- `uniqueItems`, `contains` — array keywords the Gemini schema proto has no field for
- `multipleOf` — numeric constraint, same story
- `unevaluatedProperties`, `unevaluatedItems`, `contentSchema` — 2020-12 keywords with no Gemini equivalent

One-line-ish change to an existing list; no behaviour change for any other provider.

## Verification

Checked each keyword against the live API rather than inferring from docs, one request per keyword so a cached error could not be mistaken for a real result:

| keyword | before | after |
|---|---|---|
| `uniqueItems` | 400 `Cannot find field` | passes |
| `contains` | 400 | passes |
| `multipleOf` | 400 | passes |
| `unevaluatedProperties` | 400 | passes |
| `contentSchema` | 400 | passes |

Also confirmed **accepted** by the API and therefore deliberately left alone: `pattern`, `prefixItems`, `minProperties`, `maxProperties`.

After the change, a request carrying all five at once succeeds, and a tool-using request to `ag/gemini-3-flash` returns a normal answer (and a tool call where appropriate) instead of a 400.
