### PR TITLE
fix(ollama-local): verbose debug diagnostics + timeout/retry tuning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,9 @@ NEXT_PUBLIC_CLOUD_URL=https://9router.com
 # Optional SearXNG endpoint for the built-in unauthenticated web-search provider.
 # SEARXNG_URL=http://searxng:8080/search
 
+# Optional timeout tuning for Ollama Local provider (default: 120000ms).
+# Increase if large models (e.g. 70B+) are slow to respond with first tokens.
+# OLLAMA_LOCAL_CONNECT_TIMEOUT_MS=120000
+
 # Currently unused by application runtime (kept as reference)
 # INSTANCE_NAME=9router

--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -58,6 +58,10 @@ export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_M
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
 export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 60 * 1000);
 
+// Connect timeout for ollama-local: higher default because local models may need extra time
+// to load weights (especially large models). Env: OLLAMA_LOCAL_CONNECT_TIMEOUT_MS.
+export const OLLAMA_LOCAL_CONNECT_TIMEOUT_MS = envMs("OLLAMA_LOCAL_CONNECT_TIMEOUT_MS", 120 * 1000);
+
 // Gemini native TTS fetch timeout: abort if Google does not return response headers in time.
 export const GEMINI_NATIVE_TTS_FETCH_TIMEOUT_MS = envMs("GEMINI_NATIVE_TTS_FETCH_TIMEOUT_MS", 45 * 1000);
 

--- a/open-sse/executors/base.js
+++ b/open-sse/executors/base.js
@@ -5,6 +5,13 @@ import { dbg } from "../utils/debugLog.js";
 import { ANTHROPIC_API_VERSION, OPENAI_COMPAT_BASE, ANTHROPIC_COMPAT_BASE } from "../providers/shared.js";
 import { resolveOpenAICompatibleApiType } from "../services/provider.js";
 
