### PR TITLE
fix(usage): read Gemini usageMetadata out of the antigravity response envelope

### DIFF
--- a/open-sse/handlers/chatCore/requestDetail.js
+++ b/open-sse/handlers/chatCore/requestDetail.js
@@ -44,13 +44,14 @@ export function extractUsageFromResponse(responseBody) {
     };
   }
 
-  // Gemini format
-  if (responseBody.usageMetadata) {
+  // Gemini format. Antigravity / gemini-cli wrap the payload in { response: {...} }.
+  const usageMetadata = responseBody.usageMetadata || responseBody.response?.usageMetadata;
+  if (usageMetadata) {
     return {
-      prompt_tokens: responseBody.usageMetadata.promptTokenCount || 0,
-      completion_tokens: responseBody.usageMetadata.candidatesTokenCount || 0,
-      cached_tokens: responseBody.usageMetadata.cachedContentTokenCount || 0,
-      reasoning_tokens: responseBody.usageMetadata.thoughtsTokenCount || 0
+      prompt_tokens: usageMetadata.promptTokenCount || 0,
+      completion_tokens: usageMetadata.candidatesTokenCount || 0,
+      cached_tokens: usageMetadata.cachedContentTokenCount || 0,
+      reasoning_tokens: usageMetadata.thoughtsTokenCount || 0
     };
   }
 

--- a/tests/unit/antigravity-nonstream-usage-3260.test.js
+++ b/tests/unit/antigravity-nonstream-usage-3260.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {})
+}));
+
+const { extractUsageFromResponse } = await import("../../open-sse/handlers/chatCore/requestDetail.js");
+
+const USAGE_METADATA = {
+  promptTokenCount: 1234,
+  candidatesTokenCount: 56,
+  cachedContentTokenCount: 78,
+  thoughtsTokenCount: 90,
+};
+
+const EXPECTED = {
+  prompt_tokens: 1234,
+  completion_tokens: 56,
+  cached_tokens: 78,
+  reasoning_tokens: 90,
+};
+
+describe("#3260 non-streaming usage extraction for enveloped Gemini responses", () => {
+  it("reads usageMetadata out of the antigravity { response } envelope", () => {
+    expect(extractUsageFromResponse({ response: { usageMetadata: USAGE_METADATA } })).toEqual(EXPECTED);
+  });
+
+  it("still reads a top-level usageMetadata", () => {
+    expect(extractUsageFromResponse({ usageMetadata: USAGE_METADATA })).toEqual(EXPECTED);
+  });
+
+  it("prefers the top-level metadata when both are present", () => {
+    const enveloped = { ...USAGE_METADATA, promptTokenCount: 1 };
+    const out = extractUsageFromResponse({
+      usageMetadata: USAGE_METADATA,
+      response: { usageMetadata: enveloped },
+    });
+    expect(out.prompt_tokens).toBe(1234);
+  });
+
+  it("leaves the OpenAI and Claude shapes alone", () => {
+    expect(extractUsageFromResponse({ usage: { prompt_tokens: 10, completion_tokens: 2 } }))
+      .toMatchObject({ prompt_tokens: 10, completion_tokens: 2 });
+    expect(extractUsageFromResponse({ usage: { input_tokens: 10, output_tokens: 2 } }))
+      .toMatchObject({ prompt_tokens: 10, completion_tokens: 2 });
+  });
+
+  it("returns null when there is no usage anywhere", () => {
+    expect(extractUsageFromResponse({ response: { candidates: [] } })).toBeNull();
+    expect(extractUsageFromResponse(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #3260

## Problem

Every non-streaming request through the antigravity provider logs zero usage, whatever the model, tool count or account:

```
[16:43:22] POST ag/gemini-3.6-flash-high -> antigravity/gemini-3.6-flash-high | FMT: openai->antigravity | JSON | 16 MSG | 3 TOOL | THINK:high
[16:43:29] DONE 6987ms | IN 0 | OUT 0
```

Note the `JSON` marker — these are the non-streaming requests.

## Root cause

Antigravity and gemini-cli wrap their payload in a `{ response: { ... } }` envelope. Two places in the non-streaming path already know this:

- `utils/usageTracking.js` — `chunk.usageMetadata || chunk.response?.usageMetadata`, with the comment *"Antigravity wraps usageMetadata inside response"*
- `handlers/chatCore/nonStreamingHandler.js` — `const response = responseBody.response || responseBody` before reading `usageMetadata`

`extractUsageFromResponse()` in `handlers/chatCore/requestDetail.js` did not. It only tested `responseBody.usageMetadata`, so for an enveloped body it fell through all three format branches and returned `null` — which surfaces as `IN 0 | OUT 0` and as zeroed rows in the usage dashboard.

The streaming path was unaffected, which is why this looks provider-wide rather than endpoint-specific.

## Fix

Read the envelope in the Gemini branch, the same way the two call sites above already do. Top-level metadata keeps priority, and the OpenAI and Claude branches are untouched.

## Scope note

This does not touch the `[ProjectId] onboardUser` failures mentioned at the bottom of the issue — that is a separate concern and, as the reporter notes, those requests complete anyway.

## Tests

New: `tests/unit/antigravity-nonstream-usage-3260.test.js` — enveloped metadata is read, top-level still works and wins when both are present, the OpenAI and Claude shapes are unchanged, and a body with no usage still returns `null`.

The first test fails on `master` with `expected null to deeply equal { prompt_tokens: 1234, … }` — i.e. exactly the `IN 0 | OUT 0` the issue reports — and passes with this patch.

Full suite (`npx vitest run unit translator`) against `master` as the baseline: **1670 → 1675 passed, 91 failed on both sides** — no pass→fail, the 5 new passes are this PR's tests.
