### PR TITLE
fix(headroom): stop a failed extras install from destroying the CLI

### DIFF
--- a/src/lib/headroom/process.js
+++ b/src/lib/headroom/process.js
@@ -180,7 +180,17 @@ export async function installHeadroomExtras(extras = []) {
   // so it cannot be poisoned by caller input — the comma-list is a fixed
   // ['proxy', ...requested]. No shell interpolation.
   const extrasList = ["proxy", ...requested].join(",");
-  const spec = `headroom-ai[${extrasList}]`;
+  // Floor the spec at the installed version. Without it, an extra whose deps are
+  // unsatisfiable on this platform (e.g. `ml` needs torch, which has no
+  // musl/Python-3.14 wheel) makes pip backtrack through older releases hunting
+  // for one where the extra simply doesn't exist — then DOWNGRADE to it. Seen in
+  // the wild: 0.5.4 -> 0.2.2, whose half-finished uninstall removed the
+  // `headroom` console script and left the CLI undetectable. With a floor pip
+  // reports the real conflict instead.
+  const installedVersion = getInstalledHeadroomExtras(py)?.version || null;
+  const spec = installedVersion
+    ? `headroom-ai[${extrasList}]>=${installedVersion}`
+    : `headroom-ai[${extrasList}]`;
   const args = ["-m", "pip", "install", "--upgrade", spec];
 
   ensureDir();
@@ -200,8 +210,16 @@ export async function installHeadroomExtras(extras = []) {
         const status = getInstalledHeadroomExtras(py);
         resolve({ success: true, code, spec, extras: requested, ...status });
       } else {
-        const err = new Error(`pip install exited with code=${code} — see headroom/install.log`);
-        err.code = "INSTALL_FAILED";
+        // Turn pip's resolver wall-of-text into something actionable: the common
+        // failure is an extra that cannot be built for this interpreter/libc.
+        const log = getInstallLogTail(400);
+        const unsatisfiable = /No matching distribution found|does not provide the extra|ResolutionImpossible/i.test(log);
+        const err = new Error(
+          unsatisfiable
+            ? `Could not install headroom extras [${requested.join(", ")}] — a dependency has no wheel for this interpreter/platform (the "ml" extra needs torch, which publishes nothing for musl/Alpine). Existing install left as-is. See headroom/install.log.`
+            : `pip install exited with code=${code} — see headroom/install.log`
+        );
+        err.code = unsatisfiable ? "EXTRA_UNAVAILABLE" : "INSTALL_FAILED";
         reject(err);
       }
     });


### PR DESCRIPTION
Installing a headroom extra from the dashboard can **uninstall the working CLI**. Hit in production on 2026-07-30.

## The mechanism

`installHeadroomExtras` builds an unpinned spec:

```js
const spec = `headroom-ai[${extrasList}]`;   // --upgrade
```

When an extra's dependencies can't be satisfied on the host — the `ml` extra needs torch, which publishes **no musl/Alpine wheel** — pip doesn't fail. It **backtracks through older releases hunting for one where the extra simply doesn't exist**, finds one, and *downgrades* to it.

```
0.5.4  →  0.2.2
```

That downgrade's half-finished uninstall removed the `headroom` console script. Since `detect.js` discovers the CLI via `which headroom`, headroom then reads as **not installed at all** — from a user action whose worst honest outcome was "that extra isn't available here".

## Fix

**Floor the spec at the installed version** so pip reports the real conflict instead of escaping backwards into one:

```js
const installedVersion = getInstalledHeadroomExtras(py)?.version || null;
const spec = installedVersion
  ? `headroom-ai[${extrasList}]>=${installedVersion}`
  : `headroom-ai[${extrasList}]`;
```

**And make the failure legible.** Detect `No matching distribution found` / `does not provide the extra` / `ResolutionImpossible` in the install log and raise `EXTRA_UNAVAILABLE` with a message naming the actual cause, rather than `pip install exited with code=1 — see headroom/install.log`.

Self-contained: uses `getInstalledHeadroomExtras` (detect.js) and `getInstallLogTail`, both already on `master`. No packaging changes — the downstream Dockerfile work is deliberately left out of this PR. Draft pending a maintainer view on whether the floor should instead be an exact pin.