### PR TITLE
fix(auth): block default-password remote login + redact request details (#3049)

### DIFF
--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -54,15 +54,27 @@ export async function POST(request) {
 
     if (isValid) {
       recordSuccess(ip);
-      const cookieStore = await cookies();
-      await setDashboardAuthCookie(cookieStore, request);
 
       // Default password still in use on a remote client → force a password
       // change before the dashboard is exposed remotely (keeps local UX intact).
       const mustChangePassword =
         !storedHash && !process.env.INITIAL_PASSWORD && !isLocalRequest(request);
 
-      return NextResponse.json({ success: true, mustChangePassword }, { headers: NO_STORE_HEADERS });
+      if (mustChangePassword) {
+        // Do NOT issue a session token: a fresh install's default password is
+        // public knowledge ("123456"), so handing out a valid JWT would let any
+        // remote attacker authenticate and (e.g.) PATCH /api/settings to disable
+        // authentication entirely. Require the password to be changed first.
+        return NextResponse.json(
+          { success: false, error: "Default password must be changed before remote access. Change it from the local machine (or set INITIAL_PASSWORD).", mustChangePassword },
+          { status: 403, headers: NO_STORE_HEADERS }
+        );
+      }
+
+      const cookieStore = await cookies();
+      await setDashboardAuthCookie(cookieStore, request);
+
+      return NextResponse.json({ success: true, mustChangePassword: false }, { headers: NO_STORE_HEADERS });
     }
 
     const { remainingBeforeLock } = recordFail(ip);

--- a/src/app/api/usage/request-details/route.js
+++ b/src/app/api/usage/request-details/route.js
@@ -47,8 +47,23 @@ export async function GET(request) {
     if (endDate) filter.endDate = endDate;
     
     const result = await getRequestDetails(filter);
-    
-    return NextResponse.json(result);
+
+    // Redact conversation payloads: the stored details include full request
+    // bodies (user prompts, tool calls) and provider responses. Returning them
+    // wholesale lets any dashboard-authenticated user (or, if requireLogin is
+    // disabled, anyone) read every user's conversation history. Keep the
+    // metadata (model, tokens, latency, status) but drop message content.
+    const redactedDetails = (result.details || []).map((d) => {
+      const redacted = { ...d };
+      for (const key of ["request", "providerRequest", "providerResponse", "response"]) {
+        if (redacted[key] !== undefined) {
+          redacted[key] = { redacted: true };
+        }
+      }
+      return redacted;
+    });
+
+    return NextResponse.json({ ...result, details: redactedDetails });
   } catch (error) {
     console.error("[API] Failed to get request details:", error);
     return NextResponse.json(

--- a/tests/unit/request-details-redaction.test.js
+++ b/tests/unit/request-details-redaction.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+// Mirror the redaction logic from src/app/api/usage/request-details/route.js
+// so we can test it in isolation.
+function redactDetails(details) {
+  return (details || []).map((d) => {
+    const redacted = { ...d };
+    for (const key of ["request", "providerRequest", "providerResponse", "response"]) {
+      if (redacted[key] !== undefined) {
+        redacted[key] = { redacted: true };
+      }
+    }
+    return redacted;
+  });
+}
+
+describe("request-details redaction", () => {
+  it("removes conversation payloads but keeps metadata", () => {
+    const details = [{
+      id: "abc",
+      provider: "opencode",
+      model: "deepseek-v4-flash-free",
+      timestamp: "2026-08-05T00:00:00Z",
+      status: "success",
+      tokens: { prompt_tokens: 10, completion_tokens: 5 },
+      request: { messages: [{ role: "user", content: "secret prompt" }] },
+      providerRequest: { messages: [{ role: "user", content: "secret prompt" }] },
+      providerResponse: { choices: [{ message: { content: "secret answer" } }] },
+      response: { content: "secret answer" },
+    }];
+    const out = redactDetails(details)[0];
+    expect(out.id).toBe("abc");
+    expect(out.provider).toBe("opencode");
+    expect(out.model).toBe("deepseek-v4-flash-free");
+    expect(out.tokens).toEqual({ prompt_tokens: 10, completion_tokens: 5 });
+    expect(out.request).toEqual({ redacted: true });
+    expect(out.providerRequest).toEqual({ redacted: true });
+    expect(out.providerResponse).toEqual({ redacted: true });
+    expect(out.response).toEqual({ redacted: true });
+  });
+
+  it("handles empty details", () => {
+    expect(redactDetails([])).toEqual([]);
+    expect(redactDetails(null)).toEqual([]);
+  });
+
+  it("keeps non-sensitive fields untouched", () => {
+    const details = [{ id: "x", status: "error", latency: { total: 100 } }];
+    const out = redactDetails(details)[0];
+    expect(out.id).toBe("x");
+    expect(out.status).toBe("error");
+    expect(out.latency).toEqual({ total: 100 });
+  });
+});


### PR DESCRIPTION
## Summary

Two security fixes, both **verified end-to-end on production** (Pi 500, Docker, v0.5.50 fresh install):

### 1. Default-password remote login blocked (CVE-2026-56679 class)
Fresh installs use the publicly-known default password `123456`. The login route issued a **valid JWT even when `mustChangePassword=true`** (the cookie was set before the mustChangePassword branch), so any remote attacker could:
1. Login with `123456` → get a valid `auth_token` cookie
2. `PATCH /api/settings {"requireLogin": false}` → **disable authentication globally**
3. Read all API keys, provider credentials, conversation history unauthenticated

**Fix**: when the default password is still in use on a **remote** client, return `403` **without issuing a session token**. Local logins and `INITIAL_PASSWORD`-configured deployments are unaffected.

### 2. request-details conversation redaction
`/api/usage/request-details` returned **full conversation payloads**: `request.messages` (user prompts, tool calls), `providerRequest`, `providerResponse`, `response` (model output). Any dashboard-authenticated user — or anyone, when `requireLogin` is disabled — could read every user's conversation history.

**Fix**: redact `request` / `providerRequest` / `providerResponse` / `response` to `{redacted: true}`; keep metadata (model, tokens, latency, status, provider).

## Verification (all real HTTP, Pi 500 Docker)

| Test | Before | After |
|---|---|---|
| Remote login `123456` (fresh install) | 200 + JWT cookie | **403, no cookie** |
| Local login `123456` | 200 + JWT | 200 + JWT (unchanged) |
| request-details `request` field | full messages | `{"redacted": true}` |
| request-details metadata | present | present (unchanged) |

Unit tests: `tests/unit/request-details-redaction.test.js` (3 cases) — **all pass**.

## Notes
- Root cause of #1 is that `setDashboardAuthCookie` was called before the `mustChangePassword` branch in `src/app/api/auth/login/route.js`.
- The `requireLogin`/`requireApiKey`/`tunnelDashboardAccess` PATCH fields are **intentional admin UI toggles** (dashboard profile/endpoint pages), so they are *not* removed from the PATCH surface — the fix targets the actual flaw: default-credential access.
