### PR TITLE
fix(claude): hỗ trợ Auto Mode khi dùng model Codex

### DIFF
--- a/open-sse/config/providerModels.js
+++ b/open-sse/config/providerModels.js
@@ -4,6 +4,8 @@ import REGISTRY from "../providers/registry/index.js";
 import { PROVIDER_MODELS } from "../providers/index.js";
 import { modelQuotaFamily, modelStrip, modelTargetFormat, modelSupportedFormats, normalizeModelId } from "../providers/models/schema.js";
 import { CODEX_REVIEW_SUFFIX } from "../providers/models/helpers.js";
+import { stripRecognizedContextSuffix } from "../services/model.js";
+
 export { PROVIDER_MODELS };
 
 
@@ -26,11 +28,12 @@ const DOT_VERSION_PROVIDERS = new Set(["kr", "kiro"]);
 // ("claude-sonnet-4-5" ~= "claude-sonnet-4.5"). Other providers use exact match only.
 function findModel(models, modelId, aliasOrId) {
   if (!models) return undefined;
-  const found = models.find(m => m.id === modelId);
+  const rawModelId = stripRecognizedContextSuffix(modelId);
+  const found = models.find(m => m.id === modelId) || models.find(m => m.id === rawModelId);
   if (found) return found;
   if (!DOT_VERSION_PROVIDERS.has(aliasOrId)) return undefined;
-  const normalized = normalizeModelId(modelId);
-  if (normalized === modelId) return undefined;
+  const normalized = normalizeModelId(rawModelId);
+  if (normalized === rawModelId) return undefined;
   return models.find(m => m.id === normalized);
 }
 
