### PR TITLE
feat(dashboard): show effective Codex plan badges

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 import { Badge, Toggle, Tooltip } from "@/shared/components";
 import CooldownTimer from "./CooldownTimer";
 
-export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null, autoPing = null }) {
+export default function ConnectionRow({ connection, plan = null, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null, autoPing = null }) {
   const [showProxyDropdown, setShowProxyDropdown] = useState(false);
   const [updatingProxy, setUpdatingProxy] = useState(false);
   const proxyDropdownRef = useRef(null);
@@ -83,6 +83,13 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
     : connection.name?.trim() && connection.displayName?.trim() && connection.name.trim() !== connection.displayName.trim()
       ? connection.displayName.trim()
       : null;
+  const liveCodexPlan = plan?.trim();
+  const storedCodexPlan = connection.providerSpecificData?.chatgptPlanType?.trim();
+  const codexPlan = connection.provider === "codex"
+    ? liveCodexPlan && liveCodexPlan.toLowerCase() !== "unknown"
+      ? liveCodexPlan
+      : storedCodexPlan
+    : null;
 
   // Use useState + useEffect for impure Date.now() to avoid calling during render
   const [isCooldown, setIsCooldown] = useState(false);
@@ -170,6 +177,11 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
             <Badge variant="default" size="sm">
               {authLabel}
             </Badge>
+            {codexPlan && codexPlan.toLowerCase() !== "unknown" && (
+              <Badge variant="primary" size="sm">
+                {codexPlan}
+              </Badge>
+            )}
             {hasAnyProxy && (
               <Badge variant={proxyBadgeVariant} size="sm">
                 Proxy
@@ -290,6 +302,7 @@ ConnectionRow.propTypes = {
     priority: PropTypes.number,
     globalPriority: PropTypes.number,
   }).isRequired,
+  plan: PropTypes.string,
   proxyPools: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string,
     name: PropTypes.string,

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -40,6 +40,7 @@ export default function ProviderDetailPage() {
   const providerId = params.id;
   const { getCaps } = useModelCaps();
   const [connections, setConnections] = useState([]);
+  const [codexPlans, setCodexPlans] = useState({});
   const [loading, setLoading] = useState(true);
   const [providerNode, setProviderNode] = useState(null);
   const [proxyPools, setProxyPools] = useState([]);
@@ -304,6 +305,22 @@ export default function ProviderDetailPage() {
       const settingsData = settingsRes.ok ? await settingsRes.json() : {};
       if (connectionsRes.ok) {
         const filtered = (connectionsData.connections || []).filter(c => c.provider === providerId);
+
+        if (providerId === "codex") {
+          const plans = await Promise.all(filtered.map(async (connection) => {
+            try {
+              const usageRes = await fetch(`/api/usage/${connection.id}`);
+              const usage = usageRes.ok ? await usageRes.json() : null;
+              const plan = usage?.plan?.trim();
+              return plan && plan.toLowerCase() !== "unknown" ? [connection.id, plan] : null;
+            } catch {
+              return null;
+            }
+          }));
+          setCodexPlans(Object.fromEntries(plans.filter(Boolean)));
+        } else {
+          setCodexPlans({});
+        }
         setConnections(filtered);
       }
       if (proxyPoolsRes.ok) {
@@ -956,6 +973,7 @@ export default function ProviderDetailPage() {
             <div className="flex-1 min-w-0">
               <ConnectionRow
                 connection={conn}
+                plan={codexPlans[conn.id]}
                 proxyPools={proxyPools}
                 isOAuth={isOAuth}
                 isFirst={index === 0}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -12,6 +12,7 @@ import {
   getHiddenQuotaRows,
   getQuotaVisibilityKey,
   getConnectionLabel,
+  getCodexPlan,
   getConnectionQuotaRemaining,
   sortVisibleConnections,
   buildLoadingState,
@@ -1029,6 +1030,7 @@ export default function ProviderLimits() {
           // Use table layout for all providers
           const isInactive = conn.isActive === false;
           const isCodex = conn.provider === "codex";
+          const codexPlan = isCodex ? getCodexPlan(quota, conn) : null;
           const resetCreditCount = getCodexResetCreditCount(quota);
           const isResettingLimit = resettingLimitId === conn.id;
           const rowBusy = deletingId === conn.id || togglingId === conn.id || isResettingLimit;
@@ -1069,6 +1071,11 @@ export default function ProviderLimits() {
                         <p className="text-[11px] text-text-muted/80 truncate">
                           {getConnectionSecondaryLabel(conn)}
                         </p>
+                      ) : null}
+                      {codexPlan ? (
+                        <span className="mt-1 inline-flex rounded-full bg-brand-500/10 px-2 py-0.5 text-[10px] font-semibold text-brand-600 dark:text-brand-300">
+                          {codexPlan}
+                        </span>
                       ) : null}
                       {conn.provider === "kiro" && (
                         <div className="mt-1 flex flex-wrap items-center gap-1">

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -12,6 +12,7 @@ import {
   getHiddenQuotaRows,
   getQuotaVisibilityKey,
   getConnectionLabel,
+  getCodexPlan,
   getConnectionQuotaRemaining,
   sortVisibleConnections,
   buildLoadingState,
@@ -1028,6 +1029,7 @@ export default function ProviderLimits() {
           // Use table layout for all providers
           const isInactive = conn.isActive === false;
           const isCodex = conn.provider === "codex";
+          const codexPlan = isCodex ? getCodexPlan(quota, conn) : null;
           const resetCreditCount = getCodexResetCreditCount(quota);
           const isResettingLimit = resettingLimitId === conn.id;
           const rowBusy = deletingId === conn.id || togglingId === conn.id || isResettingLimit;
@@ -1068,6 +1070,11 @@ export default function ProviderLimits() {
                         <p className="text-[11px] text-text-muted/80 truncate">
                           {getConnectionSecondaryLabel(conn)}
                         </p>
+                      ) : null}
+                      {codexPlan ? (
+                        <span className="mt-1 inline-flex rounded-full bg-brand-500/10 px-2 py-0.5 text-[10px] font-semibold text-brand-600 dark:text-brand-300">
+                          {codexPlan}
+                        </span>
                       ) : null}
                       {conn.provider === "kiro" && (
                         <div className="mt-1 flex flex-wrap items-center gap-1">

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -29,6 +29,14 @@ export function getConnectionLabel(connection) {
     || null;
 }
 
+export function getCodexPlan(quota, connection) {
+  const livePlan = quota?.plan?.trim();
+  if (livePlan && livePlan.toLowerCase() !== "unknown") return livePlan;
+
+  const storedPlan = connection?.providerSpecificData?.chatgptPlanType?.trim();
+  return storedPlan || null;
+}
+
 export function getConnectionQuotaRemaining(connection, quotaData) {
   const quota = quotaData[connection.id]?.quotas?.[0];
   if (!quota) return Number.POSITIVE_INFINITY;

--- a/tests/unit/provider-quota-visibility.test.js
+++ b/tests/unit/provider-quota-visibility.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   filterQuotasByVisibility,
+  getCodexPlan,
   getHiddenQuotaRows,
   parseQuotaData,
 } from "@/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
@@ -51,5 +52,19 @@ describe("provider quota visibility", () => {
       codex: { hidden: ["gemini-pro-agent"] },
     };
     expect(filterQuotasByVisibility("antigravity", quotas, visibility)).toHaveLength(2);
+  });
+
+  it("prefers live Codex plan over stored connection plan", () => {
+    expect(getCodexPlan(
+      { plan: "ChatGPT Pro" },
+      { providerSpecificData: { chatgptPlanType: "Plus" } },
+    )).toBe("ChatGPT Pro");
+  });
+
+  it("uses stored Codex plan when live plan is unavailable", () => {
+    const connection = { providerSpecificData: { chatgptPlanType: "Plus" } };
+    expect(getCodexPlan({ plan: "unknown" }, connection)).toBe("Plus");
+    expect(getCodexPlan({}, connection)).toBe("Plus");
+    expect(getCodexPlan({}, {})).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds compact plan badges to Codex connections and quota cards.

## Behavior

- Quota tracker prefers live quota API `plan`.
- Connections fetch live Codex usage plans and use stored OAuth metadata only as fallback.
- Empty and `unknown` plans stay hidden.

Closes #3209.

## Screenshots

### Connections

<img width="1496" height="548" alt="Codex Connections plan badges" src="https://github.com/user-attachments/assets/1938a98d-1692-43c5-8ad9-315b3cf8edc9" />

### Quota tracker

<img width="1527" height="691" alt="Codex quota tracker plan badges" src="https://github.com/user-attachments/assets/ecfad3ce-b1bd-4b75-92d9-a8b4fe751170" />

## Verification

- `npx vitest run unit/provider-quota-visibility.test.js`
- `git diff --check`

Lint is blocked by pre-existing `react-hooks/set-state-in-effect` errors in `src/app/(dashboard)/dashboard/providers/[id]/page.js`.
