### PR TITLE
fix(translator): treat an empty tool_calls array as no tool calls

### DIFF
--- a/open-sse/translator/formats/openai.js
+++ b/open-sse/translator/formats/openai.js
@@ -23,8 +23,8 @@ export function filterToOpenAIFormat(body, opts = {}) {
     // Keep tool messages as-is (OpenAI format)
     if (msg.role === ROLE.TOOL) return msg;
 
-    // Keep assistant messages with tool_calls as-is
-    if (msg.role === ROLE.ASSISTANT && msg.tool_calls) return msg;
+    // Keep assistant messages with tool_calls as-is (an empty array carries none)
+    if (msg.role === ROLE.ASSISTANT && msg.tool_calls?.length) return msg;
 
     // Handle string content
     if (typeof msg.content === "string") return msg;
@@ -64,8 +64,8 @@ export function filterToOpenAIFormat(body, opts = {}) {
   body.messages = body.messages.filter(msg => {
     // Always keep tool messages
     if (msg.role === ROLE.TOOL) return true;
-    // Always keep assistant messages with tool_calls
-    if (msg.role === ROLE.ASSISTANT && msg.tool_calls) return true;
+    // Always keep assistant messages with tool_calls (an empty array carries none)
+    if (msg.role === ROLE.ASSISTANT && msg.tool_calls?.length) return true;
     
     if (typeof msg.content === "string") return msg.content.trim() !== "";
     if (Array.isArray(msg.content)) {

--- a/tests/unit/openai-format-empty-tool-calls.test.js
+++ b/tests/unit/openai-format-empty-tool-calls.test.js
@@ -1,0 +1,67 @@
+// filterToOpenAIFormat treated `tool_calls: []` as "this message carries tool calls",
+// because an empty array is truthy. Two shortcuts keyed off that check, so an assistant
+// message with an empty tool_calls array skipped content normalisation and survived the
+// empty-message filter. Upstreams that reject Claude-only blocks or empty assistant turns
+// then rejected the whole request.
+import { describe, it, expect } from "vitest";
+import { filterToOpenAIFormat } from "../../open-sse/translator/formats/openai.js";
+
+describe("filterToOpenAIFormat with an empty tool_calls array", () => {
+  it("still strips Claude-only blocks from the assistant turn", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [],
+          content: [
+            { type: "thinking", thinking: "internal reasoning" },
+            { type: "text", text: "visible answer" },
+          ],
+        },
+      ],
+    };
+
+    const out = filterToOpenAIFormat(body);
+    const types = out.messages[0].content.map((b) => b.type);
+
+    expect(types).not.toContain("thinking");
+    expect(types).toEqual(["text"]);
+  });
+
+  it("still drops an assistant turn left with no usable content", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", tool_calls: [], content: "   " },
+      ],
+    };
+
+    const out = filterToOpenAIFormat(body);
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].role).toBe("user");
+  });
+
+  it("leaves a message with real tool calls untouched", () => {
+    const toolCall = {
+      id: "call_1",
+      type: "function",
+      function: { name: "get_weather", arguments: "{}" },
+    };
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [toolCall],
+          content: [{ type: "thinking", thinking: "keep me" }],
+        },
+      ],
+    };
+
+    const out = filterToOpenAIFormat(body);
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].tool_calls).toEqual([toolCall]);
+    expect(out.messages[0].content).toEqual([{ type: "thinking", thinking: "keep me" }]);
+  });
+});


### PR DESCRIPTION
## Summary

`filterToOpenAIFormat` treats an assistant message as "carries tool calls" whenever `msg.tool_calls` is truthy. An empty array is truthy, so `tool_calls: []` trips both shortcuts that check it:

```js
// normalisation pass — returns before any block filtering
if (msg.role === ROLE.ASSISTANT && msg.tool_calls) return msg;

// empty-message filter — keeps the message unconditionally
if (msg.role === ROLE.ASSISTANT && msg.tool_calls) return true;
```

Two things follow from that. An assistant turn with `tool_calls: []` keeps its Claude-only blocks — `thinking`, `redacted_thinking`, unstripped `signature` — because it never reaches the block filter. And a turn whose content is blank survives the filter that exists to drop exactly those. Providers that reject either shape reject the whole request, and the failure surfaces far from here.

`tool_calls: []` is not hypothetical in this codebase — #3234 and #3236 both come from upstreams that attach an empty array to ordinary content deltas.

## The fix

Both guards become `msg.tool_calls?.length`, which is what the rest of the codebase already does:

- `translator/request/claude-to-openai.js:100` — `msg.tool_calls && msg.tool_calls.length > 0`
- `executors/kiro.js:208` — `delta.tool_calls?.length`

Messages with real tool calls are unaffected.

## Tests

`tests/unit/openai-format-empty-tool-calls.test.js`, three cases:

- Claude-only blocks are still stripped when `tool_calls: []` is present
- an assistant turn left with no usable content is still dropped
- a message with a real tool call keeps both its `tool_calls` and its content

The first two fail on `master` and pass with the change:

```
before:  × still strips Claude-only blocks   → expected [ 'thinking', 'text' ] to not include 'thinking'
         × still drops an assistant turn     → expected length 1 but got 2
after:   3 passed
```

## Regression check

Per CLAUDE.md the suite is not green on a plain checkout, so I ran it both ways and diffed the failing set rather than reading the totals.

```
master:      Test Files 29 failed | 146 passed (178)   Tests 92 failed | 1652 passed
this branch: Test Files 29 failed | 147 passed (179)   Tests 92 failed | 1655 passed
```

Identical failing sets — 192 failure lines each way, no test moved in either direction. The delta is exactly the three added cases.

## One thing I noticed

`open-sse/transformer/responsesTransformer.js:374` has the same `if (delta.tool_calls)` shape, and `open-sse/handlers/responsesHandler.js` is the only importer of it — while nothing imports `handleResponsesCore` in turn. The live `/v1/responses` route (`src/app/api/v1/responses/route.js`) goes through `handleChat` and the translator registry instead. So that pair looks like it has been left behind rather than being a second live path, and I left it alone. Worth confirming on your side — if it is dead, it is a duplicate of the conversion in `translator/response/openai-responses.js` and probably wants removing.
