### PR TITLE
fix(combos): resolve provider-prefixed combo names to member models

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -218,13 +218,16 @@ export function resetComboRotation(comboName) {
  * @returns {string[]|null} Array of models or null if not a combo
  */
 export function getComboModelsFromData(modelStr, combosData) {
-  // Don't check if it's in provider/model format
-  if (modelStr.includes("/")) return null;
-  
+  // Resolve combo by full name first, then by basename (part after the last
+  // slash) so client configs like `provider/combo-name` still hit the combo
+  // instead of forwarding the raw string to the upstream provider.
+  const baseName = modelStr.includes("/") ? modelStr.split("/").pop() : null;
+
   // Handle both array and object formats
   const combos = Array.isArray(combosData) ? combosData : (combosData?.combos || []);
-  
-  const combo = combos.find(c => c.name === modelStr);
+
+  const combo = combos.find(c => c.name === modelStr) ||
+    (baseName ? combos.find(c => c.name === baseName) : null);
   if (combo && combo.models && combo.models.length > 0) {
     return combo.models;
   }

--- a/src/sse/services/model.js
+++ b/src/sse/services/model.js
@@ -83,10 +83,13 @@ export async function getModelInfo(modelStr) {
  * @returns {Promise<string[]|null>} Array of models or null if not a combo
  */
 export async function getComboModels(modelStr) {
-  // Only check if it's not in provider/model format
-  if (modelStr.includes("/")) return null;
-
-  const combo = await getComboByName(modelStr);
+  // Resolve combo by full name first, then by basename (part after the last
+  // slash) so client configs like `provider/combo-name` still hit the combo
+  // instead of forwarding the raw string to the upstream provider.
+  let combo = await getComboByName(modelStr);
+  if (!combo && modelStr.includes("/")) {
+    combo = await getComboByName(modelStr.split("/").pop());
+  }
   if (combo && combo.models && combo.models.length > 0) {
     return combo.models;
   }

--- a/tests/unit/combo-slash-resolve.test.js
+++ b/tests/unit/combo-slash-resolve.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { getComboModelsFromData } from "../../open-sse/services/combo.js";
+
+const combos = [
+  { name: "lordx.1", models: ["openrouter/nvidia/nemotron-3-super-120b-a12b:free"] },
+  { name: "my-combo", models: ["oc/deepseek-v4-flash-free"] },
+];
+
+describe("getComboModelsFromData", () => {
+  it("resolves a bare combo name", () => {
+    expect(getComboModelsFromData("lordx.1", combos))
+      .toEqual(["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]);
+  });
+
+  it("resolves a provider-prefixed combo name (openrouter/lordx.1 -> lordx.1)", () => {
+    expect(getComboModelsFromData("openrouter/lordx.1", combos))
+      .toEqual(["openrouter/nvidia/nemotron-3-super-120b-a12b:free"]);
+  });
+
+  it("prefers exact full-name match over basename", () => {
+    const data = [
+      { name: "x/y", models: ["a/m1"] },
+      { name: "y", models: ["a/m2"] },
+    ];
+    expect(getComboModelsFromData("x/y", data)).toEqual(["a/m1"]);
+  });
+
+  it("returns null when no combo matches", () => {
+    expect(getComboModelsFromData("openrouter/nonexistent", combos)).toBeNull();
+    expect(getComboModelsFromData("nonexistent", combos)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

When a client points a combo at 9router using a provider-prefixed name like `openrouter/lordx.1` (the shape OpenCode generates when you register a combo in its model config), the combo never resolves. 9router forwards the literal string `lordx.1` to the upstream provider, which rejects it as an unknown model.

## Why

`getComboModels()` / `getComboModelsFromData()` bail out as soon as the model string contains a `/`:

```js
if (modelStr.includes("/")) return null;
```

That guard exists so plain `provider/model` strings skip the combo lookup — but it also catches the `provider/combo-name` case, so the request falls through to the provider handler with the combo name still attached. OpenRouter then 400s with `"lordx.1 is not a valid model ID"`, and the retry loop just repeats the same unresolved name against the next account.

## Fix

Resolve the combo by full name first, then fall back to the basename (the part after the last `/`) before giving up:

- `src/sse/services/model.js` (`getComboModels`) — chat / image path
- `open-sse/services/combo.js` (`getComboModelsFromData`) — search path

Full-name match is checked first, so a combo literally named `x/y` still wins over a different combo named `y`. If nothing matches, behaviour is unchanged (returns `null`, falls through to provider forwarding).

## Verification

Added `tests/unit/combo-slash-resolve.test.js` covering:

- bare combo name resolves
- `openrouter/lordx.1` resolves to the `lordx.1` member models
- exact full-name match wins over basename
- no match returns null

```
✓ combo-slash-resolve.test.js  4/4
✓ combo-routing.test.js        pass
✓ combo-fusion.test.js         pass
```

(`combo-autoswitch.test.js` has 2 failures on a clean upstream checkout too — they use `toBe` where `toStrictEqual` is meant and don't touch this code path.)

## Repro from the issue

```bash
curl http://localhost:20128/v1/chat/completions \
  -H "Authorization: Bearer <key>" -H "Content-Type: application/json" \
  -d '{"model":"openrouter/lordx.1","messages":[{"role":"user","content":"hi"}]}'
# before: upstream 400 "lordx.1 is not a valid model ID"
# after:  routes to openrouter/nvidia/nemotron-3-super-120b-a12b:free
```

Closes #2996
