### PR TITLE
fix(security): require proof that x-9r-real-ip came from the socket (GHSA-pjm4-8fpg-f9p6)

### DIFF
--- a/cli/scripts/build-cli.js
+++ b/cli/scripts/build-cli.js
@@ -216,7 +216,9 @@ function buildCliPackage() {
     fs.copyFileSync(customServerSrc, path.join(cliAppDir, "custom-server.js"));
     console.log("✅ Copied custom-server.js\n");
   } else {
-    console.warn("⚠️  custom-server.js not found — server will run without real-IP injection\n");
+    console.error("❌ custom-server.js not found — without it no request can be proven local,");
+    console.error("   so the packaged CLI would demand an API key for its own dashboard and /v1.");
+    process.exit(1);
   }
 
   // Step 3b: Ensure sql.js (pure JS fallback) bundled in app/cli/app/node_modules.

--- a/custom-server.js
+++ b/custom-server.js
@@ -1,8 +1,16 @@
 const http = require("http");
 const path = require("path");
+const fs = require("fs");
+const crypto = require("crypto");
 const { pathToFileURL } = require("url");
 
 const origCreate = http.createServer.bind(http);
+
+// Per-process secret proving x-9r-real-ip was stamped below rather than sent by the client.
+// A bare `next start` / `next dev` never loads this file, so it cannot produce a matching
+// header even though the env var is inherited by child processes.
+const PEER_TRUST_TOKEN = crypto.randomBytes(24).toString("hex");
+process.env.NINEROUTER_PEER_TRUST = PEER_TRUST_TOKEN;
 
 let backgroundRefreshStarted = false;
 
@@ -57,7 +65,9 @@ http.createServer = (...args) => {
     delete req.headers["x-9r-real-ip"];
     delete req.headers["x-forwarded-for"];
     delete req.headers["x-9r-via-proxy"];
+    delete req.headers["x-9r-peer-trust"];
     req.headers["x-9r-real-ip"] = ip;
+    req.headers["x-9r-peer-trust"] = PEER_TRUST_TOKEN;
     if (viaProxy) req.headers["x-9r-via-proxy"] = "1";
     return handler(req, res);
   };
@@ -114,4 +124,15 @@ http.createServer = (...args) => {
   return server;
 };
 
-if (require.main === module) require("./server.js");
+if (require.main === module) {
+  const standalone = path.join(__dirname, "server.js");
+  if (fs.existsSync(standalone)) {
+    require(standalone);
+  } else {
+    // Repo checkout has no standalone build next to us. `next start` builds its HTTP
+    // server in-process, so the wrapper above still sanitizes every request.
+    const nextBin = require.resolve("next/dist/bin/next");
+    process.argv = [process.argv[0], nextBin, "start", ...process.argv.slice(2)];
+    require(nextBin);
+  }
+}

--- a/custom-server.js
+++ b/custom-server.js
@@ -8,9 +8,10 @@ const origCreate = http.createServer.bind(http);
 
 // Per-process secret proving x-9r-real-ip was stamped below rather than sent by the client.
 // A bare `next start` / `next dev` never loads this file, so it cannot produce a matching
-// header even though the env var is inherited by child processes.
-const PEER_TRUST_TOKEN = crypto.randomBytes(24).toString("hex");
-process.env.NINEROUTER_PEER_TRUST = PEER_TRUST_TOKEN;
+// header even though the env var is inherited by child processes. Named like x-9r-cli-token
+// so the request-detail header sanitizer redacts it too.
+const PEER_TOKEN = crypto.randomBytes(24).toString("hex");
+process.env.NINEROUTER_PEER_TOKEN = PEER_TOKEN;
 
 let backgroundRefreshStarted = false;
 
@@ -65,9 +66,9 @@ http.createServer = (...args) => {
     delete req.headers["x-9r-real-ip"];
     delete req.headers["x-forwarded-for"];
     delete req.headers["x-9r-via-proxy"];
-    delete req.headers["x-9r-peer-trust"];
+    delete req.headers["x-9r-peer-token"];
     req.headers["x-9r-real-ip"] = ip;
-    req.headers["x-9r-peer-trust"] = PEER_TRUST_TOKEN;
+    req.headers["x-9r-peer-token"] = PEER_TOKEN;
     if (viaProxy) req.headers["x-9r-via-proxy"] = "1";
     return handler(req, res);
   };

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "build": "next build --webpack",
     "postbuild": "node scripts/copy-standalone-assets.mjs",
     "postbuild:bun": "node scripts/copy-standalone-assets.mjs",
-    "start": "next start --port 20127",
+    "start": "node custom-server.js --port 20127",
     "dev:bun": "bun --bun next dev --webpack --port 20127",
     "build:bun": "bun --bun next build --webpack",
-    "start:bun": "bun ./.next/standalone/server.js",
+    "start:bun": "bun ./.next/standalone/custom-server.js",
     "cli:pack": "npm --prefix cli run pack:cli",
     "cli:publish": "npm --prefix cli run publish:cli"
   },

--- a/scripts/copy-standalone-assets.mjs
+++ b/scripts/copy-standalone-assets.mjs
@@ -29,6 +29,14 @@ export function copyStandaloneAssets({ projectRoot = process.cwd(), distDir = pr
     cpSync(publicSource, publicDestination, { recursive: true, force: true });
     console.log(`[standalone-assets] Copied public assets to ${publicDestination}`);
   }
+
+  // Without it beside server.js the standalone build serves requests unsanitized.
+  const serverWrapperSource = resolve(projectRoot, "custom-server.js");
+  const serverWrapperDestination = resolve(standaloneDir, "custom-server.js");
+  if (existsSync(serverWrapperSource)) {
+    cpSync(serverWrapperSource, serverWrapperDestination, { force: true });
+    console.log(`[standalone-assets] Copied custom-server.js to ${serverWrapperDestination}`);
+  }
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === resolve(dirname(fileURLToPath(import.meta.url)), "copy-standalone-assets.mjs")) {

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSettings, validateApiKey } from "@/lib/localDb";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
 import { verifyDashboardAuthToken } from "@/lib/auth/dashboardSession";
