### PR TITLE
fix: correct AssemblyAI STT auth header

### DIFF
--- a/open-sse/handlers/sttCore.js
+++ b/open-sse/handlers/sttCore.js
@@ -6,11 +6,12 @@ import { HTTP_STATUS } from "../config/runtimeConfig.js";
 function buildAuthHeaders(cfg, token) {
   if (!token) return {};
   switch (cfg.authHeader) {
-    case "bearer":     return { "Authorization": `Bearer ${token}` };
-    case "token":      return { "Authorization": `Token ${token}` };
-    case "x-api-key":  return { "x-api-key": token };
-    case "key":        return { "Authorization": `Key ${token}` };
-    default:           return { "Authorization": `Bearer ${token}` };
+    case "bearer":        return { "Authorization": `Bearer ${token}` };
+    case "token":         return { "Authorization": `Token ${token}` };
+    case "authorization": return { "Authorization": token };
+    case "x-api-key":     return { "x-api-key": token };
+    case "key":           return { "Authorization": `Key ${token}` };
+    default:              return { "Authorization": `Bearer ${token}` };
   }
 }
 
@@ -55,7 +56,7 @@ async function transcribeDeepgram(cfg, file, model, token, formData) {
 }
 
 // AssemblyAI: upload → submit → poll (max 120s)
-async function transcribeAssemblyAI(cfg, file, model, token) {
+async function transcribeAssemblyAI(cfg, file, model, token, formData) {
   const auth = buildAuthHeaders(cfg, token);
   const buf = await file.arrayBuffer();
   const up = await fetch("https://api.assemblyai.com/v2/upload", {
@@ -64,10 +65,15 @@ async function transcribeAssemblyAI(cfg, file, model, token) {
   if (!up.ok) return upstreamError(up);
   const { upload_url } = await up.json();
 
+  const payload = { audio_url: upload_url, speech_models: [model] };
+  const lang = formData.get("language");
+  if (typeof lang === "string" && lang.trim()) payload.language_code = lang.trim();
+  else payload.language_detection = true;
+
   const sub = await fetch(cfg.baseUrl, {
     method: "POST",
     headers: { ...auth, "Content-Type": "application/json" },
-    body: JSON.stringify({ audio_url: upload_url, speech_models: [model], language_detection: true }),
+    body: JSON.stringify(payload),
   });
   if (!sub.ok) return upstreamError(sub);
   const { id } = await sub.json();
@@ -181,7 +187,7 @@ export async function handleSttCore({ provider, model, formData, credentials, st
   try {
     switch (cfg.format) {
       case "deepgram":        return await transcribeDeepgram(cfg, file, model, token, formData);
-      case "assemblyai":      return await transcribeAssemblyAI(cfg, file, model, token);
+      case "assemblyai":      return await transcribeAssemblyAI(cfg, file, model, token, formData);
       case "nvidia-asr":      return await transcribeNvidia(cfg, file, model, token);
       case "huggingface-asr": return await transcribeHuggingFace(cfg, file, model, token);
       case "gemini-stt":      return await transcribeGemini(cfg, file, model, token, formData);

--- a/tests/unit/assemblyai-stt.test.js
+++ b/tests/unit/assemblyai-stt.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { handleSttCore } from "../../open-sse/handlers/sttCore.js";
+
+const originalFetch = global.fetch;
+
+function makeAudioFile() {
+  return new File([new Uint8Array([1, 2, 3])], "speech.wav", { type: "audio/wav" });
+}
+
+function makeFormData(language) {
+  const formData = new FormData();
+  formData.set("file", makeAudioFile());
+  if (language) formData.set("language", language);
+  return formData;
+}
+
+function makeSttConfig() {
+  return {
+    baseUrl: "https://api.assemblyai.com/v2/transcript",
+    authType: "apikey",
+    authHeader: "authorization",
+    format: "assemblyai",
+  };
+}
+
+describe("AssemblyAI STT", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("uses raw Authorization header for AssemblyAI upload/submit/poll", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ upload_url: "https://cdn.example/audio.wav" }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: "transcript-id" }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ status: "completed", text: "hello world" }) });
+
+    const result = await handleSttCore({
+      provider: "assemblyai",
+      model: "universal-2",
+      formData: makeFormData("en"),
+      credentials: { apiKey: "test-api-key" },
+      sttConfig: makeSttConfig(),
+    });
+
+    expect(result.success).toBe(true);
+    expect(await result.response.json()).toEqual({ text: "hello world" });
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://api.assemblyai.com/v2/upload",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "test-api-key" }),
+      }),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://api.assemblyai.com/v2/transcript",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "test-api-key" }),
+      }),
+    );
+  });
+
+  it("maps an explicit language field to AssemblyAI language_code", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ upload_url: "https://cdn.example/audio.wav" }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: "transcript-id" }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ status: "completed", text: "hello world" }) });
+
+    await handleSttCore({
+      provider: "assemblyai",
+      model: "universal-2",
+      formData: makeFormData("en"),
+      credentials: { apiKey: "test-api-key" },
+      sttConfig: makeSttConfig(),
+    });
+
+    const submitBody = JSON.parse(global.fetch.mock.calls[1][1].body);
+    expect(submitBody).toEqual({
+      audio_url: "https://cdn.example/audio.wav",
+      speech_models: ["universal-2"],
+      language_code: "en",
+    });
+  });
+
+  it("uses language detection when no language is provided", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ upload_url: "https://cdn.example/audio.wav" }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ id: "transcript-id" }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ status: "completed", text: "hello world" }) });
+
+    await handleSttCore({
+      provider: "assemblyai",
+      model: "universal-2",
+      formData: makeFormData(),
+      credentials: { apiKey: "test-api-key" },
+      sttConfig: makeSttConfig(),
+    });
+
+    const submitBody = JSON.parse(global.fetch.mock.calls[1][1].body);
+    expect(submitBody).toEqual({
+      audio_url: "https://cdn.example/audio.wav",
+      speech_models: ["universal-2"],
+      language_detection: true,
+    });
+  });
+});


### PR DESCRIPTION
# Description

This PR fixes AssemblyAI STT authentication for the `/v1/audio/transcriptions` endpoint.

AssemblyAI upload and transcription endpoints expect the API key to be sent as a **raw** `Authorization` header:

```http
Authorization: ***
```

The current STT configuration uses:

```js
authHeader: "authorization"
```

However, the STT authentication header builder does not currently recognize `"authorization"` as a raw authentication scheme, causing it to fall back to Bearer authentication:

```http
Authorization: Bearer ***
```

AssemblyAI rejects this request with `401 Invalid API key`, even when the provided API key is valid.

## Changes

- Add support for `authHeader: "authorization"` to send the API key as a raw `Authorization` header.
- Pass `formData` through to the AssemblyAI transcription handler.
- Map the `language` form field to AssemblyAI's `language_code` parameter.
- Enable `language_detection: true` only when no explicit language is provided.
- Add unit tests covering both authentication behavior and language parameter handling.

## Verification

Added unit tests:

```bash
cd tests
npm exec vitest run -- --reporter=verbose assemblyai-stt.test.js
```

Result:

```text
Test Files  1 passed (1)
Tests       3 passed (3)
```

Also verified against a deployed 9Router instance using AssemblyAI with a real audio sample:

```bash
curl -X POST "$NINEROUTER_URL/v1/audio/transcriptions" \
  -H "Authorization: Bearer ***" \
  -F "model=aai/universal-2" \
  -F "file=@sample.mp3" \
  -F "language=en"
```

The request completed successfully with **HTTP 200** and returned the expected transcript.