### PR TITLE
fix(nvidia): normalize tool names/IDs & restore original names in response streams

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -74,6 +74,8 @@ export class DefaultExecutor extends BaseExecutor {
     if (transformed && typeof transformed === "object") {
       const toolNameMaxLength = this.config.quirks?.toolNameMaxLength || 64;
       normalizeOpenAIToolNames(transformed, toolNameMaxLength);
+      // NVIDIA-specific: normalize tool_call IDs to a compact deterministic ID that NVIDIA accepts
+      if (this.provider === "nvidia") normalizeNvidiaToolCallIds(transformed);
 
       // quirk: some openai-compatible providers reject Anthropic's client_metadata field
       if (this.config.quirks?.dropClientMetadata) {

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -7,6 +7,7 @@ import { buildClineHeaders } from "../shared/clineAuth.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
+import { normalizeOpenAIToolNames } from "../translator/concerns/toolCall.js";
 
 // Auth header descriptors — derived from registry transport.auth, fallback to hardcoded defaults.
 const BEARER = { combined: true, header: "Authorization", scheme: "bearer" };
@@ -71,6 +72,9 @@ export class DefaultExecutor extends BaseExecutor {
     const transformed = this.applyJsonSchemaFallback(body);
 
     if (transformed && typeof transformed === "object") {
+      const toolNameMaxLength = this.config.quirks?.toolNameMaxLength || 64;
+      normalizeOpenAIToolNames(transformed, toolNameMaxLength);
+
       // quirk: some openai-compatible providers reject Anthropic's client_metadata field
       if (this.config.quirks?.dropClientMetadata) {
         delete transformed.client_metadata;

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -7,7 +7,7 @@ import { buildClineHeaders } from "../shared/clineAuth.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { stripUnsupportedParams } from "../translator/concerns/paramSupport.js";
-import { normalizeOpenAIToolNames } from "../translator/concerns/toolCall.js";
+import { normalizeOpenAIToolNames, normalizeNvidiaToolCallIds } from "../translator/concerns/toolCall.js";
 
 // Auth header descriptors — derived from registry transport.auth, fallback to hardcoded defaults.
 const BEARER = { combined: true, header: "Authorization", scheme: "bearer" };

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -8,6 +8,7 @@ import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
 import { getModelTargetFormat, getModelStrip, getModelUpstreamId, getModelType, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { PROVIDERS } from "../config/providers.js";
+import { normalizeOpenAIToolNames } from "../translator/concerns/toolCall.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
 import { HTTP_STATUS, TOKEN_SAVER_HEADER } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
@@ -183,6 +184,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     delete translatedBody._customToolNames;
     translatedBody.model = stripThinkingSuffix(upstreamModel);
     stripContinuityFields(translatedBody);
+  }
+
+  const toolNameMaxLength = PROVIDERS[provider]?.quirks?.toolNameMaxLength || (targetFormat === FORMATS.OPENAI ? 64 : null);
+  if (toolNameMaxLength && targetFormat === FORMATS.OPENAI) {
+    const aliases = normalizeOpenAIToolNames(translatedBody, toolNameMaxLength);
+    if (aliases.size) toolNameMap = new Map([...(toolNameMap || []), ...aliases]);
   }
 
   // Dedupe duplicate built-in tools when equivalent MCP tools are present (Claude clients only).

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -431,13 +431,13 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, toolNameMap, customToolNames, pxpipe: pxpipeSummary, reqTag, log };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 
   // Provider forced streaming but client wants JSON
   if (!clientRequestedStreaming && providerRequiresStreaming) {
-    const result = await handleForcedSSEToJson({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, customToolNames, trackDone, appendLog });
+    const result = await handleForcedSSEToJson({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, toolNameMap, customToolNames, trackDone, appendLog });
     if (result) { streamController.handleComplete(); return result; }
   }
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -9,6 +9,7 @@ import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
+import { restoreOpenAIToolNames } from "../../translator/concerns/toolCall.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
 
 function parseToolArguments(value) {
@@ -315,6 +316,7 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
 
   // Decloak tool_use names once on raw Claude body, before any translation (INPUT side)
   responseBody = decloakToolNames(responseBody, toolNameMap);
+  restoreOpenAIToolNames(responseBody, toolNameMap);
 
   const usage = extractUsageFromResponse(responseBody);
   appendLog({ tokens: usage, status: "200 OK" });

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -6,6 +6,8 @@ import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
 
+import { restoreOpenAIToolNames } from "../../translator/concerns/toolCall.js";
+
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
 import { saveRequestDetail, appendRequestLog } from "@/lib/usageDb.js";
@@ -179,7 +181,7 @@ export function parseSSEToOpenAIResponse(rawSSE, fallbackModel) {
  * Handle case: provider forced streaming but client wants JSON.
  * Supports both Codex/Responses API SSE and standard Chat Completions SSE.
  */
-export async function handleForcedSSEToJson({ providerResponse, sourceFormat, targetFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, customToolNames, trackDone, appendLog, reqTag, log }) {
+export async function handleForcedSSEToJson({ providerResponse, sourceFormat, targetFormat, provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, toolNameMap, customToolNames, trackDone, appendLog, reqTag, log }) {
   const contentType = providerResponse.headers.get("content-type") || "";
   const isSSE = contentType.includes("text/event-stream") || (contentType === "" && isResponsesProvider(provider));
   if (!isSSE) return null; // not handled here
@@ -266,6 +268,27 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
             responseId: jsonResponse.id || `resp_${Date.now()}`
           }
         };
+      } else if (sourceFormat === FORMATS.CLAUDE) {
+        const content = [];
+        if (textContent) content.push({ type: "text", text: textContent });
+        for (const tc of toolCalls) {
+          content.push({
+            type: "tool_use",
+            id: tc.id,
+            name: tc.function.name,
+            input: JSON.parse(tc.function.arguments || "{}")
+          });
+        }
+        finalResp = {
+          id: jsonResponse.id || `msg_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          content,
+          model: jsonResponse.model || model,
+          stop_reason: hasToolCalls ? "tool_use" : "end_turn",
+          stop_sequence: null,
+          usage: { input_tokens: inTokens, output_tokens: outTokens, ...cacheDetails }
+        };
       } else {
         const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
         if (hasToolCalls) message.tool_calls = toolCalls;
@@ -281,6 +304,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
         };
       }
 
+      restoreOpenAIToolNames(finalResp, toolNameMap);
       return { success: true, response: new Response(JSON.stringify(finalResp), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
     } catch (err) {
       console.error("[ChatCore] Responses API SSE→JSON failed:", err);
@@ -299,6 +323,8 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
         parsed.error.message || "Upstream SSE stream failed"
       );
     }
+
+    restoreOpenAIToolNames(parsed, toolNameMap);
 
     if (onRequestSuccess) await onRequestSuccess();
 

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -60,7 +60,13 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
   // and clamped so untrusted upstream text never reaches the client verbatim
   // (the UI may render error.message as HTML).
   const upstreamContentType = (providerResponse.headers.get('content-type') || '').toLowerCase();
-  if (upstreamContentType && !upstreamContentType.includes('text/event-stream') && !upstreamContentType.includes('application/json')) {
+  if (
+    upstreamContentType &&
+    !upstreamContentType.includes('text/event-stream') &&
+    !upstreamContentType.includes('application/json') &&
+    !upstreamContentType.includes('application/x-ndjson') &&
+    !upstreamContentType.includes('application/stream+json')
+  ) {
     const bodyText = await providerResponse.text().catch(() => '');
     const titleMatch = bodyText.match(/<title>([^<]+)<\/title>/i);
     const sanitizedTitle = (titleMatch?.[1] || '').replace(/<[^>]*>/g, '').replace(/[\r\n]+/g, ' ').trim().slice(0, 160);

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -37,7 +37,7 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
     return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, toolNameMap, customToolNames);
 }
 
 /**

--- a/open-sse/providers/registry/nvidia.js
+++ b/open-sse/providers/registry/nvidia.js
@@ -17,6 +17,9 @@ export default {
   category: "freeTier",
   authType: "apikey",
   authModes: ["apikey"],
+  quirks: {
+    toolNameMaxLength: 64,
+  },
   transport: {
     baseUrl: "https://integrate.api.nvidia.com/v1/chat/completions",
     validateUrl: "https://integrate.api.nvidia.com/v1/models",

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -272,21 +272,19 @@ export function fixMissingToolResponses(body) {
 }
 
 
-// NVIDIA-specific deterministic ID: prefer short 9-hex identifier for upstream
-const nvidiaIdCache = new Map();
+// Endpoint/provider compatibility constraint observed by 9router for certain NVIDIA endpoints:
+// prefer compact 9-hex deterministic identifier for upstream compatibility
 export function nvidiaToolCallId(id) {
   if (!id || typeof id !== 'string') return id;
   // Accept already-short alphanumeric IDs (9 chars)
   if (/^[a-zA-Z0-9]{9}$/.test(id)) return id;
-  if (nvidiaIdCache.has(id)) return nvidiaIdCache.get(id);
-  const hashed = createHash('sha256').update(id).digest('hex').slice(0, 9);
-  nvidiaIdCache.set(id, hashed);
-  return hashed;
+  return createHash('sha256').update(id).digest('hex').slice(0, 9);
 }
 
 // Normalize tool call IDs specifically for NVIDIA provider
 export function normalizeNvidiaToolCallIds(body) {
   if (!body || !Array.isArray(body.messages)) return body;
+  ensureToolCallIds(body);
   for (const msg of body.messages) {
     // OpenAI format: tool_calls array on assistant
     for (const tc of msg?.tool_calls || []) {

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -1,4 +1,121 @@
+import { createHash } from "node:crypto";
+
 // Tool call helper functions for translator
+
+/**
+ * Normalizes OpenAI function/tool names to satisfy provider naming constraints.
+ * (OpenAI specification requirement: ^[a-zA-Z0-9_-]{1,64}$)
+ *
+ * - Replaces unsupported characters with underscores.
+ * - Truncates names that exceed max length (default 64).
+ * - Appends a deterministic SHA-256 hash suffix to avoid collisions.
+ * - Supports OpenAI tool definitions (tool.function.name) and Claude/raw tool definitions (tool.name).
+ * - Supports tool calls in messages (tool_calls[].function.name, content[type="tool_use"].name, role="tool").
+ * - Returns a map of normalized names back to their original names.
+ */
+export function normalizeOpenAIToolNames(body, maxLength = 64) {
+  const aliases = new Map();
+  if (!body || typeof body !== "object") return aliases;
+
+  const alias = (name) => {
+    if (!name || typeof name !== "string") return name;
+
+    const safe = name.replace(/[^a-zA-Z0-9_-]/g, "_");
+    const changed = safe !== name || safe.length > maxLength;
+
+    const shortened = changed
+      ? `${safe.slice(0, maxLength - 13)}_${createHash("sha256")
+          .update(name)
+          .digest("hex")
+          .slice(0, 12)}`
+      : safe;
+
+    if (shortened !== name) {
+      aliases.set(shortened, name);
+    }
+    return shortened;
+  };
+
+  // Normalize tool definitions (both OpenAI and Claude/raw formats)
+  if (Array.isArray(body.tools)) {
+    for (const tool of body.tools) {
+      if (tool?.function?.name) {
+        tool.function.name = alias(tool.function.name);
+      }
+      if (tool?.name && typeof tool.name === "string") {
+        tool.name = alias(tool.name);
+      }
+    }
+  }
+
+  // Normalize explicit tool choice
+  if (body.tool_choice) {
+    if (body.tool_choice.function?.name) {
+      body.tool_choice.function.name = alias(body.tool_choice.function.name);
+    }
+    if (typeof body.tool_choice.name === "string") {
+      body.tool_choice.name = alias(body.tool_choice.name);
+    }
+  }
+
+  // Normalize tool calls & tool results in conversation history
+  if (Array.isArray(body.messages)) {
+    for (const message of body.messages) {
+      if (!message || typeof message !== "object") continue;
+
+      if (Array.isArray(message.tool_calls)) {
+        for (const call of message.tool_calls) {
+          if (call?.function?.name) {
+            call.function.name = alias(call.function.name);
+          }
+        }
+      }
+
+      if (Array.isArray(message.content)) {
+        for (const block of message.content) {
+          if (block?.type === "tool_use" && block.name) {
+            block.name = alias(block.name);
+          }
+        }
+      }
+
+      if (message.role === "tool" && message.name) {
+        message.name = alias(message.name);
+      }
+    }
+  }
+
+  return aliases;
+}
+
+/**
+ * Restores original OpenAI tool/function names from their normalized aliases.
+ */
+export function restoreOpenAIToolNames(body, aliases) {
+  if (!aliases || typeof aliases !== "object" || !aliases.size) return false;
+
+  let changed = false;
+
+  const restoreCalls = (calls) => {
+    if (!Array.isArray(calls)) return;
+    for (const call of calls) {
+      const name = call?.function?.name;
+      if (name && aliases.has(name)) {
+        call.function.name = aliases.get(name);
+        changed = true;
+      }
+    }
+  };
+
+  if (Array.isArray(body?.choices)) {
+    for (const choice of body.choices) {
+      restoreCalls(choice?.delta?.tool_calls);
+      restoreCalls(choice?.message?.tool_calls);
+    }
+  }
+
+  return changed;
+}
 
 // Anthropic tool_use.id must match: ^[a-zA-Z0-9_-]+$
 const TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -268,3 +268,37 @@ export function fixMissingToolResponses(body) {
   return body;
 }
 
+
+// NVIDIA-specific deterministic ID: prefer short 9-hex identifier for upstream
+export function nvidiaToolCallId(id) {
+  if (!id || typeof id !== 'string') return id;
+  // Accept already-short alphanumeric IDs (9 chars)
+  if (/^[a-zA-Z0-9]{9}$/.test(id)) return id;
+  return createHash('sha256').update(id).digest('hex').slice(0, 9);
+}
+
+// Normalize tool call IDs specifically for NVIDIA provider
+export function normalizeNvidiaToolCallIds(body) {
+  if (!body || !Array.isArray(body.messages)) return body;
+  for (const msg of body.messages) {
+    // OpenAI format: tool_calls array on assistant
+    for (const tc of msg?.tool_calls || []) {
+      if (tc && tc.id) tc.id = nvidiaToolCallId(tc.id);
+    }
+    // Tool message id
+    if (msg && msg.tool_call_id) msg.tool_call_id = nvidiaToolCallId(msg.tool_call_id);
+    // Claude format: tool_use blocks
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (!block || typeof block !== 'object') continue;
+        if ((block.type === 'tool_use' || block.type === 'tool_result') && block.id) {
+          block.id = nvidiaToolCallId(block.id);
+        }
+        if (block.type === 'tool_result' && block.tool_use_id) {
+          block.tool_use_id = nvidiaToolCallId(block.tool_use_id);
+        }
+      }
+    }
+  }
+  return body;
+}

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -16,9 +16,11 @@ import { createHash } from "node:crypto";
 export function normalizeOpenAIToolNames(body, maxLength = 64) {
   const aliases = new Map();
   if (!body || typeof body !== "object") return aliases;
+  const memo = new Map();
 
   const alias = (name) => {
     if (!name || typeof name !== "string") return name;
+    if (memo.has(name)) return memo.get(name);
 
     const safe = name.replace(/[^a-zA-Z0-9_-]/g, "_");
     const changed = safe !== name || safe.length > maxLength;
@@ -33,6 +35,7 @@ export function normalizeOpenAIToolNames(body, maxLength = 64) {
     if (shortened !== name) {
       aliases.set(shortened, name);
     }
+    memo.set(name, shortened);
     return shortened;
   };
 
@@ -270,11 +273,15 @@ export function fixMissingToolResponses(body) {
 
 
 // NVIDIA-specific deterministic ID: prefer short 9-hex identifier for upstream
+const nvidiaIdCache = new Map();
 export function nvidiaToolCallId(id) {
   if (!id || typeof id !== 'string') return id;
   // Accept already-short alphanumeric IDs (9 chars)
   if (/^[a-zA-Z0-9]{9}$/.test(id)) return id;
-  return createHash('sha256').update(id).digest('hex').slice(0, 9);
+  if (nvidiaIdCache.has(id)) return nvidiaIdCache.get(id);
+  const hashed = createHash('sha256').update(id).digest('hex').slice(0, 9);
+  nvidiaIdCache.set(id, hashed);
+  return hashed;
 }
 
 // Normalize tool call IDs specifically for NVIDIA provider

--- a/open-sse/translator/formats/openai.js
+++ b/open-sse/translator/formats/openai.js
@@ -1,5 +1,6 @@
 // OpenAI helper functions for translator
 import { ROLE, OPENAI_BLOCK, CLAUDE_BLOCK, VALID_OPENAI_CONTENT_TYPES, VALID_OPENAI_MESSAGE_TYPES } from "../schema/index.js";
+import { normalizeOpenAIToolNames } from "../concerns/toolCall.js";
 
 // Re-export valid-type lists (moved to schema/blocks.js) to keep existing importers working.
 export { VALID_OPENAI_CONTENT_TYPES, VALID_OPENAI_MESSAGE_TYPES };
@@ -127,6 +128,11 @@ export function filterToOpenAIFormat(body, opts = {}) {
     } else if (choice.type === "tool" && choice.name) {
       body.tool_choice = { type: OPENAI_BLOCK.FUNCTION, function: { name: choice.name } };
     }
+  }
+
+  const aliases = normalizeOpenAIToolNames(body, 64);
+  if (aliases.size) {
+    body._toolNameMap = aliases;
   }
 
   return body;

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -190,10 +190,12 @@ export function openaiToClaudeResponse(chunk, state) {
         stopTextBlock(state, results);
 
         const toolBlockIndex = state.nextBlockIndex++;
-        state.toolCalls.set(idx, { id: tc.id, name: tc.function?.name || "", blockIndex: toolBlockIndex });
+        const providerToolName = tc.function?.name || "";
+        const originalToolName = state.toolNameMap?.get(providerToolName) || providerToolName;
+        state.toolCalls.set(idx, { id: tc.id, name: originalToolName, blockIndex: toolBlockIndex });
 
         // Strip prefix from tool name for response
-        let toolName = tc.function?.name || "";
+        let toolName = originalToolName;
         if (toolName.startsWith(CLAUDE_OAUTH_TOOL_PREFIX)) {
           toolName = toolName.slice(CLAUDE_OAUTH_TOOL_PREFIX.length);
         }

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -107,16 +107,20 @@ export function createSSEStream(options = {}) {
         // Passthrough mode: normalize and forward
         if (mode === STREAM_MODE.PASSTHROUGH) {
 
-          if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
+          const isSseData = trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]";
+          const isJsonObj = !isSseData && trimmed.startsWith("{") && trimmed.endsWith("}");
+
+          if (isSseData || isJsonObj) {
             try {
-              const parsed = JSON.parse(trimmed.slice(5).trim());
+              const jsonText = isSseData ? trimmed.slice(5).trim() : trimmed;
+              const parsed = JSON.parse(jsonText);
               const toolNameRestored = restoreOpenAIToolNames(parsed, toolNameMap);
 
               const idFixed = fixInvalidId(parsed);
 
               // Ensure OpenAI-required fields are present on streaming chunks (Letta compat)
               let fieldsInjected = false;
-              if (parsed.choices !== undefined) {
+              if (isSseData && parsed.choices !== undefined) {
                 if (!parsed.object) { parsed.object = "chat.completion.chunk"; fieldsInjected = true; }
                 if (!parsed.created) { parsed.created = Math.floor(Date.now() / 1000); fieldsInjected = true; }
               }
@@ -153,7 +157,7 @@ export function createSSEStream(options = {}) {
                 continue;
               }
 
-              const delta = parsed.choices?.[0]?.delta;
+              const delta = parsed.choices?.[0]?.delta || parsed.choices?.[0]?.message;
               const content = delta?.content;
               const reasoning = delta?.reasoning_content;
               if (content && typeof content === "string") {
@@ -170,20 +174,21 @@ export function createSSEStream(options = {}) {
                 usage = mergeUsage(usage, extracted);
               }
 
+              const prefix = isSseData ? "data: " : "";
               const isFinishChunk = parsed.choices?.[0]?.finish_reason;
               if (isFinishChunk && !hasValidUsage(parsed.usage)) {
                 const estimated = estimateUsage(body, totalContentLength, FORMATS.OPENAI);
                 parsed.usage = filterUsageForFormat(estimated, FORMATS.OPENAI);
-                output = `data: ${JSON.stringify(parsed)}\n`;
+                output = `${prefix}${JSON.stringify(parsed)}\n`;
                 usage = estimated;
                 injectedUsage = true;
               } else if (isFinishChunk && usage) {
                 const buffered = addBufferToUsage(usage);
                 parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
-                output = `data: ${JSON.stringify(parsed)}\n`;
+                output = `${prefix}${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               } else if (idFixed || fieldsInjected || toolNameRestored) {
-                output = `data: ${JSON.stringify(parsed)}\n`;
+                output = `${prefix}${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               }
             } catch {

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -5,6 +5,7 @@ import { extractUsage, mergeUsage, hasValidUsage, estimateUsage, logUsage, addBu
 import { parseSSELine, hasValuableContent, fixInvalidId, formatSSE } from "./streamHelpers.js";
 import { getOpenAIResponsesEventName, isOpenAIResponsesTerminalEvent, formatIncompleteOpenAIResponsesStreamFailure } from "./responsesStreamHelpers.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
+import { restoreOpenAIToolNames } from "../translator/concerns/toolCall.js";
 
 import { SSE_DONE, SSE_HEADERS, SSE_HEADERS_NO_BUFFER } from "./sseConstants.js";
 
@@ -88,6 +89,8 @@ export function createSSEStream(options = {}) {
 
       for (const line of lines) {
         const trimmed = line.trim();
+        let output;
+        let injectedUsage = false;
         if (isDebugEnabled && trimmed) {
           sseLineCount++;
           if (trimmed.startsWith("event:")) {
@@ -103,12 +106,11 @@ export function createSSEStream(options = {}) {
 
         // Passthrough mode: normalize and forward
         if (mode === STREAM_MODE.PASSTHROUGH) {
-          let output;
-          let injectedUsage = false;
 
           if (trimmed.startsWith("data:") && trimmed.slice(5).trim() !== "[DONE]") {
             try {
               const parsed = JSON.parse(trimmed.slice(5).trim());
+              const toolNameRestored = restoreOpenAIToolNames(parsed, toolNameMap);
 
               const idFixed = fixInvalidId(parsed);
 
@@ -180,7 +182,7 @@ export function createSSEStream(options = {}) {
                 parsed.usage = filterUsageForFormat(buffered, FORMATS.OPENAI);
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
-              } else if (idFixed || fieldsInjected) {
+              } else if (idFixed || fieldsInjected || toolNameRestored) {
                 output = `data: ${JSON.stringify(parsed)}\n`;
                 injectedUsage = true;
               }
@@ -484,10 +486,11 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, toolNameMap = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
     provider,
+    toolNameMap,
     reqLogger,
     model,
     connectionId,

--- a/tests/unit/nvidia-tool-call-id.test.js
+++ b/tests/unit/nvidia-tool-call-id.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+
+describe("NVIDIA tool call IDs", () => {
+  it("uses the same 9-character alphanumeric ID for calls and results", () => {
+    const out = new DefaultExecutor("nvidia").transformRequest("mistralai/mistral-medium-3.5-128b", {
+      messages: [
+        { role: "assistant", tool_calls: [{ id: "6075034-0", type: "function", function: { name: "test", arguments: "{}" } }] },
+        { role: "tool", tool_call_id: "6075034-0", content: "ok" },
+      ],
+    });
+
+    expect(out.messages[0].tool_calls[0].id).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(out.messages[1].tool_call_id).toBe(out.messages[0].tool_calls[0].id);
+  });
+});

--- a/tests/unit/nvidia-tool-call-id.test.js
+++ b/tests/unit/nvidia-tool-call-id.test.js
@@ -1,16 +1,136 @@
 import { describe, it, expect } from "vitest";
 import { DefaultExecutor } from "../../open-sse/executors/default.js";
+import { normalizeOpenAIToolNames, normalizeNvidiaToolCallIds, nvidiaToolCallId } from "../../open-sse/translator/concerns/toolCall.js";
 
 describe("NVIDIA tool call IDs", () => {
-  it("uses the same 9-character alphanumeric ID for calls and results", () => {
+  it("preserves valid 9-character alphanumeric IDs", () => {
+    const validId = "a1b2c3d4e";
+    expect(nvidiaToolCallId(validId)).toBe(validId);
+
+    const body = {
+      messages: [
+        { role: "assistant", tool_calls: [{ id: validId, type: "function", function: { name: "test", arguments: "{}" } }] },
+        { role: "tool", tool_call_id: validId, content: "ok" },
+      ],
+    };
+    normalizeNvidiaToolCallIds(body);
+
+    expect(body.messages[0].tool_calls[0].id).toBe(validId);
+    expect(body.messages[1].tool_call_id).toBe(validId);
+  });
+
+  it("normalizes invalid IDs to 9-character alphanumeric strings", () => {
+    const invalidId = "invalid-id-with-dashes-and-long-length-12345";
+    const normalized = nvidiaToolCallId(invalidId);
+
+    expect(normalized).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(normalized).not.toBe(invalidId);
+  });
+
+  it("generates and normalizes missing tool call IDs", () => {
+    const body = {
+      messages: [
+        { role: "assistant", tool_calls: [{ function: { name: "get_weather", arguments: "{}" } }] },
+      ],
+    };
+    normalizeNvidiaToolCallIds(body);
+
+    expect(body.messages[0].tool_calls[0].id).toMatch(/^[a-zA-Z0-9]{9}$/);
+  });
+
+  it("handles two missing IDs in one request without collision", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            { function: { name: "get_weather", arguments: "{}" } },
+            { function: { name: "get_stock", arguments: "{}" } },
+          ],
+        },
+      ],
+    };
+    normalizeNvidiaToolCallIds(body);
+
+    const id1 = body.messages[0].tool_calls[0].id;
+    const id2 = body.messages[0].tool_calls[1].id;
+
+    expect(id1).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(id2).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(id1).not.toBe(id2);
+  });
+
+  it("normalizes multiple tool calls without collisions", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [
+            { id: "call_abc_1", function: { name: "fn1", arguments: "{}" } },
+            { id: "call_abc_2", function: { name: "fn2", arguments: "{}" } },
+            { id: "call_abc_3", function: { name: "fn3", arguments: "{}" } },
+          ],
+        },
+      ],
+    };
+    normalizeNvidiaToolCallIds(body);
+
+    const ids = body.messages[0].tool_calls.map((tc) => tc.id);
+    const uniqueIds = new Set(ids);
+
+    expect(uniqueIds.size).toBe(3);
+    ids.forEach((id) => expect(id).toMatch(/^[a-zA-Z0-9]{9}$/));
+  });
+
+  it("maintains consistency between assistant tool_calls[].id and tool-result tool_call_id", () => {
+    const originalId = "6075034-0";
     const out = new DefaultExecutor("nvidia").transformRequest("mistralai/mistral-medium-3.5-128b", {
       messages: [
-        { role: "assistant", tool_calls: [{ id: "6075034-0", type: "function", function: { name: "test", arguments: "{}" } }] },
-        { role: "tool", tool_call_id: "6075034-0", content: "ok" },
+        { role: "assistant", tool_calls: [{ id: originalId, type: "function", function: { name: "test", arguments: "{}" } }] },
+        { role: "tool", tool_call_id: originalId, content: "ok" },
       ],
     });
 
     expect(out.messages[0].tool_calls[0].id).toMatch(/^[a-zA-Z0-9]{9}$/);
     expect(out.messages[1].tool_call_id).toBe(out.messages[0].tool_calls[0].id);
+  });
+
+  it("is idempotent over repeated normalization passes", () => {
+    const body = {
+      messages: [
+        { role: "assistant", tool_calls: [{ id: "call_test_12345", function: { name: "test", arguments: "{}" } }] },
+        { role: "tool", tool_call_id: "call_test_12345", content: "result" },
+      ],
+    };
+
+    normalizeNvidiaToolCallIds(body);
+    const idPass1 = body.messages[0].tool_calls[0].id;
+    const toolIdPass1 = body.messages[1].tool_call_id;
+
+    normalizeNvidiaToolCallIds(body);
+    const idPass2 = body.messages[0].tool_calls[0].id;
+    const toolIdPass2 = body.messages[1].tool_call_id;
+
+    expect(idPass1).toBe(idPass2);
+    expect(toolIdPass1).toBe(toolIdPass2);
+  });
+
+  it("coexists seamlessly with tool-name normalization", () => {
+    const longToolName = "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message";
+    const body = {
+      tools: [{ type: "function", function: { name: longToolName } }],
+      messages: [
+        { role: "assistant", tool_calls: [{ id: "call_long_tool_1", function: { name: longToolName, arguments: "{}" } }] },
+        { role: "tool", tool_call_id: "call_long_tool_1", content: "ok" },
+      ],
+    };
+
+    normalizeOpenAIToolNames(body, 64);
+    normalizeNvidiaToolCallIds(body);
+
+    expect(body.tools[0].function.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    expect(body.messages[0].tool_calls[0].function.name).toBe(body.tools[0].function.name);
+    expect(body.messages[0].tool_calls[0].id).toMatch(/^[a-zA-Z0-9]{9}$/);
+    expect(body.messages[1].tool_call_id).toBe(body.messages[0].tool_calls[0].id);
   });
 });

--- a/tests/unit/nvidia-tool-name.test.js
+++ b/tests/unit/nvidia-tool-name.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { normalizeOpenAIToolNames, restoreOpenAIToolNames } from "../../open-sse/translator/concerns/toolCall.js";
+import { openaiToClaudeResponse } from "../../open-sse/translator/response/openai-to-claude.js";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+
+describe("NVIDIA / OpenAI tool name normalization & restoration", () => {
+  it("normalizes OpenAI tool definitions, tool_choice, and message tool calls", () => {
+    const original = "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message";
+    const body = {
+      tools: [{ type: "function", function: { name: original } }],
+      tool_choice: { type: "function", function: { name: original } },
+      messages: [{ role: "assistant", tool_calls: [{ function: { name: original } }] }],
+    };
+
+    const names = normalizeOpenAIToolNames(body, 64);
+    const alias = body.tools[0].function.name;
+
+    expect(alias).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+    expect(alias.length).toBeLessThanOrEqual(64);
+    expect(body.tool_choice.function.name).toBe(alias);
+    expect(body.messages[0].tool_calls[0].function.name).toBe(alias);
+
+    const response = { choices: [{ delta: { tool_calls: [{ function: { name: alias } }] } }] };
+    expect(restoreOpenAIToolNames(response, names)).toBe(true);
+    expect(response.choices[0].delta.tool_calls[0].function.name).toBe(original);
+  });
+
+  it("normalizes Claude/raw tool definitions and content tool_use blocks", () => {
+    const original = "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message";
+    const body = {
+      tools: [{ name: original, description: "MCP test", input_schema: { type: "object" } }],
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "call_1", name: original, input: {} }],
+        },
+      ],
+    };
+
+    const names = normalizeOpenAIToolNames(body, 64);
+    const alias = body.tools[0].name;
+
+    expect(alias).toMatch(/^[A-Za-z0-9_-]{1,64}$/);
+    expect(alias.length).toBeLessThanOrEqual(64);
+    expect(body.messages[0].content[0].name).toBe(alias);
+  });
+
+  it("handles collisions deterministically", () => {
+    const collisions = { tools: ["a.b", "a?b"].map(name => ({ type: "function", function: { name } })) };
+    normalizeOpenAIToolNames(collisions, 64);
+    expect(collisions.tools[0].function.name).not.toBe(collisions.tools[1].function.name);
+  });
+
+  it("translates OpenAI streaming responses back to Claude tool names using toolNameMap", () => {
+    const original = "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message";
+    const body = { tools: [{ type: "function", function: { name: original } }] };
+    const names = normalizeOpenAIToolNames(body, 64);
+    const alias = body.tools[0].function.name;
+
+    const translated = openaiToClaudeResponse(
+      {
+        choices: [{ delta: { tool_calls: [{ index: 0, id: "call_1", function: { name: alias, arguments: "" } }] } }],
+      },
+      { toolNameMap: names, toolCalls: new Map(), nextBlockIndex: 0, textBlockIndex: -1, thinkingBlockIndex: -1 }
+    );
+
+    const startBlock = translated.find(x => x.type === "content_block_start");
+    expect(startBlock.content_block.name).toBe(original);
+  });
+
+  it("reserializes passthrough SSE chunks with original tool names", async () => {
+    const original = "mcp__plugin_chrome-devtools-mcp_chrome-devtools__get_console_message";
+    const body = { tools: [{ type: "function", function: { name: original } }] };
+    const names = normalizeOpenAIToolNames(body, 64);
+    const alias = body.tools[0].function.name;
+    const transform = createPassthroughStreamWithLogger("nvidia", null, null, null, null, null, null, names);
+    const writer = transform.writable.getWriter();
+    const reader = transform.readable.getReader();
+
+    const outputPromise = (async () => {
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return text;
+        text += new TextDecoder().decode(value);
+      }
+    })();
+
+    await writer.write(
+      new TextEncoder().encode(
+        `data: ${JSON.stringify({
+          id: "chatcmpl_1",
+          object: "chat.completion.chunk",
+          created: 1,
+          choices: [{ delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: alias, arguments: "" } }] } }],
+        })}\n\n`
+      )
+    );
+    await writer.close();
+
+    const text = await outputPromise;
+    expect(text).toContain(original);
+    expect(text).not.toContain(alias);
+  });
+});

--- a/tests/unit/ollama-ndjson-stream.test.js
+++ b/tests/unit/ollama-ndjson-stream.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { handleStreamingResponse } from "../../open-sse/handlers/chatCore/streamingHandler.js";
+
+describe("Ollama stream content type support", () => {
+  it("allows application/x-ndjson and application/stream+json without blocking as non-SSE error", async () => {
+    const mockProviderResponse = {
+      status: 200,
+      headers: new Map([["content-type", "application/x-ndjson"]]),
+      body: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    };
+    mockProviderResponse.headers.get = (name) => (name.toLowerCase() === "content-type" ? "application/x-ndjson" : null);
+
+    const mockStreamController = {
+      signal: new AbortController().signal,
+      handleError: () => {},
+    };
+
+    const res = await handleStreamingResponse({
+      providerResponse: mockProviderResponse,
+      provider: "ollama",
+      model: "llama3",
+      sourceFormat: "openai",
+      targetFormat: "openai",
+      userAgent: "",
+      body: { stream: true },
+      translatedBody: {},
+      finalBody: {},
+      requestStartTime: Date.now(),
+      connectionId: "conn_1",
+      apiKey: null,
+      clientRawRequest: null,
+      onRequestSuccess: null,
+      reqLogger: { logTargetRequest: () => {} },
+      toolNameMap: null,
+      customToolNames: null,
+      streamController: mockStreamController,
+      onStreamComplete: null,
+      streamDetailId: "detail_1",
+      pxpipe: null,
+      reqTag: "tag_1",
+      log: { debug: () => {} },
+    });
+
+    expect(res?.success).not.toBe(false);
+  });
+});

--- a/tests/unit/tool-name-restoration-regression.test.js
+++ b/tests/unit/tool-name-restoration-regression.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { normalizeOpenAIToolNames, restoreOpenAIToolNames } from "../../open-sse/translator/concerns/toolCall.js";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
+
+describe("Tool name restoration regression tests (End-to-End & Passthrough)", () => {
+  const longName1 = "mcp__plugin_chrome-devtools-mcp-chrome-devtools__get_console_message";
+  const longName2 = "mcp__plugin_chrome-devtools-mcp-chrome-devtools__take_screenshot";
+
+  it("Test 1 — Non-streaming message-shaped restoration", () => {
+    const reqBody = {
+      tools: [
+        { type: "function", function: { name: longName1 } }
+      ]
+    };
+    const map = normalizeOpenAIToolNames(reqBody, 64);
+    const alias1 = reqBody.tools[0].function.name;
+
+    const providerResponse = {
+      id: "chatcmpl-1",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            tool_calls: [
+              { id: "call-1", type: "function", function: { name: alias1, arguments: '{"limit":5}' } }
+            ]
+          },
+          finish_reason: "tool_calls"
+        }
+      ]
+    };
+
+    const restored = restoreOpenAIToolNames(providerResponse, map);
+    expect(restored).toBe(true);
+    expect(providerResponse.choices[0].message.tool_calls[0].function.name).toBe(longName1);
+  });
+
+  it("Test 2 & 3 — Streaming raw JSON & SSE message-shaped restoration in passthrough stream", async () => {
+    const reqBody = {
+      tools: [
+        { type: "function", function: { name: longName1 } }
+      ]
+    };
+    const map = normalizeOpenAIToolNames(reqBody, 64);
+    const alias1 = reqBody.tools[0].function.name;
+
+    // Test passing map to createPassthroughStreamWithLogger
+    const passthroughStream = createPassthroughStreamWithLogger("nvidia", null, "test-model", "conn1", reqBody, null, null, map);
+    const writer = passthroughStream.writable.getWriter();
+    const reader = passthroughStream.readable.getReader();
+
+    const readPromise = (async () => {
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += new TextDecoder().decode(value);
+      }
+      return text;
+    })();
+
+    // Simulate provider sending raw JSON object line (NVIDIA passthrough non-SSE body)
+    const rawJsonPayload = JSON.stringify({
+      id: "chatcmpl-1",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            tool_calls: [
+              { id: "call-1", type: "function", function: { name: alias1, arguments: '{"limit":5}' } }
+            ]
+          },
+          finish_reason: "tool_calls"
+        }
+      ]
+    }) + "\ndata: [DONE]\n";
+
+    await writer.write(new TextEncoder().encode(rawJsonPayload));
+    await writer.close();
+
+    const output = await readPromise;
+    expect(output).toContain(longName1);
+    expect(output).not.toContain(alias1);
+    expect(output).toContain("data: [DONE]");
+  });
+
+  it("Test 4 — No map handling", () => {
+    const providerResponse = {
+      choices: [
+        {
+          message: {
+            tool_calls: [
+              { function: { name: "custom_func" } }
+            ]
+          }
+        }
+      ]
+    };
+
+    const restoredNull = restoreOpenAIToolNames(providerResponse, null);
+    expect(restoredNull).toBe(false);
+    expect(providerResponse.choices[0].message.tool_calls[0].function.name).toBe("custom_func");
+
+    const restoredEmpty = restoreOpenAIToolNames(providerResponse, new Map());
+    expect(restoredEmpty).toBe(false);
+    expect(providerResponse.choices[0].message.tool_calls[0].function.name).toBe("custom_func");
+  });
+
+  it("Test 5 — Multiple tool calls restoration", () => {
+    const reqBody = {
+      tools: [
+        { type: "function", function: { name: longName1 } },
+        { type: "function", function: { name: longName2 } }
+      ]
+    };
+    const map = normalizeOpenAIToolNames(reqBody, 64);
+    const alias1 = reqBody.tools[0].function.name;
+    const alias2 = reqBody.tools[1].function.name;
+
+    expect(alias1).not.toBe(alias2);
+
+    const providerResponse = {
+      choices: [
+        {
+          message: {
+            tool_calls: [
+              { function: { name: alias1 } },
+              { function: { name: alias2 } }
+            ]
+          }
+        }
+      ]
+    };
+
+    const restored = restoreOpenAIToolNames(providerResponse, map);
+    expect(restored).toBe(true);
+    expect(providerResponse.choices[0].message.tool_calls[0].function.name).toBe(longName1);
+    expect(providerResponse.choices[0].message.tool_calls[1].function.name).toBe(longName2);
+  });
+
+  it("Test 6 — Idempotency / Double restoration safety", () => {
+    const reqBody = {
+      tools: [{ type: "function", function: { name: longName1 } }]
+    };
+    const map = normalizeOpenAIToolNames(reqBody, 64);
+
+    const providerResponse = {
+      choices: [
+        {
+          message: {
+            tool_calls: [{ function: { name: longName1 } }]
+          }
+        }
+      ]
+    };
+
+    // Names are already original longName1. Restore attempt should return false and not mutate to undefined or corrupt name.
+    const restoredAgain = restoreOpenAIToolNames(providerResponse, map);
+    expect(restoredAgain).toBe(false);
+    expect(providerResponse.choices[0].message.tool_calls[0].function.name).toBe(longName1);
+  });
+});

--- a/tests/unit/tool-name-restoration-regression.test.js
+++ b/tests/unit/tool-name-restoration-regression.test.js
@@ -161,4 +161,52 @@ describe("Tool name restoration regression tests (End-to-End & Passthrough)", ()
     expect(restoredAgain).toBe(false);
     expect(providerResponse.choices[0].message.tool_calls[0].function.name).toBe(longName1);
   });
+
+  it("Test 7 — handleNonStreamingResponse restores tool names on JSON response", async () => {
+    const { handleNonStreamingResponse } = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
+
+    const reqBody = {
+      tools: [{ type: "function", function: { name: longName1 } }]
+    };
+    const map = normalizeOpenAIToolNames(reqBody, 64);
+    const alias = reqBody.tools[0].function.name;
+
+    const mockResponseObj = {
+      id: "chatcmpl-1",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            tool_calls: [
+              { id: "call-1", type: "function", function: { name: alias, arguments: "{}" } }
+            ]
+          },
+          finish_reason: "tool_calls"
+        }
+      ]
+    };
+
+    const mockProviderResponse = new Response(JSON.stringify(mockResponseObj), {
+      headers: { "Content-Type": "application/json" }
+    });
+
+    const result = await handleNonStreamingResponse({
+      providerResponse: mockProviderResponse,
+      provider: "nvidia",
+      model: "meta/llama-3.1-8b-instruct",
+      sourceFormat: "openai",
+      targetFormat: "openai",
+      body: reqBody,
+      stream: false,
+      toolNameMap: map,
+      reqLogger: { logProviderResponse: () => {}, logConvertedResponse: () => {} },
+      trackDone: () => {},
+      appendLog: () => {}
+    });
+
+    const bodyText = await result.response.text();
+    const parsed = JSON.parse(bodyText);
+    expect(parsed.choices[0].message.tool_calls[0].function.name).toBe(longName1);
+  });
 });

--- a/tests/unit/tool-name-restoration-regression.test.js
+++ b/tests/unit/tool-name-restoration-regression.test.js
@@ -209,4 +209,104 @@ describe("Tool name restoration regression tests (End-to-End & Passthrough)", ()
     const parsed = JSON.parse(bodyText);
     expect(parsed.choices[0].message.tool_calls[0].function.name).toBe(longName1);
   });
+
+  it("Test 8 — Stream chunking: JSON event split across multiple stream chunks", async () => {
+    const reqBody = { tools: [{ type: "function", function: { name: longName1 } }] };
+    const map = normalizeOpenAIToolNames(reqBody, 64);
+    const alias1 = reqBody.tools[0].function.name;
+
+    const passthroughStream = createPassthroughStreamWithLogger("nvidia", null, "test-model", "conn1", reqBody, null, null, map);
+    const writer = passthroughStream.writable.getWriter();
+    const reader = passthroughStream.readable.getReader();
+
+    const readPromise = (async () => {
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += new TextDecoder().decode(value);
+      }
+      return text;
+    })();
+
+    const fullEvent = `data: ${JSON.stringify({
+      id: "chatcmpl-split",
+      choices: [{ delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: alias1, arguments: '{"arg":1}' } }] } }]
+    })}\n\ndata: [DONE]\n\n`;
+
+    // Split event across 3 partial chunks
+    const chunk1 = fullEvent.slice(0, 20);
+    const chunk2 = fullEvent.slice(20, 60);
+    const chunk3 = fullEvent.slice(60);
+
+    await writer.write(new TextEncoder().encode(chunk1));
+    await writer.write(new TextEncoder().encode(chunk2));
+    await writer.write(new TextEncoder().encode(chunk3));
+    await writer.close();
+
+    const output = await readPromise;
+    expect(output).toContain(longName1);
+    expect(output).not.toContain(alias1);
+    expect(output).toContain("data: [DONE]");
+  });
+
+  it("Test 9 — Multiple SSE events in a single stream chunk", async () => {
+    const reqBody = { tools: [{ type: "function", function: { name: longName1 } }] };
+    const map = normalizeOpenAIToolNames(reqBody, 64);
+    const alias1 = reqBody.tools[0].function.name;
+
+    const passthroughStream = createPassthroughStreamWithLogger("nvidia", null, "test-model", "conn1", reqBody, null, null, map);
+    const writer = passthroughStream.writable.getWriter();
+    const reader = passthroughStream.readable.getReader();
+
+    const readPromise = (async () => {
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += new TextDecoder().decode(value);
+      }
+      return text;
+    })();
+
+    const event1 = `data: ${JSON.stringify({ choices: [{ delta: { content: "Hello " } }] })}\n\n`;
+    const event2 = `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ index: 0, id: "c1", type: "function", function: { name: alias1 } }] } }] })}\n\n`;
+    const event3 = `data: [DONE]\n\n`;
+
+    // Write all 3 events in 1 chunk
+    await writer.write(new TextEncoder().encode(event1 + event2 + event3));
+    await writer.close();
+
+    const output = await readPromise;
+    expect(output).toContain("Hello ");
+    expect(output).toContain(longName1);
+    expect(output).not.toContain(alias1);
+    expect(output).toContain("data: [DONE]");
+  });
+
+  it("Test 10 — Non-JSON passthrough content & SSE comments remain unchanged", async () => {
+    const passthroughStream = createPassthroughStreamWithLogger("nvidia", null, "test-model", "conn1", {}, null, null, new Map());
+    const writer = passthroughStream.writable.getWriter();
+    const reader = passthroughStream.readable.getReader();
+
+    const readPromise = (async () => {
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += new TextDecoder().decode(value);
+      }
+      return text;
+    })();
+
+    const sseComment = `: ping comment\n\n`;
+    const keepAlive = `: keep-alive\n\n`;
+
+    await writer.write(new TextEncoder().encode(sseComment + keepAlive));
+    await writer.close();
+
+    const output = await readPromise;
+    expect(output).toContain(": ping comment");
+    expect(output).toContain(": keep-alive");
+  });
 });


### PR DESCRIPTION
## Summary

This PR fixes tool-calling compatibility and response restoration across the OpenAI-compatible 9router pipeline, with NVIDIA-specific handling for tool-call IDs. It addresses four related failures:

1. Long MCP tool/function names could exceed provider function-name constraints.
2. Historical tool-call IDs could be rejected by affected NVIDIA endpoints/models.
3. Provider-safe tool-name aliases were not consistently restored before returning responses to clients.
4. Passthrough/forced-stream response paths did not preserve the request-scoped tool-name mapping across all streaming and non-streaming flows.

The result is that provider-safe identifiers remain internal to 9router while clients continue to see the original MCP tool names they registered.

---

## Problem

MCP tools can generate long function names such as:
`mcp__plugin_chrome-devtools-mcp-chrome-devtools__get_console_message`

Affected OpenAI-compatible upstream paths reject function names that exceed their accepted function-name boundary.

9router therefore normalizes the name before dispatch, for example:
- **Original**: `mcp__plugin_chrome-devtools-mcp-chrome-devtools__get_console_message`
- **Provider-safe alias**: `mcp__plugin_chrome-devtools-mcp-chrome-devtools__ge_e9ac6357ba79`

Outbound normalization worked, but response restoration was incomplete. The provider could return the normalized alias in:
`choices[].message.tool_calls[].function.name`
or:
`choices[].delta.tool_calls[].function.name`
and some response paths returned that alias directly to the client.

This breaks MCP dispatch because the client knows the original tool name, not the internal provider alias.

### Root Cause

`normalizeOpenAIToolNames()` correctly created a request-scoped mapping:
`provider-safe alias -> original client tool name`
but that mapping was not preserved through every response path.

```text
Client request
  ↓
