### PR TITLE
feat(usage): localize cost display by UI locale (¥/NT$/₩/₫)

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
+++ b/src/app/(dashboard)/dashboard/usage/components/OverviewCards.js
@@ -2,9 +2,9 @@
 
 import PropTypes from "prop-types";
 import Card from "@/shared/components/Card";
+import { fmtCost } from "@/shared/utils/currency";
 
 const fmt = (n) => new Intl.NumberFormat().format(n || 0);
-const fmtCost = (n) => `$${(n || 0).toFixed(2)}`;
 
 export default function OverviewCards({ stats }) {
   return (

--- a/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
+++ b/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
@@ -13,6 +13,7 @@ import {
   Legend,
 } from "recharts";
 import Card from "@/shared/components/Card";
+import { fmtCost } from "@/shared/utils/currency";
 
 const fmtTokens = (n) => {
   if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
@@ -20,7 +21,7 @@ const fmtTokens = (n) => {
   return String(n || 0);
 };
 
-const fmtCost = (n) => `$${(n || 0).toFixed(4)}`;
+const fmtChartCost = (n) => fmtCost(n, 4);
 
 export default function UsageChart({ period = "7d" }) {
   const [data, setData] = useState([]);
@@ -94,7 +95,7 @@ export default function UsageChart({ period = "7d" }) {
               tick={{ fontSize: 10, fill: "currentColor", fillOpacity: 0.5 }}
               tickLine={false}
               axisLine={false}
-              tickFormatter={viewMode === "tokens" ? fmtTokens : fmtCost}
+              tickFormatter={viewMode === "tokens" ? fmtTokens : fmtChartCost}
               width={50}
             />
             <Tooltip
@@ -105,7 +106,7 @@ export default function UsageChart({ period = "7d" }) {
                 fontSize: "12px",
               }}
               formatter={(value, name) =>
-                name === "tokens" ? [fmtTokens(value), "Tokens"] : [fmtCost(value), "Cost"]
+                name === "tokens" ? [fmtTokens(value), "Tokens"] : [fmtChartCost(value), "Cost"]
               }
             />
             {viewMode === "tokens" ? (

--- a/src/app/(dashboard)/dashboard/usage/components/UsageTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/UsageTable.js
@@ -4,9 +4,9 @@ import { useState, useEffect, useCallback, useMemo, Fragment } from "react";
 import PropTypes from "prop-types";
 import Card from "@/shared/components/Card";
 import Badge from "@/shared/components/Badge";
+import { fmtCost } from "@/shared/utils/currency";
 
 const fmt = (n) => new Intl.NumberFormat().format(n || 0);
-const fmtCost = (n) => `$${(n || 0).toFixed(2)}`;
 
 function fmtTime(iso) {
   if (!iso) return "Never";

--- a/src/shared/components/ProviderInfoCard.js
+++ b/src/shared/components/ProviderInfoCard.js
@@ -1,13 +1,14 @@
 "use client";
 
 import Card from "./Card";
+import { fmtCost } from "@/shared/utils/currency";
 
 // Only show fields user actually cares about
 const FIELD_SCHEMA = {
   mode:             { label: "Mode",       format: (v) => v },
   defaultModel:     { label: "Model",      format: (v) => v, mono: true },
   baseUrl:          { label: "Endpoint",   format: (v) => v, isLink: true, mono: true },
-  costPerQuery:     { label: "Cost / call", format: (v) => v === 0 ? "Free" : `$${v.toFixed(4)}` },
+  costPerQuery:     { label: "Cost / call", format: (v) => v === 0 ? "Free" : fmtCost(v, 4) },
   pricingUrl:       { label: "Pricing",    format: () => "View pricing", isLink: true },
   freeTier:         { label: "Free tier",  format: (v) => v },
   freeMonthlyQuota: { label: "Free quota",  format: (v) => v === 0 ? "—" : v >= 999999 ? "Unlimited" : `${v.toLocaleString()} / mo` },

--- a/src/shared/utils/currency.js
+++ b/src/shared/utils/currency.js
@@ -1,0 +1,37 @@
+// 成本显示按界面语言切换本地货币。
+// 9Router 定价数据为 USD per million tokens，成本值本身是美元金额。
+// 此工具按当前 locale 选择货币符号 + 汇率，让成本以本地货币展示。
+//
+// 汇率表（USD → 本地货币，近似值，可随行情调整）：
+//   CNY ¥ ×7.2     TWD NT$ ×31.5    JPY ¥ ×155
+//   KRW ₩ ×1350    VND ₫ ×25000
+import { LOCALE_COOKIE, normalizeLocale } from "@/i18n/config";
+
+const RATES = {
+  "zh-CN": { sym: "¥", rate: 7.2 },
+  "zh-TW": { sym: "NT$", rate: 31.5 },
+  ja: { sym: "¥", rate: 155 },
+  ko: { sym: "₩", rate: 1350 },
+  vi: { sym: "₫", rate: 25000 },
+};
+
+function getLocaleFromCookie() {
+  if (typeof document === "undefined") return "en";
+  const cookie = document.cookie
+    .split(";")
+    .find((c) => c.trim().startsWith(`${LOCALE_COOKIE}=`));
+  return cookie ? decodeURIComponent(cookie.split("=")[1]) : "en";
+}
+
+/**
+ * 把 USD 成本格式化为当前界面语言的本地货币。
+ * @param {number} n  美元成本
+ * @param {number} precision  小数位（默认 2）
+ * @returns {string}  本地货币字符串（未匹配 locale 时回退 $）
+ */
+export function fmtCost(n, precision = 2) {
+  const v = n || 0;
+  const cur = RATES[normalizeLocale(getLocaleFromCookie())];
+  if (!cur) return `$${v.toFixed(precision)}`;
+  return `${cur.sym}${(v * cur.rate).toFixed(precision)}`;
+}


### PR DESCRIPTION
## feat(usage): localize cost display by UI locale

### Problem
9Router usage pages hardcode `$` for cost display. For non-USD regions (China, Taiwan, Japan, Korea, Vietnam) users see US-dollar amounts that don't match their local currency.

### Change
Add a shared `fmtCost()` helper (`src/shared/utils/currency.js`) that reads the existing `locale` cookie (`src/i18n/config.js`) and formats cost in the UI's local currency:

| locale | currency | rate (USD→local) |
|---|---|---|
| `zh-CN` | ¥ CNY | ×7.2 |
| `zh-TW` | NT$ TWD | ×31.5 |
| `ja` | ¥ JPY | ×155 |
| `ko` | ₩ KRW | ×1350 |
| `vi` | ₫ VND | ×25000 |
| other | $ USD | ×1 |

Replace the hardcoded `$` cost formatters with the shared helper in:
- `dashboard/usage/components/OverviewCards.js`
- `dashboard/usage/components/UsageChart.js`
- `dashboard/usage/components/UsageTable.js`
- `shared/components/ProviderInfoCard.js`

### Notes
- Rates are constants in `currency.js` (adjustable as FX moves). No new deps.
- `fmtCost(n, precision)` keeps the existing precision behavior (chart/table use 4, cards use 2).
- Exchange rates convert the USD cost value to the local currency amount.
