### PR TITLE
fix(gemini): strip stray value key at schema nodes

### DIFF
--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -33,6 +33,13 @@ export const UNSUPPORTED_SCHEMA_CONSTRAINTS = [
   "gap", "padding", "strokeColor", "strokeThickness", "textColor"
 ];
 
+// Non-schema stray keys sometimes left by sloppy converters at a schema node
+// (e.g. `value: "object"` next to `type`/`properties`). They are never valid
+// JSON Schema keywords, but they ARE valid property names inside a name-map, so
+// they must only be stripped at schema nodes, never in `properties` maps
+// (issue #2902).
+const STRAY_SCHEMA_KEYS = new Set(["value"]);
+
 // Default safety settings
 export const DEFAULT_SAFETY_SETTINGS = [
   { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "OFF" },
@@ -159,6 +166,14 @@ function removeUnsupportedKeywords(obj, keywords) {
 
   for (const key of Object.keys(obj)) {
     if (key === "properties") continue; // handled above
+    // Strip stray non-schema keys (e.g. `value`) only at real schema nodes —
+    // a node is a schema when it has type/properties/items; inside a property
+    // name-map `value` is a legitimate user parameter name (issue #2902/#2884).
+    const isSchemaNode = obj.type !== undefined || obj.properties !== undefined || obj.items !== undefined;
+    if (isSchemaNode && STRAY_SCHEMA_KEYS.has(key)) {
+      delete obj[key];
+      continue;
+    }
     if (keywords.includes(key) || key.startsWith("x-")) {
       delete obj[key];
       continue;

--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -134,7 +134,11 @@ export function generateProjectId() {
 }
 
 // Helper: Remove unsupported keywords recursively from object/array
-// Also strips all vendor extension fields (x- prefixed) not supported by Gemini
+// Also strips all vendor extension fields (x- prefixed) not supported by Gemini.
+// Walks only schema nodes: a JSON Schema alternates schema-node → "properties"
+// name-map → schema-node, and the name-map keys are user parameter names, not
+// schema keywords (a param literally named "title"/"format"/"properties" must
+// survive — issue #2884).
 function removeUnsupportedKeywords(obj, keywords) {
   if (!obj || typeof obj !== "object") return;
 
@@ -145,7 +149,16 @@ function removeUnsupportedKeywords(obj, keywords) {
     return;
   }
 
+  // Property name-map: keys are user-defined parameter names. Descend into
+  // each value (which is a schema node) but never delete the key itself.
+  if (obj.properties && typeof obj.properties === "object" && !Array.isArray(obj.properties)) {
+    for (const propValue of Object.values(obj.properties)) {
+      removeUnsupportedKeywords(propValue, keywords);
+    }
+  }
+
   for (const key of Object.keys(obj)) {
+    if (key === "properties") continue; // handled above
     if (keywords.includes(key) || key.startsWith("x-")) {
       delete obj[key];
       continue;
@@ -301,11 +314,24 @@ function flattenTypeArrays(obj) {
   }
 }
 
-// Infer missing type=object when properties exist (Gemini requires explicit type)
+// Infer missing type=object when properties exist (Gemini requires explicit type).
+// Descends only into schema nodes — the property name-map is NOT a schema node,
+// so a parameter literally named "properties" must not get a bogus type injected
+// (issue #2884).
 function ensureObjectType(obj) {
   if (!obj || typeof obj !== "object") return;
   if (obj.properties && !obj.type) obj.type = "object";
-  for (const v of Object.values(obj)) if (v && typeof v === "object") ensureObjectType(v);
+  // Descend into the property name-map values (each is a schema node)
+  if (obj.properties && typeof obj.properties === "object" && !Array.isArray(obj.properties)) {
+    for (const propValue of Object.values(obj.properties)) {
+      ensureObjectType(propValue);
+    }
+  }
+  // Descend into other object-valued keys except the name-map itself
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === "properties") continue;
+    if (value && typeof value === "object") ensureObjectType(value);
+  }
 }
 
 // Clean JSON Schema for Antigravity API compatibility - removes unsupported keywords recursively
@@ -345,8 +371,15 @@ export function cleanJSONSchemaForAntigravity(schema) {
       }
     }
 
-    // Recurse into nested objects
-    for (const value of Object.values(obj)) {
+    // Descend into schema nodes only; the property name-map keys are user
+    // parameter names (issue #2884).
+    if (obj.properties && typeof obj.properties === "object" && !Array.isArray(obj.properties)) {
+      for (const propValue of Object.values(obj.properties)) {
+        cleanupRequired(propValue);
+      }
+    }
+    for (const [key, value] of Object.entries(obj)) {
+      if (key === "properties") continue;
       if (value && typeof value === "object") {
         cleanupRequired(value);
       }
@@ -384,8 +417,15 @@ export function cleanJSONSchemaForAntigravity(schema) {
       }
     }
 
-    // Recurse into nested objects
-    for (const value of Object.values(obj)) {
+    // Recurse into schema nodes only (property name-map keys are user
+    // parameter names — issue #2884)
+    if (obj.properties && typeof obj.properties === "object" && !Array.isArray(obj.properties)) {
+      for (const propValue of Object.values(obj.properties)) {
+        addPlaceholders(propValue);
+      }
+    }
+    for (const [key, value] of Object.entries(obj)) {
+      if (key === "properties") continue;
       if (value && typeof value === "object") {
         addPlaceholders(value);
       }

--- a/tests/unit/gemini-schema-cleaner.test.js
+++ b/tests/unit/gemini-schema-cleaner.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { cleanJSONSchemaForAntigravity } from "../../open-sse/translator/formats/gemini.js";
+
+describe("cleanJSONSchemaForAntigravity schema-node walking (#2884)", () => {
+  it("does not inject type=object into a property name-map when a param is named 'properties'", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        // A parameter literally named "properties" — the name-map value is a schema node
+        properties: { type: "object", properties: { title: { type: "string" } } },
+        ok: { type: "string" },
+      },
+    };
+    const out = cleanJSONSchemaForAntigravity(structuredClone(schema));
+    // The name-map key "properties" (param name) must survive untouched
+    expect(out.properties.properties).toEqual({ type: "object", properties: { title: { type: "string" } } });
+    expect(out.properties.ok).toEqual({ type: "string" });
+  });
+
+  it("does not delete a parameter named 'title' or 'format'", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        format: { type: "string" },
+        body: { type: "string" },
+      },
+    };
+    const out = cleanJSONSchemaForAntigravity(structuredClone(schema));
+    expect(out.properties.title).toEqual({ type: "string" });
+    expect(out.properties.format).toEqual({ type: "string" });
+    expect(out.properties.body).toEqual({ type: "string" });
+  });
+
+  it("still strips unsupported keywords from real schema nodes", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string", minLength: 1, format: "email", default: "x" },
+      },
+      required: ["name"],
+    };
+    const out = cleanJSONSchemaForAntigravity(structuredClone(schema));
+    expect(out.properties.name.minLength).toBeUndefined();
+    expect(out.properties.name.format).toBeUndefined();
+    expect(out.properties.name.default).toBeUndefined();
+    expect(out.properties.name.type).toBe("string");
+    expect(out.required).toEqual(["name"]);
+  });
+
+  it("still infers type=object for nested schema nodes that have properties", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        nested: { properties: { x: { type: "string" } } },
+      },
+    };
+    const out = cleanJSONSchemaForAntigravity(structuredClone(schema));
+    expect(out.properties.nested.type).toBe("object");
+    expect(out.properties.nested.properties.x).toEqual({ type: "string" });
+  });
+});

