### PR TITLE
fix(codex): route standalone web search requests

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -68,6 +68,10 @@ const nextConfig = {
         destination: "/api/v1"
       },
       {
+        source: "/codex/alpha/search",
+        destination: "/api/v1/alpha/search"
+      },
+      {
         source: "/codex/:path*",
         destination: "/api/v1/responses"
       },

--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -12,6 +12,7 @@ import { getThinkingLevels } from "../providers/thinkingLevels.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import { resolveCodexAccountId } from "../utils/codexIdentity.js";
 
 // SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
 const CODEX_SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
@@ -209,10 +210,7 @@ export class CodexExecutor extends BaseExecutor {
     // older/custom rows may use workspaceId/accountId. Prefer explicit workspaceId
     // but fall back to chatgptAccountId so requests don't cross-bind to the wrong
     // OpenAI account and surface as token_invalid after adding another account.
-    const accountId =
-      credentials?.providerSpecificData?.workspaceId ||
-      credentials?.providerSpecificData?.chatgptAccountId ||
-      credentials?.providerSpecificData?.accountId;
+    const accountId = resolveCodexAccountId(credentials);
     if (typeof accountId === "string" && accountId && !headers["ChatGPT-Account-ID"]) {
       headers["ChatGPT-Account-ID"] = accountId;
     }

--- a/open-sse/handlers/codexSearch.js
+++ b/open-sse/handlers/codexSearch.js
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+
+import { FETCH_CONNECT_TIMEOUT_MS, HTTP_STATUS } from "../config/runtimeConfig.js";
+import { proxyAwareFetch } from "../utils/proxyFetch.js";
+import { createErrorResult } from "../utils/error.js";
+import { resolveCodexAccountId } from "../utils/codexIdentity.js";
+
+export const CODEX_SEARCH_URL = "https://chatgpt.com/backend-api/codex/alpha/search";
+
+function getHeader(headers, name) {
+  if (!headers) return null;
+  if (typeof headers.get === "function") return headers.get(name);
+  const target = name.toLowerCase();
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === target);
+  return entry?.[1] ?? null;
+}
+
+export function normalizeCodexSearchBody(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new TypeError("Search body must be a JSON object");
+  }
+
+  const normalized = { ...body };
+  if (typeof normalized.model === "string") {
+    normalized.model = normalized.model.replace(/^(?:cx|codex)\//, "");
+  }
+  return normalized;
+}
+
+export function buildCodexSearchHeaders(credentials, clientHeaders, requestId) {
+  const headers = {
+    Accept: "application/json",
+    Authorization: `Bearer ${credentials.accessToken}`,
+    "Content-Type": "application/json",
+    originator: getHeader(clientHeaders, "originator") || "codex_cli_rs",
+    "session-id": getHeader(clientHeaders, "session-id") || requestId,
+    "thread-id": getHeader(clientHeaders, "thread-id") || requestId,
+    "x-client-request-id": getHeader(clientHeaders, "x-client-request-id") || requestId,
+  };
+
+  const userAgent = getHeader(clientHeaders, "user-agent");
+  if (userAgent) headers["User-Agent"] = userAgent;
+
+  const accountId = resolveCodexAccountId(credentials);
+  if (accountId) headers["ChatGPT-Account-ID"] = accountId;
+
+  return headers;
+}
+
+export function codexSearchResponseHeaders(response) {
+  const headers = new Headers(response.headers);
+  // Undici decodes response bodies but can retain the original compression metadata.
+  for (const name of ["connection", "content-encoding", "content-length", "transfer-encoding"]) {
+    headers.delete(name);
+  }
+  headers.set("Access-Control-Allow-Origin", "*");
+  return headers;
+}
+
+function upstreamErrorMessage(text, status) {
+  try {
+    const parsed = JSON.parse(text);
+    const message = parsed?.error?.message || parsed?.message || parsed?.detail;
+    if (message) return String(message);
+  } catch {
+    // Preserve a bounded plain-text upstream error when it is not JSON.
+  }
+  return String(text || `Codex search upstream returned HTTP ${status}`).replace(/\s+/g, " ").trim().slice(0, 1000);
+}
+
+export async function forwardCodexSearch({ body, credentials, clientHeaders, signal, log }) {
+  if (!credentials?.accessToken) {
+    return createErrorResult(HTTP_STATUS.UNAUTHORIZED, "Codex OAuth access token is missing");
+  }
+  if (!resolveCodexAccountId(credentials)) {
+    return createErrorResult(HTTP_STATUS.UNAUTHORIZED, "Codex OAuth account ID is missing");
+  }
+
+  let normalizedBody;
+  try {
+    normalizedBody = normalizeCodexSearchBody(body);
+  } catch (error) {
+    return createErrorResult(HTTP_STATUS.BAD_REQUEST, error.message);
+  }
+
+  const requestId = typeof normalizedBody.id === "string" && normalizedBody.id
+    ? normalizedBody.id
+    : randomUUID();
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, FETCH_CONNECT_TIMEOUT_MS);
+  const abortUpstream = () => controller.abort();
+  if (signal?.aborted) controller.abort();
+  signal?.addEventListener("abort", abortUpstream, { once: true });
+
+  try {
+    const response = await proxyAwareFetch(CODEX_SEARCH_URL, {
+      method: "POST",
+      headers: buildCodexSearchHeaders(credentials, clientHeaders, requestId),
+      body: JSON.stringify(normalizedBody),
+      signal: controller.signal,
+    }, credentials.providerSpecificData);
+
+    if (response.ok) {
+      return {
+        success: true,
+        response: new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: codexSearchResponseHeaders(response),
+        }),
+      };
+    }
+
+    const text = await response.text();
+    return {
+      success: false,
+      status: response.status,
+      error: upstreamErrorMessage(text, response.status),
+      response: new Response(text, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: codexSearchResponseHeaders(response),
+      }),
+    };
+  } catch (error) {
+    if (signal?.aborted && !timedOut) {
+      return createErrorResult(499, "Client closed request");
+    }
+    const status = timedOut ? HTTP_STATUS.GATEWAY_TIMEOUT : HTTP_STATUS.BAD_GATEWAY;
+    const code = error?.cause?.code || error?.code || error?.name;
+    const message = error?.message || "Codex search request failed";
+    const detail = code ? `${message} (${code})` : message;
+    log?.warn?.("SEARCH", `Codex alpha/search fetch failed: ${detail}`);
+    return createErrorResult(status, detail);
+  } finally {
+    clearTimeout(timeout);
+    signal?.removeEventListener("abort", abortUpstream);
+  }
+}

