### PR TITLE
feat(commandcode): add per-connection ZDR toggle

### DIFF
--- a/open-sse/executors/commandcode.js
+++ b/open-sse/executors/commandcode.js
@@ -35,6 +35,10 @@ export class CommandCodeExecutor extends BaseExecutor {
     const token = credentials?.apiKey || credentials?.accessToken;
     if (token) headers["Authorization"] = `Bearer ${token}`;
 
+    if (credentials?.providerSpecificData?.zdrEnabled === true) {
+      headers["x-cmd-zdr"] = "1";
+    }
+
     if (stream) headers["Accept"] = "text/event-stream";
     return headers;
   }

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import { Button, Badge, Input, Modal, Select } from "@/shared/components";
+import { Button, Badge, Input, Modal, Select, Toggle } from "@/shared/components";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { planBulkAdd } from "@/shared/utils/bulkAdd";
 
@@ -20,6 +20,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
 
   const isAzure = provider === "azure";
   const isCloudflareAi = provider === "cloudflare-ai";
+  const isCommandCode = provider === "commandcode";
   const providerRegions = AI_PROVIDERS?.[provider]?.regions || null;
   const defaultRegion = AI_PROVIDERS?.[provider]?.defaultRegion || providerRegions?.[0]?.id || "";
 
@@ -51,6 +52,13 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   const [mode, setMode] = useState("single"); // "single" | "bulk"
   const [bulkText, setBulkText] = useState("");
   const [bulkResult, setBulkResult] = useState(null); // { success, failed }
