### PR TITLE
Add local vs hosted deployment mode.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ JWT_SECRET=change-me-to-a-long-random-secret
 INITIAL_PASSWORD=change-me
 DATA_DIR=/var/lib/9router
 
+# Deployment mode: local (default) | hosted | remote
+# hosted/remote: require API keys on /v1, disable local-only routes, no DATA_DIR fallback
+# DEPLOYMENT_MODE=local
+# DEPLOYMENT_MODE=hosted
+
 # Recommended runtime variables
 PORT=20128
 NODE_ENV=production
@@ -26,6 +31,14 @@ CLOUD_URL=https://9router.com
 # Backward-compatible/public variables:
 NEXT_PUBLIC_BASE_URL=http://localhost:20128
 NEXT_PUBLIC_CLOUD_URL=https://9router.com
+
+# Hosted example (public URL):
+# DEPLOYMENT_MODE=hosted
+# BASE_URL=https://your-public-origin
+# NEXT_PUBLIC_BASE_URL=https://your-public-origin
+# AUTH_COOKIE_SECURE=true
+# REQUIRE_API_KEY=true
+# DATA_DIR=/var/lib/9router
 
 # Optional outbound proxy variables for upstream provider calls
 # Lowercase variants are also supported: http_proxy, https_proxy, all_proxy, no_proxy

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSettings, validateApiKey } from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { verifyDashboardAuthToken } from "@/lib/auth/dashboardSession";
+import { isHosted } from "@/shared/utils/deploymentMode";
 
 const CLI_TOKEN_HEADER = "x-9r-cli-token";
 const CLI_TOKEN_SALT = "9r-cli-auth";
