### PR TITLE
fix(stream): synthesize a terminal when upstream drops mid-response

### DIFF
--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -5,6 +5,7 @@ import { pipeWithDisconnect } from "../../utils/streamHandler.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { STREAM_STALL_TIMEOUT_MS } from "../../config/runtimeConfig.js";
 import { buildAbortedResponsesTerminalBytes } from "../../utils/responsesStreamHelpers.js";
+import { createTerminalTracker } from "../../utils/streamTerminal.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
@@ -85,7 +86,12 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
   const onAbortTerminal = isResponsesPassthrough ? buildAbortedResponsesTerminalBytes : null;
   const stallTimeoutMs = PROVIDERS[provider]?.stallTimeoutMs || STREAM_STALL_TIMEOUT_MS;
-  const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs);
+  // Watches the CLIENT-facing frames for a terminal event so an upstream that
+  // dies mid-response closes with an explicit error instead of a truncated body
+  // the caller cannot distinguish from a normal finish. Null for formats whose
+  // terminal marker is ambiguous, which leaves those unchanged.
+  const terminalTracker = createTerminalTracker(targetFormat);
+  const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs, terminalTracker);
 
   saveRequestDetail(buildRequestDetail({
     provider, model, connectionId,

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -22,6 +22,15 @@ const CODEX_SOURCE_TO_TARGET = {
 
 /**
  * Determine which SSE transform stream to use based on provider/format.
+ *
+ * Returns the emitted format alongside the stream. Anything inspecting the
+ * CLIENT-facing frames must key off that, not off `targetFormat`: the three
+ * branches below emit three different formats, and translation runs
+ * targetFormat → sourceFormat, so the provider's format is the wrong one in two
+ * of them. Returning it here keeps the two in lockstep instead of asking callers
+ * to re-derive the branch condition.
+ *
+ * @returns {{stream: TransformStream, emittedFormat: string}}
  */
 function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey }) {
   const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
@@ -31,14 +40,24 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 
   if (needsCodexTranslation) {
     const codexTarget = CODEX_SOURCE_TO_TARGET[sourceFormat] || FORMATS.OPENAI;
-    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames);
+    return {
+      stream: createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames),
+      emittedFormat: codexTarget,
+    };
   }
 
   if (needsTranslation(targetFormat, sourceFormat)) {
-    return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames);
+    return {
+      stream: createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames),
+      emittedFormat: sourceFormat,
+    };
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  // Passthrough: the provider's own frames reach the client unchanged.
+  return {
+    stream: createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey),
+    emittedFormat: targetFormat,
+  };
 }
 
 /**
@@ -80,7 +99,7 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
     };
   }
 
-  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey });
+  const { stream: transformStream, emittedFormat } = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey });
 
   // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
@@ -90,7 +109,14 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
   // dies mid-response closes with an explicit error instead of a truncated body
   // the caller cannot distinguish from a normal finish. Null for formats whose
   // terminal marker is ambiguous, which leaves those unchanged.
-  const terminalTracker = createTerminalTracker(targetFormat);
+  //
+  // Keyed on emittedFormat, NOT targetFormat. Translation runs
+  // targetFormat → sourceFormat, so using the provider's format made the tracker
+  // watch for a marker that never appears — e.g. a /v1/responses client never
+  // shows response.completed once the frames have been translated — and every
+  // healthy stream got a spurious "ended without a terminal event" frame
+  // appended. Reported by @chisewaguri on #3222.
+  const terminalTracker = createTerminalTracker(emittedFormat);
   const transformedBody = pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal, stallTimeoutMs, terminalTracker);
 
   saveRequestDetail(buildRequestDetail({

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -95,17 +95,26 @@ export function createStreamController({ onDisconnect, onError, log, provider, m
  * for long periods while raw bytes still flow (e.g. Kiro EventStream
  * binary frames buffering, Claude reasoning streams).
  */
