### PR TITLE
fix(translator): do not close the Responses message on an empty tool_calls array

### DIFF
--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -100,7 +100,7 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
   }
 
   // Handle tool_calls
-  if (delta.tool_calls) {
+  if (delta.tool_calls?.length) {
     closeMessage(state, emit, idx);
     for (const tc of delta.tool_calls) {
       emitToolCall(state, emit, tc);

--- a/tests/unit/responses-empty-tool-calls-3234.test.js
+++ b/tests/unit/responses-empty-tool-calls-3234.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { initState } from "../../open-sse/translator/index.js";
+import { openaiToOpenAIResponsesResponse } from "../../open-sse/translator/response/openai-responses.js";
+
+// Some upstreams (cbcn/*) put an empty tool_calls array on every content delta.
+const chunk = (delta, finish = null) => ({
+  id: "chatcmpl-x",
+  model: "kimi-k3",
+  choices: [{ index: 0, delta, finish_reason: finish }],
+});
+
+function run(chunks) {
+  const state = initState(FORMATS.OPENAI_RESPONSES);
+  const events = [];
+  for (const c of chunks) events.push(...openaiToOpenAIResponsesResponse(c, state));
+  return events;
+}
+
+const typesOf = (events, ...wanted) =>
+  events.map(e => e.event).filter(t => wanted.includes(t));
+
+describe("#3234 empty tool_calls array must not close the message", () => {
+  it("keeps output_text.done after the last delta when every delta carries tool_calls: []", () => {
+    const events = run([
+      chunk({ reasoning_content: "thinking" }),
+      chunk({ content: "cod", tool_calls: [] }),
+      chunk({ content: "ex", tool_calls: [] }),
+      chunk({ content: "-ok", tool_calls: [] }),
+      chunk({}, "stop"),
+    ]);
+
+    expect(typesOf(events, "response.output_text.delta", "response.output_text.done")).toEqual([
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_text.done",
+    ]);
+
+    const done = events.filter(e => e.event === "response.output_text.done");
+    expect(done).toHaveLength(1);
+    expect(done[0].data.text).toBe("codex-ok");
+  });
+
+  it("emits no tool-call events for an empty array", () => {
+    const events = run([chunk({ content: "hi", tool_calls: [] }), chunk({}, "stop")]);
+
+    expect(events.some(e => e.event.startsWith("response.function_call"))).toBe(false);
+  });
+
+  it("still closes the message when a real tool call arrives mid-stream", () => {
+    const events = run([
+      chunk({ content: "calling" }),
+      chunk({ tool_calls: [{ index: 0, id: "call_1", function: { name: "Read", arguments: "{}" } }] }),
+      chunk({}, "tool_calls"),
+    ]);
+
+    const order = typesOf(events, "response.output_text.done", "response.output_item.added");
+    expect(order).toContain("response.output_text.done");
+
+    const done = events.find(e => e.event === "response.output_text.done");
+    expect(done.data.text).toBe("calling");
+    expect(events.some(e => e.event === "response.function_call_arguments.done")).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #3234

## Problem

Streaming `cbcn/kimi-k3` or `cbcn/glm-5.2` through `/v1/responses` emits `response.output_text.done` right after the first content delta, then keeps sending deltas:

```
seq 61  output_text.delta  'cod'
seq 62  output_text.done   text='cod'
seq 65  output_text.delta  'ex'
seq 66  output_text.delta  '-'
seq 67  output_text.delta  'ok'
```

Codex CLI treats `done` as end-of-message, logs `OutputTextDelta without active item`, and truncates the answer to `cod`.

## Root cause

`openai-responses.js` gated the message-close on plain truthiness:

```js
if (delta.tool_calls) {
  closeMessage(state, emit, idx);
  for (const tc of delta.tool_calls) { … }
}
```

An empty array is truthy in JS. These upstreams attach `tool_calls: []` to every content delta, so `closeMessage()` fired on the first one while the loop that follows produced nothing. `closeMessage()` sets `msgItemDone[idx]`, so it is a no-op afterwards — but `emitTextContent()` does not check that flag, which is why the remaining deltas still stream out after `done`. That accounts for the observed gap at seq 63-64 (`content_part.done` + `output_item.done`, the other two events `closeMessage` emits).

This also explains why the issue is specific to one client format: `translator/response/openai-to-claude.js` stops the text block **inside** its per-tool-call loop, so an empty array never closes anything there. Same model, same stream, correct output on `/v1/messages`.

## Fix

Gate on a non-empty list: `if (delta.tool_calls?.length)`. A real tool call still closes the message exactly as before.

## Tests

New: `tests/unit/responses-empty-tool-calls-3234.test.js` — with `tool_calls: []` on every delta the single `output_text.done` lands after the last delta and carries the full text; no tool-call events are emitted for an empty array; and a real mid-stream tool call still closes the message with the text accumulated so far. The first test fails on `master` and passes with this patch.

Full suite (`npx vitest run unit translator`) against `master` as the baseline: **1670 → 1673 passed, 91 failed on both sides** — no pass→fail, the 3 new passes are this PR's tests.
