### PR TITLE
feat(providers): add glm-5.3 to GLM Coding and GLM (China) registries

### DIFF
--- a/open-sse/providers/registry/glm-cn.js
+++ b/open-sse/providers/registry/glm-cn.js
@@ -21,6 +21,7 @@ export default {
     },
   },
   models: [
+    { id: "glm-5.3", name: "GLM 5.3" },
     { id: "glm-5.2", name: "GLM 5.2" },
     { id: "glm-5.1", name: "GLM 5.1" },
     { id: "glm-5", name: "GLM 5" },

--- a/open-sse/providers/registry/glm.js
+++ b/open-sse/providers/registry/glm.js
@@ -45,6 +45,7 @@ export default {
     },
   ],
   models: [
+    { id: "glm-5.3", name: "GLM 5.3" },
     { id: "glm-5.2", name: "GLM 5.2" },
     { id: "glm-5.1", name: "GLM 5.1" },
     { id: "glm-5", name: "GLM 5" },


### PR DESCRIPTION
## Summary

Zhipu has released **GLM-5.3** on both coding endpoints (`api.z.ai` and `open.bigmodel.cn`). This PR adds the model id to the two GLM provider registries so it shows up in model lists and can be routed.

## Changes

- `open-sse/providers/registry/glm.js` — add `{ id: "glm-5.3", name: "GLM 5.3" }` (GLM Coding / api.z.ai)
- `open-sse/providers/registry/glm-cn.js` — add `{ id: "glm-5.3", name: "GLM 5.3" }` (GLM China / open.bigmodel.cn)

No other files need changes:

- `open-sse/providers/capabilities.js` — the `*glm-5*` family pattern already covers `glm-5.3` (reasoning: true, thinkingFormat "zai", contextWindow 200000, maxOutput 128000)
- `open-sse/providers/pricing.js` — the `glm-5*` family pattern already covers it

## Verification

Tested live against both endpoints with a real coding-plan API key (non-streaming, `max_tokens: 10`):

```
POST https://open.bigmodel.cn/api/coding/paas/v4/chat/completions
POST https://api.z.ai/api/coding/paas/v4/chat/completions

→ 200 {"choices":[{"message":{"reasoning_content":"Let me consider ...","role":"assistant"}}],
       "model":"glm-5.3", "usage":{...,"reasoning_tokens":9}}
```

GLM-5.3 returns native `reasoning_content` (reasoning model), same shape as glm-5.2.

Also verified end-to-end through 9router after applying the change (v0.5.50, glm-cn provider connection):

```
POST /v1/chat/completions {"model":"glm-cn/glm-5.3", ...}
→ 200, model:"glm-5.3", reasoning_content present, usage normal
```

## Test plan

- [ ] `npx vitest run tests/unit/` — no regression (registry model lists are not frozen by baseline snapshots; `alias-baseline.json` only tracks provider-level keys)
- [ ] Manual: `glm/glm-5.3` and `glm-cn/glm-5.3` resolve and route
