### PR TITLE
fix(models): let a curated custom-provider model list suppress the live catalog

### DIFF
--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -375,7 +375,25 @@ export async function buildModelsList(kindFilter, options = {}) {
           )
         : providerModels.map((model) => model.id);
 
-      if (isCompatibleProvider && rawModelIds.length === 0 && !skipDynamicFetch) {
+      const customModelKindById = new Map();
+      const customModelIds = customModels
+        .filter((m) => {
+          if (!m?.id) return false;
+          const kind = getModelKind(m) || LLM_KIND;
+          // imageToText custom models are vision-capable chat models: expose them
+          // both in the default LLM list and in /v1/models/image-to-text.
+          if (!kindFilter.includes(kind) && !(kind === "imageToText" && kindFilter.includes(LLM_KIND))) return false;
+          const alias = m.providerAlias;
+          return alias === staticAlias || alias === outputAlias || alias === providerId;
+        })
+        .map((m) => {
+          const modelId = String(m.id).trim();
+          if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
+          return modelId;
+        })
+        .filter((modelId) => modelId !== "");
+
+      if (isCompatibleProvider && rawModelIds.length === 0 && customModelIds.length === 0 && !skipDynamicFetch) {
         rawModelIds = await fetchCompatibleModelIds(conn);
       }
 
@@ -418,24 +436,6 @@ export async function buildModelsList(kindFilter, options = {}) {
           return modelId;
         })
         .filter((modelId) => typeof modelId === "string" && modelId.trim() !== "");