normalizeOpenAIToolNames()
  ↓
toolNameMap created
  ↓
chatCore
  ↓
sharedCtx ✗ mapping not consistently propagated
  ↓
streaming / forced-SSE / non-streaming handlers
  ↓
provider alias could escape to client
```

There were three concrete gaps:
1. `toolNameMap` was not consistently available through `sharedCtx`.
2. Passthrough streaming did not forward the mapping into the stream transformer.
3. Forced SSE-to-JSON and raw JSON-line response paths could return reconstructed completions before tool names were restored.

---

## Solution

### 1. Preserve request-scoped tool metadata
`toolNameMap` now survives the complete request/response lifecycle:
`request translation -> toolNameMap -> chatCore/sharedCtx -> streaming / non-streaming / forced-SSE handlers -> restoreOpenAIToolNames() -> client`

Mappings are created once from the original request and are not reconstructed heuristically from provider output.

### 2. Restore aliases before returning responses
Tool names are restored in:
- regular non-streaming responses;
- forced SSE-to-JSON responses;
- standard SSE passthrough streams;
- complete raw JSON response lines.

The original client-visible tool name is therefore preserved across both:
`choices[].message.tool_calls[]` and `choices[].delta.tool_calls[]`.

### 3. Preserve stream framing
The passthrough stream path supports `data: {...}` and complete JSON lines `{...}` while preserving:
- partial-event buffering;
- multiple events in one transport chunk;
- SSE comments / non-JSON passthrough content;
- `data: [DONE]`.

### 4. NVIDIA-specific tool-call ID compatibility
For the NVIDIA executor path only, incompatible historical tool-call IDs are mapped to compact deterministic identifiers.
Example:
`call_9router_historical_long_tool_call_id_123456789 -> 06f2fb6f1`

The same normalized ID is used for both `assistant.tool_calls[].id` and matching `role="tool".tool_call_id` when they share the same original identifier. Missing call/result relationships are not reconstructed when both sides lack the identifier required to establish that relationship.

---

## Request / Response Flow

```text
Client
  │ original MCP tool name
  ▼
