### PR TITLE
fix(settings): bridge REQUIRE_API_KEY env var to requireApiKey setting

### DIFF
--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -4,6 +4,11 @@ import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 const DEFAULT_MITM_ROUTER_BASE = "http://localhost:20128";
 const DEFAULT_HEADROOM_URL = process.env.HEADROOM_URL || "http://localhost:8787";
 
+// "true"/"1"/"yes"/"on" (case-insensitive) → true; anything else → false.
+function envTruthy(value) {
+  return typeof value === "string" && ["true", "1", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
 const DEFAULT_SETTINGS = {
   cloudEnabled: false,
   tunnelEnabled: false,
@@ -24,7 +29,6 @@ const DEFAULT_SETTINGS = {
     videoInput: { enabled: false, roundRobin: false, models: [] },
   },
   requireLogin: true,
-  requireApiKey: true,
   tunnelDashboardAccess: true,
   authMode: "password",
   oidcIssuerUrl: "",
@@ -56,6 +60,13 @@ const DEFAULT_SETTINGS = {
   pxpipeTimeoutMs: 15000,
 };
 
+// Env-provided defaults are resolved at merge time so REQUIRE_API_KEY set
+// after import (tests, container entrypoint ordering) is still honored, while
+// a stored dashboard setting always wins over the env default.
+function defaultRequireApiKey() {
+  return envTruthy(process.env.REQUIRE_API_KEY);
+}
+
 async function readRaw() {
   const db = await getAdapter();
   const row = db.get(`SELECT data FROM settings WHERE id = 1`);
@@ -77,6 +88,9 @@ function mergeWithDefaults(raw) {
         merged[key] = defVal;
       }
     }
+  }
+  if (merged.requireApiKey === undefined) {
+    merged.requireApiKey = defaultRequireApiKey();
   }
   return merged;
 }

--- a/tests/unit/settings-repo-env.test.js
+++ b/tests/unit/settings-repo-env.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  db: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/lib/db/driver.js", () => ({
+  getAdapter: async () => mocks.db,
+}));
+
+const { getSettings } = await import("../../src/lib/db/repos/settingsRepo.js");
+
+const ORIGINAL_ENV = process.env.REQUIRE_API_KEY;
+
+describe("settingsRepo REQUIRE_API_KEY env bridging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.REQUIRE_API_KEY = undefined;
+  });
+
+  afterEach(() => {
+    process.env.REQUIRE_API_KEY = ORIGINAL_ENV;
+  });
+
+  it("defaults requireApiKey to false when env is unset", async () => {
+    mocks.db.get.mockReturnValue(undefined);
+    const settings = await getSettings();
+    expect(settings.requireApiKey).toBe(false);
+  });
+
+  it("enables requireApiKey when REQUIRE_API_KEY=true and no stored value", async () => {
+    mocks.db.get.mockReturnValue(undefined);
+    process.env.REQUIRE_API_KEY = "true";
+    const settings = await getSettings();
+    expect(settings.requireApiKey).toBe(true);
+  });
+
+  it("accepts case-insensitive true variants", async () => {
+    mocks.db.get.mockReturnValue(undefined);
+    process.env.REQUIRE_API_KEY = "TRUE";
+    expect((await getSettings()).requireApiKey).toBe(true);
+  });
+
+  it("lets a stored dashboard setting override the env default", async () => {
+    mocks.db.get.mockReturnValue({ data: JSON.stringify({ requireApiKey: false }) });
+    process.env.REQUIRE_API_KEY = "true";
+    const settings = await getSettings();
+    expect(settings.requireApiKey).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Bridges the REQUIRE_API_KEY env var to the requireApiKey dashboard setting: env initializes the default (true/1/yes/on honored), a stored dashboard value still wins. Read lazily so env set after import is honored.

## Note on the default change
The code default was requireApiKey: true but the README (line ~1303) documents the default as false. This aligns code with docs: fresh installs default to open (README behavior), REQUIRE_API_KEY=true restores enforcement, and a stored dashboard value always wins (existing installs with the toggle on keep auth).

Closes #2834
