### PR TITLE
fix(chat): key error state to its model, and preserve the upstream status class

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -56,7 +56,77 @@ const COOLDOWN = {
  *   - cooldownMs: fixed cooldown duration
  *   - backoff: true = use exponential backoff (rate limit)
  */
+/**
+ * Phrases that identify a permanently wrong model name, whatever status the
+ * provider chose to attach to it. Providers are wildly inconsistent here: the
+ * same class of failure arrives as 400 ("model is not supported"), as 401 with
+ * a ModelError body, or as 404. Clients key their retry behaviour off the
+ * status, so these are normalised to one permanent status rather than passed
+ * through as an auth failure the caller cannot act on.
+ */
+export const PERMANENT_MODEL_ERROR_PATTERNS = [
+  "model is not supported",
+  "model not supported",
+  "model not found",
+  "model does not exist",
+  "unknown model",
+  "invalid model",
+  // Matches a lowercased `"type":"ModelError"` body, which is how at least one
+  // provider reports an unknown model — on a 401, of all statuses.
+  "modelerror",
+];
+
+/**
+ * Regex matchers for the same class, needed where the model NAME sits in the
+ * middle of the phrase: "Model does-not-exist-xyz is not supported". A plain
+ * substring cannot span that.
+ */
+export const PERMANENT_MODEL_ERROR_REGEXES = [
+  /\bmodel\s+\S+\s+is\s+not\s+supported\b/,
+  /\bmodel\s+\S+\s+(?:does\s+not\s+exist|not\s+found)\b/,
+];
+
+/**
+ * Request-scoped failures that are permanent but are NOT about the model — a
+ * parameter the model rejects, for instance. These must not cool down the
+ * account: the request is the caller's fault, so retrying on another account
+ * repeats the same failure, and locking the model makes one client's bad
+ * parameter break every other client's good request for the cooldown window.
+ *
+ * Matched on the INNER error class, because this provider wraps everything in
+ * "Upstream request failed:" — including genuinely transient socket errors. The
+ * bracketed class after that prefix is what separates them:
+ *   permanent : "Upstream request failed: [invalid_request_error] invalid temperature: ..."
+ *   transient : "Upstream request failed: connection reset by peer"
+ * Matching "invalid_request_error" alone would wrongly catch the transient case,
+ * whose envelope also carries that type.
+ */
+export const PERMANENT_REQUEST_ERROR_REGEXES = [
+  /upstream request failed:\s*\[invalid_request_error\]/,
+];
+
+/**
+ * @param {string|object} errorText - upstream error text or parsed body
+ * @returns {boolean} true when the text names a permanently wrong model
+ */
+export function isPermanentModelError(errorText) {
+  if (!errorText) return false;
+  const text = (typeof errorText === "string" ? errorText : JSON.stringify(errorText)).toLowerCase();
+  if (PERMANENT_MODEL_ERROR_PATTERNS.some((p) => text.includes(p))) return true;
+  return PERMANENT_MODEL_ERROR_REGEXES.some((re) => re.test(text));
+}
+
 export const ERROR_RULES = [
+  // --- Permanent, request-scoped failures (highest priority) ---
+  // The model name itself is wrong, so no other account can do better. Without
+  // these the default "fall back and cool down" applied: one typo walked every
+  // account into cooldown and then answered 503 "try again later" for something
+  // retrying can never fix. `permanent` returns the upstream status straight to
+  // the caller and leaves account state untouched.
+  ...PERMANENT_MODEL_ERROR_PATTERNS.map((text) => ({ text, permanent: true })),
+  ...PERMANENT_MODEL_ERROR_REGEXES.map((pattern) => ({ pattern, permanent: true })),
+  ...PERMANENT_REQUEST_ERROR_REGEXES.map((pattern) => ({ pattern, permanent: true })),
+
   // --- Text-based rules (checked first, order = priority) ---
   { text: "no credentials",           cooldownMs: COOLDOWN.long },
   { text: "request not allowed",      cooldownMs: COOLDOWN.short },

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -8,7 +8,7 @@ import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
 import { getModelTargetFormat, getModelStrip, getModelUpstreamId, getModelType, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { PROVIDERS } from "../config/providers.js";
-import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
+import { createErrorResult, parseUpstreamError, formatProviderError, clientStatusForUpstream } from "../utils/error.js";
 import { HTTP_STATUS, TOKEN_SAVER_HEADER } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
 import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
@@ -421,7 +421,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       log.errorLine(reqTag, "✗", `ERROR ${statusCode} · ${provider}/${model} · ${Date.now() - requestStartTime}ms${urlStr}\n    ${errMsg}`);
     }
     reqLogger.logError(new Error(message), finalBody || translatedBody);
-    return createErrorResult(statusCode, errMsg, resetsAtMs);
+    // Client sees the normalised class (4xx stop / 5xx retry, unknown model as
+    // 404 rather than the provider's 401); internal classification keeps the
+    // real upstream status.
+    return createErrorResult(statusCode, errMsg, resetsAtMs, clientStatusForUpstream(statusCode, message));
   }
 
   const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -26,8 +26,22 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
     : "";
 
   for (const rule of ERROR_RULES) {
+    // Regex rule: for phrases the model name sits inside, which a substring
+    // cannot span ("Model does-not-exist-xyz is not supported").
+    if (rule.pattern && lowerError && rule.pattern.test(lowerError)) {
+      if (rule.permanent) return { shouldFallback: false, cooldownMs: 0 };
+      if (rule.backoff) {
+        const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
+        return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
+      }
+      return { shouldFallback: true, cooldownMs: rule.cooldownMs };
+    }
+
     // Text-based rule: match substring in error message
     if (rule.text && lowerError && lowerError.includes(rule.text)) {
+      // Permanent: the request itself is wrong, so trying another account only
+      // repeats the same failure and cools down healthy accounts for nothing.
+      if (rule.permanent) return { shouldFallback: false, cooldownMs: 0 };
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
         return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };
@@ -37,6 +51,7 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
 
     // Status-based rule: match HTTP status code
     if (rule.status && rule.status === status) {
+      if (rule.permanent) return { shouldFallback: false, cooldownMs: 0 };
       if (rule.backoff) {
         const newLevel = Math.min(backoffLevel + 1, BACKOFF_CONFIG.maxLevel);
         return { shouldFallback: true, cooldownMs: getQuotaCooldown(newLevel), newBackoffLevel: newLevel };

--- a/open-sse/utils/error.js
+++ b/open-sse/utils/error.js
@@ -1,4 +1,5 @@
-import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES } from "../config/errorConfig.js";
+import { ERROR_TYPES, DEFAULT_ERROR_MESSAGES, isPermanentModelError } from "../config/errorConfig.js";
+import { HTTP_STATUS } from "../config/runtimeConfig.js";
 
 /**
  * Build OpenAI-compatible error response body
@@ -95,14 +96,53 @@ export async function parseUpstreamError(response, executor = null) {
  * @param {number} [resetsAtMs] - Optional precise cooldown expiry (ms epoch) for provider-specific quota errors
  * @returns {{ success: false, status: number, error: string, response: Response, resetsAtMs?: number }}
  */
-export function createErrorResult(statusCode, message, resetsAtMs) {
+export function createErrorResult(statusCode, message, resetsAtMs, clientStatus = null) {
   return {
     success: false,
+    // The true upstream status, kept for internal classification (fallback
+    // rules, cooldowns) so those keep seeing what the provider actually said.
     status: statusCode,
     error: message,
     resetsAtMs,
-    response: errorResponse(statusCode, message)
+    // What the CLIENT sees, which may be normalised — e.g. an unknown model
+    // reported as 401 becomes 404, so callers do not read it as an auth failure.
+    response: errorResponse(clientStatus ?? statusCode, message)
   };
+}
+
+/**
+ * Map an upstream failure onto the status the client should see.
+ *
+ * The contract clients actually depend on is coarse: 4xx means stop, 5xx means
+ * retry. So the rule is to preserve the upstream's CLASS, never to flatten it.
+ *
+ * An earlier version of this collapsed every non-429 4xx to 503 to stop a
+ * flaky upstream killing a turn. That was the wrong lever: the real cause of
+ * those mislabelled statuses was stale per-connection error state being replayed
+ * across requests (fixed in auth.js), and the flattening made permanent failures
+ * — a rejected temperature, a nonexistent model — look transient. Clients then
+ * burned their whole retry budget on hopeless requests, and 5xx bypassed the
+ * reactive repair paths that key off a 4xx naming the rejected parameter.
+ *
+ * Wrong-model errors are the one deliberate re-mapping: providers report them as
+ * 400, as 404, and as 401-with-a-ModelError-body. Passing a 401 through makes a
+ * client report "authentication failed" for perfectly good credentials, so those
+ * are normalised to 404.
+ *
+ * @param {number|string|null} upstreamStatus - status from the upstream attempt
+ * @param {string|object} [errorText] - upstream error text, for model detection
+ * @returns {number} status to return to the client
+ */
+export function clientStatusForUpstream(upstreamStatus, errorText = null) {
+  if (isPermanentModelError(errorText)) return HTTP_STATUS.NOT_FOUND;
+
+  const status = Number(upstreamStatus);
+  // Nothing usable to propagate (no attempt made, or a non-numeric code): this
+  // is our own "no capacity" condition, which is genuinely transient.
+  if (!Number.isFinite(status) || status < 400) return HTTP_STATUS.SERVICE_UNAVAILABLE;
+  // Anything already carrying a real class keeps it — 4xx stop, 5xx retry.
+  if (status <= 599) return status;
+  return HTTP_STATUS.SERVICE_UNAVAILABLE;
 }
 
 /**

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -13,7 +13,7 @@ import { handleChatCore } from "open-sse/handlers/chatCore.js";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
 import { getTransform as getPxpipeTransform } from "@/lib/pxpipe/loader.js";
 import { appendPxpipeEvent } from "@/lib/pxpipe/events.js";
-import { errorResponse, unavailableResponse } from "open-sse/utils/error.js";
+import { errorResponse, unavailableResponse, clientStatusForUpstream } from "open-sse/utils/error.js";
 import { handleComboChat, handleFusionChat, detectRequiredCapabilities } from "open-sse/services/combo.js";
 import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActiveAdapterStrategy } from "open-sse/services/capacityAdapter.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
@@ -231,7 +231,11 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
     if (!credentials || credentials.allRateLimited) {
       if (credentials?.allRateLimited) {
         const errorMsg = lastError || credentials.lastError || "Unavailable";
-        const status = lastStatus || Number(credentials.lastErrorCode) || HTTP_STATUS.SERVICE_UNAVAILABLE;
+        // Preserve the upstream class so 4xx still means stop and 5xx still
+        // means retry. credentials.lastErrorCode is only populated when the
+        // stored error provably belongs to THIS model (see auth.js), so a stale
+        // code from another request can no longer decide this status.
+        const status = clientStatusForUpstream(lastStatus || Number(credentials.lastErrorCode), errorMsg);
         log.warn("CHAT", `[${provider}/${model}] ${errorMsg} (${credentials.retryAfterHuman})`);
         return unavailableResponse(status, `[${provider}/${model}] ${errorMsg}`, credentials.retryAfter, credentials.retryAfterHuman);
       }
@@ -240,7 +244,7 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         return errorResponse(HTTP_STATUS.NOT_FOUND, `No active credentials for provider: ${provider}`);
       }
       log.warn("CHAT", "No more accounts available", { provider });
-      return errorResponse(lastStatus || HTTP_STATUS.SERVICE_UNAVAILABLE, lastError || "All accounts unavailable");
+      return errorResponse(clientStatusForUpstream(lastStatus, lastError), lastError || "All accounts unavailable");
     }
 
     // Account selection shown in the unified "▶" line (acc:...)

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -99,14 +99,32 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       const expiries = lockedConns.map(c => getEarliestModelLockUntil(c)).filter(Boolean);
       const earliest = expiries.sort()[0] || null;
       if (earliest) {
-        const earliestConn = lockedConns[0];
-        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(earliest)}) | lastError=${earliestConn?.lastError?.slice(0, 50)}`);
+        // Pick the connection that actually owns `earliest`, not just the first
+        // locked one — otherwise the countdown and the error came from different
+        // accounts.
+        const earliestConn = lockedConns.find((c) => getEarliestModelLockUntil(c) === earliest) || lockedConns[0];
+
+        // lastError/errorCode are per-CONNECTION, while locks are per-model, so
+        // the stored error belongs to whichever model failed on this connection
+        // most recently — not necessarily the one being requested. Serving it
+        // regardless leaked one request's error into an unrelated one: a probe
+        // for a bogus model produced a 401 ModelError that was then replayed to
+        // a live conversation on a different model for the whole backoff window,
+        // making good credentials look broken. Only surface it when it provably
+        // belongs to this model.
+        const errorMatchesModel = earliestConn?.lastErrorModel
+          ? earliestConn.lastErrorModel === (model || null)
+          : false;
+        const lastError = errorMatchesModel ? earliestConn?.lastError || null : null;
+        const lastErrorCode = errorMatchesModel ? earliestConn?.errorCode || null : null;
+
+        log.warn("AUTH", `${provider} | all ${connections.length} accounts locked for ${model || "all"} (${formatRetryAfter(earliest)}) | lastError=${errorMatchesModel ? earliestConn?.lastError?.slice(0, 50) : `<withheld: belongs to ${earliestConn?.lastErrorModel || "unknown"}>`}`);
         return {
           allRateLimited: true,
           retryAfter: earliest,
           retryAfterHuman: formatRetryAfter(earliest),
-          lastError: earliestConn?.lastError || null,
-          lastErrorCode: earliestConn?.errorCode || null
+          lastError,
+          lastErrorCode
         };
       }
       log.warn("AUTH", `${provider} | all ${connections.length} accounts unavailable`);
@@ -248,6 +266,10 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
     testStatus: "unavailable",
     lastError: reason,
     errorCode: status,
+    // Which model produced this error. Locks are per-model but lastError is a
+    // single per-connection field, so without this the reader cannot tell
+    // whether the stored error belongs to the model being asked about.
+    lastErrorModel: model || null,
     lastErrorAt: new Date().toISOString(),
     backoffLevel: newBackoffLevel ?? backoffLevel
   });
@@ -305,6 +327,7 @@ export async function clearAccountError(connectionId, currentConnection, model =
       testStatus: "active",
       lastError: null,
       errorCode: null,
+      lastErrorModel: null,
       lastErrorAt: null,
       backoffLevel: 0
     });


### PR DESCRIPTION
## Problem

Two related defects in how a failed request is classified and reported. They are in one PR because the second is only safe to fix once the first is.

### 1. An error from one request is served to a different, unrelated request

Model locks are per-model (`modelLock_${model}`), but `lastError` and `errorCode` are flat **per-connection** fields, overwritten by whichever model failed on that connection most recently. `getProviderCredentials` then hands that stored error to any request whose model happens to be locked on the same connection.

Observed in production. A throwaway probe for a nonexistent model produced a 401 ModelError. Three minutes later, a live conversation on a **different** model was served that probe's error for the whole backoff window:

```
06:56:09  503 - {'error': {'message':
  '[opencode-go/kimi-k2.7-code] [401]: {"type":"error","error":{"type":"ModelError",
  "message":"Model does-not-exist-xyz is not supported"}} (reset after 26s)'}}
06:56:12  ... same body ... (reset after 22s)
06:56:18  ... same body ... (reset after 16s)
```

Three things to note:

- The envelope is correctly tagged `[opencode-go/kimi-k2.7-code]`; the body inside describes a model that appears nowhere in the caller's config.
- `reset after` counts **down** across the retries — one shared timer replaying a stored body, not three fresh upstream attempts.
- The stored error crossed request boundaries: created by a different process, for a different model.

On a shared router this is a cross-tenant fault — anyone who fat-fingers a model name briefly degrades everyone else on the same key. It also misdirects diagnosis: the 401 made the caller report "authentication failed" for credentials that were verified fine against `/v1/chat/completions` and `/v1/models`.

### 2. Upstream 4xx reported as 503

Permanent failures were surfacing as transient. Both of these returned 503:

```
temperature the model rejects   ->  upstream said 400
model that does not exist       ->  upstream said 401 (ModelError)
```

503 means "retry later", so clients spend their whole retry budget on hopeless requests. There is a subtler cost: clients keep reactive repair paths keyed to error class — on a 4xx naming a rejected parameter, drop it and retry once — and a 5xx bypasses that logic entirely, suppressing the automatic recovery that would have fixed the request unnoticed.

## Fix

**Key the error state to its model.** Record `lastErrorModel` alongside the error, and surface the stored error only when it provably belongs to the model being asked about; otherwise return a generic unavailable message. Also select the connection that actually owns the earliest expiry rather than the first locked one, so the countdown and the error can no longer come from different accounts.

**Preserve the upstream class.** `clientStatusForUpstream` keeps 4xx as 4xx and 5xx as 5xx, because the contract clients depend on is simply *4xx means stop, 5xx means retry*.

Unknown-model errors are the one deliberate re-mapping, normalised to **404**: providers report them as 400, as 404, and as 401-with-a-ModelError-body, and passing that 401 through is what makes good credentials look broken. `createErrorResult` gained a separate client status so internal classification (fallback rules, cooldowns) keeps seeing the true upstream code.

**A rejected parameter no longer cools down the account.** Same harm as defect 1 within a single model: a bad `temperature` locked the model, so the next caller's good request failed for the cooldown window. Matched on the *inner* error class, because this provider wraps transient socket errors and permanent parameter errors in the same `Upstream request failed:` prefix — the bracketed class after it is the only thing separating them:

```
permanent : Upstream request failed: [invalid_request_error] invalid temperature: ...
transient : Upstream request failed: connection reset by peer
```

## Verification

The leak is timing-dependent and did not reproduce on demand (ten attempts), so it was verified by **forcing the exact reported state** — a stale error for model A, a lock on model B:

| check | result |
|---|---|
| model A's error served for model B | withheld, generic message |
| model A's error served for model A | still surfaced, status preserved |

Live matrix against a real provider:

| case | expected | got |
|---|---|---|
| temperature rejected by model | 400 | 400 |
| model does not exist | 404 | 404 |
| `max_tokens: 900000` | 400 | 400 |
| malformed JSON body | 400 | 400 |
| good request straight after two bad ones | 200 | 200 |
| bogus model name leaked anywhere | no | no |

`npx eslint` clean. Full vitest suite identical to a clean-HEAD baseline (128 failed / 1616 passed both before and after — the suite is not green on a plain checkout, so this is a baseline comparison, not zero).

## Note

This replaces the previous contents of this PR, which mapped every non-429 4xx to 503. That was the wrong lever: the mislabelled statuses it was chasing were defect 1 replaying stale state, and flattening the class made permanent failures look retryable. Fixing the root cause let the blanket mapping be removed.

The 404 normalisation for unknown models is the main judgement call and is easy to change if you would rather pass the provider's status through.
