### PR TITLE
feat(usage): live Sessions tab + CLI custom URL presets

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -11,7 +11,7 @@ import { PROVIDERS } from "../config/providers.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
 import { HTTP_STATUS, TOKEN_SAVER_HEADER } from "../config/runtimeConfig.js";
 import { handleBypassRequest } from "../utils/bypassHandler.js";
-import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
+import { trackPendingRequest, appendRequestLog, saveRequestDetail, trackActiveSession } from "@/lib/usageDb.js";
 import { getExecutor } from "../executors/index.js";
 import { supportsGrokCliReasoningEffort } from "../config/grokCli.js";
 import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDetail.js";
@@ -72,9 +72,20 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const sourceFormat = sourceFormatOverride || detectFormat(body);
 
-  // Check for bypass patterns (warmup, skip, cc naming)
+  // Check for bypass patterns (warmup, skip, cc naming) BEFORE tracking — these
+  // return early and never reach completion, so they must not create a session
+  // row that would linger as a phantom "active" entry on the dashboard.
   const bypassResponse = handleBypassRequest(body, model, userAgent, ccFilterNaming);
   if (bypassResponse) return bypassResponse;
+
+  // Track as an active (concurrent) session for the dashboard. clientId is the
+  // real client IP stamped by custom-server.js (x-9r-real-ip); sessionId is the
+  // conversation-stable id resolved above. Fail-open: never blocks the request.
+  try {
+    const h = clientRawRequest?.headers || {};
+    const clientId = h["x-9r-real-ip"] || h["x-real-ip"] || h["x-forwarded-for"] || "unknown";
+    trackActiveSession({ clientId, sessionId: sessionSeed, model, provider, connectionId });
+  } catch { /* dashboard tracking must never break a request */ }
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
   const modelTargetFormat = getModelTargetFormat(alias, model);

