### PR TITLE
fix: batch of community bug fixes (SSRF guard, Fusion stream_options, reasoning test probe)

### DIFF
--- a/open-sse/handlers/search/callers.js
+++ b/open-sse/handlers/search/callers.js
@@ -31,6 +31,8 @@
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
+import { assertPublicUrl } from "../../../src/shared/utils/ssrfGuard.js";
+
 /**
  * Split domain filter into includes / excludes (excludes prefixed with "-").
  * @param {string[]} [domainFilter]
@@ -69,7 +71,15 @@ export function getProviderSetting(params, key) {
  */
 export function resolveBaseUrl(config, params) {
   const override = getProviderSetting(params, "baseUrl");
-  return (override || config.baseUrl).replace(/\/+$/, "");
+  const resolved = (override || config.baseUrl).replace(/\/+$/, "");
+  // SSRF guard: reject client-controlled baseUrl targeting internal/private hosts.
+  // See issue #3049 — residual SSRF via provider_options.baseUrl.
+  try {
+    assertPublicUrl(resolved);
+  } catch (err) {
+    throw new Error(`Invalid baseUrl (SSRF guard): ${err.message}`);
+  }
+  return resolved;
 }
 
 /**

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -530,7 +530,10 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
   log.info("FUSION", `Combo "${comboName}" | panel=${panel.length} [${panel.join(", ")}] | judge=${judge} | quorum=${minPanel}`);
 
   // 1. Fan out to the panel in parallel: non-streaming, tools stripped (we want prose).
-  const { tools, tool_choice, ...rest } = body;
+  const { tools, tool_choice, stream_options, ...rest } = body;
+  // Fusion runs panel models non-streaming; drop stream_options too, or providers
+  // like DeepSeek reject it with "stream_options should be set along with stream = true".
+  // See issue #3024.
   const panelBody = { ...rest, stream: false };
 
   // Flatten tool turns to prose so panel models keep context without emitting tool_calls.

--- a/src/app/api/models/test/ping.js
+++ b/src/app/api/models/test/ping.js
@@ -135,9 +135,11 @@ export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:$
     headers,
     body: JSON.stringify({
       model,
-      // Claude-on-Copilot returns empty choices at max_tokens:1 (budget is spent
-      // before a content token emits), so a 1-token probe yields a false negative.
-      max_tokens: 16,
+      // 1024 tokens: reasoning models (ClinePass/kimi-k3, deepseek-v4-pro, etc.) spend
+      // their budget on chain-of-thought before emitting an answer. A tiny probe like
+      // max_tokens:16 starves the answer and yields a false "no choices" failure.
+      // See issue #3010.
+      max_tokens: 1024,
       stream: false,
       messages: [{ role: "user", content: "hi" }],
     }),
@@ -180,6 +182,21 @@ export async function pingModelByKind(model, kind, baseUrl = `http://127.0.0.1:$
   }
 
   const hasChoices = Array.isArray(parsed?.choices) && parsed.choices.length > 0;
+
+  // Soft-pass (issue #3010): a reasoning model may burn its whole budget on
+  // chain-of-thought and return finish_reason:"length" with empty content but
+  // non-empty reasoning/thinking. That's a successful connection, not a failure.
+  const firstChoice = parsed?.choices?.[0] || {};
+  const hasReasoning =
+    firstChoice.message?.reasoning ||
+    firstChoice.message?.reasoning_content ||
+    firstChoice.message?.thinking ||
+    firstChoice.message?.thinking_content;
+  const contentEmpty = !String(firstChoice.message?.content || "").trim();
+  if (hasChoices && firstChoice.finish_reason === "length" && contentEmpty && hasReasoning) {
+    return { ok: true, latencyMs, error: null, status: res.status, note: "reasoning-only response (length-limited)" };
+  }
+
   if (!hasChoices) {
     return {
       ok: false,

--- a/tests/unit/fusion-strip-stream-options-3024.test.js
+++ b/tests/unit/fusion-strip-stream-options-3024.test.js
@@ -1,0 +1,83 @@
+// Issue #3024 — Fusion combo must strip `stream_options` from panel requests
+// when running non-streaming, or DeepSeek rejects with
+// "stream_options should be set along with stream = true".
+
+import { describe, it, expect, vi } from "vitest";
+import { handleFusionChat } from "../../open-sse/services/combo.js";
+
+// Minimal logger stub (combo.js calls log.info/warn).
+const log = { info: () => {}, warn: () => {}, error: () => {} };
+
+function makeBody(extra = {}) {
+  return {
+    model: "combo/gemseek",
+    stream: true,
+    stream_options: { include_usage: true },
+    messages: [{ role: "user", content: "hi" }],
+    ...extra,
+  };
+}
+
+describe("Fusion strips stream_options (#3024)", () => {
+  it("removes stream_options before fanning out to panel models", async () => {
+    let capturedPanelBody = null;
+    const handleSingleModel = vi.fn(async (panelBody, model, isPanel) => {
+      if (isPanel) capturedPanelBody = panelBody;
+      // Simulate a successful non-stream JSON answer for the panel.
+      if (isPanel) {
+        return new Response(JSON.stringify({ choices: [{ message: { content: `ans-${model}` } }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // Judge leg: return a final answer.
+      return new Response(JSON.stringify({ choices: [{ message: { content: "final" } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const res = await handleFusionChat({
+      body: makeBody(),
+      models: ["ds/deepseek-v4-flash", "gemini/gemini-3.5-flash-lite"],
+      handleSingleModel,
+      log,
+      comboName: "GemSeek",
+      judgeModel: "gemini/gemini-3.5-flash-lite",
+    });
+
+    expect(res).toBeInstanceOf(Response);
+    expect(capturedPanelBody).not.toBeNull();
+    // Critical assertion: stream_options must NOT leak into panel requests.
+    expect(capturedPanelBody.stream_options).toBeUndefined();
+    expect(capturedPanelBody.stream).toBe(false);
+    // Ensure the original client body still had it (proves we stripped deliberately).
+    expect(makeBody().stream_options).toBeDefined();
+  });
+
+  it("does not throw for a 2-model fusion with stream_options present", async () => {
+    const handleSingleModel = vi.fn(async (panelBody, model, isPanel) => {
+      if (isPanel) {
+        return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ choices: [{ message: { content: "final" } }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const res = await handleFusionChat({
+      body: makeBody({ stream_options: { include_usage: true } }),
+      models: ["ds/deepseek-v4-pro", "ds/deepseek-v4-flash"],
+      handleSingleModel,
+      log,
+      comboName: "GemSeek",
+      judgeModel: "ds/deepseek-v4-pro",
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/unit/ping-reasoning-models-3010.test.js
+++ b/tests/unit/ping-reasoning-models-3010.test.js
@@ -1,0 +1,77 @@
+// Issue #3010 — Dashboard "Test" button fails for reasoning models because of a
+// tiny max_tokens probe. pingModelByKind must use a sane budget (1024) and treat a
+// reasoning-only (length-limited) response as a successful connection.
+//
+// The route module pulls in Next.js-only deps (@/lib/localDb, etc.) that don't
+// resolve under raw vitest, so we mock them and exercise the exported function.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the heavy Next.js-dependent imports BEFORE importing ping.js.
+vi.mock("@/lib/localDb", () => ({ getApiKeys: vi.fn(async () => [{ key: "test-key", isActive: true }]) }));
+vi.mock("@/shared/constants/config", () => ({ UPDATER_CONFIG: { appPort: 20127 } }));
+vi.mock("@/shared/utils/machineId", () => ({ getConsistentMachineId: vi.fn(async () => "cli-token") }));
+
+const { pingModelByKind } = await import("../../src/app/api/models/test/ping.js");
+
+describe("pingModelByKind reasoning models (#3010)", () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(obj) {
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(obj),
+      json: async () => obj,
+    };
+  }
+
+  it("uses a 1024-token budget for the chat completions probe", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ choices: [{ message: { content: "Hi there!" } }] }));
+
+    await pingModelByKind("cline-pass/kimi-k3", "llm", "http://127.0.0.1:20127");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.max_tokens).toBe(1024);
+  });
+
+  it("treats a reasoning-only (length-limited) response as ok:true", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        choices: [
+          {
+            finish_reason: "length",
+            message: { content: "", reasoning: "The user said hi — a simple greeting..." },
+          },
+        ],
+      })
+    );
+
+    const result = await pingModelByKind("cline-pass/kimi-k3", "llm", "http://127.0.0.1:20127");
+    expect(result.ok).toBe(true);
+    expect(result.note).toMatch(/reasoning-only/);
+  });
+
+  it("still fails when there are no choices and no reasoning", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ choices: [] }));
+    const result = await pingModelByKind("some/model", "llm", "http://127.0.0.1:20127");
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/no completion choices/);
+  });
+
+  it("passes a normal answer with the larger budget", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ choices: [{ message: { content: "Hello!" } }] }));
+    const result = await pingModelByKind("openai/gpt-4o", "llm", "http://127.0.0.1:20127");
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/unit/ssrf-guard-search-baseurl-3049.test.js
+++ b/tests/unit/ssrf-guard-search-baseurl-3049.test.js
@@ -1,0 +1,54 @@
+// Issue #3049 — residual SSRF via provider_options.baseUrl in /v1/search.
+// resolveBaseUrl() must reject client-controlled internal/private URLs.
+
+import { describe, it, expect } from "vitest";
+import { resolveBaseUrl } from "../../open-sse/handlers/search/callers.js";
+
+const publicConfig = { id: "searxng", baseUrl: "https://searxng.example.com" };
+const internalConfig = { id: "searxng", baseUrl: "http://127.0.0.1:18999" };
+
+describe("resolveBaseUrl SSRF guard (#3049)", () => {
+  it("allows a public admin-configured baseUrl", () => {
+    expect(resolveBaseUrl(publicConfig, {})).toBe("https://searxng.example.com");
+  });
+
+  it("rejects client override pointing to loopback IPv4", () => {
+    expect(() =>
+      resolveBaseUrl(publicConfig, { providerOptions: { baseUrl: "http://127.0.0.1:18999" } })
+    ).toThrow(/SSRF guard/);
+  });
+
+  it("rejects client override pointing to 169.254.169.254 (cloud metadata)", () => {
+    expect(() =>
+      resolveBaseUrl(publicConfig, { providerOptions: { baseUrl: "http://169.254.169.254/latest/meta-data" } })
+    ).toThrow(/SSRF guard/);
+  });
+
+  it("rejects client override pointing to RFC1918 10.x", () => {
+    expect(() =>
+      resolveBaseUrl(publicConfig, { providerOptions: { baseUrl: "http://10.0.0.5:8080" } })
+    ).toThrow(/SSRF guard/);
+  });
+
+  it("rejects client override pointing to RFC1918 192.168.x", () => {
+    expect(() =>
+      resolveBaseUrl(publicConfig, { providerOptions: { baseUrl: "http://192.168.1.1" } })
+    ).toThrow(/SSRF guard/);
+  });
+
+  it("rejects client override pointing to localhost hostname", () => {
+    expect(() =>
+      resolveBaseUrl(publicConfig, { providerOptions: { baseUrl: "http://localhost:9090" } })
+    ).toThrow(/SSRF guard/);
+  });
+
+  it("rejects internal admin-configured baseUrl too (defense in depth)", () => {
+    expect(() => resolveBaseUrl(internalConfig, {})).toThrow(/SSRF guard/);
+  });
+
+  it("strips trailing slashes on valid public URLs", () => {
+    expect(resolveBaseUrl(publicConfig, { providerOptions: { baseUrl: "https://public.example.org/" } })).toBe(
+      "https://public.example.org"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Three concrete bug fixes pulled from the open issue tracker, each with a regression test.

### 1. Security: SSRF guard on `/v1/search` baseUrl override (#3049)
`resolveBaseUrl()` in `open-sse/handlers/search/callers.js` accepted a client-controlled `provider_options.baseUrl` with no validation, allowing internal/metadata SSRF. Now applies the existing `assertPublicUrl()` guard. Blocks `127.0.0.1`, `169.254.169.254`, RFC1918 ranges, and `localhost`.

### 2. Fusion combo strips `stream_options` (#3024)
Fusion runs panel models with `stream: false` but left the client's `stream_options` in the body, so DeepSeek rejected with *"stream_options should be set along with stream = true"*. Now dropped alongside `tools`/`tool_choice`.

### 3. Dashboard "Test" button works for reasoning models (#3010)
The model-test probe hardcoded `max_tokens: 16`, which starves reasoning models (ClinePass/kimi-k3, deepseek-v4-pro, etc.) — their whole budget goes to chain-of-thought and the answer comes back empty, producing a false "no completion choices" failure. Raised to `1024` and added a soft-pass: a `finish_reason: "length"` response with non-empty `reasoning`/`thinking` is treated as a successful connection.

## Test plan
- `tests/unit/ssrf-guard-search-baseurl-3049.test.js` — 8 cases (loopback, metadata, RFC1918, localhost, trailing-slash strip)
- `tests/unit/fusion-strip-stream-options-3024.test.js` — 2 cases (strip verified via mocked panel call)
- `tests/unit/ping-reasoning-models-3010.test.js` — 4 cases (1024 budget, reasoning-only soft-pass, empty failure, normal pass)

All new tests pass; pre-existing translator failures are unrelated (present on `master`).

## Acceptance criteria
- [ ] SSRF override rejected with 400 (not fetched server-side)
- [ ] Fusion + DeepSeek no longer 400s on `stream_options`
- [ ] Reasoning models report "Test" success

Happy to split into separate PRs if you prefer.