### PR TITLE
fix(codex): retry phản hồi quá tải giả HTTP 200

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -16,14 +16,13 @@ import { resolveSessionId } from "../utils/sessionManager.js";
 // SSE error patterns inside 200-OK bodies. Some retry same account first; capacity rotates accounts.
 const CODEX_SSE_RETRY_PATTERNS = ["server_is_overloaded", "service_unavailable_error"];
 const CODEX_SSE_ACCOUNT_FALLBACK_PATTERNS = ["selected model is at capacity", "model_at_capacity"];
-const CODEX_SSE_USER_OUTPUT_PATTERNS = [
-  "event: response.output_text.delta",
+const CODEX_SSE_FUNCTION_OUTPUT_PATTERNS = [
   "event: response.function_call_arguments.delta",
-  '"type":"response.output_text.delta"',
   '"type":"response.function_call_arguments.delta"',
 ];
 const CODEX_SSE_PEEK_BYTES = 256 * 1024;
 const CODEX_MODEL_CAPACITY_MESSAGE = "Selected model is at capacity. Please try a different model.";
+const CODEX_OVERLOADED_OUTPUT_MESSAGE = "Our servers are currently overloaded. Please try again later.";
 
 // Server-generated item id prefixes that Codex /responses cannot resolve when store=false
 const SERVER_ID_PATTERN = /^(rs|fc|resp|msg)_/;
@@ -172,6 +171,24 @@ function extractSseErrorMessage(text, fallback) {
   return fallback || CODEX_MODEL_CAPACITY_MESSAGE;
 }
 
+function extractSseOutputText(text) {
+  let output = "";
+  for (const line of String(text || "").split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const data = line.slice(5).trim();
+    if (!data || data === "[DONE]") continue;
+    try {
+      const event = JSON.parse(data);
+      if (event?.type === "response.output_text.delta" && typeof event.delta === "string") {
+        output += event.delta;
+      }
+    } catch {
+      // The last SSE frame may still be incomplete; the next read will finish it.
+    }
+  }
+  return output;
+}
+
 function codexSseErrorResponse(status, message) {
   return new Response(JSON.stringify({
     error: {
@@ -313,6 +330,7 @@ export class CodexExecutor extends BaseExecutor {
     const chunks = [];
     let text = "";
     let matched = null;
+    let message = null;
     let accountFallback = false;
     try {
       while (text.length < CODEX_SSE_PEEK_BYTES) {
@@ -325,16 +343,33 @@ export class CodexExecutor extends BaseExecutor {
         if (accountHit) { matched = accountHit; accountFallback = true; break; }
         const retryHit = CODEX_SSE_RETRY_PATTERNS.find(p => lowerText.includes(p));
         if (retryHit) { matched = retryHit; break; }
-        if (CODEX_SSE_USER_OUTPUT_PATTERNS.some(p => lowerText.includes(p))) break;
+        if (CODEX_SSE_FUNCTION_OUTPUT_PATTERNS.some(p => lowerText.includes(p))) break;
+
+        // Codex sometimes disguises overload as a successful output_text stream.
+        // Join complete delta frames so detection also works across network chunks.
+        const outputText = extractSseOutputText(text);
+        if (outputText) {
+          const normalizedOutput = outputText.toLowerCase();
+          const normalizedOverload = CODEX_OVERLOADED_OUTPUT_MESSAGE.toLowerCase();
+          // Keep peeking only while the first output is still an exact prefix of the
+          // known overload message. Waiting for the next frame avoids classifying a
+          // legitimate answer that starts by quoting the message as an outage.
+          if (!normalizedOverload.startsWith(normalizedOutput)) break;
+        }
       }
     } catch (e) {
       dbg("CODEX", `peek read error: ${e.message}`);
     }
 
+    if (!matched && extractSseOutputText(text) === CODEX_OVERLOADED_OUTPUT_MESSAGE) {
+      matched = "codex_overloaded_output";
+      message = CODEX_OVERLOADED_OUTPUT_MESSAGE;
+    }
+
     if (matched) {
       try { await reader.cancel(); } catch { /* noop */ }
       try { reader.releaseLock(); } catch { /* noop */ }
-      return { matched, message: extractSseErrorMessage(text, matched), accountFallback, replacementBody: null };
+      return { matched, message: message || extractSseErrorMessage(text, matched), accountFallback, replacementBody: null };
     }
 
     reader.releaseLock();

--- a/tests/unit/codex-overload-3232.test.js
+++ b/tests/unit/codex-overload-3232.test.js
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BaseExecutor } from "../../open-sse/executors/base.js";
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+const OVERLOAD_MESSAGE = "Our servers are currently overloaded. Please try again later.";
+
+function streamFromChunks(chunks) {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function sseDelta(delta) {
+  return [
+    "event: response.output_text.delta",
+    `data: ${JSON.stringify({ type: "response.output_text.delta", delta })}`,
+    "",
+    "",
+  ].join("\n");
+}
+
+describe("Codex fake 200 overload handling (#3232)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("classifies an overload message split across SSE chunks as retryable", async () => {
+    const executor = new CodexExecutor();
+    const response = new Response(streamFromChunks([
+      "event: response.output_text.delta\n",
+      `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "Our servers are currently " })}\n\n`,
+      sseDelta("overloaded. Please try again later."),
+    ]), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+    const peek = await executor._peekSseTransientError(response);
+
+    expect(peek.matched).toBe("codex_overloaded_output");
+    expect(peek.message).toBe(OVERLOAD_MESSAGE);
+    expect(peek.accountFallback).toBe(false);
+    expect(peek.replacementBody).toBeNull();
+  });
+
+  it("does not classify similar legitimate output as an overload", async () => {
+    const executor = new CodexExecutor();
+    const text = sseDelta("Our servers are currently processing your request.");
+    const response = new Response(streamFromChunks([text]), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+    const peek = await executor._peekSseTransientError(response);
+
+    expect(peek.matched).toBeNull();
+    await expect(new Response(peek.replacementBody).text()).resolves.toBe(text);
+  });
+
+  it("does not classify an answer that quotes and continues after the overload message", async () => {
+    const executor = new CodexExecutor();
+    const chunks = [
+      sseDelta(OVERLOAD_MESSAGE),
+      sseDelta(" This upstream message means the request should be retried."),
+    ];
+    const response = new Response(streamFromChunks(chunks), {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+
+    const peek = await executor._peekSseTransientError(response);
+
+    expect(peek.matched).toBeNull();
+    await expect(new Response(peek.replacementBody).text()).resolves.toBe(chunks.join(""));
+  });
+
+  it("retries the fake success instead of returning it to the client", async () => {
+    const executor = new CodexExecutor();
+    executor.config = {
+      ...executor.config,
+      retry: { ...executor.config.retry, 503: { attempts: 1, delayMs: 0 } },
+    };
+    const recovered = sseDelta("Recovered");
+    const baseExecute = vi.spyOn(BaseExecutor.prototype, "execute")
+      .mockResolvedValueOnce({
+        response: new Response(streamFromChunks([sseDelta(OVERLOAD_MESSAGE)]), { status: 200 }),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(streamFromChunks([recovered]), { status: 200 }),
+      });
+
+    const result = await executor.execute({ body: { input: [] }, log: {} });
+
+    expect(baseExecute).toHaveBeenCalledTimes(2);
+    await expect(result.response.text()).resolves.toBe(recovered);
+  });
+});


### PR DESCRIPTION
## Vấn đề
Codex đôi khi trả HTTP 200 và phát thông điệp `Our servers are currently overloaded. Please try again later.` dưới dạng `response.output_text.delta`. 9Router vì vậy coi đây là câu trả lời thành công, không retry và không kích hoạt fallback.

## Thay đổi
- Ghép các `response.output_text.delta` đầu stream để nhận diện chính xác thông điệp quá tải, kể cả khi SSE bị chia thành nhiều frame/chunk.
- Chỉ nhận diện khi toàn bộ output đúng bằng thông điệp đã biết; câu trả lời chỉ trích dẫn rồi tiếp tục không bị đánh nhầm.
- Đưa phản hồi này vào luồng retry 503 hiện có; khi retry cạn, executor trả 503 để tầng account/model fallback xử lý.
- Giữ nguyên và ráp lại đầy đủ stream bình thường sau bước peek.

## Kiểm tra
- 15/15 test pass cho regression mới và nhóm Codex capacity hiện có.
- `node --check`: pass.
- `eslint`: pass.
- Khi chạy rộng toàn bộ unit Codex, 34/36 pass; 2 lỗi nền thuộc `codex-image-fetch.test.js` vẫn tái hiện khi chạy riêng và không liên quan diff này.

Fixes #3232