### PR TITLE
fix(translator): serialize reasoning effort for Responses API

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -108,10 +108,11 @@ export const captureThinking = extractThinking;
 // Resolve thinking format: provider override > capability > derive(targetFormat).
 function resolveFormat(targetFormat, model, provider) {
   const providerFmt = provider ? PROVIDERS[provider]?.thinkingFormat : null;
-  if (providerFmt) return providerFmt;
   const caps = getCapabilitiesForModel(provider, model);
-  if (caps.thinkingFormat) return caps.thinkingFormat;
-  return FORMAT_TO_NATIVE[targetFormat] || "openai";
+  const fmt = providerFmt || caps.thinkingFormat || FORMAT_TO_NATIVE[targetFormat] || "openai";
+  // Responses endpoints require the OpenAI reasoning object, not the Chat
+  // Completions-only top-level reasoning_effort field.
+  return targetFormat === "openai-responses" && fmt === "openai" ? "openai-responses" : fmt;
 }
 
 // Convert unified config to a budget number (for budget-based formats).
@@ -235,6 +236,11 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       if (level) body.reasoning_effort = normalizeOpenAILevel(level, supportedLevels);
       break;
     }
+    case "openai-responses": {
+      const level = none && canDisable ? "none" : toLevel(eff);
+      if (level) body.reasoning = { ...body.reasoning, effort: normalizeOpenAILevel(level, supportedLevels) };
+      break;
+    }
     case "claude-adaptive": {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
       // output_config.effort alone does NOT turn thinking on: Anthropic requires
@@ -347,7 +353,13 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
 
   const fmt = resolveFormat(targetFormat, cleanModel, provider);
   const supportedLevels = getThinkingLevels(provider, cleanModel);
+  // Preserve Responses-only reasoning options such as summary and mode while
+  // normalizing the effort field to the endpoint's nested wire shape.
+  const responsesReasoning = fmt === "openai-responses" && body.reasoning && typeof body.reasoning === "object"
+    ? body.reasoning
+    : null;
   stripAll(body);
+  if (responsesReasoning) body.reasoning = responsesReasoning;
   applyFormat(fmt, body, cfg, caps, supportedLevels);
   return body;
 }

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -170,13 +170,15 @@ describe("applyThinking per provider format", () => {
     ["gpt-5.6-terra", "ultra", "ultra"],
     ["gpt-5.6-luna", "max", "max"],
     ["gpt-5.6-luna", "ultra", "max"],
-  ])("normalizes Codex %s effort %s to %s", (model, effort, expected) => {
+  ])("normalizes Codex Responses %s effort %s to %s", (model, effort, expected) => {
     const out = apply("openai-responses", model, { reasoning: { effort } }, "codex");
-    expect(out.reasoning_effort).toBe(expected);
+    expect(out.reasoning).toEqual({ effort: expected });
+    expect(out.reasoning_effort).toBeUndefined();
   });
