### PR TITLE
fix(providers): add llm7 to provider test support

### DIFF
--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -788,6 +788,13 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         );
         return { valid: exRes.ok, error: exRes.ok ? null : "Invalid Personal Access Token" };
       }
+      case "llm7": {
+        const baseUrl = connection.providerSpecificData?.baseUrl || "https://api.llm7.io/v1";
+        const res = await fetchWithConnectionProxy(`${baseUrl.replace(/\/$/, "")}/models`, {
+          headers: { Authorization: `Bearer ${connection.apiKey}` },
+        }, effectiveProxy);
+        return { valid: res.ok, error: res.ok ? null : "Invalid API key or base URL" };
+      }
       default:
         return { valid: false, error: "Provider test not supported" };
     }


### PR DESCRIPTION
Add `llm7` case to `testApiKeyConnection()` in `testUtils.js` so the provider test no longer returns "Provider test not supported".

The test hits `https://api.llm7.io/v1/models` (from the llm7 provider registry) with Bearer auth and reports validity based on the response status.

Tested locally: provider test now passes after rebuilding and restarting the service.