### PR TITLE
fix(openai): handle Luna function tools on Chat Completions

### DIFF
--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -76,7 +76,7 @@ export class BaseExecutor {
   }
 
   // Override in subclass for provider-specific transformations
-  transformRequest(model, body, stream, credentials) {
+  transformRequest(model, body, stream, credentials, sourceFormat) {
     return body;
   }
 
@@ -97,7 +97,7 @@ export class BaseExecutor {
     return { status: response.status, message: bodyText || `HTTP ${response.status}` };
   }
 
-  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null, sourceFormat }) {
     const fallbackCount = this.getFallbackCount();
     let lastError = null;
     let lastStatus = 0;
@@ -126,7 +126,7 @@ export class BaseExecutor {
 
     for (let urlIndex = 0; urlIndex < fallbackCount; urlIndex++) {
       const url = this.buildUrl(model, stream, urlIndex, credentials);
-      const transformedBody = this.transformRequest(model, body, stream, credentials);
+      const transformedBody = this.transformRequest(model, body, stream, credentials, sourceFormat);
       const headers = this.buildHeaders(credentials, stream, url, model);
 
       if (!retryAttemptsByUrl[urlIndex]) retryAttemptsByUrl[urlIndex] = 0;

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -80,6 +80,16 @@ function normalizeOpenAIToolCallIds(body) {
   return body;
 }
 
+// GPT-5.6 Luna rejects function tools when reasoning is enabled on the Chat
+// Completions transport. Keep this compatibility override limited to the
+// first-party provider and to requests that declare current function tools.
+function normalizeLunaFunctionToolReasoning(model, body, sourceFormat) {
+  if (sourceFormat === "openai-responses") return;
+  if (model !== "gpt-5.6-luna") return;
+  if (!Array.isArray(body?.tools) || !body.tools.some((tool) => tool?.type === "function")) return;
+  body.reasoning_effort = "none";
+}
+
 // Provider-specific header quirks kept as small hooks (not pure auth).
 const HEADER_HOOKS = {
   // Stable device_id from OAuth connection (CLIProxyAPI KimiTokenStorage.DeviceID)
@@ -111,7 +121,7 @@ export class DefaultExecutor extends BaseExecutor {
     super(provider, PROVIDERS[provider] || PROVIDERS.openai);
   }
 
-  transformRequest(model, body, stream) {
+  transformRequest(model, body, stream, credentials, sourceFormat) {
     const transformed = this.applyJsonSchemaFallback(body);
 
     if (transformed && typeof transformed === "object") {
@@ -136,6 +146,7 @@ export class DefaultExecutor extends BaseExecutor {
       }
       if (this.provider === "openai") {
         normalizeOpenAIToolCallIds(transformed);
+        normalizeLunaFunctionToolReasoning(model, transformed, sourceFormat);
       }
       // quirk: some openai-compatible providers reject Anthropic's client_metadata field
       if (this.config.quirks?.dropClientMetadata) {

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS, PROVIDER_OAUTH } from "../config/providers.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE, selectAnthropicBeta } from "../providers/shared.js";
@@ -41,6 +42,42 @@ function applyAuth(headers, desc, credentials) {
 // providers may still require max_tokens for models with similar names.
 function usesOpenAIMaxCompletionTokens(model) {
   return /^(?:gpt-5(?:[.-]|$)|o[134](?:[.-]|$))/i.test(model || "");
+}
+
+const OPENAI_TOOL_CALL_ID_MAX_LENGTH = 64;
+const OPENAI_TOOL_CALL_ID_PREFIX_LENGTH = 20;
+
+// OpenAI Chat Completions rejects tool-call IDs longer than 64 characters.
+// Normalize each distinct overlong ID once per request so assistant calls and
+// their tool results always keep the same relationship. A full SHA-256 digest
+// keeps IDs collision-resistant even when their retained prefixes are equal.
+function normalizeOpenAIToolCallIds(body) {
+  if (!Array.isArray(body?.messages)) return body;
+
+  const normalizedIds = new Map();
+  const normalize = (id) => {
+    if (typeof id !== "string" || id.length <= OPENAI_TOOL_CALL_ID_MAX_LENGTH) return id;
+    if (normalizedIds.has(id)) return normalizedIds.get(id);
+
+    const prefix = id.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, OPENAI_TOOL_CALL_ID_PREFIX_LENGTH) || "call";
+    const digest = createHash("sha256").update(id).digest("base64url");
+    const normalized = `${prefix}_${digest}`;
+    normalizedIds.set(id, normalized);
+    return normalized;
+  };
+
+  for (const message of body.messages) {
+    if (message?.role === "assistant" && Array.isArray(message.tool_calls)) {
+      for (const toolCall of message.tool_calls) {
+        if (toolCall && Object.hasOwn(toolCall, "id")) toolCall.id = normalize(toolCall.id);
+      }
+    }
+    if (message?.role === "tool" && Object.hasOwn(message, "tool_call_id")) {
+      message.tool_call_id = normalize(message.tool_call_id);
+    }
+  }
+
+  return body;
 }
 
 // Provider-specific header quirks kept as small hooks (not pure auth).
@@ -96,6 +133,9 @@ export class DefaultExecutor extends BaseExecutor {
           transformed.max_completion_tokens = transformed.max_tokens;
         }
         delete transformed.max_tokens;
+      }
+      if (this.provider === "openai") {
+        normalizeOpenAIToolCallIds(transformed);
       }
       // quirk: some openai-compatible providers reject Anthropic's client_metadata field
       if (this.config.quirks?.dropClientMetadata) {

--- a/open-sse/executors/default.js
+++ b/open-sse/executors/default.js
@@ -36,6 +36,13 @@ function applyAuth(headers, desc, credentials) {
   if (desc.anthropicVersion && !headers["anthropic-version"]) headers["anthropic-version"] = ANTHROPIC_API_VERSION;
 }
 
+// OpenAI's newer Chat Completions models reject the legacy max_tokens field.
+// Keep this scoped to the first-party OpenAI provider: other OpenAI-compatible
+// providers may still require max_tokens for models with similar names.
+function usesOpenAIMaxCompletionTokens(model) {
+  return /^(?:gpt-5(?:[.-]|$)|o[134](?:[.-]|$))/i.test(model || "");
+}
+
 // Provider-specific header quirks kept as small hooks (not pure auth).
 const HEADER_HOOKS = {
   // Stable device_id from OAuth connection (CLIProxyAPI KimiTokenStorage.DeviceID)
@@ -67,10 +74,29 @@ export class DefaultExecutor extends BaseExecutor {
     super(provider, PROVIDERS[provider] || PROVIDERS.openai);
   }
 
-  transformRequest(model, body) {
+  transformRequest(model, body, stream) {
     const transformed = this.applyJsonSchemaFallback(body);
 
     if (transformed && typeof transformed === "object") {
+      // The official OpenAI transport is force-streamed even for JSON clients.
+      // Keep the actual upstream body aligned with the executor's resolved mode;
+      // the chat core still converts the SSE response back to JSON for those clients.
+      if (this.provider === "openai" && stream === true) {
+        const clientRequestedStreaming = transformed.stream === true;
+        transformed.stream = true;
+        if (!clientRequestedStreaming) {
+          transformed.stream_options = {
+            ...transformed.stream_options,
+            include_usage: true,
+          };
+        }
+      }
+      if (this.provider === "openai" && usesOpenAIMaxCompletionTokens(model) && transformed.max_tokens !== undefined) {
+        if (transformed.max_completion_tokens === undefined) {
+          transformed.max_completion_tokens = transformed.max_tokens;
+        }
+        delete transformed.max_tokens;
+      }
       // quirk: some openai-compatible providers reject Anthropic's client_metadata field
       if (this.config.quirks?.dropClientMetadata) {
         delete transformed.client_metadata;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -330,7 +330,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // exception: it is decoded by the executor into OpenAI-compatible output.
   let providerResponseFormat = targetFormat;
   try {
-    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+    const result = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, sourceFormat });
     providerResponse = result.response;
     providerUrl = result.url;
     providerHeaders = result.headers;
@@ -384,7 +384,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
           try { await onCredentialsRefreshed(newCredentials); } catch (e) { log?.warn?.("TOKEN", `onCredentialsRefreshed failed: ${e.message}`); }
         }
         try {
-          const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+          const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions, sourceFormat });
           if (retryResult.response.ok) {
             providerResponse = retryResult.response;
             providerUrl = retryResult.url;

--- a/tests/unit/openai-luna-function-tools-reasoning.test.js
+++ b/tests/unit/openai-luna-function-tools-reasoning.test.js
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args),
+}));
+
+const overlongId = `call_${"a".repeat(81)}`;
+
+function functionTool() {
+  return {
+    type: "function",
+    function: {
+      name: "lookup_weather",
+      description: "Look up the weather",
+      parameters: { type: "object", properties: { city: { type: "string" } } },
+    },
+  };
+}
+
+function toolCall(id = overlongId) {
+  return {
+    id,
+    type: "function",
+    function: { name: "lookup_weather", arguments: '{"city":"Jakarta"}' },
+  };
+}
+
+function request(overrides = {}) {
+  return {
+    model: "gpt-5.6-luna",
+    messages: [{ role: "user", content: "What is the weather?" }],
+    stream: false,
+    max_tokens: 321,
+    tools: [functionTool()],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response(null, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  }));
+});
+
+describe("official OpenAI Luna function-tool reasoning compatibility", () => {
+  it("forces reasoning_effort:none and preserves the existing compatibility transforms", async () => {
+    const executor = new DefaultExecutor("openai");
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request({
+        reasoning_effort: "high",
+        messages: [
+          { role: "assistant", content: null, tool_calls: [toolCall()] },
+          { role: "tool", tool_call_id: overlongId, content: "sunny" },
+        ],
+      }),
+      stream: true,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    const normalizedId = body.messages[0].tool_calls[0].id;
+
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(body).toMatchObject({
+      stream: true,
+      stream_options: { include_usage: true },
+      max_completion_tokens: 321,
+      reasoning_effort: "none",
+    });
+    expect(body.max_tokens).toBeUndefined();
+    expect(normalizedId).toHaveLength(64);
+    expect(body.messages[1].tool_call_id).toBe(normalizedId);
+  });
+
+  it("overrides an explicit non-none effort but leaves an explicit none unchanged", () => {
+    const executor = new DefaultExecutor("openai");
+    expect(executor.transformRequest("gpt-5.6-luna", request()).reasoning_effort)
+      .toBe("none");
+    expect(executor.transformRequest("gpt-5.6-luna", request({ reasoning_effort: "high" })).reasoning_effort)
+      .toBe("none");
+    expect(executor.transformRequest("gpt-5.6-luna", request({ reasoning_effort: "none" })).reasoning_effort)
+      .toBe("none");
+  });
+
+  it("does not infer current tools from tool-call history alone", () => {
+    const body = request({
+      reasoning_effort: "high",
+      tools: undefined,
+      messages: [
+        { role: "assistant", content: null, tool_calls: [toolCall()] },
+        { role: "tool", tool_call_id: overlongId, content: "sunny" },
+      ],
+    });
+
+    const out = new DefaultExecutor("openai").transformRequest("gpt-5.6-luna", body);
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("does not change Luna requests without a function tool declaration", () => {
+    const executor = new DefaultExecutor("openai");
+    expect(executor.transformRequest("gpt-5.6-luna", request({ tools: [], reasoning_effort: "high" })).reasoning_effort)
+      .toBe("high");
+    expect(executor.transformRequest("gpt-5.6-luna", request({ tools: [{ type: "web_search" }], reasoning_effort: "high" })).reasoning_effort)
+      .toBe("high");
+  });
+
+  it("does not apply to the client-facing Responses API path", async () => {
+    await new DefaultExecutor("openai").execute({
+      model: "gpt-5.6-luna",
+      body: request({ reasoning_effort: "high" }),
+      stream: true,
+      sourceFormat: "openai-responses",
+      credentials: { apiKey: "sk-test" },
+    });
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).reasoning_effort).toBe("high");
+  });
+
+  it("does not affect other models or providers", () => {
+    const body = request({ reasoning_effort: "high" });
+    expect(new DefaultExecutor("openai").transformRequest("gpt-4o", body).reasoning_effort).toBe("high");
+    expect(new DefaultExecutor("openrouter").transformRequest("gpt-5.6-luna", request({ reasoning_effort: "high" })).reasoning_effort)
+      .toBe("high");
+    expect(new DefaultExecutor("openai-compatible-custom").transformRequest("gpt-5.6-luna", request({ reasoning_effort: "high" })).reasoning_effort)
+      .toBe("high");
+  });
+});

--- a/tests/unit/openai-max-completion-tokens.test.js
+++ b/tests/unit/openai-max-completion-tokens.test.js
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+import { PROVIDERS } from "../../open-sse/config/providers.js";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args),
+}));
+
+const request = (overrides = {}) => ({
+  messages: [{ role: "user", content: "hello" }],
+  max_tokens: 321,
+  ...overrides,
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response(null, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  }));
+});
+
+describe("OpenAI Chat Completions token-limit compatibility", () => {
+  it("maps max_tokens for openai/gpt-5.6-luna", () => {
+    const out = new DefaultExecutor("openai").transformRequest("gpt-5.6-luna", request());
+
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.max_completion_tokens).toBe(321);
+  });
+
+  it("preserves an explicit max_completion_tokens value", () => {
+    const out = new DefaultExecutor("openai").transformRequest(
+      "gpt-5.6-luna",
+      request({ max_completion_tokens: 654 }),
+    );
+
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.max_completion_tokens).toBe(654);
+  });
+
+  it("also maps the established OpenAI reasoning-model families", () => {
+    const out = new DefaultExecutor("openai").transformRequest("o3-mini", request());
+
+    expect(out.max_tokens).toBeUndefined();
+    expect(out.max_completion_tokens).toBe(321);
+  });
+
+  it("keeps max_tokens for legacy OpenAI models", () => {
+    const out = new DefaultExecutor("openai").transformRequest("gpt-4o", request());
+
+    expect(out.max_tokens).toBe(321);
+    expect(out.max_completion_tokens).toBeUndefined();
+  });
+
+  it.each(["openrouter", "openai-compatible-custom"])(
+    "does not rewrite max_tokens for the %s provider",
+    (provider) => {
+      const out = new DefaultExecutor(provider).transformRequest("gpt-5.6-luna", request());
+
+      expect(out.max_tokens).toBe(321);
+      expect(out.max_completion_tokens).toBeUndefined();
+    },
+  );
+});
+
+describe("official OpenAI force-stream request consistency", () => {
+  it("sends stream:true upstream when the resolved executor mode is streaming", async () => {
+    const executor = new DefaultExecutor("openai");
+    expect(PROVIDERS.openai.forceStream).toBe(true);
+
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request({ stream: false }),
+      stream: PROVIDERS.openai.forceStream,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toMatchObject({
+      stream: true,
+      max_completion_tokens: 321,
+      stream_options: { include_usage: true },
+    });
+  });
+
+  it("does not add forced-stream usage options for an explicit streaming request", async () => {
+    const executor = new DefaultExecutor("openai");
+
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request({ stream: true }),
+      stream: true,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const upstreamBody = JSON.parse(init.body);
+    expect(upstreamBody.stream).toBe(true);
+    expect(upstreamBody.stream_options).toBeUndefined();
+  });
+
+  it("preserves explicit non-streaming when the executor mode is non-streaming", async () => {
+    const executor = new DefaultExecutor("openai");
+
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request({ stream: false }),
+      stream: false,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body).stream).toBe(false);
+  });
+
+  it.each(["openrouter", "openai-compatible-custom"])(
+    "does not override stream:false for the %s provider",
+    async (provider) => {
+      const executor = new DefaultExecutor(provider);
+
+      await executor.execute({
+        model: "gpt-5.6-luna",
+        body: request({ stream: false }),
+        stream: true,
+        credentials: {
+          apiKey: "sk-test",
+          providerSpecificData: { baseUrl: "https://compatible.example/v1" },
+        },
+      });
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(JSON.parse(init.body).stream).toBe(false);
+    },
+  );
+});

