### PR TITLE
fix(translator): nest reasoning effort for openai-responses targets

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -169,7 +169,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     translatedBody = { ...body, model: stripThinkingSuffix(upstreamModel) };
     if (provider === "codex") {
       const suffixThinking = {};
-      applyThinking(sourceFormat, upstreamModel, suffixThinking, provider);
+      // Pinned to OPENAI on purpose: this branch reads the flat reasoning_effort key
+      // off the scratch object and nests it itself, so applyThinking must not nest.
+      // Passing sourceFormat here would hand back {reasoning:{effort}} for a Responses
+      // client and the suffix would silently stop applying.
+      applyThinking(FORMATS.OPENAI, upstreamModel, suffixThinking, provider);
       if (suffixThinking.reasoning_effort) {
         const reasoning = translatedBody.reasoning;
         translatedBody.reasoning = {

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -5,6 +5,7 @@
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { getThinkingLevels } from "../../providers/thinkingLevels.js";
 import { PROVIDERS } from "../../providers/index.js";
+import { FORMATS } from "../formats.js";
 import { LEVEL_TO_BUDGET, budgetToLevel, effortToBudget, effortToThinkingLevel } from "./thinking.js";
 
 // Map a target wire-format to its native thinking format (when capability has none).
@@ -20,6 +21,8 @@ const FORMAT_TO_NATIVE = {
   antigravity: "gemini-budget",
   kiro: "kiro",
 };
+
+const RESPONSES_TARGETS = new Set([FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI_RESPONSE]);
 
 // Strip a trailing thinking suffix "model(value)" → "model" (no-op when absent).
 export function stripThinkingSuffix(model) {
@@ -347,7 +350,17 @@ export function applyThinking(targetFormat, model, body, provider = null, intent
 
   const fmt = resolveFormat(targetFormat, cleanModel, provider);
   const supportedLevels = getThinkingLevels(provider, cleanModel);
+  const prior = body.reasoning;
+  const priorReasoning = prior && typeof prior === "object" ? prior : null;
   stripAll(body);
   applyFormat(fmt, body, cfg, caps, supportedLevels);
+  if (RESPONSES_TARGETS.has(targetFormat)) nestReasoningEffort(body, priorReasoning);
   return body;
+}
+
+function nestReasoningEffort(body, priorReasoning) {
+  if (typeof body.reasoning_effort !== "string") return;
+  const effort = body.reasoning_effort;
+  delete body.reasoning_effort;
+  body.reasoning = { ...priorReasoning, effort };
 }

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -172,11 +172,13 @@ describe("applyThinking per provider format", () => {
     ["gpt-5.6-luna", "ultra", "max"],
   ])("normalizes Codex %s effort %s to %s", (model, effort, expected) => {
     const out = apply("openai-responses", model, { reasoning: { effort } }, "codex");
-    expect(out.reasoning_effort).toBe(expected);
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning.effort).toBe(expected);
   });
   it("applies a supported Codex Ultra suffix", () => {
     const out = apply("openai-responses", "gpt-5.6-sol(ultra)", {}, "codex");
-    expect(out.reasoning_effort).toBe("ultra");
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning.effort).toBe("ultra");
   });
   it("keeps Codex-only GPT-5.6 levels out of Kiro translation", () => {
     const out = apply("openai", "gpt-5.6-sol", { reasoning_effort: "max" }, "kiro");

--- a/tests/unit/thinking-responses-nested-3154.test.js
+++ b/tests/unit/thinking-responses-nested-3154.test.js
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+const { applyThinking } = await import("../../open-sse/translator/concerns/thinkingUnified.js");
+const { translateRequest } = await import("../../open-sse/translator/index.js");
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+
+describe("#3154 reasoning effort nesting for Responses targets", () => {
+  it("nests effort under reasoning for a gpt-5.6 model on an openai-responses target", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-5.6-luna", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toMatchObject({ effort: "high" });
+  });
+
+  it("keeps the flat key for chat completions targets", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI, "gpt-5.6-luna", body, "openai-compatible-chat-abc");
+
+    expect(body.reasoning_effort).toBe("high");
+    expect(body.reasoning).toBeUndefined();
+  });
+
+  it("nests a disabled effort too", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "none" };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-5.6-luna", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toMatchObject({ effort: "none" });
+  });
+
+  it("preserves sibling reasoning keys set by the caller", () => {
+    const body = { model: "gpt-5.6-luna", reasoning: { effort: "low", mode: "pro", summary: "detailed" } };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-5.6-luna(high)", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toEqual({ effort: "high", mode: "pro", summary: "detailed" });
+  });
+
+  // FORMAT_TO_NATIVE carries both spellings and usageTracking/modality dispatch on the
+  // singular one, so a fix keyed to "openai-responses" alone still ships the flat key here.
+  it("nests for the singular openai-response target too", () => {
+    const body = { model: "gpt-5.6-luna", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI_RESPONSE, "gpt-5.6-luna", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toMatchObject({ effort: "high" });
+  });
+
+  it("leaves a native Responses request nested rather than flattening it", () => {
+    const out = translateRequest(
+      FORMATS.OPENAI_RESPONSES,
+      FORMATS.OPENAI_RESPONSES,
+      "gpt-5.6-luna",
+      { model: "gpt-5.6-luna", input: "hi", reasoning: { effort: "high", mode: "pro" } },
+      true,
+      {},
+      "openai-compatible-responses-abc",
+    );
+
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning).toMatchObject({ effort: "high", mode: "pro" });
+  });
+
+  it("leaves non-reasoning models untouched", () => {
+    const body = { model: "gpt-4o-mini", reasoning_effort: "high" };
+    applyThinking(FORMATS.OPENAI_RESPONSES, "gpt-4o-mini", body, "openai-compatible-responses-abc");
+
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.reasoning).toBeUndefined();
+  });
+
+  it("produces a Responses body with no flat reasoning_effort end to end", () => {
+    const out = translateRequest(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI_RESPONSES,
+      "gpt-5.6-luna",
+      { model: "gpt-5.6-luna", messages: [{ role: "user", content: "hi" }], reasoning_effort: "high" },
+      true,
+      {},
+      "openai-compatible-responses-abc",
+    );
+
+    expect(out.reasoning_effort).toBeUndefined();
+    expect(out.reasoning).toMatchObject({ effort: "high", summary: "auto" });
+  });
+});


