### PR TITLE
fix(proxy): rotate no-auth pools after rate limits

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -61,6 +61,7 @@ export const ERROR_RULES = [
   { text: "no credentials",           cooldownMs: COOLDOWN.long },
   { text: "request not allowed",      cooldownMs: COOLDOWN.short },
   { text: "improperly formed request", cooldownMs: COOLDOWN.long },
+  { text: "freeusagelimiterror",      backoff: true },
   { text: "rate limit",               backoff: true },
   { text: "too many requests",        backoff: true },
   { text: "quota exceeded",           backoff: true },

--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -50,6 +50,22 @@ export function checkFallbackError(status, errorText, backoffLevel = 0) {
 }
 
 /**
+ * Check whether an error represents a rate-limit failure.
+ *
+ * Keep this classification derived from ERROR_RULES so proxy-pool cooldowns
+ * and account fallback cannot drift apart as provider error strings evolve.
+ */
+export function isRateLimitError(status, errorText) {
+  if (Number(status) === 429) return true;
+
+  const lowerError = errorText
+    ? (typeof errorText === "string" ? errorText : JSON.stringify(errorText)).toLowerCase()
+    : "";
+
+  return ERROR_RULES.some((rule) => rule.backoff && rule.text && lowerError.includes(rule.text));
+}
+
+/**
  * Check if account is currently unavailable (cooldown not expired)
  */
 export function isAccountUnavailable(unavailableUntil) {

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -221,11 +221,14 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
 
   // Try with available accounts (fallback on errors)
   const excludeConnectionIds = new Set();
+  const excludeProxyPoolIds = new Set();
   let lastError = null;
   let lastStatus = null;
 
   while (true) {
-    const credentials = await getProviderCredentials(provider, excludeConnectionIds, model);
+    const credentials = excludeProxyPoolIds.size > 0
+      ? await getProviderCredentials(provider, excludeConnectionIds, model, { excludeProxyPoolIds })
+      : await getProviderCredentials(provider, excludeConnectionIds, model);
 
     // All accounts unavailable
     if (!credentials || credentials.allRateLimited) {
@@ -294,18 +297,28 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
         });
       },
       onRequestSuccess: async () => {
-        await clearAccountError(credentials.connectionId, credentials, model);
+        if (credentials.connectionId === "noauth") {
+          await clearAccountError(credentials.connectionId, credentials, model, provider);
+        } else {
+          await clearAccountError(credentials.connectionId, credentials, model);
+        }
       }
     });
 
     if (result.success) return result.response;
 
     // Mark account unavailable (auto-calculates cooldown with exponential backoff, or precise resetsAtMs)
-    const { shouldFallback } = await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);
+    const proxyPoolId = credentials.connectionId === "noauth"
+      ? credentials.providerSpecificData?.connectionProxyPoolId
+      : null;
+    const { shouldFallback } = proxyPoolId
+      ? await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs, proxyPoolId)
+      : await markAccountUnavailable(credentials.connectionId, result.status, result.error, provider, model, result.resetsAtMs);
 
     if (shouldFallback) {
       log.warn("FALLBACK", `⇄ ACC:${credentials.connectionName} UNAVAILABLE (${result.status}) → NEXT ACCOUNT`);
       excludeConnectionIds.add(credentials.connectionId);
+      if (proxyPoolId) excludeProxyPoolIds.add(proxyPoolId);
       lastError = result.error;
       lastStatus = result.status;
       continue;

--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -1,6 +1,6 @@
-import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools } from "@/lib/localDb";
+import { getProviderConnections, validateApiKey, updateProviderConnection, getSettings, getProxyPools, getProxyPoolById, updateProxyPool } from "@/lib/localDb";
 import { resolveConnectionProxyConfig, pickProxyPoolId } from "@/lib/network/connectionProxy";
