### PR TITLE
fix(openai): support max_completion_tokens and forced streaming

### DIFF
--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -36,6 +36,13 @@ function applyAuth(headers, desc, credentials) {
   if (desc.anthropicVersion && !headers["anthropic-version"]) headers["anthropic-version"] = ANTHROPIC_API_VERSION;
 }
 
+// OpenAI's newer Chat Completions models reject the legacy max_tokens field.
+// Keep this scoped to the first-party OpenAI provider: other OpenAI-compatible
+// providers may still require max_tokens for models with similar names.
+function usesOpenAIMaxCompletionTokens(model) {
+  return /^(?:gpt-5(?:[.-]|$)|o[134](?:[.-]|$))/i.test(model || "");
+}
+
 // Provider-specific header quirks kept as small hooks (not pure auth).
 const HEADER_HOOKS = {
   // Stable device_id from OAuth connection (CLIProxyAPI KimiTokenStorage.DeviceID)
@@ -67,10 +74,29 @@ export class DefaultExecutor extends BaseExecutor {
     super(provider, PROVIDERS[provider] || PROVIDERS.openai);
   }
 
-  transformRequest(model, body) {
+  transformRequest(model, body, stream) {
     const transformed = this.applyJsonSchemaFallback(body);
 
     if (transformed && typeof transformed === "object") {
+      // The official OpenAI transport is force-streamed even for JSON clients.
+      // Keep the actual upstream body aligned with the executor's resolved mode;
+      // the chat core still converts the SSE response back to JSON for those clients.
+      if (this.provider === "openai" && stream === true) {
+        const clientRequestedStreaming = transformed.stream === true;
+        transformed.stream = true;
+        if (!clientRequestedStreaming) {
+          transformed.stream_options = {
+            ...transformed.stream_options,
+            include_usage: true,
+          };
+        }
+      }
+      if (this.provider === "openai" && usesOpenAIMaxCompletionTokens(model) && transformed.max_tokens !== undefined) {
+        if (transformed.max_completion_tokens === undefined) {
+          transformed.max_completion_tokens = transformed.max_tokens;
+        }
+        delete transformed.max_tokens;
+      }
       // quirk: some openai-compatible providers reject Anthropic's client_metadata field
       if (this.config.quirks?.dropClientMetadata) {
         delete transformed.client_metadata;

--- a/tests/unit/openai-max-completion-tokens.test.js
+++ b/tests/unit/openai-max-completion-tokens.test.js
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+import { PROVIDERS } from "../../open-sse/config/providers.js";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args),
+}));
+
+const request = (overrides = {}) => ({
+  messages: [{ role: "user", content: "hello" }],
+  max_tokens: 321,
+  ...overrides,
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response(null, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  }));
+});
+
+describe("OpenAI Chat Completions token-limit compatibility", () => {
+  it("maps max_tokens for openai/gpt-5.6-luna", () => {
+    const out = new DefaultExecutor("openai").transformRequest("gpt-5.6-luna", request());
+
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.max_completion_tokens).toBe(321);
+  });
+
+  it("preserves an explicit max_completion_tokens value", () => {
+    const out = new DefaultExecutor("openai").transformRequest(
+      "gpt-5.6-luna",
+      request({ max_completion_tokens: 654 }),
+    );
+
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.max_completion_tokens).toBe(654);
+  });
+
+  it("also maps the established OpenAI reasoning-model families", () => {
+    const out = new DefaultExecutor("openai").transformRequest("o3-mini", request());
+
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.max_completion_tokens).toBe(321);
+  });
+
+  it("keeps max_tokens for legacy OpenAI models", () => {
+    const out = new DefaultExecutor("openai").transformRequest("gpt-4o", request());
+
+    expect(out.max_tokens).toBe(321);
+    expect(out.max_completion_tokens).toBeUndefined();
+  });
+
+  it.each(["openrouter", "openai-compatible-custom"])(
+    "does not rewrite max_tokens for the %s provider",
+    (provider) => {
+      const out = new DefaultExecutor(provider).transformRequest("gpt-5.6-luna", request());
+
+      expect(out.max_tokens).toBe(321);
+      expect(out.max_completion_tokens).toBeUndefined();
+    },
+  );
+});
+
+describe("official OpenAI force-stream request consistency", () => {
+  it("sends stream:true upstream when the resolved executor mode is streaming", async () => {
+    const executor = new DefaultExecutor("openai");
+    expect(PROVIDERS.openai.forceStream).toBe(true);
+
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request({ stream: false }),
+      stream: PROVIDERS.openai.forceStream,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toMatchObject({
+      stream: true,
+      max_completion_tokens: 321,
+      stream_options: { include_usage: true },
+    });
+  });
+
+  it("does not add forced-stream usage options for an explicit streaming request", async () => {
+    const executor = new DefaultExecutor("openai");
+
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request({ stream: true }),
+      stream: true,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const upstreamBody = JSON.parse(init.body);
+    expect(upstreamBody.stream).toBe(true);
+    expect(upstreamBody.stream_options).toBeUndefined();
+  });
+
+  it("preserves explicit non-streaming when the executor mode is non-streaming", async () => {
+    const executor = new DefaultExecutor("openai");
+
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request({ stream: false }),
+      stream: false,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body).stream).toBe(false);
+  });
+
+  it.each(["openrouter", "openai-compatible-custom"])(
+    "does not override stream:false for the %s provider",
+    async (provider) => {
+      const executor = new DefaultExecutor(provider);
+
+      await executor.execute({
+        model: "gpt-5.6-luna",
+        body: request({ stream: false }),
+        stream: true,
+        credentials: {
+          apiKey: "sk-test",
+          providerSpecificData: { baseUrl: "https://compatible.example/v1" },
+        },
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(JSON.parse(init.body).stream).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## Problem

Newer first-party OpenAI Chat Completions models such as
`gpt-5.6-luna` reject the legacy `max_tokens` request field and require
`max_completion_tokens`.

After addressing that incompatibility, requests from non-streaming clients
exposed a second issue. The official OpenAI provider has `forceStream: true`,
so 9Router selected its streaming response path, but the actual upstream body
could still retain `stream: false`.

OpenAI consequently returned an ordinary JSON `chat.completion` response while
9Router attempted to handle it as SSE, producing an empty response and
`IN 0 · OUT 0`.

## Root cause

The executor received the resolved upstream streaming mode separately from the
translated request body. For same-format OpenAI-to-OpenAI requests, the body was
passed through with its original `stream` value.

The transport therefore sent `Accept: text/event-stream` while its JSON body
still contained `stream: false`.

## Behavior before

- `max_tokens` caused HTTP 400 for newer OpenAI models.
- With `forceStream: true`, a body containing `stream: false` was forwarded
  unchanged.
- OpenAI returned `application/json`.
- 9Router selected its SSE handling path and produced no usable completion.
- Usage was recorded as `IN 0 · OUT 0`.

## Behavior after

For the official OpenAI provider only:

- `max_tokens` is mapped to `max_completion_tokens` for GPT-5 and established
  OpenAI reasoning-model families.
- When the executor selects upstream streaming, the actual body sent to OpenAI
  contains `stream: true`.
- When a non-streaming client is force-streamed internally,
  `stream_options.include_usage` is enabled so the converted JSON response
  retains token usage.
- Explicit streaming requests retain their existing streaming options.
- Non-streaming executor calls remain non-streaming.

## Scope and backward compatibility

The changes are scoped to the official `openai` provider.

They do not alter:

- OpenRouter
- custom OpenAI-compatible providers
- legacy OpenAI model token fields
- unrelated providers
- routing or fallback behavior
- authentication
- token-saver behavior
- the SSE parser

Client-facing semantics remain unchanged: non-streaming clients receive JSON,
while 9Router may use SSE internally for the official OpenAI provider.

## Tests

Relevant provider, executor, Responses, and translator tests:

- 7 test files passed
- 56 tests passed

Additional verification:

- ESLint passed for changed files
- `git diff --check` passed

Regression coverage verifies:

- `gpt-5.6-luna` uses `max_completion_tokens`
- explicit `max_completion_tokens` is preserved
- legacy OpenAI models retain `max_tokens`
- forced official OpenAI streaming sends `stream: true` upstream
- internally forced streams request usage
- explicit streaming behavior is preserved
- explicit non-streaming executor behavior is preserved
- OpenRouter and custom compatible providers are unchanged

## Real smoke test

A real request through the patched local 9Router instance used:

- model: `openai/gpt-5.6-luna`
- client request: `stream: false`
- client token field: `max_tokens`

Observed result:

- OpenAI upstream: HTTP 200, `text/event-stream`
- 9Router client response: HTTP 200, `application/json`
- model: `gpt-5.6-luna`
- expected content returned successfully
- finish reason: `stop`
- usage: 14 prompt tokens, 7 completion tokens, 21 total tokens
- runtime log: `IN 14 · OUT 7`

## Unrelated pre-existing failures

The broader test command also exposes existing failures on Windows. Every one
was reproduced unchanged on unmodified `origin/master` at commit `15223724`
(v0.5.50):

- three module-alias resolution failures involving `open-sse/...` or `@/...`
- an Antigravity retry-constant expectation mismatch
- one OpenAI-to-Claude tool-delta expectation mismatch
- four translator normalization/NDJSON expectation mismatches

Those failures are unrelated to this change and are intentionally not modified
in this PR.