### PR TITLE
fix(auto-ping): select Codex model from live catalog

### DIFF
--- a/open-sse/providers/registry/codex.js
+++ b/open-sse/providers/registry/codex.js
@@ -40,6 +40,8 @@ export default {
     },
     usage: {
       url: "https://chatgpt.com/backend-api/wham/usage",
+      modelsUrl: "https://chatgpt.com/backend-api/codex/models",
+      clientVersion: "0.136.0",
       resetCreditsUrl: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
       resetCreditsConsumeUrl: "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
     },

--- a/open-sse/services/usage/codex.js
+++ b/open-sse/services/usage/codex.js
@@ -8,6 +8,8 @@ import { U, parseResetTime, toFiniteNumber } from "./shared.js";
 // Codex (OpenAI) API config
 const CODEX_CONFIG = {
   usageUrl: U("codex").url,
+  modelsUrl: U("codex").modelsUrl,
+  clientVersion: U("codex").clientVersion,
   resetCreditsUrl: U("codex").resetCreditsUrl,
   resetCreditsConsumeUrl: U("codex").resetCreditsConsumeUrl,
 };
@@ -113,6 +115,28 @@ export async function getCodexUsage(accessToken, proxyOptions = null) {
   } catch (error) {
     throw new Error(`Failed to fetch Codex usage: ${error.message}`);
   }
