### PR TITLE
feat(codex): hiển thị service tier thực tế trong log

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -272,8 +272,14 @@ export class CodexExecutor extends BaseExecutor {
     const retryConfig = { ...DEFAULT_RETRY_CONFIG, ...this.config.retry };
     const { attempts, delayMs } = resolveRetryEntry(retryConfig[503]);
     let attempt = 0;
+    let tierLogged = false;
     while (true) {
       const result = await super.execute(args);
+      if (!tierLogged) {
+        const effectiveTier = result.transformedBody?.service_tier || "default";
+        args.log?.info?.("TIER", `CODEX | ${args.model} | TIER:${effectiveTier}`);
+        tierLogged = true;
+      }
       const peek = await this._peekSseTransientError(result.response);
       if (!peek.matched) {
         // Replace body with re-assembled stream (prefix bytes already read + rest)

--- a/tests/unit/codex-tier-log-3239.test.js
+++ b/tests/unit/codex-tier-log-3239.test.js
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BaseExecutor } from "../../open-sse/executors/base.js";
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+
+function emptySseResponse() {
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("Codex effective service tier logging (#3239)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["fast", "TIER:priority"],
+    [undefined, "TIER:default"],
+  ])("logs the final transformed tier for %s", async (serviceTier, expected) => {
+    vi.spyOn(BaseExecutor.prototype, "execute").mockImplementation(function execute(args) {
+      return Promise.resolve({
+        response: emptySseResponse(),
+        transformedBody: this.transformRequest(args.model, { ...args.body }, true, {}),
+      });
+    });
+    const info = vi.fn();
+    const executor = new CodexExecutor();
+
+    await executor.execute({
+      model: "gpt-5.6-sol",
+      body: { input: "hello", service_tier: serviceTier },
+      log: { info },
+    });
+
+    expect(info).toHaveBeenCalledWith("TIER", `CODEX | gpt-5.6-sol | ${expected}`);
+  });
+});


### PR DESCRIPTION
## Vấn đề
Console Log chưa hiển thị `service_tier` thực tế sau khi Codex chuẩn hóa request. Người vận hành vì vậy không xác nhận được `fast` đã được chuyển và gửi upstream dưới dạng `priority` hay chưa.

## Thay đổi
- Ghi một dòng an toàn sau bước biến đổi cuối của Codex: `TIER:priority` hoặc `TIER:default`.
- Lấy giá trị từ `result.transformedBody`, không lấy từ request client ban đầu.
- Chỉ ghi model và tier; không ghi payload, token hay credential.
- Chỉ ghi một lần dù executor phải retry SSE.

## Kiểm tra
- Regression test xác nhận `fast` được log thành `TIER:priority`.
- Regression test xác nhận request không có tier được log `TIER:default`.
- 13/13 test của file mới và nhóm Codex fast/capacity pass.
- `node --check`, `eslint`, `git diff --check`: pass.

Fixes #3239