@@ -74,7 +77,7 @@ export function getModelUpstreamId(aliasOrId, modelId) {
   // the result so downstream applyThinking still sees the suffix (body.model is stripped separately).
   const sufMatch = typeof modelId === "string" ? modelId.match(/\([^()]+\)\s*$/) : null;
   const suffix = sufMatch ? sufMatch[0] : "";
-  const baseId = suffix ? modelId.slice(0, sufMatch.index).trim() : modelId;
+  const baseId = stripRecognizedContextSuffix(suffix ? modelId.slice(0, sufMatch.index).trim() : modelId);
   const models = PROVIDER_MODELS[aliasOrId];
   const found = findModel(models, baseId, aliasOrId);
   const resolvedId = found?.upstreamModelId || found?.id;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -29,6 +29,7 @@ import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { stripUnsupportedModalities } from "../translator/concerns/modality.js";
 import { prefetchRemoteImages } from "../translator/concerns/prefetch.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import { stripRecognizedContextSuffix } from "../services/model.js";
 
 /**
  * Core chat handler - shared between SSE and Worker
@@ -166,7 +167,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   let customToolNames;
   if (passthrough) {
     log?.debug?.("PASSTHROUGH", `${clientTool} → ${provider} | native lossless`);
-    translatedBody = { ...body, model: stripThinkingSuffix(upstreamModel) };
+    translatedBody = { ...body, model: stripRecognizedContextSuffix(stripThinkingSuffix(upstreamModel)) };
     if (provider === "codex") {
       const suffixThinking = {};
       applyThinking(sourceFormat, upstreamModel, suffixThinking, provider);
@@ -191,7 +192,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     delete translatedBody._toolNameMap;
     customToolNames = translatedBody._customToolNames;
     delete translatedBody._customToolNames;
-    translatedBody.model = stripThinkingSuffix(upstreamModel);
+    translatedBody.model = stripRecognizedContextSuffix(stripThinkingSuffix(upstreamModel));
     stripContinuityFields(translatedBody);
   }
 

--- a/open-sse/handlers/chatCore/claudeMessageResponse.js
+++ b/open-sse/handlers/chatCore/claudeMessageResponse.js
@@ -1,0 +1,101 @@
+import { FORMATS } from "../../translator/formats.js";
+import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
+
+function parseToolArguments(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function flattenTextParts(value) {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (typeof part?.text === "string") return part.text;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function normalizeClassifierDecision(text) {
+  const trimmed = String(text || "").trim();
+  if (trimmed === "<block>no</block>" || trimmed === "<block>yes</block>") return trimmed;
+  return null;
+}
+
+export function isClaudeClassifierRequest(body) {
+  if (!body || body.stream !== false) return false;
+  const stopSequences = Array.isArray(body.stop_sequences) ? body.stop_sequences : [];
+  if (!stopSequences.some((seq) => String(seq || "").trim() === "</block>")) return false;
+
+  const systemText = [
+    flattenTextParts(body.system),
+    ...(Array.isArray(body.messages)
+      ? body.messages
+        .filter((msg) => msg?.role === "system")
+        .map((msg) => flattenTextParts(msg.content))
+      : []),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return /security\s+monitor/i.test(systemText);
+}
+
+export function openAICompletionToClaudeMessage(responseBody, { classifierMode = false } = {}) {
+  if (!responseBody?.choices?.[0]) {
+    if (classifierMode) {
+      throw new Error("Claude Code classifier returned an invalid decision; expected exactly <block>no</block> or <block>yes</block>.");
+    }
+    return responseBody;
+  }
+
+  const choice = responseBody.choices[0];
+  const message = choice.message || {};
+  const content = [];
+  const textContent = typeof message.content === "string" ? message.content : "";
+  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
+
+  if (classifierMode) {
+    const decision = normalizeClassifierDecision(textContent);
+    if (!decision) {
+      throw new Error("Claude Code classifier returned an invalid decision; expected exactly <block>no</block> or <block>yes</block>.");
+    }
+    content.push({ type: "text", text: decision });
+  } else {
+    if (reasoning) content.push({ type: "thinking", thinking: reasoning });
+    if (textContent.length > 0) content.push({ type: "text", text: textContent });
+    for (const toolCall of message.tool_calls || []) {
+      const fn = toolCall.function || {};
+      content.push({
+        type: "tool_use",
+        id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
+        name: fn.name || toolCall.name || "",
+        input: parseToolArguments(fn.arguments || toolCall.arguments),
+      });
+    }
+    if (content.length === 0) content.push({ type: "text", text: "" });
+  }
+
+  const usage = responseBody.usage || {};
+  return {
+    id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
+    type: "message",
+    role: "assistant",
+    model: responseBody.model || "unknown",
+    content,
+    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
+    stop_sequence: null,
+    usage: {
+      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
+      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
+    },
+  };
+}

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -1,6 +1,5 @@
 import { FORMATS } from "../../translator/formats.js";
 import { needsTranslation } from "../../translator/index.js";
-import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
 import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.js";
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
@@ -10,56 +9,7 @@ import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, sav
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
-
-function parseToolArguments(value) {
-  if (!value) return {};
-  if (typeof value === "object") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return {};
-  }
-}
-
-function openAICompletionToClaudeMessage(responseBody) {
-  if (!responseBody?.choices?.[0]) return responseBody;
-  const choice = responseBody.choices[0];
-  const message = choice.message || {};
-  const content = [];
-
-  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
-  if (reasoning) {
-    content.push({ type: "thinking", thinking: reasoning });
-  }
-  if (typeof message.content === "string" && message.content.length > 0) {
-    content.push({ type: "text", text: message.content });
-  }
-  for (const toolCall of message.tool_calls || []) {
-    const fn = toolCall.function || {};
-    content.push({
-      type: "tool_use",
-      id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
-      name: fn.name || toolCall.name || "",
-      input: parseToolArguments(fn.arguments || toolCall.arguments),
-    });
-  }
-  if (content.length === 0) content.push({ type: "text", text: "" });
-
-  const usage = responseBody.usage || {};
-  return {
-    id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
-    type: "message",
-    role: "assistant",
-    model: responseBody.model || "unknown",
-    content,
-    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
-    stop_sequence: null,
-    usage: {
-      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
-      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
-    },
-  };
-}
+import { isClaudeClassifierRequest, openAICompletionToClaudeMessage } from "./claudeMessageResponse.js";
 
 /**
  * Convert an OpenAI Chat Completions non-streaming response body into the
@@ -141,15 +91,20 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
 /**
  * Translate non-streaming response body from provider format → OpenAI format.
  */
-export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, customToolNames = null) {
+export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, options = {}) {
   if (targetFormat === sourceFormat) return responseBody;
+  // Keep backward compatibility for callers that pass the custom-tool set directly.
+  const customToolNames = options instanceof Set ? options : options.customToolNames || null;
+  const requestBody = options instanceof Set ? null : options.body;
   // Provider responded in OpenAI Chat Completions shape but the client speaks
   // Responses API — convert so tool_calls/text surface as Responses `output`.
   if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.OPENAI_RESPONSES) {
     return openAICompletionToResponses(responseBody, customToolNames);
   }
   if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.CLAUDE) {
-    return openAICompletionToClaudeMessage(responseBody);
+    return openAICompletionToClaudeMessage(responseBody, {
+      classifierMode: isClaudeClassifierRequest(requestBody),
+    });
   }
   if (targetFormat === FORMATS.OPENAI) return responseBody;
 
@@ -321,9 +276,15 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, silent: true });
   if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency: { total: Date.now() - requestStartTime } }));
 
