### PR TITLE
feat(headroom): report effective payload savings

### DIFF
--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -25,9 +25,17 @@ function messagePayload(body) {
 
 function captureSizeSnapshot(body) {
   const messages = messagePayload(body);
+  const toolHistory = messages?.filter((message) =>
+    message?.role === "tool"
+    || message?.role === "function"
+    || message?.tool_calls?.length
+    || message?.content?.some?.((part) => part?.type === "tool_use" || part?.type === "tool_result")
+  ) || [];
   return {
     bodyBytes: jsonBytes(body),
     messageBytes: messages ? jsonBytes(messages) : 0,
+    toolSchemaBytes: jsonBytes(body?.tools || []),
+    toolHistoryBytes: jsonBytes(toolHistory),
   };
 }
 
@@ -336,7 +344,10 @@ export function formatHeadroomSizeLog(diagnostics) {
   const before = diagnostics?.before;
   const after = diagnostics?.after;
   if (!before || !after) return "";
-  return `body=${before.bodyBytes}B→${after.bodyBytes}B messages=${before.messageBytes}B→${after.messageBytes}B`;
+  const effective = before.bodyBytes > 0
+    ? (((before.bodyBytes - after.bodyBytes) / before.bodyBytes) * 100).toFixed(1)
+    : "0.0";
+  return `body=${before.bodyBytes}B→${after.bodyBytes}B messages=${before.messageBytes}B→${after.messageBytes}B tools=${before.toolSchemaBytes || 0}B→${after.toolSchemaBytes || 0}B toolHistory=${before.toolHistoryBytes || 0}B→${after.toolHistoryBytes || 0}B effective=${effective}%`;
 }
 
 export function isHeadroomPhantomSavings(stats, diagnostics, minShrinkRatio = 0.05) {

--- a/tests/unit/headroom.test.js
+++ b/tests/unit/headroom.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { compressWithHeadroom, formatHeadroomLog } from "../../open-sse/rtk/headroom.js";
+import { compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog } from "../../open-sse/rtk/headroom.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -208,5 +208,12 @@ describe("formatHeadroomLog", () => {
   it("formats reported token deltas without implying provider billing savings", () => {
     expect(formatHeadroomLog({ tokens_before: 100, tokens_after: 25, tokens_saved: 75 }))
       .toBe("reported token delta=75 before=100 after=25 (75.0%)");
+  });
+
+  it("reports effective payload, tool-schema, and tool-history sizes", () => {
+    expect(formatHeadroomSizeLog({
+      before: { bodyBytes: 1000, messageBytes: 800, toolSchemaBytes: 100, toolHistoryBytes: 500 },
+      after: { bodyBytes: 900, messageBytes: 700, toolSchemaBytes: 100, toolHistoryBytes: 400 },
+    })).toContain("tools=100B→100B toolHistory=500B→400B effective=10.0%");
   });
 });


### PR DESCRIPTION
## Summary

- report end-to-end request body and message byte deltas after Headroom compression
- break out tool schema and tool-history bytes to explain payload-heavy requests
- add an effective byte-savings percentage alongside Headroom's token delta

## Problem

Headroom reports token savings for the content it processes, but that number does not represent the complete outbound JSON payload. Requests with large tool schemas, structured tool history, metadata, or preserved content can report meaningful token savings while the actual provider payload barely shrinks.

This made logs such as `tokens_saved=8%` look effective even when the final request body decreased by less than 5%.

## Implementation

The existing size snapshot now records:

- total request body bytes
- message/input bytes
- tool schema bytes
- tool-history bytes

The formatted diagnostic also reports:

`effective=(bodyBytesBefore-bodyBytesAfter)/bodyBytesBefore`

The metrics are diagnostic only and do not change compression behavior, provider payloads, or billing calculations.

## Example

`body=2507703B→2477509B messages=2353718B→2323524B tools=... toolHistory=... effective=1.2%`

## Verification

- `vitest tests/unit/headroom.test.js tests/unit/headroom-chat-core.test.js`: 15/15 passed
- ESLint: no issues
- Production build: passed
