### PR TITLE
fix(chatCore): bound non-streaming body reads, return 504 on stall

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -58,6 +58,14 @@ export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_M
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
 export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 60 * 1000);
 
+// Non-streaming body read timeout. FETCH_CONNECT_TIMEOUT_MS only covers headers;
+// once they arrive an upstream that stalls mid-body left the read hanging with no
+// deadline at all, so the client blocked forever on a request that would never
+// complete. Streaming already has first-chunk/stall timeouts — this is the
+// non-streaming equivalent. Generous, because a buffered completion with a large
+// max_tokens legitimately takes minutes. Env: RESPONSE_BODY_TIMEOUT_MS.
+export const RESPONSE_BODY_TIMEOUT_MS = envMs("RESPONSE_BODY_TIMEOUT_MS", 300 * 1000);
+
 // Gemini native TTS fetch timeout: abort if Google does not return response headers in time.
 export const GEMINI_NATIVE_TTS_FETCH_TIMEOUT_MS = envMs("GEMINI_NATIVE_TTS_FETCH_TIMEOUT_MS", 45 * 1000);
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -5,6 +5,7 @@ import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.j
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
+import { readBodyWithTimeout, BodyReadTimeoutError } from "../../utils/bodyTimeout.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
@@ -287,7 +288,17 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   let responseBody;
 
   if (contentType.includes("text/event-stream")) {
-    const sseText = await providerResponse.text();
+    let sseText;
+    try {
+      sseText = await readBodyWithTimeout(providerResponse, "text");
+    } catch (err) {
+      if (err instanceof BodyReadTimeoutError) {
+        appendLog({ status: `FAILED ${HTTP_STATUS.GATEWAY_TIMEOUT}` });
+        return createErrorResult(HTTP_STATUS.GATEWAY_TIMEOUT, `[${provider}/${model}] ${err.message}`);
+      }
+      appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+      return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `[${provider}/${model}] failed reading SSE body: ${err.message}`);
+    }
     const parsed = parseSSEToOpenAIResponse(sseText, model);
     if (!parsed) {
       appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
@@ -296,8 +307,15 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     responseBody = parsed;
   } else {
     try {
-      responseBody = await providerResponse.json();
+      responseBody = await readBodyWithTimeout(providerResponse, "json");
     } catch (err) {
+      // A stalled upstream is a gateway timeout, not malformed JSON — the client
+      // should see 504 and retry, not a 502 that reads as "upstream sent garbage".
+      if (err instanceof BodyReadTimeoutError) {
+        appendLog({ status: `FAILED ${HTTP_STATUS.GATEWAY_TIMEOUT}` });
+        console.error(`[ChatCore] ${provider} body read timed out:`, err.message);
+        return createErrorResult(HTTP_STATUS.GATEWAY_TIMEOUT, `[${provider}/${model}] ${err.message}`);
+      }
       appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
       console.error(`[ChatCore] Failed to parse JSON from ${provider}:`, err.message);
       return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `Invalid JSON response from ${provider}`);

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -1,6 +1,7 @@
 import { convertResponsesStreamToJson } from "../../transformer/streamToJsonConverter.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
+import { readBodyWithTimeout, BodyReadTimeoutError } from "../../utils/bodyTimeout.js";
 import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
@@ -290,7 +291,9 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
 
   // Standard Chat Completions SSE path
   try {
-    const sseText = await providerResponse.text();
+    // Bounded: an upstream that opens the stream and then stalls used to hold
+    // this read open indefinitely, wedging the client with no finish_reason.
+    const sseText = await readBodyWithTimeout(providerResponse, "text");
     const parsed = parseSSEToOpenAIResponse(sseText, model);
     if (!parsed) return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
     if (parsed.error) {
@@ -353,6 +356,12 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
 
     return { success: true, response: new Response(JSON.stringify(finalBody), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {
+    // A stalled upstream is a timeout, not a conversion failure. Reporting it as
+    // 502 would hide the fact that we gave up waiting rather than got bad data.
+    if (err instanceof BodyReadTimeoutError) {
+      console.error("[ChatCore] Chat Completions SSE→JSON body read timed out:", err.message);
+      return createErrorResult(HTTP_STATUS.GATEWAY_TIMEOUT, `[${provider}/${model}] ${err.message}`);
+    }
     console.error("[ChatCore] Chat Completions SSE→JSON failed:", err);
     return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Failed to convert streaming response to JSON");
   }

--- a/open-sse/utils/bodyTimeout.js
+++ b/open-sse/utils/bodyTimeout.js
@@ -1,0 +1,55 @@
+// Bound a non-streaming upstream body read.
+//
+// FETCH_CONNECT_TIMEOUT_MS only guarantees that response HEADERS arrive. An
+// upstream that answers 200 and then stalls mid-body left `await response.json()`
+// waiting with no deadline at all, so the caller blocked indefinitely on a request
+// that was never going to finish — observed as 120s+ silent holds and client
+// sockets stranded in CLOSE-WAIT. Streaming already bounds itself with
+// first-chunk and stall timeouts; this is the non-streaming equivalent.
+import { RESPONSE_BODY_TIMEOUT_MS } from "../config/runtimeConfig.js";
+
+export class BodyReadTimeoutError extends Error {
+  constructor(timeoutMs) {
+    super(`Upstream did not finish sending the response body within ${timeoutMs}ms`);
+    this.name = "BodyReadTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
+ * Read a fetch Response body with a deadline.
+ *
+ * @param {Response} response - upstream response whose headers already arrived
+ * @param {"json"|"text"} kind - how to decode the body
+ * @param {number} [timeoutMs] - deadline; <= 0 or non-finite disables the bound
+ * @returns {Promise<any>} parsed body
+ * @throws {BodyReadTimeoutError} when the body does not arrive in time
+ */
+export async function readBodyWithTimeout(response, kind = "json", timeoutMs = RESPONSE_BODY_TIMEOUT_MS) {
+  const read = () => (kind === "text" ? response.text() : response.json());
+
+  // Explicit opt-out keeps the previous unbounded behaviour available.
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return read();
+
+  let timer = null;
+  try {
+    return await Promise.race([
+      read(),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new BodyReadTimeoutError(timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    if (error instanceof BodyReadTimeoutError) {
+      // Drop the half-read connection rather than leaking the socket.
+      try {
+        await response.body?.cancel();
+      } catch {
+        /* already torn down */
+      }
+    }
+    throw error;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Problem

`FETCH_CONNECT_TIMEOUT_MS` (60s, applied in `BaseExecutor`) only guarantees that response **headers** arrive. Once they do, the non-streaming path reads the body with no deadline at all:

```js
responseBody = await providerResponse.json();   // no timeout
const sseText = await providerResponse.text();  // no timeout
```

An upstream that answers 200 and then stalls mid-body therefore hangs forever. Observed: a request accepted, then silent for the full 120s client timeout, never responding and never erroring — plus client sockets left in `CLOSE-WAIT`:

```
CLOSE-WAIT 1 0 100.88.200.126:58824 -> 100.88.200.126:20128
```

Streaming already bounds itself with `STREAM_FIRST_CHUNK_TIMEOUT_MS` and `STREAM_STALL_TIMEOUT_MS`. Non-streaming had nothing equivalent.

## Fix

`readBodyWithTimeout()` races the decode against a deadline and cancels the body on expiry so the socket is released rather than leaked. Applied to both non-streaming reads (`nonStreamingHandler`, and the Chat Completions SSE path in `sseToJsonHandler`).

A stall surfaces as **504**, deliberately distinct from the 502 used for malformed JSON: the client should learn that we gave up waiting, not that upstream sent garbage.

Default 300s via `RESPONSE_BODY_TIMEOUT_MS`. Deliberately generous — a buffered completion with a large `max_tokens` legitimately takes minutes. Setting it to 0 or less restores the previous unbounded behaviour.

## Verification

Against a local server that sends headers, writes a partial body, then goes silent forever:

- headers arrive and the request returns 200, so the connect timeout does not catch this case
- unbounded before the change
- after: throws at the deadline (1502ms measured on a 1500ms setting)
- healthy JSON and text bodies unaffected
- malformed JSON still raises `SyntaxError`, not a timeout, so it keeps its 502

`npx eslint` clean. Full vitest suite identical to a clean-HEAD baseline (128 failed / 1616 passed both before and after).

## Note

300s is a judgement call — long enough not to cut off slow buffered completions, short enough to bound the failure. Easy to change if you would prefer tighter.
