### PR TITLE
fix: request translation hardening (combo prefix, OpenAI gpt-5 tokens, Codex IDs)

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -56,13 +56,24 @@ function convertSystemToDeveloperRole(body) {
 }
 
 // Strip server-generated item IDs (rs_/fc_/resp_/msg_) from input — avoids 404 with store=false
-function stripStoredItemReferences(body) {
+export function stripStoredItemReferences(body) {
   if (!Array.isArray(body.input)) return;
   body.input = body.input.filter((item) => {
     if (typeof item === "string" && SERVER_ID_PATTERN.test(item)) return false;
     if (item && typeof item === "object" && !Array.isArray(item)) {
       if (item.type === "item_reference") return false;
       if (typeof item.id === "string" && SERVER_ID_PATTERN.test(item.id)) delete item.id;
+      // Codex /responses rejects replayed tool-call history when function/custom
+      // tool call items carry a client-supplied `id` (it expects server-assigned IDs
+      // and 400s on collisions / unresolvable refs when store=false). Drop the
+      // optional `id` but keep `call_id` so the output can still pair to its call. #2930
+      const TOOL_CALL_TYPES = new Set([
+        "function_call", "function_call_output",
+        "custom_tool_call", "custom_tool_call_output",
+      ]);
+      if (TOOL_CALL_TYPES.has(item.type) && item.id !== undefined) {
+        delete item.id;
+      }
     }
     return true;
   });

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -217,16 +217,26 @@ export function resetComboRotation(comboName) {
  * @param {Array|Object} combosData - Array of combos or object with combos
  * @returns {string[]|null} Array of models or null if not a combo
  */
-export function getComboModelsFromData(modelStr, combosData) {
-  // Don't check if it's in provider/model format
-  if (modelStr.includes("/")) return null;
-  
+export function getComboModelsFromData(modelStr, arrayOrObject) {
+  if (!modelStr || typeof modelStr !== "string") return null;
+
+  // Combos may be referenced with a provider prefix (e.g. `openrouter/lordx.1` when
+  // the client registers the combo under a provider namespace). Strip it so we can
+  // match the combo by its bare name, and also try the full string as a fallback.
+  const candidates = modelStr.includes("/")
+    ? [modelStr.split("/").pop(), modelStr]
+    : [modelStr];
+
   // Handle both array and object formats
-  const combos = Array.isArray(combosData) ? combosData : (combosData?.combos || []);
-  
-  const combo = combos.find(c => c.name === modelStr);
-  if (combo && combo.models && combo.models.length > 0) {
-    return combo.models;
+  const combos = Array.isArray(arrayOrObject)
+    ? arrayOrObject
+    : (arrayOrObject?.combos || []);
+
+  for (const name of candidates) {
+    const combo = combos.find((c) => c.name === name);
+    if (combo && combo.models && combo.models.length > 0) {
+      return combo.models;
+    }
   }
   return null;
 }

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -21,6 +21,10 @@ const STRIP_RULES = [
   // "integer above maximum value, expected <= 32768". Pin an explicit endpoint cap;
   // min() with the model ceiling still applies if a variant's own limit is lower.
   { provider: "volcengine-ark", match: /kimi/i, maxOutputCap: 32768, clampToModelMaxOutput: true },
+  // Custom OpenAI-compatible providers (Codex App, etc.) reject reasoning_effort /
+  // reasoning — they speak plain OpenAI chat completions without thinking support.
+  // Drop them to avoid HTTP 400 "Unsupported parameter: reasoning_effort". #3008
+  { provider: /openai-compatible|custom/i, drop: ["reasoning_effort", "reasoning"] },
 ];
 
 // Test a rule's match (regex or predicate) against the model id.
@@ -39,7 +43,10 @@ function clampNumber(body, key, ceiling) {
 export function stripUnsupportedParams(provider, model, body) {
   if (!model || !body || typeof body !== "object") return body;
   for (const rule of STRIP_RULES) {
-    if (rule.provider && rule.provider !== provider) continue;
+    if (rule.provider) {
+      const pOk = rule.provider instanceof RegExp ? rule.provider.test(provider) : rule.provider === provider;
+      if (!pOk) continue;
+    }
     if (!matches(rule, model)) continue;
     for (const key of rule.drop || []) {
       if (body[key] !== undefined) delete body[key];

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -25,6 +25,9 @@ const STRIP_RULES = [
   // reasoning — they speak plain OpenAI chat completions without thinking support.
   // Drop them to avoid HTTP 400 "Unsupported parameter: reasoning_effort". #3008
   { provider: /openai-compatible|custom/i, drop: ["reasoning_effort", "reasoning"] },
+  // OpenAI gpt-5.x rejects `max_tokens`; it must be `max_completion_tokens`.
+  // Rename to avoid HTTP 400 "Unsupported parameter: 'max_tokens'". #2830
+  { provider: "openai", match: /gpt-5/i, rename: [["max_tokens", "max_completion_tokens"]] },
 ];
 
 // Test a rule's match (regex or predicate) against the model id.
@@ -36,6 +39,15 @@ function matches(rule, model) {
 function clampNumber(body, key, ceiling) {
   if (typeof body[key] === "number" && Number.isFinite(body[key]) && body[key] > ceiling) {
     body[key] = ceiling;
+  }
+}
+
+function renameParams(body, renames) {
+  for (const [from, to] of renames) {
+    if (body[from] !== undefined && body[to] === undefined) {
+      body[to] = body[from];
+      delete body[from];
+    }
   }
 }
 
@@ -51,6 +63,7 @@ export function stripUnsupportedParams(provider, model, body) {
     for (const key of rule.drop || []) {
       if (body[key] !== undefined) delete body[key];
     }
+    if (rule.rename) renameParams(body, rule.rename);
     // CF Workers AI oneOf root schema only accepts content as plain string (#1926)
     if (rule.flattenContent && Array.isArray(body.messages)) {
       for (const msg of body.messages) {

--- a/tests/unit/codex-replay-id-strip-2930.test.js
+++ b/tests/unit/codex-replay-id-strip-2930.test.js
@@ -1,0 +1,77 @@
+// Issue #2930 — Codex Responses rejects replayed tool-call history when function /
+// custom tool call items carry a client-supplied `id`. stripStoredItemReferences must
+// drop the optional `id` (keeping call_id) for function_call / function_call_output /
+// custom_tool_call / custom_tool_call_output.
+
+import { describe, expect, it } from "vitest";
+import { stripStoredItemReferences } from "../../open-sse/executors/codex.js";
+
+describe("stripStoredItemReferences tool-call id stripping (#2930)", () => {
+  it("drops id from function_call / function_call_output but keeps call_id", () => {
+    const body = {
+      input: [
+        { type: "function_call", id: "fc_abc123", call_id: "call_xyz", name: "search", arguments: "{}" },
+        { type: "function_call_output", id: "fco_def456", call_id: "call_xyz", output: "result" },
+      ],
+    };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBeUndefined();
+    expect(body.input[0].call_id).toBe("call_xyz");
+    expect(body.input[1].id).toBeUndefined();
+    expect(body.input[1].call_id).toBe("call_xyz");
+  });
+
+  it("drops id from custom_tool_call / custom_tool_call_output", () => {
+    const body = {
+      input: [
+        { type: "custom_tool_call", id: "ctc_1", call_id: "c_1", name: "py", input: {} },
+        { type: "custom_tool_call_output", id: "ctco_1", call_id: "c_1", output: "ok" },
+      ],
+    };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBeUndefined();
+    expect(body.input[0].call_id).toBe("c_1");
+    expect(body.input[1].id).toBeUndefined();
+    expect(body.input[1].call_id).toBe("c_1");
+  });
+
+  it("does NOT strip id from non-tool items with non-server id", () => {
+    const body = { input: [{ type: "message", id: "local_user_1", role: "user", content: "hi" }] };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBe("local_user_1");
+  });
+
+  it("handles long replay histories with mixed items", () => {
+    const body = {
+      input: [
+        { type: "message", id: "local_a", role: "user", content: "a" },
+        { type: "function_call", id: "fc_1", call_id: "c1", name: "f", arguments: "{}" },
+        { type: "function_call_output", id: "fco_1", call_id: "c1", output: "x" },
+        { type: "message", id: "local_b", role: "assistant", content: "b" },
+      ],
+    };
+    stripStoredItemReferences(body);
+    expect(body.input[0].id).toBe("local_a");
+    expect(body.input[1].id).toBeUndefined();
+    expect(body.input[1].call_id).toBe("c1");
+    expect(body.input[2].id).toBeUndefined();
+    expect(body.input[3].id).toBe("local_b");
+  });
+
+  it("still strips server-generated item_reference and SERVER_ID_PATTERN ids", () => {
+    const body = {
+      input: [
+        { type: "item_reference", id: "resp_abc" },
+        { type: "message", id: "resp_xyz", role: "user", content: "hi" },
+        "resp_dangling",
+      ],
+    };
+    stripStoredItemReferences(body);
+    // item_reference removed entirely
+    expect(body.input.find((i) => i?.type === "item_reference")).toBeUndefined();
+    // SERVER_ID_PATTERN id stripped from message
+    expect(body.input.find((i) => i?.type === "message")?.id).toBeUndefined();
+    // dangling server-id string removed
+    expect(body.input).not.toContain("resp_dangling");
+  });
+});

--- a/tests/unit/combo-prefix-resolution-2996.test.js
+++ b/tests/unit/combo-prefix-resolution-2996.test.js
@@ -1,0 +1,39 @@
+// Issue #2996 — Combo referenced with a provider prefix (e.g. `openrouter/lordx.1`)
+// was sent verbatim to the upstream provider because getComboModelsFromData bailed
+// out on any model string containing "/". It must strip the prefix and resolve to
+// the combo's member models.
+
+import { describe, expect, it } from "vitest";
+import { getComboModelsFromData } from "../../open-sse/services/combo.js";
+
+const COMBOS = [
+  { name: "lordx.1", models: ["openrouter/nemotron-3-super", "openrouter/nemotron-3-ultra"] },
+  { name: "plaincombo", models: ["deepseek/chat"] },
+];
+
+describe("getComboModelsFromData prefix resolution (#2996)", () => {
+  it("resolves a combo referenced with a provider prefix", () => {
+    const models = getComboModelsFromData("openrouter/lordx.1", COMBOS);
+    expect(models).toEqual(["openrouter/nemotron-3-super", "openrouter/nemotron-3-ultra"]);
+  });
+
+  it("still resolves a bare combo name", () => {
+    const models = getComboModelsFromData("plaincombo", COMBOS);
+    expect(models).toEqual(["deepseek/chat"]);
+  });
+
+  it("returns null for a real provider/model that is not a combo", () => {
+    const models = getComboModelsFromData("openai/gpt-4o", COMBOS);
+    expect(models).toBeNull();
+  });
+
+  it("returns null for an unknown combo", () => {
+    const models = getComboModelsFromData("openrouter/nope.9", COMBOS);
+    expect(models).toBeNull();
+  });
+
+  it("handles object-format combosData", () => {
+    const models = getComboModelsFromData("lordx.1", { combos: COMBOS });
+    expect(models).toEqual(["openrouter/nemotron-3-super", "openrouter/nemotron-3-ultra"]);
+  });
+});

--- a/tests/unit/param-support.test.js
+++ b/tests/unit/param-support.test.js
@@ -52,4 +52,22 @@ describe("stripUnsupportedParams", () => {
 
     expect(body.max_tokens).toBe(64000);
   });
+
+  it("drops reasoning_effort/reasoning for custom OpenAI-compatible providers (#3008)", () => {
+    const body = { reasoning_effort: "medium", reasoning: { effort: "medium" }, temperature: 0.7 };
+
+    stripUnsupportedParams("openai-compatible-responses-b7531984", "gpt-5.6-sol", body);
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toBeUndefined();
+    expect(body.temperature).toBe(0.7); // unrelated param preserved
+  });
+
+  it("does NOT drop reasoning_effort for real reasoning providers", () => {
+    const body = { reasoning_effort: "high", model: "deepseek-reasoner" };
+
+    stripUnsupportedParams("deepseek", "deepseek-reasoner", body);
+
+    expect(body.reasoning_effort).toBe("high"); // preserved for providers that support it
+  });
 });

--- a/tests/unit/param-support.test.js
+++ b/tests/unit/param-support.test.js
@@ -70,4 +70,22 @@ describe("stripUnsupportedParams", () => {
 
     expect(body.reasoning_effort).toBe("high"); // preserved for providers that support it
   });
+
+  it("renames max_tokens → max_completion_tokens for OpenAI gpt-5.x (#2830)", () => {
+    const body = { max_tokens: 4096, model: "gpt-5.6-luna" };
+
+    stripUnsupportedParams("openai", "gpt-5.6-luna", body);
+
+    expect(body.max_tokens).toBeUndefined();
+    expect(body.max_completion_tokens).toBe(4096);
+  });
+
+  it("does NOT rename for OpenAI gpt-4o (still uses max_tokens)", () => {
+    const body = { max_tokens: 2048, model: "gpt-4o" };
+
+    stripUnsupportedParams("openai", "gpt-4o", body);
+
+    expect(body.max_tokens).toBe(2048);
+    expect(body.max_completion_tokens).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Four request-handling bugs fixed, each with regression tests. All are config/regex-driven
translator or combo-logic fixes — no behavior change for unaffected providers/models.

### 1. Combo referenced with provider prefix not resolved (#2996)
`getComboModelsFromData` bailed out on any model string containing `/`, so a combo
registered as `openrouter/lordx.1` was forwarded verbatim to OpenRouter (which rejected
it as an unknown model). Now strips the provider prefix and matches the bare combo name.

### 2. OpenAI gpt-5.x rejects `max_tokens` (#2830)
OpenAI `gpt-5.x` returns HTTP 400 `Unsupported parameter: 'max_tokens'`. Added a
`rename` rule to `paramSupport.js` that maps `max_tokens → max_completion_tokens` for
`provider: "openai"` + model `gpt-5*`. `gpt-4o` and other models are untouched.

### 3. Custom OpenAI-compatible providers reject `reasoning_effort` (#3008)
Already in this branch (carried from batch-2): drops `reasoning_effort`/`reasoning` for
`openai-compatible-*` / `custom` providers so the Codex App and similar clients stop 400ing.

### 4. Codex rejects replayed tool-call IDs (#2930)
`stripStoredItemReferences` now drops client-supplied `id` on `function_call` /
`function_call_output` / `custom_tool_call` / `custom_tool_call_output` (keeping `call_id`).

## Test plan
- `tests/unit/combo-prefix-resolution-2996.test.js` — 5 cases (prefix, bare, non-combo, unknown, object format)
- `tests/unit/param-support.test.js` — +4 cases (rename gpt-5, no-rename gpt-4o, custom drop, real-reasoning preserve)
- `tests/unit/codex-replay-id-strip-2930.test.js` — 5 cases (function/custom call+output, mixed, server-ID stripping)

All new tests pass; pre-existing translator failures are unrelated (present on `master`).

## Acceptance criteria
- [ ] `openrouter/lordx.1` combo resolves to member models
- [ ] OpenAI `gpt-5.x` requests use `max_completion_tokens`
- [ ] Codex App works with custom OpenAI-compatible providers
- [ ] Replayed tool-call history no longer 400s on Codex

Happy to split if you prefer separate PRs.