### PR DESCRIPTION
Closes #3154.

A Responses target gets the Chat-Completions-only top-level `reasoning_effort` instead of the nested `reasoning: { effort }` the endpoint expects, so thinking is silently dropped.

**Credit where it is due: #3183 by @Jordannst found this three days before I did.** I said there that I had no claim, and that stands. What follows is not a claim of priority — it is the two concrete cases #3183 does not cover, both of which I verified by applying its patch locally rather than by reading it.

## 1. #3183 turns three existing tests on master red

`tests/unit/codex-native-passthrough-thinking.test.js` is already in the repo. Applying #3183 to a clean `origin/master`:

```
× native Codex passthrough thinking suffixes > forwards Ultra for Sol
  AssertionError: expected undefined to deeply equal { effort: 'ultra' }
× ... > converts unsupported Luna Ultra to Max without dropping reasoning metadata
  AssertionError: expected { effort: 'low', summary: 'detailed' }
                to deeply equal { effort: 'max', summary: 'detailed' }
× ... > forwards Ultra through a Terra review alias
  Tests  3 failed (3)
```

The cause is in `chatCore.js`, which #3183 does not touch. The codex native-passthrough branch calls `applyThinking` on a scratch object and reads the **flat** key back off it:

```js
const suffixThinking = {};
applyThinking(sourceFormat, upstreamModel, suffixThinking, provider);
if (suffixThinking.reasoning_effort) { … }   // never true once the key is nested
```

Once `resolveFormat` maps a Responses `sourceFormat` to the nested shape, that `if` stops firing. Note the second failure: it is not an error, the request still succeeds — the effort just reverts from `max` to the caller's `low`. A user's `(ultra)` suffix stops working with nothing in the logs.

This PR pins that call to `FORMATS.OPENAI` with a comment saying why, so the branch keeps getting the flat key it nests itself.

## 2. #3183 misses the singular `openai-response` target

`FORMAT_TO_NATIVE` carries both spellings, and the singular one is dispatched on in `utils/usageTracking.js:105` and `translator/concerns/modality.js:152`:

```js
"openai-responses": "openai",
"openai-response": "openai",
```

#3183 keys its mapping on `targetFormat === "openai-responses"`, so `openai-response` still ships the flat key. Here it is a set:

```js
const RESPONSES_TARGETS = new Set([FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI_RESPONSE]);
```

I checked this is a real difference and not a reading error: copying this PR's test file onto #3183's implementation, seven of the eight pass and exactly one fails —

```
× nests for the singular openai-response target too
  AssertionError: expected 'high' to be undefined
```

## Everything #3183 covers is covered here

- Responses-only siblings survive: `preserves sibling reasoning keys set by the caller` starts from `reasoning: {effort:"low", mode:"pro", summary:"detailed"}`, applies a `(high)` suffix and asserts exact equality with `{effort:"high", mode:"pro", summary:"detailed"}`.
- A native Responses request is not flattened: `leaves a native Responses request nested rather than flattening it`.
- End to end through `translateRequest`, the outgoing body has no flat key and keeps `summary: "auto"`.

## Approach

#3183 resolves the format up front — `resolveFormat()` returns `"openai-responses"` and `applyFormat` grows a matching case. This PR leaves format resolution alone and rewrites the emitted key afterwards:

```js
if (RESPONSES_TARGETS.has(targetFormat)) nestReasoningEffort(body, priorReasoning);
```

That is one line at the end of `applyThinking`, no new `applyFormat` case, and it catches anything that produces a flat `reasoning_effort` on a Responses target regardless of which branch produced it. It also uses `FORMATS.*` constants rather than the literal `"openai-responses"`, per the "never hardcode format strings" rule in `open-sse/AGENTS.md`.

If you prefer #3183's shape, the two fixes above still need to ride along with it — that is the part worth carrying over whichever you take.

## Verification

8 tests in `unit/thinking-responses-nested-3154.test.js`, plus `translator/thinking-unified.test.js` updated for the nested shape.

Full suite (`npx vitest run unit translator`) rebased on current master: failing set byte-identical to the base, `codex-native-passthrough-thinking.test.js` green. `npx eslint` clean.
