### PR TITLE
fix(translator): preserve prompt_cache_key when converting chat to responses

### DIFF
--- a/open-sse/translator/request/openai-responses.js
+++ b/open-sse/translator/request/openai-responses.js
@@ -421,6 +421,7 @@ export function openaiToOpenAIResponsesRequest(model, body, stream, credentials)
   if (body.reasoning !== undefined) result.reasoning = body.reasoning;
   if (body.reasoning_effort !== undefined) result.reasoning = { effort: body.reasoning_effort, summary: "auto" };
   if (body.service_tier !== undefined) result.service_tier = body.service_tier;
+  if (body.prompt_cache_key !== undefined) result.prompt_cache_key = body.prompt_cache_key;
 
   return result;
 }

--- a/tests/unit/responses-prompt-cache-key-3216.test.js
+++ b/tests/unit/responses-prompt-cache-key-3216.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+const { openaiToOpenAIResponsesRequest, openaiResponsesToOpenAIRequest } =
+  await import("../../open-sse/translator/request/openai-responses.js");
+
+const CHAT_BODY = (extra = {}) => ({
+  model: "example-model",
+  messages: [{ role: "user", content: "hello" }],
+  ...extra,
+});
+
+describe("#3216 prompt_cache_key across the chat/responses translation", () => {
+  it("preserves an explicit key when converting chat → responses", () => {
+    const out = openaiToOpenAIResponsesRequest(
+      "example-model",
+      CHAT_BODY({ prompt_cache_key: "stable-cache-key" }),
+      true,
+      {},
+    );
+
+    expect(out.prompt_cache_key).toBe("stable-cache-key");
+  });
+
+  it("does not invent a key when the client sent none", () => {
+    const out = openaiToOpenAIResponsesRequest("example-model", CHAT_BODY(), true, {});
+
+    expect(out.prompt_cache_key).toBeUndefined();
+  });
+
+  it("still drops the key on the responses → chat direction", () => {
+    const out = openaiResponsesToOpenAIRequest(
+      "example-model",
+      {
+        model: "example-model",
+        input: [{ role: "user", content: [{ type: "input_text", text: "hello" }] }],
+        prompt_cache_key: "stable-cache-key",
+      },
+      true,
+      {},
+    );
+
+    expect(out.prompt_cache_key).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #3216

## Problem

`openaiToOpenAIResponsesRequest()` explicitly passes through `temperature`, `max_tokens`, `top_p`, `reasoning`, `reasoning_effort` and `service_tier`, but never copied `prompt_cache_key`. Any Chat Completions client routing to a Responses-format provider had its explicit cache key dropped:

```js
const out = openaiToOpenAIResponsesRequest(
  "example-model",
  { messages: [{ role: "user", content: "hello" }], prompt_cache_key: "stable-cache-key" },
  true,
  {},
);
out.prompt_cache_key; // undefined
```

This is not cosmetic: `codex.js` only synthesizes a session-derived key when the field is absent (`if (!body.prompt_cache_key && this._currentSessionId)`), so the fallback silently took over from the client's stable key and prompt-cache hits became less reliable.

## Fix

One pass-through line alongside the existing ones. The reverse direction (`openaiResponsesToOpenAIRequest`) keeps its `delete result.prompt_cache_key` — Chat Completions has no such field.

## Tests

New: `tests/unit/responses-prompt-cache-key-3216.test.js` — explicit key survives chat → responses, no key is invented when the client sent none, and the responses → chat direction still strips it.

Full suite (`npx vitest run unit translator`) against `master` as the baseline: **1670 → 1673 passed, 91 failed on both sides** — no pass→fail, the 3 new passes are this PR's tests.

Credit to the issue reporter for the diagnosis and the proposed patch.
