### PR TITLE
fix(quota): isolate quota row visibility per connection

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -587,36 +587,36 @@ export default function ProviderLimits() {
     }
   }, []);
 
-  const handleHideQuota = useCallback((provider, quota) => {
+  const handleHideQuota = useCallback((connectionId, quota) => {
     const key = getQuotaVisibilityKey(quota);
-    if (!provider || !key) return;
+    if (!connectionId || !key) return;
 
     const previous = quotaVisibility;
-    const providerVisibility = previous[provider] || {};
-    const hidden = new Set(providerVisibility.hidden || []);
+    const entryVisibility = previous[connectionId] || {};
+    const hidden = new Set(entryVisibility.hidden || []);
     hidden.add(key);
     const next = {
       ...previous,
-      [provider]: {
-        ...providerVisibility,
+      [connectionId]: {
+        ...entryVisibility,
         hidden: [...hidden],
       },
     };
     updateQuotaVisibility(next, previous);
   }, [quotaVisibility, updateQuotaVisibility]);
 
-  const handleShowQuota = useCallback((provider, quota) => {
+  const handleShowQuota = useCallback((connectionId, quota) => {
     const key = getQuotaVisibilityKey(quota);
-    if (!provider || !key) return;
+    if (!connectionId || !key) return;
 
     const previous = quotaVisibility;
-    const providerVisibility = previous[provider] || {};
-    const hidden = new Set(providerVisibility.hidden || []);
+    const entryVisibility = previous[connectionId] || {};
+    const hidden = new Set(entryVisibility.hidden || []);
     hidden.delete(key);
     const next = {
       ...previous,
-      [provider]: {
-        ...providerVisibility,
+      [connectionId]: {
+        ...entryVisibility,
         hidden: [...hidden],
       },
     };
@@ -1032,8 +1032,8 @@ export default function ProviderLimits() {
           const isResettingLimit = resettingLimitId === conn.id;
           const rowBusy = deletingId === conn.id || togglingId === conn.id || isResettingLimit;
           const rawQuotas = quota?.quotas || [];
-          const visibleQuotas = filterQuotasByVisibility(conn.provider, rawQuotas, quotaVisibility);
-          const hiddenQuotaRows = getHiddenQuotaRows(conn.provider, rawQuotas, quotaVisibility);
+          const visibleQuotas = filterQuotasByVisibility(conn.id, rawQuotas, quotaVisibility, conn.provider);
+          const hiddenQuotaRows = getHiddenQuotaRows(conn.id, rawQuotas, quotaVisibility, conn.provider);
 
           return (
             <Card
@@ -1261,7 +1261,7 @@ export default function ProviderLimits() {
                     showSortLabel={
                       conn.provider === "codex" && quotaSortMode !== "default"
                     }
-                    onHideQuota={(quotaRow) => handleHideQuota(conn.provider, quotaRow)}
+                    onHideQuota={(quotaRow) => handleHideQuota(conn.id, quotaRow)}
                   />
                 )}
                 {hiddenQuotaRows.length > 0 && (
@@ -1275,7 +1275,7 @@ export default function ProviderLimits() {
                         <button
                           key={getQuotaVisibilityKey(quotaRow)}
                           type="button"
-                          onClick={() => handleShowQuota(conn.provider, quotaRow)}
+                          onClick={() => handleShowQuota(conn.id, quotaRow)}
                           className="shrink-0 rounded-md border border-black/10 px-1.5 py-0.5 transition-colors hover:bg-black/5 hover:text-text-primary dark:border-white/10 dark:hover:bg-white/5"
                           title="Show this quota row"
                         >

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -305,21 +305,36 @@ export function getQuotaVisibilityKey(quota) {
   return String(quota.modelKey || quota.name || "").trim();
 }
 
-function getProviderHiddenQuotaSet(provider, quotaVisibility) {
-  const hidden = quotaVisibility?.[provider]?.hidden;
-  return new Set(Array.isArray(hidden) ? hidden.map(String) : []);
+/**
+ * Resolve the hidden-quota set for a scope.
+ *
+ * The primary scope key is the connection id so that two connections of the
+ * same provider (e.g. two CodeBuddy CN accounts) hide their rows
+ * independently. We fall back to the legacy provider-scoped key so settings
+ * saved before this change (keyed by provider id) keep working — the provider
+ * fallback still applies to every connection of that provider, but any new
+ * hide/show writes use the connection id and are isolated per account.
+ */
+function getHiddenQuotaSet(scopeKey, quotaVisibility, legacyScopeKey) {
+  const byScope = quotaVisibility?.[scopeKey]?.hidden;
+  if (Array.isArray(byScope)) return new Set(byScope.map(String));
+  if (legacyScopeKey && legacyScopeKey !== scopeKey) {
+    const byLegacy = quotaVisibility?.[legacyScopeKey]?.hidden;
+    if (Array.isArray(byLegacy)) return new Set(byLegacy.map(String));
+  }
+  return new Set();
 }
 
-export function filterQuotasByVisibility(provider, quotas = [], quotaVisibility = {}) {
+export function filterQuotasByVisibility(scopeKey, quotas = [], quotaVisibility = {}, legacyScopeKey) {
   if (!Array.isArray(quotas) || quotas.length === 0) return [];
-  const hidden = getProviderHiddenQuotaSet(provider, quotaVisibility);
+  const hidden = getHiddenQuotaSet(scopeKey, quotaVisibility, legacyScopeKey);
   if (hidden.size === 0) return quotas;
   return quotas.filter((quota) => !hidden.has(getQuotaVisibilityKey(quota)));
 }
 
-export function getHiddenQuotaRows(provider, quotas = [], quotaVisibility = {}) {
+export function getHiddenQuotaRows(scopeKey, quotas = [], quotaVisibility = {}, legacyScopeKey) {
   if (!Array.isArray(quotas) || quotas.length === 0) return [];
-  const hidden = getProviderHiddenQuotaSet(provider, quotaVisibility);
+  const hidden = getHiddenQuotaSet(scopeKey, quotaVisibility, legacyScopeKey);
   if (hidden.size === 0) return [];
   return quotas.filter((quota) => hidden.has(getQuotaVisibilityKey(quota)));
 }

--- a/tests/unit/provider-quota-visibility.test.js
+++ b/tests/unit/provider-quota-visibility.test.js
@@ -52,4 +52,44 @@ describe("provider quota visibility", () => {
     };
     expect(filterQuotasByVisibility("antigravity", quotas, visibility)).toHaveLength(2);
   });
+
+  it("isolates hidden rows per connection (same provider, two accounts)", () => {
+    // Two CodeBuddy CN accounts. Hiding "Bonus Pack 1" on connection A must
+    // NOT hide it on connection B. scopeKey is the connection id; the legacy
+    // provider key only acts as a fallback for pre-existing settings.
+    const cbData = {
+      quotas: {
+        Monthly: { used: 6, total: 500, resetAt: null, recurring: true },
+        "Bonus Pack 1": { used: 12, total: 100, resetAt: null, recurring: false },
+      },
+    };
+    const quotas = parseQuotaData("codebuddy-cn", cbData);
+    const visibility = {
+      "conn-A": { hidden: ["Bonus Pack 1"] },
+    };
+
+    // Connection A hides its Bonus Pack 1.
+    const visibleA = filterQuotasByVisibility("conn-A", quotas, visibility, "codebuddy-cn");
+    expect(visibleA.map((q) => q.name)).toEqual(["Monthly"]);
+    // Connection B is unaffected.
+    const visibleB = filterQuotasByVisibility("conn-B", quotas, visibility, "codebuddy-cn");
+    expect(visibleB.map((q) => q.name)).toEqual(["Monthly", "Bonus Pack 1"]);
+  });
+
+  it("falls back to the legacy provider-scoped key when no per-connection entry exists", () => {
+    const quotas = parseQuotaData("codebuddy-cn", {
+      quotas: {
+        "Bonus Pack 1": { used: 5, total: 100, resetAt: null, recurring: false },
+        "Bonus Pack 2": { used: 5, total: 100, resetAt: null, recurring: false },
+      },
+    });
+    // Settings saved before the per-connection change are keyed by provider id.
+    const visibility = {
+      "codebuddy-cn": { hidden: ["Bonus Pack 2"] },
+    };
+    const visible = filterQuotasByVisibility("conn-A", quotas, visibility, "codebuddy-cn");
+    expect(visible.map((q) => q.name)).toEqual(["Bonus Pack 1"]);
+    const hidden = getHiddenQuotaRows("conn-A", quotas, visibility, "codebuddy-cn");
+    expect(hidden.map((q) => q.name)).toEqual(["Bonus Pack 2"]);
+  });
 });


### PR DESCRIPTION
## 已切换至独立分支 / Switched to Independent Fork

此 PR 已不再需要提交。我已切换至自己的开源分支 [techysy/9router](https://github.com/techysy/9router) 进行开发，不再向上游提交 PR。

This PR is no longer needed. I have switched to my own open-source branch [techysy/9router](https://github.com/techysy/9router) for development and will no longer submit PRs upstream.

---

感谢作者 @decolua 开源 9Router 项目，为社区提供了优秀的 AI 路由解决方案。

Thanks to the author @decolua for open-sourcing 9Router, providing the community with an excellent AI routing solution.
