### PR TITLE
fix(headroom): skip compress on oversize payloads + disable kompress by default

### DIFF
--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -6,6 +6,11 @@ import {
 } from "../translator/request/openai-responses.js";
 
 const DEFAULT_TIMEOUT_MS = 3000;
+// Skip compression for oversized payloads (fail-open): proxy compress time grows
+// non-linearly with size — measured 87KB → 0.010s but 744KB → >30s, which always
+// exceeds DEFAULT_TIMEOUT_MS and burns proxy CPU on doomed requests. 256KB keeps
+// a wide margin over the known-fast point while cutting off the pathological range.
+const MAX_COMPRESS_BODY_BYTES = 256 * 1024;
 
 function jsonBytes(value) {
   try {
@@ -254,7 +259,12 @@ export async function compressWithHeadroom(body, { enabled, url, model, format, 
   }
 
   try {
-    if (diagnostics) diagnostics.before = captureSizeSnapshot(body);
+    const sizeSnapshot = captureSizeSnapshot(body);
+    if (diagnostics) diagnostics.before = sizeSnapshot;
+    if (sizeSnapshot.bodyBytes > MAX_COMPRESS_BODY_BYTES) {
+      setDiagnostic(diagnostics, `skipped: payload too large (${sizeSnapshot.bodyBytes}B > ${MAX_COMPRESS_BODY_BYTES}B limit)`);
+      return null;
+    }
 
     // Claude shape: translate → OpenAI → compress → translate back.
     if (format === "claude") {

--- a/src/app/api/headroom/restart/route.js
+++ b/src/app/api/headroom/restart/route.js
@@ -25,7 +25,7 @@ export async function POST() {
     const result = await restartHeadroomProxy({
       port,
       codeAware: settings.headroomCodeAware === true,
-      kompress: settings.headroomKompress !== false,
+      kompress: settings.headroomKompress === true,
     });
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/src/app/api/headroom/start/route.js
+++ b/src/app/api/headroom/start/route.js
@@ -25,7 +25,7 @@ export async function POST() {
     const result = await startHeadroomProxy({
       port,
       codeAware: settings.headroomCodeAware === true,
-      kompress: settings.headroomKompress !== false,
+      kompress: settings.headroomKompress === true,
     });
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/src/lib/headroom/process.js
+++ b/src/lib/headroom/process.js
@@ -52,7 +52,7 @@ function extrasProxyArgs({ codeAware, kompress } = {}) {
   return args;
 }
 
-export async function startHeadroomProxy({ port = DEFAULT_PORT, codeAware = false, kompress = true } = {}) {
+export async function startHeadroomProxy({ port = DEFAULT_PORT, codeAware = false, kompress = false } = {}) {
   const safePort = Number(port) > 0 && Number(port) < 65536 ? Number(port) : DEFAULT_PORT;
   const binary = findHeadroomBinary();
   if (!binary) {


### PR DESCRIPTION
## Summary
Open-sse/rtk/headroom.js has DEFAULT_TIMEOUT_MS=3000 hard-coded for the compress call to the local headroom-ai proxy (localhost:8787/v1/compress). Large payloads (~744KB body / 85 messages / ~104K tokens) take >30s to compress but are aborted at 3s, logged as `[HEADROOM] skipped: request failed: 23: The operation was aborted due to timeout`. Additionally the headroom-ai proxy (v0.34.0) does not cancel in-flight compression on client abort — aborted large requests leave the proxy pegged at ~400% CPU, compounding the problem for subsequent requests.

## Changes
- Add MAX_COMPRESS_BODY_BYTES (256KB) size guard in compressWithHeadroom: skip the compress call entirely for oversize payloads before making the fetch, with a clear skip-reason log (fail-open preserved, same pattern as existing timeout-skip path).
- Disable kompress (the ML compression extra) by default when spawning/restarting the headroom-ai proxy, since it appears to be the primary CPU cost driver on large payloads.

## Testing
- 22 existing unit tests pass (headroom.test.js, headroom-chat-core.test.js, headroom-responses-format.test.js, headroom-detect.test.js)
- ESLint clean
- Functional: probed proxy directly — 76B payload 200 in 7ms, 87KB payload 200 in 10ms, 744KB payload previously timed out at 30s / now correctly skipped by size guard with clear log line; restarted proxy with kompress disabled, verified new listener on :8787 and fast 200 response

## Risks / Limitations
- MAX_COMPRESS_BODY_BYTES threshold (256KB) is a reasonable default based on observed probe timings, not exhaustively tuned; open to adjustment.
- Disabling kompress by default changes compression quality/behavior for the proxy — can be re-enabled via existing toggle if the CPU cost is addressed upstream in headroom-ai.
- No new configurable timeout setting added in this PR (kept minimal/scoped); a future PR could add a headroomTimeoutMs setting if useful.