### PR TITLE
feat(fallback): per-account RPM cap, default 40 for NVIDIA

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -39,7 +39,7 @@ export const BACKOFF_CONFIG = {
 export const TRANSIENT_COOLDOWN_MS = 30 * 1000;
 
 // Hard cap for provider-reported rate limit cooldown (e.g. codex resets_at can be 5-6h)
-export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000;
+export const MAX_RATE_LIMIT_COOLDOWN_MS = 6 * 60 * 60 * 1000;
 
 // Cooldown durations (ms)
 const COOLDOWN = {

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -1,4 +1,4 @@
-import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS } from "../config/errorConfig.js";
+import { ERROR_RULES, BACKOFF_CONFIG, TRANSIENT_COOLDOWN_MS, MAX_RATE_LIMIT_COOLDOWN_MS } from "../config/errorConfig.js";
 
 /**
  * Calculate exponential backoff cooldown for rate limits (429)
@@ -10,6 +10,50 @@ export function getQuotaCooldown(backoffLevel = 0) {
   const level = Math.max(0, backoffLevel - 1);
   const cooldown = BACKOFF_CONFIG.base * Math.pow(2, level);
   return Math.min(cooldown, BACKOFF_CONFIG.max);
+}
+
+/**
+ * Parse the provider's ACTUAL rate-limit reset window from a 429 body/headers,
+ * so an account is locked for the real duration instead of a fixed cooldown.
+ * Supports: Google/Antigravity RetryInfo ("retryDelay": "1976.3s"),
+ * OpenAI/Codex absolute reset ("resets_at"/"reset_at" epoch s|ms),
+ * OpenRouter/RateLimit ("X-RateLimit-Reset" epoch s|ms) and "Retry-After: N".
+ * @param {string|object} errorText - 429 body/headers, string or object.
+ * @param {number} now - reference epoch ms (defaults to Date.now()).
+ * @returns {number|null} ms until reset, or null when none is present.
+ */
+export function parseProviderResetMs(errorText, now = Date.now()) {
+  if (!errorText) return null;
+  const s = typeof errorText === "string" ? errorText : JSON.stringify(errorText);
+  let m;
+  // Relative seconds (Google/Antigravity RetryInfo): "retryDelay": "1976.365s"
+  if ((m = s.match(/"?retry[_-]?delay"?\s*[:=]\s*"?\s*([0-9]+(?:\.[0-9]+)?)\s*s/i))) {
+    return Math.round(parseFloat(m[1]) * 1000);
+  }
+  // Absolute reset epoch (s or ms): resets_at / reset_at / X-RateLimit-Reset
+  if ((m = s.match(/"?(?:resets?_at|x-?ratelimit-?reset|ratelimit-?reset)"?\s*[:=]\s*"?\s*([0-9]{9,})/i))) {
+    let v = parseInt(m[1], 10);
+    if (v < 1e12) v *= 1000; // seconds -> ms
+    const ms = v - now;
+    return ms > 0 ? ms : null;
+  }
+  // Retry-After: N seconds (header echoed into the body)
+  if ((m = s.match(/"?retry[_-]?after"?\s*[:=]\s*"?\s*([0-9]+)\b/i))) {
+    return parseInt(m[1], 10) * 1000;
+  }
+  return null;
+}
+
+/**
+ * Resolve the 429 account cooldown: prefer the provider's own reset window over
+ * the static exponential backoff, floored at the static value and capped at
+ * MAX_RATE_LIMIT_COOLDOWN_MS so a bogus huge value can't lock an account forever.
+ */
+export function resolveCooldownMs(newLevel, errorText) {
+  const staticMs = getQuotaCooldown(newLevel);
+  const providerMs = parseProviderResetMs(errorText);
+  if (providerMs == null || !(providerMs > 0)) return staticMs;
+  return Math.min(Math.max(providerMs, staticMs), MAX_RATE_LIMIT_COOLDOWN_MS);
 }
 
 /**
@@ -30,7 +74,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     if (rule.text && lowerError && lowerError.includes(rule.text)) {
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+        return { shouldFallback: true, cooldownMs: resolveCooldownMs(newLevel, errorText), newBackoffLevel: newLevel };
       }
       return { shouldFallback: true, cooldownMs: rule.cooldownMs };
     }
@@ -39,7 +83,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     if (rule.status && rule.status === status) {
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
-        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+        return { shouldFallback: true, cooldownMs: resolveCooldownMs(newLevel, errorText), newBackoffLevel: newLevel };
       }
       return { shouldFallback: true, cooldownMs: rule.cooldownMs };
     }

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -6,7 +6,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { getProviderIconSrc, markProviderIconMissing } from "@/shared/utils/providerIcon";
 import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal } from "@/shared/components";
-import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS } from "@/shared/constants/providers";
+import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS, DEFAULT_PROVIDER_RPM } from "@/shared/constants/providers";
 import { getModelsByProviderId, getModelKind } from "@/shared/constants/models";
 import { getThinkingLevels } from "open-sse/providers/thinkingLevels.js";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
@@ -84,6 +84,7 @@ export default function ProviderDetailPage() {
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [liveModels, setLiveModels] = useState([]);
+  const [rpmLimit, setRpmLimit] = useState("");
   const [kiloFreeModels, setKiloFreeModels] = useState([]);
   const [disabledModelIds, setDisabledModelIds] = useState([]);
   const [confirmState, setConfirmState] = useState(null);
@@ -335,6 +336,9 @@ export default function ProviderDetailPage() {
       // Load per-provider retry-delay override
       const rd = (settingsData.retryDelayByProvider || {})[providerId];
       setRetryDelay(rd != null && rd !== "auto" ? String(rd) : "auto");
+      // Per-account RPM cap; blank input means "use the provider default"
+      const rpm = (settingsData.rpmByProvider || {})[providerId];
+      setRpmLimit(rpm != null ? String(rpm) : "");
       const autoPingSettingsKey = AUTO_PING_SETTINGS_KEYS[providerId];
       const apCfg = autoPingSettingsKey ? settingsData[autoPingSettingsKey] || {} : {};
       setAutoPing({ enabled: apCfg.enabled === true, connections: apCfg.connections || {} });
@@ -468,6 +472,27 @@ export default function ProviderDetailPage() {
       });
     } catch (error) {
       console.log("Error saving retry delay:", error);
+    }
+  };
+
+  const saveRpmLimit = async (value) => {
+    try {
+      const settingsRes = await fetch("/api/settings", { cache: "no-store" });
+      const settingsData = settingsRes.ok ? await settingsRes.json() : {};
+      const updated = { ...(settingsData.rpmByProvider || {}) };
+      const trimmed = String(value ?? "").trim();
+      if (trimmed === "") {
+        delete updated[providerId]; // fall back to the provider default
+      } else {
+        updated[providerId] = Math.max(0, Number(trimmed) || 0);
+      }
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rpmByProvider: updated }),
+      });
+    } catch (error) {
+      console.log("Error saving RPM limit:", error);
     }
   };
 
@@ -1375,6 +1400,17 @@ export default function ProviderDetailPage() {
           </div>
           {/* Retry-delay control — right side of the provider header */}
           <div className="ml-auto flex shrink-0 items-center gap-2">
+            <span className="hidden text-xs text-text-muted sm:inline">RPM / account</span>
+            <input
+              type="number"
+              min="0"
+              value={rpmLimit}
+              placeholder={String(DEFAULT_PROVIDER_RPM[providerId] || 0)}
+              onChange={(e) => setRpmLimit(e.target.value)}
+              onBlur={(e) => saveRpmLimit(e.target.value)}
+              title="Max requests per minute per account. Accounts over the cap are skipped before a request is sent, so the provider never sees a 429. Blank = provider default, 0 = unlimited."
+              className="w-16 rounded-md border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+            />
             <span className="hidden text-xs text-text-muted sm:inline">Retry delay</span>
             <select
               value={retryDelay}

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -30,6 +30,21 @@ const AUTO_PING_SETTINGS_KEYS = {
   codex: "codexAutoPing",
 };
 
+// Per-provider retry-delay options. "auto" = honor the provider's reported reset
+// (retryDelay / Retry-After / resets_at), else the built-in backoff. A number is
+// the cooldown (seconds) used only when the provider reports no reset of its own.
+const RETRY_DELAY_OPTIONS = [
+  { value: "auto", label: "Retry: Auto" },
+  { value: "15", label: "Retry: 15s" },
+  { value: "30", label: "Retry: 30s" },
+  { value: "60", label: "Retry: 1m" },
+  { value: "120", label: "Retry: 2m" },
+  { value: "300", label: "Retry: 5m" },
+  { value: "600", label: "Retry: 10m" },
+  { value: "1800", label: "Retry: 30m" },
+  { value: "3600", label: "Retry: 1h" },
+];
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -65,6 +80,7 @@ export default function ProviderDetailPage() {
   const [providerStrategy, setProviderStrategy] = useState(null);
   const [providerStickyLimit, setProviderStickyLimit] = useState("");
   const [thinkingMode, setThinkingMode] = useState("auto");
+  const [retryDelay, setRetryDelay] = useState("auto");
   const [autoPing, setAutoPing] = useState({ enabled: false, connections: {} });
   const [suggestedModels, setSuggestedModels] = useState([]);
   const [liveModels, setLiveModels] = useState([]);
@@ -316,6 +332,9 @@ export default function ProviderDetailPage() {
       // Load per-provider thinking config
       const thinkingCfg = (settingsData.providerThinking || {})[providerId] || {};
       setThinkingMode(thinkingCfg.mode || "auto");
+      // Load per-provider retry-delay override
+      const rd = (settingsData.retryDelayByProvider || {})[providerId];
+      setRetryDelay(rd != null && rd !== "auto" ? String(rd) : "auto");
       const autoPingSettingsKey = AUTO_PING_SETTINGS_KEYS[providerId];
       const apCfg = autoPingSettingsKey ? settingsData[autoPingSettingsKey] || {} : {};
       setAutoPing({ enabled: apCfg.enabled === true, connections: apCfg.connections || {} });
@@ -429,6 +448,32 @@ export default function ProviderDetailPage() {
   const handleThinkingModeChange = (mode) => {
     setThinkingMode(mode);
     saveThinkingConfig(mode);
+  };
+
+  const saveRetryDelay = async (value) => {
+    try {
+      const settingsRes = await fetch("/api/settings", { cache: "no-store" });
+      const settingsData = settingsRes.ok ? await settingsRes.json() : {};
+      const current = settingsData.retryDelayByProvider || {};
+      const updated = { ...current };
+      if (!value || value === "auto") {
+        delete updated[providerId];
+      } else {
+        updated[providerId] = Number(value);
+      }
+      await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ retryDelayByProvider: updated }),
+      });
+    } catch (error) {
+      console.log("Error saving retry delay:", error);
+    }
+  };
+
+  const handleRetryDelayChange = (value) => {
+    setRetryDelay(value);
+    saveRetryDelay(value);
   };
 
   const saveAutoPing = async (next) => {
@@ -1327,6 +1372,20 @@ export default function ProviderDetailPage() {
             <p className="text-text-muted">
               {connections.length} connection{connections.length === 1 ? "" : "s"}
             </p>
+          </div>
+          {/* Retry-delay control — right side of the provider header */}
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            <span className="hidden text-xs text-text-muted sm:inline">Retry delay</span>
+            <select
+              value={retryDelay}
+              onChange={(e) => handleRetryDelayChange(e.target.value)}
+              title="Cooldown after a rate-limit/error when the provider reports no reset time of its own. Auto = honor the provider's reported delay, else built-in backoff."
+              className="rounded-md border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+            >
+              {RETRY_DELAY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
           </div>
         </div>
       </div>

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -18,6 +18,9 @@ const DEFAULT_SETTINGS = {
   // "auto"/absent → provider-reported reset else built-in backoff; a number is
   // the lock duration used when the provider reports no reset of its own.
   retryDelayByProvider: {},
+  // Per-provider requests-per-minute cap per ACCOUNT: { [providerId]: <number> }.
+  // Absent → DEFAULT_PROVIDER_RPM, 0 → unlimited.
+  rpmByProvider: {},
   comboStrategy: "fallback",
   comboStickyRoundRobinLimit: 1,
   comboStrategies: {},

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -14,6 +14,10 @@ const DEFAULT_SETTINGS = {
   stickyRoundRobinLimit: 3,
   providerStrategies: {},
   quotaVisibility: {},
+  // Per-provider retry-delay fallback: { [providerId]: "auto" | <seconds> }.
+  // "auto"/absent → provider-reported reset else built-in backoff; a number is
+  // the lock duration used when the provider reports no reset of its own.
+  retryDelayByProvider: {},
   comboStrategy: "fallback",
   comboStickyRoundRobinLimit: 1,
   comboStrategies: {},

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -124,6 +124,22 @@ export function resolveProviderId(aliasOrId) {
 }
 
 // Helper: Get alias from provider ID
+// Per-account requests-per-minute defaults. NVIDIA NIM enforces ~40 RPM per
+// API key, so cap there by default rather than discovering it via 429s.
+// Anything not listed is uncapped unless the user sets a value.
+export const DEFAULT_PROVIDER_RPM = {
+  nvidia: 40,
+};
+
+// settings.rpmByProvider wins; "" / null falls back to the default; 0 = unlimited.
+export function resolveProviderRpm(settings, providerId) {
+  const configured = (settings?.rpmByProvider || {})[providerId];
+  if (configured === 0 || configured === "0") return 0;
+  const n = Number(configured);
+  if (Number.isFinite(n) && n > 0) return n;
+  return DEFAULT_PROVIDER_RPM[providerId] || 0;
+}
+
 export function getProviderAlias(providerId) {
   const provider = AI_PROVIDERS[providerId];
   return provider?.alias || providerId;

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -2,7 +2,8 @@ import { getProviderConnections, validateApiKey, updateProviderConnection, getSe
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
 import { formatRetryAfter, checkFallbackError, parseProviderResetMs, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
-import { resolveProviderId, FREE_PROVIDERS, FREE_TIER_PROVIDERS } from "@/shared/constants/providers.js";
+import { resolveProviderId, resolveProviderRpm, FREE_PROVIDERS, FREE_TIER_PROVIDERS } from "@/shared/constants/providers.js";
+import { isOverLimit, recordRequest, retryAfterMs } from "./rpmLimiter.js";
 import * as log from "../utils/logger.js";
 
 // Mutex to prevent race conditions during account selection
@@ -89,10 +90,17 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       return null;
     }
 
-    // Filter out model-locked and excluded connections
+    const settings = await getSettings();
+    // Per-account requests-per-minute cap. Skipping an account that has used
+    // its budget keeps us inside the provider's limit instead of collecting a
+    // 429 and parking the account on a cooldown.
+    const rpmLimit = resolveProviderRpm(settings, providerId);
+
+    // Filter out model-locked, excluded and rate-capped connections
     const availableConnections = connections.filter(c => {
       if (excludeSet.has(c.id)) return false;
       if (isModelLockActive(c, model)) return false;
+      if (isOverLimit(c.id, rpmLimit)) return false;
       return true;
     });
 
@@ -122,11 +130,25 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
           lastErrorCode: earliestConn?.errorCode || null
         };
       }
+      const capped = connections
+        .map(c => retryAfterMs(c.id, rpmLimit))
+        .filter(ms => ms !== null && ms !== undefined);
+      if (capped.length === connections.length && capped.length > 0) {
+        const waitMs = Math.min(...capped);
+        const until = new Date(Date.now() + waitMs).toISOString();
+        log.warn("AUTH", `${provider} | all ${connections.length} accounts at the ${rpmLimit} RPM cap (${Math.ceil(waitMs / 1000)}s)`);
+        return {
+          allRateLimited: true,
+          retryAfter: until,
+          retryAfterHuman: formatRetryAfter(until),
+          lastError: `Local ${rpmLimit} RPM cap reached for every ${provider} account`,
+          lastErrorCode: null
+        };
+      }
       log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`);
       return null;
     }
 
-    const settings = await getSettings();
     // Per-provider strategy overrides global setting
     const providerOverride = (settings.providerStrategies || {})[providerId] || {};
     const strategy = providerOverride.fallbackStrategy || settings.fallbackStrategy || "fill-first";
@@ -183,6 +205,10 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
     } else {
       // Default: fill-first (already sorted by priority in getProviderConnections)
       connection = availableConnections[0];
+    }
+
+    if (rpmLimit > 0) {
+      recordRequest(connection.id);
     }
 
     const resolvedProxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,8 +1,8 @@
 import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, parseProviderResetMs, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
-import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
+import { resolveProviderId, FREE_PROVIDERS, FREE_TIER_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
 
 // Mutex to prevent race conditions during account selection
@@ -16,6 +16,19 @@ function githubMonthlyResetMs(status, errorText, provider) {
   const now = new Date();
   return Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
 }
+// Community/free tiers (NVIDIA NIM, opencode-free, …) rate-limit on a short,
+// roughly per-minute window. The generic exponential backoff can bench a 429'd
+// account for up to 5 min — and with only a handful of free accounts that locks
+// the entire pool at once, so the gateway runs out of accounts and returns a 500.
+// Cap the STATIC fallback cooldown for these providers to one recovery window so
+// accounts come back quickly and keep rotating. Only the static backoff is
+// capped: a provider that reports an explicit reset (resetsAtMs / Retry-After /
+// retryDelay / X-RateLimit-Reset) still takes precedence and is never shortened.
+const FREE_TIER_STATIC_COOLDOWN_CAP_MS = 60 * 1000;
+const SHORT_COOLDOWN_PROVIDERS = new Set([
+  ...Object.keys(FREE_PROVIDERS),
+  ...Object.keys(FREE_TIER_PROVIDERS),
+]);
 
 /**
  * Get provider credentials from localDb
@@ -224,6 +237,23 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
 
   // GitHub premium-request exhaustion is account-wide until the next UTC month.
   const githubResetAtMs = githubMonthlyResetMs(status, errorText, provider);
+  const providerKey = resolveProviderId(provider);
+
+  // Per-provider retry-delay fallback (dashboard: Providers → Retry delay).
+  // "auto"/unset keeps the built-in behavior; a numeric value (seconds) is used
+  // as the lock duration ONLY when the provider itself reports no reset window.
+  // A provider-reported reset is always honored and never shortened by this.
+  let fallbackOverrideMs = null;
+  try {
+    const settings = await getSettings();
+    const sel = settings?.retryDelayByProvider?.[providerKey];
+    if (sel != null && sel !== "auto") {
+      const secs = Number(sel);
+      if (Number.isFinite(secs) && secs > 0) {
+        fallbackOverrideMs = Math.min(secs * 1000, MAX_RATE_LIMIT_COOLDOWN_MS);
+      }
+    }
+  } catch { /* settings unavailable → fall through to auto behavior */ }
 
   // Provider-specific precise cooldown (e.g. codex usage_limit_reached resets_at) overrides backoff
   let shouldFallback, cooldownMs, newBackoffLevel;
@@ -237,6 +267,21 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     newBackoffLevel = 0;
   } else {
     ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));
+    // Only reshape the STATIC backoff — when the provider reported no reset of its own.
+    if (shouldFallback && parseProviderResetMs(errorText) == null) {
+      if (fallbackOverrideMs != null) {
+        // User pinned a fixed retry delay for this provider.
+        cooldownMs = fallbackOverrideMs;
+        newBackoffLevel = 0;
+      } else if (
+        // Default for free/free-tier pools: cap the static backoff so the small
+        // account set recovers within its real per-minute window and keeps rotating.
+        cooldownMs > FREE_TIER_STATIC_COOLDOWN_CAP_MS &&
+        SHORT_COOLDOWN_PROVIDERS.has(providerKey)
+      ) {
+        cooldownMs = FREE_TIER_STATIC_COOLDOWN_CAP_MS;
+      }
+    }
   }
   if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
 

--- a/src/sse/services/rpmLimiter.js
+++ b/src/sse/services/rpmLimiter.js
@@ -1,0 +1,64 @@
+// Per-account requests-per-minute cap.
+//
+// Providers like NVIDIA NIM enforce a per-key RPM limit and answer 429 once it
+// is crossed, which then parks the whole account on a cooldown. Counting our
+// own requests and skipping to the next account before the limit is reached
+// keeps the pool inside the provider's budget instead of learning about it
+// from an error.
+//
+// ponytail: in-process counters, so each 9router instance gets its own budget.
+// Move to the DB/Redis if this ever runs multi-instance behind a load balancer.
+
+const WINDOW_MS = 60_000;
+
+/** connectionId -> array of request timestamps inside the current window */
+const hits = new Map();
+
+function prune(connectionId, now) {
+  const list = hits.get(connectionId);
+  if (!list) return [];
+  const cutoff = now - WINDOW_MS;
+  // Timestamps are appended in order, so drop from the front.
+  let i = 0;
+  while (i < list.length && list[i] <= cutoff) i += 1;
+  const kept = i === 0 ? list : list.slice(i);
+  if (kept.length) hits.set(connectionId, kept);
+  else hits.delete(connectionId);
+  return kept;
+}
+
+/** Requests made by this account in the last minute. */
+export function usage(connectionId, now = Date.now()) {
+  return prune(connectionId, now).length;
+}
+
+/** True when the account has already used its whole minute budget. */
+export function isOverLimit(connectionId, limit, now = Date.now()) {
+  if (!limit || limit <= 0) return false; // 0 / unset == unlimited
+  return usage(connectionId, now) >= limit;
+}
+
+/** Count one request against the account. Call when an account is handed out. */
+export function recordRequest(connectionId, now = Date.now()) {
+  if (!connectionId) return;
+  const list = prune(connectionId, now);
+  list.push(now);
+  hits.set(connectionId, list);
+}
+
+/**
+ * When the oldest request in the window ages out, i.e. when this account gets
+ * capacity back. Null when it is not currently at the limit.
+ */
+export function retryAfterMs(connectionId, limit, now = Date.now()) {
+  if (!isOverLimit(connectionId, limit, now)) return null;
+  const list = hits.get(connectionId) || [];
+  const oldest = list[0];
+  if (!oldest) return null;
+  return Math.max(0, oldest + WINDOW_MS - now);
+}
+
+/** Test seam. */
+export function _reset() {
+  hits.clear();
+}

--- a/tests/unit/rpmLimiter.test.js
+++ b/tests/unit/rpmLimiter.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { isOverLimit, recordRequest, retryAfterMs, usage, _reset } from "@/sse/services/rpmLimiter.js";
+
+describe("rpmLimiter", () => {
+  beforeEach(() => _reset());
+
+  it("treats 0 / unset as unlimited", () => {
+    const t = 1_000_000;
+    for (let i = 0; i < 100; i += 1) recordRequest("a", t);
+    expect(isOverLimit("a", 0, t)).toBe(false);
+    expect(isOverLimit("a", undefined, t)).toBe(false);
+  });
+
+  it("caps at the limit and frees up as the window slides", () => {
+    const t = 1_000_000;
+    for (let i = 0; i < 40; i += 1) recordRequest("a", t + i); // 40 within the minute
+    expect(usage("a", t + 40)).toBe(40);
+    expect(isOverLimit("a", 40, t + 40)).toBe(true);
+
+    // still capped just before the oldest request ages out
+    expect(isOverLimit("a", 40, t + 59_999)).toBe(true);
+    // oldest has aged out -> capacity again
+    expect(isOverLimit("a", 40, t + 60_001)).toBe(false);
+  });
+
+  it("counts each account separately", () => {
+    const t = 1_000_000;
+    for (let i = 0; i < 40; i += 1) recordRequest("a", t);
+    expect(isOverLimit("a", 40, t)).toBe(true);
+    expect(isOverLimit("b", 40, t)).toBe(false);
+  });
+
+  it("reports when capacity returns", () => {
+    const t = 1_000_000;
+    for (let i = 0; i < 40; i += 1) recordRequest("a", t);
+    expect(retryAfterMs("a", 40, t + 10_000)).toBe(50_000);
+    expect(retryAfterMs("b", 40, t + 10_000)).toBeNull();
+  });
+});


### PR DESCRIPTION
> Stacked on #2895 (which is stacked on #2879). The diff below is only the last commit; it collapses to 6 files once those merge.

## Problem

NVIDIA NIM enforces a per-API-key requests-per-minute limit. Crossing it returns 429, which parks that account on a cooldown — so a short burst can take the whole pool out for minutes even though every account is healthy. The limit is known up front, but nothing counts against it, so it is always discovered by tripping it.

## Change

Count our own requests per account and skip an account that has already spent its minute budget, so the request goes to the next account instead of earning a 429.

- `src/sse/services/rpmLimiter.js` — sliding 60s window per connection id: `recordRequest`, `isOverLimit`, `retryAfterMs`.
- `getAuth` filters out capped accounts alongside model-locked/excluded ones, and records a request against whichever account it hands out.
- When *every* account for a provider is capped, it returns the usual `allRateLimited` shape with the time capacity comes back, rather than failing hard.
- Editable per provider from **Providers → [id]** (`RPM / account`, beside Retry delay), stored in `settings.rpmByProvider`. Blank = `DEFAULT_PROVIDER_RPM` (**40** for `nvidia`, unset elsewhere), `0` = unlimited.

Counters are in-process. That is the right scope for a single gateway; a multi-instance deployment behind a load balancer would need shared state, and there is a `ponytail:` note in the file saying so.

## Verification

Unit test in `tests/unit/rpmLimiter.test.js` covers unlimited-when-0, capping at the limit, the window sliding open again, per-account isolation, and `retryAfterMs`.

End to end against a live instance with 7 NVIDIA accounts, cap temporarily set to 1:

```
req 1..6 -> 200 ok                     (one account each)
req 7    -> 503 Local 1 RPM cap reached for every nvidia account (reset after 30s)
req 8,9  -> 503 (same)
```

Log line: `[AUTH] nvidia | all 7 accounts at the 1 RPM cap (30s)`. No 429 was sent upstream. After the window elapsed, requests succeeded again, and with the override removed the default of 40 applies.
