### PR TITLE
feat(codex): support fast service tier for image generation

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -12,6 +12,7 @@ import { getThinkingLevels } from "../providers/thinkingLevels.js";
 import { DEFAULT_RETRY_CONFIG, HTTP_STATUS, resolveRetryEntry } from "../config/runtimeConfig.js";
 import { dbg } from "../utils/debugLog.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import { normalizeCodexServiceTier } from "../shared/codexServiceTier.js";
 
 // SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
 const CODEX_SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
@@ -477,8 +478,9 @@ export class CodexExecutor extends BaseExecutor {
     delete body.safety_identifier; // Droid CLI sends this but Codex doesn't support it
     delete body.previous_response_id; // store=false → backend can't resolve previous resp; avoid 404
 
-    if (body.service_tier === "fast") body.service_tier = "priority";
-    if (body.service_tier && body.service_tier !== "priority") delete body.service_tier;
+    const serviceTier = normalizeCodexServiceTier(body.service_tier);
+    if (serviceTier) body.service_tier = serviceTier;
+    else delete body.service_tier;
 
     // Final allowlist filter — strip any unknown field that could trigger upstream "routing_unsupported"
     for (const k of Object.keys(body)) {

--- a/open-sse/handlers/imageProviders/codex.js
+++ b/open-sse/handlers/imageProviders/codex.js
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { nowSec } from "./_base.js";
 import { PROVIDERS } from "../../config/providers.js";
+import { normalizeCodexServiceTier } from "../../shared/codexServiceTier.js";
 
 const CODEX_RESPONSES_URL = PROVIDERS["codex"].baseUrl;
 const CODEX_USER_AGENT = "codex_cli_rs/0.136.0";
@@ -171,7 +172,7 @@ export default {
     if (body.size && body.size !== "") imgTool.size = body.size;
     if (body.quality && body.quality !== "") imgTool.quality = body.quality;
     if (body.background && body.background !== "") imgTool.background = body.background;
-    return {
+    const payload = {
       model: stripImageSuffix(model),
       instructions: "",
       input: [{ type: "message", role: "user", content: buildContent(body.prompt, refs, detail) }],
@@ -183,6 +184,11 @@ export default {
       store: false,
       reasoning: null,
     };
+    // Opt into Codex's accelerated tier when asked. Omitted entirely otherwise —
+    // an unrecognized service_tier makes the backend reject the request.
+    const serviceTier = normalizeCodexServiceTier(body.service_tier);
+    if (serviceTier) payload.service_tier = serviceTier;
+    return payload;
   },
   // Custom: codex parses SSE → either pipe to client or collect b64
   async parseResponse(response, { log, streamToClient, onRequestSuccess }) {

--- a/open-sse/providers/registry/codex.js
+++ b/open-sse/providers/registry/codex.js
@@ -59,9 +59,9 @@ export default {
     { id: "gpt-5.4-mini-review", name: "GPT 5.4 Mini Review", upstreamModelId: "gpt-5.4-mini", quotaFamily: "review" },
     { id: "gpt-5.3-codex-spark", name: "GPT 5.3 Codex Spark" },
     { id: "gpt-5.3-codex-spark-review", name: "GPT 5.3 Codex Spark Review", upstreamModelId: "gpt-5.3-codex-spark", quotaFamily: "review" },
-    { id: "gpt-5.5-image", name: "GPT 5.5 Image", capabilities: ["text2img","edit"], params: ["size","quality","background","image_detail","output_format"], kind: "image" },
-    { id: "gpt-5.4-image", name: "GPT 5.4 Image", capabilities: ["text2img","edit"], params: ["size","quality","background","image_detail","output_format"], kind: "image" },
-    { id: "gpt-5.3-image", name: "GPT 5.3 Image", capabilities: ["text2img","edit"], params: ["size","quality","background","image_detail","output_format"], kind: "image" },
+    { id: "gpt-5.5-image", name: "GPT 5.5 Image", capabilities: ["text2img","edit"], params: ["size","quality","background","image_detail","output_format","service_tier"], kind: "image" },
+    { id: "gpt-5.4-image", name: "GPT 5.4 Image", capabilities: ["text2img","edit"], params: ["size","quality","background","image_detail","output_format","service_tier"], kind: "image" },
+    { id: "gpt-5.3-image", name: "GPT 5.3 Image", capabilities: ["text2img","edit"], params: ["size","quality","background","image_detail","output_format","service_tier"], kind: "image" },
   ],
   serviceKinds: ["llm","image"],
   oauth: {

--- a/open-sse/shared/codexServiceTier.js
+++ b/open-sse/shared/codexServiceTier.js
@@ -1,0 +1,23 @@
+// Codex service tier normalization — shared by the chat executor and the image adapter
+// so both paths agree on what "fast" means upstream.
+//
+// Codex's Responses backend only recognizes "priority" as an accelerated tier. Clients
+// (and 9Router's own UI) say "fast", so map it. Anything else is dropped rather than
+// forwarded — an unknown service_tier makes the backend reject the whole request with
+// "routing_unsupported".
+
+export const CODEX_FAST_TIER = "fast";
+export const CODEX_PRIORITY_TIER = "priority";
+
+/**
+ * @param {unknown} tier - Raw service_tier from the client request
+ * @returns {string|null} "priority" when the request asked for the fast tier, else null
+ */
+export function normalizeCodexServiceTier(tier) {
+  if (typeof tier !== "string") return null;
+  const normalized = tier.trim().toLowerCase();
+  if (normalized === CODEX_FAST_TIER || normalized === CODEX_PRIORITY_TIER) {
+    return CODEX_PRIORITY_TIER;
+  }
+  return null;
+}

--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/exampleShared.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/exampleShared.js
@@ -49,6 +49,7 @@ export const KIND_EXAMPLE_CONFIG = {
       { key: "response_format", label: "Format", type: "select", default: "", options: ["", "url", "b64_json"] },
       { key: "image_detail", label: "Image Detail", type: "select", default: "high", options: ["auto", "low", "high", "original"] },
       { key: "output_format", label: "Codec", type: "select", default: "png", options: ["png", "jpeg", "webp"] },
+      { key: "service_tier", label: "Speed", type: "select", default: "", options: ["", "fast"] },
     ],
   },
   imageToText: {

--- a/tests/unit/codex-image-service-tier.test.js
+++ b/tests/unit/codex-image-service-tier.test.js
@@ -1,0 +1,67 @@
+/**
+ * Codex image adapter: the accelerated ("fast") service tier must reach the
+ * Responses backend on the image path, not just the chat path.
+ *
+ * Before this, imageProviders/codex.js built its own body and never set
+ * service_tier, so a fast-tier image request was silently downgraded.
+ */
+
+import { describe, it, expect } from "vitest";
+import codexImageAdapter from "../../open-sse/handlers/imageProviders/codex.js";
+import { normalizeCodexServiceTier } from "../../open-sse/shared/codexServiceTier.js";
+
+const MODEL = "gpt-5.5-image";
+const PROMPT = "A cute cat wearing a hat";
+
+function build(extra = {}) {
+  return codexImageAdapter.buildBody(MODEL, { prompt: PROMPT, ...extra });
+}
+
+describe("normalizeCodexServiceTier", () => {
+  it.each([
+    ["fast", "priority"],
+    ["priority", "priority"],
+    ["FAST", "priority"],
+    ["  fast  ", "priority"],
+  ])("maps %s to %s", (input, expected) => {
+    expect(normalizeCodexServiceTier(input)).toBe(expected);
+  });
+
+  it.each([undefined, null, "", "flex", "default", "auto", 42, {}])(
+    "drops unrecognized tier %s",
+    (input) => {
+      expect(normalizeCodexServiceTier(input)).toBeNull();
+    }
+  );
+});
+
+describe("codex image adapter service_tier", () => {
+  it("forwards the fast tier as priority", () => {
+    expect(build({ service_tier: "fast" }).service_tier).toBe("priority");
+  });
+
+  it("passes priority through unchanged", () => {
+    expect(build({ service_tier: "priority" }).service_tier).toBe("priority");
+  });
+
+  it("omits service_tier entirely when not requested", () => {
+    expect("service_tier" in build()).toBe(false);
+  });
+
+  it("omits an unrecognized tier rather than forwarding it upstream", () => {
+    expect("service_tier" in build({ service_tier: "flex" })).toBe(false);
+  });
+
+  it("leaves the rest of the image payload untouched", () => {
+    const body = build({ service_tier: "fast", size: "1024x1024", quality: "low" });
+    expect(body.model).toBe("gpt-5.5");
+    expect(body.stream).toBe(true);
+    expect(body.store).toBe(false);
+    expect(body.tools[0]).toMatchObject({
+      type: "image_generation",
+      size: "1024x1024",
+      quality: "low",
+      output_format: "png",
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The Codex chat path already honours `service_tier: "fast"` — `CodexExecutor.transformRequest()` maps it to the backend's `"priority"` tier ([`open-sse/executors/codex.js`](https://github.com/decolua/9router/blob/master/open-sse/executors/codex.js)).

Image generation does not. `imageProviders/codex.js` builds its own Responses payload in `buildBody()` and never sets `service_tier`, so a fast-tier text-to-image request against `gpt-5.5-image` (or `gpt-5.4-image` / `gpt-5.3-image`) is silently downgraded to the standard tier. `service_tier` is already in `RESPONSES_API_ALLOWLIST` and both paths POST to the same `chatgpt.com/backend-api/codex/responses` endpoint, so the field was simply being dropped on the image side.

## Change

- Add `open-sse/shared/codexServiceTier.js` with `normalizeCodexServiceTier()`, and use it from **both** the executor and the image adapter so the two paths can't drift apart.
- Unknown tiers are dropped rather than forwarded — an unrecognized `service_tier` makes the backend reject the whole request with `routing_unsupported`. This preserves the executor's previous behaviour exactly.
- Expose `service_tier` in the `params` list of the three Codex image models.
- Add a "Speed" selector to the image example card in the dashboard.

Behaviour is opt-in: with no `service_tier` the payload is byte-identical to before.

## Testing

New `tests/unit/codex-image-service-tier.test.js` (17 cases) covers the normalizer (case/whitespace handling, rejection of `flex`/`default`/non-strings) and the adapter payload (fast → priority, omission when absent, unknown tier dropped, rest of the payload untouched).

```
npx vitest run unit/codex-image-service-tier.test.js unit/codex-fast-capacity.test.js unit/capabilities.test.js
Test Files  3 passed (3)
     Tests  32 passed (32)
```

The pre-existing `unit/codex-fast-capacity.test.js` still passes, confirming the executor refactor is behaviour-preserving.

Full-suite comparison before vs. after this branch, on the same checkout:

| | before | after |
|---|---|---|
| failed | 88 | 88 |
| passed | 1656 | 1673 |

Same 24 failing files in both runs — all pre-existing per `CLAUDE.md`. The +17 are this PR's new tests. `npx eslint` on the touched files reports 0 errors. Provider/alias baselines are unaffected (`params` is not snapshotted; `verify-alias.mjs` is byte-for-byte equal, and the one `verify-providers.mjs` diff — `tokenrouter.thinkingFormat` — reproduces on master without this branch).

## Note

I could not exercise this against a live ChatGPT Plus account, so the wire-level assertion that the image endpoint honours `service_tier` the same way the chat endpoint does is unverified. The field is already allowlisted for the same endpoint on the chat path, and the change is inert unless a caller opts in.

Codex is flagged `deprecated: true` in the registry — happy to close this if the provider isn't taking new features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
