### PR TITLE
fix(usage): make hourly usage chart timezone-aware

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
+++ b/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
@@ -30,7 +30,8 @@ export default function UsageChart({ period = "7d" }) {
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/usage/chart?period=${period}`);
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      const res = await fetch(`/api/usage/chart?period=${period}&tz=${encodeURIComponent(tz)}`);
       if (res.ok) {
         const json = await res.json();
         setData(json);

--- a/src/app/api/usage/chart/route.js
+++ b/src/app/api/usage/chart/route.js
@@ -7,12 +7,13 @@ export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
     const period = searchParams.get("period") || "7d";
+    const tz = searchParams.get("tz") || undefined;
 
     if (!VALID_PERIODS.has(period)) {
       return NextResponse.json({ error: "Invalid period" }, { status: 400 });
     }
 
-    const data = await getChartData(period);
+    const data = await getChartData(period, tz);
     return NextResponse.json(data);
   } catch (error) {
     console.error("[API] Failed to get chart data:", error);

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -3,6 +3,16 @@ import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 import { getMeta, setMeta } from "../helpers/metaStore.js";
 
+function isValidTimeZone(timeZone) {
+  if (!timeZone || typeof timeZone !== "string") return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function maskApiKey(key) {
   if (!key || typeof key !== "string") return null;
   if (key.length <= 8) return key.charAt(0) + "***";
@@ -658,18 +668,43 @@ export async function getUsageStats(period = "all") {
   return stats;
 }
 
-export async function getChartData(period = "7d") {
+// Offset (ms) to add to a UTC instant to get the wall-clock time in `timeZone`.
+function tzOffsetMs(date, timeZone) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+    .formatToParts(date)
+    .reduce((acc, p) => { acc[p.type] = p.value; return acc; }, {});
+  const asUTC = Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second);
+  return asUTC - date.getTime();
+}
+
+// Start of "today" (00:00) expressed as a UTC epoch ms, for the given IANA timeZone.
+function startOfDayInTz(now, timeZone) {
+  const offset = tzOffsetMs(now, timeZone);
+  const localNow = new Date(now.getTime() + offset);
+  localNow.setUTCHours(0, 0, 0, 0);
+  return localNow.getTime() - offset;
+}
+
+export async function getChartData(period = "7d", timeZone) {
   const db = await getAdapter();
   const now = Date.now();
+  const tz = isValidTimeZone(timeZone) ? timeZone : undefined;
 
   if (period === "today") {
     const bucketCount = 24;
     const bucketMs = 3600000;
-    const startOfDay = new Date();
-    startOfDay.setHours(0, 0, 0, 0);
-    const startTime = startOfDay.getTime();
+    const startTime = tz ? startOfDayInTz(new Date(now), tz) : (() => { const d = new Date(); d.setHours(0, 0, 0, 0); return d.getTime(); })();
     const endTime = startTime + bucketCount * bucketMs;
-    const labelFn = (ts) => new Date(ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+    const labelFn = (ts) => new Date(ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false, ...(tz ? { timeZone: tz } : {}) });
     const buckets = Array.from({ length: bucketCount }, (_, i) => ({ label: labelFn(startTime + i * bucketMs), tokens: 0, cost: 0 }));
 
     const rows = db.all(
@@ -691,7 +726,7 @@ export async function getChartData(period = "7d") {
   if (period === "24h") {
     const bucketCount = 24;
     const bucketMs = 3600000;
-    const labelFn = (ts) => new Date(ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+    const labelFn = (ts) => new Date(ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false, ...(tz ? { timeZone: tz } : {}) });
     const startTime = now - bucketCount * bucketMs;
     const buckets = Array.from({ length: bucketCount }, (_, i) => ({ label: labelFn(startTime + i * bucketMs), tokens: 0, cost: 0 }));
 


### PR DESCRIPTION
## Summary

- Fixes a mismatch on the Usage & Analytics dashboard where the hourly chart's
  x-axis (`period=today` / `24h`) does not line up with the viewer's actual
  local time.
- Sends the browser's IANA timezone to `/api/usage/chart` and uses it to
  compute hour buckets/labels, instead of implicitly relying on the server
  process's own local clock.

## Use case / motivation

This surfaced in a **self-hosted 9Router** deployment: the gateway runs on a
host (e.g. a Docker container) whose system timezone is offset from the
timezone of the machine/browser actually viewing the dashboard. In that setup,
`getChartData()` built bucket boundaries and hour labels with the server
process's local clock (`new Date()`, `setHours()`,
`toLocaleTimeString()` with no explicit `timeZone`). When the two clocks
don't match, the chart silently renders shifted by the offset between them:
e.g. a spike from activity that just happened locally shows up several hours
"earlier" on the x-axis than expected. This is easy to miss when running
9Router directly on your own workstation (server clock == browser clock by
coincidence), but becomes visible as soon as server and client are on
different offsets (for us, a container defaulting to UTC vs. a UTC+7 local
browser).

## Root cause

`getChartData()` in `src/lib/db/repos/usageRepo.js` (period `today`/`24h`)
computed:
- the start-of-day boundary via `new Date().setHours(0,0,0,0)`
- hour labels via `toLocaleTimeString(...)` without a `timeZone` option

Both resolve against the **server's** OS timezone, not the browser's, so the
two can silently diverge.

## Changes

1. **`src/lib/db/repos/usageRepo.js`**: `getChartData(period, timeZone)` now
   accepts an optional IANA timezone. New helpers `tzOffsetMs` /
   `startOfDayInTz` compute the correct start-of-day boundary in that
   timezone, and hour labels are formatted with `timeZone` set. Falls back to
   the previous server-local behavior when no (or an invalid) timezone is
   passed, so it stays fully backward compatible for any other caller.
2. **`src/app/api/usage/chart/route.js`**: accepts an optional `tz` query
   param and forwards it through.
3. **`src/app/(dashboard)/dashboard/usage/components/UsageChart.js`**: sends
   `Intl.DateTimeFormat().resolvedOptions().timeZone` (the browser's own
   timezone) with each chart request.

Scope note: the day-bucketed periods (`7d`/`30d`/`60d`) are untouched. Those
read from a `usageDaily` table whose `dateKey` is written at insert time using
the server-local date (`getLocalDateKey`). Fixing that is a write-path change
in a different part of the code and was kept out of this PR to stay focused.