### PR TITLE
fix(auth): allow local JWT-less browser on local-only routes when login disabled

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -141,8 +141,16 @@ async function canAccessPublicLlmApi(request) {
 
 async function canAccessLocalOnlyRoute(request) {
   if (await hasValidCliToken(request)) return true;
-  // Browser on host: loopback Host + Origin (blocks tunnel/CSRF) + auth (JWT or requireLogin=false)
-  if (isLocalRequest(request) && await isAuthenticated(request)) return true;
+  // Browser on host: loopback Host + Origin (blocks tunnel/CSRF). When
+  // password auth is disabled, allow the JWT-less browser directly instead
+  // of demanding the CLI token (issue #2916). Non-browser calls from other
+  // hosts still need the CLI token.
+  const settings = await loadSettings();
+  const loginDisabled = settings && settings.requireLogin === false;
+  if (isLocalRequest(request)) {
+    if (loginDisabled) return true;
+    return await isAuthenticated(request);
+  }
   return false;
 }
 

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -248,6 +248,17 @@ describe("dashboard guard local-only access", () => {
     expect(response.status).toBe(403);
   });
 
+  it("allows local-only route on loopback when requireLogin=false (JWT-less browser)", async () => {
+    mocks.getSettings.mockResolvedValue({ requireLogin: false });
+
+    const response = await proxy(request("/api/headroom/start", {
+      host: "localhost:20128",
+      origin: "http://localhost:20128",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+  });
+
   it("allows local-only route with valid CLI token", async () => {
     const response = await proxy(request("/api/mcp/filesystem/sse", {
       host: "router.example.com",


### PR DESCRIPTION
## What

Allows JWT-less browser access to local-only routes (e.g. headroom start/stop) when the request is loopback Host+Origin and requireLogin is disabled, while still blocking tunnel/CSRF.

Fixes local dashboard access when login is disabled.
