### PR TITLE
feat(headroom): add lossless mode to proxy start

### DIFF
--- a/src/app/api/headroom/restart/route.js
+++ b/src/app/api/headroom/restart/route.js
@@ -26,6 +26,7 @@ export async function POST() {
       port,
       codeAware: settings.headroomCodeAware === true,
       kompress: settings.headroomKompress !== false,
+      lossless: settings.headroomLossless === true,
     });
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/src/app/api/headroom/start/route.js
+++ b/src/app/api/headroom/start/route.js
@@ -26,6 +26,7 @@ export async function POST() {
       port,
       codeAware: settings.headroomCodeAware === true,
       kompress: settings.headroomKompress !== false,
+      lossless: settings.headroomLossless === true,
     });
     return NextResponse.json({ success: true, ...result });
   } catch (error) {

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -46,6 +46,7 @@ const DEFAULT_SETTINGS = {
   headroomEnabled: false,
   headroomUrl: DEFAULT_HEADROOM_URL,
   headroomCompressUserMessages: false,
+  headroomLossless: false,
   cavemanEnabled: false,
   cavemanLevel: "full",
   ponytailEnabled: false,

--- a/src/lib/headroom/process.js
+++ b/src/lib/headroom/process.js
@@ -45,14 +45,17 @@ export function getManagedPid() {
 // Build proxy CLI flags for the active compression extras. `[code]` (AST
 // compression) is off by default in headroom → pass --code-aware to turn it on;
 // `[ml]` (Kompress) is on by default → pass --disable-kompress to turn it off.
-function extrasProxyArgs({ codeAware, kompress } = {}) {
+// `--lossless` makes headroom emit compact content directly instead of
+// reversible `<<ccr:...>>` pointers that leak into LLM-visible tool output.
+function extrasProxyArgs({ codeAware, kompress, lossless } = {}) {
   const args = [];
   if (codeAware) args.push("--code-aware");
   if (kompress === false) args.push("--disable-kompress");
+  if (lossless) args.push("--lossless");
   return args;
 }
 
-export async function startHeadroomProxy({ port = DEFAULT_PORT, codeAware = false, kompress = true } = {}) {
+export async function startHeadroomProxy({ port = DEFAULT_PORT, codeAware = false, kompress = true, lossless = false } = {}) {
   const safePort = Number(port) > 0 && Number(port) < 65536 ? Number(port) : DEFAULT_PORT;
   const binary = findHeadroomBinary();
   if (!binary) {
@@ -68,7 +71,7 @@ export async function startHeadroomProxy({ port = DEFAULT_PORT, codeAware = fals
   // spawn stdio requires fd numbers, not WriteStream objects.
   const outFd = fs.openSync(LOG_FILE, "a");
 
-  const args = ["proxy", "--port", String(safePort), ...extrasProxyArgs({ codeAware, kompress })];
+  const args = ["proxy", "--port", String(safePort), ...extrasProxyArgs({ codeAware, kompress, lossless })];
   const child = spawn(binary, args, {
     stdio: ["ignore", outFd, outFd],
     detached: true,

--- a/tests/unit/headroom-process-lossless.test.js
+++ b/tests/unit/headroom-process-lossless.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  existsSync: vi.fn(() => true),
+  openSync: vi.fn(() => 3),
+  closeSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ spawn: mocks.spawn }));
+vi.mock("node:fs", () => ({
+  default: {
+    existsSync: mocks.existsSync,
+    openSync: mocks.openSync,
+    closeSync: mocks.closeSync,
+    unlinkSync: mocks.unlinkSync,
+    writeFileSync: mocks.writeFileSync,
+  },
+  existsSync: mocks.existsSync,
+  openSync: mocks.openSync,
+  closeSync: mocks.closeSync,
+  unlinkSync: mocks.unlinkSync,
+  writeFileSync: mocks.writeFileSync,
+}));
+vi.mock("@/lib/dataDir.js", () => ({ DATA_DIR: "/tmp/9router-test" }));
+
+// Find the ACTUAL mock function from the detect module — hoisted mocks are
+// resolved per-file; grab it after import for the assertions below.
+const detectMocks = vi.hoisted(() => ({
+  findHeadroomBinary: vi.fn(() => "/usr/local/bin/headroom"),
+  findPython310: vi.fn(() => null),
+  HEADROOM_COMPRESSION_EXTRAS: [],
+  EXTRA_MARKERS: [],
+  getInstalledHeadroomExtras: vi.fn(() => []),
+  DEFAULT_HEADROOM_URL: "http://localhost:8787",
+  isLoopbackHeadroomUrl: vi.fn(() => true),
+}));
+// process.js imports detect.js via RELATIVE path './detect.js' — mock that too.
+vi.mock("../../src/lib/headroom/detect.js", () => detectMocks);
+vi.mock("@/lib/headroom/detect.js", () => detectMocks);
+
+import { startHeadroomProxy } from "../../src/lib/headroom/process.js";
+
+function fakeChild() {
+  const child = { pid: 12345, unref: vi.fn(), on: vi.fn(), once: vi.fn(), stderr: { on: vi.fn() } };
+  // make the "stays alive briefly" probe pass: process.kill(pid,0) returns true
+  return child;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(process, "kill").mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("startHeadroomProxy lossless flag (#2915)", () => {
+  it("adds --lossless when lossless option is set", async () => {
+    mocks.spawn.mockReturnValue(fakeChild());
+    await startHeadroomProxy({ port: 8787, lossless: true });
+    const args = mocks.spawn.mock.calls[0][1];
+    expect(args).toContain("--lossless");
+  }, 20000);
+
+  it("does not add --lossless by default", async () => {
+    mocks.spawn.mockReturnValue(fakeChild());
+    await startHeadroomProxy({ port: 8787 });
+    const args = mocks.spawn.mock.calls[0][1];
+    expect(args).not.toContain("--lossless");
+  }, 20000);
+
+  it("keeps existing code-aware/kompress flags alongside lossless", async () => {
+    mocks.spawn.mockReturnValue(fakeChild());
+    await startHeadroomProxy({ port: 8787, codeAware: true, kompress: false, lossless: true });
+    const args = mocks.spawn.mock.calls[0][1];
+    expect(args).toContain("--code-aware");
+    expect(args).toContain("--disable-kompress");
+    expect(args).toContain("--lossless");
+  }, 20000);
+});


### PR DESCRIPTION
## What

Adds `headroomLossless` setting (default false) that passes `--lossless` to the headroom proxy, preserving current compression behavior by default and enabling SmartCrusher/CCR-preserving mode on demand.

Closes #2915
