### PR TITLE
fix(cli): ngăn cài SQLite native khi khởi động

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -80,9 +80,9 @@ if (args[0] === "xai" && args[1] === "video") {
   return;
 }
 
-// Self-heal SQLite runtime deps (sql.js + better-sqlite3) into ~/.9router/runtime
-// so the server can resolve them via NODE_PATH. Best-effort — sql.js is required,
-// better-sqlite3 is optional. Logs to stderr only on failure.
+// Verify SQLite runtime deps. Missing sql.js may be repaired because it is the
+// required fallback; optional better-sqlite3 installation is postinstall-only so
+// ordinary startup never blocks on npm/node-gyp.
 try { ensureSqliteRuntime({ silent: true }); } catch {}
 
 // Self-heal tray runtime (systray for macOS/Linux only). Windows skipped.

--- a/cli/hooks/postinstall.js
+++ b/cli/hooks/postinstall.js
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 
-// Postinstall: warm-up SQLite deps into ~/.9router/runtime so the first
-// `9router` start doesn't need network. Failure here is non-fatal —
-// cli.js will retry at runtime if anything is missing.
+// Postinstall: warm up SQLite deps into ~/.9router/runtime so normal CLI startup
+// never attempts to install the optional native accelerator. Failure is non-fatal.
 const { ensureSqliteRuntime } = require("./sqliteRuntime");
 const { ensureTrayRuntime } = require("./trayRuntime");
 
 try {
-  ensureSqliteRuntime({ silent: false });
+  ensureSqliteRuntime({ silent: false, installBetterSqlite: true });
   console.log("[9router] runtime SQLite deps ready");
 } catch (e) {
   console.warn(`[9router] runtime warm-up skipped: ${e.message}`);

--- a/cli/hooks/sqliteRuntime.js
+++ b/cli/hooks/sqliteRuntime.js
@@ -6,7 +6,8 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
-const BETTER_SQLITE3_VERSION = "12.6.2";
+const BETTER_SQLITE3_VERSION = "12.10.1";
+const BETTER_SQLITE3_INSTALL_TIMEOUT = 30000;
 const SQL_JS_VERSION = "1.14.1";
 
 function getDataDir() {
@@ -114,7 +115,7 @@ function isSqlJsWasmValid() {
   return fs.existsSync(runtimeWasm);
 }
 
-function ensureSqliteRuntime({ silent = false } = {}) {
+function ensureSqliteRuntime({ silent = false, installBetterSqlite = false } = {}) {
   ensureRuntimeDir();
 
   let sqlJsOk = isSqlJsWasmValid();
@@ -129,7 +130,17 @@ function ensureSqliteRuntime({ silent = false } = {}) {
     return { betterSqlite: true, sqlJs: sqlJsOk };
   }
 
-  const ok = npmInstall([`better-sqlite3@${BETTER_SQLITE3_VERSION}`], { optional: true, silent });
+  // Native SQLite is an optional accelerator. Normal CLI startup must never block
+  // on npm/node-gyp; only postinstall explicitly opts into this bounded warm-up.
+  if (!installBetterSqlite) {
+    return { betterSqlite: false, sqlJs: sqlJsOk };
+  }
+
+  const ok = npmInstall([`better-sqlite3@${BETTER_SQLITE3_VERSION}`], {
+    optional: true,
+    silent,
+    timeout: BETTER_SQLITE3_INSTALL_TIMEOUT,
+  });
   return {
     betterSqlite: ok && hasModule("better-sqlite3") && isBetterSqliteBinaryValid(),
     sqlJs: sqlJsOk,

--- a/tests/unit/sqlite-runtime-startup-3312.test.js
+++ b/tests/unit/sqlite-runtime-startup-3312.test.js
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
+const modulePath = require.resolve("../../cli/hooks/sqliteRuntime.js");
+
+let dataDir;
+let previousDataDir;
+
+function loadRuntimeHook() {
+  delete require.cache[modulePath];
+  return require(modulePath);
+}
+
+function seedSqlJsFallback() {
+  const wasm = path.join(dataDir, "runtime", "node_modules", "sql.js", "dist", "sql-wasm.wasm");
+  fs.mkdirSync(path.dirname(wasm), { recursive: true });
+  fs.writeFileSync(wasm, "wasm");
+}
+
+beforeEach(() => {
+  previousDataDir = process.env.DATA_DIR;
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-sqlite-runtime-"));
+  process.env.DATA_DIR = dataDir;
+  seedSqlJsFallback();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete require.cache[modulePath];
+  if (previousDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = previousDataDir;
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("SQLite runtime startup (#3312)", () => {
+  it("does not invoke npm for missing better-sqlite3 during normal startup", () => {
+    const spawnSync = vi.spyOn(childProcess, "spawnSync");
+    const { ensureSqliteRuntime } = loadRuntimeHook();
+
+    expect(ensureSqliteRuntime({ silent: true })).toEqual({
+      betterSqlite: false,
+      sqlJs: true,
+    });
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("limits the postinstall native warm-up to 30 seconds on a Node 26-compatible version", () => {
+    const spawnSync = vi.spyOn(childProcess, "spawnSync").mockReturnValue({
+      status: null,
+      stderr: "timed out",
+      stdout: "",
+    });
+    const { ensureSqliteRuntime } = loadRuntimeHook();
+
+    expect(ensureSqliteRuntime({ silent: true, installBetterSqlite: true })).toEqual({
+      betterSqlite: false,
+      sqlJs: true,
+    });
+    expect(spawnSync).toHaveBeenCalledWith(
+      expect.stringMatching(/^npm(?:\.cmd)?$/),
+      expect.arrayContaining(["better-sqlite3@12.10.1", "--no-save"]),
+      expect.objectContaining({ timeout: 30000 }),
+    );
+  });
+});


### PR DESCRIPTION
## Vấn đề
CLI gọi bước tự sửa SQLite ngay khi khởi động. Trên Node.js 26, `better-sqlite3@12.6.2` không có binary tương thích nên npm chuyển sang node-gyp và có thể chờ đủ 180 giây ở mỗi lần chạy.

## Thay đổi
- Không cài `better-sqlite3` trong luồng khởi động CLI thông thường; vẫn dùng `sql.js` làm fallback bắt buộc.
- Chỉ warm-up native SQLite trong `postinstall`.
- Nâng bản native lên `better-sqlite3@12.10.1`, có khai báo hỗ trợ Node.js 26.
- Giới hạn thời gian warm-up native còn 30 giây và giữ lỗi này ở mức không chặn cài đặt.
- Bổ sung regression test xác nhận khởi động không gọi npm và postinstall có timeout hữu hạn.

## Kiểm tra
- `vitest`: 2/2 test pass.
- `node --check`: pass cho toàn bộ file thay đổi.
- `eslint`: pass.

Fixes #3312