### PR TITLE
fix(responses): forward usage on streamed response.completed

### DIFF
--- a/open-sse/translator/concerns/usage.js
+++ b/open-sse/translator/concerns/usage.js
@@ -67,3 +67,37 @@ export function toOpenAIUsage(raw, kind) {
   if (!extract || !raw || typeof raw !== "object") return null;
   return buildUsage(extract(raw));
 }
+
+// Convert Chat Completions usage to the Responses API field names expected by
+// clients such as Codex and OpenCode.
+export function toResponsesUsage(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const inputTokens = n(raw.input_tokens) || n(raw.prompt_tokens);
+  const outputTokens = n(raw.output_tokens) || n(raw.completion_tokens);
+  if (!inputTokens && !outputTokens) return null;
+
+  const usage = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: n(raw.total_tokens) || inputTokens + outputTokens,
+  };
+
+  const cachedTokens =
+    n(raw.input_tokens_details?.cached_tokens) ||
+    n(raw.prompt_tokens_details?.cached_tokens) ||
+    n(raw.cached_tokens);
+  if (cachedTokens > 0) {
+    usage.input_tokens_details = { cached_tokens: cachedTokens };
+  }
+
+  const reasoningTokens =
+    n(raw.output_tokens_details?.reasoning_tokens) ||
+    n(raw.completion_tokens_details?.reasoning_tokens) ||
+    n(raw.reasoning_tokens);
+  if (reasoningTokens > 0) {
+    usage.output_tokens_details = { reasoning_tokens: reasoningTokens };
+  }
+
+  return usage;
+}

--- a/open-sse/translator/index.js
+++ b/open-sse/translator/index.js
@@ -262,6 +262,7 @@ export function initState(sourceFormat) {
       funcArgsDone: {},
       funcItemDone: {},
       customToolNames: new Set(),
+      completionPending: false,
       completedSent: false
     };
   }

--- a/open-sse/translator/response/openai-responses.js
+++ b/open-sse/translator/response/openai-responses.js
@@ -5,7 +5,7 @@
 import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { buildChunk } from "../concerns/chunk.js";
-import { buildUsage } from "../concerns/usage.js";
+import { buildUsage, toResponsesUsage } from "../concerns/usage.js";
 import { fallbackToolCallId } from "../concerns/toolCall.js";
 import { reasoningDelta, extractReasoningText } from "../concerns/reasoning.js";
 import { ROLE, OPENAI_BLOCK, RESPONSES_ITEM, OPENAI_FINISH, MODEL_FALLBACK } from "../schema/index.js";
@@ -18,16 +18,26 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
   if (!chunk) {
     return flushEvents(state);
   }
-  
-  if (!chunk.choices?.length) return [];
-  
+
   const events = [];
   const nextSeq = () => ++state.seq;
-  
+
   const emit = (eventType, data) => {
     data.sequence_number = nextSeq();
     events.push({ event: eventType, data });
   };
+
+  // OpenAI-compatible streams commonly send usage in a final choices: []
+  // chunk after the finish_reason chunk. Capture it before the early return so
+  // response.completed can include it.
+  if (chunk.usage && typeof chunk.usage === "object") {
+    state.usage = chunk.usage;
+  }
+
+  if (!chunk.choices?.length) {
+    if (state.completionPending && state.usage) sendCompleted(state, emit);
+    return events;
+  }
 
   const choice = chunk.choices[0];
   const idx = choice.index || 0;
@@ -112,7 +122,10 @@ export function openaiToOpenAIResponsesResponse(chunk, state) {
     for (const i in state.msgItemAdded) closeMessage(state, emit, i);
     closeReasoning(state, emit);
     for (const i in state.funcCallIds) closeToolCall(state, emit, i);
-    sendCompleted(state, emit);
+    state.completionPending = true;
+    // Emit immediately when usage is carried on the finish chunk. Otherwise,
+    // wait for the standard trailing usage-only chunk (or stream flush).
+    if (state.usage) sendCompleted(state, emit);
   }
 
   return events;