--- a/tests/unit/openai-tool-call-id-normalization.test.js
+++ b/tests/unit/openai-tool-call-id-normalization.test.js
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DefaultExecutor } from "../../open-sse/executors/default.js";
+
+const fetchMock = vi.fn();
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: (...args) => fetchMock(...args),
+}));
+
+const validToolCallId = /^[a-zA-Z0-9_-]+$/;
+const overlongId = `call_${"a".repeat(81)}`;
+
+function toolCall(id, name = "lookup") {
+  return {
+    id,
+    type: "function",
+    function: { name, arguments: "{}" },
+  };
+}
+
+function request(messages) {
+  return {
+    model: "gpt-5.6-luna",
+    messages,
+    stream: false,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response(null, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  }));
+});
+
+describe("official OpenAI tool-call ID normalization", () => {
+  it("normalizes an 86-character multi-turn ID and preserves its call/result relationship", () => {
+    const shortId = "call_short_1";
+    const out = new DefaultExecutor("openai").transformRequest(
+      "gpt-5.6-luna",
+      request([
+        { role: "assistant", content: null, tool_calls: [toolCall(shortId)] },
+        { role: "tool", tool_call_id: shortId, content: "short result" },
+        { role: "assistant", content: null, tool_calls: [toolCall(overlongId)] },
+        { role: "tool", tool_call_id: overlongId, content: "long result" },
+      ]),
+      true,
+    );
+
+    const normalizedCallId = out.messages[2].tool_calls[0].id;
+    expect(overlongId).toHaveLength(86);
+    expect(normalizedCallId).toHaveLength(64);
+    expect(normalizedCallId).toMatch(validToolCallId);
+    expect(out.messages[3].tool_call_id).toBe(normalizedCallId);
+    expect(out.messages[0].tool_calls[0].id).toBe(shortId);
+    expect(out.messages[1].tool_call_id).toBe(shortId);
+  });
+
+  it("normalizes repeated occurrences of the same overlong ID identically", () => {
+    const out = new DefaultExecutor("openai").transformRequest(
+      "gpt-5.6-luna",
+      request([
+        { role: "assistant", content: null, tool_calls: [toolCall(overlongId, "first")] },
+        { role: "tool", tool_call_id: overlongId, content: "first result" },
+        { role: "assistant", content: null, tool_calls: [toolCall(overlongId, "replayed")] },
+        { role: "tool", tool_call_id: overlongId, content: "replayed result" },
+      ]),
+      true,
+    );
+
+    const ids = [
+      out.messages[0].tool_calls[0].id,
+      out.messages[1].tool_call_id,
+      out.messages[2].tool_calls[0].id,
+      out.messages[3].tool_call_id,
+    ];
+    expect(new Set(ids)).toEqual(new Set([ids[0]]));
+  });
+
+  it("is encounter-order independent when the tool result precedes its assistant call", () => {
+    const out = new DefaultExecutor("openai").transformRequest(
+      "gpt-5.6-luna",
+      request([
+        { role: "tool", tool_call_id: overlongId, content: "result first" },
+        { role: "assistant", content: null, tool_calls: [toolCall(overlongId)] },
+      ]),
+      true,
+    );
+
+    expect(out.messages[0].tool_call_id).toBe(out.messages[1].tool_calls[0].id);
+  });
+
+  it("keeps IDs distinct when truncation alone would collide", () => {
+    const sharedPrefix = `call_${"z".repeat(80)}`;
+    const firstId = `${sharedPrefix}x`;
+    const secondId = `${sharedPrefix}y`;
+    const out = new DefaultExecutor("openai").transformRequest(
+      "gpt-5.6-luna",
+      request([
+        { role: "assistant", content: null, tool_calls: [toolCall(firstId), toolCall(secondId)] },
+        { role: "tool", tool_call_id: firstId, content: "first" },
+        { role: "tool", tool_call_id: secondId, content: "second" },
+      ]),
+      true,
+    );
+
+    const [first, second] = out.messages[0].tool_calls.map(({ id }) => id);
+    expect(firstId.slice(0, 64)).toBe(secondId.slice(0, 64));
+    expect(first).not.toBe(second);
+    expect(first).toHaveLength(64);
+    expect(second).toHaveLength(64);
+    expect(first).toMatch(validToolCallId);
+    expect(second).toMatch(validToolCallId);
+    expect(out.messages[1].tool_call_id).toBe(first);
+    expect(out.messages[2].tool_call_id).toBe(second);
+  });
+
+  it("is deterministic for the same ID across independent requests", () => {
+    const executor = new DefaultExecutor("openai");
+    const normalize = () => executor.transformRequest(
+      "gpt-5.6-luna",
+      request([{ role: "assistant", content: null, tool_calls: [toolCall(overlongId)] }]),
+      true,
+    ).messages[0].tool_calls[0].id;
+
+    expect(normalize()).toBe(normalize());
+  });
+
+  it.each(["openrouter", "openai-compatible-custom"])(
+    "does not normalize IDs for the %s provider",
+    (provider) => {
+      const out = new DefaultExecutor(provider).transformRequest(
+        "gpt-5.6-luna",
+        request([
+          { role: "assistant", content: null, tool_calls: [toolCall(overlongId)] },
+          { role: "tool", tool_call_id: overlongId, content: "result" },
+        ]),
+        true,
+      );
+
+      expect(out.messages[0].tool_calls[0].id).toBe(overlongId);
+      expect(out.messages[1].tool_call_id).toBe(overlongId);
+    },
+  );
+
+  it("sends the same normalized ID on both sides of the upstream request", async () => {
+    const executor = new DefaultExecutor("openai");
+    await executor.execute({
+      model: "gpt-5.6-luna",
+      body: request([
+        { role: "assistant", content: null, tool_calls: [toolCall(overlongId)] },
+        { role: "tool", tool_call_id: overlongId, content: "result" },
+        { role: "user", content: "continue" },
+      ]),
+      stream: true,
+      credentials: { apiKey: "sk-test" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    const upstreamBody = JSON.parse(init.body);
+    const assistantId = upstreamBody.messages[0].tool_calls[0].id;
+    expect(assistantId).toHaveLength(64);
+    expect(assistantId).toMatch(validToolCallId);
+    expect(upstreamBody.messages[1].tool_call_id).toBe(assistantId);
+  });
+});


### PR DESCRIPTION
## Problem

`gpt-5.6-luna` rejects Chat Completions requests that combine function tools with a non-`none` `reasoning_effort`.

A real Cursor → 9Router → OpenAI request returned:

`Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.`

9Router currently routes the official OpenAI provider through `/v1/chat/completions`, so Cursor agent requests that declare function tools can fail with HTTP 400.

## Fix

For the official `openai` provider only, when:

- model is exactly `gpt-5.6-luna`
- the request is using the Chat Completions path
- at least one declared tool has `type: "function"`

9Router normalizes:

`reasoning_effort` → `"none"`

This also overrides explicit non-`none` values such as `high`, since the upstream API rejects that combination.

## Scope

The change does not affect:

- Luna requests without declared function tools
- tool-call history without a current function-tool declaration
- other OpenAI models
- OpenRouter
- custom OpenAI-compatible providers
- Responses API flows

Existing OpenAI compatibility fixes remain intact, including:

- `max_tokens` → `max_completion_tokens`
- internal forced streaming and usage preservation
- overlong tool-call ID normalization

## Why this approach

9Router's official OpenAI transport currently targets `/v1/chat/completions`.

Although 9Router contains Responses API translation infrastructure, the official OpenAI provider does not yet have a transparent Responses transport suitable for automatically moving these Cursor requests to `/v1/responses`.

Using `reasoning_effort: "none"` is therefore the smallest compatibility fallback for the current Chat Completions architecture.

A native official OpenAI Responses transport would be the preferred long-term solution for combining Luna reasoning with function tools.

## Tests

Regression coverage verifies:

- Luna + function tools + absent reasoning → `"none"`
- Luna + function tools + explicit `high` → `"none"`
- explicit `"none"` remains unchanged
- Luna without function tools is unchanged
- tool-call history without declared tools is unchanged
- other OpenAI models are unchanged
- OpenRouter and custom compatible providers are unchanged
- Responses-origin requests are not affected
- compatibility with existing OpenAI token, streaming, usage, and tool-call-ID handling

Validation:

- targeted OpenAI/Luna/provider tests passed
- combined relevant suite: 73 passed, 3 expected-fail
- ESLint passed
- `git diff --check` passed

No real OpenAI API smoke test was performed for this commit to avoid unnecessary API usage.