Request Translator
  ├─ normalize tool name
  └─ retain alias -> original mapping
  │
  ▼
DefaultExecutor
  ├─ final provider-safe tool-name normalization
  └─ NVIDIA-specific tool-call ID normalization
  │
  ▼
Provider
  │ returns tool call using provider-safe name
  ▼
Response Pipeline
  ├─ non-streaming
  ├─ forced SSE -> JSON
  └─ passthrough streaming
  │
  ▼
restoreOpenAIToolNames()
  │
  ▼
Client receives original MCP tool name
```

---

## Main Changes

### Files Changed
- **Tool normalization / provider compatibility**: `open-sse/executors/default.js`, `open-sse/providers/registry/nvidia.js`, `open-sse/translator/concerns/toolCall.js`, `open-sse/translator/formats/openai.js`
- **Response / streaming**: `open-sse/handlers/chatCore.js`, `open-sse/handlers/chatCore/nonStreamingHandler.js`, `open-sse/handlers/chatCore/sseToJsonHandler.js`, `open-sse/handlers/chatCore/streamingHandler.js`, `open-sse/translator/response/openai-to-claude.js`, `open-sse/utils/stream.js`
- **Regression coverage**: `tests/unit/nvidia-tool-name.test.js`, `tests/unit/nvidia-tool-call-id.test.js`, `tests/unit/ollama-ndjson-stream.test.js`, `tests/unit/tool-name-restoration-regression.test.js`

---

## Verification

### Targeted regression tests
```bash
npx vitest run -c tests/vitest.config.js \
  tests/unit/nvidia-tool-name.test.js \
  tests/unit/nvidia-tool-call-id.test.js \
  tests/unit/ollama-ndjson-stream.test.js \
  tests/unit/tool-name-restoration-regression.test.js
