### PR TITLE
fix(antigravity): harden Gemini streaming and 3.6 handling

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -54,6 +54,36 @@ const stripBlacklisted = obj => {
   for (const key of ANTIGRAVITY_REQUEST_BLACKLIST) delete obj[key];
 };
 
+function normalizeAntigravityContents(contents) {
+  const normalized = [];
+
+  for (const content of contents || []) {
+    if (
+      !content?.role ||
+      !Array.isArray(content.parts) ||
+      content.parts.length === 0
+    ) {
+      continue;
+    }
+
+    const previous = normalized.at(-1);
+
+    // Removing a reasoning-only model message can leave adjacent
+    // messages with the same role. Gemini expects alternating roles,
+    // so merge their parts.
+    if (previous?.role === content.role) {
+      previous.parts.push(...content.parts);
+    } else {
+      normalized.push({
+        ...content,
+        parts: [...content.parts],
+      });
+    }
+  }
+
+  return normalized;
+}
+
 // Image generation model name patterns
 const IMAGE_MODEL_PATTERNS = [
   /image/i,
@@ -189,7 +219,7 @@ export class AntigravityExecutor extends BaseExecutor {
 
     // ─── Standard (non-image) request ───
     // Fix contents for Claude models via Antigravity
-    const contents = body.request?.contents?.map(c => {
+    const rawContents = body.request?.contents?.map(c => {
       let role = c.role;
       // functionResponse must be role "user" for Claude models
       if (c.parts?.some(p => p.functionResponse)) {
@@ -217,6 +247,9 @@ export class AntigravityExecutor extends BaseExecutor {
       }
       return c;
     });
+
+    const contents =
+      normalizeAntigravityContents(rawContents);
 
     // Sanitize tool schemas and function names before sending to Antigravity.
     let tools = body.request?.tools;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -58,7 +58,7 @@ export function stripContinuityFields(body) {
   return body;
 }
 
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, onUpstreamEmptyExhausted, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, onUpstreamEmptyExhausted, onAccountRotate, chatCoreCtx, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -280,6 +280,17 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   trackPendingRequest(model, provider, connectionId, true);
   appendRequestLog({ model, provider, connectionId, status: "PENDING" }).catch(() => { });
 
+  // Expose post-translation body + active signal to the caller so a server-
+  // side account rotation hook can re-issue the same logical request with
+  // rotated credentials without re-running translation. Translation is
+  // provider/credentials-aware (projectId, session id), but the rotated
+  // executor's `transformRequest` re-reads credentials at execute-time, so
+  // reusing the body is safe across rotations.
+  if (chatCoreCtx) {
+    chatCoreCtx.translatedBody = translatedBody;
+    chatCoreCtx.streamControllerSignal = streamController.signal;
+  }
+
   const msgCount = translatedBody.messages?.length || translatedBody.input?.length || translatedBody.contents?.length || translatedBody.request?.contents?.length || 0;
   log?.debug?.("REQUEST", `${provider.toUpperCase()} | ${model} | ${msgCount} msgs`);
 
@@ -433,7 +444,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   // lets the caller bench the account so the client's retry rotates to the next
   // one (#2188, #2229, #2250, #2259, #2431).
   if (provider === "antigravity" && stream && providerResponse.body) {
-    const reexecute = async () => {
+    let reexecute = async () => {
       const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
       if (!retryResult.response.ok) {
         const { statusCode, message } = await parseUpstreamError(retryResult.response, executor);
@@ -458,6 +469,20 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
             resetMs ? Date.now() + resetMs : undefined
           );
         },
+        // Server-side account recovery. Returns null when no more accounts are
+        // eligible, in which case the exhaustion event surfaces to the client.
+        // Returns { reexecute } with a NEW re-execution factory bound to the
+        // next account's credentials/proxy/projectId; the empty-stream guard
+        // splices it into the same client stream transparently.
+        onAccountRotate: onAccountRotate ? async (reason, meta) => {
+          try {
+            const next = await onAccountRotate({ reason, upstreamError: meta?.upstreamError || null, translatedBody, model, stream, proxyOptions });
+            return next || null;
+          } catch (error) {
+            log?.warn?.("STREAM", `ANTIGRAVITY | onAccountRotate threw: ${error?.message || error}`);
+            return null;
+          }
+        } : undefined,
       }),
       { status: providerResponse.status, headers: providerResponse.headers }
     );

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -18,6 +18,7 @@ import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDeta
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
+import { createEmptyRetryStream } from "./chatCore/emptyStreamGuard.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
 import { dedupeTools } from "../utils/toolDeduper.js";
 import { injectCaveman } from "../rtk/caveman.js";
@@ -57,7 +58,7 @@ export function stripContinuityFields(body) {
   return body;
 }
 
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, onUpstreamEmptyExhausted, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -422,6 +423,44 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     }
     reqLogger.logError(new Error(message), finalBody || translatedBody);
     return createErrorResult(statusCode, errMsg, resetsAtMs);
+  }
+
+  // Antigravity empty-stream guard — oh-my-pi parity: bytes (thinking included)
+  // stream to the client live; emptiness is judged per upstream attempt and an
+  // empty attempt is retried in-stream with the identical request, spliced into
+  // the same client message (see emptyStreamGuard.js). Exhaustion surfaces as an
+  // in-stream error event (retryable by Claude Code); onUpstreamEmptyExhausted
+  // lets the caller bench the account so the client's retry rotates to the next
+  // one (#2188, #2229, #2250, #2259, #2431).
+  if (provider === "antigravity" && stream && providerResponse.body) {
+    const reexecute = async () => {
+      const retryResult = await executor.execute({ model, body: translatedBody, stream, credentials, signal: streamController.signal, log, proxyOptions });
+      if (!retryResult.response.ok) {
+        const { statusCode, message } = await parseUpstreamError(retryResult.response, executor);
+        throw new Error(`[${statusCode}] ${message}`);
+      }
+      if (!retryResult.response.body) throw new Error("upstream returned no body");
+      return retryResult.response.body;
+    };
+    providerResponse = new Response(
+      createEmptyRetryStream({
+        body: providerResponse.body,
+        reexecute,
+        signal: streamController.signal,
+        log,
+        onExhausted: (reason, { upstreamError } = {}) => {
+          if (!onUpstreamEmptyExhausted) return;
+          // Quota-style exhaustion carries the reset time only inside the error
+          // message ("Your quota will reset after 2h7m23s") — bench precisely.
+          const resetMs = executor.parseRetryFromErrorMessage?.(upstreamError?.message || reason);
+          return onUpstreamEmptyExhausted(
+            formatProviderError(new Error(reason), provider, model, HTTP_STATUS.BAD_GATEWAY),
+            resetMs ? Date.now() + resetMs : undefined
+          );
+        },
+      }),
+      { status: providerResponse.status, headers: providerResponse.headers }
+    );
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };

--- a/open-sse/handlers/chatCore/emptyStreamGuard.js
+++ b/open-sse/handlers/chatCore/emptyStreamGuard.js
@@ -102,9 +102,16 @@ function classifyEvent(parsed, meaningfulSeen) {
  *   observer for "every attempt came back empty" (e.g. bench the account so
  *   client retries rotate); awaited before the error event is emitted, and
  *   handed the held upstream error object so quota reset times can be parsed
+ * @param {() => Promise<{reexecute: () => Promise<ReadableStream>, signal?: AbortSignal}|null>} [options.onAccountRotate]
+ *   server-side account recovery hook. When every same-account empty retry
+ *   fails, the guard invokes this to obtain a NEW `reexecute` factory bound to
+ *   the next eligible account; attempts then continue transparently. Only safe
+ *   while NO client-actionable output (visible text, tool call, inline data)
+ *   has been emitted yet — the empty-stream guard withholds content until
+ *   meaningful, so this condition holds by construction.
  * @returns {ReadableStream} byte stream for the SSE transform pipeline
  */
-export function createEmptyRetryStream({ body, reexecute, signal, log, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, baseDelayMs = EMPTY_STREAM_BASE_DELAY_MS, onExhausted }) {
+export function createEmptyRetryStream({ body, reexecute, signal, log, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, baseDelayMs = EMPTY_STREAM_BASE_DELAY_MS, onExhausted, onAccountRotate }) {
   const encoder = new TextEncoder();
   let currentReader = null;
   let downstreamGone = false;
@@ -147,7 +154,6 @@ export function createEmptyRetryStream({ body, reexecute, signal, log, stallTime
         emit(line);
         closeStream();
       };
-
       for (let attempt = 0; ; attempt++) {
         const decoder = new TextDecoder();
         let lineBuffer = "";
@@ -232,6 +238,27 @@ export function createEmptyRetryStream({ body, reexecute, signal, log, stallTime
         log?.warn?.("STREAM", `ANTIGRAVITY | empty (${reason}) | attempt ${attempt + 1}/${EMPTY_STREAM_MAX_RETRIES + 1}`);
 
         if (attempt >= EMPTY_STREAM_MAX_RETRIES) {
+          // Server-side account recovery: before surfacing exhaustion to the
+          // client, give the caller a chance to rotate to a different
+          // account and re-issue the request in-stream. Only safe because
+          // meaningfulSeen === false at this point (no visible text, no
+          // tool call, no inline data has crossed the wire).
+          if (onAccountRotate) {
+            try {
+              const next = await onAccountRotate(reason, { upstreamError: lastHeld?.error || null });
+              if (next && typeof next.reexecute === "function") {
+                if (signal?.aborted) return abortStream();
+                reexecute = next.reexecute;
+                log?.warn?.("STREAM", `ANTIGRAVITY | rotating account in-stream after ${attempt + 1} empty attempts`);
+                // Reset attempt counter for the new account and continue.
+                attempt = -1; // loop will increment to 0
+                continue;
+              }
+            } catch (error) {
+              // Rotation failure: fall through to the normal exhaustion path.
+              log?.warn?.("STREAM", `ANTIGRAVITY | account rotation failed: ${error?.message || error}`);
+            }
+          }
           return exhaust(`empty response from upstream (${reason}) after ${attempt + 1} attempts`);
         }
 

--- a/open-sse/handlers/chatCore/emptyStreamGuard.js
+++ b/open-sse/handlers/chatCore/emptyStreamGuard.js
@@ -1,0 +1,259 @@
+// Empty-stream guard for Antigravity — oh-my-pi parity.
+//
+// Gemini occasionally answers HTTP 200 with a stream that carries no usable
+// output (no candidates at all, thought-only parts, a bare STOP with empty
+// text) or aborts the turn (MALFORMED_FUNCTION_CALL) before emitting anything.
+// Delivered as-is the client receives a blank turn and silently halts
+// (#2188, #2229, #2250, #2259, #2431).
+//
+// Mirrors oh-my-pi: every byte — thinking included — streams to the client
+// live; emptiness is judged per upstream attempt, after the fact. An attempt
+// that ends without meaningful content has its terminal event withheld and is
+// retried in place with the identical request; the retried attempt splices
+// into the same client stream (the translator inits its message once, so the
+// splice continues the same client message). Accepted wart, same as oh-my-pi:
+// the client may see thinking from a discarded attempt followed by the retry's
+// thinking inside one message. On exhaustion an {error:{...}} event is emitted
+// in-stream — the gemini translator turns it into the client-facing error
+// finish, which Anthropic clients treat as retryable.
+import { GEMINI_FINISH, GEMINI_ERROR_FINISH_REASONS, GEMINI_CONTENT_FILTER_FINISH_REASONS } from "../../translator/schema/finishReasons.js";
+import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
+
+// Mirrors oh-my-pi's empty-response policy: 2 retries, 500ms * 2^attempt backoff.
+export const EMPTY_STREAM_MAX_RETRIES = 2;
+export const EMPTY_STREAM_BASE_DELAY_MS = 500;
+
+// A part is meaningful when it carries output the client can act on: a tool
+// call, inline data, or non-whitespace visible text. Thought-only parts are
+// not — thinking that never produced an answer IS the empty-response failure
+// (#2229). Thought parts still stream to the client live; they just don't mark
+// the attempt as non-empty.
+export function isMeaningfulPart(part) {
+  if (!part) return false;
+  if (part.functionCall) return true;
+  if (part.inlineData?.data || part.inline_data?.data) return true;
+  if (part.thought === true) return false;
+  return typeof part.text === "string" && part.text.trim().length > 0;
+}
+
+// Decide what to do with one parsed SSE event.
+// - forward: pass the original line through (optionally marking the stream
+//   terminal so the attempt is never retried)
+// - hold: withhold it — it is the terminal of an empty attempt; the message
+//   must stay open so the retried attempt can splice in.
+function classifyEvent(parsed, meaningfulSeen) {
+  // Antigravity wrapper
+  const response = parsed.response || parsed;
+  if (!response || typeof response !== "object") return { action: "forward" };
+
+  const errorObj = response.error || parsed.error;
+  if (errorObj) {
+    // Embedded error object in a 200 stream. After content: forward — the
+    // translator closes the message with the error finish. Before content:
+    // withhold and retry (usually transient, e.g. RESOURCE_EXHAUSTED blips).
+    if (meaningfulSeen) return { action: "forward", terminal: true };
+    return { action: "hold", kind: "error_object", reason: errorObj.status || errorObj.message || "error", error: errorObj };
+  }
+
+  // Prompt blocked by policy: deterministic for this prompt — never retried.
+  // Forward so the translator closes the stream as content_filter (#2188).
+  if (!response.candidates?.length && response.promptFeedback?.blockReason) {
+    return { action: "forward", terminal: true };
+  }
+
+  const candidate = response.candidates?.[0];
+  if (!candidate) return { action: "forward" }; // keep-alive / usage-only
+
+  let meaningful = false;
+  for (const part of candidate.content?.parts || []) {
+    if (isMeaningfulPart(part)) { meaningful = true; break; }
+  }
+
+  const finishReason = candidate.finishReason && String(candidate.finishReason).toUpperCase();
+  if (!finishReason) return { action: "forward", meaningful };
+
+  // Content blocks and token exhaustion are deterministic whatever the content
+  // — retrying re-runs the same outcome (oh-my-pi never retries these either).
+  if (GEMINI_CONTENT_FILTER_FINISH_REASONS.has(finishReason) || finishReason === GEMINI_FINISH.MAX_TOKENS) {
+    return { action: "forward", meaningful, terminal: true };
+  }
+
+  // Any other finish (bare STOP, MALFORMED_FUNCTION_CALL family, unknown) with
+  // content forwards normally — the translator emits the tool_calls upgrade or
+  // the error event. Without content it is the empty attempt's terminal.
+  if (meaningful || meaningfulSeen) return { action: "forward", meaningful, terminal: true };
+  return {
+    action: "hold",
+    kind: GEMINI_ERROR_FINISH_REASONS.has(finishReason) ? "error_finish" : "stop",
+    reason: finishReason,
+  };
+}
+
+/**
+ * Wrap the upstream SSE body so empty attempts are retried in-stream.
+ *
+ * @param {ReadableStream} options.body       attempt 1's body
+ * @param {() => Promise<ReadableStream>} options.reexecute  re-issue the
+ *   identical request; resolves to the new attempt's body, throws on failure
+ * @param {AbortSignal} options.signal        client-disconnect signal
+ * @param {object} options.log
+ * @param {number} options.stallTimeoutMs     per-read stall escape
+ * @param {(reason: string, meta: { upstreamError: object|null }) => void|Promise<void>} options.onExhausted
+ *   observer for "every attempt came back empty" (e.g. bench the account so
+ *   client retries rotate); awaited before the error event is emitted, and
+ *   handed the held upstream error object so quota reset times can be parsed
+ * @returns {ReadableStream} byte stream for the SSE transform pipeline
+ */
+export function createEmptyRetryStream({ body, reexecute, signal, log, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, baseDelayMs = EMPTY_STREAM_BASE_DELAY_MS, onExhausted }) {
+  const encoder = new TextEncoder();
+  let currentReader = null;
+  let downstreamGone = false;
+
+  return new ReadableStream({
+    async start(controller) {
+      currentReader = body.getReader();
+      let meaningfulSeen = false;
+      let lastHeld = null; // last withheld terminal, kept for the exhaustion event
+
+      const emit = (text) => {
+        if (downstreamGone) return;
+        try { controller.enqueue(encoder.encode(text)); } catch { downstreamGone = true; }
+      };
+      const closeStream = () => {
+        if (downstreamGone) return;
+        try { controller.close(); } catch { /* already closed */ }
+      };
+      const abortStream = () => {
+        // cancel() rejects when the stream already errored — swallow the promise too
+        try { currentReader.cancel().catch(() => { }); } catch { /* already closed */ }
+        if (downstreamGone) return;
+        const err = new Error("Request aborted");
+        err.name = "AbortError";
+        try { controller.error(err); } catch { /* already closed */ }
+      };
+      const exhaust = async (reason) => {
+        // Bench-before-emit: the error event triggers the client's automatic
+        // retry, so the observer (account bench) must complete first or the
+        // retry can land on the account that just failed.
+        try {
+          await Promise.resolve(onExhausted?.(reason, { upstreamError: lastHeld?.error || null }));
+        } catch { /* observer must not break the stream */ }
+        // Re-emit the real upstream error when we held one (true status/message,
+        // e.g. RESOURCE_EXHAUSTED); otherwise synthesize an embedded error. The
+        // gemini translator converts either into the client-facing error finish.
+        const line = lastHeld?.kind === "error_object"
+          ? lastHeld.line
+          : `data: ${JSON.stringify({ error: { code: 502, status: "EMPTY_RESPONSE", message: reason } })}\n\n`;
+        emit(line);
+        closeStream();
+      };
+
+      for (let attempt = 0; ; attempt++) {
+        const decoder = new TextDecoder();
+        let lineBuffer = "";
+        let held = null; // this attempt's withheld terminal
+        let terminalForwarded = false;
+        let endReason = "empty";
+
+        readAttempt: while (true) {
+          if (signal?.aborted) return abortStream();
+
+          let readResult;
+          let stallTimer;
+          try {
+            // Defensive stall escape: a byte-silent upstream must not hang the pipe.
+            readResult = await Promise.race([
+              currentReader.read(),
+              new Promise((resolve) => { stallTimer = setTimeout(() => resolve({ __stalled: true }), stallTimeoutMs); }),
+            ]);
+          } catch {
+            // A client abort rejects the pending read — never treat it as an
+            // empty attempt or a disconnect turns into a retry/error.
+            if (signal?.aborted) return abortStream();
+            endReason = "read_error";
+            break readAttempt; // truncated attempt
+          } finally {
+            clearTimeout(stallTimer);
+          }
+          if (readResult.__stalled) {
+            try { currentReader.cancel().catch(() => { }); } catch { /* already closed */ }
+            endReason = "stall";
+            break readAttempt;
+          }
+
+          const { done, value } = readResult;
+          if (done) break readAttempt;
+
+          lineBuffer += decoder.decode(value, { stream: true });
+          const lines = lineBuffer.split("\n");
+          lineBuffer = lines.pop(); // trailing partial line
+
+          for (const line of lines) {
+            // Empty-attempt tail: everything after the withheld terminal is
+            // part of the discarded attempt (usage trailers etc.) — drop it.
+            if (held) continue;
+
+            const trimmed = line.trim();
+            if (!trimmed.startsWith("data:")) { emit(line + "\n"); continue; }
+            const payload = trimmed.slice(5).trim();
+            if (!payload || payload === "[DONE]") { emit(line + "\n"); continue; }
+
+            let parsed;
+            try {
+              parsed = JSON.parse(payload);
+            } catch {
+              emit(line + "\n"); // not ours to judge — forward verbatim
+              continue;
+            }
+
+            const decision = classifyEvent(parsed, meaningfulSeen);
+            if (decision.meaningful) meaningfulSeen = true;
+            if (decision.action === "hold") {
+              held = { kind: decision.kind, reason: decision.reason, error: decision.error || null, line: `${line}\n\n` };
+              lastHeld = held;
+              continue;
+            }
+            if (decision.terminal) terminalForwarded = true;
+            emit(line + "\n");
+          }
+        }
+
+        // Attempt over. Content or a forwarded terminal ends the stream here —
+        // a truncated-with-content attempt is closed by the translator's flush
+        // finalization and is never retried (replay-unsafe, as in oh-my-pi).
+        if (meaningfulSeen || terminalForwarded) {
+          const remaining = lineBuffer + decoder.decode();
+          if (!held && remaining) emit(remaining);
+          closeStream();
+          return;
+        }
+
+        const reason = held ? held.reason : endReason;
+        log?.warn?.("STREAM", `ANTIGRAVITY | empty (${reason}) | attempt ${attempt + 1}/${EMPTY_STREAM_MAX_RETRIES + 1}`);
+
+        if (attempt >= EMPTY_STREAM_MAX_RETRIES) {
+          return exhaust(`empty response from upstream (${reason}) after ${attempt + 1} attempts`);
+        }
+
+        // Abort-aware backoff, then splice the retried attempt into this stream.
+        await new Promise((resolve) => {
+          const t = setTimeout(resolve, baseDelayMs * 2 ** attempt);
+          signal?.addEventListener?.("abort", () => { clearTimeout(t); resolve(); }, { once: true });
+        });
+        if (signal?.aborted) return abortStream();
+
+        try {
+          currentReader = (await reexecute()).getReader();
+        } catch (error) {
+          if (error?.name === "AbortError" || signal?.aborted) return abortStream();
+          return exhaust(error?.message || "retry request failed");
+        }
+      }
+    },
+
+    cancel(reason) {
+      downstreamGone = true;
+      try { currentReader?.cancel(reason)?.catch?.(() => { }); } catch { /* already closed */ }
+    },
+  });
+}

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -44,13 +44,21 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
 export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId, pxpipe, reqTag, log }) {
-  if (onRequestSuccess) {
+  // Defer the account-success callback until the stream actually produces
+  // SOMETHING — HTTP 200 with zero bytes / thought-only / empty attempts is
+  // still a failure mode for the client. Clearing the account's error state
+  // before that risks marking a quota-exhausted account healthy again from a
+  // 200-with-no-body response. See #2517 / #2520 (empty-stream guard parity).
+  let requestSuccessFired = false;
+  const fireRequestSuccess = () => {
+    if (requestSuccessFired || !onRequestSuccess) return;
+    requestSuccessFired = true;
     Promise.resolve()
       .then(onRequestSuccess)
       .catch(err => {
         console.error("[ChatCore] onRequestSuccess failed:", err?.message || err);
       });
-  }
+  };
 
   // When upstream returns HTML/text instead of SSE (e.g. Cloudflare 5xx error
   // page), piping it through the SSE transform stream causes Next.js
@@ -81,11 +89,30 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 
   const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey });
 
+  // Tee the stream: fire the deferred success callback the first time a
+  // translated byte actually crosses the wire. A 200 stream that aborts or
+  // empties before emitting anything never reaches this tee and therefore
+  // never clears the account error state.
+  const successTee = new TransformStream({
+    transform(chunk, controller) {
+      fireRequestSuccess();
+      controller.enqueue(chunk);
+    },
+  });
+
   // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
   const onAbortTerminal = isResponsesPassthrough ? buildAbortedResponsesTerminalBytes : null;
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
-  const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
+  // Inject the success tee between the transform stream and the disconnect-aware
+  // wrapper. We do this by wrapping the transform's readable with a tee pipe so
+  // the callback fires on the first byte that survives the transform.
+  const teeWrappedTransform = {
+    ...transformStream,
+    get readable() { return transformStream.readable.pipeThrough(successTee); },
+    get writable() { return transformStream.writable; },
+  };
+  const transformedBody = pipeWithDisconnect(providerResponse, teeWrappedTransform, streamController, onAbortTerminal, stallTimeoutMs);
 
   saveRequestDetail(buildRequestDetail({
     provider, model, connectionId,

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -113,7 +113,7 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
-  const onStreamComplete = (contentObj, usage, ttftAt) => {
+  const onStreamComplete = (contentObj, usage, ttftAt, meta) => {
     const latency = {
       ttft: ttftAt ? ttftAt - requestStartTime : Date.now() - requestStartTime,
       total: Date.now() - requestStartTime
@@ -121,16 +121,32 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     const safeContent = contentObj?.content || "[Empty streaming response]";
     const safeThinking = contentObj?.thinking || null;
 
+    // Truthful status: an exhausted empty stream (no content + embedded error
+    // or "error" finish from the empty-stream guard) is a failed attempt, not a
+    // healthy completion. Mark it "error" so the request-detail panel renders
+    // the real cause instead of a misleading ordinary assistant turn.
+    const isExhausted = meta?.empty && (meta?.upstreamError || meta?.finishReason === "error");
+    const status = isExhausted ? "error" : "success";
+    const reportedContent = isExhausted
+      ? `[Empty streaming response] upstream=${meta?.upstreamError?.status || meta?.finishReason || "EMPTY_RESPONSE"}`
+      : safeContent;
+
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
       latency,
       tokens: usage || { prompt_tokens: 0, completion_tokens: 0 },
       request: extractRequestConfig(body, stream),
       providerRequest: finalBody || translatedBody || null,
-      providerResponse: safeContent,
-      response: { content: safeContent, thinking: safeThinking, type: "streaming" },
+      providerResponse: reportedContent,
+      response: {
+        content: reportedContent,
+        thinking: safeThinking,
+        type: "streaming",
+        finishReason: meta?.finishReason,
+        upstreamError: meta?.upstreamError,
+      },
       pxpipe,
-      status: "success"
+      status
     }, { id: streamDetailId })).catch(err => {
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -205,6 +205,7 @@ export const PATTERN_CAPABILITIES = [
 
   // ── Gemini (all 2.0+ multimodal + google_search grounding, 1M ctx) ─
   { pattern: "*gemini*image*",  caps: { vision: true, imageOutput: true, contextWindow: 1048576 } },
+  { pattern: "*gemini-3.6*",    caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini-3*pro*",  caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65535 } },
   { pattern: "*gemini-3*",      caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-level", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 65536 } },
   { pattern: "*gemini-2.5*",    caps: { vision: true, audioInput: true, videoInput: true, reasoning: true, search: true, thinkingFormat: "gemini-budget", thinkingRange: { min: 0, max: 24576 }, contextWindow: 1048576, maxOutput: 65536 } },

--- a/open-sse/translator/concerns/finishReason.js
+++ b/open-sse/translator/concerns/finishReason.js
@@ -1,6 +1,6 @@
 // Concern #6: finish_reason / stop_reason mapping.
 // One entry per direction; switch by special format, default handles common providers.
-import { OPENAI_FINISH, CLAUDE_STOP, GEMINI_FINISH } from "../schema/finishReasons.js";
+import { OPENAI_FINISH, CLAUDE_STOP, GEMINI_FINISH, GEMINI_ERROR_FINISH_REASONS, GEMINI_CONTENT_FILTER_FINISH_REASONS } from "../schema/finishReasons.js";
 
 // upstream finish/stop reason → OpenAI finish_reason
 export function toOpenAIFinish(reason, format) {
@@ -23,16 +23,20 @@ export function toOpenAIFinish(reason, format) {
         case "error": return OPENAI_FINISH.STOP;
         default: return reason || OPENAI_FINISH.STOP;
       }
-    case "gemini":
-      switch (String(reason).toUpperCase()) {
+    case "gemini": {
+      const geminiReason = String(reason).toUpperCase();
+      // Aborted turns (MALFORMED_FUNCTION_CALL, OTHER, ...) must surface as errors,
+      // not clean stops — a clean stop makes the client treat a broken turn as done.
+      if (GEMINI_ERROR_FINISH_REASONS.has(geminiReason)) return OPENAI_FINISH.ERROR;
+      if (GEMINI_CONTENT_FILTER_FINISH_REASONS.has(geminiReason)) return OPENAI_FINISH.CONTENT_FILTER;
+      switch (geminiReason) {
         case GEMINI_FINISH.STOP: return OPENAI_FINISH.STOP;
         case GEMINI_FINISH.MAX_TOKENS: return OPENAI_FINISH.LENGTH;
-        case GEMINI_FINISH.SAFETY:
-        case GEMINI_FINISH.RECITATION:
-        case GEMINI_FINISH.BLOCKLIST:
-        case GEMINI_FINISH.PROHIBITED_CONTENT: return OPENAI_FINISH.CONTENT_FILTER;
+        // Unknown values stay a clean stop: a future benign Gemini reason must not
+        // start erroring every Gemini-family provider at once.
         default: return OPENAI_FINISH.STOP;
       }
+    }
     case "kiro":
     case "ollama":
       switch (reason) {

--- a/open-sse/translator/concerns/thoughtSignature.js
+++ b/open-sse/translator/concerns/thoughtSignature.js
@@ -1,0 +1,80 @@
+// Gemini thought-signature preservation across the OpenAI-compat bridge.
+//
+// Google Gemini 3 attaches a `thoughtSignature` to the functionCall part it
+// returns. When a structured functionCall is converted to an OpenAI tool_call
+// and replayed by the client, the signature MUST travel with the tool_call or
+// the next turn is rejected with 400 INVALID_ARGUMENT ("function call is
+// missing a thought_signature"). See:
+//   https://ai.google.dev/gemini-api/docs/openai#thought-signatures
+//   https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures
+//
+// OpenAI-compat convention used by the official Gemini OpenAI endpoint:
+//
+//   tool_calls[i].extra_content.google.thought_signature = "<sig>"
+//
+// Rules we honor (per Google's docs):
+//   - Single functionCall     : signature on the functionCall part only.
+//   - Parallel functionCalls  : signature on the FIRST functionCall part only.
+//   - Sequential functionCalls: every step's functionCall carries its own sig.
+//
+// Antigravity's internal endpoint (v1internal:...) does NOT speak the
+// OpenAI-compat `extra_content` envelope — it consumes the native Gemini
+// `Part.thoughtSignature` field directly. We keep both shapes in sync.
+//
+// This module is intentionally tiny: read/write the signature from a tool_call
+// or functionCall part. It does NOT decide whether to backfill a synthetic
+// default — that policy lives in the request translator where we know whether
+// real history is available.
+
+export const GOOGLE_EXTRA_CONTENT = "google";
+export const THOUGHT_SIGNATURE_KEY = "thought_signature";
+
+// Read a real thought signature from an OpenAI-compat tool_call.
+// Sources (first match wins):
+//   1. tool_call.extra_content.google.thought_signature
+//   2. tool_call.thought_signature            (legacy / non-standard)
+// Returns null when no signature is present.
+export function readOpenAIToolCallSignature(toolCall) {
+  if (!toolCall || typeof toolCall !== "object") return null;
+  const extra = toolCall[OPENAI_TOOL_EXTRA_CONTENT_KEY];
+  if (extra && typeof extra === "object") {
+    const google = extra[GOOGLE_EXTRA_CONTENT];
+    if (google && typeof google === "object") {
+      const sig = google[THOUGHT_SIGNATURE_KEY];
+      if (typeof sig === "string" && sig.length > 0) return sig;
+    }
+  }
+  const legacy = toolCall[THOUGHT_SIGNATURE_KEY];
+  if (typeof legacy === "string" && legacy.length > 0) return legacy;
+  return null;
+}
+
+// Read a thought signature from a native Gemini Part (response-side).
+// Gemini uses both `thoughtSignature` (newer) and `thought_signature`
+// (snake-case legacy) — handle either.
+export function readGeminiPartSignature(part) {
+  if (!part || typeof part !== "object") return null;
+  const sig = part.thoughtSignature || part.thought_signature;
+  return typeof sig === "string" && sig.length > 0 ? sig : null;
+}
+
+// Attach a thought signature to an OpenAI-compat tool_call using the
+// documented `extra_content.google.thought_signature` envelope. The object
+// is mutated in place to keep this allocation-free in the hot path.
+export function attachOpenAIToolCallSignature(toolCall, signature) {
+  if (!toolCall || typeof toolCall !== "object" || !signature) return toolCall;
+  const extra = toolCall[OPENAI_TOOL_EXTRA_CONTENT_KEY] || {};
+  const google = extra[GOOGLE_EXTRA_CONTENT] || {};
+  google[THOUGHT_SIGNATURE_KEY] = signature;
+  extra[GOOGLE_EXTRA_CONTENT] = google;
+  toolCall[OPENAI_TOOL_EXTRA_CONTENT_KEY] = extra;
+  return toolCall;
+}
+
+// Read a thought signature from a Gemini functionCall part (response-side
+// helper — equivalent to readGeminiPartSignature but explicit).
+export function readGeminiFunctionCallSignature(part) {
+  return readGeminiPartSignature(part);
+}
+
+const OPENAI_TOOL_EXTRA_CONTENT_KEY = "extra_content";

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -192,6 +192,14 @@ export function translateResponse(targetFormat, sourceFormat, chunk, state) {
     }
   }
 
+  // Flush sentinel: a null chunk means "the stream ended" (stream.js flush).
+  // When step 1 has nothing to convert, forward the sentinel so the source-side
+  // translator can finalize a dangling message (all openai→X translators
+  // null-check their chunk, so this is a no-op unless one implements a flush).
+  if (chunk === null && results.length === 0) {
+    results = [null];
+  }
+
   // Step 2: openai -> source (if source is not openai)
   if (sourceFormat !== FORMATS.OPENAI) {
     const fromOpenAI = responseRegistry.get(`${FORMATS.OPENAI}:${sourceFormat}`);

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -2,6 +2,7 @@ import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { DEFAULT_THINKING_AG_SIGNATURE, DEFAULT_THINKING_GEMINI_CLI_SIGNATURE } from "../../config/defaultThinkingSignature.js";
 import { openaiToClaudeRequestForAntigravity } from "./openai-to-claude.js";
+import { readOpenAIToolCallSignature } from "../concerns/thoughtSignature.js";
 function generateUUID() {
   return crypto.randomUUID();
 }
@@ -32,6 +33,19 @@ function sanitizeGeminiFunctionName(name) {
   }
   // Truncate to 64 chars
   return sanitized.substring(0, 64);
+}
+
+// Read a thought_signature from an assistant message's `extra_content.google`
+// envelope — the OpenAI-compat channel for non-text reasoning signatures
+// (some clients surface per-turn reasoning sigs this way).
+function readAssistantExtraContentSignature(msg) {
+  if (!msg || typeof msg !== "object") return null;
+  const extra = msg.extra_content;
+  if (!extra || typeof extra !== "object") return null;
+  const google = extra.google;
+  if (!google || typeof google !== "object") return null;
+  const sig = google.thought_signature;
+  return typeof sig === "string" && sig.length > 0 ? sig : null;
 }
 
 function normalizeGeminiContents(contents) {
@@ -118,8 +132,12 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
             thought: true,
             text: msg.reasoning_content
           });
+          // Prefer real signature from assistant.extra_content when the client
+          // round-tripped it (some clients surface reasoning signatures this
+          // way). Fall back to the synthetic default.
+          const realSignature = readAssistantExtraContentSignature(msg);
           parts.push({
-            thoughtSignature: signature,
+            thoughtSignature: realSignature || signature,
             text: ""
           });
         }
@@ -137,8 +155,15 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
             if (tc.type !== OPENAI_BLOCK.FUNCTION) continue;
 
             const args = tryParseJSON(tc.function?.arguments || "{}");
+            // Prefer the REAL signature the client carried back from the
+            // previous turn (`tool_calls[i].extra_content.google.thought_signature`).
+            // Google 3 rejects tool_calls without it on the first functionCall
+            // per turn; a synthetic static default only works when the upstream
+            // accepts it as a validator-skip (Antigravity does, Gemini CLI may
+            // not). Real signature wins whenever it exists.
+            const realSignature = readOpenAIToolCallSignature(tc);
             parts.push({
-              thoughtSignature: signature,
+              thoughtSignature: realSignature || signature,
               functionCall: {
                 id: tc.id,
                 name: sanitizeGeminiFunctionName(tc.function.name),

--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -19,8 +19,19 @@ function emitFunctionCall(functionCall, state) {
   const fcName = state.toolNameMap?.get(rawName) || rawName;
   const fcArgs = functionCall.args || {};
   const toolCallIndex = state.functionIndex++;
+  // Prefer the upstream-provided call id (Gemini 3 sends one) — it round-trips to
+  // functionResponse without name reconstruction. Fall back to a generated id.
+  // Anthropic tool_use ids must match [a-zA-Z0-9_-], so sanitize either way.
+  if (!state.seenToolCallIds) state.seenToolCallIds = new Set();
+  const upstreamId = functionCall.id;
+  const rawId = upstreamId && !state.seenToolCallIds.has(upstreamId)
+    ? upstreamId
+    : `${fcName}_${Date.now()}_${toolCallIndex}`;
+  const id = rawId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  state.seenToolCallIds.add(id);
+  if (upstreamId) state.seenToolCallIds.add(upstreamId);
   const toolCall = {
-    id: `${fcName}-${Date.now()}-${toolCallIndex}`,
+    id,
     index: toolCallIndex,
     type: OPENAI_BLOCK.FUNCTION,
     function: { name: fcName, arguments: JSON.stringify(fcArgs) },
@@ -35,14 +46,24 @@ function emitFunctionCall(functionCall, state) {
 // Convert Gemini response chunk to OpenAI format
 export function geminiToOpenAIResponse(chunk, state) {
   if (!chunk) return null;
-  
+
   // Handle Antigravity wrapper
   const response = chunk.response || chunk;
-  if (!response || !response.candidates?.[0]) return null;
+  if (!response) return null;
 
   const results = [];
-  const candidate = response.candidates[0];
-  const content = candidate.content;
+  const candidate = response.candidates?.[0];
+  const upstreamError = response.error || chunk.error;
+  const blockReason = response.promptFeedback?.blockReason;
+
+  // Candidate-less chunk with nothing to surface: harvest usage from keep-alive
+  // chunks (usageMetadata-only) and skip. Dropping error/blockReason chunks here
+  // used to leave the client with an empty 200 stream that never closes.
+  if (!candidate && !upstreamError && !blockReason) {
+    const keepAliveUsage = toOpenAIUsage(response.usageMetadata || chunk.usageMetadata, "gemini");
+    if (keepAliveUsage) state.usage = keepAliveUsage;
+    return null;
+  }
 
   // Initialize state
   if (!state.messageId) {
@@ -53,17 +74,39 @@ export function geminiToOpenAIResponse(chunk, state) {
     results.push(buildChunk(chunkMeta(state), { role: ROLE.ASSISTANT }, null));
   }
 
+  // Error object embedded mid-stream in a 200 response (e.g. RESOURCE_EXHAUSTED):
+  // close the message with an error finish so downstream surfaces it instead of hanging.
+  if (!candidate && upstreamError) {
+    state.upstreamError = upstreamError;
+    const errorChunk = buildChunk(chunkMeta(state), {}, OPENAI_FINISH.ERROR);
+    if (state.usage) errorChunk.usage = state.usage;
+    results.push(errorChunk);
+    state.finishReason = OPENAI_FINISH.ERROR;
+    return results;
+  }
+
+  // Prompt blocked before any candidate was produced: close as content_filter.
+  if (!candidate && blockReason) {
+    const blockedChunk = buildChunk(chunkMeta(state), {}, OPENAI_FINISH.CONTENT_FILTER);
+    if (state.usage) blockedChunk.usage = state.usage;
+    results.push(blockedChunk);
+    state.finishReason = OPENAI_FINISH.CONTENT_FILTER;
+    return results;
+  }
+
+  const content = candidate.content;
+
   // Process parts
   if (content?.parts) {
     for (const part of content.parts) {
       const hasThoughtSig = part.thoughtSignature || part.thought_signature;
       const isThought = part.thought === true;
-      
+
       // Handle thought signature (thinking mode)
       if (hasThoughtSig) {
         const hasTextContent = part.text !== undefined && part.text !== "";
         const hasFunctionCall = !!part.functionCall;
-        
+
         if (hasTextContent) {
           results.push(buildChunk(
             chunkMeta(state),
@@ -71,7 +114,7 @@ export function geminiToOpenAIResponse(chunk, state) {
             null
           ));
         }
-        
+
         if (hasFunctionCall) {
           results.push(emitFunctionCall(part.functionCall, state));
         }
@@ -121,17 +164,19 @@ export function geminiToOpenAIResponse(chunk, state) {
   // Finish reason - include usage in final chunk
   if (candidate.finishReason) {
     let finishReason = toOpenAIFinish(candidate.finishReason, "gemini");
+    // An aborted/error finish must NOT upgrade to tool_calls even if a functionCall
+    // was emitted earlier — that would re-execute the aborted tool call.
     if (finishReason === OPENAI_FINISH.STOP && state.geminiToolCallCount > 0) {
       finishReason = OPENAI_FINISH.TOOL_CALLS;
     }
-    
+
     const finalChunk = buildChunk(chunkMeta(state), {}, finishReason);
-    
+
     // Include usage in final chunk for downstream translators
     if (state.usage) {
       finalChunk.usage = state.usage;
     }
-    
+
     results.push(finalChunk);
     state.finishReason = finishReason;
   }
@@ -144,4 +189,3 @@ register(FORMATS.GEMINI, FORMATS.OPENAI, null, geminiToOpenAIResponse);
 register(FORMATS.GEMINI_CLI, FORMATS.OPENAI, null, geminiToOpenAIResponse);
 register(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, null, geminiToOpenAIResponse);
 register(FORMATS.VERTEX, FORMATS.OPENAI, null, geminiToOpenAIResponse);
-

--- a/open-sse/translator/response/gemini-to-openai.js
+++ b/open-sse/translator/response/gemini-to-openai.js
@@ -6,14 +6,18 @@ import { toOpenAIUsage } from "../concerns/usage.js";
 import { reasoningDelta } from "../concerns/reasoning.js";
 import { encodeDataUri } from "../concerns/image.js";
 import { toOpenAIFinish } from "../concerns/finishReason.js";
+import { readGeminiFunctionCallSignature, attachOpenAIToolCallSignature } from "../concerns/thoughtSignature.js";
 
 // Build chunk meta for current gemini state
 function chunkMeta(state) {
   return { id: `chatcmpl-${state.messageId}`, created: Math.floor(Date.now() / 1000), model: state.model };
 }
 
-// Build a tool_call chunk from a gemini functionCall part (shared by sig/non-sig branches)
-function emitFunctionCall(functionCall, state) {
+// Build a tool_call chunk from a gemini functionCall part (shared by sig/non-sig branches).
+// `signature` is the real thoughtSignature Google returned for this functionCall
+// part (null when the part has none — Gemini 3 attaches a signature to the
+// FIRST parallel functionCall only; subsequent parallel calls carry none).
+function emitFunctionCall(functionCall, signature, state) {
   const rawName = functionCall.name;
   // Restore original tool name from mapping (AG cloaking)
   const fcName = state.toolNameMap?.get(rawName) || rawName;
@@ -36,6 +40,10 @@ function emitFunctionCall(functionCall, state) {
     type: OPENAI_BLOCK.FUNCTION,
     function: { name: fcName, arguments: JSON.stringify(fcArgs) },
   };
+  // Preserve Gemini's thoughtSignature on the tool_call so the client replays
+  // it back in the next turn (Gemini 3 rejects tool_calls without it on the
+  // first functionCall per turn). See concerns/thoughtSignature.js.
+  if (signature) attachOpenAIToolCallSignature(toolCall, signature);
   // Keep Gemini bookkeeping separate from the shared translator state.toolCalls map.
   // The downstream OpenAI→Claude translator uses state.toolCalls for Claude block
   // metadata; pre-populating it here makes Anthropic tool deltas lose index.
@@ -99,11 +107,11 @@ export function geminiToOpenAIResponse(chunk, state) {
   // Process parts
   if (content?.parts) {
     for (const part of content.parts) {
-      const hasThoughtSig = part.thoughtSignature || part.thought_signature;
+      const partSignature = readGeminiFunctionCallSignature(part);
       const isThought = part.thought === true;
 
       // Handle thought signature (thinking mode)
-      if (hasThoughtSig) {
+      if (partSignature) {
         const hasTextContent = part.text !== undefined && part.text !== "";
         const hasFunctionCall = !!part.functionCall;
 
@@ -116,7 +124,7 @@ export function geminiToOpenAIResponse(chunk, state) {
         }
 
         if (hasFunctionCall) {
-          results.push(emitFunctionCall(part.functionCall, state));
+          results.push(emitFunctionCall(part.functionCall, partSignature, state));
         }
         continue;
       }
@@ -133,9 +141,12 @@ export function geminiToOpenAIResponse(chunk, state) {
         ));
       }
 
-      // Function call
+      // Function call. Google only attaches a thoughtSignature to the FIRST
+      // parallel functionCall part; sibling parallel parts arrive here with
+      // no signature and are emitted verbatim — the upstream payload shape
+      // must not be altered (per Gemini tool-state rules).
       if (part.functionCall) {
-        results.push(emitFunctionCall(part.functionCall, state));
+        results.push(emitFunctionCall(part.functionCall, partSignature, state));
       }
 
       // Inline data (images)

--- a/open-sse/translator/response/openai-to-claude.js
+++ b/open-sse/translator/response/openai-to-claude.js
@@ -1,6 +1,6 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
-import { ROLE, CLAUDE_BLOCK, MODEL_FALLBACK } from "../schema/index.js";
+import { ROLE, CLAUDE_BLOCK, MODEL_FALLBACK, OPENAI_FINISH } from "../schema/index.js";
 import { fromOpenAIFinish } from "../concerns/finishReason.js";
 import { extractReasoningText } from "../concerns/reasoning.js";
 
@@ -67,46 +67,96 @@ function stopTextBlock(state, results) {
   state.textBlockStarted = false;
 }
 
+// Helper: flush buffered tool args + close every open tool_use block
+function flushToolBlocks(state, results) {
+  for (const [idx, toolInfo] of state.toolCalls) {
+    // Emit buffered + sanitized args as single delta before stop
+    const buffered = state.toolArgBuffers?.get(idx);
+    if (buffered) {
+      const sanitized = sanitizeToolArgs(toolInfo.name, buffered);
+      results.push({
+        type: "content_block_delta",
+        index: toolInfo.blockIndex,
+        delta: { type: "input_json_delta", partial_json: sanitized }
+      });
+    }
+    results.push({
+      type: "content_block_stop",
+      index: toolInfo.blockIndex
+    });
+  }
+}
+
+// Convert OpenAI-shaped usage ({prompt_tokens, completion_tokens, ...}) to the
+// Claude shape ({input_tokens, output_tokens, cache_*}).
+function toClaudeUsage(usage) {
+  const promptTokens = typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : 0;
+  const outputTokens = typeof usage.completion_tokens === "number" ? usage.completion_tokens : 0;
+
+  // Extract cache tokens from prompt_tokens_details
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
+  const cacheCreationTokens = usage.prompt_tokens_details?.cache_creation_tokens;
+  const cacheReadTokens = typeof cachedTokens === "number" ? cachedTokens : 0;
+  const cacheCreateTokens = typeof cacheCreationTokens === "number" ? cacheCreationTokens : 0;
+
+  // input_tokens = prompt_tokens - cached_tokens - cache_creation_tokens
+  // Because OpenAI's prompt_tokens includes all prompt-side tokens
+  const claudeUsage = {
+    input_tokens: promptTokens - cacheReadTokens - cacheCreateTokens,
+    output_tokens: outputTokens
+  };
+  if (cacheReadTokens > 0) claudeUsage.cache_read_input_tokens = cacheReadTokens;
+  if (cacheCreationTokens > 0) claudeUsage.cache_creation_tokens = cacheCreateTokens;
+
+  // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
+  // No need to add separately as Claude expects total output_tokens
+  return claudeUsage;
+}
+
+// Flush-time finalization: the upstream stream ended without a finish_reason
+// (truncated connection, or a gemini-family stream that closed after content).
+// Close open blocks and emit message_delta + message_stop so the Claude client
+// never hangs on a dangling message.
+function finalizeOnFlush(state) {
+  if (!state.messageStartSent || state.claudeFinishHandled) return null;
+  state.claudeFinishHandled = true;
+
+  const results = [];
+  stopThinkingBlock(state, results);
+  stopTextBlock(state, results);
+  flushToolBlocks(state, results);
+
+  // state.usage may still be OpenAI-shaped here: the gemini stage writes
+  // prompt/completion counts into the shared pivot state, and only a real
+  // finish chunk converts them — which a truncated stream never delivers.
+  const usage = state.usage?.input_tokens != null
+    ? state.usage
+    : state.usage?.prompt_tokens != null
+      ? toClaudeUsage(state.usage)
+      : { input_tokens: 0, output_tokens: 0 };
+
+  const stopReason = state.toolCalls.size > 0 ? "tool_use" : "end_turn";
+  results.push({
+    type: "message_delta",
+    delta: { stop_reason: stopReason },
+    usage
+  });
+  results.push({ type: "message_stop" });
+  return results;
+}
+
 // Convert OpenAI stream chunk to Claude format
 export function openaiToClaudeResponse(chunk, state) {
-  if (!chunk || !chunk.choices?.[0]) return null;
+  if (!chunk) return finalizeOnFlush(state);
+  if (!chunk.choices?.[0]) return null;
 
   const results = [];
   const choice = chunk.choices[0];
   const delta = choice.delta;
 
-  // Track usage from OpenAI chunk if available
+  // Track usage from OpenAI chunk if present
   if (chunk.usage && typeof chunk.usage === "object") {
-    const promptTokens = typeof chunk.usage.prompt_tokens === "number" ? chunk.usage.prompt_tokens : 0;
-    const outputTokens = typeof chunk.usage.completion_tokens === "number" ? chunk.usage.completion_tokens : 0;
-
-    // Extract cache tokens from prompt_tokens_details
-    const cachedTokens = chunk.usage.prompt_tokens_details?.cached_tokens;
-    const cacheCreationTokens = chunk.usage.prompt_tokens_details?.cache_creation_tokens;
-    const cacheReadTokens = typeof cachedTokens === "number" ? cachedTokens : 0;
-    const cacheCreateTokens = typeof cacheCreationTokens === "number" ? cacheCreationTokens : 0;
-
-    // input_tokens = prompt_tokens - cached_tokens - cache_creation_tokens
-    // Because OpenAI's prompt_tokens includes all prompt-side tokens
-    const inputTokens = promptTokens - cacheReadTokens - cacheCreateTokens;
-
-    state.usage = {
-      input_tokens: inputTokens,
-      output_tokens: outputTokens
-    };
-
-    // Add cache_read_input_tokens if present
-    if (cacheReadTokens > 0) {
-      state.usage.cache_read_input_tokens = cacheReadTokens;
-    }
-
-    // Add cache_creation_input_tokens if present
-    if (cacheCreateTokens > 0) {
-      state.usage.cache_creation_input_tokens = cacheCreateTokens;
-    }
-
-    // Note: completion_tokens_details.reasoning_tokens is already included in output_tokens
-    // No need to add separately as Claude expects total output_tokens
+    state.usage = toClaudeUsage(chunk.usage);
   }
 
   // First chunk - ALWAYS send message_start first
@@ -221,39 +271,41 @@ export function openaiToClaudeResponse(chunk, state) {
     }
   }
 
-  // Finish
-  if (choice.finish_reason) {
+  // Finish — guard with a Claude-specific flag, NOT the shared state.finishReason:
+  // in a pivot like Antigravity/Gemini → OpenAI → Claude the upstream stage already
+  // sets state.finishReason (for stream.js usage injection); keying on it would
+  // suppress this flush and drop the buffered tool-call input_json_delta. The flag
+  // also dedupes repeated finish_reason chunks from OpenAI-compatible models.
+  if (choice.finish_reason && !state.claudeFinishHandled) {
+    state.claudeFinishHandled = true;
     stopThinkingBlock(state, results);
     stopTextBlock(state, results);
-
-    for (const [idx, toolInfo] of state.toolCalls) {
-      // Emit buffered + sanitized args as single delta before stop
-      const buffered = state.toolArgBuffers?.get(idx);
-      if (buffered) {
-        const sanitized = sanitizeToolArgs(toolInfo.name, buffered);
-        results.push({
-          type: "content_block_delta",
-          index: toolInfo.blockIndex,
-          delta: { type: "input_json_delta", partial_json: sanitized }
-        });
-      }
-      results.push({
-        type: "content_block_stop",
-        index: toolInfo.blockIndex
-      });
-    }
+    flushToolBlocks(state, results);
 
     // Mark finish for later usage injection in stream.js
     state.finishReason = choice.finish_reason;
 
-    // Use tracked usage (will be estimated in stream.js if not valid)
-    const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
-    results.push({
-      type: "message_delta",
-      delta: { stop_reason: convertFinishReason(choice.finish_reason) },
-      usage: finalUsage
-    });
-    results.push({ type: "message_stop" });
+    if (choice.finish_reason === OPENAI_FINISH.ERROR) {
+      // Upstream aborted the turn (e.g. Gemini MALFORMED_FUNCTION_CALL or an error
+      // object embedded in a 200 stream). A clean end_turn here makes the client
+      // treat a broken turn as a finished answer; a mid-stream error event is
+      // retryable by Anthropic clients.
+      const message = state.upstreamError?.message ||
+        "Upstream aborted the response (malformed function call or empty candidate)";
+      results.push({
+        type: "error",
+        error: { type: "api_error", message }
+      });
+    } else {
+      // Use tracked usage (will be estimated in stream.js if not valid)
+      const finalUsage = state.usage || { input_tokens: 0, output_tokens: 0 };
+      results.push({
+        type: "message_delta",
+        delta: { stop_reason: convertFinishReason(choice.finish_reason) },
+        usage: finalUsage
+      });
+      results.push({ type: "message_stop" });
+    }
   }
 
   return results.length > 0 ? results : null;

--- a/open-sse/translator/schema/blocks.js
+++ b/open-sse/translator/schema/blocks.js
@@ -9,6 +9,10 @@ export const OPENAI_BLOCK = {
   AUDIO_URL: "audio_url",
   FILE: "file",
   FUNCTION: "function",
+  // Non-OpenAI-spec field used by Gemini OpenAI-compat endpoints to attach
+  // provider metadata per tool_call (e.g. extra_content.google.thought_signature).
+  // Reference: https://ai.google.dev/gemini-api/docs/openai
+  EXTRA_CONTENT: "extra_content",
 };
 
 // Claude content blocks.

--- a/open-sse/translator/schema/finishReasons.js
+++ b/open-sse/translator/schema/finishReasons.js
@@ -6,6 +6,9 @@ export const OPENAI_FINISH = {
   LENGTH: "length",
   TOOL_CALLS: "tool_calls",
   CONTENT_FILTER: "content_filter",
+  // Internal hub value: upstream aborted the turn (e.g. Gemini MALFORMED_FUNCTION_CALL).
+  // Response translators surface it as an error instead of a clean stop.
+  ERROR: "error",
 };
 
 // Claude stop_reason values.
@@ -24,4 +27,38 @@ export const GEMINI_FINISH = {
   RECITATION: "RECITATION",
   BLOCKLIST: "BLOCKLIST",
   PROHIBITED_CONTENT: "PROHIBITED_CONTENT",
+  SPII: "SPII",
+  IMAGE_SAFETY: "IMAGE_SAFETY",
+  MALFORMED_FUNCTION_CALL: "MALFORMED_FUNCTION_CALL",
+  UNEXPECTED_TOOL_CALL: "UNEXPECTED_TOOL_CALL",
+  FINISH_REASON_UNSPECIFIED: "FINISH_REASON_UNSPECIFIED",
+  OTHER: "OTHER",
+  LANGUAGE: "LANGUAGE",
+  NO_IMAGE: "NO_IMAGE",
 };
+
+// Gemini finishReasons that mean the turn was aborted upstream, not completed.
+// Forwarding them as a clean stop makes the client treat a broken turn (e.g. an
+// aborted tool call) as a finished answer — the "model says it will act but does
+// nothing" failure. Shared with the antigravity empty-stream guard.
+export const GEMINI_ERROR_FINISH_REASONS = new Set([
+  GEMINI_FINISH.MALFORMED_FUNCTION_CALL,
+  GEMINI_FINISH.UNEXPECTED_TOOL_CALL,
+  GEMINI_FINISH.FINISH_REASON_UNSPECIFIED,
+  GEMINI_FINISH.OTHER,
+  GEMINI_FINISH.LANGUAGE,
+  GEMINI_FINISH.NO_IMAGE,
+]);
+
+// Gemini finishReasons that mean the content was blocked by policy. Deterministic
+// for a given prompt: retrying is pointless (same block every time), so the
+// empty-stream guard must release these instead of retrying — the translator
+// closes them as content_filter. Also the content_filter mapping source.
+export const GEMINI_CONTENT_FILTER_FINISH_REASONS = new Set([
+  GEMINI_FINISH.SAFETY,
+  GEMINI_FINISH.RECITATION,
+  GEMINI_FINISH.BLOCKLIST,
+  GEMINI_FINISH.SPII,
+  GEMINI_FINISH.IMAGE_SAFETY,
+  GEMINI_FINISH.PROHIBITED_CONTENT,
+]);

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -33,7 +33,10 @@ const STREAM_MODE = {
  * @param {string} options.model - Model name
  * @param {string} options.connectionId - Connection ID for usage tracking
  * @param {object} options.body - Request body (for input token estimation)
- * @param {function} options.onStreamComplete - Callback when stream completes (content, usage)
+ * @param {function} options.onStreamComplete - Callback when stream completes (content, usage, ttftAt, meta)
+ *   meta: { finishReason, upstreamError, empty } from the translator state — used by
+ *   request-detail to record a "totally exhausted empty Anthropic attempt" as an error,
+ *   not a misleading healthy completion.
  * @param {string} options.apiKey - API key for usage tracking
  */
 export function createSSEStream(options = {}) {
@@ -381,7 +384,11 @@ export function createSSEStream(options = {}) {
             onStreamComplete({
               content: accumulatedContent,
               thinking: accumulatedThinking
-            }, usage, ttftAt);
+            }, usage, ttftAt, {
+              finishReason: state?.finishReason,
+              upstreamError: state?.upstreamError,
+              empty: !accumulatedContent,
+            });
           }
           return;
         }
@@ -458,7 +465,11 @@ export function createSSEStream(options = {}) {
           onStreamComplete({
             content: accumulatedContent,
             thinking: accumulatedThinking
-          }, state?.usage, ttftAt);
+          }, state?.usage, ttftAt, {
+            finishReason: state?.finishReason,
+            upstreamError: state?.upstreamError,
+            empty: !accumulatedContent,
+          });
         }
       } catch (error) {
         console.log("Error in flush:", error);

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -295,6 +295,14 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       },
       onRequestSuccess: async () => {
         await clearAccountError(credentials.connectionId, credentials, model);
+      },
+      // Antigravity empty-stream guard: when every in-stream retry came back
+      // empty (the literal [Empty streaming response] case), bench the account
+      // so the client's automatic retry rotates to the next one. resetsAtMs
+      // comes from the upstream quota-reset parser when available, so the
+      // cooldown is precise instead of the generic exponential backoff.
+      onUpstreamEmptyExhausted: async (reason, resetsAtMs) => {
+        await markAccountUnavailable(credentials.connectionId, HTTP_STATUS.BAD_GATEWAY, reason, provider, model, resetsAtMs);
       }
     });
 

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -22,6 +22,7 @@ import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
 import { getProjectIdForConnection } from "open-sse/services/projectId.js";
+import { getExecutor } from "open-sse/executors/index.js";
 
 /**
  * Handle chat completion request
@@ -259,6 +260,67 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     // Use shared chatCore
     const chatSettings = await getSettings();
     const providerThinking = (chatSettings.providerThinking || {})[provider] || null;
+
+    // Server-side account rotation hook: invoked from inside the empty-stream
+    // guard when same-account empty retries exhaust, BEFORE the error event
+    // surfaces to the client. Only safe because no client-actionable output
+    // has been emitted yet (visible text, tool call, inline data). Each
+    // rotation uses its own credentials/proxy/projectId — Account A metadata
+    // never leaks into Account B's request.
+    const chatCoreCtx = {};
+    const rotationTracker = { benchedInStream: new Set() };
+    const onAccountRotate = async ({ reason, upstreamError }) => {
+      // Account A is already benched by the onUpstreamEmptyExhausted observer;
+      // pick the next eligible one (excluding A and any account we already
+      // tried in this rotation pass).
+      const excludeForNext = new Set([...excludeConnectionIds, ...rotationTracker.benchedInStream]);
+      const next = await getProviderCredentials(provider, excludeForNext, model);
+      if (!next || next.allRateLimited) return null;
+      rotationTracker.benchedInStream.add(next.connectionId);
+
+      // Refresh token + resolve projectId for the new account.
+      const nextRefreshed = await checkAndRefreshToken(provider, next);
+      if ((provider === "antigravity" || provider === "gemini-cli") && !nextRefreshed.projectId) {
+        const pid = await getProjectIdForConnection(next.connectionId, nextRefreshed.accessToken, provider);
+        if (pid) {
+          nextRefreshed.projectId = pid;
+          updateProviderCredentials(next.connectionId, { projectId: pid }).catch(() => { });
+        }
+      }
+
+      // Recompute proxy options from the new credentials — Account A's proxy
+      // config must NOT be reused.
+      const nextProxyOptions = {
+        connectionProxyEnabled: nextRefreshed?.providerSpecificData?.connectionProxyEnabled === true,
+        connectionProxyUrl: nextRefreshed?.providerSpecificData?.connectionProxyUrl || "",
+        connectionNoProxy: nextRefreshed?.providerSpecificData?.connectionNoProxy || "",
+        vercelRelayUrl: nextRefreshed?.providerSpecificData?.vercelRelayUrl || "",
+      };
+
+      log.warn("ROTATE", `⇄ ACC:${refreshedCredentials.connectionName} EMPTY-EXHAUSTED → ACC:${nextRefreshed.connectionName || next.connectionId.slice(0, 8)}`);
+      log.warn("ROTATE", `    reason=${reason?.slice?.(0, 80)} | upstream=${upstreamError?.status || upstreamError?.code || "EMPTY"}`);
+
+      return {
+        reexecute: async () => {
+          const retryResult = await getExecutor(provider).execute({
+            model,
+            body: chatCoreCtx.translatedBody,
+            stream: true,
+            credentials: nextRefreshed,
+            signal: chatCoreCtx.streamControllerSignal,
+            log,
+            proxyOptions: nextProxyOptions,
+          });
+          if (!retryResult.response.ok) {
+            const status = retryResult.response.status;
+            throw new Error(`[${status}] rotation upstream non-2xx`);
+          }
+          if (!retryResult.response.body) throw new Error("rotation upstream returned no body");
+          return retryResult.response.body;
+        },
+      };
+    };
+
     const result = await handleChatCore({
       body: { ...body, model: `${provider}/${model}` },
       modelInfo: { provider, model },
@@ -303,7 +365,12 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       // cooldown is precise instead of the generic exponential backoff.
       onUpstreamEmptyExhausted: async (reason, resetsAtMs) => {
         await markAccountUnavailable(credentials.connectionId, HTTP_STATUS.BAD_GATEWAY, reason, provider, model, resetsAtMs);
-      }
+      },
+      // Server-side account recovery: rotate to the next eligible account
+      // while no client-actionable output has been emitted yet. See the
+      // safety constraints in src/sse/README and the empty-stream guard docs.
+      onAccountRotate,
+      chatCoreCtx,
     });
 
     if (result.success) return result.response;

--- a/tests/translator/antigravity-pseudo-tool-prose.test.js
+++ b/tests/translator/antigravity-pseudo-tool-prose.test.js
@@ -1,0 +1,134 @@
+// Regression: a structured Gemini functionCall part MUST reach OpenCode as an
+// OpenAI `tool_calls` SSE chunk, never as literal assistant prose. The brief
+// documented a real OpenCode Build failure where the UI displayed
+// `{# call:default_api:read{filePath:...,limit:50,offset:160}}` instead of
+// executing a real Read tool call. We do not (and must not) convert prose
+// into tool calls; the correct fix is protocol-level correctness: a real
+// structured functionCall part always becomes a structured tool_call.
+//
+// Companion to bugs-antigravity.test.js — that file covers the openai->
+// gemini direction; this file covers the gemini -> openai direction and
+// guards specifically against the pseudo-tool-prose symptom.
+import { describe, it, expect } from "vitest";
+import "./registerAll.js";
+import { translateResponse, initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const wrap = (response) => ({ response });
+const dataEvents = (events) => events.flatMap((e) => (e.choices?.[0]?.delta?.tool_calls ? [e] : []));
+
+describe("Antigravity → OpenAI: pseudo-tool-prose regression", () => {
+  // 1. A single structured functionCall surfaces as tool_calls, never as
+  //    assistant content delta.
+  it("structured functionCall becomes tool_calls, not assistant prose", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r1", modelVersion: "gemini-3-flash",
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{
+            thoughtSignature: "REAL_SIG",
+            functionCall: { id: "call_read_1", name: "default_api:read", args: { filePath: "/a", limit: 50, offset: 160 } },
+          }],
+        },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+
+    const toolChunks = dataEvents(events);
+    expect(toolChunks).toHaveLength(1);
+    const tool = toolChunks[0].choices[0].delta.tool_calls[0];
+    expect(tool.function.name).toBe("default_api:read");
+    expect(JSON.parse(tool.function.arguments)).toEqual({ filePath: "/a", limit: 50, offset: 160 });
+    expect(tool.extra_content.google.thought_signature).toBe("REAL_SIG");
+
+    // No content delta ever carries literal pseudo-tool prose.
+    for (const e of events) {
+      const content = e.choices?.[0]?.delta?.content;
+      if (typeof content === "string") {
+        expect(content).not.toMatch(/^call:[a-zA-Z_]+:/);
+        expect(content).not.toContain("default_api:read{");
+      }
+    }
+  });
+
+  // 2. Multiple parallel functionCalls — all become tool_calls, never prose.
+  it("parallel functionCalls become tool_calls, never assistant prose", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r2", modelVersion: "gemini-3-flash",
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [
+            { thoughtSignature: "PAR_SIG", functionCall: { id: "call_a", name: "read", args: { filePath: "/x" } } },
+            { functionCall: { id: "call_b", name: "grep", args: { pattern: "y" } } },
+          ],
+        },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+
+    const toolChunks = dataEvents(events);
+    expect(toolChunks).toHaveLength(2);
+    const names = toolChunks.map((c) => c.choices[0].delta.tool_calls[0].function.name);
+    expect(names).toEqual(["read", "grep"]);
+    for (const e of events) {
+      const content = e.choices?.[0]?.delta?.content;
+      if (typeof content === "string") {
+        expect(content).not.toMatch(/^call:[a-zA-Z_]+:/);
+      }
+    }
+  });
+
+  // 3. Text + functionCall: text is fine, functionCall is a tool_call, no prose.
+  it("text + functionCall: text stays text, functionCall stays tool_call", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r3", modelVersion: "gemini-3-flash",
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [
+            { text: "Let me read that file." },
+            { thoughtSignature: "MIX_SIG", functionCall: { id: "call_m", name: "read", args: { filePath: "/m" } } },
+          ],
+        },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+
+    const toolChunks = dataEvents(events);
+    expect(toolChunks).toHaveLength(1);
+    expect(toolChunks[0].choices[0].delta.tool_calls[0].function.name).toBe("read");
+    // Text content present but no pseudo-tool prose.
+    const contentChunks = events.filter((e) => typeof e.choices?.[0]?.delta?.content === "string");
+    expect(contentChunks.map((e) => e.choices[0].delta.content)).toContain("Let me read that file.");
+    for (const e of events) {
+      const content = e.choices?.[0]?.delta?.content;
+      if (typeof content === "string") {
+        expect(content).not.toMatch(/^call:[a-zA-Z_]+:/);
+      }
+    }
+  });
+
+  // 4. A real functionCall part with signature produces a tool_call whose
+  //    id round-trips byte-for-byte (no Date.now() regeneration when the
+  //    upstream provided an id).
+  it("upstream functionCall.id is preserved so the next request matches", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r4", modelVersion: "gemini-3-flash",
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{ thoughtSignature: "ID_SIG", functionCall: { id: "call_abc123", name: "read", args: {} } }],
+        },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+    const toolChunks = dataEvents(events);
+    expect(toolChunks[0].choices[0].delta.tool_calls[0].id).toBe("call_abc123");
+  });
+});

--- a/tests/translator/bugs-antigravity.test.js
+++ b/tests/translator/bugs-antigravity.test.js
@@ -137,3 +137,267 @@ describe("Antigravity executor", () => {
     expect(system).not.toContain("Please ignore the following [ignore]");
   });
 });
+
+// Stability fixes: empty/aborted Antigravity streams must never surface as clean
+// end_turn to Claude Code (#2188, #2229, #2259, #2431).
+describe("Antigravity → OpenAI stream stability", () => {
+  const wrap = (response) => ({ response });
+
+  // concerns/finishReason.js — MALFORMED_FUNCTION_CALL used to fall through the
+  // default case to "stop" → end_turn: the model narrates a tool call, Gemini
+  // aborts it, and the client thinks the turn finished cleanly (#2250).
+  it("MALFORMED_FUNCTION_CALL maps to error finish, not stop", () => {
+    const state = initState(FORMATS.OPENAI);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r1", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "I'll call the tool now." }] }, index: 0 }],
+    }), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL", index: 0 }],
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("error");
+  });
+
+  // gemini-to-openai.js — an error finish must not be upgraded to tool_calls even
+  // when a functionCall was emitted earlier in the stream.
+  it("error finish is not upgraded to tool_calls", () => {
+    const state = initState(FORMATS.OPENAI);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r2", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] }, index: 0 }],
+    }), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      candidates: [{ finishReason: "UNEXPECTED_TOOL_CALL", index: 0 }],
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("error");
+  });
+
+  it("STOP with emitted tool call still upgrades to tool_calls", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r3", modelVersion: "gemini-pro-agent",
+      candidates: [{
+        content: { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  // gemini-to-openai.js — candidate-less chunk with promptFeedback.blockReason was
+  // dropped (return null) → empty 200 stream that never closes (#2188).
+  it("promptFeedback-only chunk closes the stream as content_filter", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r4", modelVersion: "gemini-pro-agent",
+      promptFeedback: { blockReason: "SAFETY" },
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("content_filter");
+  });
+
+  // gemini-to-openai.js — a {error:{...}} object embedded mid-stream in a 200
+  // response was dropped silently (#2259, #2431).
+  it("mid-stream error object closes the stream with an error finish", () => {
+    const state = initState(FORMATS.OPENAI);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r5", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "partial" }] }, index: 0 }],
+    }), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded" },
+    }), state);
+    const finish = events.find((e) => e.choices?.[0]?.finish_reason);
+    expect(finish.choices[0].finish_reason).toBe("error");
+    expect(state.upstreamError).toMatchObject({ status: "RESOURCE_EXHAUSTED" });
+  });
+
+  // gemini-to-openai.js — usage-only keep-alive chunks must stay silent but keep usage.
+  it("candidate-less usage chunk returns nothing but preserves usage", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+    }), state);
+    // pivot returns empty array when no translated events are produced
+    expect(events).toEqual([]);
+    expect(state.usage).toBeTruthy();
+  });
+
+  // gemini-to-openai.js — upstream functionCall.id was discarded and replaced by a
+  // regenerated name-based id, breaking functionResponse matching on replay.
+  it("upstream functionCall.id is preserved on the tool_call", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r6", modelVersion: "gemini-pro-agent",
+      candidates: [{
+        content: { role: "model", parts: [{ functionCall: { id: "call_abc123", name: "bash", args: {} } }] },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].id).toBe("call_abc123");
+  });
+
+  it("generated tool ids use underscore separators and the Anthropic charset", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, wrap({
+      responseId: "r7", modelVersion: "gemini-pro-agent",
+      candidates: [{
+        content: { role: "model", parts: [{ functionCall: { name: "my-tool", args: {} } }] },
+        finishReason: "STOP", index: 0,
+      }],
+    }), state);
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].id).toMatch(/^my-tool_\d+_0$/);
+  });
+});
+
+// Claude-side stream finalization: truncated/aborted Antigravity streams must
+// always yield a well-formed Claude SSE sequence (#2229, #2259, #2431).
+describe("Antigravity → Claude stream finalization", () => {
+  const wrap = (response) => ({ response });
+  const textChunk = (text) => wrap({
+    responseId: "resp-x", modelVersion: "gemini-pro-agent",
+    candidates: [{ content: { role: "model", parts: [{ text }] }, index: 0 }],
+  });
+
+  // openai-to-claude.js — stream ends without finishReason (connection dropped):
+  // the message was never closed, Claude Code hung on a dangling message.
+  it("flush closes a stream that ended without finishReason", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, textChunk("partial answer"), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    const types = flushed.map((e) => e.type);
+    expect(types).toContain("content_block_stop");
+    expect(types).toContain("message_delta");
+    expect(types).toContain("message_stop");
+    const delta = flushed.find((e) => e.type === "message_delta");
+    expect(delta.delta.stop_reason).toBe("end_turn");
+  });
+
+  it("flush after a handled finish emits nothing", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-y", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "done" }] }, finishReason: "STOP", index: 0 }],
+    }), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    // pivot returns an empty array when the Claude translator has no more
+    // events to emit (the message was already finalized).
+    expect(flushed).toEqual([]);
+  });
+
+  // openai-to-claude.js — a truncated stream with an unfinished tool call must
+  // still flush the buffered input_json_delta and close as tool_use.
+  it("flush finalizes an unfinished tool call as tool_use", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-z", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] }, index: 0 }],
+    }), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    const jsonDelta = flushed.find((e) => e.delta?.type === "input_json_delta");
+    expect(JSON.parse(jsonDelta.delta.partial_json)).toEqual({ command: "ls" });
+    const delta = flushed.find((e) => e.type === "message_delta");
+    expect(delta.delta.stop_reason).toBe("tool_use");
+    expect(flushed.map((e) => e.type)).toContain("message_stop");
+  });
+
+  // openai-to-claude.js — the gemini stage stores usageMetadata OpenAI-shaped in
+  // the shared state; a truncated stream never sees the finish chunk that would
+  // convert it. The flush must emit Claude-shaped usage, not prompt_tokens.
+  it("flush converts OpenAI-shaped usage to Claude shape", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-u", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "partial" }] }, index: 0 }],
+      usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 7, totalTokenCount: 27 },
+    }), state);
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    const delta = flushed.find((e) => e.type === "message_delta");
+    expect(delta.usage.input_tokens).toBe(20);
+    expect(delta.usage.output_tokens).toBe(7);
+    expect(delta.usage.prompt_tokens).toBeUndefined();
+  });
+
+  // openai-to-claude.js — duplicate finish_reason chunks (common from
+  // OpenAI-compatible upstreams) must not emit message_stop twice.
+  it("duplicate finish chunks emit a single message_stop", () => {
+    const state = initState(FORMATS.CLAUDE);
+    const first = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      responseId: "resp-d", modelVersion: "gemini-pro-agent",
+      candidates: [{ content: { role: "model", parts: [{ text: "hi" }] }, finishReason: "STOP", index: 0 }],
+    }), state);
+    const second = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      candidates: [{ finishReason: "STOP", index: 0 }],
+    }), state);
+    const stops = [...first, ...second].filter((e) => e.type === "message_stop");
+    expect(stops).toHaveLength(1);
+  });
+
+  // Full pivot: MALFORMED_FUNCTION_CALL must reach the Claude client as an error
+  // event, never as a clean end_turn (#2250).
+  it("MALFORMED_FUNCTION_CALL surfaces as an error event, not end_turn", () => {
+    const state = initState(FORMATS.CLAUDE);
+    translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, textChunk("I'll run the command now."), state);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, wrap({
+      candidates: [{ finishReason: "MALFORMED_FUNCTION_CALL", index: 0 }],
+    }), state);
+    const error = events.find((e) => e.type === "error");
+    expect(error).toBeTruthy();
+    expect(error.error.type).toBe("api_error");
+    const endTurn = events.find((e) => e.type === "message_delta" && e.delta?.stop_reason === "end_turn");
+    expect(endTurn).toBeUndefined();
+  });
+});
+
+// Request-side tool id ↔ name round-trip: functionResponse.name must match the
+// original functionCall name or Gemini rejects/ignores the tool loop.
+describe("OpenAI → Gemini functionResponse name recovery", () => {
+  const O2G = (messages) =>
+    translateRequest(FORMATS.OPENAI, FORMATS.GEMINI, "gemini-2.5-pro", { messages }, true, null, null);
+
+  const findResponse = (out) => {
+    for (const c of out.contents) {
+      const p = (c.parts || []).find((p) => p.functionResponse);
+      if (p) return p.functionResponse;
+    }
+    return null;
+  };
+
+  it("assistant tool_calls in history map id ↔ name (tcID2Name)", () => {
+    const out = O2G([
+      { role: "user", content: "run it" },
+      { role: "assistant", tool_calls: [{ id: "my-tool_1736000000000_0", type: "function", function: { name: "my-tool", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "my-tool_1736000000000_0", content: "ok" },
+    ]);
+    expect(findResponse(out)?.name).toBe("my-tool");
+  });
+
+  // openai-to-gemini.js — the old fallback split the id on "-" and joined
+  // all-but-two segments; ids in the current `name_<ts>_<idx>` shape (or legacy
+  // hyphen shape with hyphenated tool names) must still recover the name when
+  // the assistant turn carrying the name was truncated out of history.
+  it("fallback recovers hyphenated names from generated ids (both separators)", () => {
+    for (const fid of ["my-tool_1736000000000_0", "my-tool-1736000000000-0"]) {
+      const out = O2G([
+        { role: "user", content: "run it" },
+        { role: "assistant", content: null, tool_calls: [{ id: fid, type: "function", function: { name: "my-tool", arguments: "{}" } }] },
+        { role: "tool", tool_call_id: fid, content: "ok" },
+      ]);
+      expect(findResponse(out)?.name, `id ${fid}`).toBe("my-tool");
+    }
+  });
+
+  it("foreign ids fall back to the id itself", () => {
+    const out = O2G([
+      { role: "user", content: "run it" },
+      { role: "assistant", tool_calls: [{ id: "toolu_01AbCdEf", type: "function", function: { name: "", arguments: "{}" } }] },
+      { role: "tool", tool_call_id: "toolu_01AbCdEf", content: "ok" },
+    ]);
+    expect(findResponse(out)?.name).toBe("toolu_01AbCdEf");
+  });
+});

--- a/tests/translator/golden-response-stream.test.js
+++ b/tests/translator/golden-response-stream.test.js
@@ -12,7 +12,7 @@ function stripVolatile(chunks) {
     if (key === "created") return 0;
     if (key === "id" && typeof val === "string") {
       return val
-        .replace(/-\d{10,}-(\d+)$/, "-<TS>-$1")   // gemini: name-<ts>-idx
+        .replace(/[-_]\d{10,}[-_](\d+)$/, "-<TS>-$1")   // gemini: name[-_]<ts>[-_]idx
         .replace(/^chatcmpl-\d{10,}$/, "chatcmpl-<TS>")  // kiro/ollama stream id
         .replace(/^call_(\d+)_\d{10,}$/, "call_$1_<TS>"); // ollama tool id
     }

--- a/tests/translator/thought-signature-roundtrip.test.js
+++ b/tests/translator/thought-signature-roundtrip.test.js
@@ -1,0 +1,384 @@
+// Gemini 3 thought-signature round-trip preservation across the OpenAI-compat
+// bridge. See https://ai.google.dev/gemini-api/docs/openai and
+// https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures.
+//
+// Gemini 3 mandates that every functionCall part in the current turn's first
+// step carry the exact `thought_signature` Google returned for it on the
+// previous turn. The official OpenAI-compat envelope is:
+//
+//   tool_calls[i].extra_content.google.thought_signature = "<sig>"
+//
+// Without it the next request returns 400 INVALID_ARGUMENT
+// ("function call is missing a thought_signature"). The previous 9router
+// code discarded the real signature on response and backfilled a static
+// default on the next request — multi-step tool loops silently corrupted
+// the model's reasoning state and the tool call eventually failed or
+// degenerated into prose ("call:default_api:read{...}").
+//
+// These tests cover:
+//   - Round-trip preservation of the real signature byte-for-byte
+//   - Parallel function calls (signature on FIRST call only)
+//   - Sequential function calls (every step carries its own signature)
+//   - Synthetic history fallback (no real signature → static default)
+//   - Normalization preserves signature Part order (no semantic merge)
+//   - Read/grep/bash/edit name sanitization round-trip
+//   - Colon/namespace-style names (e.g. "default_api:read") preserved
+//   - Response-side functionCall + signature always becomes a tool_call
+//     (never assistant prose)
+import { describe, it, expect } from "vitest";
+import "./registerAll.js";
+import { translateRequest, translateResponse, initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { openaiToAntigravityRequest } from "../../open-sse/translator/request/openai-to-gemini.js";
+import {
+  readOpenAIToolCallSignature,
+  attachOpenAIToolCallSignature,
+  readGeminiPartSignature,
+} from "../../open-sse/translator/concerns/thoughtSignature.js";
+
+// Tiny helpers
+const O2G = (messages) =>
+  translateRequest(FORMATS.OPENAI, FORMATS.GEMINI, "gemini-3-flash", { messages }, true, null, null);
+const O2AG = (messages) =>
+  openaiToAntigravityRequest("gemini-3-flash", { messages }, true, { projectId: "p", connectionId: "c" });
+
+const findFunctionCallParts = (contents) => {
+  const out = [];
+  for (const c of contents) {
+    for (const p of c.parts || []) {
+      if (p.functionCall) out.push({ role: c.role, part: p });
+    }
+  }
+  return out;
+};
+
+describe("thought-signature helpers", () => {
+  it("reads the canonical extra_content.google.thought_signature envelope", () => {
+    const tc = { id: "call_1", type: "function", function: { name: "read", arguments: "{}" }, extra_content: { google: { thought_signature: "REAL_SIG_A" } } };
+    expect(readOpenAIToolCallSignature(tc)).toBe("REAL_SIG_A");
+  });
+
+  it("falls back to legacy tool_call.thought_signature when extra_content is absent", () => {
+    const tc = { id: "call_1", type: "function", function: { name: "read", arguments: "{}" }, thought_signature: "LEGACY_SIG" };
+    expect(readOpenAIToolCallSignature(tc)).toBe("LEGACY_SIG");
+  });
+
+  it("attaches signature via extra_content.google.thought_signature (mutates in place)", () => {
+    const tc = { id: "call_1", type: "function", function: { name: "read", arguments: "{}" } };
+    attachOpenAIToolCallSignature(tc, "REAL_SIG_A");
+    expect(tc.extra_content.google.thought_signature).toBe("REAL_SIG_A");
+  });
+
+  it("reads Gemini part signatures from both camelCase and snake_case", () => {
+    expect(readGeminiPartSignature({ thoughtSignature: "C" })).toBe("C");
+    expect(readGeminiPartSignature({ thought_signature: "S" })).toBe("S");
+    expect(readGeminiPartSignature({})).toBe(null);
+  });
+});
+
+describe("Gemini 3 thought-signature round-trip (response → OpenAI → next request → Gemini)", () => {
+  // 1. Gemini functionCall with REAL thoughtSignature → OpenAI tool_call
+  //    retains the exact signature metadata.
+  it("emits extra_content.google.thought_signature on the OpenAI tool_call", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, {
+      response: {
+        responseId: "r-sig", modelVersion: "gemini-3-flash",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ thoughtSignature: "REAL_SIG_A", functionCall: { id: "call_x", name: "read", args: { filePath: "/a" } } }],
+          },
+          finishReason: "STOP", index: 0,
+        }],
+      },
+    }, state);
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].id).toBe("call_x");
+    expect(toolChunk.choices[0].delta.tool_calls[0].extra_content.google.thought_signature).toBe("REAL_SIG_A");
+  });
+
+  // 2. Same OpenAI assistant tool_call on the next request → Gemini functionCall
+  //    receives the exact ORIGINAL signature.
+  it("preserves the real signature byte-for-byte on next request", () => {
+    const out = O2G([
+      { role: "user", content: "read /a" },
+      { role: "assistant", tool_calls: [{
+        id: "call_x", type: "function",
+        function: { name: "read", arguments: JSON.stringify({ filePath: "/a" }) },
+        extra_content: { google: { thought_signature: "REAL_SIG_A" } },
+      }] },
+    ]);
+    const fc = out.contents[1].parts[0];
+    expect(fc.functionCall.name).toBe("read");
+    expect(fc.thoughtSignature).toBe("REAL_SIG_A");
+  });
+
+  // 3. Signature equality is byte-for-byte (no truncation, no re-encoding).
+  it("preserves very long signatures without mutation", () => {
+    const longSig = "A".repeat(4000);
+    const out = O2G([
+      { role: "user", content: "x" },
+      { role: "assistant", tool_calls: [{
+        id: "call_x", type: "function",
+        function: { name: "read", arguments: "{}" },
+        extra_content: { google: { thought_signature: longSig } },
+      }] },
+    ]);
+    expect(out.contents[1].parts[0].thoughtSignature).toBe(longSig);
+  });
+
+  // 4. Sequential FC1+A → FR1 → FC2+B → FR2. Each step's signature survives.
+  it("sequential multi-step tool loop preserves each step's signature", () => {
+    const out = O2G([
+      { role: "user", content: "step1 then step2" },
+      { role: "assistant", tool_calls: [{
+        id: "call_a", type: "function",
+        function: { name: "read", arguments: "{}" },
+        extra_content: { google: { thought_signature: "SIG_A" } },
+      }] },
+      { role: "tool", tool_call_id: "call_a", content: '{"content":"A"}' },
+      { role: "assistant", tool_calls: [{
+        id: "call_b", type: "function",
+        function: { name: "grep", arguments: "{}" },
+        extra_content: { google: { thought_signature: "SIG_B" } },
+      }] },
+      { role: "tool", tool_call_id: "call_b", content: '{"matches":[]}' },
+    ]);
+    const fcParts = findFunctionCallParts(out.contents);
+    expect(fcParts).toHaveLength(2);
+    expect(fcParts[0].part.thoughtSignature).toBe("SIG_A");
+    expect(fcParts[1].part.thoughtSignature).toBe("SIG_B");
+  });
+
+  // 5. Parallel FC1+A + FC2(no signature). Sibling parallel parts carry no sig.
+  it("parallel function calls: first carries sig, siblings do not", () => {
+    const out = O2G([
+      { role: "user", content: "parallel" },
+      { role: "assistant", tool_calls: [
+        { id: "call_a", type: "function", function: { name: "read", arguments: "{}" },
+          extra_content: { google: { thought_signature: "SIG_PARALLEL" } } },
+        { id: "call_b", type: "function", function: { name: "grep", arguments: "{}" } },
+      ] },
+    ]);
+    const fcParts = findFunctionCallParts(out.contents);
+    // Parallel siblings get merged into a single model turn by openai-to-gemini;
+    // the first carries the real signature, siblings fall back to the default.
+    expect(fcParts).toHaveLength(2);
+    expect(fcParts[0].part.functionCall.name).toBe("read");
+    // Real signature on the FIRST parallel tool_call is preserved exactly.
+    expect(fcParts[0].part.thoughtSignature).toBe("SIG_PARALLEL");
+    // The sibling parallel call has no extra_content.google.thought_signature
+    // (per Google's protocol: only the first parallel FC carries one) and
+    // therefore falls back to the synthetic default — the Antigravity
+    // validator-skip behavior. The default is non-empty so Gemini accepts
+    // the request, and the loop continues.
+    expect(typeof fcParts[1].part.thoughtSignature).toBe("string");
+    expect(fcParts[1].part.thoughtSignature.length).toBeGreaterThan(0);
+  });
+
+  // 6. Synthetic / legacy history without a real signature → synthetic default.
+  //    This covers: another model/provider, an older client, manual history.
+  it("falls back to the synthetic default signature when no real signature is present", () => {
+    const out = O2G([
+      { role: "user", content: "x" },
+      { role: "assistant", tool_calls: [{
+        id: "call_x", type: "function",
+        function: { name: "read", arguments: "{}" },
+      }] },
+    ]);
+    const sig = out.contents[1].parts[0].thoughtSignature;
+    expect(sig).toBeTruthy();
+    expect(typeof sig).toBe("string");
+    expect(sig.length).toBeGreaterThan(50); // default is a long opaque blob
+  });
+
+  // 7. Valid text + tool call together — sig still emitted on tool_call.
+  it("text + functionCall: signature attaches only to functionCall", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, {
+      response: {
+        responseId: "r-mix", modelVersion: "gemini-3-flash",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [
+              { text: "I'll read the file now." },
+              { thoughtSignature: "REAL_SIG_MIX", functionCall: { id: "call_mix", name: "read", args: { filePath: "/b" } } },
+            ],
+          },
+          finishReason: "STOP", index: 0,
+        }],
+      },
+    }, state);
+    const textChunk = events.find((e) => e.choices?.[0]?.delta?.content === "I'll read the file now.");
+    expect(textChunk).toBeTruthy();
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].extra_content.google.thought_signature).toBe("REAL_SIG_MIX");
+  });
+
+  // 8. Tool-only response (no text): still a proper tool_call.
+  it("tool-only response: structured functionCall surfaces as tool_call", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, {
+      response: {
+        responseId: "r-tool", modelVersion: "gemini-3-flash",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{ thoughtSignature: "SIG_TOOL_ONLY", functionCall: { id: "call_t", name: "bash", args: { command: "ls" } } }],
+          },
+          finishReason: "STOP", index: 0,
+        }],
+      },
+    }, state);
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].function.name).toBe("bash");
+    expect(toolChunk.choices[0].delta.tool_calls[0].extra_content.google.thought_signature).toBe("SIG_TOOL_ONLY");
+    // No assistant content delta should be emitted alongside the tool_call
+    // (a tool-only model turn is exactly that — no prose narration).
+    const textChunks = events.filter((e) => typeof e.choices?.[0]?.delta?.content === "string");
+    expect(textChunks).toHaveLength(0);
+  });
+
+  // 9. Signature-containing empty-text Part: must NOT surface as empty content.
+  //    Gemini sometimes emits { thoughtSignature, text: "" } alone; the translator
+  //    must drop the empty text but preserve the part's signature association
+  //    for any sibling functionCall in the same content.
+  it("empty-text + thoughtSignature Part: empty text is dropped, signature is retained for sibling FC", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, {
+      response: {
+        responseId: "r-empty-sig", modelVersion: "gemini-3-flash",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [
+              { thoughtSignature: "SIG_X", text: "" },
+              { thoughtSignature: "SIG_X", functionCall: { id: "call_e", name: "read", args: { filePath: "/c" } } },
+            ],
+          },
+          finishReason: "STOP", index: 0,
+        }],
+      },
+    }, state);
+    // No empty-text content delta should be emitted.
+    const textChunks = events.filter((e) => typeof e.choices?.[0]?.delta?.content === "string");
+    expect(textChunks).toHaveLength(0);
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk.choices[0].delta.tool_calls[0].id).toBe("call_e");
+  });
+
+  // 10. Common OpenCode tool names round-trip cleanly.
+  it.each(["read", "grep", "bash", "edit", "glob", "list", "write"])(
+    "name %s round-trips through Gemini function call without mutation",
+    (name) => {
+      const out = O2G([
+        { role: "user", content: "x" },
+        { role: "assistant", tool_calls: [{
+          id: `call_${name}`, type: "function",
+          function: { name, arguments: "{}" },
+          extra_content: { google: { thought_signature: `SIG_${name}` } },
+        }] },
+      ]);
+      expect(out.contents[1].parts[0].functionCall.name).toBe(name);
+      expect(out.contents[1].parts[0].thoughtSignature).toBe(`SIG_${name}`);
+    },
+  );
+
+  // 11. Colon/namespace-style names (e.g. "default_api:read") preserved.
+  it("colon/namespace-style tool names survive sanitization", () => {
+    const out = O2G([
+      { role: "user", content: "x" },
+      { role: "assistant", tool_calls: [{
+        id: "call_ns", type: "function",
+        function: { name: "default_api:read", arguments: JSON.stringify({ filePath: "/d" }) },
+        extra_content: { google: { thought_signature: "SIG_NS" } },
+      }] },
+    ]);
+    expect(out.contents[1].parts[0].functionCall.name).toBe("default_api:read");
+    expect(out.contents[1].parts[0].thoughtSignature).toBe("SIG_NS");
+  });
+
+  // 12. functionResponse.name maps back to the correct functionCall (round-trip).
+  it("functionResponse recovers the original functionCall name when history carries the call", () => {
+    const out = O2G([
+      { role: "user", content: "read it" },
+      { role: "assistant", tool_calls: [{
+        id: "read_1736000000000_0", type: "function",
+        function: { name: "read", arguments: "{}" },
+        extra_content: { google: { thought_signature: "SIG" } },
+      }] },
+      { role: "tool", tool_call_id: "read_1736000000000_0", content: '{"content":"data"}' },
+    ]);
+    const fr = out.contents.find((c) => c.parts?.[0]?.functionResponse)?.parts[0].functionResponse;
+    expect(fr.name).toBe("read");
+  });
+
+  // 13. Normalization does not reorder signed Parts. Two adjacent model
+  //     contents must merge without dropping/reordering signature-bearing
+  //     functionCall Parts (the empty-parts filter is upstream of normalize).
+  it("normalizeGeminiContents preserves positional order of signed Parts when merging adjacent model turns", () => {
+    // Force the merge: two model turns in a row (e.g. when a client emits
+    // a separate assistant message per parallel tool call). The merged
+    // content must keep Parts in original order with their signatures.
+    const out = O2AG([
+      { role: "user", content: "step" },
+      { role: "assistant", tool_calls: [{
+        id: "call_1", type: "function",
+        function: { name: "read", arguments: "{}" },
+        extra_content: { google: { thought_signature: "FIRST_SIG" } },
+      }] },
+      { role: "assistant", content: "thinking..." },
+      { role: "assistant", tool_calls: [{
+        id: "call_2", type: "function",
+        function: { name: "grep", arguments: "{}" },
+        extra_content: { google: { thought_signature: "SECOND_SIG" } },
+      }] },
+    ]);
+    const modelContent = out.request.contents.find((c) => c.role === "model");
+    expect(modelContent).toBeTruthy();
+    // First functionCall part must carry FIRST_SIG, second must carry SECOND_SIG.
+    const fcParts = modelContent.parts.filter((p) => p.functionCall);
+    expect(fcParts).toHaveLength(2);
+    expect(fcParts[0].functionCall.name).toBe("read");
+    expect(fcParts[0].thoughtSignature).toBe("FIRST_SIG");
+    expect(fcParts[1].functionCall.name).toBe("grep");
+    expect(fcParts[1].thoughtSignature).toBe("SECOND_SIG");
+  });
+
+  // 14. Structured functionCall must translate to a tool_calls SSE chunk,
+  //     NEVER to literal assistant prose ("call:default_api:read{...}").
+  //     Regression guard for the OpenCode "pseudo-tool prose" symptom: if
+  //     the upstream emits a structured functionCall, the OpenAI-facing SSE
+  //     contains tool_calls, not content.
+  it("structured functionCall becomes tool_calls SSE, not assistant prose", () => {
+    const state = initState(FORMATS.OPENAI);
+    const events = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.OPENAI, {
+      response: {
+        responseId: "r-no-prose", modelVersion: "gemini-3-flash",
+        candidates: [{
+          content: {
+            role: "model",
+            parts: [{
+              thoughtSignature: "SIG_NO_PROSE",
+              functionCall: { id: "call_real", name: "default_api:read", args: { filePath: "/e" } },
+            }],
+          },
+          finishReason: "STOP", index: 0,
+        }],
+      },
+    }, state);
+    // tool_calls chunk exists with the upstream function name.
+    const toolChunk = events.find((e) => e.choices?.[0]?.delta?.tool_calls);
+    expect(toolChunk).toBeTruthy();
+    expect(toolChunk.choices[0].delta.tool_calls[0].function.name).toBe("default_api:read");
+    // No content delta carries literal pseudo-tool prose.
+    for (const e of events) {
+      const content = e.choices?.[0]?.delta?.content;
+      if (typeof content === "string") {
+        expect(content).not.toMatch(/^call:[a-z_]+:/);
+      }
+    }
+  });
+});

--- a/tests/unit/antigravity-normalize-contents.test.js
+++ b/tests/unit/antigravity-normalize-contents.test.js
@@ -1,0 +1,163 @@
+// Regression: normalizeAntigravityContents() in open-sse/executors/antigravity.js
+// was introduced to remove empty contents that survived thought-only filtering
+// and to merge adjacent same-role messages. After thought-only filtering the
+// payload must remain structurally valid:
+//
+// - no content object has an empty/missing parts array
+// - adjacent same-role contents are merged
+// - valid text remains
+// - valid functionCall remains
+// - valid functionResponse remains
+// - thoughtSignature handling remains valid
+//
+// Drift in either direction breaks the Antigravity upstream (400 from the
+// server) or alternately — if the prior buggy copy is reinstated — leaves
+// adjacent model messages in history and the empty-parts object that Gemini
+// rejects.
+import { describe, it, expect } from "vitest";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
+
+const wrap = (contents) => ({ request: { contents }, stream: true });
+
+describe("Antigravity normalizeAntigravityContents (via transformRequest)", () => {
+  it("removes content entries that have empty parts after thought-only filtering", () => {
+    // The upstream transformRequest strips thought-only parts (line 233-238 of
+    // antigravity.js). If a model's reasoning-only message loses its only part,
+    // the resulting contents array would have an empty parts[] — Gemini rejects
+    // that. The normalize step must drop it.
+    const ex = new AntigravityExecutor();
+    const out = ex.transformRequest(
+      "gemini-2.5-pro",
+      wrap([
+        { role: "user", parts: [{ text: "hi" }] },
+        // thought-only entry — its only part is dropped, leaving parts: []
+        { role: "model", parts: [{ thought: true, text: "internal monologue" }] },
+      ]),
+      true,
+      { projectId: "p", connectionId: "c" },
+    );
+
+    // The reasoning-only "model" entry was dropped; only the user entry remains.
+    expect(out.request.contents).toHaveLength(1);
+    expect(out.request.contents[0].parts[0].text).toBe("hi");
+  });
+
+  it("merges adjacent same-role contents", () => {
+    const ex = new AntigravityExecutor();
+    const out = ex.transformRequest(
+      "gemini-2.5-pro",
+      wrap([
+        { role: "user", parts: [{ text: "first" }] },
+        { role: "user", parts: [{ text: "second" }] },
+        { role: "model", parts: [{ text: "answer" }] },
+      ]),
+      true,
+      { projectId: "p", connectionId: "c" },
+    );
+
+    expect(out.request.contents).toHaveLength(2);
+    expect(out.request.contents[0].parts).toHaveLength(2);
+    expect(out.request.contents[0].parts[0].text).toBe("first");
+    expect(out.request.contents[0].parts[1].text).toBe("second");
+    expect(out.request.contents[1].parts[0].text).toBe("answer");
+  });
+
+  it("preserves valid text content", () => {
+    const ex = new AntigravityExecutor();
+    const out = ex.transformRequest(
+      "gemini-2.5-pro",
+      wrap([
+        { role: "user", parts: [{ text: "question" }] },
+        { role: "model", parts: [{ text: "answer" }] },
+      ]),
+      true,
+      { projectId: "p", connectionId: "c" },
+    );
+
+    expect(out.request.contents).toHaveLength(2);
+    expect(out.request.contents[0].parts[0].text).toBe("question");
+    expect(out.request.contents[1].parts[0].text).toBe("answer");
+  });
+
+  it("preserves valid functionCall content", () => {
+    const ex = new AntigravityExecutor();
+    const out = ex.transformRequest(
+      "gemini-2.5-pro",
+      wrap([
+        { role: "user", parts: [{ text: "run it" }] },
+        { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] },
+      ]),
+      true,
+      { projectId: "p", connectionId: "c" },
+    );
+
+    expect(out.request.contents).toHaveLength(2);
+    expect(out.request.contents[1].parts[0].functionCall.name).toBe("bash");
+    expect(out.request.contents[1].parts[0].functionCall.args).toEqual({ command: "ls" });
+  });
+
+  it("preserves valid functionResponse with role normalized to user (Claude models)", () => {
+    const ex = new AntigravityExecutor();
+    const out = ex.transformRequest(
+      "claude-opus-4-6",
+      wrap([
+        { role: "user", parts: [{ text: "run it" }] },
+        { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] },
+        // functionResponse must be role "user" for Claude models via Antigravity
+        { role: "function", parts: [{ functionResponse: { name: "bash", response: { result: "ok" } } }] },
+      ]),
+      true,
+      { projectId: "p", connectionId: "c" },
+    );
+
+    expect(out.request.contents).toHaveLength(3);
+    expect(out.request.contents[2].role).toBe("user");
+    expect(out.request.contents[2].parts[0].functionResponse.name).toBe("bash");
+  });
+
+  it("keeps thoughtSignature on functionCall parts (Gemini 3+ requires it) and backfills default when missing", () => {
+    const ex = new AntigravityExecutor();
+    const out = ex.transformRequest(
+      "gemini-3-pro",
+      wrap([
+        { role: "user", parts: [{ text: "do it" }] },
+        // functionCall without thoughtSignature — must be backfilled
+        { role: "model", parts: [{ functionCall: { name: "bash", args: { command: "ls" } } }] },
+        // functionCall WITH thoughtSignature — must be preserved
+        { role: "model", parts: [{ functionCall: { name: "grep", args: {} }, thoughtSignature: "sig-123" }] },
+      ]),
+      true,
+      { projectId: "p", connectionId: "c" },
+    );
+
+    // After merging adjacent same-role model contents
+    const modelContent = out.request.contents.find((c) => c.role === "model");
+    expect(modelContent.parts).toHaveLength(2);
+
+    const fcBash = modelContent.parts.find((p) => p.functionCall?.name === "bash");
+    expect(fcBash.thoughtSignature).toBeTruthy(); // backfilled
+
+    const fcGrep = modelContent.parts.find((p) => p.functionCall?.name === "grep");
+    expect(fcGrep.thoughtSignature).toBe("sig-123"); // preserved
+  });
+
+  it("drops a content entry that becomes empty after thought-only filter AND merges adjacent same-role", () => {
+    const ex = new AntigravityExecutor();
+    const out = ex.transformRequest(
+      "gemini-2.5-pro",
+      wrap([
+        { role: "user", parts: [{ text: "hi" }] },
+        // thought-only model → empty parts after filter
+        { role: "model", parts: [{ thought: true, text: "thinking..." }] },
+        // adjacent same-role model → should merge
+        { role: "model", parts: [{ text: "answer" }] },
+      ]),
+      true,
+      { projectId: "p", connectionId: "c" },
+    );
+
+    expect(out.request.contents).toHaveLength(2);
+    expect(out.request.contents[0].parts[0].text).toBe("hi");
+    expect(out.request.contents[1].parts[0].text).toBe("answer");
+  });
+});

--- a/tests/unit/capabilities.test.js
+++ b/tests/unit/capabilities.test.js
@@ -56,3 +56,40 @@ describe("getCapabilitiesForModel", () => {
     expect(getCapabilitiesForModel("kiro", "gpt-5.6-sol-thinking-agentic")).toMatchObject(kiroGpt56Expected);
   });
 });
+
+describe("Gemini 3.x capability pattern (regression for *gemini-3.6* addition)", () => {
+  // Locks in the new *gemini-3.6* PATTERN_CAPABILITIES entry added in
+  // fix/gemini-3.6-capabilities. The literal name "gemini-3.6" is a
+  // defensive pre-recognition; the actual registered model ids end in
+  // "-flash" / "-flash-high" / "-flash-medium" / "-flash-low" and would
+  // also match the broader *gemini-3* pattern. The new pattern must
+  // match the literal name anyway so a future "gemini-3.6" id (no
+  // suffix) is classified as a Gemini-3-class multimodal model.
+  it("matches the literal gemini-3.6 model id with full multimodal caps", () => {
+    const caps = getCapabilitiesForModel("antigravity", "gemini-3.6");
+    expect(caps.contextWindow).toBe(1048576);
+    expect(caps.maxOutput).toBe(65536);
+    expect(caps.vision).toBe(true);
+    expect(caps.audioInput).toBe(true);
+    expect(caps.videoInput).toBe(true);
+    expect(caps.reasoning).toBe(true);
+    expect(caps.search).toBe(true);
+    expect(caps.thinkingFormat).toBe("gemini-level");
+    expect(caps.thinkingCanDisable).toBe(false);
+  });
+
+  it("matches gemini-3.6-flash and tiered variants (provider-prefixed too)", () => {
+    for (const model of [
+      "gemini-3.6-flash",
+      "gemini-3.6-flash-high",
+      "gemini-3.6-flash-medium",
+      "gemini-3.6-flash-low",
+      "google/gemini-3.6-flash",
+    ]) {
+      const caps = getCapabilitiesForModel("antigravity", model);
+      expect(caps.contextWindow, model).toBe(1048576);
+      expect(caps.maxOutput, model).toBe(65536);
+      expect(caps.thinkingFormat, model).toBe("gemini-level");
+    }
+  });
+});

--- a/tests/unit/deferred-request-success.test.js
+++ b/tests/unit/deferred-request-success.test.js
@@ -1,0 +1,79 @@
+// Deferred onRequestSuccess: clearing the account error state must not happen
+// on the first byte of a stream that later proves to be empty/aborted.
+//
+// Phase 10 fix: handleStreamingResponse wraps the transform stream's readable
+// side with a success tee that fires onRequestSuccess on the first byte that
+// actually crosses the wire. A 200-with-no-body response never reaches the
+// tee and therefore never clears the account error state.
+//
+// We exercise the wiring directly: build the same tee the production code
+// builds, pipe the provider stream through it, and assert whether the
+// callback fires based on whether any translated bytes survived.
+import { describe, it, expect, vi } from "vitest";
+
+const encoder = new TextEncoder();
+
+function makeResponse(bytes) {
+  return new Response(new ReadableStream({
+    start(controller) {
+      if (bytes.length) controller.enqueue(bytes);
+      controller.close();
+    },
+  }), { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+// Mirror the production tee construction from streamingHandler.js. Kept
+// here so this test does not depend on the full handleStreamingResponse
+// (which requires an SSE parser to emit anything).
+function makeSuccessTee(onFirstChunk) {
+  let fired = false;
+  return new TransformStream({
+    transform(chunk, controller) {
+      if (!fired) {
+        fired = true;
+        Promise.resolve().then(onFirstChunk).catch(() => {});
+      }
+      controller.enqueue(chunk);
+    },
+  });
+}
+
+async function drain(stream) {
+  const reader = stream.getReader();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) out += new TextDecoder().decode(value, { stream: true });
+  }
+  return out;
+}
+
+describe("deferred success tee (mirrors handleStreamingResponse wiring)", () => {
+  it("fires the callback when at least one chunk crosses the tee", async () => {
+    const onRequestSuccess = vi.fn();
+    const tee = makeSuccessTee(onRequestSuccess);
+    const body = makeResponse(encoder.encode("first byte\nsecond byte\n")).body;
+    await drain(body.pipeThrough(tee));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onRequestSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire the callback when the stream is empty", async () => {
+    const onRequestSuccess = vi.fn();
+    const tee = makeSuccessTee(onRequestSuccess);
+    const body = makeResponse(encoder.encode("")).body;
+    await drain(body.pipeThrough(tee));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onRequestSuccess).not.toHaveBeenCalled();
+  });
+
+  it("fires the callback only once even across many chunks", async () => {
+    const onRequestSuccess = vi.fn();
+    const tee = makeSuccessTee(onRequestSuccess);
+    const body = makeResponse(encoder.encode("a\nb\nc\nd\n")).body;
+    await drain(body.pipeThrough(tee));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onRequestSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/empty-stream-account-rotation.test.js
+++ b/tests/unit/empty-stream-account-rotation.test.js
@@ -1,0 +1,305 @@
+// Server-side account recovery in the Antigravity empty-stream guard.
+// OpenCode does NOT automatically retry after an in-stream error (its
+// /goal plugin counts a textual fake-tool as no-tool, but a real error
+// just stops the agent). To avoid surfacing the error to OpenCode when
+// another eligible account exists, the empty-stream guard now calls an
+// `onAccountRotate` hook BEFORE emitting the synthetic error event.
+//
+// These tests cover the contract from the brief:
+//   1. A empty → A retry succeeds → no rotation
+//   2. A exhausts → B succeeds (same logical request, new credentials)
+//   3. A RESOURCE_EXHAUSTED → A benched → B succeeds
+//   4. A+B exhaust → C succeeds
+//   5. all accounts exhaust → final error event
+//   6. one account only → bounded retries then error
+//   7. visible text then truncation → NO rotation (safety)
+//   8. functionCall then truncation → NO rotation / NO duplicate tool
+//   9. client abort → all work stops, no rotation
+//  10. rotated account has separate proxy config
+//  11. rotated account requires OAuth refresh
+//  12. rotated account requires projectId resolution
+//  13. no Account A metadata leaks into Account B request
+//  14. non-Antigravity provider unchanged
+import { describe, it, expect, vi } from "vitest";
+import { createEmptyRetryStream } from "../../open-sse/handlers/chatCore/emptyStreamGuard.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const wrap = (response) => ({ response });
+const bareStop = () => wrap({ candidates: [{ content: { role: "model", parts: [] }, finishReason: "STOP" }] });
+const text = (t) => wrap({ candidates: [{ content: { role: "model", parts: [{ text: t }] } }] });
+const finish = (finishReason) => wrap({ candidates: [{ finishReason }] });
+const sseText = (events) => events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+
+function sseBody(events) {
+  const bytes = encoder.encode(sseText(events));
+  return new ReadableStream({
+    start(controller) { if (bytes.length) controller.enqueue(bytes); controller.close(); },
+  });
+}
+
+async function drain(stream) {
+  const reader = stream.getReader();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+const dataEvents = (out) => out.split("\n").map((l) => l.trim()).filter((l) => l.startsWith("data:")).map((l) => JSON.parse(l.slice(5).trim()));
+
+// Build a wrapper whose initial attempt is empty and each reexecute() returns
+// the next scripted attempt. `onAccountRotate` may return a replacement
+// reexecute (used to simulate "rotate to a new account"); if it returns null
+// the guard emits the exhaustion error.
+function buildWrapper({ attempts, accountSequence, onAccountRotate, onExhausted, baseDelayMs = 1 }) {
+  let attemptsFired = 0;
+  let reexecuteCallCount = 0;
+  const calls = { reexecute: [], rotate: [] };
+
+  const reexecute = async () => {
+    reexecuteCallCount++;
+    calls.reexecute.push(reexecuteCallCount);
+    attemptsFired++;
+    const next = attempts[attemptsFired];
+    if (!next) throw new Error(`scripted attempts exhausted at attempt ${attemptsFired}`);
+    return sseBody(next);
+  };
+
+  const wrapper = async () => {
+    const stream = createEmptyRetryStream({
+      body: sseBody(attempts[0]),
+      reexecute,
+      signal: undefined,
+      log: null,
+      baseDelayMs,
+      onExhausted,
+      onAccountRotate: onAccountRotate ? async (reason, meta) => {
+        calls.rotate.push({ reason, meta });
+        const next = await onAccountRotate(reason, meta, accountSequence);
+        return next || null;
+      } : undefined,
+    });
+    return drain(stream);
+  };
+
+  return { run: wrapper, calls };
+}
+
+describe("empty-stream guard: server-side account rotation", () => {
+  it("A empty → A retry succeeds → no rotation", async () => {
+    const attempt2 = [text("Hello there"), finish("STOP")];
+    const onAccountRotate = vi.fn();
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], attempt2],
+      onAccountRotate,
+    });
+    const out = await run();
+    expect(out).toBe(sseText(attempt2));
+    expect(onAccountRotate).not.toHaveBeenCalled();
+  });
+
+  it("A exhausts → B succeeds (same logical request, new credentials)", async () => {
+    const accountSequence = ["A", "B"];
+    const attemptFromB = [text("from B"), finish("STOP")];
+    const onAccountRotate = vi.fn(async () => ({
+      reexecute: async () => sseBody(attemptFromB),
+    }));
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      accountSequence,
+      onAccountRotate,
+    });
+    const out = await run();
+    expect(out).toBe(sseText(attemptFromB));
+    expect(onAccountRotate).toHaveBeenCalledTimes(1);
+  });
+
+  it("A RESOURCE_EXHAUSTED → A benched → B succeeds", async () => {
+    const onExhausted = vi.fn();
+    const onAccountRotate = vi.fn(async () => ({
+      reexecute: async () => sseBody([text("B-OK"), finish("STOP")]),
+    }));
+    const quota = wrap({ error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded. Your quota will reset after 1h" } });
+    const { run } = buildWrapper({
+      attempts: [[quota], [quota], [quota]],
+      onAccountRotate,
+      onExhausted,
+    });
+    const out = await run();
+    expect(out).toContain("B-OK");
+    // onExhausted must NOT have fired — rotation saved the request from
+    // surfacing the error to the client.
+    expect(onExhausted).not.toHaveBeenCalled();
+  });
+
+  it("A+B exhaust → C succeeds (rotation is multi-hop)", async () => {
+    let rotationIndex = 0;
+    const onAccountRotate = vi.fn(async () => {
+      rotationIndex++;
+      // 1st rotation: account B, also empty → forces a 2nd rotation
+      // 2nd rotation: account C, succeeds
+      const attempt = rotationIndex === 1
+        ? [bareStop(), bareStop(), bareStop()]
+        : [text("C-OK"), finish("STOP")];
+      return { reexecute: async () => sseBody(attempt) };
+    });
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      onAccountRotate,
+    });
+    const out = await run();
+    expect(out).toContain("C-OK");
+    expect(onAccountRotate).toHaveBeenCalledTimes(2);
+  });
+
+  it("all accounts exhaust → final error event", async () => {
+    const onAccountRotate = vi.fn(async () => null);
+    const onExhausted = vi.fn();
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      onAccountRotate,
+      onExhausted,
+    });
+    const out = await run();
+    const events = dataEvents(out);
+    expect(events).toHaveLength(1);
+    expect(events[0].error.status).toBe("EMPTY_RESPONSE");
+    expect(onAccountRotate).toHaveBeenCalledTimes(1);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  it("one account only → bounded retries then error (no rotation possible)", async () => {
+    const onAccountRotate = vi.fn(async () => null);
+    const onExhausted = vi.fn();
+    const { run, calls } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      onAccountRotate,
+      onExhausted,
+    });
+    const out = await run();
+    expect(dataEvents(out)).toHaveLength(1);
+    expect(onAccountRotate).toHaveBeenCalledTimes(1); // guard asked once; no more accounts
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    // EMPTY_STREAM_MAX_RETRIES=2 → 3 attempts (1 initial + 2 retries).
+    expect(calls.reexecute.length).toBe(2);
+  });
+
+  it("visible text then truncation → NO rotation (safety: never replay meaningful output)", async () => {
+    const onAccountRotate = vi.fn(async () => ({ reexecute: async () => sseBody([text("B"), finish("STOP")]) }));
+    const { run } = buildWrapper({
+      attempts: [[text("partial answer")]], // truncated with content; guard does NOT retry
+      onAccountRotate,
+    });
+    const out = await run();
+    expect(out).toContain("partial answer");
+    expect(onAccountRotate).not.toHaveBeenCalled();
+  });
+
+  it("functionCall then truncation → NO rotation (never duplicate a tool call)", async () => {
+    const fc = wrap({ candidates: [{ content: { role: "model", parts: [{ functionCall: { id: "call_x", name: "read", args: {} } }] }, finishReason: "STOP", index: 0 }] });
+    const onAccountRotate = vi.fn(async () => ({ reexecute: async () => sseBody([text("B"), finish("STOP")]) }));
+    const { run } = buildWrapper({
+      attempts: [[fc]], // tool call emitted → never retried
+      onAccountRotate,
+    });
+    const out = await run();
+    expect(out).toContain("call_x");
+    expect(onAccountRotate).not.toHaveBeenCalled();
+  });
+
+  it("client abort → all work stops, no rotation", async () => {
+    const ac = new AbortController();
+    let ctrl;
+    const body = new ReadableStream({ start(c) { ctrl = c; } }); // never emits
+    ac.signal.addEventListener("abort", () => {
+      ctrl.error(Object.assign(new Error("aborted"), { name: "AbortError" }));
+    });
+    const onAccountRotate = vi.fn();
+    const stream = createEmptyRetryStream({
+      body,
+      reexecute: vi.fn(),
+      signal: ac.signal,
+      log: null,
+      baseDelayMs: 1,
+      onAccountRotate,
+    });
+    const drained = drain(stream);
+    setTimeout(() => ac.abort(), 10);
+    await expect(drained).rejects.toMatchObject({ name: "AbortError" });
+    expect(onAccountRotate).not.toHaveBeenCalled();
+  });
+
+  it("rotated account has separate proxy config (callback is invoked with credentials to use)", async () => {
+    // Verify that the reexecute() factory from the rotated account is
+    // called with its OWN credentials, not the failed account's. We capture
+    // via a counter and assert that the new factory is the one used (it is
+    // the same instance returned by onAccountRotate).
+    let rotatedCalls = 0;
+    const rotatedFactory = vi.fn(async () => {
+      rotatedCalls++;
+      return sseBody([text("from rotated"), finish("STOP")]);
+    });
+    const onAccountRotate = vi.fn(async () => ({ reexecute: rotatedFactory }));
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      onAccountRotate,
+    });
+    await run();
+    expect(rotatedCalls).toBeGreaterThan(0);
+    expect(rotatedFactory).toHaveBeenCalled();
+  });
+
+  it("onAccountRotate failure → guard falls through to the normal exhaustion path", async () => {
+    const onAccountRotate = vi.fn(async () => { throw new Error("credential lookup failed"); });
+    const onExhausted = vi.fn();
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      onAccountRotate,
+      onExhausted,
+    });
+    const out = await run();
+    expect(dataEvents(out)).toHaveLength(1);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  it("onAccountRotate returning null → normal exhaustion path", async () => {
+    const onAccountRotate = vi.fn(async () => null);
+    const onExhausted = vi.fn();
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      onAccountRotate,
+      onExhausted,
+    });
+    await run();
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  it("rotation never duplicates client-actionable output (the empty-stream guard withholds until meaningful)", async () => {
+    // The whole point: meaningfulSeen is false at the point where rotation
+    // happens, so the rotated attempt's meaningful content is the FIRST
+    // content the client sees. If a meaningful chunk ever crossed the wire
+    // before rotation, the guard's content-OR-terminalForwarded early-exit
+    // would prevent rotation entirely.
+    const seen = [];
+    const onAccountRotate = vi.fn(async () => ({
+      reexecute: async () => {
+        seen.push("rotated");
+        return sseBody([text("first meaningful content after rotation"), finish("STOP")]);
+      },
+    }));
+    const { run } = buildWrapper({
+      attempts: [[bareStop()], [bareStop()], [bareStop()]],
+      onAccountRotate,
+    });
+    const out = await run();
+    expect(seen).toEqual(["rotated"]);
+    expect(out).toContain("first meaningful content after rotation");
+    // No content from the discarded empty attempts.
+    expect(out).not.toContain("partial");
+  });
+});

--- a/tests/unit/empty-stream-guard.test.js
+++ b/tests/unit/empty-stream-guard.test.js
@@ -1,0 +1,281 @@
+// Antigravity empty-stream guard — oh-my-pi parity: everything (thinking
+// included) streams live; empty attempts are retried in-stream by splicing the
+// retried upstream into the same client stream; exhaustion emits an in-stream
+// {error} event (#2188, #2229, #2250, #2259, #2431).
+import { describe, it, expect, vi } from "vitest";
+import { createEmptyRetryStream } from "../../open-sse/handlers/chatCore/emptyStreamGuard.js";
+import { translateResponse, initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const wrap = (response) => ({ response });
+const thought = (text) => wrap({ candidates: [{ content: { role: "model", parts: [{ text, thought: true }] } }] });
+const text = (t) => wrap({ candidates: [{ content: { role: "model", parts: [{ text: t }] } }] });
+const finish = (finishReason) => wrap({ candidates: [{ finishReason }] });
+const bareStop = () => wrap({ candidates: [{ content: { role: "model", parts: [] }, finishReason: "STOP" }] });
+
+const sseText = (events) => events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+
+function sseBody(events, { chunkSize } = {}) {
+  const bytes = encoder.encode(sseText(events));
+  return new ReadableStream({
+    start(controller) {
+      if (!chunkSize) {
+        if (bytes.length) controller.enqueue(bytes);
+      } else {
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+          controller.enqueue(bytes.slice(i, i + chunkSize));
+        }
+      }
+      controller.close();
+    },
+  });
+}
+
+async function drain(stream) {
+  const reader = stream.getReader();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+const dataEvents = (out) => out.split("\n")
+  .map((l) => l.trim())
+  .filter((l) => l.startsWith("data:"))
+  .map((l) => JSON.parse(l.slice(5).trim()));
+
+const finishEvents = (out) => dataEvents(out).filter((e) => (e.response || e).candidates?.[0]?.finishReason);
+
+// Scripted attempts: attempt 0 is the initial body; each reexecute() serves the
+// next list. Throws when the script runs out (exercises the reexecute-failure path).
+async function runWrapper(attemptLists, { signal, onExhausted, reexecute, chunkSize } = {}) {
+  let calls = 0;
+  const stream = createEmptyRetryStream({
+    body: sseBody(attemptLists[0], { chunkSize }),
+    reexecute: reexecute || (async () => {
+      calls++;
+      const next = attemptLists[calls];
+      if (!next) throw new Error("no scripted attempt left");
+      return sseBody(next, { chunkSize });
+    }),
+    signal,
+    onExhausted,
+    log: null,
+    baseDelayMs: 1,
+  });
+  const out = await drain(stream);
+  return { out, retries: calls };
+}
+
+describe("createEmptyRetryStream", () => {
+  it("streams thought-only chunks live and byte-faithfully before any answer", async () => {
+    const events = [thought("let me think"), thought("still thinking"), text("Answer"), finish("STOP")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  it("suppresses a bare-STOP empty attempt and splices the retry", async () => {
+    const attempt2 = [text("Hello there"), finish("STOP")];
+    const { out, retries } = await runWrapper([[bareStop()], attempt2]);
+    expect(out).toBe(sseText(attempt2)); // attempt 1 fully withheld
+    expect(retries).toBe(1);
+    expect(finishEvents(out)).toHaveLength(1);
+  });
+
+  it("splices correctly when events are split across tiny reads", async () => {
+    const attempt2 = [text("Split across reads"), finish("STOP")];
+    const { out, retries } = await runWrapper([[bareStop()], attempt2], { chunkSize: 7 });
+    expect(out).toBe(sseText(attempt2));
+    expect(retries).toBe(1);
+  });
+
+  // The accepted oh-my-pi wart: a discarded thought-only attempt has already
+  // streamed its thinking, so the client sees both attempts' thinking in one message.
+  it("thought-only STOP attempt retries; both attempts' thinking reach the client", async () => {
+    const { out, retries } = await runWrapper([
+      [thought("first try"), bareStop()],
+      [thought("second try"), text("answer"), finish("STOP")],
+    ]);
+    expect(out).toContain("first try");
+    expect(out).toContain("second try");
+    expect(retries).toBe(1);
+    expect(finishEvents(out)).toHaveLength(1); // attempt 1's STOP withheld
+  });
+
+  it("exhaustion emits a synthetic error event and reports the reason", async () => {
+    const onExhausted = vi.fn();
+    const { out, retries } = await runWrapper(
+      [[bareStop()], [bareStop()], [bareStop()]],
+      { onExhausted },
+    );
+    expect(retries).toBe(2);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted.mock.calls[0][0]).toContain("after 3 attempts");
+    const events = dataEvents(out);
+    expect(events).toHaveLength(1);
+    expect(events[0].error.status).toBe("EMPTY_RESPONSE");
+    expect(events[0].error.message).toContain("STOP");
+  });
+
+  it("exhaustion re-emits a held real upstream error instead of the synthetic one", async () => {
+    const quota = wrap({ error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded" } });
+    const { out, retries } = await runWrapper([[quota], [quota], [quota]]);
+    expect(retries).toBe(2);
+    const events = dataEvents(out);
+    expect(events).toHaveLength(1); // held errors of earlier attempts never forwarded
+    expect(events[0].response.error.status).toBe("RESOURCE_EXHAUSTED");
+    expect(events[0].response.error.message).toBe("Quota exceeded");
+  });
+
+  it("MALFORMED_FUNCTION_CALL before content is withheld and retried", async () => {
+    const attempt2 = [text("recovered"), finish("STOP")];
+    const { out, retries } = await runWrapper([
+      [thought("about to call the tool"), finish("MALFORMED_FUNCTION_CALL")],
+      attempt2,
+    ]);
+    expect(retries).toBe(1);
+    expect(out).not.toContain("MALFORMED_FUNCTION_CALL");
+    expect(finishEvents(out)).toHaveLength(1);
+  });
+
+  it("MALFORMED_FUNCTION_CALL after content forwards (translator surfaces the error)", async () => {
+    const events = [text("Partial answer"), finish("MALFORMED_FUNCTION_CALL")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  // Content blocks are deterministic — never retried; the translator closes
+  // them as content_filter (#2188).
+  it("promptFeedback.blockReason forwards untouched with no retry", async () => {
+    const events = [wrap({ promptFeedback: { blockReason: "SAFETY" } })];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  it("SAFETY finish with no content forwards untouched with no retry", async () => {
+    const events = [thought("hmm"), finish("SAFETY")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  it("MAX_TOKENS with no visible content forwards with no retry", async () => {
+    const events = [thought("thinking ate the budget"), finish("MAX_TOKENS")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  it("a stream truncated after content closes without retry", async () => {
+    const events = [text("half an answer")];
+    const { out, retries } = await runWrapper([events]);
+    expect(out).toBe(sseText(events));
+    expect(retries).toBe(0);
+  });
+
+  it("cancelling the wrapper cancels the upstream reader", async () => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(sseText([text("hi")])));
+        // stream stays open
+      },
+      cancel() { cancelled = true; },
+    });
+    const stream = createEmptyRetryStream({ body, reexecute: async () => sseBody([]), baseDelayMs: 1 });
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel();
+    expect(cancelled).toBe(true);
+  });
+
+  it("client abort surfaces as an AbortError, not a retry", async () => {
+    const ac = new AbortController();
+    let ctrl;
+    const body = new ReadableStream({ start(c) { ctrl = c; } }); // never emits
+    ac.signal.addEventListener("abort", () => {
+      ctrl.error(Object.assign(new Error("This operation was aborted"), { name: "AbortError" }));
+    });
+    const reexecute = vi.fn();
+    const stream = createEmptyRetryStream({ body, reexecute, signal: ac.signal, baseDelayMs: 1 });
+    const drained = drain(stream);
+    setTimeout(() => ac.abort(), 10);
+    await expect(drained).rejects.toMatchObject({ name: "AbortError" });
+    expect(reexecute).not.toHaveBeenCalled();
+  });
+
+  // The error event triggers the client's automatic retry — the bench must have
+  // landed before it, or the retry can re-pick the account that just failed.
+  it("awaits onExhausted (account bench) before emitting the error event", async () => {
+    const order = [];
+    const stream = createEmptyRetryStream({
+      body: sseBody([bareStop()]),
+      reexecute: async () => { throw new Error("no more attempts"); },
+      onExhausted: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        order.push("benched");
+      },
+      baseDelayMs: 1,
+    });
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (decoder.decode(value, { stream: true }).includes("error")) order.push("error-event");
+    }
+    expect(order).toEqual(["benched", "error-event"]);
+  });
+
+  it("passes the held upstream error to onExhausted so quota reset times can be parsed", async () => {
+    const onExhausted = vi.fn();
+    const quota = wrap({ error: { code: 429, status: "RESOURCE_EXHAUSTED", message: "Quota exceeded. Your quota will reset after 1h2m3s" } });
+    await runWrapper([[quota], [quota], [quota]], { onExhausted });
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted.mock.calls[0][1].upstreamError.message).toContain("reset after 1h2m3s");
+  });
+
+  it("reexecute failure emits an error event carrying the upstream message", async () => {
+    const onExhausted = vi.fn();
+    const { out } = await runWrapper([[bareStop()]], {
+      onExhausted,
+      reexecute: async () => { throw new Error("[429] Quota exceeded for account"); },
+    });
+    const events = dataEvents(out);
+    expect(events).toHaveLength(1);
+    expect(events[0].error.message).toContain("[429] Quota exceeded for account");
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  // End-to-end sanity: a spliced retry must still translate into ONE well-formed
+  // Claude message (single message_start, single message_stop).
+  it("spliced output translates to a single well-formed Claude message", async () => {
+    const { out } = await runWrapper([
+      [thought("first try"), bareStop()],
+      [thought("second try"), text("final answer"), finish("STOP")],
+    ]);
+    const state = initState(FORMATS.CLAUDE);
+    const claudeEvents = [];
+    for (const parsed of dataEvents(out)) {
+      const translated = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, parsed, state);
+      if (translated?.length) claudeEvents.push(...translated.filter(Boolean));
+    }
+    const flushed = translateResponse(FORMATS.ANTIGRAVITY, FORMATS.CLAUDE, null, state);
+    if (flushed?.length) claudeEvents.push(...flushed.filter(Boolean));
+
+    expect(claudeEvents.filter((e) => e.type === "message_start")).toHaveLength(1);
+    expect(claudeEvents.filter((e) => e.type === "message_stop")).toHaveLength(1);
+    expect(claudeEvents.some((e) => e.delta?.type === "thinking_delta")).toBe(true);
+    expect(claudeEvents.some((e) => e.delta?.type === "text_delta" && e.delta.text === "final answer")).toBe(true);
+    const delta = claudeEvents.find((e) => e.type === "message_delta");
+    expect(delta.delta.stop_reason).toBe("end_turn");
+  });
+});

--- a/tests/unit/finish-reason-concern.test.js
+++ b/tests/unit/finish-reason-concern.test.js
@@ -9,7 +9,19 @@ describe("toOpenAIFinish - gemini", () => {
     ["RECITATION", "content_filter"],
     ["BLOCKLIST", "content_filter"],
     ["PROHIBITED_CONTENT", "content_filter"],
-    ["OTHER", "stop"],
+    ["SPII", "content_filter"],
+    ["IMAGE_SAFETY", "content_filter"],
+    // Aborted/error-family Gemini reasons must surface as an error finish,
+    // not a clean stop — a clean stop makes the client treat a broken turn
+    // (e.g. MALFORMED_FUNCTION_CALL) as a finished answer. (#2250, #2259)
+    ["MALFORMED_FUNCTION_CALL", "error"],
+    ["UNEXPECTED_TOOL_CALL", "error"],
+    ["FINISH_REASON_UNSPECIFIED", "error"],
+    ["OTHER", "error"],
+    ["LANGUAGE", "error"],
+    ["NO_IMAGE", "error"],
+    // Unknown Gemini reasons stay a clean stop — a future benign value must
+    // not start erroring every Gemini-family provider at once.
     ["UNKNOWN_XYZ", "stop"],
     ["STOP", "stop"],
     ["MAX_TOKENS", "length"],
@@ -69,6 +81,7 @@ describe("enum literals (catch drift)", () => {
     expect(OPENAI_FINISH.LENGTH).toBe("length");
     expect(OPENAI_FINISH.TOOL_CALLS).toBe("tool_calls");
     expect(OPENAI_FINISH.CONTENT_FILTER).toBe("content_filter");
+    expect(OPENAI_FINISH.ERROR).toBe("error");
   });
   it("CLAUDE_STOP literals", () => {
     expect(CLAUDE_STOP.END_TURN).toBe("end_turn");
@@ -79,5 +92,7 @@ describe("enum literals (catch drift)", () => {
     expect(GEMINI_FINISH.STOP).toBe("STOP");
     expect(GEMINI_FINISH.MAX_TOKENS).toBe("MAX_TOKENS");
     expect(GEMINI_FINISH.SAFETY).toBe("SAFETY");
+    expect(GEMINI_FINISH.MALFORMED_FUNCTION_CALL).toBe("MALFORMED_FUNCTION_CALL");
+    expect(GEMINI_FINISH.UNEXPECTED_TOOL_CALL).toBe("UNEXPECTED_TOOL_CALL");
   });
 });


### PR DESCRIPTION
## Problem

Antigravity/Gemini has several related failure modes that can stop coding agents unexpectedly:

- Thought-only part filtering can leave the outbound Gemini conversation history structurally invalid (empty `contents`, adjacent same-role entries).
- Antigravity can return `HTTP 200` with no actionable model output (thought-only or fully empty), which bypasses the existing non-2xx retry path and is persisted as a healthy "empty" completion.
- Aborted Gemini function-call finishes (`MALFORMED_FUNCTION_CALL`, `UNEXPECTED_TOOL_CALL`, and the rest of the error-family finish reasons) can fall through to a clean `stop` / `end_turn`, hiding the failure from the downstream client.
- Significant candidate-less Gemini events — `promptFeedback.blockReason`, usage-only / keepalive chunks, and embedded error objects such as `RESOURCE_EXHAUSTED` — can be silently dropped during translation.
- Truncated streams can leave downstream Claude / OpenCode messages hanging when Gemini closes without a `finishReason` after meaningful output.
- The Gemini 3.6 model family currently relies on the broader Gemini 3 capability match. An explicit rule for the 3.6 line preserves the multimodal flags, the Gemini-level thinking behavior, and the 3-tier context/output limits.

One captured OpenCode → Antigravity reproduction (before this change):

- provider: `Antigravity`
- user-selected model: `gemini-3.6-flash-high`
- underlying Antigravity model: `gemini-3.6-flash-tiered`
- TTFT: ~1.38s
- Total: ~1.64s
- Input Tokens: 54,189
- Output Tokens: 0
- Status: `success`
- Response: `[Empty streaming response]`

OpenCode considered the turn complete and stopped autonomous execution; the user had to send `continue` manually. The issue was intermittent.

## Root cause

- Thought-only part filtering in `open-sse/executors/antigravity.js` could leave empty `contents` entries and adjacent same-role history after Gemini-side filtering.
- `HTTP 200` empty SSE responses bypass the non-2xx retry handling already in the chat core.
- Significant candidate-less Gemini events were dropped during response translation.
- Aborted Gemini finish reasons could fall through to a clean `stop`.
- Truncated Claude-target streams lacked flush-time finalization.
- Gemini 3.6 lacked a dedicated capability-family entry.

## Fix

This patchset ports a six-commit series onto current upstream and combines the inbound empty-stream/translator hardening with outbound Antigravity conversation normalization and an explicit Gemini 3.6 capability rule.

1. **Outbound Antigravity history normalization** (`open-sse/executors/antigravity.js`):
   - `normalizeAntigravityContents()` removes entries without a role, entries without a valid `parts` array, and entries whose `parts` become empty after thought filtering.
   - Adjacent entries with the same role are merged into one; merged part order is stable; `thoughtSignature` handling is preserved.
   - Keeps valid `text`, `functionCall`, and `functionResponse` payloads intact.

2. **Gemini response translation hardening** (`open-sse/translator/concerns/finishReason.js`, `open-sse/translator/response/gemini-to-openai.js`, `open-sse/translator/response/openai-to-claude.js`, `open-sse/translator/schema/finishReasons.js`, `open-sse/translator/index.js`):
   - Preserves embedded error objects (e.g. `RESOURCE_EXHAUSTED`) inside otherwise-candidate-less events.
   - Surfaces `promptFeedback.blockReason` so downstream sees the policy block.
   - Preserves `functionCall` ids end-to-end.
   - Classifies the aborted/error-family finish reasons correctly (no silent `stop` / `end_turn`).
   - Adds the `FINISH_REASONS` constants used across the translator.

3. **Truncated Claude-target stream finalization**:
   - Partial visible text is preserved and the downstream block is closed cleanly.
   - Buffered tool arguments are preserved; the tool block is finalized with the correct termination semantics.
   - Usage is converted into the correct downstream shape on finalize.
   - Duplicate `message_stop` / finish events are guarded.

4. **Antigravity-specific empty-stream recovery** (`open-sse/handlers/chatCore.js`, `open-sse/handlers/chatCore/streamingHandler.js`, `open-sse/handlers/chatCore/emptyStreamGuard.js`):
   - 3 total upstream attempts, 2 retries.
   - ~500 ms backoff before attempt 2, ~1000 ms before attempt 3.
   - Thought-only dead-ends are retryable.
   - Text, tool calls, and supported inline output are meaningful — once seen, the attempt is not replayed.
   - Deterministic safety / `MAX_TOKENS` outcomes are not retried.
   - Embedded real upstream errors are preserved across attempts and surfaced on exhaustion.
   - Client cancellation stops hidden retry work; discarded upstream readers are cancelled.
   - Uses an in-stream retry architecture: bytes stream immediately, emptiness is judged per upstream attempt, the retry response is spliced into the same logical downstream stream.

5. **Account bench on exhaustion** (`src/sse/handlers/chat.js`):
   - When all internal empty attempts fail, the active Antigravity account is marked/benched via the existing 9router account cooldown infrastructure before the retryable downstream failure is emitted, so a subsequent client retry rotates accounts.
   - When available, Antigravity / Gemini reset-time information is honored in place of a generic cooldown.

6. **Gemini 3.6 capability recognition** (`open-sse/providers/capabilities.js` + `tests/unit/capabilities.test.js`):
   - Adds an explicit `*gemini-3.6*` capability entry with the same multimodal + Gemini-level thinking shape used by the existing Gemini 3 baseline.
   - Locks the pattern with regression coverage.

## Safety / behavior

- Emitted tool calls are never transparently replayed (no double side-effects).
- Deterministic safety/policy blocks and `MAX_TOKENS` are not transiently retried.
- Meaningful partial output (visible text or tool arguments) is preserved on truncation; the retry layer does not replay it.
- Real embedded upstream errors are retained where possible.
- Empty-stream recovery is scoped to Antigravity streaming and does not change behavior for non-Antigravity paths.
- Account cooldown reuses the existing 9router infrastructure.
- The Gemini 3.6 capability rule is independent of the empty-stream root cause and is presented as a related model-handling improvement included in the same PR.
- No credentials, OAuth tokens, or sensitive prompt bodies are written to logs for debugging.

## Verification

```
npx vitest run unit/antigravity-normalize-contents.test.js   # 7/7 passed
npx vitest run unit/empty-stream-guard.test.js              # 18/18 passed
npx vitest run unit/finish-reason-concern.test.js           # 30/30 passed
npx vitest run unit/capabilities.test.js                    # 6/6 passed
npx vitest run translator/bugs-antigravity.test.js          # 24/24 passed
npx vitest run translator/golden-response-stream.test.js    # 7/7 passed
git diff --check upstream/master...HEAD                     # clean
npm --prefix .\cli run build                                # successful ("CLI package build completed!"); the trailing 'du' is not recognized on Windows is a known platform-specific packaging-size command artifact, not a compilation failure
```

Broader validation: full `npx vitest run` against this branch produces the same set of failing files as a clean upstream-master worktree at `15223724` (same 70 file-fails / 138 individual fails — all pre-existing baseline failures, no new regressions). The patchset adds 25 new passing tests on top of that baseline.

## Manual validation

Before this change, OpenCode + Antigravity + `gemini-3.6-flash-high` intermittently produced an `HTTP 200` completion with 0 output tokens and `[Empty streaming response]`, ending the agent turn.

After installing the patched local build and exercising the same OpenCode → 9router → Antigravity path, that zero-output failure has not reproduced so far.

Smoke-test evidence is observational, not exhaustive — this is not a guarantee of complete stability.

## Prior work

This PR is informed by and builds on #2462's Antigravity empty-stream investigation and its final in-stream retry architecture.

The current PR ports and adapts that behavior onto current upstream and combines it with:

- outbound Antigravity conversation normalization
- Gemini 3.6 capability recognition
- current regression coverage
- current build validation
- current OpenCode smoke-test evidence

Thanks to @anhdiepmmk (verified author of #2462) for the original investigation and implementation.

## Related

- Addresses the Antigravity streaming/aborted/translated-stream portion of #2462
- Related: #2188
- Related: #2229
- Related: #2250
- Related: #2259
- Related: #2431
