### PR TITLE
fix(rtk): inject the system prompt with the target API's content-part type

### DIFF
--- a/open-sse/rtk/systemInject.js
+++ b/open-sse/rtk/systemInject.js
@@ -3,6 +3,7 @@
 // native-passthrough flows. Used by caveman.js and ponytail.js.
 
 import { FORMATS } from "../translator/formats.js";
+import { OPENAI_BLOCK, RESPONSES_ITEM, ROLE } from "../translator/schema/index.js";
 
 const SEP = "\n\n";
 
@@ -36,25 +37,38 @@ function injectMessagesSystem(body, prompt) {
     return;
   }
 
-  const arr = Array.isArray(body.messages) ? body.messages
+  const isChatMessages = Array.isArray(body.messages);
+  const arr = isChatMessages ? body.messages
     : Array.isArray(body.input) ? body.input
     : null;
-  if (!arr) return;
+  if (!arr) {
+    // Responses also accepts a bare string input with no instructions field. There is
+    // no array to append a part to, so the system channel has to be created instead —
+    // otherwise the prompt is dropped without a trace.
+    if (typeof body.input === "string") body.instructions = prompt;
+    return;
+  }
 
-  const idx = arr.findIndex(m => m && (m.role === "system" || m.role === "developer"));
+  const partType = isChatMessages ? OPENAI_BLOCK.TEXT : RESPONSES_ITEM.INPUT_TEXT;
+
+  const idx = arr.findIndex(m => m && (m.role === ROLE.SYSTEM || m.role === ROLE.DEVELOPER));
   if (idx >= 0) {
-    appendToOpenAIMessage(arr[idx], prompt);
+    appendToOpenAIMessage(arr[idx], prompt, partType);
+  } else if (isChatMessages) {
+    arr.unshift({ role: ROLE.SYSTEM, content: prompt });
   } else {
-    arr.unshift({ role: "system", content: prompt });
+    // A Responses input[] item carries its own type; upstream rejects a bare {role,content}.
+    arr.unshift({ type: RESPONSES_ITEM.MESSAGE, role: ROLE.SYSTEM, content: [{ type: partType, text: prompt }] });
   }
 }
 
-function appendToOpenAIMessage(msg, prompt) {
+function appendToOpenAIMessage(msg, prompt, partType) {
   if (typeof msg.content === "string") {
-    msg.content = `${msg.content}${SEP}${prompt}`;
+    // Guarded like the instructions and Claude branches: an empty string would
+    // otherwise leave the prompt behind two blank lines.
+    msg.content = msg.content ? `${msg.content}${SEP}${prompt}` : prompt;
   } else if (Array.isArray(msg.content)) {
-    // Responses-style array of parts {type:"input_text"|"text", text}
-    msg.content.push({ type: "input_text", text: prompt });
+    msg.content.push({ type: partType, text: prompt });
   } else {
     msg.content = prompt;
   }

--- a/tests/unit/system-inject-part-type-3202.test.js
+++ b/tests/unit/system-inject-part-type-3202.test.js
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+const { injectSystemPrompt } = await import("../../open-sse/rtk/systemInject.js");
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+
+const PROMPT = "speak like a caveman";
+
+describe("#3202 system injection uses the content-part type of the target API", () => {
+  it("appends {type:'text'} to an array-content system message in messages[]", () => {
+    const body = {
+      messages: [
+        { role: "system", content: [{ type: "text", text: "you are a helper" }] },
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    injectSystemPrompt(body, FORMATS.OPENAI, PROMPT);
+
+    expect(body.messages[0].content).toEqual([
+      { type: "text", text: "you are a helper" },
+      { type: "text", text: PROMPT },
+    ]);
+    expect(JSON.stringify(body)).not.toContain("input_text");
+  });
+
+  it("appends {type:'input_text'} to an array-content system item in input[]", () => {
+    const body = {
+      input: [
+        { role: "system", content: [{ type: "input_text", text: "you are a helper" }] },
+        { role: "user", content: [{ type: "input_text", text: "hi" }] },
+      ],
+    };
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.input[0].content).toEqual([
+      { type: "input_text", text: "you are a helper" },
+      { type: "input_text", text: PROMPT },
+    ]);
+  });
+
+  it("uses the chat part type for a developer message too", () => {
+    const body = {
+      messages: [{ role: "developer", content: [{ type: "text", text: "rules" }] }],
+    };
+    injectSystemPrompt(body, FORMATS.OPENAI, PROMPT);
+
+    expect(body.messages[0].content[1]).toEqual({ type: "text", text: PROMPT });
+  });
+
+  it("still concatenates plain-string system content", () => {
+    const body = { messages: [{ role: "system", content: "you are a helper" }] };
+    injectSystemPrompt(body, FORMATS.OPENAI, PROMPT);
+
+    expect(body.messages[0].content).toBe(`you are a helper\n\n${PROMPT}`);
+  });
+
+  it("still prepends a system message when none exists", () => {
+    const body = { messages: [{ role: "user", content: "hi" }] };
+    injectSystemPrompt(body, FORMATS.OPENAI, PROMPT);
+
+    expect(body.messages[0]).toEqual({ role: "system", content: PROMPT });
+  });
+
+  it("prepends a typed message item when input[] has no system item", () => {
+    const body = { input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }] };
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "system",
+      content: [{ type: "input_text", text: PROMPT }],
+    });
+    expect(body.input[1].role).toBe("user");
+  });
+
+  // detectFormatByEndpoint deliberately labels /v1/chat/completions + input[] as
+  // FORMATS.OPENAI because Cursor CLI posts a Responses body to the chat endpoint.
+  // The part type therefore has to follow the body shape, not the format label.
+  it("uses Responses part types for a Cursor-CLI body labelled FORMATS.OPENAI", () => {
+    const body = { input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }] };
+    injectSystemPrompt(body, FORMATS.OPENAI, PROMPT);
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "system",
+      content: [{ type: "input_text", text: PROMPT }],
+    });
+    expect(JSON.stringify(body)).not.toContain('"type":"text"');
+  });
+
+  it("creates instructions when the Responses body carries a bare string input", () => {
+    const body = { model: "gpt-5.6-sol", input: "hello", stream: false };
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.instructions).toBe(PROMPT);
+    expect(body.input).toBe("hello");
+  });
+
+  it("leaves a chat body without messages[] untouched", () => {
+    const body = { model: "gpt-4o-mini" };
+    injectSystemPrompt(body, FORMATS.OPENAI, PROMPT);
+
+    expect(body).toEqual({ model: "gpt-4o-mini" });
+  });
+
+  it("does not leave blank lines in front of an empty system message", () => {
+    const body = { messages: [{ role: "system", content: "" }, { role: "user", content: "hi" }] };
+    injectSystemPrompt(body, FORMATS.OPENAI, PROMPT);
+
+    expect(body.messages[0].content).toBe(PROMPT);
+  });
+
+  it("appends to top-level instructions when present", () => {
+    const body = { instructions: "you are a helper", input: [] };
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, PROMPT);
+
+    expect(body.instructions).toBe(`you are a helper\n\n${PROMPT}`);
+  });
+});


