### PR TITLE
fix(usage): read cached_tokens from nested prompt_tokens_details

### DIFF
--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -176,6 +176,12 @@ export function canonicalizeUsage(usage) {
   let prompt = num(usage.prompt_tokens ?? usage.input_tokens);
   let cached;
 
+  // buildUsage() (openai-responses streaming) writes cache-read only into the
+  // nested prompt_tokens_details.cached_tokens — treat that as top-level
+  // cached_tokens so streaming usage records cache hits instead of billing
+  // them at full input rate (issue #2873).
+  const nestedCached = num(usage.prompt_tokens_details?.cached_tokens);
+
   // Claude path: prompt excludes cache; cache_read_input_tokens and/or
   // cache_creation_input_tokens are separate. A cache-miss "first write" only
   // carries cache_creation_input_tokens (no cache_read_input_tokens yet), so
@@ -190,7 +196,7 @@ export function canonicalizeUsage(usage) {
     prompt = prompt + cached + cacheCreation;
   } else {
     // OpenAI/Gemini path (or already-canonical input): prompt already includes cached_tokens.
-    cached = num(usage.cached_tokens);
+    cached = num(usage.cached_tokens) || nestedCached;
   }
 
   const result = {

--- a/tests/unit/canonicalize-nested-cache.test.js
+++ b/tests/unit/canonicalize-nested-cache.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeUsage } from "../../open-sse/utils/usageTracking.js";
+
+describe("canonicalizeUsage nested prompt_tokens_details (#2873)", () => {
+  it("reads cached_tokens from nested prompt_tokens_details (buildUsage shape)", () => {
+    const out = canonicalizeUsage({
+      prompt_tokens: 27985,
+      completion_tokens: 60,
+      total_tokens: 28045,
+      prompt_tokens_details: { cached_tokens: 27136 },
+    });
+    expect(out.cached_tokens).toBe(27136);
+    // prompt already includes cache in the OpenAI shape; keep as-is
+    expect(out.prompt_tokens).toBe(27985);
+  });
+
+  it("prefers top-level cached_tokens when both are present", () => {
+    const out = canonicalizeUsage({
+      prompt_tokens: 100,
+      completion_tokens: 10,
+      cached_tokens: 90,
+      prompt_tokens_details: { cached_tokens: 50 },
+    });
+    expect(out.cached_tokens).toBe(90);
+  });
+
+  it("does not break the Claude fold path", () => {
+    const out = canonicalizeUsage({
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 5,
+    });
+    // prompt = input + cacheRead + cacheCreation
+    expect(out.prompt_tokens).toBe(135);
+    expect(out.cached_tokens).toBe(30);
+    expect(out.cache_creation_input_tokens).toBe(5);
+  });
+});


### PR DESCRIPTION
## What

`canonicalizeUsage` now reads cached_tokens from the nested `prompt_tokens_details.cached_tokens` shape that buildUsage writes for OpenAI Responses streaming, so cache-read tokens are not dropped.

Closes #2873
