### PR TITLE
fix(auth): disable Qoder connection on quota exhaustion (403/code 112)

### DIFF
--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -18,6 +18,19 @@ function githubMonthlyResetMs(status, errorText, provider) {
 }
 
 /**
+ * Detect Qoder account-wide quota exhaustion.
+ * Qoder delivers it as an HTTP-200 SSE payload whose first envelope carries
+ * statusCodeValue 403 and a body containing "code":"112"; the qoder executor
+ * converts that billing block into a plain 403 error before we get here.
+ * Unlike transient billing blocks (queue throttle code 10605 / pricingUrl
+ * nudges), code 112 does not recover on its own.
+ */
+function isQoderQuotaExhausted(status, errorText, provider) {
+  if (resolveProviderId(provider) !== "qoder" || Number(status) !== 403) return false;
+  return /"code"\s*:\s*"112"/.test(String(errorText || ""));
+}
+
+/**
  * Get provider credentials from localDb
  * Filters out unavailable accounts and returns the selected account based on strategy
  * @param {string} provider - Provider name
@@ -221,6 +234,25 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   const connections = await getProviderConnections({ provider });
   const conn = connections.find(c => c.id === connectionId);
   const backoffLevel = conn?.backoffLevel || 0;
+
+  // Qoder code 112 is an account-wide quota signal. A timed lock alone would
+  // keep retrying a dead account after the cooldown, so deactivate the
+  // connection (what an operator would do manually) and let selection move to
+  // the next Qoder account or the next combo fallback model.
+  if (isQoderQuotaExhausted(status, errorText, provider)) {
+    const reason = typeof errorText === "string" ? errorText.slice(0, 200) : "Qoder quota exhausted (code 112)";
+    await updateProviderConnection(connectionId, {
+      isActive: false,
+      testStatus: "unavailable",
+      lastError: reason,
+      errorCode: 403,
+      lastErrorAt: new Date().toISOString(),
+      backoffLevel: 0,
+    });
+    const connName = conn?.displayName || conn?.name || conn?.email || connectionId.slice(0, 8);
+    log.warn("AUTH", `${connName} disabled: Qoder quota exhausted [403/code 112]`);
+    return { shouldFallback: true, cooldownMs: 0 };
+  }
 
   // GitHub premium-request exhaustion is account-wide until the next UTC month.
   const githubResetAtMs = githubMonthlyResetMs(status, errorText, provider);

--- a/tests/unit/qoder-quota-112-disable.test.js
+++ b/tests/unit/qoder-quota-112-disable.test.js
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  getProviderConnections: vi.fn(),
+  updateProviderConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => dbMocks);
+vi.mock("@/lib/network/connectionProxy", () => ({
+  pickProxyPoolId: vi.fn(),
+  resolveConnectionProxyConfig: vi.fn(),
+}));
+vi.mock("@/shared/constants/providers.js", () => ({
+  FREE_PROVIDERS: {},
+  resolveProviderId: (provider) => provider,
+}));
+vi.mock("@/sse/utils/logger.js", () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }));
+
+const { markAccountUnavailable } = await import("../../src/sse/services/auth.js");
+
+const QODER_QUOTA_BODY = '{"code":"112","message":"Quota exhausted","pricingUrl":"https://qoder.com/pricing"}';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.getProviderConnections.mockResolvedValue([{
+    id: "qoder-a",
+    provider: "qoder",
+    name: "qoder-a",
+    backoffLevel: 2,
+  }]);
+});
+
+describe("Qoder quota exhaustion (403/code 112)", () => {
+  it("disables the connection so the pool stops retrying a dead account", async () => {
+    const result = await markAccountUnavailable(
+      "qoder-a",
+      403,
+      QODER_QUOTA_BODY,
+      "qoder",
+      "qoder/ultimate",
+    );
+
+    expect(result).toEqual({ shouldFallback: true, cooldownMs: 0 });
+    expect(dbMocks.updateProviderConnection).toHaveBeenCalledWith(
+      "qoder-a",
+      expect.objectContaining({
+        isActive: false,
+        testStatus: "unavailable",
+        errorCode: 403,
+        backoffLevel: 0,
+      }),
+    );
+    // No timed model lock: the connection stays disabled until re-enabled.
+    const update = dbMocks.updateProviderConnection.mock.calls[0][1];
+    expect(Object.keys(update).some(k => k.startsWith("modelLock_"))).toBe(false);
+  });
+
+  it("leaves transient billing blocks (queue throttle code 10605) on the normal cooldown path", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-04T19:30:00.000Z"));
+
+    try {
+      await markAccountUnavailable(
+        "qoder-a",
+        403,
+        '{"code":"10605","message":"Queue limit"}',
+        "qoder",
+        "qoder/ultimate",
+      );
+
+      const update = dbMocks.updateProviderConnection.mock.calls[0][1];
+      expect(update.isActive).toBeUndefined();
+      expect(update).toEqual(
+        expect.objectContaining({
+          "modelLock_qoder/ultimate": "2026-08-04T19:32:00.000Z",
+          testStatus: "unavailable",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves plain qoder 403 errors without code 112 on the normal cooldown path", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-04T19:30:00.000Z"));
+
+    try {
+      await markAccountUnavailable(
+        "qoder-a",
+        403,
+        "Access denied",
+        "qoder",
+        "qoder/ultimate",
+      );
+
+      const update = dbMocks.updateProviderConnection.mock.calls[0][1];
+      expect(update.isActive).toBeUndefined();
+      expect(update).toEqual(
+        expect.objectContaining({
+          "modelLock_qoder/ultimate": "2026-08-04T19:32:00.000Z",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not disable non-qoder providers that happen to report code 112", async () => {
+    dbMocks.getProviderConnections.mockResolvedValue([{
+      id: "other-a",
+      provider: "other",
+      name: "other-a",
+      backoffLevel: 0,
+    }]);
+
+    await markAccountUnavailable(
+      "other-a",
+      403,
+      '{"code":"112","message":"something else"}',
+      "other",
+      "some-model",
+    );
+
+    const update = dbMocks.updateProviderConnection.mock.calls[0][1];
+    expect(update.isActive).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Issue**: #1667, #1996

**Problem**: Qoder accounts whose quota is exhausted answer with HTTP 200 and put the real error in the first SSE envelope (`statusCodeValue: 403`, body containing `"code":"112"`). Since v0.5.55 the qoder executor already detects that billing block and converts it into a plain 403 error — but `markAccountUnavailable` then only applies the generic status-403 rule: a 2-minute, model-scoped lock. The connection stays `isActive`, so the pool keeps picking the dead account every couple of minutes until an operator disables it manually.

**Fix**: `src/sse/services/auth.js` — treat qoder `403` + body containing `"code":"112"` as an account-wide quota signal, mirroring the existing GitHub 402 monthly-limit handling: deactivate the connection (`isActive: false`, `testStatus: "unavailable"`, `backoffLevel: 0`) and return `shouldFallback: true` immediately, so selection moves on to the next Qoder account or the next combo fallback model.

**Scope**: only code 112 triggers the disable. The other billing blocks the executor detects (queue throttle code 10605, `pricingUrl` nudges) are transient and stay on the normal cooldown path. Non-qoder providers reporting a code-112 body are untouched.

**Test coverage**: `tests/unit/qoder-quota-112-disable.test.js` — 4 new tests following the `github-monthly-usage-lock.test.js` pattern:
- code 112 disables the connection without any timed model lock
- code 10605 keeps the normal 2-minute model lock, connection stays active
- plain qoder 403 (no billing body) keeps the normal cooldown path
- non-qoder provider with a code-112 body is not disabled

Existing auth/qoder unit suites re-run green: `github-monthly-usage-lock`, `qoder-billing`, `qoder`, `fetch-success-clears-account`, `embedding-usage-persistence`, `gemini-native-endpoint`, `xai-video-handler`.

**Note for maintainers**: if Qoder quota is known to reset on a schedule, the `isActive: false` disable can be swapped for a timed account-wide lock (like GitHub's `modelLock___all`) — detection is isolated in `isQoderQuotaExhausted`, so that change is one branch.
