### PR TITLE
feat: selective client-identity header passthrough (preserveClientIde…

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -4,6 +4,7 @@ import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE } from "../providers/shared.js";
 import { resolveOpenAICompatibleApiType } from "../services/provider.js";
+import { mergeInboundClientIdentityHeaders } from "../utils/clientIdentityHeaders.js";
 
 /**
  * BaseExecutor - Base class for provider executors
@@ -70,6 +71,11 @@ export class BaseExecutor {
 
     if (stream) {
       headers["Accept"] = "text/event-stream";
+    }
+
+    // Selective passthrough of client identity headers (opt-in per provider)
+    if (this.config?.preserveClientIdentity) {
+      mergeInboundClientIdentityHeaders(headers, credentials);
     }
 
     return headers;

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -5,6 +5,7 @@ import { resolveOpenAICompatibleApiType } from "../services/provider.js";
 import { OAUTH_ENDPOINTS, buildKimiHeaders } from "../config/appConstants.js";
 import { buildClineHeaders } from "../shared/clineAuth.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
+import { mergeInboundClientIdentityHeaders } from "../utils/clientIdentityHeaders.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
 
@@ -154,7 +155,7 @@ export class DefaultExecutor extends BaseExecutor {
     for (const hook of desc.hooks || []) HEADER_HOOKS[hook]?.(headers, credentials);
     applyAuth(headers, desc, credentials);
 
-    if (this.provider === "claude" && model) {
+    if (this.provider === "claude" && model && !this.config.preserveClientIdentity) {
       headers["Anthropic-Beta"] = selectAnthropicBeta(model);
     }
 
@@ -162,7 +163,7 @@ export class DefaultExecutor extends BaseExecutor {
     if (this.provider?.startsWith?.("anthropic-compatible-")) {
       const baseUrl = credentials?.providerSpecificData?.baseUrl || "";
       const isOfficialAnthropic = baseUrl === "" || baseUrl.includes("api.anthropic.com");
-      if (!isOfficialAnthropic) {
+      if (!isOfficialAnthropic && !this.config.preserveClientIdentity) {
         // Some third-party Anthropic-compatible gateways require Bearer auth in
         // addition to x-api-key. Send both (x-api-key already set above) so
         // gateways that read either header succeed.
@@ -189,6 +190,11 @@ export class DefaultExecutor extends BaseExecutor {
           }
         }
       }
+    }
+
+    // Selective passthrough of client identity headers (opt-in per provider)
+    if (this.config.preserveClientIdentity) {
+      mergeInboundClientIdentityHeaders(headers, credentials);
     }
 
     if (stream) headers["Accept"] = "text/event-stream";

--- a/open-sse/utils/clientIdentityHeaders.js
+++ b/open-sse/utils/clientIdentityHeaders.js
@@ -1,0 +1,56 @@
+// open-sse/utils/clientIdentityHeaders.js
+// Selective passthrough: only re-inject the client's identity fingerprint headers
+// upstream. Never forwards auth/transport headers (authorization, x-api-key,
+// host, content-length, content-type, accept). Never overwrites headers that
+// 9router itself manages.
+
+// Allowlisted client identity headers (lowercase)
+export const CLIENT_IDENTITY_HEADERS = new Set([
+  "user-agent",
+  "originator",
+  "openai-beta",
+  "anthropic-beta",
+  "anthropic-version",
+  "x-app",
+  "anthropic-dangerous-direct-browser-access",
+  "chatgpt-account-id",
+  "oai-organization",
+  "openai-organization",
+  "x-request-id",
+  "x-client-request-id",
+  "x-codex-beta-features",
+  "x-codex-turn-metadata",
+  "x-openai-subagent",
+  "x-stainless-lang",
+  "x-stainless-package-version",
+  "x-stainless-os",
+  "x-stainless-arch",
+  "x-stainless-runtime",
+  "session_id",
+]);
+
+function hasHeaderCaseInsensitive(headers, name) {
+  const lk = String(name).toLowerCase();
+  return Object.keys(headers).some((k) => k.toLowerCase() === lk);
+}
+
+/**
+ * Re-inject inbound client identity headers into the outbound header set,
+ * filtered by an allowlist.
+ * - Only fills a header when it is not already set by 9router (so 9router-managed
+ *   auth / own fingerprints always win).
+ * - Case-insensitive de-dup to avoid two naming variants of the same header.
+ * @param {Record<string,string>} headers outbound headers (mutated in place)
+ * @param {object} credentials carries rawHeaders (the inbound request headers)
+ */
+export function mergeInboundClientIdentityHeaders(headers, credentials) {
+  const fwd = credentials && credentials.rawHeaders;
+  if (!fwd || typeof fwd !== "object") return;
+  for (const [k, v] of Object.entries(fwd)) {
+    const lk = String(k).toLowerCase();
+    if (!CLIENT_IDENTITY_HEADERS.has(lk)) continue; // allowlist only
+    if (v == null) continue;
+    if (hasHeaderCaseInsensitive(headers, k)) continue; // never clobber 9router's own
+    headers[k] = Array.isArray(v) ? v[0] : v;
+  }
+}


### PR DESCRIPTION
…ntity)

Add allowlisted passthrough of inbound Codex/Claude identity headers so requests survive new-api/sub2api 'Codex 校验' client-restriction checks. Opt-in via per-provider config.preserveClientIdentity; default behavior unchanged. See 9router-codex-passthrough-patch.md.