### PR TITLE
fix: expand namespace tools so codex subagents work

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -204,6 +204,12 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
           return tool.tools
             .filter(sub => sub && sub.name)
             .map(sub => {
+              // Keep a flat-name -> namespace map so the response side can route a
+              // tool call that arrives by flat name (wait_agent, not collaboration.wait_agent).
+              if (ns) {
+                globalThis.__CB_NS_TOOLS__ ||= {};
+                globalThis.__CB_NS_TOOLS__[sub.name] = ns;
+              }
               // Some providers (deepseek, codebuddy) reject dotted tool names, so
               // sanitize dots to `__` on the way out and keep the map for the
               // response side to restore the namespace-qualified name.

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -181,15 +181,35 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
   ];
   if (responseTools.length > 0) {
     result.tools = responseTools
-      .map(tool => {
+      .flatMap(tool => {
         // Already in Chat Completions format: { type: "function", function: { name, ... } }
         if (tool.function) return tool;
+        // Responses API namespace tool (e.g. codex `collaboration`): a group of sub-tools.
+        // Chat Completions has no namespace concept, so expand each sub-tool into an
+        // individual `{namespace}.{subtool}` function. The response side splits the name
+        // back into Responses `name` + `namespace`.
+        if (tool.type === "namespace" && Array.isArray(tool.tools)) {
+          const ns = tool.name || "";
+          return tool.tools
+            .filter(sub => sub && sub.name)
+            .map(sub => ({
+              type: OPENAI_BLOCK.FUNCTION,
+              function: {
+                name: ns ? `${ns}.${sub.name}` : sub.name,
+                description: String(sub.description || tool.description || ""),
+                parameters: normalizeToolParameters(sub.parameters),
+                strict: sub.strict
+              }
+            }));
+        }
         // Responses API function/custom tool: { type, name, description, parameters|format }.
         // Chat Completions has no freeform custom-tool declaration, so expose custom
         // tools as functions with one raw `input` string while retaining their names
         // in translator-only metadata for the response conversion.
         const name = tool.name;
         if (!name || typeof name !== "string" || name.trim() === "") return null;
+        // Some providers reject dotted tool names; sanitize every function/custom tool
+        // name and keep the map so the response side restores the original.
         if (tool.type === "custom") {
           customToolNames.add(name);
           const formatHint = [tool.format?.syntax, tool.format?.definition].filter(Boolean).join("\n");

--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -183,7 +183,18 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
     result.tools = responseTools
       .flatMap(tool => {
         // Already in Chat Completions format: { type: "function", function: { name, ... } }
-        if (tool.function) return tool;
+        if (tool.function) {
+          // Some providers reject dotted tool names; sanitize and keep the map so the
+          // response side restores the original name.
+          const fn = tool.function;
+          if (fn?.name && fn.name.includes(".")) {
+            const safe = fn.name.replace(/\./g, "__");
+            globalThis.__CB_TOOL_MAP__ ||= {};
+            globalThis.__CB_TOOL_MAP__[safe] = fn.name;
+            return { ...tool, function: { ...fn, name: safe } };
+          }
+          return tool;
+        }
         // Responses API namespace tool (e.g. codex `collaboration`): a group of sub-tools.
         // Chat Completions has no namespace concept, so expand each sub-tool into an
         // individual `{namespace}.{subtool}` function. The response side splits the name
@@ -192,15 +203,26 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
           const ns = tool.name || "";
           return tool.tools
             .filter(sub => sub && sub.name)
-            .map(sub => ({
-              type: OPENAI_BLOCK.FUNCTION,
-              function: {
-                name: ns ? `${ns}.${sub.name}` : sub.name,
-                description: String(sub.description || tool.description || ""),
-                parameters: normalizeToolParameters(sub.parameters),
-                strict: sub.strict
+            .map(sub => {
+              // Some providers (deepseek, codebuddy) reject dotted tool names, so
+              // sanitize dots to `__` on the way out and keep the map for the
+              // response side to restore the namespace-qualified name.
+              const full = ns ? `${ns}.${sub.name}` : sub.name;
+              const safe = full.includes(".") ? full.replace(/\./g, "__") : full;
+              if (full !== safe) {
+                globalThis.__CB_TOOL_MAP__ ||= {};
+                globalThis.__CB_TOOL_MAP__[safe] = full;
               }
-            }));
+              return {
+                type: OPENAI_BLOCK.FUNCTION,
+                function: {
+                  name: safe,
+                  description: String(sub.description || tool.description || ""),
+                  parameters: normalizeToolParameters(sub.parameters),
+                  strict: sub.strict
+                }
+              };
+            });
         }
         // Responses API function/custom tool: { type, name, description, parameters|format }.
         // Chat Completions has no freeform custom-tool declaration, so expose custom
@@ -210,13 +232,18 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
         if (!name || typeof name !== "string" || name.trim() === "") return null;
         // Some providers reject dotted tool names; sanitize every function/custom tool
         // name and keep the map so the response side restores the original.
+        const safeName = name.includes(".") ? name.replace(/\./g, "__") : name;
+        if (safeName !== name) {
+          globalThis.__CB_TOOL_MAP__ ||= {};
+          globalThis.__CB_TOOL_MAP__[safeName] = name;
+        }
         if (tool.type === "custom") {
           customToolNames.add(name);
           const formatHint = [tool.format?.syntax, tool.format?.definition].filter(Boolean).join("\n");
           return {
             type: OPENAI_BLOCK.FUNCTION,
             function: {
-              name,
+              name: safeName,
               description: [String(tool.description || ""), formatHint].filter(Boolean).join("\n\n"),
               parameters: {
                 type: "object",
@@ -237,7 +264,7 @@ export function openaiResponsesToOpenAIRequest(model, body, stream, credentials)
         return {
           type: OPENAI_BLOCK.FUNCTION,
           function: {
-            name,
+            name: safeName,
             description: String(tool.description || ""),
             parameters: normalizeToolParameters(tool.parameters),
             strict: tool.strict

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -21,7 +21,12 @@ function splitToolName(name) {
   let n = name;
   if (n.startsWith("functions.")) n = n.slice("functions.".length);
   const dot = n.indexOf(".");
-  if (dot < 0) return { name: n, namespace: null };
+  if (dot < 0) {
+    if (globalThis.__CB_NS_TOOLS__ && globalThis.__CB_NS_TOOLS__[n]) {
+      return { name: n, namespace: globalThis.__CB_NS_TOOLS__[n] };
+    }
+    return { name: n, namespace: null };
+  }
   return { name: n.slice(dot + 1), namespace: n.slice(0, dot) };
 }
 

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -10,6 +10,18 @@ import { fallbackToolCallId } from "../concerns/toolCall.js";
 import { reasoningDelta, extractReasoningText } from "../concerns/reasoning.js";
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM, OPENAI_FINISH, MODEL_FALLBACK } from "../schema/index.js";
 
+// Namespace tools are expanded into dotted names (`collaboration.spawn_agent`) on the
+// request side. Split them back into Responses `name` + `namespace` so the client router
+// can route the tool call. Flat names pass through unchanged.
+function splitToolName(name) {
+  if (typeof name !== "string") return { name: name || "", namespace: null };
+  let n = name;
+  if (n.startsWith("functions.")) n = n.slice("functions.".length);
+  const dot = n.indexOf(".");
+  if (dot < 0) return { name: n, namespace: null };
+  return { name: n.slice(dot + 1), namespace: n.slice(0, dot) };
+}
+
 /**
  * Translate OpenAI chunk to Responses API events
  * @returns {Array} Array of events with { event, data } structure
@@ -295,7 +307,7 @@ function emitToolCall(state, emit, tc) {
         type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
         ...(custom ? { input: "" } : { arguments: "" }),
         call_id: callId,
-        name: state.funcNames[tcIdx] || ""
+        ...splitToolName(state.funcNames[tcIdx] || "")
       }
     });
   }
@@ -356,7 +368,7 @@ function closeToolCall(state, emit, idx) {
         type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
         ...(custom ? { input: extractCustomToolInput(args) } : { arguments: args }),
         call_id: callId,
-        name: state.funcNames[idx] || ""
+        ...splitToolName(state.funcNames[idx] || "")
       }
     });
 

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -15,6 +15,9 @@ import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM, OPENAI_FINISH, MODEL_FALLBACK } fro
 // can route the tool call. Flat names pass through unchanged.
 function splitToolName(name) {
   if (typeof name !== "string") return { name: name || "", namespace: null };
+  if (globalThis.__CB_TOOL_MAP__ && globalThis.__CB_TOOL_MAP__[name]) {
+    name = globalThis.__CB_TOOL_MAP__[name];
+  }
   let n = name;
   if (n.startsWith("functions.")) n = n.slice("functions.".length);
   const dot = n.indexOf(".");

--- a/tests/unit/openai-responses-namespace-tools.test.js
+++ b/tests/unit/openai-responses-namespace-tools.test.js
@@ -1,0 +1,59 @@
+/**
+ * Namespace tools (e.g. codex `collaboration`) must expand into individual
+ * `{namespace}.{subtool}` functions on the request, and split back into
+ * `name` + `namespace` on the response so the client router can route them.
+ */
+import { describe, expect, it } from "vitest";
+import { openaiResponsesToOpenAIRequest } from "../../open-sse/translator/request/openai-responses.js";
+import { openaiToOpenAIResponsesResponse } from "../../open-sse/translator/response/openai-responses.js";
+import { initState } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const COLLAB_NAMESPACE = {
+  type: "namespace",
+  name: "collaboration",
+  description: "collaboration tools",
+  tools: [
+    { type: "function", name: "spawn_agent", description: "spawn a subagent", parameters: { type: "object" } },
+    { type: "function", name: "wait_agent", description: "wait for subagents", parameters: { type: "object" } },
+    { type: "function", name: "list_agents", description: "list subagents", parameters: { type: "object" } },
+  ],
+};
+
+describe("Responses namespace tools", () => {
+  it("expands a namespace tool into individual {ns}.{subtool} functions", () => {
+    const out = openaiResponsesToOpenAIRequest("m", {
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "spawn a helper" }] }],
+      tools: [COLLAB_NAMESPACE],
+    }, true, null);
+
+    expect(out.tools).toHaveLength(3);
+    expect(out.tools.map((t) => t.function.name)).toEqual([
+      "collaboration__spawn_agent",
+      "collaboration__wait_agent",
+      "collaboration__list_agents",
+    ]);
+  });
+
+  it("splits a namespaced tool call back into name + namespace on the response", () => {
+    const state = initState(FORMATS.OPENAI_RESPONSES);
+    const chunks = [
+      { id: "cmb-1", choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "collaboration__spawn_agent", arguments: "" } }] }, finish_reason: null }] },
+      { id: "cmb-1", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] },
+    ];
+    const events = chunks.flatMap((c) => openaiToOpenAIResponsesResponse(c, state));
+    const added = events.find((e) => e.event === "response.output_item.added" && e.data.item?.type === "function_call");
+
+    expect(added.data.item.name).toBe("spawn_agent");
+    expect(added.data.item.namespace).toBe("collaboration");
+  });
+
+  it("leaves flat tool names unchanged", () => {
+    const out = openaiResponsesToOpenAIRequest("m", {
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      tools: [{ type: "function", name: "get_weather", description: "weather", parameters: { type: "object" } }],
+    }, true, null);
+
+    expect(out.tools.map((t) => t.function.name)).toEqual(["get_weather"]);
+  });
+});


### PR DESCRIPTION
## what

codex sends its subagent tools as one responses namespace tool called collaboration, holding spawn_agent, wait_agent and list_agents. the chat completions request translator dropped namespace tools entirely, so codex subagents did not work through providers that convert responses to chat format.

## commits

- expand namespace tools into chat functions
- sanitize dotted tool names for strict providers
- route flat sub tool names back to their namespace
- tests

## fix

the first commit expands each namespace sub tool into a `namespace.subtool` function and splits the tool call back into responses `name` plus `namespace` on the response.

the second commit sanitizes dots to `__` because deepseek and codebuddy reject dotted tool names. this covers the namespace sub tools, plain function and custom tools, and the chat format passthrough, since codex sends `functions.exec` and similar with dots.

the third commit handles the case where the model calls a sub tool by its flat name (wait_agent instead of collaboration.wait_agent), routing it back to the right namespace.

## tests

- namespace tool expands into individual namespace.subtool functions
- namespaced tool call splits into name and namespace on the response
- flat tool names pass through unchanged

26 tests pass across the responses suite.

## related

- #2944 flattens namespace tools for chat translation but does not handle the dot rejection from deepseek and codebuddy. this PR adds that sanitize step.
- #1758 and #1873 describe the codex subagent failures this addresses.