### PR TITLE
fix(usage): fix React reconciliation bug when switching viewMode

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/UsageTable.js
+++ b/src/app/(dashboard)/dashboard/usage/components/UsageTable.js
@@ -204,7 +204,7 @@ export default function UsageTable({
                     </div>
                   </td>
                   {renderSummaryCells(group)}
-                  <ValueCells item={group.summary} viewMode={viewMode} isSummary />
+                  <ValueCells key={`valcells-${viewMode}`} item={group.summary} viewMode={viewMode} isSummary />
                 </tr>
                 {/* Detail rows */}
                 {expanded.has(group.groupKey) && group.items.map((item) => (
@@ -213,7 +213,7 @@ export default function UsageTable({
                     className="group-detail hover:bg-bg-subtle/20 transition-colors"
                   >
                     {renderDetailCells(item)}
-                    <ValueCells item={item} viewMode={viewMode} />
+                    <ValueCells key={`valcells-${viewMode}`} item={item} viewMode={viewMode} />
                   </tr>
                 ))}
               </Fragment>

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -204,14 +204,24 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const sortBy = searchParams.get("sortBy") || "rawModel";
-  const sortOrder = searchParams.get("sortOrder") || "asc";
+  // Sort state initialized from URL, reset when viewMode changes
+  const [sortBy, setSortBy] = useState(() => searchParams.get("sortBy") || "rawModel");
+  const [sortOrder, setSortOrder] = useState(() => searchParams.get("sortOrder") || "asc");
 
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [fetching, setFetching] = useState(false);
   const [tableView, setTableView] = useState("model");
   const [viewMode, setViewMode] = useState("costs");
+  const switchViewMode = useCallback((mode) => {
+    setViewMode(mode);
+    setSortBy("rawModel");
+    setSortOrder("asc");
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("sortBy");
+    params.delete("sortOrder");
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }, [searchParams, router]);
   const [providers, setProviders] = useState([]);
   const [periodLocal, setPeriodLocal] = useState("today");
   const isInitialLoad = useRef(true);
@@ -308,8 +318,13 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
   const toggleSort = useCallback((tableType, field) => {
     const params = new URLSearchParams(searchParams.toString());
     if (params.get("sortBy") === field) {
-      params.set("sortOrder", params.get("sortOrder") === "asc" ? "desc" : "asc");
+      const nextOrder = params.get("sortOrder") === "asc" ? "desc" : "asc";
+      setSortBy(field);
+      setSortOrder(nextOrder);
+      params.set("sortOrder", nextOrder);
     } else {
+      setSortBy(field);
+      setSortOrder("asc");
       params.set("sortBy", field);
       params.set("sortOrder", "asc");
     }
@@ -498,13 +513,13 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
           </select>
           <div className="grid grid-cols-2 items-center gap-1 rounded-lg border border-border bg-bg-subtle p-1 sm:flex">
             <button
-              onClick={() => setViewMode("costs")}
+              onClick={() => switchViewMode("costs")}
               className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "costs" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}
             >
               Costs
             </button>
             <button
-              onClick={() => setViewMode("tokens")}
+              onClick={() => switchViewMode("tokens")}
               className={`px-3 py-1 rounded-md text-sm font-medium transition-colors ${viewMode === "tokens" ? "bg-primary text-white shadow-sm" : "text-text-muted hover:text-text hover:bg-bg-hover"}`}
             >
               Tokens


### PR DESCRIPTION
## Summary

Fixes a React reconciliation bug in the Usage dashboard where switching between view modes (Costs ↔ Tokens) caused stale DOM nodes to persist, leaking cost values into latency columns after sorting.

## Root Cause

`ValueCells` renders **4 `<td>`** in costs/tokens mode but **6 `<td>`** in latency mode. When `viewMode` changes, React's diffing algorithm reuses the first 4 DOM nodes and only adds the 2 new cells — stale cost values leak into the first latency columns.

## Changes (2 files)

### `src/app/(dashboard)/dashboard/usage/components/UsageTable.js`
- Add `key={`valcells-${viewMode}`}` to both `<ValueCells>` instances (summary row + detail rows)
- Forces clean remount on viewMode change, preventing stale cell reuse

### `src/shared/components/UsageStats.js`
- Move `sortBy`/`sortOrder` from direct `searchParams` reads to local `useState` initialized from URL
- Add `switchViewMode` callback that:
  - Sets `viewMode`
  - Resets `sortBy` → `"rawModel"`, `sortOrder` → `"asc"`
  - Clears sort params from URL via `router.replace`
- Update `toggleSort` to sync local state + URL together
- Update view mode buttons to use `switchViewMode`

## Testing

- Build passes (`npm run build`)
- All 66 usage-related unit tests pass
- Verified manually via Chrome DevTools: switching view modes and sorting no longer leaks cost values


## Screenshots
Before:
<img width="1329" height="857" alt="image" src="https://github.com/user-attachments/assets/8c4f7380-c5d2-4592-ba1e-be8dae37ddbd" />

After:
<img width="1316" height="695" alt="image" src="https://github.com/user-attachments/assets/17e2355f-43dc-453f-a272-78082efd4760" />