### PR DESCRIPTION
Closes #3202.

`injectSystemPrompt` (caveman / ponytail) pushed `{type:"input_text"}` into every array-shaped system message, including Chat Completions bodies where the valid part type is `text`. The provider rejects the request or drops the part.

**Credit where it is due: #3204 by @2Bdou found this two days before I did.** I said there that theirs was the more complete fix and offered to close this one. That was true at the time. It is no longer — this now covers everything #3204 does plus two cases it misses, and I verified both by applying its patch to a clean `origin/master` and running this PR's tests against it:

```
× creates instructions when the Responses body carries a bare string input
  → expected undefined to be 'speak like a caveman'
× does not leave blank lines in front of an empty system message
  → expected '\n\nspeak like a caveman' to be 'speak like a caveman'
  the other 9 pass
```

## 1. A Responses body with a string input drops the prompt silently

`/v1/responses` accepts `input` as a bare string, not only as an array — `{model, input: "hello", stream: false}` is the exact shape `tests/unit/codex-native-passthrough-thinking.test.js` already sends. On master, on #3204, and in this PR's first revision, that body walks straight past both branches:

```js
const arr = Array.isArray(body.messages) ? body.messages
  : Array.isArray(body.input) ? body.input
  : null;
if (!arr) return;          // ← string input lands here
```

`instructions` is absent too, so there is nothing to append to and the caveman/ponytail prompt is dropped with no error and no log. Toggling the feature on simply does nothing for native Codex traffic. Fixed by creating the Responses system channel in that case:

```js
if (typeof body.input === "string") body.instructions = prompt;
```

## 2. An empty system message leaves the prompt behind two blank lines

The other two string branches in this same file already guard it — `injectMessagesSystem` does `body.instructions ? … : prompt`, `injectClaudeSystem` checks `body.system.length > 0`. `appendToOpenAIMessage` was the only one that did not, so `content: ""` produced `"\n\nspeak like a caveman"`. Now guarded the same way.

## 3. The untyped unshift (this is #3204's find)

With no system item in a Responses `input[]`, the old code unshifted a bare `{role, content}`, which is invalid there. #3204 fixed it; this PR now does too, keyed off which array was selected rather than a separate shape probe, and built from `RESPONSES_ITEM.MESSAGE` / `ROLE.SYSTEM` instead of literals.

## Shape, not format label

Both fixes derive the part type from the body, and that is deliberate rather than incidental — `detectFormatByEndpoint` labels `/v1/chat/completions` + `input[]` as `FORMATS.OPENAI` on purpose, because Cursor CLI posts a Responses body to the chat endpoint:

```js
// /v1/chat/completions + input[] → treat as openai (Cursor CLI sends Responses body via chat endpoint)
if (pathname.includes("/v1/chat/completions") && Array.isArray(body?.input)) return FORMATS.OPENAI;
```

So keying on `format` would put `text` parts into a Responses body for every Cursor CLI request. #3204 gets this right too, but nothing pins it in either PR's tests, and a later "simplify to use the format we were handed" refactor would break Cursor silently. `uses Responses part types for a Cursor-CLI body labelled FORMATS.OPENAI` pins it.

Per `open-sse/AGENTS.md` — "Never hardcode role/block/model strings — use `open-sse/translator/schema/`" — the part types and roles come from `OPENAI_BLOCK.TEXT`, `RESPONSES_ITEM.INPUT_TEXT`, `RESPONSES_ITEM.MESSAGE`, `ROLE.SYSTEM` / `ROLE.DEVELOPER` rather than literals.

## Not changed on purpose

`appendToOpenAIMessage` still overwrites when `content` is some other object, which loses the original. That is the whole file's convention for unexpected shapes (`injectClaudeSystem` and `injectGeminiSystem` both end the same way), so changing it in one branch would make the file less predictable, not more. Worth doing as its own change if you want it.

## Verification

11 tests in `unit/system-inject-part-type-3202.test.js`: chat vs Responses part types, `developer` role, string content, plain unshift, typed unshift, the Cursor CLI body, string `input`, a chat body with no `messages[]` left untouched, the empty-content guard, and `instructions` appending.

Full suite (`npx vitest run unit translator`) rebased on current master: failing set byte-identical to the base. `npx eslint` clean. RTK stays fail-open — no new throw paths.