--- a/src/app/(dashboard)/dashboard/cli-tools/components/BaseUrlSelect.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/BaseUrlSelect.js
@@ -61,7 +61,9 @@ const buildOptions = ({ requiresExternalUrl, tunnelEnabled, tunnelPublicUrl, tai
     opts.push({ value: "cloud", label: u, url: u });
   }
   savedPresets.forEach((p) => {
-    opts.push({ value: `saved:${p.name}`, label: p.baseUrl, url: p.baseUrl, saved: true });
+    const url = p.baseUrl;
+    const label = p.name === url ? url : `${p.name} — ${url}`;
+    opts.push({ value: `saved:${p.name}`, label, url, saved: true });
   });
   opts.push({ value: CUSTOM_VALUE, label: "Custom URL...", url: "" });
   return opts;
@@ -116,10 +118,13 @@ export default function BaseUrlSelect({
       try { defaultName = new URL(trimmed).host; } catch {}
       const name = window.prompt("Save endpoint as:", defaultName);
       if (!name?.trim()) return;
-      const updated = [...savedPresets.filter((p) => p.name !== name.trim()), { name: name.trim(), baseUrl: trimmed }]
+      const savedName = name.trim();
+      const updated = [...savedPresets.filter((p) => p.name !== savedName), { name: savedName, baseUrl: trimmed }]
         .sort((a, b) => a.name.localeCompare(b.name));
       setSavedPresets(updated);
       writeSavedPresets(updated);
+      setMode(`saved:${savedName}`);
+      onChange(trimmed);
       return;
     }
     setMode(next);

--- a/src/app/(dashboard)/dashboard/cli-tools/components/BaseUrlSelect.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/BaseUrlSelect.js
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
 
 const STORAGE_KEY = "9router.cliToolEndpointPresets";
+const CUSTOM_LAST_KEY = "9router.cliToolEndpointCustom";
 const CUSTOM_VALUE = "__custom__";
 const SAVE_VALUE = "__save__";
 
@@ -27,6 +28,17 @@ const readSavedPresets = () => {
 const writeSavedPresets = (presets) => {
   if (typeof window === "undefined") return;
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+};
+
+// Remember the last manually-entered custom URL so re-selecting "Custom URL..."
+// repopulates the field instead of showing a blank input.
+const readLastCustom = () => {
+  if (typeof window === "undefined") return "";
+  try { return window.localStorage.getItem(CUSTOM_LAST_KEY) || ""; } catch { return ""; }
+};
+const writeLastCustom = (url) => {
+  if (typeof window === "undefined") return;
+  try { window.localStorage.setItem(CUSTOM_LAST_KEY, url || ""); } catch { /* noop */ }
 };
 
 const buildOptions = ({ requiresExternalUrl, tunnelEnabled, tunnelPublicUrl, tailscaleEnabled, tailscaleUrl, cloudEnabled, cloudUrl, savedPresets, withV1 }) => {
@@ -112,8 +124,16 @@ export default function BaseUrlSelect({
     }
     setMode(next);
     if (next === CUSTOM_VALUE) {
-      setCustomInput("");
-      onChange("");
+      // Prefer the current selected URL (so switching from Local/Tunnel keeps
+      // that value in the input), then the last remembered custom, else blank.
+      const seed = (value || "").trim() || readLastCustom();
+      setCustomInput(seed);
+      if (seed) {
+        writeLastCustom(seed);
+        onChange(seed);
+      } else {
+        onChange("");
+      }
       return;
     }
     const opt = options.find((o) => o.value === next);
@@ -124,6 +144,7 @@ export default function BaseUrlSelect({
     const v = e.target.value;
     setCustomInput(v);
     onChange(v);
+    if (v.trim()) writeLastCustom(v.trim());
   };
 
   const handleDeleteSaved = () => {
@@ -132,9 +153,10 @@ export default function BaseUrlSelect({
     const updated = savedPresets.filter((p) => p.name !== name);
     setSavedPresets(updated);
     writeSavedPresets(updated);
+    const seed = (value || "").trim() || readLastCustom();
     setMode(CUSTOM_VALUE);
-    setCustomInput("");
-    onChange("");
+    setCustomInput(seed);
+    onChange(seed);
   };
 
   const isSaved = mode.startsWith("saved:");

--- a/src/app/(dashboard)/dashboard/usage/components/RequestsPanel.js
+++ b/src/app/(dashboard)/dashboard/usage/components/RequestsPanel.js
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Card from "@/shared/components/Card";
+import { fmt } from "./UsageTable";
+
+// Auto-update relative time / duration displays every second without
+// re-rendering the parent (UsageStats).
+function useTickEverySecond() {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+}
+
+function timeAgo(timestamp) {
+  if (!timestamp) return "—";
+  const diff = Math.floor((Date.now() - new Date(timestamp).getTime()) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function fmtDuration(ms) {
+  if (ms == null) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.floor(s % 60);
+  return `${m}m${rem}s`;
+}
+
+const PANEL_TABS = [
+  { value: "recent", label: "Recent Requests" },
+  { value: "sessions", label: "Sessions" },
+];
+
+/**
+ * Small tabbed card that lives where the old Recent Requests panel sat.
+ * Tab 1: Recent Requests (recent per-request tallies).
+ * Tab 2: Concurrent Sessions (in-flight + just-finished requests with
+ *        client id / session id / model / in / out tokens).
+ *
+ * @param {object} props
+ * @param {Array}  props.recentRequests  - stats.recentRequests
+ * @param {Array}  props.activeSessions  - stats.activeSessions
+ */
+export default function RequestsPanel({ recentRequests = [], activeSessions = [] }) {
+  const [tab, setTab] = useState("recent");
+  useTickEverySecond();
+
+  return (
+    <Card className="flex min-w-0 flex-col overflow-hidden" padding="sm" style={{ height: 480 }}>
+      {/* Tab header */}
+      <div className="flex items-center justify-between px-1 py-2 border-b border-border shrink-0 gap-2">
+        <div className="flex items-center gap-1">
+          {PANEL_TABS.map((t) => (
+            <button
+              key={t.value}
+              onClick={() => setTab(t.value)}
+              className={`rounded-md px-2.5 py-1 text-xs font-semibold uppercase tracking-wide transition-colors ${
+                tab === t.value
+                  ? "bg-primary/10 text-primary"
+                  : "text-text-muted hover:bg-bg-subtle hover:text-text"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        {tab === "sessions" && (
+          <span className="text-[11px] text-text-muted whitespace-nowrap">
+            {activeSessions.filter((s) => s.status === "active").length} active
+          </span>
+        )}
+      </div>
+
+      {tab === "recent" ? (
+        <RecentRequestsView requests={recentRequests} />
+      ) : (
+        <SessionsView sessions={activeSessions} />
+      )}
+    </Card>
+  );
+}
+
+function RecentRequestsView({ requests = [] }) {
+  if (!requests.length) {
+    return <div className="flex-1 flex items-center justify-center text-text-muted text-sm">No requests yet.</div>;
+  }
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <table className="w-full min-w-[300px] border-collapse text-xs">
+        <thead className="sticky top-0 bg-bg z-10">
+          <tr className="border-b border-border">
+            <th className="py-1.5 text-left font-semibold text-text-muted w-2"></th>
+            <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
+            <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
+            <th className="py-1.5 text-right font-semibold text-text-muted">When</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/50">
+          {requests.map((r, i) => {
+            const ok = !r.status || r.status === "ok" || r.status === "success";
+            return (
+              <tr key={i} className="hover:bg-bg-subtle transition-colors">
+                <td className="py-1.5">
+                  <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} />
+                </td>
+                <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
+                <td className="py-1.5 text-right whitespace-nowrap">
+                  <span className="text-primary">{fmt(r.promptTokens)}↑</span>{" "}
+                  <span className="text-success">{fmt(r.completionTokens)}↓</span>
+                </td>
+                <td className="py-1.5 text-right text-text-muted whitespace-nowrap">{timeAgo(r.timestamp)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Ended (done / error / disconnected) rows stay visible for this long so the
+// user can read the final in/out tally, then are hidden. Active rows always show.
+const ENDED_VISIBILITY_MS = 15 * 1000;
+
+function SessionsView({ sessions = [] }) {
+  // useTickEverySecond (from parent) drives re-evaluation of the 15s cutoff.
+  const now = Date.now();
+  const visible = sessions.filter((s) => {
+    if (s.status === "active") return true;
+    if (!s.completedAt) return true; // not stamped yet — keep until we know
+    return now - s.completedAt < ENDED_VISIBILITY_MS;
+  });
+
+  if (!visible.length) {
+    return <div className="flex-1 flex items-center justify-center text-text-muted text-sm">No active sessions.</div>;
+  }
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <table className="w-full min-w-[320px] border-collapse text-xs">
+        <thead className="sticky top-0 bg-bg z-10">
+          <tr className="border-b border-border">
+            <th className="py-1.5 text-left font-semibold text-text-muted w-2"></th>
+            <th className="py-1.5 text-left font-semibold text-text-muted">Client IP</th>
+            <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
+            <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/50">
+          {visible.map((s) => {
+            const isActive = s.status === "active";
+            const isError = s.status === "error";
+            const dot = isError ? "bg-error" : isActive ? "bg-primary animate-pulse" : "bg-success";
+            const hasTokens = !(s.promptTokens == null && s.completionTokens == null);
+            return (
+              <tr key={s.requestId} className="hover:bg-bg-subtle transition-colors">
+                <td className="py-1.5">
+                  <span className={`block w-1.5 h-1.5 rounded-full ${dot}`} title={fmtDuration(s.durationMs)} />
+                </td>
+                <td className="py-1.5 font-mono truncate max-w-[110px]" title={s.clientId}>{s.clientId}</td>
+                <td className="py-1.5 font-mono truncate max-w-[140px]" title={`${s.model} · ${s.provider}`}>{s.model}</td>
+                <td className="py-1.5 text-right whitespace-nowrap">
+                  {hasTokens ? (
+                    <>
+                      <span className="text-primary">{fmt(s.promptTokens)}↑</span>{" "}
+                      <span className="text-success">{fmt(s.completionTokens)}↓</span>
+                    </>
+                  ) : "—"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/api/usage/stream/route.js
+++ b/src/app/api/usage/stream/route.js
@@ -14,8 +14,8 @@ export async function GET() {
         try {
           // Push lightweight update immediately so UI reflects changes fast
           if (state.cachedStats) {
-            const { activeRequests, recentRequests, errorProvider } = await getActiveRequests();
-            const quickStats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider };
+            const { activeRequests, activeSessions, recentRequests, errorProvider } = await getActiveRequests();
+            const quickStats = { ...state.cachedStats, activeRequests, activeSessions, recentRequests, errorProvider };
             controller.enqueue(encoder.encode(`data: ${JSON.stringify(quickStats)}\n\n`));
           }
           // Then do full recalc and update cache
@@ -30,12 +30,12 @@ export async function GET() {
         }
       };
 
-      // Lightweight push: only refresh activeRequests + recentRequests on pending changes
+      // Lightweight push: refresh activeRequests + activeSessions + recentRequests on pending changes
       state.sendPending = async () => {
         if (state.closed || !state.cachedStats) return;
         try {
-          const { activeRequests, recentRequests, errorProvider } = await getActiveRequests();
-          const stats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider };
+          const { activeRequests, activeSessions, recentRequests, errorProvider } = await getActiveRequests();
+          const stats = { ...state.cachedStats, activeRequests, activeSessions, recentRequests, errorProvider };
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
         } catch {
           state.closed = true;

--- a/src/lib/db/index.js
+++ b/src/lib/db/index.js
@@ -58,6 +58,7 @@ export {
 // Usage
 export {
   statsEmitter, trackPendingRequest, getActiveRequests,
+  trackActiveSession, getActiveSessions,
   saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
 } from "./repos/usageRepo.js";

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from "events";
+import crypto from "crypto";
 import { getAdapter } from "../driver.js";
 import { parseJson, stringifyJson } from "../helpers/jsonCol.js";
 import { getMeta, setMeta } from "../helpers/metaStore.js";
@@ -14,6 +15,13 @@ const RING_CAP = 50;
 const CONN_CACHE_TTL_MS = 30 * 1000;
 const PERIOD_MS = { "24h": 86400000, "7d": 604800000, "30d": 2592000000, "60d": 5184000000 };
 
+// Active (concurrent) sessions: in-flight + just-finished requests keyed by requestId.
+// Token counts are back-filled from saveRequestUsage on completion; rows linger briefly
+// so the dashboard can show the final in/out tallies before evicting.
+const ACTIVE_SESSION_TTL_MS = 120 * 1000;       // safety evict if completion never recorded
+const ACTIVE_SESSION_DONE_LINGER_MS = 20 * 1000; // keep finished rows visible so user sees tokens
+const ACTIVE_SESSION_CAP = 200;
+
 // In-memory state shared across Next.js modules
 if (!global._pendingRequests) global._pendingRequests = { byModel: {}, byAccount: {} };
 if (!global._lastErrorProvider) global._lastErrorProvider = { provider: "", ts: 0 };
@@ -25,6 +33,8 @@ if (!global._pendingTimers) global._pendingTimers = {};
 if (!global._recentRing) global._recentRing = { items: [], initialized: false };
 if (!global._connectionMapCache) global._connectionMapCache = { map: {}, ts: 0 };
 if (!global._statsEmitTimers) global._statsEmitTimers = { pending: null, update: null };
+if (!global._activeSessions) global._activeSessions = new Map();
+if (!global._activeSessionTimers) global._activeSessionTimers = {};
 
 const pendingRequests = global._pendingRequests;
 const lastErrorProvider = global._lastErrorProvider;
@@ -32,6 +42,8 @@ const pendingTimers = global._pendingTimers;
 const recentRing = global._recentRing;
 const connCache = global._connectionMapCache;
 const statsEmitTimers = global._statsEmitTimers;
+const activeSessions = global._activeSessions;
+const activeSessionTimers = global._activeSessionTimers;
 
 export const statsEmitter = global._statsEmitter;
 
@@ -187,10 +199,118 @@ export function trackPendingRequest(model, provider, connectionId, started, erro
   if (!started && error && provider) {
     lastErrorProvider.provider = provider.toLowerCase();
     lastErrorProvider.ts = Date.now();
+    stampActiveSession({ provider, model, connectionId, status: "error" });
   }
 
   // [PENDING] console line removed; lifecycle is visible via "▶" and "📊 done" lines
   scheduleStatsEvent("pending");
+}
+
+// ---- Active (concurrent) sessions ----
+// One row per in-flight request. Completion tokens are back-filled from
+// saveRequestUsage; errors are stamped from trackPendingRequest(error=true).
+// Everything here is fail-open: a throw must never escape, since these run
+// inline on the request hot path.
+
+function newRequestId() {
+  try { return crypto.randomUUID(); } catch { return Math.random().toString(36).slice(2) + Date.now().toString(36); }
+}
+
+function evictActiveSession(requestId) {
+  activeSessions.delete(requestId);
+  const t = activeSessionTimers[requestId];
+  if (t) { clearTimeout(t); delete activeSessionTimers[requestId]; }
+}
+
+function scheduleActiveSessionEviction(requestId, delayMs) {
+  clearTimeout(activeSessionTimers[requestId]);
+  const timer = setTimeout(() => {
+    delete activeSessionTimers[requestId];
+    activeSessions.delete(requestId);
+    scheduleStatsEvent("pending");
+  }, delayMs);
+  if (timer.unref) timer.unref();
+  activeSessionTimers[requestId] = timer;
+}
+
+export function trackActiveSession({ clientId, sessionId, model, provider, connectionId } = {}) {
+  try {
+    const requestId = newRequestId();
+    if (activeSessions.size >= ACTIVE_SESSION_CAP) {
+      const oldest = activeSessions.keys().next().value;
+      if (oldest) evictActiveSession(oldest);
+    }
+    activeSessions.set(requestId, {
+      requestId,
+      clientId: clientId || "unknown",
+      sessionId: sessionId || "",
+      model: model || "unknown",
+      provider: (provider || "unknown").toLowerCase(),
+      connectionId: connectionId || null,
+      startedAt: Date.now(),
+      completedAt: null,
+      durationMs: 0,
+      promptTokens: null,
+      completionTokens: null,
+      status: "active",
+    });
+    scheduleActiveSessionEviction(requestId, ACTIVE_SESSION_TTL_MS);
+    scheduleStatsEvent("pending");
+    return requestId;
+  } catch {
+    return null;
+  }
+}
+
+// FIFO-match the oldest still-tokenless row for this key and stamp it.
+// Used by saveRequestUsage (success) and trackPendingRequest(error) alike.
+function stampActiveSession({ provider, model, connectionId, promptTokens, completionTokens, status }) {
+  try {
+    const prov = (provider || "").toLowerCase();
+    let target = null;
+    for (const entry of activeSessions.values()) {
+      if (entry.promptTokens !== null && status !== "error") continue; // already stamped
+      if (status === "error" && entry.status === "error") continue;
+      if (entry.provider !== prov) continue;
+      if (model && entry.model !== model) continue;
+      if (connectionId && entry.connectionId && entry.connectionId !== connectionId) continue;
+      target = entry; break; // Map iterates insertion order → oldest first
+    }
+    if (!target) return;
+    target.promptTokens = promptTokens ?? target.promptTokens;
+    target.completionTokens = completionTokens ?? target.completionTokens;
+    target.completedAt = Date.now();
+    target.durationMs = target.completedAt - target.startedAt;
+    target.status = status || "done";
+    scheduleActiveSessionEviction(target.requestId, ACTIVE_SESSION_DONE_LINGER_MS);
+    scheduleStatsEvent("pending");
+  } catch { /* fail-open */ }
+}
+
+export async function getActiveSessions() {
+  const connectionMap = await getConnectionMapCached();
+  const now = Date.now();
+  const rows = [];
+  for (const e of activeSessions.values()) {
+    rows.push({
+      requestId: e.requestId,
+      clientId: e.clientId,
+      sessionId: e.sessionId,
+      model: e.model,
+      provider: e.provider,
+      account: e.connectionId
+        ? (connectionMap[e.connectionId] || `Account ${String(e.connectionId).slice(0, 8)}...`)
+        : null,
+      startedAt: e.startedAt,
+      completedAt: e.completedAt,
+      durationMs: e.completedAt ? e.durationMs : (now - e.startedAt),
+      promptTokens: e.promptTokens,
+      completionTokens: e.completionTokens,
+      status: e.status,
+    });
+  }
+  rows.sort((a, b) => b.startedAt - a.startedAt);
+  return rows;
 }
 
 export async function getActiveRequests() {
@@ -235,7 +355,8 @@ export async function getActiveRequests() {
     .slice(0, 20);
 
   const errorProvider = (Date.now() - lastErrorProvider.ts < 10000) ? lastErrorProvider.provider : "";
-  return { activeRequests, recentRequests, errorProvider };
+  const sessions = await getActiveSessions();
+  return { activeRequests, recentRequests, errorProvider, activeSessions: sessions };
 }
 
 export async function saveRequestUsage(entry) {
@@ -306,6 +427,10 @@ export async function saveRequestUsage(entry) {
 
     if (inserted) {
       pushToRing(entry);
+      stampActiveSession({
+        provider: entry.provider, model: entry.model, connectionId: entry.connectionId,
+        promptTokens, completionTokens, status: "done",
+      });
       scheduleStatsEvent("update", 250);
     }
   } catch (e) {
@@ -399,6 +524,7 @@ export async function getUsageStats(period = "all") {
     last10Minutes: [],
     pending: pendingRequests,
     activeRequests: [],
+    activeSessions: [],
     recentRequests,
     errorProvider: (Date.now() - lastErrorProvider.ts < 10000) ? lastErrorProvider.provider : "",
   };
@@ -417,6 +543,7 @@ export async function getUsageStats(period = "all") {
       }
     }
   }
+  stats.activeSessions = await getActiveSessions();
 
   // last10Minutes — query 10min window
   const now = new Date();

--- a/src/lib/usageDb.js
+++ b/src/lib/usageDb.js
@@ -1,6 +1,7 @@
 // Shim → re-export from new SQLite-based DB layer (src/lib/db/)
 export {
   statsEmitter, trackPendingRequest, getActiveRequests,
+  trackActiveSession, getActiveSessions,
   saveRequestUsage, getUsageHistory, getUsageStats, getChartData,
   appendRequestLog, getRecentLogs,
   saveRequestDetail, getRequestDetails, getRequestDetailById,

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -18,73 +18,7 @@ import dynamic from "next/dynamic";
 // Lazy-load: keeps @xyflow/react out of the shared bundle until topology renders
 const ProviderTopology = dynamic(() => import("@/app/(dashboard)/dashboard/usage/components/ProviderTopology"), { ssr: false });
 import UsageChart from "@/app/(dashboard)/dashboard/usage/components/UsageChart";
-
-function timeAgo(timestamp) {
-  const diff = Math.floor((Date.now() - new Date(timestamp)) / 1000);
-  if (diff < 60) return `${diff}s ago`;
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
-  return `${Math.floor(diff / 86400)}d ago`;
-}
-
-// Auto-update time display every second without re-rendering parent
-function TimeAgo({ timestamp }) {
-  const [, setTick] = useState(0);
-  
-  useEffect(() => {
-    const timer = setInterval(() => setTick(t => t + 1), 1000);
-    return () => clearInterval(timer);
-  }, []);
-  
-  return <>{timeAgo(timestamp)}</>;
-}
-
-function RecentRequests({ requests = [] }) {
-  return (
-    <Card className="flex min-w-0 flex-col overflow-hidden" padding="sm" style={{ height: 480 }}>
-      {/* Header */}
-      <div className="px-1 py-2 border-b border-border shrink-0">
-        <span className="text-xs font-semibold text-text-muted uppercase tracking-wide">Recent Requests</span>
-      </div>
-
-      {!requests.length ? (
-        <div className="flex-1 flex items-center justify-center text-text-muted text-sm">No requests yet.</div>
-      ) : (
-        <div className="flex-1 overflow-y-auto">
-          <table className="w-full min-w-[300px] border-collapse text-xs">
-            <thead className="sticky top-0 bg-bg z-10">
-              <tr className="border-b border-border">
-                <th className="py-1.5 text-left font-semibold text-text-muted w-2"></th>
-                <th className="py-1.5 text-left font-semibold text-text-muted">Model</th>
-                <th className="py-1.5 text-right font-semibold text-text-muted whitespace-nowrap">In / Out</th>
-                <th className="py-1.5 text-right font-semibold text-text-muted">When</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border/50">
-              {requests.map((r, i) => {
-                const ok = !r.status || r.status === "ok" || r.status === "success";
-                return (
-                  <tr key={i} className="hover:bg-bg-subtle transition-colors">
-                    <td className="py-1.5">
-                      <span className={`block w-1.5 h-1.5 rounded-full ${ok ? "bg-success" : "bg-error"}`} />
-                    </td>
-                    <td className="py-1.5 font-mono truncate max-w-[120px]" title={r.model}>{r.model}</td>
-                    <td className="py-1.5 text-right whitespace-nowrap">
-                      <span className="text-primary">{fmt(r.promptTokens)}↑</span>
-                      {" "}
-                      <span className="text-success">{fmt(r.completionTokens)}↓</span>
-                    </td>
-                    <td className="py-1.5 text-right text-text-muted whitespace-nowrap"><TimeAgo timestamp={r.timestamp} /></td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </Card>
-  );
-}
+import RequestsPanel from "@/app/(dashboard)/dashboard/usage/components/RequestsPanel";
 
 function sortData(dataMap, pendingMap = {}, sortBy, sortOrder) {
   return Object.entries(dataMap || {})
@@ -276,7 +210,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       });
   }, [period]);
 
-  // SSE connection - real-time updates for activeRequests + recentRequests only
+  // SSE connection - real-time updates for activeRequests, activeSessions, recentRequests
   useEffect(() => {
     const es = new EventSource("/api/usage/stream");
 
@@ -289,6 +223,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
           return {
             ...prev,
             activeRequests: data.activeRequests,
+            activeSessions: data.activeSessions,
             recentRequests: data.recentRequests,
             errorProvider: data.errorProvider,
             pending: data.pending,
@@ -467,7 +402,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       {/* Overview cards */}
       {loading ? spinner : <OverviewCards stats={stats} />}
 
-      {/* Provider topology + Recent Requests */}
+      {/* Provider topology + tabbed requests panel (Recent Requests | Concurrent Sessions) */}
       {loading ? spinner : (
         <div className="grid min-w-0 grid-cols-1 items-stretch gap-2 lg:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)]">
           <ProviderTopology
@@ -476,7 +411,10 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
             lastProvider={stats.recentRequests?.[0]?.provider || ""}
             errorProvider={stats.errorProvider || ""}
           />
-          <RecentRequests requests={stats.recentRequests || []} />
+          <RequestsPanel
+            recentRequests={stats.recentRequests || []}
+            activeSessions={stats.activeSessions || []}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Add a **Sessions** tab next to Recent Requests on `/dashboard/usage`. In-flight requests show client IP, model, and in/out tokens via the existing usage SSE. Bypass/warmup probes are skipped; ended/error rows hide after 15s in the UI. Dashboard tracking is fail-open and does not affect the real stream.
- Prefill **Custom URL** in CLI tools (`BaseUrlSelect`) with the currently selected endpoint, then the last remembered custom URL from localStorage.
- Saved endpoint presets now display as `name — url` and the new preset is selected immediately after save.

## Test plan
- [ ] Open `/dashboard/usage` → Overview panel next to topology has Recent Requests | Sessions tabs
- [ ] Start a chat request → Sessions shows a pulsing row with client IP + model; tokens fill on completion
- [ ] Confirm warmup/naming probes do not create phantom Sessions rows
- [ ] Ended rows disappear from Sessions after ~15s; long streams are not aborted by this UI
- [ ] Open `/dashboard/cli-tools/claude` → pick Custom URL → field is prefilled, not blank
- [ ] Type a custom URL, leave and re-select Custom URL → last value is restored
- [ ] Save current as a named preset → dropdown shows `name — url` and selects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)