-  it("applies a supported Codex Ultra suffix", () => {
+  it("applies a supported Codex Responses Ultra suffix", () => {
     const out = apply("openai-responses", "gpt-5.6-sol(ultra)", {}, "codex");
-    expect(out.reasoning_effort).toBe("ultra");
+    expect(out.reasoning).toEqual({ effort: "ultra" });
+    expect(out.reasoning_effort).toBeUndefined();
   });
   it("keeps Codex-only GPT-5.6 levels out of Kiro translation", () => {
     const out = apply("openai", "gpt-5.6-sol", { reasoning_effort: "max" }, "kiro");

--- a/tests/unit/openai-responses-multiturn.test.js
+++ b/tests/unit/openai-responses-multiturn.test.js
@@ -137,6 +137,65 @@ describe("openai ↔ responses multi-turn reasoning", () => {
   });
 });
 
+describe("OpenAI Chat → Responses reasoning", () => {
+  it("uses reasoning.effort instead of Chat Completions reasoning_effort", () => {
+    const out = translateRequest(
+      "openai",
+      "openai-responses",
+      "gpt-5.6-luna",
+      {
+        model: "gpt-5.6-luna",
+        messages: [{ role: "user", content: "hi" }],
+        reasoning_effort: "high",
+      },
+      true,
+      null,
+      "openai-compatible-responses-test"
+    );
+
+    expect(out.reasoning).toEqual({ effort: "high", summary: "auto" });
+    expect(out.reasoning_effort).toBeUndefined();
+  });
+
+  it("preserves Responses-only reasoning mode", () => {
+    const out = translateRequest(
+      "openai",
+      "openai-responses",
+      "gpt-5.6-luna",
+      {
+        model: "gpt-5.6-luna",
+        messages: [{ role: "user", content: "hi" }],
+        reasoning: { effort: "high", mode: "pro" },
+      },
+      true,
+      null,
+      "openai-compatible-responses-test"
+    );
+
+    expect(out.reasoning).toEqual({ effort: "high", mode: "pro" });
+    expect(out.reasoning_effort).toBeUndefined();
+  });
+
+  it("keeps the nested shape for native Responses requests", () => {
+    const out = translateRequest(
+      "openai-responses",
+      "openai-responses",
+      "gpt-5.6-luna",
+      {
+        model: "gpt-5.6-luna",
+        input: "hi",
+        reasoning: { effort: "high", mode: "pro" },
+      },
+      true,
+      null,
+      "openai-compatible-responses-test"
+    );
+
+    expect(out.reasoning).toEqual({ effort: "high", mode: "pro" });
+    expect(out.reasoning_effort).toBeUndefined();
+  });
+});
+
 describe("GrokCliExecutor multi-turn input", () => {
   it("keeps native Grok reasoning and item ids", () => {
     _resetGrokCliTurnStore();


### PR DESCRIPTION
## Summary

Fixes #3154.

OpenAI-compatible providers using the native `/v1/responses` transport were receiving the Chat Completions-only top-level `reasoning_effort` parameter. OpenAI rejects that parameter on the Responses API; its required wire shape is `reasoning: { effort: ... }`.

## Root cause

`applyThinking()` is the final, shared request-normalization stage after format conversion. It derived the generic `openai` thinking format for an `openai-responses` target, then:

1. removed existing reasoning fields with `stripAll()`;
2. re-added `reasoning_effort` using the Chat Completions serializer.

Changing only `openaiToOpenAIResponsesRequest()` would not solve the issue because this later normalization step would add the invalid flat field again.

## Changes

- Add an `openai-responses` thinking format for the native Responses target.
- Serialize effort as `reasoning.effort`, never `reasoning_effort`, when the target is `openai-responses`.
- Preserve Responses-only siblings in the existing `reasoning` object, including `mode` and `summary`.
- Retain the existing flat `reasoning_effort` behavior for Chat Completions targets.
- Add regression coverage for:
  - Chat Completions → Responses translation for `gpt-5.6-luna`.
  - Native Responses passthrough with `reasoning: { effort: "high", mode: "pro" }`.
  - GPT-5.6 effort normalization and suffix handling on the Responses wire format.

## Result

A request such as:

```json
{ "reasoning_effort": "high" }
```

now reaches a native Responses provider as:

```json
{ "reasoning": { "effort": "high" } }
```

and an existing Responses request preserves fields such as:

```json
{ "reasoning": { "effort": "high", "mode": "pro" } }
```

## Verification

```text
node ../9router/tests/node_modules/vitest/vitest.mjs run --config tests/vitest.config.js tests/translator/thinking-unified.test.js tests/unit/openai-responses-multiturn.test.js

Test Files  2 passed (2)
Tests       53 passed (53)
```

Also verified with direct assertions that:

- Chat → Responses emits nested `reasoning.effort` and omits `reasoning_effort`.
- Native Responses retains nested `reasoning.effort` and `reasoning.mode`.
- Chat Completions keeps its flat `reasoning_effort` shape.
- Disabled reasoning becomes `reasoning: { effort: "none" }` for Responses.
- `git diff --check` passes.
