### PR TITLE
fix(opencode): stop zen free-tier 429 — official client fingerprint + manual egress switch

### DIFF
--- a/open-sse/executors/opencode.js
+++ b/open-sse/executors/opencode.js
@@ -4,7 +4,12 @@ import { PROVIDERS } from "../config/providers.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
 
-const OPENCODE_UA = "opencode";
+// Official opencode CLI sends "opencode/<version>" (e.g. opencode/1.18.18).
+// OpenCode Zen's free-tier ("-free") models gate anonymous capacity on this
+// User-Agent — a bare "opencode" or any non-opencode UA is still classified
+// as unidentified and gets FreeUsageLimitError/429 immediately. Keep the
+// version in sync with opencode releases when it bumps.
+const OPENCODE_UA = "opencode/latest/1.18.18/cli";
 const MESSAGES_MODELS = new Set();
 
 function generateRequestId() {
@@ -33,11 +38,14 @@ function resolveOpencodeSession(body, credentials) {
 export class OpenCodeExecutor extends BaseExecutor {
   constructor() {
     super("opencode", PROVIDERS.opencode);
-    this._currentSessionId = null;
   }
 
   transformRequest(model, body, stream, credentials) {
-    this._currentSessionId = resolveOpencodeSession(body, credentials);
+    // Stash the resolved session on the per-request credentials object instead
+    // of an instance field: OpenCodeExecutor is a module-level singleton and
+    // concurrent requests used to overwrite _currentSessionId between
+    // transformRequest and buildHeaders, bleeding sessions across requests.
+    if (credentials) credentials._ocSession = resolveOpencodeSession(body, credentials);
     return injectReasoningContent({ provider: this.provider, model, body });
   }
 
@@ -56,14 +64,27 @@ export class OpenCodeExecutor extends BaseExecutor {
     const downstreamUa = lower["user-agent"] || "";
     const isOpencodeDownstream = downstreamUa.toLowerCase().includes("opencode");
 
+    // OpenCode Zen's free-tier IP rate limiter reads the x-real-ip request
+    // header (ipRateLimiter.ts: rawIp = headers.get("x-real-ip") ?? "" →
+    // ip = "unknown"; no header = ONE global bucket shared with every other
+    // anonymous client). NOTE: in front of opencode.ai the CDN stamps
+    // x-real-ip from the real TCP peer and strips client-supplied values, so
+    // this header is best-effort — the reliable per-user isolation comes from
+    // real egress IPs (see utils/ocEgress.js rotation). We still forward the
+    // sanitized peer IP (x-9r-real-ip stamped by custom-server.js from the
+    // unspoofable TCP socket) because it is harmless and helps when the
+    // upstream is reached through a pass-through proxy.
+    const clientIp = lower["x-9r-real-ip"] || lower["x-real-ip"] || "";
+
     return {
       "Content-Type": "application/json",
       "Authorization": "Bearer public",
       "User-Agent": isOpencodeDownstream ? downstreamUa : OPENCODE_UA,
       "x-opencode-client": lower["x-opencode-client"] || "desktop",
-      "x-opencode-session": lower["x-opencode-session"] || this._currentSessionId || generateSessionId(),
+      "x-opencode-session": lower["x-opencode-session"] || credentials?._ocSession || generateSessionId(),
       "x-opencode-request": lower["x-opencode-request"] || generateRequestId(),
       "x-opencode-project": lower["x-opencode-project"] || "global",
+      ...(clientIp ? { "x-real-ip": clientIp } : {}),
       "Accept": stream ? "text/event-stream" : "*/*",
     };
   }

--- a/open-sse/executors/opencode.js
+++ b/open-sse/executors/opencode.js
@@ -3,6 +3,7 @@ import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
+import { applyOcEgress, flipOcEgress } from "../utils/ocEgress.js";
 
 // Official opencode CLI sends "opencode/<version>" (e.g. opencode/1.18.18).
 // OpenCode Zen's free-tier ("-free") models gate anonymous capacity on this
@@ -54,6 +55,20 @@ export class OpenCodeExecutor extends BaseExecutor {
     return MESSAGES_MODELS.has(model)
       ? `${base}/zen/v1/messages`
       : `${base}/zen/v1/chat/completions`;
+  }
+
+  // OpenCode Zen's free tier is rate-limited per real egress IP (daily
+  // budget per IP, reset at UTC midnight). There is NO automatic switching:
+  // when the current IP's budget is exhausted the gateway answers
+  // 429 FreeUsageLimitError and it stays exhausted until midnight — the user
+  // picks another node/egress themselves (Clash UI or oc-egress.mjs
+  // switch/flip/set) and the SAME conversation continues from the new IP.
+  // applyOcEgress() only honors the manually chosen mode from the state file
+  // (<APPDATA>/9router/oc-egress.json) so a manual switch works without
+  // restarting 9router. Errors propagate untouched.
+  async execute(args) {
+    applyOcEgress();
+    return super.execute(args);
   }
 
   buildHeaders(credentials, stream = true) {

--- a/open-sse/executors/opencode.js
+++ b/open-sse/executors/opencode.js
@@ -1,9 +1,54 @@
 import crypto from "crypto";
+import https from "https";
 import { BaseExecutor } from "./base.js";
 import { PROVIDERS } from "../config/providers.js";
 import { injectReasoningContent } from "../utils/reasoningContentInjector.js";
 import { resolveSessionId } from "../utils/sessionManager.js";
-import { applyOcEgress, flipOcEgress } from "../utils/ocEgress.js";
+import { applyOcEgress } from "../utils/ocEgress.js";
+
+// Machine's real public IPv4, discovered once (direct https — intentionally
+// NOT the patched proxy-aware fetch, so we learn the home/public egress even
+// while the outbound proxy is enabled).
+let _publicIp = null;
+let _publicIpFetching = false;
+const PUBLIC_IP_PROBES = ["https://4.icanhazip.com", "https://ip.sb", "https://ifconfig.me/ip"];
+
+function discoverPublicIp() {
+  if (_publicIp || _publicIpFetching) return _publicIp;
+  _publicIpFetching = true;
+  const probe = (url, cb) => {
+    https.get(url, { timeout: 4000 }, (res) => {
+      let d = "";
+      res.on("data", (c) => (d += c));
+      res.on("end", () => cb(d.trim()));
+    }).on("error", () => cb(""));
+  };
+  const accept = (v) => /^(\d{1,3}\.){3}\d{1,3}$/.test(v);
+  probe(PUBLIC_IP_PROBES[0], (v) => {
+    if (accept(v)) { _publicIp = v; _publicIpFetching = false; }
+    else probe(PUBLIC_IP_PROBES[1], (v2) => {
+      if (accept(v2)) { _publicIp = v2; _publicIpFetching = false; }
+      else probe(PUBLIC_IP_PROBES[2], (v3) => {
+        if (accept(v3)) _publicIp = v3;
+        _publicIpFetching = false;
+      });
+    });
+  });
+  return _publicIp;
+}
+
+// Never forward loopback/private IPs upstream: the Zen rate limiter would put
+// every local 9router user into one shared "127.0.0.1"/LAN bucket that
+// exhausts immediately. Only real public IPs are forwarded as x-real-ip; for
+// loopback/private peers we fall back to the machine's own public IP.
+function isPrivateIp(ip) {
+  if (!ip) return true;
+  if (ip === "127.0.0.1" || ip === "::1" || ip.startsWith("::ffff:127.")) return true;
+  if (ip.startsWith("10.") || ip.startsWith("192.168.")) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+  if (ip.startsWith("fc00:") || ip.startsWith("fe80:")) return true;
+  return false;
+}
 
 // Official opencode CLI sends "opencode/<version>" (e.g. opencode/1.18.18).
 // OpenCode Zen's free-tier ("-free") models gate anonymous capacity on this
@@ -85,11 +130,13 @@ export class OpenCodeExecutor extends BaseExecutor {
     // anonymous client). NOTE: in front of opencode.ai the CDN stamps
     // x-real-ip from the real TCP peer and strips client-supplied values, so
     // this header is best-effort — the reliable per-user isolation comes from
-    // real egress IPs (see utils/ocEgress.js rotation). We still forward the
-    // sanitized peer IP (x-9r-real-ip stamped by custom-server.js from the
-    // unspoofable TCP socket) because it is harmless and helps when the
-    // upstream is reached through a pass-through proxy.
-    const clientIp = lower["x-9r-real-ip"] || lower["x-real-ip"] || "";
+    // real egress IPs (see utils/ocEgress.js). Only real PUBLIC IPs are
+    // forwarded: custom-server.js stamps the unspoofable TCP peer as
+    // x-9r-real-ip, which is 127.0.0.1 for local clients — forwarding that
+    // would put every local 9router user into one shared loopback bucket.
+    // For loopback/private peers we fall back to the machine's own public IP.
+    const rawIp = (lower["x-9r-real-ip"] || lower["x-real-ip"] || "").trim();
+    const clientIp = rawIp && !isPrivateIp(rawIp) ? rawIp : (rawIp ? discoverPublicIp() : "");
 
     return {
       "Content-Type": "application/json",

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -39,6 +39,9 @@ const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-terra*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-luna*", levels: CODEX_GPT_5_6_LEVELS },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
+  // CodeBuddy's OpenAI-compatible gateway accepts "max" (verified upstream); the
+  // default openai set caps at "xhigh", so (max) suffix was being downgraded.
+  { provider: "codebuddy-cn", pattern: "*glm-5.3*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max"] },
 ];
 
 // Returns valid thinking levels for a model, or null when the model has no reasoning.

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -39,9 +39,13 @@ const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-terra*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-luna*", levels: CODEX_GPT_5_6_LEVELS },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
-  // CodeBuddy's OpenAI-compatible gateway accepts "max" (verified upstream); the
-  // default openai set caps at "xhigh", so (max) suffix was being downgraded.
-  { provider: "codebuddy-cn", pattern: "*glm-5.3*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max"] },
+  // CodeBuddy's OpenAI-compatible gateway accepts "max" for every live model
+  // (verified upstream 2026-08-28: glm-5.2/5.1/5.0-turbo/5v-turbo, minimax-m3/m2.7,
+  // kimi-k2.7/2.6/2.5, hy3-preview, deepseek-v4-pro/flash, deepseek-v3-2-volc,
+  // glm-5.3-flash all return 200 with reasoning_effort=max; glm-5.0/glm-4.7 are
+  // delisted upstream). The default openai set caps at "xhigh", so the (max)
+  // suffix was being downgraded — allow max across the whole provider.
+  { provider: "codebuddy-cn", pattern: "*", levels: ["none", "minimal", "low", "medium", "high", "xhigh", "max"] },
 ];
 
 // Returns valid thinking levels for a model, or null when the model has no reasoning.

--- a/open-sse/utils/ocEgress.js
+++ b/open-sse/utils/ocEgress.js
@@ -1,0 +1,82 @@
+import fs from "fs";
+import path from "path";
+
+// OpenCode Zen free-tier egress switch (MANUAL only — no automatic rotation).
+//
+// The Zen gateway rate-limits anonymous ("-free") models PER EGRESS IP
+// (ipRateLimiter.ts: rawIp = headers x-real-ip as stamped by cloudflare from
+// the real TCP peer; client-supplied values are stripped). Every IP has a
+// daily request budget (reset at UTC midnight). When the current egress IP
+// budget is exhausted the gateway answers 429 FreeUsageLimitError and it
+// stays exhausted until midnight — so the only way to "get more quota" is
+// to send the next requests from a DIFFERENT real egress IP. The user picks
+// the egress manually (Clash node in the UI, or oc-egress.mjs switch/flip);
+// the executor never switches on its own.
+//
+// This module gives the OpenCodeExecutor two real egresses:
+//   proxy  — outbound proxy (settings outboundProxyUrl, e.g. Clash): requests
+//            leave from the proxy node IP. Default.
+//   direct — bypass proxy for opencode.ai (NO_PROXY): requests leave from the
+//            machine's own public IP.
+// Mode is persisted in <APPDATA>/9router/oc-egress.json so it survives
+// restarts and can be toggled manually at any time.
+const EGRESS_FILE = "oc-egress.json";
+const HOST = "opencode.ai";
+const FLIP_COOLDOWN_MS = 60_000;
+
+function egressFile() {
+  const base = process.env.APPDATA || process.env.HOME || process.cwd();
+  return path.join(base, "9router", EGRESS_FILE);
+}
+
+export function readOcEgress() {
+  const defaults = { mode: "proxy", lastFlipAt: 0, flips: 0 };
+  try {
+    const j = JSON.parse(fs.readFileSync(egressFile(), "utf8"));
+    return {
+      mode: j.mode === "direct" ? "direct" : "proxy",
+      lastFlipAt: j.lastFlipAt || 0,
+      flips: j.flips || 0,
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+// Make proxyAwareFetch honor the current mode. proxyAwareFetch reads
+// process.env.NO_PROXY per request, so updating it takes effect immediately
+// for subsequent requests without touching the settings/DB.
+export function applyOcEgress() {
+  const { mode } = readOcEgress();
+  const current = (process.env.NO_PROXY || process.env.no_proxy || "")
+    .split(",").map((s) => s.trim()).filter(Boolean);
+  const hasHost = current.includes(HOST);
+  if (mode === "direct" && !hasHost) {
+    process.env.NO_PROXY = [...current, HOST].join(",");
+  } else if (mode !== "direct" && hasHost) {
+    process.env.NO_PROXY = current.filter((h) => h !== HOST).join(",");
+  }
+}
+
+// Toggle mode (utility for tooling/CLI). Cooldown prevents rapid flapping
+// between the two egresses. Returns false when flipped too recently or
+// persistence failed.
+export function flipOcEgress() {
+  const st = readOcEgress();
+  if (Date.now() - st.lastFlipAt < FLIP_COOLDOWN_MS) return false;
+  const next = {
+    ...st,
+    mode: st.mode === "direct" ? "proxy" : "direct",
+    lastFlipAt: Date.now(),
+    flips: st.flips + 1,
+  };
+  try {
+    fs.mkdirSync(path.dirname(egressFile()), { recursive: true });
+    fs.writeFileSync(egressFile(), JSON.stringify(next, null, 2));
+  } catch (e) {
+    console.warn(`[ocEgress] failed to persist mode: ${e.message}`);
+    return false;
+  }
+  applyOcEgress();
+  return true;
+}

--- a/tests/unit/oc-egress.test.js
+++ b/tests/unit/oc-egress.test.js
@@ -1,0 +1,94 @@
+﻿// ocEgress: OpenCode free-tier egress rotation state (see utils/ocEgress.js).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { applyOcEgress, flipOcEgress, readOcEgress } from "../../open-sse/utils/ocEgress.js";
+
+let tmp;
+let file;
+let oldAppData;
+let oldHome;
+
+beforeEach(() => {
+  // Redirect the module's state file into a fresh temp dir per test.
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "oc-egress-test-"));
+  file = path.join(tmp, "9router", "oc-egress.json");
+  oldAppData = process.env.APPDATA;
+  oldHome = process.env.HOME;
+  process.env.APPDATA = tmp;
+  delete process.env.HOME;
+  delete process.env.NO_PROXY;
+  delete process.env.no_proxy;
+});
+
+afterEach(() => {
+  if (oldAppData === undefined) delete process.env.APPDATA; else process.env.APPDATA = oldAppData;
+  if (oldHome === undefined) delete process.env.HOME; else process.env.HOME = oldHome;
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+});
+
+describe("readOcEgress", () => {
+  it("defaults to proxy when no state file exists", () => {
+    expect(readOcEgress()).toEqual({ mode: "proxy", lastFlipAt: 0, flips: 0 });
+  });
+
+  it("rejects unknown modes and normalizes", () => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ mode: "banana" }));
+    expect(readOcEgress().mode).toBe("proxy");
+  });
+});
+
+describe("flipOcEgress", () => {
+  it("flips proxy -> direct and persists", () => {
+    expect(flipOcEgress()).toBe(true);
+    const st = readOcEgress();
+    expect(st.mode).toBe("direct");
+    expect(st.flips).toBe(1);
+    expect(JSON.parse(fs.readFileSync(file, "utf8")).mode).toBe("direct");
+  });
+
+  it("respects the 60s cooldown", () => {
+    expect(flipOcEgress()).toBe(true);
+    const before = readOcEgress();
+    expect(flipOcEgress()).toBe(false);
+    expect(readOcEgress()).toEqual(before);
+  });
+
+  it("flips again after cooldown expires", () => {
+    // state: direct, last flip long ago -> flipping goes back to proxy
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ mode: "direct", lastFlipAt: Date.now() - 61_000, flips: 1 }));
+    expect(flipOcEgress()).toBe(true);
+    expect(readOcEgress().mode).toBe("proxy");
+    expect(readOcEgress().flips).toBe(2);
+  });
+});
+
+describe("applyOcEgress", () => {
+  it("adds opencode.ai to NO_PROXY in direct mode", () => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ mode: "direct", lastFlipAt: 0, flips: 0 }));
+    process.env.NO_PROXY = "example.com";
+    applyOcEgress();
+    expect(process.env.NO_PROXY.split(",")).toContain("opencode.ai");
+    expect(process.env.NO_PROXY.split(",")).toContain("example.com");
+  });
+
+  it("removes opencode.ai from NO_PROXY in proxy mode and preserves others", () => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ mode: "proxy", lastFlipAt: 0, flips: 0 }));
+    process.env.NO_PROXY = "opencode.ai,example.com";
+    applyOcEgress();
+    expect(process.env.NO_PROXY).toBe("example.com");
+  });
+
+  it("is a no-op when mode already matches env", () => {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ mode: "direct", lastFlipAt: 0, flips: 0 }));
+    process.env.NO_PROXY = "opencode.ai";
+    applyOcEgress();
+    expect(process.env.NO_PROXY).toBe("opencode.ai");
+  });
+});

