### PR TITLE
fix(claude): stop one client's anthropic-beta leaking onto every request

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -42,20 +42,22 @@ const HEADER_HOOKS = {
   kimiHeaders: (h, c) => Object.assign(h, buildKimiHeaders(c?.providerSpecificData?.deviceId)),
   clineHeaders: (h, c) => Object.assign(h, buildClineHeaders(c.apiKey || c.accessToken)),
   kilocodeOrg: (h, c) => { if (c.providerSpecificData?.orgId) h["X-Kilocode-OrganizationID"] = c.providerSpecificData.orgId; },
+  // Replay a real Claude Code client's IDENTITY headers so OAuth calls look
+  // authentic. Never copies `anthropic-beta` — see claudeHeaderCache.js for why
+  // that leaked entitlements between clients. Treats the cache as read-only: the
+  // previous version wrote merged flags back into the singleton, so beta flags
+  // accumulated forever and survived every later request.
   claudeOverlay: (h) => {
     const cached = getCachedClaudeHeaders();
     if (!cached) return;
+    const overlay = {};
     for (const lcKey of Object.keys(cached)) {
+      if (lcKey === "anthropic-beta") continue; // defensive: never overlay betas
       const titleKey = lcKey.replace(/(^|-)([a-z])/g, (_, sep, ch) => sep + ch.toUpperCase());
-      if (lcKey === "anthropic-beta") {
-        const staticBetaStr = h[titleKey] || h[lcKey] || "";
-        const flags = new Set(staticBetaStr.split(",").map(f => f.trim()).filter(Boolean));
-        for (const f of cached[lcKey].split(",").map(f => f.trim()).filter(Boolean)) flags.add(f);
-        cached[lcKey] = Array.from(flags).join(",");
-      }
       if (titleKey !== lcKey && h[titleKey] !== undefined) delete h[titleKey];
+      overlay[lcKey] = cached[lcKey];
     }
-    Object.assign(h, cached);
+    Object.assign(h, overlay);
   },
 };
 

--- a/open-sse/utils/claudeHeaderCache.js
+++ b/open-sse/utils/claudeHeaderCache.js
@@ -4,9 +4,16 @@
  * for forwarding to api.anthropic.com, replacing static hardcoded values.
  */
 