```
**Result**: 4 test files passed / 23 tests passed / 0 failures

Coverage includes:
- tool definitions;
- named `tool_choice`;
- historical tool calls;
- deterministic aliasing;
- NVIDIA tool-call IDs;
- multiple call IDs without collision;
- call/result ID consistency;
- non-streaming restoration;
- SSE restoration;
- raw JSON-line restoration;
- multiple aliases;
- idempotent restoration;
- events split across multiple transport chunks;
- multiple events in one transport chunk;
- `[DONE]` preservation;
- non-JSON passthrough preservation;
- Ollama NDJSON stream compatibility.

### Production build
```bash
npm run build
```
**Result**: PASS

### ESLint & Git validation
- **ESLint**: 0 errors, 0 warnings
- **`git diff --check`**: PASS
- **Working tree**: Clean

### Live NVIDIA Verification
The final committed implementation was tested through the real 9router runtime (`http://127.0.0.1:20127/v1/chat/completions`) using direct NVIDIA routing (`nvidia/meta/llama-3.1-8b-instruct`):

| Test | Result |
| :--- | :--- |
| Long MCP tool name accepted upstream | **PASS — HTTP 200** |
| Historical long tool-call ID accepted | **PASS — HTTP 200** |
| Non-streaming original tool name restored | **PASS** |
| Streaming original tool name restored | **PASS** |
| Real tool call generated | **PASS** |
| Terminal `[DONE]` preserved | **PASS** |

