### PR TITLE
fix(kimi): route API-key connections to Moonshot Open Platform

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -79,7 +79,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);
   // Multi-endpoint providers: pick transport matching sourceFormat → zero translation
-  const runtimeTransport = resolveTransport(provider, sourceFormat);
+  const runtimeTransport = resolveTransport(provider, sourceFormat, credentials?.authType);
   const targetFormat = modelTargetFormat || runtimeTransport?.format || getTargetFormat(provider, credentials);
   if (runtimeTransport && credentials) credentials.runtimeTransport = runtimeTransport;
   const stripList = getModelStrip(alias, model);

--- a/open-sse/providers/registry/kimi.js
+++ b/open-sse/providers/registry/kimi.js
@@ -38,15 +38,22 @@ export default {
       hooks: ["kimiHeaders"],
     },
   },
-  // Multi-endpoint: pick the transport matching client sourceFormat to skip translation.
   transports: [
     {
       format: "openai",
+      authType: "apikey",
+      baseUrl: "https://api.moonshot.ai/v1/chat/completions",
+      auth: { combined: true, header: "Authorization", scheme: "bearer" },
+    },
+    {
+      format: "openai",
+      authType: "oauth",
       baseUrl: "https://api.kimi.com/coding/v1/chat/completions",
       auth: { combined: true, header: "Authorization", scheme: "bearer", hooks: ["kimiHeaders"] },
     },
     {
       format: "claude",
+      authType: "oauth",
       baseUrl: "https://api.kimi.com/coding/v1/messages",
       urlSuffix: "?beta=true",
       headers: { ...CLAUDE_API_HEADERS },

--- a/open-sse/services/provider.js
+++ b/open-sse/services/provider.js
@@ -142,14 +142,18 @@ export function getTargetFormat(provider, credentials = null) {
   return config.format || "openai";
 }
 
-// Resolve which transport to use for a provider given the client sourceFormat.
-// Multi-endpoint providers (transport.transports[]) pick the entry matching sourceFormat
-// to avoid lossy translation; falls back to the default transport when no match.
-export function resolveTransport(provider, sourceFormat) {
+// Resolve transport by auth type first, then client source format.
+// This keeps dual-auth providers (e.g. Kimi OAuth/API key) on the correct endpoint.
+export function resolveTransport(provider, sourceFormat, authType) {
   const config = PROVIDERS[provider];
   const transports = config?.transports;
   if (!Array.isArray(transports) || !transports.length) return null;
-  return transports.find(t => t.format === sourceFormat) || null;
+  const exactAuth = transports.filter(t => t.authType && t.authType === authType);
+  const generic = transports.filter(t => !t.authType);
+  return exactAuth.find(t => t.format === sourceFormat)
+    || exactAuth[0]
+    || generic.find(t => t.format === sourceFormat)
+    || null;
 }
 
 // Check if last message is from user

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -594,13 +594,25 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         return { valid, error: valid ? null : "Invalid API key" };
       }
       case "kimi": {
-        const res = await fetchWithConnectionProxy("https://api.kimi.com/coding/v1/messages", {
+        // API-key connections use the Moonshot Open Platform endpoint.
+        // OAuth connections never enter this branch; they retain the Kimi Code OAuth flow.
+        const res = await fetchWithConnectionProxy("https://api.moonshot.ai/v1/chat/completions", {
           method: "POST",
-          headers: { "x-api-key": connection.apiKey, "anthropic-version": "2023-06-01", "content-type": "application/json" },
-          body: JSON.stringify({ model: "kimi-latest", max_tokens: 1, messages: [{ role: "user", content: "test" }] }),
+          headers: {
+            "Authorization": `Bearer ${connection.apiKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "kimi-k2.6",
+            max_tokens: 1,
+            messages: [{ role: "user", content: "test" }],
+          }),
         }, effectiveProxy);
         const valid = res.status !== 401 && res.status !== 403;
-        return { valid, error: valid ? null : "Invalid API key" };
+        const warning = res.status === 402 || res.status === 429
+          ? "Connected, but account balance/quota is exhausted."
+          : null;
+        return { valid, error: valid ? null : "Invalid API key", warning };
       }
       case "alicode":
       case "alicode-intl":


### PR DESCRIPTION
## Summary

- Route Kimi API-key connections to the Moonshot Open Platform endpoint.
- Keep Kimi OAuth connections on the Kimi Code Platform endpoints.
- Select the runtime transport using both authentication type and client request format.
- Treat Moonshot insufficient-balance responses as authenticated provider responses during API-key validation.

## Details

API-key connections now use:

- `https://api.moonshot.ai/v1/chat/completions`
- `Authorization: Bearer <API_KEY>`

OAuth connections continue using the existing Kimi Code transport and authentication headers.

## Verification

- Node syntax checks passed for the modified files.
- Transport selection self-check passed for Kimi API-key and OAuth combinations.
- `npm run build` passed.
- `npm --prefix cli run build` passed.
- Runtime health check passed with `{"ok":true}`.
