### PR TITLE
fix(open-sse): send opencode-cli headers for zen free models to avoid 429

### DIFF
--- a/open-sse/executors/opencode.js
+++ b/open-sse/executors/opencode.js
@@ -22,11 +22,21 @@ export class OpenCodeExecutor extends BaseExecutor {
   }
 
   buildHeaders() {
+    const randomId = (length) =>
+      Array.from({ length }, () =>
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".charAt(
+          Math.floor(Math.random() * 62)
+        )
+      ).join("");
     return {
       "Content-Type": "application/json",
       "Authorization": "Bearer public",
       "x-opencode-client": "desktop",
-      "Accept": "text/event-stream"
+      "x-opencode-session": `ses_${randomId(24)}`,
+      "x-opencode-project": "/opencode",
+      "x-opencode-request": `req_${randomId(24)}`,
+      "User-Agent": "opencode/latest/1.18.18/cli",
+      "Accept": "text/event-stream",
     };
   }
 }


### PR DESCRIPTION
### Problem

Requests to the **OpenCode Free** (`oc`) provider are rate-limited with `429 FreeUsageLimitError` even when quota is available. opencode.ai classifies requests as anonymous unless they carry the same client fingerprint headers the official opencode CLI sends. 9router only sent `x-opencode-client: desktop` and no `x-opencode-session` / `x-opencode-project` / `x-opencode-request` / `User-Agent`, so free-tier requests were throttled after a few calls per day even though direct opencode CLI usage on the same IP was fine.

### Fix

Send the official CLI fingerprint headers in `OpenCodeExecutor.buildHeaders()` while keeping `x-opencode-client: desktop`:

- `x-opencode-session` / `x-opencode-request` – dynamically generated ids (`ses_`/`req_`)
- `x-opencode-project: /opencode`
- `User-Agent: opencode/latest/1.18.18/cli`

Verified that `User-Agent` is required (without it, `429` persists) and that `desktop` is a valid client value.

### Verification

After the fix, `POST /v1/chat/completions` with `model: oc/deepseek-v4-flash-free` returns HTTP 200 with a normal completion; before the fix it returned 429 `FreeUsageLimitError`.

Fixes #3270
Fixes #3262