+// Format byte count to human-readable string for debug logs
+function fmtBytes(n) {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)}MB`;
+}
+
 /**
  * BaseExecutor - Base class for provider executors
  */
@@ -140,7 +147,7 @@ export class BaseExecutor {
       try {
         const bodyStr = JSON.stringify(transformedBody);
         const fetchT0 = Date.now();
-        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | body=${bodyStr.length}B | connectTimeout=${timeoutMs}ms`);
+        dbg("FETCH", `${this.provider.toUpperCase()} → ${url} | model=${model} | body=${fmtBytes(bodyStr.length)} | connectTimeout=${timeoutMs}ms`);
         const response = await proxyAwareFetch(url, {
           method: "POST",
           headers,

--- a/open-sse/executors/ollama-local.js
+++ b/open-sse/executors/ollama-local.js
@@ -1,13 +1,182 @@
 import { DefaultExecutor } from "./default.js";
 import { resolveOllamaLocalHost } from "../config/providers.js";
+import { OLLAMA_LOCAL_CONNECT_TIMEOUT_MS } from "../config/runtimeConfig.js";
+import { dbg } from "../utils/debugLog.js";
+
+// ─── Formatting helpers ────────────────────────────────────────────────────
+
+function fmtBytes(n) {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)}MB`;
+}
+
+function fmtMs(ms) {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Summarise messages array into a compact breakdown string.
+ * e.g. "12 msgs [sys=1 usr=6 asst=5] | tool_calls=2 | ~84.3KB content"
+ */
+function summariseMessages(messages) {
+  if (!Array.isArray(messages) || messages.length === 0) return "no messages";
+
+  const counts = { system: 0, user: 0, assistant: 0, tool: 0, other: 0 };
+  let totalContentChars = 0;
+  let toolCallCount = 0;
+  let imageCount = 0;
+
+  for (const msg of messages) {
+    const role = msg?.role || "other";
+    counts[role] != null ? counts[role]++ : counts.other++;
+
+    // Count tool_calls inside assistant messages
+    if (Array.isArray(msg?.tool_calls)) toolCallCount += msg.tool_calls.length;
+
+    // Accumulate content length
+    if (typeof msg?.content === "string") {
+      totalContentChars += msg.content.length;
+    } else if (Array.isArray(msg?.content)) {
+      for (const block of msg.content) {
+        if (block?.type === "text") totalContentChars += (block.text || "").length;
+        else if (block?.type === "image_url" || block?.type === "image") imageCount++;
+        else if (block?.type === "tool_result" || block?.type === "tool_use") {
+          totalContentChars += JSON.stringify(block).length;
+        }
+      }
+    }
+  }
+
+  const roleParts = [];
+  if (counts.system) roleParts.push(`sys=${counts.system}`);
+  if (counts.user) roleParts.push(`usr=${counts.user}`);
+  if (counts.assistant) roleParts.push(`asst=${counts.assistant}`);
+  if (counts.tool) roleParts.push(`tool=${counts.tool}`);
+  if (counts.other) roleParts.push(`other=${counts.other}`);
+
+  const parts = [`${messages.length} msgs [${roleParts.join(" ")}]`];
+  if (toolCallCount) parts.push(`tool_calls=${toolCallCount}`);
+  if (imageCount) parts.push(`images=${imageCount}`);
+  parts.push(`~${fmtBytes(totalContentChars)} content`);
+
+  return parts.join(" | ");
+}
+
+/**
+ * Emit targeted hints when a large body is detected.
+ * Breaks down where the size is coming from.
+ */
+function warnLargeBody(body, bodyBytes, host) {
+  const msgs = body?.messages || [];
+  const totalMsgs = msgs.length;
+
+  // Find biggest messages (top 3)
+  const withSize = msgs
+    .map((m, i) => ({ i, role: m?.role, size: JSON.stringify(m).length }))
+    .sort((a, b) => b.size - a.size)
+    .slice(0, 3);
+
+  const topStr = withSize
+    .map(m => `  msg[${m.i}] ${m.role} = ${fmtBytes(m.size)}`)
+    .join("\n");
+
+  dbg("OLLAMA-LOCAL", [
+    `⚠ Large body (${fmtBytes(bodyBytes)}) — breakdown:`,
+    `  total_messages : ${totalMsgs}`,
+    `  top offenders  :\n${topStr}`,
+    `  tools          : ${body?.tools?.length ?? 0} defined`,
+    `  max_tokens     : ${body?.max_tokens ?? "unset"}`,
+    `Hints: trim old messages, reduce tool definitions, or set a lower max_tokens.`,
+    `Ollama timeout raised to ${fmtMs(OLLAMA_LOCAL_CONNECT_TIMEOUT_MS)} — if it still fails,`,
+    `consider setting OLLAMA_LOCAL_CONNECT_TIMEOUT_MS env var higher.`,
+  ].join("\n    "));
+}
+
+// ─── Executor ─────────────────────────────────────────────────────────────
 
 export class OllamaLocalExecutor extends DefaultExecutor {
   constructor() {
     super("ollama-local");
+    // Override connect timeout: local models (especially large ones) need more
+    // time to load weights before returning response headers.
+    this.config = {
+      ...this.config,
+      timeoutMs: OLLAMA_LOCAL_CONNECT_TIMEOUT_MS,
+      // Disable network retry for local — no fallback host exists.
+      // Retrying multiplies latency (3 × timeout) with zero benefit when Ollama is down.
+      retry: {
+        502: { attempts: 0, delayMs: 0 },
+        503: { attempts: 0, delayMs: 0 },
+        504: { attempts: 0, delayMs: 0 },
+      },
+    };
   }
 
   buildUrl(model, stream, urlIndex = 0, credentials = null) {
-    return `${resolveOllamaLocalHost(credentials)}/api/chat`;
+    const host = resolveOllamaLocalHost(credentials);
+    return `${host}/api/chat`;
+  }
+
+  // Override execute: emit rich debug diagnostics then delegate to BaseExecutor.
+  async execute({ model, body, stream, credentials, signal, log, proxyOptions = null }) {
+    const host = resolveOllamaLocalHost(credentials);
+    const timeoutMs = this.config.timeoutMs;
+    const t0 = Date.now();
+
+    // ── Pre-flight diagnostics ──────────────────────────────────────────
+    const bodyStr = JSON.stringify(body);
+    const bodyBytes = bodyStr.length;
+    const msgSummary = summariseMessages(body?.messages);
+
+    dbg("OLLAMA-LOCAL", [
+      `→ ${host}/api/chat`,
+      `model=${model}`,
+      `stream=${stream ?? "unset"}`,
+      `body=${fmtBytes(bodyBytes)}`,
+      `timeout=${fmtMs(timeoutMs)}`,
+      `max_tokens=${body?.max_tokens ?? "unset"}`,
+      `tools=${body?.tools?.length ?? 0}`,
+    ].join(" | "));
+
+    dbg("OLLAMA-LOCAL", `  messages: ${msgSummary}`);
+
+    if (bodyBytes > 200 * 1024) {
+      warnLargeBody(body, bodyBytes, host);
+    }
+
+    // ── Delegate ────────────────────────────────────────────────────────
+    try {
+      const result = await super.execute({ model, body, stream, credentials, signal, log, proxyOptions });
+      const elapsed = Date.now() - t0;
+      dbg("OLLAMA-LOCAL", `✓ connected in ${fmtMs(elapsed)} | url=${result.url}`);
+      return result;
+    } catch (error) {
+      const elapsed = Date.now() - t0;
+      const isTimeout =
+        error.name === "AbortError" || error.message?.includes("fetch connect timeout");
+
+      const lines = [
+        `✖ ${error.name}: ${error.message}`,
+        `  elapsed    : ${fmtMs(elapsed)} / timeout=${fmtMs(timeoutMs)}`,
+        `  target     : ${host}/api/chat`,
+        `  model      : ${model}`,
+        `  body size  : ${fmtBytes(bodyBytes)}`,
+      ];
+
+      if (isTimeout) {
+        lines.push(
+          `  diagnosis  : Ollama did not return response headers within ${fmtMs(timeoutMs)}.`,
+          `  candidates : model not loaded, Ollama not running, or body too large for available RAM.`,
+          `  check      : curl -s ${host}/api/tags | jq '.models[].name'`,
+          `  env fix    : OLLAMA_LOCAL_CONNECT_TIMEOUT_MS=${timeoutMs * 2} (current × 2)`,
+        );
+      }
+
+      dbg("OLLAMA-LOCAL", lines.join("\n    "));
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
Problem
-------
OLLAMA-LOCAL requests were timing out silently with unhelpful logs:

  [DBG:FETCH] OLLAMA-LOCAL → http://localhost:11434/api/chat | body=564270B | connectTimeout=60000ms
  [DBG:FETCH] OLLAMA-LOCAL ✖ Error: fetch connect timeout

Issues:
- 60s connect timeout too short for large local models loading weights
- 3× network retry on 502/503/504 wasted 3+ min with no benefit (no fallback host)
- Log had no model name, no message breakdown, no actionable hints

Changes
-------
open-sse/executors/ollama-local.js
  - Raise connect timeout to 120s (OLLAMA_LOCAL_CONNECT_TIMEOUT_MS env, default 2×60s)
  - Disable 502/503/504 retry — ollama-local has no fallback, retrying only adds latency
  - Pre-flight [DBG:OLLAMA-LOCAL] line with: host, model, stream, body size (KB/MB), timeout, max_tokens, tool count
  - Message breakdown: total count, per-role counts [sys/usr/asst/tool], tool_calls, image blocks, approximate content size
  - Large-body warning (>200 KB): top-3 offender messages by size, hints to trim history
  - On timeout: elapsed vs timeout, curl diagnostic command, suggested env override
  - On success: 'connected in Xs' confirmation line

open-sse/executors/base.js
  - Add fmtBytes() helper (B / KB / MB)
  - Include model= in generic [DBG:FETCH] line for all providers

open-sse/config/runtimeConfig.js
  - Export OLLAMA_LOCAL_CONNECT_TIMEOUT_MS (default 120 000 ms)

.env.example
  - Document OLLAMA_LOCAL_CONNECT_TIMEOUT_MS with guidance for large models

Sample output after this change:
  [DBG:OLLAMA-LOCAL] → http://localhost:11434/api/chat | model=qwen2.5:72b | stream=true | body=551.0KB | timeout=120.0s | max_tokens=8192 | tools=3
  [DBG:OLLAMA-LOCAL]   messages: 12 msgs [sys=1 usr=6 asst=5] | ~392.6KB content
  [DBG:OLLAMA-LOCAL] ⚠ Large body (551.0KB) — breakdown:
      total_messages : 12
      top offenders  :
    msg[2] assistant = 39.1KB
      ...
  [DBG:OLLAMA-LOCAL] ✖ AbortError: fetch connect timeout
      elapsed    : 120.3s / timeout=120.0s
      diagnosis  : Ollama did not return response headers within 120.0s.
      check      : curl -s http://localhost:11434/api/tags | jq .models[].name
      env fix    : OLLAMA_LOCAL_CONNECT_TIMEOUT_MS=240000 (current x 2)