### PR TITLE
fix(cursor): tunnel AgentService through HTTP/2 proxy so vendor models stream

### DIFF
--- a/open-sse/executors/cursor.js
+++ b/open-sse/executors/cursor.js
@@ -14,7 +14,8 @@ import { estimateUsage } from "../utils/usageTracking.js";
 import { SSE_DONE, SSE_HEADERS } from "../utils/sseConstants.js";
 import { chatChunkSse, sseChunk } from "../utils/sse.js";
 import { FORMATS } from "../translator/formats.js";
-import { proxyAwareFetch } from "../utils/proxyFetch.js";
+import { proxyAwareFetch, resolveOutboundProxyUrl } from "../utils/proxyFetch.js";
+import { connectHttp2 } from "../utils/http2Connect.js";
 import zlib from "zlib";
 import crypto from "crypto";
 
@@ -46,6 +47,15 @@ const AGENT_RUN_PATH = "/agent.v1.AgentService/Run";
 const PROTOBUF_LEN = 2;
 const PROTOBUF_VARINT = 0;
 
+function maskProxyUrl(proxyUrl) {
+  try {
+    const parsed = new URL(proxyUrl);
+    return `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ""}`;
+  } catch {
+    return "proxy";
+  }
+}
+
 function concatBuffers(...parts) {
   const length = parts.reduce((total, part) => total + part.length, 0);
   const result = new Uint8Array(length);
@@ -59,7 +69,6 @@ function concatBuffers(...parts) {
 
 const agentString = (field, value) => encodeField(field, PROTOBUF_LEN, value);
 const agentMessage = (field, value) => encodeField(field, PROTOBUF_LEN, value);
-const agentBool = (field, value) => encodeField(field, PROTOBUF_VARINT, value ? 1 : 0);
 
 function textFromContent(content) {
   if (typeof content === "string") return content;
@@ -68,6 +77,17 @@ function textFromContent(content) {
     .filter((part) => part?.type === "text" && typeof part.text === "string")
     .map((part) => part.text)
     .join("\n");
+}
+
+// Cursor's live GetUsableModels catalog has no `claude-fable-*-fast` slugs.
+// `-fast` is a real speed-tier id for Opus / GPT / Grok; sending it as Fable's
+// RequestedModel.model_id yields HTTP 200 and an empty Agent stream.
+export function resolveCursorAgentModel(model) {
+  if (typeof model !== "string") return model;
+  if (model.includes("claude-fable-") && model.endsWith("-fast")) {
+    return model.slice(0, -"-fast".length);
+  }
+  return model;
 }
 
 function isAgentTextRequest(body) {
@@ -123,7 +143,8 @@ function buildAgentRunFrame(messages, model) {
     ...(conversationHistory ? [agentMessage(7, conversationHistory)] : []),
   );
   const conversationAction = agentMessage(1, userAction);
-  const requestedModel = concatBuffers(agentString(1, model), agentBool(7, true));
+  // RequestedModel.model_id only. Field 7 is Bedrock credentials, not a bool flag.
+  const requestedModel = agentString(1, model);
   const runRequest = concatBuffers(
     // An empty ConversationStateStructure starts a fresh local agent session.
     agentMessage(1, new Uint8Array()),
@@ -164,6 +185,42 @@ function createRequestContextResponse() {
   const requestContextResult = agentMessage(1, requestContextSuccess);
   const execClientMessage = agentMessage(10, requestContextResult);
   return wrapConnectRPCFrame(agentMessage(2, execClientMessage));
+}
+
+function blobStoreKey(blobId) {
+  return Buffer.from(blobId || []).toString("hex");
+}
+
+function createKvClientFrame(kvId, resultField, resultMessage) {
+  const parts = [];
+  if (Number.isFinite(kvId)) {
+    parts.push(encodeField(1, PROTOBUF_VARINT, kvId));
+  }
+  parts.push(agentMessage(resultField, resultMessage));
+  return wrapConnectRPCFrame(agentMessage(3, concatBuffers(...parts)));
+}
+
+// AgentService field 4 (kv_server_message) is a blob store handshake.
+// Claude / GPT wait for get/set acks; ignoring them leaves only heartbeats.
+function handleKvServerMessage(kvMessage, blobStore) {
+  const kvId = kvMessage.has(1) ? kvMessage.get(1)[0].value : undefined;
+  if (kvMessage.has(2)) {
+    const args = decodeMessage(kvMessage.get(2)[0].value);
+    const blobId = args.get(1)?.[0]?.value;
+    const data = blobId ? blobStore.get(blobStoreKey(blobId)) : null;
+    const result = data?.length ? agentMessage(1, data) : new Uint8Array();
+    return createKvClientFrame(kvId, 2, result);
+  }
+  if (kvMessage.has(3)) {
+    const args = decodeMessage(kvMessage.get(3)[0].value);
+    const blobId = args.get(1)?.[0]?.value;
+    const blobData = args.get(2)?.[0]?.value;
+    if (blobId && blobData) {
+      blobStore.set(blobStoreKey(blobId), Buffer.from(blobData));
+    }
+    return createKvClientFrame(kvId, 3, new Uint8Array());
+  }
+  return null;
 }
 
 const CURSOR_STREAM_DEBUG = process.env.CURSOR_STREAM_DEBUG === "1";
@@ -385,13 +442,25 @@ export class CursorExecutor extends BaseExecutor {
    * AgentService (agent.api5.cursor.sh) is HTTP/2-only. Node's fetch/undici speaks
    * HTTP/1.1 and fails with HTTPParserError on the h2 preface — use http2 duplex.
    */
-  openAgentHttp2Stream(url, headers, signal) {
+  async openAgentHttp2Stream(url, headers, signal, proxyOptions = null) {
     if (!http2) {
       throw new Error("HTTP/2 is required for Cursor AgentService (endpoint is h2-only)");
     }
 
     const urlObj = new URL(url);
-    const client = http2.connect(`https://${urlObj.host}`);
+    // AgentService is h2-only and http2.connect() ignores every proxy setting.
+    // Cursor gates its model catalog by client IP, so a direct session silently
+    // downgrades the account to the local-region models (see utils/http2Connect.js).
+    const proxyUrl = resolveOutboundProxyUrl(url, proxyOptions);
+    if (proxyOptions?.connectionProxyEnabled === true && !proxyUrl) {
+      throw new Error("Cursor AgentService proxy is bound but could not be resolved");
+    }
+    if (proxyUrl) {
+      console.info("CURSOR_AGENT", `Run via HTTP/2 proxy ${maskProxyUrl(proxyUrl)}`);
+    } else {
+      console.warn("CURSOR_AGENT", "Run via direct HTTP/2 (no proxy) — Cursor will gate models by this machine's IP");
+    }
+    const client = await connectHttp2(url, { proxyUrl });
     const chunkQueue = [];
     let waiting = null;
     let ended = false;
@@ -479,9 +548,13 @@ export class CursorExecutor extends BaseExecutor {
     };
   }
 
-  async executeAgent({ model, body, stream, credentials, signal }) {
+  async executeAgent({ model, body, stream, credentials, signal, proxyOptions = null, log = null }) {
     const agentEndpoint = PROVIDER_OAUTH.cursor?.agentEndpoint;
     if (!agentEndpoint) throw new Error("Cursor AgentService endpoint is not configured");
+    const agentModel = resolveCursorAgentModel(model);
+    if (agentModel !== model) {
+      console.info("CURSOR_AGENT", `resolved ${model} → ${agentModel}`);
+    }
 
     const url = `${agentEndpoint}${AGENT_RUN_PATH}`;
     const headers = this.buildHeaders(credentials);
@@ -492,8 +565,8 @@ export class CursorExecutor extends BaseExecutor {
 
     let session;
     try {
-      session = this.openAgentHttp2Stream(url, headers, requestController.signal);
-      session.write(buildAgentRunFrame(body.messages || [], model));
+      session = await this.openAgentHttp2Stream(url, headers, requestController.signal, proxyOptions);
+      session.write(buildAgentRunFrame(body.messages || [], agentModel));
     } catch (error) {
       throw new Error(`Cursor AgentService request failed: ${error.message}`);
     }
@@ -535,8 +608,11 @@ export class CursorExecutor extends BaseExecutor {
     const created = Math.floor(Date.now() / 1000);
     let pending = Buffer.alloc(0);
     let finished = false;
+    const agentStats = { frames: 0, textChars: 0, updateFields: new Set(), serverFields: new Set() };
+    const blobStore = new Map();
 
     const consume = async (onEvent) => {
+      let consumeError = null;
       try {
         while (!finished) {
           const { done, value } = await session.read();
@@ -547,13 +623,23 @@ export class CursorExecutor extends BaseExecutor {
             // rest of the batch must not reach the already-closed controller.
             if (finished) return;
             const serverMessage = decodeMessage(payload);
+            agentStats.frames += 1;
+            for (const key of serverMessage.keys()) agentStats.serverFields.add(key);
 
             // agent.v1.AgentServerMessage.interaction_update
             if (serverMessage.has(1)) {
               const update = decodeMessage(serverMessage.get(1)[0].value);
+              for (const key of update.keys()) agentStats.updateFields.add(key);
               if (update.has(1)) {
                 const textDelta = extractAgentString(decodeMessage(update.get(1)[0].value), 1);
-                if (textDelta) onEvent({ type: "text", value: textDelta });
+                if (textDelta) {
+                  agentStats.textChars += textDelta.length;
+                  onEvent({ type: "text", value: textDelta });
+                }
+              }
+              if (update.has(4)) {
+                const thinkingDelta = extractAgentString(decodeMessage(update.get(4)[0].value), 1);
+                if (thinkingDelta) onEvent({ type: "thinking", value: thinkingDelta });
               }
               // Cursor's AgentService emits internal reasoning without the
               // cryptographic signature required by Anthropic thinking blocks.
@@ -581,12 +667,22 @@ export class CursorExecutor extends BaseExecutor {
                 onEvent({ type: "error", value: "Cursor AgentService requested an unsupported IDE tool" });
               }
             }
+
+            if (serverMessage.has(4)) {
+              const kvMessage = decodeMessage(serverMessage.get(4)[0].value);
+              const reply = handleKvServerMessage(kvMessage, blobStore);
+              if (reply) session.write(reply);
+            }
           });
         }
+      } catch (error) {
+        consumeError = error;
+        throw error;
       } finally {
+        console.info("CURSOR_AGENT", `${agentModel} frames=${agentStats.frames} textChars=${agentStats.textChars} serverFields=${[...agentStats.serverFields].join(",") || "-"} updateFields=${[...agentStats.updateFields].join(",") || "-"}`);
         try { session.end(); } catch {}
         try { session.close(); } catch {}
-        if (!finished) onEvent({ type: "done" });
+        if (!finished && !consumeError) onEvent({ type: "done" });
       }
     };
 
@@ -666,7 +762,7 @@ export class CursorExecutor extends BaseExecutor {
   async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
     if (isAgentTextRequest(body)) {
       try {
-        return await this.executeAgent({ model, body, stream, credentials, signal });
+        return await this.executeAgent({ model, body, stream, credentials, signal, proxyOptions, log });
       } catch (error) {
         return {
           response: new Response(JSON.stringify({

--- a/open-sse/services/cursorModels.js
+++ b/open-sse/services/cursorModels.js
@@ -4,13 +4,18 @@
  * Cursor exposes the account-specific model picker through the AgentService
  * `GetUsableModels` Connect RPC. Unlike the static provider registry, this
  * includes models newly enabled for the account and omits unavailable ones.
+ *
+ * The endpoint is HTTP/2-only. Direct http2.connect() ignores HTTP_PROXY, so
+ * when a proxy pool / outbound proxy is configured we tunnel h2 through
+ * CONNECT or SOCKS (see utils/http2Connect.js).
  */
 
 import crypto from "crypto";
-import http2 from "http2";
 import { PROVIDER_OAUTH } from "../providers/index.js";
 import { buildCursorHeaders } from "../utils/cursorChecksum.js";
 import { decodeMessage } from "../utils/cursorProtobuf.js";
+import { connectHttp2 } from "../utils/http2Connect.js";
+import { resolveOutboundProxyUrl } from "../utils/proxyFetch.js";
 
 const FETCH_TIMEOUT_MS = 10_000;
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -31,10 +36,11 @@ function getCursorModelsUrl() {
   return `${config.agentEndpoint.replace(/\/$/, "")}${config.modelsEndpoint}`;
 }
 
-function cacheKey(credentials) {
+function cacheKey(credentials, proxyUrl = "") {
   const seed = [
     credentials?.providerSpecificData?.machineId,
     credentials?.accessToken,
+    proxyUrl || "direct",
   ].filter(Boolean).join(":");
   if (!seed) return "cursor-anonymous";
   return crypto.createHash("sha256").update(`cursor:${seed}`).digest("hex");
@@ -44,6 +50,16 @@ function firstString(fields, fieldNumber) {
   const value = fields.get(fieldNumber)?.[0]?.value;
   if (!value || typeof value === "number") return "";
   return Buffer.from(value).toString("utf8");
+}
+
+function maskProxyUrl(proxyUrl) {
+  try {
+    const parsed = new URL(proxyUrl);
+    if (parsed.password) parsed.password = "***";
+    return `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ""}`;
+  } catch {
+    return "proxy";
+  }
 }
 
 /**
@@ -77,58 +93,71 @@ export function parseCursorUsableModels(payload) {
 /**
  * agent.api5.cursor.sh is HTTP/2-only; Node fetch/undici cannot speak h2.
  * Unary GetUsableModels uses an unframed protobuf body (application/proto).
+ * Optional HTTP/SOCKS proxy is applied via CONNECT tunnel + ALPN h2.
  */
-function http2PostProto(url, headers, body, signal, timeoutMs) {
+function http2PostProto(url, headers, body, signal, timeoutMs, proxyOptions = null) {
   return new Promise((resolve, reject) => {
     const urlObj = new URL(url);
-    const client = http2.connect(`https://${urlObj.host}`);
-    const chunks = [];
-    let responseHeaders = {};
+    const proxyUrl = resolveOutboundProxyUrl(url, proxyOptions);
     let settled = false;
+    let client = null;
+    let timeoutId = null;
 
     const finish = (fn) => (...args) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timeoutId);
-      try { client.close(); } catch {}
+      if (timeoutId) clearTimeout(timeoutId);
+      try { client?.close(); } catch {}
       fn(...args);
     };
 
-    const timeoutId = setTimeout(finish(() => {
-      reject(new Error("Cursor GetUsableModels timed out"));
-    }), timeoutMs);
+    const fail = finish(reject);
+    const succeed = finish(resolve);
 
-    client.on("error", finish(reject));
+    timeoutId = setTimeout(() => fail(new Error("Cursor GetUsableModels timed out")), timeoutMs);
 
-    const req = client.request({
-      ":method": "POST",
-      ":path": urlObj.pathname,
-      ":authority": urlObj.host,
-      ":scheme": "https",
-      ...headers,
-    });
+    connectHttp2(url, { proxyUrl, timeoutMs })
+      .then((session) => {
+        if (settled) {
+          try { session.close(); } catch {}
+          return;
+        }
+        client = session;
+        client.on("error", fail);
 
-    req.on("response", (hdrs) => { responseHeaders = hdrs; });
-    req.on("data", (chunk) => { chunks.push(chunk); });
-    req.on("end", finish(() => {
-      resolve({
-        status: Number(responseHeaders[":status"] || 0),
-        body: Buffer.concat(chunks),
-      });
-    }));
-    req.on("error", finish(reject));
+        const req = client.request({
+          ":method": "POST",
+          ":path": urlObj.pathname,
+          ":authority": urlObj.host,
+          ":scheme": "https",
+          ...headers,
+        });
 
-    if (signal) {
-      const onAbort = finish(() => reject(new Error("Request aborted")));
-      if (signal.aborted) onAbort();
-      else signal.addEventListener("abort", onAbort, { once: true });
-    }
+        const chunks = [];
+        let responseHeaders = {};
+        req.on("response", (hdrs) => { responseHeaders = hdrs; });
+        req.on("data", (chunk) => { chunks.push(chunk); });
+        req.on("end", () => {
+          succeed({
+            status: Number(responseHeaders[":status"] || 0),
+            body: Buffer.concat(chunks),
+          });
+        });
+        req.on("error", fail);
 
-    req.end(body && body.length ? Buffer.from(body) : undefined);
+        if (signal) {
+          const onAbort = () => fail(new Error("Request aborted"));
+          if (signal.aborted) onAbort();
+          else signal.addEventListener("abort", onAbort, { once: true });
+        }
+
+        req.end(body && body.length ? Buffer.from(body) : undefined);
+      })
+      .catch(fail);
   });
 }
 
-async function fetchCursorCatalog(credentials, signal) {
+async function fetchCursorCatalog(credentials, signal, options = {}) {
   const accessToken = credentials?.accessToken;
   const machineId = credentials?.providerSpecificData?.machineId;
   const url = getCursorModelsUrl();
@@ -144,7 +173,17 @@ async function fetchCursorCatalog(credentials, signal) {
   delete headers["connect-accept-encoding"];
   delete headers["connect-protocol-version"];
 
-  const response = await http2PostProto(url, headers, new Uint8Array(), signal, FETCH_TIMEOUT_MS);
+  const body = new Uint8Array();
+  let response;
+  if (typeof options.http2Post === "function") {
+    response = await options.http2Post(url, headers, body, signal);
+  } else {
+    const proxyUrl = resolveOutboundProxyUrl(url, options.proxyOptions);
+    if (proxyUrl) {
+      options.log?.info?.("CURSOR_MODELS", `GetUsableModels via HTTP/2 proxy ${maskProxyUrl(proxyUrl)}`);
+    }
+    response = await http2PostProto(url, headers, body, signal, FETCH_TIMEOUT_MS, options.proxyOptions);
+  }
   if (response.status !== 200) {
     const error = new Error(`Cursor GetUsableModels returned ${response.status}`);
     error.status = response.status;
@@ -164,7 +203,9 @@ export async function resolveCursorModels(credentials, options = {}) {
     return null;
   }
 
-  const key = cacheKey(credentials);
+  const catalogUrl = getCursorModelsUrl() || "https://agent.api5.cursor.sh/";
+  const proxyUrl = resolveOutboundProxyUrl(catalogUrl, options.proxyOptions);
+  const key = cacheKey(credentials, proxyUrl);
   const now = Date.now();
   if (!options.forceRefresh) {
     const cached = catalogCache.get(key);
@@ -172,7 +213,7 @@ export async function resolveCursorModels(credentials, options = {}) {
   }
 
   try {
-    const models = await fetchCursorCatalog(credentials, options.signal);
+    const models = await fetchCursorCatalog(credentials, options.signal, options);
     if (!models?.length) return null;
     catalogCache.set(key, { expiresAt: now + CACHE_TTL_MS, models });
     return { models };

--- a/open-sse/utils/http2Connect.js
+++ b/open-sse/utils/http2Connect.js
@@ -2,13 +2,45 @@
  * HTTP/2 client sessions, optionally tunneled through an HTTP CONNECT or SOCKS proxy.
  *
  * Node's http2.connect() is a direct TCP/TLS connection and ignores HTTP_PROXY.
- * Cursor's AgentService (GetUsableModels) is HTTP/2-only, so we must keep h2
- * and tunnel it: CONNECT (or SOCKS) → TLS(ALPN=h2) → http2 session.
+ * Cursor's AgentService (GetUsableModels and Run) is HTTP/2-only, so we must
+ * keep h2 and tunnel it: CONNECT (or SOCKS) → TLS(ALPN=h2) → http2 session.
  */
 
 import net from "net";
 import tls from "tls";
 import http2 from "http2";
+
+function waitForHttp2Session(client, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    if (client.destroyed) {
+      reject(new Error("HTTP/2 session destroyed"));
+      return;
+    }
+    if (!client.connecting) {
+      resolve(client);
+      return;
+    }
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("HTTP/2 session connect timed out"));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      client.off("connect", onConnect);
+      client.off("error", onError);
+    };
+    const onConnect = () => {
+      cleanup();
+      resolve(client);
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+    client.once("connect", onConnect);
+    client.once("error", onError);
+  });
+}
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const SOCKS_PROTOCOLS = new Set(["socks:", "socks4:", "socks4a:", "socks5:", "socks5h:"]);
@@ -58,6 +90,7 @@ async function connectViaHttpProxy(proxyUrl, targetHost, targetPort, timeoutMs) 
     socket.setTimeout(timeoutMs);
 
     socket.once("connect", () => {
+      socket.setNoDelay(true);
       socket.write(buildHttpConnectRequest(targetHost, targetPort, proxyUrl));
     });
 
@@ -123,6 +156,7 @@ async function createProxiedTlsSocket(proxyUrl, targetHost, targetPort, timeoutM
     }, timeoutMs);
     tlsSocket.once("secureConnect", () => {
       clearTimeout(timer);
+      tlsSocket.setNoDelay(true);
       resolve(tlsSocket);
     });
     tlsSocket.once("error", (error) => {
@@ -143,11 +177,29 @@ export async function connectHttp2(url, { proxyUrl, timeoutMs = DEFAULT_TIMEOUT_
   const authority = `https://${host}${urlObj.port ? `:${urlObj.port}` : ""}`;
 
   if (!proxyUrl) {
-    return http2.connect(authority);
+    const client = http2.connect(authority);
+    try {
+      return await waitForHttp2Session(client, timeoutMs);
+    } catch (error) {
+      try { client.close(); } catch {}
+      throw error;
+    }
   }
 
   const tlsSocket = await createProxiedTlsSocket(proxyUrl, host, port, timeoutMs);
-  return http2.connect(authority, {
+  const client = http2.connect(authority, {
     createConnection: () => tlsSocket,
   });
+  const destroySocket = () => {
+    try { tlsSocket.destroy(); } catch {}
+  };
+  client.once("close", destroySocket);
+  client.once("error", destroySocket);
+  try {
+    return await waitForHttp2Session(client, timeoutMs);
+  } catch (error) {
+    try { client.close(); } catch {}
+    destroySocket();
+    throw error;
+  }
 }

--- a/open-sse/utils/http2Connect.js
+++ b/open-sse/utils/http2Connect.js
@@ -1,0 +1,153 @@
+/**
+ * HTTP/2 client sessions, optionally tunneled through an HTTP CONNECT or SOCKS proxy.
+ *
+ * Node's http2.connect() is a direct TCP/TLS connection and ignores HTTP_PROXY.
+ * Cursor's AgentService (GetUsableModels) is HTTP/2-only, so we must keep h2
+ * and tunnel it: CONNECT (or SOCKS) → TLS(ALPN=h2) → http2 session.
+ */
+
+import net from "net";
+import tls from "tls";
+import http2 from "http2";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const SOCKS_PROTOCOLS = new Set(["socks:", "socks4:", "socks4a:", "socks5:", "socks5h:"]);
+
+export function isSocksProxyUrl(proxyUrl) {
+  try {
+    return SOCKS_PROTOCOLS.has(new URL(proxyUrl).protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function buildHttpConnectRequest(targetHost, targetPort, proxyUrl) {
+  const proxy = new URL(proxyUrl);
+  let auth = "";
+  if (proxy.username || proxy.password) {
+    const user = decodeURIComponent(proxy.username || "");
+    const pass = decodeURIComponent(proxy.password || "");
+    auth = `Proxy-Authorization: Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}\r\n`;
+  }
+  return (
+    `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\n` +
+    `Host: ${targetHost}:${targetPort}\r\n` +
+    auth +
+    `\r\n`
+  );
+}
+
+async function connectViaHttpProxy(proxyUrl, targetHost, targetPort, timeoutMs) {
+  const proxy = new URL(proxyUrl);
+  const proxyPort = Number(proxy.port) || (proxy.protocol === "https:" ? 443 : 80);
+
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: proxy.hostname, port: proxyPort });
+    let settled = false;
+
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      socket.setTimeout(0);
+      socket.destroy();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+
+    socket.once("error", fail);
+    socket.once("timeout", () => fail(new Error("Proxy CONNECT timed out")));
+    socket.setTimeout(timeoutMs);
+
+    socket.once("connect", () => {
+      socket.write(buildHttpConnectRequest(targetHost, targetPort, proxyUrl));
+    });
+
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString("latin1");
+      const headerEnd = buf.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return;
+      socket.off("data", onData);
+      const statusLine = buf.slice(0, buf.indexOf("\r\n"));
+      const code = Number(statusLine.split(" ")[1]);
+      if (code !== 200) {
+        fail(new Error(`Proxy CONNECT failed: ${statusLine.trim()}`));
+        return;
+      }
+      const leftover = buf.slice(headerEnd + 4);
+      if (leftover.length) socket.unshift(Buffer.from(leftover, "latin1"));
+      settled = true;
+      socket.setTimeout(0);
+      socket.removeListener("error", fail);
+      resolve(socket);
+    };
+    socket.on("data", onData);
+  });
+}
+
+async function connectViaSocks(proxyUrl, targetHost, targetPort, timeoutMs) {
+  const { SocksProxyAgent } = await import("socks-proxy-agent");
+  const agent = new SocksProxyAgent(proxyUrl, { timeout: timeoutMs });
+  const req = {
+    protocol: "http:",
+    host: targetHost,
+    port: Number(targetPort),
+    path: `${targetHost}:${targetPort}`,
+    method: "CONNECT",
+  };
+  const opts = {
+    host: targetHost,
+    port: Number(targetPort),
+    secureEndpoint: false,
+  };
+  if (typeof agent.connect !== "function") {
+    throw new Error("SOCKS agent does not expose connect()");
+  }
+  const socket = agent.connect(req, opts);
+  return socket && typeof socket.then === "function" ? await socket : socket;
+}
+
+async function createProxiedTlsSocket(proxyUrl, targetHost, targetPort, timeoutMs) {
+  const plain = isSocksProxyUrl(proxyUrl)
+    ? await connectViaSocks(proxyUrl, targetHost, targetPort, timeoutMs)
+    : await connectViaHttpProxy(proxyUrl, targetHost, targetPort, timeoutMs);
+
+  return new Promise((resolve, reject) => {
+    const tlsSocket = tls.connect({
+      socket: plain,
+      servername: targetHost,
+      ALPNProtocols: ["h2"],
+    });
+    const timer = setTimeout(() => {
+      tlsSocket.destroy();
+      reject(new Error("TLS handshake through proxy timed out"));
+    }, timeoutMs);
+    tlsSocket.once("secureConnect", () => {
+      clearTimeout(timer);
+      resolve(tlsSocket);
+    });
+    tlsSocket.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+/**
+ * Open an HTTP/2 client session to `url`.
+ * When `proxyUrl` is set (http://, https://, socks5://, …), tunnel via CONNECT/SOCKS.
+ */
+export async function connectHttp2(url, { proxyUrl, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const urlObj = new URL(url);
+  const host = urlObj.hostname;
+  const port = Number(urlObj.port) || 443;
+  const authority = `https://${host}${urlObj.port ? `:${urlObj.port}` : ""}`;
+
+  if (!proxyUrl) {
+    return http2.connect(authority);
+  }
+
+  const tlsSocket = await createProxiedTlsSocket(proxyUrl, host, port, timeoutMs);
+  return http2.connect(authority, {
+    createConnection: () => tlsSocket,
+  });
+}

--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -214,6 +214,17 @@ function resolveConnectionProxyUrl(targetUrl, proxyOptions) {
 }
 
 /**
+ * Resolve the outbound proxy for a target URL.
+ * Connection proxy pool wins; otherwise HTTP(S)_PROXY / ALL_PROXY from env
+ * (including 9Router Settings → Outbound Proxy).
+ */
+export function resolveOutboundProxyUrl(targetUrl, proxyOptions = null) {
+  const connectionProxyUrl = resolveConnectionProxyUrl(targetUrl, proxyOptions);
+  if (connectionProxyUrl) return connectionProxyUrl;
+  return normalizeProxyUrl(getEnvProxyUrl(targetUrl));
+}
+
+/**
  * Create proxy dispatcher lazily (undici-compatible)
  */
 async function getDispatcher(proxyUrl) {
@@ -306,9 +317,7 @@ export async function proxyAwareFetch(url, options = {}, proxyOptions = null) {
     return originalFetch(vercelRelayUrl, { ...options, headers: relayHeaders });
   }
 
-  const connectionProxyUrl = resolveConnectionProxyUrl(targetUrl, proxyOptions);
-  const envProxyUrl = connectionProxyUrl ? null : normalizeProxyUrl(getEnvProxyUrl(targetUrl));
-  const proxyUrl = connectionProxyUrl || envProxyUrl;
+  const proxyUrl = resolveOutboundProxyUrl(targetUrl, proxyOptions);
 
   // MITM DNS bypass: for known MITM-intercepted hosts, resolve real IP to avoid DNS spoof
   if (shouldBypassMitmDns(targetUrl)) {

--- a/src/app/api/providers/[id]/models/route.js
+++ b/src/app/api/providers/[id]/models/route.js
@@ -275,10 +275,21 @@ const PROVIDER_MODELS_CONFIG = {
   },
   cursor: {
     customResolver: async (connection) => {
+      const proxy = await resolveConnectionProxyConfig(connection.providerSpecificData || {});
       const result = await resolveCursorModels({
         accessToken: connection.accessToken,
         providerSpecificData: connection.providerSpecificData || {},
-      }, { forceRefresh: true, log: console });
+      }, {
+        forceRefresh: true,
+        log: console,
+        proxyOptions: {
+          enabled: proxy.connectionProxyEnabled === true,
+          connectionProxyEnabled: proxy.connectionProxyEnabled === true,
+          connectionProxyUrl: proxy.connectionProxyUrl || "",
+          connectionNoProxy: proxy.connectionNoProxy || "",
+          strictProxy: proxy.strictProxy === true,
+        },
+      });
       if (result?.models?.length) return { models: result.models };
       return {
         models: getStaticProviderModels("cursor"),

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -100,10 +100,20 @@ const LIVE_MODEL_RESOLVERS = {
     return result?.models?.length ? { models: result.models } : null;
   },
   cursor: async (conn) => {
+    const proxy = await resolveConnectionProxyConfig(conn.providerSpecificData || {});
     const result = await resolveCursorModels({
       accessToken: conn.accessToken,
       providerSpecificData: conn.providerSpecificData || {},
-    }, { log: console });
+    }, {
+      log: console,
+      proxyOptions: {
+        enabled: proxy.connectionProxyEnabled === true,
+        connectionProxyEnabled: proxy.connectionProxyEnabled === true,
+        connectionProxyUrl: proxy.connectionProxyUrl || "",
+        connectionNoProxy: proxy.connectionNoProxy || "",
+        strictProxy: proxy.strictProxy === true,
+      },
+    });
     return result?.models?.length ? { models: result.models } : null;
   },
   zed: async (conn) => {

--- a/tests/unit/cursor-agent-exec-request.test.js
+++ b/tests/unit/cursor-agent-exec-request.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
-import { CursorExecutor } from "../../open-sse/executors/cursor.js";
-import { encodeField, wrapConnectRPCFrame } from "../../open-sse/utils/cursorProtobuf.js";
+import { CursorExecutor, resolveCursorAgentModel } from "../../open-sse/executors/cursor.js";
+import { decodeMessage, encodeField, wrapConnectRPCFrame } from "../../open-sse/utils/cursorProtobuf.js";
 
 const LEN = 2;
 
@@ -110,5 +110,74 @@ describe("CursorExecutor AgentService exec_request handling", () => {
     expect(result.response.status).not.toBe(200);
     const payload = await result.response.json();
     expect(payload.error.message).toContain("unsupported IDE tool");
+  });
+
+  it("acks KV blob set/get without treating it as assistant text", async () => {
+    const blobId = Buffer.from("kv-blob-id");
+    const blobData = Buffer.from("not-visible-payload");
+    const setArgs = Buffer.concat([
+      Buffer.from(encodeField(1, LEN, blobId)),
+      Buffer.from(encodeField(2, LEN, blobData)),
+    ]);
+    const setKv = Buffer.concat([
+      Buffer.from(encodeField(1, 0, 7)),
+      Buffer.from(encodeField(3, LEN, setArgs)),
+    ]);
+    const kvFrame = Buffer.from(wrapConnectRPCFrame(encodeField(4, LEN, setKv)));
+
+    const { result, written } = await runAgent({
+      frames: [kvFrame, textFrame("pong")],
+      stream: true,
+    });
+
+    expect(written.length).toBe(2); // run frame + KV ack
+    const events = parseSSE(await result.response.text());
+    const content = events.map((e) => e.choices?.[0]?.delta?.content || "").join("");
+    expect(content).toBe("pong");
+  });
+
+  it("passes the connection proxy into AgentService Run", async () => {
+    const executor = new CursorExecutor();
+    let seenProxy = undefined;
+    stubAgentSession(executor, [textFrame("pong")]);
+    const original = executor.openAgentHttp2Stream;
+    executor.openAgentHttp2Stream = (url, headers, signal, proxyOptions) => {
+      seenProxy = proxyOptions;
+      return original(url, headers, signal, proxyOptions);
+    };
+
+    const proxyOptions = {
+      connectionProxyEnabled: true,
+      connectionProxyUrl: "http://127.0.0.1:10808",
+    };
+    await executor.execute({
+      model: "claude-fable-5",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials,
+      proxyOptions,
+    });
+
+    expect(seenProxy).toEqual(proxyOptions);
+  });
+
+  it("maps Fable *-fast slugs to the catalog id in RequestedModel.model_id", async () => {
+    expect(resolveCursorAgentModel("claude-fable-5-thinking-max-fast")).toBe("claude-fable-5-thinking-max");
+    expect(resolveCursorAgentModel("claude-fable-5-max-fast")).toBe("claude-fable-5-max");
+    expect(resolveCursorAgentModel("claude-opus-5-thinking-max-fast")).toBe("claude-opus-5-thinking-max-fast");
+    expect(resolveCursorAgentModel("gpt-5.6-sol-max-fast")).toBe("gpt-5.6-sol-max-fast");
+
+    const executor = new CursorExecutor();
+    const written = stubAgentSession(executor, [textFrame("pong")]);
+    await executor.executeAgent({
+      model: "claude-fable-5-thinking-max-fast",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: false,
+      credentials,
+    });
+
+    const run = decodeMessage(decodeMessage(written[0].subarray(5)).get(1)[0].value);
+    const requested = decodeMessage(run.get(9)[0].value);
+    expect(Buffer.from(requested.get(1)[0].value).toString("utf8")).toBe("claude-fable-5-thinking-max");
   });
 });

--- a/tests/unit/cursor-models.test.js
+++ b/tests/unit/cursor-models.test.js
@@ -4,8 +4,8 @@ import {
   parseCursorUsableModels,
   resolveCursorModels,
 } from "../../open-sse/services/cursorModels.js";
-
-const originalFetch = global.fetch;
+import { resolveOutboundProxyUrl } from "../../open-sse/utils/proxyFetch.js";
+import { buildHttpConnectRequest, isSocksProxyUrl } from "../../open-sse/utils/http2Connect.js";
 
 function varint(value) {
   const bytes = [];
@@ -46,7 +46,6 @@ describe("Cursor live model catalog", () => {
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
     clearCursorModelCache();
   });
 
@@ -65,39 +64,80 @@ describe("Cursor live model catalog", () => {
 
   it("fetches the account-specific catalog and caches it", async () => {
     const payload = concat(model("claude-4.6-opus", "Claude 4.6 Opus"));
-    global.fetch = vi.fn().mockResolvedValue(new Response(payload, { status: 200 }));
+    const http2Post = vi.fn().mockResolvedValue({ status: 200, body: payload });
     const credentials = {
       accessToken: "cursor-token",
       providerSpecificData: { machineId: "machine-id" },
     };
 
-    await expect(resolveCursorModels(credentials)).resolves.toEqual({
+    await expect(resolveCursorModels(credentials, { http2Post })).resolves.toEqual({
       models: [{ id: "claude-4.6-opus", name: "Claude 4.6 Opus" }],
     });
-    await expect(resolveCursorModels(credentials)).resolves.toEqual({
+    await expect(resolveCursorModels(credentials, { http2Post })).resolves.toEqual({
       models: [{ id: "claude-4.6-opus", name: "Claude 4.6 Opus" }],
     });
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(http2Post).toHaveBeenCalledTimes(1);
+    expect(http2Post).toHaveBeenCalledWith(
       "https://agent.api5.cursor.sh/agent.v1.AgentService/GetUsableModels",
       expect.objectContaining({
-        method: "POST",
-        body: expect.any(Uint8Array),
-        headers: expect.objectContaining({
-          "content-type": "application/proto",
-          accept: "application/proto",
-        }),
+        "content-type": "application/proto",
+        accept: "application/proto",
       }),
+      expect.any(Uint8Array),
+      undefined,
     );
   });
 
   it("fails open when the Cursor catalog request fails", async () => {
-    global.fetch = vi.fn().mockResolvedValue(new Response("no", { status: 403 }));
+    const http2Post = vi.fn().mockResolvedValue({ status: 403, body: Buffer.from("no") });
 
     await expect(resolveCursorModels({
       accessToken: "cursor-token",
       providerSpecificData: { machineId: "machine-id" },
-    })).resolves.toBeNull();
+    }, { http2Post })).resolves.toBeNull();
+  });
+});
+
+describe("HTTP/2 proxy tunnel helpers", () => {
+  const envKeys = ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "all_proxy", "no_proxy"];
+  const saved = {};
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it("builds an HTTP CONNECT request for mixed-port proxies", () => {
+    expect(buildHttpConnectRequest("agent.api5.cursor.sh", 443, "http://127.0.0.1:10808"))
+      .toBe("CONNECT agent.api5.cursor.sh:443 HTTP/1.1\r\nHost: agent.api5.cursor.sh:443\r\n\r\n");
+  });
+
+  it("detects SOCKS proxy URLs", () => {
+    expect(isSocksProxyUrl("socks5://127.0.0.1:10808")).toBe(true);
+    expect(isSocksProxyUrl("http://127.0.0.1:10808")).toBe(false);
+  });
+
+  it("prefers a bound connection proxy over env proxy", () => {
+    process.env.HTTPS_PROXY = "http://127.0.0.1:7890";
+    expect(resolveOutboundProxyUrl("https://agent.api5.cursor.sh/models", {
+      connectionProxyEnabled: true,
+      connectionProxyUrl: "http://127.0.0.1:10808",
+    })).toBe("http://127.0.0.1:10808");
+  });
+
+  it("falls back to HTTPS_PROXY when no connection proxy is bound", () => {
+    process.env.HTTPS_PROXY = "http://127.0.0.1:10808";
+    expect(resolveOutboundProxyUrl("https://agent.api5.cursor.sh/models", null))
+      .toBe("http://127.0.0.1:10808");
   });
 });


### PR DESCRIPTION
## Summary

Cursor's AgentService is HTTP/2-only and **gates both the model catalog and chat by client IP**. `http2.connect()` ignores proxy pools, `HTTP_PROXY`, and the system proxy. This PR tunnels **GetUsableModels and AgentService/Run** through the same HTTP CONNECT / SOCKS path so a proxied Cursor connection can list *and* use international vendor models.

### 1. Catalog was proxied; chat was not

`GetUsableModels` used a direct `http2.connect()` to `agent.api5.cursor.sh`, so the picker stayed on the regional catalog (Grok / Kimi / GLM) even after a proxy pool was bound.

This PR (first commit) tunnels that unary call: CONNECT/SOCKS → TLS ALPN h2 → HTTP/2, using the same proxy order as other providers (connection pool first, then outbound / env). The catalog cache key includes the proxy URL so direct and proxied lists do not overwrite each other.

### 2. Agent Run still went out on the machine IP

ChatService (`api2.cursor.sh`) is retired (HTTP 464). Pure-text turns already go to `AgentService/Run` on `agent.api5.cursor.sh`, but Run still used a raw `http2.connect()`. Cursor then accepted Claude / GPT / Fable with **HTTP 200 and an empty stream** (no error frame). Grok/Composer on the same token worked because they are in the regional catalog.

Run now uses `connectHttp2(url, { proxyUrl })`. A bound proxy that cannot be resolved **fails closed** instead of silently going direct. The tunnel waits for the h2 `connect` event, sets `TCP_NODELAY`, and destroys the TLS socket when the session closes.

### 3. Claude / GPT need a KV blob handshake

`AgentServerMessage` field 4 is `kv_server_message` (`get_blob_args` / `set_blob_args`). Ignoring it leaves heartbeats only, then an empty assistant. Grok often does not wait on this; Anthropic / OpenAI models do.

The executor now keeps an in-memory blob store and acks get/set via `AgentClientMessage.kv_client_message`. Proto3: omit KV `id` when the server did not send one (do not write `id=0`).

### 4. `RequestedModel` field 7 was not a flag

`agent.v1.RequestedModel` is `model_id = 1`, `max_mode = 2`, `parameters = 3`. Field 7 on nearby messages is Bedrock credentials. Writing `agentBool(7, true)` was incorrect. The run frame now sends `model_id` only.

### 5. Fable has no `*-fast` catalog slugs

Live `GetUsableModels` includes `claude-opus-5-thinking-max-fast` and `gpt-5.6-sol-max-fast`, but **no** `claude-fable-*-fast`. Clients that copy the Opus name (`claude-fable-5-thinking-max-fast`) get HTTP 200 + empty stream. Real ids are `claude-fable-5-thinking-max` and `claude-fable-5-max`.

`resolveCursorAgentModel()` strips a trailing `-fast` **only** for Fable before `RequestedModel.model_id`. Opus / GPT / Grok are unchanged.

### 6. Other stream fixes

- Abort no longer emits `done` with empty content (was recorded as a successful blank turn).
- `interaction_update` thinking deltas (field 4) are forwarded as `reasoning_content`.
- Stats log: frames, text chars, server/update field numbers, to debug empty streams.

## 中文说明

Cursor 按 **客户端 IP** 同时裁剪「可用模型」和「对话」。`http2.connect()` 不走 9Router 代理池，也不读 `HTTP_PROXY`。

先前只有 **GetUsableModels** 做了 HTTP/2 隧道，所以面板里能刷出国际目录（Opus / GPT / Fable），但 **AgentService/Run 仍直连本机 IP**。表现是：Grok / Composer 正常出字，Claude / GPT / Fable 返回 HTTP 200、没有任何错误帧、内容为空。旧 ChatService（`api2.cursor.sh`）已经 464，纯文本都走 `agent.api5.cursor.sh` 的 Run。

这次把 Run 接到同一条 CONNECT/SOCKS 隧道。绑定了代理却解析失败会直接报错，不再静默直连。另外补了 Claude/GPT 必需的 KV blob 握手（忽略的话只剩心跳然后空回复）、去掉误写进 `RequestedModel` field 7 的 bool（那不是 max-mode 开关）、以及 Fable 没有 `*-fast` 目录 ID 的映射（`claude-fable-5-thinking-max-fast` → `claude-fable-5-thinking-max`）。Opus/GPT/Grok 的 `-fast` 不动。

## Test plan

- [x] `cd tests && npx vitest run unit/cursor-models.test.js unit/cursor-agent-exec-request.test.js`
- [x] Bind an HTTP proxy pool to a Cursor connection; `/v1/models` lists international ids (`claude-opus-5-*`, `gpt-5.6-sol-*`, `claude-fable-5-*`)
- [x] Same connection without proxy: catalog stays regional (expected Cursor IP gate)
- [ ] Live chat (`/v1/chat/completions` or `/v1/responses`):
  - `cu/cursor-grok-4.6-xhigh-fast` still streams
  - `cu/claude-opus-5-thinking-max-fast` streams (not empty 200)
  - `cu/gpt-5.6-sol-max-fast` streams
  - `cu/claude-fable-5-thinking-max` streams
  - `cu/claude-fable-5-thinking-max-fast` also streams (mapped to `thinking-max`)
- [ ] Logs show `GetUsableModels via HTTP/2 proxy` and `CURSOR_AGENT Run via HTTP/2 proxy`
- [ ] Fable-fast logs `resolved …-fast → …`
- [ ] Bound proxy that cannot be resolved fails closed
- [ ] Aborting a stream is not recorded as an empty successful completion