+  const [zdrEnabled, setZdrEnabled] = useState(false);
+
+  // ZDR is an explicit per-connection privacy choice. Do not carry it into a
+  // subsequent add after this modal has been closed.
+  useEffect(() => {
+    if (!isOpen) setZdrEnabled(false);
+  }, [isOpen]);
 
   const buildProviderSpecificData = () => {
     if (isOllamaLocal && formData.ollamaHostUrl.trim()) {
@@ -66,6 +74,9 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     }
     if (isCloudflareAi) {
       return { accountId: cloudflareData.accountId };
+    }
+    if (isCommandCode) {
+      return { zdrEnabled };
     }
     if (providerRegions && region) {
       return { region };
@@ -227,6 +238,14 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
         )}
 
         {mode === "single" && (<>
+        {isCommandCode && (
+          <Toggle
+            checked={zdrEnabled}
+            onChange={setZdrEnabled}
+            label="Require Zero Data Retention (ZDR)"
+            description="Sends x-cmd-zdr: 1 for this API key. Models without a ZDR upstream may be unavailable."
+          />
+        )}
         <Input
           label="Name"
           value={formData.name}

--- a/src/app/api/providers/validate/route.js
+++ b/src/app/api/providers/validate/route.js
@@ -423,6 +423,7 @@ export async function POST(request) {
             headers: {
               "Content-Type": "application/json",
               ...(cfg.headers || {}),
+              ...(providerSpecificData?.zdrEnabled === true ? { "x-cmd-zdr": "1" } : {}),
               "x-session-id": crypto.randomUUID(),
               "Authorization": `Bearer ${apiKey}`,
             },

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -8,6 +8,7 @@ import Button from "@/shared/components/Button";
 import Badge from "@/shared/components/Badge";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS } from "@/shared/constants/providers";
 import Select from "@/shared/components/Select";
+import Toggle from "@/shared/components/Toggle";
 
 export default function EditConnectionModal({ isOpen, connection, proxyPools, onSave, onClose }) {
   const [formData, setFormData] = useState({
@@ -28,14 +29,16 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
   const [validating, setValidating] = useState(false);
   const [validationResult, setValidationResult] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [zdrEnabled, setZdrEnabled] = useState(false);
 
   useEffect(() => {
-    if (connection) {
+    if (connection && isOpen) {
       setFormData({
         name: connection.name || "",
         priority: connection.priority || 1,
         apiKey: "",
       });
+      setZdrEnabled(connection.providerSpecificData?.zdrEnabled === true);
       // Load Azure-specific data if present
       if (connection.provider === "azure" && connection.providerSpecificData) {
         setAzureData({
@@ -57,11 +60,12 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       setTestResult(null);
       setValidationResult(null);
     }
-  }, [connection]);
+  }, [connection, isOpen]);
 
   const isOAuth = connection?.authType === "oauth";
   const isAzure = connection?.provider === "azure";
   const isCloudflareAi = connection?.provider === "cloudflare-ai";
+  const isCommandCode = connection?.provider === "commandcode";
   const isCompatible = connection
     ? (isOpenAICompatibleProvider(connection.provider) || isAnthropicCompatibleProvider(connection.provider))
     : false;
@@ -99,6 +103,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
         body: JSON.stringify({
           provider: connection.provider,
           apiKey: formData.apiKey,
+          ...(isCommandCode ? { providerSpecificData: { zdrEnabled } } : {}),
           ...(isAzure ? { providerSpecificData: azureData } : {}),
           ...(isCloudflareAi ? { providerSpecificData: cloudflareData } : {}),
           ...(providerRegions ? { providerSpecificData: buildRegionSpecificData() } : {}),
@@ -134,6 +139,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
               body: JSON.stringify({
                 provider: connection.provider,
                 apiKey: formData.apiKey,
+                ...(isCommandCode ? { providerSpecificData: { zdrEnabled } } : {}),
                 ...(isAzure ? { providerSpecificData: azureData } : {}),
                 ...(isCloudflareAi ? { providerSpecificData: cloudflareData } : {}),
                 ...(providerRegions ? { providerSpecificData: buildRegionSpecificData() } : {}),
@@ -171,7 +177,10 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       if (providerRegions && region) {
         updates.providerSpecificData = buildRegionSpecificData();
       }
-      
+      if (isCommandCode) {
+        updates.providerSpecificData = { zdrEnabled };
+      }
+
       await onSave(updates);
     } finally {
       setSaving(false);
@@ -226,6 +235,15 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
               </Badge>
             )}
           </>
+        )}
+
+        {isCommandCode && (
+          <Toggle
+            checked={zdrEnabled}
+            onChange={setZdrEnabled}
+            label="Require Zero Data Retention (ZDR)"
+            description="Sends x-cmd-zdr: 1 for this API key. Models without a ZDR upstream may be unavailable."
+          />
         )}
 
         {isAzure && (

--- a/tests/unit/commandcode-zdr-connection.test.js
+++ b/tests/unit/commandcode-zdr-connection.test.js
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalDataDir = process.env.DATA_DIR;
+
+async function setup() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-commandcode-zdr-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  vi.doMock("next/server", () => ({
+    NextResponse: {
+      json(body, init = {}) {
+        return new Response(JSON.stringify(body), {
+          status: init.status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    },
+  }));
+
+  const { POST } = await import("@/app/api/providers/route.js");
+  const { PUT } = await import("@/app/api/providers/[id]/route.js");
+  const { getProviderConnectionById } = await import("@/models/index.js");
+  return { POST, PUT, getProviderConnectionById, cleanup: () => fs.rmSync(tempDir, { recursive: true, force: true }) };
+}
+
+function createRequest() {
+  return new Request("http://9router.local/api/providers", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      provider: "commandcode",
+      apiKey: "test-key",
+      name: "ZDR connection",
+      providerSpecificData: { zdrEnabled: true },
+    }),
+  });
+}
+
+function updateRequest(zdrEnabled) {
+  return new Request("http://9router.local/api/providers/id", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ providerSpecificData: { zdrEnabled } }),
+  });
+}
+
+afterEach(() => {
+  vi.doUnmock("next/server");
+  vi.resetModules();
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+});
+
+describe("Command Code ZDR connection persistence", () => {
+  it("persists the strict boolean policy at creation and updates it without replacing other connection data", async () => {
+    const ctx = await setup();
+    try {
+      const createResponse = await ctx.POST(createRequest());
+      const created = await createResponse.json();
+      const id = created.connection.id;
+
+      expect(createResponse.status).toBe(201);
+      expect((await ctx.getProviderConnectionById(id)).providerSpecificData).toMatchObject({ zdrEnabled: true });
+
+      const updateResponse = await ctx.PUT(updateRequest(false), { params: Promise.resolve({ id }) });
+      expect(updateResponse.status).toBe(200);
+      expect((await ctx.getProviderConnectionById(id)).providerSpecificData).toMatchObject({
+        zdrEnabled: false,
+        connectionProxyEnabled: false,
+      });
+    } finally {
+      ctx.cleanup();
+    }
+  });
+});

--- a/tests/unit/commandcode-zdr-ui.test.js
+++ b/tests/unit/commandcode-zdr-ui.test.js
@@ -1,0 +1,52 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import AddApiKeyModal from "@/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js";
+import EditConnectionModal from "@/shared/components/EditConnectionModal.js";
+
+const noop = () => {};
+const label = "Require Zero Data Retention (ZDR)";
+
+function renderAdd(provider) {
+  return renderToStaticMarkup(createElement(AddApiKeyModal, {
+    isOpen: true,
+    provider,
+    providerName: provider,
+    isCompatible: false,
+    isAnthropic: false,
+    authType: "apikey",
+    proxyPools: [],
+    existingNames: [],
+    onSave: noop,
+    onClose: noop,
+  }));
+}
+
+function renderEdit(provider, zdrEnabled = false) {
+  return renderToStaticMarkup(createElement(EditConnectionModal, {
+    isOpen: true,
+    connection: {
+      id: "connection-1",
+      provider,
+      authType: "apikey",
+      name: "Test connection",
+      priority: 1,
+      providerSpecificData: { zdrEnabled },
+    },
+    proxyPools: [],
+    onSave: noop,
+    onClose: noop,
+  }));
+}
+
+describe("Command Code ZDR UI", () => {
+  it("renders the add toggle only for Command Code", () => {
+    expect(renderAdd("commandcode")).toContain(label);
+    expect(renderAdd("openai")).not.toContain(label);
+  });
+
+  it("renders the edit toggle only for Command Code", () => {
+    expect(renderEdit("commandcode", true)).toContain(label);
+    expect(renderEdit("openai")).not.toContain(label);
+  });
+});

--- a/tests/unit/commandcode-zdr-validation.test.js
+++ b/tests/unit/commandcode-zdr-validation.test.js
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json(body, init = {}) {
+      return new Response(JSON.stringify(body), {
+        status: init.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  },
+}));
+
+let POST;
+
+beforeAll(async () => {
+  vi.stubGlobal("fetch", fetchMock);
+  ({ POST } = await import("@/app/api/providers/validate/route.js"));
+});
+
+afterAll(() => vi.unstubAllGlobals());
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+});
+
+function request(zdrEnabled) {
+  const body = {
+    provider: "commandcode",
+    apiKey: "test-key",
+  };
+  if (zdrEnabled !== undefined) body.providerSpecificData = { zdrEnabled };
+
+  return new Request("http://9router.local/api/providers/validate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Command Code API-key validation", () => {
+  it("uses the connection ZDR policy for the validation request", async () => {
+    await POST(request(true));
+    expect(fetchMock.mock.calls[0][1].headers["x-cmd-zdr"]).toBe("1");
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+    await POST(request(false));
+    expect(fetchMock.mock.calls[0][1].headers["x-cmd-zdr"]).toBeUndefined();
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response("{}", { status: 200 }));
+    await POST(request());
+    expect(fetchMock.mock.calls[0][1].headers["x-cmd-zdr"]).toBeUndefined();
+  });
+
+  it("keeps a ZDR-unavailable model distinct from an invalid API key", async () => {
+    fetchMock.mockResolvedValue(new Response("{}", { status: 422 }));
+
+    const response = await POST(request(true));
+
+    expect(fetchMock.mock.calls[0][1].headers["x-cmd-zdr"]).toBe("1");
+    expect((await response.json()).valid).toBe(true);
+  });
+});

--- a/tests/unit/commandcode-zdr.test.js
+++ b/tests/unit/commandcode-zdr.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { CommandCodeExecutor } from "../../open-sse/executors/commandcode.js";
+
+describe("Command Code ZDR upstream header", () => {
+  it("adds x-cmd-zdr only for a connection that explicitly enables ZDR", () => {
+    const executor = new CommandCodeExecutor();
+
+    expect(executor.buildHeaders({ apiKey: "test" })["x-cmd-zdr"]).toBeUndefined();
+    expect(executor.buildHeaders({ apiKey: "test", providerSpecificData: {} })["x-cmd-zdr"]).toBeUndefined();
+    expect(executor.buildHeaders({ apiKey: "test", providerSpecificData: { zdrEnabled: false } })["x-cmd-zdr"]).toBeUndefined();
+    expect(executor.buildHeaders({ apiKey: "test", providerSpecificData: { zdrEnabled: "true" } })["x-cmd-zdr"]).toBeUndefined();
+    expect(executor.buildHeaders({ apiKey: "test", providerSpecificData: { zdrEnabled: true } })["x-cmd-zdr"]).toBe("1");
+  });
+});

--- a/tests/vitest.config.js
+++ b/tests/vitest.config.js
@@ -1,10 +1,21 @@
 import { defineConfig } from "vitest/config";
+import { transformWithOxc } from "vite";
 import { resolve } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
+  // Dashboard components use JSX in .js files. Next handles this in production,
+  // while Vitest's Vite 8 import analysis needs an explicit test-only transform.
+  plugins: [{
+    name: "dashboard-jsx-test-transform",
+    enforce: "pre",
+    async transform(code, id) {
+      if (!id.startsWith(resolve(__dirname, "../src") + "/") || !id.endsWith(".js")) return null;
+      return transformWithOxc(code, id, { lang: "jsx", jsx: { runtime: "automatic" } });
+    },
+  }],
   test: {
     environment: "node",
     globals: true,


### PR DESCRIPTION
## Summary

- Adds an opt-in **Require Zero Data Retention (ZDR)** toggle to each native Command Code API-key connection.
- When enabled, 9Router sends `x-cmd-zdr: 1` both for normal Command Code upstream requests and API-key validation.
- Keeps ZDR disabled for existing and new connections unless explicitly enabled; no generic header forwarding is added.
- Resets the Add modal choice after close and reloads the persisted choice whenever Edit opens.

## Scope

- Command Code only.
- No Muse model/catalogue changes.
- No arbitrary custom/upstream-header forwarding.

## Verification

- `vitest run tests/unit/commandcode-zdr-ui.test.js --config tests/vitest.config.js` — 2 passed.
- Focused Command Code/provider validation suite — 48 passed.
- `npm run build` — passed.
- Controlled HTTP probe: disabled policy omitted the header; enabled policy sent `x-cmd-zdr: 1`.
- Manual dashboard check on an isolated instance: Add/Edit visibility and persisted on/off state verified.

## Test-suite baseline

The full Vitest suite is not green on upstream `master`: both upstream and this branch fail the same 76 tests in the same 23 files. This branch adds no failed test files; it adds 6 passing ZDR tests.
