### PR TITLE
feat(opencode-go): read the plan usage endpoint, and stop calling a spent key invalid

### DIFF
--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -21,6 +21,13 @@ export default {
   transport: {
     baseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
     headers: {},
+    usage: {
+      url: "https://opencode.ai/zen/go/v1/usage",
+    },
+  },
+  features: {
+    usage: true,
+    usageApikey: true,
   },
   models: [
     { id: "glm-5.2", name: "GLM 5.2" },

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -12,6 +12,7 @@ import { getKiroUsage } from "./usage/kiro.js";
 import { getMiniMaxUsage } from "./usage/minimax.js";
 import { getCodeBuddyCnUsage, getCodeBuddyIntlUsage } from "./usage/codebuddy-cn.js";
 import { getGrokCliUsage } from "./usage/grok-cli.js";
+import { getOpenCodeGoUsage } from "./usage/opencode-go.js";
 import { getKimiUsage } from "./usage/kimi.js";
 import { getDeepseekUsage } from "./usage/deepseek.js";
 import { resolveQoderCredentials } from "./qoderModels.js";
@@ -52,6 +53,7 @@ const USAGE_HANDLERS = {
   "codebuddy-cn": (c) => getCodeBuddyCnUsage(c.accessToken, c.apiKey, c.providerSpecificData, c.proxyOptions),
   "codebuddy-intl": (c) => getCodeBuddyIntlUsage(c.accessToken, c.apiKey, c.providerSpecificData, c.proxyOptions),
   "grok-cli": (c) => getGrokCliUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
+  "opencode-go": (c) => getOpenCodeGoUsage(c.apiKey, c.proxyOptions),
   kimi: (c) => getKimiUsage(c.accessToken, c.apiKey, c.proxyOptions, c.providerSpecificData),
   deepseek: (c) => getDeepseekUsage(c.apiKey, c.proxyOptions),
 };

--- a/open-sse/services/usage/opencode-go.js
+++ b/open-sse/services/usage/opencode-go.js
@@ -1,0 +1,182 @@
+/**
+ * OpenCode Go usage handler
+ *
+ * Source of truth: GET https://opencode.ai/zen/go/v1/usage, authenticated with the
+ * same sk-... key used for chat. Measured live on 2026-08-12 against a key whose
+ * monthly window was depleted:
+ *
+ * {
+ *   "usage": {
+ *     "rolling": { "status": "ok",           "percent": 0,   "resetsAt": "2026-08-12T09:43:25.596Z" },
+ *     "weekly":  { "status": "ok",           "percent": 0,   "resetsAt": "2026-08-17T00:00:00.596Z" },
+ *     "monthly": { "status": "rate-limited", "percent": 100, "resetsAt": "2026-08-12T19:57:51.596Z" }
+ *   }
+ * }
+ *
+ * Four properties drive the parsing below, all measured rather than assumed:
+ *
+ * 1. `percent` is percent USED. The depleted window reads 100, not 0.
+ * 2. `status` is "ok" or "rate-limited". A window counts as blocked on EITHER
+ *    signal (status, or percent at 100), so an upstream that renames the status
+ *    string still reports the window as blocked instead of silently healthy.
+ * 3. On an untouched window `resetsAt` is a PROJECTION, not a deadline: two samples
+ *    34 minutes apart showed `rolling` move while `monthly` stayed put. Only a
+ *    window that is blocked or partly used gets its reset surfaced, so the table
+ *    does not show an idle window as having a pending deadline.
+ * 4. `monthly` is a rolling ~30 day window, not a calendar month: the depleted key
+ *    reported a reset 10 hours out, not the first of the next month.
+ *
+ * The endpoint exists only on the Go tier. The keyless `opencode` provider is a
+ * different base URL and answers this path with a 404 HTML page.
+ */
+
+import { U, parseResetTime, toFiniteNumber, fetchWithTimeout } from "./shared.js";
+
+const USAGE = U("opencode-go");
+export const OPENCODE_GO_USAGE_URL = USAGE.url || "https://opencode.ai/zen/go/v1/usage";
+
+// Display order for the windows the upstream is known to report. Anything else it
+// starts sending is appended after these, sorted, so a new window shows up in the
+// table the day it appears instead of waiting for a code change.
+const KNOWN_WINDOWS = [
+  ["rolling", "Rolling"],
+  ["weekly", "Weekly"],
+  ["monthly", "Monthly"],
+];
+
+function labelFor(key) {
+  const known = KNOWN_WINDOWS.find(([k]) => k === key);
+  if (known) return known[1];
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+/**
+ * Blocked on EITHER signal (property 2 above). `status` is compared case
+ * insensitively with `_` folded to `-`, so "rate_limited" reads the same as
+ * "rate-limited".
+ */
+function isBlocked(status, percentUsed) {
+  const byStatus =
+    typeof status === "string" &&
+    status.trim().toLowerCase().replace(/_/g, "-") === "rate-limited";
+  const byPercent = Number.isFinite(percentUsed) && percentUsed >= 100;
+  return byStatus || byPercent;
+}
+
+/**
+ * Turn the raw payload into the quota map the dashboard renders.
+ *
+ * Exported for tests. `used`/`total` are a 0-100 pair because QuotaTable reads
+ * `remaining` as a percentage, never an absolute count (same trap documented on
+ * the Qoder and Grok handlers). `remainingPercentage` is set for the same reason.
+ *
+ * @param {object} payload - Parsed JSON body of GET /zen/go/v1/usage
+ * @returns {{ quotas: object, limitReached: boolean }|null} null when unparsable
+ */
+export function parseOpenCodeGoUsage(payload) {
+  const usage = payload?.usage;
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return null;
+
+  const known = KNOWN_WINDOWS.map(([key]) => key).filter((key) => key in usage);
+  const extra = Object.keys(usage)
+    .filter((key) => !KNOWN_WINDOWS.some(([k]) => k === key))
+    .sort();
+
+  const quotas = {};
+  let limitReached = false;
+
+  for (const key of [...known, ...extra]) {
+    const window = usage[key];
+    // One malformed window must not blind the table to the others.
+    if (!window || typeof window !== "object" || Array.isArray(window)) continue;
+
+    const rawPercent = toFiniteNumber(window.percent, NaN);
+    const hasPercent = Number.isFinite(rawPercent);
+    const blocked = isBlocked(window.status, hasPercent ? rawPercent : NaN);
+    if (blocked) limitReached = true;
+
+    const used = hasPercent ? Math.max(0, Math.min(100, Math.round(rawPercent))) : blocked ? 100 : 0;
+    // Property 3: an untouched window's resetsAt is "now plus the window length",
+    // which is not a fact about anything.
+    const showReset = blocked || used > 0;
+
+    quotas[labelFor(key)] = {
+      used,
+      total: 100,
+      remainingPercentage: 100 - used,
+      resetAt: showReset ? parseResetTime(window.resetsAt) : null,
+      unlimited: false,
+    };
+  }
+
+  if (Object.keys(quotas).length === 0) return null;
+  return { quotas, limitReached };
+}
+
+/**
+ * True when a 4xx body says the plan window is spent rather than the key being
+ * bad. Exhausted: {"error":{"type":"CreditsError","message":"Insufficient balance..."}}
+ * Revoked:   {"error":{"type":"AuthError","message":"Invalid API key."}}
+ *
+ * Match on the STRUCTURE, never a substring of the message: that message embeds a
+ * workspace-scoped billing URL, so reading it would make an account identifier
+ * load-bearing, and a substring like "balance" would misfire on an unrelated body.
+ *
+ * @param {string} bodyText
+ * @returns {boolean}
+ */
+export function isOpenCodeGoCreditsError(bodyText) {
+  try {
+    return JSON.parse(bodyText)?.error?.type === "CreditsError";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string} apiKey
+ * @param {object|null} proxyOptions
+ */
+export async function getOpenCodeGoUsage(apiKey, proxyOptions = null) {
+  if (!apiKey) {
+    return { message: "OpenCode Go API key not available." };
+  }
+
+  try {
+    const response = await fetchWithTimeout(
+      OPENCODE_GO_USAGE_URL,
+      { headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" } },
+      10000,
+      proxyOptions,
+    );
+
+    // A key with every window spent still answers 200 here (it is the chat call
+    // that 401s), so a 401 on this endpoint really does mean a bad key.
+    if (response.status === 401 || response.status === 403) {
+      return { message: "OpenCode Go API key invalid or expired." };
+    }
+    if (!response.ok) {
+      return { message: `OpenCode Go usage API error (${response.status}).` };
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch {
+      return { message: "OpenCode Go usage response was not JSON." };
+    }
+
+    const parsed = parseOpenCodeGoUsage(data);
+    if (!parsed) {
+      return { plan: "OpenCode Go", message: "OpenCode Go reported no usage windows.", quotas: {} };
+    }
+
+    return {
+      plan: "OpenCode Go",
+      limitReached: parsed.limitReached,
+      quotas: parsed.quotas,
+    };
+  } catch (error) {
+    return { message: `OpenCode Go usage fetch failed: ${error.message}` };
+  }
+}

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -8,6 +8,7 @@ import {
   refreshProviderCredentials,
   shouldRefreshCredentials,
 } from "open-sse/services/oauthCredentialManager.js";
+import { OPENCODE_GO_USAGE_URL, isOpenCodeGoCreditsError } from "open-sse/services/usage/opencode-go.js";
 import {
   GEMINI_CONFIG,
   ANTIGRAVITY_CONFIG,
@@ -745,12 +746,15 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
         return { valid, error: valid ? null : "Session expired — re-paste cookie" };
       }
       case "opencode-go": {
-        const res = await fetchWithConnectionProxy("https://opencode.ai/zen/go/v1/chat/completions", {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: `Bearer ${connection.apiKey}` },
-          body: JSON.stringify({ model: getDefaultModel("opencode-go"), messages: [{ role: "user", content: "ping" }], max_tokens: 1, stream: false }),
+        // Probe /usage rather than a chat completion: a key whose plan window is
+        // spent still answers 200 here but 401 on chat, so the old ping reported a
+        // working key as "Invalid API key". It also costs no tokens.
+        const res = await fetchWithConnectionProxy(OPENCODE_GO_USAGE_URL, {
+          headers: { Authorization: `Bearer ${connection.apiKey}`, Accept: "application/json" },
         }, effectiveProxy);
-        const valid = res.status !== 401 && res.status !== 403;
+        // Belt and braces: if this endpoint ever starts 401ing an exhausted plan
+        // the way chat does, CreditsError still means the key itself is good.
+        const valid = res.ok || isOpenCodeGoCreditsError(await res.text().catch(() => ""));
         return { valid, error: valid ? null : "Invalid API key" };
       }
       case "xiaomi-mimo":

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -5,6 +5,7 @@ import { getDefaultModel } from "open-sse/config/providerModels.js";
 import { resolveOllamaLocalHost, resolveXiaomiTokenplanBaseUrl, PROVIDERS } from "open-sse/config/providers.js";
 import { openaiToCommandCodeRequest } from "open-sse/translator/request/openai-to-commandcode.js";
 import { resolveQoderCredentials, resolveQoderModels } from "open-sse/services/qoderModels.js";
+import { OPENCODE_GO_USAGE_URL, isOpenCodeGoCreditsError } from "open-sse/services/usage/opencode-go.js";
 import { normalizeProviderId } from "@/lib/providerNormalization";
 
 // Probe a webSearch/webFetch provider using its searchConfig/fetchConfig.
@@ -396,17 +397,16 @@ export async function POST(request) {
         }
 
         case "opencode-go": {
-          const res = await fetch("https://opencode.ai/zen/go/v1/chat/completions", {
-            method: "POST",
-            headers: { "Content-Type": "application/json", "Authorization": `Bearer ${apiKey}` },
-            body: JSON.stringify({
-              model: getDefaultModel("opencode-go"),
-              messages: [{ role: "user", content: "ping" }],
-              max_tokens: 1,
-              stream: false,
-            }),
+          // Probe /usage rather than a chat completion: a key whose plan window is
+          // spent still answers 200 here but 401 on chat, so the old ping reported
+          // a working key as invalid. It also costs no tokens.
+          const res = await fetch(OPENCODE_GO_USAGE_URL, {
+            headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+            signal: AbortSignal.timeout(8000),
           });
-          isValid = res.status !== 401 && res.status !== 403;
+          // Belt and braces: if this endpoint ever starts 401ing an exhausted plan
+          // the way chat does, CreditsError still means the key itself is good.
+          isValid = res.ok || isOpenCodeGoCreditsError(await res.text().catch(() => ""));
           break;
         }
 

--- a/tests/unit/opencode-go-usage.test.js
+++ b/tests/unit/opencode-go-usage.test.js
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+import { PROVIDERS } from "../../open-sse/providers/index.js";
+import { USAGE_SUPPORTED_PROVIDERS, USAGE_APIKEY_PROVIDERS } from "../../src/shared/constants/providers.js";
+import {
+  parseQuotaData,
+  getRemainingPercentage,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+import {
+  OPENCODE_GO_USAGE_URL,
+  isOpenCodeGoCreditsError,
+  parseOpenCodeGoUsage,
+} from "../../open-sse/services/usage/opencode-go.js";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Verbatim response from GET /zen/go/v1/usage on 2026-08-12, from a key whose
+// monthly window was spent while the other two were untouched.
+const LIVE_PAYLOAD = {
+  usage: {
+    rolling: { status: "ok", percent: 0, resetsAt: "2026-08-12T09:43:25.596Z" },
+    weekly: { status: "ok", percent: 0, resetsAt: "2026-08-17T00:00:00.596Z" },
+    monthly: { status: "rate-limited", percent: 100, resetsAt: "2026-08-12T19:57:51.596Z" },
+  },
+};
+
+describe("opencode-go registry wiring", () => {
+  it("carries the usage URL on the registry entry, not only in the handler", () => {
+    // Asserted on PROVIDERS rather than the exported constant: the constant has a
+    // hardcoded fallback, so it would still read correct with the registry block
+    // deleted, and the dashboard resolves the provider through PROVIDERS.
+    expect(PROVIDERS["opencode-go"].usage?.url).toBe("https://opencode.ai/zen/go/v1/usage");
+    expect(OPENCODE_GO_USAGE_URL).toBe(PROVIDERS["opencode-go"].usage.url);
+  });
+
+  it("exposes usage + usageApikey so the API-key card appears on /usage", () => {
+    expect(USAGE_SUPPORTED_PROVIDERS).toContain("opencode-go");
+    expect(USAGE_APIKEY_PROVIDERS).toContain("opencode-go");
+  });
+});
+
+describe("parseOpenCodeGoUsage", () => {
+  it("reads percent as percent USED, not remaining", () => {
+    const { quotas } = parseOpenCodeGoUsage(LIVE_PAYLOAD);
+
+    expect(quotas.Monthly.used).toBe(100);
+    expect(quotas.Monthly.remainingPercentage).toBe(0);
+    expect(quotas.Rolling.used).toBe(0);
+    expect(quotas.Rolling.remainingPercentage).toBe(100);
+  });
+
+  it("reports limitReached when any window is spent", () => {
+    expect(parseOpenCodeGoUsage(LIVE_PAYLOAD).limitReached).toBe(true);
+  });
+
+  it("reports limitReached false when every window is healthy", () => {
+    const healthy = {
+      usage: {
+        rolling: { status: "ok", percent: 0, resetsAt: "2026-08-12T09:43:25.596Z" },
+        monthly: { status: "ok", percent: 40, resetsAt: "2026-08-12T19:57:51.596Z" },
+      },
+    };
+
+    expect(parseOpenCodeGoUsage(healthy).limitReached).toBe(false);
+  });
+
+  it("treats a window at 100 percent as blocked even when status still reads ok", () => {
+    const stale = { usage: { monthly: { status: "ok", percent: 100, resetsAt: "2026-08-12T19:57:51.596Z" } } };
+
+    expect(parseOpenCodeGoUsage(stale).limitReached).toBe(true);
+  });
+
+  it("folds underscores and case in the status string", () => {
+    // No percent field, so only the status signal can block this window.
+    const renamed = { usage: { monthly: { status: "Rate_Limited", resetsAt: "2026-08-12T19:57:51.596Z" } } };
+
+    expect(parseOpenCodeGoUsage(renamed).limitReached).toBe(true);
+  });
+
+  it("still blocks on the status signal when percent is missing", () => {
+    const noPercent = { usage: { monthly: { status: "rate-limited", resetsAt: "2026-08-12T19:57:51.596Z" } } };
+    const { quotas, limitReached } = parseOpenCodeGoUsage(noPercent);
+
+    expect(limitReached).toBe(true);
+    expect(quotas.Monthly.used).toBe(100);
+  });
+
+  it("hides the reset of an untouched window and surfaces it for a spent one", () => {
+    const { quotas } = parseOpenCodeGoUsage(LIVE_PAYLOAD);
+
+    // resetsAt on an idle window is a projection of now plus the window length,
+    // not a deadline, so it must not render as a pending reset.
+    expect(quotas.Rolling.resetAt).toBeNull();
+    expect(quotas.Weekly.resetAt).toBeNull();
+    expect(quotas.Monthly.resetAt).toBe("2026-08-12T19:57:51.596Z");
+  });
+
+  it("surfaces the reset of a partly used window", () => {
+    const partial = { usage: { rolling: { status: "ok", percent: 35, resetsAt: "2026-08-12T09:43:25.596Z" } } };
+
+    expect(parseOpenCodeGoUsage(partial).quotas.Rolling.resetAt).toBe("2026-08-12T09:43:25.596Z");
+  });
+
+  it("orders known windows rolling, weekly, monthly regardless of payload order", () => {
+    const shuffled = {
+      usage: {
+        monthly: LIVE_PAYLOAD.usage.monthly,
+        rolling: LIVE_PAYLOAD.usage.rolling,
+        weekly: LIVE_PAYLOAD.usage.weekly,
+      },
+    };
+
+    expect(Object.keys(parseOpenCodeGoUsage(shuffled).quotas)).toEqual(["Rolling", "Weekly", "Monthly"]);
+  });
+
+  it("appends an unrecognized window after the known ones", () => {
+    const extra = {
+      usage: {
+        daily: { status: "ok", percent: 10, resetsAt: "2026-08-12T09:43:25.596Z" },
+        rolling: LIVE_PAYLOAD.usage.rolling,
+      },
+    };
+    const keys = Object.keys(parseOpenCodeGoUsage(extra).quotas);
+
+    expect(keys).toEqual(["Rolling", "Daily"]);
+  });
+
+  it("skips a malformed window without losing its siblings", () => {
+    const broken = { usage: { rolling: LIVE_PAYLOAD.usage.rolling, monthly: "not an object" } };
+    const keys = Object.keys(parseOpenCodeGoUsage(broken).quotas);
+
+    expect(keys).toEqual(["Rolling"]);
+  });
+
+  it("returns null when the payload carries no usable windows", () => {
+    expect(parseOpenCodeGoUsage(null)).toBeNull();
+    expect(parseOpenCodeGoUsage({})).toBeNull();
+    expect(parseOpenCodeGoUsage({ usage: {} })).toBeNull();
+    expect(parseOpenCodeGoUsage({ usage: [] })).toBeNull();
+  });
+
+  it("clamps a percent outside 0..100 so the bar cannot leave its track", () => {
+    const odd = {
+      usage: {
+        rolling: { status: "ok", percent: -5, resetsAt: null },
+        monthly: { status: "ok", percent: 140, resetsAt: "2026-08-12T19:57:51.596Z" },
+      },
+    };
+    const { quotas } = parseOpenCodeGoUsage(odd);
+
+    expect(quotas.Rolling.used).toBe(0);
+    expect(quotas.Monthly.used).toBe(100);
+  });
+});
+
+describe("getUsageForProvider(opencode-go)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls the usage endpoint with the chat API key as a bearer token", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(LIVE_PAYLOAD));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "sk-test" });
+
+    const [url, opts] = proxyAwareFetch.mock.calls[0];
+    expect(url).toBe("https://opencode.ai/zen/go/v1/usage");
+    expect(opts.headers.Authorization).toBe("Bearer sk-test");
+    expect(opts.method ?? "GET").toBe("GET");
+    expect(usage.message).toBeUndefined();
+    expect(usage.plan).toBe("OpenCode Go");
+    expect(usage.limitReached).toBe(true);
+  });
+
+  it("reports an invalid key rather than empty quotas on 401", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ error: { type: "AuthError" } }, 401));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "sk-bad" });
+
+    expect(usage.quotas).toBeUndefined();
+    expect(usage.message).toMatch(/invalid or expired/i);
+  });
+
+  it("reports a soft message rather than throwing when the fetch fails", async () => {
+    proxyAwareFetch.mockRejectedValueOnce(new Error("socket hang up"));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "sk-test" });
+
+    expect(usage.message).toMatch(/socket hang up/);
+  });
+
+  it("says so when no key is stored on the connection", async () => {
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "" });
+
+    expect(proxyAwareFetch).not.toHaveBeenCalled();
+    expect(usage.message).toMatch(/not available/i);
+  });
+});
+
+describe("dashboard rendering of opencode-go quotas", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders one row per window with the remaining percentage the bar draws", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(LIVE_PAYLOAD));
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "sk-test" });
+
+    // parseQuotaData has no opencode-go arm on purpose: its generic fallback
+    // forwards used/total, and getRemainingPercentage derives the bar from those.
+    // This asserts that path end to end rather than trusting it.
+    const rows = parseQuotaData("opencode-go", usage);
+    const byName = Object.fromEntries(rows.map((r) => [r.name, r]));
+
+    expect(rows).toHaveLength(3);
+    expect(getRemainingPercentage(byName.Rolling)).toBe(100);
+    expect(getRemainingPercentage(byName.Weekly)).toBe(100);
+    expect(getRemainingPercentage(byName.Monthly)).toBe(0);
+    expect(byName.Monthly.resetAt).toBe("2026-08-12T19:57:51.596Z");
+    expect(byName.Rolling.resetAt).toBeNull();
+  });
+
+  it("draws a partly used window at its true remaining percentage", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse({ usage: { rolling: { status: "ok", percent: 35, resetsAt: "2026-08-12T09:43:25.596Z" } } }),
+    );
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "sk-test" });
+
+    const [row] = parseQuotaData("opencode-go", usage);
+    expect(getRemainingPercentage(row)).toBe(65);
+  });
+});
+
+describe("isOpenCodeGoCreditsError", () => {
+  // Both bodies are verbatim from the live API on 2026-08-12, with the workspace
+  // id in the CreditsError message replaced. Same status, same shape, opposite
+  // meaning: only error.type separates a spent plan from a revoked key.
+  const CREDITS =
+    '{"type":"error","error":{"type":"CreditsError","message":"Insufficient balance. Manage your billing here: https://opencode.ai/workspace/wrk_test/billing"}}';
+  const AUTH = '{"type":"error","error":{"type":"AuthError","message":"Invalid API key."}}';
+
+  it("recognizes a spent plan window", () => {
+    expect(isOpenCodeGoCreditsError(CREDITS)).toBe(true);
+  });
+
+  it("does not treat a revoked key as a spent plan", () => {
+    expect(isOpenCodeGoCreditsError(AUTH)).toBe(false);
+  });
+
+  it("ignores prose and reads only the structural type", () => {
+    // A body that mentions balance but carries no error.type must not decide this.
+    expect(isOpenCodeGoCreditsError('{"message":"Insufficient balance."}')).toBe(false);
+  });
+
+  it("survives a non-JSON body", () => {
+    expect(isOpenCodeGoCreditsError("<html>502 Bad Gateway</html>")).toBe(false);
+    expect(isOpenCodeGoCreditsError("")).toBe(false);
+  });
+});


