### PR TITLE
feat(tts): add Fish Audio as a text-to-speech provider

### DIFF
--- a/open-sse/handlers/ttsProviders/genericFormats.js
+++ b/open-sse/handlers/ttsProviders/genericFormats.js
@@ -51,6 +51,25 @@ async function huggingface({ baseUrl, apiKey, text, modelId }) {
   return responseToBase64(res, "wav");
 }
 
+// Fish Audio: model travels in an HTTP header, the voice is a reference_id, returns binary
+async function fishAudio({ baseUrl, apiKey, text, modelId, voiceId }) {
+  const res = await fetch(baseUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+      "model": modelId || "s2.1-pro-free",
+    },
+    body: JSON.stringify({
+      text,
+      format: "mp3",
+      ...(voiceId ? { reference_id: voiceId } : {}),
+    }),
+  });
+  if (!res.ok) await throwUpstreamError(res);
+  return responseToBase64(res, "mp3");
+}
+
 // Inworld: Basic auth, JSON { audioContent }
 async function inworld({ baseUrl, apiKey, text, modelId, voiceId }) {
   const res = await fetch(baseUrl, {
@@ -166,4 +185,5 @@ export const FORMAT_HANDLERS = {
   tortoise,
   openai: openaiCompat,
   "minimax-tts": minimaxTts,
+  "fish-audio": fishAudio,
 };

--- a/open-sse/providers/registry/fish-audio.js
+++ b/open-sse/providers/registry/fish-audio.js
@@ -1,0 +1,31 @@
+// Fish Audio TTS — the model id travels in an HTTP `model` header rather than the
+// JSON body, and the voice is a reference_id (a cloned or preset voice model).
+export default {
+  id: "fish-audio",
+  alias: "fish",
+  display: {
+    name: "Fish Audio",
+    icon: "record_voice_over",
+    color: "#1E9BF0",
+    textIcon: "FA",
+    website: "https://fish.audio",
+    notice: {
+      apiKeyUrl: "https://fish.audio/app/api-keys/",
+    },
+  },
+  category: "apikey",
+  authType: "apikey",
+  serviceKinds: ["tts"],
+  ttsConfig: {
+    baseUrl: "https://api.fish.audio/v1/tts",
+    authType: "apikey",
+    authHeader: "bearer",
+    format: "fish-audio",
+    models: [
+      { id: "s2.1-pro-free", name: "S2.1 Pro Free" },
+      { id: "s2.1-pro", name: "S2.1 Pro" },
+      { id: "s2-pro", name: "S2 Pro" },
+      { id: "s1", name: "S1" },
+    ],
+  },
+};

--- a/open-sse/providers/registry/index.js
+++ b/open-sse/providers/registry/index.js
@@ -119,6 +119,7 @@ import p116 from "./tokenrouter.js";
 import p117 from "./selfhosted-stt.js";
 import p118 from "./selfhosted-tts.js";
 import p119 from "./selfhosted-embedding.js";
+import p120 from "./fish-audio.js";
 
 export default [
   p0,
@@ -239,4 +240,5 @@ export default [
   p117,
   p118,
   p119,
+  p120,
 ];

--- a/tests/unit/fish-audio-tts.test.js
+++ b/tests/unit/fish-audio-tts.test.js
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import REGISTRY from "../../open-sse/providers/registry/index.js";
+import { PROVIDER_MEDIA } from "../../open-sse/providers/index.js";
+import { FORMAT_HANDLERS } from "../../open-sse/handlers/ttsProviders/genericFormats.js";
+import { AI_PROVIDERS } from "@/shared/constants/providers";
+
+const AUDIO = new Uint8Array(256).fill(7);
+
+function okResponse() {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "audio/mpeg" }),
+    arrayBuffer: async () => AUDIO.buffer,
+  };
+}
+
+describe("Fish Audio TTS provider", () => {
+  const entry = REGISTRY.find((e) => e.id === "fish-audio");
+
+  it("is registered as a TTS-only apikey provider", () => {
+    expect(entry).toBeDefined();
+    expect(entry.category).toBe("apikey");
+    expect(entry.serviceKinds).toEqual(["tts"]);
+    expect(PROVIDER_MEDIA["fish-audio"]?.ttsConfig?.baseUrl).toBe("https://api.fish.audio/v1/tts");
+  });
+
+  it("is visible to the generic dispatcher, which reads AI_PROVIDERS", () => {
+    // synthesizeViaConfig() looks the provider up here, not in PROVIDER_MEDIA.
+    expect(AI_PROVIDERS["fish-audio"]?.ttsConfig?.format).toBe("fish-audio");
+    expect(typeof FORMAT_HANDLERS["fish-audio"]).toBe("function");
+  });
+
+  it("exposes the four documented models", () => {
+    const ids = (entry.ttsConfig.models || []).map((m) => m.id);
+    expect(ids).toEqual(["s2.1-pro-free", "s2.1-pro", "s2-pro", "s1"]);
+  });
+
+  it("keeps registry ids and aliases unique", () => {
+    const ids = REGISTRY.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const aliases = REGISTRY.map((e) => e.alias).filter(Boolean);
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+});
+
+describe("Fish Audio TTS request shape", () => {
+  const handler = FORMAT_HANDLERS["fish-audio"];
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => okResponse());
+    global.fetch = fetchMock;
+  });
+
+  const callArgs = () => {
+    const [url, init] = fetchMock.mock.calls.at(-1);
+    return { url, init, body: JSON.parse(init.body) };
+  };
+
+  it("sends the model as an HTTP header, not in the body", async () => {
+    await handler({
+      baseUrl: "https://api.fish.audio/v1/tts",
+      apiKey: "sk-test",
+      text: "xin chào",
+      modelId: "s1",
+      voiceId: "",
+    });
+
+    const { url, init, body } = callArgs();
+    expect(url).toBe("https://api.fish.audio/v1/tts");
+    expect(init.headers.model).toBe("s1");
+    expect(init.headers.Authorization).toBe("Bearer sk-test");
+    expect(body).toEqual({ text: "xin chào", format: "mp3" });
+  });
+
+  it("maps the voice onto reference_id, and omits it when unset", async () => {
+    await handler({ baseUrl: "u", apiKey: "k", text: "t", modelId: "s1", voiceId: "voice-abc" });
+    expect(callArgs().body.reference_id).toBe("voice-abc");
+
+    await handler({ baseUrl: "u", apiKey: "k", text: "t", modelId: "s1", voiceId: "" });
+    expect(callArgs().body).not.toHaveProperty("reference_id");
+  });
+
+  it("defaults to the free model when none is given", async () => {
+    await handler({ baseUrl: "u", apiKey: "k", text: "t", modelId: "", voiceId: "" });
+    expect(callArgs().init.headers.model).toBe("s2.1-pro-free");
+  });
+
+  it("returns base64 audio with its format", async () => {
+    const out = await handler({ baseUrl: "u", apiKey: "k", text: "t", modelId: "s1", voiceId: "" });
+    expect(out.format).toBe("mp3");
+    expect(typeof out.base64).toBe("string");
+    expect(out.base64.length).toBeGreaterThan(0);
+  });
+
+  it("surfaces the upstream error message", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 402,
+      text: async () => JSON.stringify({ message: "Insufficient credit" }),
+    }));
+
+    await expect(
+      handler({ baseUrl: "u", apiKey: "k", text: "t", modelId: "s1", voiceId: "" }),
+    ).rejects.toThrow("Insufficient credit");
+  });
+});


