### PR TITLE
fix(kimi): route API-key auth to platform endpoint, not Kimi Code

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -78,9 +78,23 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);
-  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation
-  const runtimeTransport = resolveTransport(provider, sourceFormat);
-  const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider, credentials);
+  // Multi-endpoint providers: pick transport matching sourceFormat → zero translation.
+  // Kimi API-key connections speak OpenAI Chat Completions against the platform
+  // endpoint (api.moonshot.cn / platform.kimi.ai), NOT the Kimi Code subscription
+  // endpoint (api.kimi.com/coding) — pick the apikey transport when present. The
+  // platform API is OpenAI-compatible only, so a Claude-format client is translated
+  // to OpenAI too (issue #2881).
+  const transportOverrides = (provider === "kimi" && credentials?.authType === "apikey")
+    ? { openai: "openai-apikey", claude: "openai-apikey", "openai-responses": "openai-apikey" }
+    : null;
+  const effectiveSourceFormat = transportOverrides?.[sourceFormat] || sourceFormat;
+  const runtimeTransport = resolveTransport(provider, effectiveSourceFormat) || resolveTransport(provider, sourceFormat);
+  // The apikey transports carry format tags like "openai-apikey" that are only
+  // lookup keys, not real output formats — normalize for targetFormat.
+  const transportFormat = runtimeTransport?.format?.replace(/-apikey$/, "") || null;
+  // For apikey connections the transport format IS the target format (the body
+  // is translated to what the endpoint speaks — OpenAI for Moonshot).
+  const targetFormat = modelTargetFormat || transportFormat || getTargetFormat(provider, credentials);
   if (runtimeTransport && credentials) credentials.runtimeTransport = runtimeTransport;
   const stripList = getModelStrip(alias, model);
   const upstreamModel = getModelUpstreamId(alias, model);

--- a/open-sse/providers/registry/kimi.js
+++ b/open-sse/providers/registry/kimi.js
@@ -52,6 +52,14 @@ export default {
       headers: { ...CLAUDE_API_HEADERS },
       auth: { combined: true, header: "x-api-key", scheme: "raw", hooks: ["kimiHeaders"] },
     },
+    // API-key (platform) endpoints — api.moonshot.cn is the platform API base
+    // (CN); intl platform keys also work there. Issue #2881: apikey auth must
+    // NOT hit the Kimi Code subscription endpoint.
+    {
+      format: "openai-apikey",
+      baseUrl: "https://api.moonshot.cn/v1/chat/completions",
+      auth: { combined: true, header: "Authorization", scheme: "bearer" },
+    },
   ],
   models: [
     // Flagship K3 — platform.kimi.ai id `kimi-k3`, Kimi Code OAuth id `k3` (up to 1M)

--- a/open-sse/services/usage/kimi.js
+++ b/open-sse/services/usage/kimi.js
@@ -14,6 +14,8 @@ import { parseResetTime, toFiniteNumber } from "./shared.js";
 import { buildKimiHeaders } from "../../config/appConstants.js";
 
 const USAGE_URL = "https://api.kimi.com/coding/v1/usages";
+// Platform (API-key) usage endpoint
+const USAGE_URL_APIKEY = "https://api.moonshot.cn/v1/usage";
 
 const PLAN_LEVELS = {
   LEVEL_BASIC: "Moderato",
@@ -122,7 +124,7 @@ export async function getKimiUsage(
 
   try {
     const response = await proxyAwareFetch(
-      USAGE_URL,
+      useApiKey ? USAGE_URL_APIKEY : USAGE_URL,
       {
         method: "GET",
         headers: {

--- a/tests/unit/kimi-apikey-transport.test.js
+++ b/tests/unit/kimi-apikey-transport.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveTransport } from "../../open-sse/services/provider.js";
+
+describe("kimi apikey transport selection (#2881)", () => {
+  it("selects the platform endpoint for apikey auth", () => {
+    const t = resolveTransport("kimi", "openai-apikey");
+    expect(t.baseUrl).toBe("https://api.moonshot.cn/v1/chat/completions");
+  });
+
+  it("keeps the Kimi Code subscription endpoint for OAuth", () => {
+    const t = resolveTransport("kimi", "openai");
+    expect(t.baseUrl).toBe("https://api.kimi.com/coding/v1/chat/completions");
+  });
+
+  it("routes claude-format clients to the OpenAI platform endpoint (Moonshot is OpenAI-only)", () => {
+    // A Claude-format client (sourceFormat 'claude') must NOT get a claude-format
+    // transport — the platform API is OpenAI-compatible only (#2881).
+    expect(resolveTransport("kimi", "openai-apikey").baseUrl).toBe("https://api.moonshot.cn/v1/chat/completions");
+  });
+
+  it("returns null when no apikey transport matches a non-kimi provider", () => {
+    const t = resolveTransport("anthropic", "openai-apikey");
+    expect(t).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Routes Kimi API-key (platform) connections to the Moonshot platform endpoint instead of the Kimi Code endpoint: adds an `openai-apikey` transport to the kimi registry, selects it by authType at runtime, and uses the platform usage URL for apikey auth.

The platform API (api.moonshot.cn) is OpenAI-compatible only, so Claude-format clients are translated to OpenAI too.

Closes #2881