### PR DESCRIPTION
### What

OpenCode Go meters three plan windows and exposes them at `GET /zen/go/v1/usage`, authenticated with the same `sk-...` key chat uses. This adds a usage handler so the windows show up on `/usage`, and fixes the key test, which currently reports a working key as invalid.

### The key-test bug

`validate/route.js` and `testUtils.js` both probe a chat completion and treat 401 or 403 as a bad key. A key whose plan window is spent answers **401 on chat** while `/usage` and `/models` both answer **200**, so the dashboard says "Invalid API key" about a key that is fine and recovers on its own.

Run against a live key with its monthly window spent, just now:

```
OLD  chat ping status 401 -> valid = false     # working key reported invalid
NEW  usage    status 200 -> valid = true
NEW  bad key  status 401 -> valid = false      # a genuinely revoked key is still rejected
```

Probing `/usage` is accurate, costs no tokens, and drops the dependency on `getDefaultModel`. There is precedent for this shape right above the case being changed: `xai` treats 403 as valid-but-no-credit, `xiaomi-tokenplan` treats only 401 as invalid.

### Measured, not inferred

Everything below came from probing the live API on 2026-08-12, because the payload is not documented:

```json
{"usage":{
  "rolling": {"status":"ok",           "percent":0,   "resetsAt":"2026-08-12T09:43:25.596Z"},
  "weekly":  {"status":"ok",           "percent":0,   "resetsAt":"2026-08-17T00:00:00.596Z"},
  "monthly": {"status":"rate-limited", "percent":100, "resetsAt":"2026-08-12T19:57:51.596Z"}}}
```

