### PR TITLE
Sửa đối số tool call và khả năng Xiaomi Token Plan

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -116,11 +116,22 @@ const KIRO_GPT_5_6_CAPABILITIES = { vision: true, reasoning: true, search: true,
 // (lower than OpenAI API's 1.05M). Sol differs from Terra/Luna. #2720
 const CODEX_GPT_56_SOL_CAPS  = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 372000, maxOutput: 128000 };
 const CODEX_GPT_56_DEFAULT_CAPS = { vision: true, reasoning: true, search: true, thinkingFormat: "openai", contextWindow: 272000, maxOutput: 128000 };
+const XIAOMI_TOKENPLAN_TEXT_CAPS = { vision: false, audioInput: false, videoInput: false, contextWindow: 1048576, maxOutput: 131072 };
+const XIAOMI_TOKENPLAN_CAPABILITIES = {
+  "mimo-v2.5-pro": XIAOMI_TOKENPLAN_TEXT_CAPS,
+  "mimo-v2.5-pro-claude": XIAOMI_TOKENPLAN_TEXT_CAPS,
+  "mimo-v2.5": XIAOMI_TOKENPLAN_TEXT_CAPS,
+};
 
 /**
  * Provider-specific capability overrides. Keyed by provider alias/id.
  */
 export const PROVIDER_CAPABILITIES = {
+  // Token Plan exposes text-only V2.5 chat models under the same IDs that the
+  // standard MiMo API uses for a multimodal family. Keep both the canonical ID
+  // and the routed model alias because combo/capacity checks receive either.
+  "xiaomi-tokenplan": XIAOMI_TOKENPLAN_CAPABILITIES,
+  "xmtp": XIAOMI_TOKENPLAN_CAPABILITIES,
   // NVIDIA NIM is OpenAI-compatible → rejects MiniMax/GLM native `thinking` field.
   // Force openai reasoning_effort format for its reasoning models. #issue
   "nvidia": {

--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -38,9 +38,15 @@ export function ensureToolCallIds(body) {
         if (!tc.type) {
           tc.type = "function";
         }
-        // Ensure arguments is JSON string, not object
-        if (tc.function?.arguments && typeof tc.function.arguments !== "string") {
-          tc.function.arguments = JSON.stringify(tc.function.arguments);
+        // OpenAI-compatible history requires function.arguments to be a JSON
+        // string even when the tool takes no arguments. Some clients replay an
+        // empty call as missing/null/"", which strict upstreams reject.
+        if (tc.function && typeof tc.function === "object") {
+          if (tc.function.arguments == null || tc.function.arguments === "") {
+            tc.function.arguments = "{}";
+          } else if (typeof tc.function.arguments !== "string") {
+            tc.function.arguments = JSON.stringify(tc.function.arguments);
+          }
         }
       }
     }

--- a/tests/unit/tool-call-arguments.test.js
+++ b/tests/unit/tool-call-arguments.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { ensureToolCallIds } from "../../open-sse/translator/concerns/toolCall.js";
+
+function normalize(argumentsValue, includeArguments = true) {
+  const fn = { name: "probe_tool" };
+  if (includeArguments) fn.arguments = argumentsValue;
+  const body = {
+    messages: [{
+      role: "assistant",
+      tool_calls: [{ id: "call_probe", type: "function", function: fn }],
+    }],
+  };
+
+  ensureToolCallIds(body);
+  return body.messages[0].tool_calls[0].function;
+}
+
+describe("ensureToolCallIds function arguments", () => {
+  it.each([
+    ["missing", undefined, false],
+    ["undefined", undefined, true],
+    ["null", null, true],
+    ["empty", "", true],
+  ])("normalizes %s arguments to an empty JSON object", (_label, value, include) => {
+    expect(normalize(value, include).arguments).toBe("{}");
+  });
+
+  it("serializes object arguments", () => {
+    expect(normalize({ query: "nine router" }).arguments).toBe('{"query":"nine router"}');
+  });
+
+  it("preserves a non-empty argument string", () => {
+    expect(normalize('{"query":"nine router"}').arguments).toBe('{"query":"nine router"}');
+  });
+
+  it("does not fabricate a missing function object", () => {
+    const body = {
+      messages: [{
+        role: "assistant",
+        tool_calls: [{ id: "call_probe", type: "function" }],
+      }],
+    };
+
+    ensureToolCallIds(body);
+    expect(body.messages[0].tool_calls[0].function).toBeUndefined();
+  });
+});

--- a/tests/unit/xiaomi-tokenplan-capabilities.test.js
+++ b/tests/unit/xiaomi-tokenplan-capabilities.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import { augmentModelsWithCapacityAdapter } from "../../open-sse/services/capacityAdapter.js";
+
+const TOKENPLAN_TEXT_MODELS = [
+  "mimo-v2.5-pro",
+  "mimo-v2.5-pro-claude",
+  "mimo-v2.5",
+];
+
+describe("Xiaomi Token Plan capabilities", () => {
+  it.each(["xiaomi-tokenplan", "xmtp"])(
+    "marks V2.5 chat models as text-only through %s",
+    (provider) => {
+      for (const model of TOKENPLAN_TEXT_MODELS) {
+        expect(getCapabilitiesForModel(provider, model)).toMatchObject({
+          vision: false,
+          audioInput: false,
+          videoInput: false,
+          contextWindow: 1048576,
+          maxOutput: 131072,
+        });
+      }
+    },
+  );
+
+  it("does not change the standard MiMo capability pattern", () => {
+    expect(getCapabilitiesForModel("xiaomi-mimo", "mimo-v2.5-pro")).toMatchObject({
+      vision: true,
+      audioInput: true,
+      videoInput: true,
+    });
+  });
+
+  it("keeps Token Plan omni models multimodal", () => {
+    expect(getCapabilitiesForModel("xmtp", "mimo-v2-omni")).toMatchObject({
+      vision: true,
+      audioInput: true,
+    });
+  });
+
+  it("adds the configured vision fallback before a Token Plan text model", () => {
+    const settings = {
+      capacityAdapter: {
+        vision: { enabled: true, models: ["glm/glm-4.6v"] },
+      },
+    };
+
+    expect(augmentModelsWithCapacityAdapter(
+      ["xmtp/mimo-v2.5-pro"],
+      new Set(["vision"]),
+      settings,
+    )).toEqual(["glm/glm-4.6v", "xmtp/mimo-v2.5-pro"]);
+  });
+});


### PR DESCRIPTION
## Thay đổi

- Chuẩn hóa `function.arguments` bị thiếu, `null` hoặc chuỗi rỗng thành chuỗi JSON `{}` trước khi chuyển tiếp tool call.
- Nhận diện đúng các model MiMo V2.5 dạng text-only khi đi qua provider `xiaomi-tokenplan` hoặc alias `xmtp`.
- Giữ nguyên khả năng đa phương thức của provider MiMo tiêu chuẩn và các model Omni.
- Bổ sung test hồi quy cho cả hai trường hợp.

## Nguyên nhân

- Đối số tool call chỉ được chuẩn hóa khi có giá trị truthy, khiến giá trị thiếu hoặc rỗng lọt xuống bước serialize.
- Capability adapter tra cứu theo provider/alias thực tế nhưng chưa có cấu hình riêng cho Xiaomi Token Plan, nên áp dụng nhầm pattern MiMo đa phương thức toàn cục.

## Ảnh hưởng

- Tránh lỗi API khi tool call không có đối số.
- Vision adapter có thể chọn model dự phòng đúng cho các model Xiaomi Token Plan không hỗ trợ ảnh.

## Kiểm thử

- `vitest`: 4 file test, 22 test đều đạt.
- `git diff --check`: đạt.

Fixes #3308
Fixes #3304