### PR TITLE
fix: Sanitize competitive system prompts to prevent 429 quota errors. (Fix resource exhausted issue for Antigravity models in Zed IDE)

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -245,6 +245,18 @@ export class AntigravityExecutor extends BaseExecutor {
     // Strip tools/toolConfig (handled separately) and blacklisted fields that Google rejects
     const { tools: _originalTools, toolConfig: _originalToolConfig, ...requestWithoutTools } = body.request || {};
     stripBlacklisted(requestWithoutTools);
+    
+    // Rewrite competitive system prompts (e.g. Zed IDE's Claude prompt) to prevent Antigravity from 
+    // flagging the request and immediately blocking it with a 429 Quota Exhausted response.
+    if (requestWithoutTools.systemInstruction?.parts) {
+      const oldText = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
+      for (const part of requestWithoutTools.systemInstruction.parts) {
+        if (typeof part.text === "string" && part.text.includes(oldText)) {
+          part.text = part.text.split(oldText).join("");
+        }
+      }
+    }
+
     const generationConfig = { ...(requestWithoutTools.generationConfig || {}) };
     if (generationConfig.maxOutputTokens > MAX_ANTIGRAVITY_OUTPUT_TOKENS) {
       generationConfig.maxOutputTokens = MAX_ANTIGRAVITY_OUTPUT_TOKENS;


### PR DESCRIPTION
This pull request introduces a safeguard to the `AntigravityExecutor` to prevent requests from being blocked due to the presence of competitive system prompts, specifically those referencing Claude agents. The main change rewrites such prompts to avoid triggering Antigravity's quota-exhausted response.

This error comes with Zed IDE requests calling Antigravity models. So this will fix that issue for who uses Zed IDE.

**System prompt handling:**

* Added logic to scan and remove the phrase `"You are a Claude agent, built on Anthropic's Claude Agent SDK."` from any string `part.text` within `systemInstruction.parts` in the request, preventing Antigravity from flagging and blocking these requests.…ta errors in antigravity executor

@decolua