### PR TITLE
feat(usage): TokenRouter quota tracker via optional Management Key

### DIFF
--- a/open-sse/providers/registry/tokenrouter.js
+++ b/open-sse/providers/registry/tokenrouter.js
@@ -23,6 +23,9 @@ export default {
     baseUrl: "https://api.tokenrouter.com/v1/chat/completions",
     validateUrl: "https://api.tokenrouter.com/v1/models",
     thinkingFormat: "tokenrouter",
+    usage: {
+      url: "https://api.tokenrouter.com/api/management",
+    },
   },
   // Seed snapshot from live /v1/models (120 entries). Latest catalogue is
   // fetched via modelsFetcher; other ids still accepted via passthroughModels.
@@ -159,4 +162,8 @@ export default {
   },
   modelsFetcher: { url: "https://api.tokenrouter.com/v1/models", type: "openai" },
   passthroughModels: true,
+  features: {
+    usage: true,
+    usageApikey: true,
+  },
 };

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -12,6 +12,7 @@ import { getKiroUsage } from "./usage/kiro.js";
 import { getMiniMaxUsage } from "./usage/minimax.js";
 import { getCodeBuddyCnUsage, getCodeBuddyIntlUsage } from "./usage/codebuddy-cn.js";
 import { getGrokCliUsage } from "./usage/grok-cli.js";
+import { getTokenRouterUsage } from "./usage/tokenrouter.js";
 import { getKimiUsage } from "./usage/kimi.js";
 import { getDeepseekUsage } from "./usage/deepseek.js";
 import { resolveQoderCredentials } from "./qoderModels.js";
