### PR TITLE
feat(telemetry): add model, kiro credits, and session id to the done line

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -236,7 +236,10 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });
   saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
-  if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
+  if (log?.line) {
+    const sessionId = (finalBody || translatedBody)?.conversationState?.conversationId;
+    log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime }, provider, model, sessionId }));
+  }
 
   const translatedResponse = needsTranslation(targetFormat, sourceFormat)
     ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat)

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -75,8 +75,11 @@ export function buildRequestDetail(base, overrides = {}) {
   };
 }
 
-// Build the "done" summary: duration, ttft, in/out tokens with cache breakdown
-export function formatDoneLine({ usage, latency }) {
+// Build the "done" summary: duration, ttft, in/out tokens with cache breakdown,
+// plus route identity (provider/model), metered kiro credits, and session id.
+// This console line is the only per-request record that reaches log aggregation,
+// so the appended fields are what let dashboards slice usage per model/session.
+export function formatDoneLine({ usage, latency, provider, model, sessionId }) {
   const u = usage || {};
   const inTok = u.prompt_tokens ?? u.input_tokens ?? 0;
   const outTok = u.completion_tokens ?? u.output_tokens ?? 0;
@@ -90,7 +93,11 @@ export function formatDoneLine({ usage, latency }) {
     inStr += ` (CACHE ${parts.join(" ")})`;
   }
   const ttftStr = latency?.ttft ? ` · TTFT ${latency.ttft}ms` : "";
-  return `DONE ${latency?.total ?? 0}ms${ttftStr} · ${inStr} · OUT ${outTok}`;
+  let line = `DONE ${latency?.total ?? 0}ms${ttftStr} · ${inStr} · OUT ${outTok}`;
+  if (model) line += ` · ${provider ? `${provider}/${model}` : model}`;
+  if (Number.isFinite(u.kiro_credits)) line += ` · ${Number(u.kiro_credits.toFixed(4))}cr`;
+  if (sessionId) line += ` · sid:${sessionId}`;
+  return line;
 }
 
 export function saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint, label = "USAGE", silent = false }) {

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -137,7 +137,10 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
 
     // Persist stream usage to DB (no console line; the "📊 done" line below is authoritative)
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE", silent: true });
-    if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
+    if (log?.line) {
+      const sessionId = (finalBody || translatedBody)?.conversationState?.conversationId;
+      log.line(reqTag, "📊", formatDoneLine({ usage, latency, provider, model, sessionId }));
+    }
   };
 
   return { onStreamComplete, streamDetailId };