-import { formatRetryAfter, checkFallbackError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
+import { formatRetryAfter, checkFallbackError, isRateLimitError, isModelLockActive, buildModelLockUpdate, getEarliestModelLockUntil } from "open-sse/services/accountFallback.js";
 import { MAX_RATE_LIMIT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
 import { resolveProviderId, FREE_PROVIDERS } from "@/shared/constants/providers.js";
 import * as log from "../utils/logger.js";
@@ -17,18 +17,80 @@ function githubMonthlyResetMs(status, errorText, provider) {
   return Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
 }
 
+function getProxyPoolProviderState(pool, providerId) {
+  const state = pool?.rateLimitState?.[providerId];
+  if (!state || typeof state !== "object") return null;
+  const cooldownUntilMs = new Date(state.cooldownUntil || 0).getTime();
+  if (!Number.isFinite(cooldownUntilMs)) return null;
+  return { ...state, cooldownUntilMs };
+}
+
+function isProxyPoolCoolingDown(pool, providerId) {
+  const state = getProxyPoolProviderState(pool, providerId);
+  return Boolean(state && state.cooldownUntilMs > Date.now());
+}
+
+function getEarliestProxyPoolCooldown(pools, providerId) {
+  let earliestMs = Infinity;
+  for (const pool of pools || []) {
+    const state = getProxyPoolProviderState(pool, providerId);
+    if (state && state.cooldownUntilMs > Date.now() && state.cooldownUntilMs < earliestMs) {
+      earliestMs = state.cooldownUntilMs;
+    }
+  }
+  return Number.isFinite(earliestMs) ? new Date(earliestMs).toISOString() : null;
+}
+
+function getProxyPoolLastError(pools, providerId) {
+  return (pools || [])
+    .map((pool) => getProxyPoolProviderState(pool, providerId)?.lastError)
+    .find(Boolean) || null;
+}
+
+function buildProxyPoolUnavailable(pools, providerId) {
+  const earliest = getEarliestProxyPoolCooldown(pools, providerId);
+  const retryAfter = earliest || new Date(Date.now() + 1000).toISOString();
+  return {
+    allRateLimited: true,
+    retryAfter,
+    retryAfterHuman: earliest ? formatRetryAfter(retryAfter) : "retry after 1s",
+    lastError: getProxyPoolLastError(pools, providerId) || "All proxy pools are unavailable",
+    lastErrorCode: 429,
+  };
+}
+
+function normalizeProxyPoolExclusions(value) {
+  if (value instanceof Set) return value;
+  if (Array.isArray(value)) return new Set(value);
+  return value ? new Set([value]) : new Set();
+}
+
+async function clearProxyPoolRateLimit(proxyPoolId, provider) {
+  if (!proxyPoolId || !provider) return;
+  const providerId = resolveProviderId(provider);
+  const pool = await getProxyPoolById(proxyPoolId);
+  if (!pool?.rateLimitState?.[providerId]) return;
+
+  const rateLimitState = { ...pool.rateLimitState };
+  delete rateLimitState[providerId];
+  await updateProxyPool(proxyPoolId, { rateLimitState });
+  log.info("PROXY", `${providerId} pool ${proxyPoolId.slice(0, 8)} cooldown cleared after success`);
+}
+
 /**
  * Get provider credentials from localDb
  * Filters out unavailable accounts and returns the selected account based on strategy
  * @param {string} provider - Provider name
  * @param {Set<string>|string|null} excludeConnectionIds - Connection ID(s) to exclude (for retry with next account)
  * @param {string|null} model - Model name for per-model rate limit filtering
+ * @param {object} options - Selection options, including no-auth proxy-pool exclusions
  */
 export async function getProviderCredentials(provider, excludeConnectionIds = null, model = null, options = {}) {
   // Normalize to Set for consistent handling
   const excludeSet = excludeConnectionIds instanceof Set
     ? excludeConnectionIds
     : (excludeConnectionIds ? new Set([excludeConnectionIds]) : new Set());
+  const excludeProxyPoolIds = normalizeProxyPoolExclusions(options?.excludeProxyPoolIds);
   const preferredConnectionId = options?.preferredConnectionId || null;
   // Acquire mutex to prevent race conditions
   const currentMutex = selectionMutex;
@@ -46,15 +108,37 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       const settings = await getSettings();
       const override = (settings.providerStrategies || {})[providerId] || {};
       const strategy = override.rotateStrategy || "none";
-      let pickedId = override.proxyPoolId || null;
-      if (strategy !== "none") {
+      const configuredPoolId = override.proxyPoolId || null;
+      let pickedId = configuredPoolId;
+
+      if (strategy !== "none" || configuredPoolId) {
         const allPools = await getProxyPools({ isActive: true });
-        const poolIds = allPools.filter(p => p.proxyUrl).map(p => p.id);
-        pickedId = pickProxyPoolId(poolIds, strategy, providerId);
+        const usablePools = allPools.filter((pool) => String(pool.proxyUrl || "").trim());
+
+        if (strategy !== "none") {
+          const availablePools = usablePools.filter((pool) =>
+            !excludeProxyPoolIds.has(pool.id) && !isProxyPoolCoolingDown(pool, providerId)
+          );
+
+          if (usablePools.length > 0 && availablePools.length === 0) {
+            return buildProxyPoolUnavailable(usablePools, providerId);
+          }
+
+          pickedId = pickProxyPoolId(availablePools.map((pool) => pool.id), strategy, providerId);
+        } else if (configuredPoolId) {
+          const configuredPool = usablePools.find((pool) => pool.id === configuredPoolId);
+          if (configuredPool && (excludeProxyPoolIds.has(configuredPoolId) || isProxyPoolCoolingDown(configuredPool, providerId))) {
+            return buildProxyPoolUnavailable([configuredPool], providerId);
+          }
+          // Preserve the existing behavior for a deleted/inactive fixed pool:
+          // resolveConnectionProxyConfig will fall back to no proxy.
+          pickedId = configuredPool ? configuredPoolId : null;
+        }
       }
       const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: pickedId || "" });
       return {
         id: "noauth",
+        connectionId: "noauth",
         connectionName: "Public",
         isActive: true,
         accessToken: "public",
@@ -214,10 +298,52 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
  * @param {string} errorText
  * @param {string|null} provider
  * @param {string|null} model - The specific model that triggered the error
+ * @param {number|null} resetsAtMs - Optional provider-reported reset time
+ * @param {string|null} proxyPoolId - Proxy pool used by a no-auth request
  * @returns {{ shouldFallback: boolean, cooldownMs: number }}
  */
-export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null) {
-  if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 };
+export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null, proxyPoolId = null) {
+  if (connectionId === "noauth") {
+    if (!proxyPoolId || !provider || !isRateLimitError(status, errorText)) {
+      return { shouldFallback: false, cooldownMs: 0 };
+    }
+
+    const providerId = resolveProviderId(provider);
+    const pool = await getProxyPoolById(proxyPoolId);
+    if (!pool || pool.isActive !== true) return { shouldFallback: false, cooldownMs: 0 };
+
+    const previousState = getProxyPoolProviderState(pool, providerId);
+    const backoffLevel = Number(previousState?.backoffLevel) || 0;
+    let shouldFallback;
+    let cooldownMs;
+    let newBackoffLevel;
+
+    if (resetsAtMs && resetsAtMs > Date.now()) {
+      shouldFallback = true;
+      cooldownMs = Math.min(resetsAtMs - Date.now(), MAX_RATE_LIMIT_COOLDOWN_MS);
+      newBackoffLevel = 0;
+    } else {
+      ({ shouldFallback, cooldownMs, newBackoffLevel } = checkFallbackError(status, errorText, backoffLevel));
+    }
+    if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
+
+    const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider rate limit";
+    const rateLimitState = { ...(pool.rateLimitState || {}) };
+    rateLimitState[providerId] = {
+      cooldownUntil: new Date(Date.now() + cooldownMs).toISOString(),
+      backoffLevel: newBackoffLevel ?? backoffLevel,
+      lastError: reason,
+      errorCode: status,
+      lastErrorAt: new Date().toISOString(),
+    };
+
+    await updateProxyPool(proxyPoolId, { rateLimitState });
+    log.warn("PROXY", `${providerId} pool ${proxyPoolId.slice(0, 8)} unavailable for ${Math.round(cooldownMs / 1000)}s [${status}]`);
+    console.error(`❌ ${provider} proxy pool [${status}]: ${reason}`);
+    return { shouldFallback: true, cooldownMs };
+  }
+
+  if (!connectionId) return { shouldFallback: false, cooldownMs: 0 };
   const connections = await getProviderConnections({ provider });
   const conn = connections.find(c => c.id === connectionId);
   const backoffLevel = conn?.backoffLevel || 0;
@@ -271,10 +397,15 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
  * @param {string} connectionId
  * @param {object} currentConnection - credentials object (has _connection) or raw connection
  * @param {string|null} model - model that succeeded
+ * @param {string|null} provider - provider ID, used for no-auth proxy-pool state
  */
-export async function clearAccountError(connectionId, currentConnection, model = null) {
-  if (!connectionId || connectionId === "noauth") return;
-  const conn = currentConnection._connection || currentConnection;
+export async function clearAccountError(connectionId, currentConnection, model = null, provider = null) {
+  if (connectionId === "noauth") {
+    await clearProxyPoolRateLimit(currentConnection?.providerSpecificData?.connectionProxyPoolId, provider);
+    return;
+  }
+  if (!connectionId) return;
+  const conn = currentConnection?._connection || currentConnection;
   const now = Date.now();
   const allLockKeys = Object.keys(conn).filter(k => k.startsWith("modelLock_"));
 

--- a/tests/unit/chat-no-auth-proxy-fallback.test.js
+++ b/tests/unit/chat-no-auth-proxy-fallback.test.js
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getProviderCredentials: vi.fn(),
+  markAccountUnavailable: vi.fn(),
+  clearAccountError: vi.fn(),
+  extractApiKey: vi.fn(() => null),
+  isValidApiKey: vi.fn(),
+  getSettings: vi.fn(),
+  getModelInfo: vi.fn(),
+  getComboModels: vi.fn(),
+  handleChatCore: vi.fn(),
+  checkAndRefreshToken: vi.fn(),
+  updateProviderCredentials: vi.fn(),
+  unavailableResponse: vi.fn((status, message) => new Response(JSON.stringify({ error: { message } }), { status })),
+}));
+
+vi.mock("open-sse/index.js", () => ({}));
+vi.mock("@/sse/services/auth.js", () => ({
+  getProviderCredentials: mocks.getProviderCredentials,
+  markAccountUnavailable: mocks.markAccountUnavailable,
+  clearAccountError: mocks.clearAccountError,
+  extractApiKey: mocks.extractApiKey,
+  isValidApiKey: mocks.isValidApiKey,
+}));
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+}));
+vi.mock("@/sse/services/model.js", () => ({
+  getModelInfo: mocks.getModelInfo,
+  getComboModels: mocks.getComboModels,
+}));
+vi.mock("open-sse/handlers/chatCore.js", () => ({
+  handleChatCore: mocks.handleChatCore,
+}));
+vi.mock("@/lib/headroom/detect", () => ({
+  DEFAULT_HEADROOM_URL: "https://headroom.invalid",
+}));
+vi.mock("@/lib/pxpipe/loader.js", () => ({
+  getTransform: vi.fn(),
+}));
+vi.mock("@/lib/pxpipe/events.js", () => ({
+  appendPxpipeEvent: vi.fn(),
+}));
+vi.mock("open-sse/utils/error.js", () => ({
+  errorResponse: vi.fn((status, message) => new Response(JSON.stringify({ error: { message } }), { status })),
+  unavailableResponse: mocks.unavailableResponse,
+}));
+vi.mock("open-sse/services/combo.js", () => ({
+  handleComboChat: vi.fn(),
+  handleFusionChat: vi.fn(),
+  detectRequiredCapabilities: vi.fn(() => new Set()),
+}));
+vi.mock("open-sse/services/capacityAdapter.js", () => ({
+  augmentModelsWithCapacityAdapter: vi.fn((models) => models),
+  withCapacityAdapterStripping: vi.fn((handler) => handler),
+  getActiveAdapterStrategy: vi.fn(() => "fallback"),
+}));
+vi.mock("open-sse/utils/bypassHandler.js", () => ({
+  handleBypassRequest: vi.fn(() => null),
+}));
+vi.mock("open-sse/config/runtimeConfig.js", () => ({
+  HTTP_STATUS: {
+    BAD_REQUEST: 400,
+    UNAUTHORIZED: 401,
+    NOT_FOUND: 404,
+    SERVICE_UNAVAILABLE: 503,
+  },
+}));
+vi.mock("open-sse/translator/formats.js", () => ({
+  detectFormatByEndpoint: vi.fn(() => null),
+}));
+vi.mock("@/sse/utils/logger.js", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  maskKey: vi.fn(() => "masked"),
+  nextTag: vi.fn(() => "tag"),
+}));
+vi.mock("@/sse/services/tokenRefresh.js", () => ({
+  updateProviderCredentials: mocks.updateProviderCredentials,
+  checkAndRefreshToken: mocks.checkAndRefreshToken,
+}));
+vi.mock("open-sse/services/projectId.js", () => ({
+  getProjectIdForConnection: vi.fn(),
+}));
+
+const { handleChat } = await import("../../src/sse/handlers/chat.js");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSettings.mockResolvedValue({
+    requireApiKey: false,
+    ccFilterNaming: false,
+    providerThinking: {},
+  });
+  mocks.getModelInfo.mockResolvedValue({ provider: "opencode", model: "deepseek-v4-flash-free" });
+  mocks.getComboModels.mockResolvedValue(null);
+  mocks.checkAndRefreshToken.mockImplementation(async (_provider, credentials) => credentials);
+  mocks.getProviderCredentials
+    .mockResolvedValueOnce({
+      connectionId: "noauth",
+      connectionName: "Public",
+      providerSpecificData: { connectionProxyPoolId: "pool-a" },
+    })
+    .mockResolvedValueOnce({
+      connectionId: "noauth",
+      connectionName: "Public",
+      providerSpecificData: { connectionProxyPoolId: "pool-b" },
+    });
+  mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 2000 });
+  mocks.handleChatCore.mockResolvedValueOnce({
+    success: false,
+    status: 429,
+    error: "Too Many Requests",
+    resetsAtMs: null,
+  });
+  mocks.handleChatCore.mockImplementationOnce(async ({ onRequestSuccess }) => {
+    await onRequestSuccess?.();
+    return { success: true, response: new Response("ok", { status: 200 }) };
+  });
+});
+
+describe("chat no-auth proxy fallback", () => {
+  it("passes the failed pool to cooldown and retries with a different pool", async () => {
+    const request = new Request("http://router.test/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "opencode/deepseek-v4-flash-free",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    const response = await handleChat(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.getProviderCredentials).toHaveBeenCalledTimes(2);
+    expect(mocks.getProviderCredentials.mock.calls[1][3]).toEqual({
+      excludeProxyPoolIds: new Set(["pool-a"]),
+    });
+    expect(mocks.markAccountUnavailable).toHaveBeenCalledWith(
+      "noauth",
+      429,
+      "Too Many Requests",
+      "opencode",
+      "deepseek-v4-flash-free",
+      null,
+      "pool-a",
+    );
+    expect(mocks.clearAccountError).toHaveBeenCalledWith(
+      "noauth",
+      expect.objectContaining({
+        providerSpecificData: { connectionProxyPoolId: "pool-b" },
+      }),
+      "deepseek-v4-flash-free",
+      "opencode",
+    );
+  });
+
+  it("returns unavailable after every pool fails without retrying a pool", async () => {
+    mocks.getProviderCredentials.mockReset();
+    const exclusionSnapshots = [];
+    const credentialResponses = [
+      {
+        connectionId: "noauth",
+        connectionName: "Public",
+        providerSpecificData: { connectionProxyPoolId: "pool-a" },
+      },
+      {
+        connectionId: "noauth",
+        connectionName: "Public",
+        providerSpecificData: { connectionProxyPoolId: "pool-b" },
+      },
+      {
+        allRateLimited: true,
+        retryAfter: "2026-08-13T00:00:10.000Z",
+        retryAfterHuman: "reset after 10s",
+        lastError: "429 from pool-b",
+        lastErrorCode: 429,
+      },
+    ];
+    mocks.getProviderCredentials.mockImplementation(async (_provider, _excludeConnectionIds, _model, options) => {
+      exclusionSnapshots.push(new Set(options?.excludeProxyPoolIds ?? []));
+      return credentialResponses.shift();
+    });
+    mocks.markAccountUnavailable.mockReset();
+    mocks.markAccountUnavailable.mockResolvedValue({ shouldFallback: true, cooldownMs: 2000 });
+    mocks.handleChatCore.mockReset();
+    mocks.handleChatCore
+      .mockResolvedValueOnce({ success: false, status: 429, error: "429 from pool-a", resetsAtMs: null })
+      .mockResolvedValueOnce({ success: false, status: 429, error: "429 from pool-b", resetsAtMs: null });
+
+    const request = new Request("http://router.test/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "opencode/deepseek-v4-flash-free",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    const response = await handleChat(request);
+
+    expect(response.status).toBe(429);
+    expect(mocks.getProviderCredentials).toHaveBeenCalledTimes(3);
+    expect(exclusionSnapshots).toEqual([
+      new Set(),
+      new Set(["pool-a"]),
+      new Set(["pool-a", "pool-b"]),
+    ]);
+    expect(mocks.markAccountUnavailable).toHaveBeenCalledTimes(2);
+    expect(mocks.unavailableResponse).toHaveBeenCalledWith(
+      429,
+      expect.stringContaining("429 from pool-b"),
+      "2026-08-13T00:00:10.000Z",
+      "reset after 10s",
+    );
+  });
+});

--- a/tests/unit/no-auth-proxy-cooldown.test.js
+++ b/tests/unit/no-auth-proxy-cooldown.test.js
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  getSettings: vi.fn(),
+  getProxyPools: vi.fn(),
+  getProxyPoolById: vi.fn(),
+  updateProxyPool: vi.fn(),
+}));
+
+const proxyMocks = vi.hoisted(() => ({
+  pickProxyPoolId: vi.fn(),
+  resolveConnectionProxyConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => dbMocks);
+vi.mock("@/lib/network/connectionProxy", () => proxyMocks);
+vi.mock("@/shared/constants/providers.js", () => ({
+  FREE_PROVIDERS: { opencode: { noAuth: true } },
+  resolveProviderId: (provider) => provider,
+}));
+vi.mock("@/sse/utils/logger.js", () => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+const {
+  getProviderCredentials,
+  markAccountUnavailable,
+  clearAccountError,
+} = await import("../../src/sse/services/auth.js");
+
+function makePool(id, state = {}) {
+  return {
+    id,
+    proxyUrl: `http://${id}.example.test:8080`,
+    isActive: true,
+    rateLimitState: state,
+  };
+}
+
+function installPoolStore(pools) {
+  dbMocks.getProxyPools.mockImplementation(async () => pools);
+  dbMocks.getProxyPoolById.mockImplementation(async (id) => pools.find((pool) => pool.id === id) || null);
+  dbMocks.updateProxyPool.mockImplementation(async (id, data) => {
+    const pool = pools.find((candidate) => candidate.id === id);
+    if (pool) Object.assign(pool, data);
+    return pool;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.getSettings.mockResolvedValue({
+    providerStrategies: {
+      opencode: { rotateStrategy: "round-robin" },
+    },
+  });
+  dbMocks.getProviderConnections.mockResolvedValue([]);
+  proxyMocks.pickProxyPoolId.mockImplementation((poolIds) => poolIds[0] || null);
+  proxyMocks.resolveConnectionProxyConfig.mockImplementation(async ({ proxyPoolId }) => ({
+    connectionProxyEnabled: Boolean(proxyPoolId),
+    connectionProxyUrl: proxyPoolId ? `http://${proxyPoolId}.example.test:8080` : "",
+    connectionNoProxy: "",
+    proxyPoolId: proxyPoolId || null,
+    vercelRelayUrl: "",
+  }));
+});
+
+describe("no-auth proxy-pool rate-limit fallback", () => {
+  it("rotates from a pool that returned 429 to the next available pool", async () => {
+    const pools = [makePool("pool-a"), makePool("pool-b")];
+    installPoolStore(pools);
+
+    const firstCredentials = await getProviderCredentials("opencode", null, "deepseek-v4-flash-free");
+    expect(firstCredentials.connectionId).toBe("noauth");
+    expect(firstCredentials.providerSpecificData.connectionProxyPoolId).toBe("pool-a");
+
+    const failure = await markAccountUnavailable(
+      "noauth",
+      429,
+      "Too Many Requests",
+      "opencode",
+      "deepseek-v4-flash-free",
+      null,
+      "pool-a",
+    );
+    expect(failure.shouldFallback).toBe(true);
+    expect(pools[0].rateLimitState.opencode.backoffLevel).toBe(1);
+
+    const secondCredentials = await getProviderCredentials(
+      "opencode",
+      new Set(["noauth"]),
+      "deepseek-v4-flash-free",
+      { excludeProxyPoolIds: new Set(["pool-a"]) },
+    );
+    expect(secondCredentials.providerSpecificData.connectionProxyPoolId).toBe("pool-b");
+    expect(proxyMocks.pickProxyPoolId).toHaveBeenLastCalledWith(["pool-b"], "round-robin", "opencode");
+  });
+
+  it("treats FreeUsageLimitError as a rate limit and skips the cooled pool", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T00:00:00.000Z"));
+
+    try {
+      const pools = [makePool("pool-a"), makePool("pool-b")];
+      installPoolStore(pools);
+
+      const failure = await markAccountUnavailable(
+        "noauth",
+        500,
+        "FreeUsageLimitError: retry later",
+        "opencode",
+        "deepseek-v4-flash-free",
+        null,
+        "pool-a",
+      );
+      expect(failure.shouldFallback).toBe(true);
+      expect(pools[0].rateLimitState.opencode).toMatchObject({
+        cooldownUntil: "2026-08-13T00:00:02.000Z",
+        backoffLevel: 1,
+      });
+
+      const credentials = await getProviderCredentials("opencode", null, "deepseek-v4-flash-free");
+      expect(credentials.providerSpecificData.connectionProxyPoolId).toBe("pool-b");
+      expect(proxyMocks.pickProxyPoolId).toHaveBeenLastCalledWith(["pool-b"], "round-robin", "opencode");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns the earliest retry time when every pool is cooling down", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-13T00:00:00.000Z"));
+
+    try {
+      const pools = [
+        makePool("pool-a", { opencode: { cooldownUntil: "2026-08-13T00:00:10.000Z", lastError: "429 from A" } }),
+        makePool("pool-b", { opencode: { cooldownUntil: "2026-08-13T00:00:20.000Z", lastError: "429 from B" } }),
+      ];
+      installPoolStore(pools);
+
+      const credentials = await getProviderCredentials("opencode", null, "deepseek-v4-flash-free");
+      expect(credentials).toMatchObject({
+        allRateLimited: true,
+        retryAfter: "2026-08-13T00:00:10.000Z",
+        retryAfterHuman: "reset after 10s",
+        lastErrorCode: 429,
+      });
+      expect(proxyMocks.pickProxyPoolId).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops after all pools in the current request were attempted", async () => {
+    const pools = [makePool("pool-a"), makePool("pool-b")];
+    installPoolStore(pools);
+
+    const credentials = await getProviderCredentials(
+      "opencode",
+      null,
+      "deepseek-v4-flash-free",
+      { excludeProxyPoolIds: new Set(["pool-a", "pool-b"]) },
+    );
+    expect(credentials).toMatchObject({
+      allRateLimited: true,
+      lastErrorCode: 429,
+      retryAfterHuman: "retry after 1s",
+    });
+  });
+
+  it("clears provider-specific pool cooldown after a successful request", async () => {
+    const pools = [makePool("pool-a", {
+      opencode: {
+        cooldownUntil: "2099-01-01T00:00:00.000Z",
+        backoffLevel: 3,
+        lastError: "429",
+      },
+    })];
+    installPoolStore(pools);
+
+    await clearAccountError(
+      "noauth",
+      { providerSpecificData: { connectionProxyPoolId: "pool-a" } },
+      "deepseek-v4-flash-free",
+      "opencode",
+    );
+
+    expect(dbMocks.updateProxyPool).toHaveBeenCalledWith("pool-a", { rateLimitState: {} });
+    expect(pools[0].rateLimitState).toEqual({});
+  });
+
+  it("keeps authenticated-provider fallback behavior unchanged", async () => {
+    dbMocks.getProviderConnections.mockResolvedValue([{
+      id: "account-a",
+      provider: "opencode",
+      backoffLevel: 0,
+    }]);
+
+    const result = await markAccountUnavailable("account-a", 429, "rate limit", "opencode", "model");
+
+    expect(result.shouldFallback).toBe(true);
+    expect(dbMocks.updateProviderConnection).toHaveBeenCalledWith(
+      "account-a",
+      expect.objectContaining({
+        modelLock_model: expect.any(String),
+        errorCode: 429,
+      }),
+    );
+    expect(dbMocks.updateProxyPool).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- persist provider-scoped rate-limit cooldown state on proxy pools used by no-auth providers
- retry a failed OpenCode Free request through the next available proxy pool after HTTP 429, `FreeUsageLimitError`, or equivalent rate-limit errors
- skip proxy pools already attempted by the current request and pools still cooling down
- return the earliest retry time when every eligible pool is unavailable
- clear the provider-specific pool cooldown after a successful request
- preserve the existing authenticated-account fallback behavior

## Root cause

No-auth free providers use a virtual connection whose ID is `noauth`. The existing account fallback path intentionally ignored that connection, so a rate-limit response could not mark the proxy pool that produced it as unavailable. The chat fallback loop therefore had no reliable way to select a different proxy for the retry.

This change stores cooldown metadata in the proxy pool's existing persisted data and passes per-request proxy exclusions through the chat fallback loop.

## Validation

- focused Vitest suite: 4 files, 11 tests passed
- ESLint passed for all changed production and test files
- `node --check` passed for all changed JavaScript files
- the full repository suite was also attempted; it retains unrelated baseline/environment failures involving missing optional modules, unavailable cloud sources, and stale snapshots

Fixes #3228