@@ -134,12 +135,18 @@ async function hasValidApiKey(request) {
 }
 
 async function canAccessPublicLlmApi(request) {
+  // Hosted: never skip API key just because the peer looks local (proxy collapse).
+  if (isHosted()) {
+    if (await hasValidCliToken(request)) return true;
+    return await hasValidApiKey(request);
+  }
   if (isLocalRequest(request)) return true;
   if (await hasValidCliToken(request)) return true;
   return await hasValidApiKey(request);
 }
 
 async function canAccessLocalOnlyRoute(request) {
+  if (isHosted()) return false; // Cursor import, MITM, tunnels, etc.
   if (await hasValidCliToken(request)) return true;
   // Browser on host: loopback Host + Origin (blocks tunnel/CSRF) + auth (JWT or requireLogin=false)
   if (isLocalRequest(request) && await isAuthenticated(request)) return true;
@@ -178,6 +185,7 @@ export const __test__ = {
   extractApiKey,
   canAccessPublicLlmApi,
   canAccessLocalOnlyRoute,
+  isHosted,
 };
 
 export async function proxy(request) {

--- a/src/lib/dataDir.js
+++ b/src/lib/dataDir.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "path";
 import os from "os";
+import { isHosted } from "@/shared/utils/deploymentMode";
 
 const APP_NAME = "9router";
 
@@ -27,6 +28,12 @@ export function getDataDir() {
     return configured;
   } catch (e) {
     if (e?.code === "EACCES" || e?.code === "EPERM") {
+      // Hosted: never fall back to ephemeral ~/.9router
+      if (isHosted()) {
+        throw new Error(
+          `[DATA_DIR] '${configured}' is not writable and DEPLOYMENT_MODE is hosted. Use a persistent volume.`
+        );
+      }
       console.warn(`[DATA_DIR] '${configured}' not writable → fallback ~/.${APP_NAME}`);
       return defaultDir();
     }

--- a/src/shared/components/CursorAuthModal.js
+++ b/src/shared/components/CursorAuthModal.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Modal, Button, Input } from "@/shared/components";
+import { isHostedBrowser } from "@/shared/utils/deploymentMode";
 
 /**
  * Cursor Auth Modal
@@ -18,6 +19,14 @@ export default function CursorAuthModal({ isOpen, onSuccess, onClose }) {
   const [windowsManual, setWindowsManual] = useState(false);
 
   const runAutoDetect = async () => {
+    if (isHostedBrowser()) {
+      setAutoDetecting(false);
+      setAutoDetected(false);
+      setWindowsManual(false);
+      setError("Auto-import is local-only. Paste Access Token + Machine ID, or run 9Router locally.");
+      return;
+    }
+
     setAutoDetecting(true);
     setError(null);
     setAutoDetected(false);

--- a/src/shared/components/OAuthModal.js
+++ b/src/shared/components/OAuthModal.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
 import { Modal, Button, Input } from "@/shared/components";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
+import { isHostedBrowser } from "@/shared/utils/deploymentMode";
 
 // Providers using the dynamic-port local callback proxy.
 // Browser OAuth: popup → auto callback → auto exchange → poll-status.
@@ -293,8 +294,12 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
 
       // Authorization code flow - build redirect URI (some providers require fixed ports)
       const appPort = window.location.port || (window.location.protocol === "https:" ? "443" : "80");
+      const hosted = isHostedBrowser();
       let redirectUri;
-      if (provider === "codex") {
+      if (hosted) {
+        // Public callback on this origin (no loopback proxy).
+        redirectUri = `${window.location.origin}/callback`;
+      } else if (provider === "codex") {
         redirectUri = "http://localhost:1455/auth/callback";
       } else if (provider === "xai") {
         redirectUri = "http://127.0.0.1:56121/callback";
@@ -313,9 +318,10 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
       if (!res.ok) throw new Error(data.error);
 
       // Codex: start proxy with server-side session (auto-exchange) + fallback to channels
+      // Hosted: skip loopback proxies (they bind 127.0.0.1 on the server, not the user's browser).
       let codexProxyActive = false;
       let codexServerSide = false;
-      if (provider === "codex") {
+      if (provider === "codex" && !hosted) {
         try {
           const proxyUrl = new URL(`/api/oauth/codex/start-proxy`, window.location.origin);
           proxyUrl.searchParams.set("app_port", appPort);
@@ -334,7 +340,7 @@ export default function OAuthModal({ isOpen, provider, providerInfo, onSuccess, 
       // xAI: same fixed-port server-side proxy pattern as codex (port 56121)
       let xaiProxyActive = false;
       let xaiServerSide = false;
-      if (provider === "xai") {
+      if (provider === "xai" && !hosted) {
         try {
           const proxyUrl = new URL(`/api/oauth/xai/start-proxy`, window.location.origin);
           proxyUrl.searchParams.set("app_port", appPort);

--- a/src/shared/utils/deploymentMode.js
+++ b/src/shared/utils/deploymentMode.js
@@ -1,0 +1,61 @@
+/**
+ * Local (default) vs hosted (public URL / remote VM).
+ * Hosted is opt-in via env or a non-loopback BASE_URL.
+ */
+
+function trimSlash(url) {
+  return (url || "").trim().replace(/\/+$/, "");
+}
+
+export function getConfiguredBaseUrl() {
+  return trimSlash(
+    process.env.BASE_URL ||
+      process.env.NEXT_PUBLIC_BASE_URL ||
+      ""
+  );
+}
+
+export function isLoopbackHostname(hostname) {
+  if (!hostname) return false;
+  const host = String(hostname).toLowerCase().replace(/^\[|\]$/g, "");
+  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+}
+
+export function isLoopbackUrl(url) {
+  if (!url) return true;
+  try {
+    return isLoopbackHostname(new URL(url).hostname);
+  } catch {
+    return true;
+  }
+}
+
+/** Browser: public https origin that is not loopback. */
+export function isHostedBrowser() {
+  if (typeof window === "undefined") return false;
+  if (window.location.protocol !== "https:") return false;
+  return !isLoopbackHostname(window.location.hostname);
+}
+
+/**
+ * True when running as a public/remote deploy.
+ * Local npm/docker remain false unless DEPLOYMENT_MODE forces hosted.
+ */
+export function isHosted() {
+  if (typeof window !== "undefined") return isHostedBrowser();
+
+  const mode = (process.env.DEPLOYMENT_MODE || "").toLowerCase();
+  if (mode === "hosted" || mode === "remote") return true;
+  if (mode === "local") return false;
+
+  const base = getConfiguredBaseUrl();
+  if (base && !isLoopbackUrl(base)) return true;
+  return false;
+}
+
+export function getPublicOrigin() {
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return window.location.origin.replace(/\/+$/, "");
+  }
+  return getConfiguredBaseUrl() || "http://localhost:20128";
+}

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -48,6 +48,9 @@ function request(pathname, headers = {}) {
 describe("dashboard guard public LLM API access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.DEPLOYMENT_MODE;
+    delete process.env.BASE_URL;
+    delete process.env.NEXT_PUBLIC_BASE_URL;
     mocks.getSettings.mockResolvedValue({ requireLogin: true });
     mocks.validateApiKey.mockResolvedValue(false);
     mocks.getConsistentMachineId.mockResolvedValue("cli-token");
@@ -191,6 +194,9 @@ describe("dashboard guard public LLM API access", () => {
 describe("dashboard guard local-only access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.DEPLOYMENT_MODE;
+    delete process.env.BASE_URL;
+    delete process.env.NEXT_PUBLIC_BASE_URL;
     mocks.getSettings.mockResolvedValue({ requireLogin: true });
     mocks.validateApiKey.mockResolvedValue(false);
     mocks.getConsistentMachineId.mockResolvedValue("cli-token");
@@ -255,6 +261,55 @@ describe("dashboard guard local-only access", () => {
     }));
 
     expect(response).toBe(mocks.nextResponse);
+  });
+});
+
+describe("dashboard guard hosted mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DEPLOYMENT_MODE = "hosted";
+    mocks.getSettings.mockResolvedValue({ requireLogin: true });
+    mocks.validateApiKey.mockResolvedValue(false);
+    mocks.getConsistentMachineId.mockResolvedValue("cli-token");
+    mocks.verifyDashboardAuthToken.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    delete process.env.DEPLOYMENT_MODE;
+  });
+
+  it("requires API key on loopback when hosted", async () => {
+    const response = await proxy(request("/v1/chat/completions", {
+      host: "localhost:20128",
+      "x-9r-real-ip": "127.0.0.1",
+    }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("API key required for remote API access");
+  });
+
+  it("allows /v1 with API key when hosted", async () => {
+    mocks.validateApiKey.mockResolvedValue(true);
+
+    const response = await proxy(request("/v1/models", {
+      host: "localhost:20128",
+      "x-9r-real-ip": "127.0.0.1",
+      authorization: "Bearer sk-valid",
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).toHaveBeenCalledWith("sk-valid");
+  });
+
+  it("blocks local-only routes even with CLI token when hosted", async () => {
+    const response = await proxy(request("/api/oauth/cursor/auto-import", {
+      host: "localhost:20128",
+      "x-9r-real-ip": "127.0.0.1",
+      "x-9r-cli-token": "cli-token",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Local only: CLI token required");
   });
 });
 

--- a/tests/unit/deployment-mode.test.js
+++ b/tests/unit/deployment-mode.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getConfiguredBaseUrl,
+  isLoopbackHostname,
+  isLoopbackUrl,
+  isHosted,
+  getPublicOrigin,
+} from "../../src/shared/utils/deploymentMode.js";
+
+describe("deploymentMode", () => {
+  const envKeys = ["DEPLOYMENT_MODE", "BASE_URL", "NEXT_PUBLIC_BASE_URL"];
+  let saved = {};
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of envKeys) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("treats empty config as local", () => {
+    expect(isHosted()).toBe(false);
+    expect(getConfiguredBaseUrl()).toBe("");
+    expect(getPublicOrigin()).toBe("http://localhost:20128");
+  });
+
+  it("forces hosted via DEPLOYMENT_MODE", () => {
+    process.env.DEPLOYMENT_MODE = "hosted";
+    expect(isHosted()).toBe(true);
+  });
+
+  it("forces local via DEPLOYMENT_MODE even with public BASE_URL", () => {
+    process.env.DEPLOYMENT_MODE = "local";
+    process.env.BASE_URL = "https://example.com";
+    expect(isHosted()).toBe(false);
+  });
+
+  it("infers hosted from non-loopback BASE_URL", () => {
+    process.env.BASE_URL = "https://router.example.com";
+    expect(isHosted()).toBe(true);
+    expect(getPublicOrigin()).toBe("https://router.example.com");
+  });
+
+  it("keeps localhost BASE_URL as local", () => {
+    process.env.BASE_URL = "http://localhost:20128";
+    expect(isHosted()).toBe(false);
+    expect(isLoopbackUrl(process.env.BASE_URL)).toBe(true);
+  });
+
+  it("detects loopback hostnames", () => {
+    expect(isLoopbackHostname("localhost")).toBe(true);
+    expect(isLoopbackHostname("127.0.0.1")).toBe(true);
+    expect(isLoopbackHostname("::1")).toBe(true);
+    expect(isLoopbackHostname("[::1]")).toBe(true);
+    expect(isLoopbackHostname("example.com")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Add an explicit local vs hosted deployment mode so 9Router works on public URLs without breaking local defaults.
## Why
Local loopback OAuth, IDE auto-import, and "local means no API key" break or are unsafe behind a public reverse proxy.
## Fix
- `isHosted()` / `DEPLOYMENT_MODE`
- Hosted: require API keys, block local-only routes, no ephemeral DATA_DIR fallback
- Hosted OAuth: public `/callback`, skip loopback proxies
- Cursor modal: skip auto-import when hosted

## Verification
✓ deployment-mode.test.js ✓ dashboard-guard.test.js (incl. hosted cases)