--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -131,6 +131,9 @@ export function normalizeUsage(usage) {
   assignNumber("cache_creation_input_tokens", usage?.cache_creation_input_tokens);
   assignNumber("cached_tokens", usage?.cached_tokens);
   assignNumber("reasoning_tokens", usage?.reasoning_tokens);
+  // Kiro metering: the only authoritative cost signal for kiro (no token-level
+  // cache metrics upstream) — must survive normalization to reach the done line.
+  assignNumber("kiro_credits", usage?.kiro_credits);
 
   // Preserve nested details objects for OpenAI format forwarding
   if (usage?.prompt_tokens_details && typeof usage.prompt_tokens_details === "object") {
@@ -279,6 +282,7 @@ export function extractUsage(chunk) {
       completion_tokens: chunk.usage.completion_tokens || 0,
       cached_tokens: chunk.usage.prompt_tokens_details?.cached_tokens || chunk.usage.prompt_cache_hit_tokens,
       reasoning_tokens: chunk.usage.completion_tokens_details?.reasoning_tokens,
+      kiro_credits: chunk.usage.kiro_credits,
       prompt_tokens_details: chunk.usage.prompt_tokens_details,
       completion_tokens_details: chunk.usage.completion_tokens_details
     });

--- a/tests/unit/done-line-telemetry.test.js
+++ b/tests/unit/done-line-telemetry.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { formatDoneLine } = await import("../../open-sse/handlers/chatCore/requestDetail.js");
+const { extractUsage, normalizeUsage, mergeUsage } = await import("../../open-sse/utils/usageTracking.js");
+
+// The "📊 DONE" console line is the only per-request record that reaches log
+// aggregation (Loki). These tests pin the extended contract: route identity
+// (provider/model), metered kiro credits, and session id must appear so
+// dashboards can aggregate cache-effectiveness and cost per model/job.
+describe("formatDoneLine", () => {
+  const usage = { prompt_tokens: 100, completion_tokens: 42 };
+  const latency = { total: 2537, ttft: 2530 };
+
+  it("keeps the legacy shape when no telemetry fields are provided", () => {
+    expect(formatDoneLine({ usage, latency })).toBe(
+      "DONE 2537ms · TTFT 2530ms · IN 100 · OUT 42"
+    );
+  });
+
+  it("appends provider/model, credits, and session id after the token stats", () => {
+    const line = formatDoneLine({
+      usage: { ...usage, kiro_credits: 0.21239843011608625 },
+      latency,
+      provider: "kiro",
+      model: "claude-opus-4.8",
+      sessionId: "ses_abc123",
+    });
+    expect(line).toBe(
+      "DONE 2537ms · TTFT 2530ms · IN 100 · OUT 42 · kiro/claude-opus-4.8 · 0.2124cr · sid:ses_abc123"
+    );
+  });
+
+  it("keeps the cache breakdown intact when telemetry fields are appended", () => {
+    const line = formatDoneLine({
+      usage: {
+        prompt_tokens: 3644,
+        completion_tokens: 47,
+        cache_read_input_tokens: 3328,
+        cache_creation_input_tokens: 30,
+      },
+      latency: { total: 2365, ttft: 2343 },
+      provider: "kiro",
+      model: "gpt-5.6-luna",
+    });
+    expect(line).toBe(
+      "DONE 2365ms · TTFT 2343ms · IN 3644 (CACHE ↻3328 +30) · OUT 47 · kiro/gpt-5.6-luna"
+    );
+  });
+
+  it("prints the model alone when provider is missing", () => {
+    const line = formatDoneLine({ usage, latency, model: "gpt-5.4" });
+    expect(line).toBe("DONE 2537ms · TTFT 2530ms · IN 100 · OUT 42 · gpt-5.4");
+  });
+
+  it("reports zero credits explicitly (free-tier metering is a real signal)", () => {
+    const line = formatDoneLine({
+      usage: { ...usage, kiro_credits: 0 },
+      latency,
+      provider: "kiro",
+      model: "claude-opus-4.8",
+    });
+    expect(line).toBe(
+      "DONE 2537ms · TTFT 2530ms · IN 100 · OUT 42 · kiro/claude-opus-4.8 · 0cr"
+    );
+  });
+
+  it("omits credits when kiro_credits is not a finite number", () => {
+    const line = formatDoneLine({
+      usage: { ...usage, kiro_credits: "n/a" },
+      latency,
+      provider: "kiro",
+      model: "claude-opus-4.8",
+    });
+    expect(line).toBe("DONE 2537ms · TTFT 2530ms · IN 100 · OUT 42 · kiro/claude-opus-4.8");
+  });
+
+  it("omits session id when blank and skips TTFT when absent", () => {
+    const line = formatDoneLine({
+      usage,
+      latency: { total: 900 },
+      provider: "codex",
+      model: "gpt-5.4",
+      sessionId: "",
+    });
+    expect(line).toBe("DONE 900ms · IN 100 · OUT 42 · codex/gpt-5.4");
+  });
+});
+
+// kiro_credits must survive the stream-usage pipeline (extract → merge) or the
+// done line can never show it: the kiro executor emits it on the final OpenAI-
+// format chunk, and stream.js runs every chunk through extractUsage/mergeUsage.
+describe("kiro_credits propagation through usage extraction", () => {
+  it("extractUsage keeps kiro_credits from an OpenAI-format final chunk", () => {
+    const usage = extractUsage({
+      choices: [],
+      usage: { prompt_tokens: 6066, completion_tokens: 2, kiro_credits: 0.2124 },
+    });
+    expect(usage).toMatchObject({ prompt_tokens: 6066, completion_tokens: 2, kiro_credits: 0.2124 });
+  });
+
+  it("normalizeUsage keeps kiro_credits and drops non-numeric values", () => {
+    expect(normalizeUsage({ prompt_tokens: 10, kiro_credits: 0.1123 })).toMatchObject({ kiro_credits: 0.1123 });
+    expect(normalizeUsage({ prompt_tokens: 10, kiro_credits: "credit" })).not.toHaveProperty("kiro_credits");
+  });
+
+  it("mergeUsage carries kiro_credits across chunk merges", () => {
+    const merged = mergeUsage(
+      { prompt_tokens: 6066, completion_tokens: 0 },
+      { prompt_tokens: 6066, completion_tokens: 2, kiro_credits: 0.2124 }
+    );
+    expect(merged.kiro_credits).toBe(0.2124);
+  });
+});


### PR DESCRIPTION
## Motivation

The `📊 DONE` console line is the only per-request record that reaches log aggregation (Loki/CloudWatch/etc. via container stdout), but it carries no route identity — so per-model usage, latency, or cache dashboards cannot be built from logs. The `▶` request line has the model, but log queries cannot join two lines.

Additionally, Kiro's `meteringEvent` credits are the **only** authoritative cost signal for the kiro provider (its API reports no token-level cache metrics upstream — for many models, no `metricsEvent` at all, so token counts are estimated). The executor already parses them into `usage.kiro_credits`, but the usage-extraction allowlist (`extractUsage`/`normalizeUsage`) silently dropped the field before it reached the done line or the client.

## Changes

- `formatDoneLine` appends `· provider/model`, `· <credits>cr` (4 dp, only when finite), and `· sid:<conversationId>` (only when present) after the existing stats — existing format is byte-identical when the new fields are absent, and the error path already appends the model this way.
- `extractUsage` (OpenAI-format branch) and `normalizeUsage` preserve `kiro_credits`; `mergeUsage` needed no change.
- Both call sites (`streamingHandler`, `nonStreamingHandler`) pass `provider`, `model`, and the kiro `conversationState.conversationId`.

Example before → after:

```
DONE 54441ms · TTFT 54412ms · IN 7301 · OUT 1
DONE 54441ms · TTFT 54412ms · IN 7301 · OUT 1 · kiro/claude-opus-4.8-agentic · 0.0516cr · sid:f31212b8-…
```

## Testing

- `tests/unit/done-line-telemetry.test.js`: 10 cases — legacy-shape invariant, full telemetry line, cache-breakdown interplay, model-without-provider, zero/invalid credits, blank sid, and `kiro_credits` propagation through `extractUsage`/`normalizeUsage`/`mergeUsage`. All pass.
- Related suites (`cached-token-usage`, `usage-concern`, `usage-dispatch`, `kiro-nonstream-error`, `kiro-terminal-integrity`) unchanged vs master (the two `kiro-terminal-integrity` retry-timeout failures reproduce on unpatched master).
- Verified live against a real kiro connection: the done line above is from an actual `claude-opus-4.8-agentic` request through the patched dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)