### PR TITLE
fix(compat): normalize NVIDIA/vLLM reasoning to reasoning_content

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -142,7 +142,20 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
  * Translate non-streaming response body from provider format → OpenAI format.
  */
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, customToolNames = null) {
-  if (targetFormat === sourceFormat) return responseBody;
+  // Same-format passthrough still normalizes NVIDIA/vLLM-style
+  // `message.reasoning` → `reasoning_content` (issue #2936).
+  if (targetFormat === sourceFormat) {
+    if (targetFormat === FORMATS.OPENAI) {
+      for (const choice of responseBody?.choices || []) {
+        const msg = choice?.message;
+        if (msg?.reasoning && typeof msg.reasoning === "string" && !msg.reasoning_content) {
+          msg.reasoning_content = msg.reasoning;
+          delete msg.reasoning;
+        }
+      }
+    }
+    return responseBody;
+  }
   // Provider responded in OpenAI Chat Completions shape but the client speaks
   // Responses API — convert so tool_calls/text surface as Responses `output`.
   if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.OPENAI_RESPONSES) {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -144,6 +144,13 @@ export function createSSEStream(options = {}) {
                     delete choice.delta.tool_calls;
                     fieldsInjected = true;
                   }
+                  // Normalize NVIDIA/vLLM-style `delta.reasoning` → `reasoning_content`
+                  // so clients (Cursor thinking UI, AI SDK) render thinking (issue #2936).
+                  if (choice.delta?.reasoning && typeof choice.delta.reasoning === "string" && !choice.delta.reasoning_content) {
+                    choice.delta.reasoning_content = choice.delta.reasoning;
+                    delete choice.delta.reasoning;
+                    fieldsInjected = true;
+                  }
                 }
               }
 

--- a/tests/unit/reasoning-alias-normalize.test.js
+++ b/tests/unit/reasoning-alias-normalize.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+// nonStreamingHandler pulls in requestDetail → src/lib/usageDb via @/ alias.
+vi.mock("@/lib/usageDb.js", () => ({
+  saveRequestUsage: vi.fn(),
+  appendRequestLog: vi.fn(),
+  saveRequestDetail: vi.fn(),
+}));
+
+import { translateNonStreamingResponse } from "../../open-sse/handlers/chatCore/nonStreamingHandler.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+describe("reasoning alias normalization (#2936)", () => {
+  it("non-streaming: renames message.reasoning to reasoning_content (OpenAI target)", () => {
+    const body = {
+      choices: [{
+        message: { role: "assistant", reasoning: "think step by step", content: "42" },
+        finish_reason: "stop",
+      }],
+    };
+    const out = translateNonStreamingResponse(body, FORMATS.OPENAI, FORMATS.OPENAI);
+    expect(out.choices[0].message.reasoning_content).toBe("think step by step");
+    expect(out.choices[0].message.reasoning).toBeUndefined();
+    expect(out.choices[0].message.content).toBe("42");
+  });
+
+  it("non-streaming: leaves existing reasoning_content untouched", () => {
+    const body = {
+      choices: [{
+        message: { role: "assistant", reasoning: "ignored", reasoning_content: "kept", content: "x" },
+        finish_reason: "stop",
+      }],
+    };
+    const out = translateNonStreamingResponse(body, FORMATS.OPENAI, FORMATS.OPENAI);
+    expect(out.choices[0].message.reasoning_content).toBe("kept");
+    expect(out.choices[0].message.reasoning).toBe("ignored");
+  });
+});


### PR DESCRIPTION
## What

Normalizes `delta.reasoning` / `message.reasoning` to `reasoning_content` in both streaming (`stream.js`) and non-streaming (`nonStreamingHandler.js`) paths for OpenAI-compatible passthrough.

Closes #2936