--- a/tests/unit/gemini-schema-cleaner.test.js
+++ b/tests/unit/gemini-schema-cleaner.test.js
@@ -32,7 +32,23 @@ describe("cleanJSONSchemaForAntigravity schema-node walking (#2884)", () => {
     expect(out.properties.body).toEqual({ type: "string" });
   });
 
-  it("still strips unsupported keywords from real schema nodes", () => {
+  it("strips stray value:'object' sibling at a schema node but keeps a legit 'value' param (#2902)", () => {
+    const bad = {
+      type: "object",
+      properties: {
+        param2: { type: "object", value: "object", properties: { x: { type: "number" } } },
+      },
+    };
+    const cleanedBad = cleanJSONSchemaForAntigravity(JSON.parse(JSON.stringify(bad)));
+    expect(cleanedBad.properties.param2.value).toBeUndefined();
+    expect(cleanedBad.properties.param2.properties.x.type).toBe("number");
+
+    const good = { type: "object", properties: { value: { type: "string" }, a: { type: "number" } } };
+    const cleanedGood = cleanJSONSchemaForAntigravity(JSON.parse(JSON.stringify(good)));
+    expect(cleanedGood.properties.value.type).toBe("string");
+  });
+
+  it("strips unsupported keywords from nested schema nodes", () => {
     const schema = {
       type: "object",
       properties: {


### PR DESCRIPTION
## What

Strips a stray non-schema `value` key (e.g. `value: "object"`) at real schema nodes in the Gemini/Antigravity schema cleaner, while keeping a legitimate user parameter literally named 'value'.

Depends on #3082's schema-node walker (the name-map keys are user parameter names, never schema keywords).

Closes #2902