-export function createDisconnectAwareStream(transformStream, streamController, onAbortTerminal = null) {
+export function createDisconnectAwareStream(transformStream, streamController, onAbortTerminal = null, terminalTracker = null) {
   const reader = transformStream.readable.getReader();
   const writer = transformStream.writable.getWriter();
   let terminalEmitted = false;
 
-  // Emit a synthesized terminal payload (e.g. Responses response.failed + [DONE]) once
+  // Emit a synthesized terminal payload once.
+  //
+  // Falls back to the format tracker when no onAbortTerminal is configured: an
+  // abort, stall or network reset on an OpenAI/Claude stream used to close with
+  // nothing appended, leaving the client with a truncated body and no way to
+  // tell a dropped connection from a finished answer. Suppressed once a real
+  // terminal has already gone out, so a completed stream is never decorated.
   const emitTerminal = (controller) => {
-    if (terminalEmitted || !onAbortTerminal) return;
+    if (terminalEmitted) return;
+    const build = onAbortTerminal
+      || (terminalTracker && !terminalTracker.sawTerminal() ? () => terminalTracker.buildDrop() : null);
+    if (!build) return;
     terminalEmitted = true;
     try {
-      const bytes = onAbortTerminal();
+      const bytes = build();
       if (bytes) controller.enqueue(bytes);
     } catch { /* best-effort terminal */ }
   };
@@ -122,10 +131,25 @@ export function createDisconnectAwareStream(transformStream, streamController, o
         const { done, value } = await reader.read();
 
         if (done) {
-          streamController.handleComplete();
+          // Upstream EOF. Reaching here does NOT mean the response finished —
+          // a provider that dies mid-response also lands here, and closing
+          // silently left the client with a truncated body carrying no
+          // finish_reason and no error, so it waited for a terminal event that
+          // was never coming. Synthesize one instead. Only fires when the
+          // format has an unambiguous terminal marker AND none was seen.
+          if (terminalTracker && !terminalTracker.sawTerminal() && !terminalEmitted) {
+            terminalEmitted = true;
+            try {
+              controller.enqueue(terminalTracker.buildDrop());
+            } catch { /* downstream already gone */ }
+            streamController.handleError(new Error("upstream stream ended without a terminal event"));
+          } else {
+            streamController.handleComplete();
+          }
           controller.close();
           return;
         }
+        if (terminalTracker) terminalTracker.observe(value);
         controller.enqueue(value);
       } catch (error) {
         const wasConnected = streamController.isConnected();
@@ -152,9 +176,12 @@ export function createDisconnectAwareStream(transformStream, streamController, o
           code === "UND_ERR_SOCKET";
 
         // Graceful close on network/abort, or when a structured terminal is available
-        // (Responses passthrough prefers response.failed + [DONE] over a raw transport error)
+        // (Responses passthrough prefers response.failed + [DONE] over a raw transport error).
+        // terminalTracker counts as a structured terminal too, so an OpenAI/Claude
+        // stream cut by a reset now closes with an explicit error frame rather
+        // than a bare truncation the client cannot interpret.
         try {
-          if (!wasConnected || isNetworkClose || onAbortTerminal) {
+          if (!wasConnected || isNetworkClose || onAbortTerminal || terminalTracker) {
             emitTerminal(controller);
             controller.close();
           } else {
@@ -188,7 +215,7 @@ export function createDisconnectAwareStream(transformStream, streamController, o
  * @param {TransformStream} transformStream - Transform stream for SSE
  * @param {object} streamController - Stream controller from createStreamController
  */
-export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS) {
+export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, terminalTracker = null) {
   let stallTimer = null;
   let chunkCount = 0;
   let totalBytes = 0;
@@ -248,7 +275,8 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
   return createDisconnectAwareStream(
     { readable: transformedBody, writable: { getWriter: () => ({ abort: () => Promise.resolve() }) } },
     wrappedController,
-    onAbortTerminal
+    onAbortTerminal,
+    terminalTracker
   );
 }
 

--- a/open-sse/utils/streamTerminal.js
+++ b/open-sse/utils/streamTerminal.js
@@ -1,0 +1,109 @@
+// Detect a stream that ended without ever delivering a terminal event, and
+// synthesize one so the client sees a failure instead of silence.
+//
+// When an upstream dies mid-response the transform stream simply reaches EOF.
+// createDisconnectAwareStream then closed the client stream normally, so the
+// caller received a truncated body with no finish_reason and no error — it could
+// not tell "the model stopped" from "the connection died". Clients that wait for
+// a terminal event blocked until their own timeout (observed: an 11-minute wedge
+// and sockets stranded in CLOSE-WAIT).
+//
+// SAFETY: a false positive here is worse than the bug — appending a spurious
+// error frame to a HEALTHY stream would break working traffic. So detection is
+// deliberately narrow: only formats whose terminal marker is unambiguous get a
+// tracker, and `createTerminalTracker` returns null for everything else, which
+// preserves today's behaviour exactly. Note that [DONE] alone is NOT a reliable
+// signal — a live provider here emits finish_reason and never sends [DONE].
+import { FORMATS } from "../translator/formats.js";
+import { buildAbortedResponsesTerminalBytes } from "./responsesStreamHelpers.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8", { fatal: false });
+
+const DROP_MESSAGE =
+  "Upstream stream ended before completing: the provider closed the connection " +
+  "without sending a terminal event. The response above is incomplete.";
+
+// ── per-format definitions ──────────────────────────────────────────────
+// sawTerminal: does this outgoing text prove the stream reached a proper end?
+// buildDrop:   bytes to append when it did not.
+const HANDLERS = {
+  [FORMATS.OPENAI]: {
+    // A non-null finish_reason on any choice is the real terminal for Chat
+    // Completions. [DONE] is accepted too but not required.
+    sawTerminal: (text) =>
+      /"finish_reason"\s*:\s*"[^"]+"/.test(text) || text.includes("data: [DONE]"),
+    buildDrop: () =>
+      encoder.encode(
+        `data: ${JSON.stringify({
+          error: {
+            message: DROP_MESSAGE,
+            type: "upstream_error",
+            code: "upstream_stream_incomplete",
+          },
+        })}\n\ndata: [DONE]\n\n`
+      ),
+  },
+
+  [FORMATS.CLAUDE]: {
+    sawTerminal: (text) => text.includes("message_stop"),
+    buildDrop: () =>
+      encoder.encode(
+        `event: error\ndata: ${JSON.stringify({
+          type: "error",
+          error: { type: "api_error", message: DROP_MESSAGE },
+        })}\n\n`
+      ),
+  },
+
+  // Responses passthrough already has a synthesized failure payload used on the
+  // abort path; reuse it verbatim so both paths emit an identical terminal.
+  [FORMATS.OPENAI_RESPONSES]: {
+    sawTerminal: (text) =>
+      text.includes("response.completed") ||
+      text.includes("response.failed") ||
+      text.includes("response.incomplete"),
+    buildDrop: () => buildAbortedResponsesTerminalBytes(),
+  },
+};
+
+/**
+ * Build a tracker for the client-facing format, or null when the format has no
+ * unambiguous terminal marker (in which case the caller must not synthesize
+ * anything and behaviour stays as it was).
+ *
+ * @param {string} targetFormat - the format the CLIENT receives
+ * @returns {{observe: (chunk: Uint8Array) => void, sawTerminal: () => boolean, buildDrop: () => Uint8Array} | null}
+ */
+export function createTerminalTracker(targetFormat) {
+  const handler = HANDLERS[targetFormat];
+  if (!handler) return null;
+
+  let seen = false;
+  // A terminal marker can straddle two chunks, so keep a small tail of the
+  // previous chunk and test the join. Bounded so this never grows with the
+  // response.
+  let tail = "";
+  const TAIL = 64;
+
+  return {
+    observe(chunk) {
+      if (seen || !chunk) return;
+      let text;
+      try {
+        text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+      } catch {
+        return;
+      }
+      if (!text) return;
+      if (handler.sawTerminal(tail + text)) {
+        seen = true;
+        tail = "";
+        return;
+      }
+      tail = (tail + text).slice(-TAIL);
+    },
+    sawTerminal: () => seen,
+    buildDrop: () => handler.buildDrop(),
+  };
+}


### PR DESCRIPTION
## Problem

An upstream dying mid-stream reaches the same EOF path as a completed one, so the client stream simply closes:

```js
if (done) {
  streamController.handleComplete();
  controller.close();
  return;
}
```

The caller receives a truncated body with no `finish_reason` and no error, and cannot tell "the model stopped" from "the connection died". A client waiting for a terminal event blocks until its own timeout. Observed: one such stall wedged a turn for 11 minutes and needed a gateway restart, with sockets left in `CLOSE-WAIT`. Downstream logs it as:

```
WARNING agent.chat_completion_helpers: Stream ended with no finish_reason after
delivering text with no tool calls; treating as a mid-stream drop.
```

The network-reset path had the same hole: `emitTerminal` no-ops unless `onAbortTerminal` is configured, which only the Responses passthrough sets. So an OpenAI or Claude stream cut by `ECONNRESET` also closed silently.

## Fix

Both paths now append an explicit error frame plus a terminator, keeping whatever partial content already arrived.

A false positive here would be worse than the bug, since decorating a **healthy** stream breaks working traffic. So detection is deliberately narrow:

- Keyed on the real terminal marker per format (`finish_reason`, `message_stop`, `response.completed`/`failed`), **not** on `[DONE]`. A live provider here emits `finish_reason` and never sends `[DONE]`, so keying on `[DONE]` would have flagged every good stream as dropped.
- Markers split across chunk boundaries are joined via a bounded tail.
- Formats whose terminal is ambiguous (gemini, kiro, cursor, ollama, ...) get **no tracker at all** and keep their existing behaviour byte for byte.
- Suppressed once a real terminal has gone out, so a completed stream is never decorated and never double-terminated.

The Responses passthrough reuses the existing `buildAbortedResponsesTerminalBytes`, so both paths emit an identical terminal.

## Verification

28 targeted tests driving real chunks through the real close path:

- healthy: `finish_reason` alone, `finish_reason` + `[DONE]`, `[DONE]` alone, `tool_calls`, Claude `message_stop`, Responses `response.completed` — none decorated
- markers split mid-token across two chunks — still detected, no false positive
- truncated: error frame appended, partial content preserved, reported as error rather than complete
- `ECONNRESET` mid-stream: error frame appended; after a real terminal: nothing appended, exactly one `[DONE]`
- gemini/kiro/cursor/ollama: no tracker, output byte-identical

Live after deploy: a normal stream returns 200 with its `finish_reason` and no added error, a Claude-format stream returns 200 with its `message_stop` and no added error, exactly one `[DONE]`, non-streaming unaffected.

`npx eslint` clean. Full vitest suite identical to a clean-HEAD baseline (128 failed / 1616 passed both before and after).

## Note

The format list is the reviewable part. I only added trackers for formats whose terminal marker I could confirm; extending it to gemini and the rest is straightforward if you know their terminals well enough to be certain.
