### PR TITLE
fix(stream): finalize interrupted streaming request details

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -282,12 +282,21 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const msgCount = translatedBody.messages?.length || translatedBody.input?.length || translatedBody.contents?.length || translatedBody.request?.contents?.length || 0;
   log?.debug?.("REQUEST", `${provider.toUpperCase()} | ${model} | ${msgCount} msgs`);
 
+  // Set when the response turns out to be streaming; called by the stream
+  // controller on disconnect/error to finalize the placeholder requestDetail
+  // row (flush() never runs on those paths).
+  let abandonStreamingDetail = null;
+
   const streamController = createStreamController({
     onDisconnect: (reason) => {
       trackPendingRequest(model, provider, connectionId, false);
+      abandonStreamingDetail?.(typeof reason?.reason === "string" ? reason.reason : "client_disconnected");
       if (onDisconnect) onDisconnect(reason);
     },
-    onError: () => trackPendingRequest(model, provider, connectionId, false),
+    onError: (err) => {
+      trackPendingRequest(model, provider, connectionId, false);
+      abandonStreamingDetail?.(err?.message === "stream stall timeout" ? "stall_timeout" : "stream_error");
+    },
     log, provider, model, reqTag
   });
 
@@ -442,7 +451,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   // Streaming response
-  const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
+  const { onStreamComplete, onStreamAbandoned, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
+  abandonStreamingDetail = onStreamAbandoned;
   return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, userAgent, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId });
 }
 

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -112,8 +112,10 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
  */
 export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  let completed = false;
 
   const onStreamComplete = (contentObj, usage, ttftAt) => {
+    completed = true;
     const latency = {
       ttft: ttftAt ? ttftAt - requestStartTime : Date.now() - requestStartTime,
       total: Date.now() - requestStartTime
@@ -140,5 +142,29 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
   };
 
-  return { onStreamComplete, streamDetailId };
+  // Finalize the placeholder row when the stream ends without flush() ever running:
+  // client disconnect (cancel()), upstream stall timeout, or a mid-stream network
+  // reset. Without this, the row saved by handleStreamingResponse stays
+  // "[Streaming in progress...]" with tokens 0/0 and status "success" forever.
+  // Reuses streamDetailId so the ON CONFLICT(id) upsert overwrites the placeholder.
+  const onStreamAbandoned = (reason) => {
+    if (completed) return;
+    completed = true;
+    const detail = `[Streaming interrupted: ${reason || "unknown"}]`;
+    saveRequestDetail(buildRequestDetail({
+      provider, model, connectionId,
+      latency: { ttft: 0, total: Date.now() - requestStartTime },
+      tokens: { prompt_tokens: 0, completion_tokens: 0 },
+      request: extractRequestConfig(body, stream),
+      providerRequest: finalBody || translatedBody || null,
+      providerResponse: detail,
+      response: { content: detail, thinking: null, type: "streaming" },
+      pxpipe,
+      status: "cancelled"
+    }, { id: streamDetailId })).catch(err => {
+      console.error("[RequestDetail] Failed to finalize interrupted stream:", err.message);
+    });
+  };
+
+  return { onStreamComplete, onStreamAbandoned, streamDetailId };
 }