-  const translatedResponse = needsTranslation(targetFormat, sourceFormat)
-    ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, customToolNames)
-    : responseBody;
+  let translatedResponse;
+  try {
+    translatedResponse = needsTranslation(targetFormat, sourceFormat)
+      ? translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, { body, customToolNames })
+      : responseBody;
+  } catch (err) {
+    appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, err.message || "Claude classifier returned an invalid decision");
+  }
   const isClaudeMessageResponse = sourceFormat === FORMATS.CLAUDE && translatedResponse?.type === "message";
   // Responses-format translation produces a `object:"response"` body with no
   // `choices`; skip the Chat-Completions-specific post-processing below for it.

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -5,6 +5,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { isClaudeClassifierRequest, openAICompletionToClaudeMessage } from "./claudeMessageResponse.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -17,6 +18,20 @@ function textFromResponsesMessageItem(item) {
   const anyText = item.content.find((c) => typeof c.text === "string");
   if (typeof anyText?.text === "string") return anyText.text;
   return "";
+}
+
+function reasoningTextFromResponsesOutput(output) {
+  if (!Array.isArray(output)) return "";
+  return output
+    .filter((item) => item?.type === "reasoning")
+    .flatMap((item) => Array.isArray(item.summary) ? item.summary : [])
+    .map((part) => {
+      if (typeof part?.text === "string") return part.text;
+      if (typeof part?.summary === "string") return part.summary;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
 }
 
 /**
@@ -213,13 +228,14 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
         + (usage.cache_read_input_tokens || usage.cached_tokens || 0)
         + (usage.cache_creation_input_tokens || 0);
       const { msgItem, textContent } = pickAssistantMessageForChatCompletion(jsonResponse.output);
+      const reasoningText = reasoningTextFromResponsesOutput(jsonResponse.output);
       const totalLatency = Date.now() - requestStartTime;
 
       saveRequestDetail(buildRequestDetail({
         ...ctx,
         latency: { ttft: totalLatency, total: totalLatency },
         tokens: { prompt_tokens: inTokensForLog, completion_tokens: usage.output_tokens || 0 },
-        response: { content: textContent, thinking: null, finish_reason: jsonResponse.status || "unknown" },
+        response: { content: textContent, thinking: reasoningText || null, finish_reason: jsonResponse.status || "unknown" },
         status: "success"
       }, { endpoint: clientRawRequest?.endpoint || null })).catch(() => {});
 
@@ -268,6 +284,7 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
         };
       } else {
         const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
+        if (reasoningText) message.reasoning_content = reasoningText;
         if (hasToolCalls) message.tool_calls = toolCalls;
         const responseDone = jsonResponse.status === "completed" || jsonResponse.status === "done";
         const finishReason = hasToolCalls ? "tool_calls" : (responseDone ? "stop" : (jsonResponse.status || "stop"));
@@ -279,6 +296,16 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
           choices: [{ index: 0, message, finish_reason: finishReason }],
           usage: { prompt_tokens: inTokens, completion_tokens: outTokens, total_tokens: inTokens + outTokens, ...cacheDetails }
         };
+      }
+
+      if (sourceFormat === FORMATS.CLAUDE) {
+        try {
+          finalResp = openAICompletionToClaudeMessage(finalResp, {
+            classifierMode: isClaudeClassifierRequest(body),
+          });
+        } catch (err) {
+          return createErrorResult(HTTP_STATUS.BAD_GATEWAY, err.message || "Claude classifier returned an invalid decision");
+        }
       }
 
       return { success: true, response: new Response(JSON.stringify(finalResp), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
@@ -328,6 +355,17 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
     // must not be left unable to account for its own token spend: a caller cannot tell
     // a 90%-cached request from a cheap one without this.
     if (usage && Object.keys(usage).length > 0) parsed.usage = usage;
+
+    if (sourceFormat === FORMATS.CLAUDE) {
+      try {
+        const finalResp = openAICompletionToClaudeMessage(parsed, {
+          classifierMode: isClaudeClassifierRequest(body),
+        });
+        return { success: true, response: new Response(JSON.stringify(finalResp), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
+      } catch (err) {
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, err.message || "Claude classifier returned an invalid decision");
+      }
+    }
 
     // Strip reasoning_content only when content is non-empty.
     // When content is empty (e.g. thinking models that used all tokens for reasoning),

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -23,6 +23,7 @@
 // 2.0+, Grok, Perplexity). Verify with: curl -s https://models.dev/api.json
 
 import { matchPattern } from "./pricing.js";
+import { stripRecognizedContextSuffix } from "../services/model.js";
 
 /**
  * Safe floor — every resolved result is merged over this so consumers
@@ -329,22 +330,25 @@ export function getCapabilitiesForModel(provider, model) {
   if (!model) return { ...DEFAULT_CAPABILITIES };
 
   // Canonical exact lookup strips vendor prefix: "anthropic/claude-opus-4.7" -> "claude-opus-4.7".
-  const baseModel = model.includes("/") ? model.split("/").pop() : model;
+  const normalizedModel = stripRecognizedContextSuffix(model);
+  const baseModel = stripRecognizedContextSuffix(normalizedModel.includes("/") ? normalizedModel.split("/").pop() : normalizedModel);
 
   // 1. Provider-specific override
   if (provider) {
     const providerCaps = PROVIDER_CAPABILITIES[provider];
+    if (providerCaps?.[normalizedModel]) return { ...DEFAULT_CAPABILITIES, ...providerCaps[normalizedModel] };
     if (providerCaps?.[model]) return { ...DEFAULT_CAPABILITIES, ...providerCaps[model] };
     if (providerCaps?.[baseModel]) return { ...DEFAULT_CAPABILITIES, ...providerCaps[baseModel] };
   }
 
   // 2. Canonical exact
   if (MODEL_CAPABILITIES[baseModel]) return { ...DEFAULT_CAPABILITIES, ...MODEL_CAPABILITIES[baseModel] };
+  if (MODEL_CAPABILITIES[normalizedModel]) return { ...DEFAULT_CAPABILITIES, ...MODEL_CAPABILITIES[normalizedModel] };
   if (MODEL_CAPABILITIES[model]) return { ...DEFAULT_CAPABILITIES, ...MODEL_CAPABILITIES[model] };
 
   // 3. Pattern match (first match wins)
   for (const { pattern, caps } of PATTERN_CAPABILITIES) {
-    if (matchPattern(pattern, baseModel) || matchPattern(pattern, model)) {
+    if (matchPattern(pattern, baseModel) || matchPattern(pattern, normalizedModel) || matchPattern(pattern, model)) {
       return { ...DEFAULT_CAPABILITIES, ...caps };
     }
   }

--- a/open-sse/services/combo.js
+++ b/open-sse/services/combo.js
@@ -6,6 +6,7 @@ import { checkFallbackError, formatRetryAfter } from "./accountFallback.js";
 import { unavailableResponse } from "../utils/error.js";
 import { getCapabilitiesForModel } from "../providers/capabilities.js";
 import { extractTextContent } from "../translator/formats/gemini.js";
+import { stripRecognizedContextSuffix } from "./model.js";
 
 // Hard capabilities = input modalities; missing one drops request data (e.g. image
 // stripped). Must be prioritized. Soft (e.g. search) only degrades a feature.
@@ -258,7 +259,11 @@ export function getComboModelsFromData(modelStr, combosData) {
   // Handle both array and object formats
   const combos = Array.isArray(combosData) ? combosData : (combosData?.combos || []);
   
-  const combo = combos.find(c => c.name === modelStr);
+  const combo = combos.find(c => c.name === modelStr)
+    || (() => {
+      const baseName = stripRecognizedContextSuffix(modelStr);
+      return baseName !== modelStr ? combos.find(c => c.name === baseName) : null;
+    })();
   if (combo && combo.models && combo.models.length > 0) {
     return combo.models;
   }

--- a/open-sse/services/model.js
+++ b/open-sse/services/model.js
@@ -21,6 +21,22 @@ const BUILTIN_MODEL_ALIASES = {
   "grok-build": "gcli/grok-build",
 };
 
+const CONTEXT_SUFFIX_RE = /(?:\[(1m)\]|-(1m))$/i;
+
+export function splitRecognizedContextSuffix(modelId) {
+  if (typeof modelId !== "string") return { baseModel: modelId, suffix: "" };
+  const match = modelId.match(CONTEXT_SUFFIX_RE);
+  if (!match) return { baseModel: modelId, suffix: "" };
+  return {
+    baseModel: modelId.slice(0, match.index).trimEnd(),
+    suffix: match[0],
+  };
+}
+
+export function stripRecognizedContextSuffix(modelId) {
+  return splitRecognizedContextSuffix(modelId).baseModel;
+}
+
 /**
  * Resolve provider alias to provider ID
  */
@@ -108,17 +124,21 @@ export async function getModelInfoCore(modelStr, aliasesOrGetter) {
       : aliasesOrGetter;
 
   // Resolve alias
+  const rawModel = parsed.model;
+  const baseModel = stripRecognizedContextSuffix(rawModel);
   const resolved =
-    resolveModelAliasFromMap(parsed.model, aliases) ||
-    resolveModelAliasFromMap(parsed.model, BUILTIN_MODEL_ALIASES);
+    resolveModelAliasFromMap(rawModel, aliases) ||
+    resolveModelAliasFromMap(rawModel, BUILTIN_MODEL_ALIASES) ||
+    (baseModel !== rawModel ? resolveModelAliasFromMap(baseModel, aliases) : null) ||
+    (baseModel !== rawModel ? resolveModelAliasFromMap(baseModel, BUILTIN_MODEL_ALIASES) : null);
   if (resolved) {
     return resolved;
   }
 
   // Fallback: infer provider from model name prefix
   return {
-    provider: inferProviderFromModelName(parsed.model),
-    model: parsed.model,
+    provider: inferProviderFromModelName(baseModel),
+    model: baseModel,
   };
 }
 

--- a/src/sse/services/model.js
+++ b/src/sse/services/model.js
@@ -1,6 +1,6 @@
 // Re-export from open-sse with localDb integration
 import { getModelAliases, getComboByName, getProviderNodes } from "@/lib/localDb";
-import { parseModel as parseModelCore, resolveModelAliasFromMap, getModelInfoCore } from "open-sse/services/model.js";
+import { parseModel as parseModelCore, resolveModelAliasFromMap, getModelInfoCore, stripRecognizedContextSuffix } from "open-sse/services/model.js";
 import REGISTRY from "open-sse/providers/registry/index.js";
 
 // Local provider alias overrides (HMR-friendly, applied on top of open-sse map)
@@ -69,10 +69,12 @@ export async function getModelInfo(modelStr) {
   // Check if this is a combo name before resolving as alias
   // This prevents combo names from being incorrectly routed to providers
   const combo = await getComboByName(parsed.model);
-  if (combo) {
+  const baseComboName = stripRecognizedContextSuffix(parsed.model);
+  const matchedCombo = combo || (baseComboName !== parsed.model ? await getComboByName(baseComboName) : null);
+  if (matchedCombo) {
     // Return null provider to signal this should be handled as combo
     // The caller (handleChat) will detect this and handle it as combo
-    return { provider: null, model: parsed.model };
+    return { provider: null, model: matchedCombo.name };
   }
 
   return getModelInfoCore(modelStr, getModelAliases);
@@ -87,8 +89,10 @@ export async function getComboModels(modelStr) {
   if (modelStr.includes("/")) return null;
 
   const combo = await getComboByName(modelStr);
-  if (combo && combo.models && combo.models.length > 0) {
-    return combo.models;
+  const baseModelStr = stripRecognizedContextSuffix(modelStr);
+  const matchedCombo = combo || (baseModelStr !== modelStr ? await getComboByName(baseModelStr) : null);
+  if (matchedCombo && matchedCombo.models && matchedCombo.models.length > 0) {
+    return matchedCombo.models;
   }
   return null;
 }

--- a/tests/unit/claude-auto-mode-fallback.test.js
+++ b/tests/unit/claude-auto-mode-fallback.test.js
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/usageDb.js", () => ({
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {}),
+}));
+
+const { FORMATS } = await import("../../open-sse/translator/formats.js");
+const { handleForcedSSEToJson } = await import("../../open-sse/handlers/chatCore/sseToJsonHandler.js");
+const { handleNonStreamingResponse } = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
+const { handleComboChat } = await import("../../open-sse/services/combo.js");
+const {
+  isClaudeClassifierRequest,
+  openAICompletionToClaudeMessage,
+} = await import("../../open-sse/handlers/chatCore/claudeMessageResponse.js");
+
+function makeResponsesSseResponse(items, usage = { input_tokens: 11, output_tokens: 3, total_tokens: 14 }) {
+  const encoder = new TextEncoder();
+  const raw = [
+    'event: response.created',
+    'data: {"type":"response.created","response":{"id":"resp_classifier","created_at":1700000000}}',
+    "",
+    ...items.flatMap((item, index) => ([
+      "event: response.output_item.done",
+      `data: ${JSON.stringify({ type: "response.output_item.done", output_index: index, item })}`,
+      "",
+    ])),
+    "event: response.completed",
+    `data: ${JSON.stringify({ type: "response.completed", response: { id: "resp_classifier", status: "completed", usage } })}`,
+    "",
+  ].join("\n");
+
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(raw));
+      controller.close();
+    },
+  }), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function makeChatCompletionsSseResponse(chunks) {
+  const encoder = new TextEncoder();
+  const raw = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}`).join("\n\n")}\n\ndata: [DONE]\n`;
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(raw));
+      controller.close();
+    },
+  }), {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function makeOpenAIJsonResponse(content) {
+  return new Response(JSON.stringify({
+    id: "chatcmpl_classifier",
+    object: "chat.completion",
+    created: 1700000000,
+    model: "gpt-5.5",
+    choices: [{
+      index: 0,
+      message: { role: "assistant", content },
+      finish_reason: "stop",
+    }],
+    usage: { prompt_tokens: 8, completion_tokens: 2, total_tokens: 10 },
+  }), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeClassifierBody(overrides = {}) {
+  return {
+    model: "subscription",
+    stream: false,
+    system: "You are the security monitor for Claude Code. Reply with exactly one <block> decision.",
+    stop_sequences: ["</block>"],
+    messages: [{ role: "user", content: "Can I continue?" }],
+    ...overrides,
+  };
+}
+
+async function runForcedClaudeResponses(items, body = makeClassifierBody()) {
+  return handleForcedSSEToJson({
+    providerResponse: makeResponsesSseResponse(items),
+    sourceFormat: FORMATS.CLAUDE,
+    provider: "codex",
+    model: "gpt-5.6-terra",
+    body,
+    stream: false,
+    requestStartTime: Date.now(),
+    connectionId: "test-connection",
+    clientRawRequest: { endpoint: "/v1/messages", body },
+    trackDone: vi.fn(),
+    appendLog: vi.fn(),
+  });
+}
+
+async function runForcedClaudeChatCompletionSse(chunks, body = makeClassifierBody()) {
+  return handleForcedSSEToJson({
+    providerResponse: makeChatCompletionsSseResponse(chunks),
+    sourceFormat: FORMATS.CLAUDE,
+    provider: "openai",
+    model: "gpt-5.5",
+    body,
+    stream: false,
+    requestStartTime: Date.now(),
+    connectionId: "test-connection",
+    clientRawRequest: { endpoint: "/v1/messages", body },
+    trackDone: vi.fn(),
+    appendLog: vi.fn(),
+  });
+}
+
+async function runNonStreamingClaudeJson(providerResponse, body = makeClassifierBody()) {
+  return handleNonStreamingResponse({
+    providerResponse,
+    provider: "openai",
+    model: "gpt-5.5",
+    sourceFormat: FORMATS.CLAUDE,
+    targetFormat: FORMATS.OPENAI,
+    body,
+    stream: false,
+    translatedBody: body,
+    finalBody: body,
+    requestStartTime: Date.now(),
+    connectionId: "test-connection",
+    clientRawRequest: { endpoint: "/v1/messages", body },
+    trackDone: vi.fn(),
+    appendLog: vi.fn(),
+    reqLogger: {
+      logProviderResponse: vi.fn(),
+      logConvertedResponse: vi.fn(),
+    },
+    log: { line: vi.fn() },
+  });
+}
+
+describe("Claude Code auto-mode fallback", () => {
+  it("detects classifier payloads from Anthropic-style system arrays", () => {
+    expect(isClaudeClassifierRequest(makeClassifierBody({
+      system: [{ type: "text", text: "You are the security monitor for Claude Code." }],
+    }))).toBe(true);
+  });
+
+  it("does not mis-detect near-miss payloads without the stop sequence or security monitor marker", () => {
+    expect(isClaudeClassifierRequest(makeClassifierBody({
+      stop_sequences: ["</done>"],
+    }))).toBe(false);
+    expect(isClaudeClassifierRequest(makeClassifierBody({
+      system: "You are a helpful assistant.",
+    }))).toBe(false);
+  });
+
+  it("fails closed when classifier mode receives no choices at all", () => {
+    expect(() => openAICompletionToClaudeMessage({}, { classifierMode: true })).toThrow(/invalid decision/i);
+    expect(() => openAICompletionToClaudeMessage({ choices: [] }, { classifierMode: true })).toThrow(/invalid decision/i);
+  });
+
+  it("returns a real Anthropic Message JSON for a classifier allow decision from Responses SSE", async () => {
+    const result = await runForcedClaudeResponses([
+      { type: "reasoning", summary: [{ type: "summary_text", text: "Looks safe." }] },
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "<block>no</block>" }] },
+    ]);
+    const json = await result.response.json();
+
+    expect(result.success).toBe(true);
+    expect(json).toMatchObject({
+      id: "resp_classifier",
+      type: "message",
+      role: "assistant",
+      model: "gpt-5.6-terra",
+    });
+    expect(json.content).toEqual([{ type: "text", text: "<block>no</block>" }]);
+  });
+
+  it("preserves a classifier deny decision from GPT fallback", async () => {
+    const result = await runForcedClaudeResponses([
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "<block>yes</block>" }] },
+    ]);
+    const json = await result.response.json();
+
+    expect(result.success).toBe(true);
+    expect(json.content).toEqual([{ type: "text", text: "<block>yes</block>" }]);
+  });
+
+  it("fails closed when the classifier response is prose instead of a block decision", async () => {
+    const result = await runForcedClaudeResponses([
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "This looks safe to me." }] },
+    ]);
+    const json = await result.response.json();
+
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(502);
+    expect(json.error.message).toMatch(/classifier/i);
+  });
+
+  it("fails closed when the classifier response is empty", async () => {
+    const result = await runForcedClaudeResponses([
+      { type: "message", role: "assistant", content: [] },
+    ]);
+    const json = await result.response.json();
+
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(502);
+    expect(json.error.message).toMatch(/classifier/i);
+  });
+
+  it("returns Anthropic Message JSON for non-streaming OpenAI JSON classifier allow decisions", async () => {
+    const result = await runNonStreamingClaudeJson(makeOpenAIJsonResponse("<block>no</block>"));
+    const json = await result.response.json();
+
+    expect(result.success).toBe(true);
+    expect(json.type).toBe("message");
+    expect(json.content).toEqual([{ type: "text", text: "<block>no</block>" }]);
+  });
+
+  it("fails closed for malformed non-streaming OpenAI JSON classifier decisions", async () => {
+    const result = await runNonStreamingClaudeJson(makeOpenAIJsonResponse("allow"));
+    const json = await result.response.json();
+
+    expect(result.success).toBe(false);
+    expect(result.response.status).toBe(502);
+    expect(json.error.message).toMatch(/classifier/i);
+  });
+
+  it("returns Anthropic Message JSON for standard chat-completions SSE classifier decisions", async () => {
+    const result = await runForcedClaudeChatCompletionSse([
+      {
+        id: "chatcmpl_sse",
+        object: "chat.completion.chunk",
+        created: 1700000000,
+        model: "gpt-5.5",
+        choices: [{ index: 0, delta: { content: "<block>no</block>" }, finish_reason: "stop" }],
+      },
+    ]);
+    const json = await result.response.json();
+
+    expect(result.success).toBe(true);
+    expect(json.type).toBe("message");
+    expect(json.content).toEqual([{ type: "text", text: "<block>no</block>" }]);
+  });
+
+  it("does not break ordinary non-classifier Claude responses routed through GPT/Codex", async () => {
+    const body = makeClassifierBody({
+      system: "You are a helpful assistant.",
+      stop_sequences: undefined,
+    });
+    const result = await runForcedClaudeResponses([
+      { type: "reasoning", summary: [{ type: "summary_text", text: "I should answer concisely." }] },
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "General answer." }] },
+    ], body);
+    const json = await result.response.json();
+
+    expect(result.success).toBe(true);
+    expect(json.type).toBe("message");
+    expect(json.content).toEqual([
+      { type: "thinking", thinking: "I should answer concisely." },
+      { type: "text", text: "General answer." },
+    ]);
+  });
+
+  it("keeps a successful native Claude classifier response without falling back", async () => {
+    const handleSingleModel = vi.fn(async (body, modelStr) => {
+      if (modelStr.startsWith("cc/")) {
+        return new Response(JSON.stringify({
+          id: "msg_claude",
+          type: "message",
+          role: "assistant",
+          model: "claude-opus-4-8",
+          content: [{ type: "text", text: "<block>no</block>" }],
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      throw new Error(`unexpected fallback for ${body.model}`);
+    });
+
+    const response = await handleComboChat({
+      body: makeClassifierBody(),
+      models: ["cc/claude-opus-4-8", "cx/gpt-5.6-terra"],
+      handleSingleModel,
+      log: { info: vi.fn(), warn: vi.fn() },
+      comboName: "subscription",
+      comboStrategy: "fallback",
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.content).toEqual([{ type: "text", text: "<block>no</block>" }]);
+    expect(handleSingleModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back from Claude to GPT/Codex for classifier responses without changing the schema", async () => {
+    const handleSingleModel = vi.fn(async (body, modelStr) => {
+      if (modelStr.startsWith("cc/")) {
+        return new Response(JSON.stringify({ error: { message: "anthropic overloaded" } }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      const result = await runForcedClaudeResponses([
+        { type: "reasoning", summary: [{ type: "summary_text", text: "Allow." }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "<block>no</block>" }] },
+      ], body);
+      return result.response;
+    });
+
+    const response = await handleComboChat({
+      body: makeClassifierBody(),
+      models: ["cc/claude-opus-4-8", "cx/gpt-5.6-terra"],
+      handleSingleModel,
+      log: { info: vi.fn(), warn: vi.fn() },
+      comboName: "subscription",
+      comboStrategy: "fallback",
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.type).toBe("message");
+    expect(json.content).toEqual([{ type: "text", text: "<block>no</block>" }]);
+    expect(handleSingleModel).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([401, 429, 503])("propagates upstream %s failures instead of synthesizing an allow", async (status) => {
+    const response = await handleComboChat({
+      body: makeClassifierBody(),
+      models: ["cc/claude-opus-4-8", "cx/gpt-5.6-terra"],
+      handleSingleModel: vi.fn(async () => new Response(JSON.stringify({
+        error: { message: `upstream ${status}` },
+      }), {
+        status,
+        headers: { "content-type": "application/json" },
+      })),
+      log: { info: vi.fn(), warn: vi.fn() },
+      comboName: "subscription",
+      comboStrategy: "fallback",
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(status);
+    expect(json.error.message).toContain(`upstream ${status}`);
+  });
+});

--- a/tests/unit/model-context-suffix.test.js
+++ b/tests/unit/model-context-suffix.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+
+import { getModelInfoCore } from "../../open-sse/services/model.js";
+import { getComboModelsFromData } from "../../open-sse/services/combo.js";
+import { getModelUpstreamId } from "../../open-sse/config/providerModels.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+
+describe("recognized 1M context suffix routing", () => {
+  it("prefers an exact alias over the base-name fallback", async () => {
+    await expect(getModelInfoCore("cc-gpt-main-agent[1m]", {
+      "cc-gpt-main-agent[1m]": "cx/gpt-5.5",
+      "cc-gpt-main-agent": "cx/gpt-5.6-terra",
+    })).resolves.toEqual({
+      provider: "codex",
+      model: "gpt-5.5",
+    });
+  });
+
+  it("falls back to the base alias when Claude Code appends [1m]", async () => {
+    await expect(getModelInfoCore("cc-gpt-main-agent[1m]", {
+      "cc-gpt-main-agent": "cx/gpt-5.6-terra",
+    })).resolves.toEqual({
+      provider: "codex",
+      model: "gpt-5.6-terra",
+    });
+  });
+
+  it("resolves combo lookup through the base name when the request ends with [1m]", () => {
+    expect(getComboModelsFromData("subscription[1m]", [
+      {
+        name: "subscription",
+        models: ["cc/claude-opus-4-8", "cx/gpt-5.6-terra"],
+      },
+    ])).toEqual(["cc/claude-opus-4-8", "cx/gpt-5.6-terra"]);
+  });
+
+  it("prefers an exact combo name over the base-name fallback", () => {
+    expect(getComboModelsFromData("subscription[1m]", [
+      {
+        name: "subscription[1m]",
+        models: ["cx/gpt-5.5"],
+      },
+      {
+        name: "subscription",
+        models: ["cc/claude-opus-4-8", "cx/gpt-5.6-terra"],
+      },
+    ])).toEqual(["cx/gpt-5.5"]);
+  });
+
+  it("strips [1m] from direct Claude upstream model forwarding", () => {
+    expect(getModelUpstreamId("cc", "claude-opus-4-8[1m]")).toBe("claude-opus-4-8");
+  });
+
+  it("also strips [1M] from direct Claude upstream model forwarding", () => {
+    expect(getModelUpstreamId("cc", "claude-opus-4-8[1M]")).toBe("claude-opus-4-8");
+  });
+
+  it("strips -1m from GPT/Codex fallback model forwarding", () => {
+    expect(getModelUpstreamId("cx", "gpt-5.6-terra-1m")).toBe("gpt-5.6-terra");
+  });
+
+  it("keeps Claude 1M capabilities when the client suffix is present", () => {
+    expect(getCapabilitiesForModel("claude", "claude-opus-4-8[1M]").contextWindow).toBe(1000000);
+  });
+
+  it("does not strip unrecognized suffixes", async () => {
+    await expect(getModelInfoCore("cc-gpt-main-agent[preview]", {
+      "cc-gpt-main-agent": "cx/gpt-5.6-terra",
+    })).resolves.toEqual({
+      provider: "openai",
+      model: "cc-gpt-main-agent[preview]",
+    });
+    expect(getComboModelsFromData("subscription[preview]", [
+      {
+        name: "subscription",
+        models: ["cc/claude-opus-4-8", "cx/gpt-5.6-terra"],
+      },
+    ])).toBeNull();
+    expect(getModelUpstreamId("cc", "claude-opus-4-8[preview]")).toBe("claude-opus-4-8[preview]");
+  });
+});


### PR DESCRIPTION
## Vấn đề

Claude Code Auto Mode gửi một request classifier không streaming qua `/v1/messages`. Khi model Claude được ánh xạ/fallback sang Codex, upstream trả Responses SSE; 9router đã gom được kết quả nhưng trả JSON dạng OpenAI `chat.completion`. Claude Code không đọc được quyết định classifier nên fail-closed và chặn Bash/tool call, khiến người dùng tưởng phải bật `bypassPermissions`.

Claude Code mới cũng có thể gắn suffix `[1m]`/`-1m` vào model hoặc combo, làm sai bước resolve/fallback.

## Cách sửa

- Nhận diện đúng payload security classifier của Claude Code.
- Chuyển kết quả GPT/Codex về Anthropic Message JSON cho cả Responses SSE, Chat Completions SSE và OpenAI JSON.
- Chỉ chấp nhận chính xác `<block>no</block>` hoặc `<block>yes</block>`; phản hồi trống/sai định dạng trả 502 để giữ fail-closed, không tổng hợp quyết định cho phép.
- Giữ nguyên lỗi upstream 401/429/503 để combo fallback xử lý đúng.
- Chuẩn hóa suffix context `[1m]`/`-1m` khi resolve alias, combo, capability và model upstream.
- Giữ tương thích với luồng Responses/custom tool mới trên master.

## Kiểm thử

- 52/52 test tập trung đạt: classifier/fallback, Responses SSE, Chat SSE, OpenAI JSON, custom tool, combo/model routing, capability/context 1M và lỗi non-stream.
- ESLint các file thay đổi: đạt.
- Full unit suite hiện chưa xanh trên Windows do các lỗi ngoài phạm vi/baseline (native `better-sqlite3`, test live, mock cũ và khóa thư mục tạm).

## Nguồn và liên quan

Bản này port/rebase từ #2780 của @AlanSyue lên master hiện tại và giữ attribution trong commit. Khác #2254, bản sửa không tự động cho phép classifier và không bỏ qua cơ chế an toàn.

Liên quan:
- anthropics/claude-code#78372
- anthropics/claude-code#69950
- anthropics/claude-code#84673