-
-      const customModelKindById = new Map();
-      const customModelIds = customModels
-        .filter((m) => {
-          if (!m?.id) return false;
-          const kind = getModelKind(m) || LLM_KIND;
-          // imageToText custom models are vision-capable chat models: expose them
-          // both in the default LLM list and in /v1/models/image-to-text.
-          if (!kindFilter.includes(kind) && !(kind === "imageToText" && kindFilter.includes(LLM_KIND))) return false;
-          const alias = m.providerAlias;
-          return alias === staticAlias || alias === outputAlias || alias === providerId;
-        })
-        .map((m) => {
-          const modelId = String(m.id).trim();
-          if (modelId) customModelKindById.set(modelId, getModelKind(m) || LLM_KIND);
-          return modelId;
-        })
-        .filter((modelId) => modelId !== "");
 
       const aliasModelIds = Object.values(modelAliases || {})
         .filter((fullModel) => {

--- a/tests/unit/custom-provider-model-list-3115.test.js
+++ b/tests/unit/custom-provider-model-list-3115.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { connectionsMock, customModelsMock, fetchMock } = vi.hoisted(() => ({
+  connectionsMock: vi.fn(),
+  customModelsMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: connectionsMock,
+  getCombos: vi.fn(async () => []),
+  getCustomModels: customModelsMock,
+  getModelAliases: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/lib/disabledModelsDb", () => ({
+  getDisabledModels: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/sse/services/tokenRefresh", () => ({
+  updateProviderCredentials: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: vi.fn(() => null),
+}));
+
+const { buildModelsList } = await import("../../src/app/api/v1/models/route.js");
+
+const PROVIDER_ID = "openai-compatible-chat-11111111";
+
+const connection = {
+  provider: PROVIDER_ID,
+  isActive: true,
+  apiKey: "sk-test",
+  providerSpecificData: { prefix: "hn", apiType: "chat", baseUrl: "https://api.example.com/v1" },
+};
+
+// The upstream catalog the provider's own /models endpoint advertises.
+const UPSTREAM = ["keep-me", "drop-me-1", "drop-me-2"];
+
+function idsFor(models) {
+  return models.filter(m => m.id.startsWith("hn/")).map(m => m.id.slice(3));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = fetchMock;
+  connectionsMock.mockResolvedValue([connection]);
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: UPSTREAM.map(id => ({ id })) }),
+  });
+});
+
+describe("#3115 curated custom-provider model list wins over the live upstream catalog", () => {
+  it("lists only the curated models and never hits the upstream /models endpoint", async () => {
+    customModelsMock.mockResolvedValue([{ providerAlias: "hn", id: "keep-me", type: "llm" }]);
+
+    const data = await buildModelsList(["llm"]);
+
+    expect(idsFor(data)).toEqual(["keep-me"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still falls back to the live catalog when nothing is curated", async () => {
+    customModelsMock.mockResolvedValue([]);
+
+    const data = await buildModelsList(["llm"]);
+
+    expect(idsFor(data).sort()).toEqual([...UPSTREAM].sort());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores curated models belonging to a different provider", async () => {
+    customModelsMock.mockResolvedValue([{ providerAlias: "other", id: "not-mine", type: "llm" }]);
+
+    const data = await buildModelsList(["llm"]);
+
+    expect(idsFor(data).sort()).toEqual([...UPSTREAM].sort());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps honouring skipDynamicFetch", async () => {
+    customModelsMock.mockResolvedValue([]);
+
+    const data = await buildModelsList(["llm"], { skipDynamicFetch: true });
+
+    expect(idsFor(data)).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #3115

## Problem

Add a custom OpenAI-compatible provider, bulk-import its models, delete all but one in the dashboard, then `curl /v1/models` — every model from the upstream is still listed, and the deleted ones reappear after every reload. A clean reinstall with a fresh database does not help.

## Root cause

In `buildModelsList()`, a custom node has no entry in the static `PROVIDER_MODELS` registry, so:

```js
let rawModelIds = hasExplicitEnabledModels ? … : providerModels.map(m => m.id);   // []

if (isCompatibleProvider && rawModelIds.length === 0 && !skipDynamicFetch) {
  rawModelIds = await fetchCompatibleModelIds(conn);   // the upstream's ENTIRE catalogue
}
```

The user's own list lives in `customModels` (written by `/api/models/custom`, which is what the dashboard's model management calls). But `customModelIds` is only computed ~45 lines *below* this fallback and merged in at the end:

```js
const mergedModelIds = Array.from(new Set([...modelIds, ...customModelIds, ...aliasModelIds]));
```

So the fallback fires even when the user has curated a list, and the merge then unions the curated models with the full upstream catalogue. Deleting a model in the dashboard removes it from `customModels` — and the live fetch adds it right back. That is the "they reappear" symptom.

## Fix

Move the `customModelIds` computation above the fallback and include it in the guard. The block was already independent of everything between the two points (it only reads `customModels`, `kindFilter`, and the alias variables), so this is a pure reorder plus one added condition.

```js
if (isCompatibleProvider && rawModelIds.length === 0 && customModelIds.length === 0 && !skipDynamicFetch) {
```

A provider with nothing configured still falls back to the live catalogue, so first-time discovery and bulk-import are unchanged. `skipDynamicFetch` (the cross-instance recursion guard) is unaffected.

Note this also covers the `enabledModels` half of #3135: that field is read here but never written anywhere server-side, so it can never be the mechanism that filters a custom provider's list — `customModels` is.

## Tests

New: `tests/unit/custom-provider-model-list-3115.test.js` — the first test coverage for `buildModelsList()`, with the DB layer and `fetch` mocked. Curated list wins and the upstream endpoint is never called; an empty curated list still falls back and does call it; curated models belonging to another provider do not suppress the fallback; `skipDynamicFetch` still short-circuits.

The first test fails on `master` with `expected [ 'keep-me', 'drop-me-1', 'drop-me-2' ] to deeply equal [ 'keep-me' ]` — the exact reported symptom — and passes with this patch.

Full suite (`npx vitest run unit translator`) against `master` as the baseline: **1670 → 1674 passed, 91 failed on both sides** — no pass→fail, the 4 new passes are this PR's tests.