--- a/open-sse/utils/codexIdentity.js
+++ b/open-sse/utils/codexIdentity.js
@@ -1,0 +1,6 @@
+export function resolveCodexAccountId(credentials) {
+  return credentials?.providerSpecificData?.workspaceId
+    || credentials?.providerSpecificData?.chatgptAccountId
+    || credentials?.providerSpecificData?.accountId
+    || null;
+}

--- a/src/app/api/v1/alpha/search/route.js
+++ b/src/app/api/v1/alpha/search/route.js
@@ -1,0 +1,15 @@
+import { handleCodexSearch } from "@/sse/handlers/codexSearch.js";
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+    },
+  });
+}
+
+export async function POST(request) {
+  return handleCodexSearch(request);
+}

--- a/src/sse/handlers/codexSearch.js
+++ b/src/sse/handlers/codexSearch.js
@@ -1,0 +1,83 @@
+import {
+  clearAccountError,
+  extractApiKey,
+  getProviderCredentials,
+  isValidApiKey,
+  markAccountUnavailable,
+} from "../services/auth.js";
+import { checkAndRefreshToken } from "../services/tokenRefresh.js";
+import { getSettings } from "@/lib/localDb";
+import { forwardCodexSearch, normalizeCodexSearchBody } from "open-sse/handlers/codexSearch.js";
+import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
+import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+import * as log from "../utils/logger.js";
+
+async function validateClientApiKey(request) {
+  const settings = await getSettings();
+  if (!settings.requireApiKey) return null;
+
+  const apiKey = extractApiKey(request);
+  if (!apiKey) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Missing API key");
+  if (!(await isValidApiKey(apiKey))) return errorResponse(HTTP_STATUS.UNAUTHORIZED, "Invalid API key");
+  return null;
+}
+
+export async function handleCodexSearch(request) {
+  const authError = await validateClientApiKey(request);
+  if (authError) return authError;
+
+  let body;
+  try {
+    body = normalizeCodexSearchBody(await request.json());
+  } catch (error) {
+    return errorResponse(HTTP_STATUS.BAD_REQUEST, error instanceof SyntaxError ? "Invalid JSON body" : error.message);
+  }
+
+  const model = typeof body.model === "string" && body.model ? body.model : "__codex_search";
+  const excludeConnectionIds = new Set();
+  let lastError = null;
+  let lastStatus = null;
+
+  while (true) {
+    const credentials = await getProviderCredentials("codex", excludeConnectionIds, model);
+    if (!credentials || credentials.allRateLimited) {
+      if (credentials?.allRateLimited) {
+        const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
+        const message = lastError || credentials.lastError || "Codex search unavailable";
+        return unavailableResponse(status, message, credentials.retryAfter, credentials.retryAfterHuman);
+      }
+      return errorResponse(
+        excludeConnectionIds.size ? (lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE) : HTTP_STATUS.NOT_FOUND,
+        lastError || "No active credentials for provider: codex"
+      );
+    }
+
+    const refreshed = await checkAndRefreshToken("codex", credentials);
+    const result = await forwardCodexSearch({
+      body,
+      credentials: refreshed,
+      clientHeaders: request.headers,
+      signal: request.signal,
+      log,
+    });
+
+    if (result.success) {
+      await clearAccountError(credentials.connectionId, credentials, model);
+      return result.response;
+    }
+
+    const { shouldFallback } = await markAccountUnavailable(
+      credentials.connectionId,
+      result.status,
+      result.error,
+      "codex",
+      model
+    );
+
+    if (!shouldFallback) return result.response;
+
+    excludeConnectionIds.add(credentials.connectionId);
+    lastError = result.error;
+    lastStatus = result.status;
+  }
+}

