### PR TITLE
fix(auth): give no-auth free providers a stable upstream session id

### DIFF
--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -55,6 +55,12 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
       const resolvedProxy = await resolveConnectionProxyConfig({ proxyPoolId: pickedId || "" });
       return {
         id: "noauth",
+        // Executors key their upstream session id on connectionId. Without it
+        // deriveSessionId() falls through to a fresh random id on every call, so
+        // each turn of one conversation reaches the provider as a new session and
+        // burns a free-tier slot. "noauth" is the sentinel markAccountUnavailable
+        // and clearAccountError already test for.
+        connectionId: "noauth",
         connectionName: "Public",
         isActive: true,
         accessToken: "public",

--- a/tests/unit/noauth-session-id-3262.test.js
+++ b/tests/unit/noauth-session-id-3262.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/localDb", () => ({
+  getProviderConnections: vi.fn(async () => []),
+  validateApiKey: vi.fn(),
+  updateProviderConnection: vi.fn(),
+  getSettings: vi.fn(async () => ({})),
+  getProxyPools: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/network/connectionProxy", () => ({
+  resolveConnectionProxyConfig: vi.fn(async () => ({
+    connectionProxyEnabled: false,
+    connectionProxyUrl: "",
+    connectionNoProxy: "",
+    proxyPoolId: null,
+    vercelRelayUrl: "",
+  })),
+  pickProxyPoolId: vi.fn(() => null),
+}));
+
+const { getProviderCredentials } = await import("../../src/sse/services/auth.js");
+const { OpenCodeExecutor } = await import("../../open-sse/executors/opencode.js");
+
+// Turn 1: nothing but the user prompt.
+const userOnly = {
+  model: "oc/deepseek-v4-flash-free",
+  messages: [{ role: "user", content: "List the files in this repo." }],
+};
+
+// Turn 2 — the first tool call. The assistant item carries a tool_call and no
+// prose, so the assistant-text heuristic cannot identify the conversation and
+// the connection-level fallback is what has to hold the session together.
+const afterFirstToolCall = {
+  model: "oc/deepseek-v4-flash-free",
+  messages: [
+    { role: "user", content: "List the files in this repo." },
+    {
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "call_1", type: "function", function: { name: "ls", arguments: "{}" } }],
+    },
+    { role: "tool", tool_call_id: "call_1", content: "README.md" },
+  ],
+};
+
+function sessionFor(body, credentials) {
+  const ex = new OpenCodeExecutor();
+  ex.transformRequest("oc/deepseek-v4-flash-free", body, true, credentials);
+  return ex.buildHeaders(credentials, true)["x-opencode-session"];
+}
+
+describe("#3262 no-auth free providers keep one upstream session", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("gives the virtual no-auth connection the sentinel connectionId", async () => {
+    const creds = await getProviderCredentials("opencode");
+    expect(creds.connectionId).toBe("noauth");
+    // The value markAccountUnavailable / clearAccountError already test for, so a
+    // free provider is never cooled down as if it were a real account.
+    expect(creds.id).toBe("noauth");
+  });
+
+  it("holds the session across the first tool call", () => {
+    const creds = { rawHeaders: {}, connectionId: "noauth" };
+    expect(sessionFor(afterFirstToolCall, creds)).toBe(sessionFor(userOnly, creds));
+  });
+
+  it("keeps the session reproducible for repeats of the same turn", () => {
+    const creds = { rawHeaders: {}, connectionId: "noauth" };
+    expect(sessionFor(userOnly, creds)).toBe(sessionFor(userOnly, creds));
+  });
+
+  // Without the field every call minted a new ses_, which is what burned the
+  // free-tier quota on the second request of a conversation.
+  it("mints a new session per call when connectionId is missing", () => {
+    const creds = () => ({ rawHeaders: {} });
+    expect(sessionFor(userOnly, creds())).not.toBe(sessionFor(userOnly, creds()));
+  });
+
+  it("still honours a client-supplied session id", () => {
+    const creds = { rawHeaders: { "x-opencode-session": "ses_from_client" }, connectionId: "noauth" };
+    expect(sessionFor(userOnly, creds)).toBe("ses_from_client");
+  });
+});


