### PR TITLE
fix(open-sse): ESM interop fixes for plain-Node consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ graphify-out/*
 .codegraph/
 .PR/
 .next-analyze/*
+
+# Local development artifacts
+.serena/
+apps/

--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -17,6 +17,7 @@ import { FORMATS } from "../translator/formats.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import zlib from "zlib";
 import crypto from "crypto";
+import { createRequire } from "module";
 
 // Detect cloud environment
 const isCloudEnv = () => {
@@ -25,11 +26,15 @@ const isCloudEnv = () => {
   return false;
 };
 
-// Lazy import http2 (only in Node.js environment)
+// Lazy require http2 (only in Node.js environment). Uses synchronous
+// createRequire instead of a top-level await import so this module stays
+// compatible with CJS-mode transpilation (e.g. tsx/esbuild in the 9router-api
+// standalone server).
 let http2 = null;
 if (!isCloudEnv()) {
   try {
-    http2 = await import("http2");
+    const require = createRequire(import.meta.url);
+    http2 = require("http2");
   } catch {
     // http2 not available
   }

--- a/open-sse/package.json
+++ b/open-sse/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/open-sse/shared/machineId.js
+++ b/open-sse/shared/machineId.js
@@ -1,5 +1,8 @@
-import { machineIdSync } from "node-machine-id";
+import { createRequire } from "module";
 import crypto from "node:crypto";
+
+const require = createRequire(import.meta.url);
+const { machineIdSync } = require("node-machine-id");
 
 let cachedRawId = null;
 


### PR DESCRIPTION
## Summary

`open-sse` is written as ES modules (`import`/`export`, `import.meta.url`, top-level await) but `9router/package.json` has no `"type"` field, so Node and esbuild-based tools default to CJS when loading from outside the Next.js bundler. Any plain-Node consumer (standalone server, test runner, scripts) hits three failures:

### 1. Top-level await in `cursor.js`

esbuild emits `Top-level await not supported with cjs output format` for the bare `await import('http2')` at module scope.

**Fix:** replace with synchronous `createRequire`, which works in both CJS and ESM modes and avoids the TLA restriction.

### 2. Named import from `node-machine-id` in `machineId.js`

Node ESM loader rejects `import { machineIdSync } from 'node-machine-id'` because `node-machine-id` ships a UMD bundle without a named-export map. Named imports from CJS packages only work when `cjs-module-lexer` can statically detect the exports — UMD wrappers defeat that.

**Fix:** use `createRequire` so Node loads it via the CJS `require` path, where destructuring of `module.exports` works as expected.

### 3. No `package.json` in `open-sse/`

Without one, the parent scope (`9router` root, CJS by default) governs the module type of all `open-sse` files.

**Fix:** add a minimal `open-sse/package.json` with `"type": "module"` — scopes ESM declaration to `open-sse` only, leaving the rest of the repo (CLI, tests, scripts) unaffected.

## Testing

Verified: plain `tsx server.ts` and `node --import tsx server.ts` both boot without errors after this change.

## Risks / Limitations

No behavior change for the Next.js app — Next's bundler already handled ESM/CJS interop internally. Only affects direct Node consumers of `open-sse`.