- `percent` is percent **USED**. The depleted window reads 100, not 0.
- `status` is `ok` or `rate-limited`. A window counts as blocked on **either** signal (status, or percent at 100), so an upstream that renames the status string still reports the window as blocked rather than silently healthy.
- On an untouched window `resetsAt` is a **projection**, not a deadline: two samples 34 minutes apart showed `rolling` move from 07:13:11 to 07:47:05 while `monthly` did not move at all. Only a window that is blocked or partly used gets its reset surfaced, so the table never shows an idle window as having a pending deadline.
- `monthly` is a rolling ~30 day window, not a calendar month.
- A spent plan answers `401 {"error":{"type":"CreditsError"}}`, byte-identical on streaming. A revoked key answers `401 {"error":{"type":"AuthError"}}`. The status alone cannot separate them, so the check reads `error.type` and never a substring of the message, which embeds a workspace-scoped billing URL.

### Notes on the diff

- `parseQuotaData` gets **no** `opencode-go` arm. Its generic fallback forwards `used`/`total`, and `getRemainingPercentage` derives the bar from those, so the existing path is already correct. A test asserts that end to end rather than trusting it.
- `used`/`total` are a 0-100 pair and `remaining` is never set to an absolute count, per the warnings on the Qoder and Grok handlers.
- `providers-baseline.json` snapshots only `baseUrl`, `headers` and `format` per provider, so adding `transport.usage` and `features` does not require a regenerated baseline. `verify-providers.mjs` is red on `tokenrouter.thinkingFormat` both before and after this branch (the baseline says `openai`, `registry/tokenrouter.js` says `tokenrouter` since 41588bea); untouched here.

### Verified

- `tests/unit/opencode-go-usage.test.js`, 25 cases, green.
- Full suite under `CI=true`, master vs this branch: **115 failed / 1629 passed** on `origin/master` and **115 failed / 1654 passed** here. Same failures, plus the 25 new ones passing. No new breakage.
- `verify-alias.mjs` and `verify-oauth-urls.mjs` byte-for-byte equal.
- `eslint` clean on all six files (one `import/no-anonymous-default-export` warning that every registry file already has).
- Every assertion in the new suite was break-tested: 15 separate mutations of the source (percent direction inverted, each blocked signal removed, status folding removed, reset suppression removed, window ordering, malformed-window handling, `CreditsError` matched on prose, registry block deleted, feature flags deleted, handler unregistered, 401 case removed, bearer swapped for `x-api-key`, `total` made absolute). Each one turned the suite red, and the source was restored byte-identical after each.
- Handler run live against a real key: renders Rolling 100% / Weekly 100% / Monthly 0% remaining with a reset only on the spent window, and returns "invalid or expired" for a bad key.

---

Separately: #2313 (Kenari registry entry, two files, 26 lines) has been open since July 3, and is rebased onto v0.5.50 and mergeable. Would appreciate a look.