### PR DESCRIPTION
Closes #2411

## What

Fish Audio as a TTS provider: a registry entry plus one entry in the config-driven `FORMAT_HANDLERS` table.

It is not a `SPECIAL_ADAPTERS` provider — it needs no voice fetcher and no credential quirks — but it does not fit any existing generic format either, because of two things the API does differently:

- **The model id travels in an HTTP `model` header**, not in the JSON body. Every other handler in that file puts the model in the body, the query string, or the path.
- **The voice is a `reference_id`** — a preset or cloned voice model — rather than a `voice` field.

Response is a binary audio stream, so `responseToBase64` handles it as-is.

## Contract

Taken from the [API reference](https://docs.fish.audio/api-reference/endpoint/openapi-v1/text-to-speech), not only from the issue:

| | |
|---|---|
| Endpoint | `POST https://api.fish.audio/v1/tts` |
| Auth | `Authorization: Bearer <key>` |
| Model header | `s1`, `s2-pro`, `s2.1-pro`, `s2.1-pro-free` |
| Body | `{ text, reference_id?, format }` |

The issue listed only `s2.1-pro-free` and `s1`; the docs list four, so all four are registered with `s2.1-pro-free` as the default the handler falls back to.

`format` is pinned to `mp3` in the request. The generic dispatcher calls `synthesizeViaConfig(provider, text, model, credentials)` without options, and `responseFormat` is applied downstream by `createTtsResponse` (it selects JSON-vs-binary framing, not the codec) — so plumbing wav/pcm/opus through would mean changing that signature for every provider. Out of scope here; the other config-driven handlers pin a format the same way.

## Baselines

No snapshot regeneration needed. A media-only provider does not enter `PROVIDERS` or `PROVIDER_MODELS`, so `verify-providers` and `verify-alias` are unchanged by this PR. (`verify-providers` is red on a clean `master` for an unrelated pre-existing `tokenrouter.thinkingFormat` drift, both before and after this branch.)

## Verification

Honest scope: **I have no Fish Audio key**, so no live call was made. The wire shape is asserted against the published contract with a mocked `fetch`.

New: `tests/unit/fish-audio-tts.test.js` (9 cases) — registration as a TTS-only apikey provider; visibility to the dispatcher through `AI_PROVIDERS` (which is where `synthesizeViaConfig` looks it up, not `PROVIDER_MEDIA`); the four model ids; registry id **and alias** uniqueness; then the request shape — model in the header and absent from the body, `reference_id` set when a voice is given and omitted when not, the default model fallback, base64 output, and that an upstream `402` surfaces its `message`.

Full suite (`npx vitest run unit translator`) against `master` as the baseline: **1670 → 1679 passed, 91 failed on both sides** — no pass→fail, the 9 new passes are this PR's tests.