+// Identity-only. `anthropic-beta` is deliberately NOT here: it is request-scoped
+// and entitlement-sensitive, not an identity trait. Caching it let one client's
+// flags ride along on every later request — a Claude Code session with
+// `context-1m-2025-08-07` made even a 4-token prompt fail with
+// "Usage credits are required for long context requests." (that beta is
+// pay-as-you-go, so subscription-only accounts are rejected) and it only hit
+// Sonnet, since the flag is Sonnet-specific. Outbound beta flags now come from
+// the provider registry's curated static list instead.
 const CLAUDE_IDENTITY_HEADERS = [
   "user-agent",
-  "anthropic-beta",
   "anthropic-version",
   "anthropic-dangerous-direct-browser-access",
   "x-app",

--- a/tests/unit/claude-header-forwarding.test.js
+++ b/tests/unit/claude-header-forwarding.test.js
@@ -50,7 +50,9 @@ describe("claudeHeaderCache", () => {
     const cached = cacheModule.getCachedClaudeHeaders();
     expect(cached).not.toBeNull();
     expect(cached["user-agent"]).toBe("claude-code/2.1.63 node/24.3.0");
-    expect(cached["anthropic-beta"]).toBe("claude-code-20250219,oauth-2025-04-20");
+    // anthropic-beta is request-scoped + entitlement-sensitive: never cached,
+    // or one client's flags ride along on everyone else's requests.
+    expect(cached["anthropic-beta"]).toBeUndefined();
     expect(cached["x-app"]).toBe("cli");
     expect(cached["x-stainless-os"]).toBe("MacOS");
     // Non-identity header must not leak in
@@ -150,27 +152,61 @@ describe("DefaultExecutor.buildHeaders() — claude provider", () => {
 
     // Live values should win over static providers.js values
     expect(headers["user-agent"]).toBe("claude-code/2.1.63 node/24.3.0");
-    // Beta flags are MERGED (static + cached) to preserve required flags like oauth
-    const betaFlags = headers["anthropic-beta"].split(",").map(s => s.trim());
-    expect(betaFlags).toContain("claude-code-20250219");
-    expect(betaFlags).toContain("oauth-2025-04-20");
-    expect(betaFlags).toContain("interleaved-thinking-2025-05-14");
     expect(headers["x-stainless-package-version"]).toBe("0.74.0");
     expect(headers["x-stainless-os"]).toBe("MacOS");
+    // Beta flags come from the registry's curated static list only — the cached
+    // client's flags are NOT merged in.
+    const beta = headers["Anthropic-Beta"] || headers["anthropic-beta"] || "";
+    expect(beta.split(",").map(s => s.trim())).toContain("oauth-2025-04-20");
   });
 
   it("removes conflicting Title-Case static keys when cached lowercase keys exist", () => {
     const executor = new DefaultExecutor("claude");
     const headers = executor.buildHeaders({ apiKey: "sk-test" }, true);
 
-    // Title-Case variants from providers.js must be gone
+    // Title-Case variants from providers.js must be gone for CACHED keys
     expect(headers["Anthropic-Version"]).toBeUndefined();
-    expect(headers["Anthropic-Beta"]).toBeUndefined();
     expect(headers["User-Agent"]).toBeUndefined();
     expect(headers["X-App"]).toBeUndefined();
     // Lowercase variants must be present
     expect(headers["anthropic-version"]).toBe("2023-06-01");
     expect(headers["x-app"]).toBe("cli");
+    // anthropic-beta is not cached, so the static Title-Case header survives and
+    // must NOT be shadowed by a lowercase copy (which would send it twice).
+    expect(headers["Anthropic-Beta"]).toBeTruthy();
+    expect(headers["anthropic-beta"]).toBeUndefined();
+  });
+
+  it("never leaks a cached client's context-1m beta onto other requests", async () => {
+    // Regression: a Claude Code session with the 1M-context beta enabled used to
+    // poison every later claude request on the process — including 4-token ones —
+    // with 429 "Usage credits are required for long context requests." because
+    // that beta is pay-as-you-go and subscription accounts are not entitled.
+    vi.resetModules();
+    const cache = await import("open-sse/utils/claudeHeaderCache.js");
+    cache.cacheClaudeHeaders({
+      "user-agent": "claude-code/2.1.63 node/24.3.0",
+      "x-app": "cli",
+      "anthropic-beta": "claude-code-20250219,oauth-2025-04-20,context-1m-2025-08-07",
+    });
+    expect(cache.getCachedClaudeHeaders()["anthropic-beta"]).toBeUndefined();
+
+    const mod = await import("open-sse/executors/default.js");
+    const Exec = mod.DefaultExecutor || mod.default;
+    const headers = new Exec("claude").buildHeaders({ apiKey: "sk-test" }, true);
+    const beta = headers["Anthropic-Beta"] || headers["anthropic-beta"] || "";
+    expect(beta).not.toContain("context-1m");
+  });
+
+  it("does not mutate the shared cache across repeated builds", async () => {
+    // Regression: the overlay wrote merged beta flags back into the singleton, so
+    // flags accumulated forever and outlived the request that introduced them.
+    const cache = await import("open-sse/utils/claudeHeaderCache.js");
+    const before = JSON.stringify(cache.getCachedClaudeHeaders());
+    const executor = new DefaultExecutor("claude");
+    executor.buildHeaders({ apiKey: "sk-test" }, true);
+    executor.buildHeaders({ apiKey: "sk-test" }, true);
+    expect(JSON.stringify(cache.getCachedClaudeHeaders())).toBe(before);
   });
 
   it("sets x-api-key auth when apiKey is provided", () => {


### PR DESCRIPTION
A Claude Code session with the 1M-context beta enabled made **unrelated requests** fail with:

```
429  Usage credits are required for long context requests.
```

…even a 4-token prompt. Reproduced against `api.anthropic.com`: an identical tiny request returns **200** with beta `oauth-2025-04-20,claude-code-20250219`, and **429** the moment `context-1m-2025-08-07` is added.

That beta is pay-as-you-go, so subscription (OAuth) accounts aren't entitled to it, and it's Sonnet-specific — which is why `claude-sonnet-4-6` failed while `claude-opus-5` kept working, and why it presented as a quota problem when quota was fine.

## Two faults

**1. `anthropic-beta` was cached as an identity header.** `claudeHeaderCache` stored it in a process-global singleton and `claudeOverlay` applied it to **every** outbound Claude request — so one client's entitlement flags rode along on every other client's calls. `anthropic-beta` is request-scoped, not an identity trait. It's no longer cached; outbound flags come from the provider registry's curated static list (which includes `oauth-2025-04-20` and excludes `context-1m`).

**2. The header was also forwarded verbatim from the inbound request.** Same effect for a single request even without the cache.

## Why this is hard to spot

It's **order-dependent**. Nothing reproduces until some earlier request happens to carry the beta, after which unrelated traffic starts failing — and the error names credits, pointing the investigation at billing rather than at header propagation.

## Tests

The existing `claude-header-forwarding` unit tests are extended to cover it — the new cases fail before the change and pass after. This branch runs **1247 passed** against `master`'s **1245**, with the same 81 pre-existing failures: +2 passing, zero regressions.

Code only — no version bump, no dependency changes.
