### PR TITLE
fix(stream): an empty stream returns HTTP 200 with an empty body

### DIFF
--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -121,6 +121,16 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     const safeContent = contentObj?.content || "[Empty streaming response]";
     const safeThinking = contentObj?.thinking || null;
 
+    // An empty stream is NOT a success. This was hardcoded to "success", so a
+    // request that produced no content at all was recorded green — the dashboard,
+    // the usage view and anything reading requestDetails all agreed nothing was
+    // wrong while the caller received an empty body. Recording it truthfully is
+    // what makes the failure findable; pipeWithDisconnect emits the client-facing
+    // error frame (2026-08-05, expired Claude OAuth left isActive).
+    const producedNothing = !contentObj?.content && !contentObj?.thinking &&
+      !(usage?.completion_tokens > 0);
+    const detailStatus = producedNothing ? "error" : "success";
+
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
       latency,
@@ -130,10 +140,13 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
       providerResponse: safeContent,
       response: { content: safeContent, thinking: safeThinking, type: "streaming" },
       pxpipe,
-      status: "success"
+      status: detailStatus
     }, { id: streamDetailId })).catch(err => {
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
+    if (producedNothing && log?.errorLine) {
+      log.errorLine(reqTag, "✗", `EMPTY STREAM · ${provider}/${model} · no content and no completion tokens`);
+    }
 
     // Persist stream usage to DB (no console line; the "📊 done" line below is authoritative)
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE", silent: true });

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -241,9 +241,44 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
     flush() { dbg(tag, `upstream EOF | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); }
   });
 
+  // A stream that delivers ZERO bytes to the client is never a legitimate
+  // completion — even an empty answer emits a role delta, a finish_reason and
+  // [DONE]. Without this guard that case reaches the caller as HTTP 200 with an
+  // empty body: no content, no error, nothing to branch on. Anything checking
+  // status codes reads it as success.
+  //
+  // Seen in production on 2026-08-05: a Claude account whose OAuth had expired
+  // stayed isActive, requests routed to it, and callers got 200/0 bytes while
+  // observability recorded "success" with "[Empty streaming response]".
+  //
+  // The status line is already committed by the time we know — headers go out
+  // before the first chunk — so the honest remedy is an in-band error frame. It
+  // fires ONLY on a completely empty stream, so a normal response never sees it.
+  let outBytes = 0;
+  const emptyStreamGuard = new TransformStream({
+    transform(chunk, controller) {
+      outBytes += chunk?.byteLength || chunk?.length || 0;
+      controller.enqueue(chunk);
+    },
+    flush(controller) {
+      if (outBytes > 0) return;
+      dbg(tag, `EMPTY STREAM — upstream chunks=${chunkCount} bytes=${totalBytes}; emitting error frame`);
+      const payload = JSON.stringify({
+        error: {
+          message: "Upstream returned an empty stream — no content was produced. " +
+                   "The provider connection may be unauthenticated or unavailable.",
+          type: "upstream_empty_response",
+          code: "empty_stream"
+        }
+      });
+      controller.enqueue(new TextEncoder().encode(`data: ${payload}\n\ndata: [DONE]\n\n`));
+    }
+  });
+
   const transformedBody = providerResponse.body
     .pipeThrough(upstreamTap)
-    .pipeThrough(transformStream);
+    .pipeThrough(transformStream)
+    .pipeThrough(emptyStreamGuard);
 
   return createDisconnectAwareStream(
     { readable: transformedBody, writable: { getWriter: () => ({ abort: () => Promise.resolve() }) } },


### PR DESCRIPTION
A request that produces **nothing at all** reaches the caller as `HTTP 200` with a zero-byte body — no content, no error, nothing to branch on. Anything checking status codes reads it as success.

Found in production when a Claude account's OAuth expired while its connection was still marked active. Requests routed to it and callers got:

```
$ curl -w '%{http_code} %{size_download}' … -d '{"model":"cc/claude-opus-5", …}'
200 0
```

…while `requestDetails` recorded:

```
status: success   response: {"content":"[Empty streaming response]"}
```

**Every layer agreed nothing was wrong**, which is exactly why it went unnoticed.

## Two failures, so two fixes

**1. It was recorded as a success.** `status: "success"` is hardcoded in `onStreamComplete`, so a request with no content *and* no completion tokens shows green in the dashboard, the usage view and `requestDetails`. Now `status: "error"` plus an `EMPTY STREAM` log line — recording it truthfully is what makes it findable at all.

**2. The caller got silence.** The status line is already committed by the time this is knowable — headers go out before the first chunk — so the remedy is an in-band error frame:

```
data: {"error":{"message":"Upstream returned an empty stream — no content was produced. The provider connection may be unauthenticated or unavailable.","type":"upstream_empty_response","code":"empty_stream"}}
data: [DONE]
```

## Safe in the hot path

The guard sits after `transformStream` and counts output bytes. It fires **only** when a stream delivers literally zero bytes — never a legitimate completion, since even an empty answer emits a role delta, a `finish_reason` and `[DONE]`.

```
normal stream (3 chunks)   outLen=111   errorFrame=false   ← byte-identical passthrough
EMPTY stream (0 chunks)    outLen=224   errorFrame=true
```

Running in production since the incident. Code only — no version bump, no dependency changes.