@@ -54,6 +55,7 @@ const USAGE_HANDLERS = {
   "grok-cli": (c) => getGrokCliUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
   kimi: (c) => getKimiUsage(c.accessToken, c.apiKey, c.proxyOptions, c.providerSpecificData),
   deepseek: (c) => getDeepseekUsage(c.apiKey, c.proxyOptions),
+  tokenrouter: (c) => getTokenRouterUsage(c.providerSpecificData, c.proxyOptions),
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null) {

--- a/open-sse/services/usage/tokenrouter.js
+++ b/open-sse/services/usage/tokenrouter.js
@@ -1,0 +1,139 @@
+/**
+ * TokenRouter usage — Management API (read-only)
+ *
+ * A single account-level Management Key (separate from the inference key) is
+ * used to inspect every API key on the account via the Management API:
+ *   GET /api/management/api-keys      → per-key quota snapshot
+ *   GET /api/management/self/wallet   → account wallet balance
+ *
+ * Docs: https://api.tokenrouter.com/api/management
+ * Auth: Authorization: Bearer <Management Key>
+ *
+ * The management key is optional. When missing or invalid we return a
+ * `message` (instead of throwing) so the quota tracker can prompt the user
+ * to add a management key on the connection.
+ */
+
+import { proxyAwareFetch } from "../../utils/proxyFetch.js";
+import { U } from "./shared.js";
+
+const MANAGEMENT_BASE_URL = U("tokenrouter").url || "https://api.tokenrouter.com/api/management";
+
+function parseExpiry(expiredTime) {
+  // -1 → never expires; otherwise a UTC Unix (seconds) timestamp.
+  if (expiredTime === undefined || expiredTime === null || Number(expiredTime) === -1) return null;
+  const seconds = Number(expiredTime);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return new Date(seconds * 1000).toISOString();
+}
+
+function formatMoney(value) {
+  const num = Number(value) || 0;
+  return num > 0 ? `$${num.toFixed(2)}` : "$0.00";
+}
+
+/**
+ * Get TokenRouter usage for a management key.
+ * @param {Object} providerSpecificData - Connection credentials (managementKey).
+ * @param {Object|null} proxyOptions - Optional proxy config.
+ * @returns {Object} { quotas, plan, message }
+ */
+export async function getTokenRouterUsage(providerSpecificData = {}, proxyOptions = null) {
+  const managementKey = providerSpecificData?.managementKey?.trim();
+
+  if (!managementKey) {
+    return {
+      message:
+        "Add a TokenRouter Management Key to track quotas. Find it on the TokenRouter dashboard (Settings → Management Key).",
+      quotas: {},
+    };
+  }
+
+  const headers = {
+    Authorization: `Bearer ${managementKey}`,
+    Accept: "application/json",
+  };
+
+  try {
+    // ── 1. Account wallet (best-effort; 404/empty is fine for personal accounts) ──
+    let wallet = {};
+    try {
+      const walletRes = await proxyAwareFetch(`${MANAGEMENT_BASE_URL}/self/wallet`, { headers }, proxyOptions);
+      if (walletRes.ok) {
+        const walletJson = await walletRes.json();
+        wallet = walletJson?.data && typeof walletJson.data === "object" ? walletJson.data : {};
+      }
+    } catch {
+      // Wallet is optional — never fail the whole quota fetch on it.
+    }
+
+    // ── 2. API keys + per-key quota ──
+    const keysRes = await proxyAwareFetch(`${MANAGEMENT_BASE_URL}/api-keys?page=1&page_size=100`, { headers }, proxyOptions);
+
+    if (keysRes.status === 401 || keysRes.status === 403) {
+      return {
+        message: "TokenRouter Management Key invalid or expired. Re-check the key on the connection.",
+        quotas: {},
+      };
+    }
+
+    if (!keysRes.ok) {
+      return { message: `TokenRouter Management API error (${keysRes.status}).` };
+    }
+
+    const keysJson = await keysRes.json();
+    const items = Array.isArray(keysJson?.data?.items) ? keysJson.data.items : [];
+
+    const quotas = {};
+
+    // Account wallet row (if any balance exists)
+    const topUp = Number(wallet.topUpBalance) || 0;
+    const voucher = Number(wallet.voucherEfficientAmount) || 0;
+    const totalBalance = topUp + voucher;
+    if (totalBalance > 0) {
+      quotas["Account Balance"] = {
+        used: 0,
+        total: totalBalance,
+        remaining: totalBalance,
+        remainingPercentage: 100,
+        unlimited: false,
+        wallet: true,
+        meta: {
+          topUpBalance: formatMoney(topUp),
+          voucherEfficientAmount: formatMoney(voucher),
+        },
+      };
+    }
+
+    // One quota row per API key
+    for (const key of items) {
+      const unlimited = Boolean(key.unlimited_quota);
+      const used = Number(key.used_quota) || 0;
+      const remaining = Number(key.remain_quota) || 0;
+      const name = key.name || "Unnamed key";
+
+      quotas[`Key: ${name}`] = {
+        used,
+        total: unlimited ? 0 : remaining + used,
+        remaining: unlimited ? null : Math.max(0, remaining),
+        remainingPercentage: unlimited ? 100 : undefined,
+        unlimited,
+        status: Number(key.status) === 1 ? "enabled" : "disabled",
+        expiresAt: parseExpiry(key.expired_time),
+        keyName: name,
+      };
+    }
+
+    if (Object.keys(quotas).length === 0) {
+      return {
+        plan: "TokenRouter",
+        message: "No API keys or wallet balance found for this Management Key.",
+        quotas: {},
+      };
+    }
+
+    return { plan: "TokenRouter", quotas };
+  } catch (error) {
+    return { message: `TokenRouter usage error: ${error.message}` };
+  }
+}

--- a/open-sse/services/usage/tokenrouter.js
+++ b/open-sse/services/usage/tokenrouter.js
@@ -98,6 +98,8 @@ export async function getTokenRouterUsage(providerSpecificData = {}, proxyOption
         remainingPercentage: 100,
         unlimited: false,
         wallet: true,
+        unit: "USD",
+        plan: "Pay as you go",
         meta: {
           topUpBalance: formatMoney(topUp),
           voucherEfficientAmount: formatMoney(voucher),

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -20,12 +20,14 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
 
   const isAzure = provider === "azure";
   const isCloudflareAi = provider === "cloudflare-ai";
+  const isTokenRouter = provider === "tokenrouter";
   const providerRegions = AI_PROVIDERS?.[provider]?.regions || null;
   const defaultRegion = AI_PROVIDERS?.[provider]?.defaultRegion || providerRegions?.[0]?.id || "";
 
   const [formData, setFormData] = useState({
     name: "",
     apiKey: "",
+    managementKey: "",
     defaultModel: "",
     priority: 1,
     proxyPoolId: NONE_PROXY_POOL_VALUE,
@@ -66,6 +68,10 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     }
     if (isCloudflareAi) {
       return { accountId: cloudflareData.accountId };
+    }
+    if (isTokenRouter) {
+      const managementKey = formData.managementKey.trim();
+      return managementKey ? { managementKey } : undefined;
     }
     if (providerRegions && region) {
       return { region };
@@ -291,6 +297,20 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
             onChange={(e) => setRegion(e.target.value)}
             options={providerRegions.map((r) => ({ value: r.id, label: r.label }))}
           />
+        )}
+        {isTokenRouter && (
+          <>
+            <Input
+              label="Management Key (optional)"
+              type="password"
+              value={formData.managementKey}
+              onChange={(e) => setFormData({ ...formData, managementKey: e.target.value })}
+              placeholder="sk-..."
+            />
+            <p className="text-xs text-text-muted">
+              Optional. Used by the Quota Tracker to show per-key usage and account balance. Get it from the TokenRouter dashboard (Settings → Management Key). Leave empty to skip quota tracking.
+            </p>
+          </>
         )}
         {isCompatible && (
           <Input

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/QuotaTable.js
@@ -128,6 +128,13 @@ export default function QuotaTable({
   const pageStart = sortedQuotas.length === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
   const pageEnd = Math.min(page * PAGE_SIZE, sortedQuotas.length);
 
+  // Currency rows (unit:"USD") render a dollar value instead of a percentage.
+  const isCurrency = (quota) => quota.unit === "USD";
+  const formatCurrency = (value) => {
+    const num = Number(value) || 0;
+    return `$${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  };
+
   const cellPad = compact ? "py-1 px-1.5" : "py-2 px-3";
   const nameText = compact ? "text-[11px]" : "text-sm";
   const resetPrimary = compact ? "text-[11px]" : "text-sm";
@@ -174,31 +181,46 @@ export default function QuotaTable({
 
               {/* Progress + used/total */}
               <div className={`min-w-0 flex-1 ${compact ? "space-y-1" : "space-y-1.5"}`}>
-                <div className={`${compact ? "h-1" : "h-1.5"} rounded-full overflow-hidden border ${colors.bgLight} ${
-                  quota.remaining === 0 ? "border-black/10 dark:border-white/10" : "border-transparent"
-                }`}>
-                  <div
-                    className={`h-full transition-all duration-300 ${colors.bg}`}
-                    style={{ width: `${Math.min(quota.remaining, 100)}%` }}
-                  />
-                </div>
+                {isCurrency(quota) ? (
+                  <div className={`flex items-center justify-between gap-1 min-w-0 ${compact ? "text-[10px]" : "text-xs"}`}>
+                    <span className="text-text-muted truncate">
+                      {quota.plan ? quota.plan : "Balance"}
+                    </span>
+                    <span className={`font-medium ${colors.text} shrink-0`}>
+                      {formatCurrency(quota.remaining)}
+                    </span>
+                  </div>
+                ) : (
+                  <>
+                    <div className={`${compact ? "h-1" : "h-1.5"} rounded-full overflow-hidden border ${colors.bgLight} ${
+                      quota.remaining === 0 ? "border-black/10 dark:border-white/10" : "border-transparent"
+                    }`}>
+                      <div
+                        className={`h-full transition-all duration-300 ${colors.bg}`}
+                        style={{ width: `${Math.min(quota.remaining, 100)}%` }}
+                      />
+                    </div>
 
-                <div className={`flex items-center justify-between gap-1 min-w-0 ${compact ? "text-[10px]" : "text-xs"}`}>
-                  <span
-                    className="text-text-muted truncate"
-                    title={`${quota.used.toLocaleString()} / ${quota.total > 0 ? quota.total.toLocaleString() : "∞"}`}
-                  >
-                    {quota.used.toLocaleString()} / {quota.total > 0 ? quota.total.toLocaleString() : "∞"}
-                  </span>
-                  <span className={`font-medium ${colors.text} shrink-0`}>
-                    {quota.remaining}%
-                  </span>
-                </div>
+                    <div className={`flex items-center justify-between gap-1 min-w-0 ${compact ? "text-[10px]" : "text-xs"}`}>
+                      <span
+                        className="text-text-muted truncate"
+                        title={`${quota.used.toLocaleString()} / ${quota.total > 0 ? quota.total.toLocaleString() : "∞"}`}
+                      >
+                        {quota.used.toLocaleString()} / {quota.total > 0 ? quota.total.toLocaleString() : "∞"}
+                      </span>
+                      <span className={`font-medium ${colors.text} shrink-0`}>
+                        {quota.remaining}%
+                      </span>
+                    </div>
+                  </>
+                )}
               </div>
 
               {/* Reset time */}
               <div className="min-w-0 shrink">
-                {countdown !== "-" || resetDisplay ? (
+                {quota.unlimited ? (
+                  <div className={`${resetPrimary} text-text-muted italic`}>Never expires</div>
+                ) : countdown !== "-" || resetDisplay ? (
                   compact ? (
                     <div
                       className={`${resetPrimary} text-text-primary font-medium truncate`}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -544,7 +544,8 @@ export function parseQuotaData(provider, data) {
         // `status`/`expiresAt` so QuotaTable can show enable state & expiry.
         // `remaining` is forwarded only when it's a finite number: for unlimited
         // keys it's null, and getRemainingPercentage would round(null) to 0% —
-        // fall back to remainingPercentage (100) instead.
+        // fall back to remainingPercentage (100) instead. The account-balance
+        // row carries unit:"USD" so QuotaTable renders a currency value, not a %.
         if (data.quotas) {
           Object.entries(data.quotas).forEach(([name, quota]) => {
             normalizedQuotas.push({
@@ -556,6 +557,8 @@ export function parseQuotaData(provider, data) {
               unlimited: quota.unlimited !== false,
               resetAt: quota.expiresAt || quota.resetAt || null,
               status: quota.status,
+              unit: quota.unit,
+              plan: quota.plan,
             });
           });
         }

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -538,6 +538,29 @@ export function parseQuotaData(provider, data) {
         }
         break;
 
+      case "tokenrouter":
+        // TokenRouter Management API — account wallet + one quota row per API key.
+        // Keys may be unlimited (no bar) or limited (remain_quota). Forward
+        // `status`/`expiresAt` so QuotaTable can show enable state & expiry.
+        // `remaining` is forwarded only when it's a finite number: for unlimited
+        // keys it's null, and getRemainingPercentage would round(null) to 0% —
+        // fall back to remainingPercentage (100) instead.
+        if (data.quotas) {
+          Object.entries(data.quotas).forEach(([name, quota]) => {
+            normalizedQuotas.push({
+              name,
+              used: quota.used || 0,
+              total: quota.total || 0,
+              remaining: Number.isFinite(quota.remaining) ? quota.remaining : undefined,
+              remainingPercentage: quota.remainingPercentage,
+              unlimited: quota.unlimited !== false,
+              resetAt: quota.expiresAt || quota.resetAt || null,
+              status: quota.status,
+            });
+          });
+        }
+        break;
+
       default:
         // Generic fallback for unknown providers
         if (data.quotas) {

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -22,6 +22,8 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
     organization: "",
   });
   const [cloudflareData, setCloudflareData] = useState({ accountId: "" });
+  const [managementKey, setManagementKey] = useState("");
+  const [managementKeyTouched, setManagementKeyTouched] = useState(false);
   const [region, setRegion] = useState("");
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
@@ -47,6 +49,9 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       }
       if (connection.provider === "cloudflare-ai" && connection.providerSpecificData) {
         setCloudflareData({ accountId: connection.providerSpecificData.accountId || "" });
+      }
+      if (connection.provider === "tokenrouter") {
+        setManagementKey(connection.providerSpecificData?.managementKey || "");
       }
       // Load region for providers that support it (e.g. xiaomi-tokenplan)
       const providerCfg = AI_PROVIDERS?.[connection.provider];
@@ -167,6 +172,18 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       if (isCloudflareAi) {
         updates.providerSpecificData = { accountId: cloudflareData.accountId };
       }
+      if (connection.provider === "tokenrouter") {
+        // The client route never exposes the stored management key, so the
+        // field starts blank. Only change the stored key when the user
+        // actually typed in the field: a non-empty value sets it, an empty
+        // submission clears it. Untouched field → leave the stored key alone.
+        if (managementKeyTouched) {
+          updates.providerSpecificData = {
+            ...(connection.providerSpecificData || {}),
+            managementKey: managementKey.trim() || null,
+          };
+        }
+      }
       // Persist updated region for region-aware providers
       if (providerRegions && region) {
         updates.providerSpecificData = buildRegionSpecificData();
@@ -271,6 +288,22 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
             onChange={(e) => setRegion(e.target.value)}
             options={providerRegions.map((r) => ({ value: r.id, label: r.label }))}
           />
+        )}
+
+        {connection.provider === "tokenrouter" && (
+          <>
+            <Input
+              label="Management Key (optional)"
+              type="password"
+              value={managementKey}
+              onChange={(e) => { setManagementKey(e.target.value); setManagementKeyTouched(true); }}
+              placeholder="sk-..."
+              hint="Used by the Quota Tracker to show per-key usage and account balance. Leave blank to clear."
+            />
+            <p className="text-xs text-text-muted">
+              Optional. Get it from the TokenRouter dashboard (Settings → Management Key). The stored key is never shown; type a new one to replace it, or leave blank and save to remove it.
+            </p>
+          </>
         )}
 
         {!isCompatible && !isAzure && !isCloudflareAi && (

--- a/tests/unit/tokenrouter-usage.test.js
+++ b/tests/unit/tokenrouter-usage.test.js
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+import {
+  USAGE_SUPPORTED_PROVIDERS,
+  USAGE_APIKEY_PROVIDERS,
+} from "../../src/shared/constants/providers.js";
+import { parseQuotaData } from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+const MGMT_BASE = "https://api.tokenrouter.com/api/management";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const WALLET = {
+  data: {
+    topUpBalance: 70,
+    toppedUpSpent: 0,
+    voucherEfficientAmount: 30.019508,
+    voucherSpent: 0.000492,
+  },
+};
+
+const KEYS_PAGE = {
+  data: {
+    page: 1,
+    page_size: 10,
+    total: 1,
+    items: [
+      {
+        name: "dasep",
+        key: "sk-GDZ0t6b2SSSVsq0w98GmfS419sfRtPDmOH5Ua8FBUjGJfRa8",
+        status: 1,
+        unlimited_quota: true,
+        remain_quota: -0.000492,
+        used_quota: 0.000492,
+        expired_time: -1,
+        created_time: 1785861287,
+      },
+    ],
+  },
+};
+
+describe("tokenrouter registry usage flags", () => {
+  it("is listed for apikey quota dashboard", () => {
+    expect(USAGE_SUPPORTED_PROVIDERS).toContain("tokenrouter");
+    expect(USAGE_APIKEY_PROVIDERS).toContain("tokenrouter");
+  });
+});
+
+describe("getUsageForProvider(tokenrouter)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GETs wallet + api-keys with Bearer management key", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse(WALLET))
+      .mockResolvedValueOnce(jsonResponse(KEYS_PAGE));
+
+    const usage = await getUsageForProvider({
+      provider: "tokenrouter",
+      providerSpecificData: { managementKey: "sk-mgmt-test" },
+    });
+
+    expect(usage.message).toBeUndefined();
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+
+    const [walletUrl, walletOpts] = proxyAwareFetch.mock.calls[0];
+    expect(walletUrl).toBe(`${MGMT_BASE}/self/wallet`);
+    expect(walletOpts.headers.Authorization).toBe("Bearer sk-mgmt-test");
+
+    const [keysUrl] = proxyAwareFetch.mock.calls[1];
+    expect(keysUrl).toBe(`${MGMT_BASE}/api-keys?page=1&page_size=100`);
+  });
+
+  it("maps account wallet + unlimited key rows", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse(WALLET))
+      .mockResolvedValueOnce(jsonResponse(KEYS_PAGE));
+
+    const usage = await getUsageForProvider({
+      provider: "tokenrouter",
+      providerSpecificData: { managementKey: "sk-mgmt-test" },
+    });
+
+    expect(usage.plan).toBe("TokenRouter");
+
+    // Wallet row
+    expect(usage.quotas["Account Balance"]).toMatchObject({
+      used: 0,
+      total: 100.019508,
+      unlimited: false,
+    });
+
+    // Unlimited key row: no absolute remaining (null → UI falls back to 100%)
+    expect(usage.quotas["Key: dasep"]).toMatchObject({
+      used: 0.000492,
+      total: 0,
+      remaining: null,
+      remainingPercentage: 100,
+      unlimited: true,
+      status: "enabled",
+      expiresAt: null,
+    });
+  });
+
+  it("returns message when management key is missing", async () => {
+    const usage = await getUsageForProvider({
+      provider: "tokenrouter",
+      providerSpecificData: {},
+    });
+
+    expect(usage.message).toMatch(/management key/i);
+    expect(usage.quotas).toEqual({});
+    expect(proxyAwareFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns message on 401 (invalid management key)", async () => {
+    // Wallet call fails silently (best-effort), then api-keys 401 surfaces the auth message.
+    proxyAwareFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false }), { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: false }), { status: 401 }));
+
+    const usage = await getUsageForProvider({
+      provider: "tokenrouter",
+      providerSpecificData: { managementKey: "sk-bad" },
+    });
+
+    expect(usage.message).toMatch(/invalid|expired/i);
+  });
+});
+
+describe("parseQuotaData(tokenrouter)", () => {
+  it("forwards unlimited/status and drops null remaining", () => {
+    const rows = parseQuotaData("tokenrouter", {
+      quotas: {
+        "Key: dasep": {
+          used: 0.000492,
+          total: 0,
+          remaining: null,
+          remainingPercentage: 100,
+          unlimited: true,
+          status: "enabled",
+        },
+      },
+    });
+
+    expect(rows[0]).toMatchObject({
+      name: "Key: dasep",
+      total: 0,
+      remainingPercentage: 100,
+      unlimited: true,
+      status: "enabled",
+    });
+    // null remaining must not be forwarded (getRemainingPercentage would round it to 0%)
+    expect(rows[0].remaining).toBeUndefined();
+  });
+
+  it("forwards numeric remaining for limited keys", () => {
+    const rows = parseQuotaData("tokenrouter", {
+      quotas: {
+        "Key: prod": {
+          used: 2.5,
+          total: 10,
+          remaining: 7.5,
+          remainingPercentage: 75,
+          unlimited: false,
+          status: "enabled",
+        },
+      },
+    });
+
+    expect(rows[0].remaining).toBe(7.5);
+    expect(rows[0].unlimited).toBe(false);
+  });
+});

--- a/tests/unit/tokenrouter-usage.test.js
+++ b/tests/unit/tokenrouter-usage.test.js
@@ -100,6 +100,8 @@ describe("getUsageForProvider(tokenrouter)", () => {
       used: 0,
       total: 100.019508,
       unlimited: false,
+      unit: "USD",
+      plan: "Pay as you go",
     });
 
     // Unlimited key row: no absolute remaining (null → UI falls back to 100%)
@@ -182,5 +184,29 @@ describe("parseQuotaData(tokenrouter)", () => {
 
     expect(rows[0].remaining).toBe(7.5);
     expect(rows[0].unlimited).toBe(false);
+  });
+
+  it("forwards unit for the account balance (currency) row", () => {
+    const rows = parseQuotaData("tokenrouter", {
+      quotas: {
+        "Account Balance": {
+          used: 0,
+          total: 100.019508,
+          remaining: 100.019508,
+          remainingPercentage: 100,
+          unlimited: false,
+          unit: "USD",
+          plan: "Pay as you go",
+        },
+      },
+    });
+
+    expect(rows[0]).toMatchObject({
+      name: "Account Balance",
+      remaining: 100.019508,
+      unit: "USD",
+      unlimited: false,
+      plan: "Pay as you go",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds opt-in quota tracking for **TokenRouter** connections via the separate **Management API key** (the normal inference key is rejected by `/api/management` with 401).

## What it does

When a user adds a TokenRouter API key they can optionally also paste a Management Key. The **Quota Tracker** page then shows:

- **Account Balance** (top-up + voucher balance)
- **Per API key**: used / remaining, unlimited-vs-limited badge, enabled/disabled state, expiry
- If the Management Key is **missing** → the tracker shows a hint prompting to add one
- If the Management Key is **invalid/expired** → the tracker shows an error message

The field is **fully optional** — connections without a Management Key work exactly as before.

## Changes

- `open-sse/providers/registry/tokenrouter.js` — `features.usage` + `usageApikey`, Management API base URL in `transport.usage`
- `open-sse/services/usage/tokenrouter.js` — new `getTokenRouterUsage()` handler (wallet + `/api-keys` quota)
- `open-sse/services/usage.js` — register `tokenrouter` in `USAGE_HANDLERS`
- `AddApiKeyModal` — optional Management Key field (stored in `providerSpecificData.managementKey`)
- `EditConnectionModal` — optional Management Key field (untouched field leaves the stored key alone)
- `ProviderLimits/utils.js` `parseQuotaData` — normalize tokenrouter rows; drop `null` remaining for unlimited keys so the progress bar shows 100% instead of 0%
- `tests/unit/tokenrouter-usage.test.js` — registry flags, handler, parse normalization

## Verified

- `npx vitest run unit/tokenrouter-usage.test.js` → 7/7 pass
- `npx vitest run unit/deepseek-usage.test.js unit/minimax-usage.test.js` → no regressions
- `node tests/__baseline__/verify-alias.mjs` → byte-for-byte equal
- `npx eslint` on changed files → only pre-existing warnings/errors