### PR TITLE
fix(antigravity): preserve schema-keyword property names

### DIFF
--- a/open-sse/translator/formats/gemini.js
+++ b/open-sse/translator/formats/gemini.js
@@ -135,25 +135,27 @@ export function generateProjectId() {
 
 // Helper: Remove unsupported keywords recursively from object/array
 // Also strips all vendor extension fields (x- prefixed) not supported by Gemini
-function removeUnsupportedKeywords(obj, keywords) {
+function removeUnsupportedKeywords(obj, keywords, isSchema = true) {
   if (!obj || typeof obj !== "object") return;
 
   if (Array.isArray(obj)) {
     for (const item of obj) {
-      removeUnsupportedKeywords(item, keywords);
+      removeUnsupportedKeywords(item, keywords, isSchema);
     }
     return;
   }
 
   for (const key of Object.keys(obj)) {
-    if (keywords.includes(key) || key.startsWith("x-")) {
+    if (isSchema && (keywords.includes(key) || key.startsWith("x-"))) {
       delete obj[key];
       continue;
     }
 
     const value = obj[key];
     if (value && typeof value === "object") {
-      removeUnsupportedKeywords(value, keywords);
+      // `properties` contains user-defined names, not schema keywords. Its
+      // values resume the schema tree one level below the name map.
+      removeUnsupportedKeywords(value, keywords, isSchema ? key !== "properties" : true);
     }
   }
 }
@@ -302,10 +304,18 @@ function flattenTypeArrays(obj) {
 }
 
 // Infer missing type=object when properties exist (Gemini requires explicit type)
-function ensureObjectType(obj) {
+function ensureObjectType(obj, isSchema = true) {
   if (!obj || typeof obj !== "object") return;
-  if (obj.properties && !obj.type) obj.type = "object";
-  for (const v of Object.values(obj)) if (v && typeof v === "object") ensureObjectType(v);
+  if (isSchema && obj.properties && !obj.type) obj.type = "object";
+  if (Array.isArray(obj)) {
+    for (const item of obj) ensureObjectType(item, isSchema);
+    return;
+  }
+  for (const [key, value] of Object.entries(obj)) {
+    if (value && typeof value === "object") {
+      ensureObjectType(value, isSchema ? key !== "properties" : true);
+    }
+  }
 }
 
 // Clean JSON Schema for Antigravity API compatibility - removes unsupported keywords recursively
@@ -396,4 +406,3 @@ export function cleanJSONSchemaForAntigravity(schema) {
 
   return cleaned;
 }
-

--- a/tests/unit/antigravity-schema-cleaner.test.js
+++ b/tests/unit/antigravity-schema-cleaner.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { cleanJSONSchemaForAntigravity } from "../../open-sse/translator/formats/gemini.js";
+
+describe("cleanJSONSchemaForAntigravity", () => {
+  it("preserves schema-keyword names used as object properties", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        page_id: { type: "string" },
+        properties: {
+          type: "object",
+          description: "Page property values",
+          additionalProperties: true,
+        },
+        title: { type: "string" },
+      },
+    };
+
+    const cleaned = cleanJSONSchemaForAntigravity(structuredClone(schema));
+
+    expect(cleaned.properties).toEqual({
+      page_id: { type: "string" },
+      properties: {
+        type: "object",
+        description: "Page property values",
+        properties: {
+          reason: {
+            type: "string",
+            description: "Brief explanation of why you are calling this tool",
+          },
+        },
+        required: ["reason"],
+      },
+      title: { type: "string" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes: Gemini requests fail with HTTP 400 when an MCP tool has a parameter named properties, while parameters such as title are silently removed from the submitted tool schema.
- Root cause: The recursive cleaner treats the JSON Schema properties name map as a schema node, so ensureObjectType injects a bogus type entry into the map and removeUnsupportedKeywords deletes user-defined names that collide with schema keywords.

Closes #2884.

## Regression evidence

- Before: `cd tests && npx vitest run unit/antigravity-schema-cleaner.test.js --reporter=verbose` exited `1`

- After: `cd tests && npx vitest run unit/antigravity-schema-cleaner.test.js --reporter=verbose` exited `0`

## Verification

- `cd tests && npx vitest run unit/antigravity-schema-cleaner.test.js translator/bugs-antigravity.test.js unit/gemini-36-integration.test.js unit/antigravity-stream-options.test.js --reporter=verbose`
- `npx eslint open-sse/translator/formats/gemini.js tests/unit/antigravity-schema-cleaner.test.js`
- `npm run build`
- CI-mode full Vitest comparison: the frozen base and patched tree have identical 129-test failure sets; the patched tree adds one passing regression test.

## Scope

- 2 files changed, +54 / -8 lines