--- a/tests/unit/streaming-interrupted-detail.test.js
+++ b/tests/unit/streaming-interrupted-detail.test.js
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  saveRequestDetail: vi.fn(),
+  saveRequestUsage: vi.fn(),
+  appendRequestLog: vi.fn(),
+}));
+
+vi.mock("@/lib/usageDb.js", () => ({
+  saveRequestDetail: mocks.saveRequestDetail,
+  saveRequestUsage: mocks.saveRequestUsage,
+  appendRequestLog: mocks.appendRequestLog,
+}));
+
+import { buildOnStreamComplete } from "../../open-sse/handlers/chatCore/streamingHandler.js";
+
+const ctx = {
+  provider: "testprov",
+  model: "test-model",
+  connectionId: "conn-12345678",
+  apiKey: "client-key",
+  requestStartTime: Date.now() - 1000,
+  body: { messages: [{ role: "user", content: "hi" }] },
+  stream: true,
+  finalBody: null,
+  translatedBody: null,
+  clientRawRequest: { endpoint: "/v1/chat/completions" },
+  pxpipe: undefined,
+  reqTag: "T1",
+  log: null,
+};
+
+describe("interrupted streaming request detail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.saveRequestDetail.mockResolvedValue(undefined);
+    mocks.saveRequestUsage.mockResolvedValue(undefined);
+  });
+
+  it("finalizes the placeholder row as cancelled with the same streamDetailId", () => {
+    const { onStreamAbandoned, streamDetailId } = buildOnStreamComplete({ ...ctx });
+    onStreamAbandoned("client_disconnected");
+
+    expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
+    const detail = mocks.saveRequestDetail.mock.calls[0][0];
+    expect(detail.id).toBe(streamDetailId);
+    expect(detail.status).toBe("cancelled");
+    expect(detail.response.content).toContain("interrupted");
+    expect(detail.response.content).toContain("client_disconnected");
+    expect(detail.tokens).toEqual({ prompt_tokens: 0, completion_tokens: 0 });
+  });
+
+  it("does not overwrite after normal completion", () => {
+    const { onStreamComplete, onStreamAbandoned } = buildOnStreamComplete({ ...ctx });
+    onStreamComplete({ content: "done" }, { prompt_tokens: 5, completion_tokens: 7 }, Date.now());
+    onStreamAbandoned("client_disconnected");
+
+    expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
+    expect(mocks.saveRequestDetail.mock.calls[0][0].status).toBe("success");
+  });
+
+  it("keeps normal completion behavior intact (success row + usage save)", () => {
+    const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...ctx });
+    onStreamComplete({ content: "ok" }, { prompt_tokens: 3, completion_tokens: 4 }, null);
+
+    const detail = mocks.saveRequestDetail.mock.calls[0][0];
+    expect(detail.id).toBe(streamDetailId);
+    expect(detail.status).toBe("success");
+    expect(detail.response.content).toBe("ok");
+    expect(mocks.saveRequestUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("abandons only once even if both disconnect and error fire", () => {
+    const { onStreamAbandoned } = buildOnStreamComplete({ ...ctx });
+    onStreamAbandoned("stall_timeout");
+    onStreamAbandoned("client_disconnected");
+
+    expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
+    expect(mocks.saveRequestDetail.mock.calls[0][0].providerResponse).toContain("stall_timeout");
+  });
+});


### PR DESCRIPTION
Part of #3090. Implements the semantic gap fix discussed there (marking the placeholder row from the disconnect/error handler).

## Problem

Streaming requests save a placeholder `requestDetails` row at stream start (`[Streaming in progress...]`, tokens 0/0, status `success`). That row is only updated from the SSE transform `flush()` via `onStreamComplete`. `flush()` never runs when:

* the client disconnects (`cancel()` on the response body),
* the upstream stall watchdog aborts (`stream stall timeout`),
* the upstream connection resets midstream (`reader.cancel()` + `writer.abort()` in the error path).

Those rows stay as fake `success` placeholders forever and never reach `usageHistory`. On a busy gateway this was the majority of streaming rows (measured: ~80% of placeholders never finalized over an 8h window).

## Change

`buildOnStreamComplete` (open-sse/handlers/chatCore/streamingHandler.js) now also returns `onStreamAbandoned(reason)`:

* Reuses the same `streamDetailId`, so the existing `INSERT ... ON CONFLICT(id) DO UPDATE` overwrites the placeholder in place (no extra row).
* Sets `status: "cancelled"` and `response.content` / `providerResponse` to `[Streaming interrupted: <reason>]` (reasons: client provided disconnect reason, `stall_timeout`, `stream_error`).
* A `completed` flag guards against overwriting a row that already finalized normally (flush ran first).

chatCore.js wires it into the stream controller's `onDisconnect`/`onError` callbacks; it is only set once the response turns out to be streaming, so nonstreaming paths are untouched.

## Correction to my earlier comment in this issue

My "duplicate row / id mismatch" datapoint (comment on 2026-08-09) was wrong: rechecking timestamps, the placeholder and the "real" row belonged to two different requests (one dead stream + one completed stream). The id propagation already works on v0.5.50. The remaining bug is purely the abandoned placeholder semantics this PR addresses.

## Tests

New `tests/unit/streaming-interrupted-detail.test.js` (4 tests): abandoned finalizes with same id + `cancelled`; no overwrite after normal completion; normal completion unchanged; abandon fires once. All pass. Nearby streaming/request details suites checked: no new failures vs master (the 2 preexisting reds in request-details-tab and 2 in force-stream-config fail identically on a clean checkout).