### PR TITLE
feat(providers): add per-provider toggle for usage topology canvas

### DIFF
--- a/open-sse/providers/registry/mimo-free.js
+++ b/open-sse/providers/registry/mimo-free.js
@@ -1,8 +1,11 @@
 // Xiaomi ended the free MiMo channel ("MiMo free API service has ended").
-// Hidden until/unless a replacement (OAuth MiMo Platform) is wired.
+// Kept visible as a configurable card so the user can choose whether it shows
+// on the usage topology canvas; by default it is hidden there (service ended),
+// and it carries a deprecation notice. Override the default via the
+// topologyVisibility setting toggle on the providers page.
 export default {
   id: "mimo-free",
-  hidden: true,
+  hidden: false,
   priority: 50,
   hasFree: true,
   alias: "mmf",
@@ -12,7 +15,10 @@ export default {
     icon: "smart_toy",
     color: "#FF6900",
     textIcon: "MF",
+    deprecationNotice:
+      "MiMo free API service has ended. This provider is no longer free. It is hidden from the usage topology by default — enable it via the toggle if you still want it shown.",
   },
+  topologyHiddenByDefault: true,
   category: "free",
   noAuth: true,
   transport: {

--- a/src/app/(dashboard)/dashboard/providers/page.js
+++ b/src/app/(dashboard)/dashboard/providers/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import {
   Card,
@@ -105,6 +105,7 @@ export default function ProvidersPage() {
     useState(false);
   const [testingMode, setTestingMode] = useState(null);
   const [testResults, setTestResults] = useState(null);
+  const [topologyVisibility, setTopologyVisibility] = useState({});
   const notify = useNotificationStore();
   const searchQuery = useHeaderSearchStore((s) => s.query);
   const registerSearch = useHeaderSearchStore((s) => s.register);
@@ -148,15 +149,20 @@ export default function ProvidersPage() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [connectionsRes, nodesRes] = await Promise.all([
+        const [connectionsRes, nodesRes, settingsRes] = await Promise.all([
           fetch("/api/providers"),
           fetch("/api/provider-nodes"),
+          fetch("/api/settings", { cache: "no-store" }),
         ]);
         const connectionsData = await connectionsRes.json();
         const nodesData = await nodesRes.json();
         if (connectionsRes.ok)
           setConnections(connectionsData.connections || []);
         if (nodesRes.ok) setProviderNodes(nodesData.nodes || []);
+        if (settingsRes.ok) {
+          const settingsData = await settingsRes.json();
+          setTopologyVisibility(settingsData.topologyVisibility || {});
+        }
       } catch (error) {
         console.log("Error fetching data:", error);
       } finally {
@@ -165,6 +171,24 @@ export default function ProvidersPage() {
     };
     fetchData();
   }, []);
+
+  // Toggle whether a noAuth free provider appears on the usage topology canvas.
+  const handleToggleTopology = useCallback(async (providerId, visible) => {
+    const previous = topologyVisibility;
+    const next = { ...previous, [providerId]: visible };
+    setTopologyVisibility(next);
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ topologyVisibility: next }),
+      });
+      if (!response.ok) throw new Error("Failed to update topology visibility");
+    } catch (error) {
+      console.error("Error updating topology visibility:", error);
+      setTopologyVisibility(previous);
+    }
+  }, [topologyVisibility]);
 
   const getProviderStats = (providerId, authType) => {
     const authTypes = Array.isArray(authType) ? authType : [authType];
@@ -502,6 +526,15 @@ export default function ProvidersPage() {
             // Dual-auth (e.g. kiro): count/toggle oauth + apikey/api_key so the
             // card total matches the provider detail page.
             const freeAuthTypes = dualAuthTypes(info, key);
+            // noAuth free providers (opencode, mimo-free) get a topology
+            // visibility toggle instead of an enable/disable switch.
+            const topologySetting = topologyVisibility?.[key];
+            const topologyVisible =
+              topologySetting === false
+                ? false
+                : topologySetting === true
+                  ? true
+                  : !info.topologyHiddenByDefault;
             return (
               <ProviderCard
                 key={key}
@@ -511,6 +544,12 @@ export default function ProvidersPage() {
                 authType="free"
                 onToggle={(active) =>
                   handleToggleProvider(key, freeAuthTypes, active)
+                }
+                topologyVisible={topologyVisible}
+                onToggleTopology={
+                  info.noAuth
+                    ? (visible) => handleToggleTopology(key, visible)
+                    : undefined
                 }
               />
             );
@@ -653,7 +692,7 @@ export default function ProvidersPage() {
   );
 }
 
-function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
+function ProviderCard({ providerId, provider, stats, authType, onToggle, topologyVisible, onToggleTopology }) {
   const { connected, error, errorCode, errorTime, allDisabled } = stats;
   const isNoAuth = !!provider.noAuth;
 
@@ -669,6 +708,13 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
     apikey: "API Key",
     compatible: "Compatible",
   };
+
+  // noAuth free providers have no connections, so they can't be enabled/disabled
+  // in the usual sense. Instead the toggle controls whether they appear on the
+  // usage topology canvas.
+  const hasConnection = stats.total > 0;
+  const topologyToggleable = isNoAuth && typeof onToggleTopology === "function";
+  const topologyOn = topologyVisible !== false;
 
   return (
     <Link href={`/dashboard/providers/${providerId}`} className="group min-w-0">
@@ -721,7 +767,7 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            {stats.total > 0 && (
+            {hasConnection && (
               <div
                 className="opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
                 onClick={(e) => {
@@ -735,6 +781,27 @@ function ProviderCard({ providerId, provider, stats, authType, onToggle }) {
                   checked={!allDisabled}
                   onChange={() => {}}
                   title={allDisabled ? "Enable provider" : "Disable provider"}
+                />
+              </div>
+            )}
+            {topologyToggleable && (
+              <div
+                className="opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onToggleTopology(!topologyOn);
+                }}
+              >
+                <Toggle
+                  size="sm"
+                  checked={topologyOn}
+                  onChange={() => {}}
+                  title={
+                    topologyOn
+                      ? "Hide from usage topology"
+                      : "Show on usage topology"
+                  }
                 />
               </div>
             )}

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   stickyRoundRobinLimit: 3,
   providerStrategies: {},
   quotaVisibility: {},
+  topologyVisibility: {},
   comboStrategy: "fallback",
   comboStickyRoundRobinLimit: 1,
   comboStrategies: {},

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -10,6 +10,16 @@ function isLLMProvider(id) {
   if (!p?.serviceKinds) return true;
   return p.serviceKinds.includes("llm");
 }
+
+// A noAuth free provider is shown on the usage topology canvas unless the user
+// has hidden it via the providers-page toggle, or it defaults hidden (e.g. a
+// terminated service like mimo-free) and hasn't been explicitly shown.
+function isTopologyVisible(p, topologyVisibility) {
+  const setting = topologyVisibility?.[p.id];
+  if (setting === false) return false;
+  if (setting === true) return true;
+  return !p.topologyHiddenByDefault;
+}
 import Badge from "./Badge";
 import Card from "./Card";
 import OverviewCards from "@/app/(dashboard)/dashboard/usage/components/OverviewCards";
@@ -213,6 +223,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
   const [tableView, setTableView] = useState("model");
   const [viewMode, setViewMode] = useState("costs");
   const [providers, setProviders] = useState([]);
+  const [topologyVisibility, setTopologyVisibility] = useState({});
   const [periodLocal, setPeriodLocal] = useState("today");
   const isInitialLoad = useRef(true);
   const hasLoadedStats = useRef(false);
@@ -225,8 +236,12 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
     Promise.all([
       fetch("/api/providers").then((r) => r.ok ? r.json() : null),
       fetch("/api/provider-nodes").then((r) => r.ok ? r.json() : null),
+      fetch("/api/settings", { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((s) => s?.topologyVisibility || {}),
     ])
-      .then(([d, nodesData]) => {
+      .then(([d, nodesData, topologyVisibility]) => {
+        setTopologyVisibility(topologyVisibility);
         // Build node name lookup for custom providers
         const nodeNameMap = {};
         for (const node of (nodesData?.nodes || [])) {
@@ -244,7 +259,13 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
           nodeName: nodeNameMap[c.provider] || null,
         }));
         const noAuthProviders = Object.values(FREE_PROVIDERS)
-          .filter((p) => p.noAuth && !seen.has(p.id) && isLLMProvider(p.id))
+          .filter((p) =>
+            p.noAuth &&
+            !p.hidden &&
+            !seen.has(p.id) &&
+            isLLMProvider(p.id) &&
+            isTopologyVisible(p, topologyVisibility),
+          )
           .map((p) => ({ provider: p.id, name: p.name }));
         setProviders([...unique, ...noAuthProviders]);
       })

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -23,6 +23,7 @@ function buildProviderEntry(r) {
     id: r.id,
     alias: r.uiAlias || r.alias,
     ...(r.hidden ? { hidden: true } : {}),
+    ...(r.topologyHiddenByDefault ? { topologyHiddenByDefault: true } : {}),
     ...mediaFields,
     ...(r.priority !== undefined ? { priority: r.priority } : {}),
     ...(r.hasFree ? { hasFree: true } : {}),


### PR DESCRIPTION
## 已切换至独立分支 / Switched to Independent Fork

此 PR 已不再需要提交。我已切换至自己的开源分支 [techysy/9router](https://github.com/techysy/9router) 进行开发，不再向上游提交 PR。

This PR is no longer needed. I have switched to my own open-source branch [techysy/9router](https://github.com/techysy/9router) for development and will no longer submit PRs upstream.

---

感谢作者 @decolua 开源 9Router 项目，为社区提供了优秀的 AI 路由解决方案。

Thanks to the author @decolua for open-sourcing 9Router, providing the community with an excellent AI routing solution.