@@ -368,6 +381,7 @@ function closeToolCall(state, emit, idx) {
 function sendCompleted(state, emit) {
   if (!state.completedSent) {
     state.completedSent = true;
+    const usage = toResponsesUsage(state.usage);
     emit("response.completed", {
       type: "response.completed",
       response: {
@@ -376,7 +390,8 @@ function sendCompleted(state, emit) {
         created_at: state.created,
         status: "completed",
         background: false,
-        error: null
+        error: null,
+        ...(usage ? { usage } : {})
       }
     });
   }

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -409,6 +409,14 @@ export function createSSEStream(options = {}) {
           }
         }
 
+        // Make fallback usage available before translators emit their terminal
+        // event. Responses clients read usage from response.completed, so
+        // estimating after flush leaves their context counters at zero.
+        if (sourceFormat === FORMATS.OPENAI_RESPONSES &&
+            !hasValidUsage(state?.usage) && totalContentLength > 0) {
+          state.usage = estimateUsage(body, totalContentLength, sourceFormat);
+        }
+
         const flushed = translateResponse(targetFormat, sourceFormat, null, state);
 
         if (flushed?._openaiIntermediate) {
@@ -444,6 +452,8 @@ export function createSSEStream(options = {}) {
           streamDoneSent = true;
         }
 
+        // Preserve the existing post-translation estimation timing for every
+        // other client format.
         if (!hasValidUsage(state?.usage) && totalContentLength > 0) {
           state.usage = estimateUsage(body, totalContentLength, sourceFormat);
         }

--- a/tests/unit/openai-responses-streaming-usage.test.js
+++ b/tests/unit/openai-responses-streaming-usage.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
+
+async function translateStream(chunks) {
+  const encoder = new TextEncoder();
+  const input = chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("") + "data: [DONE]\n\n";
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(input));
+      controller.close();
+    },
+  });
+
+  const output = stream.pipeThrough(
+    createSSETransformStreamWithLogger(
+      FORMATS.OPENAI,
+      FORMATS.OPENAI_RESPONSES,
+      "codebuddy-cn",
+      null,
+      null,
+      "deepseek-v4-flash",
+      null,
+      { input: "Say OK" },
+    ),
+  );
+
+  const reader = output.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
+
+function findCompletedEvents(output) {
+  const completed = [];
+  for (const line of output.split("\n")) {
+    if (!line.startsWith("data: ") || line === "data: [DONE]") continue;
+    const event = JSON.parse(line.slice(6));
+    if (event.type === "response.completed") completed.push(event);
+  }
+  return completed;
+}
+
+describe("OpenAI Chat Completions to Responses streaming usage", () => {
+  it("forwards a trailing usage-only chunk on response.completed", async () => {
+    const output = await translateStream([
+      {
+        id: "chatcmpl-usage",
+        choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: null }],
+      },
+      {
+        id: "chatcmpl-usage",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+      {
+        id: "chatcmpl-usage",
+        choices: [],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 7,
+          total_tokens: 19,
+          prompt_tokens_details: { cached_tokens: 4 },
+          completion_tokens_details: { reasoning_tokens: 3 },
+        },
+      },
+    ]);
+
+    const completed = findCompletedEvents(output);
+    expect(completed).toHaveLength(1);
+    expect(output.indexOf('"type":"response.completed"')).toBeGreaterThan(
+      output.indexOf('"type":"response.output_text.done"'),
+    );
+    expect(completed[0].response.usage).toEqual({
+      input_tokens: 12,
+      output_tokens: 7,
+      total_tokens: 19,
+      input_tokens_details: { cached_tokens: 4 },
+      output_tokens_details: { reasoning_tokens: 3 },
+    });
+  });
+
+  it("forwards usage carried on the finish chunk", async () => {
+    const output = await translateStream([
+      {
+        id: "chatcmpl-finish-usage",
+        choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: null }],
+      },
+      {
+        id: "chatcmpl-finish-usage",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+    ]);
+
+    const completed = findCompletedEvents(output);
+    expect(completed).toHaveLength(1);
+    expect(completed[0].response.usage).toEqual({
+      input_tokens: 5,
+      output_tokens: 2,
+      total_tokens: 7,
+    });
+  });
+
+  it("includes estimated usage when upstream usage is unavailable", async () => {
+    const output = await translateStream([
+      {
+        id: "chatcmpl-no-usage",
+        choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: null }],
+      },
+      {
+        id: "chatcmpl-no-usage",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+    ]);
+
+    const completed = findCompletedEvents(output);
+    expect(completed).toHaveLength(1);
+    expect(completed[0].response.usage.input_tokens).toBeGreaterThan(0);
+    expect(completed[0].response.usage.output_tokens).toBeGreaterThan(0);
+    expect(completed[0].response.usage.total_tokens).toBe(
+      completed[0].response.usage.input_tokens + completed[0].response.usage.output_tokens,
+    );
+  });
+});

