### PR TITLE
fix(cli): attach to existing server instead of killing it; enable macOS auto-restart

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -540,9 +540,20 @@ if (!fs.existsSync(serverPath)) {
 
 // Start server immediately; run update check in parallel (not on the critical path).
 const updatePromise = checkForUpdate();
-killAllAppProcesses(port)
-  .then(() => killProcessOnPort(port))
-  .then(() => startServer(updatePromise));
+// If a server is already listening (e.g. a launchd/systemd-managed always-on
+// instance), attach to it instead of killing/restarting — killing races with the
+// supervisor's KeepAlive and crashes the CLI. Short timeout: a live server
+// resolves immediately; a free port resolves false after ~500ms.
+waitServerReady(port, { timeoutMs: 500 }).then((alreadyRunning) => {
+  if (alreadyRunning) {
+    console.log(`\x1b[33mℹ 9Router already running on port ${port}. Attaching to existing instance.\x1b[0m`);
+    startServer(updatePromise, { attachOnly: true });
+  } else {
+    killAllAppProcesses(port)
+      .then(() => killProcessOnPort(port))
+      .then(() => startServer(updatePromise));
+  }
+});
 
 // Show interface selection menu
 async function showInterfaceMenu(latestVersion) {
@@ -592,7 +603,7 @@ async function showInterfaceMenu(latestVersion) {
 const MAX_RESTARTS = 2;
 const RESTART_RESET_MS = 30000; // Reset counter if alive > 30s
 
-function startServer(updatePromise) {
+function startServer(updatePromise, { attachOnly = false } = {}) {
   // Accept either a Promise (parallel update check) or a resolved value.
   const latestVersionPromise = Promise.resolve(updatePromise);
   const displayHost = getDisplayHost();
@@ -633,7 +644,9 @@ function startServer(updatePromise) {
     return child;
   }
 
-  let server = spawnServer();
+  // In attach-only mode we do NOT own the server process, so cleanup must not
+  // kill it. We only manage the tray and tunnel, never the shared server.
+  let server = attachOnly ? null : spawnServer();
 
   // Cleanup function - force kill server process
   let isCleaningUp = false;
@@ -650,12 +663,14 @@ function startServer(updatePromise) {
       killProxyByPidFile();
       // Kill cloudflared/tailscale via PID file (only this app's tunnel)
       killTunnelByPidFile();
-      // Kill server process directly
-      if (server.pid) {
+      // Kill server process directly (only when we own it)
+      if (server && server.pid) {
         process.kill(server.pid, "SIGKILL");
       }
       // Also try to kill process group
-      process.kill(-server.pid, "SIGKILL");
+      if (server && server.pid) {
+        process.kill(-server.pid, "SIGKILL");
+      }
     } catch (e) { }
   }
 
@@ -866,5 +881,10 @@ function startServer(updatePromise) {
     }, delay);
   }
 
-  attachServerEvents();
+  // Only attach crash/restart handlers when we own the server process. In
+  // attach-only mode the server is managed externally (launchd/systemd), so we
+  // must not try to restart it or listen for its exit.
+  if (!attachOnly) {
+    attachServerEvents();
+  }
 }

--- a/cli/src/cli/tray/autostart.js
+++ b/cli/src/cli/tray/autostart.js
@@ -180,7 +180,7 @@ function enableMacOS(cliPath) {
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
-    <false/>
+    <true/>
     <key>StandardOutPath</key>
     <string>/tmp/9router.log</string>
     <key>StandardErrorPath</key>


### PR DESCRIPTION
## Summary

Two related CLI robustness fixes that make 9router behave correctly when run alongside a supervisor-managed (launchd/systemd) always-on instance.

### 1. Avoid clash with an already-running instance
When 9router is managed by launchd/systemd with `KeepAlive`, running the CLI used to `killAllAppProcesses(port)` → `killProcessOnPort(port)` → `startServer()`. Killing the supervised server makes the supervisor instantly restart it, which then races the CLI for the port and crashes the CLI.

Now the CLI reuses the existing `waitServerReady` (with a short 500ms timeout) to detect whether a server is already listening. If one is, it attaches to it (`attachOnly` mode) and just shows the menu — it never kills the supervised server. It only kills/restarts when no server is present.

`attachOnly` mode:
- does not spawn a server process
- `cleanup()` does not kill the shared server
- crash/restart handlers are not attached (the supervisor owns restarts)

### 2. Enable auto-restart on macOS
The autostart launchd plist now writes `KeepAlive=true` so the tray/server process is restarted by launchd if it crashes, matching the robust always-on behavior users expect.

## Test plan
- With a launchd-managed server running, `9router` now prints `ℹ 9Router already running on port 20128. Attaching to existing instance.` and shows the menu without killing the server.
- With no server running, `9router` starts fresh as before.