### PR TITLE
fix: Codex request hardening (custom provider params, replayed tool-call IDs)

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -56,13 +56,24 @@ function convertSystemToDeveloperRole(body) {
 }
 
 // Strip server-generated item IDs (rs_/fc_/resp_/msg_) from input — avoids 404 with store=false
-function stripStoredItemReferences(body) {
+export function stripStoredItemReferences(body) {
   if (!Array.isArray(body.input)) return;
   body.input = body.input.filter((item) => {
     if (typeof item === "string" && SERVER_ID_PATTERN.test(item)) return false;
     if (item && typeof item === "object" && !Array.isArray(item)) {
       if (item.type === "item_reference") return false;
       if (typeof item.id === "string" && SERVER_ID_PATTERN.test(item.id)) delete item.id;
+      // Codex /responses rejects replayed tool-call history when function/custom
+      // tool call items carry a client-supplied `id` (it expects server-assigned IDs
+      // and 400s on collisions / unresolvable refs when store=false). Drop the
+      // optional `id` but keep `call_id` so the output can still pair to its call. #2930
+      const TOOL_CALL_TYPES = new Set([
+        "function_call", "function_call_output",
+        "custom_tool_call", "custom_tool_call_output",
+      ]);
+      if (TOOL_CALL_TYPES.has(item.type) && item.id !== undefined) {
+        delete item.id;
+      }
     }
     return true;
   });

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -21,6 +21,10 @@ const STRIP_RULES = [
   // "integer above maximum value, expected <= 32768". Pin an explicit endpoint cap;
   // min() with the model ceiling still applies if a variant's own limit is lower.
   { provider: "volcengine-ark", match: /kimi/i, maxOutputCap: 32768, clampToModelMaxOutput: true },
+  // Custom OpenAI-compatible providers (Codex App, etc.) reject reasoning_effort /
+  // reasoning — they speak plain OpenAI chat completions without thinking support.
+  // Drop them to avoid HTTP 400 "Unsupported parameter: reasoning_effort". #3008
+  { provider: /openai-compatible|custom/i, drop: ["reasoning_effort", "reasoning"] },
 ];
 
 // Test a rule's match (regex or predicate) against the model id.
@@ -39,7 +43,10 @@ function clampNumber(body, key, ceiling) {
 export function stripUnsupportedParams(provider, model, body) {
   if (!model || !body || typeof body !== "object") return body;
   for (const rule of STRIP_RULES) {
-    if (rule.provider && rule.provider !== provider) continue;
+    if (rule.provider) {
+      const pOk = rule.provider instanceof RegExp ? rule.provider.test(provider) : rule.provider === provider;
+      if (!pOk) continue;
+    }
     if (!matches(rule, model)) continue;
     for (const key of rule.drop || []) {
       if (body[key] !== undefined) delete body[key];

--- a/tests/unit/codex-replay-id-strip-2930.test.js
+++ b/tests/unit/codex-replay-id-strip-2930.test.js
@@ -1,0 +1,77 @@
+// Issue #2930 — Codex Responses rejects replayed tool-call history when function /
+// custom tool call items carry a client-supplied `id`. stripStoredItemReferences must
+// drop the optional `id` (keeping call_id) for function_call / function_call_output /
+// custom_tool_call / custom_tool_call_output.
+
+import { describe, expect, it } from "vitest";
+import { stripStoredItemReferences } from "../../open-sse/executors/codex.js";
+
+describe("stripStoredItemReferences tool-call id stripping (#2930)", () => {
+  it("drops id from function_call / function_call_output but keeps call_id", () => {
+    const body = {
+      input: [
+        { type: "function_call", id: "fc_abc123", call_id: "call_xyz", name: "search", arguments: "{}" },
+        { type: "function_call_output", id: "fco_def456", call_id: "call_xyz", output: "result" },
+      ],
+    };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBeUndefined();
+    expect(body.input[0].call_id).toBe("call_xyz");
+    expect(body.input[1].id).toBeUndefined();
+    expect(body.input[1].call_id).toBe("call_xyz");
+  });
+
+  it("drops id from custom_tool_call / custom_tool_call_output", () => {
+    const body = {
+      input: [
+        { type: "custom_tool_call", id: "ctc_1", call_id: "c_1", name: "py", input: {} },
+        { type: "custom_tool_call_output", id: "ctco_1", call_id: "c_1", output: "ok" },
+      ],
+    };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBeUndefined();
+    expect(body.input[0].call_id).toBe("c_1");
+    expect(body.input[1].id).toBeUndefined();
+    expect(body.input[1].call_id).toBe("c_1");
+  });
+
+  it("does NOT strip id from non-tool items with non-server id", () => {
+    const body = { input: [{ type: "message", id: "local_user_1", role: "user", content: "hi" }] };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBe("local_user_1");
+  });
+
+  it("handles long replay histories with mixed items", () => {
+    const body = {
+      input: [
+        { type: "message", id: "local_a", role: "user", content: "a" },
+        { type: "function_call", id: "fc_1", call_id: "c1", name: "f", arguments: "{}" },
+        { type: "function_call_output", id: "fco_1", call_id: "c1", output: "x" },
+        { type: "message", id: "local_b", role: "assistant", content: "b" },
+      ],
+    };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBe("local_a");
+    expect(body.input[1].id).toBeUndefined();
+    expect(body.input[1].call_id).toBe("c1");
+    expect(body.input[2].id).toBeUndefined();
+    expect(body.input[3].id).toBe("local_b");
+  });
+
+  it("still strips server-generated item_reference and SERVER_ID_PATTERN ids", () => {
+    const body = {
+      input: [
+        { type: "item_reference", id: "resp_abc" },
+        { type: "message", id: "resp_xyz", role: "user", content: "hi" },
+        "resp_dangling",
+      ],
+    };
+    stripStoredItemReferences(body);
+    // item_reference removed entirely
+    expect(body.input.find((i) => i?.type === "item_reference")).toBeUndefined();
+    // SERVER_ID_PATTERN id stripped from message
+    expect(body.input.find((i) => i?.type === "message")?.id).toBeUndefined();
+    // dangling server-id string removed
+    expect(body.input).not.toContain("resp_dangling");
+  });
+});

--- a/tests/unit/param-support.test.js
+++ b/tests/unit/param-support.test.js
@@ -52,4 +52,22 @@ describe("stripUnsupportedParams", () => {
 
     expect(body.max_tokens).toBe(64000);
   });
+
+  it("drops reasoning_effort/reasoning for custom OpenAI-compatible providers (#3008)", () => {
+    const body = { reasoning_effort: "medium", reasoning: { effort: "medium" }, temperature: 0.7 };
+
+    stripUnsupportedParams("openai-compatible-responses-b7531984", "gpt-5.6-sol", body);
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toBeUndefined();
+    expect(body.temperature).toBe(0.7); // unrelated param preserved
+  });
+
+  it("does NOT drop reasoning_effort for real reasoning providers", () => {
+    const body = { reasoning_effort: "high", model: "deepseek-reasoner" };
+
+    stripUnsupportedParams("deepseek", "deepseek-reasoner", body);
+
+    expect(body.reasoning_effort).toBe("high"); // preserved for providers that support it
+  });
 });


### PR DESCRIPTION
## Summary

Two Codex-related request bugs fixed, each with regression tests.

### 1. Custom OpenAI-compatible providers reject `reasoning_effort` (#3008)
The Codex App (and other Responses-API clients) send `reasoning_effort` / `reasoning` to every provider. Custom OpenAI-compatible providers (e.g. `openai-compatible-responses-*`) don't support thinking params and return HTTP 400 `Unsupported parameter: reasoning_effort`.

`stripUnsupportedParams` in `open-sse/translator/concerns/paramSupport.js` now matches provider by regex (`/openai-compatible|custom/i`) and drops `reasoning_effort` + `reasoning` for those providers, while leaving real reasoning providers (deepseek, etc.) untouched.

### 2. Codex rejects replayed tool-call history with client `id` (#2930)
When forwarding stateless /responses requests, 9Router kept client-supplied `id` on `function_call` / `function_call_output` / `custom_tool_call` / `custom_tool_call_output` items. Codex expects server-assigned IDs and 400s on replay. `stripStoredItemReferences` now drops the optional `id` (preserving `call_id`) for those four item types.

## Test plan
- `tests/unit/param-support.test.js` — 2 new cases (drop for custom providers, preserve for real reasoning providers)
- `tests/unit/codex-replay-id-strip-2930.test.js` — 5 cases (function/custom call+output, mixed histories, server-ID stripping still works)

All new tests pass; pre-existing translator failures are unrelated (present on `master`).

## Acceptance criteria
- [ ] Codex App works with custom OpenAI-compatible providers (no 400 on reasoning_effort)
- [ ] Replayed tool-call history no longer 400s on Codex

Happy to split if you prefer separate PRs.