### PR TITLE
fix(cli): don't kill config subcommand processes during startup cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ graphify-out/*
 .codegraph/
 .PR/
 .next-analyze/*
+dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,13 @@ Pre-translate hooks that compress `tool_result` content in-place to cut tokens. 
 - Security-sensitive env: `JWT_SECRET` (session cookie), `INITIAL_PASSWORD` (default `123456` — must override), `API_KEY_SECRET`, `MACHINE_ID_SALT`. Full env contract in `.env.example` and ARCHITECTURE.md's env matrix.
 - Binary/protobuf upstreams (kiro EventStream, cursor protobuf, commandcode NDJSON) don't round-trip through OpenAI — they're handled inside their own executor, not the translator.
 - Versioning: root and `cli/` are versioned independently; changes are logged in `CHANGELOG.md`. Commit style is Conventional Commits (`fix(translator): …`, `feat(...)`).
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -296,9 +296,14 @@ function killAllAppProcesses(appPort) {
             // Whitelist: real node process running 9router/cli.js, or next-server.
             // Avoids killing editors/grep/strace/cursor that just have "9router" in cmdline.
             const cmd = line.toLowerCase();
+            const isConfigCmd =
+              cmd.includes("config receive") || cmd.includes("config publish") ||
+              cmd.includes("config status") || cmd.includes("config import") ||
+              cmd.includes("config export") || cmd.includes("config device-name");
             const isAppProcess =
-              (cmd.includes("node") && cmd.includes("9router") && (cmd.includes("cli.js") || cmd.includes("\\9router") || cmd.includes("/9router")))
-              || cmd.includes("next-server");
+              !isConfigCmd &&
+              ((cmd.includes("node") && cmd.includes("9router") && (cmd.includes("cli.js") || cmd.includes("\\9router") || cmd.includes("/9router")))
+              || cmd.includes("next-server"));
             if (isAppProcess) {
               const match = line.match(/^"(\d+)"/);
               if (match && match[1] && match[1] !== process.pid.toString()) {
@@ -322,9 +327,14 @@ function killAllAppProcesses(appPort) {
             // Whitelist: real node process running 9router/cli.js, or next-server.
             // Avoids killing grep/strace/editors/cursor that incidentally match "9router".
             const cmd = line.toLowerCase();
+            const isConfigCmd =
+              cmd.includes("config receive") || cmd.includes("config publish") ||
+              cmd.includes("config status") || cmd.includes("config import") ||
+              cmd.includes("config export") || cmd.includes("config device-name");
             const isAppProcess =
-              (cmd.includes("node") && cmd.includes("9router") && (cmd.includes("cli.js") || cmd.includes("/9router")))
-              || cmd.includes("next-server");
+              !isConfigCmd &&
+              ((cmd.includes("node") && cmd.includes("9router") && (cmd.includes("cli.js") || cmd.includes("/9router")))
+              || cmd.includes("next-server"));
             if (isAppProcess) {
               const parts = line.trim().split(/\s+/);
               const pid = parts[1];

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -133,6 +133,7 @@ let noBrowser = false;
 let skipUpdate = false;
 let showLog = false;
 let trayMode = false;
+let noTray = false;
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "--port" || args[i] === "-p") {
@@ -149,7 +150,10 @@ for (let i = 0; i < args.length; i++) {
     skipUpdate = true;
   } else if (args[i] === "--tray" || args[i] === "-t") {
     trayMode = true;
+    noTray = false;
     process.env.TRAY_MODE = "1";
+  } else if (args[i] === "--no-tray") {
+    noTray = true;
   } else if (args[i] === "--help" || args[i] === "-h") {
     console.log(`
 Usage: ${APP_NAME} [options]
@@ -160,6 +164,7 @@ Options:
   -n, --no-browser    Don't open browser automatically
   -l, --log           Show server logs (default: hidden)
   -t, --tray          Run in system tray mode (background)
+  --no-tray           Background mode without tray icon (for desktop app wrapper)
   --skip-update       Skip auto-update check
   -h, --help          Show this help message
   -v, --version       Show version
@@ -179,7 +184,8 @@ Commands:
   }
 }
 
-// Auto-relaunch after update: detached process has no TTY → fallback to tray
+// Auto-relaunch after update: detached process has no TTY → fallback to tray.
+// --no-tray (desktop app wrapper) opts out of the tray icon entirely.
 if (skipUpdate && !trayMode && !process.stdin.isTTY) {
   trayMode = true;
   process.env.TRAY_MODE = "1";
@@ -730,9 +736,12 @@ function startServer(updatePromise) {
     console.log(`Server: http://${displayHost}:${port}`);
 
     waitServerReady(port).then(() => {
-      initTrayIcon();
-      console.log("\n💡 Router is now running in system tray. Close this terminal if you want.");
-      console.log("   Right-click tray icon to open dashboard or quit.\n");
+      if (!noTray) initTrayIcon();
+      console.log(noTray
+        ? "\n💡 Router is now running in background (--no-tray)."
+        : "\n💡 Router is now running in system tray. Close this terminal if you want.");
+      if (!noTray) console.log("   Right-click tray icon to open dashboard or quit.");
+      console.log("\n");
     });
 
     return;

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -67,12 +67,23 @@ const { ensureSqliteRuntime, buildEnvWithRuntime } = require("./hooks/sqliteRunt
 const { ensureTrayRuntime } = require("./hooks/trayRuntime");
 const args = process.argv.slice(2);
 
-// Subcommands (`9router xai video …`) run against an already-running gateway
+// Subcommands run against an already-running gateway / local data dir
 // and bypass the launcher flow (no runtime self-heal, no server spawn).
 if (args[0] === "xai" && args[1] === "video") {
   const { run } = require("./src/cli/commands/xaiVideo");
   run(args.slice(2))
     .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(`❌ ${err?.message || err}`);
+      process.exit(1);
+    });
+  return;
+}
+
+if (args[0] === "config") {
+  const { run } = require("./src/cli/commands/config");
+  run(args.slice(1))
+    .then((code) => process.exit(code ?? 0))
     .catch((err) => {
       console.error(`❌ ${err?.message || err}`);
       process.exit(1);
@@ -154,6 +165,9 @@ Options:
   -v, --version       Show version
 
 Commands:
+  config export|import|publish|receive|status|device-name
+                      Export/import config or auto-sync via private git repo
+                      (see: ${APP_NAME} config --help)
   xai video --prompt "..." --output video.mp4
                       Generate a Grok Imagine video via the running gateway
                       (see: ${APP_NAME} xai video --help)

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,6 +10,7 @@
     "src",
     "hooks",
     "app",
+    "scripts",
     "README.md",
     "LICENSE"
   ],

--- a/cli/scripts/install-sync-daemon.sh
+++ b/cli/scripts/install-sync-daemon.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Install/uninstall the 9router config receive daemon (macOS launchd).
+#
+# The daemon polls the private sync repo every N seconds and auto-imports
+# configs published for this device (backup → import → restart → health check).
+#
+# Usage:
+#   install-sync-daemon.sh [--interval 60]
+#   install-sync-daemon.sh --uninstall
+#
+# Requires: the 9router CLI on PATH (with `config receive --daemon`).
+
+set -euo pipefail
+
+LABEL="com.9router.config-sync"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST="$PLIST_DIR/$LABEL.plist"
+INTERVAL="${INTERVAL:-60}"
+
+for a in "$@"; do
+  case "$a" in
+    --uninstall)
+      launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+      rm -f "$PLIST"
+      echo "✅ Removed $LABEL"
+      exit 0
+      ;;
+    --interval)
+      INTERVAL="$2"; shift 2
+      ;;
+  esac
+done
+
+command -v 9router >/dev/null || { echo "❌ 9router CLI not found on PATH" >&2; exit 1; }
+CLI="$(command -v 9router)"
+
+mkdir -p "$PLIST_DIR"
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$CLI</string>
+    <string>config</string>
+    <string>receive</string>
+    <string>--daemon</string>
+    <string>--interval</string>
+    <string>$INTERVAL</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ProcessType</key><string>Background</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>$(npm prefix -g)/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+  <key>StandardOutPath</key><string>$HOME/.9router/logs/sync-daemon.log</string>
+  <key>StandardErrorPath</key><string>$HOME/.9router/logs/sync-daemon.log</string>
+</dict>
+</plist>
+EOF
+
+mkdir -p "$HOME/.9router/logs"
+launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+echo "✅ Installed $LABEL (interval ${INTERVAL}s, CLI: $CLI)"
+echo "   Logs: ~/.9router/logs/sync-daemon.log"
+echo "   Device: $("$CLI" config device-name)"

--- a/cli/scripts/macos/Info.plist
+++ b/cli/scripts/macos/Info.plist
@@ -16,6 +16,8 @@
 	<string>1</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>

--- a/cli/scripts/macos/Info.plist
+++ b/cli/scripts/macos/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>9Router</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.9router.desktop</string>
+	<key>CFBundleName</key>
+	<string>9Router</string>
+	<key>CFBundleDisplayName</key>
+	<string>9Router</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.5.50</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2026 kkunkunya</string>
+</dict>
+</plist>

--- a/cli/scripts/macos/MenuBarApp.swift
+++ b/cli/scripts/macos/MenuBarApp.swift
@@ -39,6 +39,11 @@ final class RouterController: ObservableObject {
             self?.refreshHealth()
         }
         refreshHealth()
+        // Launch behaviour: make sure the service is up, then open the dashboard.
+        // Wait for the first health poll so we don't blindly restart a running gateway.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+            self?.launchAndOpenDashboard()
+        }
     }
 
     deinit {
@@ -63,6 +68,26 @@ final class RouterController: ObservableObject {
                 }
             }
         }.resume()
+    }
+
+    /// Ensure the gateway is running, then open the dashboard.
+    func launchAndOpenDashboard() {
+        if status.running {
+            openDashboard()
+            return
+        }
+        start()
+        // Wait until /v1/models answers, then open the dashboard (boot can take ~60s).
+        var attempts = 0
+        Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] timer in
+            attempts += 1
+            guard let self else { timer.invalidate(); return }
+            self.refreshHealth()
+            if self.status.running || attempts > 40 {
+                timer.invalidate()
+                if self.status.running { self.openDashboard() }
+            }
+        }
     }
 
     func start() {
@@ -168,8 +193,21 @@ struct NineRouterApp: App {
             .padding(8)
             .frame(width: 220)
         } label: {
-            Image(systemName: "network")
+            if let img = NSImage(named: "menubar") ?? loadMenubarImage() {
+                Image(nsImage: img)
+            } else {
+                Image(systemName: "network")
+            }
         }
         .menuBarExtraStyle(.window)
     }
+}
+
+/// Load the bundled tray icon (menubar.png in Resources).
+private func loadMenubarImage() -> NSImage? {
+    guard let url = Bundle.main.resourceURL?
+        .appendingPathComponent("menubar.png") else { return nil }
+    let img = NSImage(contentsOf: url)
+    img?.size = NSSize(width: 18, height: 18)
+    return img
 }

--- a/cli/scripts/macos/MenuBarApp.swift
+++ b/cli/scripts/macos/MenuBarApp.swift
@@ -1,0 +1,175 @@
+// 9Router menu bar app — thin control plane for the local 9router gateway.
+//
+// The app bundles a Node runtime + the 9router CLI in Contents/Resources and
+// spawns `node cli.js --no-tray --skip-update --host 127.0.0.1` on demand.
+// Menu bar shows live status (via /v1/models), start/stop, open dashboard.
+//
+// Build: scripts/macos/build-app.sh (no Xcode project needed).
+
+import AppKit
+import SwiftUI
+
+let kPort = 20128
+let kHost = "127.0.0.1"
+let kDashboardURL = "http://127.0.0.1:\(kPort)/dashboard"
+
+struct Status {
+    var running: Bool = false
+    var health: String = "checking…"
+}
+
+final class RouterController: ObservableObject {
+    @Published var status = Status()
+    private var child: Process?
+    private var timer: Timer?
+
+    private var resourcesDir: URL {
+        Bundle.main.resourceURL!
+    }
+    private var nodeBin: URL {
+        resourcesDir.appendingPathComponent("node/bin/node")
+    }
+    private var cliJs: URL {
+        resourcesDir.appendingPathComponent("9router/cli.js")
+    }
+
+    init() {
+        // Poll health every 5s so the menu reflects reality.
+        timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            self?.refreshHealth()
+        }
+        refreshHealth()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    func refreshHealth() {
+        let url = URL(string: "http://\(kHost):\(kPort)/v1/models")!
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 3
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if let error = error {
+                    self.status = Status(running: false, health: "stopped (\(error.localizedDescription.prefix(12)))")
+                } else if (200..<500).contains(code) {
+                    let models = (data.flatMap { try? JSONSerialization.jsonObject(with: $0) } as? [String: Any])?["data"] as? [Any] ?? []
+                    self.status = Status(running: true, health: "running · \(models.count) models")
+                } else {
+                    self.status = Status(running: false, health: "error \(code)")
+                }
+            }
+        }.resume()
+    }
+
+    func start() {
+        guard child == nil else { return }
+        guard FileManager.default.fileExists(atPath: nodeBin.path),
+              FileManager.default.fileExists(atPath: cliJs.path) else {
+            status = Status(running: false, health: "bundled runtime missing")
+            return
+        }
+        let proc = Process()
+        proc.executableURL = nodeBin
+        proc.arguments = [cliJs.path, "--no-tray", "--skip-update", "--host", kHost, "--port", String(kPort)]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        proc.terminationHandler = { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.child = nil
+                self?.refreshHealth()
+            }
+        }
+        do {
+            try proc.run()
+            child = proc
+            status = Status(running: false, health: "starting…")
+            // First boot of the Next.js server can take ~60s; poll a bit faster.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                self?.refreshHealth()
+            }
+        } catch {
+            status = Status(running: false, health: "start failed: \(error.localizedDescription)")
+        }
+    }
+
+    func stop() {
+        // Kill whatever listens on the port first (covers stale server children),
+        // then terminate the CLI parent.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+        task.arguments = ["-f", "9router/cli.js --no-tray"]
+        try? task.run()
+        task.waitUntilExit()
+
+        if let child {
+            child.terminate()
+            self.child = nil
+        }
+        status = Status(running: false, health: "stopped")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.refreshHealth()
+        }
+    }
+
+    func openDashboard() {
+        NSWorkspace.shared.open(URL(string: kDashboardURL)!)
+    }
+
+    func openConfigDir() {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".9router")
+        NSWorkspace.shared.open(dir)
+    }
+}
+
+@main
+struct NineRouterApp: App {
+    @StateObject private var controller = RouterController()
+
+    var body: some Scene {
+        MenuBarExtra {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Circle()
+                        .fill(controller.status.running ? Color.green : Color.red)
+                        .frame(width: 8, height: 8)
+                    Text(controller.status.running ? "9Router" : "9Router")
+                        .fontWeight(.semibold)
+                    Spacer()
+                }
+                Text(controller.status.health)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                Divider()
+
+                Button(controller.status.running ? "Stop" : "Start") {
+                    controller.status.running ? controller.stop() : controller.start()
+                }
+                .disabled(!controller.status.running && controller.status.health == "starting…")
+
+                Button("Open Dashboard") { controller.openDashboard() }
+                    .disabled(!controller.status.running)
+
+                Button("Open Config Dir") { controller.openConfigDir() }
+
+                Divider()
+
+                Button("Quit") {
+                    controller.stop()
+                    NSApplication.shared.terminate(nil)
+                }
+            }
+            .padding(8)
+            .frame(width: 220)
+        } label: {
+            Image(systemName: "network")
+        }
+        .menuBarExtraStyle(.window)
+    }
+}

--- a/cli/scripts/macos/build-app.sh
+++ b/cli/scripts/macos/build-app.sh
@@ -60,6 +60,24 @@ swiftc -O -parse-as-library -framework AppKit -framework SwiftUI \
 sed "s|<string>0.5.50</string>|<string>$APP_VERSION</string>|" \
   "$SCRIPT_DIR/Info.plist" > "$APP_BUNDLE/Contents/Info.plist"
 
+# App icon (.icns) from the repo's PWA icon asset
+ICON_DIR="$BUILD_DIR/icon-work"
+mkdir -p "$ICON_DIR/AppIcon.iconset"
+sips -s format png --resampleWidth 1024 "$REPO_ROOT/public/icons/icon-512.svg" \
+  --out "$ICON_DIR/AppIcon.iconset/icon_512x512@2x.png" >/dev/null 2>&1 || \
+sips -s format png --resampleWidth 1024 "$REPO_ROOT/public/icons/icon-512.svg" \
+  --out "$ICON_DIR/app-1024.png" >/dev/null
+for px in 16 32 64 128 256 512; do
+  sips -s format png --resampleWidth $px "$ICON_DIR/app-1024.png" \
+    --out "$ICON_DIR/AppIcon.iconset/icon_${px}x${px}.png" >/dev/null 2>&1
+  sips -s format png --resampleWidth $((px * 2)) "$ICON_DIR/app-1024.png" \
+    --out "$ICON_DIR/AppIcon.iconset/icon_${px}x${px}@2x.png" >/dev/null 2>&1
+done
+iconutil -c icns "$ICON_DIR/AppIcon.iconset" -o "$APP_BUNDLE/Contents/Resources/AppIcon.icns"
+
+# Menu bar icon — reuse the CLI's existing tray icon asset
+cp "$REPO_ROOT/cli/src/cli/tray/icon.png" "$APP_BUNDLE/Contents/Resources/menubar.png"
+
 # Node runtime — keep bin + lib only (BSD tar: member paths include top dir)
 NODE_TOP="node-v$NODE_VERSION-darwin-arm64"
 mkdir -p "$APP_BUNDLE/Contents/Resources/node"
@@ -96,7 +114,13 @@ echo "==> 6/6 packaging .dmg + .zip"
 DMG="$DIST_DIR/9Router-$APP_VERSION-arm64.dmg"
 ZIP="$DIST_DIR/9Router-$APP_VERSION-arm64.zip"
 rm -f "$DMG" "$ZIP"
-hdiutil create -volname "9Router $APP_VERSION" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG" >/dev/null
+# Staging dir with an Applications symlink so users can drag-to-install.
+STAGE="$BUILD_DIR/dmg-stage"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+cp -R "$APP_BUNDLE" "$STAGE/"
+ln -s /Applications "$STAGE/Applications"
+hdiutil create -volname "9Router $APP_VERSION" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
 ditto -c -k --keepParent "$APP_BUNDLE" "$ZIP"
 echo "✅ $DMG"
 echo "✅ $ZIP"

--- a/cli/scripts/macos/build-app.sh
+++ b/cli/scripts/macos/build-app.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Build the 9Router macOS menu bar app (Apple Silicon), then package .dmg + .zip.
+#
+# Bundles: SwiftUI menu bar shell + Node runtime + 9router CLI (with deps).
+# Alpha: ad-hoc signed (no Developer ID) — Gatekeeper will warn on other Macs.
+#
+# Usage:
+#   build-app.sh                # build app + dmg + zip into dist/
+#   build-app.sh --no-package   # build .app only (faster iteration)
+#
+# Env:
+#   NODE_VERSION   Node version to bundle (default: 22.23.2)
+#   CLI_TGZ        Path to a prebuilt 9router CLI tarball (default: build fresh)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CLI_DIR="$REPO_ROOT/cli"
+
+NODE_VERSION="${NODE_VERSION:-22.23.2}"
+APP_VERSION="$(node -p "require('$CLI_DIR/package.json').version")"
+DIST_DIR="${DIST_DIR:-$REPO_ROOT/dist}"
+CACHE_DIR="${CACHE_DIR:-$HOME/.9router/build-cache}"
+BUILD_DIR="$DIST_DIR/build"
+APP_NAME="9Router"
+APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
+PKG_ONLY=0
+[[ "${1:-}" == "--no-package" ]] && PKG_ONLY=1
+
+mkdir -p "$DIST_DIR" "$CACHE_DIR"
+
+echo "==> 1/6 Node runtime ($NODE_VERSION arm64)"
+NODE_TGZ="$CACHE_DIR/node-v$NODE_VERSION-darwin-arm64.tar.gz"
+if [[ ! -f "$NODE_TGZ" ]]; then
+  echo "    downloading nodejs.org…"
+  curl -fsSL -o "$NODE_TGZ" "https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-darwin-arm64.tar.gz"
+fi
+
+echo "==> 2/6 9router CLI tarball"
+CLI_TGZ="${CLI_TGZ:-}"
+if [[ -z "$CLI_TGZ" || ! -f "$CLI_TGZ" ]]; then
+  CLI_TGZ="$DIST_DIR/9router-$APP_VERSION.tgz"
+  if [[ ! -f "$CLI_TGZ" ]]; then
+    (cd "$CLI_DIR" && npm run build >/dev/null && npm pack --pack-destination "$DIST_DIR" >/dev/null)
+  fi
+  CLI_TGZ="$(ls -t "$DIST_DIR"/9router-*.tgz | head -1)"
+fi
+
+echo "==> 3/6 assembling .app bundle"
+rm -rf "$BUILD_DIR"
+mkdir -p "$APP_BUNDLE/Contents/MacOS" "$APP_BUNDLE/Contents/Resources"
+
+# Swift menu bar shell
+swiftc -O -parse-as-library -framework AppKit -framework SwiftUI \
+  -o "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
+  "$SCRIPT_DIR/MenuBarApp.swift"
+
+# Info.plist
+sed "s|<string>0.5.50</string>|<string>$APP_VERSION</string>|" \
+  "$SCRIPT_DIR/Info.plist" > "$APP_BUNDLE/Contents/Info.plist"
+
+# Node runtime — keep bin + lib only (BSD tar: member paths include top dir)
+NODE_TOP="node-v$NODE_VERSION-darwin-arm64"
+mkdir -p "$APP_BUNDLE/Contents/Resources/node"
+tar -xzf "$NODE_TGZ" -C "$APP_BUNDLE/Contents/Resources/node" --strip-components=1 \
+  "$NODE_TOP/bin" "$NODE_TOP/lib" "$NODE_TOP/include"
+rm -rf "$APP_BUNDLE/Contents/Resources/node/include" \
+       "$APP_BUNDLE/Contents/Resources/node/share" 2>/dev/null || true
+
+# 9router CLI
+mkdir -p "$APP_BUNDLE/Contents/Resources/9router"
+tar -xzf "$CLI_TGZ" -C "$APP_BUNDLE/Contents/Resources/9router" --strip-components=1
+(cd "$APP_BUNDLE/Contents/Resources/9router" && \
+  NODE="$APP_BUNDLE/Contents/Resources/node/bin/node" && \
+  "$NODE" "$APP_BUNDLE/Contents/Resources/node/lib/node_modules/npm/bin/npm-cli.js" \
+    install --omit=dev --no-audit --no-fund --no-progress >/dev/null 2>&1 || \
+  npm install --omit=dev --no-audit --no-fund --no-progress >/dev/null)
+
+echo "==> 4/6 ad-hoc codesign"
+codesign --force --sign - "$APP_BUNDLE" >/dev/null 2>&1 || true
+
+echo "==> 5/6 verify"
+if [[ ! -x "$APP_BUNDLE/Contents/MacOS/$APP_NAME" ]]; then
+  echo "❌ binary missing" >&2; exit 1
+fi
+codesign -v "$APP_BUNDLE" >/dev/null 2>&1 && echo "    codesign: ok (ad-hoc)" || true
+file "$APP_BUNDLE/Contents/MacOS/$APP_NAME" | sed 's/^/    /'
+echo "    bundle: $APP_BUNDLE"
+echo "    node:   $("$APP_BUNDLE/Contents/Resources/node/bin/node" --version)"
+echo "    cli:    $APP_VERSION"
+
+[[ "$PKG_ONLY" == 1 ]] && { echo "✅ .app built (no package)"; exit 0; }
+
+echo "==> 6/6 packaging .dmg + .zip"
+DMG="$DIST_DIR/9Router-$APP_VERSION-arm64.dmg"
+ZIP="$DIST_DIR/9Router-$APP_VERSION-arm64.zip"
+rm -f "$DMG" "$ZIP"
+hdiutil create -volname "9Router $APP_VERSION" -srcfolder "$APP_BUNDLE" -ov -format UDZO "$DMG" >/dev/null
+ditto -c -k --keepParent "$APP_BUNDLE" "$ZIP"
+echo "✅ $DMG"
+echo "✅ $ZIP"

--- a/cli/src/cli/commands/config.js
+++ b/cli/src/cli/commands/config.js
@@ -1,0 +1,653 @@
+/**
+ * 9router config export/import/publish/receive — minimal auto migration.
+ *
+ * Keeps the useful SQLite config, leaves machine runtime junk behind.
+ * No device key system, no merge rules: source package replaces target DB.
+ */
+
+const { execFileSync, spawn } = require("child_process");
+const fs = require("fs");
+const http = require("http");
+const os = require("os");
+const path = require("path");
+const { createHash } = require("crypto");
+
+const DEFAULT_PORT = 20128;
+const DEFAULT_HOST = "127.0.0.1";
+const BUNDLE_NAME = "config.bundle";
+const META_NAME = "meta.json";
+const STATUS_NAME = "status.json";
+const SYNC_CONFIG_FILE = "sync.json";
+
+const HELP = `
+Usage:
+  9router config export [--out <path>] [--target <device>]
+  9router config import --file <path> [--no-restart] [--port <port>] [--host <host>]
+  9router config publish --target <device> [--repo <path>] [--file <path>]
+  9router config receive [--repo <path>] [--once] [--daemon] [--interval <sec>] [--no-restart] [--port <port>]
+  9router config status --target <device> [--repo <path>]
+  9router config device-name
+
+Export copies the live config DB (+ optional auth secrets) into a portable
+bundle. Import backups the current DB, replaces it, restarts 9router, and
+health-checks /v1/models. Publish/receive use a private git repo directory
+as a dumb file drop for fully automatic cross-machine sync.
+`;
+
+function getDataDir() {
+  if (process.env.DATA_DIR) return process.env.DATA_DIR;
+  return process.platform === "win32"
+    ? path.join(process.env.APPDATA || os.homedir(), "9router")
+    : path.join(os.homedir(), ".9router");
+}
+
+function dbPath() {
+  return path.join(getDataDir(), "db", "data.sqlite");
+}
+
+function defaultDeviceName() {
+  try {
+    if (process.platform === "darwin") {
+      return execFileSync("scutil", ["--get", "LocalHostName"], { encoding: "utf8" }).trim() || os.hostname();
+    }
+  } catch {}
+  return (os.hostname() || "device").replace(/\.local$/i, "");
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function readJson(file, fallback = null) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(file, data) {
+  ensureDir(path.dirname(file));
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
+}
+
+function sha256File(file) {
+  const h = createHash("sha256");
+  h.update(fs.readFileSync(file));
+  return h.digest("hex");
+}
+
+function runSqliteBackup(srcDb, destDb) {
+  ensureDir(path.dirname(destDb));
+  if (!fs.existsSync(srcDb)) {
+    throw new Error(`Config DB not found: ${srcDb}`);
+  }
+  // Prefer sqlite3 CLI: copies main DB + WAL into a clean standalone file.
+  try {
+    execFileSync("sqlite3", [srcDb, `.backup '${destDb.replace(/'/g, "''")}'`], {
+      stdio: ["ignore", "ignore", "pipe"],
+      timeout: 60000,
+    });
+    return;
+  } catch (err) {
+    // Fallback: raw copy of main file only.
+    fs.copyFileSync(srcDb, destDb);
+    const msg = err?.stderr?.toString?.() || err.message;
+    if (msg) console.warn(`⚠️  sqlite3 backup failed, used file copy: ${msg.trim()}`);
+  }
+}
+
+function packagePaths(bundleDir) {
+  return {
+    dir: bundleDir,
+    bundle: path.join(bundleDir, BUNDLE_NAME),
+    meta: path.join(bundleDir, META_NAME),
+  };
+}
+
+function isBundleDir(p) {
+  return fs.existsSync(path.join(p, BUNDLE_NAME)) && fs.existsSync(path.join(p, META_NAME));
+}
+
+function resolveBundleDir(fileArg) {
+  if (!fileArg) throw new Error("--file is required");
+  const abs = path.resolve(fileArg);
+  if (fs.existsSync(abs) && fs.statSync(abs).isDirectory() && isBundleDir(abs)) return abs;
+  if (fs.existsSync(abs) && path.basename(abs) === BUNDLE_NAME) {
+    const dir = path.dirname(abs);
+    if (isBundleDir(dir)) return dir;
+  }
+  throw new Error(`Not a 9router config bundle: ${abs}`);
+}
+
+function exportConfig(opts) {
+  const outRoot = opts.out
+    ? path.resolve(opts.out)
+    : path.join(getDataDir(), "exports", `config-${stamp()}`);
+  const paths = packagePaths(outRoot);
+  ensureDir(paths.dir);
+
+  runSqliteBackup(dbPath(), paths.bundle);
+
+  const extra = [];
+  for (const rel of ["jwt-secret", "auth/cli-secret"]) {
+    const src = path.join(getDataDir(), rel);
+    if (!fs.existsSync(src)) continue;
+    const dest = path.join(paths.dir, path.basename(rel));
+    fs.copyFileSync(src, dest);
+    try { fs.chmodSync(dest, 0o600); } catch {}
+    extra.push(path.basename(rel));
+  }
+
+  const meta = {
+    kind: "9router-config",
+    version: 1,
+    createdAt: new Date().toISOString(),
+    sourceDevice: defaultDeviceName(),
+    targetDevice: opts.target || null,
+    sourceHostname: os.hostname(),
+    dbSha256: sha256File(paths.bundle),
+    files: [BUNDLE_NAME, ...extra],
+    note: "Replace target DB with this bundle. Runtime cache/logs are not included.",
+  };
+  writeJson(paths.meta, meta);
+  try { fs.chmodSync(paths.bundle, 0o600); } catch {}
+
+  console.log(`✅ Exported config → ${paths.dir}`);
+  console.log(`   DB: ${paths.bundle}`);
+  if (opts.target) console.log(`   Target: ${opts.target}`);
+  return paths.dir;
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function waitPort(port, host, timeoutMs = 90000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve) => {
+    const tryOnce = () => {
+      const req = http.get({ host, port, path: "/v1/models", timeout: 2000 }, (res) => {
+        res.resume();
+        resolve(res.statusCode && res.statusCode < 500);
+      });
+      req.on("error", () => {
+        if (Date.now() >= deadline) return resolve(false);
+        setTimeout(tryOnce, 250);
+      });
+      req.on("timeout", () => {
+        req.destroy();
+        if (Date.now() >= deadline) return resolve(false);
+        setTimeout(tryOnce, 250);
+      });
+    };
+    tryOnce();
+  });
+}
+
+function healthCheck(port, host) {
+  return new Promise((resolve) => {
+    const req = http.get({ host, port, path: "/v1/models", timeout: 5000 }, (res) => {
+      let body = "";
+      res.on("data", (c) => (body += c));
+      res.on("end", () => {
+        resolve({
+          ok: res.statusCode >= 200 && res.statusCode < 500,
+          status: res.statusCode,
+          bytes: body.length,
+        });
+      });
+    });
+    req.on("error", (err) => resolve({ ok: false, error: err.message }));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve({ ok: false, error: "timeout" });
+    });
+  });
+}
+
+function killRunningRouter(port) {
+  // Best-effort: free the port before swapping DB.
+  try {
+    if (process.platform === "win32") {
+      execFileSync("powershell", [
+        "-NonInteractive",
+        "-Command",
+        `Get-NetTCPConnection -LocalPort ${port} -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue }`,
+      ], { stdio: "ignore", timeout: 8000 });
+      return;
+    }
+    const out = execFileSync("lsof", ["-ti", `tcp:${port}`], { encoding: "utf8", timeout: 5000 }).trim();
+    if (!out) return;
+    for (const pid of out.split(/\s+/).filter(Boolean)) {
+      try { process.kill(parseInt(pid, 10), "SIGKILL"); } catch {}
+    }
+  } catch {
+    // nothing listening
+  }
+}
+
+function startRouterBackground({ port, host }) {
+  const cliJs = path.resolve(__dirname, "../../../cli.js");
+  const child = spawn(process.execPath, [cliJs, "--tray", "--skip-update", "--host", host, "--port", String(port)], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env },
+  });
+  child.unref();
+  return child.pid;
+}
+
+async function importConfig(opts) {
+  const bundleDir = resolveBundleDir(opts.file);
+  const paths = packagePaths(bundleDir);
+  const meta = readJson(paths.meta, {});
+  if (meta.kind && meta.kind !== "9router-config") {
+    throw new Error(`Unsupported bundle kind: ${meta.kind}`);
+  }
+  if (meta.dbSha256) {
+    const actual = sha256File(paths.bundle);
+    if (actual !== meta.dbSha256) {
+      throw new Error(`Bundle checksum mismatch (expected ${meta.dbSha256}, got ${actual})`);
+    }
+  }
+
+  const dataDir = getDataDir();
+  const liveDb = dbPath();
+  const backupDir = ensureDir(path.join(dataDir, "db", "backups"));
+  const backupPath = path.join(backupDir, `data.sqlite.bak-${stamp()}`);
+
+  if (fs.existsSync(liveDb)) {
+    runSqliteBackup(liveDb, backupPath);
+    console.log(`📦 Backup → ${backupPath}`);
+  } else {
+    ensureDir(path.dirname(liveDb));
+  }
+
+  const port = opts.port || DEFAULT_PORT;
+  const host = opts.host || DEFAULT_HOST;
+  killRunningRouter(port);
+  await sleep(500);
+
+  // Replace live DB (+ wipe WAL/SHM so sqlite doesn't revive old state).
+  fs.copyFileSync(paths.bundle, liveDb);
+  try { fs.chmodSync(liveDb, 0o600); } catch {}
+  for (const suffix of ["-wal", "-shm"]) {
+    const p = liveDb + suffix;
+    try { if (fs.existsSync(p)) fs.unlinkSync(p); } catch {}
+  }
+
+  for (const name of ["jwt-secret", "cli-secret"]) {
+    const src = path.join(bundleDir, name);
+    if (!fs.existsSync(src)) continue;
+    const dest = name === "cli-secret"
+      ? path.join(dataDir, "auth", "cli-secret")
+      : path.join(dataDir, name);
+    ensureDir(path.dirname(dest));
+    fs.copyFileSync(src, dest);
+    try { fs.chmodSync(dest, 0o600); } catch {}
+  }
+
+  if (opts.noRestart) {
+    console.log("✅ Imported config (service not restarted)");
+    return { ok: true, restarted: false, backupPath };
+  }
+
+  const pid = startRouterBackground({ port, host });
+  console.log(`🔄 Restarting 9router (pid ${pid || "?"}) on ${host}:${port}...`);
+  const ready = await waitPort(port, host, 90000);
+  if (!ready) {
+    // Rollback
+    if (fs.existsSync(backupPath)) {
+      fs.copyFileSync(backupPath, liveDb);
+      for (const suffix of ["-wal", "-shm"]) {
+        const p = liveDb + suffix;
+        try { if (fs.existsSync(p)) fs.unlinkSync(p); } catch {}
+      }
+      killRunningRouter(port);
+      startRouterBackground({ port, host });
+      console.error("❌ Health wait failed; restored backup and restarted previous config");
+      return { ok: false, restarted: true, backupPath, rolledBack: true };
+    }
+    throw new Error("Import applied but 9router did not become ready");
+  }
+
+  const health = await healthCheck(port, host);
+  if (!health.ok) {
+    if (fs.existsSync(backupPath)) {
+      killRunningRouter(port);
+      await sleep(300);
+      fs.copyFileSync(backupPath, liveDb);
+      for (const suffix of ["-wal", "-shm"]) {
+        const p = liveDb + suffix;
+        try { if (fs.existsSync(p)) fs.unlinkSync(p); } catch {}
+      }
+      startRouterBackground({ port, host });
+      console.error(`❌ Health check failed (${health.error || health.status}); restored backup`);
+      return { ok: false, restarted: true, backupPath, rolledBack: true, health };
+    }
+    throw new Error(`Health check failed: ${health.error || health.status}`);
+  }
+
+  console.log(`✅ Imported config and verified /v1/models (HTTP ${health.status})`);
+  if (meta.sourceDevice) console.log(`   From: ${meta.sourceDevice}`);
+  return { ok: true, restarted: true, backupPath, health };
+}
+
+function syncConfigPath() {
+  return path.join(getDataDir(), SYNC_CONFIG_FILE);
+}
+
+function readSyncConfig() {
+  return readJson(syncConfigPath(), {});
+}
+
+function resolveSyncRepo(repoArg) {
+  // Priority: --repo flag > env > ~/.9router/sync.json > default on this machine.
+  const fromFile = readSyncConfig();
+  const repo =
+    repoArg ||
+    process.env.NINE_ROUTER_SYNC_REPO ||
+    fromFile.repo ||
+    "";
+  if (!repo) {
+    throw new Error(
+      "Sync repo required: pass --repo, set NINE_ROUTER_SYNC_REPO, or write ~/.9router/sync.json {\"repo\":\"<path>\"}"
+    );
+  }
+  const abs = path.resolve(repo);
+  if (!fs.existsSync(abs)) throw new Error(`Sync repo not found: ${abs}`);
+  return abs;
+}
+
+function migrationRoot(repo) {
+  return path.join(repo, "private", "9router-migrations");
+}
+
+function targetDir(repo, target) {
+  return path.join(migrationRoot(repo), target);
+}
+
+function git(repo, args, opts = {}) {
+  return execFileSync("git", ["-C", repo, ...args], {
+    encoding: "utf8",
+    stdio: opts.stdio || ["ignore", "pipe", "pipe"],
+    timeout: opts.timeout || 120000,
+  });
+}
+
+function gitAvailable(repo) {
+  try {
+    git(repo, ["rev-parse", "--is-inside-work-tree"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function copyBundle(srcDir, destDir) {
+  ensureDir(destDir);
+  const src = packagePaths(srcDir);
+  const dest = packagePaths(destDir);
+  fs.copyFileSync(src.bundle, dest.bundle);
+  fs.copyFileSync(src.meta, dest.meta);
+  for (const name of ["jwt-secret", "cli-secret"]) {
+    const p = path.join(srcDir, name);
+    if (fs.existsSync(p)) fs.copyFileSync(p, path.join(destDir, name));
+  }
+  try { fs.chmodSync(dest.bundle, 0o600); } catch {}
+  return destDir;
+}
+
+function publishConfig(opts) {
+  if (!opts.target) throw new Error("--target is required");
+  const repo = resolveSyncRepo(opts.repo);
+  if (!gitAvailable(repo)) throw new Error(`Not a git repo: ${repo}`);
+
+  const exported = opts.file
+    ? resolveBundleDir(opts.file)
+    : exportConfig({ target: opts.target });
+
+  // Pull latest first to reduce push races.
+  try { git(repo, ["pull", "--ff-only"]); } catch (err) {
+    console.warn(`⚠️  git pull skipped/failed: ${(err.stderr || err.message || "").toString().trim()}`);
+  }
+
+  const dest = targetDir(repo, opts.target);
+  copyBundle(exported, dest);
+  const meta = readJson(packagePaths(dest).meta, {});
+  meta.targetDevice = opts.target;
+  meta.publishedAt = new Date().toISOString();
+  writeJson(packagePaths(dest).meta, meta);
+  writeJson(path.join(dest, STATUS_NAME), {
+    state: "pending",
+    target: opts.target,
+    sourceDevice: meta.sourceDevice || defaultDeviceName(),
+    updatedAt: new Date().toISOString(),
+    message: "Waiting for target receive",
+  });
+
+  const rel = path.relative(repo, dest);
+  git(repo, ["add", "-A", "--", rel]);
+  const status = git(repo, ["status", "--porcelain", "--", rel]).trim();
+  if (status) {
+    git(repo, ["commit", "-m", `chore(9router): publish config to ${opts.target}`]);
+    try {
+      git(repo, ["push"]);
+    } catch (err) {
+      throw new Error(`git push failed: ${(err.stderr || err.message || "").toString().trim()}`);
+    }
+  }
+
+  console.log(`✅ Published config for ${opts.target}`);
+  console.log(`   Repo path: ${dest}`);
+  return dest;
+}
+
+async function receiveConfig(opts) {
+  const repo = resolveSyncRepo(opts.repo);
+  if (!gitAvailable(repo)) throw new Error(`Not a git repo: ${repo}`);
+  const device = opts.device || defaultDeviceName();
+  const dest = targetDir(repo, device);
+
+  try { git(repo, ["pull", "--ff-only"]); } catch (err) {
+    console.warn(`⚠️  git pull failed: ${(err.stderr || err.message || "").toString().trim()}`);
+  }
+  if (!isBundleDir(dest)) {
+    console.log(`ℹ️  No pending config for device "${device}"`);
+    return { ok: true, applied: false };
+  }
+
+  const status = readJson(path.join(dest, STATUS_NAME), {});
+  if (status.state === "applied" && status.dbSha256) {
+    const current = sha256File(packagePaths(dest).bundle);
+    if (status.dbSha256 === current) {
+      console.log(`ℹ️  Latest config already applied for "${device}"`);
+      return { ok: true, applied: false, already: true };
+    }
+  }
+  // A crashed previous run leaves state "applying" — treat as retryable.
+  if (status.state === "applying") {
+    console.log(`↻ Previous receive was interrupted; retrying for "${device}"`);
+  }
+
+  writeJson(path.join(dest, STATUS_NAME), {
+    state: "applying",
+    target: device,
+    updatedAt: new Date().toISOString(),
+    message: "Import in progress",
+  });
+  try {
+    git(repo, ["add", "-A", "--", path.relative(repo, dest)]);
+    if (git(repo, ["status", "--porcelain", "--", path.relative(repo, dest)]).trim()) {
+      git(repo, ["commit", "-m", `chore(9router): receiving config on ${device}`]);
+      try { git(repo, ["push"]); } catch {}
+    }
+  } catch {}
+
+  const result = await importConfig({
+    file: dest,
+    noRestart: opts.noRestart,
+    port: opts.port,
+    host: opts.host,
+  });
+
+  const meta = readJson(packagePaths(dest).meta, {});
+  const nextStatus = {
+    state: result.ok ? "applied" : "failed",
+    target: device,
+    sourceDevice: meta.sourceDevice || null,
+    updatedAt: new Date().toISOString(),
+    message: result.ok
+      ? (result.rolledBack ? "Failed health check; rolled back" : "Imported and verified")
+      : "Import failed",
+    dbSha256: meta.dbSha256 || null,
+    backupPath: result.backupPath || null,
+    rolledBack: !!result.rolledBack,
+  };
+  writeJson(path.join(dest, STATUS_NAME), nextStatus);
+
+  // After success, drop secrets from the shared drop folder but keep status for polling.
+  if (result.ok && !result.rolledBack) {
+    for (const name of [BUNDLE_NAME, "jwt-secret", "cli-secret"]) {
+      const p = path.join(dest, name);
+      try { if (fs.existsSync(p)) fs.unlinkSync(p); } catch {}
+    }
+  }
+
+  const rel = path.relative(repo, dest);
+  git(repo, ["add", "-A", "--", rel]);
+  if (git(repo, ["status", "--porcelain", "--", rel]).trim()) {
+    git(repo, ["commit", "-m", `chore(9router): ${nextStatus.state} config on ${device}`]);
+    try { git(repo, ["push"]); } catch (err) {
+      console.warn(`⚠️  status push failed: ${(err.stderr || err.message || "").toString().trim()}`);
+    }
+  }
+
+  // On failure the bundle stays in place (with a "failed" status committed
+  // above) so the next cycle retries the import automatically.
+  if (!result.ok) {
+    console.error(`❌ Receive failed for ${device}`);
+    return { ok: false, applied: true, ...result };
+  }
+  console.log(`✅ Received and applied config for ${device}`);
+  return { ok: true, applied: true, ...result };
+}
+
+async function runDaemonLoop(opts) {
+  const intervalSec = Math.max(15, opts.intervalSec || 60);
+  console.log(`🔁 9router config receive daemon: polling every ${intervalSec}s`);
+  console.log(`   Device: ${opts.device || defaultDeviceName()}`);
+  let lastSha = null;
+  for (;;) {
+    try {
+      const r = await receiveConfig(opts);
+      if (r?.ok && r?.applied) lastSha = r.dbSha || null;
+    } catch (err) {
+      console.error(`⚠️  receive cycle failed: ${err?.message || err}`);
+    }
+    await sleep(intervalSec * 1000);
+  }
+}
+
+function statusConfig(opts) {
+  if (!opts.target) throw new Error("--target is required");
+  const repo = resolveSyncRepo(opts.repo);
+  try { git(repo, ["pull", "--ff-only"]); } catch {}
+  const statusPath = path.join(targetDir(repo, opts.target), STATUS_NAME);
+  const status = readJson(statusPath, null);
+  if (!status) {
+    console.log(`ℹ️  No status for ${opts.target}`);
+    return null;
+  }
+  console.log(JSON.stringify(status, null, 2));
+  return status;
+}
+
+function parseArgs(argv) {
+  const opts = {
+    port: DEFAULT_PORT,
+    host: DEFAULT_HOST,
+    once: false,
+    noRestart: false,
+  };
+  if (!argv.length || argv[0] === "-h" || argv[0] === "--help") {
+    opts.help = true;
+    opts.action = "help";
+    return opts;
+  }
+  opts.action = argv[0];
+  for (let i = 1; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    if (a === "--out" || a === "-o") opts.out = next();
+    else if (a === "--file" || a === "-f") opts.file = next();
+    else if (a === "--target") opts.target = next();
+    else if (a === "--repo") opts.repo = next();
+    else if (a === "--device") opts.device = next();
+    else if (a === "--interval" || a === "-i") opts.intervalSec = parseInt(next(), 10);
+    else if (a === "--port" || a === "-p") opts.port = parseInt(next(), 10) || DEFAULT_PORT;
+    else if (a === "--host" || a === "-H") opts.host = next() || DEFAULT_HOST;
+    else if (a === "--once") opts.once = true;
+    else if (a === "--no-restart") opts.noRestart = true;
+    else if (a === "--daemon") opts.daemon = true;
+    else if (a === "-h" || a === "--help") opts.help = true;
+    else throw new Error(`Unknown option: ${a}`);
+  }
+  return opts;
+}
+
+async function run(argv) {
+  const opts = parseArgs(argv);
+  if (opts.help || opts.action === "help") {
+    console.log(HELP.trim());
+    return 0;
+  }
+  switch (opts.action) {
+    case "export":
+      exportConfig(opts);
+      return 0;
+    case "import":
+      if (!opts.file) throw new Error("--file is required");
+      {
+        const r = await importConfig(opts);
+        return r.ok ? 0 : 2;
+      }
+    case "publish":
+      publishConfig(opts);
+      return 0;
+    case "receive":
+      if (opts.daemon) {
+        await runDaemonLoop(opts);
+        return 0;
+      }
+      {
+        const r = await receiveConfig(opts);
+        return r.ok ? 0 : 2;
+      }
+    case "status":
+      statusConfig(opts);
+      return 0;
+    case "device-name":
+      console.log(defaultDeviceName());
+      return 0;
+    default:
+      throw new Error(`Unknown config action: ${opts.action}\n${HELP}`);
+  }
+}
+
+module.exports = {
+  run,
+  parseArgs,
+  exportConfig,
+  importConfig,
+  publishConfig,
+  receiveConfig,
+  defaultDeviceName,
+  getDataDir,
+};

--- a/open-sse/executors/grok-cli.js
+++ b/open-sse/executors/grok-cli.js
@@ -237,10 +237,127 @@ function stripStoredItemReferences(body) {
 }
 
 /**
+ * Grok validates JSON Schema URI fields more strictly than most OpenAI-compatible
+ * endpoints. TypeBox emits cyclic definitions under the subschema that uses them:
+ *
+ *   items: { $defs: { AddTask: ... }, $ref: "AddTask" }
+ *
+ * Responses expects local references to use a JSON Pointer and rejects bare names.
+ * Hoist local definitions to the tool-parameter root, then rewrite references to
+ * the canonical form. Definitions are renamed only when separate scopes collide.
+ */
+function normalizeGrokCliSchema(schema) {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema;
+
+  const root = schema;
+  const rootScope = { defs: new Map(), parent: null };
+  const scopeByNode = new WeakMap();
+  const records = [];
+  const usedNames = new Set();
+
+  const isObject = (value) => value && typeof value === "object" && !Array.isArray(value);
+  const allocateName = (name) => {
+    let candidate = name;
+    let suffix = 2;
+    while (usedNames.has(candidate)) candidate = `${name}_${suffix++}`;
+    usedNames.add(candidate);
+    return candidate;
+  };
+
+  const collect = (node, inheritedScope) => {
+    if (!isObject(node)) return;
+    const currentScope = node === root
+      ? rootScope
+      : (isObject(node.$defs) ? { defs: new Map(), parent: inheritedScope } : inheritedScope);
+    scopeByNode.set(node, currentScope);
+
+    if (isObject(node.$defs)) {
+      for (const [name, definition] of Object.entries(node.$defs)) {
+        if (!isObject(definition)) continue;
+        const targetName = allocateName(name);
+        currentScope.defs.set(name, targetName);
+        records.push({ definition, scope: currentScope, targetName });
+        collect(definition, currentScope);
+      }
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$defs") continue;
+      if (Array.isArray(value)) {
+        for (const item of value) collect(item, currentScope);
+      } else {
+        collect(value, currentScope);
+      }
+    }
+  };
+
+  const lookup = (scope, name) => {
+    for (let current = scope; current; current = current.parent) {
+      if (current.defs.has(name)) return current.defs.get(name);
+    }
+    return null;
+  };
+
+  const localRefName = (ref) => {
+    if (typeof ref !== "string") return null;
+    if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(ref)) return null;
+    const encodedName = ref.startsWith("#/$defs/")
+      ? ref.slice("#/$defs/".length)
+      : ref.startsWith("#/$definitions/")
+        ? ref.slice("#/$definitions/".length)
+        : ref.startsWith("#")
+          ? null
+          : ref;
+    if (encodedName == null) return null;
+    try {
+      return decodeURIComponent(encodedName);
+    } catch {
+      return encodedName;
+    }
+  };
+
+  const rewrite = (node, inheritedScope) => {
+    if (!isObject(node)) return;
+    const currentScope = scopeByNode.get(node) || inheritedScope;
+    if (typeof node.$ref === "string") {
+      const name = localRefName(node.$ref);
+      const targetName = name && lookup(currentScope, name);
+      if (targetName) node.$ref = `#/$defs/${targetName.replace(/~/g, "~0").replace(/\//g, "~1")}`;
+    }
+    // Local $id values such as "AddTask" are rejected by Grok and are not
+    // needed once definitions are rooted under #/$defs.
+    if (typeof node.$id === "string") delete node.$id;
+    if (node !== root) delete node.$defs;
+
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$defs") continue;
+      if (Array.isArray(value)) {
+        for (const item of value) rewrite(item, currentScope);
+      } else {
+        rewrite(value, currentScope);
+      }
+    }
+  };
+
+  collect(root, rootScope);
+  rewrite(root, rootScope);
+  for (const { definition, scope, targetName } of records) {
+    rewrite(definition, scope);
+  }
+
+  if (records.length > 0) {
+    const defs = {};
+    for (const { definition, targetName } of records) defs[targetName] = definition;
+    root.$defs = defs;
+  }
+  return root;
+}
+
+/**
  * Flatten Chat Completions tool shape → Responses flat format.
  * Keep hosted tools (web_search / x_search) passthrough.
  */
-function normalizeGrokCliTools(body) {
+export function normalizeGrokCliTools(body) {
   if (!Array.isArray(body.tools) || body.tools.length === 0) {
     delete body.tools;
     delete body.tool_choice;
@@ -301,7 +418,7 @@ function normalizeGrokCliTools(body) {
     tool.type = "function";
     tool.name = name.slice(0, 128);
     if (description) tool.description = description;
-    tool.parameters = parameters;
+    tool.parameters = normalizeGrokCliSchema(parameters);
     validNames.add(tool.name);
     return true;
   });

--- a/open-sse/handlers/imageGenerationCore.js
+++ b/open-sse/handlers/imageGenerationCore.js
@@ -118,9 +118,10 @@ export async function handleImageGenerationCore({
     return createErrorResult(HTTP_STATUS.BAD_GATEWAY, errMsg);
   }
 
-  // Handle 401/403 — try token refresh (skipped for noAuth providers)
+  // Handle 401/403 — try token refresh (skipped for noAuth providers / providers without executor)
   const executor = getExecutor(provider);
   if (
+    executor &&
     !executor?.noAuth &&
     !adapter.noAuth &&
     (providerResponse.status === HTTP_STATUS.UNAUTHORIZED ||

--- a/open-sse/handlers/imageProviders/index.js
+++ b/open-sse/handlers/imageProviders/index.js
@@ -13,6 +13,9 @@ import runwayml from "./runwayml.js";
 import cloudflareAi from "./cloudflareAi.js";
 import antigravity from "./antigravity.js";
 
+// OpenAI-compatible custom-node image adapter (user-defined nodes: openai-compatible-*)
+import createOpenAICompatibleAdapter from "./openaiCompatible.js";
+
 const ADAPTERS = {
   openai: createOpenAIAdapter("openai"),
   minimax: createOpenAIAdapter("minimax"),
@@ -35,6 +38,8 @@ const ADAPTERS = {
 };
 
 export function getImageAdapter(provider) {
+  // Custom openai-compatible nodes: use the generic adapter (node's own baseUrl)
+  if (provider?.startsWith?.("openai-compatible-")) return createOpenAICompatibleAdapter();
   return ADAPTERS[provider] || null;
 }
 

--- a/open-sse/handlers/imageProviders/openaiCompatible.js
+++ b/open-sse/handlers/imageProviders/openaiCompatible.js
@@ -1,0 +1,43 @@
+// OpenAI-compatible custom-node image adapter (for user-defined openai-compatible nodes)
+// Uses the node's own baseUrl + /images/generations, Bearer apiKey, passthrough body.
+// Supports URL reference images via `image` / `images` array (gpt-image style), matching pi-image.
+
+export default function createOpenAICompatibleAdapter() {
+  return {
+    noAuth: false,
+
+    buildUrl: (_model, credentials) => {
+      const base = credentials?.providerSpecificData?.baseUrl || credentials?.baseUrl;
+      if (!base) throw new Error("No baseUrl for openai-compatible image node");
+      return `${base.replace(/\/+$/, "")}/images/generations`;
+    },
+
+    buildHeaders: (credentials) => {
+      const headers = { "Content-Type": "application/json" };
+      const key = credentials?.apiKey || credentials?.accessToken;
+      if (key) headers["Authorization"] = `Bearer ${key}`;
+      return headers;
+    },
+
+    buildBody: (model, body) => {
+      const { prompt, n = 1, size, quality, style, response_format, image_detail, background, output_format } = body;
+      const full = { model, prompt, n };
+      if (size) full.size = size;
+      if (quality) full.quality = quality;
+      if (style) full.style = style;
+      if (response_format) full.response_format = response_format;
+      if (image_detail) full.image_detail = image_detail;
+      if (background) full.background = background;
+      if (output_format) full.output_format = output_format;
+
+      // Reference images (pi-image compatibility): `image` (string) or `images` (array of URLs/dataURIs)
+      const refs = body.image || body.images || body.image_url || body.image_urls;
+      if (typeof refs === "string") full.image = [refs];
+      else if (Array.isArray(refs) && refs.length > 0) full.image = refs;
+
+      return full;
+    },
+
+    normalize: (responseBody) => responseBody,
+  };
+}

--- a/src/app/(dashboard)/dashboard/combos/page.js
+++ b/src/app/(dashboard)/dashboard/combos/page.js
@@ -71,8 +71,8 @@ export default function CombosPage() {
       const providersData = await providersRes.json();
       const settingsData = settingsRes.ok ? await settingsRes.json() : {};
       
-      // Only LLM combos here - webSearch/webFetch combos belong to media-providers/web
-      if (combosRes.ok) setCombos((combosData.combos || []).filter(c => !c.kind || c.kind === "llm"));
+      // Only chat/image combos here - webSearch/webFetch combos belong to media-providers/web
+      if (combosRes.ok) setCombos((combosData.combos || []).filter(c => c.kind !== "webSearch" && c.kind !== "webFetch"));
       if (providersRes.ok) {
         setActiveProviders(providersData.connections || []);
       }

--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/page.js
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useState, useEffect } from "react";
 import { Card, Badge, Button, AddCustomEmbeddingModal, NoAuthProxyCard, ProviderInfoCard } from "@/shared/components";
 import ProviderIcon from "@/shared/components/ProviderIcon";
-import { MEDIA_PROVIDER_KINDS, AI_PROVIDERS, isCustomEmbeddingProvider } from "@/shared/constants/providers";
+import { MEDIA_PROVIDER_KINDS, AI_PROVIDERS, isCustomEmbeddingProvider, isOpenAICompatibleProvider } from "@/shared/constants/providers";
 import ConnectionsCard from "@/app/(dashboard)/dashboard/providers/components/ConnectionsCard";
 import ModelsCard from "@/app/(dashboard)/dashboard/providers/components/ModelsCard";
 import { KIND_EXAMPLE_CONFIG } from "./components/exampleShared";
@@ -19,7 +19,8 @@ export default function MediaProviderDetailPage() {
   const { kind, id } = useParams();
   const router = useRouter();
   const kindConfig = MEDIA_PROVIDER_KINDS.find((k) => k.id === kind);
-  const isCustom = isCustomEmbeddingProvider(id) && kind === "embedding";
+  const isCustom = (isCustomEmbeddingProvider(id) && kind === "embedding") || (isOpenAICompatibleProvider(id) && kind === "image");
+  const customKind = isCustomEmbeddingProvider(id) ? "embedding" : "image";
 
   const handleDeleteCustom = async () => {
     if (!confirm("Delete this Custom Embedding node?")) return;
@@ -54,9 +55,9 @@ export default function MediaProviderDetailPage() {
 
   const builtInProvider = AI_PROVIDERS[id];
 
-  // For custom embedding nodes, build a synthetic provider object
+  // For custom nodes, build a synthetic provider object
   const provider = isCustom
-    ? (customNode ? { id, name: customNode.name || "Custom Embedding", color: "#6366F1", textIcon: "CE" } : null)
+    ? (customNode ? { id, name: customNode.name || (customKind === "embedding" ? "Custom Embedding" : "Custom Image Provider"), color: "#6366F1", textIcon: customKind === "embedding" ? "CE" : "CI" } : null)
     : builtInProvider;
 
   if (!isCustom && !builtInProvider) return notFound();
@@ -65,7 +66,7 @@ export default function MediaProviderDetailPage() {
     return <div className="text-text-muted text-sm py-12 text-center">Loading...</div>;
   }
 
-  const kinds = isCustom ? ["embedding"] : (provider.serviceKinds ?? ["llm"]);
+  const kinds = isCustom ? [customKind] : (provider.serviceKinds ?? ["llm"]);
   if (!isCustom && !kinds.includes(kind)) return notFound();
 
   return (
@@ -116,11 +117,18 @@ export default function MediaProviderDetailPage() {
               ))}
             </div>
           </div>
-          {isCustom && (
+          {isCustom && customKind === "embedding" && (
             <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
               <Button size="sm" variant="secondary" icon="edit" onClick={() => setShowEditModal(true)}>
                 Edit
               </Button>
+              <Button size="sm" variant="secondary" icon="delete" onClick={handleDeleteCustom}>
+                Delete
+              </Button>
+            </div>
+          )}
+          {isCustom && customKind === "image" && (
+            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
               <Button size="sm" variant="secondary" icon="delete" onClick={handleDeleteCustom}>
                 Delete
               </Button>
@@ -194,7 +202,7 @@ export default function MediaProviderDetailPage() {
       {kind === "stt" && !isCustom && <SttExampleCard providerId={id} />}
       {!isCustom && KIND_EXAMPLE_CONFIG[kind] && <GenericExampleCard providerId={id} kind={kind} />}
 
-      {isCustom && (
+      {isCustom && customKind === "embedding" && (
         <AddCustomEmbeddingModal
           isOpen={showEditModal}
           node={customNode}

--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/page.js
@@ -154,6 +154,7 @@ export default function MediaProviderKindPage() {
 
   const kindConfig = MEDIA_PROVIDER_KINDS.find((k) => k.id === kind);
   const isEmbedding = kind === "embedding";
+  const isImage = kind === "image";
   const supportsCombo = COMBO_KINDS.has(kind);
 
   useEffect(() => {
@@ -162,10 +163,10 @@ export default function MediaProviderKindPage() {
       .then((r) => r.json())
       .then((d) => setConnections(d.connections || []))
       .catch(() => {});
-    if (isEmbedding) {
+    if (isEmbedding || isImage) {
       fetch("/api/provider-nodes", { cache: "no-store" })
         .then((r) => r.json())
-        .then((d) => setCustomNodes((d.nodes || []).filter((n) => n.type === "custom-embedding")))
+        .then((d) => setCustomNodes((d.nodes || []).filter((n) => isEmbedding ? n.type === "custom-embedding" : (n.type === "openai-compatible" && n.apiType === "chat"))))
         .catch(() => {});
     }
     if (supportsCombo) {
@@ -184,9 +185,9 @@ export default function MediaProviderKindPage() {
   // Map custom nodes to MediaProviderCard shape
   const customProviders = customNodes.map((n) => ({
     id: n.id,
-    name: n.name || "Custom Embedding",
+    name: n.name || (isEmbedding ? "Custom Embedding" : "Custom Image Provider"),
     color: "#6366F1",
-    textIcon: "CE",
+    textIcon: isEmbedding ? "CE" : "CI",
   }));
 
   const allProviders = [...providers, ...customProviders];

--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/page.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/page.js
@@ -3,7 +3,7 @@
 import { useParams, notFound, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Card, Badge, Button, Toggle, AddCustomEmbeddingModal } from "@/shared/components";
+import { Card, Badge, Button, Toggle, AddCustomEmbeddingModal, AddCustomImageProviderModal } from "@/shared/components";
 import ProviderIcon from "@/shared/components/ProviderIcon";
 import { MEDIA_PROVIDER_KINDS, AI_PROVIDERS, getProvidersByKind } from "@/shared/constants/providers";
 
@@ -144,6 +144,7 @@ export default function MediaProviderKindPage() {
   const [customNodes, setCustomNodes] = useState([]);
   const [combos, setCombos] = useState([]);
   const [showAddCustomEmbedding, setShowAddCustomEmbedding] = useState(false);
+  const [showAddCustomImage, setShowAddCustomImage] = useState(false);
 
   // webSearch/webFetch listing pages are merged into /web
   useEffect(() => {
@@ -163,10 +164,29 @@ export default function MediaProviderKindPage() {
       .then((r) => r.json())
       .then((d) => setConnections(d.connections || []))
       .catch(() => {});
-    if (isEmbedding || isImage) {
+    if (isImage) {
+      // Whitelist: only show nodes that have image-type custom models registered.
+      // Add providers explicitly via the "Add Image Provider" button (creates node +
+      // lets user register image models from upstream) — nothing is auto-shown.
+      Promise.all([
+        fetch("/api/provider-nodes", { cache: "no-store" }).then((r) => r.json()),
+        fetch("/api/models/custom", { cache: "no-store" }).then((r) => r.json()),
+      ])
+        .then(([nodesRes, customRes]) => {
+          const nodes = nodesRes.nodes || [];
+          const customModels = customRes.models || [];
+          const imageNodeIds = new Set(
+            customModels.filter((m) => m.type === "image").map((m) => m.providerAlias)
+          );
+          setCustomNodes(
+            nodes.filter((n) => n.type === "openai-compatible" && imageNodeIds.has(n.id))
+          );
+        })
+        .catch(() => {});
+    } else if (isEmbedding) {
       fetch("/api/provider-nodes", { cache: "no-store" })
         .then((r) => r.json())
-        .then((d) => setCustomNodes((d.nodes || []).filter((n) => isEmbedding ? n.type === "custom-embedding" : (n.type === "openai-compatible" && n.apiType === "chat"))))
+        .then((d) => setCustomNodes((d.nodes || []).filter((n) => n.type === "custom-embedding")))
         .catch(() => {});
     }
     if (supportsCombo) {
@@ -240,6 +260,11 @@ export default function MediaProviderKindPage() {
               Add Custom Embedding
             </Button>
           )}
+          {isImage && (
+            <Button size="sm" icon="add" onClick={() => setShowAddCustomImage(true)}>
+              Add Image Provider
+            </Button>
+          )}
         </div>
       )}
 
@@ -282,6 +307,16 @@ export default function MediaProviderKindPage() {
           onCreated={(node) => {
             setCustomNodes((prev) => [...prev, node]);
             setShowAddCustomEmbedding(false);
+          }}
+        />
+      )}
+      {isImage && (
+        <AddCustomImageProviderModal
+          isOpen={showAddCustomImage}
+          onClose={() => setShowAddCustomImage(false)}
+          onCreated={(node) => {
+            setCustomNodes((prev) => [...prev, node]);
+            setShowAddCustomImage(false);
           }}
         />
       )}

--- a/src/app/(dashboard)/dashboard/providers/components/ModelsCard.js
+++ b/src/app/(dashboard)/dashboard/providers/components/ModelsCard.js
@@ -116,6 +116,10 @@ export default function ModelsCard({ providerId, kindFilter, providerAliasOverri
   const [testingModelId, setTestingModelId] = useState(null);
   const [testError, setTestError] = useState("");
   const [showAddCustomModel, setShowAddCustomModel] = useState(false);
+  const [fetchedModels, setFetchedModels] = useState(null);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [fetchError, setFetchError] = useState("");
+  const [addedModels, setAddedModels] = useState(new Set());
 
   const providerAlias = providerAliasOverride || getProviderAlias(providerId);
   const effectiveType = kindFilter || "llm";
@@ -177,6 +181,31 @@ export default function ModelsCard({ providerId, kindFilter, providerAliasOverri
         window.dispatchEvent(new CustomEvent("customModelChanged"));
       }
     } catch (e) { console.log("delete custom model error:", e); }
+  };
+
+  const handleFetchModels = async () => {
+    if (fetchingModels) return;
+    setFetchingModels(true);
+    setFetchError("");
+    try {
+      const res = await fetch(`/api/providers/${providerId}/models`, { cache: "no-store" });
+      const data = await res.json();
+      if (res.ok && data.models) {
+        setFetchedModels(data.models);
+      } else {
+        setFetchError(data.error || `Failed to fetch models (${res.status})`);
+      }
+    } catch (e) {
+      setFetchError("Network error");
+    } finally {
+      setFetchingModels(false);
+    }
+  };
+
+  const handleAddFetchedModel = async (modelId) => {
+    if (addedModels.has(modelId)) return;
+    await handleAddCustomModel(modelId);
+    setAddedModels((prev) => new Set(prev).add(modelId));
   };
 
   const handleTestModel = async (modelId) => {
@@ -268,6 +297,15 @@ export default function ModelsCard({ providerId, kindFilter, providerAliasOverri
             <span className="material-symbols-outlined text-sm">add</span>
             Add Model
           </button>
+
+          <button
+            onClick={handleFetchModels}
+            disabled={fetchingModels}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-dashed border-black/15 dark:border-white/15 text-xs text-text-muted hover:text-primary hover:border-primary/40 transition-colors"
+          >
+            <span className="material-symbols-outlined text-sm">{fetchingModels ? "sync" : "cloud_download"}</span>
+            {fetchingModels ? "Fetching..." : "Fetch from upstream"}
+          </button>
         </div>
       </Card>
 
@@ -279,9 +317,88 @@ export default function ModelsCard({ providerId, kindFilter, providerAliasOverri
         }}
         onClose={() => setShowAddCustomModel(false)}
       />
+
+      {fetchedModels && (
+        <FetchedModelsModal
+          models={fetchedModels}
+          addedModels={addedModels}
+          error={fetchError}
+          onAdd={handleAddFetchedModel}
+          onClose={() => { setFetchedModels(null); setAddedModels(new Set()); setFetchError(""); }}
+        />
+      )}
+      {!fetchedModels && fetchError && (
+        <FetchedModelsModal
+          models={[]}
+          addedModels={addedModels}
+          error={fetchError}
+          onAdd={handleAddFetchedModel}
+          onClose={() => { setFetchedModels(null); setAddedModels(new Set()); setFetchError(""); }}
+        />
+      )}
     </>
   );
 }
+
+function FetchedModelsModal({ models, addedModels, error, onAdd, onClose }) {
+  const [filter, setFilter] = useState("");
+  const shown = filter
+    ? models.filter((m) => (m.id || "").toLowerCase().includes(filter.toLowerCase()))
+    : models;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-md max-h-[80vh] flex flex-col rounded-xl bg-white dark:bg-[#1a1a1a] border border-black/10 dark:border-white/10 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-black/10 dark:border-white/10">
+          <h3 className="text-sm font-semibold">Models from upstream ({models.length})</h3>
+          <button onClick={onClose} className="material-symbols-outlined text-text-muted hover:text-text">close</button>
+        </div>
+        {error && <p className="px-4 py-2 text-xs text-red-500">{error}</p>}
+        <div className="px-4 py-2">
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter..."
+            className="w-full px-2.5 py-1.5 text-xs rounded-lg bg-black/5 dark:bg-white/5 outline-none"
+          />
+        </div>
+        <div className="flex-1 overflow-y-auto px-2 pb-3">
+          {shown.length === 0 && <p className="px-2 py-4 text-xs text-text-muted text-center">No models</p>}
+          {shown.map((m) => {
+            const id = m.id || m.model || m.name;
+            if (!id) return null;
+            const added = addedModels.has(id);
+            return (
+              <div key={id} className="flex items-center justify-between px-2 py-1.5 rounded-lg hover:bg-black/5 dark:hover:bg-white/5">
+                <div className="min-w-0">
+                  <p className="text-xs truncate">{id}</p>
+                  {m.name && m.name !== id && <p className="text-[10px] text-text-muted truncate">{m.name}</p>}
+                </div>
+                <button
+                  onClick={() => onAdd(id)}
+                  disabled={added}
+                  className={`ml-3 shrink-0 px-2 py-1 rounded-md text-[10px] border ${added ? "text-text-muted border-black/10 dark:border-white/10 cursor-default" : "text-primary border-primary/40 hover:bg-primary/10"}`}
+                >
+                  {added ? "Added" : "Add"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+FetchedModelsModal.propTypes = {
+  models: PropTypes.array.isRequired,
+  addedModels: PropTypes.object.isRequired,
+  error: PropTypes.string,
+  onAdd: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
 
 ModelsCard.propTypes = {
   providerId: PropTypes.string.isRequired,

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getProviderConnectionById } from "@/models";
+import { getProviderConnectionById, getProviderNodeById, getProviderConnections } from "@/models";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { GEMINI_CONFIG } from "@/lib/oauth/constants/oauth";
 import { refreshGoogleToken, refreshCodexToken, updateProviderCredentials } from "@/sse/services/tokenRefresh";
@@ -442,7 +442,16 @@ const PROVIDER_MODELS_CONFIG = {
 export async function GET(request, { params }) {
   try {
     const { id } = await params;
-    const connection = await getProviderConnectionById(id);
+    let connection = await getProviderConnectionById(id);
+
+    // If not found by connection id, try node id (openai-compatible-* / anthropic-compatible-*)
+    if (!connection && (isOpenAICompatibleProvider(id) || isAnthropicCompatibleProvider(id))) {
+      const node = await getProviderNodeById(id);
+      if (node) {
+        const list = await getProviderConnections({ provider: id });
+        connection = list[0] || null;
+      }
+    }
 
     if (!connection) {
       return NextResponse.json({ error: "Connection not found" }, { status: 404 });

--- a/src/app/api/v1/images/edits/route.js
+++ b/src/app/api/v1/images/edits/route.js
@@ -1,0 +1,93 @@
+import { handleImageGeneration } from "@/sse/handlers/imageGeneration.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+const MIME_TO_EXT = {
+  "image/png": "png",
+  "image/jpeg": "jpeg",
+  "image/jpg": "jpeg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+};
+
+async function fileToDataUri(file) {
+  const buf = Buffer.from(await file.arrayBuffer());
+  const mime = file.type || "image/png";
+  const b64 = buf.toString("base64");
+  return `data:${mime};base64,${b64}`;
+}
+
+/**
+ * POST /v1/images/edits - OpenAI-compatible image edit endpoint (multipart).
+ * Local reference images + optional mask are converted to data URIs and
+ * forwarded through the standard generation flow (custom nodes supported).
+ */
+export async function POST(request) {
+  let form;
+  try {
+    form = await request.formData();
+  } catch {
+    return new Response(JSON.stringify({ error: { message: "Expected multipart/form-data body" } }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const model = form.get("model") || "cx/gpt-5.5-image";
+  const prompt = form.get("prompt");
+  if (!prompt) {
+    return new Response(JSON.stringify({ error: { message: "Missing required field: prompt" } }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const size = form.get("size") || "1024x1024";
+  const n = form.get("n") || "1";
+  const responseFormat = form.get("response_format") || null;
+
+  // Collect image files (local paths → data URIs)
+  const images = [];
+  const imageEntries = form.getAll("image");
+  for (const entry of imageEntries) {
+    if (entry instanceof File || entry?.arrayBuffer) {
+      images.push(await fileToDataUri(entry));
+    } else if (typeof entry === "string") {
+      images.push(entry); // already a URL/data URI
+    }
+  }
+
+  const mask = form.get("mask");
+  if (mask instanceof File || mask?.arrayBuffer) {
+    images.push(await fileToDataUri(mask));
+  } else if (typeof mask === "string" && mask) {
+    images.push(mask);
+  }
+
+  if (images.length === 0) {
+    return new Response(JSON.stringify({ error: { message: "At least one image or mask is required" } }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Rebuild as JSON body and reuse the generation flow
+  const jsonBody = { model, prompt, image: images, n: Number(n) || 1, size };
+  if (responseFormat) jsonBody.response_format = responseFormat;
+
+  const jsonRequest = new Request(request.url.replace(/\/edits$/, "/generations"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...(request.headers.get("authorization") ? { authorization: request.headers.get("authorization") } : {}) },
+    body: JSON.stringify(jsonBody),
+  });
+
+  return await handleImageGeneration(jsonRequest);
+}

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -224,6 +224,12 @@ async function fetchCompatibleModelIds(connection) {
 // LLM is the default kind for providers missing serviceKinds.
 function providerMatchesKinds(providerId, kindFilter) {
   const provider = AI_PROVIDERS[providerId];
+  // Custom openai-compatible nodes carry per-model kinds via customModels
+  // (e.g. type: "image"). They're LLM by default but must surface image/tts/...
+  // entries when such custom models exist, so treat them as matching any kind.
+  if (isOpenAICompatibleProvider(providerId) || isAnthropicCompatibleProvider(providerId)) {
+    return true;
+  }
   const kinds = Array.isArray(provider?.serviceKinds) && provider.serviceKinds.length > 0
     ? provider.serviceKinds
     : [LLM_KIND];
@@ -326,9 +332,12 @@ export async function buildModelsList(kindFilter, options = {}) {
     }
 
     for (const customModel of customModels) {
-      if (!customModel?.id || (customModel.type && customModel.type !== "llm")) continue;
-      // Custom models without active connection are LLM-only by current schema
-      if (!kindFilter.includes(LLM_KIND)) continue;
+      if (!customModel?.id) continue;
+      // Custom models carry a type (llm / image / tts / embedding / ...).
+      // Match against kindFilter when set, otherwise treat as LLM.
+      const customType = customModel.type || "llm";
+      const customKinds = customType === "llm" ? ["llm"] : [customType];
+      if (!kindFilter.some((k) => customKinds.includes(k))) continue;
       const providerAlias = customModel.providerAlias;
       if (!providerAlias) continue;
 

--- a/src/shared/components/AddCustomImageProviderModal.js
+++ b/src/shared/components/AddCustomImageProviderModal.js
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { Modal, Input, Button } from "@/shared/components";
+
+const DEFAULT_BASE_URL = "https://api.openai.com/v1";
+
+// Add a custom image provider node (openai-compatible, chat apiType) + bind API key.
+export default function AddCustomImageProviderModal({ isOpen, onClose, onCreated }) {
+  const [formData, setFormData] = useState({
+    name: "",
+    prefix: "",
+    baseUrl: DEFAULT_BASE_URL,
+    apiKey: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setError("");
+    setFormData({ name: "", prefix: "", baseUrl: DEFAULT_BASE_URL, apiKey: "" });
+  }, [isOpen]);
+
+  const handleSubmit = async () => {
+    if (!formData.name.trim() || !formData.prefix.trim() || !formData.baseUrl.trim()) return;
+    if (!formData.apiKey.trim()) {
+      setError("API Key is required");
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    try {
+      // 1. Create openai-compatible node
+      const nodeRes = await fetch("/api/provider-nodes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: formData.name,
+          prefix: formData.prefix,
+          baseUrl: formData.baseUrl,
+          type: "openai-compatible",
+          apiType: "chat",
+        }),
+      });
+      const nodeData = await nodeRes.json();
+      if (!nodeRes.ok) {
+        setError(nodeData.error || "Failed to create node");
+        return;
+      }
+      const node = nodeData.node;
+
+      // 2. Bind API key to the node
+      const connRes = await fetch("/api/providers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: node.id,
+          name: formData.name,
+          apiKey: formData.apiKey,
+        }),
+      });
+      const connData = await connRes.json();
+      if (!connRes.ok) {
+        setError(connData.error || "Failed to bind API key");
+        return;
+      }
+
+      onCreated?.(node);
+      onClose();
+    } catch (e) {
+      setError("Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Add Custom Image Provider">
+      <div className="flex flex-col gap-3">
+        <div>
+          <label className="text-xs text-text-muted">Name</label>
+          <Input
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            placeholder="e.g. my-relay"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-text-muted">Prefix (model alias, e.g. my-relay/&lt;model&gt;)</label>
+          <Input
+            value={formData.prefix}
+            onChange={(e) => setFormData({ ...formData, prefix: e.target.value })}
+            placeholder="e.g. mr"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-text-muted">Base URL</label>
+          <Input
+            value={formData.baseUrl}
+            onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
+            placeholder="https://api.example.com/v1"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-text-muted">API Key</label>
+          <Input
+            type="password"
+            value={formData.apiKey}
+            onChange={(e) => setFormData({ ...formData, apiKey: e.target.value })}
+            placeholder="sk-..."
+          />
+        </div>
+        {error && <p className="text-xs text-red-500">{error}</p>}
+        <div className="flex justify-end gap-2 pt-1">
+          <Button size="sm" variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSubmit} disabled={submitting}>
+            {submitting ? "Adding..." : "Add Provider"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+AddCustomImageProviderModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onCreated: PropTypes.func,
+};

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -32,6 +32,7 @@ export { default as IFlowCookieModal } from "./IFlowCookieModal";
 export { default as GitLabAuthModal } from "./GitLabAuthModal";
 export { default as EditConnectionModal } from "./EditConnectionModal";
 export { default as AddCustomEmbeddingModal } from "./AddCustomEmbeddingModal";
+export { default as AddCustomImageProviderModal } from "./AddCustomImageProviderModal";
 export { default as NoAuthProxyCard } from "./NoAuthProxyCard";
 export { default as SegmentedControl } from "./SegmentedControl";
 export { default as Tooltip } from "./Tooltip";

--- a/tests/unit/grok-cli-schema.test.js
+++ b/tests/unit/grok-cli-schema.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { GrokCliExecutor } from "../../open-sse/executors/grok-cli.js";
+
+function taskParameters() {
+  return {
+    type: "object",
+    properties: {
+      tasks: {
+        type: "array",
+        items: {
+          $defs: {
+            AddTask: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                children: {
+                  type: "array",
+                  items: { $ref: "AddTask" },
+                },
+              },
+              $id: "AddTask",
+            },
+          },
+          $ref: "AddTask",
+        },
+      },
+    },
+  };
+}
+
+describe("Grok CLI tool schema compatibility", () => {
+  it("hoists TypeBox cyclic definitions and rewrites local refs", () => {
+    const body = {
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "set_tasks",
+            parameters: taskParameters(),
+          },
+        },
+      ],
+    };
+
+    const out = new GrokCliExecutor().transformRequest("grok-4.5", body, true, {
+      connectionId: "schema-test",
+      rawHeaders: {},
+    });
+
+    const parameters = out.tools[0].parameters;
+    expect(parameters.$defs.AddTask).toBeDefined();
+    expect(parameters.properties.tasks.items).toEqual({ $ref: "#/$defs/AddTask" });
+    expect(parameters.$defs.AddTask).not.toHaveProperty("$id");
+    expect(parameters.$defs.AddTask.properties.children.items.$ref).toBe("#/$defs/AddTask");
+  });
+
+  it("leaves already-qualified and external refs untouched", () => {
+    const body = {
+      tools: [{
+        type: "function",
+        function: {
+          name: "lookup",
+          parameters: {
+            type: "object",
+            properties: {
+              local: { $ref: "#/$defs/Local" },
+              external: { $ref: "https://example.com/schema.json" },
+            },
+            $defs: { Local: { type: "string" } },
+          },
+        },
+      }],
+    };
+
+    const out = new GrokCliExecutor().transformRequest("grok-4.5", body, true, {
+      connectionId: "schema-test",
+      rawHeaders: {},
+    });
+    const parameters = out.tools[0].parameters;
+    expect(parameters.properties.local.$ref).toBe("#/$defs/Local");
+    expect(parameters.properties.external.$ref).toBe("https://example.com/schema.json");
+  });
+});


### PR DESCRIPTION
## Problem

`killAllAppProcesses` (run at every gateway startup) matches any node process whose command line contains `9router` + `cli.js` and SIGKILLs it. A running `9router config receive / publish / status` invocation matches that same pattern, so every time the gateway (re)starts it kills the in-flight config-sync subcommand.

On the receiving side this caused:
- `config receive` exiting with 137 right after spawning the new gateway
- status stuck at `applying` forever (never reaches `applied`)
- the sync daemon retry loop: backup → restart → kill → retry, each cycle leaving a junk commit in the sync repo

## Fix

Exclude the config subcommands (`receive`, `publish`, `status`, `import`, `export`, `device-name`) from the kill whitelist. The gateway/tray process itself still matches, so startup cleanup behavior is unchanged.

Applies the same guard in both the Windows (WMI) and macOS/Linux (ps) branches.