### PR TITLE
fix(handlers): honor the client format for non-streaming binary-transport replies

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -141,17 +141,17 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
  */
+// Provider responded in OpenAI Chat Completions shape — hand the client whatever
+// dialect it speaks, or the body unchanged when that dialect is OpenAI itself.
+function fromOpenAICompletion(responseBody, sourceFormat, customToolNames) {
+  if (sourceFormat === FORMATS.OPENAI_RESPONSES) return openAICompletionToResponses(responseBody, customToolNames);
+  if (sourceFormat === FORMATS.CLAUDE) return openAICompletionToClaudeMessage(responseBody);
+  return responseBody;
+}
+
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, customToolNames = null) {
   if (targetFormat === sourceFormat) return responseBody;
-  // Provider responded in OpenAI Chat Completions shape but the client speaks
-  // Responses API — convert so tool_calls/text surface as Responses `output`.
-  if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.OPENAI_RESPONSES) {
-    return openAICompletionToResponses(responseBody, customToolNames);
-  }
-  if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.CLAUDE) {
-    return openAICompletionToClaudeMessage(responseBody);
-  }
-  if (targetFormat === FORMATS.OPENAI) return responseBody;
+  if (targetFormat === FORMATS.OPENAI) return fromOpenAICompletion(responseBody, sourceFormat, customToolNames);
 
   // Gemini / Antigravity
   if (targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.ANTIGRAVITY || targetFormat === FORMATS.GEMINI_CLI || targetFormat === FORMATS.VERTEX) {
@@ -273,6 +273,10 @@ export function translateNonStreamingResponse(responseBody, targetFormat, source
   // Ollama
   if (targetFormat === FORMATS.OLLAMA) {
     return ollamaBodyToOpenAI(responseBody);
+  }
+
+  if (Array.isArray(responseBody?.choices)) {
+    return fromOpenAICompletion(responseBody, sourceFormat, customToolNames);
   }
 
   return responseBody;

--- a/tests/unit/nonstream-binary-transport-source-format-3199.test.js
+++ b/tests/unit/nonstream-binary-transport-source-format-3199.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { translateNonStreamingResponse } = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
+
+// The kiro executor decodes its EventStream frames into a chat.completion body
+// before chatCore ever sees them, so translateNonStreamingResponse is handed
+// OpenAI shape under targetFormat "kiro".
+const KIRO_DECODED_BODY = {
+  id: "chatcmpl-1786352438097",
+  object: "chat.completion",
+  created: 1786352438,
+  model: "claude-haiku-4.5",
+  choices: [{
+    index: 0,
+    message: { role: "assistant", content: "Hey there." },
+    finish_reason: "stop",
+  }],
+  usage: { prompt_tokens: 10, completion_tokens: 8 },
+};
+
+const KIRO_TOOL_BODY = {
+  id: "chatcmpl-tool",
+  object: "chat.completion",
+  model: "claude-haiku-4.5",
+  choices: [{
+    index: 0,
+    message: {
+      role: "assistant",
+      content: null,
+      tool_calls: [{ id: "toolu_1", type: "function", function: { name: "Read", arguments: '{"path":"a.txt"}' } }],
+    },
+    finish_reason: "tool_calls",
+  }],
+  usage: {},
+};
+
+describe("#3199 non-streaming responses from binary-transport targets", () => {
+  it("returns an Anthropic message to a Claude client", () => {
+    const out = translateNonStreamingResponse(KIRO_DECODED_BODY, FORMATS.KIRO, FORMATS.CLAUDE);
+
+    expect(out.type).toBe("message");
+    expect(out.role).toBe("assistant");
+    expect(out.content).toEqual([{ type: "text", text: "Hey there." }]);
+    expect(out.stop_reason).toBe("end_turn");
+    expect(out.usage).toEqual({ input_tokens: 10, output_tokens: 8 });
+    expect(out.choices).toBeUndefined();
+  });
+
+  it("maps tool calls to tool_use blocks for a Claude client", () => {
+    const out = translateNonStreamingResponse(KIRO_TOOL_BODY, FORMATS.KIRO, FORMATS.CLAUDE);
+
+    expect(out.content).toEqual([
+      { type: "tool_use", id: "toolu_1", name: "Read", input: { path: "a.txt" } },
+    ]);
+    expect(out.stop_reason).toBe("tool_use");
+  });
+
+  it("returns a Responses body to a Responses client", () => {
+    const out = translateNonStreamingResponse(KIRO_DECODED_BODY, FORMATS.KIRO, FORMATS.OPENAI_RESPONSES);
+
+    expect(out.object).toBe("response");
+    expect(out.output).toEqual([{
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Hey there.", annotations: [] }],
+    }]);
+  });
+
+  it("leaves an OpenAI client's body untouched", () => {
+    const out = translateNonStreamingResponse(KIRO_DECODED_BODY, FORMATS.KIRO, FORMATS.OPENAI);
+
+    expect(out).toBe(KIRO_DECODED_BODY);
+  });
+
+  it("does not touch a body that has no choices array", () => {
+    const raw = { some: "proprietary shape" };
+    const out = translateNonStreamingResponse(raw, FORMATS.KIRO, FORMATS.CLAUDE);
+
+    expect(out).toBe(raw);
+  });
+});


### PR DESCRIPTION
Fixes #3199

## Problem

```bash
curl -s http://localhost:20128/v1/messages -H "anthropic-version: 2023-06-01" \
  -d '{"model":"kr/claude-haiku-4.5","max_tokens":20,"stream":false,"messages":[{"role":"user","content":"Say hi"}]}'
```

returns `{"id":"chatcmpl-…","object":"chat.completion","choices":[…]}` instead of an Anthropic message. Streaming against the same route is correct.

Providers on a binary or proprietary transport decode their upstream reply to OpenAI Chat Completions inside their own executor — the kiro executor emits `chat.completion.chunk` SSE, which `handleNonStreamingResponse` collapses via `parseSSEToOpenAIResponse()`. By the time `translateNonStreamingResponse()` runs, `targetFormat` is `kiro` and the body is already OpenAI-shaped.

`translateNonStreamingResponse()` branches on `openai`, `gemini`/`vertex`/`antigravity`, `claude` and `ollama`. `kiro` (and `cursor`, `commandcode`) match none of them, so control reached the trailing `return responseBody` and the OpenAI shape went straight to a Claude client. The existing `targetFormat === OPENAI && sourceFormat === CLAUDE` branch was the right conversion — it just was not reachable for these targets.

Downstream impact: LiteLLM's `anthropic/` prefix expects an Anthropic body from `/v1/messages` and fails with `KeyError: 'content'`.

## Fix

The "body is OpenAI Chat Completions — what does the client speak?" dispatch existed once already, keyed on `targetFormat === OPENAI`. Rather than write it a second time, it is extracted into `fromOpenAICompletion()` and called from both places: the existing `targetFormat === OPENAI` branch, and a new trailing guard for bodies that carry a `choices` array under a target format with no branch of its own.

Net result is one list of client formats instead of two. The Responses arm covers the identical gap for a Responses client on the same targets. An OpenAI client is unaffected, and a body without `choices` is returned untouched.

## Scope note — the deeper seam, deliberately not taken

The codebase already has the right long-term mechanism for this: `result.responseFormat`, honored in `chatCore.js` ("Most executors return their registry format. Cursor AgentService is an exception: it is decoded by the executor into OpenAI-compatible output."). Today only `executors/cursor.js` sets it.

`executors/kiro.js` and `executors/commandcode.js` both qualify — kiro's `execute()` always runs `transformEventStreamToSSE`, and commandcode's always runs `wrapNdjsonAsOpenAISse()`, so both unconditionally return OpenAI Chat Completions. Declaring `responseFormat: FORMATS.OPENAI` on those two executors would fix this issue with no new code at all, since the existing `targetFormat === OPENAI` branch would then handle them.

I did not do that here because `providerResponseFormat` also feeds `handleStreamingResponse`, so it would reroute kiro's streaming path off the direct `kiro:claude` route onto `openai:claude` and make `translator/response/kiro-to-claude.js` dead. That should be behavior-neutral, but it is a much larger change on a heavily used provider and belongs in its own PR. Flagging it so the direction is on record.

## Tests

New: `tests/unit/nonstream-binary-transport-source-format-3199.test.js` — a kiro-decoded body converts to an Anthropic message (text, `stop_reason`, `usage`), tool calls become `tool_use` blocks, a Responses client gets `object:"response"`, an OpenAI client's body is returned by identity, and a body with no `choices` is untouched.

Full suite (`npx vitest run unit translator`) against `master` as the baseline: **1670 → 1675 passed, 91 failed on both sides** — no pass→fail, the 5 new passes are this PR's tests.
