### PR TITLE
fix(vertex): validate RSA-2048 requirement for SA private key before jose RS256 signing

### DIFF
--- a/open-sse/services/tokenRefresh.js
+++ b/open-sse/services/tokenRefresh.js
@@ -1,3 +1,4 @@
+import { createPrivateKey } from "node:crypto";
 import { PROVIDERS } from "../config/providers.js";
 import { OAUTH_ENDPOINTS, REFRESH_LEAD_MS } from "../config/appConstants.js";
 import {
@@ -72,6 +73,27 @@ export function parseVertexSaJson(apiKey) {
 }
 
 // Cache Vertex tokens keyed by service account email { token, expiresAt }
+
+// Validate that private_key is an RSA-2048+ PEM jose can sign RS256 with.
+// Returns null on success, or a user-facing error message.
+export function validateVertexSaKey(saJson) {
+  if (!saJson?.private_key) return "Vertex: service account JSON missing private_key";
+  let key;
+  try {
+    key = createPrivateKey(saJson.private_key.replace(/\\n/g, "\n"));
+  } catch {
+    return "Vertex: service account private_key is not a valid PEM key";
+  }
+  if (key.asymmetricKeyType !== "rsa") {
+    return `Vertex: service account private_key must be RSA (got ${key.asymmetricKeyType})`;
+  }
+  const bits = key.asymmetricKeyDetails?.modulusLength || 0;
+  if (bits < 2048) {
+    return `Vertex: service account private_key must be RSA-2048 or larger (RS256), got ${bits} bits`;
+  }
+  return null;
+}
+
 const vertexTokenCache = new Map();
 
 export async function refreshVertexToken(saJson, log) {
@@ -83,6 +105,11 @@ export async function refreshVertexToken(saJson, log) {
   }
 
   try {
+    const keyError = validateVertexSaKey(saJson);
+    if (keyError) {
+      log?.error?.("TOKEN_REFRESH", keyError);
+      return null;
+    }
     const { SignJWT, importPKCS8 } = await import("jose");
     log?.debug?.("TOKEN_REFRESH", `Vertex minting token for ${saJson.client_email}`);
     const privateKey = await importPKCS8(saJson.private_key.replace(/\\n/g, "\n"), "RS256");

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -6,6 +6,7 @@ import { resolveOllamaLocalHost, resolveXiaomiTokenplanBaseUrl, PROVIDERS } from
 import { openaiToCommandCodeRequest } from "open-sse/translator/request/openai-to-commandcode.js";
 import { resolveQoderCredentials, resolveQoderModels } from "open-sse/services/qoderModels.js";
 import { normalizeProviderId } from "@/lib/providerNormalization";
+import { validateVertexSaKey } from "open-sse/services/tokenRefresh.js";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
 // Returns true if API key is accepted (status !== 401 && !== 403).
@@ -463,8 +464,15 @@ export async function POST(request) {
           // SA JSON: attempt token mint via JWT assertion
           const saJson = (() => { try { const p = JSON.parse(apiKey); return p.type === "service_account" ? p : null; } catch { return null; } })();
           if (saJson) {
-            // Validate SA JSON has required fields
+            // Required fields + RSA-2048+ private key (jose RS256 requirement)
             isValid = !!(saJson.client_email && saJson.private_key && saJson.project_id);
+            if (isValid) {
+              const keyError = validateVertexSaKey(saJson);
+              if (keyError) {
+                isValid = false;
+                error = keyError;
+              }
+            }
           } else {
             // Raw key: probe Vertex — 404 means key is valid (model just doesn't exist), 401 means invalid key
             const probeRes = await fetch(
@@ -479,7 +487,15 @@ export async function POST(request) {
         case "vertex-partner": {
           const saJson = (() => { try { const p = JSON.parse(apiKey); return p.type === "service_account" ? p : null; } catch { return null; } })();
           if (saJson) {
+            // Required fields + RSA-2048+ private key (jose RS256 requirement)
             isValid = !!(saJson.client_email && saJson.private_key && saJson.project_id);
+            if (isValid) {
+              const keyError = validateVertexSaKey(saJson);
+              if (keyError) {
+                isValid = false;
+                error = keyError;
+              }
+            }
           } else {
             const probeRes = await fetch(
               `https://aiplatform.googleapis.com/v1/publishers/google/models/__probe__:generateContent?key=${apiKey}`,

--- a/tests/unit/vertex-sa-key.test.js
+++ b/tests/unit/vertex-sa-key.test.js
@@ -1,0 +1,100 @@
+/**
+ * Vertex SA JSON key validation — guards the jose RS256 requirement:
+ * RSA key must be 2048 bits or larger, otherwise jose throws
+ * "RS256 requires key modulusLength to be 2048 bits or larger".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const RSA1024 = `-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQC9s2WlG2fi5V58yOhlNNWMSUBBNGl2vnhhhSNKIizroY0pyg2u
+F4e6E8vFFW7UFea1+IrdxanVwa7Qw6wFAhGOoAt+GbRdXNjaLzRUNZdGMb9cyAiu
+4wt7eYon+hbSe5Na5KcWiO0Nxfe2aZyaT0K5T2ku8kp6WF2URqebzKQUiwIDAQAB
+AoGATvF+JkSOafz74kAVfjCLgdLl+3ydOv4uyJ6IPgyU1wYm4bIlGULPh98/GGg/
+8+CdXzLsTzg34i2020nipz7iINj8/YbHA7aml4+s/wtvMFsMSulEARouBkQrg/To
+HdfQnjY3ZzouU2vbjnBiel1NqmQDhG2zGUMVVOkZ/ACWULECQQD1Z27lxzmykOWw
+oVsr8CGaJuPs6SGfoaG4AXfbAqc8bhHPDYCDqpMq9yLbz1sL8I/cVrESlr6i4UA2
+GnKoEwbDAkEAxeQ/09S1+hBnQI1CTiUABRV5NRgm2D7r75rz+3v1Z+qltm7feXEF
+cy9DLV/PuXD4tUIAm6T8vy0pfhMuZNoumQJAFgpKHXz9I5p75pc3VwTkH7Iqelad
+3HZpzdrj5tmgJ39DPjNaPXkOaqdzjAZdiP78DLAEi0TarkpIuBM8BPhgfQJBAI1+
+4tSIJ4Yh7HIPjvVpJ1Z7QCtilYPRmcm9Ne7/dz1SXiLPrCKdWZQ+mv36oACscmjI
+RL8FfWME28I13Npn1yECQC3V5vfU9bgeoE/dXm+1xL8sQmCVy5rubDMqz51qoal+
+7aLclziWIE3R9VTOHQmh4P8lMZXAyzcy6Z5zasZUwpQ=
+-----END RSA PRIVATE KEY-----`;
+
+const RSA2048 = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA0DtJ2qNJT1riQwv6u5E3T5jhVx2R1a+FEAEg5UkmvCosKP5n
+bRPPHpaWbyOFAenC55UOeWx9YNXwfZYZziGWycfsmcCPdDjLB7/6N8xedAtyfP01
+moXyGLeICl9Kfz3pXJ1+it5I4dNXhy5Wsxwl3d4upWV+WbnANxW22EdwfNackFkH
+ahy7OClXBg8M2kist6ZZUNDtuVAtSl/Rqa6evIlnc13jWxdbqCJKVRMwIN6W9Bp1
+cCtu9C8dr+kBTEPOlXlZ3PwoWK/jesU6fdV78LYm5uEb6rLAR4rS5fM9s8XEvgG5
+WUHYlYmXki/+VVtySmOqH6elh2XzOyiKCJTemQIDAQABAoIBADBfFXDsrYL5ocXh
+aoVX3nlnEjGidNYmx8pH+NRKge0D/u4m6u+zwlFgueFnZuZi3xvczFf4k8eC6zLB
+Q41W0ChfgN7WlHxzFPbf6cg8eVSLtDTEvUcABpUnTTrbl/qm7ybMjzDDIjsTVSnZ
+4doJl+JKUpupUAiX1cb2DFuBfOgCp2FUnnRtzuAkZOjf1u1P0zeuQvj28dkGefPC
+wVvTPia3Cy3bGuG6qt0JSGPzUa70qFrisL1lu1fbAUnmrBxYjDuFltsHytqUvsmb
+QDJvuiapzDVKsc9pDVqErZRdlBvOUlqTxPhO+wJyiTgei1MqwX+4lGgE5EzEVfYQ
+c4pasYECgYEA67yTEwDaDHY8TE06EV8lsNkWhMYLRt7HWDf6nD1KLMP14skLFMl5
+t8G4sKppMh+ykUYaJrowy5/DhYKPD5IhLDHK2p8OEGOBA06P5xf2DfyW26CM/Nhj
+HrA9O4wLnH5azc69LCut+H9pN3qQOddhCPyEhSi/ITwFHMoMnGZ9Sg0CgYEA4iF2
+DQLzQfYzcp7sZJetRB4IUcweY/7ZxBWLdkm+AVdUIBfa7uhs3XtC5obRcplY1JYB
+MCweAWcln1vlv6Icki2Sedm7adfdD9JyPCoCu3d8eJ/wuRENXXYtCN9MyLxOEqGt
+wdfRs2Z6lGCswi0pSCtmAMRwlTd1PVAK84FMP70CgYAVkU8zceSBN2AU6wvhAv+D
+ypjQ1P27Ii7C13xKRyE+Lz+T3CjzYeuM8GBhaXXubA/+UpeZ63cDaj6NPICyQABg
+9r1Ee0DiJvhqwQlRb1PHu9Bhj7LWf0WyTRWNGScGzlioc73DCMwF7EJIHSKM6DOs
+is3lEPFLrR4aoDG/LXFREQKBgETH5L5kbVVc650rlb+rGvqjH+ixa3UC6X3pB7h9
+CZwi0eXJG8CbVbGwclLoIwD2f7x5u/bJFH9cvmbQbvtw9bvIvMrvXT/+drD/U9vU
+82vOFkAidff0pdoNvfj64sIT9LNaFh3l5VTqENLc7O9LCUl4WdhV5+CbM7/ofsw+
+QdEJAoGBAKY3PgLz3WLigXL9hhnmk7zKvxsRv3adXre2HEjHIKhnwNZ78SgOP4+6
+L8srgUm7bGwLK4DuLpabeGDlROdu6OV6V3ecKRYtYE8IxJyhaa5fj4KTIY79Nt29
+9NEkC5xLCFtQCDk4hHf2fr/Jc2OyMXYY/jG3lfayHOCQlUYQlAJr
+-----END RSA PRIVATE KEY-----`;
+
+const EC256 = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIF9II7FMdqoQhbohjGGnhMdzn5Fswb2Vuqty2g6dqKjDoAoGCCqGSM49
+AwEHoUQDQgAEBukiJhenCjETxA2sKkbuybvPvb9FWzKK8ZEdydxVDwnQ9wTJdm7G
+8tTPLEDhTYNgh+IvsTNE1GsiKcNBIaoUnw==
+-----END EC PRIVATE KEY-----`;
+
+describe("validateVertexSaKey", () => {
+  it("accepts RSA-2048 private keys (jose RS256 requirement)", async () => {
+    const { validateVertexSaKey } = await import("../../open-sse/services/tokenRefresh.js");
+    expect(validateVertexSaKey({ private_key: RSA2048 })).toBeNull();
+  });
+
+  it("rejects RSA keys below 2048 bits with a user-facing message", async () => {
+    const { validateVertexSaKey } = await import("../../open-sse/services/tokenRefresh.js");
+    const err = validateVertexSaKey({ private_key: RSA1024 });
+    expect(err).toMatch(/RSA-2048 or larger/);
+    expect(err).toMatch(/1024 bits/);
+  });
+
+  it("rejects non-RSA keys", async () => {
+    const { validateVertexSaKey } = await import("../../open-sse/services/tokenRefresh.js");
+    expect(validateVertexSaKey({ private_key: EC256 })).toMatch(/must be RSA/);
+  });
+
+  it("rejects garbage and missing private_key", async () => {
+    const { validateVertexSaKey } = await import("../../open-sse/services/tokenRefresh.js");
+    expect(validateVertexSaKey({ private_key: "not-a-key" })).toMatch(/not a valid PEM/);
+    expect(validateVertexSaKey({})).toMatch(/missing private_key/);
+  });
+});
+
+describe("refreshVertexToken — invalid SA key", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => { global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => ({}) }); });
+  afterEach(() => { global.fetch = originalFetch; });
+
+  it("returns null without minting when private key is below 2048 bits", async () => {
+    const { refreshVertexToken } = await import("../../open-sse/services/tokenRefresh.js");
+    const log = { error: vi.fn(), debug: vi.fn(), info: vi.fn() };
+    const result = await refreshVertexToken(
+      { client_email: "test@example.com", private_key: RSA1024 },
+      log
+    );
+    expect(result).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Vertex/Gemini service-account flows fail with jose's raw error:

```
RS256 requires key modulusLength to be 2048 bits or larger
```

Root cause: `refreshVertexToken` (open-sse/services/tokenRefresh.js) signs an RS256 JWT with a user-supplied service-account private key, but only field presence was validated — a small RSA key (<2048 bits), an EC key, or garbage PEM passed validation and blew up at mint time.

## Fix

- `open-sse/services/tokenRefresh.js`: new `validateVertexSaKey()` parses the PEM via node `createPrivateKey`, rejects non-RSA keys and RSA keys below 2048 bits with a clear message. `refreshVertexToken` validates before calling jose, so the raw jose error no longer escapes.
- `src/app/api/providers/validate/route.js`: vertex and vertex-partner SA JSON branches now key-check at save time, so the UI reports `private_key must be RSA-2048 or larger (RS256)` immediately instead of accepting then failing at runtime.
- `tests/unit/vertex-sa-key.test.js`: accepts RSA-2048, rejects 1024/EC/garbage/missing keys, and `refreshVertexToken` returns null without network on invalid keys.