### PR TITLE
fix(headroom): rewrite dashboard asset/link URLs behind proxy prefix

### DIFF
--- a/src/app/api/headroom/proxy/[...path]/route.js
+++ b/src/app/api/headroom/proxy/[...path]/route.js
@@ -50,10 +50,14 @@ function forwardedHeaders(request, target) {
 }
 
 function rewriteDashboardHtml(html) {
-  return html.replace(
-    /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
-    `fetch('${DASHBOARD_PREFIX}`,
-  );
+  return html
+    .replace(
+      /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
+      `fetch('${DASHBOARD_PREFIX}`,
+    )
+    // Static assets and internal links (e.g. src="/dashboard/static/htmx.min.js",
+    // href="/dashboard/settings") must stay under the proxy prefix.
+    .replace(/(src|href)="(?=\/dashboard(?:\/|"))/g, `$1="${DASHBOARD_PREFIX}`);
 }
 
 async function proxy(request, { params }) {
@@ -78,7 +82,7 @@ async function proxy(request, { params }) {
       if (HOP_BY_HOP_HEADERS.has(header.toLowerCase())) headers.delete(header);
     }
 
-    if (path.join("/") === "dashboard") {
+    if (path[0] === "dashboard") {
       const contentType = response.headers.get("content-type") || "";
       if (contentType.includes("text/html")) {
         headers.delete("content-length");

--- a/src/app/api/headroom/proxy/[...path]/route.js
+++ b/src/app/api/headroom/proxy/[...path]/route.js
@@ -52,7 +52,7 @@ function forwardedHeaders(request, target) {
 function rewriteDashboardHtml(html) {
   return html
     .replace(
-      /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
+      /fetch\('(?=\/(?:stats|health|stats-history|settings|transformations\/feed))/g,
       `fetch('${DASHBOARD_PREFIX}`,
     )
     // Static assets and internal links (e.g. src="/dashboard/static/htmx.min.js",


### PR DESCRIPTION
## Summary
The embedded Headroom dashboard (`/api/headroom/proxy/dashboard`) renders unstyled/broken with recent headroom-ai versions (tested with 0.34.0).

Newer headroom dashboards reference external static assets and internal links with root-relative URLs:
- `src="/dashboard/static/alpine.min.js"` (also htmx, tailwind)
- `href="/dashboard/settings"`

`rewriteDashboardHtml()` only rewrites `fetch('...` calls, so these URLs resolve against the 9router app instead of the proxy prefix and 404 — no CSS/JS loads.

Changes in `src/app/api/headroom/proxy/[...path]/route.js`:
- Also prefix `src"/dashboard/..."` and `href="/dashboard/..."` attributes with `/api/headroom/proxy`
- Apply the HTML rewrite to all `dashboard/*` sub-pages (e.g. `/dashboard/settings`), not only the exact `/dashboard` path

## Testing
- `node --check` passes
- Manual: with headroom-ai 0.34.0 proxy running, `/api/headroom/proxy/dashboard` loads fully styled; Settings page and live stats work
- No-op for older headroom versions whose HTML lacks these attributes (regex simply doesn't match)

## Risks / Limitations
- Attribute rewrite assumes double-quoted `src`/`href` attributes, which matches current headroom dashboard HTML