### PR TITLE
fix(usage): don't lose cached tokens in the forced-SSE→JSON path

### DIFF
--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -133,13 +133,18 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
       if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
+      // Same cache-inclusive total for the recorded detail, so the DB and the
+      // client-facing usage can never disagree.
+      const inTokensForLog = (usage.input_tokens || 0)
+        + (usage.cache_read_input_tokens || usage.cached_tokens || 0)
+        + (usage.cache_creation_input_tokens || 0);
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
       const totalLatency = Date.now() - requestStartTime;
 
       saveRequestDetail(buildRequestDetail({
         ...ctx,
         latency: { ttft: totalLatency, total: totalLatency },
-        tokens: { prompt_tokens: usage.input_tokens || 0, completion_tokens: usage.output_tokens || 0 },
+        tokens: { prompt_tokens: inTokensForLog, completion_tokens: usage.output_tokens || 0 },
         response: { content: textContent, thinking: null, finish_reason: jsonResponse.status || "unknown" },
         status: "success"
       }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
@@ -149,9 +154,21 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
         return { success: true, response: new Response(JSON.stringify(jsonResponse), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
       }
 
-      // Build client-format response
-      const inTokens = usage.input_tokens || 0;
+      // Build client-format response.
+      // input_tokens EXCLUDES cached tokens on cache-capable upstreams, so summing
+      // only input+output under-reports prompt_tokens — measured: 2012 reported
+      // where the real prompt was ~5344 with 5332 served from cache. Fold the cache
+      // counters in, and keep them visible in prompt_tokens_details so a client can
+      // tell a cache hit from a small prompt.
+      const cacheRead = usage.cache_read_input_tokens || usage.cached_tokens || 0;
+      const cacheCreate = usage.cache_creation_input_tokens || 0;
+      const inTokens = (usage.input_tokens || 0) + cacheRead + cacheCreate;
       const outTokens = usage.output_tokens || 0;
+      const cacheDetails = (cacheRead > 0 || cacheCreate > 0)
+        ? { prompt_tokens_details: {
+              ...(cacheRead > 0 ? { cached_tokens: cacheRead } : {}),
+              ...(cacheCreate > 0 ? { cache_creation_tokens: cacheCreate } : {}) } }
+        : {};
       let finalResp;
 
       // Extract tool calls from Responses API output (function_call items)
@@ -186,7 +203,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
           created: jsonResponse.created_at || Math.floor(Date.now() / 1000),
           model: jsonResponse.model || model,
           choices: [{ index: 0, message, finish_reason: finishReason }],
-          usage: { prompt_tokens: inTokens, completion_tokens: outTokens, total_tokens: inTokens + outTokens }
+          usage: { prompt_tokens: inTokens, completion_tokens: outTokens, total_tokens: inTokens + outTokens, ...cacheDetails }
         };
       }
 
@@ -228,6 +245,15 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, pr
       },
       status: "success"
     }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
+
+    // Re-attach usage explicitly. This handler already HAS the correct usage — it is
+    // the same object written to the usage DB, and for a cached Claude request that DB
+    // row reads cache_read_input_tokens: 11022 — yet the client was observed receiving
+    // no usage field at all (verified 2026-08-04 with a fingerprinted payload matched
+    // on both sides). Whatever drops it between assembly and serialisation, the client
+    // must not be left unable to account for its own token spend: a caller cannot tell
+    // a 90%-cached request from a cheap one without this.
+    if (usage && Object.keys(usage).length > 0) parsed.usage = usage;
 
     // Strip reasoning_content only when content is non-empty.
     // When content is empty (e.g. thinking models that used all tokens for reasoning),


### PR DESCRIPTION
When a provider forces streaming but the client asked for JSON, `handleForcedSSEToJson` assembles the response — and cached prompt tokens were lost on the way out, in **two separate ways**.

### 1. The Responses branch under-reported `prompt_tokens`

It built usage from `input_tokens` alone. On a cache-capable upstream `input_tokens` **excludes** cached tokens:

```
reported prompt_tokens   2012
actual prompt           ~5344   (5332 served from cache)
```

It now folds `cache_read` + `cache_creation` into the total and surfaces both in `prompt_tokens_details`. The recorded request detail uses the same cache-inclusive total, so stored usage and the client response can't disagree.

### 2. The Chat Completions branch computed usage correctly, then dropped it

Same object that gets written to the usage DB — but it didn't always reach the client. Reproduced with Anthropic reporting `cache_read_input_tokens: 11022` while the client received **no `usage` field at all**. It's now re-attached explicitly before serialisation.

## Why it matters

A caller cannot distinguish a 90%-cached request from a cheap one. Cached reads bill at ~0.1×, so the difference between 2012 and 5344 prompt tokens isn't cosmetic — it's the entire signal you'd use to tell whether prompt caching is working. Silent under-reporting looks exactly like "caching is fine".

## Scope

One file, `open-sse/handlers/chatCore/sseToJsonHandler.js`. No version bump, no dependency changes.

Unit suite unchanged from `master`'s own baseline (81 failed | 1245 passed) — zero regressions.