--- a/tests/unit/codex-alpha-search.test.js
+++ b/tests/unit/codex-alpha-search.test.js
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  proxyAwareFetch: vi.fn(),
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  extractApiKey: vi.fn(),
+  isValidApiKey: vi.fn(),
+  checkAndRefreshToken: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock("open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: mocks.proxyAwareFetch,
+}));
+
+vi.mock("@/sse/services/auth.js", () => ({
+  getProviderCredentials: mocks.getProviderCredentials,
+  markAccountUnavailable: mocks.markAccountUnavailable,
+  clearAccountError: mocks.clearAccountError,
+  extractApiKey: mocks.extractApiKey,
+  isValidApiKey: mocks.isValidApiKey,
+}));
+
+vi.mock("@/sse/services/tokenRefresh.js", () => ({
+  checkAndRefreshToken: mocks.checkAndRefreshToken,
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+}));
+
+vi.mock("@/sse/utils/logger.js", () => ({
+  warn: vi.fn(),
+}));
+
+const { CODEX_SEARCH_URL, forwardCodexSearch } = await import("../../open-sse/handlers/codexSearch.js");
+const { handleCodexSearch } = await import("../../src/sse/handlers/codexSearch.js");
+const nextConfig = (await import("../../next.config.mjs")).default;
+
+function searchBody(model = "gpt-5.6-sol") {
+  return {
+    id: "request-id",
+    model,
+    input: "current OpenAI Codex web search documentation",
+    commands: {
+      search_query: [{ q: "current OpenAI Codex web search documentation" }],
+      response_length: "short",
+    },
+    settings: {
+      search_context_size: "medium",
+      external_web_access: true,
+    },
+    max_output_tokens: 2000,
+  };
+}
+
+function request(body = searchBody()) {
+  return new Request("http://router.test/v1/alpha/search", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer router-client-key",
+      "Content-Type": "application/json",
+      "User-Agent": "codex_cli_rs/0.147.0",
+      originator: "codex_cli_rs",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function credentials(id, token) {
+  return {
+    accessToken: token,
+    connectionId: id,
+    connectionName: id,
+    providerSpecificData: {
+      chatgptAccountId: `${id}-account`,
+      connectionProxyEnabled: true,
+      connectionProxyUrl: "http://proxy.test:8080",
+    },
+  };
+}
+
+describe("Codex alpha search routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSettings.mockResolvedValue({ requireApiKey: true });
+    mocks.extractApiKey.mockReturnValue("router-client-key");
+    mocks.isValidApiKey.mockResolvedValue(true);
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: false });
+    mocks.checkAndRefreshToken.mockImplementation(async (_provider, value) => value);
+  });
+
+  it("forwards the standalone search envelope with stored Codex OAuth", async () => {
+    mocks.proxyAwareFetch.mockResolvedValue(new Response(JSON.stringify({ output: "answer", results: [] }), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Encoding": "gzip",
+        "Content-Length": "123",
+      },
+    }));
+
+    const inboundHeaders = request().headers;
+    const result = await forwardCodexSearch({
+      body: searchBody("cx/gpt-5.6-sol"),
+      credentials: credentials("codex-one", "oauth-secret"),
+      clientHeaders: inboundHeaders,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.proxyAwareFetch).toHaveBeenCalledTimes(1);
+    const [url, options, proxyOptions] = mocks.proxyAwareFetch.mock.calls[0];
+    expect(url).toBe(CODEX_SEARCH_URL);
+    expect(options.headers.Authorization).toBe("Bearer oauth-secret");
+    expect(options.headers.Authorization).not.toContain("router-client-key");
+    expect(options.headers["ChatGPT-Account-ID"]).toBe("codex-one-account");
+    expect(options.headers["session-id"]).toBe("request-id");
+    expect(JSON.parse(options.body)).toEqual(searchBody("gpt-5.6-sol"));
+    expect(proxyOptions.connectionProxyUrl).toBe("http://proxy.test:8080");
+    expect(result.response.headers.get("content-encoding")).toBeNull();
+    expect(result.response.headers.get("content-length")).toBeNull();
+  });
+
+  it("uses the Codex account selected by 9Router and clears its stale lock", async () => {
+    const selected = credentials("codex-selected", "selected-token");
+    mocks.getProviderCredentials.mockResolvedValue(selected);
+    mocks.proxyAwareFetch.mockResolvedValue(Response.json({ output: "ok", results: [] }));
+
+    const response = await handleCodexSearch(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.getProviderCredentials).toHaveBeenCalledWith("codex", expect.any(Set), "gpt-5.6-sol");
+    expect(mocks.checkAndRefreshToken).toHaveBeenCalledWith("codex", selected);
+    expect(mocks.clearAccountError).toHaveBeenCalledWith("codex-selected", selected, "gpt-5.6-sol");
+  });
+
+  it("falls back to another Codex account after a retryable upstream error", async () => {
+    const first = credentials("codex-first", "first-token");
+    const second = credentials("codex-second", "second-token");
+    mocks.getProviderCredentials.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    mocks.markAccountUnavailable.mockResolvedValueOnce({ shouldFallback: true });
+    mocks.proxyAwareFetch
+      .mockResolvedValueOnce(Response.json({ error: { message: "rate limited" } }, { status: 429 }))
+      .mockResolvedValueOnce(Response.json({ output: "ok", results: [] }));
+
+    const response = await handleCodexSearch(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(mocks.proxyAwareFetch.mock.calls[0][1].headers.Authorization).toBe("Bearer first-token");
+    expect(mocks.proxyAwareFetch.mock.calls[1][1].headers.Authorization).toBe("Bearer second-token");
+    expect(mocks.getProviderCredentials.mock.calls[1][1]).toEqual(new Set(["codex-first"]));
+  });
+
+  it("rejects an invalid gateway key before selecting Codex credentials", async () => {
+    mocks.isValidApiKey.mockResolvedValue(false);
+
+    const response = await handleCodexSearch(request());
+
+    expect(response.status).toBe(401);
+    expect(mocks.getProviderCredentials).not.toHaveBeenCalled();
+    expect(mocks.proxyAwareFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not send an OAuth token without its ChatGPT account binding", async () => {
+    const result = await forwardCodexSearch({
+      body: searchBody(),
+      credentials: { accessToken: "oauth-secret", providerSpecificData: {} },
+      clientHeaders: request().headers,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe(401);
+    expect(mocks.proxyAwareFetch).not.toHaveBeenCalled();
+  });
+
+  it("maps the /codex compatibility path before the catch-all Responses rewrite", async () => {
+    const rewrites = await nextConfig.rewrites();
+    const exactIndex = rewrites.findIndex((rule) => rule.source === "/codex/alpha/search");
+    const catchAllIndex = rewrites.findIndex((rule) => rule.source === "/codex/:path*");
+
+    expect(exactIndex).toBeGreaterThanOrEqual(0);
+    expect(rewrites[exactIndex].destination).toBe("/api/v1/alpha/search");
+    expect(exactIndex).toBeLessThan(catchAllIndex);
+  });
+});


### PR DESCRIPTION
## Summary

- add a dedicated `POST /v1/alpha/search` route for Codex standalone web-search traffic
- route `/codex/alpha/search` to that handler before the existing `/codex/*` Responses catch-all
- forward the search command envelope to the hosted Codex search endpoint with 9Router-managed OAuth, ChatGPT account binding, token refresh, account fallback, and per-connection proxy settings
- share Codex account-ID resolution between Responses and standalone search traffic
- prevent the inbound 9Router API key from being forwarded upstream

## Why

Current Codex versions expose web search as a standalone tool request. With a 9Router provider whose base URL ends in `/v1`, Codex sends that request to `/v1/alpha/search`. 9Router currently has no route for that path, while the `/codex/*` compatibility rewrite sends all subpaths to the normal Responses handler. As a result, the search command envelope is either 404ed or parsed as a Responses request instead of being routed as search traffic.

This change keeps search on the selected 9Router Codex account rather than reading a separate `~/.codex/auth.json`, so existing account rotation, refresh, and outbound proxy behavior continue to apply.

Official Codex configuration documents standalone web-search modes and tool settings: https://developers.openai.com/codex/config-reference/

## Verification

- `npx vitest run --config tests/vitest.config.js tests/unit/codex-alpha-search.test.js --reporter=verbose` — 6/6 passed
- targeted Codex tests — 34 passed, 2 expected failures; two unrelated pre-existing remote-image tests still fail
- targeted ESLint — passed
- `npm run build` — passed; `/api/v1/alpha/search` appears in the compiled route table
- live transport probe using redacted Codex OAuth — HTTP 200 in 1.7s with output, result records, and encrypted output

The repository-wide unit baseline remains red independently of this branch: 1340 passed, 24 skipped, and 69 failures across existing Cursor, DB concurrency, snapshot, and other tests. This aligns with the existing test-suite regression report in #2263.

## Security notes

- upstream authorization is built only from the selected stored Codex credential
- OAuth access tokens require a matching ChatGPT account ID before any upstream request is made
- compression and hop-by-hop response headers are stripped before returning decoded bodies
- request errors are bounded and credentials are never included in logs or responses