### PR TITLE
feat(combos): add import/export with capacity adapter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+**/node_modules
 /.pnp
 .pnp.*
 .yarn/*
@@ -11,16 +11,16 @@
 !.yarn/versions
 
 # testing
-/coverage
+**/coverage
 
 # next.js
-/.next/
+**/.next/
 /.next-cli-build/
 /out/
 cli/.build-home/
 product
 # production
-/build
+**/build
 .idea/
 
 # misc
@@ -86,3 +86,6 @@ graphify-out/*
 .codegraph/
 .PR/
 .next-analyze/*
+
+# local tool state
+.serena/

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -55,6 +55,8 @@ export default function CombosPage() {
   const { getCaps } = useModelCaps();
   const [confirmState, setConfirmState] = useState(null);
   const { copied, copy } = useCopyToClipboard();
+  const [importing, setImporting] = useState(false);
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     fetchData();
@@ -184,6 +186,65 @@ export default function CombosPage() {
     }
   };
 
+  const handleExport = async () => {
+    try {
+      const res = await fetch("/api/combos/export");
+      if (!res.ok) throw new Error("Export failed");
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "combos-export.json";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.log("Error exporting combos:", error);
+    }
+  };
+
+  const handleImportFile = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    e.target.value = "";
+
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+
+      setConfirmState({
+        title: "Import Combos",
+        message: `This will replace all ${combos.length} existing combo(s) with ${data.combos?.length || 0} combo(s) from this file. Are you sure?`,
+        onConfirm: async () => {
+          setConfirmState(null);
+          setImporting(true);
+          try {
+            const res = await fetch("/api/combos/import", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: text,
+            });
+            if (res.ok) {
+              await fetchData();
+            } else {
+              const err = await res.json();
+              alert(err.error || "Failed to import combos");
+            }
+          } catch (err) {
+            console.log("Error importing combos:", err);
+            alert("Failed to import combos");
+          } finally {
+            setImporting(false);
+          }
+        },
+      });
+    } catch (error) {
+      console.log("Error reading import file:", error);
+      alert("Invalid JSON file");
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex flex-col gap-6">
@@ -207,9 +268,24 @@ export default function CombosPage() {
             <li><span className="font-medium text-text-main">Fusion</span> — queries all models in parallel, then a judge synthesizes one answer. Best quality, but costs the most: every request bills all panel models + the judge (N+1 calls)</li>
           </ul>
         </div>
-        <Button icon="add" onClick={() => setShowCreateModal(true)} className="w-full sm:w-auto whitespace-nowrap">
-          Create Combo
-        </Button>
+        <div className="flex gap-2 w-full sm:w-auto">
+          <Button variant="secondary" size="sm" iconRight="download" onClick={handleExport} className="flex-1 sm:flex-none">
+            Export
+          </Button>
+          <Button variant="secondary" size="sm" iconRight="upload" loading={importing} onClick={() => fileInputRef.current?.click()} className="flex-1 sm:flex-none">
+            Import
+          </Button>
+          <Button icon="add" size="sm" onClick={() => setShowCreateModal(true)} className="flex-1 sm:flex-none whitespace-nowrap">
+            Create
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json"
+            onChange={handleImportFile}
+            className="hidden"
+          />
+        </div>
       </div>
 
       {/* Combos List */}

--- a/src/app/api/combos/export/route.js
+++ b/src/app/api/combos/export/route.js
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getCombos, getSettings } from "@/lib/localDb";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const [combos, settings] = await Promise.all([
+      getCombos(),
+      getSettings(),
+    ]);
+
+    const comboStrategies = settings?.comboStrategies || {};
+    const capacityAdapter = settings?.capacityAdapter || null;
+
+    const exportData = {
+      version: 2,
+      exportedAt: new Date().toISOString(),
+      ...(capacityAdapter ? { capacityAdapter } : {}),
+      combos: combos.map((combo) => {
+        const strategy = comboStrategies[combo.name];
+        return {
+          name: combo.name,
+          kind: combo.kind,
+          models: combo.models,
+          strategy: strategy
+            ? {
+                fallbackStrategy: strategy.fallbackStrategy || "fallback",
+                ...(strategy.judgeModel ? { judgeModel: strategy.judgeModel } : {}),
+              }
+            : { fallbackStrategy: "fallback" },
+        };
+      }),
+    };
+
+    const jsonStr = JSON.stringify(exportData, null, 2);
+
+    return new NextResponse(jsonStr, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Disposition": `attachment; filename="combos-export.json"`,
+      },
+    });
+  } catch (error) {
+    console.log("Error exporting combos:", error);
+    return NextResponse.json({ error: "Failed to export combos" }, { status: 500 });
+  }
+}

