### PR TITLE
fix(translator): preserve Responses prompt cache key

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -421,6 +421,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.reasoning !== undefined) result.reasoning = body.reasoning;
   if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
   if (body.service_tier !== undefined) result.service_tier = body.service_tier;
+  if (body.prompt_cache_key !== undefined) result.prompt_cache_key = body.prompt_cache_key;
 
   return result;
 }

--- a/tests/unit/openai-responses-multiturn.test.js
+++ b/tests/unit/openai-responses-multiturn.test.js
@@ -11,6 +11,19 @@ import { GrokCliExecutor, _resetGrokCliTurnStore } from "../../open-sse/executor
 import { translateRequest } from "../../open-sse/translator/index.js";
 
 describe("openai ↔ responses multi-turn reasoning", () => {
+  it("openai→responses preserves an explicit prompt cache key", () => {
+    const out = openaiToOpenAIResponsesRequest(
+      "gpt-example",
+      {
+        messages: [{ role: "user", content: "hello" }],
+        prompt_cache_key: "stable-cache-key",
+      },
+      true,
+      null
+    );
+    expect(out.prompt_cache_key).toBe("stable-cache-key");
+  });
+
   it("openai→responses re-emits reasoning item with summary + encrypted_content", () => {
     const body = {
       model: "grok-4.5",


### PR DESCRIPTION
## Summary

- preserve an explicit `prompt_cache_key` when translating OpenAI Chat Completions requests to the Responses format
- add a focused regression test for the Chat → Responses conversion

## Problem

The translator passes through Responses-compatible fields such as `reasoning` and `service_tier`, but omitted `prompt_cache_key`. A client-supplied stable key therefore never reached Responses-format providers.

## Test plan

- `cd tests && npx vitest run unit/openai-responses-multiturn.test.js` — 7/7 passed
- `npm run build` — passed

Fixes #3216
