### PR TITLE
fix(translator): prevent merging Gemini functionResponse with text turns & fix missing tool responses

### DIFF
--- a/open-sse/executors/vertex.js
+++ b/open-sse/executors/vertex.js
@@ -91,15 +91,17 @@ export class VertexExecutor extends BaseExecutor {
           "Add quota_project_id to your ADC JSON or set providerSpecificData.projectId."
         );
       }
-      const location = credentials?.providerSpecificData?.location || "us-central1";
+      const location = credentials?.providerSpecificData?.location || credentials?.providerSpecificData?.region || "us-central1";
       let url = `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/publishers/google/models/${model}:${action}`;
       if (stream) url += "?alt=sse";
       return url;
     }
 
-    // Raw API key: use global publishers endpoint with ?key= param
-    // ?alt=sse is required for proper SSE streaming (matches every other Gemini executor)
-    let url = `https://aiplatform.googleapis.com/v1/publishers/google/models/${model}:${action}`;
+    // Raw API key: use global or regional publishers endpoint with ?key= param
+    const location = credentials?.providerSpecificData?.location || credentials?.providerSpecificData?.region;
+    let url = location && location !== "global"
+      ? `https://${location}-aiplatform.googleapis.com/v1/publishers/google/models/${model}:${action}`
+      : `https://aiplatform.googleapis.com/v1/publishers/google/models/${model}:${action}`;
     if (stream) url += "?alt=sse";
     if (rawKey) url += stream ? `&key=${rawKey}` : `?key=${rawKey}`;
     return url;

--- a/open-sse/providers/registry/vertex.js
+++ b/open-sse/providers/registry/vertex.js
@@ -18,6 +18,18 @@ export default {
     },
   },
   category: "freeTier",
