### PR TITLE
Sửa Test Connection Xiaomi Token Plan theo vùng

### DIFF
--- a/open-sse/config/providers.js
+++ b/open-sse/config/providers.js
@@ -17,3 +17,12 @@ export function resolveXiaomiTokenplanBaseUrl(credentials) {
   const region = credentials?.providerSpecificData?.region;
   return XIAOMI_TOKENPLAN_REGIONS[region] || XIAOMI_TOKENPLAN_REGIONS[XIAOMI_TOKENPLAN_DEFAULT_REGION];
 }
+
+export function resolveXiaomiTokenplanModelsUrl(credentials) {
+  return `${resolveXiaomiTokenplanBaseUrl(credentials)}/models`;
+}
+
+export function isXiaomiTokenplanTestResponseValid(response) {
+  // Some valid Token Plan keys cannot list models and return 403; only 401 proves invalid auth.
+  return response?.status !== 401;
+}

--- a/src/app/api/providers/[id]/test/testUtils.js
+++ b/src/app/api/providers/[id]/test/testUtils.js
@@ -3,7 +3,12 @@ import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { testProxyUrl } from "@/lib/network/proxyTest";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider } from "@/shared/constants/providers";
 import { getDefaultModel } from "open-sse/config/providerModels.js";
-import { resolveOllamaLocalHost, PROVIDERS } from "open-sse/config/providers.js";
+import {
+  resolveOllamaLocalHost,
+  resolveXiaomiTokenplanModelsUrl,
+  isXiaomiTokenplanTestResponseValid,
+  PROVIDERS,
+} from "open-sse/config/providers.js";
 import {
   refreshProviderCredentials,
   shouldRefreshCredentials,
@@ -755,11 +760,15 @@ async function testApiKeyConnection(connection, effectiveProxy = null) {
       }
       case "xiaomi-mimo":
       case "xiaomi-tokenplan": {
-        const baseUrls = { "xiaomi-mimo": "https://api.xiaomimimo.com/v1", "xiaomi-tokenplan": "https://token-plan-sgp.xiaomimimo.com/v1" };
-        const res = await fetchWithConnectionProxy(`${baseUrls[connection.provider]}/models`, {
+        const isTokenPlan = connection.provider === "xiaomi-tokenplan";
+        const modelsUrl = isTokenPlan
+          ? resolveXiaomiTokenplanModelsUrl(connection)
+          : "https://api.xiaomimimo.com/v1/models";
+        const res = await fetchWithConnectionProxy(modelsUrl, {
           headers: { Authorization: `Bearer ${connection.apiKey}` },
         }, effectiveProxy);
-        return { valid: res.ok, error: res.ok ? null : "Invalid API key" };
+        const valid = isTokenPlan ? isXiaomiTokenplanTestResponseValid(res) : res.ok;
+        return { valid, error: valid ? null : "Invalid API key" };
       }
       case "blackbox": {
         const baseUrl = PROVIDERS["blackbox"]?.baseUrl?.replace(/\/chat\/completions$/, "") || "https://api.blackbox.ai/v1";

--- a/tests/unit/xiaomi-tokenplan-connection-test.test.js
+++ b/tests/unit/xiaomi-tokenplan-connection-test.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  isXiaomiTokenplanTestResponseValid,
+  resolveXiaomiTokenplanModelsUrl,
+} from "../../open-sse/config/providers.js";
+
+const REGION_URLS = {
+  sgp: "https://token-plan-sgp.xiaomimimo.com/v1/models",
+  cn: "https://token-plan-cn.xiaomimimo.com/v1/models",
+  ams: "https://token-plan-ams.xiaomimimo.com/v1/models",
+};
+
+function connection(region) {
+  return {
+    providerSpecificData: region ? { region } : {},
+  };
+}
+
+describe("Xiaomi Token Plan connection test", () => {
+  it.each(Object.entries(REGION_URLS))("tests the %s cluster selected by the connection", (region, expectedUrl) => {
+    expect(resolveXiaomiTokenplanModelsUrl(connection(region))).toBe(expectedUrl);
+  });
+
+  it.each([undefined, "unknown"])("falls back to the default cluster for region %s", (region) => {
+    expect(resolveXiaomiTokenplanModelsUrl(connection(region))).toBe(REGION_URLS.sgp);
+  });
+
+  it("accepts a non-401 response because valid keys may not list models", () => {
+    expect(isXiaomiTokenplanTestResponseValid({ ok: false, status: 403 })).toBe(true);
+  });
+
+  it("rejects a 401 response", () => {
+    expect(isXiaomiTokenplanTestResponseValid({ ok: false, status: 401 })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Thay đổi

- Dùng vùng lưu trong `providerSpecificData.region` khi kiểm tra kết nối Xiaomi Token Plan.
- Dựng URL `/models` từ registry dùng chung, với fallback về vùng mặc định SGP khi vùng thiếu hoặc không hợp lệ.
- Xem HTTP 403 là xác thực thành công vì một số key hợp lệ không có quyền liệt kê model; chỉ HTTP 401 được xem là key không hợp lệ.
- Giữ nguyên endpoint và quy tắc kiểm tra nghiêm ngặt của Xiaomi MiMo tiêu chuẩn.
- Bổ sung test hồi quy cho SGP, CN, AMS, fallback vùng và phản hồi 401/403.

## Nguyên nhân

Route Test Connection đang hardcode endpoint Singapore, trong khi key Token Plan gắn với từng cluster. Vì vậy key AMS/CN hợp lệ bị kiểm tra sai vùng và lưu trạng thái lỗi.

## Ảnh hưởng

Nút Test Connection phản ánh đúng trạng thái key theo vùng đã chọn, tránh cảnh báo sai và tránh người dùng xóa hoặc nhập lại kết nối vẫn đang hoạt động.

## Kiểm thử

- `vitest`: 1 file, 7 test đạt.
- `node --check`: các file nguồn và test đạt.
- `git diff --check`: đạt.

Fixes #3303