### PR TITLE
fix(headroom): rewrite dashboard static asset paths through proxy

### DIFF
--- a/src/app/api/headroom/proxy/[...path]/route.js
+++ b/src/app/api/headroom/proxy/[...path]/route.js
@@ -50,10 +50,12 @@ function forwardedHeaders(request, target) {
 }
 
 function rewriteDashboardHtml(html) {
-  return html.replace(
-    /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
-    `fetch('${DASHBOARD_PREFIX}`,
-  );
+  return html
+    .replace(
+      /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
+      `fetch('${DASHBOARD_PREFIX}`,
+    )
+    .replace(/(src|href)="\/dashboard\//g, `$1="${DASHBOARD_PREFIX}/dashboard/`);
 }
 
 async function proxy(request, { params }) {

--- a/src/app/api/headroom/proxy/[...path]/route.js
+++ b/src/app/api/headroom/proxy/[...path]/route.js
@@ -52,10 +52,11 @@ function forwardedHeaders(request, target) {
 function rewriteDashboardHtml(html) {
   return html
     .replace(
-      /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed))/g,
+      /fetch\('(?=\/(?:stats|health|stats-history|transformations\/feed|settings))/g,
       `fetch('${DASHBOARD_PREFIX}`,
     )
-    .replace(/(src|href)="\/dashboard\//g, `$1="${DASHBOARD_PREFIX}/dashboard/`);
+    .replace(/(src|href)="\/dashboard\//g, `$1="${DASHBOARD_PREFIX}/dashboard/`)
+    .replace(/(src|href)="\/dashboard"/g, `$1="${DASHBOARD_PREFIX}/dashboard"`);
 }
 
 async function proxy(request, { params }) {
@@ -80,7 +81,8 @@ async function proxy(request, { params }) {
       if (HOP_BY_HOP_HEADERS.has(header.toLowerCase())) headers.delete(header);
     }
 
-    if (path.join("/") === "dashboard") {
+    const joinedPath = path.join("/");
+    if (joinedPath === "dashboard" || joinedPath.startsWith("dashboard/")) {
       const contentType = response.headers.get("content-type") || "";
       if (contentType.includes("text/html")) {
         headers.delete("content-length");


### PR DESCRIPTION
## Problem

When opening the Headroom dashboard through the 9Router proxy (`/api/headroom/proxy/dashboard`), the page renders unstyled in browsers with a fresh cache (e.g. Brave). Chrome looked fine only due to cached assets.

**Root cause:** `rewriteDashboardHtml()` only rewrites `fetch('/stats')` calls, but not absolute `<script src="/dashboard/static/...">` and `<a href="/dashboard/settings">` references. Those resolve against the 9Router origin (port 20128) where they don't exist → 404 → JS fails → broken layout.

## Fix

Rewrite absolute `/dashboard/*` src/href references to go through the proxy prefix:

```js
.replace(/(src|href)="\/dashboard\//g, `$1="${DASHBOARD_PREFIX}/dashboard/`)
```

## Verification

- `/api/headroom/proxy/dashboard/static/tailwind.min.js` → 200
- `/api/headroom/proxy/dashboard/static/htmx.min.js` → 200
- `/api/headroom/proxy/dashboard/static/alpine.min.js` → 200
- Dashboard renders correctly in Brave after hard refresh