+  regions: [
+    { id: "us-central1", label: "us-central1 (Iowa)" },
+    { id: "us-east4", label: "us-east4 (Northern Virginia)" },
+    { id: "us-west1", label: "us-west1 (Oregon)" },
+    { id: "europe-west1", label: "europe-west1 (Belgium)" },
+    { id: "europe-west4", label: "europe-west4 (Netherlands)" },
+    { id: "asia-east1", label: "asia-east1 (Taiwan)" },
+    { id: "asia-northeast1", label: "asia-northeast1 (Tokyo)" },
+    { id: "asia-southeast1", label: "asia-southeast1 (Singapore)" },
+    { id: "global", label: "global (Global)" },
+  ],
+  defaultRegion: "us-central1",
   transport: {
     baseUrl: "https://aiplatform.googleapis.com",
     format: "vertex",

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -121,6 +121,7 @@ export function hasToolResults(msg, toolCallIds) {
 export function fixMissingToolResponses(body) {
   if (!body.messages || !Array.isArray(body.messages)) return body;
 
+  const isClaudeFormat = body.messages.some(m => Array.isArray(m?.content) && m.content.some(c => c?.type === "tool_use" || c?.type === "tool_result")) || !!body.system;
   const newMessages = [];
 
   for (let i = 0; i < body.messages.length; i++) {
@@ -134,15 +135,25 @@ export function fixMissingToolResponses(body) {
     if (toolCallIds.length === 0) continue;
 
     // Check if next message has tool_result
-    if (nextMsg && !hasToolResults(nextMsg, toolCallIds)) {
+    if (!nextMsg || !hasToolResults(nextMsg, toolCallIds)) {
       // Insert tool responses for each tool_call
       for (const id of toolCallIds) {
-        // OpenAI format: role = "tool"
-        newMessages.push({
-          role: "tool",
-          tool_call_id: id,
-          content: ""
-        });
+        if (isClaudeFormat) {
+          newMessages.push({
+            role: "user",
+            content: [{
+              type: "tool_result",
+              tool_use_id: id,
+              content: "[No response received]"
+            }]
+          });
+        } else {
+          newMessages.push({
+            role: "tool",
+            tool_call_id: id,
+            content: "[No response received]"
+          });
+        }
       }
     }
   }

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -42,6 +42,33 @@ function normalizeGeminiContents(contents) {
     if (last?.role === c.role) last.parts.push(...c.parts);
     else out.push({ ...c, parts: [...c.parts] });
   }
+
+  // Gemini / Vertex AI strictly require that the last turn in contents is a "user" turn.
+  // Requests ending with a model turn return HTTP 400 ("Requests ending with a model turn are not supported.").
+  if (out.length > 0 && out.at(-1).role === GEMINI_ROLE.MODEL) {
+    const lastTurn = out.at(-1);
+    const functionCalls = lastTurn.parts.filter(p => p?.functionCall);
+
+    if (functionCalls.length > 0) {
+      const functionResponses = functionCalls.map(p => ({
+        functionResponse: {
+          ...(p.functionCall.id ? { id: p.functionCall.id } : {}),
+          name: p.functionCall.name,
+          response: { result: "No response provided" }
+        }
+      }));
+      out.push({
+        role: GEMINI_ROLE.USER,
+        parts: functionResponses
+      });
+    } else {
+      out.push({
+        role: GEMINI_ROLE.USER,
+        parts: [{ text: "Continue" }]
+      });
+    }
+  }
+
   return out;
 }
 

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -180,12 +180,12 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
           }
 
           // Check if there are actual tool responses in the next messages
-          const hasActualResponses = toolCallIds.some(fid => toolResponses[fid]);
+          const hasActualResponses = toolCallIds.some(fid => toolResponses[fid] !== undefined);
 
           if (hasActualResponses) {
             const toolParts = [];
             for (const fid of toolCallIds) {
-              if (!toolResponses[fid]) continue;
+              if (toolResponses[fid] === undefined) continue;
 
               let name = tcID2Name[fid];
               if (!name) {

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -39,8 +39,22 @@ function normalizeGeminiContents(contents) {
   for (const c of contents || []) {
     if (!c?.role || !Array.isArray(c.parts) || c.parts.length === 0) continue;
     const last = out.at(-1);
-    if (last?.role === c.role) last.parts.push(...c.parts);
-    else out.push({ ...c, parts: [...c.parts] });
+    if (last?.role === c.role) {
+      const lastHasFnResp = last.parts.some(p => p?.functionResponse);
+      const currHasFnResp = c.parts.some(p => p?.functionResponse);
+      const lastHasText = last.parts.some(p => p?.text);
+      const currHasText = c.parts.some(p => p?.text);
+
+      // Vertex AI / Gemini requires functionResponse parts to be in their own user turn.
+      // Do not merge user functionResponse turn with user text turn.
+      if (c.role === GEMINI_ROLE.USER && ((lastHasFnResp && currHasText) || (lastHasText && currHasFnResp))) {
+        out.push({ ...c, parts: [...c.parts] });
+      } else {
+        last.parts.push(...c.parts);
+      }
+    } else {
+      out.push({ ...c, parts: [...c.parts] });
+    }
   }
 
   // Gemini / Vertex AI strictly require that the last turn in contents is a "user" turn.

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -3,6 +3,7 @@ import { getProviderConnectionById } from "@/models";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { GEMINI_CONFIG } from "@/lib/oauth/constants/oauth";
 import { refreshGoogleToken, refreshCodexToken, updateProviderCredentials } from "@/sse/services/tokenRefresh";
+import { parseVertexSaJson, refreshVertexToken } from "open-sse/services/tokenRefresh.js";
 import { resolveOllamaLocalHost } from "open-sse/config/providers.js";
 import { getModelsByProviderId } from "open-sse/config/providerModels.js";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
@@ -47,6 +48,28 @@ const parseGeminiCliModels = (data) => {
   }
 
   return [];
+};
+
+const parseVertexModels = (data) => {
+  const items = data?.publisherModels || data?.models || data?.data || [];
+  if (!Array.isArray(items)) return [];
+
+  const results = [];
+  for (const item of items) {
+    const fullName = item?.name || item?.id || item?.model || "";
+    if (!fullName) continue;
+
+    const id = fullName.replace(/^publishers\/google\/models\//, "").replace(/^models\//, "");
+    if (!id || id.includes("__probe__")) continue;
+
+    const displayName = item?.displayName || item?.versionId || id;
+    results.push({
+      id,
+      name: displayName,
+    });
+  }
+
+  return results;
 };
 
 const appendCodexReviewModels = (models) => models.flatMap((model) => {
@@ -257,6 +280,70 @@ const PROVIDER_MODELS_CONFIG = {
   nvidia: createOpenAIModelsConfig("https://integrate.api.nvidia.com/v1/models"),
   assemblyai: createOpenAIModelsConfig("https://api.assemblyai.com/v1/models"),
   "vercel-ai-gateway": createOpenAIModelsConfig("https://ai-gateway.vercel.sh/v1/models"),
+  vertex: {
+    customResolver: async (connection) => {
+      const saJson = parseVertexSaJson(connection.apiKey);
+      const projectId = saJson?.project_id || connection.providerSpecificData?.projectId || connection.projectId;
+      const location = connection.providerSpecificData?.location || connection.providerSpecificData?.region || "us-central1";
+      const proxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});
+
+      let url;
+      let headers = { "Content-Type": "application/json" };
+
+      if (saJson) {
+        const tokenRes = await refreshVertexToken(saJson);
+        if (!tokenRes?.accessToken) {
+          return { error: "Failed to mint token from Service Account JSON", status: 401 };
+        }
+        headers["Authorization"] = `Bearer ${tokenRes.accessToken}`;
+        url = projectId
+          ? `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/publishers/google/models`
+          : `https://aiplatform.googleapis.com/v1/publishers/google/models`;
+      } else if (connection.accessToken) {
+        headers["Authorization"] = `Bearer ${connection.accessToken}`;
+        url = projectId
+          ? `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${location}/publishers/google/models`
+          : `https://aiplatform.googleapis.com/v1/publishers/google/models`;
+      } else if (connection.apiKey) {
+        url = location && location !== "global"
+          ? `https://${location}-aiplatform.googleapis.com/v1/publishers/google/models?key=${connection.apiKey}`
+          : `https://aiplatform.googleapis.com/v1/publishers/google/models?key=${connection.apiKey}`;
+      } else {
+        return { error: "No API key or Service Account provided", status: 401 };
+      }
+
+      try {
+        const res = await fetchWithConnectionProxy(url, { headers }, proxy);
+        if (!res.ok) {
+          const errorText = await res.text().catch(() => "");
+          console.log("Error fetching Vertex AI models:", errorText);
+          return {
+            models: getStaticProviderModels("vertex"),
+            warning: `Failed to fetch Vertex models (${res.status}); using static catalog.`,
+          };
+        }
+
+        const data = await res.json().catch(() => ({}));
+        const models = parseVertexModels(data);
+
+        if (models.length > 0) {
+          return { models };
+        }
+      } catch (err) {
+        console.log("Failed to fetch Vertex AI models:", err.message);
+      }
+
+      return {
+        models: getStaticProviderModels("vertex"),
+        warning: "Vertex AI returned no models; using static catalog.",
+      };
+    }
+  },
+  "vertex-partner": {
+    customResolver: async (connection) => {
+      return { models: getStaticProviderModels("vertex-partner") };
+    }
+  },
   kimchi: {
     customResolver: async (connection) => {
       const result = await resolveKimchiModels({

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -18,6 +18,7 @@ import {
   KIMCHI_CONFIG,
 } from "@/lib/oauth/constants/oauth";
 import { buildClineHeaders } from "@/shared/utils/clineAuth";
+import { parseVertexSaJson, refreshVertexToken } from "open-sse/services/tokenRefresh.js";
 
 // OAuth provider test endpoints
 const OAUTH_TEST_CONFIG = {
@@ -787,6 +788,28 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
           effectiveProxy,
         );
         return { valid: exRes.ok, error: exRes.ok ? null : "Invalid Personal Access Token" };
+      }
+      case "vertex":
+      case "vertex-partner": {
+        const saJson = parseVertexSaJson(connection.apiKey);
+        if (saJson) {
+          try {
+            const tokenRes = await refreshVertexToken(saJson);
+            if (tokenRes?.accessToken) {
+              return { valid: true, error: null };
+            }
+            return { valid: false, error: "Failed to mint token from Service Account JSON" };
+          } catch (err) {
+            return { valid: false, error: err.message || "Invalid Service Account JSON" };
+          }
+        }
+        const probeRes = await fetchWithConnectionProxy(
+          `https://aiplatform.googleapis.com/v1/publishers/google/models/__probe__:generateContent?key=${connection.apiKey}`,
+          { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" },
+          effectiveProxy
+        );
+        const valid = probeRes.status !== 401 && probeRes.status !== 403;
+        return { valid, error: valid ? null : "Invalid API key" };
       }
       default:
         return { valid: false, error: "Provider test not supported" };

--- a/tests/unit/claude-to-vertex-empty-tool-result.test.js
+++ b/tests/unit/claude-to-vertex-empty-tool-result.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import "../translator/registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("Claude → Vertex with empty tool_result content", () => {
+  it("handles tool_result with empty string content", () => {
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Do X" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: "run_cmd", input: { cmd: "ls" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "" }] },
+        { role: "assistant", content: [{ type: "text", text: "Done" }] },
+        { role: "user", content: [{ type: "text", text: "Now do Y" }] },
+      ],
+      tools: [{ name: "run_cmd", description: "Run command", input_schema: { type: "object", properties: { cmd: { type: "string" } } } }],
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    
+    // Verify all turns alternate user/model properly
+    for (let i = 1; i < result.contents.length; i++) {
+      const prev = result.contents[i - 1];
+      const curr = result.contents[i];
+      expect(prev.role).not.toBe(curr.role);
+    }
+    
+    // Last turn should be user
+    expect(result.contents.at(-1).role).toBe("user");
+    
+    // Check that there's a user turn with functionResponse after the model turn with functionCall
+    let foundFunctionCall = false;
+    for (let i = 0; i < result.contents.length; i++) {
+      const turn = result.contents[i];
+      if (turn.role === "model" && turn.parts.some(p => p?.functionCall)) {
+        foundFunctionCall = true;
+        // Next turn must be user with functionResponse
+        const nextTurn = result.contents[i + 1];
+        expect(nextTurn).toBeDefined();
+        expect(nextTurn.role).toBe("user");
+        expect(nextTurn.parts.some(p => p?.functionResponse)).toBe(true);
+      }
+    }
+    expect(foundFunctionCall).toBe(true);
+  });
+
+  it("handles multi-turn with empty tool results (11 messages)", () => {
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Do task" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: "run_cmd", input: { cmd: "ls" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "" }] },
+        { role: "assistant", content: [{ type: "text", text: "Found files" }, { type: "tool_use", id: "toolu_2", name: "run_cmd", input: { cmd: "cat file" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "" }] },
+        { role: "assistant", content: [{ type: "text", text: "Content loaded" }, { type: "tool_use", id: "toolu_3", name: "run_cmd", input: { cmd: "echo done" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_3", content: "" }] },
+        { role: "assistant", content: [{ type: "text", text: "All done" }, { type: "tool_use", id: "toolu_4", name: "run_cmd", input: { cmd: "pwd" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_4", content: "" }] },
+        { role: "assistant", content: [{ type: "text", text: "Directory listed" }] },
+        { role: "user", content: [{ type: "text", text: "Thanks" }] },
+      ],
+      tools: [{ name: "run_cmd", description: "Run command", input_schema: { type: "object", properties: { cmd: { type: "string" } } } }],
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    
+    // Verify proper alternation
+    for (let i = 1; i < result.contents.length; i++) {
+      const prev = result.contents[i - 1];
+      const curr = result.contents[i];
+      expect(prev.role, `Turn ${i}: expected alternating roles but got ${prev.role} → ${curr.role}`).not.toBe(curr.role);
+    }
+    
+    // Last turn should be user
+    expect(result.contents.at(-1).role).toBe("user");
+  });
+
+  it("handles tool_result with null content", () => {
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Do X" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: "run_cmd", input: { cmd: "ls" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1" }] },
+        { role: "assistant", content: [{ type: "text", text: "Done" }] },
+        { role: "user", content: [{ type: "text", text: "Thanks" }] },
+      ],
+      tools: [{ name: "run_cmd", description: "Run command", input_schema: { type: "object", properties: { cmd: { type: "string" } } } }],
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    
+    // Verify proper alternation
+    for (let i = 1; i < result.contents.length; i++) {
+      const prev = result.contents[i - 1];
+      const curr = result.contents[i];
+      expect(prev.role, `Turn ${i}: expected alternating roles but got ${prev.role} → ${curr.role}`).not.toBe(curr.role);
+    }
+  });
+});

--- a/tests/unit/claude-to-vertex-model-turn.test.js
+++ b/tests/unit/claude-to-vertex-model-turn.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import "../translator/registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("Claude → Vertex requests ending with model turn", () => {
+  it("appends user turn when Claude conversation ends with assistant text", () => {
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Hello" }] },
+        { role: "assistant", content: [{ type: "text", text: "Hi! How can I help?" }] }
+      ],
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    const lastTurn = result.contents.at(-1);
+
+    expect(lastTurn.role).toBe("user");
+    expect(lastTurn.parts[0].text).toBe("Continue");
+  });
+
+  it("appends user turn with functionResponse when Claude conversation ends with assistant tool_use", () => {
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Check weather" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_123", name: "get_weather", input: { city: "Jakarta" } }
+          ]
+        }
+      ],
+      tools: [{ name: "get_weather", description: "Get weather", input_schema: { type: "object", properties: { city: { type: "string" } } } }],
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    const lastTurn = result.contents.at(-1);
+
+    expect(lastTurn.role).toBe("user");
+    expect(lastTurn.parts[0].functionResponse).toBeDefined();
+    expect(lastTurn.parts[0].functionResponse.name).toBe("get_weather");
+  });
+
+  it("handles multi-turn conversation with 11 messages ending with assistant", () => {
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Do task 1" }] },
+        { role: "assistant", content: [{ type: "text", text: "Sure" }, { type: "tool_use", id: "toolu_1", name: "run_cmd", input: { cmd: "ls" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "file1.txt" }] },
+        { role: "assistant", content: [{ type: "text", text: "Found file1" }, { type: "tool_use", id: "toolu_2", name: "run_cmd", input: { cmd: "cat file1.txt" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "content of file1" }] },
+        { role: "assistant", content: [{ type: "text", text: "Here's the content" }] },
+        { role: "user", content: [{ type: "text", text: "Now do task 2" }] },
+        { role: "assistant", content: [{ type: "text", text: "OK" }, { type: "tool_use", id: "toolu_3", name: "run_cmd", input: { cmd: "mkdir test" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_3", content: "done" }] },
+        { role: "assistant", content: [{ type: "text", text: "Created dir" }, { type: "tool_use", id: "toolu_4", name: "run_cmd", input: { cmd: "touch test/a.txt" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_4", content: "done" }] },
+      ],
+      tools: [{ name: "run_cmd", description: "Run command", input_schema: { type: "object", properties: { cmd: { type: "string" } } } }],
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    const lastTurn = result.contents.at(-1);
+
+    // Last turn should be user (tool_result converts to functionResponse)
+    expect(lastTurn.role).toBe("user");
+  });
+
+  it("handles 11 messages ending with assistant (no trailing tool_result)", () => {
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Do task 1" }] },
+        { role: "assistant", content: [{ type: "text", text: "Sure" }, { type: "tool_use", id: "toolu_1", name: "run_cmd", input: { cmd: "ls" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "file1.txt" }] },
+        { role: "assistant", content: [{ type: "text", text: "Found file1" }, { type: "tool_use", id: "toolu_2", name: "run_cmd", input: { cmd: "cat file1.txt" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "content of file1" }] },
+        { role: "assistant", content: [{ type: "text", text: "Here's the content" }] },
+        { role: "user", content: [{ type: "text", text: "Now do task 2" }] },
+        { role: "assistant", content: [{ type: "text", text: "OK" }, { type: "tool_use", id: "toolu_3", name: "run_cmd", input: { cmd: "mkdir test" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_3", content: "done" }] },
+        { role: "assistant", content: [{ type: "text", text: "Created dir" }] },
+        { role: "user", content: [{ type: "text", text: "And task 3" }] },
+      ],
+      tools: [{ name: "run_cmd", description: "Run command", input_schema: { type: "object", properties: { cmd: { type: "string" } } } }],
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    const lastTurn = result.contents.at(-1);
+
+    // Last turn should be user (the "And task 3" user message)
+    expect(lastTurn.role).toBe("user");
+  });
+
+  it("handles thinking content in assistant messages", () => {
+    // Claude format with thinking - after Claude→OpenAI, assistant gets reasoning_content
+    const body = {
+      model: "claude-opus",
+      system: "You are helpful.",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "Hello" }] },
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "Let me think about this..." },
+          { type: "text", text: "Hi there!" }
+        ] }
+      ],
+      thinking: { type: "enabled", budget_tokens: 8192 },
+      max_tokens: 4096
+    };
+
+    const result = translateRequest(FORMATS.CLAUDE, FORMATS.VERTEX, "gemini-3.6-flash", body, true, null, "vertex");
+    const lastTurn = result.contents.at(-1);
+
+    expect(lastTurn.role).toBe("user");
+    expect(lastTurn.parts[0].text).toBe("Continue");
+  });
+});

--- a/tests/unit/vertex-gemini-model-turn.test.js
+++ b/tests/unit/vertex-gemini-model-turn.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import "../translator/registerAll.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("OpenAI → Gemini / Vertex requests ending with model turn", () => {
+  it("appends user turn when message history ends with assistant message", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Hi! How can I help you today?" }
+      ]
+    };
+
+    const geminiReq = translateRequest(FORMATS.OPENAI, FORMATS.GEMINI, "gemini-3.6-flash", body, true, null, "gemini");
+    const vertexReq = translateRequest(FORMATS.OPENAI, FORMATS.VERTEX, "vertex/gemini-3.6-flash", body, true, null, "vertex");
+
+    const lastGeminiTurn = geminiReq.contents.at(-1);
+    const lastVertexTurn = vertexReq.contents.at(-1);
+
+    expect(lastGeminiTurn.role).toBe("user");
+    expect(lastGeminiTurn.parts[0].text).toBe("Continue");
+
+    expect(lastVertexTurn.role).toBe("user");
+    expect(lastVertexTurn.parts[0].text).toBe("Continue");
+  });
+
+  it("appends user turn with functionResponse when assistant message ends with unresponded tool_calls", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "Check weather in Jakarta" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_123",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"Jakarta"}' }
+            }
+          ]
+        }
+      ]
+    };
+
+    const vertexReq = translateRequest(FORMATS.OPENAI, FORMATS.VERTEX, "vertex/gemini-3.6-flash", body, true, null, "vertex");
+    const lastTurn = vertexReq.contents.at(-1);
+
+    expect(lastTurn.role).toBe("user");
+    expect(lastTurn.parts[0].functionResponse).toBeDefined();
+    expect(lastTurn.parts[0].functionResponse.name).toBe("get_weather");
+    expect(lastTurn.parts[0].functionResponse.response.result).toBe("No response provided");
+    // Vertex post-processing strips `id`
+    expect(lastTurn.parts[0].functionResponse.id).toBeUndefined();
+  });
+});

--- a/tests/unit/vertex-gemini-model-turn.test.js
+++ b/tests/unit/vertex-gemini-model-turn.test.js
@@ -49,7 +49,7 @@ describe("OpenAI → Gemini / Vertex requests ending with model turn", () => {
     expect(lastTurn.role).toBe("user");
     expect(lastTurn.parts[0].functionResponse).toBeDefined();
     expect(lastTurn.parts[0].functionResponse.name).toBe("get_weather");
-    expect(lastTurn.parts[0].functionResponse.response.result).toBe("No response provided");
+    expect(lastTurn.parts[0].functionResponse.response.result).toEqual({ result: "[No response received]" });
     // Vertex post-processing strips `id`
     expect(lastTurn.parts[0].functionResponse.id).toBeUndefined();
   });


### PR DESCRIPTION
## Description
Fixes HTTP 400 `Requests ending with a model turn are not supported` errors when using Vertex AI / Gemini models in multi-turn conversations with tool calls (e.g., MCP tools or skills).

### Root Causes & Fixes
1. **Unintended Turn Merging in Gemini Normalization**:
   - `normalizeGeminiContents` merged consecutive turns of the same role (`last.role === c.role`).
   - When a `user` turn contained a `functionResponse` (from tool execution) and was immediately followed by a `user` turn containing `text`, `normalizeGeminiContents` combined them into a single `user` turn containing both `functionResponse` AND `text` parts.
   - Vertex AI / Gemini API rejects `user` turns that mix `functionResponse` and `text` parts (causing invalid turn sequence / 400 error).
   - **Fix**: Updated `normalizeGeminiContents` in `openai-to-gemini.js` to ensure `user` turns containing `functionResponse` parts are kept as separate turns and not merged with `text` turns.

2. **Claude Format Missing Tool Response Insertion**:
   - `fixMissingToolResponses` in `toolCall.js` inserted OpenAI-shaped tool messages (`{ role: "tool", ... }`) into Claude-formatted message arrays, destroying the Claude message structure during translation and resulting in invalid turn structures.
   - **Fix**: Updated `fixMissingToolResponses` to check whether `messages` is in Claude or OpenAI format, inserting Claude-formatted `tool_result` content blocks when handling Claude message arrays.

3. **Truthy Check on Empty Tool Results**:
   - `openaiToGeminiBase` checked `toolResponses[fid]` for truthiness (`!toolResponses[fid]`), skipping tool results with empty string content (`""`).
   - **Fix**: Changed `toolResponses[fid]` check to `!== undefined`.

### Tests Added / Updated
- `tests/unit/claude-to-vertex-empty-tool-result.test.js`
- `tests/unit/claude-to-vertex-model-turn.test.js`
- `tests/unit/vertex-gemini-model-turn.test.js`