### PR TITLE
fix(chat): send JSON content-type when client omits the stream field

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -101,7 +101,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  let stream = body.stream === true || (providerRequiresStreaming && body.stream !== false);
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);


### PR DESCRIPTION
## Problem

A request to `/v1/chat/completions` **without** a `stream` field (which per the
OpenAI spec means non-streaming) is handled as streaming: `chatCore.js` defaults
`stream = true` via `body.stream !== false`. The handler then returns a
**plain JSON body** (non-stream shape) but with `Content-Type: text/event-stream`.

Clients that don't explicitly send `stream: false` (e.g. curl, CLI tools, some
SDK paths) receive a `text/event-stream` content-type over a JSON body and fail
to parse it:

```bash
curl -s -D- http://localhost:20128/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"ds/deepseek-v4-flash","max_tokens":50,"messages":[{"role":"user","content":"hi"}]}'
# Content-Type: text/event-stream   <- wrong
# {"id":"...","object":"chat.completion", ...}  <- plain JSON body
```

AI SDK clients report `Invalid JSON response` on this mismatch. Explicitly
sending `stream: false` works around it, but omitting the field is valid OpenAI
usage and should also work.

## Fix

Only default to streaming when the client explicitly asks for it (`stream: true`)
or the upstream provider forces streaming AND the client did not opt out:

```js
let stream = body.stream === true || (providerRequiresStreaming && body.stream !== false);
```

Verified:
- no `stream` field → `Content-Type: application/json` ✅
- `stream: true` → `text/event-stream` with `data:` chunks ✅ (unchanged)
- `stream: false` → `application/json` ✅ (unchanged)
