### PR TITLE
fix(models): expose snake_case token limits on /v1/models

### DIFF
--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -485,6 +485,27 @@ export async function buildModelsList(kindFilter, options = {}) {
           || capabilitiesFromServiceKind(customKind || liveKind)
           || (kind === LLM_KIND ? getCapabilitiesForModel(providerId, modelId) : null);
         if (caps) model.capabilities = caps;
+        // Token limits under the snake_case names the OpenAI/OpenRouter
+        // convention uses. `capabilities.contextWindow` is camelCase and nested,
+        // so clients matching context_length find nothing, fall back to guessing
+        // the window from the model name, and guess high — a 372k model read as
+        // 1.05M never reaches its compaction threshold and hard-fails upstream.
+        // Emitted at top level because not every client recurses into nested
+        // objects; the camelCase `capabilities` block stays for compatibility.
+        if (kind === LLM_KIND || allowAsLlm) {
+          let contextWindow = caps?.contextWindow;
+          let maxOutput = caps?.maxOutput;
+          // Live-catalog and service-kind capabilities are usually partial
+          // (often just { tools: true }), so fill the gaps from the static
+          // table rather than emitting null and leaving clients to guess.
+          if (!Number.isFinite(contextWindow) || !Number.isFinite(maxOutput)) {
+            const fallback = getCapabilitiesForModel(providerId, modelId);
+            if (!Number.isFinite(contextWindow)) contextWindow = fallback.contextWindow;
+            if (!Number.isFinite(maxOutput)) maxOutput = fallback.maxOutput;
+          }
+          if (Number.isFinite(contextWindow)) model.context_length = contextWindow;
+          if (Number.isFinite(maxOutput)) model.max_completion_tokens = maxOutput;
+        }
         models.push(model);
       }
 


### PR DESCRIPTION
## Problem

`/v1/models` exposes each model's limits only as `capabilities.contextWindow` and `capabilities.maxOutput`. Both names are non-standard and nested, so OpenAI-compatible clients matching the OpenAI/OpenRouter convention (`context_length`, `max_completion_tokens`) find nothing.

Clients that find nothing fall back to guessing the window from the model name, and they guess high. Observed downstream: a client matched `gpt-5.6-sol` against its own catalog and assumed 1,050,000 tokens against a real 372,000 — a 2.8x overestimate. Its compaction threshold sat at 525,000, so it sailed to 399,248 tokens (7% past the real limit) without ever compacting, then hard-failed.

Every model in the catalog is affected, not one family.

## Fix

Emit `context_length` and `max_completion_tokens` at the **top level**, alongside the existing `capabilities` block, which is left untouched for backwards compatibility.

```json
{
  "id": "cx/gpt-5.6-sol",
  "context_length": 372000,
  "max_completion_tokens": 128000,
  "capabilities": { "contextWindow": 372000, "maxOutput": 128000 }
}
```

Top level rather than nested because not every client recurses into nested objects; this covers both.

One subtlety worth reviewing: live-catalog resolvers (kiro/qoder/github/clinepass) usually return only `{ id, name }`, so their capabilities are partial — often just `{ tools: true }`. Emitting straight from `caps` would produce `null` for exactly those models. This falls back to the static capability table per field instead.

## Verification

Against a live instance with 54 models across several providers:

```
total models          : 54
missing context_length: 0

cx/gpt-5.6-sol     372000  128000
cx/gpt-5.6-terra   272000  128000
cx/gpt-5.5         400000  128000
```

Three distinct windows, so it is reading real per-model metadata rather than a default. `npx eslint` clean. Full vitest suite identical to a clean-HEAD baseline (128 failed / 1616 passed both before and after — the suite is not green on a plain checkout, so the comparison is against baseline, not zero).
