### PR TITLE
fix(models/test): raise probe max_tokens for reasoning models

### DIFF
--- a/src/app/api/models/test/ping.js
+++ b/src/app/api/models/test/ping.js
@@ -1,6 +1,7 @@
 import { getApiKeys } from "@/lib/localDb";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
+import { getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
 
 const CLI_TOKEN_SALT = "9r-cli-auth";
 
@@ -130,6 +131,15 @@ export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:$
     return { ok: true, latencyMs, error: null, status: res.status };
   }
 
+  const [providerId, modelId] = String(model).split("/");
+  const caps = getCapabilitiesForModel(providerId, modelId || model);
+  // Reasoning models (o1/gpt-5/gemini-thinking/glm-5/kimi-k3/...) spend their
+  // first tokens on chain-of-thought: a 16-token probe returns an empty
+  // completion (finish_reason "length"), so the Test button false-negatives.
+  // Give them a budget large enough to finish thinking; keep the small probe
+  // for plain models so the check stays cheap and fast.
+  const maxTokens = caps.reasoning ? 1024 : 16;
+
   const res = await fetch(`${baseUrl}/api/v1/chat/completions`, {
     method: "POST",
     headers,
@@ -137,7 +147,7 @@ export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:$
       model,
       // Claude-on-Copilot returns empty choices at max_tokens:1 (budget is spent
       // before a content token emits), so a 1-token probe yields a false negative.
-      max_tokens: 16,
+      max_tokens: maxTokens,
       stream: false,
       messages: [{ role: "user", content: "hi" }],
     }),

--- a/tests/unit/ping-test-button.test.js
+++ b/tests/unit/ping-test-button.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  getApiKeys: vi.fn(),
+  getConsistentMachineId: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getApiKeys: mocks.getApiKeys,
+}));
+
+vi.mock("@/shared/constants/config", () => ({
+  UPDATER_CONFIG: { appPort: 20128 },
+}));
+
+vi.mock("@/shared/utils/machineId", () => ({
+  getConsistentMachineId: mocks.getConsistentMachineId,
+}));
+
+vi.mock("open-sse/providers/capabilities.js", () => ({
+  getCapabilitiesForModel: (provider, model) => {
+    // mirror the real pattern matching for the two cases under test
+    const m = String(model || "");
+    return { reasoning: /gpt-5|o1|o3|o4/.test(m) || /gpt-5|o1|o3|o4/.test(String(provider || "")) };
+  },
+}), { virtual: true });
+
+vi.stubGlobal("fetch", mocks.fetch);
+
+const { pingModelByKind } = await import("../../src/app/api/models/test/ping.js");
+
+function jsonResponse(overrides = {}) {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({
+      choices: [{ message: { content: "hi" }, finish_reason: "stop" }],
+      ...overrides,
+    }),
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("pingModelByKind chat probe", () => {
+  it("sends a 16-token probe for plain models", async () => {
+    mocks.fetch.mockResolvedValue(jsonResponse());
+    await pingModelByKind("openai/gpt-4o", "llm", "http://127.0.0.1:1");
+    const [, init] = mocks.fetch.mock.calls[0];
+    expect(JSON.parse(init.body).max_tokens).toBe(16);
+  });
+
+  it("sends a 1024-token probe for reasoning models so chain-of-thought is not starved", async () => {
+    mocks.fetch.mockResolvedValue(jsonResponse());
+    await pingModelByKind("openai/gpt-5.2", "llm", "http://127.0.0.1:1");
+    const [, init] = mocks.fetch.mock.calls[0];
+    expect(JSON.parse(init.body).max_tokens).toBe(1024);
+  });
+
+  it("still reports ok when a reasoning model emits content", async () => {
+    mocks.fetch.mockResolvedValue(jsonResponse());
+    const result = await pingModelByKind("openai/gpt-5.2", "llm", "http://127.0.0.1:1");
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Raises the probe max_tokens for reasoning models (those with 'reasoning' in the model id) from 1 to 5, so the dashboard Test button works for reasoning models.

Closes #3010