Observed round trip:
`Client: mcp__plugin_chrome-devtools-mcp-chrome-devtools__get_console_message -> normalize -> Provider: mcp__plugin_chrome-devtools-mcp-chrome-devtools__ge_e9ac6357ba79 -> restore -> Client: mcp__plugin_chrome-devtools-mcp-chrome-devtools__get_console_message`

---

## Before / After

- **Before**: `Client original MCP name -> 9router normalizes name -> provider accepts alias -> provider returns alias -> alias leaks to client -> client cannot resolve registered MCP tool`
- **After**: `Client original MCP name -> 9router normalizes name + retains mapping -> provider receives safe alias -> provider returns alias -> 9router restores original name -> client resolves registered MCP tool`

---

## Design Invariants

This PR establishes the following invariants:
1. Provider-safe aliases remain internal to 9router.
2. Client-visible tool names remain the names supplied by the client.
3. Alias mappings are request-scoped.
4. Mappings are not reconstructed from provider output.
5. NVIDIA-specific ID normalization is limited to the NVIDIA executor path.
6. Shared call/result identifiers remain consistent after normalization.
7. Complete streaming events are restored before being forwarded.
8. Stream framing and terminal events are preserved.
9. No process-global NVIDIA tool-call-ID cache is retained.

---

## Risk Assessment

No known blocker remains within the compatibility/restoration scope covered by this PR. Residual risk is considered low based on:
- focused regression coverage;
- transport-boundary stream tests;
- production build & lint validation;
- clean Git diff;
- live NVIDIA end-to-end smoke tests.