### PR TITLE
feat(commandcode): support Muse reasoning effort

### DIFF
--- a/open-sse/executors/commandcode.js
+++ b/open-sse/executors/commandcode.js
@@ -4,6 +4,20 @@ import { PROVIDERS } from "../config/providers.js";
 import { commandCodeToOpenAIResponse } from "../translator/response/commandcode-to-openai.js";
 import { SSE_DONE } from "../utils/sseConstants.js";
 
+const INITIAL_INSPECTION_MAX_LINES = 32;
+const INITIAL_INSPECTION_MAX_BYTES = 128 * 1024;
+
+const METADATA_EVENTS = new Set([
+  "start",
+  "start-step",
+  "reasoning-start",
+  "reasoning-end",
+  "text-start",
+  "text-end",
+  "provider-metadata",
+  "message-metadata",
+]);
+
 /**
  * CommandCodeExecutor — talks to https://api.commandcode.ai/alpha/generate
  *
@@ -21,8 +35,8 @@ export class CommandCodeExecutor extends BaseExecutor {
   }
 
   transformRequest(model, body, stream, credentials) {
-    body.stream = true;
-    return body;
+    const { model: _rootModel, stream: _rootStream, ...request } = body;
+    return request;
   }
 
   buildHeaders(credentials, stream = true) {
@@ -40,11 +54,123 @@ export class CommandCodeExecutor extends BaseExecutor {
   }
 
   async execute(opts) {
-    const result = await super.execute(opts);
-    if (!result?.response?.ok || !result.response.body) return result;
-    result.response = wrapNdjsonAsOpenAISse(result.response, opts.model);
-    return result;
+    let inBandRetries = 0;
+
+    while (true) {
+      const result = await super.execute(opts);
+      if (!result?.response?.ok || !result.response.body) return result;
+
+      const inspected = await inspectInitialResponse(result.response);
+      if (!inspected.error) {
+        result.response = wrapNdjsonAsOpenAISse(inspected.response, opts.model);
+        return result;
+      }
+
+      const retry = this.config.retry?.[String(inspected.error.status)] || null;
+      if (inspected.error.retryable && retry && inBandRetries < (retry.attempts || 0)) {
+        inBandRetries++;
+        if (retry.delayMs > 0) await new Promise((resolve) => setTimeout(resolve, retry.delayMs));
+        continue;
+      }
+
+      result.response = createCommandCodeErrorResponse(inspected.error);
+      return result;
+    }
   }
+}
+
+function parseEvent(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const json = trimmed.startsWith("data:") ? trimmed.slice(5).trim() : trimmed;
+  if (!json || json === "[DONE]") return null;
+  try { return JSON.parse(json); } catch { return null; }
+}
+
+function normalizeError(event) {
+  const details = event?.error && typeof event.error === "object" ? event.error : {};
+  const rawStatus = details.statusCode ?? event?.statusCode;
+  const status = Number.isInteger(Number(rawStatus)) ? Number(rawStatus) : 502;
+  const rawMessage = details.message ?? event?.message ?? event?.error;
+  const message = typeof rawMessage === "string"
+    ? rawMessage
+    : rawMessage
+      ? JSON.stringify(rawMessage)
+      : "Command Code upstream error";
+
+  return {
+    status,
+    message,
+    retryable: details.isRetryable === true || event?.isRetryable === true || status >= 500,
+  };
+}
+
+async function inspectInitialResponse(response) {
+  if (!response.body?.tee) return { response, error: null };
+
+  const [inspectionBody, replayBody] = response.body.tee();
+  const reader = inspectionBody.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let bytes = 0;
+  let lines = 0;
+  let error = null;
+  let stop = false;
+
+  try {
+    while (!stop && lines < INITIAL_INSPECTION_MAX_LINES && bytes < INITIAL_INSPECTION_MAX_BYTES) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      bytes += value?.byteLength || 0;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split("\n");
+      buffer = parts.pop() || "";
+
+      for (const line of parts) {
+        const event = parseEvent(line);
+        if (!event?.type) continue;
+        lines++;
+        if (event.type === "error") {
+          error = normalizeError(event);
+          stop = true;
+          break;
+        }
+        if (!METADATA_EVENTS.has(event.type)) {
+          stop = true;
+          break;
+        }
+      }
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+
+  const replayResponse = new Response(replayBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+
+  if (error) {
+    replayBody.cancel().catch(() => {});
+    return { response: replayResponse, error };
+  }
+  return { response: replayResponse, error: null };
+}
+
+function createCommandCodeErrorResponse(error) {
+  return new Response(JSON.stringify({
+    error: {
+      type: error.status >= 500 ? "server_error" : "upstream_error",
+      message: error.message,
+      code: "commandcode_upstream_error",
+      statusCode: error.status,
+      isRetryable: error.retryable,
+    },
+  }), {
+    status: error.status,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function wrapNdjsonAsOpenAISse(originalResponse, model) {

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -42,7 +42,7 @@ export const DEFAULT_CAPABILITIES = {
   tools: true,          // function / tool calling
   reasoning: false,     // thinking / reasoning
   // thinking wire format (only meaningful when reasoning:true). null → derive from transport.format.
-  // enum: openai|claude-adaptive|claude-budget|gemini-level|gemini-budget|zai|qwen|deepseek|kimi|minimax|hunyuan|step
+  // enum: openai|commandcode|claude-adaptive|claude-budget|gemini-level|gemini-budget|zai|qwen|deepseek|kimi|minimax|hunyuan|step
   thinkingFormat: null,
   thinkingCanDisable: true,  // false → model cannot turn thinking off (clamp to min instead of disable)
   thinkingRange: null,       // { min, max } for budget formats; null = no clamp
@@ -121,6 +121,16 @@ const CODEX_GPT_56_DEFAULT_CAPS = { vision: true, reasoning: true, search: true,
  * Provider-specific capability overrides. Keyed by provider alias/id.
  */
 export const PROVIDER_CAPABILITIES = {
+  // Command Code's alpha endpoint returns an in-band 503 when a tool-bearing
+  // Muse request exceeds 32K output tokens, including the global 64K default.
+  "commandcode": {
+    "muse-spark-1.2-contributor": {
+      reasoning: true,
+      thinkingFormat: "commandcode",
+      thinkingCanDisable: false,
+      maxOutput: 32768,
+    },
+  },
   // NVIDIA NIM is OpenAI-compatible → rejects MiniMax/GLM native `thinking` field.
   // Force openai reasoning_effort format for its reasoning models. #issue
   "nvidia": {

--- a/open-sse/providers/registry/commandcode.js
+++ b/open-sse/providers/registry/commandcode.js
@@ -18,18 +18,28 @@ export default {
     },
   },
   category: "apikey",
+  thinkingConfig: {
+    options: ["auto", "low", "medium", "high", "xhigh", "max"],
+    defaultMode: "auto",
+  },
   transport: {
     baseUrl: "https://api.commandcode.ai/alpha/generate",
     format: "commandcode",
     forceStream: true,
     headers: {
-      "x-command-code-version": "0.25.7",
+      // Command Code v1.14+ rejects tool-bearing Muse requests with older
+      // client metadata. Keep this aligned with the current CLI protocol.
+      "x-command-code-version": "1.15.1",
       "x-cli-environment": "cli",
+    },
+    retry: {
+      "503": { attempts: 1, delayMs: 250 },
     },
   },
   models: [
     { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" },
     { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash" },
+    { id: "meta/muse-spark-1.2-contributor", name: "Muse Spark 1.2 Contributor" },
     { id: "moonshotai/Kimi-K2.6", name: "Kimi K2.6" },
     { id: "moonshotai/Kimi-K2.5", name: "Kimi K2.5" },
     { id: "zai-org/GLM-5.1", name: "GLM 5.1" },

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -18,6 +18,7 @@ const L = {
 // thinkingFormat → valid selectable levels (source of truth for UI options).
 const FORMAT_LEVELS = {
   openai: L.openai,
+  commandcode: ["low", "medium", "high", "xhigh", "max"],
   "claude-adaptive": L.levelMax,
   "claude-budget": L.budgetX,
   "gemini-level": L.gemini,

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -210,15 +210,21 @@ function ensureGeminiOutputFloor(body, floor, caps) {
 
 // Strip every known thinking field from a body (used before re-applying / when unsupported).
 function stripAll(body) {
-  delete body.thinking;
-  delete body.reasoning_effort;
-  delete body.reasoning;
-  delete body.thinkingConfig;
-  delete body.enable_thinking;
-  delete body.thinking_budget;
-  delete body.output_config;
-  if (body.generationConfig) delete body.generationConfig.thinkingConfig;
-  if (body.request?.generationConfig) delete body.request.generationConfig.thinkingConfig;
+  const targets = [body];
+  if (body.params && typeof body.params === "object" && Array.isArray(body.params.messages)) {
+    targets.push(body.params);
+  }
+  for (const target of targets) {
+    delete target.thinking;
+    delete target.reasoning_effort;
+    delete target.reasoning;
+    delete target.thinkingConfig;
+    delete target.enable_thinking;
+    delete target.thinking_budget;
+    delete target.output_config;
+    if (target.generationConfig) delete target.generationConfig.thinkingConfig;
+    if (target.request?.generationConfig) delete target.request.generationConfig.thinkingConfig;
+  }
 }
 
 // Apply unified thinking config to body in the resolved provider-native format.
@@ -233,6 +239,15 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       if (none && canDisable) { body.reasoning_effort = "none"; break; }
       const level = toLevel(eff);
       if (level) body.reasoning_effort = normalizeOpenAILevel(level, supportedLevels);
+      break;
+    }
+    case "commandcode": {
+      // Command Code's native field lives inside the alpha envelope's params.
+      // Its validator accepts only these selectable levels; auto/none mean that
+      // no override is sent because the API has no disable/auto enum value.
+      const params = body.params && typeof body.params === "object" ? body.params : body;
+      const level = toLevel(eff);
+      if (level && supportedLevels?.includes(level)) params.reasoning_effort = level;
       break;
     }
     case "claude-adaptive": {

--- a/open-sse/translator/request/openai-to-commandcode.js
+++ b/open-sse/translator/request/openai-to-commandcode.js
@@ -14,6 +14,8 @@ import { FORMATS } from "../formats.js";
 import { randomUUID } from "crypto";
 import { ROLE, OPENAI_BLOCK } from "../schema/index.js";
 import { DEFAULT_MAX_TOKENS } from "../../config/runtimeConfig.js";
+import { getCapabilitiesForModel } from "../../providers/capabilities.js";
+import { stripThinkingSuffix } from "../concerns/thinkingUnified.js";
 
 function flattenText(content) {
   if (content == null) return "";
@@ -134,12 +136,15 @@ function convertTools(tools) {
 }
 
 export function openaiToCommandCodeRequest(model, body, stream /* , credentials */) {
+  const cleanModel = stripThinkingSuffix(model);
   const { messages, system } = convertMessages(body.messages);
+  const requestedMaxTokens = body.max_tokens ?? body.max_output_tokens ?? DEFAULT_MAX_TOKENS;
+  const maxTokens = Math.min(requestedMaxTokens, getCapabilitiesForModel("commandcode", cleanModel).maxOutput);
   const params = {
-    model,
+    model: cleanModel,
     messages,
     stream: stream !== false,
-    max_tokens: body.max_tokens ?? body.max_output_tokens ?? DEFAULT_MAX_TOKENS,
+    max_tokens: maxTokens,
     temperature: body.temperature ?? 0.3,
   };
 

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -49,7 +49,7 @@ export const FREE_TIER_PROVIDERS = byCategory("freeTier");
 // options: list of selectable modes ("auto" = no override from server)
 // defaultMode: fallback when user hasn't configured
 // extended: claude-style thinking (thinking.type + budget_tokens) — used by most providers
-// effort: openai-style reasoning_effort — only openai + codex
+// effort: openai-style reasoning_effort — OpenAI-compatible effort providers
 export const THINKING_CONFIG = {
   extended: {
     options: ["auto", "on", "off"],

--- a/tests/unit/commandcode-executor.test.js
+++ b/tests/unit/commandcode-executor.test.js
@@ -1,0 +1,232 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import "../translator/registerAll.js";
+import { PROVIDER_MODELS } from "../../open-sse/config/providerModels.js";
+import { BaseExecutor } from "../../open-sse/executors/base.js";
+import { CommandCodeExecutor } from "../../open-sse/executors/commandcode.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { openaiToCommandCodeRequest } from "../../open-sse/translator/request/openai-to-commandcode.js";
+
+const baseExecute = vi.spyOn(BaseExecutor.prototype, "execute");
+const MUSE_MODEL = "meta/muse-spark-1.2-contributor";
+
+afterAll(() => baseExecute.mockRestore());
+
+describe("CommandCodeExecutor", () => {
+  beforeEach(() => {
+    baseExecute.mockReset();
+  });
+
+  it("uses the current protocol version and exposes Muse Contributor", () => {
+    const executor = new CommandCodeExecutor();
+    const headers = executor.buildHeaders({ apiKey: "user-test" });
+
+    expect(headers["x-command-code-version"]).toBe("1.15.1");
+    expect(headers["x-cli-environment"]).toBe("cli");
+    expect(PROVIDER_MODELS.commandcode).toContainEqual({
+      id: "meta/muse-spark-1.2-contributor",
+      name: "Muse Spark 1.2 Contributor",
+    });
+  });
+
+  it("advertises Muse as a Command Code reasoning model with the exact API levels", () => {
+    expect(getCapabilitiesForModel("commandcode", MUSE_MODEL)).toMatchObject({
+      reasoning: true,
+      thinkingFormat: "commandcode",
+      thinkingCanDisable: false,
+      maxOutput: 32768,
+    });
+    expect(getThinkingLevels("commandcode", MUSE_MODEL)).toEqual([
+      "low", "medium", "high", "xhigh", "max",
+    ]);
+  });
+
+  it.each(["low", "medium", "high", "xhigh", "max"])(
+    "forwards Muse reasoning_effort=%s into params unchanged",
+    (effort) => {
+      const translated = translateRequest(
+        FORMATS.OPENAI,
+        FORMATS.COMMANDCODE,
+        MUSE_MODEL,
+        {
+          messages: [{ role: "user", content: "hello" }],
+          reasoning_effort: effort,
+        },
+        true,
+        null,
+        "commandcode",
+      );
+
+      expect(translated.params.model).toBe(MUSE_MODEL);
+      expect(translated.params.reasoning_effort).toBe(effort);
+      expect(translated.reasoning_effort).toBeUndefined();
+    },
+  );
+
+  it("does not send unsupported auto/none values to Command Code", () => {
+    for (const effort of ["auto", "none"]) {
+      const translated = translateRequest(
+        FORMATS.OPENAI,
+        FORMATS.COMMANDCODE,
+        MUSE_MODEL,
+        {
+          messages: [{ role: "user", content: "hello" }],
+          reasoning_effort: effort,
+        },
+        true,
+        null,
+        "commandcode",
+      );
+
+      expect(translated.params.reasoning_effort).toBeUndefined();
+    }
+  });
+
+  it("uses a clean upstream model when the selected model carries an effort suffix", () => {
+    const translated = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.COMMANDCODE,
+      `${MUSE_MODEL}(high)`,
+      { messages: [{ role: "user", content: "hello" }] },
+      true,
+      null,
+      "commandcode",
+    );
+
+    expect(translated.params.model).toBe(MUSE_MODEL);
+    expect(translated.params.reasoning_effort).toBe("high");
+  });
+
+  it("wraps normal NDJSON as OpenAI SSE", async () => {
+    baseExecute.mockResolvedValue({
+      response: new Response(
+        '{"type":"start"}\n{"type":"text-delta","text":"OK"}\n{"type":"finish"}\n',
+        { status: 200 },
+      ),
+      url: "https://api.commandcode.ai/alpha/generate",
+      headers: {},
+      transformedBody: {},
+    });
+
+    const result = await new CommandCodeExecutor().execute({
+      model: "meta/muse-spark-1.2-contributor",
+      body: {},
+      stream: true,
+      credentials: { apiKey: "user-test" },
+    });
+    const text = await result.response.text();
+
+    expect(result.response.status).toBe(200);
+    expect(text).toContain('data: {"id":"chatcmpl-');
+    expect(text).toContain('"content":"OK"');
+    expect(text).toContain("data: [DONE]");
+  });
+
+  it("retries retryable in-band errors before exposing an HTTP error", async () => {
+    let calls = 0;
+    const proxyOptions = [];
+    baseExecute.mockImplementation(async (receivedOpts) => {
+      calls++;
+      proxyOptions.push(receivedOpts.proxyOptions);
+      if (calls === 1) {
+        return {
+          response: new Response(
+            '{"type":"start"}\n{"type":"error","error":{"message":"temporary","statusCode":503,"isRetryable":true}}\n',
+            { status: 200 },
+          ),
+          url: "https://api.commandcode.ai/alpha/generate",
+          headers: {},
+          transformedBody: {},
+        };
+      }
+      return {
+        response: new Response(
+          '{"type":"start"}\n{"type":"text-delta","text":"OK"}\n{"type":"finish"}\n',
+          { status: 200 },
+        ),
+        url: "https://api.commandcode.ai/alpha/generate",
+        headers: {},
+        transformedBody: {},
+      };
+    });
+
+    const result = await new CommandCodeExecutor().execute({
+      model: "meta/muse-spark-1.2-contributor",
+      body: {},
+      stream: true,
+      credentials: { apiKey: "user-test" },
+      proxyOptions: {
+        connectionProxyEnabled: true,
+        connectionProxyUrl: "http://proxy.example",
+      },
+    });
+
+    expect(calls).toBe(2);
+    expect(proxyOptions[1]).toEqual(proxyOptions[0]);
+    expect(result.response.status).toBe(200);
+    expect(await result.response.text()).toContain('"content":"OK"');
+  });
+
+  it("returns a real HTTP error when the in-band error persists", async () => {
+    baseExecute.mockImplementation(async () => ({
+      response: new Response(
+        '{"type":"start"}\n{"type":"error","error":{"message":"unavailable","statusCode":503,"isRetryable":true}}\n',
+        { status: 200 },
+      ),
+      url: "https://api.commandcode.ai/alpha/generate",
+      headers: {},
+      transformedBody: {},
+    }));
+
+    const result = await new CommandCodeExecutor().execute({
+      model: "meta/muse-spark-1.2-contributor",
+      body: {},
+      stream: true,
+      credentials: { apiKey: "user-test" },
+    });
+    const body = await result.response.json();
+
+    expect(result.response.status).toBe(503);
+    expect(body.error.message).toBe("unavailable");
+  });
+
+  it("does not add an unsupported root-level stream field", () => {
+    const body = {
+      model: "meta/muse-spark-1.2-contributor",
+      stream: true,
+      params: { model: "meta/muse-spark-1.2-contributor", stream: true },
+    };
+    const transformed = new CommandCodeExecutor().transformRequest(
+      "meta/muse-spark-1.2-contributor",
+      body,
+      true,
+    );
+
+    expect(transformed).not.toHaveProperty("model");
+    expect(transformed).not.toHaveProperty("stream");
+    expect(transformed.params).toEqual(body.params);
+  });
+
+  it("clamps tool-bearing Muse requests to Command Code's supported limit", () => {
+    const request = openaiToCommandCodeRequest(
+      "meta/muse-spark-1.2-contributor",
+      {
+        max_tokens: 64000,
+        messages: [{ role: "user", content: "hello" }],
+        tools: [{
+          type: "function",
+          function: {
+            name: "read_file",
+            description: "Read a file",
+            parameters: { type: "object", properties: { path: { type: "string" } } },
+          },
+        }],
+      },
+      true,
+    );
+
+    expect(request.params.max_tokens).toBe(32768);
+  });
+});


### PR DESCRIPTION
## Summary

- Add Command Code alpha protocol support for Muse Spark 1.2 Contributor.
- Forward OpenCode reasoning variants low, medium, high, xhigh, and max to params.reasoning_effort without changing valid values.
- Remove unsupported root model/stream fields, clamp Muse output tokens to 32768, and handle early in-band 503 retry/error responses.

## Validation

- 71 targeted Vitest tests passed.
- ESLint completed with 0 errors and one pre-existing anonymous-default-export warning.
- OpenCode 1.18.14 live-tested with high, max, and a tool call through the installed runtime.
- npm run cli:pack and global runtime health validation passed.

The local OpenCode configuration is intentionally not included in this PR.