### PR TITLE
feat(cowork): add Lians memory plugin

### DIFF
--- a/src/app/(dashboard)/dashboard/cli-tools/components/CoworkToolCard.js
+++ b/src/app/(dashboard)/dashboard/cli-tools/components/CoworkToolCard.js
@@ -471,13 +471,16 @@ export default function CoworkToolCard({
                                 {p.extensionUrl && (
                                   <a href={p.extensionUrl} target="_blank" rel="noopener noreferrer" className="text-[10px] text-primary underline">Install Chrome extension</a>
                                 )}
+                                {p.setupUrl && (
+                                  <a href={p.setupUrl} target="_blank" rel="noopener noreferrer" className="text-[10px] text-primary underline">{p.setupLabel || "Setup guide"}</a>
+                                )}
                               </div>
                             </label>
                           );
                         })}
                       </div>
                       <p className="text-[10px] text-text-muted leading-snug">
-                        ⚠️ Local plugins run as subprocess via <code className="px-1 py-0.5 rounded bg-black/5 dark:bg-white/5">npx</code>. Requires Node.js installed.
+                        ⚠️ Local plugins run as subprocesses. Install the runtime shown for each plugin before enabling it.
                       </p>
                     </div>
                   </div>

--- a/src/shared/constants/coworkPlugins.js
+++ b/src/shared/constants/coworkPlugins.js
@@ -31,6 +31,26 @@ const LOCAL_STDIO_PLUGINS = [
     args: ["-y", "@browsermcp/mcp@latest"],
     toolNames: ["browser_navigate", "browser_snapshot", "browser_click", "browser_type", "browser_screenshot", "browser_get_console_logs", "browser_wait", "browser_press_key", "browser_go_back", "browser_go_forward"],
   },
+  {
+    name: "lians-memory",
+    title: "Lians Memory",
+    description: "Local-first memory shared across agent sessions, with current and point-in-time recall",
+    setupUrl: "https://docs.astral.sh/uv/getting-started/installation/",
+    setupLabel: "Install uv",
+    command: "uvx",
+    args: ["--from", "lians-sdk[mcp]", "lians-mcp"],
+    toolNames: [
+      "remember",
+      "recall",
+      "recall_at",
+      "reconstruct",
+      "list_conflicts",
+      "memory_lineage",
+      "fact_history",
+      "backtest_check",
+      "memory_feedback",
+    ],
+  },
 ];
 
 function buildManagedMcpServers(plugins) {

--- a/tests/unit/cowork-lians-memory.test.js
+++ b/tests/unit/cowork-lians-memory.test.js
@@ -1,0 +1,35 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { LOCAL_STDIO_PLUGINS } = require("../../src/shared/constants/coworkPlugins.js");
+
+const lians = LOCAL_STDIO_PLUGINS.find((plugin) => plugin.name === "lians-memory");
+
+describe("Lians Cowork memory plugin", () => {
+  it("launches the published local MCP server through uvx", () => {
+    expect(lians).toBeDefined();
+    expect(lians.command).toBe("uvx");
+    expect(lians.args).toEqual(["--from", "lians-sdk[mcp]", "lians-mcp"]);
+    expect(lians.setupUrl).toBe("https://docs.astral.sh/uv/getting-started/installation/");
+  });
+
+  it("declares the published Lians 0.5.0 MCP tool surface", () => {
+    expect(lians.toolNames).toEqual([
+      "remember",
+      "recall",
+      "recall_at",
+      "reconstruct",
+      "list_conflicts",
+      "memory_lineage",
+      "fact_history",
+      "backtest_check",
+      "memory_feedback",
+    ]);
+  });
+
+  it("does not duplicate a local plugin name or tool name", () => {
+    expect(LOCAL_STDIO_PLUGINS.filter((plugin) => plugin.name === lians.name)).toHaveLength(1);
+    expect(new Set(lians.toolNames).size).toBe(lians.toolNames.length);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Lians as an opt-in local MCP memory plugin in the Claude Cowork settings card.

- launches the published local server with `uvx --from 'lians-sdk[mcp]' lians-mcp`
- exposes its nine current v0.5.0 tools through the existing stdio-to-SSE bridge
- links the `uv` prerequisite directly in the plugin UI
- makes the local-plugin runtime note generic instead of implying every plugin uses `npx`

This is intentionally a small first step toward #2719: it gives 9Router users working in Cowork durable local memory without introducing a second database or changing the routing path. The default Lians setup uses a local SQLite database and requires no Lians account or API key.

## Validation

- live MCP initialization and `tools/list` against the published package: 9 tools matched the preset exactly
- `npx vitest run unit/cowork-lians-memory.test.js`: 3 passed
- ESLint passes for the changed constants and new test
- `git diff --check` passes

The existing `CoworkToolCard.js` baseline has four React-hook lint errors and two warnings on unchanged lines 55-96; linting `HEAD` from stdin produces the same findings. This patch adds no new lint finding.

## Scope / disclosure

This PR only adds the Cowork preset and generic setup-link support. It does not yet inject memory into every 9Router-supported client.

I maintain Lians and am proposing our own open-source Apache-2.0 project. Codex assisted with implementation and validation; I reviewed the changes and live protocol output.