--- a/tests/unit/usage-concern.test.js
+++ b/tests/unit/usage-concern.test.js
@@ -1,6 +1,6 @@
 // A3: locks toOpenAIUsage per-provider token math (claude/gemini/kiro/ollama/commandcode).
 import { describe, it, expect } from "vitest";
-import { toOpenAIUsage } from "../../open-sse/translator/concerns/usage.js";
+import { toOpenAIUsage, toResponsesUsage } from "../../open-sse/translator/concerns/usage.js";
 
 describe("toOpenAIUsage", () => {
   it("claude: folds cache read+create into prompt, exposes details", () => {
@@ -65,5 +65,28 @@ describe("toOpenAIUsage", () => {
   it("unknown kind / null raw -> null", () => {
     expect(toOpenAIUsage({}, "nope")).toBeNull();
     expect(toOpenAIUsage(null, "claude")).toBeNull();
+  });
+});
+
+describe("toResponsesUsage", () => {
+  it("maps Chat Completions usage and token details", () => {
+    expect(toResponsesUsage({
+      prompt_tokens: 12,
+      completion_tokens: 7,
+      total_tokens: 19,
+      prompt_tokens_details: { cached_tokens: 4 },
+      completion_tokens_details: { reasoning_tokens: 3 },
+    })).toEqual({
+      input_tokens: 12,
+      output_tokens: 7,
+      total_tokens: 19,
+      input_tokens_details: { cached_tokens: 4 },
+      output_tokens_details: { reasoning_tokens: 3 },
+    });
+  });
+
+  it("returns null when no token counts are available", () => {
+    expect(toResponsesUsage(null)).toBeNull();
+    expect(toResponsesUsage({})).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- preserve Chat Completions usage chunks before the empty-`choices` early return
- delay `response.completed` until trailing usage arrives or the stream flushes
- map Chat Completions token fields to the Responses API shape, including cached and reasoning token details
- expose 9Router's existing estimated usage before the terminal Responses event when an upstream omits usage

## Root cause

The OpenAI Chat Completions → Responses translator emitted `response.completed` as soon as it saw `finish_reason`. OpenAI-compatible providers may send usage in a later `choices: []` chunk, so the terminal event was already gone before those token counts were available. When no upstream usage existed, fallback estimation also ran after translator flush, which was too late for Responses clients.

This is the missing production-path coverage in the approach explored by #2082: its test manually assigned `state.usage`, while the real stream path still lost trailing usage.

## Impact

Responses clients such as OpenCode and Codex can read token usage from `response.completed.response.usage` instead of showing a zero context count.

Addresses Defect 1 in #2880.

## Validation

- `npx vitest run --config vitest.config.js unit/openai-responses-streaming-usage.test.js unit/usage-concern.test.js unit/usage-dispatch.test.js unit/cached-token-usage.test.js unit/openai-responses-nonstream.test.js unit/openai-responses-terminal-event.test.js unit/openai-responses-multiturn.test.js unit/openai-responses-custom-tools.test.js` — 53 passed
- ESLint on all changed source and test files — passed
- `npm run build` — passed