+}
+
+export async function getCodexModels(accessToken, proxyOptions = null, providerSpecificData = null) {
+  if (!CODEX_CONFIG.modelsUrl) return [];
+
+  const url = new URL(CODEX_CONFIG.modelsUrl);
+  if (CODEX_CONFIG.clientVersion) url.searchParams.set("client_version", CODEX_CONFIG.clientVersion);
+  const headers = {
+    "Authorization": `Bearer ${accessToken}`,
+    "Accept": "application/json",
+  };
+  const accountId = getCodexAccountId(providerSpecificData);
+  if (accountId) headers["ChatGPT-Account-ID"] = accountId;
+
+  const response = await proxyAwareFetch(url, { method: "GET", headers }, proxyOptions);
+  if (!response.ok) return [];
+
+  const data = await response.json();
+  const models = Array.isArray(data?.models) ? data.models : [];
+  return models
+    .filter((model) => model?.supported_in_api !== false && typeof model?.slug === "string" && model.slug)
+    .sort((a, b) => Number(a.priority || 0) - Number(b.priority || 0));
 }
 
 export async function getCodexRateLimitResetCredits(accessToken, proxyOptions = null, providerSpecificData = null) {

--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -24,7 +24,7 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
         ? `Legacy: ${connection.providerSpecificData?.connectionProxyUrl}`
         : "";
   const autoPingTooltip = autoPing?.provider === "codex"
-    ? "Auto-starts the next 5h Codex window after reset by sending a tiny gpt-5.5 request. Consumes a small amount of quota."
+    ? "Auto-starts the next 5h Codex window after reset by sending a tiny request to an available model. Consumes a small amount of quota."
     : "When your 5h quota runs out, auto-sends a request the moment it resets so a new window starts right away.";
 
   let maskedProxyUrl = "";

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -62,7 +62,7 @@ const AUTO_PING_SETTINGS_KEYS = {
 
 const AUTO_PING_TOOLTIPS = {
   claude: "When your 5h quota runs out, auto-sends a request the moment it resets so a new window starts right away.",
-  codex: "Auto-starts the next 5h Codex window after reset by sending a tiny gpt-5.5 request. Consumes a small amount of quota.",
+  codex: "Auto-starts the next 5h Codex window after reset by sending a tiny request to an available model. Consumes a small amount of quota.",
 };
 
 function kiroMethodLabel(conn) {

--- a/src/shared/constants/config.js
+++ b/src/shared/constants/config.js
@@ -83,8 +83,6 @@ export const QUOTA_AUTOPING_CONFIG = {
       resetAtDriftMs: 30000,
       minPingIntervalMs: 600000,
       skipWhenBlockingQuotaExhausted: true,
-      // Free and Plus Codex accounts both expose gpt-5.5; avoid fallback probes that waste requests.
-      pingModel: "gpt-5.5",
       pingText: "hi",
       pingInstructions: "Reply with OK.",
       pingReasoningEffort: "none",

--- a/src/shared/services/quotaAutoPing.js
+++ b/src/shared/services/quotaAutoPing.js
@@ -3,7 +3,7 @@ import "open-sse/index.js";
 
 import { getSettings, getProviderConnections, updateProviderConnection } from "@/lib/localDb";
 import { getClaudeUsage } from "open-sse/services/usage/claude.js";
-import { getCodexUsage } from "open-sse/services/usage/codex.js";
+import { getCodexUsage, getCodexModels } from "open-sse/services/usage/codex.js";
 import { getExecutor } from "open-sse/executors/index.js";
 import { CLAUDE_CLI_SPOOF_HEADERS } from "open-sse/providers/shared.js";
 import { proxyAwareFetch } from "open-sse/utils/proxyFetch.js";
@@ -21,6 +21,7 @@ const providerHandlers = {
   },
   codex: {
     getUsage: getCodexUsage,
+    getModels: getCodexModels,
     sendPing: sendCodexPing,
   },
 };
@@ -147,10 +148,10 @@ async function drainResponseBody(response) {
   }
 }
 
-async function sendCodexPing(connection, providerConfig, proxyOptions, deps) {
+async function sendCodexPing(connection, providerConfig, model, proxyOptions, deps) {
   const executor = deps.getExecutor("codex");
   const { response } = await executor.execute({
-    model: providerConfig.pingModel,
+    model,
     stream: true,
     credentials: {
       accessToken: connection.accessToken,
@@ -160,7 +161,7 @@ async function sendCodexPing(connection, providerConfig, proxyOptions, deps) {
     proxyOptions,
     log: console,
     body: {
-      model: providerConfig.pingModel,
+      model,
       input: buildCodexPingInput(providerConfig.pingText),
       instructions: providerConfig.pingInstructions,
       reasoning: providerConfig.pingReasoningEffort
@@ -228,7 +229,18 @@ async function pingConnection(conn, provider, providerConfig, handler, deps, sta
   if (wasPingedRecently(connection, providerConfig.minPingIntervalMs, now)) return;
   if (lastPingedResetKey === resetKey) return;
 
-  const ok = await handler.sendPing(connection, providerConfig, proxyOptions, deps);
+  const model = provider === "codex"
+    ? (await handler.getModels(connection.accessToken, proxyOptions, connection.providerSpecificData))[0]?.slug
+    : providerConfig.pingModel;
+  if (!model) {
+    state.failureCache[key] = Date.now();
+    console.warn(`[AutoPing] ${provider}:${connection.id}: no supported model available`);
+    return;
+  }
+
+  const ok = provider === "codex"
+    ? await handler.sendPing(connection, providerConfig, model, proxyOptions, deps)
+    : await handler.sendPing(connection, providerConfig, proxyOptions, deps);
   if (!ok) {
     // Do not mark reset as pinged unless upstream accepted the tiny request.
     state.failureCache[key] = Date.now();

--- a/tests/unit/codex-models.test.js
+++ b/tests/unit/codex-models.test.js
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+describe("Codex model catalog", () => {
+  let getCodexModels;
+  let proxyAwareFetch;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ getCodexModels } = await import("../../open-sse/services/usage/codex.js"));
+    ({ proxyAwareFetch } = await import("../../open-sse/utils/proxyFetch.js"));
+  });
+
+  it("uses the live account catalog and orders supported models by preference", async () => {
+    proxyAwareFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [
+          { slug: "gpt-low", priority: 10, supported_in_api: true },
+          { slug: "gpt-hidden", priority: 100, supported_in_api: false },
+          { slug: "gpt-high", priority: 1, supported_in_api: true },
+        ],
+      }),
+    });
+
+    await expect(getCodexModels("token", {}, { chatgptAccountId: "acct-1" })).resolves.toEqual([
+      { slug: "gpt-high", priority: 1, supported_in_api: true },
+      { slug: "gpt-low", priority: 10, supported_in_api: true },
+    ]);
+
+    const [url, options] = proxyAwareFetch.mock.calls[0];
+    expect(url.toString()).toBe("https://chatgpt.com/backend-api/codex/models?client_version=0.136.0");
+    expect(options.headers).toMatchObject({
+      Authorization: "Bearer token",
+      "ChatGPT-Account-ID": "acct-1",
+    });
+  });
+
+  it("returns no models when the catalog request fails", async () => {
+    proxyAwareFetch.mockResolvedValue({ ok: false });
+    await expect(getCodexModels("token")).resolves.toEqual([]);
+  });
+});

--- a/tests/unit/quota-auto-ping.test.js
+++ b/tests/unit/quota-auto-ping.test.js
@@ -37,7 +37,6 @@ vi.mock("@/shared/constants/config", () => ({
         resetAtDriftMs: 30000,
         minPingIntervalMs: 600000,
         skipWhenBlockingQuotaExhausted: true,
-        pingModel: "gpt-5.5",
         pingText: "hi",
         pingInstructions: "Reply with OK.",
         pingReasoningEffort: "none",
@@ -64,6 +63,7 @@ vi.mock("open-sse/services/usage/claude.js", () => ({
 
 vi.mock("open-sse/services/usage/codex.js", () => ({
   getCodexUsage: vi.fn(),
+  getCodexModels: vi.fn(),
 }));
 
 vi.mock("open-sse/executors/index.js", () => ({
@@ -76,6 +76,7 @@ describe("quota auto-ping", () => {
   let deps;
   let state;
   let getCodexUsage;
+  let getCodexModels;
   let getClaudeUsage;
   let getExecutor;
   let codexResponseText;
@@ -87,6 +88,7 @@ describe("quota auto-ping", () => {
     delete global.__quotaAutoPing;
 
     ({ getCodexUsage } = await import("open-sse/services/usage/codex.js"));
+    ({ getCodexModels } = await import("open-sse/services/usage/codex.js"));
     ({ getClaudeUsage } = await import("open-sse/services/usage/claude.js"));
     ({ getExecutor } = await import("open-sse/executors/index.js"));
     ({ runQuotaAutoPingTick, configureQuotaAutoPing } = await import("../../src/shared/services/quotaAutoPing.js"));
@@ -106,6 +108,7 @@ describe("quota auto-ping", () => {
     getExecutor.mockReturnValue({
       execute: vi.fn().mockResolvedValue({ response: { ok: true, text: codexResponseText } }),
     });
+    getCodexModels.mockResolvedValue([{ slug: "gpt-5.6-terra", priority: 1 }]);
     state = { running: false, resetCache: {}, failureCache: {} };
     vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
   });
@@ -278,7 +281,7 @@ describe("quota auto-ping", () => {
     expect(deps.updateProviderConnection).not.toHaveBeenCalled();
   });
 
-  it("sends one tiny gpt-5.5 Codex request through the executor", async () => {
+  it("uses the account's preferred supported Codex model", async () => {
     deps.getSettings.mockResolvedValue({ codexAutoPing: { connections: { "codex-1": true } } });
     deps.getProviderConnections.mockImplementation(async ({ provider }) => (
       provider === "codex"
@@ -289,13 +292,21 @@ describe("quota auto-ping", () => {
     getCodexUsage.mockResolvedValue({
       quotas: { session: { used: 1, total: 100, remaining: 99, resetAt: "2026-01-01T17:01:00.000Z" } },
     });
+    getCodexModels.mockResolvedValue([
+      { slug: "gpt-5.6-terra", priority: 1 },
+      { slug: "gpt-5.6-luna", priority: 10 },
+    ]);
 
     await runQuotaAutoPingTick(deps, state);
 
     const executor = deps.getExecutor.mock.results[0].value;
     expect(deps.getExecutor).toHaveBeenCalledWith("codex");
+    expect(getCodexModels).toHaveBeenCalledWith("token", expect.objectContaining({
+      connectionProxyEnabled: false,
+      strictProxy: false,
+    }), { workspaceId: "ws-1" });
     expect(executor.execute).toHaveBeenCalledWith(expect.objectContaining({
-      model: "gpt-5.5",
+      model: "gpt-5.6-terra",
       stream: true,
       credentials: expect.objectContaining({
         accessToken: "token",
@@ -303,7 +314,7 @@ describe("quota auto-ping", () => {
         providerSpecificData: { workspaceId: "ws-1" },
       }),
       body: {
-        model: "gpt-5.5",
+        model: "gpt-5.6-terra",
         input: [{
           type: "message",
           role: "user",
@@ -320,6 +331,23 @@ describe("quota auto-ping", () => {
       lastPingedResetAt: "2026-01-01T17:01:00.000Z",
       lastPingedResetKey: "2026-01-01T17:01:00.000Z",
     }));
+  });
+
+  it("does not ping Codex when the live model catalog is empty", async () => {
+    deps.getSettings.mockResolvedValue({ codexAutoPing: { connections: { "codex-1": true } } });
+    deps.getProviderConnections.mockImplementation(async ({ provider }) => (
+      provider === "codex" ? [{ id: "codex-1", provider: "codex", authType: "oauth", accessToken: "token" }] : []
+    ));
+    state.resetCache["codex:codex-1"] = "2026-01-01T17:00:00.000Z";
+    getCodexUsage.mockResolvedValue({
+      quotas: { session: { used: 1, total: 100, remaining: 99, resetAt: "2026-01-01T17:01:00.000Z" } },
+    });
+    getCodexModels.mockResolvedValue([]);
+
+    await runQuotaAutoPingTick(deps, state);
+
+    expect(deps.getExecutor).not.toHaveBeenCalled();
+    expect(deps.updateProviderConnection).not.toHaveBeenCalled();
   });
 
   it("does not ping same Codex reset twice when seconds drift", async () => {


### PR DESCRIPTION
## Summary

Makes Codex auto-ping choose a model dynamically from each account's live Codex catalog instead of sending a fixed `gpt-5.5` request.

Closes #3212.

## Behavior

- Calls the authenticated Codex `models` catalog with the connection's account binding.
- Filters models not supported in the API.
- Uses the catalog's preferred model for the tiny request that starts the next 5-hour window.
- Skips the ping when no supported model is returned.
- Removes fixed-model wording from Codex auto-ping tooltips.

## Verification

- `npx vitest run unit/quota-auto-ping.test.js unit/codex-models.test.js`
- `git diff --check`

Lint has no errors. Existing React hook dependency warnings remain in the two touched UI files.