### PR DESCRIPTION
Closes #3262.

`oc/deepseek-v4-flash-free` and `oc/mimo-v2.5-free` answer `FreeUsageLimitError` on the **first tool call**, on clean IPs, on fresh accounts, for five different reporters. The same models work fine in the OpenCode CLI and desktop app — and, per the thread, they also fail through omnirouter, bifrost and omniroute. That "every third-party router, none of the official clients" pattern is the tell: the difference is not the account, it is what we put on the wire.

## What is actually happening

`OpenCodeExecutor.buildHeaders` sends `x-opencode-session`, which is supposed to be stable for one conversation. It comes from `resolveSessionId({ connectionId: credentials?.connectionId, … })`, whose last fallback is `deriveSessionId(connectionId)`:

```js
export function deriveSessionId(connectionId) {
    if (!connectionId) {
        return generateBinaryStyleId();   // ← fresh random id, not cached
    }
    …
}
```

And `credentials.connectionId` is never set for a no-auth provider. `getProviderCredentials` returns a real connection with `connectionId: connection.id`, but the virtual connection it injects for `FREE_PROVIDERS[...].noAuth` sets only `id: "noauth"`:

```js
return {
  id: "noauth",
  connectionName: "Public",
  isActive: true,
  accessToken: "public",
  …                       // no connectionId
};
```

So every request mints a new `ses_`. Driving the executor directly, one conversation on master:

```
turn 1 (user only)              session=ses_1b7185c625dd4d3f916b6f948b0344b7…
turn 2 (first tool call)        session=ses_d5d85d6fb3a545759ac15af7cd4b1f92…   ← new session
turn 1 again                    session=ses_702fe70b48b4246c2abfcb52d855adae…   ← not even reproducible
```

Upstream sees a brand-new session for every turn and the free-tier allowance is gone by the second request — which is exactly "rate limit on the first tool call". The official client keeps one `ses_` per conversation, which is why it never trips.

## The fix

One field on the virtual connection:

```js
id: "noauth",
connectionId: "noauth",
```

`"noauth"` is not an arbitrary string — it is the sentinel this file already tests for in two places, which today are only reachable through their `!connectionId` arm:

```js
// markAccountUnavailable
if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 };
// clearAccountError
if (!connectionId || connectionId === "noauth") return;
```

So a free provider still cannot be cooled down or error-cleared as if it were a real account, and the value now matches what those guards were written for.

Same conversation after the change:

```
turn 1 (user only)              session=ses_bfb0823f91664523b504591e3f4e0a3c…
turn 2 (first tool call)        session=ses_bfb0823f91664523b504591e3f4e0a3c…   ← held
turn 1 again                    session=ses_bfb0823f91664523b504591e3f4e0a3c…   ← reproducible
```

## Scope and what this does not change

Nine providers declare `noAuth` — `opencode`, `mimo-free`, `mmf` on the chat path, the rest TTS/local/search — and all of them were minting a session per request.

Once the assistant has produced ~50 characters of prose, `assistantTextSessionId` takes over and returns a conversation-specific id, so a long conversation still moves from the connection-level session to a per-conversation one exactly once, then stays there. That hand-off is deliberate: on a shared no-auth provider, distinct conversations should not collapse into one session as soon as they can be told apart. The bug was only that the pre-hand-off fallback was random instead of stable.

This does not touch the `x-opencode-request` id, which is per-request by design.

## Verification

5 tests in `unit/noauth-session-id-3262.test.js`: the virtual connection carries the sentinel, the session holds across the first tool call, the same turn is reproducible, a missing `connectionId` still mints a new session per call (pinning the failure mode this fixes), and a client-supplied `x-opencode-session` still wins.

I checked the tests bite by deleting the added line and re-running — `expected undefined to be 'noauth'`.

Full suite (`npx vitest run unit translator`) on current master: **failing set byte-identical to the base**, `comm` empty in both directions. `npx eslint` clean.

What I could not do from here: reproduce the upstream 429 against opencode.ai, since that needs the free tier to be exhausted on a real account. The header behaviour is reproduced and fixed directly at the executor; the link from "one session per turn" to `FreeUsageLimitError` is the thread's evidence, not mine.
