### PR TITLE
fix(kiro): report real output tokens, stop discarding usable turns, and keep a malformed body from cooling accounts down

### DIFF
--- a/open-sse/config/codexConstants.js
+++ b/open-sse/config/codexConstants.js
@@ -1,0 +1,8 @@
+export const CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite";
+export const CODEX_RESPONSES_LITE_HEADER_VALUE = "true";
+export const CODEX_MODELS_BASE_INSTRUCTIONS = "You are Codex, a coding agent. Follow the user's instructions and use the provided tools to complete the task.";
+export const CODEX_FORWARD_HEADER_ALLOWLIST = Object.freeze([CODEX_RESPONSES_LITE_HEADER]);
+export const CODEX_RESPONSES_LITE_INPUT_TYPES = Object.freeze([
+  "additional_tools", "function_call", "function_call_output", "custom_tool_call",
+  "custom_tool_call_output", "tool_search_call", "tool_search_output", "reasoning", "message",
+]);

--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -28,6 +28,14 @@ export const DEFAULT_ERROR_MESSAGES = {
   504: "Gateway timeout"
 };
 
+export const CODEX_REQUEST_SCHEMA_ERROR_CODES = new Set([
+  "invalid_request_error",
+  "unknown_parameter",
+  "unsupported_value",
+]);
+
+export const CODEX_REQUEST_SCHEMA_ERROR_PATTERN =
+  /unknown[_ ]parameter|unsupported[_ ]value|(?:invalid|unsupported)[_ ]?(?:parameter|schema)|(?:parameter|schema).*(?:invalid|unsupported)/i;
 // Exponential backoff config for rate limits
 export const BACKOFF_CONFIG = {
   base: 2000,
@@ -50,14 +58,22 @@ const COOLDOWN = {
 /**
  * Unified error classification rules.
  * Checked top-to-bottom: text rules first (by order), then status rules.
- * Each rule: { text?, status?, cooldownMs?, backoff? }
+ * Each rule: { text?, status?, cooldownMs?, backoff?, fallback? }
  *   - text: substring match (case-insensitive) on error message
  *   - status: HTTP status code match
  *   - cooldownMs: fixed cooldown duration
  *   - backoff: true = use exponential backoff (rate limit)
+ *   - fallback: false = request-scoped failure. Do not switch accounts and do
+ *     not cool the current one down, because a retry with the same body cannot
+ *     succeed anywhere.
  */
 export const ERROR_RULES = [
   // --- Text-based rules (checked first, order = priority) ---
+  // An over-long prompt is a property of the request, not of the account: every
+  // account will reject the same body with the same error, so falling back
+  // burns a second upstream call for nothing and the cooldown takes healthy
+  // accounts out of rotation for unrelated (short) traffic on the same model.
+  { text: "context_length_exceeded",  fallback: false },
   { text: "no credentials",           cooldownMs: COOLDOWN.long },
   { text: "request not allowed",      cooldownMs: COOLDOWN.short },
   { text: "improperly formed request", cooldownMs: COOLDOWN.long },

--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -76,7 +76,14 @@ export const ERROR_RULES = [
   { text: "context_length_exceeded",  fallback: false },
   { text: "no credentials",           cooldownMs: COOLDOWN.long },
   { text: "request not allowed",      cooldownMs: COOLDOWN.short },
-  { text: "improperly formed request", cooldownMs: COOLDOWN.long },
+  // A malformed body is a property of the REQUEST, not of the account: every
+  // account rejects the identical payload the same way. Cooling accounts down for
+  // it took 12 Kiro connections out of rotation in 18s (39 of 44 rows carried
+  // errorCode 400) and burned one upstream call per account for a guaranteed
+  // failure. Same reasoning as context_length_exceeded above.
+  { text: "improperly formed request", fallback: false },
+  { text: "request_body_invalid", fallback: false },
+  { text: "invalid_request_error", fallback: false },
   { text: "rate limit",               backoff: true },
   { text: "too many requests",        backoff: true },
   { text: "quota exceeded",           backoff: true },

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -397,6 +397,11 @@ export class AntigravityExecutor extends BaseExecutor {
 
     const errorMessage = this.extractErrorMessage(errorJson, bodyText);
 
+    // NOTE: capacity 503 fail-fast is no longer hardcoded here. It is handled by
+    // the seeded skip-rule ({ provider:"antigravity", status:503, contains:"capacity",
+    // action:"skip" }): a skip-rule resolves attempts=0, so BaseExecutor.tryRetry
+    // short-circuits before ever calling this hook. If the user deletes that rule,
+    // capacity 503 falls through to the transient-retry path below — their choice.
     if (!retryMs) {
       retryMs = this.parseRetryFromErrorMessage(errorMessage);
     }

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -1,5 +1,6 @@
 import { HTTP_STATUS, RETRY_CONFIG, DEFAULT_RETRY_CONFIG, resolveRetryEntry, FETCH_CONNECT_TIMEOUT_MS } from "../config/runtimeConfig.js";
 import { shouldRefreshCredentials } from "../services/oauthCredentialManager.js";
+import { matchSkipRule } from "../services/accountFallback.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { dbg } from "../utils/debugLog.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE } from "../providers/shared.js";
@@ -97,19 +98,62 @@ export class BaseExecutor {
     return { status: response.status, message: bodyText || `HTTP ${response.status}` };
   }
 
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null, requestPolicy = null }) {
     const fallbackCount = this.getFallbackCount();
     let lastError = null;
     let lastStatus = 0;
     const retryAttemptsByUrl = {};
 
-    // Merge default retry config with provider-specific config
-    const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
+    // Merge default retry config with provider-specific config (base ceiling per status).
+    // NOTE: never mutate this.config — executors are cached singletons shared across
+    // concurrent requests. All per-request policy lives in local vars derived from requestPolicy.
+    const baseRetry = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
+    const maxTransportAttempts = requestPolicy?.maxTransportAttempts;
+    const skipRules = requestPolicy?.skipRules || null;
+    // Whether any skip-rule for THIS provider matches on response body text
+    // (match.contains). Only then do we pay to read the error body below.
+    const hasContainsRule = Array.isArray(skipRules) &&
+      skipRules.some(r => r && r.provider === this.provider && r.match?.contains != null);
+    // Header/connect timeout: per-request override → provider config → global default.
+    const headerTimeoutMs = requestPolicy?.headerTimeoutMs || this.config?.timeoutMs || FETCH_CONNECT_TIMEOUT_MS;
 
-    // Schedule retry via retryConfig[statusKey]. Returns true when caller should `urlIndex--; continue`
+    // Resolve how many in-place retries are allowed for a failure, honoring user skip-rules
+    // and the transport-attempt ceiling. See the retry table in the plan:
+    //   rule skip       → 0
+    //   rule retry      → maxTransportAttempts - 1 (user intent overrides registry retry)
+    //   no rule         → min(baseRetry[status].attempts, maxTransportAttempts - 1)
+    //   connect_timeout → 0 unless an explicit retry rule matches it
+    const resolveAttempts = ({ statusKey, errorKind, text }) => {
+      const base = resolveRetryEntry(baseRetry[statusKey]);
+      const rule = skipRules
+        ? matchSkipRule(this.provider, { status: statusKey, errorKind, text }, skipRules)
+        : null;
+      const cap = maxTransportAttempts != null ? Math.max(0, maxTransportAttempts - 1) : null;
+
+      if (rule?.action === "skip") return { attempts: 0, delayMs: base.delayMs };
+      if (rule?.action === "retry") {
+        return { attempts: cap != null ? cap : base.attempts, delayMs: base.delayMs };
+      }
+      // No explicit rule
+      if (errorKind === "connect_timeout") return { attempts: 0, delayMs: base.delayMs };
+      const attempts = cap != null ? Math.min(base.attempts, cap) : base.attempts;
+      return { attempts, delayMs: base.delayMs };
+    };
+
+    // A matched skip-rule means: abandon this account entirely — do NOT cycle the
+    // remaining transport fallback URLs on the same account (which would keep hitting
+    // a stalled/at-capacity upstream). The account-selection layer picks the next
+    // account/model. Returns the matched skip-rule ({action:"skip", ...}) or null.
+    const matchedSkip = ({ statusKey, errorKind, text }) => {
+      if (!skipRules) return null;
+      const rule = matchSkipRule(this.provider, { status: statusKey, errorKind, text }, skipRules);
+      return rule?.action === "skip" ? rule : null;
+    };
+
+    // Schedule retry. Returns true when caller should `urlIndex--; continue`.
     // response (optional) lets a subclass hook compute a dynamic delay (e.g. antigravity Retry-After).
-    const tryRetry = async (urlIndex, statusKey, reason, response = null) => {
-      const { attempts, delayMs } = resolveRetryEntry(retryConfig[statusKey]);
+    const tryRetry = async (urlIndex, statusKey, reason, response = null, errorKind = null, text = null) => {
+      const { attempts, delayMs } = resolveAttempts({ statusKey, errorKind, text });
       if (attempts <= 0 || retryAttemptsByUrl[urlIndex] >= attempts) return false;
       // Hook: subclass may derive delay from the response (headers/body). null → skip retry, use fallback.
       let waitMs = delayMs;
@@ -131,16 +175,22 @@ export class BaseExecutor {
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;
 
-      // Abort if upstream doesn't return response headers within connection timeout
+      // Abort if upstream doesn't return response headers within the connect/header timeout.
+      // Use a closure flag to detect OUR timeout: undici rejects with the exact reason object
+      // we pass to abort(), so error.name stays "Error" (NOT "AbortError") on Node/undici —
+      // the old `error.name === "AbortError"` check never fired. The flag is authoritative.
       const connectCtrl = new AbortController();
-      const timeoutMs = this.config?.timeoutMs || FETCH_CONNECT_TIMEOUT_MS;
-      const connectTimer = setTimeout(() => connectCtrl.abort(new Error("fetch connect timeout")), timeoutMs);
+      let connectTimedOut = false;
+      const connectTimer = setTimeout(() => {
+        connectTimedOut = true;
+        connectCtrl.abort(new Error("fetch connect timeout"));
+      }, headerTimeoutMs);
       const mergedSignal = signal ? AbortSignal.any([signal, connectCtrl.signal]) : connectCtrl.signal;
 
       try {
         const bodyStr = JSON.stringify(transformedBody);
         const fetchT0 = Date.now();
-        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${timeoutMs}ms`);
+        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${headerTimeoutMs}ms`);
         const response = await proxyAwareFetch(url, {
           method: "POST",
           headers,
@@ -152,7 +202,22 @@ export class BaseExecutor {
         const cl = response.headers?.get?.("content-length") || "?";
         dbg("FETCH", `${this.provider.toUpperCase()} ← ${response.status} | ttft=${Date.now() - fetchT0}ms | ct=${ct} | cl=${cl}`);
 
-        if (await tryRetry(urlIndex, response.status, `status ${response.status}`, response)) { urlIndex--; continue; }
+        // Read the error body ONLY when a contains-rule for this provider could fire
+        // (and the status is an error). Clone so the original body stays intact for the
+        // caller/translator. Without this, match.contains never matches at the transport
+        // tier and a status-based retry could run against the user's intent.
+        let errorText = null;
+        if (hasContainsRule && response.status >= 400) {
+          try { errorText = await response.clone().text(); } catch { /* body unreadable → skip contains */ }
+        }
+
+        if (await tryRetry(urlIndex, response.status, `status ${response.status}`, response, `http_${response.status}`, errorText)) { urlIndex--; continue; }
+
+        // A skip-rule matched this HTTP failure → abandon this account now; do NOT
+        // fall through to shouldRetry()/other base URLs on the same account.
+        if (matchedSkip({ statusKey: response.status, errorKind: `http_${response.status}`, text: errorText })) {
+          return { response, url, headers, transformedBody };
+        }
 
         if (this.shouldRetry(response.status, urlIndex)) {
           log?.debug?.("RETRY", `${response.status} on ${url}, trying fallback ${urlIndex + 1}`);
@@ -164,18 +229,31 @@ export class BaseExecutor {
       } catch (error) {
         clearTimeout(connectTimer);
         lastError = error;
-        const isConnectTimeout = connectCtrl.signal.aborted && error.name === "AbortError";
+        const isConnectTimeout = connectTimedOut;
+        // Classify: our header-timeout vs a caller-initiated abort vs a generic network error.
+        const errorKind = isConnectTimeout ? "connect_timeout" : "network";
         dbg("FETCH", `${this.provider.toUpperCase()} ✖ ${error.name}: ${error.message}${isConnectTimeout ? " (connect timeout)" : ""}`);
-        // Connect timeout is internal — convert to retryable network error, don't propagate AbortError
-        if (error.name === "AbortError" && !isConnectTimeout) throw error;
+        // A caller-initiated abort (signal aborted but NOT our connect timer) must propagate.
+        if (!isConnectTimeout && signal?.aborted) {
+          error.errorKind = "aborted";
+          throw error;
+        }
 
-        // Map network/fetch exceptions to 502 retry config
-        if (await tryRetry(urlIndex, HTTP_STATUS.BAD_GATEWAY, `network "${error.message}"`)) { urlIndex--; continue; }
+        // connect_timeout / network → retryable per resolveAttempts (default: connect_timeout=0 retries)
+        if (await tryRetry(urlIndex, HTTP_STATUS.BAD_GATEWAY, `${errorKind} "${error.message}"`, null, errorKind, error.message)) { urlIndex--; continue; }
+
+        // A skip-rule matched this exception → abandon this account now; do NOT cycle
+        // the remaining base URLs on the same account. Let the account layer fall back.
+        if (matchedSkip({ statusKey: HTTP_STATUS.BAD_GATEWAY, errorKind, text: error.message })) {
+          error.errorKind = errorKind;
+          throw error;
+        }
 
         if (urlIndex + 1 < fallbackCount) {
           log?.debug?.("RETRY", `Error on ${url}, trying fallback ${urlIndex + 1}`);
           continue;
         }
+        error.errorKind = errorKind;
         throw error;
       }
     }

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -12,6 +12,12 @@ import { getThinkingLevels } from "../providers/thinkingLevels.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import {
+  CODEX_FORWARD_HEADER_ALLOWLIST,
+  CODEX_RESPONSES_LITE_HEADER,
+  CODEX_RESPONSES_LITE_HEADER_VALUE,
+  CODEX_RESPONSES_LITE_INPUT_TYPES,
+} from "../config/codexConstants.js";
 
 // SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
 const CODEX_SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
@@ -42,8 +48,100 @@ const CODEX_PASSTHROUGH_TOOL_TYPES = new Set(["custom"]);
 const RESPONSES_API_ALLOWLIST = new Set([
   "model", "input", "instructions", "tools", "tool_choice", "stream", "store",
   "reasoning", "service_tier", "include", "prompt_cache_key", "client_metadata",
-  "text"
+  "text", "parallel_tool_calls"
 ]);
+
+const RESPONSES_LITE_INPUT_TYPES = new Set(CODEX_RESPONSES_LITE_INPUT_TYPES);
+
+function getHeaderValue(rawHeaders, name) {
+  if (!rawHeaders) return null;
+  if (typeof rawHeaders.get === "function") return rawHeaders.get(name);
+  const entry = Object.entries(rawHeaders).find(([key]) => key.toLowerCase() === name);
+  return entry?.[1] ?? null;
+}
+
+export function isCodexResponsesLiteRequest(rawHeaders) {
+  const value = getHeaderValue(rawHeaders, CODEX_RESPONSES_LITE_HEADER);
+  return typeof value === "string"
+    && value.trim().toLowerCase() === CODEX_RESPONSES_LITE_HEADER_VALUE;
+}
+
+export function hasCodexResponsesLitePayload(body) {
+  if (Array.isArray(body?.input) && body.input.some((item) =>
+    item?.type === "additional_tools" || typeof item?.namespace === "string"
+  )) return true;
+  return Array.isArray(body?.tools) && body.tools.some((tool) => tool?.type === "namespace");
+}
+
+export function stripRejectedCodexInputNamespaces(body) {
+  if (!Array.isArray(body?.input)) return false;
+  let stripped = false;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !("namespace" in item)) continue;
+    delete item.namespace;
+    stripped = true;
+  }
+  return stripped;
+}
+
+function isRejectedCodexInputNamespace(status, errorText) {
+  return Number(status) === 400
+    && /unknown parameter:\s*['"]input\[\d+\]\.namespace['"]/i.test(String(errorText || ""));
+}
+export function applyCodexForwardHeaders(headers, rawHeaders, responsesLite = false) {
+  for (const name of CODEX_FORWARD_HEADER_ALLOWLIST) {
+    if (name === CODEX_RESPONSES_LITE_HEADER && (responsesLite || isCodexResponsesLiteRequest(rawHeaders))) {
+      headers[name] = CODEX_RESPONSES_LITE_HEADER_VALUE;
+    }
+  }
+  return headers;
+}
+
+function isMessageItem(item) {
+  return item?.type === "message" || (!item?.type && typeof item?.role === "string");
+}
+
+export function normalizeCodexInputItems(body, { responsesLite = false } = {}) {
+  if (!Array.isArray(body.input)) return;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    if (!isMessageItem(item)) {
+      if (responsesLite && item.type && RESPONSES_LITE_INPUT_TYPES.has(item.type)) continue;
+      continue;
+    }
+    if (!item.type) item.type = "message";
+    if (typeof item.content === "string") {
+      const type = item.role === "assistant" ? "output_text" : "input_text";
+      item.content = [{ type, text: item.content }];
+    }
+  }
+}
+
+export function hasResponsesLiteInstructions(body) {
+  if (!Array.isArray(body.input)) return false;
+  return body.input.some((item) => {
+    if (!isMessageItem(item) || !["developer", "system"].includes(item.role)) return false;
+    if (typeof item.content === "string") return item.content.trim().length > 0;
+    return Array.isArray(item.content) && item.content.some((part) =>
+      typeof part?.text === "string" && part.text.trim().length > 0
+    );
+  });
+}
+
+function ensureResponsesLiteInstructions(body) {
+  const instructions = typeof body.instructions === "string" && body.instructions.trim()
+    ? body.instructions
+    : CODEX_DEFAULT_INSTRUCTIONS;
+  if (!hasResponsesLiteInstructions(body)) {
+    const additionalToolsIndex = body.input.findIndex((item) => item?.type === "additional_tools");
+    const insertAt = additionalToolsIndex >= 0 ? additionalToolsIndex + 1 : 0;
+    body.input.splice(insertAt, 0, {
+      type: "message", role: "developer",
+      content: [{ type: "input_text", text: instructions }],
+    });
+  }
+  delete body.instructions;
+}
 
 // Convert role=system → role=developer in body.input (keeps content in cacheable prefix)
 function convertSystemToDeveloperRole(body) {
@@ -125,9 +223,12 @@ function resolveCacheSessionId(body, credentials) {
   });
 }
 
-function normalizeReasoningEffort(model, value) {
+function normalizeReasoningEffort(model, value, responsesLite = false) {
   const supportedLevels = getThinkingLevels("codex", model);
   if (supportedLevels?.includes(value)) return value;
+  // Responses-Lite forwards "max" to the upstream verbatim; only the classic
+  // Responses path downgrades it to the highest level Codex actually accepts.
+  if (value === "max" && responsesLite) return value;
   if (value === "ultra" && supportedLevels?.includes("max")) return "max";
   if (value === "max" || value === "ultra") return "xhigh";
   return value;
@@ -193,6 +294,7 @@ export class CodexExecutor extends BaseExecutor {
   constructor() {
     super("codex", PROVIDERS.codex);
     this._currentSessionId = null;
+    this._responsesLite = false;
   }
 
   /**
@@ -201,6 +303,7 @@ export class CodexExecutor extends BaseExecutor {
    */
   buildHeaders(credentials, stream = true) {
     const headers = super.buildHeaders(credentials, stream);
+    applyCodexForwardHeaders(headers, credentials?.rawHeaders, this._responsesLite);
     headers["session_id"] = this._currentSessionId || credentials?.connectionId || "default";
     // Identify client type to Codex backend (matches official codex CLI)
     if (!headers["originator"]) headers["originator"] = "codex_cli_rs";
@@ -272,8 +375,18 @@ export class CodexExecutor extends BaseExecutor {
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
     const { attempts, delayMs } = resolveRetryEntry(retryConfig[503]);
     let attempt = 0;
+    let namespaceSchemaRetried = false;
     while (true) {
       const result = await super.execute(args);
+      if (!namespaceSchemaRetried && result.response?.status === 400) {
+        const errorText = await result.response.clone().text();
+        if (isRejectedCodexInputNamespace(result.response.status, errorText)
+            && stripRejectedCodexInputNamespaces(args.body)) {
+          namespaceSchemaRetried = true;
+          args.log?.warn?.("CODEX", "Upstream rejected input namespace; retrying once without history namespace fields");
+          continue;
+        }
+      }
       const peek = await this._peekSseTransientError(result.response);
       if (!peek.matched) {
         // Replace body with re-assembled stream (prefix bytes already read + rest)
@@ -393,6 +506,8 @@ export class CodexExecutor extends BaseExecutor {
   transformRequest(model, body, stream, credentials) {
     this._isCompact = !!body._compact;
     delete body._compact;
+    const responsesLite = isCodexResponsesLiteRequest(credentials?.rawHeaders) || hasCodexResponsesLitePayload(body);
+    this._responsesLite = responsesLite;
     // Resolve conversation-stable session_id (priority: body → assistant-text → workspace → machine)
     this._currentSessionId = resolveCacheSessionId(body, credentials);
     // Convert string input to array format (Codex API requires input as array)
@@ -404,6 +519,8 @@ export class CodexExecutor extends BaseExecutor {
       body.input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "..." }] }];
     }
 
+    normalizeCodexInputItems(body, { responsesLite });
+
     // Keep system prompts in body.input as role=developer so they stay in the cacheable prefix
     convertSystemToDeveloperRole(body);
     // Strip server-generated item IDs (rs_/fc_/resp_/msg_) — Codex /responses can't resolve when store=false
@@ -414,8 +531,9 @@ export class CodexExecutor extends BaseExecutor {
     // Ensure streaming is enabled (Codex API requires it)
     body.stream = true;
 
-    // If no instructions provided, inject default Codex instructions
-    if (!body.instructions || body.instructions.trim() === "") {
+    if (responsesLite) {
+      ensureResponsesLiteInstructions(body);
+    } else if (!body.instructions || body.instructions.trim() === "") {
       body.instructions = CODEX_DEFAULT_INSTRUCTIONS;
     }
 
@@ -432,7 +550,7 @@ export class CodexExecutor extends BaseExecutor {
 
     // Extract thinking level from model name suffix
     // e.g., gpt-5.3-codex-high → high, gpt-5.3-codex → medium (default)
-    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+    const effortLevels = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
     let modelEffort = null;
     for (const level of effortLevels) {
       if (body.model.endsWith(`-${level}`)) {
@@ -445,12 +563,13 @@ export class CodexExecutor extends BaseExecutor {
 
     // Priority: explicit reasoning.effort > reasoning_effort param > model suffix > default (medium)
     if (!body.reasoning) {
-      const effort = normalizeReasoningEffort(body.model, body.reasoning_effort || modelEffort || 'low');
+      const effort = normalizeReasoningEffort(body.model, body.reasoning_effort || modelEffort || 'low', responsesLite);
       body.reasoning = { effort, summary: "auto" };
     } else {
-      body.reasoning.effort = normalizeReasoningEffort(body.model, body.reasoning.effort);
+      body.reasoning.effort = normalizeReasoningEffort(body.model, body.reasoning.effort, responsesLite);
       if (!body.reasoning.summary) body.reasoning.summary = "auto";
     }
+    if (responsesLite) body.reasoning.context = "all_turns";
     delete body.reasoning_effort;
 
     // Include reasoning encrypted content (required by Codex backend for reasoning models)

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -4,6 +4,10 @@ import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE, selec
 import { resolveOpenAICompatibleApiType } from "../services/provider.js";
 import { OAUTH_ENDPOINTS, buildKimiHeaders } from "../config/appConstants.js";
 import { buildClineHeaders } from "../shared/clineAuth.js";
+import {
+  buildClientIdentityHeaders,
+  shouldStripClaudeIdentityHeaders,
+} from "../shared/clientIdentityHeaders.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
@@ -152,23 +156,36 @@ export class DefaultExecutor extends BaseExecutor {
     const desc = rt?.auth || AUTH_DESCRIPTORS[this.provider] || this.resolveAuthDescriptor();
     // Hooks run BEFORE auth so dynamic overlays can't clobber the token.
     for (const hook of desc.hooks || []) HEADER_HOOKS[hook]?.(headers, credentials);
-    applyAuth(headers, desc, credentials);
+    const identityConfig = credentials?.providerSpecificData || {};
+    const identityHeaders = buildClientIdentityHeaders(identityConfig);
+    Object.assign(headers, identityHeaders);
+
+    const authHeaders = {};
+    applyAuth(authHeaders, desc, credentials);
+    Object.assign(headers, authHeaders);
 
     if (this.provider === "claude" && model) {
       headers["Anthropic-Beta"] = selectAnthropicBeta(model);
     }
 
-    // Strip first-party Claude Code identity headers for non-Anthropic anthropic-compatible upstreams
     if (this.provider?.startsWith?.("anthropic-compatible-")) {
       const baseUrl = credentials?.providerSpecificData?.baseUrl || "";
       const isOfficialAnthropic = baseUrl === "" || baseUrl.includes("api.anthropic.com");
+      if (!isOfficialAnthropic && credentials.apiKey && !headers["Authorization"]) {
+        headers["Authorization"] = `Bearer ${credentials.apiKey}`;
+      }
+    }
+
+    // Strip first-party Claude Code identity headers for non-Anthropic anthropic-compatible upstreams
+    if (shouldStripClaudeIdentityHeaders({
+      provider: this.provider,
+      baseUrl: credentials?.providerSpecificData?.baseUrl || "",
+      clientIdentityProfile: identityConfig.clientIdentityProfile,
+      identityHeaders,
+    })) {
+      const baseUrl = credentials?.providerSpecificData?.baseUrl || "";
+      const isOfficialAnthropic = baseUrl === "" || baseUrl.includes("api.anthropic.com");
       if (!isOfficialAnthropic) {
-        // Some third-party Anthropic-compatible gateways require Bearer auth in
-        // addition to x-api-key. Send both (x-api-key already set above) so
-        // gateways that read either header succeed.
-        if (credentials.apiKey && !headers["Authorization"]) {
-          headers["Authorization"] = `Bearer ${credentials.apiKey}`;
-        }
         delete headers["anthropic-dangerous-direct-browser-access"];
         delete headers["Anthropic-Dangerous-Direct-Browser-Access"];
         delete headers["x-app"];

--- a/open-sse/executors/kiro.js
+++ b/open-sse/executors/kiro.js
@@ -144,6 +144,12 @@ function normalizeStopReason(value) {
   return reason || null;
 }
 
+// Of the reasons stopDisposition() folds into "terminal_incomplete", only these
+// mean "usable as far as it got, then the budget ran out" -- the case
+// finish_reason "length" exists for. cancelled / pause_turn are abandoned turns
+// whose partial content must stay private, so they are deliberately absent.
+const KIRO_TRUNCATION_STOP_REASONS = new Set(["model_context_window_exceeded", "max_tokens"]);
+
 function stopDisposition(stopReason, hasToolCalls) {
   if (["malformed_model_output", "invalid_model_output"].includes(stopReason)) return "retryable_protocol_failure";
   if (["cancelled", "pause_turn", "model_context_window_exceeded"].includes(stopReason)) return "terminal_incomplete";
@@ -711,14 +717,25 @@ export class KiroExecutor extends BaseExecutor {
     };
     const emitTools = (controller) => {
       for (const tool of state.tools.values()) {
-        const input = parsedToolInput(tool);
-        if (tool.name === "tool_call") {
-          if (typeof input.name !== "string" || !input.name.trim()) {
-            throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool name");
+        // Validate per tool, not per turn: one unusable fragment used to throw out
+        // of emitTools and take every other complete tool call in the same turn
+        // with it, which the client saw as a turn that answered nothing.
+        let input;
+        try {
+          input = parsedToolInput(tool);
+          if (tool.name === "tool_call") {
+            if (typeof input.name !== "string" || !input.name.trim()) {
+              throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool name");
+            }
+            if (!Object.prototype.hasOwnProperty.call(input, "arguments")) {
+              throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool arguments");
+            }
           }
-          if (!Object.prototype.hasOwnProperty.call(input, "arguments")) {
-            throw new Error("Invalid Kiro tool_call payload: missing nested MCP tool arguments");
-          }
+        } catch (error) {
+          state.droppedTools = (state.droppedTools || 0) + 1;
+          state.toolValidationError ||= error.message;
+          console.error(`[Kiro] dropping unusable tool call ${tool.id} (${tool.name}): ${error.message}`);
+          continue;
         }
         const index = state.toolCounter++;
         emitDelta(controller, {
@@ -729,14 +746,26 @@ export class KiroExecutor extends BaseExecutor {
             function: { name: tool.name, arguments: "" }
           }]
         });
+        const serializedInput = JSON.stringify(input);
         emitDelta(controller, {
-          tool_calls: [{ index, function: { arguments: JSON.stringify(input) } }]
+          tool_calls: [{ index, function: { arguments: serializedInput } }]
         });
+        // Tool arguments are billed output like any other completion bytes. They
+        // were never added to totalContentLength, so the /4 estimator in finish()
+        // reported OUT 0 -- or the Math.max floor of 1 -- for every turn whose
+        // entire answer was a tool call.
+        state.totalContentLength += tool.name.length + serializedInput.length;
         state.hasToolCalls = true;
       }
       state.tools.clear();
       state.bufferedToolBytes = 0;
-      if (state.stopReason === "tool_use" && !state.hasToolCalls) {
+      // A declared tool turn that emitted no usable call is only fatal when the
+      // turn produced nothing else. Throwing unconditionally here escaped
+      // emitTools() with provenance "invalid_tool_call", which the integrity gate
+      // re-derived into a repair retry -- discarding text the client had already
+      // been promised.
+      if (state.stopReason === "tool_use" && !state.hasToolCalls &&
+          !state.hasText && !state.hasReasoning && !state.hasCode) {
         throw new Error("Kiro tool_use stop reason did not include a complete tool call");
       }
     };
@@ -796,7 +825,6 @@ export class KiroExecutor extends BaseExecutor {
         emitDelta(controller, { content: event.payload.content });
       } else if (eventType === "toolUseEvent") {
         state.sawToolUse = true;
-        if (state.toolValidationError) return true;
         const values = Array.isArray(event.payload) ? event.payload : [event.payload];
         if (!values[0]) throw new Error("Kiro toolUseEvent is empty");
         for (const value of values) {
@@ -924,9 +952,10 @@ export class KiroExecutor extends BaseExecutor {
         } catch (error) {
           const bufferExceeded = error.code === "KIRO_BUFFER_EXCEEDED";
           if (!bufferExceeded) {
+            // Keep whatever is already buffered: the rejected fragment belongs to
+            // one tool, and clearing the map dropped the complete calls too.
             state.toolValidationError ||= error.message;
-            state.tools.clear();
-            state.bufferedToolBytes = 0;
+            console.error(`[Kiro] tool fragment rejected, keeping ${state.tools.size} buffered tool(s): ${error.message}`);
             continue;
           }
           fail(
@@ -958,7 +987,16 @@ export class KiroExecutor extends BaseExecutor {
       }
       state.transportState = "clean_eof";
       const declaredDisposition = stopDisposition(state.stopReason, state.sawToolUse);
-      if (["retryable_protocol_failure", "terminal_incomplete", "terminal_refusal", "unknown_failure"].includes(declaredDisposition)) {
+      // model_context_window_exceeded / max_tokens map to terminal_incomplete. When
+      // they arrive after the model already streamed content, fail() threw away a
+      // complete-enough answer; a truncated turn is what finish_reason "length" is
+      // for. chunkIndex > 0 means at least one delta already reached the client.
+      const declaredTruncatedAfterOutput = declaredDisposition === "terminal_incomplete" &&
+        KIRO_TRUNCATION_STOP_REASONS.has(state.stopReason) && state.chunkIndex > 0;
+      if (declaredTruncatedAfterOutput) {
+        console.error(`[Kiro] truncated after ${state.chunkIndex} chunk(s) (stop_reason=${state.stopReason}); keeping output`);
+      }
+      if (!declaredTruncatedAfterOutput && ["retryable_protocol_failure", "terminal_incomplete", "terminal_refusal", "unknown_failure"].includes(declaredDisposition)) {
         const code = declaredDisposition === "retryable_protocol_failure"
           ? "kiro_retryable_protocol_failure"
           : declaredDisposition === "terminal_refusal"
@@ -975,16 +1013,6 @@ export class KiroExecutor extends BaseExecutor {
         );
         return;
       }
-      if (state.toolValidationError) {
-        fail(
-          controller,
-          "invalid_tool_call",
-          "invalid_kiro_tool_call",
-          state.toolValidationError,
-          { transport_state: state.transportState, stop_disposition: "retryable_protocol_failure" }
-        );
-        return;
-      }
       try {
         emitTools(controller);
       } catch (error) {
@@ -993,6 +1021,22 @@ export class KiroExecutor extends BaseExecutor {
           "invalid_tool_call",
           "invalid_kiro_tool_call",
           error.message,
+          { transport_state: state.transportState, stop_disposition: "retryable_protocol_failure" }
+        );
+        return;
+      }
+      // Fail only when the turn has nothing usable left. emitTools() validates
+      // per tool and drops just the unusable ones, so this has to run AFTER it:
+      // before, the rejected tool was still buffered and tools.size was never 0.
+      // A turn that also produced text keeps that text -- the dropped call is
+      // logged, not fatal.
+      if (state.toolValidationError && !state.hasToolCalls &&
+          !state.hasText && !state.hasReasoning && !state.hasCode) {
+        fail(
+          controller,
+          "invalid_tool_call",
+          "invalid_kiro_tool_call",
+          state.toolValidationError,
           { transport_state: state.transportState, stop_disposition: "retryable_protocol_failure" }
         );
         return;
@@ -1011,7 +1055,13 @@ export class KiroExecutor extends BaseExecutor {
       }
 
       const disposition = stopDisposition(state.stopReason, state.hasToolCalls);
-      if (["retryable_protocol_failure", "terminal_incomplete", "terminal_refusal", "unknown_failure"].includes(disposition)) {
+      // Same reasoning as declaredTruncatedAfterOutput above.
+      const truncatedAfterOutput = disposition === "terminal_incomplete" &&
+        KIRO_TRUNCATION_STOP_REASONS.has(state.stopReason) && state.chunkIndex > 0;
+      if (truncatedAfterOutput) {
+        console.error(`[Kiro] truncated after ${state.chunkIndex} chunk(s) (stop_reason=${state.stopReason}); closing as length`);
+      }
+      if (!truncatedAfterOutput && ["retryable_protocol_failure", "terminal_incomplete", "terminal_refusal", "unknown_failure"].includes(disposition)) {
         const code = disposition === "retryable_protocol_failure"
           ? "kiro_retryable_protocol_failure"
           : disposition === "terminal_refusal"
@@ -1041,18 +1091,24 @@ export class KiroExecutor extends BaseExecutor {
           total_tokens: prompt + completion
         };
       }
-      const finishReason = state.hasToolCalls
-        ? "tool_calls"
-        : disposition === "length"
-          ? "length"
-          : "stop";
+      const finishReason = truncatedAfterOutput
+        ? "length"
+        : state.hasToolCalls
+          ? "tool_calls"
+          : disposition === "length"
+            ? "length"
+            : "stop";
       controller.enqueue(sseChunk({}, finishReason, state.usage));
       controller.enqueue(encoder.encode(SSE_DONE));
       state.finished = true;
       options.onTerminalState?.(diagnostics({
         terminal_provenance: state.terminalProvenance || "clean_eventstream_eof",
         transport_state: state.transportState,
-        stop_disposition: disposition
+        // Report what this exit actually did, not the raw disposition. The
+        // integrity gate re-derives its verdict from stop_disposition, so
+        // reporting "terminal_incomplete" for a turn we deliberately kept made
+        // it discard the very bytes we just released to the client.
+        stop_disposition: truncatedAfterOutput ? "length" : disposition
       }));
     };
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -57,7 +57,7 @@ export function stripContinuityFields(body) {
   return body;
 }
 
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking, requestPolicy = null }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -330,7 +330,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // exception: it is decoded by the executor into OpenAI-compatible output.
   let providerResponseFormat = targetFormat;
   try {
-    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, requestPolicy });
     providerResponse = result.response;
     providerUrl = result.url;
     providerHeaders = result.headers;
@@ -351,15 +351,16 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       status: "error"
     })).catch(() => { });
 
-    if (error.name === "AbortError") {
+    if (error.name === "AbortError" || error.errorKind === "aborted") {
       streamController.handleError(error);
-      return createErrorResult(499, "Request aborted");
+      return createErrorResult(499, "Request aborted", undefined, "aborted");
     }
     const errMsg = formatProviderError(error, provider, model, HTTP_STATUS.BAD_GATEWAY);
     if (log?.errorLine) {
       log.errorLine(reqTag, "✗", `ERROR 502 · ${provider}/${model} · ${Date.now() - requestStartTime}ms\n    ${errMsg}${error.stack ? `\n    ${error.stack}` : ""}`);
     }
-    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg);
+    // errorKind classified by BaseExecutor (connect_timeout | network); default to "network".
+    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg, undefined, error.errorKind || "network");
   }
 
   // Handle 401/403 - try token refresh (skip for noAuth providers)
@@ -421,7 +422,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       log.errorLine(reqTag, "✗", `ERROR ${statusCode} · ${provider}/${model} · ${Date.now() - requestStartTime}ms${urlStr}\n    ${errMsg}`);
     }
     reqLogger.logError(new Error(message), finalBody || translatedBody);
-    return createErrorResult(statusCode, errMsg, resetsAtMs);
+    return createErrorResult(statusCode, errMsg, resetsAtMs, `http_${statusCode}`);
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };

--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -44,13 +44,15 @@ export function extractUsageFromResponse(responseBody) {
     };
   }
 
-  // Gemini format
-  if (responseBody.usageMetadata) {
+  // Gemini / Antigravity format. Antigravity wraps the native Gemini response
+  // under `response`, so usage can be either top-level or nested.
+  const usageMetadata = responseBody.usageMetadata || responseBody.response?.usageMetadata;
+  if (usageMetadata) {
     return {
-      prompt_tokens: responseBody.usageMetadata.promptTokenCount || 0,
-      completion_tokens: responseBody.usageMetadata.candidatesTokenCount || 0,
-      cached_tokens: responseBody.usageMetadata.cachedContentTokenCount || 0,
-      reasoning_tokens: responseBody.usageMetadata.thoughtsTokenCount || 0
+      prompt_tokens: usageMetadata.promptTokenCount || 0,
+      completion_tokens: usageMetadata.candidatesTokenCount || 0,
+      cached_tokens: usageMetadata.cachedContentTokenCount || 0,
+      reasoning_tokens: usageMetadata.thoughtsTokenCount || 0
     };
   }
 

--- a/open-sse/handlers/embeddingProviders/openaiCompatNode.js
+++ b/open-sse/handlers/embeddingProviders/openaiCompatNode.js
@@ -1,5 +1,6 @@
 // Custom node providers (openai-compatible-* / custom-embedding-*) — baseUrl from credentials
 import createOpenAIEmbeddingAdapter from "./openai.js";
+import { mergeClientIdentityHeaders } from "../../shared/clientIdentityHeaders.js";
 
 const baseAdapter = createOpenAIEmbeddingAdapter("openai");
 
@@ -10,4 +11,9 @@ export default {
     const baseUrl = rawBaseUrl.replace(/\/$/, "").replace(/\/embeddings$/, "");
     return `${baseUrl}/embeddings`;
   },
+  buildHeaders: (creds) => mergeClientIdentityHeaders(
+    { "Content-Type": "application/json" },
+    creds?.providerSpecificData || {},
+    { "Authorization": `Bearer ${creds?.apiKey || creds?.accessToken}` },
+  ),
 };

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -1,4 +1,29 @@
-import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
+import {
+  ERROR_RULES,
+  BACKOFF_CONFIG,
+  TRANSIENT_COOLDOWN_MS,
+  CODEX_REQUEST_SCHEMA_ERROR_CODES,
+  CODEX_REQUEST_SCHEMA_ERROR_PATTERN,
+} from "../config/errorConfig.js";
+
+function parseErrorPayload(errorText) {
+  if (errorText && typeof errorText === "object") return errorText;
+  if (typeof errorText !== "string") return {};
+  try { return JSON.parse(errorText); } catch { return { message: errorText }; }
+}
+
+export function isCodexRequestSchemaError(provider, status, errorText = "") {
+  if (provider !== "codex" || Number(status) !== 400) return false;
+  const payload = parseErrorPayload(errorText);
+  const error = payload?.error && typeof payload.error === "object" ? payload.error : payload;
+  const message = String(error?.message || errorText || "");
+  const code = String(error?.code || "").toLowerCase();
+  const type = String(error?.type || "").toLowerCase();
+  const recognizedMetadata = !code && !type
+    || CODEX_REQUEST_SCHEMA_ERROR_CODES.has(code)
+    || CODEX_REQUEST_SCHEMA_ERROR_CODES.has(type);
+  return recognizedMetadata && CODEX_REQUEST_SCHEMA_ERROR_PATTERN.test(message || code || type);
+}
 
 /**
  * Calculate exponential backoff cooldown for rate limits (429)
@@ -28,6 +53,9 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
   for (const rule of ERROR_RULES) {
     // Text-based rule: match substring in error message
     if (rule.text && lowerError && lowerError.includes(rule.text)) {
+      // fallback:false marks a request-scoped failure: do not switch accounts
+      // and do not cool the current one down — retrying cannot help.
+      if (rule.fallback === false) return { shouldFallback: false, cooldownMs: 0 };
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
         return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
@@ -37,6 +65,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
 
     // Status-based rule: match HTTP status code
     if (rule.status && rule.status === status) {
+      if (rule.fallback === false) return { shouldFallback: false, cooldownMs: 0 };
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
         return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
@@ -47,6 +76,93 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
 
   // Default: transient cooldown for any unmatched error
   return { shouldFallback: true, cooldownMs: TRANSIENT_COOLDOWN_MS };
+}
+
+/**
+ * Match a user-configured skip-rule against a failure.
+ *
+ * A rule's `match` may carry any combination of { kind, status, contains }; the
+ * rule matches only when EVERY present condition holds (AND). At least one
+ * condition must be present. Rules are evaluated in ARRAY ORDER — the first rule
+ * (for this provider) whose conditions all match wins. Order is user-controlled
+ * via the settings UI. There is no hardcoded provider default: the legacy
+ * Antigravity capacity skip is now shipped as an ordinary seeded rule
+ * ({ status:503, contains:"capacity", action:"skip" }) the user can edit or delete.
+ *
+ * @param {string} provider   provider id (e.g. "anthropic-compatible-<uuid>", "antigravity")
+ * @param {{status?: number|string, errorKind?: string, text?: string}} failure
+ * @param {Array<{provider, match:{kind?,status?,contains?}, action, headerTimeoutMs?, sweep?}>} skipRules
+ * @returns {{action:"retry"|"skip", headerTimeoutMs?:number, sweep?:boolean}|null}
+ */
+export function matchSkipRule(provider, failure = {}, skipRules = []) {
+  const r = findMatchingSkipRule(provider, failure, skipRules);
+  if (!r) return null;
+  const out = { action: r.action };
+  if (r.headerTimeoutMs != null) out.headerTimeoutMs = r.headerTimeoutMs;
+  // `sweep` is only meaningful for skip rules — it asks the account loop to
+  // re-try the whole pool after exhausting it (momentary saturation recovery).
+  if (r.action === "skip" && r.sweep === true) out.sweep = true;
+  return out;
+}
+
+/**
+ * Find the FIRST rule (in array order) that matches this failure for `provider`,
+ * and return the rule object itself (not a derived shape) — or null.
+ *
+ * A rule's `match` may carry any combination of { kind, status, contains }; the
+ * rule matches only when EVERY present condition holds (AND). At least one usable
+ * condition must be present (an empty match never matches — avoids skip-all).
+ * Array order is user-controlled via the settings UI (first match wins).
+ *
+ * @param {string} provider
+ * @param {{status?: number|string, errorKind?: string, text?: string}} failure
+ * @param {Array} skipRules
+ * @returns {object|null} the matching rule object, or null
+ */
+export function findMatchingSkipRule(provider, failure = {}, skipRules = []) {
+  const status = failure.status != null ? Number(failure.status) : null;
+  const errorKind = failure.errorKind || null;
+  const text = typeof failure.text === "string" ? failure.text.toLowerCase() : "";
+  const rules = Array.isArray(skipRules) ? skipRules : [];
+
+  const conditionsMatch = (m) => {
+    let has = false;
+    if (m.kind != null) {
+      has = true;
+      if (errorKind == null || m.kind !== errorKind) return false;
+    }
+    if (m.status != null) {
+      has = true;
+      if (status == null || Number(m.status) !== status) return false;
+    }
+    if (m.contains != null && m.contains !== "") {
+      has = true;
+      if (!text.includes(String(m.contains).toLowerCase())) return false;
+    }
+    // A match block with no usable condition never matches (avoids skip-all).
+    return has;
+  };
+
+  for (const r of rules) {
+    if (!r || r.provider !== provider || !r.match || !r.action) continue;
+    if (conditionsMatch(r.match)) return r;
+  }
+  return null;
+}
+
+/**
+ * Resolve the header/connect timeout for a provider from skip-rules.
+ * Scans rules matching this provider with match.kind === "connect_timeout" that
+ * carry a headerTimeoutMs; earlier rule wins. Returns null → caller uses default.
+ */
+export function resolveProviderHeaderTimeout(provider, skipRules = []) {
+  const rules = Array.isArray(skipRules) ? skipRules : [];
+  for (const r of rules) {
+    if (r && r.provider === provider && r.match?.kind === "connect_timeout" && r.headerTimeoutMs != null) {
+      return r.headerTimeoutMs;
+    }
+  }
+  return null;
 }
 
 /**

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -2,8 +2,9 @@
  * Shared combo (model combo) handling with fallback support
  */
 
-import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
+import { checkFallbackError, formatRetryAfter, isCodexRequestSchemaError } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
+import { getRoutingMeta } from "./routingMeta.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
 
@@ -297,6 +298,10 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
         try { errorText = JSON.stringify(errorText); } catch { errorText = String(errorText); }
       }
 
+      if (modelStr.startsWith("cx/") && isCodexRequestSchemaError("codex", result.status, errorText)) {
+        log.warn("COMBO", `Model ${modelStr} failed with a non-retryable request schema error`, { status: result.status });
+        return result;
+      }
       // Check if should fallback to next model
       const { shouldFallback, cooldownMs } = checkFallbackError(result.status, errorText);
 
@@ -305,10 +310,17 @@ export async function handleComboChat({ body, models, handleSingleModel, log, co
         return result;
       }
 
+      // Fail-fast when the router flagged this failure as such: connect_timeout
+      // (upstream stalled before headers) OR a user skip-rule fired (status/contains/
+      // kind + action:"skip"). Both mean waiting a cooldown just delays the jump to
+      // the next backup model. Read the in-process routing metadata (never serialized).
+      const meta = getRoutingMeta(result);
+      const failFast = meta?.failFast === true || meta?.errorKind === "connect_timeout";
+
       // For transient errors (503/502/504), wait for cooldown before falling through
       // so a briefly-overloaded provider gets a chance to recover rather than being
       // skipped immediately (fixes: combo falls through on transient 503)
-      if (cooldownMs && cooldownMs > 0 && cooldownMs <= 5000 &&
+      if (!failFast && cooldownMs && cooldownMs > 0 && cooldownMs <= 5000 &&
           (result.status === 503 || result.status === 502 || result.status === 504)) {
         log.info("COMBO", `Model ${modelStr} transient ${result.status}, waiting ${cooldownMs}ms before next`);
         await new Promise(r => setTimeout(r, cooldownMs));

--- a/open-sse/services/routingMeta.js
+++ b/open-sse/services/routingMeta.js
@@ -1,0 +1,16 @@
+// In-process routing metadata attached to Response objects.
+// Kept in a WeakMap so it never leaks into the response headers/body sent to
+// clients, yet downstream routing code (combo fallback) can read the error
+// classification of a failed single-model Response.
+
+const _meta = new WeakMap(); // Response → { errorKind, status, failFast? }
+
+export function setRoutingMeta(response, metadata) {
+  if (response && typeof response === "object") _meta.set(response, metadata);
+  return response;
+}
+
+export function getRoutingMeta(response) {
+  if (!response || typeof response !== "object") return null;
+  return _meta.get(response) || null;
+}

--- a/open-sse/shared/clientIdentityHeaders.js
+++ b/open-sse/shared/clientIdentityHeaders.js
@@ -1,0 +1,138 @@
+import { CLAUDE_CLI_SPOOF_HEADERS } from "../providers/shared.js";
+
+export const CLIENT_IDENTITY_PROFILES = {
+  default: {
+    label: "Default",
+    headers: {},
+  },
+  "claude-cli": {
+    label: "Claude CLI",
+    headers: CLAUDE_CLI_SPOOF_HEADERS,
+  },
+  "codex-cli": {
+    label: "Codex CLI",
+    headers: {
+      originator: "codex_cli_rs",
+      "User-Agent": "codex_cli_rs/0.136.0",
+    },
+  },
+  openclaw: {
+    label: "OpenClaw",
+    headers: {
+      "User-Agent": "openclaw/2026.2.3",
+    },
+  },
+  custom: {
+    label: "Custom",
+    headers: {},
+  },
+};
+
+const AUTH_HEADER_NAMES = new Set([
+  "authorization",
+  "x-api-key",
+  "api-key",
+  "cookie",
+]);
+
+export function normalizeClientIdentityProfile(profile) {
+  return CLIENT_IDENTITY_PROFILES[profile] ? profile : "default";
+}
+
+export function isBlockedClientIdentityHeader(name) {
+  return AUTH_HEADER_NAMES.has(String(name || "").trim().toLowerCase());
+}
+
+function sanitizeHeaderEntries(entries) {
+  const headers = {};
+  for (const [rawName, rawValue] of entries) {
+    const name = String(rawName || "").trim();
+    if (!name || isBlockedClientIdentityHeader(name)) continue;
+    if (rawValue === undefined || rawValue === null) continue;
+    const value = String(rawValue).trim();
+    if (!value) continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function parseHeaderLines(input) {
+  const entries = [];
+  for (const line of String(input || "").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const sep = trimmed.indexOf(":");
+    if (sep <= 0) continue;
+    entries.push([trimmed.slice(0, sep), trimmed.slice(sep + 1)]);
+  }
+  return entries;
+}
+
+export function parseClientIdentityHeaders(input) {
+  if (!input) return {};
+
+  if (typeof input === "object" && !Array.isArray(input)) {
+    return sanitizeHeaderEntries(Object.entries(input));
+  }
+
+  const text = String(input).trim();
+  if (!text) return {};
+
+  if (text.startsWith("{")) {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return sanitizeHeaderEntries(Object.entries(parsed));
+  }
+
+  return sanitizeHeaderEntries(parseHeaderLines(text));
+}
+
+export function buildClientIdentityHeaders(identity = {}) {
+  const profile = normalizeClientIdentityProfile(identity.clientIdentityProfile);
+  if (profile === "custom") {
+    return parseClientIdentityHeaders(identity.clientIdentityHeaders);
+  }
+  return { ...(CLIENT_IDENTITY_PROFILES[profile]?.headers || {}) };
+}
+
+export function mergeClientIdentityHeaders(baseHeaders = {}, identity = {}, authHeaders = {}) {
+  return {
+    ...(baseHeaders || {}),
+    ...buildClientIdentityHeaders(identity),
+    ...(authHeaders || {}),
+  };
+}
+
+export function normalizeClientIdentityData(data = {}) {
+  const clientIdentityProfile = normalizeClientIdentityProfile(data.clientIdentityProfile);
+  return {
+    clientIdentityProfile,
+    clientIdentityHeaders: clientIdentityProfile === "custom"
+      ? parseClientIdentityHeaders(data.clientIdentityHeaders)
+      : {},
+  };
+}
+
+export function hasClaudeClientIdentityHeaders(headers = {}) {
+  for (const [rawName, rawValue] of Object.entries(headers || {})) {
+    const name = rawName.toLowerCase();
+    const value = String(rawValue || "").toLowerCase();
+    if (name === "x-app" && value === "cli") return true;
+    if (name === "anthropic-dangerous-direct-browser-access") return true;
+    if (name === "anthropic-beta" && value.includes("claude-code-20250219")) return true;
+    if (name === "user-agent" && (value.includes("claude-cli/") || value.includes("claude-code/"))) return true;
+  }
+  return false;
+}
+
+export function shouldStripClaudeIdentityHeaders({ provider, baseUrl = "", clientIdentityProfile, identityHeaders = {} } = {}) {
+  if (!provider?.startsWith?.("anthropic-compatible-")) return false;
+  const normalizedBaseUrl = String(baseUrl || "");
+  const isOfficialAnthropic = normalizedBaseUrl === "" || normalizedBaseUrl.includes("api.anthropic.com");
+  if (isOfficialAnthropic) return false;
+
+  const profile = normalizeClientIdentityProfile(clientIdentityProfile);
+  if (profile === "claude-cli") return false;
+  if (profile === "custom" && hasClaudeClientIdentityHeaders(identityHeaders)) return false;
+  return true;
+}

--- a/open-sse/translator/concerns/usage.js
+++ b/open-sse/translator/concerns/usage.js
@@ -67,3 +67,29 @@ export function toOpenAIUsage(raw, kind) {
   if (!extract || !raw || typeof raw !== "object") return null;
   return buildUsage(extract(raw));
 }
+
+// Convert an OpenAI Chat usage object → Responses API shape.
+// Chat uses prompt_tokens/completion_tokens with cache under
+// prompt_tokens_details; Responses uses input_tokens/output_tokens with cache
+// under input_tokens_details. Clients that size their context from
+// response.completed read the Responses spelling only, so a Chat-shaped object
+// forwarded verbatim reads as zero. Returns null when there is nothing to send.
+export function toResponsesUsage(usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const input = n(usage.prompt_tokens) || n(usage.input_tokens);
+  const output = n(usage.completion_tokens) || n(usage.output_tokens);
+  const total = n(usage.total_tokens) || input + output;
+  if (!input && !output) return null;
+
+  const out = { input_tokens: input, output_tokens: output, total_tokens: total };
+
+  // prompt_tokens is already cache-inclusive here (see claude-to-openai), which
+  // matches the Responses contract: input_tokens includes cached_tokens.
+  const cached = n(usage.cached_tokens) || n(usage.prompt_tokens_details?.cached_tokens);
+  if (cached > 0) out.input_tokens_details = { cached_tokens: cached };
+
+  const reasoning = n(usage.completion_tokens_details?.reasoning_tokens);
+  if (reasoning > 0) out.output_tokens_details = { reasoning_tokens: reasoning };
+
+  return out;
+}

--- a/open-sse/translator/request/claude-to-kiro.js
+++ b/open-sse/translator/request/claude-to-kiro.js
@@ -287,6 +287,18 @@ export function claudeToKiroRequest(model, body, stream, credentials) {
     toolSpecs,
     nameMap,
   });
+  // canonicalizeKiroConversation() already ran its second-chance repair (flatten
+  // every structured tool turn to text, then re-validate). A body that is STILL
+  // invalid here cannot be made shippable, and Kiro answers it with
+  // 400 {"message":"Improperly formed request.","reason":"REQUEST_BODY_INVALID"}.
+  // Fail locally instead: chatCore turns a falsy return into a 400 without
+  // spending an upstream call or a per-account cooldown. The taxonomy
+  // (role:N | pair:N | id:N | spec:N | orphan:0 | current) names the offending
+  // turn so the shape can be diagnosed from the log alone.
+  if (!canonical.valid) {
+    console.error(`[Kiro] refusing invalid conversation (claude → kiro): ${(canonical.errors || []).join(", ") || "unknown"} | turns=${(canonical.history || []).length + 1}`);
+    return null;
+  }
   const replayCurrent = canonical.currentMessage.userInputMessage;
   const userInputMessage = {
     content: replayCurrent.content || "",

--- a/open-sse/translator/request/openai-to-claude.js
+++ b/open-sse/translator/request/openai-to-claude.js
@@ -194,6 +194,15 @@ Respond ONLY with the JSON object, no other text.`);
     result._toolNameMap = toolNameMap;
   }
 
+  // Responses-API custom/freeform tool names ride along as translator metadata.
+  // openai-responses -> claude has no direct translator, so it pivots through
+  // this one; a fresh result object is built above, so the metadata has to be
+  // carried over explicitly or chatCore loses it and emits function_call
+  // instead of custom_tool_call for freeform tools.
+  if (body._customToolNames) {
+    result._customToolNames = body._customToolNames;
+  }
+
   return result;
 }
 

--- a/open-sse/translator/request/openai-to-kiro.js
+++ b/open-sse/translator/request/openai-to-kiro.js
@@ -379,6 +379,18 @@ export function openaiToKiroRequest(model, body, stream, credentials) {
     toolSpecs,
     nameMap,
   });
+  // canonicalizeKiroConversation() already ran its second-chance repair (flatten
+  // every structured tool turn to text, then re-validate). A body that is STILL
+  // invalid here cannot be made shippable, and Kiro answers it with
+  // 400 {"message":"Improperly formed request.","reason":"REQUEST_BODY_INVALID"}.
+  // Fail locally instead: chatCore turns a falsy return into a 400 without
+  // spending an upstream call or a per-account cooldown. The taxonomy
+  // (role:N | pair:N | id:N | spec:N | orphan:0 | current) names the offending
+  // turn so the shape can be diagnosed from the log alone.
+  if (!canonical.valid) {
+    console.error(`[Kiro] refusing invalid conversation (openai → kiro): ${(canonical.errors || []).join(", ") || "unknown"} | turns=${(canonical.history || []).length + 1}`);
+    return null;
+  }
   const replayCurrent = canonical.currentMessage.userInputMessage;
 
   const payload = {

--- a/open-sse/translator/response/claude-to-openai.js
+++ b/open-sse/translator/response/claude-to-openai.js
@@ -41,7 +41,12 @@ export function claudeToOpenAIResponse(chunk, state) {
           completion_tokens: 0,
           total_tokens: promptTokens,
           input_tokens: inputTokens,
-          output_tokens: 0
+          output_tokens: 0,
+          // prompt_tokens above is already cache-inclusive. canonicalizeUsage()
+          // treats a present top-level cached_tokens as already-folded and takes its
+          // passthrough branch, so this key must always be set (even at 0) or the
+          // cache totals get folded into prompt_tokens a second time downstream.
+          cached_tokens: cacheReadTokens
         };
         if (cacheReadTokens > 0) state.usage.cache_read_input_tokens = cacheReadTokens;
         if (cacheCreationTokens > 0) state.usage.cache_creation_input_tokens = cacheCreationTokens;
@@ -140,7 +145,10 @@ export function claudeToOpenAIResponse(chunk, state) {
           completion_tokens: outputTokens,
           total_tokens: promptTokens + outputTokens,
           input_tokens: inputTokens,
-          output_tokens: outputTokens
+          output_tokens: outputTokens,
+          // Always present so canonicalizeUsage() sees an already-folded object
+          // and does not add the cache totals again (see message_start above).
+          cached_tokens: cacheReadTokens
         };
 
         if (cacheReadTokens > 0) state.usage.cache_read_input_tokens = cacheReadTokens;
@@ -171,12 +179,18 @@ export function claudeToOpenAIResponse(chunk, state) {
     case "message_stop": {
       if (!state.finishReasonSent) {
         const finishReason = state.finishReason || (state.toolCalls?.size > 0 ? OPENAI_FINISH.TOOL_CALLS : OPENAI_FINISH.STOP);
+        // Same construction as the message_delta branch above: input_tokens is
+        // cache-EXCLUSIVE, so reporting it as prompt_tokens understates the
+        // prompt by the whole cache component and drops cached_tokens entirely.
+        // Streams that end on message_stop without a stop_reason-bearing
+        // message_delta are the only ones that reach here.
         const usageObj = (state.usage && typeof state.usage === 'object') ? {
-          usage: {
-            prompt_tokens: state.usage.input_tokens || 0,
-            completion_tokens: state.usage.output_tokens || 0,
-            total_tokens: (state.usage.input_tokens || 0) + (state.usage.output_tokens || 0)
-          }
+          usage: toOpenAIUsage({
+            input_tokens: state.usage.input_tokens || 0,
+            output_tokens: state.usage.output_tokens || 0,
+            cache_read_input_tokens: state.usage.cache_read_input_tokens,
+            cache_creation_input_tokens: state.usage.cache_creation_input_tokens
+          }, "claude")
         } : {};
         results.push({ ...createChunk(state, {}, finishReason), ...usageObj });
         state.finishReasonSent = true;

--- a/open-sse/translator/response/kiro-to-claude.js
+++ b/open-sse/translator/response/kiro-to-claude.js
@@ -75,6 +75,15 @@ export function kiroToClaudeResponse(chunk, state) {
         ? data.usage.completion_tokens
         : 0;
     state.usage = { input_tokens: promptTokens, output_tokens: outputTokens };
+    // Claude clients read cache_read/cache_creation to price a turn and to size
+    // their prompt cache. Both spellings are accepted because the Kiro executor
+    // emits the Chat shape and passthrough responses use the nested details form.
+    const cacheRead = data.usage.cache_read_input_tokens
+      ?? data.usage.prompt_tokens_details?.cached_tokens;
+    const cacheCreation = data.usage.cache_creation_input_tokens
+      ?? data.usage.prompt_tokens_details?.cache_creation_tokens;
+    if (typeof cacheRead === "number") state.usage.cache_read_input_tokens = cacheRead;
+    if (typeof cacheCreation === "number") state.usage.cache_creation_input_tokens = cacheCreation;
   }
 
   // First chunk → emit message_start.
@@ -254,6 +263,13 @@ export function kiroToClaudeNonStreaming(data) {
     usage: {
       input_tokens: usage.prompt_tokens || 0,
       output_tokens: usage.completion_tokens || 0,
+      // Same cache preservation as the streaming path above.
+      ...(typeof (usage.cache_read_input_tokens ?? usage.prompt_tokens_details?.cached_tokens) === "number"
+        ? { cache_read_input_tokens: usage.cache_read_input_tokens ?? usage.prompt_tokens_details.cached_tokens }
+        : {}),
+      ...(typeof (usage.cache_creation_input_tokens ?? usage.prompt_tokens_details?.cache_creation_tokens) === "number"
+        ? { cache_creation_input_tokens: usage.cache_creation_input_tokens ?? usage.prompt_tokens_details.cache_creation_tokens }
+        : {}),
     },
   };
 }

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -5,7 +5,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { buildChunk } from "../concerns/chunk.js";
-import { buildUsage } from "../concerns/usage.js";
+import { buildUsage, toResponsesUsage } from "../concerns/usage.js";
 import { fallbackToolCallId } from "../concerns/toolCall.js";
 import { reasoningDelta, extractReasoningText } from "../concerns/reasoning.js";
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM, OPENAI_FINISH, MODEL_FALLBACK } from "../schema/index.js";
@@ -368,16 +368,26 @@ function closeToolCall(state, emit, idx) {
 function sendCompleted(state, emit) {
   if (!state.completedSent) {
     state.completedSent = true;
+    const response = {
+      id: state.responseId,
+      object: "response",
+      created_at: state.created,
+      status: "completed",
+      background: false,
+      error: null
+    };
+    // Responses-API clients size their context from response.completed and
+    // compact their history once it nears the model window. On a passthrough
+    // route the upstream supplies this field; on a pivot (e.g.
+    // openai-responses -> claude) we synthesize the event ourselves, so it has
+    // to be filled in here or the client sees every turn as costing zero
+    // tokens, never compacts, and grows until the upstream rejects the request
+    // with context_length_exceeded.
+    const usage = toResponsesUsage(state.usage);
+    if (usage) response.usage = usage;
     emit("response.completed", {
       type: "response.completed",
-      response: {
-        id: state.responseId,
-        object: "response",
-        created_at: state.created,
-        status: "completed",
-        background: false,
-        error: null
-      }
+      response
     });
   }
 }

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -1,4 +1,5 @@
 import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
+import { setRoutingMeta } from "../services/routingMeta.js";
 
 /**
  * Build OpenAI-compatible error response body
@@ -95,13 +96,18 @@ export async function parseUpstreamError(response, executor = null) {
  * @param {number} [resetsAtMs] - Optional precise cooldown expiry (ms epoch) for provider-specific quota errors
  * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number }}
  */
-export function createErrorResult(statusCode, message, resetsAtMs) {
+export function createErrorResult(statusCode, message, resetsAtMs, errorKind = null) {
+  const response = errorResponse(statusCode, message);
+  // Attach internal routing metadata (in-process WeakMap only — never serialized
+  // into headers/body) so combo fallback can read the error kind off the Response.
+  if (errorKind != null) setRoutingMeta(response, { errorKind, status: statusCode });
   return {
     success: false,
     status: statusCode,
     error: message,
     resetsAtMs,
-    response: errorResponse(statusCode, message)
+    errorKind,
+    response
   };
 }
 

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -22,6 +22,24 @@ const STREAM_MODE = {
   PASSTHROUGH: "passthrough" // No translation, normalize output, extract usage
 };
 
+function getGeminiFamilyParts(chunk) {
+  const parts = chunk?.response?.candidates?.[0]?.content?.parts
+    || chunk?.candidates?.[0]?.content?.parts;
+  return Array.isArray(parts) ? parts : [];
+}
+
+function accumulateGeminiFamilyParts(parts, accumulate) {
+  for (const part of parts) {
+    if (part.text && typeof part.text === "string") {
+      accumulate(part.text, part.thought === true);
+    }
+  }
+}
+
+function hasGeminiFamilyFinishReason(chunk) {
+  return !!(chunk?.response?.candidates?.[0]?.finishReason || chunk?.candidates?.[0]?.finishReason);
+}
+
 /**
  * Create unified SSE transform stream
  * @param {object} options
@@ -75,6 +93,32 @@ export function createSSEStream(options = {}) {
   let openAIResponsesTerminalSeen = false;
   let openAIResponsesDoneSent = false;
   let streamDoneSent = false;  // track duplicate [DONE] across transform + flush
+  let completionRecorded = false;
+
+  const recordStreamCompletion = (currentUsage) => {
+    if (completionRecorded) return currentUsage;
+    let finalUsage = currentUsage;
+
+    if (!hasValidUsage(finalUsage) && totalContentLength > 0) {
+      finalUsage = estimateUsage(body, totalContentLength, mode === STREAM_MODE.PASSTHROUGH ? FORMATS.OPENAI : sourceFormat);
+    }
+
+    if (hasValidUsage(finalUsage)) {
+      logUsage(mode === STREAM_MODE.TRANSLATE ? (state?.provider || targetFormat) : provider, finalUsage, model, connectionId, apiKey);
+    } else {
+      appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
+    }
+
+    if (onStreamComplete) {
+      onStreamComplete({
+        content: accumulatedContent,
+        thinking: accumulatedThinking
+      }, finalUsage, ttftAt);
+    }
+
+    completionRecorded = true;
+    return finalUsage;
+  };
 
   return new TransformStream({
     transform(chunk, controller) {
@@ -163,6 +207,15 @@ export function createSSEStream(options = {}) {
                 accumulatedThinking += reasoning;
               }
 
+              accumulateGeminiFamilyParts(getGeminiFamilyParts(parsed), (text, isThought) => {
+                totalContentLength += text.length;
+                if (isThought) {
+                  accumulatedThinking += text;
+                } else {
+                  accumulatedContent += text;
+                }
+              });
+
               const extracted = extractUsage(parsed);
               if (extracted) {
                 usage = mergeUsage(usage, extracted);
@@ -183,6 +236,10 @@ export function createSSEStream(options = {}) {
               } else if (idFixed || fieldsInjected) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
+              }
+
+              if (isFinishChunk || hasGeminiFamilyFinishReason(parsed)) {
+                usage = recordStreamCompletion(usage);
               }
             } catch {
               // Skip non-JSON data lines silently — don't forward garbage to clients.
@@ -266,24 +323,23 @@ export function createSSEStream(options = {}) {
           accumulatedThinking += parsed.choices[0].delta.reasoning_content;
         }
         
-        // Gemini format
-        if (parsed.candidates?.[0]?.content?.parts) {
-          for (const part of parsed.candidates[0].content.parts) {
-            if (part.text && typeof part.text === "string") {
-              totalContentLength += part.text.length;
-              // Check if this is thinking content
-              if (part.thought === true) {
-                accumulatedThinking += part.text;
-              } else {
-                accumulatedContent += part.text;
-              }
-            }
+        // Gemini-family format (Gemini/Vertex direct and Antigravity wrapped)
+        accumulateGeminiFamilyParts(getGeminiFamilyParts(parsed), (text, isThought) => {
+          totalContentLength += text.length;
+          if (isThought) {
+            accumulatedThinking += text;
+          } else {
+            accumulatedContent += text;
           }
-        }
+        });
 
         // Extract usage
         const extracted = extractUsage(parsed);
         if (extracted) state.usage = mergeUsage(state.usage, extracted); // Keep original usage for logging
+
+        if (hasGeminiFamilyFinishReason(parsed)) {
+          state.usage = recordStreamCompletion(state.usage);
+        }
 
         // Responses same-format passthrough: re-emit with original event framing
         if (keepsOpenAIResponsesFormat && openAIResponsesEventName) {
@@ -359,11 +415,7 @@ export function createSSEStream(options = {}) {
             usage = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
           }
 
-          if (hasValidUsage(usage)) {
-            logUsage(provider, usage, model, connectionId, apiKey);
-          } else {
-            appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
-          }
+          usage = recordStreamCompletion(usage);
           
           // IMPORTANT: In passthrough mode we still must terminate the SSE stream.
           // Some clients (e.g. OpenClaw) expect the OpenAI-style sentinel:
@@ -377,12 +429,6 @@ export function createSSEStream(options = {}) {
             controller.enqueue(sharedEncoder.encode(doneOutput));
           }
 
-          if (onStreamComplete) {
-            onStreamComplete({
-              content: accumulatedContent,
-              thinking: accumulatedThinking
-            }, usage, ttftAt);
-          }
           return;
         }
 
@@ -448,18 +494,7 @@ export function createSSEStream(options = {}) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);
         }
 
-        if (hasValidUsage(state?.usage)) {
-          logUsage(state.provider || targetFormat, state.usage, model, connectionId, apiKey);
-        } else {
-          appendRequestLog({ model, provider, connectionId, tokens: null, status: "200 OK" }).catch(() => { });
-        }
-        
-        if (onStreamComplete) {
-          onStreamComplete({
-            content: accumulatedContent,
-            thinking: accumulatedThinking
-          }, state?.usage, ttftAt);
-        }
+        state.usage = recordStreamCompletion(state?.usage);
       } catch (error) {
         console.log("Error in flush:", error);
       }

--- a/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CodexToolCard.js
@@ -57,7 +57,7 @@ export default function CodexToolCard({ tool, isExpanded, onToggle, baseUrl, api
       if (modelMatch) setSelectedModel(modelMatch[1]);
 
       // Parse subagent settings
-      const subagentModelMatch = codexStatus.config.match(/\[agents\.subagent\]\s*\n\s*model\s*=\s*"([^"]+)"/m);
+      const subagentModelMatch = codexStatus.config.match(/\[agents\.subagent\][\s\S]*?^model\s*=\s*"([^"]+)"/m);
       if (subagentModelMatch) setSubagentModel(subagentModelMatch[1]);
     }
   }, [codexStatus]);
@@ -173,6 +173,7 @@ base_url = "${getEffectiveBaseUrl()}"
 wire_api = "responses"
 
 [agents.subagent]
+description = "Fast subagent for codebase exploration"
 model = "${effectiveSubagentModel}"
 `;
 

--- a/src/app/(dashboard)/dashboard/profile/SkipRulesModal.js
+++ b/src/app/(dashboard)/dashboard/profile/SkipRulesModal.js
@@ -1,0 +1,311 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button, Select, Input, SegmentedControl, Toggle } from "@/shared/components";
+import Modal from "@/shared/components/Modal";
+import { cn } from "@/shared/utils/cn";
+import { AI_PROVIDERS } from "@/shared/constants/config";
+import { ruleToRow, rowToRule, mergeProviderOptions } from "./skipRulesLogic.js";
+
+// Suggested error codes for the datalist (from open-sse errorConfig status map).
+const SUGGESTED_STATUSES = [400, 401, 402, 403, 404, 406, 408, 429, 500, 502, 503, 504];
+
+// How to match: an HTTP failure (status and/or body text) or a transport error kind.
+const MATCH_MODES = [
+  { value: "http", label: "HTTP" },
+  { value: "kind", label: "Transport" },
+];
+
+const KIND_OPTIONS = [
+  { value: "connect_timeout", label: "connect_timeout" },
+  { value: "network", label: "network" },
+];
+
+// Short labels so the two segments never clip inside the control.
+const ACTION_OPTIONS = [
+  { value: "skip", label: "Skip" },
+  { value: "retry", label: "Retry" },
+];
+
+// Turn the shared Input/Select into a *real* field on the card. The shared
+// components hardcode `bg-surface-2 border-transparent rounded-[10px] py-2.5`
+// and cn() is a plain string-join (NOT tailwind-merge), so overriding those
+// exact props needs `!` to win. Only the overridden props carry `!`:
+//   bg-surface-2 → !bg-bg   (bg-bg = var(--color-bg), the real contrasting token;
+//                            `bg-background` does NOT exist in this theme)
+//   border-transparent → !border-border   (resting border)
+//   rounded-[10px] → !rounded-lg           (app-standard radius)
+//   py-2.5 → !py-0 + h-10                  (fixed 40px height; h-10 not set by
+//                                           the component so it needs no `!`)
+// hover carries `!` because it must beat the `!border-border` base on hover.
+// Focus ring is already provided by the shared component (focus:ring-2).
+const FIELD_CLS = "h-10 !py-0 !bg-bg !border-border !rounded-lg hover:!border-brand-500/60";
+
+// Small fixed label above each field (12px), so placeholders aren't the only label.
+function Field({ label, children, className }) {
+  return (
+    <div className={cn("flex flex-col gap-1 min-w-0", className)}>
+      {label && <span className="text-xs text-text-muted leading-none">{label}</span>}
+      {children}
+    </div>
+  );
+}
+
+function emptyRule() {
+  return { provider: "", matchMode: "http", status: "", contains: "", kind: "connect_timeout", action: "skip", headerTimeoutMs: "", sweep: false };
+}
+
+export default function SkipRulesModal({ open, onClose, onSaved }) {
+  const [rows, setRows] = useState([]);
+  const [providerOpts, setProviderOpts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [rowErrors, setRowErrors] = useState({});
+  const [expanded, setExpanded] = useState({}); // UI-only: which rows show advanced options
+
+  // Provider dropdown = static registry (AI_PROVIDERS) + dynamic compatible nodes
+  // (/api/provider-nodes) so user-created providers like anthropic-compatible-<uuid> appear.
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError("");
+    Promise.all([
+      fetch("/api/settings", { cache: "no-store" }).then(r => r.ok ? r.json() : {}),
+      fetch("/api/provider-nodes", { cache: "no-store" }).then(r => r.ok ? r.json() : { nodes: [] }).catch(() => ({ nodes: [] })),
+    ]).then(([settings, nodesData]) => {
+      const rules = Array.isArray(settings.providerSkipRules) ? settings.providerSkipRules : [];
+      setRows(rules.map(ruleToRow));
+      setProviderOpts(mergeProviderOptions(AI_PROVIDERS, nodesData.nodes));
+    }).finally(() => setLoading(false));
+  }, [open]);
+
+  const updateRow = (i, patch) => {
+    setRows(rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+    setRowErrors(prev => { const next = { ...prev }; delete next[i]; return next; });
+  };
+  const addRow = () => setRows([...rows, emptyRule()]);
+  const removeRow = (i) => setRows(rows.filter((_, idx) => idx !== i));
+  const toggleExpanded = (i) => setExpanded(prev => ({ ...prev, [i]: !prev[i] }));
+
+  const save = async () => {
+    setError("");
+    // Validate every row up front. Flag the exact rows that fail instead of
+    // silently dropping incomplete/invalid ones on save.
+    const providerSkipRules = [];
+    const errs = {};
+    rows.forEach((row, i) => {
+      const { rule, error: rowErr } = rowToRule(row);
+      if (rowErr) errs[i] = rowErr;
+      else providerSkipRules.push(rule);
+    });
+    if (Object.keys(errs).length > 0) {
+      setRowErrors(errs);
+      setError(`Có ${Object.keys(errs).length} dòng chưa hợp lệ — sửa các dòng được đánh dấu.`);
+      return;
+    }
+    setRowErrors({});
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerSkipRules }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Failed to save");
+        return;
+      }
+      onSaved?.(providerSkipRules);
+      onClose?.();
+    } catch (e) {
+      setError(e.message || "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Compact footer: the Modal footer bar is a separate flow row below the
+  // scrollable body (single scroll region, never overlaps a rule). -my-2.5
+  // trims the bar's hardcoded p-6 to ~14px vertical without touching Modal.
+  const footer = (
+    <div className="flex items-center gap-3 w-full -my-2.5">
+      {error && <div className="mr-auto text-xs text-red-500">{error}</div>}
+      <div className="ml-auto flex items-center gap-2">
+        <Button size="sm" variant="ghost" onClick={onClose} disabled={saving}>Hủy</Button>
+        <Button size="sm" variant="primary" onClick={save} loading={saving}>Lưu</Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Modal
+      isOpen={open}
+      onClose={onClose}
+      title="Skip-error rules"
+      size="lg"
+      className="!max-w-[800px] w-full"
+      footer={footer}
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-xs text-text-muted leading-relaxed">
+          Khi provider trả lỗi khớp rule: <b>Skip</b> = bỏ account, nhảy backup ngay (không cooldown) ·
+          <b> Retry</b> = gọi lại account. Điền status và/hoặc text (có cả hai thì phải khớp cả hai).
+        </p>
+
+        {loading ? (
+          <div className="text-sm text-text-muted">Loading…</div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {/* Shared suggestions for every HTTP-status input (list="skip-rule-status-suggestions"). */}
+            <datalist id="skip-rule-status-suggestions">
+              {SUGGESTED_STATUSES.map(s => (
+                <option key={s} value={s} />
+              ))}
+            </datalist>
+            {rows.length === 0 && (
+              <div className="text-sm text-text-muted italic py-2">Chưa có quy tắc nào. Bấm &quot;Thêm quy tắc&quot; để bắt đầu.</div>
+            )}
+            {rows.map((row, i) => {
+              const showAdvanced = row.action === "skip" || (row.matchMode === "kind" && row.kind === "connect_timeout");
+              return (
+              <div key={i} className={cn("px-3 py-2.5 border rounded-lg bg-surface-2", rowErrors[i] ? "border-red-500" : "border-border")}>
+                {/* Responsive main row:
+                    mobile  → 1 col, everything stacked
+                    md      → 2 cols × 2 rows  (Provider | Điều kiện  /  Action | Xóa)
+                    lg      → 1 row: Provider | Điều kiện | Action | Xóa */}
+                <div className="grid gap-2 items-end grid-cols-1 md:grid-cols-[140px_minmax(0,1fr)] lg:grid-cols-[minmax(120px,150px)_minmax(280px,1fr)_auto_auto]">
+                  {/* 1 · Provider */}
+                  <Field label="Provider">
+                    <Select
+                      options={providerOpts}
+                      value={row.provider}
+                      onChange={(e) => updateRow(i, { provider: e.target.value })}
+                      placeholder="Chọn provider"
+                      selectClassName={FIELD_CLS}
+                      aria-label="Provider"
+                    />
+                  </Field>
+
+                  {/* 2 · Điều kiện: Kiểu lỗi + (Status + Text) | (Loại transport) */}
+                  <div className="flex flex-wrap gap-2 items-end min-w-0">
+                    <Field label="Kiểu lỗi" className="w-[104px] shrink-0">
+                      <Select
+                        options={MATCH_MODES}
+                        value={row.matchMode}
+                        onChange={(e) => updateRow(i, { matchMode: e.target.value })}
+                        selectClassName={FIELD_CLS}
+                        aria-label="Kiểu lỗi"
+                      />
+                    </Field>
+                    {row.matchMode === "http" ? (
+                      <>
+                        <Field label="HTTP status" className="w-[92px] shrink-0">
+                          <Input
+                            type="number"
+                            list="skip-rule-status-suggestions"
+                            value={row.status}
+                            onChange={(e) => updateRow(i, { status: e.target.value })}
+                            placeholder="mọi mã"
+                            inputClassName={FIELD_CLS}
+                            title="HTTP status — để trống = mọi mã lỗi"
+                            aria-label="HTTP status"
+                          />
+                        </Field>
+                        <Field label="Text chứa" className="flex-1 min-w-[120px]">
+                          <Input
+                            value={row.contains}
+                            onChange={(e) => updateRow(i, { contains: e.target.value })}
+                            placeholder="tùy chọn — vd: overloaded"
+                            inputClassName={FIELD_CLS}
+                            title="Text trong body lỗi — điền để lọc chắc hơn (khớp cả mã + text)"
+                            aria-label="Text chứa"
+                          />
+                        </Field>
+                      </>
+                    ) : (
+                      <Field label="Loại transport" className="flex-1 min-w-[140px]">
+                        <Select
+                          options={KIND_OPTIONS}
+                          value={row.kind}
+                          onChange={(e) => updateRow(i, { kind: e.target.value })}
+                          selectClassName={FIELD_CLS}
+                          aria-label="Loại lỗi transport"
+                        />
+                      </Field>
+                    )}
+                  </div>
+
+                  {/* 3 · Action — one segmented control; contrast root vs card via !bg-bg + border */}
+                  <SegmentedControl
+                    size="md"
+                    options={ACTION_OPTIONS}
+                    value={row.action}
+                    onChange={(v) => updateRow(i, v === "retry" ? { action: v, sweep: false } : { action: v })}
+                    className="!bg-bg border border-border"
+                  />
+
+                  {/* 4 · Xóa */}
+                  <div className="flex justify-start md:justify-end lg:justify-start">
+                    <Button size="sm" variant="ghost" icon="delete" onClick={() => removeRow(i)} title="Xóa quy tắc" aria-label="Xóa quy tắc" />
+                  </div>
+                </div>
+
+                {rowErrors[i] && (
+                  <div className="mt-1.5 text-xs text-red-500">{rowErrors[i]}</div>
+                )}
+
+                {/* Advanced options — collapsed by default; only when relevant */}
+                {showAdvanced && (
+                  <div className="mt-1.5">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(i)}
+                      className="flex items-center gap-1 text-xs text-text-muted hover:text-text-main transition-colors"
+                    >
+                      <span className={cn("material-symbols-outlined text-[16px] transition-transform", expanded[i] && "rotate-180")}>expand_more</span>
+                      Tùy chọn nâng cao
+                    </button>
+                    {expanded[i] && (
+                      <div className="mt-2 flex flex-col gap-2.5 pl-1">
+                        {row.action === "skip" && (
+                          <Toggle
+                            checked={!!row.sweep}
+                            onChange={(v) => updateRow(i, { sweep: v })}
+                            label="Quét lại toàn pool khi hết account"
+                            description="Cho lỗi capacity thoáng qua — thử lại tất cả account thêm vài vòng."
+                          />
+                        )}
+                        {row.matchMode === "kind" && row.kind === "connect_timeout" && (
+                          <div className="w-[200px]">
+                            <Field label="Header timeout (ms)">
+                              <Input
+                                type="number"
+                                value={row.headerTimeoutMs}
+                                onChange={(e) => updateRow(i, { headerTimeoutMs: e.target.value })}
+                                placeholder="25000"
+                                inputClassName={FIELD_CLS}
+                                title="Mặc định 60000"
+                                aria-label="Header timeout (ms)"
+                              />
+                            </Field>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+              );
+            })}
+
+            <div className="mt-0.5">
+              <Button size="sm" variant="ghost" icon="add" onClick={addRow}>Thêm quy tắc</Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Card, Button, Toggle, Input } from "@/shared/components";
 import Modal, { ConfirmModal } from "@/shared/components/Modal";
 import LanguageSwitcher from "@/shared/components/LanguageSwitcher";
+import SkipRulesModal from "./SkipRulesModal";
 import { useTheme } from "@/shared/hooks/useTheme";
 import { cn } from "@/shared/utils/cn";
 import { APP_CONFIG } from "@/shared/constants/config";
@@ -48,6 +49,7 @@ export default function ProfilePage() {
   const [oidcTestStatus, setOidcTestStatus] = useState({ type: "", message: "" });
   const [oidcRedirectUri, setOidcRedirectUri] = useState("/api/auth/oidc/callback");
   const [oidcExpanded, setOidcExpanded] = useState(false);
+  const [skipRulesOpen, setSkipRulesOpen] = useState(false);
   const importFileRef = useRef(null);
   const [proxyForm, setProxyForm] = useState({
     outboundProxyEnabled: false,
@@ -237,6 +239,21 @@ export default function ProfilePage() {
       if (res.ok) {
         setSettings(prev => ({ ...prev, fallbackStrategy: strategy }));
       }
+    } catch (err) {
+      console.error("Failed to update settings:", err);
+    }
+  };
+
+  const updateMaxTransportAttempts = async (value) => {
+    const n = parseInt(value, 10);
+    if (!Number.isInteger(n) || n < 1 || n > 5) return;
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxTransportAttempts: n }),
+      });
+      if (res.ok) setSettings(prev => ({ ...prev, maxTransportAttempts: n }));
     } catch (err) {
       console.error("Failed to update settings:", err);
     }
@@ -1006,6 +1023,45 @@ export default function ProfilePage() {
           </div>
         </Card>
 
+        {/* Reliability: retries + skip-error rules */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-amber-500/10 text-amber-500 shrink-0">
+              <span className="material-symbols-outlined text-[20px]">bolt</span>
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-text-main">Reliability & Fail-fast</h2>
+              <p className="text-sm text-text-muted">Số lần gọi lại tối đa và cách xử lý lỗi từng provider.</p>
+            </div>
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-3 flex-wrap">
+              <span className="text-sm text-text-main font-medium">Max transport attempts</span>
+              <input
+                type="number"
+                min={1}
+                max={5}
+                value={settings.maxTransportAttempts ?? 2}
+                onChange={(e) => setSettings(prev => ({ ...prev, maxTransportAttempts: e.target.value }))}
+                onBlur={(e) => updateMaxTransportAttempts(e.target.value)}
+                className="w-16 px-2 py-1 text-sm border border-border rounded-md bg-background focus:outline-none focus:border-primary"
+              />
+              <span className="text-xs text-text-muted">Số lần gọi tối đa mỗi account (gồm lần đầu). Mặc định 2.</span>
+            </div>
+            <div className="flex items-center justify-between gap-3 pt-3 border-t border-border">
+              <div>
+                <div className="text-sm text-text-main font-medium">Skip-error rules</div>
+                <div className="text-xs text-text-muted">
+                  Khai báo provider + mã lỗi để bỏ qua nhanh (skip) hoặc gọi lại (retry).
+                </div>
+              </div>
+              <Button size="sm" variant="secondary" icon="tune" onClick={() => setSkipRulesOpen(true)}>
+                Cấu hình
+              </Button>
+            </div>
+          </div>
+        </Card>
+
         {/* Network */}
         <Card>
           <div className="flex items-center gap-3 mb-4">
@@ -1177,6 +1233,12 @@ export default function ProfilePage() {
           autoFocus
         />
       </Modal>
+
+      <SkipRulesModal
+        open={skipRulesOpen}
+        onClose={() => setSkipRulesOpen(false)}
+        onSaved={(rules) => setSettings(prev => ({ ...prev, providerSkipRules: rules }))}
+      />
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/profile/skipRulesLogic.js
+++ b/src/app/(dashboard)/dashboard/profile/skipRulesLogic.js
@@ -1,0 +1,84 @@
+// Pure, framework-free helpers for the Skip-rules modal. Extracted from
+// SkipRulesModal.js so they can be unit-tested without a JSX/React harness
+// (the vitest env is "node" and cannot parse JSX imported from a .js file).
+
+// Row model (editable form state):
+//   { provider, matchMode: "http" | "kind",
+//     status, contains,          // used when matchMode === "http" (either/both)
+//     kind,                      // used when matchMode === "kind"
+//     action, headerTimeoutMs, sweep }
+// Stored rule: { provider, match: { status?, contains?, kind? }, action, headerTimeoutMs?, sweep? }
+// A rule's match may carry any combination of status/contains/kind (AND at runtime).
+// sweep (skip only) asks the account loop to re-try the whole pool after exhaustion.
+
+// Convert stored rule → editable row.
+export function ruleToRow(rule) {
+  const m = rule.match || {};
+  const matchMode = m.kind != null ? "kind" : "http";
+  return {
+    provider: rule.provider || "",
+    matchMode,
+    status: m.status != null ? String(m.status) : "",
+    contains: m.contains != null ? String(m.contains) : "",
+    kind: m.kind != null ? String(m.kind) : "connect_timeout",
+    action: rule.action === "retry" ? "retry" : "skip",
+    headerTimeoutMs: rule.headerTimeoutMs != null ? String(rule.headerTimeoutMs) : "",
+    sweep: rule.sweep === true,
+  };
+}
+
+// Convert an editable row → stored rule. Returns { rule } when valid, or
+// { error } with a human-readable reason so the caller can flag the exact row
+// instead of silently dropping it.
+export function rowToRule(row) {
+  if (!row.provider) return { error: "Chọn provider" };
+  const match = {};
+
+  if (row.matchMode === "kind") {
+    if (!row.kind) return { error: "Chọn loại lỗi (error kind)" };
+    match.kind = row.kind;
+  } else {
+    // HTTP mode: status and/or contains — at least one required.
+    const hasStatus = row.status != null && String(row.status).trim() !== "";
+    const hasContains = row.contains != null && String(row.contains).trim() !== "";
+    if (!hasStatus && !hasContains) {
+      return { error: "Nhập HTTP status hoặc text (ít nhất một)" };
+    }
+    if (hasStatus) {
+      const n = parseInt(row.status, 10);
+      if (!Number.isInteger(n) || n < 100 || n > 599) return { error: "HTTP status phải là số 100–599" };
+      match.status = n;
+    }
+    if (hasContains) {
+      const c = String(row.contains).trim();
+      if (c.length > 200) return { error: "Text quá dài (tối đa 200 ký tự)" };
+      match.contains = c;
+    }
+  }
+
+  const rule = { provider: row.provider, match, action: row.action === "retry" ? "retry" : "skip" };
+  if (row.matchMode === "kind" && row.kind === "connect_timeout" && row.headerTimeoutMs) {
+    const t = parseInt(row.headerTimeoutMs, 10);
+    if (!Number.isInteger(t) || t < 1000 || t > 120000) return { error: "Header timeout phải là số 1000–120000ms" };
+    rule.headerTimeoutMs = t;
+  }
+  // sweep (re-try whole pool after exhaustion) is only meaningful for skip.
+  if (rule.action === "skip" && row.sweep === true) rule.sweep = true;
+  return { rule };
+}
+
+// Merge the static provider registry (AI_PROVIDERS) with dynamic compatible
+// nodes from /api/provider-nodes so user-created providers (anthropic-compatible-<uuid>)
+// appear in the dropdown. Deduped by id, static entries win.
+export function mergeProviderOptions(aiProviders, nodes) {
+  const staticOpts = Object.values(aiProviders || {})
+    .filter(p => p && !p.hidden)
+    .map(p => ({ value: p.id, label: p.name || p.id }));
+  const nodeOpts = (nodes || []).map(n => ({ value: n.id, label: `${n.name || n.id} (${n.type || "custom"})` }));
+  const seen = new Set();
+  return [...staticOpts, ...nodeOpts].filter(o => {
+    if (seen.has(o.value)) return false;
+    seen.add(o.value);
+    return true;
+  });
+}

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -8,7 +8,7 @@ import { planBulkAdd } from "@/shared/utils/bulkAdd";
 
 const BULK_PLACEHOLDER = `name1|sk-key1\nname2|sk-key2\nsk-key-only-auto-named`;
 
-export default function AddApiKeyModal({ isOpen, provider, providerName, isCompatible, isAnthropic, authType, authHint, website, proxyPools, error, existingNames, onSave, onBulkDone, onClose }) {
+export default function AddApiKeyModal({ isOpen, provider, providerName, isCompatible, isAnthropic, providerNode, authType, authHint, website, proxyPools, error, existingNames, onSave, onBulkDone, onClose }) {
   const NONE_PROXY_POOL_VALUE = "__none__";
   const isOllamaLocal = provider === "ollama-local";
   const isCookie = authType === "cookie";
@@ -53,6 +53,16 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   const [bulkResult, setBulkResult] = useState(null); // { success, failed }
 
   const buildProviderSpecificData = () => {
+    if (isCompatible && providerNode) {
+      return {
+        prefix: providerNode.prefix,
+        ...(providerNode.apiType ? { apiType: providerNode.apiType } : {}),
+        baseUrl: providerNode.baseUrl,
+        nodeName: providerNode.name,
+        clientIdentityProfile: providerNode.clientIdentityProfile || "default",
+        clientIdentityHeaders: providerNode.clientIdentityHeaders || {},
+      };
+    }
     if (isOllamaLocal && formData.ollamaHostUrl.trim()) {
       return { baseUrl: formData.ollamaHostUrl.trim() };
     }
@@ -74,12 +84,21 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   };
 
   const handleValidate = async () => {
+    if (isCompatible && !formData.defaultModel.trim()) {
+      setValidationResult("failed");
+      return;
+    }
     setValidating(true);
     try {
       const res = await fetch("/api/providers/validate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider, apiKey: formData.apiKey, providerSpecificData: buildProviderSpecificData() }),
+        body: JSON.stringify({
+          provider,
+          apiKey: formData.apiKey,
+          defaultModel: isCompatible ? formData.defaultModel.trim() : undefined,
+          providerSpecificData: buildProviderSpecificData(),
+        }),
       });
       const data = await res.json();
       setValidationResult(data.valid ? "success" : "failed");
@@ -108,7 +127,12 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         const res = await fetch("/api/providers/validate", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ provider, apiKey: formData.apiKey, providerSpecificData: buildProviderSpecificData() }),
+          body: JSON.stringify({
+            provider,
+            apiKey: formData.apiKey,
+            defaultModel: isCompatible ? formData.defaultModel.trim() : undefined,
+            providerSpecificData: buildProviderSpecificData(),
+          }),
         });
         const data = await res.json();
         isValid = !!data.valid;
@@ -412,6 +436,14 @@ AddApiKeyModal.propTypes = {
   providerName: PropTypes.string,
   isCompatible: PropTypes.bool,
   isAnthropic: PropTypes.bool,
+  providerNode: PropTypes.shape({
+    name: PropTypes.string,
+    prefix: PropTypes.string,
+    apiType: PropTypes.string,
+    baseUrl: PropTypes.string,
+    clientIdentityProfile: PropTypes.string,
+    clientIdentityHeaders: PropTypes.object,
+  }),
   authType: PropTypes.string,
   authHint: PropTypes.string,
   website: PropTypes.string,

--- a/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/EditCompatibleNodeModal.js
@@ -4,12 +4,60 @@ import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Button, Badge, Input, Modal, Select } from "@/shared/components";
 
+const CLIENT_IDENTITY_OPTIONS = [
+  { value: "default", label: "Default" },
+  { value: "claude-cli", label: "Claude CLI" },
+  { value: "codex-cli", label: "Codex CLI" },
+  { value: "openclaw", label: "OpenClaw" },
+  { value: "custom", label: "Custom Headers" },
+];
+
+const BLOCKED_CUSTOM_HEADERS = new Set(["authorization", "x-api-key", "api-key", "cookie"]);
+
+function parseCustomIdentityHeaders(text) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed) return { headers: {} };
+
+  try {
+    let entries;
+    if (trimmed.startsWith("{")) {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { error: "Use a JSON object or Header: value lines." };
+      }
+      entries = Object.entries(parsed);
+    } else {
+      entries = [];
+      for (const line of trimmed.split(/\r?\n/)) {
+        const value = line.trim();
+        if (!value || value.startsWith("#")) continue;
+        const sep = value.indexOf(":");
+        if (sep <= 0) return { error: "Each custom header line must use Header: value." };
+        entries.push([value.slice(0, sep), value.slice(sep + 1)]);
+      }
+    }
+
+    const headers = {};
+    for (const [rawName, rawValue] of entries) {
+      const name = String(rawName || "").trim();
+      const value = String(rawValue || "").trim();
+      if (!name || !value || BLOCKED_CUSTOM_HEADERS.has(name.toLowerCase())) continue;
+      headers[name] = value;
+    }
+    return { headers };
+  } catch {
+    return { error: "Use valid JSON or Header: value lines." };
+  }
+}
+
 export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose, isAnthropic }) {
   const [formData, setFormData] = useState({
     name: "",
     prefix: "",
     apiType: "chat",
     baseUrl: "https://api.openai.com/v1",
+    clientIdentityProfile: "default",
+    clientIdentityHeadersText: "",
   });
   const [saving, setSaving] = useState(false);
   const [checkKey, setCheckKey] = useState("");
@@ -24,6 +72,10 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
         prefix: node.prefix || "",
         apiType: node.apiType || "chat",
         baseUrl: node.baseUrl || (isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"),
+        clientIdentityProfile: node.clientIdentityProfile || "default",
+        clientIdentityHeadersText: node.clientIdentityHeaders
+          ? JSON.stringify(node.clientIdentityHeaders, null, 2)
+          : "",
       });
     }
   }, [node, isAnthropic]);
@@ -35,12 +87,21 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
 
   const handleSubmit = async () => {
     if (!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim()) return;
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult("failed");
+      return;
+    }
     setSaving(true);
     try {
       const payload = {
         name: formData.name,
         prefix: formData.prefix,
         baseUrl: formData.baseUrl,
+        clientIdentityProfile: formData.clientIdentityProfile,
+        clientIdentityHeaders: customHeaders.headers,
       };
       if (!isAnthropic) {
         payload.apiType = formData.apiType;
@@ -52,6 +113,13 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
   };
 
   const handleValidate = async () => {
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult("failed");
+      return;
+    }
     setValidating(true);
     try {
       const res = await fetch("/api/provider-nodes/validate", {
@@ -61,7 +129,9 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
           baseUrl: formData.baseUrl,
           apiKey: checkKey,
           type: isAnthropic ? "anthropic-compatible" : "openai-compatible",
-          modelId: checkModelId.trim() || undefined
+          modelId: checkModelId.trim() || undefined,
+          clientIdentityProfile: formData.clientIdentityProfile,
+          clientIdentityHeaders: customHeaders.headers,
         }),
       });
       const data = await res.json();
@@ -107,6 +177,26 @@ export default function EditCompatibleNodeModal({ isOpen, node, onSave, onClose,
           placeholder={isAnthropic ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1"}
           hint={`Use the base URL (ending in /v1) for your ${isAnthropic ? "Anthropic" : "OpenAI"}-compatible API.`}
         />
+        <Select
+          label="Client Identity"
+          options={CLIENT_IDENTITY_OPTIONS}
+          value={formData.clientIdentityProfile}
+          onChange={(e) => setFormData({ ...formData, clientIdentityProfile: e.target.value })}
+          hint="Optional. Adds client fingerprint headers for compatible gateways."
+        />
+        {formData.clientIdentityProfile === "custom" && (
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Custom Headers</label>
+            <textarea
+              value={formData.clientIdentityHeadersText}
+              onChange={(e) => setFormData({ ...formData, clientIdentityHeadersText: e.target.value })}
+              placeholder={'{\n  "User-Agent": "custom/1.0"\n}'}
+              rows={5}
+              className="w-full resize-y rounded-[10px] border border-transparent bg-surface-2 px-3 py-2.5 text-[16px] text-text-main placeholder-text-muted/70 transition-all duration-150 focus:border-brand-500/40 focus:outline-none focus:ring-2 focus:ring-brand-500/30 sm:text-sm"
+            />
+            <p className="text-xs text-text-muted">JSON object or Header: value lines. Auth headers are ignored.</p>
+          </div>
+        )}
         <div className="flex gap-2">
           <Input
             label="API Key (for Check)"
@@ -154,6 +244,8 @@ EditCompatibleNodeModal.propTypes = {
     prefix: PropTypes.string,
     apiType: PropTypes.string,
     baseUrl: PropTypes.string,
+    clientIdentityProfile: PropTypes.string,
+    clientIdentityHeaders: PropTypes.object,
   }),
   onSave: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -1728,6 +1728,7 @@ export default function ProviderDetailPage() {
         providerName={providerInfo.name}
         isCompatible={isCompatible}
         isAnthropic={isAnthropicCompatible}
+        providerNode={providerNode}
         authType={providerInfo?.authType}
         authHint={providerInfo?.authHint}
         website={providerInfo?.website}

--- a/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
+++ b/src/app/(dashboard)/dashboard/providers/components/AddCompatibleModal.js
@@ -34,6 +34,52 @@ const API_TYPE_OPTIONS = [
   { value: "responses", label: "Responses API" },
 ];
 
+const CLIENT_IDENTITY_OPTIONS = [
+  { value: "default", label: "Default" },
+  { value: "claude-cli", label: "Claude CLI" },
+  { value: "codex-cli", label: "Codex CLI" },
+  { value: "openclaw", label: "OpenClaw" },
+  { value: "custom", label: "Custom Headers" },
+];
+
+const BLOCKED_CUSTOM_HEADERS = new Set(["authorization", "x-api-key", "api-key", "cookie"]);
+
+function parseCustomIdentityHeaders(text) {
+  const trimmed = String(text || "").trim();
+  if (!trimmed) return { headers: {} };
+
+  try {
+    let entries;
+    if (trimmed.startsWith("{")) {
+      const parsed = JSON.parse(trimmed);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { error: "Use a JSON object or Header: value lines." };
+      }
+      entries = Object.entries(parsed);
+    } else {
+      entries = [];
+      for (const line of trimmed.split(/\r?\n/)) {
+        const value = line.trim();
+        if (!value || value.startsWith("#")) continue;
+        const sep = value.indexOf(":");
+        if (sep <= 0) return { error: "Each custom header line must use Header: value." };
+        entries.push([value.slice(0, sep), value.slice(sep + 1)]);
+      }
+    }
+
+    const headers = {};
+    for (const [rawName, rawValue] of entries) {
+      const name = String(rawName || "").trim();
+      const value = String(rawValue || "").trim();
+      if (!name || !value || BLOCKED_CUSTOM_HEADERS.has(name.toLowerCase())) continue;
+      headers[name] = value;
+    }
+    return { headers };
+  } catch {
+    return { error: "Use valid JSON or Header: value lines." };
+  }
+}
+
 function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
   const config = VARIANT_CONFIG[variant];
   const initialFormData = () => ({
@@ -41,6 +87,8 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
     prefix: "",
     ...(config.hasApiType ? { apiType: "chat" } : {}),
     baseUrl: config.defaultBaseUrl,
+    clientIdentityProfile: "default",
+    clientIdentityHeadersText: "",
   });
 
   const [formData, setFormData] = useState(initialFormData);
@@ -63,6 +111,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
 
   const handleSubmit = async () => {
     if (!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim()) return;
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult({ valid: false, error: customHeaders.error });
+      return;
+    }
     setSubmitting(true);
     try {
       const res = await fetch("/api/provider-nodes", {
@@ -74,6 +129,8 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           ...(config.hasApiType ? { apiType: formData.apiType } : {}),
           baseUrl: formData.baseUrl,
           type: config.type,
+          clientIdentityProfile: formData.clientIdentityProfile,
+          clientIdentityHeaders: customHeaders.headers,
         }),
       });
       const data = await res.json();
@@ -91,6 +148,13 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
   };
 
   const handleValidate = async () => {
+    const customHeaders = formData.clientIdentityProfile === "custom"
+      ? parseCustomIdentityHeaders(formData.clientIdentityHeadersText)
+      : { headers: {} };
+    if (customHeaders.error) {
+      setValidationResult({ valid: false, error: customHeaders.error });
+      return;
+    }
     setValidating(true);
     try {
       const res = await fetch("/api/provider-nodes/validate", {
@@ -101,6 +165,8 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           apiKey: checkKey,
           type: config.type,
           modelId: checkModelId.trim() || undefined,
+          clientIdentityProfile: formData.clientIdentityProfile,
+          clientIdentityHeaders: customHeaders.headers,
         }),
       });
       const data = await res.json();
@@ -165,6 +231,26 @@ function AddCompatibleModal({ variant, isOpen, onClose, onCreated }) {
           placeholder={config.defaultBaseUrl}
           hint={config.baseUrlHint}
         />
+        <Select
+          label="Client Identity"
+          options={CLIENT_IDENTITY_OPTIONS}
+          value={formData.clientIdentityProfile}
+          onChange={(e) => setFormData({ ...formData, clientIdentityProfile: e.target.value })}
+          hint="Optional. Adds client fingerprint headers for compatible gateways."
+        />
+        {formData.clientIdentityProfile === "custom" && (
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium text-text-main">Custom Headers</label>
+            <textarea
+              value={formData.clientIdentityHeadersText}
+              onChange={(e) => setFormData({ ...formData, clientIdentityHeadersText: e.target.value })}
+              placeholder={'{\n  "User-Agent": "custom/1.0"\n}'}
+              rows={5}
+              className="w-full resize-y rounded-[10px] border border-transparent bg-surface-2 px-3 py-2.5 text-[16px] text-text-main placeholder-text-muted/70 transition-all duration-150 focus:border-brand-500/40 focus:outline-none focus:ring-2 focus:ring-brand-500/30 sm:text-sm"
+            />
+            <p className="text-xs text-text-muted">JSON object or Header: value lines. Auth headers are ignored.</p>
+          </div>
+        )}
         <Input
           label="API Key (for Check)"
           type="password"

--- a/src/app/api/cli-tools/codex-settings/config.js
+++ b/src/app/api/cli-tools/codex-settings/config.js
@@ -1,0 +1,6 @@
+export const CODEX_SUBAGENT_DESCRIPTION = "Fast subagent for codebase exploration";
+
+export const buildCodexSubagentRole = (model) => ({
+  description: CODEX_SUBAGENT_DESCRIPTION,
+  model,
+});

--- a/src/app/api/cli-tools/codex-settings/route.js
+++ b/src/app/api/cli-tools/codex-settings/route.js
@@ -7,6 +7,7 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import { parseTOML, stringifyTOML } from "confbox";
+import { buildCodexSubagentRole } from "./config.js";
 
 const execAsync = promisify(exec);
 
@@ -143,9 +144,7 @@ export async function POST(request) {
 
     // Add subagent configuration
     const effectiveSubagentModel = subagentModel || model;
-    setNestedSection(parsed, "agents.subagent", {
-      model: effectiveSubagentModel,
-    });
+    setNestedSection(parsed, "agents.subagent", buildCodexSubagentRole(effectiveSubagentModel));
 
     // Write merged config
     const configContent = stringifyTOML(parsed);

--- a/src/app/api/provider-nodes/[id]/route.js
+++ b/src/app/api/provider-nodes/[id]/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { deleteProviderConnectionsByProvider, deleteProviderNode, getProviderConnections, getProviderNodeById, updateProviderConnection, updateProviderNode } from "@/models";
+import { normalizeClientIdentityData } from "open-sse/shared/clientIdentityHeaders.js";
 
 // PUT /api/provider-nodes/[id] - Update provider node
 export async function PUT(request, { params }) {
@@ -8,6 +9,15 @@ export async function PUT(request, { params }) {
     const body = await request.json();
     const { name, prefix, apiType, baseUrl } = body;
     const node = await getProviderNodeById(id);
+    const isCompatibleNode = node?.type === "openai-compatible" || node?.type === "anthropic-compatible";
+    const hasIdentityUpdate = Object.prototype.hasOwnProperty.call(body, "clientIdentityProfile") ||
+      Object.prototype.hasOwnProperty.call(body, "clientIdentityHeaders");
+    const identityData = isCompatibleNode
+      ? (hasIdentityUpdate ? normalizeClientIdentityData(body) : {
+          clientIdentityProfile: node.clientIdentityProfile || "default",
+          clientIdentityHeaders: node.clientIdentityHeaders || {},
+        })
+      : {};
 
     if (!node) {
       return NextResponse.json({ error: "Provider node not found" }, { status: 404 });
@@ -52,6 +62,7 @@ export async function PUT(request, { params }) {
       name: name.trim(),
       prefix: prefix.trim(),
       baseUrl: sanitizedBaseUrl,
+      ...identityData,
     };
 
     if (node.type === "openai-compatible") {
@@ -69,6 +80,7 @@ export async function PUT(request, { params }) {
           apiType: node.type === "openai-compatible" ? apiType : undefined,
           baseUrl: sanitizedBaseUrl,
           nodeName: updated.name,
+          ...identityData,
         }
       })
     )));

--- a/src/app/api/provider-nodes/route.js
+++ b/src/app/api/provider-nodes/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createProviderNode, getProviderNodes } from "@/models";
 import { OPENAI_COMPATIBLE_PREFIX, ANTHROPIC_COMPATIBLE_PREFIX, CUSTOM_EMBEDDING_PREFIX } from "@/shared/constants/providers";
 import { generateId } from "@/shared/utils";
+import { normalizeClientIdentityData } from "open-sse/shared/clientIdentityHeaders.js";
 
 export const dynamic = "force-dynamic";
 
@@ -46,6 +47,7 @@ export async function POST(request) {
     const nodeType = type || "openai-compatible";
 
     if (nodeType === "openai-compatible") {
+      const identityData = normalizeClientIdentityData(body);
       if (!apiType || !["chat", "responses"].includes(apiType)) {
         return NextResponse.json({ error: "Invalid OpenAI compatible API type" }, { status: 400 });
       }
@@ -57,6 +59,7 @@ export async function POST(request) {
         apiType,
         baseUrl: (baseUrl || OPENAI_COMPATIBLE_DEFAULTS.baseUrl).trim(),
         name: name.trim(),
+        ...identityData,
       });
       return NextResponse.json({ node }, { status: 201 });
     }
@@ -79,6 +82,7 @@ export async function POST(request) {
     }
 
     if (nodeType === "anthropic-compatible") {
+      const identityData = normalizeClientIdentityData(body);
       // Sanitize Base URL: remove trailing slash, and remove trailing /messages if user added it
       // This prevents double-appending /messages at runtime
       let sanitizedBaseUrl = (baseUrl || ANTHROPIC_COMPATIBLE_DEFAULTS.baseUrl).trim().replace(/\/$/, "");
@@ -92,6 +96,7 @@ export async function POST(request) {
         prefix: prefix.trim(),
         baseUrl: sanitizedBaseUrl,
         name: name.trim(),
+        ...identityData,
       });
       return NextResponse.json({ node }, { status: 201 });
     }

--- a/src/app/api/provider-nodes/validate/route.js
+++ b/src/app/api/provider-nodes/validate/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
 import { isLocalRequest } from "@/dashboardGuard";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // Fetch with timeout wrapper
 const fetchWithTimeout = (url, options, timeout = 10000) => {
@@ -55,7 +56,8 @@ const getChatErrorMessage = (status) => {
 export async function POST(request) {
   try {
     const body = await request.json();
-    const { baseUrl, apiKey, type, modelId } = body;
+    const { baseUrl, apiKey, type, modelId, clientIdentityProfile, clientIdentityHeaders } = body;
+    const identity = { clientIdentityProfile, clientIdentityHeaders };
 
     if (!baseUrl || !apiKey) {
       return NextResponse.json({ error: "Base URL and API key required" }, { status: 400 });
@@ -115,11 +117,15 @@ export async function POST(request) {
       const modelsUrl = `${normalizedBase}/models`;
       const res = await fetchWithTimeout(modelsUrl, {
         method: "GET",
-        headers: {
-          "x-api-key": apiKey,
-          "anthropic-version": "2023-06-01",
-          "Authorization": `Bearer ${apiKey}`
-        }
+        headers: mergeClientIdentityHeaders(
+          {},
+          identity,
+          {
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+            "Authorization": `Bearer ${apiKey}`,
+          },
+        ),
       });
 
       if (res.ok) return NextResponse.json({ valid: true });
@@ -133,12 +139,15 @@ export async function POST(request) {
       if (modelId) {
         const chatRes = await fetchWithTimeout(`${normalizedBase}/chat/completions`, {
           method: "POST",
-          headers: {
-            "Authorization": `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-            "anthropic-version": "2023-06-01"
-          },
+          headers: mergeClientIdentityHeaders(
+            { "Content-Type": "application/json" },
+            identity,
+            {
+              "Authorization": `Bearer ${apiKey}`,
+              "x-api-key": apiKey,
+              "anthropic-version": "2023-06-01",
+            },
+          ),
           body: JSON.stringify({
             model: modelId,
             messages: [{ role: "user", content: "ping" }],
@@ -161,7 +170,11 @@ export async function POST(request) {
     // OpenAI Compatible Validation (Default)
     const modelsUrl = `${baseUrl.replace(/\/$/, "")}/models`;
     const res = await fetchWithTimeout(modelsUrl, {
-      headers: { "Authorization": `Bearer ${apiKey}` },
+      headers: mergeClientIdentityHeaders(
+        {},
+        identity,
+        { "Authorization": `Bearer ${apiKey}` },
+      ),
     });
 
     if (res.ok) return NextResponse.json({ valid: true });
@@ -175,10 +188,11 @@ export async function POST(request) {
     if (modelId) {
       const chatRes = await fetchWithTimeout(`${baseUrl.replace(/\/$/, "")}/chat/completions`, {
         method: "POST",
-        headers: {
-          "Authorization": `Bearer ${apiKey}`,
-          "Content-Type": "application/json"
-        },
+        headers: mergeClientIdentityHeaders(
+          { "Content-Type": "application/json" },
+          identity,
+          { "Authorization": `Bearer ${apiKey}` },
+        ),
         body: JSON.stringify({
           model: modelId,
           messages: [{ role: "user", content: "ping" }],

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -11,6 +11,7 @@ import { resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { resolveGrokCliModels } from "open-sse/services/grokCliModels.js";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { resolveCursorModels } from "open-sse/services/cursorModels.js";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 const GEMINI_CLI_MODELS_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 
@@ -456,10 +457,11 @@ export async function GET(request, { params }) {
       const url = `${baseUrl.replace(/\/$/, "")}/models`;
       const response = await fetch(url, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${connection.apiKey}`,
-        },
+        headers: mergeClientIdentityHeaders(
+          { "Content-Type": "application/json" },
+          connection.providerSpecificData || {},
+          { "Authorization": `Bearer ${connection.apiKey}` },
+        ),
       });
 
       if (!response.ok) {
@@ -495,12 +497,17 @@ export async function GET(request, { params }) {
       const url = `${baseUrl}/models`;
       const response = await fetch(url, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": connection.apiKey,
-          "anthropic-version": "2023-06-01",
-          "Authorization": `Bearer ${connection.apiKey}`
-        },
+        headers: mergeClientIdentityHeaders(
+          {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+          },
+          connection.providerSpecificData || {},
+          {
+            "x-api-key": connection.apiKey,
+            "Authorization": `Bearer ${connection.apiKey}`,
+          },
+        ),
       });
 
       if (!response.ok) {

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -18,6 +18,7 @@ import {
   KIMCHI_CONFIG,
 } from "@/lib/oauth/constants/oauth";
 import { buildClineHeaders } from "@/shared/utils/clineAuth";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // OAuth provider test endpoints
 const OAUTH_TEST_CONFIG = {
@@ -471,7 +472,11 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
     if (!modelsBase) return { valid: false, error: "Missing base URL" };
     try {
       const res = await fetchWithConnectionProxy(`${modelsBase.replace(/\/$/, "")}/models`, {
-        headers: { "Authorization": `Bearer ${connection.apiKey}` },
+        headers: mergeClientIdentityHeaders(
+          {},
+          connection.providerSpecificData || {},
+          { "Authorization": `Bearer ${connection.apiKey}` },
+        ),
       }, effectiveProxy);
       return { valid: res.ok, error: res.ok ? null : "Invalid API key or base URL" };
     } catch (err) {
@@ -485,16 +490,20 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
     try {
       modelsBase = modelsBase.replace(/\/$/, "");
       if (modelsBase.endsWith("/messages")) modelsBase = modelsBase.slice(0, -9);
+      if (modelsBase.endsWith("/v1")) modelsBase = modelsBase.slice(0, -3);
       const messagesUrl = `${modelsBase}/v1/messages`;
       const model = connection.defaultModel || "claude-3-haiku-20240307";
       const res = await fetchWithConnectionProxy(messagesUrl, {
         method: "POST",
-        headers: {
-          "x-api-key": connection.apiKey,
-          "anthropic-version": "2023-06-01",
-          "content-type": "application/json",
-          "Authorization": `Bearer ${connection.apiKey}`,
-        },
+        headers: mergeClientIdentityHeaders(
+          { "content-type": "application/json" },
+          connection.providerSpecificData || {},
+          {
+            "x-api-key": connection.apiKey,
+            "anthropic-version": "2023-06-01",
+            "Authorization": `Bearer ${connection.apiKey}`,
+          },
+        ),
         body: JSON.stringify({
           model,
           max_tokens: 1,

--- a/src/app/api/providers/route.js
+++ b/src/app/api/providers/route.js
@@ -138,6 +138,8 @@ export async function POST(request) {
         apiType: node.apiType,
         baseUrl: node.baseUrl,
         nodeName: node.name,
+        clientIdentityProfile: node.clientIdentityProfile || "default",
+        clientIdentityHeaders: node.clientIdentityHeaders || {},
       };
     } else if (isAnthropicCompatibleProvider(provider)) {
       const node = await getProviderNodeById(provider);
@@ -148,6 +150,8 @@ export async function POST(request) {
         prefix: node.prefix,
         baseUrl: node.baseUrl,
         nodeName: node.name,
+        clientIdentityProfile: node.clientIdentityProfile || "default",
+        clientIdentityHeaders: node.clientIdentityHeaders || {},
       };
     } else if (isCustomEmbeddingProvider(provider)) {
       const node = await getProviderNodeById(provider);

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -6,6 +6,7 @@ import { resolveOllamaLocalHost, resolveXiaomiTokenplanBaseUrl, PROVIDERS } from
 import { openaiToCommandCodeRequest } from "open-sse/translator/request/openai-to-commandcode.js";
 import { resolveQoderCredentials, resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { normalizeProviderId } from "@/lib/providerNormalization";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
@@ -105,7 +106,14 @@ export async function POST(request) {
         }
         const modelsUrl = `${node.baseUrl?.replace(/\/$/, "")}/models`;
         const res = await fetch(modelsUrl, {
-          headers: { "Authorization": `Bearer ${apiKey}` },
+          headers: mergeClientIdentityHeaders(
+            { "Content-Type": "application/json" },
+            {
+              clientIdentityProfile: providerSpecificData?.clientIdentityProfile ?? node.clientIdentityProfile,
+              clientIdentityHeaders: providerSpecificData?.clientIdentityHeaders ?? node.clientIdentityHeaders,
+            },
+            { "Authorization": `Bearer ${apiKey}` },
+          ),
         });
         isValid = res.ok;
         return NextResponse.json({
@@ -155,18 +163,29 @@ export async function POST(request) {
         if (normalizedBase.endsWith("/messages")) {
           normalizedBase = normalizedBase.slice(0, -9); // remove /messages
         }
+        if (normalizedBase.endsWith("/v1")) {
+          normalizedBase = normalizedBase.slice(0, -3);
+        }
 
         const messagesUrl = `${normalizedBase}/v1/messages`;
-        const model = node.defaultModel || "claude-3-haiku-20240307";
+        const model = body.defaultModel || node.defaultModel || "claude-3-haiku-20240307";
 
         const res = await fetch(messagesUrl, {
           method: "POST",
-          headers: {
-            "x-api-key": apiKey,
-            "anthropic-version": "2023-06-01",
-            "content-type": "application/json",
-            "Authorization": `Bearer ${apiKey}`,
-          },
+          headers: mergeClientIdentityHeaders(
+            {
+              "content-type": "application/json",
+              "anthropic-version": "2023-06-01",
+            },
+            {
+              clientIdentityProfile: providerSpecificData?.clientIdentityProfile ?? node.clientIdentityProfile,
+              clientIdentityHeaders: providerSpecificData?.clientIdentityHeaders ?? node.clientIdentityHeaders,
+            },
+            {
+              "x-api-key": apiKey,
+              "Authorization": `Bearer ${apiKey}`,
+            },
+          ),
           body: JSON.stringify({
             model,
             max_tokens: 1,

--- a/src/app/api/settings/route.js
+++ b/src/app/api/settings/route.js
@@ -14,6 +14,57 @@ const SETTINGS_RESPONSE_HEADERS = {
 // Secrets must never be mass-assigned from request body (CWE-915)
 const PROTECTED_SETTING_KEYS = ["password", "mitmSudoEncrypted"];
 
+const SKIP_RULE_KINDS = new Set(["connect_timeout", "network"]);
+const SKIP_RULE_ACTIONS = new Set(["retry", "skip"]);
+
+// Validate maxTransportAttempts + providerSkipRules when present in the PATCH body.
+// Returns an error string (→ 400) or null when valid / absent.
+function validateSkipRuleSettings(body) {
+  if (Object.prototype.hasOwnProperty.call(body, "maxTransportAttempts")) {
+    const n = body.maxTransportAttempts;
+    if (!Number.isInteger(n) || n < 1 || n > 5) return "maxTransportAttempts must be an integer 1-5";
+  }
+  if (!Object.prototype.hasOwnProperty.call(body, "providerSkipRules")) return null;
+
+  const rules = body.providerSkipRules;
+  if (!Array.isArray(rules)) return "providerSkipRules must be an array";
+  if (rules.length > 100) return "providerSkipRules cannot exceed 100 rules";
+
+  for (let i = 0; i < rules.length; i++) {
+    const r = rules[i];
+    const at = `providerSkipRules[${i}]`;
+    if (!r || typeof r !== "object") return `${at} must be an object`;
+    if (typeof r.provider !== "string" || !r.provider.trim() || r.provider.length > 128) {
+      return `${at}.provider must be a non-empty string ≤128 chars`;
+    }
+    if (!SKIP_RULE_ACTIONS.has(r.action)) return `${at}.action must be "retry" or "skip"`;
+    const m = r.match;
+    if (!m || typeof m !== "object") return `${at}.match is required`;
+    // Match may carry any combination of kind|status|contains; at least one is
+    // required, and every present condition must be valid (AND semantics at runtime).
+    const present = ["kind", "status", "contains"].filter(k => m[k] != null && m[k] !== "");
+    if (present.length < 1) return `${at}.match must have at least one of kind|status|contains`;
+    if (m.kind != null && !SKIP_RULE_KINDS.has(m.kind)) return `${at}.match.kind invalid`;
+    if (m.status != null && (!Number.isInteger(m.status) || m.status < 100 || m.status > 599)) {
+      return `${at}.match.status must be an integer 100-599`;
+    }
+    if (m.contains != null && m.contains !== "" && (typeof m.contains !== "string" || m.contains.length > 200)) {
+      return `${at}.match.contains must be a string ≤200 chars`;
+    }
+    if (r.headerTimeoutMs != null) {
+      if (m.kind !== "connect_timeout") return `${at}.headerTimeoutMs only allowed when match.kind is "connect_timeout"`;
+      if (!Number.isInteger(r.headerTimeoutMs) || r.headerTimeoutMs < 1000 || r.headerTimeoutMs > 120000) {
+        return `${at}.headerTimeoutMs must be an integer 1000-120000`;
+      }
+    }
+    if (r.sweep != null) {
+      if (typeof r.sweep !== "boolean") return `${at}.sweep must be a boolean`;
+      if (r.sweep === true && r.action !== "skip") return `${at}.sweep is only allowed when action is "skip"`;
+    }
+  }
+  return null;
+}
+
 export async function GET() {
   try {
     const settings = await getSettings();
@@ -74,6 +125,12 @@ export async function PATCH(request) {
       if (!body.oidcClientSecret || !String(body.oidcClientSecret).trim()) {
         delete body.oidcClientSecret;
       }
+    }
+
+    // Validate skip-rules feature settings (reject invalid rather than mass-assign blindly)
+    const skipRulesError = validateSkipRuleSettings(body);
+    if (skipRulesError) {
+      return NextResponse.json({ error: skipRulesError }, { status: 400 });
     }
 
     const settings = await updateSettings(body);

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -18,6 +18,9 @@ import { resolveZedModels } from "open-sse/shared/zedAuth.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { getThinkingLevels } from "open-sse/providers/thinkingLevels.js";
+import { CODEX_MODELS_BASE_INSTRUCTIONS } from "open-sse/config/codexConstants.js";
+import { mergeClientIdentityHeaders } from "open-sse/shared/clientIdentityHeaders.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -163,7 +166,7 @@ function inferKindFromUnknownModelId(modelId) {
   return LLM_KIND;
 }
 
-async function fetchCompatibleModelIds(connection) {
+export async function fetchCompatibleModelIds(connection) {
   if (!connection?.apiKey) return [];
 
   const baseUrl = typeof connection?.providerSpecificData?.baseUrl === "string"
@@ -173,24 +176,33 @@ async function fetchCompatibleModelIds(connection) {
   if (!baseUrl) return [];
 
   let url = `${baseUrl}/models`;
-  const headers = {
+  const baseHeaders = {
     "Content-Type": "application/json",
   };
+  let authHeaders = {};
 
   if (isOpenAICompatibleProvider(connection.provider)) {
-    headers.Authorization = `Bearer ${connection.apiKey}`;
+    authHeaders = { Authorization: `Bearer ${connection.apiKey}` };
   } else if (isAnthropicCompatibleProvider(connection.provider)) {
     if (url.endsWith("/messages/models")) {
       url = url.slice(0, -9);
     } else if (url.endsWith("/messages")) {
       url = `${url.slice(0, -9)}/models`;
     }
-    headers["x-api-key"] = connection.apiKey;
-    headers["anthropic-version"] = "2023-06-01";
-    headers.Authorization = `Bearer ${connection.apiKey}`;
+    authHeaders = {
+      "x-api-key": connection.apiKey,
+      "anthropic-version": "2023-06-01",
+      Authorization: `Bearer ${connection.apiKey}`,
+    };
   } else {
     return [];
   }
+
+  const headers = mergeClientIdentityHeaders(
+    baseHeaders,
+    connection.providerSpecificData || {},
+    authHeaders,
+  );
 
   try {
     const controller = new AbortController();
@@ -537,12 +549,101 @@ export async function OPTIONS() {
  * GET /v1/models - OpenAI compatible models list (LLM/chat models only by default).
  * For other capabilities use /v1/models/{kind} (image, tts, stt, embedding, image-to-text, web).
  */
+export function isCodexModelsRequest(request) {
+  if (!request?.url || typeof request.headers?.get !== "function") return false;
+  const clientVersion = new URL(request.url).searchParams.get("client_version");
+  const userAgent = request.headers.get("user-agent") || "";
+  return Boolean(clientVersion) && /\bcodex(?:[_ -](?:desktop|cli_rs|cli|exec))?\b/i.test(userAgent);
+}
+
+const CODEX_REASONING_DESCRIPTIONS = Object.freeze({
+  none: "No reasoning",
+  minimal: "Minimal reasoning",
+  low: "Fast responses with lighter reasoning",
+  medium: "Balanced reasoning for everyday tasks",
+  high: "Greater reasoning depth for complex tasks",
+  xhigh: "Extra high reasoning depth",
+  max: "Maximum reasoning depth",
+});
+
+function codexModelIdentity(model) {
+  const slug = typeof model?.id === "string" ? model.id.trim() : "";
+  if (!slug) return null;
+  const separator = slug.indexOf("/");
+  return {
+    slug,
+    provider: separator > 0 ? slug.slice(0, separator) : String(model.owned_by || "combo"),
+    modelId: separator > 0 ? slug.slice(separator + 1) : slug,
+  };
+}
+
+export function buildCodexModelInfo(model, priority = 0) {
+  const identity = codexModelIdentity(model);
+  if (!identity) return null;
+
+  const capabilities = getCapabilitiesForModel(identity.provider, identity.modelId);
+  const reasoningLevels = getThinkingLevels(identity.provider, identity.modelId) || [];
+  const defaultReasoningLevel = reasoningLevels.includes("medium")
+    ? "medium"
+    : reasoningLevels.find((level) => level !== "none") || null;
+  const isGpt56 = /^gpt-5\.6-(?:sol|terra|luna)(?:$|-)/i.test(identity.modelId);
+
+  return {
+    slug: identity.slug,
+    display_name: identity.slug,
+    description: model.owned_by === "combo"
+      ? "9Router combo model"
+      : `9Router model via ${model.owned_by || identity.provider}`,
+    default_reasoning_level: defaultReasoningLevel,
+    supported_reasoning_levels: reasoningLevels.map((effort) => ({
+      effort,
+      description: CODEX_REASONING_DESCRIPTIONS[effort] || effort,
+    })),
+    shell_type: "shell_command",
+    visibility: "list",
+    supported_in_api: true,
+    priority,
+    upgrade: null,
+    base_instructions: CODEX_MODELS_BASE_INSTRUCTIONS,
+    supports_reasoning_summaries: capabilities.reasoning,
+    default_reasoning_summary: isGpt56 ? "none" : "auto",
+    support_verbosity: isGpt56,
+    default_verbosity: isGpt56 ? "low" : null,
+    apply_patch_tool_type: isGpt56 ? "freeform" : null,
+    web_search_tool_type: capabilities.search ? "text_and_image" : "text",
+    truncation_policy: { mode: "tokens", limit: 10000 },
+    supports_parallel_tool_calls: capabilities.tools,
+    supports_image_detail_original: isGpt56,
+    context_window: capabilities.contextWindow || null,
+    max_context_window: capabilities.contextWindow || null,
+    effective_context_window_percent: 95,
+    experimental_supported_tools: [],
+    input_modalities: capabilities.vision ? ["text", "image"] : ["text"],
+    supports_search_tool: capabilities.search,
+    use_responses_lite: isGpt56,
+    tool_mode: isGpt56 ? "code_mode_only" : null,
+    multi_agent_version: isGpt56 ? "v2" : null,
+  };
+}
+
+export function buildCompatibleModelsResponse(data, { includeCodexCatalog = false } = {}) {
+  if (includeCodexCatalog) {
+    return {
+      models: data
+        .map((model, index) => buildCodexModelInfo(model, index))
+        .filter(Boolean),
+    };
+  }
+  return { object: "list", data };
+}
 export async function GET(request) {
   try {
     // Detect cross-instance recursive /models fetch (another 9router fetching our /models)
     const skipDynamicFetch = request?.headers?.get(INTERNAL_MODELS_FETCH_HEADER) === "1";
     const data = await buildModelsList([LLM_KIND], { skipDynamicFetch });
-    return Response.json({ object: "list", data }, {
+    return Response.json(buildCompatibleModelsResponse(data, {
+      includeCodexCatalog: isCodexModelsRequest(request),
+    }), {
       headers: { "Access-Control-Allow-Origin": "*" },
     });
   } catch (error) {

--- a/src/lib/db/migrate.js
+++ b/src/lib/db/migrate.js
@@ -7,6 +7,7 @@ import { getMetaSync, setMetaSync } from "./helpers/metaStore.js";
 import { makeBackupDir, backupFile, backupDbLite, pruneOldBackups } from "./backup.js";
 import { getAppVersion } from "./version.js";
 import { stringifyJson } from "./helpers/jsonCol.js";
+import { seedAntigravityRule } from "./repos/settingsRepo.js";
 
 // Marker file: prevents re-importing legacy JSON when user wipes data.sqlite.
 const MIGRATED_MARKER = path.join(DB_DIR, ".migrated-from-json");
@@ -113,7 +114,13 @@ function importLegacyMain(adapter, data) {
   if (!data || typeof data !== "object") return;
 
   if (data.settings) {
-    adapter.run(`INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`, [stringifyJson(data.settings)]);
+    // Seed the default Antigravity capacity skip-rule onto imported legacy settings.
+    // The versioned migration (#2) runs while the DB is still fresh (no settings row
+    // yet) and returns early, so the legacy-JSON path must seed here — otherwise a
+    // direct upgrade from db.json would lose the capacity fail-fast after the hardcode
+    // removal. Uses the SAME helper as migration #2 (idempotent, respects the flag).
+    const settingsToStore = seedAntigravityRule({ ...data.settings });
+    adapter.run(`INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`, [stringifyJson(settingsToStore)]);
   }
 
   importWithAssertion(adapter, "providerConnections", data.providerConnections || [], (c) => {

--- a/src/lib/db/migrations/002-seed-antigravity-skip-rule.js
+++ b/src/lib/db/migrations/002-seed-antigravity-skip-rule.js
@@ -1,0 +1,38 @@
+// One-time seed of the default Antigravity capacity skip-rule for EXISTING installs.
+//
+// Fresh DBs get the rule from DEFAULT_SETTINGS. Installs created before this feature
+// have a settings row with providerSkipRules:[] (or absent) and no skipRulesSeeded
+// flag — and mergeWithDefaults only fills keys that are `undefined`, so it would never
+// backfill the rule. This migration seeds it exactly once via the shared helper.
+//
+// The seeding logic lives in settingsRepo.seedAntigravityRule so this migration and
+// the legacy-db.json import path (migrate.js) behave identically. It is idempotent,
+// only adds the rule when no capacity-equivalent antigravity rule exists (an unrelated
+// antigravity rule like 429→retry does NOT block it), and respects a user who later
+// deletes the rule (the flag stays set).
+import { seedAntigravityRule } from "../repos/settingsRepo.js";
+
+export default {
+  version: 2,
+  name: "seed-antigravity-skip-rule",
+  up(db) {
+    const row = db.get(`SELECT data FROM settings WHERE id = 1`);
+    if (!row) return; // no settings row yet → DEFAULT_SETTINGS covers fresh installs
+
+    let data;
+    try {
+      data = JSON.parse(row.data) || {};
+    } catch {
+      return; // unreadable settings blob → leave untouched
+    }
+
+    if (data.skipRulesSeeded) return; // already seeded (or fresh) → respect user state
+
+    seedAntigravityRule(data);
+
+    db.run(
+      `INSERT INTO settings(id, data) VALUES(1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data`,
+      [JSON.stringify(data)]
+    );
+  },
+};

--- a/src/lib/db/migrations/index.js
+++ b/src/lib/db/migrations/index.js
@@ -2,8 +2,9 @@
 // Each migration: { version: number, name: string, up(db): void }
 // Versions MUST be unique and monotonically increasing.
 import m001 from "./001-initial.js";
+import m002 from "./002-seed-antigravity-skip-rule.js";
 
-export const MIGRATIONS = [m001].sort((a, b) => a.version - b.version);
+export const MIGRATIONS = [m001, m002].sort((a, b) => a.version - b.version);
 
 export function latestVersion() {
   return MIGRATIONS.length ? MIGRATIONS[MIGRATIONS.length - 1].version : 0;

--- a/src/lib/db/repos/nodesRepo.js
+++ b/src/lib/db/repos/nodesRepo.js
@@ -62,6 +62,8 @@ export async function createProviderNode(data) {
     prefix: data.prefix,
     apiType: data.apiType,
     baseUrl: data.baseUrl,
+    clientIdentityProfile: data.clientIdentityProfile,
+    clientIdentityHeaders: data.clientIdentityHeaders,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -1,8 +1,61 @@
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
+import { findMatchingSkipRule } from "open-sse/services/accountFallback.js";
 
 const DEFAULT_MITM_ROUTER_BASE = "http://localhost:20128";
 const DEFAULT_HEADROOM_URL = process.env.HEADROOM_URL || "http://localhost:8787";
+
+// Seeded skip-rule: the former hardcoded Antigravity capacity fail-fast, now shipped
+// as an ordinary, user-editable rule. Matches 503 AND body text containing "capacity"
+// (covers both MODEL_CAPACITY_EXHAUSTED and "No capacity available for model").
+// sweep:true preserves the legacy full-pool resweep on momentary capacity saturation.
+export const DEFAULT_ANTIGRAVITY_CAPACITY_RULE = {
+  provider: "antigravity",
+  match: { status: 503, contains: "capacity" },
+  action: "skip",
+  sweep: true,
+};
+
+// The two canonical Antigravity capacity-503 error shapes the legacy hardcode caught.
+// We probe the user's rules with these (via the REAL match logic) to decide whether a
+// rule already covers capacity — rather than guessing from rule shape, which breaks
+// with first-match ordering and partial matches (e.g. contains-only / status-only).
+const ANTIGRAVITY_CAPACITY_PROBES = [
+  { status: 503, errorKind: "http_503", text: "MODEL_CAPACITY_EXHAUSTED" },
+  { status: 503, errorKind: "http_503", text: "No capacity available for model x" },
+];
+
+// Pure seed of the default Antigravity capacity rule into a settings object.
+// Idempotent + respects the user's array-order intent. Runs only when skipRulesSeeded
+// is falsy. For each canonical capacity-503 probe, we find the FIRST rule that fires:
+//   - no rule fires        → that pattern is uncovered → append the default at the end
+//   - a "retry" rule fires → user's deliberate choice; leave it, treat probe as handled
+//   - a "skip" rule fires  → ensure sweep:true on it (restores the legacy pool resweep)
+// Existing user rules keep their order/priority; the default is only appended when at
+// least one capacity pattern is matched by no rule. Always stamps the flag.
+// Shared by migration #2 and the legacy-JSON import so both upgrade paths agree (DRY).
+export function seedAntigravityRule(data) {
+  if (!data || typeof data !== "object") return data;
+  if (data.skipRulesSeeded) return data;
+  const rules = Array.isArray(data.providerSkipRules) ? data.providerSkipRules : [];
+
+  let allCovered = true;
+  for (const probe of ANTIGRAVITY_CAPACITY_PROBES) {
+    const rule = findMatchingSkipRule("antigravity", probe, rules);
+    if (rule == null) {
+      allCovered = false; // this capacity pattern is caught by no rule → need default
+    } else if (rule.action === "skip" && rule.sweep !== true) {
+      rule.sweep = true; // restore legacy full-pool resweep for the rule that catches it
+    }
+    // rule.action === "retry" → deliberate user choice; leave untouched.
+  }
+  if (!allCovered) {
+    rules.push({ ...DEFAULT_ANTIGRAVITY_CAPACITY_RULE });
+  }
+  data.providerSkipRules = rules;
+  data.skipRulesSeeded = true;
+  return data;
+}
 
 const DEFAULT_SETTINGS = {
   cloudEnabled: false,
@@ -54,6 +107,9 @@ const DEFAULT_SETTINGS = {
   pxpipeAutoInstall: true,
   pxpipeMinChars: 25000,
   pxpipeTimeoutMs: 15000,
+  maxTransportAttempts: 2,
+  providerSkipRules: [DEFAULT_ANTIGRAVITY_CAPACITY_RULE],
+  skipRulesSeeded: true,
 };
 
 async function readRaw() {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -1,4 +1,5 @@
 import "open-sse/index.js";
+import { isCodexRequestSchemaError } from "open-sse/services/accountFallback.js";
 
 import {
   getProviderCredentials,
@@ -19,9 +20,15 @@ import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActi
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
 import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
+import { resolveProviderHeaderTimeout } from "open-sse/services/accountFallback.js";
+import { setRoutingMeta } from "open-sse/services/routingMeta.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+
+// How many times to re-sweep the whole account pool when a matched skip-rule opts
+// in via sweep:true (momentary capacity/saturation recovery). Not provider-specific.
+const POOL_RESWEEP_RETRIES = 2;
 
 /**
  * Handle chat completion request
@@ -223,6 +230,10 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
   const excludeConnectionIds = new Set();
   let lastError = null;
   let lastStatus = null;
+  let lastErrorKind = null;
+  let lastFailFast = false;
+  let lastResweep = false;
+  let poolResweeps = 0;
 
   while (true) {
     const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
@@ -233,14 +244,36 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         const errorMsg = lastError || credentials.lastError || "Unavailable";
         const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
         log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
-        return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
+        // Carry the fail-fast classification of the last account failure onto the
+        // terminal response so combo can jump to the next model without a cooldown wait.
+        const resp = unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
+        setRoutingMeta(resp, { errorKind: lastErrorKind, status, failFast: lastFailFast });
+        return resp;
       }
       if (excludeConnectionIds.size === 0) {
         log.warn("AUTH", `No active credentials for provider: ${provider}`);
         return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
       }
+      // Pool resweep: a matched skip-rule with sweep:true asks us to re-try the whole
+      // account pool a few times before giving up (momentary capacity/saturation
+      // recovery). Gated ONLY on the rule's opt-in resweep signal — NOT on failFast
+      // (which fires for every skip / connect_timeout) and NOT hardcoded to any
+      // provider. lastResweep reflects the most recent account failure's rule.
+      if (
+        lastResweep &&
+        poolResweeps < POOL_RESWEEP_RETRIES
+      ) {
+        poolResweeps += 1;
+        log.warn("CHAT", `[${provider}/${model}] pool exhausted with resweep rule; restarting account sweep ${poolResweeps}/${POOL_RESWEEP_RETRIES}`);
+        excludeConnectionIds.clear();
+        continue;
+      }
       log.warn("CHAT", "No more accounts available", { provider });
-      return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+      // Skip-loop terminal: all accounts exhausted. Attach the last failure's
+      // fail-fast signal so combo reads it off THIS response (the object it receives).
+      const resp = errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+      setRoutingMeta(resp, { errorKind: lastErrorKind, status: lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, failFast: lastFailFast });
+      return resp;
     }
 
     // Account selection shown in the unified "▶" line (acc:...)
@@ -259,10 +292,20 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Use shared chatCore
     const chatSettings = await getSettings();
     const providerThinking = (chatSettings.providerThinking || {})[provider] || null;
+    // Request-scoped transport policy (never mutate the cached executor's this.config).
+    const skipRules = chatSettings.providerSkipRules || [];
+    const resolvedHeaderTimeout = resolveProviderHeaderTimeout(provider, skipRules);
+    const requestPolicy = {
+      providerId: provider,
+      maxTransportAttempts: chatSettings.maxTransportAttempts,
+      skipRules,
+      ...(resolvedHeaderTimeout != null ? { headerTimeoutMs: resolvedHeaderTimeout } : {})
+    };
     const result = await handleChatCore({
       body: { ...body, model: `${provider}/${model}` },
       modelInfo: { provider, model },
       credentials: refreshedCredentials,
+      requestPolicy,
       log,
       clientRawRequest,
       connectionId: credentials.connectionId,
@@ -300,17 +343,35 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
 
     if (result.success) return result.response;
 
-    // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise resetsAtMs)
-    const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);
+    if (isCodexRequestSchemaError(provider, result.status, result.error)) {
+      log.warn("REQUEST", `Non-retryable Codex request schema error (${result.status})`);
+      return result.response;
+    }
+
+    // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise
+    // resetsAtMs). Pass the request-scoped skipRules so the fallback tier matches on the SAME
+    // rules the transport tier used — no second getSettings() read that could drift mid-request.
+    const { shouldFallback, failFast, resweep } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs, result.errorKind, skipRules);
 
     if (shouldFallback) {
       log.warn("FALLBACK", `⇄ ACC:${credentials.connectionName} UNAVAILABLE (${result.status}) → NEXT ACCOUNT`);
       excludeConnectionIds.add(credentials.connectionId);
       lastError = result.error;
       lastStatus = result.status;
+      // Preserve the last failure's classification so the terminal response (built
+      // when accounts run out) can signal fail-fast to combo, and resweep to gate
+      // the pool-resweep loop.
+      lastErrorKind = result.errorKind || lastErrorKind;
+      lastFailFast = !!failFast;
+      lastResweep = !!resweep;
       continue;
     }
 
+    // Terminal: this account failed but is NOT eligible for fallback (e.g. no-auth
+    // provider, or a non-fallback error). Attach the fail-fast classification onto
+    // the response combo receives so a skip-rule / connect_timeout still skips the
+    // cooldown wait even when there is no next account to try.
+    setRoutingMeta(result.response, { errorKind: result.errorKind, status: result.status, failFast: !!failFast });
     return result.response;
   }
 }

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,6 +1,6 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, matchSkipRule, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
@@ -214,31 +214,75 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
  * @param {string} errorText
  * @param {string|null} provider
  * @param {string|null} model - The specific model that triggered the error
- * @returns {{ shouldFallback: boolean, cooldownMs: number }}
+ * @param {number|null} resetsAtMs - Precise cooldown expiry (overrides backoff) if known
+ * @param {string|null} errorKind - Classified error kind from the executor (connect_timeout | network | http_<status>)
+ * @param {Array|null} skipRules - Request-scoped skip-rules captured for THIS attempt. When
+ *   provided, they are authoritative (same rules the transport tier used); when null we fall
+ *   back to reading settings so non-chat callers (image/search/stt/tts) keep working.
+ * @returns {{ shouldFallback: boolean, cooldownMs: number, failFast?: boolean, resweep?: boolean }}
  */
-export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null) {
-  if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 };
+export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null, errorKind = null, skipRules = null) {
+  // connect_timeout is always fail-fast: the upstream stalled before returning
+  // headers, so a cooldown wait just delays the jump to the next backup model.
+  const connectTimeoutFailFast = errorKind === "connect_timeout";
+
+  // Match skip-rules using the request-scoped rules when passed (authoritative — the
+  // same set the BaseExecutor retry tier saw). Only read settings as a fallback for
+  // callers that don't thread a policy through. Compute BEFORE the noauth early-return
+  // so a skip signal is not lost for no-auth providers.
+  const effectiveSkipRules = Array.isArray(skipRules)
+    ? skipRules
+    : ((await getSettings()) || {}).providerSkipRules || [];
+  const skipRule = matchSkipRule(provider, { status, errorKind, text: errorText }, effectiveSkipRules);
+  const failFast = skipRule?.action === "skip" || connectTimeoutFailFast;
+  // resweep is a SEPARATE, opt-in signal (rule.sweep:true) — NOT every failFast.
+  // It asks the account loop to re-try the whole pool after exhausting it. Kept
+  // distinct so a plain skip / connect_timeout does NOT trigger a full-pool sweep.
+  const resweep = skipRule?.action === "skip" && skipRule?.sweep === true;
+
+  // No-auth / no-connection: there is a single virtual connection, so we must NOT
+  // ask the account loop to fall back (it would re-select the same virtual connection
+  // forever). Return shouldFallback:false, but still surface the fail-fast
+  // classification so combo can route to the next model without a cooldown wait.
+  if (!connectionId || connectionId === "noauth") {
+    return { shouldFallback: false, cooldownMs: 0, failFast, resweep };
+  }
+
   const connections = await getProviderConnections({ provider });
   const conn = connections.find(c => c.id === connectionId);
   const backoffLevel = conn?.backoffLevel || 0;
+
+  // A "skip" rule means: transient/busy signal — fall back WITHOUT writing a DB
+  // cooldown lock, so the next request can use this account again immediately.
+  if (skipRule?.action === "skip") {
+    const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8);
+    log.warn("AUTH", `${connName} skip-rule (${errorKind || status}) for ${model || "unknown model"}; fallback without cooldown`);
+    return { shouldFallback: true, cooldownMs: 0, failFast: true, resweep };
+  }
 
   // GitHub premium-request exhaustion is account-wide until the next UTC month.
   const githubResetAtMs = githubMonthlyResetMs(status, errorText, provider);
 
   // Provider-specific precise cooldown (e.g. codex usage_limit_reached resets_at) overrides backoff
+  // Classify first: a request-scoped failure (fallback:false, e.g.
+  // context_length_exceeded) is a property of the body, not of the account, so it
+  // must win over any provider-supplied reset hint riding along on the same
+  // response — otherwise the precise-cooldown branches would lock a healthy
+  // account for a request that no account could serve.
+  const classified = checkFallbackError(status, errorText, backoffLevel);
   let shouldFallback, cooldownMs, newBackoffLevel;
-  if (githubResetAtMs) {
+  if (classified.shouldFallback && githubResetAtMs) {
     shouldFallback = true;
     cooldownMs = githubResetAtMs - Date.now();
     newBackoffLevel = 0;
-  } else if (resetsAtMs && resetsAtMs > Date.now()) {
+  } else if (classified.shouldFallback && resetsAtMs && resetsAtMs > Date.now()) {
     shouldFallback = true;
     cooldownMs = Math.min(resetsAtMs - Date.now(), MAX_RATE_LIMIT_COOLDOWN_MS);
     newBackoffLevel = 0;
   } else {
-    ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));
+    ({ shouldFallback, cooldownMs, newBackoffLevel } = classified);
   }
-  if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
+  if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0, failFast: connectTimeoutFailFast };
 
   const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
   const lockUpdate = buildModelLockUpdate(githubResetAtMs ? null : model, cooldownMs);
@@ -260,7 +304,7 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     console.error(`❌ ${provider} [${status}]: ${reason}`);
   }
 
-  return { shouldFallback: true, cooldownMs };
+  return { shouldFallback: true, cooldownMs, failFast: connectTimeoutFailFast };
 }
 
 /**

--- a/tests/unit/antigravity-capacity-fallback.test.js
+++ b/tests/unit/antigravity-capacity-fallback.test.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  validateApiKey: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: mocks.validateApiKey,
+  getSettings: mocks.getSettings,
+}));
+
+describe("Antigravity capacity fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "ag-1", provider: "antigravity", email: "ag@example.com", backoffLevel: 4 },
+    ]);
+    // Capacity fail-fast is no longer hardcoded — it is the seeded skip-rule
+    // (which ships with sweep:true). markAccountUnavailable reads it from settings
+    // when no request-scoped rules are passed.
+    mocks.getSettings.mockResolvedValue({
+      providerSkipRules: [
+        { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+      ],
+    });
+  });
+
+  it("falls back without writing model cooldown for MODEL_CAPACITY_EXHAUSTED", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "ag-1",
+      503,
+      '{"reason":"MODEL_CAPACITY_EXHAUSTED","message":"No capacity available for model claude-opus-4-6-thinking on the server"}',
+      "antigravity",
+      "claude-opus-4-6-thinking",
+    );
+
+    // failFast: combo skips its cooldown wait. resweep:true: seeded rule opts into
+    // the full-pool resweep (cooldownMs was already 0 — no DB lock written).
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: true });
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("keeps normal cooldown behavior for non-Antigravity capacity text", async () => {
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "ag-1",
+      503,
+      "No capacity available for model x",
+      "kiro",
+      "some-model",
+    );
+
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(0);
+    expect(mocks.updateProviderConnection).toHaveBeenCalledWith(
+      "ag-1",
+      expect.objectContaining({
+        testStatus: "unavailable",
+        errorCode: 503,
+      }),
+    );
+  });
+});

--- a/tests/unit/antigravity-combo-capacity-cycle.test.js
+++ b/tests/unit/antigravity-combo-capacity-cycle.test.js
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getComboModels: vi.fn(),
+  getModelInfo: vi.fn(),
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  extractApiKey: vi.fn(),
+  isValidApiKey: vi.fn(),
+  handleChatCore: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+}));
+
+vi.mock("../../src/sse/services/model.js", () => ({
+  getComboModels: mocks.getComboModels,
+  getModelInfo: mocks.getModelInfo,
+}));
+
+vi.mock("../../src/sse/services/auth.js", () => ({
+  getProviderCredentials: mocks.getProviderCredentials,
+  markAccountUnavailable: mocks.markAccountUnavailable,
+  clearAccountError: mocks.clearAccountError,
+  extractApiKey: mocks.extractApiKey,
+  isValidApiKey: mocks.isValidApiKey,
+}));
+
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_provider, credentials) => credentials),
+  updateProviderCredentials: vi.fn(),
+}));
+
+vi.mock("../../open-sse/handlers/chatCore.js", () => ({
+  handleChatCore: mocks.handleChatCore,
+}));
+
+vi.mock("../../open-sse/services/projectId.js", () => ({
+  getProjectIdForConnection: vi.fn(),
+}));
+
+function makeRequest(model = "combo-ag") {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+}
+
+function capacityError(model = "claude-opus-4-6-thinking") {
+  return JSON.stringify({
+    error: {
+      code: 503,
+      message: `No capacity available for model ${model} on the server`,
+      status: "UNAVAILABLE",
+      details: [{
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        reason: "MODEL_CAPACITY_EXHAUSTED",
+        domain: "cloudcode-pa.googleapis.com",
+        metadata: { model },
+      }],
+    },
+  });
+}
+
+describe("Antigravity combo capacity cycling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      comboStrategy: "fallback",
+      comboStickyRoundRobinLimit: 1,
+      rtkEnabled: false,
+      headroomEnabled: false,
+      cavemanEnabled: false,
+      ponytailEnabled: false,
+    });
+    mocks.getComboModels.mockImplementation(async (model) => (
+      model === "combo-ag"
+        ? ["ag/claude-opus-4-6-thinking", "kiro/claude-sonnet-4.5"]
+        : null
+    ));
+    mocks.getModelInfo.mockImplementation(async (modelStr) => {
+      if (modelStr === "ag/claude-opus-4-6-thinking") {
+        return { provider: "antigravity", model: "claude-opus-4-6-thinking" };
+      }
+      if (modelStr === "kiro/claude-sonnet-4.5") {
+        return { provider: "kiro", model: "claude-sonnet-4.5" };
+      }
+      return { provider: null, model: modelStr };
+    });
+    // Pool resweep gates on the rule's opt-in resweep signal (sweep:true), not a
+    // hardcoded capacity check — so markAccountUnavailable must report resweep:true.
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: true });
+  });
+
+  it("restarts the Antigravity account sweep after all accounts report model capacity before trying the next combo model", async () => {
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+
+    const excludeSnapshots = [];
+    let antigravityEmptySweepCount = 0;
+    mocks.getProviderCredentials.mockImplementation(async (provider, excludeConnectionIds) => {
+      const excluded = [...(excludeConnectionIds || [])];
+      excludeSnapshots.push({ provider, excluded });
+
+      if (provider === "kiro") {
+        return { connectionId: "kiro-1", connectionName: "Kiro 1" };
+      }
+
+      if (excluded.length === 0) {
+        antigravityEmptySweepCount += 1;
+        return { connectionId: "ag-1", connectionName: `AG 1 sweep ${antigravityEmptySweepCount}` };
+      }
+
+      if (excluded.length === 1 && excluded[0] === "ag-1") {
+        return { connectionId: "ag-2", connectionName: "AG 2" };
+      }
+
+      return null;
+    });
+
+    mocks.handleChatCore.mockImplementation(async ({ modelInfo }) => {
+      if (modelInfo.provider === "kiro") {
+        return { success: true, response: new Response("kiro-ok", { status: 200 }) };
+      }
+      if (antigravityEmptySweepCount >= 2) {
+        return { success: true, response: new Response("ag-ok", { status: 200 }) };
+      }
+      return { success: false, status: 503, error: capacityError() };
+    });
+
+    const response = await handleChat(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ag-ok");
+    expect(excludeSnapshots).toEqual([
+      { provider: "antigravity", excluded: [] },
+      { provider: "antigravity", excluded: ["ag-1"] },
+      { provider: "antigravity", excluded: ["ag-1", "ag-2"] },
+      { provider: "antigravity", excluded: [] },
+    ]);
+    expect(mocks.handleChatCore).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelInfo: expect.objectContaining({ provider: "kiro" }),
+      }),
+    );
+  });
+
+  it("does NOT resweep the pool when resweep:false → each account tried once, combo moves to next model", async () => {
+    // Negative control for the chat.js gate (the exact site of the prior regression):
+    // a plain skip (resweep:false) must try each Antigravity account exactly once and
+    // then let combo advance to the next model — NOT restart the account sweep.
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: false });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const excludeSnapshots = [];
+    mocks.getProviderCredentials.mockImplementation(async (provider, excludeConnectionIds) => {
+      const excluded = [...(excludeConnectionIds || [])];
+      excludeSnapshots.push({ provider, excluded });
+      if (provider === "kiro") return { connectionId: "kiro-1", connectionName: "Kiro 1" };
+      if (excluded.length === 0) return { connectionId: "ag-1", connectionName: "AG 1" };
+      if (excluded.length === 1 && excluded[0] === "ag-1") return { connectionId: "ag-2", connectionName: "AG 2" };
+      return null; // pool exhausted, no resweep
+    });
+    mocks.handleChatCore.mockImplementation(async ({ modelInfo }) => {
+      if (modelInfo.provider === "kiro") {
+        return { success: true, response: new Response("kiro-ok", { status: 200 }) };
+      }
+      return { success: false, status: 503, error: capacityError() };
+    });
+
+    const response = await handleChat(makeRequest());
+
+    // Antigravity: each of the two accounts tried exactly once (no resweep loop).
+    const agCalls = mocks.handleChatCore.mock.calls.filter(
+      ([arg]) => arg?.modelInfo?.provider === "antigravity"
+    );
+    expect(agCalls).toHaveLength(2);
+    // Kiro: tried once and succeeded → combo actually advanced to the next model.
+    const kiroCalls = mocks.handleChatCore.mock.calls.filter(
+      ([arg]) => arg?.modelInfo?.provider === "kiro"
+    );
+    expect(kiroCalls).toHaveLength(1);
+    // Antigravity account selection never restarts (no second excluded:[] for antigravity).
+    const agEmptySweeps = excludeSnapshots.filter(s => s.provider === "antigravity" && s.excluded.length === 0);
+    expect(agEmptySweeps).toHaveLength(1);
+    // Final response is Kiro's success.
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("kiro-ok");
+  });
+});

--- a/tests/unit/antigravity-recent-requests.test.js
+++ b/tests/unit/antigravity-recent-requests.test.js
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import {
+  createPassthroughStreamWithLogger,
+  createSSETransformStreamWithLogger,
+} from "../../open-sse/utils/stream.js";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(() => Promise.resolve()),
+}));
+
+async function writeAndCollect(transform, chunks) {
+  const writer = transform.writable.getWriter();
+  const reader = transform.readable.getReader();
+  const readAll = (async () => {
+    const out = [];
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      out.push(value);
+    }
+    return out;
+  })();
+
+  for (const chunk of chunks) {
+    await writer.write(new TextEncoder().encode(chunk));
+  }
+  await writer.close();
+  return await readAll;
+}
+
+describe("Antigravity Recent Requests usage", () => {
+  it("finalizes native Antigravity usage when the final chunk arrives before stream close", async () => {
+    let completed = null;
+    const stream = createPassthroughStreamWithLogger(
+      "antigravity",
+      null,
+      "claude-opus-4-6-thinking",
+      "conn-1",
+      { request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] } },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+    const readOne = reader.read();
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "AG_NATIVE_USAGE_OK" }],
+          },
+          finishReason: "STOP",
+        }],
+        usageMetadata: {
+          promptTokenCount: 18,
+          candidatesTokenCount: 12,
+          totalTokenCount: 30,
+        },
+      },
+    };
+
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+    await readOne;
+
+    expect(completed?.content?.content).toBe("AG_NATIVE_USAGE_OK");
+    expect(completed?.usage).toMatchObject({
+      prompt_tokens: 18,
+      completion_tokens: 12,
+      total_tokens: 30,
+    });
+
+    await writer.abort();
+    await reader.cancel().catch(() => {});
+  });
+
+  it("finalizes translated Responses API Antigravity usage when the final chunk arrives before stream close", async () => {
+    let completed = null;
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.ANTIGRAVITY,
+      FORMATS.OPENAI_RESPONSES,
+      "antigravity",
+      null,
+      null,
+      "gemini-pro-agent",
+      "conn-1",
+      { input: "hello", stream: true },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const writer = stream.writable.getWriter();
+    const reader = stream.readable.getReader();
+    const readOne = reader.read();
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "AG_RESPONSES_USAGE_OK" }],
+          },
+          finishReason: "STOP",
+        }],
+        usageMetadata: {
+          promptTokenCount: 21,
+          candidatesTokenCount: 13,
+          totalTokenCount: 34,
+        },
+      },
+    };
+
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`));
+    await readOne;
+
+    expect(completed?.content?.content).toBe("AG_RESPONSES_USAGE_OK");
+    expect(completed?.usage).toMatchObject({
+      prompt_tokens: 21,
+      completion_tokens: 13,
+      total_tokens: 34,
+    });
+
+    await writer.abort();
+    await reader.cancel().catch(() => {});
+  });
+
+  it("estimates usage for Antigravity passthrough content when upstream omits usageMetadata", async () => {
+    let completed = null;
+    const stream = createPassthroughStreamWithLogger(
+      "antigravity",
+      null,
+      "gemini-pro-agent",
+      "conn-1",
+      { request: { contents: [{ role: "user", parts: [{ text: "hello" }] }] } },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "A useful Antigravity response." }],
+          },
+          finishReason: "STOP",
+        }],
+      },
+    };
+
+    await writeAndCollect(stream, [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(completed?.content?.content).toBe("A useful Antigravity response.");
+    expect(completed?.usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.completion_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.estimated).toBe(true);
+  });
+
+  it("estimates usage for translated Antigravity wrapped content when upstream omits usageMetadata", async () => {
+    let completed = null;
+    const stream = createSSETransformStreamWithLogger(
+      FORMATS.ANTIGRAVITY,
+      FORMATS.OPENAI,
+      "antigravity",
+      null,
+      null,
+      "claude-opus-4-6-thinking",
+      "conn-1",
+      { messages: [{ role: "user", content: "hello" }] },
+      (content, usage) => {
+        completed = { content, usage };
+      },
+      null,
+    );
+
+    const event = {
+      response: {
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ text: "Translated Antigravity response." }],
+          },
+          finishReason: "STOP",
+        }],
+      },
+    };
+
+    await writeAndCollect(stream, [`data: ${JSON.stringify(event)}\n\n`]);
+
+    expect(completed?.content?.content).toBe("Translated Antigravity response.");
+    expect(completed?.usage?.prompt_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.completion_tokens).toBeGreaterThan(0);
+    expect(completed?.usage?.estimated).toBe(true);
+  });
+});

--- a/tests/unit/antigravity-retry-hook.test.js
+++ b/tests/unit/antigravity-retry-hook.test.js
@@ -37,6 +37,20 @@ describe("antigravity computeRetryDelay hook (D3)", () => {
     expect(await ag.computeRetryDelay(res(503), 1)).toBe(2000);
   });
 
+  it("capacity 503 no longer vetoed at the hook — fail-fast is a skip-rule now", async () => {
+    // The hardcoded capacity veto was removed. In isolation the hook treats a
+    // capacity 503 as a transient error (backoff). Fail-fast is enforced upstream:
+    // the seeded skip-rule resolves attempts=0, so BaseExecutor never calls this hook
+    // for capacity 503. This test locks the hook's post-removal behavior.
+    const r = res(503, {}, {
+      error: {
+        reason: "MODEL_CAPACITY_EXHAUSTED",
+        message: "No capacity available for model claude-opus-4-6-thinking on the server",
+      },
+    });
+    expect(await ag.computeRetryDelay(r, 1)).toBe(2000); // transient backoff, not false
+  });
+
   it("retries Antigravity agent terminated body even when status is not 429", async () => {
     const r = res(500, {}, { error: { message: "Agent execution terminated due to error" } });
     expect(await ag.computeRetryDelay(r, 1)).toBe(2000);

--- a/tests/unit/base-executor-connect-timeout.test.js
+++ b/tests/unit/base-executor-connect-timeout.test.js
@@ -1,0 +1,244 @@
+// Locks the connect-timeout classification + retry policy in BaseExecutor.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args),
+}));
+
+const { BaseExecutor } = await import("../../open-sse/executors/base.js");
+
+const creds = { apiKey: "k" };
+
+// Upstream that never returns headers: settles ONLY when the merged abort signal
+// fires (our connect timer). undici rejects with the abort REASON object, so
+// error.name stays "Error" — the whole point of the closure-flag fix.
+// base.js ALWAYS passes a signal (connectCtrl.signal, or AbortSignal.any([...])),
+// so a call with no signal is a genuine anomaly — throw loudly instead of
+// swallowing it, so a stray/background request would fail the test rather than hide.
+function hangingFetch(url, opts) {
+  const sig = opts?.signal;
+  if (!sig) throw new Error("proxyAwareFetch called without a signal — base.js must always pass one");
+  return new Promise((_resolve, reject) => {
+    const onAbort = () => reject(sig.reason || new Error("aborted"));
+    if (sig.aborted) return onAbort();
+    sig.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+// NOTE: block body (not `() => fetchMock.mockReset()`). mockReset() returns the
+// mock, and an arrow that returns a function hands it to vitest as a teardown
+// callback — vitest then invokes it after the test with zero args, producing a
+// phantom no-signal fetch call during cleanup. Returning undefined avoids that.
+beforeEach(() => { fetchMock.mockReset(); });
+
+describe("BaseExecutor connect timeout", () => {
+  it("classifies header-timeout via closure flag (NOT error.name); 0 in-place retries by default", async () => {
+    fetchMock.mockImplementation(hangingFetch);
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr-ac", maxTransportAttempts: 2, skipRules: [], headerTimeoutMs: 40 },
+    }).catch(e => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errorKind).toBe("connect_timeout");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  }, 8000);
+
+  it("retries same account for connect_timeout when a retry rule matches", async () => {
+    fetchMock.mockImplementation(hangingFetch);
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr-ac",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "retry" }],
+        headerTimeoutMs: 25,
+      },
+    }).catch(e => e);
+
+    expect(err.errorKind).toBe("connect_timeout");
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  }, 8000);
+
+  it("does not classify a real HTTP 502 as connect_timeout", async () => {
+    fetchMock.mockResolvedValue({ status: 502, headers: { get: () => "" } });
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr-ac", maxTransportAttempts: 1, skipRules: [], headerTimeoutMs: 5000 },
+    });
+    expect(out.response.status).toBe(502);
+  }, 8000);
+});
+
+// An HTTP error whose body carries text a `contains` rule matches. The mock's
+// clone().text() returns that body; base.js must read it and drive retry policy.
+function httpErrorWithBody(status, bodyText) {
+  return () => Promise.resolve({
+    status,
+    headers: { get: () => "application/json" },
+    clone: () => ({ text: () => Promise.resolve(bodyText) }),
+  });
+}
+
+describe("BaseExecutor contains-rule drives transport retry", () => {
+  it("action:retry on a matching body substring retries maxTransportAttempts-1 times", async () => {
+    fetchMock.mockImplementation(httpErrorWithBody(500, '{"error":"Server OVERLOADED, try later"}'));
+    const ex = new BaseExecutor("prov-x", { baseUrl: "https://x/api", retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "prov-x",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "prov-x", match: { contains: "overloaded" }, action: "retry" }],
+      },
+    });
+    // 500 has no default retry entry, so WITHOUT the contains rule this would be 1 call.
+    // The rule forces retry → 1 + 2 = 3 calls, then returns the last error response.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(out.response.status).toBe(500);
+  }, 8000);
+
+  it("action:skip on a matching body substring does NOT retry (0 in-place)", async () => {
+    fetchMock.mockImplementation(httpErrorWithBody(500, "upstream is overloaded right now"));
+    const ex = new BaseExecutor("prov-x", { baseUrl: "https://x/api", retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "prov-x",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "prov-x", match: { contains: "overloaded" }, action: "skip" }],
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1); // skip → jump to fallback, no in-place retry
+    expect(out.response.status).toBe(500);
+  }, 8000);
+
+  it("does NOT read the body when no contains-rule applies to this provider", async () => {
+    let cloned = 0;
+    fetchMock.mockImplementation(() => Promise.resolve({
+      status: 500,
+      headers: { get: () => "application/json" },
+      clone: () => { cloned++; return { text: () => Promise.resolve("overloaded") }; },
+    }));
+    const ex = new BaseExecutor("prov-y", { baseUrl: "https://x/api", retry: {} });
+
+    await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "prov-y",
+        maxTransportAttempts: 2,
+        // contains rule is for a DIFFERENT provider → must not trigger a body read here
+        skipRules: [{ provider: "other", match: { contains: "overloaded" }, action: "retry" }],
+      },
+    });
+    expect(cloned).toBe(0);
+  }, 8000);
+});
+
+describe("BaseExecutor error classification + policy isolation", () => {
+  it("classifies a generic fetch failure (ECONNRESET) as network, not connect_timeout", async () => {
+    fetchMock.mockImplementation(() => {
+      const e = new Error("read ECONNRESET");
+      e.code = "ECONNRESET";
+      return Promise.reject(e);
+    });
+    const ex = new BaseExecutor("prov-x", { baseUrl: "https://x/api", retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "prov-x", maxTransportAttempts: 1, skipRules: [], headerTimeoutMs: 5000 },
+    }).catch(e => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errorKind).toBe("network");
+  }, 8000);
+
+  it("two concurrent executes with different policies do not bleed timeouts/retries", async () => {
+    // A: 30ms header timeout, no retry → 1 call, connect_timeout.
+    // B: 200ms header timeout + retry rule maxTransportAttempts 3 → 3 calls, connect_timeout.
+    // Shared singleton executor; policy must be per-call (never on this.config).
+    fetchMock.mockImplementation(hangingFetch);
+    const ex = new BaseExecutor("kr-ac", { baseUrl: "https://x/api", retry: {} });
+
+    const callsBefore = () => fetchMock.mock.calls.length;
+    const pA = ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr-ac", maxTransportAttempts: 2, skipRules: [], headerTimeoutMs: 30 },
+    }).catch(e => e);
+    const pB = ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr-ac",
+        maxTransportAttempts: 3,
+        skipRules: [{ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "retry" }],
+        headerTimeoutMs: 200,
+      },
+    }).catch(e => e);
+
+    const [errA, errB] = await Promise.all([pA, pB]);
+    expect(errA.errorKind).toBe("connect_timeout");
+    expect(errB.errorKind).toBe("connect_timeout");
+    // A: 1 call (no retry). B: 3 calls (1 + 2 retries). Total 4 — proves no cross-bleed.
+    expect(callsBefore()).toBe(4);
+  }, 8000);
+});
+
+describe("BaseExecutor skip-rule abandons account without cycling base URLs", () => {
+  const THREE_URLS = ["https://a/api", "https://b/api", "https://c/api"];
+
+  it("HTTP skip: does NOT cycle the remaining base URLs on the same account", async () => {
+    // 429 that WITHOUT a skip rule would cycle all 3 URLs (shouldRetry on 429).
+    fetchMock.mockImplementation(httpErrorWithBody(429, "rate limited"));
+    const ex = new BaseExecutor("kr", { baseUrls: THREE_URLS, retry: {} });
+
+    const out = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr",
+        maxTransportAttempts: 2,
+        skipRules: [{ provider: "kr", match: { status: 429 }, action: "skip" }],
+      },
+    });
+    expect(out.response.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // one URL only, then abandon account
+  }, 8000);
+
+  it("exception skip: does NOT cycle the remaining base URLs on the same account", async () => {
+    // network error that WITHOUT a skip rule would fall through all 3 base URLs.
+    fetchMock.mockImplementation(() => Promise.reject(new Error("read ECONNRESET")));
+    const ex = new BaseExecutor("kr", { baseUrls: THREE_URLS, retry: {} });
+
+    const err = await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: {
+        providerId: "kr",
+        maxTransportAttempts: 2,
+        skipRules: [{ provider: "kr", match: { kind: "network" }, action: "skip" }],
+      },
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errorKind).toBe("network");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // abandoned after the first URL
+  }, 8000);
+
+  it("no skip rule → still cycles all base URLs (unchanged default behavior)", async () => {
+    // Guards against over-reach: only a matched skip rule short-circuits URL cycling.
+    fetchMock.mockImplementation(() => Promise.reject(new Error("read ECONNRESET")));
+    const ex = new BaseExecutor("kr", { baseUrls: THREE_URLS, retry: {} });
+
+    await ex.execute({
+      model: "m", body: {}, stream: false, credentials: creds,
+      requestPolicy: { providerId: "kr", maxTransportAttempts: 1, skipRules: [] },
+    }).catch(e => e);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // all three URLs tried
+  }, 8000);
+});

--- a/tests/unit/chat-skip-terminal-meta.test.js
+++ b/tests/unit/chat-skip-terminal-meta.test.js
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getRoutingMeta } from "../../open-sse/services/routingMeta.js";
+
+// Drive the REAL account-selection loop in chat.js AND the real auth.js
+// (getProviderCredentials + markAccountUnavailable) so we lock the terminal-branch
+// reattach that was silently dropping fail-fast metadata:
+//   1. keyed provider: single account fails with a skip-rule → excluded → accounts
+//      run out → chat.js builds a NEW errorResponse and must reattach { failFast:true }.
+//   2. no-auth provider (FREE_PROVIDERS[*].noAuth): getProviderCredentials returns the
+//      virtual "noauth" connection (no connectionId) → markAccountUnavailable takes the
+//      noauth early-return (shouldFallback:false, NO infinite re-select) → chat.js hits
+//      the terminal `return result.response`, which must still carry failFast.
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  getProviderConnections: vi.fn(),
+  getComboModels: vi.fn(),
+  getModelInfo: vi.fn(),
+  handleChatCore: vi.fn(),
+}));
+
+// Real auth.js is used (the code under test); only its DB-backed deps are stubbed.
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: vi.fn(),
+  validateApiKey: vi.fn(),
+  getProxyPools: vi.fn(async () => []),
+}));
+vi.mock("../../src/sse/services/model.js", () => ({
+  getComboModels: mocks.getComboModels,
+  getModelInfo: mocks.getModelInfo,
+}));
+vi.mock("../../src/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: vi.fn(async (_p, c) => c),
+  updateProviderCredentials: vi.fn(),
+}));
+vi.mock("../../open-sse/handlers/chatCore.js", () => ({ handleChatCore: mocks.handleChatCore }));
+vi.mock("../../open-sse/services/projectId.js", () => ({ getProjectIdForConnection: vi.fn() }));
+
+function makeRequest(model) {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model, messages: [{ role: "user", content: "hi" }] }),
+  });
+}
+
+describe("chat.js terminal-branch routing metadata (real account loop)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getComboModels.mockResolvedValue(null);
+  });
+
+  it("reattaches failFast onto the terminal errorResponse when keyed accounts run out", async () => {
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      providerSkipRules: [{ provider: "kr-ac", match: { status: 502 }, action: "skip" }],
+      maxTransportAttempts: 2,
+    });
+    mocks.getModelInfo.mockResolvedValue({ provider: "kr-ac", model: "m1" });
+    // One keyed connection; once excluded, the next lookup finds nothing available.
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", isActive: true, backoffLevel: 0 },
+    ]);
+    mocks.handleChatCore.mockResolvedValue({
+      success: false, status: 502, error: "[502]: connect timeout", errorKind: "http_502",
+    });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const resp = await handleChat(makeRequest("kr-ac/m1"));
+
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(1); // one account tried, then exhausted
+    const meta = getRoutingMeta(resp);
+    expect(meta).not.toBeNull();
+    expect(meta.failFast).toBe(true); // survived skip → exhaust → freshly-built Response
+  });
+
+  it("carries failFast on the no-auth terminal return without looping", async () => {
+    // mimo-free is a real FREE_PROVIDERS entry with noAuth:true → virtual connection.
+    mocks.getSettings.mockResolvedValue({
+      requireApiKey: false,
+      providerSkipRules: [{ provider: "mimo-free", match: { status: 502 }, action: "skip" }],
+      maxTransportAttempts: 2,
+    });
+    mocks.getModelInfo.mockResolvedValue({ provider: "mimo-free", model: "mimo-auto" });
+    mocks.getProviderConnections.mockResolvedValue([]); // unused on the noAuth path
+    mocks.handleChatCore.mockResolvedValue({
+      success: false, status: 502, error: "[502]: connect timeout", errorKind: "http_502",
+      response: new Response("err", { status: 502 }),
+    });
+
+    const { handleChat } = await import("../../src/sse/handlers/chat.js");
+    const resp = await handleChat(makeRequest("mimo-free/mimo-auto"));
+
+    expect(mocks.handleChatCore).toHaveBeenCalledTimes(1); // no infinite re-select of noauth
+    expect(getRoutingMeta(resp)?.failFast).toBe(true);
+  });
+});

--- a/tests/unit/claude-header-forwarding.test.js
+++ b/tests/unit/claude-header-forwarding.test.js
@@ -137,6 +137,67 @@ describe("DefaultExecutor.buildHeaders() — anthropic-compatible stripping", ()
     expect(betaVal).not.toContain("claude-code-20250219");
   });
 
+  it("keeps Claude identity headers for claude-cli profile on non-Anthropic host", () => {
+    const executor = new DefaultExecutor("anthropic-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "key",
+        providerSpecificData: {
+          baseUrl: "https://myproxy.example.com/v1",
+          clientIdentityProfile: "claude-cli",
+        },
+      },
+      true
+    );
+
+    expect(headers["X-App"]).toBe("cli");
+    expect(headers["Anthropic-Beta"]).toContain("claude-code-20250219");
+    expect(headers["Authorization"]).toBe("Bearer key");
+    expect(headers["x-api-key"]).toBe("key");
+  });
+
+  it("keeps custom Claude identity headers on non-Anthropic host", () => {
+    const executor = new DefaultExecutor("anthropic-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "key",
+        providerSpecificData: {
+          baseUrl: "https://myproxy.example.com/v1",
+          clientIdentityProfile: "custom",
+          clientIdentityHeaders: {
+            "X-App": "cli",
+            "Anthropic-Beta": "claude-code-20250219",
+          },
+        },
+      },
+      false
+    );
+
+    expect(headers["X-App"]).toBe("cli");
+    expect(headers["Anthropic-Beta"]).toBe("claude-code-20250219");
+  });
+
+  it("keeps auth headers ahead of custom identity headers", () => {
+    const executor = new DefaultExecutor("openai-compatible-custom");
+    const headers = executor.buildHeaders(
+      {
+        apiKey: "real-key",
+        providerSpecificData: {
+          baseUrl: "https://openai-compatible.example.com/v1",
+          clientIdentityProfile: "custom",
+          clientIdentityHeaders: {
+            Authorization: "Bearer fake-key",
+            "User-Agent": "custom/1.0",
+          },
+        },
+      },
+      false
+    );
+
+    expect(headers["Authorization"]).toBe("Bearer real-key");
+    expect(headers["User-Agent"]).toBe("custom/1.0");
+  });
+
   it("keeps other beta flags intact after stripping", () => {
     const executor = new DefaultExecutor("anthropic-compatible-custom");
     // The static CLAUDE_API_HEADERS used by anthropic-compatible providers include

--- a/tests/unit/client-identity-headers.test.js
+++ b/tests/unit/client-identity-headers.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildClientIdentityHeaders,
+  mergeClientIdentityHeaders,
+  parseClientIdentityHeaders,
+} from "open-sse/shared/clientIdentityHeaders.js";
+
+describe("client identity headers", () => {
+  it("default profile does not add headers", () => {
+    expect(buildClientIdentityHeaders({ clientIdentityProfile: "default" })).toEqual({});
+  });
+
+  it("claude-cli profile includes Claude CLI fingerprint headers", () => {
+    const headers = buildClientIdentityHeaders({ clientIdentityProfile: "claude-cli" });
+
+    expect(headers["User-Agent"]).toContain("claude-cli/");
+    expect(headers["X-App"]).toBe("cli");
+    expect(headers["Anthropic-Beta"]).toContain("claude-code-20250219");
+  });
+
+  it("codex-cli profile includes Codex originator headers", () => {
+    const headers = buildClientIdentityHeaders({ clientIdentityProfile: "codex-cli" });
+
+    expect(headers.originator).toBe("codex_cli_rs");
+    expect(headers["User-Agent"]).toContain("codex_cli_rs/");
+  });
+
+  it("openclaw profile includes OpenClaw user agent", () => {
+    expect(buildClientIdentityHeaders({ clientIdentityProfile: "openclaw" })).toEqual({
+      "User-Agent": "openclaw/2026.2.3",
+    });
+  });
+
+  it("invalid profile normalizes to default headers", () => {
+    expect(buildClientIdentityHeaders({ clientIdentityProfile: "unknown-profile" })).toEqual({});
+  });
+
+  it("parses custom headers from JSON and blocks auth headers", () => {
+    const headers = parseClientIdentityHeaders(JSON.stringify({
+      "User-Agent": "custom/1.0",
+      Authorization: "Bearer wrong",
+      "x-api-key": "wrong",
+      "X-Trace": "abc",
+    }));
+
+    expect(headers).toEqual({
+      "User-Agent": "custom/1.0",
+      "X-Trace": "abc",
+    });
+  });
+
+  it("parses custom headers from Header: value lines", () => {
+    const headers = parseClientIdentityHeaders([
+      "User-Agent: custom/1.0",
+      "X-App: cli",
+      "api-key: blocked",
+      "Malformed",
+    ].join("\n"));
+
+    expect(headers).toEqual({
+      "User-Agent": "custom/1.0",
+      "X-App": "cli",
+    });
+  });
+
+  it("merges base, identity, and auth with auth winning", () => {
+    const headers = mergeClientIdentityHeaders(
+      { "Content-Type": "application/json", Authorization: "Bearer base" },
+      {
+        clientIdentityProfile: "custom",
+        clientIdentityHeaders: {
+          "User-Agent": "custom/1.0",
+          Authorization: "Bearer custom",
+        },
+      },
+      { Authorization: "Bearer real-token" },
+    );
+
+    expect(headers).toEqual({
+      "Content-Type": "application/json",
+      "User-Agent": "custom/1.0",
+      Authorization: "Bearer real-token",
+    });
+  });
+});

--- a/tests/unit/codex-namespace-retry.test.js
+++ b/tests/unit/codex-namespace-retry.test.js
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BaseExecutor } from "../../open-sse/executors/base.js";
+import { CodexExecutor, stripRejectedCodexInputNamespaces } from "../../open-sse/executors/codex.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("Codex rejected input namespace compatibility", () => {
+  it("removes namespace only from input history", () => {
+    const body = {
+      input: [{ type: "function_call", namespace: "collaboration", name: "spawn_agent" }],
+      tools: [{ type: "namespace", name: "collaboration", tools: [] }],
+    };
+
+    expect(stripRejectedCodexInputNamespaces(body)).toBe(true);
+    expect(body.input[0].namespace).toBeUndefined();
+    expect(body.tools[0].type).toBe("namespace");
+  });
+
+  it("retries once after the exact upstream schema error", async () => {
+    const executeSpy = vi.spyOn(BaseExecutor.prototype, "execute")
+      .mockResolvedValueOnce({
+        response: new Response(JSON.stringify({
+          error: { message: "Unknown parameter: 'input[150].namespace'.", type: "invalid_request_error", code: "unknown_parameter" },
+        }), { status: 400 }),
+      })
+      .mockResolvedValueOnce({ response: new Response("ok", { status: 200 }) });
+    const executor = new CodexExecutor();
+    executor._peekSseTransientError = vi.fn().mockResolvedValue({ matched: null, replacementBody: null });
+    const body = {
+      input: [{ type: "function_call", namespace: "collaboration", name: "spawn_agent" }],
+      tools: [{ type: "namespace", name: "collaboration", tools: [] }],
+    };
+
+    const result = await executor.execute({ body, credentials: {}, log: { warn: vi.fn() } });
+
+    expect(result.response.status).toBe(200);
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(body.input[0].namespace).toBeUndefined();
+    expect(body.tools[0].type).toBe("namespace");
+  });
+
+  it("does not retry unrelated 400 responses", async () => {
+    const executeSpy = vi.spyOn(BaseExecutor.prototype, "execute").mockResolvedValue({
+      response: new Response("unsupported model", { status: 400 }),
+    });
+    const executor = new CodexExecutor();
+    executor._peekSseTransientError = vi.fn().mockResolvedValue({ matched: null, replacementBody: null });
+
+    await executor.execute({
+      body: { input: [{ type: "function_call", namespace: "collaboration" }] },
+      credentials: {},
+      log: { warn: vi.fn() },
+    });
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/codex-responses-lite.test.js
+++ b/tests/unit/codex-responses-lite.test.js
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+import { CODEX_RESPONSES_LITE_HEADER } from "../../open-sse/config/codexConstants.js";
+
+function credentials(rawHeaders = {}) {
+  return {
+    accessToken: "upstream-token",
+    connectionId: "codex-test",
+    providerSpecificData: {},
+    rawHeaders,
+  };
+}
+
+describe("Codex Responses Lite compatibility", () => {
+  it("forwards only an explicitly enabled Responses Lite header", () => {
+    const executor = new CodexExecutor();
+    const headers = executor.buildHeaders(credentials({
+      [CODEX_RESPONSES_LITE_HEADER]: "true",
+      authorization: "Bearer client-token",
+      cookie: "session=private",
+      "x-api-key": "private",
+    }));
+
+    expect(headers[CODEX_RESPONSES_LITE_HEADER]).toBe("true");
+    expect(headers.Authorization).toBe("Bearer upstream-token");
+    expect(headers.cookie).toBeUndefined();
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("does not infer Responses Lite from the model name", () => {
+    const executor = new CodexExecutor();
+    const headers = executor.buildHeaders(credentials());
+
+    expect(headers[CODEX_RESPONSES_LITE_HEADER]).toBeUndefined();
+  });
+
+  it("preserves Responses Lite input, namespace calls, and parallel tool settings", () => {
+    const executor = new CodexExecutor();
+    const additionalTools = {
+      type: "additional_tools",
+      role: "developer",
+      tools: [{
+        type: "namespace",
+        name: "collaboration",
+        description: "agent tools",
+        tools: [{
+          type: "function",
+          name: "spawn_agent",
+          description: "spawn",
+          strict: false,
+          parameters: { type: "object", properties: {} },
+        }],
+      }],
+    };
+    const developerMessage = {
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "Codex instructions" }],
+    };
+    const namespacedCall = {
+      type: "function_call",
+      name: "spawn_agent",
+      namespace: "collaboration",
+      arguments: "{}",
+      call_id: "call-1",
+    };
+    const output = {
+      type: "function_call_output",
+      call_id: "call-1",
+      output: "done",
+    };
+    const body = {
+      model: "gpt-5.6-sol",
+      input: [additionalTools, developerMessage, namespacedCall, output],
+      parallel_tool_calls: false,
+      stream: true,
+      reasoning: { effort: "high", summary: "auto" },
+    };
+
+    executor.transformRequest("gpt-5.6-sol", body, true, credentials({
+      [CODEX_RESPONSES_LITE_HEADER]: "true",
+    }));
+
+    expect(body.instructions).toBeUndefined();
+    expect(body.parallel_tool_calls).toBe(false);
+    expect(body.input).toEqual([additionalTools, developerMessage, namespacedCall, output]);
+  });
+
+  it("normalizes legacy message content without changing non-message items", () => {
+    const executor = new CodexExecutor();
+    const functionCall = {
+      type: "function_call",
+      name: "run",
+      arguments: "{}",
+      call_id: "call-2",
+    };
+    const body = {
+      model: "gpt-5.5",
+      input: [{ role: "user", content: "hello" }, functionCall],
+      stream: true,
+    };
+
+    executor.transformRequest("gpt-5.5", body, true, credentials());
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "hello" }],
+    });
+    expect(body.input[1]).toEqual(functionCall);
+    expect(body.instructions).toBeTypeOf("string");
+  });
+
+  it("keeps max on the Responses Lite wire contract", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.6-sol-max",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }],
+      stream: true,
+    };
+
+    executor.transformRequest("gpt-5.6-sol-max", body, true, credentials({
+      [CODEX_RESPONSES_LITE_HEADER]: "true",
+    }));
+
+    expect(body.model).toBe("gpt-5.6-sol");
+    expect(body.reasoning).toEqual({ effort: "max", summary: "auto", context: "all_turns" });
+  });
+  it("detects namespace payloads without a client Lite header", () => {
+    const executor = new CodexExecutor();
+    const body = {
+      model: "gpt-5.6-sol",
+      input: [{ type: "function_call", name: "run", namespace: "tools", arguments: "{}", call_id: "call-3" }],
+      tools: [{ type: "namespace", name: "tools", tools: [] }],
+      stream: true,
+    };
+
+    executor.transformRequest("gpt-5.6-sol", body, true, credentials());
+    const headers = executor.buildHeaders(credentials());
+
+    expect(headers[CODEX_RESPONSES_LITE_HEADER]).toBe("true");
+    expect(body.reasoning.context).toBe("all_turns");
+    expect(body.input.find((item) => item.namespace === "tools")).toBeDefined();
+  });
+});

--- a/tests/unit/codex-schema-fallback.test.js
+++ b/tests/unit/codex-schema-fallback.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isCodexRequestSchemaError } from "../../open-sse/services/accountFallback.js";
+import { handleComboChat } from "../../open-sse/services/combo.js";
+
+const log = { info: vi.fn(), warn: vi.fn() };
+
+function errorResponse(status, error) {
+  return new Response(JSON.stringify({ error }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("Codex request schema fallback", () => {
+  it.each([
+    ["Unknown parameter: 'input[150].namespace'.", true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "unknown_parameter", message: "Unknown parameter: input[2].namespace" } }), true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "unsupported_value", message: "Unsupported value for input[2].type" } }), true],
+    [JSON.stringify({ error: { type: "invalid_request_error", code: "invalid_prompt", message: "Prompt is too long" } }), false],
+    ["The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.", false],
+  ])("classifies only request schema incompatibilities", (message, expected) => {
+    expect(isCodexRequestSchemaError("codex", 400, message)).toBe(expected);
+  });
+
+  it("does not intercept other providers or retryable statuses", () => {
+    expect(isCodexRequestSchemaError("openai", 400, "Unknown parameter: input[0].x")).toBe(false);
+    expect(isCodexRequestSchemaError("codex", 429, "rate limit")).toBe(false);
+    expect(isCodexRequestSchemaError("codex", 401, "invalid token")).toBe(false);
+  });
+
+  it("stops a combo after a Codex schema error", async () => {
+    const handleSingleModel = vi.fn().mockResolvedValue(errorResponse(400, {
+      message: "Unknown parameter: 'input[150].namespace'.",
+      type: "invalid_request_error",
+      code: "unknown_parameter",
+    }));
+
+    const response = await handleComboChat({
+      body: {},
+      models: ["cx/gpt-5.6-sol", "cx/gpt-5.5"],
+      handleSingleModel,
+      log,
+    });
+
+    expect(response.status).toBe(400);
+    expect(handleSingleModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps normal combo fallback for rate limits", async () => {
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce(errorResponse(429, { message: "rate limit" }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const response = await handleComboChat({
+      body: {},
+      models: ["cx/gpt-5.6-sol", "cx/gpt-5.5"],
+      handleSingleModel,
+      log,
+    });
+
+    expect(response.status).toBe(200);
+    expect(handleSingleModel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/codex-settings.test.js
+++ b/tests/unit/codex-settings.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCodexSubagentRole } from "../../src/app/api/cli-tools/codex-settings/config.js";
+
+describe("Codex CLI settings", () => {
+  it("writes a valid subagent role with required description", () => {
+    expect(buildCodexSubagentRole("cx/gpt-5.5")).toEqual({
+      description: "Fast subagent for codebase exploration",
+      model: "cx/gpt-5.5",
+    });
+  });
+});

--- a/tests/unit/codex-to-claude-usage-and-custom-tools.test.js
+++ b/tests/unit/codex-to-claude-usage-and-custom-tools.test.js
@@ -1,0 +1,329 @@
+/**
+ * Two regressions on the openai-responses -> claude route (Codex app talking to
+ * an Anthropic-compatible connection). Both come from the same structural fact:
+ * there is no direct `openai-responses:claude` translator, so translateRequest()
+ * pivots openai-responses -> openai -> claude, and the response side comes back
+ * claude -> openai -> openai-responses.
+ *
+ * 1. Token double-count. claude-to-openai folds Claude's cache-exclusive
+ *    input_tokens into a cache-inclusive prompt_tokens, but did not set the
+ *    top-level `cached_tokens` key that canonicalizeUsage() uses as its
+ *    already-folded marker. saveUsageStats() therefore folded the cache totals a
+ *    second time, so usageHistory recorded roughly double what requestDetails did
+ *    (observed in production: 483,711 stored vs 967,422 reported for one request,
+ *    and rows above 1.4M -- larger than the model context window).
+ *
+ * 2. Lost custom tool names. openai-responses sets `_customToolNames` for
+ *    Responses-API custom/freeform tools; openai-to-claude built a fresh result
+ *    object and dropped it, so chatCore saw undefined and emitted `function_call`
+ *    with a JSON `{"input": ...}` wrapper instead of `custom_tool_call` with the
+ *    raw freeform program.
+ *
+ * 3. Never-compacting client. sendCompleted() synthesized response.completed
+ *    without `usage`. Codex sizes its context from that field, so every turn
+ *    read as free, it never hit its compaction threshold, and history grew
+ *    +2 messages/turn until the upstream returned 400 context_length_exceeded
+ *    (production: 1,022,873 estimated input against a 1,000,000 window).
+ *
+ * 4. Account punished for a request-scoped error. That same 400 was classified
+ *    as account-unavailable, locking modelLock_claude-sonnet-5 on both accounts
+ *    and retrying an identical payload that could only fail again.
+ *
+ * 5. message_stop reported a cache-exclusive prompt_tokens. Streams that end
+ *    without a stop_reason-bearing message_delta took a second usage-building
+ *    path that read input_tokens (cache-EXCLUSIVE) as prompt_tokens and emitted
+ *    no cached_tokens at all.
+ *
+ * 6. A provider reset hint outranked the request-scoped verdict.
+ *    markAccountUnavailable() hardcoded shouldFallback = true in its
+ *    githubResetAtMs / resetsAtMs branches, so a fallback:false error arriving
+ *    alongside one of those hints still locked the account.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  ...dbMocks,
+  validateApiKey: vi.fn(),
+  getSettings: vi.fn(async () => ({})),
+  getProxyPools: vi.fn(async () => []),
+}));
+vi.mock("@/lib/network/connectionProxy", () => ({
+  pickProxyPoolId: vi.fn(),
+  resolveConnectionProxyConfig: vi.fn(),
+}));
+vi.mock("@/shared/constants/providers.js", () => ({
+  FREE_PROVIDERS: {},
+  resolveProviderId: (provider) => provider,
+}));
+vi.mock("@/sse/utils/logger.js", () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }));
+
+import { claudeToOpenAIResponse } from "../../open-sse/translator/response/claude-to-openai.js";
+import { canonicalizeUsage } from "../../open-sse/utils/usageTracking.js";
+import { openaiToClaudeRequest } from "../../open-sse/translator/request/openai-to-claude.js";
+import { openaiResponsesToOpenAIRequest } from "../../open-sse/translator/request/openai-responses.js";
+import { initState, translateResponse } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { toResponsesUsage } from "../../open-sse/translator/concerns/usage.js";
+import { applyErrorState, checkFallbackError } from "../../open-sse/services/accountFallback.js";
+
+const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+
+const freshState = () => ({ id: "chatcmpl-test", created: 0, model: "claude-sonnet-4-5" });
+
+// Drive the streaming translator the way stream.js does: one shared state object
+// across message_start -> message_delta.
+function runClaudeStream(startUsage, deltaUsage) {
+  const state = freshState();
+  claudeToOpenAIResponse({ type: "message_start", message: { model: "claude-sonnet-4-5", usage: startUsage } }, state);
+  claudeToOpenAIResponse({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: deltaUsage }, state);
+  return state.usage;
+}
+
+describe("claude-to-openai usage is canonicalizeUsage-idempotent", () => {
+  it("does not fold cache_read into prompt_tokens a second time", () => {
+    // Real shape of the production request that reported 967,422:
+    // input 0, cache_read 481,799, cache_creation 1,912 -> prompt 483,711.
+    const usage = runClaudeStream(
+      { input_tokens: 0, cache_read_input_tokens: 481799, cache_creation_input_tokens: 1912 },
+      { output_tokens: 640 }
+    );
+
+    expect(usage.prompt_tokens).toBe(483711);
+    expect(usage.cached_tokens).toBe(481799);
+
+    const canonical = canonicalizeUsage(usage);
+    expect(canonical.prompt_tokens).toBe(483711); // was 967,422
+    expect(canonical.cached_tokens).toBe(481799);
+    expect(canonical.completion_tokens).toBe(640);
+  });
+
+  it("marks a cache-creation-only first write as folded too (cached_tokens 0)", () => {
+    // The marker must be set unconditionally: gating it on cache_read > 0 leaves
+    // first-write requests (creation only, no read) double-folded.
+    const usage = runClaudeStream(
+      { input_tokens: 12, cache_creation_input_tokens: 8000 },
+      { output_tokens: 30 }
+    );
+
+    expect(usage.prompt_tokens).toBe(8012);
+    expect(usage.cached_tokens).toBe(0);
+    expect(canonicalizeUsage(usage).prompt_tokens).toBe(8012); // was 16,012
+  });
+
+  it("leaves a no-cache request untouched through both folds", () => {
+    const usage = runClaudeStream({ input_tokens: 500 }, { output_tokens: 20 });
+    expect(usage.prompt_tokens).toBe(500);
+    expect(usage.cached_tokens).toBe(0);
+    expect(canonicalizeUsage(usage).prompt_tokens).toBe(500);
+  });
+});
+
+describe("_customToolNames survives the openai-responses -> openai -> claude pivot", () => {
+  const EXEC_TOOL = {
+    type: "custom",
+    name: "exec",
+    description: "Run JavaScript code to orchestrate tool calls.",
+    format: { type: "grammar", syntax: "lark", definition: "start: /(.|\\n)+/" },
+  };
+
+  it("carries the metadata through hop 2", () => {
+    const hop1 = openaiResponsesToOpenAIRequest("cx/gpt-5.6-sol", {
+      input: [
+        { type: "additional_tools", role: "developer", tools: [EXEC_TOOL] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "Run pwd" }] },
+      ],
+      tool_choice: "auto",
+    }, true, null);
+    expect(hop1._customToolNames).toEqual(["exec"]);
+
+    const hop2 = openaiToClaudeRequest("claude-sonnet-4-5", hop1, true);
+    expect(hop2._customToolNames).toEqual(["exec"]);
+  });
+
+  it("adds nothing when the client declared no custom tools", () => {
+    const hop2 = openaiToClaudeRequest("claude-sonnet-4-5", {
+      messages: [{ role: "user", content: "hi" }],
+    }, true);
+    expect("_customToolNames" in hop2).toBe(false);
+  });
+});
+
+describe("response.completed carries usage on the claude -> openai-responses pivot", () => {
+  // Codex sizes its context from response.usage in response.completed and
+  // compacts once that nears the model window. On a passthrough route the
+  // upstream supplies the field; on this pivot 9router synthesizes the event,
+  // so an empty response.completed reads as "this turn cost 0 tokens" and the
+  // client never compacts -- history grows until the upstream rejects the
+  // request with a 400 context_length_exceeded (observed in production at
+  // ~1,022,873 estimated input tokens against a 1,000,000 window).
+  function runPivot(startUsage, deltaUsage) {
+    const state = initState(FORMATS.OPENAI_RESPONSES);
+    const events = [];
+    const push = (chunk) => events.push(...translateResponse(FORMATS.CLAUDE, FORMATS.OPENAI_RESPONSES, chunk, state));
+
+    push({ type: "message_start", message: { id: "msg_1", model: "claude-sonnet-4-5", usage: startUsage } });
+    push({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } });
+    push({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hello" } });
+    push({ type: "content_block_stop", index: 0 });
+    push({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: deltaUsage });
+    push(null); // flush
+
+    return events.find(e => e.event === "response.completed")?.data?.response;
+  }
+
+  it("emits Responses-shaped usage, not the Chat spelling", () => {
+    const response = runPivot(
+      { input_tokens: 12, cache_read_input_tokens: 481799, cache_creation_input_tokens: 1912 },
+      { output_tokens: 640 }
+    );
+
+    expect(response).toBeDefined();
+    expect(response.usage).toBeDefined();
+    // Chat keys would read as zero to a Responses-API client.
+    expect(response.usage.prompt_tokens).toBeUndefined();
+    expect(response.usage.input_tokens).toBe(483723);
+    expect(response.usage.output_tokens).toBe(640);
+    expect(response.usage.total_tokens).toBe(484363);
+    // Responses contract: input_tokens already includes cached_tokens.
+    expect(response.usage.input_tokens_details).toEqual({ cached_tokens: 481799 });
+  });
+
+  it("omits usage entirely when the upstream reported none", () => {
+    // Better an absent field than input_tokens: 0, which a client would read as
+    // a real measurement of an empty context.
+    const response = runPivot(undefined, undefined);
+    expect(response).toBeDefined();
+    expect("usage" in response).toBe(false);
+  });
+
+  it("omits usage when every count came back zero", () => {
+    const response = runPivot({ input_tokens: 0 }, { output_tokens: 0 });
+    expect(response).toBeDefined();
+    expect("usage" in response).toBe(false);
+  });
+});
+
+describe("toResponsesUsage", () => {
+  it("passes an already-Responses-shaped object through", () => {
+    expect(toResponsesUsage({ input_tokens: 100, output_tokens: 20 }))
+      .toEqual({ input_tokens: 100, output_tokens: 20, total_tokens: 120 });
+  });
+
+  it("forwards reasoning tokens under the Responses spelling", () => {
+    const out = toResponsesUsage({
+      prompt_tokens: 10, completion_tokens: 90, total_tokens: 100,
+      completion_tokens_details: { reasoning_tokens: 64 }
+    });
+    expect(out.output_tokens_details).toEqual({ reasoning_tokens: 64 });
+  });
+
+  it("returns null for nothing worth sending", () => {
+    expect(toResponsesUsage(null)).toBeNull();
+    expect(toResponsesUsage({})).toBeNull();
+    expect(toResponsesUsage({ prompt_tokens: 0, completion_tokens: 0 })).toBeNull();
+  });
+});
+
+describe("context_length_exceeded is request-scoped, not account-scoped", () => {
+  // The body is identical on every retry, so a second account rejects it the
+  // same way: falling back burns an extra upstream call and the cooldown pulls
+  // a healthy account out of rotation for unrelated short traffic on the model.
+  const CLE = 'Model "claude-sonnet-5" supports at most 1000000 input tokens; ' +
+    'estimated request input is 1022873 tokens (type: context_length_exceeded)';
+
+  it("does not fall back and does not cool the account down", () => {
+    expect(checkFallbackError(400, CLE)).toEqual({ shouldFallback: false, cooldownMs: 0 });
+  });
+
+  it("leaves rateLimitedUntil untouched", () => {
+    const account = { id: "a1", backoffLevel: 0, rateLimitedUntil: null };
+    expect(applyErrorState(account, 400, CLE).rateLimitedUntil).toBeNull();
+  });
+
+  it("still falls back on a genuine rate limit", () => {
+    const result = checkFallbackError(429, "rate limit exceeded", 0);
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(0);
+  });
+});
+
+describe("message_stop reports a cache-inclusive prompt_tokens", () => {
+  // Streams that end on message_stop without a stop_reason-bearing message_delta
+  // take a second usage-building path. It used to read input_tokens, which is
+  // cache-EXCLUSIVE on Claude, so the client saw a prompt understated by the
+  // whole cache component and no cached_tokens at all.
+  function runToStop(startUsage, deltaUsage) {
+    const state = freshState();
+    claudeToOpenAIResponse({ type: "message_start", message: { model: "claude-sonnet-4-5", usage: startUsage } }, state);
+    if (deltaUsage) claudeToOpenAIResponse({ type: "message_delta", delta: {}, usage: deltaUsage }, state);
+    const out = claudeToOpenAIResponse({ type: "message_stop" }, state);
+    return out?.[0];
+  }
+
+  it("folds cache into prompt_tokens and reports cached_tokens", () => {
+    const chunk = runToStop(
+      { input_tokens: 12, cache_read_input_tokens: 481799, cache_creation_input_tokens: 1912 },
+      { output_tokens: 640 }
+    );
+
+    expect(chunk.usage.prompt_tokens).toBe(483723); // was 12
+    expect(chunk.usage.completion_tokens).toBe(640);
+    expect(chunk.usage.total_tokens).toBe(484363);
+    expect(chunk.usage.prompt_tokens_details).toEqual({
+      cached_tokens: 481799,
+      cache_creation_tokens: 1912
+    });
+  });
+
+  it("still reports a plain no-cache request unchanged", () => {
+    const chunk = runToStop({ input_tokens: 500 }, { output_tokens: 20 });
+    expect(chunk.usage.prompt_tokens).toBe(500);
+    expect(chunk.usage.completion_tokens).toBe(20);
+    expect(chunk.usage).not.toHaveProperty("prompt_tokens_details");
+  });
+
+  it("emits no usage when the upstream reported none", () => {
+    const chunk = runToStop(undefined, undefined);
+    expect(chunk).toBeDefined();
+    expect("usage" in chunk).toBe(false);
+  });
+});
+
+describe("a provider reset hint does not override a request-scoped verdict", () => {
+  // markAccountUnavailable() hardcoded shouldFallback = true whenever a precise
+  // reset timestamp was available, so a fallback:false error riding along with
+  // one still locked the account for a body no account could serve.
+  const CLE_400 = 'estimated request input is 1022873 tokens (type: context_length_exceeded)';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.getProviderConnections.mockResolvedValue([
+      { id: "c1", provider: "claude", name: "c1", backoffLevel: 0 }
+    ]);
+  });
+
+  it("writes no lock when resetsAtMs accompanies a context_length_exceeded", async () => {
+    const resetsAtMs = Date.now() + 5 * 60 * 1000;
+    const result = await markAccountUnavailable("c1", 400, CLE_400, "claude", "claude-sonnet-5", resetsAtMs);
+
+    expect(result).toMatchObject({ shouldFallback: false, cooldownMs: 0 });
+    expect(dbMocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("still honours resetsAtMs for a genuine rate limit", async () => {
+    const resetsAtMs = Date.now() + 5 * 60 * 1000;
+    const result = await markAccountUnavailable("c1", 429, "rate limit exceeded", "claude", "claude-sonnet-5", resetsAtMs);
+
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(4 * 60 * 1000);
+    expect(dbMocks.updateProviderConnection).toHaveBeenCalledWith(
+      "c1",
+      expect.objectContaining({ "modelLock_claude-sonnet-5": expect.any(String) })
+    );
+  });
+});

--- a/tests/unit/combo-failfast-meta.test.js
+++ b/tests/unit/combo-failfast-meta.test.js
@@ -1,0 +1,61 @@
+// Integration: routing metadata (failFast) must survive to the Response combo
+// receives, so combo skips the cooldown wait and jumps to the next model fast.
+// This is the #1/#3 fix — the skip→exhaust path builds a NEW errorResponse, so the
+// meta has to be re-attached there (not just on the direct-return object).
+import { describe, expect, it, vi } from "vitest";
+import { handleComboChat } from "../../open-sse/services/combo.js";
+import { setRoutingMeta } from "../../open-sse/services/routingMeta.js";
+import { errorResponse } from "../../open-sse/utils/error.js";
+
+const log = { info: () => {}, warn: () => {}, error: () => {} };
+
+// A 503 whose text hits the "request not allowed" rule → cooldownMs 5000 (≤5000),
+// which is exactly the branch combo would WAIT on unless fail-fast is signalled.
+function transientResponse({ failFast }) {
+  const resp = errorResponse(503, "request not allowed");
+  if (failFast != null) setRoutingMeta(resp, { errorKind: failFast ? "connect_timeout" : null, status: 503, failFast });
+  return resp;
+}
+
+describe("combo fail-fast honors routing metadata", () => {
+  it("skips the cooldown wait when the failed Response is flagged failFast", async () => {
+    let waited = 0;
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((fn, ms) => {
+      waited += ms || 0;
+      return realSetTimeout(fn, 0); // fire immediately so the test stays fast
+    });
+
+    const models = ["prov/m1", "prov/m2"];
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce(transientResponse({ failFast: true }))  // model 1 fails, fail-fast
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));   // model 2 succeeds
+
+    const out = await handleComboChat({ body: {}, models, handleSingleModel, log, comboName: "c" });
+    vi.restoreAllMocks();
+
+    expect(out.status).toBe(200);
+    expect(handleSingleModel).toHaveBeenCalledTimes(2);
+    expect(waited).toBe(0); // fail-fast → no cooldown delay before the next model
+  });
+
+  it("waits the cooldown when the failure is NOT flagged fail-fast", async () => {
+    let waited = 0;
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((fn, ms) => {
+      waited += ms || 0;
+      return realSetTimeout(fn, 0);
+    });
+
+    const models = ["prov/m1", "prov/m2"];
+    const handleSingleModel = vi.fn()
+      .mockResolvedValueOnce(transientResponse({ failFast: false })) // model 1 fails, normal
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const out = await handleComboChat({ body: {}, models, handleSingleModel, log, comboName: "c" });
+    vi.restoreAllMocks();
+
+    expect(out.status).toBe(200);
+    expect(waited).toBe(5000); // transient 503 → combo waited the cooldown
+  });
+});

--- a/tests/unit/compatible-client-identity-routes.test.js
+++ b/tests/unit/compatible-client-identity-routes.test.js
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalFetch = globalThis.fetch;
+
+function mockNextResponse() {
+  vi.doMock("next/server", () => ({
+    NextResponse: {
+      json(body, init = {}) {
+        return new Response(JSON.stringify(body), {
+          status: init.status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+  }));
+}
+
+describe("compatible client identity route headers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockNextResponse();
+    vi.doMock("@/dashboardGuard", () => ({ isLocalRequest: () => true }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.doUnmock("next/server");
+    vi.doUnmock("@/dashboardGuard");
+    vi.resetModules();
+  });
+
+  it("provider node validation sends identity headers for OpenAI compatible", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/provider-nodes/validate/route.js");
+
+    const response = await POST(new Request("https://9router.local/api/provider-nodes/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: "https://gateway.example.com/v1",
+        apiKey: "real-key",
+        type: "openai-compatible",
+        clientIdentityProfile: "openclaw",
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("provider node validation sends identity headers for Anthropic compatible", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/provider-nodes/validate/route.js");
+
+    await POST(new Request("https://9router.local/api/provider-nodes/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        baseUrl: "https://gateway.example.com/v1",
+        apiKey: "real-key",
+        type: "anthropic-compatible",
+        clientIdentityProfile: "claude-cli",
+      }),
+    }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "x-api-key": "real-key",
+          "X-App": "cli",
+          "Anthropic-Beta": expect.stringContaining("claude-code-20250219"),
+        }),
+      }),
+    );
+  });
+
+  it("/v1/models compatible discovery sends identity headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "glm-5.2" }] }),
+    });
+    globalThis.fetch = fetchMock;
+    const { fetchCompatibleModelIds } = await import("@/app/api/v1/models/route.js");
+
+    const models = await fetchCompatibleModelIds({
+      provider: "openai-compatible-chat-node",
+      apiKey: "real-key",
+      providerSpecificData: {
+        baseUrl: "https://gateway.example.com/v1",
+        clientIdentityProfile: "openclaw",
+      },
+    });
+
+    expect(models).toEqual(["glm-5.2"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("/api/providers/validate sends identity headers for OpenAI compatible saved node validation", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderNodeById: vi.fn().mockResolvedValue({
+        id: "openai-compatible-chat-node",
+        type: "openai-compatible",
+        baseUrl: "https://gateway.example.com/v1",
+        clientIdentityProfile: "openclaw",
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/providers/validate/route.js");
+
+    const response = await POST(new Request("https://9router.local/api/providers/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider: "openai-compatible-chat-node",
+        apiKey: "real-key",
+        providerSpecificData: {
+          clientIdentityProfile: "openclaw",
+        },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("/api/providers/validate sends identity headers and body defaultModel for Anthropic compatible", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderNodeById: vi.fn().mockResolvedValue({
+        id: "anthropic-compatible-node",
+        type: "anthropic-compatible",
+        baseUrl: "https://gateway.example.com/v1/messages",
+        defaultModel: "node-model",
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "bad request" }),
+      text: async () => "bad request",
+    });
+    globalThis.fetch = fetchMock;
+    const { POST } = await import("@/app/api/providers/validate/route.js");
+
+    const response = await POST(new Request("https://9router.local/api/providers/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider: "anthropic-compatible-node",
+        apiKey: "real-key",
+        defaultModel: "body-model",
+        providerSpecificData: {
+          clientIdentityProfile: "claude-cli",
+        },
+      }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ valid: true, error: null });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "x-api-key": "real-key",
+          "X-App": "cli",
+          "Anthropic-Beta": expect.stringContaining("claude-code-20250219"),
+        }),
+        body: expect.any(String),
+      }),
+    );
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body).model).toBe("body-model");
+  });
+
+  it("/api/providers/[id]/models uses saved OpenAI compatible connection identity", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderConnectionById: vi.fn().mockResolvedValue({
+        id: "conn-1",
+        provider: "openai-compatible-chat-node",
+        apiKey: "real-key",
+        providerSpecificData: {
+          baseUrl: "https://gateway.example.com/v1",
+          clientIdentityProfile: "openclaw",
+        },
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "model-a" }] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { GET } = await import("@/app/api/providers/[id]/models/route.js");
+
+    const response = await GET(new Request("https://9router.local/api/providers/conn-1/models"), {
+      params: Promise.resolve({ id: "conn-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "User-Agent": "openclaw/2026.2.3",
+        }),
+      }),
+    );
+  });
+
+  it("/api/providers/[id]/models uses saved Anthropic compatible connection identity", async () => {
+    vi.doMock("@/models", () => ({
+      getProviderConnectionById: vi.fn().mockResolvedValue({
+        id: "conn-1",
+        provider: "anthropic-compatible-node",
+        apiKey: "real-key",
+        providerSpecificData: {
+          baseUrl: "https://gateway.example.com/v1/messages",
+          clientIdentityProfile: "claude-cli",
+        },
+      }),
+    }));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ id: "claude-like" }] }),
+      text: async () => "",
+    });
+    globalThis.fetch = fetchMock;
+    const { GET } = await import("@/app/api/providers/[id]/models/route.js");
+
+    const response = await GET(new Request("https://9router.local/api/providers/conn-1/models"), {
+      params: Promise.resolve({ id: "conn-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gateway.example.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer real-key",
+          "x-api-key": "real-key",
+          "X-App": "cli",
+          "Anthropic-Beta": expect.stringContaining("claude-code-20250219"),
+        }),
+      }),
+    );
+  });
+});

--- a/tests/unit/compatible-provider-connections.test.js
+++ b/tests/unit/compatible-provider-connections.test.js
@@ -115,6 +115,98 @@ describe("compatible provider connections API", () => {
     });
   });
 
+  it("copies client identity settings from compatible node into its connection", async () => {
+    const ctx = await setupTestContext({
+      id: "openai-compatible-identity-test",
+      type: "openai-compatible",
+      name: "Identity Test Node",
+      prefix: "ident",
+      apiType: "chat",
+      baseUrl: "https://identity.test/v1",
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+        "X-App": "cli",
+      },
+    });
+    cleanup = ctx.cleanup;
+
+    expect(ctx.node.clientIdentityProfile).toBe("custom");
+    expect(ctx.node.clientIdentityHeaders).toEqual({
+      "User-Agent": "custom/1.0",
+      "X-App": "cli",
+    });
+
+    const response = await ctx.POST(makeRequest(ctx.node.id));
+    const body = await response.json();
+    const storedConnections = await ctx.getProviderConnections({ provider: ctx.node.id });
+
+    expect(response.status).toBe(201);
+    expect(body.connection.providerSpecificData).toMatchObject({
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+        "X-App": "cli",
+      },
+    });
+    expect(storedConnections[0].providerSpecificData).toMatchObject({
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+        "X-App": "cli",
+      },
+    });
+  });
+
+  it("preserves and propagates existing client identity when updating a compatible node without identity fields", async () => {
+    const ctx = await setupTestContext({
+      id: "openai-compatible-update-identity-test",
+      type: "openai-compatible",
+      name: "Identity Update Test Node",
+      prefix: "ident",
+      apiType: "chat",
+      baseUrl: "https://identity.test/v1",
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+      },
+    });
+    cleanup = ctx.cleanup;
+    const createResponse = await ctx.POST(makeRequest(ctx.node.id));
+    expect(createResponse.status).toBe(201);
+
+    const { PUT } = await import("@/app/api/provider-nodes/[id]/route.js");
+    const response = await PUT(new Request(`https://9router.local/api/provider-nodes/${ctx.node.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Renamed Identity Node",
+        prefix: "ident2",
+        apiType: "responses",
+        baseUrl: "https://identity-updated.test/v1",
+      }),
+    }), {
+      params: Promise.resolve({ id: ctx.node.id }),
+    });
+    const body = await response.json();
+    const storedConnections = await ctx.getProviderConnections({ provider: ctx.node.id });
+
+    expect(response.status).toBe(200);
+    expect(body.node).toMatchObject({
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+      },
+    });
+    expect(storedConnections[0].providerSpecificData).toMatchObject({
+      baseUrl: "https://identity-updated.test/v1",
+      clientIdentityProfile: "custom",
+      clientIdentityHeaders: {
+        "User-Agent": "custom/1.0",
+      },
+    });
+  });
+
   it("creates one API-key connection for an Anthropic-compatible node", async () => {
     const ctx = await setupTestContext({
       id: "anthropic-compatible-test",

--- a/tests/unit/db-migration-chain.test.js
+++ b/tests/unit/db-migration-chain.test.js
@@ -57,7 +57,14 @@ describe("Schema migrations", () => {
     expect(parseInt(row.value, 10)).toBe(latestVersion());
 
     const settings = db2.get(`SELECT data FROM settings WHERE id=1`);
-    expect(JSON.parse(settings.data)).toEqual({ foo: "bar" });
+    // Migration #1 preserves the row; migration #2 (seed-antigravity-skip-rule)
+    // then augments it — proving the FULL pending chain re-applied, not just #1.
+    const parsed = JSON.parse(settings.data);
+    expect(parsed.foo).toBe("bar"); // existing data preserved
+    expect(parsed.skipRulesSeeded).toBe(true); // migration #2 ran
+    expect(parsed.providerSkipRules).toEqual([
+      { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+    ]);
   });
 
   it("fresh DB + legacy db.json → imports data automatically", async () => {
@@ -73,7 +80,14 @@ describe("Schema migrations", () => {
     const db = await getAdapter();
 
     const settings = db.get(`SELECT data FROM settings WHERE id=1`);
-    expect(JSON.parse(settings.data)).toEqual({ foo: "legacy-value" });
+    // Legacy import now seeds the Antigravity capacity rule (Fix #3) so a direct
+    // upgrade from db.json keeps capacity fail-fast after the hardcode removal.
+    const parsed = JSON.parse(settings.data);
+    expect(parsed.foo).toBe("legacy-value"); // legacy settings preserved
+    expect(parsed.skipRulesSeeded).toBe(true);
+    expect(parsed.providerSkipRules).toEqual([
+      { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+    ]);
 
     const keys = db.all(`SELECT * FROM apiKeys`);
     expect(keys).toHaveLength(1);

--- a/tests/unit/embeddingsCore.test.js
+++ b/tests/unit/embeddingsCore.test.js
@@ -368,6 +368,48 @@ describe("buildEmbeddingsHeaders", () => {
     expect(init.headers["HTTP-Referer"]).toBeUndefined();
     expect(init.headers["X-Title"]).toBeUndefined();
   });
+
+  it("openai-compatible-* sends client identity headers for embeddings", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
+
+    await handleEmbeddingsCore(makeOptions({
+      modelInfo: { provider: "openai-compatible-local", model: "nomic-embed" },
+      credentials: {
+        apiKey: "local-key",
+        providerSpecificData: {
+          baseUrl: "http://localhost:11434/v1",
+          clientIdentityProfile: "openclaw",
+        },
+      },
+    }));
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init.headers["Authorization"]).toBe("Bearer local-key");
+    expect(init.headers["User-Agent"]).toBe("openclaw/2026.2.3");
+  });
+
+  it("openai-compatible-* embeddings auth header wins over custom identity Authorization", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(makeProviderResponse(VALID_EMBEDDING_RESPONSE));
+
+    await handleEmbeddingsCore(makeOptions({
+      modelInfo: { provider: "openai-compatible-local", model: "nomic-embed" },
+      credentials: {
+        apiKey: "local-key",
+        providerSpecificData: {
+          baseUrl: "http://localhost:11434/v1",
+          clientIdentityProfile: "custom",
+          clientIdentityHeaders: {
+            Authorization: "Bearer wrong-key",
+            "User-Agent": "custom/1.0",
+          },
+        },
+      },
+    }));
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    expect(init.headers["Authorization"]).toBe("Bearer local-key");
+    expect(init.headers["User-Agent"]).toBe("custom/1.0");
+  });
 });
 
 // ─── Test: handleEmbeddingsCore — input validation ───────────────────────────

--- a/tests/unit/kiro-usage-and-tool-integrity.test.js
+++ b/tests/unit/kiro-usage-and-tool-integrity.test.js
@@ -1,0 +1,391 @@
+/**
+ * Seven Kiro defects, all on the OAuth/social Kiro route (kr/claude-sonnet-4.5
+ * with a >100k context). Production shape: 402 of 2156 usageHistory rows for
+ * Kiro recorded completionTokens 0, and the 25 newest rows all sat pinned at
+ * exactly 1 output token against prompts of 80k-103k -- i.e. the router was not
+ * measuring the answer, it was measuring nothing and rounding up.
+ *
+ * A. OUT 0 / OUT 1. finish() estimates completion tokens as
+ *    totalContentLength / 4, but tool-call bytes were never added to
+ *    totalContentLength. A turn whose entire answer is a tool call therefore
+ *    measured as an empty answer (Math.max(1, ...) is where the 1 comes from).
+ *
+ * B. Truncation threw away a complete-enough answer. stopDisposition() maps
+ *    model_context_window_exceeded (and max_tokens alongside tool calls) to
+ *    terminal_incomplete, which hard-fails the turn -- even when the model had
+ *    already streamed text. A truncated turn is what finish_reason "length" is
+ *    for. Both disposition gates needed the bypass: the declared-stop-reason
+ *    gate runs first and returns, so patching only finish() would be dead code.
+ *
+ * C. One bad tool fragment killed every good one. Three separate latches:
+ *    emitTools() validated per turn and threw out of the loop; the frame-loop
+ *    catch cleared state.tools wholesale; and the toolUseEvent branch returned
+ *    early forever once toolValidationError was set. Net effect for the client:
+ *    a turn that answered nothing.
+ *
+ * D. Cache tokens dropped on the kiro:claude route. kiro-to-claude built usage
+ *    from prompt_tokens/completion_tokens only, so Claude clients lost
+ *    cache_read_input_tokens / cache_creation_input_tokens and could neither
+ *    price the turn nor size their prompt cache.
+ *
+ * E. A malformed body cooled accounts down. Kiro answers an unusable
+ *    conversation with 400 {"message":"Improperly formed request.","reason":
+ *    "REQUEST_BODY_INVALID"}, which fell through to the default transient rule.
+ *    Measured: 12 different Kiro connections locked inside 1.6 seconds
+ *    (2026-08-04T09:13:14.290Z -> 09:13:32.221Z), 39 of 44 rows carrying
+ *    errorCode 400. Every account rejects the identical payload the same way,
+ *    so this is request-scoped, exactly like context_length_exceeded.
+ *
+ * F. Defence-in-depth only: both request translators discarded canonical.valid.
+ *    canonicalizeKiroConversation() self-heals every failure mode it can detect
+ *    (see the test below), so the guard is unreachable by construction today --
+ *    it exists so a future validator rule cannot ship an unusable body silently.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args)
+}));
+
+const { KiroExecutor } = await import("../../open-sse/executors/kiro.js");
+const { kiroToClaudeResponse, kiroToClaudeNonStreaming } = await import(
+  "../../open-sse/translator/response/kiro-to-claude.js"
+);
+const { checkFallbackError } = await import("../../open-sse/services/accountFallback.js");
+const { validateKiroConversation, canonicalizeKiroConversation } = await import(
+  "../../open-sse/translator/concerns/kiroConversation.js"
+);
+
+const encoder = new TextEncoder();
+const credentials = {
+  accessToken: "test-token",
+  providerSpecificData: { kiroToolCallRepair: true }
+};
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function encodeHeader(name, value) {
+  const nameBytes = encoder.encode(name);
+  const valueBytes = encoder.encode(value);
+  const bytes = new Uint8Array(1 + nameBytes.length + 3 + valueBytes.length);
+  let offset = 0;
+  bytes[offset++] = nameBytes.length;
+  bytes.set(nameBytes, offset);
+  offset += nameBytes.length;
+  bytes[offset++] = 7;
+  new DataView(bytes.buffer).setUint16(offset, valueBytes.length, false);
+  offset += 2;
+  bytes.set(valueBytes, offset);
+  return bytes;
+}
+
+function concat(chunks) {
+  const output = new Uint8Array(chunks.reduce((size, chunk) => size + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+function checksum(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  view.setUint32(8, crc32(bytes.subarray(0, 8)), false);
+  view.setUint32(bytes.byteLength - 4, crc32(bytes.subarray(0, bytes.byteLength - 4)), false);
+  return bytes;
+}
+
+function frameFromEntries(entries, payload) {
+  const headers = concat(entries.map(([name, value]) => encodeHeader(name, value)));
+  const payloadBytes = encoder.encode(JSON.stringify(payload));
+  const totalLength = 12 + headers.byteLength + payloadBytes.byteLength + 4;
+  const frame = new Uint8Array(totalLength);
+  const view = new DataView(frame.buffer);
+  view.setUint32(0, totalLength, false);
+  view.setUint32(4, headers.byteLength, false);
+  frame.set(headers, 12);
+  frame.set(payloadBytes, 12 + headers.byteLength);
+  return checksum(frame);
+}
+
+function frame(eventType, payload) {
+  return frameFromEntries([[":event-type", eventType]], payload);
+}
+
+function response(frames, status = 200) {
+  return new Response(new ReadableStream({
+    start(controller) {
+      for (const value of frames) controller.enqueue(value);
+      controller.close();
+    }
+  }), { status, statusText: status === 200 ? "OK" : "Upstream Error" });
+}
+
+async function execute(executor = new KiroExecutor(), overrides = {}) {
+  return executor.execute({
+    model: "kr/claude-opus-4.8",
+    body: { systemPrompt: "base", conversationState: {} },
+    stream: true,
+    credentials,
+    ...overrides
+  });
+}
+
+// Output is held behind the ": kiro-validation" heartbeat until clean EOF, so
+// every executor assertion has to drain the whole response.
+async function run(frames) {
+  fetchMock.mockResolvedValueOnce(response(frames));
+  return await (await execute()).response.text();
+}
+
+// Same as run(), but with the bounded tool-call repair retry disabled, so a
+// hard failure is surfaced from the first attempt instead of triggering a
+// second upstream fetch.
+async function runNoRepair(frames) {
+  fetchMock.mockResolvedValueOnce(response(frames));
+  const result = await execute(new KiroExecutor(), {
+    credentials: { accessToken: "test-token", providerSpecificData: { kiroToolCallRepair: false } }
+  });
+  return await result.response.text();
+}
+
+// The estimator only runs when metering and context usage both arrived and the
+// upstream reported no token totals of its own -- the exact production shape.
+const METERED = [
+  frame("meteringEvent", { usage: 2, unit: "credit" }),
+  frame("contextUsageEvent", { contextUsagePercentage: 10 })
+];
+
+function usageFrom(body) {
+  const usages = body
+    .split("\n")
+    .filter(line => line.startsWith("data: ") && line.includes('"usage"'))
+    .map(line => JSON.parse(line.slice(6)).usage)
+    .filter(Boolean);
+  return usages[usages.length - 1];
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("A: tool-call bytes count as output tokens", () => {
+  it("does not report a tool-only turn as OUT 1", async () => {
+    const body = await run([
+      frame("toolUseEvent", {
+        toolUseId: "call_a",
+        name: "tool_call",
+        input: { name: "mcp_search", arguments: { query: "why is the router reporting zero output" } }
+      }),
+      frame("metadataEvent", { stopReason: "tool_use" }),
+      ...METERED
+    ]);
+
+    const usage = usageFrom(body);
+    expect(usage).toBeDefined();
+    // Was 1: the Math.max floor over a totalContentLength of 0.
+    expect(usage.completion_tokens).toBeGreaterThan(10);
+    expect(usage.total_tokens).toBe(usage.prompt_tokens + usage.completion_tokens);
+  });
+
+  it("still counts plain text output", async () => {
+    const body = await run([
+      frame("assistantResponseEvent", { content: "x".repeat(400) }),
+      frame("metadataEvent", { stopReason: "end_turn" }),
+      ...METERED
+    ]);
+    expect(usageFrom(body).completion_tokens).toBe(100);
+  });
+});
+
+describe("C: one unusable tool fragment does not take the whole turn with it", () => {
+  it("ships the valid call and drops only the invalid one", async () => {
+    const body = await run([
+      frame("toolUseEvent", {
+        toolUseId: "good",
+        name: "tool_call",
+        input: { name: "mcp_search", arguments: { q: "router" } }
+      }),
+      // No nested MCP name -> unusable, cannot be forwarded to the client.
+      frame("toolUseEvent", { toolUseId: "bad", name: "tool_call", input: { arguments: { q: "router" } } }),
+      frame("metadataEvent", { stopReason: "tool_use" }),
+      ...METERED
+    ]);
+
+    expect(body).toContain('\\"name\\":\\"mcp_search\\"');
+    expect(body).not.toContain('"id":"bad"');
+    expect(body).toContain('"finish_reason":"tool_calls"');
+  });
+
+  it("keeps streamed text when the only tool call is unusable", async () => {
+    const body = await run([
+      frame("assistantResponseEvent", { content: "Here is what I found." }),
+      frame("toolUseEvent", { toolUseId: "bad", name: "tool_call", input: { arguments: {} } }),
+      frame("metadataEvent", { stopReason: "tool_use" }),
+      ...METERED
+    ]);
+
+    expect(body).toContain("Here is what I found.");
+    expect(body).not.toContain("invalid_kiro_tool_call");
+  });
+
+  it("still hard-fails when nothing usable was produced at all", async () => {
+    const body = await runNoRepair([
+      frame("toolUseEvent", { toolUseId: "bad", name: "tool_call", input: { arguments: {} } }),
+      frame("metadataEvent", { stopReason: "tool_use" })
+    ]);
+    expect(body).toContain("invalid_kiro_tool_call");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("B: truncation after output closes as length, not as a failure", () => {
+  it("keeps the text and reports finish_reason length", async () => {
+    const body = await run([
+      frame("assistantResponseEvent", { content: "Partial but usable answer." }),
+      frame("metadataEvent", { stopReason: "model_context_window_exceeded" }),
+      ...METERED
+    ]);
+
+    expect(body).toContain("Partial but usable answer.");
+    expect(body).toContain('"finish_reason":"length"');
+    expect(body).not.toContain("kiro_terminal_incomplete");
+  });
+
+  it("still fails a truncation that produced nothing", async () => {
+    const body = await run([
+      frame("metadataEvent", { stopReason: "model_context_window_exceeded" })
+    ]);
+    expect(body).toContain("kiro_terminal_incomplete");
+  });
+});
+
+describe("D: cache tokens survive the kiro -> claude translation", () => {
+  const finishChunk = (usage) => ({
+    choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    usage
+  });
+
+  function finalUsage(usage) {
+    const state = {};
+    // Usage rides an earlier chunk in the real stream; feed it the same way.
+    kiroToClaudeResponse({ choices: [{ index: 0, delta: { content: "hi" } }], usage }, state);
+    const events = kiroToClaudeResponse(finishChunk(usage), state) || [];
+    return events.find(e => e.type === "message_delta")?.usage;
+  }
+
+  it("forwards the flat Chat spelling the executor emits", () => {
+    expect(finalUsage({
+      prompt_tokens: 103000,
+      completion_tokens: 640,
+      cache_read_input_tokens: 98000,
+      cache_creation_input_tokens: 1912
+    })).toEqual({
+      input_tokens: 103000,
+      output_tokens: 640,
+      cache_read_input_tokens: 98000,
+      cache_creation_input_tokens: 1912
+    });
+  });
+
+  it("also accepts the nested details spelling used on passthrough", () => {
+    expect(finalUsage({
+      prompt_tokens: 500,
+      completion_tokens: 20,
+      prompt_tokens_details: { cached_tokens: 480, cache_creation_tokens: 20 }
+    })).toEqual({
+      input_tokens: 500,
+      output_tokens: 20,
+      cache_read_input_tokens: 480,
+      cache_creation_input_tokens: 20
+    });
+  });
+
+  it("omits the cache keys when the upstream reported none", () => {
+    expect(finalUsage({ prompt_tokens: 500, completion_tokens: 20 }))
+      .toEqual({ input_tokens: 500, output_tokens: 20 });
+  });
+
+  it("preserves cache on the non-streaming path too", () => {
+    const message = kiroToClaudeNonStreaming({
+      choices: [{ message: { content: "hi" } }],
+      usage: { prompt_tokens: 90, completion_tokens: 4, cache_read_input_tokens: 80 }
+    });
+    expect(message.usage).toMatchObject({
+      input_tokens: 90,
+      output_tokens: 4,
+      cache_read_input_tokens: 80
+    });
+    expect(message.usage).not.toHaveProperty("cache_creation_input_tokens");
+  });
+});
+
+describe("E: an improperly formed body is request-scoped, not account-scoped", () => {
+  // The verbatim upstream body from the 12-connection lockout.
+  const KIRO_400 = '{"message":"Improperly formed request.","reason":"REQUEST_BODY_INVALID"}';
+
+  it("does not fall back and writes no cooldown", () => {
+    expect(checkFallbackError(400, KIRO_400)).toEqual({ shouldFallback: false, cooldownMs: 0 });
+  });
+
+  it("covers the reason code and the generic invalid_request_error spelling", () => {
+    expect(checkFallbackError(400, "REQUEST_BODY_INVALID").shouldFallback).toBe(false);
+    expect(checkFallbackError(400, '{"type":"invalid_request_error"}').shouldFallback).toBe(false);
+  });
+
+  it("still falls back on a genuine rate limit", () => {
+    const result = checkFallbackError(429, "rate limit exceeded", 0);
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(0);
+  });
+});
+
+describe("F: the translator valid-guard is defence-in-depth", () => {
+  const SPECS = [{ toolSpecification: { name: "read_file", inputSchema: { json: { type: "object" } } } }];
+
+  it("validateKiroConversation names the offending turn", () => {
+    // Hand-built, NOT normalized: assistant first, then a tool call with no
+    // matching result and a name no spec declares.
+    const result = validateKiroConversation(
+      [{ assistantResponseMessage: { content: "hi", toolUses: [{ toolUseId: "t1", name: "ghost" }] } }],
+      { userInputMessage: { content: "go" } },
+      SPECS
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("role:0");
+    expect(result.errors).toContain("pair:0");
+    expect(result.errors).toContain("spec:0");
+  });
+
+  it("canonicalizeKiroConversation heals that same conversation", () => {
+    // This is why the guard cannot fire today: normalizeTurns() forces
+    // user-first/user-last alternation and non-empty content, and the
+    // second-chance pass flattens every structured tool turn to text.
+    const out = canonicalizeKiroConversation({
+      history: [{ assistantResponseMessage: { content: "hi", toolUses: [{ toolUseId: "t1", name: "ghost" }] } }],
+      currentMessage: { userInputMessage: { content: "" } },
+      modelId: "claude-sonnet-4-5",
+      toolSpecs: SPECS
+    });
+
+    expect(out.valid).toBe(true);
+    expect(out.errors).toEqual([]);
+    expect(out.currentMessage.userInputMessage.content).toBe("continue");
+    expect(out.history[0].userInputMessage).toBeDefined();
+  });
+});

--- a/tests/unit/models-response-compatibility.test.js
+++ b/tests/unit/models-response-compatibility.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCompatibleModelsResponse,
+  isCodexModelsRequest,
+} from "@/app/api/v1/models/route.js";
+
+const data = [
+  { id: "gpt-5.6-sol", object: "model", owned_by: "combo" },
+  { id: "cx/gpt-5.6-sol", object: "model", owned_by: "cx" },
+  { id: "oa/gpt-4.1", object: "model", owned_by: "oa" },
+];
+
+describe("GET /v1/models response compatibility", () => {
+  it("preserves the exact OpenAI model-list envelope by default", () => {
+    expect(buildCompatibleModelsResponse(data)).toEqual({ object: "list", data });
+  });
+
+  it("returns the Codex models protocol only for Codex clients", () => {
+    const response = buildCompatibleModelsResponse(data, { includeCodexCatalog: true });
+
+    expect(Object.keys(response)).toEqual(["models"]);
+    expect(response.models.map((model) => model.slug)).toEqual([
+      "gpt-5.6-sol",
+      "cx/gpt-5.6-sol",
+      "oa/gpt-4.1",
+    ]);
+    expect(response).not.toHaveProperty("data");
+    expect(response).not.toHaveProperty("object");
+  });
+
+  it("maps GPT-5.6 capabilities into Codex model metadata", () => {
+    const response = buildCompatibleModelsResponse(data, { includeCodexCatalog: true });
+    const model = response.models.find((entry) => entry.slug === "cx/gpt-5.6-sol");
+
+    expect(model).toMatchObject({
+      display_name: "cx/gpt-5.6-sol",
+      default_reasoning_level: "medium",
+      shell_type: "shell_command",
+      visibility: "list",
+      supported_in_api: true,
+      supports_reasoning_summaries: true,
+      support_verbosity: true,
+      truncation_policy: { mode: "tokens", limit: 10000 },
+      supports_parallel_tool_calls: true,
+      context_window: 400000,
+      input_modalities: ["text", "image"],
+      use_responses_lite: true,
+      tool_mode: "code_mode_only",
+      multi_agent_version: "v2",
+    });
+    expect(model.supported_reasoning_levels.map(({ effort }) => effort)).toEqual([
+      "none",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(model.base_instructions).toContain("coding agent");
+  });
+
+  it("does not advertise reasoning for a non-reasoning model", () => {
+    const response = buildCompatibleModelsResponse(data, { includeCodexCatalog: true });
+    const model = response.models.find((entry) => entry.slug === "oa/gpt-4.1");
+
+    expect(model.default_reasoning_level).toBeNull();
+    expect(model.supported_reasoning_levels).toEqual([]);
+    expect(model.supports_reasoning_summaries).toBe(false);
+    expect(model.use_responses_lite).toBe(false);
+  });
+
+  it.each([
+    ["Codex Desktop/0.144.0-alpha.4", true],
+    ["codex_cli_rs/0.144.1", true],
+    ["codex_exec/0.144.1", true],
+    ["openai-node/6.0.0", false],
+  ])("detects %s only when client_version is present", (userAgent, expected) => {
+    const request = new Request("https://router.example/v1/models?client_version=0.144.0", {
+      headers: { "User-Agent": userAgent },
+    });
+    expect(isCodexModelsRequest(request)).toBe(expected);
+  });
+
+  it("does not alter Codex-looking requests without the version query", () => {
+    const request = new Request("https://router.example/v1/models", {
+      headers: { "User-Agent": "Codex Desktop/0.144.0-alpha.4" },
+    });
+    expect(isCodexModelsRequest(request)).toBe(false);
+  });
+});

--- a/tests/unit/request-detail-usage.test.js
+++ b/tests/unit/request-detail-usage.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { extractUsageFromResponse } from "../../open-sse/handlers/chatCore/requestDetail.js";
+
+describe("request detail usage extraction", () => {
+  it("extracts usage from Antigravity wrapped response usageMetadata", () => {
+    const usage = extractUsageFromResponse({
+      response: {
+        usageMetadata: {
+          promptTokenCount: 77187,
+          candidatesTokenCount: 236,
+          totalTokenCount: 77423,
+          cachedContentTokenCount: 69387,
+          thoughtsTokenCount: 12,
+        },
+      },
+    });
+
+    expect(usage).toEqual({
+      prompt_tokens: 77187,
+      completion_tokens: 236,
+      cached_tokens: 69387,
+      reasoning_tokens: 12,
+    });
+  });
+});

--- a/tests/unit/routing-meta.test.js
+++ b/tests/unit/routing-meta.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { setRoutingMeta, getRoutingMeta } from "../../open-sse/services/routingMeta.js";
+
+describe("routingMeta", () => {
+  it("stores and reads metadata on the same Response object", () => {
+    const resp = new Response("err", { status: 502 });
+    setRoutingMeta(resp, { errorKind: "connect_timeout", status: 502 });
+    expect(getRoutingMeta(resp)).toEqual({ errorKind: "connect_timeout", status: 502 });
+  });
+
+  it("does NOT leak metadata into headers or body", async () => {
+    const resp = new Response(JSON.stringify({ error: "boom" }), {
+      status: 502,
+      headers: { "content-type": "application/json" },
+    });
+    setRoutingMeta(resp, { errorKind: "connect_timeout", status: 502 });
+
+    // No header carries the kind
+    for (const [, value] of resp.headers.entries()) {
+      expect(String(value)).not.toContain("connect_timeout");
+    }
+    const text = await resp.clone().text();
+    expect(text).not.toContain("connect_timeout");
+  });
+
+  it("returns null for an unknown Response", () => {
+    expect(getRoutingMeta(new Response("x"))).toBeNull();
+    expect(getRoutingMeta(null)).toBeNull();
+  });
+});

--- a/tests/unit/seed-antigravity-skip-rule.test.js
+++ b/tests/unit/seed-antigravity-skip-rule.test.js
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import m002 from "../../src/lib/db/migrations/002-seed-antigravity-skip-rule.js";
+import { DEFAULT_ANTIGRAVITY_CAPACITY_RULE } from "../../src/lib/db/repos/settingsRepo.js";
+
+// Fake adapter: only the settings id=1 row is exercised by the migration.
+function makeDb(initialData) {
+  let store = initialData == null ? null : JSON.stringify(initialData);
+  return {
+    get: () => (store == null ? null : { data: store }),
+    run: (_sql, params) => { store = params[0]; },
+    dump: () => (store == null ? null : JSON.parse(store)),
+  };
+}
+
+// Seeding is probe-based: it checks whether the two canonical Antigravity capacity-503
+// error shapes (MODEL_CAPACITY_EXHAUSTED / "No capacity available for model") are caught
+// by the user's rules via the REAL match logic, appends the default only for uncovered
+// patterns, and raises sweep:true on a skip rule that catches capacity.
+describe("migration 002: seed Antigravity capacity skip-rule (probe-based)", () => {
+  it("seeds the default (sweep:true) for legacy installs (empty rules, no flag)", () => {
+    const db = makeDb({ providerSkipRules: [], other: 1 });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toEqual([DEFAULT_ANTIGRAVITY_CAPACITY_RULE]);
+    expect(d.skipRulesSeeded).toBe(true);
+    expect(d.other).toBe(1); // preserves unrelated keys
+  });
+
+  it("is idempotent — re-running does not duplicate", () => {
+    const db = makeDb({ providerSkipRules: [] });
+    m002.up(db);
+    m002.up(db);
+    expect(db.dump().providerSkipRules).toHaveLength(1);
+  });
+
+  it("500+capacity skip does NOT cover 503 → keeps rule 500 and appends default", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 500, contains: "capacity" }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(2);
+    expect(d.providerSkipRules[0].match.status).toBe(500); // user rule kept, unchanged
+    expect(d.providerSkipRules[1]).toEqual(DEFAULT_ANTIGRAVITY_CAPACITY_RULE);
+    expect(d.skipRulesSeeded).toBe(true);
+  });
+
+  it("contains-only capacity skip (no status) covers both patterns → raise sweep, no append", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { contains: "capacity" }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(1);
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { contains: "capacity" }, action: "skip", sweep: true });
+  });
+
+  it("status-only 503 skip (no contains) covers both patterns → raise sweep, no append", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 503 }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(1);
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { status: 503 }, action: "skip", sweep: true });
+  });
+
+  it("503+model_capacity_exhausted skip covers only ONE pattern → raise sweep AND append default", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 503, contains: "model_capacity_exhausted" }, action: "skip" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(2);
+    // partial rule caught MODEL_CAPACITY_EXHAUSTED → sweep raised
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { status: 503, contains: "model_capacity_exhausted" }, action: "skip", sweep: true });
+    // "No capacity available for model" still uncovered → default appended to catch it
+    expect(d.providerSkipRules[1]).toEqual(DEFAULT_ANTIGRAVITY_CAPACITY_RULE);
+  });
+
+  it("503+capacity RETRY (deliberate user choice) → NOT mutated to skip, no sweep, no append", () => {
+    const db = makeDb({
+      providerSkipRules: [{ provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "retry" }],
+    });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toHaveLength(1); // array-order: retry wins, covers both probes
+    expect(d.providerSkipRules[0]).toEqual({ provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "retry" });
+    expect(d.providerSkipRules[0].sweep).toBeUndefined();
+    expect(d.skipRulesSeeded).toBe(true);
+  });
+
+  it("full default already present (sweep:true) → unchanged, no duplicate", () => {
+    const db = makeDb({ providerSkipRules: [{ ...DEFAULT_ANTIGRAVITY_CAPACITY_RULE }] });
+    m002.up(db);
+    const d = db.dump();
+    expect(d.providerSkipRules).toEqual([DEFAULT_ANTIGRAVITY_CAPACITY_RULE]);
+  });
+
+  it("respects a user who deleted the rule after seeding (flag already set)", () => {
+    const db = makeDb({ providerSkipRules: [], skipRulesSeeded: true });
+    m002.up(db);
+    expect(db.dump().providerSkipRules).toHaveLength(0); // not re-seeded
+  });
+
+  it("is a no-op when there is no settings row (DEFAULT_SETTINGS covers fresh DB)", () => {
+    const db = makeDb(null);
+    m002.up(db);
+    expect(db.dump()).toBeNull();
+  });
+});

--- a/tests/unit/skip-rule-fallback.test.js
+++ b/tests/unit/skip-rule-fallback.test.js
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  validateApiKey: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: mocks.getProviderConnections,
+  updateProviderConnection: mocks.updateProviderConnection,
+  validateApiKey: mocks.validateApiKey,
+  getSettings: mocks.getSettings,
+}));
+
+describe("skip-rule fallback (generalized, non-Antigravity)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProviderConnections.mockResolvedValue([
+      { id: "kr-1", provider: "kr-ac", email: "k@example.com", backoffLevel: 0 },
+    ]);
+  });
+
+  it("connect_timeout with action:skip → fallback without DB cooldown", async () => {
+    mocks.getSettings.mockResolvedValue({
+      providerSkipRules: [{ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip" }],
+    });
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "kr-1", 502, "[502]: fetch connect timeout", "kr-ac", "claude-sonnet-5", null, "connect_timeout",
+    );
+    // resweep:false — the connect_timeout skip rule has no sweep:true opt-in.
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: false });
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled(); // no lock written
+  });
+
+  it("skip rule with sweep:true → resweep:true (separate from failFast)", async () => {
+    mocks.getSettings.mockResolvedValue({
+      providerSkipRules: [{ provider: "kr-ac", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true }],
+    });
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "kr-1", 503, "MODEL_CAPACITY_EXHAUSTED", "kr-ac", "claude-sonnet-5", null, "http_503",
+    );
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0, failFast: true, resweep: true });
+    expect(mocks.updateProviderConnection).not.toHaveBeenCalled();
+  });
+
+  it("no matching rule → normal cooldown + DB lock", async () => {
+    mocks.getSettings.mockResolvedValue({ providerSkipRules: [] });
+    const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+    const result = await markAccountUnavailable(
+      "kr-1", 502, "[502]: fetch connect timeout", "kr-ac", "claude-sonnet-5", null, "connect_timeout",
+    );
+    expect(result.shouldFallback).toBe(true);
+    expect(result.cooldownMs).toBeGreaterThan(0);
+    expect(mocks.updateProviderConnection).toHaveBeenCalledWith(
+      "kr-1",
+      expect.objectContaining({ testStatus: "unavailable", errorCode: 502 }),
+    );
+  });
+});

--- a/tests/unit/skip-rules-match.test.js
+++ b/tests/unit/skip-rules-match.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { matchSkipRule, findMatchingSkipRule, resolveProviderHeaderTimeout } from "../../open-sse/services/accountFallback.js";
+
+describe("matchSkipRule", () => {
+  const rules = [
+    { provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 },
+    { provider: "kr-ac", match: { status: 429 }, action: "retry" },
+    { provider: "foo", match: { contains: "overloaded" }, action: "skip" },
+  ];
+
+  it("matches by error kind", () => {
+    const r = matchSkipRule("kr-ac", { errorKind: "connect_timeout" }, rules);
+    expect(r).toEqual({ action: "skip", headerTimeoutMs: 25000 });
+  });
+
+  it("matches by status (string/number normalized)", () => {
+    expect(matchSkipRule("kr-ac", { status: 429 }, rules)?.action).toBe("retry");
+    expect(matchSkipRule("kr-ac", { status: "429" }, rules)?.action).toBe("retry");
+  });
+
+  it("matches by substring (case-insensitive)", () => {
+    expect(matchSkipRule("foo", { text: "Server OVERLOADED now" }, rules)?.action).toBe("skip");
+  });
+
+  it("returns null when provider does not match", () => {
+    expect(matchSkipRule("other", { status: 429 }, rules)).toBeNull();
+  });
+
+  it("AND-matches when a rule carries both status and contains", () => {
+    const mixed = [
+      { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip" },
+    ];
+    // both conditions hold → match
+    expect(matchSkipRule("antigravity", { status: 503, text: "MODEL_CAPACITY_EXHAUSTED" }, mixed)?.action).toBe("skip");
+    expect(matchSkipRule("antigravity", { status: 503, text: "No capacity available for model x" }, mixed)?.action).toBe("skip");
+    // status matches but text does not → NO match
+    expect(matchSkipRule("antigravity", { status: 503, text: "gateway boom" }, mixed)).toBeNull();
+    // text matches but status does not → NO match
+    expect(matchSkipRule("antigravity", { status: 500, text: "capacity" }, mixed)).toBeNull();
+  });
+
+  it("uses array order — first fully-matching rule wins", () => {
+    const ordered = [
+      { provider: "p", match: { status: 503 }, action: "retry" },
+      { provider: "p", match: { status: 503, contains: "capacity" }, action: "skip" },
+    ];
+    // first rule (status:503 only) matches first → retry, even though the 2nd also would
+    const r = matchSkipRule("p", { status: 503, text: "capacity" }, ordered);
+    expect(r.action).toBe("retry");
+  });
+
+  it("a match block with no usable condition never matches (no skip-all)", () => {
+    expect(matchSkipRule("p", { status: 503 }, [{ provider: "p", match: {}, action: "skip" }])).toBeNull();
+  });
+
+  it("returns sweep:true only when a matched skip rule opts in", () => {
+    const withSweep = [{ provider: "ag", match: { status: 503 }, action: "skip", sweep: true }];
+    expect(matchSkipRule("ag", { status: 503 }, withSweep)).toEqual({ action: "skip", sweep: true });
+
+    const noSweep = [{ provider: "ag", match: { status: 503 }, action: "skip" }];
+    expect(matchSkipRule("ag", { status: 503 }, noSweep)).toEqual({ action: "skip" });
+
+    // sweep is ignored on retry rules (not a skip)
+    const retrySweep = [{ provider: "ag", match: { status: 429 }, action: "retry", sweep: true }];
+    expect(matchSkipRule("ag", { status: 429 }, retrySweep)).toEqual({ action: "retry" });
+  });
+});
+
+describe("findMatchingSkipRule", () => {
+  const rules = [
+    { provider: "ag", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true },
+    { provider: "ag", match: { status: 429 }, action: "retry" },
+  ];
+
+  it("returns the ACTUAL matching rule object (first match), not a derived shape", () => {
+    const r = findMatchingSkipRule("ag", { status: 503, text: "MODEL_CAPACITY_EXHAUSTED" }, rules);
+    expect(r).toBe(rules[0]); // same object reference → callers can mutate (e.g. raise sweep)
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(findMatchingSkipRule("ag", { status: 500, text: "boom" }, rules)).toBeNull();
+    expect(findMatchingSkipRule("other", { status: 503, text: "capacity" }, rules)).toBeNull();
+  });
+
+  it("matchSkipRule is a thin wrapper — derives {action,sweep} from the found rule", () => {
+    expect(matchSkipRule("ag", { status: 503, text: "capacity" }, rules)).toEqual({ action: "skip", sweep: true });
+    expect(matchSkipRule("ag", { status: 429 }, rules)).toEqual({ action: "retry" });
+  });
+});
+
+describe("resolveProviderHeaderTimeout", () => {
+  it("returns configured timeout for connect_timeout rule", () => {
+    const rules = [{ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 }];
+    expect(resolveProviderHeaderTimeout("kr-ac", rules)).toBe(25000);
+  });
+
+  it("returns null for a different provider (no cross-provider leak)", () => {
+    const rules = [{ provider: "A", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 }];
+    expect(resolveProviderHeaderTimeout("B", rules)).toBeNull();
+  });
+
+  it("earlier rule wins when multiple connect_timeout rules exist", () => {
+    const rules = [
+      { provider: "A", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 10000 },
+      { provider: "A", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 30000 },
+    ];
+    expect(resolveProviderHeaderTimeout("A", rules)).toBe(10000);
+  });
+});

--- a/tests/unit/skip-rules-modal-merge.test.js
+++ b/tests/unit/skip-rules-modal-merge.test.js
@@ -1,0 +1,95 @@
+// Skip-rules modal pure logic: provider dropdown merge + row↔rule validation.
+// These live in skipRulesLogic.js (no JSX) so the "node" vitest env can import them.
+import { describe, expect, it } from "vitest";
+import { mergeProviderOptions, rowToRule, ruleToRow } from "../../src/app/(dashboard)/dashboard/profile/skipRulesLogic.js";
+
+describe("mergeProviderOptions", () => {
+  const AI = {
+    kiro: { id: "kiro", name: "Kiro" },
+    antigravity: { id: "antigravity", name: "Antigravity" },
+    secret: { id: "secret", name: "Secret", hidden: true },
+  };
+
+  it("includes dynamic compatible nodes so kr-ac appears", () => {
+    const nodes = [{ id: "anthropic-compatible-5edf", name: "kr-ac", type: "anthropic-compatible" }];
+    const opts = mergeProviderOptions(AI, nodes);
+    expect(opts.map(o => o.value)).toContain("anthropic-compatible-5edf");
+    expect(opts.find(o => o.value === "anthropic-compatible-5edf").label).toBe("kr-ac (anthropic-compatible)");
+  });
+
+  it("hides providers flagged hidden", () => {
+    expect(mergeProviderOptions(AI, []).map(o => o.value)).not.toContain("secret");
+  });
+
+  it("dedupes by id (static wins over node)", () => {
+    const opts = mergeProviderOptions(AI, [{ id: "kiro", name: "Kiro Node", type: "custom" }]);
+    expect(opts.filter(o => o.value === "kiro")).toHaveLength(1);
+    expect(opts.find(o => o.value === "kiro").label).toBe("Kiro");
+  });
+
+  it("tolerates null/undefined inputs", () => {
+    expect(mergeProviderOptions(null, null)).toEqual([]);
+    expect(mergeProviderOptions(AI, undefined).length).toBeGreaterThan(0);
+  });
+});
+
+describe("rowToRule validation (no silent drop, multi-condition)", () => {
+  const httpRow = (o) => ({ provider: "kiro", matchMode: "http", status: "", contains: "", action: "skip", ...o });
+  const kindRow = (o) => ({ provider: "kr-ac", matchMode: "kind", kind: "connect_timeout", action: "skip", ...o });
+
+  it("flags a row missing provider", () => {
+    expect(rowToRule(httpRow({ provider: "", status: "429" })).error).toBeTruthy();
+  });
+
+  it("flags an http row with neither status nor contains", () => {
+    expect(rowToRule(httpRow({ status: "", contains: "" })).error).toBeTruthy();
+  });
+
+  it("flags an out-of-range status", () => {
+    expect(rowToRule(httpRow({ status: "99" })).error).toBeTruthy();
+    expect(rowToRule(httpRow({ status: "700" })).error).toBeTruthy();
+  });
+
+  it("flags a bad headerTimeoutMs on a connect_timeout rule", () => {
+    expect(rowToRule(kindRow({ headerTimeoutMs: "50" })).error).toBeTruthy();
+  });
+
+  it("builds a valid status-only rule", () => {
+    const { rule, error } = rowToRule(httpRow({ status: "429", action: "retry" }));
+    expect(error).toBeUndefined();
+    expect(rule).toEqual({ provider: "kiro", match: { status: 429 }, action: "retry" });
+  });
+
+  it("builds a valid status+contains rule (AND)", () => {
+    const { rule, error } = rowToRule(httpRow({ provider: "antigravity", status: "503", contains: "capacity" }));
+    expect(error).toBeUndefined();
+    expect(rule).toEqual({ provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip" });
+  });
+
+  it("builds a valid contains-only rule", () => {
+    const { rule } = rowToRule(httpRow({ provider: "some", contains: "overloaded" }));
+    expect(rule).toEqual({ provider: "some", match: { contains: "overloaded" }, action: "skip" });
+  });
+
+  it("builds a valid connect_timeout rule with headerTimeoutMs", () => {
+    const { rule } = rowToRule(kindRow({ headerTimeoutMs: "25000" }));
+    expect(rule).toEqual({ provider: "kr-ac", match: { kind: "connect_timeout" }, action: "skip", headerTimeoutMs: 25000 });
+  });
+
+  it("round-trips a combined rule: rule → row → rule", () => {
+    const original = { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip" };
+    const { rule } = rowToRule(ruleToRow(original));
+    expect(rule).toEqual(original);
+  });
+
+  it("round-trips sweep:true through row and back", () => {
+    const original = { provider: "antigravity", match: { status: 503, contains: "capacity" }, action: "skip", sweep: true };
+    const { rule } = rowToRule(ruleToRow(original));
+    expect(rule).toEqual(original);
+  });
+
+  it("drops sweep when action is retry (sweep only meaningful for skip)", () => {
+    const { rule } = rowToRule({ provider: "kiro", matchMode: "http", status: "429", contains: "", action: "retry", sweep: true });
+    expect(rule).toEqual({ provider: "kiro", match: { status: 429 }, action: "retry" });
+  });
+});


### PR DESCRIPTION
## Summary
- Count tool-call bytes into `state.totalContentLength`, so a turn whose entire answer is a tool call no longer reports `completion_tokens: 0` through the `/4` estimator in `finish()`.
- Add `KIRO_TRUNCATION_STOP_REASONS` and close a turn that was truncated *after* producing output as `finish_reason: "length"`, keeping the bytes instead of failing the turn.
- Validate tool calls per tool rather than per turn, keep the buffered map on a rejected fragment, and drop the latched early return — one unusable fragment no longer discards the complete calls (and the streamed text) alongside it.
- Forward `cache_read_input_tokens` / `cache_creation_input_tokens` through `kiro-to-claude`, in both the streaming and the non-streaming exit.
- Classify `improperly formed request` / `request_body_invalid` / `invalid_request_error` as `fallback: false`, so a malformed body stops cooling down every account that rejects it.
- Return `null` from the two Kiro request translators when `canonicalizeKiroConversation()` reports an invalid conversation, matching the translator local-fail contract in `chatCore.js`.

## Notes
- Kiro's executor is two layers: `transformEventStreamToSSE()` parses EventStream frames and enqueues OpenAI SSE deltas as they arrive, and `attachIntegrityGate()` wraps it, buffers the whole body, and re-derives a verdict from the reported `stop_disposition` before releasing anything. A transform-level exit that reports `terminal_incomplete` therefore causes the gate to discard bytes the transform had already produced — which is why block 2 has to change what the exit *reports*, not only what it emits.
- Tool arguments are billed output like any other completion bytes, but were never added to `totalContentLength`. With no text in the turn the estimator saw `0`, so `Math.max(1, …)` was not even reached and usage went out as `OUT 0`.
- Of the reasons `stopDisposition()` folds into `terminal_incomplete`, only `model_context_window_exceeded` and `max_tokens` mean "usable as far as it got, then the budget ran out". `cancelled` and `pause_turn` are abandoned turns whose partial content must stay private, so they are deliberately excluded from the new set; the gate is additionally conditioned on `state.chunkIndex > 0`.
- Three separate sites compounded into the tool-loss symptom: a per-turn `try` around `emitTools()`, a `state.tools.clear()` in the frame-loop catch, and a latched early return in the `toolUseEvent` branch. The "nothing usable was produced" check has to run *after* `emitTools()` — before it, the rejected tool was still buffered and `tools.size` was never `0`.
- Both cache spellings are accepted on the `kiro-to-claude` path because the Kiro executor emits the Chat shape (`prompt_tokens_details.cached_tokens`) while passthrough responses use the nested details form.
- A malformed body is a property of the request, not of the account: every account rejects the identical payload the same way. Observed on this instance, 39 of 44 error rows carried `errorCode 400` and 12 Kiro connections were pulled out of rotation within 18 seconds, each costing one upstream call for a guaranteed failure. Same reasoning as the existing `context_length_exceeded` rule.
- The two translator guards are defence-in-depth and are **unreachable by construction** on the current code path: `normalizeTurns()` guarantees strict alternation, coerces every user `content` to a non-empty string, and `flattenAllStructuredTools()` strips structured tools on retry, so `canonicalizeKiroConversation()` cannot return `valid: false`. They are covered in the tests through the exported, non-normalizing `validateKiroConversation()`. Included so the contract is enforced at the boundary rather than assumed.
- One further issue was investigated and deliberately **not** fixed here: `KiroExecutor.transformRequest()` is a passthrough with no request-size guard, so an over-large conversation is only rejected by the upstream. That is upstream-owned behaviour and a local cap would need a limit this repo cannot know; no code change.

## Test Plan
- `CI=true npx vitest run -c tests/vitest.config.js tests/unit/kiro-usage-and-tool-integrity.test.js` -> 16 passed (16), 1 file passed
- `CI=true npx vitest run -c tests/vitest.config.js tests/unit/kiro-terminal-integrity.test.js` -> 2 failed | 68 passed (70); both failures are pre-existing on the unpatched tree (verified by stashing the change set and re-running) and are the two retry-HTTP tests that time out at the 5000 ms default
- Differential full suite against the unpatched tree: 118 failing before, 118 failing after, zero regressions and zero newly-passing tests outside the new file
- `npx eslint` on the 6 changed files -> no findings
- `git diff --check` -> clean
- Deployed to a production instance and verified `service healthy`; the reporting user has since confirmed correct behaviour on the traffic that originally reproduced blocks 1-3
