### PR TITLE
fix(docker): ship sql.js so the pure-JS DB fallback can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ COPY --from=builder /app/src/mitm ./src/mitm
 COPY --from=builder /app/node_modules/node-forge ./node_modules/node-forge
 # Ensure `next` is available at runtime in case tracing did not include it.
 COPY --from=builder /app/node_modules/next ./node_modules/next
+# sql.js loads dist/sql-wasm.wasm by path at runtime; tracing only follows JS imports,
+# so the last-resort DB driver would abort with ENOENT on the missing binary.
+COPY --from=builder /app/node_modules/sql.js ./node_modules/sql.js
 
 RUN mkdir -p /app/data && chown -R node:node /app && \
   mkdir -p /app/data-home && chown node:node /app/data-home && \


### PR DESCRIPTION
Fixes #3248

## Problem

The container starts but never gets a database:

```
[DB] better-sqlite3 unavailable: disk I/O error
[DB] node:sqlite unavailable: disk I/O error
failed to asynchronously prepare wasm: Error: ENOENT: no such file or directory, open '/app/node_modules/sql.js/dist/sql-wasm.wasm'
[DB] sql.js unavailable: Error: ENOENT: ...
RuntimeError: Aborted(...)
```

The first two lines are the reporter's volume — native SQLite wants WAL/journal files and file locks, which routinely fail on overlay and network-backed Docker volumes even when the mount is writable (`touch /app/data/test` returns 0 for them).

That is exactly what the pure-JS fallback exists for. `CLAUDE.md` describes the chain as `bun:sqlite → better-sqlite3 → node:sqlite → sql.js (pure-JS fallback, always works)`. In the image it does not, because of the third line.

## Root cause

`sqljsAdapter.js` calls `initSqlJs()` with no `locateFile`, so sql.js resolves `dist/sql-wasm.wasm` relative to its own package directory at runtime. Next's file tracing only follows JS imports, so the standalone output ships `sql.js/dist/sql-wasm.js` but not the `.wasm` binary next to it — which is why the error is ENOENT on a path that otherwise resolves.

`sql.js` being in `serverExternalPackages` does not help: that keeps the module external, it does not pull in non-imported assets.

## Fix

Copy the package into the runtime stage, exactly as `node-forge` and `next` already are two lines above — both there for the same reason, per their own comments.

**This is not a new idea in the project:** `cli/scripts/build-cli.js` already does it deliberately for the CLI bundle —

```js
// Step 3b: Ensure sql.js (pure JS fallback) bundled in app/cli/app/node_modules.
...
ensureModuleInBundle("sql.js");
```

and its `better-sqlite3` comment calls that "the same belt-and-braces guard used for sql.js". The Docker image simply never got the equivalent.

## Alternative considered

`outputFileTracingIncludes: { "*": ["./node_modules/sql.js/dist/sql-wasm.wasm"] }` in `next.config.mjs` would fix the standalone output itself rather than patching one consumer, and is arguably the better home for it. I did not take it because I could not verify the glob resolves under both tracing roots (`outputFileTracingRoot` switches to the workspace parent for `NEXT_TRACING_ROOT_MODE=workspace`), and a glob that silently matches nothing would look fixed while still shipping broken images. Happy to switch if you prefer it.

## Verification

Honest scope: **I could not build the image here**, so this is reasoned from the sources rather than from a green build —

- `sql.js` is a regular dependency (`package.json`), so `/app/node_modules/sql.js` exists in the builder stage.
- `sqljsAdapter.js` loads the wasm by path, matching the ENOENT in the report.
- The runtime stage otherwise only receives `.next/standalone` plus the two manual package copies, so nothing else supplies the binary.

No test is included: asserting a `COPY` line in a Dockerfile only restates the diff. The meaningful check is `docker build` followed by a start with both native drivers unavailable.
