### PR TITLE
fix(security): chặn SSRF khi kiểm tra provider node

### DIFF
--- a/src/app/api/provider-nodes/validate/route.js
+++ b/src/app/api/provider-nodes/validate/route.js
@@ -1,11 +1,15 @@
 import { NextResponse } from "next/server";
-import { assertPublicUrl } from "@/shared/utils/ssrfGuard.js";
+import {
+  assertPublicUrl,
+  fetchPublicUrl,
+  SSRF_BLOCKED_ERROR_CODE,
+} from "@/shared/utils/ssrfGuard.js";
 import { isLocalRequest } from "@/dashboardGuard";
 
 // Fetch with timeout wrapper
-const fetchWithTimeout = (url, options, timeout = 10000) => {
+const fetchWithTimeout = (fetchImpl, url, options, timeout = 10000) => {
   return Promise.race([
-    fetch(url, options),
+    fetchImpl(url, options),
     new Promise((_, reject) => 
       setTimeout(() => reject(new Error("Request timeout")), timeout)
     )
@@ -66,8 +70,11 @@ export async function POST(request) {
       return NextResponse.json({ error: "Invalid URL format" }, { status: 400 });
     }
 
-    // SSRF guard for remote callers; local host keeps self-hosted nodes (e.g. ollama-local)
-    if (!isLocalRequest(request)) {
+    // Trusted local callers keep self-hosted nodes (e.g. ollama-local). Remote callers
+    // use a DNS-aware dispatcher that also validates redirect destinations.
+    const localRequest = isLocalRequest(request);
+    const outboundFetch = localRequest ? fetch : fetchPublicUrl;
+    if (!localRequest) {
       try {
         assertPublicUrl(baseUrl);
       } catch {
@@ -81,7 +88,7 @@ export async function POST(request) {
       if (!modelId?.trim()) {
         return NextResponse.json({ valid: false, error: "Model ID required for embedding validation" });
       }
-      const embedRes = await fetchWithTimeout(`${normalizedBase}/embeddings`, {
+      const embedRes = await fetchWithTimeout(outboundFetch, `${normalizedBase}/embeddings`, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${apiKey}`,
@@ -113,7 +120,7 @@ export async function POST(request) {
       }
 
       const modelsUrl = `${normalizedBase}/models`;
-      const res = await fetchWithTimeout(modelsUrl, {
+      const res = await fetchWithTimeout(outboundFetch, modelsUrl, {
         method: "GET",
         headers: {
           "x-api-key": apiKey,
@@ -131,7 +138,7 @@ export async function POST(request) {
 
       // Fallback: try chat/completions if modelId provided
       if (modelId) {
-        const chatRes = await fetchWithTimeout(`${normalizedBase}/chat/completions`, {
+        const chatRes = await fetchWithTimeout(outboundFetch, `${normalizedBase}/chat/completions`, {
           method: "POST",
           headers: {
             "Authorization": `Bearer ${apiKey}`,
@@ -160,7 +167,7 @@ export async function POST(request) {
 
     // OpenAI Compatible Validation (Default)
     const modelsUrl = `${baseUrl.replace(/\/$/, "")}/models`;
-    const res = await fetchWithTimeout(modelsUrl, {
+    const res = await fetchWithTimeout(outboundFetch, modelsUrl, {
       headers: { "Authorization": `Bearer ${apiKey}` },
     });
 
@@ -173,7 +180,7 @@ export async function POST(request) {
 
     // Fallback: try chat/completions if modelId provided
     if (modelId) {
-      const chatRes = await fetchWithTimeout(`${baseUrl.replace(/\/$/, "")}/chat/completions`, {
+      const chatRes = await fetchWithTimeout(outboundFetch, `${baseUrl.replace(/\/$/, "")}/chat/completions`, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${apiKey}`,
@@ -197,6 +204,9 @@ export async function POST(request) {
 
     return NextResponse.json({ valid: false, error: getModelsErrorMessage(res.status) });
   } catch (error) {
+    if (error?.code === SSRF_BLOCKED_ERROR_CODE || error?.cause?.code === SSRF_BLOCKED_ERROR_CODE) {
+      return NextResponse.json({ error: "URL not allowed" }, { status: 400 });
+    }
     const errorMessage = getErrorMessage(error);
     console.error("Error validating provider node:", {
       message: error.message,

--- a/src/shared/utils/ssrfGuard.js
+++ b/src/shared/utils/ssrfGuard.js
@@ -1,5 +1,11 @@
 // SSRF guard: block internal/private/metadata targets for server-side fetch.
 
+import { lookup as dnsLookup } from "node:dns";
+import { isIP } from "node:net";
+import { Agent, buildConnector } from "undici";
+
+export const SSRF_BLOCKED_ERROR_CODE = "ERR_SSRF_BLOCKED";
+
 const BLOCKED_HOSTNAMES = new Set(["localhost", "ip6-localhost", "ip6-loopback"]);
 const BLOCKED_SUFFIXES = [".internal", ".local", ".localhost"];
 
@@ -21,10 +27,18 @@ function ipv4ToInt(host) {
 const BLOCKED_V4_RANGES = [
   [ipv4ToInt("0.0.0.0"), 8],
   [ipv4ToInt("10.0.0.0"), 8],
+  [ipv4ToInt("100.64.0.0"), 10],
   [ipv4ToInt("127.0.0.0"), 8],
   [ipv4ToInt("169.254.0.0"), 16],
   [ipv4ToInt("172.16.0.0"), 12],
+  [ipv4ToInt("192.0.0.0"), 24],
+  [ipv4ToInt("192.0.2.0"), 24],
   [ipv4ToInt("192.168.0.0"), 16],
+  [ipv4ToInt("198.18.0.0"), 15],
+  [ipv4ToInt("198.51.100.0"), 24],
+  [ipv4ToInt("203.0.113.0"), 24],
+  [ipv4ToInt("224.0.0.0"), 4],
+  [ipv4ToInt("240.0.0.0"), 4],
 ];
 
 function isBlockedIpv4(host) {
@@ -36,21 +50,136 @@ function isBlockedIpv4(host) {
   });
 }
 
+function ipv6ToWords(host) {
+  const raw = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (!raw || raw.includes("%")) return null;
+
+  let normalized;
+  try {
+    normalized = new URL(`http://[${raw}]/`).hostname.slice(1, -1);
+  } catch {
+    return null;
+  }
+
+  const halves = normalized.split("::");
+  if (halves.length > 2) return null;
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves[1] ? halves[1].split(":") : [];
+  const missing = 8 - left.length - right.length;
+  if (missing < 0 || (halves.length === 1 && missing !== 0)) return null;
+
+  const parts = halves.length === 2
+    ? [...left, ...Array(missing).fill("0"), ...right]
+    : left;
+  if (parts.length !== 8 || parts.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) return null;
+  return parts.map((part) => Number.parseInt(part, 16));
+}
+
+function wordsToIpv4(words) {
+  const value = ((words[6] << 16) | words[7]) >>> 0;
+  return `${value >>> 24}.${(value >>> 16) & 255}.${(value >>> 8) & 255}.${value & 255}`;
+}
+
 function isBlockedIpv6(host) {
-  const h = host.replace(/^\[|\]$/g, "").toLowerCase();
-  const v4Mapped = h.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (v4Mapped) return isBlockedIpv4(v4Mapped[1]);
-  if (h === "::1" || h === "::") return true;
-  return h.startsWith("fe80:") || h.startsWith("fc") || h.startsWith("fd");
+  const words = ipv6ToWords(host);
+  if (!words) return true;
+
+  // IPv4-mapped IPv6 (including hexadecimal forms such as ::ffff:7f00:1).
+  if (words.slice(0, 5).every((word) => word === 0) && words[5] === 0xffff) {
+    return isBlockedIpv4(wordsToIpv4(words));
+  }
+
+  // Unspecified, loopback and deprecated IPv4-compatible IPv6 (::/96).
+  if (words.slice(0, 6).every((word) => word === 0)) return true;
+
+  const first = words[0];
+  if ((first & 0xfe00) === 0xfc00) return true; // Unique local fc00::/7
+  if ((first & 0xffc0) === 0xfe80) return true; // Link-local fe80::/10
+  if ((first & 0xffc0) === 0xfec0) return true; // Deprecated site-local fec0::/10
+  if ((first & 0xff00) === 0xff00) return true; // Multicast ff00::/8
+  if (first === 0x2001 && words[1] === 0x0db8) return true; // Documentation 2001:db8::/32
+  return false;
+}
+
+function blockedError(message) {
+  const error = new Error(message);
+  error.code = SSRF_BLOCKED_ERROR_CODE;
+  return error;
+}
+
+export function assertPublicAddress(address) {
+  const family = isIP(address);
+  if (family === 4 && !isBlockedIpv4(address)) return;
+  if (family === 6 && !isBlockedIpv6(address)) return;
+  if (family === 4 || family === 6) throw blockedError("Blocked URL: private IP");
+  throw blockedError("Blocked URL: invalid DNS address");
 }
 
 // Throw if URL targets a non-public host. Caller should map to 400.
+export function assertPublicHostname(rawHost) {
+  const host = String(rawHost || "").toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+  if (!host) throw blockedError("Blocked URL: missing host");
+  if (BLOCKED_HOSTNAMES.has(host)) throw blockedError("Blocked URL: internal host");
+  if (BLOCKED_SUFFIXES.some((s) => host.endsWith(s))) throw blockedError("Blocked URL: internal host");
+  if (isIP(host)) assertPublicAddress(host);
+}
+
 export function assertPublicUrl(rawUrl) {
   const parsed = new URL(rawUrl);
-  const host = parsed.hostname.toLowerCase();
-
-  if (BLOCKED_HOSTNAMES.has(host)) throw new Error("Blocked URL: internal host");
-  if (BLOCKED_SUFFIXES.some((s) => host.endsWith(s))) throw new Error("Blocked URL: internal host");
-  if (isBlockedIpv4(host)) throw new Error("Blocked URL: private IP");
-  if (host.includes(":") && isBlockedIpv6(host)) throw new Error("Blocked URL: private IP");
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw blockedError("Blocked URL: unsupported protocol");
+  }
+  assertPublicHostname(parsed.hostname);
 }
+
+/**
+ * DNS lookup hook for undici. Every address returned to the socket is checked,
+ * so DNS rebinding and redirect targets cannot bypass a pre-fetch string check.
+ */
+export function createPublicOnlyLookup(lookup = dnsLookup) {
+  return (hostname, options, callback) => {
+    const requestedAll = options?.all === true;
+    lookup(hostname, { ...options, all: true, verbatim: true }, (error, records, family) => {
+      if (error) return callback(error);
+
+      const addresses = Array.isArray(records)
+        ? records
+        : [{ address: records, family }];
+
+      try {
+        if (addresses.length === 0) throw blockedError("Blocked URL: DNS returned no addresses");
+        for (const record of addresses) assertPublicAddress(record.address);
+      } catch (validationError) {
+        return callback(validationError);
+      }
+
+      if (requestedAll) return callback(null, addresses);
+      return callback(null, addresses[0].address, addresses[0].family);
+    });
+  };
+}
+
+export function createPublicOnlyFetch(lookup = dnsLookup) {
+  const dispatcher = new Agent({ connect: createPublicOnlyConnector(lookup) });
+  return (rawUrl, options = {}) => {
+    assertPublicUrl(rawUrl);
+    return fetch(rawUrl, { ...options, dispatcher });
+  };
+}
+
+export function createPublicOnlyConnector(lookup = dnsLookup) {
+  const connect = buildConnector({ lookup: createPublicOnlyLookup(lookup) });
+  return (options, callback) => {
+    try {
+      // net.connect skips DNS for IP literals. Checking here ensures direct and
+      // redirected literal IPs cannot bypass the DNS lookup hook.
+      assertPublicHostname(options.hostname);
+    } catch (error) {
+      queueMicrotask(() => callback(error));
+      return;
+    }
+    return connect(options, callback);
+  };
+}
+
+export const fetchPublicUrl = createPublicOnlyFetch();

--- a/tests/unit/provider-node-ssrf-3293.test.js
+++ b/tests/unit/provider-node-ssrf-3293.test.js
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST } from "../../src/app/api/provider-nodes/validate/route.js";
+
+function validationRequest(baseUrl, headers = {}) {
+  return new Request("http://router.example/api/provider-nodes/validate", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Host: "router.example",
+      ...headers,
+    },
+    body: JSON.stringify({
+      baseUrl,
+      apiKey: "test-key",
+      type: "openai",
+    }),
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("provider node validation SSRF boundary (#3293)", () => {
+  it("returns 400 for the reported IPv4-mapped IPv6 bypass", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(validationRequest("http://[::ffff:7f00:1]:19998"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "URL not allowed" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps a public provider URL working through the guarded dispatcher", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(validationRequest("https://api.example.com/v1"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ valid: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/v1/models",
+      expect.objectContaining({ dispatcher: expect.any(Object) }),
+    );
+  });
+
+  it("preserves private self-hosted validation for a trusted local peer", async () => {
+    vi.stubEnv("NINEROUTER_PEER_TOKEN", "server-secret");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(validationRequest("http://127.0.0.1:11434/v1", {
+      Host: "localhost:20127",
+      "x-9r-real-ip": "127.0.0.1",
+      "x-9r-peer-token": "server-secret",
+    }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ valid: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:11434/v1/models",
+      { headers: { Authorization: "Bearer test-key" } },
+    );
+  });
+});

--- a/tests/unit/resolved-ssrf-guard.test.js
+++ b/tests/unit/resolved-ssrf-guard.test.js
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { createServer } from "node:http";
+import {
+  assertPublicAddress,
+  assertPublicUrl,
+  createPublicOnlyConnector,
+  createPublicOnlyFetch,
+  createPublicOnlyLookup,
+  SSRF_BLOCKED_ERROR_CODE,
+} from "../../src/shared/utils/ssrfGuard.js";
+
+function runLookup(lookup, hostname, options = { all: true }) {
+  return new Promise((resolve, reject) => {
+    lookup(hostname, options, (error, address, family) => {
+      if (error) reject(error);
+      else resolve({ address, family });
+    });
+  });
+}
+
+describe("resolved SSRF guard", () => {
+  it.each([
+    "http://[::ffff:7f00:1]:19998",
+    "http://[::ffff:a9fe:a9fe]/latest/meta-data",
+    "http://[0:0:0:0:0:ffff:7f00:1]",
+    "http://[::7f00:1]",
+  ])("rejects IPv4-compatible or mapped private address %s", (url) => {
+    expect(() => assertPublicUrl(url)).toThrow(expect.objectContaining({ code: SSRF_BLOCKED_ERROR_CODE }));
+  });
+
+  it.each([
+    "127.0.0.1",
+    "169.254.169.254",
+    "10.0.0.1",
+    "::1",
+    "fc00::1",
+    "fe80::1",
+    "::ffff:7f00:1",
+  ])("rejects a private DNS result %s", (address) => {
+    expect(() => assertPublicAddress(address)).toThrow(expect.objectContaining({ code: SSRF_BLOCKED_ERROR_CODE }));
+  });
+
+  it.each(["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"])("allows a public DNS result %s", (address) => {
+    expect(() => assertPublicAddress(address)).not.toThrow();
+  });
+
+  it("rejects a hostname when any DNS answer is private", async () => {
+    const dnsLookup = vi.fn((hostname, options, callback) => callback(null, [
+      { address: "93.184.216.34", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]));
+
+    await expect(runLookup(createPublicOnlyLookup(dnsLookup), "rebind.example")).rejects.toMatchObject({
+      code: SSRF_BLOCKED_ERROR_CODE,
+    });
+    expect(dnsLookup).toHaveBeenCalledWith(
+      "rebind.example",
+      expect.objectContaining({ all: true, verbatim: true }),
+      expect.any(Function),
+    );
+  });
+
+  it("returns public DNS answers to the socket lookup", async () => {
+    const answers = [
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+    ];
+    const dnsLookup = vi.fn((hostname, options, callback) => callback(null, answers));
+
+    await expect(runLookup(createPublicOnlyLookup(dnsLookup), "public.example")).resolves.toEqual({
+      address: answers,
+      family: undefined,
+    });
+  });
+
+  it("blocks the real fetch socket before it reaches a DNS-rebound private service", async () => {
+    let hits = 0;
+    const server = createServer((request, response) => {
+      hits += 1;
+      response.end("internal secret");
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const port = server.address().port;
+      const dnsLookup = vi.fn((hostname, options, callback) => callback(null, [
+        { address: "127.0.0.1", family: 4 },
+      ]));
+      const guardedFetch = createPublicOnlyFetch(dnsLookup);
+
+      let fetchError;
+      try {
+        await guardedFetch(`http://rebind.example:${port}/secret`);
+      } catch (error) {
+        fetchError = error;
+      }
+
+      expect(fetchError?.code || fetchError?.cause?.code).toBe(SSRF_BLOCKED_ERROR_CODE);
+      expect(hits).toBe(0);
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+  });
+
+  it("blocks a redirected IP literal at the socket connector boundary", async () => {
+    const connector = createPublicOnlyConnector();
+
+    const error = await new Promise((resolve) => {
+      connector({ hostname: "::ffff:7f00:1", protocol: "http:", port: "19998" }, resolve);
+    });
+
+    expect(error).toMatchObject({ code: SSRF_BLOCKED_ERROR_CODE });
+  });
+});


### PR DESCRIPTION
## Kết quả

Bản vá đóng đường SSRF chính trong `POST /api/provider-nodes/validate` nhưng giữ khả năng kiểm tra node self-hosted cho caller local đã được xác thực bằng trusted peer token.

## Đường tấn công

Caller remote có dashboard session điều khiển `baseUrl`. Guard cũ chỉ kiểm tra chuỗi hostname trước khi fetch nên cho qua IPv4-mapped IPv6 dạng hex, tên miền phân giải về IP riêng và redirect sang đích nội bộ. Nhánh `custom-embedding` sau đó có thể phản chiếu 200 byte từ dịch vụ nội bộ.

## Thay đổi

- Chuẩn hóa và chặn IPv4-compatible/mapped IPv6, private/link-local/reserved IPv4/IPv6.
- Kiểm tra toàn bộ DNS answer ngay trong lookup callback được socket sử dụng, tránh DNS rebinding/TOCTOU giữa precheck và connect.
- Kiểm tra hostname tại connector để IP literal trên redirect không thể bỏ qua DNS hook.
- Buộc mọi outbound fetch của route remote dùng dispatcher an toàn và trả HTTP 400 khi đích bị chặn.
- Giữ raw fetch cho trusted-local peer để Ollama và node self-hosted nội bộ vẫn được kiểm tra.

## Kiểm chứng

- PoC `http://[::ffff:7f00:1]:19998` và mapped metadata: trước vá `ALLOWED`, sau vá `ERR_SSRF_BLOCKED`.
- Vitest: 3 file, 28 test đạt.
- Test socket thực xác nhận hostname DNS-rebound về `127.0.0.1` bị chặn trước khi dịch vụ nội bộ nhận request.
- Test route xác nhận remote exploit trả 400, URL public vẫn hoạt động và trusted-local private URL vẫn hoạt động.
- ESLint trên 4 file thay đổi: đạt.
- `git diff --check`: đạt.

## Gate còn bị chặn

`npm run build` được chạy hai lần nhưng đều dừng ở lỗi môi trường Windows ngoài patch:

`EPERM: operation not permitted, readlink 'C:\Users\DungArtoriaML\AppData\Local\Temp\...scratch\lock'`

Lần hai đã đổi `TEMP/TMP` sang thư mục riêng nhưng Next vẫn truy cập scratch path cũ. CI của repo cần xác nhận production build.

## Phạm vi còn lại

Issue cũng nêu một sink OIDC liên quan. PR này chưa thay đổi OIDC vì việc chặn issuer/JWKS nội bộ có thể phá cấu hình OIDC self-hosted và cần quyết định policy riêng. Vì vậy PR dùng `Refs` thay vì tự động đóng issue.

Refs #3293