### PR TITLE
Akar masalah: saat request di-route ke openai/gpt-5.1, body body clie…

### DIFF
--- a/param-support.test.js
+++ b/param-support.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+
+import { stripUnsupportedParams } from "../../open-sse/translator/concerns/paramSupport.js";
+
+describe("stripUnsupportedParams", () => {
+  it("flattens Cloudflare AI OpenAI content-part arrays", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "hello " },
+            { type: "image_url", image_url: { url: "data:image/png;base64,xx" } },
+            { type: "text", text: "world" },
+          ],
+        },
+      ],
+    };
+
+    expect(() => stripUnsupportedParams("cloudflare-ai", "@cf/meta/llama-3.1-8b-instruct", body)).not.toThrow();
+    expect(body.messages[0].content).toBe("hello world");
+  });
+
+  it("still drops unsupported GitHub model params", () => {
+    const body = { temperature: 0.7, top_p: 1 };
+
+    stripUnsupportedParams("github", "gpt-5.4", body);
+
+    expect(body).toEqual({ top_p: 1 });
+  });
+
+  it("clamps VolcEngine Ark GLM max token fields to the model output ceiling", () => {
+    const body = {
+      max_tokens: 131072,
+      max_completion_tokens: 131072,
+      max_output_tokens: 131072,
+    };
+
+    stripUnsupportedParams("volcengine-ark", "GLM-5.2", body);
+
+    expect(body).toEqual({
+      max_tokens: 128000,
+      max_completion_tokens: 128000,
+      max_output_tokens: 128000,
+    });
+  });
+
+  it("keeps VolcEngine Ark GLM max tokens when already under the ceiling", () => {
+    const body = { max_tokens: 64000 };
+
+    stripUnsupportedParams("volcengine-ark", "GLM-5.2", body);
+
+    expect(body.max_tokens).toBe(64000);
+  });
+
+  it("renames max_tokens to max_completion_tokens for OpenAI gpt-5 models", () => {
+    const body = { max_tokens: 8192, temperature: 0.7 };
+
+    stripUnsupportedParams("openai", "gpt-5.1", body);
+
+    expect(body).toEqual({ max_completion_tokens: 8192, temperature: 0.7 });
+  });
+
+  it("renames max_tokens for o-series reasoning models", () => {
+    const body = { max_tokens: 4096 };
+
+    stripUnsupportedParams("openai", "o3-mini", body);
+
+    expect(body).toEqual({ max_completion_tokens: 4096 });
+  });
+
+  it("renames max_tokens for prefixed reseller model ids", () => {
+    const body = { max_tokens: 1000 };
+
+    stripUnsupportedParams("openrouter", "openai/gpt-5.1", body);
+
+    expect(body).toEqual({ max_completion_tokens: 1000 });
+  });
+
+  it("keeps an already-present max_completion_tokens and drops max_tokens", () => {
+    const body = { max_tokens: 1000, max_completion_tokens: 5000 };
+
+    stripUnsupportedParams("openai", "gpt-5.1", body);
+
+    expect(body).toEqual({ max_completion_tokens: 5000 });
+  });
+
+  it("leaves max_tokens alone for models that still support it", () => {
+    const body = { max_tokens: 4096 };
+
+    stripUnsupportedParams("openai", "gpt-4o", body);
+
+    expect(body).toEqual({ max_tokens: 4096 });
+  });
+});