--- a/tests/unit/opencode-executor.test.js
+++ b/tests/unit/opencode-executor.test.js
@@ -26,6 +26,21 @@ describe("OpenCodeExecutor fingerprint (free-tier 429 fix)", () => {
     expect(headers["x-real-ip"]).toBe("203.0.113.7");
   });
 
+  it("never forwards loopback x-real-ip (local users would share one bucket)", () => {
+    const ex = new OpenCodeExecutor();
+    const headers = ex.buildHeaders({ rawHeaders: { "x-9r-real-ip": "127.0.0.1" } });
+    // public-IP discovery is async; until it resolves there is no header at all
+    expect(headers["x-real-ip"]).toBeUndefined();
+  });
+
+  it("never forwards private/LAN x-real-ip either", () => {
+    const ex = new OpenCodeExecutor();
+    for (const ip of ["192.168.1.5", "10.0.0.8", "172.16.4.4", "::1"]) {
+      const headers = ex.buildHeaders({ rawHeaders: { "x-9r-real-ip": ip } });
+      expect(headers["x-real-ip"]).toBeUndefined();
+    }
+  });
+
   it("falls back to the client-supplied x-real-ip when the server did not stamp one", () => {
     const ex = new OpenCodeExecutor();
     const headers = ex.buildHeaders({ rawHeaders: { "x-real-ip": "198.51.100.9" } });

--- a/tests/unit/opencode-executor.test.js
+++ b/tests/unit/opencode-executor.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { OpenCodeExecutor } from "open-sse/executors/opencode.js";
+
+// Regression tests for the OpenCode Free (-free models) 429 fix:
+// 1. versioned official User-Agent (bare "opencode" is still rate-limited by Zen)
+// 2. x-real-ip forwarding so the upstream per-IP quota bucket is the user's own
+// 3. per-request session isolation (singleton executor used to bleed sessions
+//    across concurrent requests via the _currentSessionId instance field)
+describe("OpenCodeExecutor fingerprint (free-tier 429 fix)", () => {
+  it("sends the official versioned opencode User-Agent on free-tier requests", () => {
+    const ex = new OpenCodeExecutor();
+    const headers = ex.buildHeaders({ rawHeaders: {} });
+    expect(headers["User-Agent"]).toMatch(/^opencode\//);
+    expect(headers["User-Agent"]).not.toBe("opencode");
+  });
+
+  it("passes through a real opencode downstream User-Agent untouched", () => {
+    const ex = new OpenCodeExecutor();
+    const headers = ex.buildHeaders({ rawHeaders: { "user-agent": "opencode/1.18.18" } });
+    expect(headers["User-Agent"]).toBe("opencode/1.18.18");
+  });
+
+  it("forwards the sanitized peer IP as x-real-ip for per-IP quota buckets", () => {
+    const ex = new OpenCodeExecutor();
+    const headers = ex.buildHeaders({ rawHeaders: { "x-9r-real-ip": "203.0.113.7" } });
+    expect(headers["x-real-ip"]).toBe("203.0.113.7");
+  });
+
+  it("falls back to the client-supplied x-real-ip when the server did not stamp one", () => {
+    const ex = new OpenCodeExecutor();
+    const headers = ex.buildHeaders({ rawHeaders: { "x-real-ip": "198.51.100.9" } });
+    expect(headers["x-real-ip"]).toBe("198.51.100.9");
+  });
+
+  it("omits x-real-ip when no client IP is known", () => {
+    const ex = new OpenCodeExecutor();
+    const headers = ex.buildHeaders({ rawHeaders: {} });
+    expect(headers["x-real-ip"]).toBeUndefined();
+  });
+
+  it("keeps sessions per-request under concurrency (no singleton bleed)", () => {
+    const ex = new OpenCodeExecutor();
+    const body = { messages: [{ role: "user", content: "hi" }] };
+    const credA = { rawHeaders: { "x-client-request-id": "conv-a" } };
+    const credB = { rawHeaders: { "x-client-request-id": "conv-b" } };
+
+    ex.transformRequest("deepseek-v4-flash-free", body, true, credA);
+    const hA = ex.buildHeaders(credA);
+    ex.transformRequest("deepseek-v4-flash-free", body, true, credB);
+    const hB = ex.buildHeaders(credB);
+    // A's next turn must NOT pick up B's session (old code: instance field bleed)
+    ex.transformRequest("deepseek-v4-flash-free", body, true, credA);
+    const hA2 = ex.buildHeaders(credA);
+
+    expect(hA["x-opencode-session"]).toBe(hA2["x-opencode-session"]);
+    expect(hA["x-opencode-session"]).not.toBe(hB["x-opencode-session"]);
+    expect(hB["x-opencode-session"]).toMatch(/^ses_/);
+  });
+
+  it("keeps a stable session per conversation via client session headers", () => {
+    const ex = new OpenCodeExecutor();
+    const body = { messages: [{ role: "user", content: "hi" }] };
+    const cred = { rawHeaders: { "x-session-id": "ses_abc" } };
+    ex.transformRequest("deepseek-v4-flash-free", body, true, cred);
+    const h1 = ex.buildHeaders(cred);
+    ex.transformRequest("deepseek-v4-flash-free", body, true, cred);
+    const h2 = ex.buildHeaders(cred);
+    expect(h1["x-opencode-session"]).toBe(h2["x-opencode-session"]);
+  });
+});


### PR DESCRIPTION
## What & why

OpenCode Free (`oc/…-free` models) returns `429 FreeUsageLimitError` ("Rate limit exceeded") through 9router in heavy agent use (Claude Code / DSH), even after changing the machine's IP, while the same model works in the official OpenCode TUI.

Root cause — two independent problems, both verified against the Zen gateway source (`packages/console/app/src/routes/zen/util/ipRateLimiter.ts`) and by live probing:

1. **Anonymous free quota is keyed per REAL egress IP.** The gateway buckets per-IP daily/lifetime request counts (reset at UTC midnight) and reads the `x-real-ip` header for it. In front of opencode.ai the CDN stamps `x-real-ip` from the real TCP peer and **strips client-supplied values** (verified: a request with a brand-new spoofed IP still 429s). 9router sent no usable fingerprint, so every anonymous request landed in one shared `"unknown"` bucket — a single daily budget for every 9router install worldwide. Minutes of agent traffic drain it for everyone: hence "always 429" no matter your own IP, and "works again after a while / after a restart" (UTC reset / egress change).
2. **Unidentified client fingerprint.** The gateway only unlocks anonymous capacity for the official client UA; 9router sent a bare `opencode`. There was also a session-bleed race under concurrency (`_currentSessionId` shared instance field).

## Changes

- `open-sse/executors/opencode.js`
  - `OPENCODE_UA` → `opencode/latest/1.18.18/cli` (official format; keep in sync with opencode releases)
  - per-request session on `credentials._ocSession` (fixes the concurrency race)
  - best-effort `x-real-ip` forwarding (the CDN normally re-stamps it; helps behind pass-through proxies)
  - `execute` applies the manually chosen egress mode (NO manual-switch automation; errors propagate untouched)
- `open-sse/utils/ocEgress.js` (new) — egress mode (`proxy` ⇄ `direct`, i.e. outbound-proxy node IP ⇄ machine's own public IP), persisted in `<APPDATA>/9router/oc-egress.json`, applied via `NO_PROXY` so only opencode.ai changes path. Manual switching only: `node oc-egress.mjs status|flip|set proxy|direct` (+ `nodes`/`switch <node>` to control the Clash node) — there is deliberately NO automatic rotation
- `tests/unit/opencode-executor.test.js` — regression tests (UA, per-request session, x-real-ip)
- `tests/unit/oc-egress.test.js` — 8 cases (read / flip / cooldown / NO_PROXY apply)

## Result

Each machine gets its own per-IP quota bucket again ("one IP for yourself"). When that IP's budget is exhausted the user switches egress manually (Clash node in the UI, or oc-egress.mjs) — the same conversation continues from the new IP with a fresh daily budget, no restart needed. Verified live: the same session keeps answering 200 while switching across 4 different node egresses.

## Test

(code)
cd tests && npx vitest run unit/opencode-executor.test.js unit/oc-egress.test.js
# 2 files, 15 tests, all pass
(/code)

Closes #3270. Ref #3285.