--- a/src/app/api/combos/import/route.js
+++ b/src/app/api/combos/import/route.js
@@ -1,0 +1,187 @@
+import { NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+import { getAdapter } from "@/lib/db/driver.js";
+import { stringifyJson } from "@/lib/db/helpers/jsonCol.js";
+import { getSettings, updateSettings } from "@/lib/localDb";
+
+export const dynamic = "force-dynamic";
+
+const VALID_NAME_REGEX = /^[a-zA-Z0-9_.\-]+$/;
+const VALID_KINDS = ["llm", "webSearch", "webFetch"];
+const VALID_STRATEGIES = ["fallback", "round-robin", "fusion"];
+const VALID_CAPACITY_KEYS = ["vision", "pdf", "audioInput", "videoInput"];
+
+// Validate and normalize a capacityAdapter object; returns { error } or { value }
+function validateCapacityAdapter(raw) {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { error: "capacityAdapter must be an object" };
+  }
+  const value = {};
+  for (const [key, entry] of Object.entries(raw)) {
+    if (!VALID_CAPACITY_KEYS.includes(key)) {
+      return { error: `capacityAdapter: unknown capability "${key}"` };
+    }
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      return { error: `capacityAdapter.${key}: must be an object` };
+    }
+    if (entry.enabled != null && typeof entry.enabled !== "boolean") {
+      return { error: `capacityAdapter.${key}: enabled must be a boolean` };
+    }
+    if (entry.roundRobin != null && typeof entry.roundRobin !== "boolean") {
+      return { error: `capacityAdapter.${key}: roundRobin must be a boolean` };
+    }
+    if (entry.models != null && (!Array.isArray(entry.models) || entry.models.some((m) => typeof m !== "string"))) {
+      return { error: `capacityAdapter.${key}: models must be an array of strings` };
+    }
+    value[key] = {
+      enabled: entry.enabled !== false,
+      roundRobin: !!entry.roundRobin,
+      models: Array.isArray(entry.models) ? entry.models.filter(Boolean) : [],
+    };
+  }
+  return { value };
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+
+    // Validate top-level structure
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return NextResponse.json({ error: "Invalid JSON: expected an object with version and combos" }, { status: 400 });
+    }
+
+    if (!body.version || typeof body.version !== "number") {
+      return NextResponse.json({ error: "Missing or invalid version field" }, { status: 400 });
+    }
+
+    if (!Array.isArray(body.combos)) {
+      return NextResponse.json({ error: "Combos must be an array" }, { status: 400 });
+    }
+
+    if (body.combos.length === 0) {
+      return NextResponse.json({ error: "At least one combo is required" }, { status: 400 });
+    }
+
+    // Validate optional capacityAdapter (vision/audio fallback pools)
+    let importedCapacityAdapter = null;
+    if (body.capacityAdapter != null) {
+      const result = validateCapacityAdapter(body.capacityAdapter);
+      if (result.error) {
+        return NextResponse.json({ error: result.error }, { status: 400 });
+      }
+      importedCapacityAdapter = result.value;
+    }
+
+    // Validate each combo
+    const nameSet = new Set();
+    for (let i = 0; i < body.combos.length; i++) {
+      const combo = body.combos[i];
+      const idx = i + 1;
+
+      if (!combo || typeof combo !== "object" || Array.isArray(combo)) {
+        return NextResponse.json({ error: `Combo ${idx}: invalid entry` }, { status: 400 });
+      }
+
+      if (!combo.name || typeof combo.name !== "string" || !combo.name.trim()) {
+        return NextResponse.json({ error: `Combo ${idx}: name is required` }, { status: 400 });
+      }
+
+      if (!VALID_NAME_REGEX.test(combo.name)) {
+        return NextResponse.json({ error: `Combo ${idx}: name "${combo.name}" can only contain letters, numbers, -, _ and .` }, { status: 400 });
+      }
+
+      if (nameSet.has(combo.name)) {
+        return NextResponse.json({ error: `Combo ${idx}: duplicate name "${combo.name}"` }, { status: 400 });
+      }
+      nameSet.add(combo.name);
+
+      if (combo.kind != null && !VALID_KINDS.includes(combo.kind)) {
+        return NextResponse.json({ error: `Combo ${idx}: invalid kind "${combo.kind}"` }, { status: 400 });
+      }
+
+      if (!Array.isArray(combo.models)) {
+        return NextResponse.json({ error: `Combo ${idx}: models must be an array` }, { status: 400 });
+      }
+
+      if (combo.roundRobin != null && typeof combo.roundRobin !== "boolean") {
+        return NextResponse.json({ error: `Combo ${idx}: roundRobin must be a boolean` }, { status: 400 });
+      }
+
+      if (combo.strategy != null) {
+        if (typeof combo.strategy !== "object" || Array.isArray(combo.strategy)) {
+          return NextResponse.json({ error: `Combo ${idx}: strategy must be an object` }, { status: 400 });
+        }
+        if (combo.strategy.fallbackStrategy && !VALID_STRATEGIES.includes(combo.strategy.fallbackStrategy)) {
+          return NextResponse.json({ error: `Combo ${idx}: invalid strategy "${combo.strategy.fallbackStrategy}"` }, { status: 400 });
+        }
+        if (combo.strategy.judgeModel != null && typeof combo.strategy.judgeModel !== "string") {
+          return NextResponse.json({ error: `Combo ${idx}: judgeModel must be a string` }, { status: 400 });
+        }
+      }
+    }
+
+    // Execute import in a single transaction
+    const db = await getAdapter();
+    const now = new Date().toISOString();
+
+    db.transaction(() => {
+      // Delete all existing combos
+      db.run(`DELETE FROM combos`);
+
+      // Insert each combo with new UUID and current timestamp
+      for (const combo of body.combos) {
+        db.run(
+          `INSERT INTO combos(id, name, kind, models, createdAt, updatedAt) VALUES(?, ?, ?, ?, ?, ?)`,
+          [
+            uuidv4(),
+            combo.name.trim(),
+            combo.kind || null,
+            stringifyJson(combo.models || []),
+            now,
+            now,
+          ]
+        );
+      }
+    });
+
+    // Persist combo strategies in settings
+    const settings = await getSettings();
+    const currentStrategies = settings?.comboStrategies || {};
+    const updatedStrategies = { ...currentStrategies };
+
+    for (const combo of body.combos) {
+      const name = combo.name.trim();
+
+      // New format (v2): explicit strategy object
+      if (combo.strategy) {
+        const strategy = { fallbackStrategy: combo.strategy.fallbackStrategy || "fallback" };
+        if (combo.strategy.judgeModel) strategy.judgeModel = combo.strategy.judgeModel;
+        updatedStrategies[name] = strategy;
+        continue;
+      }
+
+      // Legacy format (v1): roundRobin boolean
+      if (combo.roundRobin === true) {
+        updatedStrategies[name] = { fallbackStrategy: "round-robin" };
+      } else {
+        delete updatedStrategies[name];
+      }
+    }
+
+    const settingsPatch = { comboStrategies: updatedStrategies };
+
+    // Merge imported capacity adapter over existing entries (only keys present in file)
+    if (importedCapacityAdapter) {
+      const currentAdapter = settings?.capacityAdapter || {};
+      settingsPatch.capacityAdapter = { ...currentAdapter, ...importedCapacityAdapter };
+    }
+
+    await updateSettings(settingsPatch);
+
+    return NextResponse.json({ success: true, count: body.combos.length }, { status: 201 });
+  } catch (error) {
+    console.log("Error importing combos:", error);
+    return NextResponse.json({ error: "Failed to import combos" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
Adds import/export for combos on the dashboard combos page.

- `GET /api/combos/export`: downloads a v2 JSON file containing all combos (name, kind, models), per-combo strategy (fallbackStrategy, judgeModel), and the capacityAdapter settings (vision/pdf/audioInput/videoInput pools)
- `POST /api/combos/import`: validates structure (names, kinds, strategies, duplicates, capacityAdapter shape), then atomically replaces combos in a transaction and merges imported capacityAdapter over existing settings
- Combos page: Export / Import buttons with confirm modal before replacing existing combos
- Also includes minor `.gitignore` hardening for built files (`**/node_modules`, `**/.next/`, etc.)

## Testing
- `node --check` passes on both API routes
- Manual: export → import roundtrip on /dashboard/combos, including Vision/Audio capacity pools

## Risks / Limitations
- Import replaces all existing combos (atomic DELETE + INSERT); user is warned via confirm modal before import proceeds