--- a/paramSupport.js
+++ b/paramSupport.js
@@ -1,0 +1,90 @@
+import { getCapabilitiesForModel } from "../../providers/capabilities.js";
+
+// Strip request params a given provider/model rejects upstream (e.g. HTTP 400).
+// Config-driven: add a rule instead of scattering `delete body.x` across executors.
+
+// Each rule: optional provider, regex match on model, list of params to drop.
+// A param is removed only when it is present (!== undefined).
+const STRIP_RULES = [
+  // All Claude models: temperature deprecated/rejected upstream (Anthropic 400). #1748
+  { match: /claude/i, drop: ["temperature"] },
+  // GitHub Copilot gpt-5.4: temperature unsupported.
+  { provider: "github", match: /gpt-5\.4/i, drop: ["temperature"] },
+  // GitHub Copilot Claude (except opus/sonnet 4.6): thinking + reasoning_effort rejected. #713
+  { provider: "github", match: (m) => /claude/i.test(m) && !/claude.*(opus|sonnet).*4\.6/i.test(m), drop: ["thinking", "reasoning_effort"] },
+  // Cloudflare Workers AI: content must be plain string, rejects OpenAI content-part array (#1926)
+  { provider: "cloudflare-ai", flattenContent: true },
+  { provider: "volcengine-ark", match: /glm-5/i, clampToModelMaxOutput: true },
+  // VolcEngine Ark caps the Kimi family at max_tokens <= 32768, but the model's
+  // advertised ceiling is far higher (Kimi-K2.7-Code resolves to maxOutput 262144),
+  // so clampToModelMaxOutput alone leaves it uncapped and the request 400s with
+  // "integer above maximum value, expected <= 32768". Pin an explicit endpoint cap;
+  // min() with the model ceiling still applies if a variant's own limit is lower.
+  { provider: "volcengine-ark", match: /kimi/i, maxOutputCap: 32768, clampToModelMaxOutput: true },
+  // OpenAI gpt-5 family + o-series reject `max_tokens` upstream (HTTP 400:
+  // "Use 'max_completion_tokens' instead.") — rename so the output cap survives.
+  // Provider-agnostic: the OpenAI API contract applies to resellers/proxies too
+  // (openai, github copilot, azure, openrouter, ...). #2742
+  { match: /(^|[^a-z0-9])(gpt-5|o[134])([^a-z0-9]|$)/i, rename: { max_tokens: "max_completion_tokens" } },
+];
+
+// Test a rule's match (regex or predicate) against the model id.
+function matches(rule, model) {
+  if (!rule.match) return true;
+  return typeof rule.match === "function" ? rule.match(model) : rule.match.test(model);
+}
+
+function clampNumber(body, key, ceiling) {
+  if (typeof body[key] === "number" && Number.isFinite(body[key]) && body[key] > ceiling) {
+    body[key] = ceiling;
+  }
+}
+
+// Remove unsupported params from body in place; returns body.
+export function stripUnsupportedParams(provider, model, body) {
+  if (!model || !body || typeof body !== "object") return body;
+  for (const rule of STRIP_RULES) {
+    if (rule.provider && rule.provider !== provider) continue;
+    if (!matches(rule, model)) continue;
+    for (const key of rule.drop || []) {
+      if (body[key] !== undefined) delete body[key];
+    }
+    // CF Workers AI oneOf root schema only accepts content as plain string (#1926)
+    if (rule.flattenContent && Array.isArray(body.messages)) {
+      for (const msg of body.messages) {
+        if (msg && Array.isArray(msg.content)) {
+          msg.content = msg.content
+            .map(b => (b?.type === "text" && typeof b.text === "string") ? b.text : "")
+            .join("");
+        }
+      }
+    }
+    if (rule.clampToModelMaxOutput || Number.isFinite(rule.maxOutputCap)) {
+      const modelCeiling = getCapabilitiesForModel(provider, model).maxOutput;
+      const candidates = [];
+      if (rule.clampToModelMaxOutput && Number.isFinite(modelCeiling) && modelCeiling > 0) {
+        candidates.push(modelCeiling);
+      }
+      if (Number.isFinite(rule.maxOutputCap) && rule.maxOutputCap > 0) {
+        candidates.push(rule.maxOutputCap);
+      }
+      if (candidates.length > 0) {
+        const ceiling = Math.min(...candidates);
+        clampNumber(body, "max_tokens", ceiling);
+        clampNumber(body, "max_completion_tokens", ceiling);
+        clampNumber(body, "max_output_tokens", ceiling);
+      }
+    }
+    // Rename params the upstream rejects under their old name (e.g. OpenAI
+    // gpt-5/o-series: max_tokens → max_completion_tokens). Prefer keeping an
+    // already-present target name, then drop the rejected one.
+    if (rule.rename) {
+      for (const [from, to] of Object.entries(rule.rename)) {
+        if (body[from] === undefined) continue;
+        if (body[to] === undefined) body[to] = body[from];
+        delete body[from];
+      }
+    }
+  }
+  return body;
+}


### PR DESCRIPTION
## **Ringkasan / Context**

Memperbaiki *error* HTTP 400 saat mengirim *request* ke model OpenAI keluarga `gpt-5` dan `o-series` (`o1`, `o3`, `o4`). Parameter `max_tokens` kini secara otomatis di-rename menjadi `max_completion_tokens` sesuai kontrak API OpenAI terbaru.

---

### **Akar Masalah**

Saat *request* di-route ke model seperti `openai/gpt-5.1`, `body` dari *client* yang berisi `max_tokens` diteruskan tanpa perubahan ke endpoint `[https://api.openai.com/v1/chat/completions](https://api.openai.com/v1/chat/completions)`. Karena model OpenAI keluarga `gpt-5` dan `o-series` menolak parameter `max_tokens`, API mengembalikan *response* HTTP 400.

---

### **Perubahan yang Done (Perbaikan)**

1. **Fitur Rename pada Rule Engine**
* Menambahkan kapabilitas `rename` pada mekanisme *rule transformation* (melengkapi aksi `drop`, `flatten`, dan `clamp` yang sudah ada).
* **Logika:** Jika `max_tokens` ditemukan, parameternya di-rename menjadi `max_completion_tokens`. Jika `max_completion_tokens` sudah ada di *payload*, nilai tersebut dipertahankan dan `max_tokens` akan dihapus.


2. **Aturan Baru (Provider-Agnostic)**
* Menambahkan rule regex:
`{ match: /(^|[^a-z0-9])(gpt-5|o[134])([^a-z0-9]|$)/i, rename: { max_tokens: "max_completion_tokens" } }`
* Solusi ini bersifat *provider-agnostic* (berlaku universal untuk GitHub Copilot, Azure OpenAI, OpenRouter, maupun reseller lain yang menggunakan kontrak API OpenAI).
* Dapat mendeteksi *model ID* ber-prefix seperti `openai/gpt-5.1`.
* **Catatan:** Model legacy/lama yang masih mendukung `max_tokens` (seperti `gpt-4o` atau `gpt-4.1`) tidak terpengaruh.



---

### **Verifikasi & Pengujian**

* [x] **Unit Testing:** `tests/unit/param-support.test.js` — **9 test pass** (5 test case baru ditambahkan: `gpt-5.1` rename, `o3` rename, *model ID* ber-prefix reseller, *handling* jika `max_completion_tokens` sudah ada, serta verifikasi `gpt-4o` tidak diubah).
* [x] **Build:** Executed `npm run build` — **Sukses (0 error)**.

---