+import { hasTrustedPeerHeaders } from "@/lib/auth/trustedPeer";
 
 const CLI_TOKEN_HEADER = "x-9r-cli-token";
 const CLI_TOKEN_SALT = "9r-cli-auth";
@@ -92,18 +93,23 @@ function isLoopbackHostname(h) {
   return LOOPBACK_HOSTS.has(name);
 }
 
+function isLoopbackPeer(request) {
+  if (hasTrustedPeerHeaders(request)) {
+    return isLoopbackHostname(request.headers.get("x-9r-real-ip"));
+  }
+  // Bare `next dev` forks its server, so the wrapper never loads and no peer address
+  // reaches us. Host is spoofable, so this stays confined to development.
+  if (process.env.NODE_ENV === "development") {
+    return isLoopbackHostname(request.headers.get("host"));
+  }
+  return false;
+}
+
 export function isLocalRequest(request) {
   // Stamped by custom-server.js when forwarding headers exist: request came through
   // a reverse proxy, so the loopback socket is the proxy hop, not the end-user.
   if (request.headers.get("x-9r-via-proxy")) return false;
-  // Trusted peer IP from TCP socket (custom-server.js); unspoofable. Primary anchor for "local".
-  const realIp = request.headers.get("x-9r-real-ip");
-  if (realIp) {
-    if (!isLoopbackHostname(realIp)) return false;
-  } else if (!isLoopbackHostname(request.headers.get("host"))) {
-    // Fallback for bare server.js (dev) without custom-server: legacy Host-based check.
-    return false;
-  }
+  if (!isLoopbackPeer(request)) return false;
   const origin = request.headers.get("origin");
   if (origin) {
     try {

--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -87,9 +87,20 @@ const LOCAL_ONLY_PATHS = [
 
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
+// Accepts a Host header, a URL hostname or a raw socket address. Splitting on the first
+// colon only works for IPv4 and would reduce every IPv6 form to "", so a dual-stack
+// listener handing back ::ffff:127.0.0.1 would not read as loopback.
 function isLoopbackHostname(h) {
   if (!h) return false;
-  const name = h.split(":")[0].replace(/^\[|\]$/g, "").toLowerCase();
+  let name = String(h).trim().toLowerCase();
+  if (name.startsWith("[")) {
+    const end = name.indexOf("]");
+    if (end === -1) return false;
+    name = name.slice(1, end);
+  } else if (name.indexOf(":") !== -1 && name.indexOf(":") === name.lastIndexOf(":")) {
+    name = name.slice(0, name.indexOf(":"));
+  }
+  if (name.startsWith("::ffff:")) name = name.slice(7);
   return LOOPBACK_HOSTS.has(name);
 }
 

--- a/src/lib/auth/loginLimiter.js
+++ b/src/lib/auth/loginLimiter.js
@@ -1,4 +1,5 @@
 // In-memory progressive lockout for dashboard login. Resets on process restart.
+import { hasTrustedPeerHeaders } from "./trustedPeer.js";
 
 const MAX_FAILS_BEFORE_LOCK = 5;
 const LOCK_STEPS_MS = [30_000, 120_000, 600_000, 1_800_000]; // 30s, 2m, 10m, 30m
@@ -46,9 +47,12 @@ export function recordSuccess(ip) {
 }
 
 export function getClientIp(request) {
-  // Trusted: set from TCP socket by custom-server.js (client cannot spoof).
-  const realIp = request.headers.get("x-9r-real-ip");
-  if (realIp) return realIp;
+  // Trusted only when custom-server.js proves it stamped the header from the TCP socket;
+  // otherwise a client could rotate the value to escape its own lockout bucket.
+  if (hasTrustedPeerHeaders(request)) {
+    const realIp = request.headers.get("x-9r-real-ip");
+    if (realIp) return realIp;
+  }
   // Behind a trusted reverse proxy that overwrites XFF with the real client IP.
   if (process.env.TRUST_PROXY === "true") {
     const xff = request.headers.get("x-forwarded-for");

--- a/src/lib/auth/trustedPeer.js
+++ b/src/lib/auth/trustedPeer.js
@@ -1,0 +1,7 @@
+// x-9r-real-ip is only trustworthy when custom-server.js stamped it from the TCP socket.
+// It proves that by echoing the per-process secret it generated at boot, which a client
+// cannot guess. Without the proof the header is just attacker-supplied input.
+export function hasTrustedPeerHeaders(request) {
+  const token = process.env.NINEROUTER_PEER_TRUST;
+  return Boolean(token) && request.headers.get("x-9r-peer-trust") === token;
+}

--- a/src/lib/auth/trustedPeer.js
+++ b/src/lib/auth/trustedPeer.js
@@ -2,6 +2,6 @@
 // It proves that by echoing the per-process secret it generated at boot, which a client
 // cannot guess. Without the proof the header is just attacker-supplied input.
 export function hasTrustedPeerHeaders(request) {
-  const token = process.env.NINEROUTER_PEER_TRUST;
-  return Boolean(token) && request.headers.get("x-9r-peer-trust") === token;
+  const token = process.env.NINEROUTER_PEER_TOKEN;
+  return Boolean(token) && request.headers.get("x-9r-peer-token") === token;
 }

--- a/src/lib/db/repos/requestDetailsRepo.js
+++ b/src/lib/db/repos/requestDetailsRepo.js
@@ -68,6 +68,8 @@ function sanitizeHeaders(headers) {
   return sanitized;
 }
 
+export const __test__ = { sanitizeHeaders };
+
 function generateDetailId(model) {
   const timestamp = new Date().toISOString();
   const random = Math.random().toString(36).substring(2, 8);

--- a/tests/unit/custom-server-peer-headers.test.js
+++ b/tests/unit/custom-server-peer-headers.test.js
@@ -1,0 +1,69 @@
+// custom-server.js is the only thing that makes x-9r-real-ip trustworthy. Boot a real
+// HTTP server through it and confirm a client cannot smuggle its own peer headers in.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createRequire } from "node:module";
+import http from "node:http";
+
+const require = createRequire(import.meta.url);
+
+let server;
+let baseUrl;
+let seenHeaders;
+
+beforeAll(async () => {
+  require("../../custom-server.js");
+  server = http.createServer((req, res) => {
+    seenHeaders = req.headers;
+    res.end("ok");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+async function get(headers = {}) {
+  await fetch(baseUrl, { headers });
+  return seenHeaders;
+}
+
+describe("custom-server peer header sanitizing", () => {
+  it("generates a peer trust token at boot", () => {
+    expect(process.env.NINEROUTER_PEER_TRUST).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("replaces a client-supplied x-9r-real-ip with the socket address", async () => {
+    const headers = await get({ "x-9r-real-ip": "203.0.113.55" });
+
+    expect(headers["x-9r-real-ip"]).toMatch(/^(::ffff:)?127\.0\.0\.1$/);
+  });
+
+  it("stamps the trust token so downstream can tell the wrapper ran", async () => {
+    const headers = await get();
+
+    expect(headers["x-9r-peer-trust"]).toBe(process.env.NINEROUTER_PEER_TRUST);
+  });
+
+  it("drops a client-supplied peer trust token", async () => {
+    const headers = await get({ "x-9r-peer-trust": "forged-token" });
+
+    expect(headers["x-9r-peer-trust"]).toBe(process.env.NINEROUTER_PEER_TRUST);
+    expect(headers["x-9r-peer-trust"]).not.toBe("forged-token");
+  });
+
+  it("drops a client-supplied x-9r-via-proxy marker", async () => {
+    const headers = await get({ "x-9r-via-proxy": "1" });
+
+    expect(headers["x-9r-via-proxy"]).toBeUndefined();
+  });
+
+  it("marks via-proxy and adopts the forwarded IP for a loopback proxy hop", async () => {
+    const headers = await get({ "x-forwarded-for": "203.0.113.9, 10.0.0.1" });
+
+    expect(headers["x-9r-via-proxy"]).toBe("1");
+    expect(headers["x-9r-real-ip"]).toBe("203.0.113.9");
+    expect(headers["x-forwarded-for"]).toBeUndefined();
+  });
+});

--- a/tests/unit/custom-server-peer-headers.test.js
+++ b/tests/unit/custom-server-peer-headers.test.js
@@ -3,6 +3,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createRequire } from "node:module";
 import http from "node:http";
+import { __test__ as requestDetails } from "@/lib/db/repos/requestDetailsRepo.js";
 
 const require = createRequire(import.meta.url);
 
@@ -31,7 +32,7 @@ async function get(headers = {}) {
 
 describe("custom-server peer header sanitizing", () => {
   it("generates a peer trust token at boot", () => {
-    expect(process.env.NINEROUTER_PEER_TRUST).toMatch(/^[0-9a-f]{48}$/);
+    expect(process.env.NINEROUTER_PEER_TOKEN).toMatch(/^[0-9a-f]{48}$/);
   });
 
   it("replaces a client-supplied x-9r-real-ip with the socket address", async () => {
@@ -43,14 +44,14 @@ describe("custom-server peer header sanitizing", () => {
   it("stamps the trust token so downstream can tell the wrapper ran", async () => {
     const headers = await get();
 
-    expect(headers["x-9r-peer-trust"]).toBe(process.env.NINEROUTER_PEER_TRUST);
+    expect(headers["x-9r-peer-token"]).toBe(process.env.NINEROUTER_PEER_TOKEN);
   });
 
   it("drops a client-supplied peer trust token", async () => {
-    const headers = await get({ "x-9r-peer-trust": "forged-token" });
+    const headers = await get({ "x-9r-peer-token": "forged-token" });
 
-    expect(headers["x-9r-peer-trust"]).toBe(process.env.NINEROUTER_PEER_TRUST);
-    expect(headers["x-9r-peer-trust"]).not.toBe("forged-token");
+    expect(headers["x-9r-peer-token"]).toBe(process.env.NINEROUTER_PEER_TOKEN);
+    expect(headers["x-9r-peer-token"]).not.toBe("forged-token");
   });
 
   it("drops a client-supplied x-9r-via-proxy marker", async () => {
@@ -65,5 +66,21 @@ describe("custom-server peer header sanitizing", () => {
     expect(headers["x-9r-via-proxy"]).toBe("1");
     expect(headers["x-9r-real-ip"]).toBe("203.0.113.9");
     expect(headers["x-forwarded-for"]).toBeUndefined();
+  });
+
+  // chat.js snapshots every client header into the request detail. Anything that grants
+  // access must not survive into a record the dashboard renders and cloud sync uploads.
+  it("keeps the peer token out of persisted request details", () => {
+    const sanitized = requestDetails.sanitizeHeaders({
+      "x-9r-peer-token": "secret",
+      "x-9r-cli-token": "secret",
+      "authorization": "Bearer sk-x",
+      "x-9r-real-ip": "127.0.0.1",
+    });
+
+    expect(sanitized["x-9r-peer-token"]).toBeUndefined();
+    expect(sanitized["x-9r-cli-token"]).toBeUndefined();
+    expect(sanitized["authorization"]).toBeUndefined();
+    expect(sanitized["x-9r-real-ip"]).toBe("127.0.0.1");
   });
 });

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -35,6 +35,8 @@ vi.mock("@/lib/auth/dashboardSession", () => ({
 
 const { proxy, __test__ } = await import("../../src/dashboardGuard.js");
 
+const PEER_TRUST = "peer-trust-token";
+
 function request(pathname, headers = {}) {
   const normalizedHeaders = new Headers(headers);
   return {
@@ -45,9 +47,16 @@ function request(pathname, headers = {}) {
   };
 }
 
+// A request that actually came through custom-server.js: peer IP stamped from the TCP
+// socket and proven by the per-process secret.
+function localRequest(pathname, headers = {}) {
+  return request(pathname, { "x-9r-peer-trust": PEER_TRUST, "x-9r-real-ip": "127.0.0.1", ...headers });
+}
+
 describe("dashboard guard public LLM API access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
     mocks.getSettings.mockResolvedValue({ requireLogin: true });
     mocks.validateApiKey.mockResolvedValue(false);
     mocks.getConsistentMachineId.mockResolvedValue("cli-token");
@@ -55,14 +64,14 @@ describe("dashboard guard public LLM API access", () => {
   });
 
   it("allows loopback public LLM API without API key", async () => {
-    const response = await proxy(request("/v1/chat/completions", { host: "localhost:20128" }));
+    const response = await proxy(localRequest("/v1/chat/completions", { host: "localhost:20128" }));
 
     expect(response).toBe(mocks.nextResponse);
     expect(mocks.validateApiKey).not.toHaveBeenCalled();
   });
 
   it("rejects remote Host-spoof when real peer IP is non-loopback", async () => {
-    const response = await proxy(request("/v1/chat/completions", {
+    const response = await proxy(localRequest("/v1/chat/completions", {
       host: "localhost",
       "x-9r-real-ip": "10.204.111.34",
     }));
@@ -72,7 +81,7 @@ describe("dashboard guard public LLM API access", () => {
   });
 
   it("allows loopback peer IP regardless of Host", async () => {
-    const response = await proxy(request("/v1/chat/completions", {
+    const response = await proxy(localRequest("/v1/chat/completions", {
       host: "localhost:20128",
       "x-9r-real-ip": "127.0.0.1",
     }));
@@ -89,7 +98,7 @@ describe("dashboard guard public LLM API access", () => {
   });
 
   it("allows loopback rewritten public LLM API without API key", async () => {
-    const response = await proxy(request("/api/v1/chat/completions", { host: "localhost:20128" }));
+    const response = await proxy(localRequest("/api/v1/chat/completions", { host: "localhost:20128" }));
 
     expect(response).toBe(mocks.nextResponse);
     expect(mocks.validateApiKey).not.toHaveBeenCalled();
@@ -191,6 +200,7 @@ describe("dashboard guard public LLM API access", () => {
 describe("dashboard guard local-only access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
     mocks.getSettings.mockResolvedValue({ requireLogin: true });
     mocks.validateApiKey.mockResolvedValue(false);
     mocks.getConsistentMachineId.mockResolvedValue("cli-token");
@@ -207,7 +217,7 @@ describe("dashboard guard local-only access", () => {
   });
 
   it("rejects local-only route on loopback when requireLogin=true and no JWT", async () => {
-    const response = await proxy(request("/api/mcp/filesystem/sse", {
+    const response = await proxy(localRequest("/api/mcp/filesystem/sse", {
       host: "localhost:20128",
       origin: "http://localhost:20128",
     }));
@@ -219,7 +229,7 @@ describe("dashboard guard local-only access", () => {
   it("allows local-only route on loopback when requireLogin=false", async () => {
     mocks.getSettings.mockResolvedValue({ requireLogin: false });
 
-    const response = await proxy(request("/api/cli-tools/antigravity-mitm", {
+    const response = await proxy(localRequest("/api/cli-tools/antigravity-mitm", {
       host: "localhost:20128",
       origin: "http://localhost:20128",
     }));
@@ -240,7 +250,7 @@ describe("dashboard guard local-only access", () => {
   it("rejects local-only route when Origin is non-loopback (CSRF block)", async () => {
     mocks.getSettings.mockResolvedValue({ requireLogin: false });
 
-    const response = await proxy(request("/api/cli-tools/antigravity-mitm", {
+    const response = await proxy(localRequest("/api/cli-tools/antigravity-mitm", {
       host: "localhost:20128",
       origin: "http://evil.example.com",
     }));

--- a/tests/unit/dashboard-guard.test.js
+++ b/tests/unit/dashboard-guard.test.js
@@ -35,7 +35,7 @@ vi.mock("@/lib/auth/dashboardSession", () => ({
 
 const { proxy, __test__ } = await import("../../src/dashboardGuard.js");
 
-const PEER_TRUST = "peer-trust-token";
+const PEER_TOKEN = "peer-token-fixture";
 
 function request(pathname, headers = {}) {
   const normalizedHeaders = new Headers(headers);
@@ -50,13 +50,13 @@ function request(pathname, headers = {}) {
 // A request that actually came through custom-server.js: peer IP stamped from the TCP
 // socket and proven by the per-process secret.
 function localRequest(pathname, headers = {}) {
-  return request(pathname, { "x-9r-peer-trust": PEER_TRUST, "x-9r-real-ip": "127.0.0.1", ...headers });
+  return request(pathname, { "x-9r-peer-token": PEER_TOKEN, "x-9r-real-ip": "127.0.0.1", ...headers });
 }
 
 describe("dashboard guard public LLM API access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
+    process.env.NINEROUTER_PEER_TOKEN = PEER_TOKEN;
     mocks.getSettings.mockResolvedValue({ requireLogin: true });
     mocks.validateApiKey.mockResolvedValue(false);
     mocks.getConsistentMachineId.mockResolvedValue("cli-token");
@@ -200,7 +200,7 @@ describe("dashboard guard public LLM API access", () => {
 describe("dashboard guard local-only access", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
+    process.env.NINEROUTER_PEER_TOKEN = PEER_TOKEN;
     mocks.getSettings.mockResolvedValue({ requireLogin: true });
     mocks.validateApiKey.mockResolvedValue(false);
     mocks.getConsistentMachineId.mockResolvedValue("cli-token");

--- a/tests/unit/local-request-peer-trust-3294.test.js
+++ b/tests/unit/local-request-peer-trust-3294.test.js
@@ -1,0 +1,183 @@
+// GHSA-pjm4-8fpg-f9p6 (#3294): `next start` leaves custom-server.js out of the request
+// path, so x-9r-real-ip arrives straight from the client and a remote caller can claim to
+// be loopback. Host is spoofable the same way, so it cannot be the production fallback.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  nextResponse: Symbol("next"),
+  jsonResponse: vi.fn((body, init) => ({ status: init?.status || 200, body })),
+  getSettings: vi.fn(),
+  validateApiKey: vi.fn(),
+  getConsistentMachineId: vi.fn(),
+  verifyDashboardAuthToken: vi.fn(),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    next: vi.fn(() => mocks.nextResponse),
+    json: mocks.jsonResponse,
+    redirect: vi.fn((url) => ({ status: 307, url })),
+  },
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+  validateApiKey: mocks.validateApiKey,
+}));
+
+vi.mock("@/shared/utils/machineId", () => ({
+  getConsistentMachineId: mocks.getConsistentMachineId,
+}));
+
+vi.mock("@/lib/auth/dashboardSession", () => ({
+  verifyDashboardAuthToken: mocks.verifyDashboardAuthToken,
+}));
+
+const { proxy } = await import("../../src/dashboardGuard.js");
+const { getClientIp } = await import("../../src/lib/auth/loginLimiter.js");
+
+const PEER_TRUST = "peer-trust-token";
+
+function request(pathname, headers = {}) {
+  return {
+    nextUrl: { pathname, searchParams: new URL(`http://localhost${pathname}`).searchParams },
+    headers: new Headers(headers),
+    cookies: { get: vi.fn(() => undefined) },
+    url: `http://localhost${pathname}`,
+  };
+}
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+describe("peer header trust", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
+    process.env.NODE_ENV = "production";
+    mocks.getSettings.mockResolvedValue({ requireLogin: true });
+    mocks.validateApiKey.mockResolvedValue(false);
+    mocks.getConsistentMachineId.mockResolvedValue("cli-token");
+    mocks.verifyDashboardAuthToken.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    delete process.env.NINEROUTER_PEER_TRUST;
+  });
+
+  it("rejects a spoofed loopback peer IP that carries no trust proof", async () => {
+    const response = await proxy(request("/api/v1/models", {
+      host: "172.18.192.1:20140",
+      "x-9r-real-ip": "127.0.0.1",
+    }));
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("API key required for remote API access");
+  });
+
+  it("rejects a spoofed loopback peer IP carrying a wrong trust token", async () => {
+    const response = await proxy(request("/api/v1/models", {
+      host: "172.18.192.1:20140",
+      "x-9r-real-ip": "127.0.0.1",
+      "x-9r-peer-trust": "guessed-token",
+    }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a spoofed loopback Host in production", async () => {
+    const response = await proxy(request("/api/v1/models", { host: "localhost" }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a spoofed loopback peer IP when the wrapper never booted", async () => {
+    delete process.env.NINEROUTER_PEER_TRUST;
+
+    const response = await proxy(request("/api/v1/models", {
+      host: "172.18.192.1:20140",
+      "x-9r-real-ip": "127.0.0.1",
+      "x-9r-peer-trust": "any-token",
+    }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("keeps serving a genuinely local request stamped by the wrapper", async () => {
+    const response = await proxy(request("/api/v1/models", {
+      host: "localhost:20128",
+      "x-9r-real-ip": "127.0.0.1",
+      "x-9r-peer-trust": PEER_TRUST,
+    }));
+
+    expect(response).toBe(mocks.nextResponse);
+    expect(mocks.validateApiKey).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a stamped non-loopback peer IP", async () => {
+    const response = await proxy(request("/api/v1/models", {
+      host: "localhost:20128",
+      "x-9r-real-ip": "10.204.111.34",
+      "x-9r-peer-trust": PEER_TRUST,
+    }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("blocks spoofed local-only routes that would otherwise spawn processes", async () => {
+    mocks.getSettings.mockResolvedValue({ requireLogin: false });
+
+    const response = await proxy(request("/api/mcp/filesystem/sse", {
+      host: "172.18.192.1:20140",
+      "x-9r-real-ip": "127.0.0.1",
+    }));
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Local only: CLI token required");
+  });
+
+  it("accepts the legacy Host fallback only in development", async () => {
+    process.env.NODE_ENV = "development";
+
+    const response = await proxy(request("/api/v1/models", { host: "localhost:20127" }));
+
+    expect(response).toBe(mocks.nextResponse);
+  });
+});
+
+describe("login limiter client IP", () => {
+  beforeEach(() => {
+    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
+    delete process.env.TRUST_PROXY;
+  });
+
+  afterEach(() => {
+    delete process.env.NINEROUTER_PEER_TRUST;
+    delete process.env.TRUST_PROXY;
+  });
+
+  it("buckets spoofed peer IPs together so lockout cannot be rotated away", () => {
+    const first = getClientIp(request("/api/auth/login", { "x-9r-real-ip": "1.1.1.1" }));
+    const second = getClientIp(request("/api/auth/login", { "x-9r-real-ip": "2.2.2.2" }));
+
+    expect(first).toBe("unknown");
+    expect(second).toBe("unknown");
+  });
+
+  it("keys on the stamped peer IP when the wrapper proved it", () => {
+    const ip = getClientIp(request("/api/auth/login", {
+      "x-9r-real-ip": "203.0.113.9",
+      "x-9r-peer-trust": PEER_TRUST,
+    }));
+
+    expect(ip).toBe("203.0.113.9");
+  });
+
+  it("still honours TRUST_PROXY for operators fronting 9router with a reverse proxy", () => {
+    process.env.TRUST_PROXY = "true";
+
+    const ip = getClientIp(request("/api/auth/login", { "x-forwarded-for": "198.51.100.7, 10.0.0.1" }));
+
+    expect(ip).toBe("198.51.100.7");
+  });
+});

--- a/tests/unit/local-request-peer-trust-3294.test.js
+++ b/tests/unit/local-request-peer-trust-3294.test.js
@@ -36,7 +36,7 @@ vi.mock("@/lib/auth/dashboardSession", () => ({
 const { proxy } = await import("../../src/dashboardGuard.js");
 const { getClientIp } = await import("../../src/lib/auth/loginLimiter.js");
 
-const PEER_TRUST = "peer-trust-token";
+const PEER_TOKEN = "peer-token-fixture";
 
 function request(pathname, headers = {}) {
   return {
@@ -52,7 +52,7 @@ const originalNodeEnv = process.env.NODE_ENV;
 describe("peer header trust", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
+    process.env.NINEROUTER_PEER_TOKEN = PEER_TOKEN;
     process.env.NODE_ENV = "production";
     mocks.getSettings.mockResolvedValue({ requireLogin: true });
     mocks.validateApiKey.mockResolvedValue(false);
@@ -62,7 +62,7 @@ describe("peer header trust", () => {
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
-    delete process.env.NINEROUTER_PEER_TRUST;
+    delete process.env.NINEROUTER_PEER_TOKEN;
   });
 
   it("rejects a spoofed loopback peer IP that carries no trust proof", async () => {
@@ -79,7 +79,7 @@ describe("peer header trust", () => {
     const response = await proxy(request("/api/v1/models", {
       host: "172.18.192.1:20140",
       "x-9r-real-ip": "127.0.0.1",
-      "x-9r-peer-trust": "guessed-token",
+      "x-9r-peer-token": "guessed-token",
     }));
 
     expect(response.status).toBe(401);
@@ -92,12 +92,12 @@ describe("peer header trust", () => {
   });
 
   it("rejects a spoofed loopback peer IP when the wrapper never booted", async () => {
-    delete process.env.NINEROUTER_PEER_TRUST;
+    delete process.env.NINEROUTER_PEER_TOKEN;
 
     const response = await proxy(request("/api/v1/models", {
       host: "172.18.192.1:20140",
       "x-9r-real-ip": "127.0.0.1",
-      "x-9r-peer-trust": "any-token",
+      "x-9r-peer-token": "any-token",
     }));
 
     expect(response.status).toBe(401);
@@ -107,7 +107,7 @@ describe("peer header trust", () => {
     const response = await proxy(request("/api/v1/models", {
       host: "localhost:20128",
       "x-9r-real-ip": "127.0.0.1",
-      "x-9r-peer-trust": PEER_TRUST,
+      "x-9r-peer-token": PEER_TOKEN,
     }));
 
     expect(response).toBe(mocks.nextResponse);
@@ -118,7 +118,7 @@ describe("peer header trust", () => {
     const response = await proxy(request("/api/v1/models", {
       host: "localhost:20128",
       "x-9r-real-ip": "10.204.111.34",
-      "x-9r-peer-trust": PEER_TRUST,
+      "x-9r-peer-token": PEER_TOKEN,
     }));
 
     expect(response.status).toBe(401);
@@ -147,12 +147,12 @@ describe("peer header trust", () => {
 
 describe("login limiter client IP", () => {
   beforeEach(() => {
-    process.env.NINEROUTER_PEER_TRUST = PEER_TRUST;
+    process.env.NINEROUTER_PEER_TOKEN = PEER_TOKEN;
     delete process.env.TRUST_PROXY;
   });
 
   afterEach(() => {
-    delete process.env.NINEROUTER_PEER_TRUST;
+    delete process.env.NINEROUTER_PEER_TOKEN;
     delete process.env.TRUST_PROXY;
   });
 
@@ -167,7 +167,7 @@ describe("login limiter client IP", () => {
   it("keys on the stamped peer IP when the wrapper proved it", () => {
     const ip = getClientIp(request("/api/auth/login", {
       "x-9r-real-ip": "203.0.113.9",
-      "x-9r-peer-trust": PEER_TRUST,
+      "x-9r-peer-token": PEER_TOKEN,
     }));
 
     expect(ip).toBe("203.0.113.9");

--- a/tests/unit/local-request-peer-trust-3294.test.js
+++ b/tests/unit/local-request-peer-trust-3294.test.js
@@ -114,6 +114,34 @@ describe("peer header trust", () => {
     expect(mocks.validateApiKey).not.toHaveBeenCalled();
   });
 
+  // A dual-stack listener reports loopback as ::ffff:127.0.0.1, which the old
+  // split-on-first-colon check reduced to "".
+  it.each(["::ffff:127.0.0.1", "::1", "[::1]", "127.0.0.1", "::FFFF:127.0.0.1"])(
+    "treats %s as a loopback peer",
+    async (peerIp) => {
+      const response = await proxy(request("/api/v1/models", {
+        host: "localhost:20128",
+        "x-9r-real-ip": peerIp,
+        "x-9r-peer-token": PEER_TOKEN,
+      }));
+
+      expect(response).toBe(mocks.nextResponse);
+    }
+  );
+
+  it.each(["::ffff:10.204.111.34", "2001:db8::1", "[2001:db8::1]", "10.204.111.34"])(
+    "refuses %s as a peer",
+    async (peerIp) => {
+      const response = await proxy(request("/api/v1/models", {
+        host: "localhost:20128",
+        "x-9r-real-ip": peerIp,
+        "x-9r-peer-token": PEER_TOKEN,
+      }));
+
+      expect(response.status).toBe(401);
+    }
+  );
+
   it("still refuses a stamped non-loopback peer IP", async () => {
     const response = await proxy(request("/api/v1/models", {
       host: "localhost:20128",

--- a/tests/unit/standalone-assets.test.js
+++ b/tests/unit/standalone-assets.test.js
@@ -37,6 +37,17 @@ describe("standalone build assets", () => {
       .toBe("static asset");
   });
 
+  // Without the wrapper beside server.js nothing can prove a request is local.
+  it("copies the request-sanitizing server wrapper into the standalone output", () => {
+    const projectRoot = createBuildFixture(".next");
+    writeFileSync(join(projectRoot, "custom-server.js"), "wrapper");
+
+    copyStandaloneAssets({ projectRoot, distDir: ".next" });
+
+    expect(readFileSync(join(projectRoot, ".next", "standalone", "custom-server.js"), "utf8"))
+      .toBe("wrapper");
+  });
+
   it("does not modify workspace-traced CLI builds", () => {
     const projectRoot = createBuildFixture(".next-cli-build");
     const previousMode = process.env.NEXT_TRACING_ROOT_MODE;


### PR DESCRIPTION
Closes #3294 — GHSA-pjm4-8fpg-f9p6 (High, 8.6).

## The hole

`isLocalRequest()` decides "this caller is local, skip the API key" from headers the client controls:

```js
const realIp = request.headers.get("x-9r-real-ip");
if (realIp) { if (!isLoopbackHostname(realIp)) return false; }
else if (!isLoopbackHostname(request.headers.get("host"))) return false;
```

That is only safe because `custom-server.js` deletes and re-stamps `x-9r-real-ip` from the TCP socket. It is **not** in the request path for `"start": "next start"` — the command README "Production mode" and `gitbook/*/deployment/cloud.md` both tell operators to run.

Two things the report does not mention:

1. The `else` branch is spoofable in exactly the same way, so **`Host: localhost` alone bypasses the gate even without `x-9r-real-ip`**. Fixing only the reported header would have left an equivalent bypass.
2. With `requireLogin=false` — the common single-user setup — the spoof also satisfies `canAccessLocalOnlyRoute`, so `LOCAL_ONLY_PATHS` becomes remotely reachable: `/api/mcp/*` (spawns processes), `/api/tunnel/enable`, `/api/auth/reset-password`. Those are the routes explicitly carved out as too dangerous for remote callers.

`start:bun` (`bun ./.next/standalone/server.js`) is a third unsanitized path. Docker (`CMD ["node", "custom-server.js"]`) and the CLI launcher were never affected.

## The fix

Make the header contract enforceable instead of assumed.

- `custom-server.js` generates a 24-byte per-process secret at boot and stamps it as `x-9r-peer-token` on every request it sanitizes, deleting any client-supplied copy first.
- `hasTrustedPeerHeaders()` (new `src/lib/auth/trustedPeer.js`) is the single place that answers "did the wrapper actually handle this request".
- The guard trusts `x-9r-real-ip` only when the secret matches. Otherwise it falls back to `Host` **only when `NODE_ENV === "development"`** — `next dev` forks its server (`next-dev.js` → `fork(startServerPath, { execArgv })`), so no wrapper can reach it and there is no peer address to use. Everything else fails closed.

The secret is random rather than a boolean flag: `process.env` is inherited by forked children, and a `.env` entry or a leaked flag must not be able to re-enable the trust. `custom-server.js` stamps from the constant it generated, not from `process.env`, so if anything ever clobbers the variable the guard stops matching and fails closed instead of trusting a value someone else chose.

Same gate on `loginLimiter.getClientIp()`, so a spoofed header can no longer rotate the login lockout bucket (the report's secondary finding).

### isLoopbackHostname had to be fixed first

`h.split(":")[0]` only works for IPv4. It reduces `::ffff:127.0.0.1`, `::1` and `[::1]` all to the empty string, so none of them matched `LOOPBACK_HOSTS`. That was latent while `Host` could cover for it; once `x-9r-real-ip` is the only production signal it is fatal, because a dual-stack listener reports a loopback peer as `::ffff:127.0.0.1` — which is exactly what `next start` does. I hit this as a live 401 on my own loopback request before shipping. It now strips brackets, strips the port only when a single colon makes that unambiguous, and unwraps the IPv4-mapped prefix; `::ffff:10.204.111.34` and `2001:db8::1` stay rejected.

### Two build-time details this depends on, both verified in next@16

- `process.env.NODE_ENV` is a DefinePlugin constant — `define-env.js:77` emits `dev ? 'development' : 'production'`. In a production build the development branch becomes `"production" === "development"` and is eliminated outright, so **no `.env` value and no runtime environment can switch the `Host` fallback back on in a production build**. My local `.env` has `NODE_ENV=development` and the built server still refused the `Host` spoof.
- Only `NEXT_PUBLIC_*` is statically inlined (`lib/static-env.js:42`), so `NINEROUTER_PEER_TOKEN` stays a genuine runtime lookup. Confirmed live: the token the wrapper stamps and the value the proxy reads are the same string.

### Keeping the secret out of logs

`chat.js:46` snapshots every client header into `clientRawRequest`, which lands in the request detail the dashboard renders and cloud sync uploads. The header is therefore named `x-9r-peer-token` so `requestDetailsRepo.sanitizeHeaders` strips it under the existing `token` rule — the same protection `x-9r-cli-token` already relies on. A test pins that, so a future refactor of the sanitizer cannot silently expose it. It is also weaker than `x-9r-cli-token` by design: machine-independent and regenerated on every restart.

## Keeping the documented deployments working

Gating alone would make `npm run start` lose local access, so the sanitizer now covers those paths too:

- `"start": "node custom-server.js --port 20127"` — `next start` builds its HTTP server in-process (`next-start.js` → `startServer()`), so the wrapper still sees every request. `custom-server.js` runs the sibling standalone `server.js` when present (Docker/CLI, unchanged) and otherwise dispatches to `next start`.
- `postbuild` copies `custom-server.js` into `.next/standalone/`, and `start:bun` points at it. That also makes `node .next/standalone/custom-server.js` available for anyone following Next's own advice — `next start` has always warned that it does not work with `output: standalone`, which is pre-existing on master and not something this PR changes.
- `build-cli.js` only warned when `custom-server.js` was missing. With this change that would ship a CLI where nothing can be proven local — it would demand an API key for its own dashboard and `/v1` — so it now fails the build.

`npm run start`, `pm2 start npm -- start`, the Docker image and the CLI all keep their current commands — **no documentation changes needed**. `HOSTNAME` behaviour is unchanged: only the standalone server template reads it (`build/utils.js:1088`), and `next start` binds `0.0.0.0` either way.

## Verification

### Live, against a real production build

`npm run build`, then `npm run start -- --port 20142`, driven from this machine's LAN address so the TCP peer is genuinely not loopback — the reporter's setup:

```
loopback, no key                                 -> 200
LAN, no key                          [baseline]  -> 401
LAN + x-9r-real-ip: 127.0.0.1        [CVE]       -> 401
LAN + Host: localhost                [extra]     -> 401
LAN + both spoofs                                -> 401
LAN + forged x-9r-peer-token                     -> 401
LAN + spoof -> /api/mcp/filesystem/sse           -> 403
```

The first line matters as much as the rest: a genuine local caller still gets in with no API key, so nothing regresses for existing users.

### Unit level

The new tests reproduce the bypass. Reverting only `src/dashboardGuard.js` and `src/lib/auth/loginLimiter.js` to master and re-running `unit/local-request-peer-trust-3294.test.js`:

```
PASS (3) FAIL (5)
1. rejects a spoofed loopback peer IP that carries no trust proof
   AssertionError: expected undefined to be 401
2. rejects a spoofed loopback peer IP carrying a wrong trust token
3. rejects a spoofed loopback Host in production
4. rejects a spoofed loopback peer IP when the wrapper never booted
5. blocks spoofed local-only routes that would otherwise spawn processes
   AssertionError: expected undefined to be 403
```

`undefined` is `NextResponse.next()` — master lets the spoofed request through. All pass with the patch.

`unit/custom-server-peer-headers.test.js` boots a real `http.createServer` through the wrapper and asserts the sanitizing directly: a client-supplied `x-9r-real-ip: 203.0.113.55` comes out as the loopback socket address, a forged `x-9r-peer-token` is replaced, `x-9r-via-proxy` is dropped, and the loopback-reverse-proxy path still adopts the forwarded IP.

`isLocalRequest` is also read by `api/auth/login` and `api/provider-nodes/validate`; both fail in the safe direction — forcing a password change, applying the SSRF guard — rather than locking anyone out.

### Suite

`npx vitest run unit translator`: **1670 to 1698 passed, 91 failed before and after, and the failing sets are byte-identical** (`comm -13` on the sorted fail lists is empty). The 91 are the usual pre-existing reds; I confirmed `unit/security-audit.test.js`'s 13 fail the same way on a clean checkout. `unit/cli-build-artifacts.test.js` and `unit/standalone-assets.test.js` cover the packaging changes — the latter never created a `custom-server.js`, so the new copy step was silently uncovered until this PR added a case for it. `npx eslint` is clean on every changed file.

Six existing `dashboard-guard` cases asserted the pre-fix contract, that `Host: localhost` alone implies local. They now go through a `localRequest()` helper that stamps the peer headers the way `custom-server.js` does — same intent, stated explicitly. The old behaviour is still covered, as a development-only case.

One note for anyone reproducing on Windows: `next build` dies here with `EPERM scandir 'C:\Users\...\Application Data'` unless `HOME`, `USERPROFILE`, `APPDATA` and `LOCALAPPDATA` are redirected the way `cli/scripts/build-cli.js` already does. That is pre-existing — it fails identically on a clean `origin/master` checkout.
