### PR TITLE
fix(fusion): trim trailing assistant messages so panel ends on user turn (#2876)

### DIFF
--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -58,6 +58,21 @@ function flattenToolHistory(messages) {
     });
 }
 
+// Remove trailing assistant messages so the conversation ends on a user turn.
+// Anthropic/Claude reject requests whose last message is from the assistant
+// ("conversation must end with a user message"). When a client echoes a partial
+// assistant reply into the next request, trim those trailing assistant roles. #2876
+export function trimTrailingAssistant(messages) {
+  if (!Array.isArray(messages) || messages.length === 0) return messages;
+  const out = messages.slice();
+  while (out.length > 0 && out[out.length - 1]?.role === "assistant") {
+    out.pop();
+  }
+  // If we stripped everything (all-assistant input), keep at least the last user-ish
+  // msg by falling back to the original so we never send an empty array.
+  return out.length > 0 ? out : messages;
+}
+
 // Reorder combo models by capability fit. Stable; never drops a model (fallback intact).
 // Tier 0: satisfies all hard + all soft. Tier 1: all hard only. Tier 2: rest.
 export function reorderByCapabilities(models, required) {
@@ -536,8 +551,14 @@ export async function handleFusionChat({ body, models, handleSingleModel, log, c
   // Flatten tool turns to prose so panel models keep context without emitting tool_calls.
   if (Array.isArray(panelBody.messages)) {
     panelBody.messages = flattenToolHistory(panelBody.messages);
+    // Claude/Anthropic reject assistant-message prefill ("conversation must end with
+    // a user message"). If the inbound turn ends on an assistant msg (e.g. the client
+    // echoed a partial assistant reply), trim trailing assistant roles so the panel
+    // request terminates on a user turn. #2876
+    panelBody.messages = trimTrailingAssistant(panelBody.messages);
   } else if (Array.isArray(panelBody.input)) {
     panelBody.input = flattenToolHistory(panelBody.input);
+    panelBody.input = trimTrailingAssistant(panelBody.input);
   }
 
   const t0 = Date.now();

--- a/tests/unit/fusion-trim-trailing-assistant-2876.test.js
+++ b/tests/unit/fusion-trim-trailing-assistant-2876.test.js
@@ -1,0 +1,49 @@
+// Issue #2876 — Fusion panel requests fail on Claude with
+// "conversation must end with a user message" because the inbound turn can end on an
+// assistant message (client echoed a partial assistant reply). trimTrailingAssistant
+// removes trailing assistant roles so the panel request terminates on a user turn.
+
+import { describe, expect, it } from "vitest";
+import { trimTrailingAssistant } from "../../open-sse/services/combo.js";
+
+describe("trimTrailingAssistant (#2876)", () => {
+  it("leaves a user-ending conversation untouched", () => {
+    const msgs = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+      { role: "user", content: "again" },
+    ];
+    expect(trimTrailingAssistant(msgs)).toEqual(msgs);
+  });
+
+  it("trims a single trailing assistant message", () => {
+    const msgs = [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+      { role: "assistant", content: "continued" },
+    ];
+    const out = trimTrailingAssistant(msgs);
+    expect(out).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("trims multiple trailing assistant messages", () => {
+    const msgs = [
+      { role: "user", content: "q" },
+      { role: "assistant", content: "a1" },
+      { role: "assistant", content: "a2" },
+      { role: "assistant", content: "a3" },
+    ];
+    const out = trimTrailingAssistant(msgs);
+    expect(out).toEqual([{ role: "user", content: "q" }]);
+  });
+
+  it("returns original when all messages are assistant (never empty)", () => {
+    const msgs = [{ role: "assistant", content: "only" }];
+    expect(trimTrailingAssistant(msgs)).toEqual(msgs);
+  });
+
+  it("handles empty / non-array input", () => {
+    expect(trimTrailingAssistant([])).toEqual([]);
+    expect(trimTrailingAssistant(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fusion combos fail on Claude/Anthropic panels with `400 This model does not support assistant message prefill. The conversation must end with a user message.` (#2876). The Fusion fan-out forwards the full inbound `messages` array to each panel model, and when the client's request ends on an assistant message (e.g. it echoed a partial assistant reply), Claude rejects it.

### Fix
Added `trimTrailingAssistant()` in `open-sse/services/combo.js`, called on the panel body's `messages` / `input` after `flattenToolHistory`. It removes trailing `assistant` roles so the panel request terminates on a user turn. If stripping would leave an empty array (all-assistant input), it falls back to the original so we never send an empty `messages` array.

This complements the earlier Fusion fix (#3024, strip `stream_options`).

### Test plan
- `tests/unit/fusion-trim-trailing-assistant-2876.test.js` — 5 cases (user-ending untouched, single/multi trailing assistant trimmed, all-assistant fallback, empty/null input)

All new tests pass; pre-existing translator failures are unrelated (present on `master`).

## Acceptance criteria
- [ ] Fusion panel requests no longer 400 on Claude with "must end with a user message"
- [ ] Normal (user-ending) conversations unaffected

Happy to split if you prefer separate PRs.