### PR TITLE
fix(tools): DeepSeek same-name tool dedup + endpoint matrix tests

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -195,9 +195,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     stripContinuityFields(translatedBody);
   }
 
-  // Dedupe duplicate built-in tools when equivalent MCP tools are present (Claude clients only).
-  if (clientTool === "claude" && Array.isArray(translatedBody.tools)) {
-    const { tools: deduped, stripped } = dedupeTools(translatedBody.tools);
+  // Tool normalization: MCP-equivalent built-in dedup (Claude clients) + same-name
+  // dedup for DeepSeek models (upstream rejects duplicate tool names on all endpoints).
+  if (Array.isArray(translatedBody.tools)) {
+    const { tools: deduped, stripped } = dedupeTools(translatedBody.tools, { clientTool, model });
     if (stripped.length > 0) {
       translatedBody.tools = deduped;
       log?.debug?.("TOOLDEDUP", `stripped ${stripped.length}: ${stripped.slice(0, 3).join(", ")}${stripped.length > 3 ? "..." : ""}`);

--- a/open-sse/utils/toolDeduper.js
+++ b/open-sse/utils/toolDeduper.js
@@ -1,6 +1,11 @@
 /**
- * Strip built-in/duplicate tools when equivalent MCP tools are present.
- * Goal: reduce tool definitions token bloat for Claude clients.
+ * Tool normalization before dispatch:
+ * - MCP-equivalent built-in tool dedup (Claude clients only, reduces token bloat).
+ * - Exact same-name tool dedup for DeepSeek models — the DeepSeek upstream rejects
+ *   duplicate tool names with 400 "Tool names must be unique" on every endpoint
+ *   (verified live 2026-08-15 against api.deepseek.com, opencode.go and a LiteLLM
+ *   gateway; GLM/MiniMax/Kimi upstreams accept duplicates). First definition wins,
+ *   tool_choice and message-history references are by name/id so nothing breaks.
  */
 
 const DEDUP_RULES = [
@@ -30,20 +35,53 @@ function matches(name, pattern) {
   return pattern instanceof RegExp ? pattern.test(name) : false;
 }
 
-function dedupeTools(tools) {
+// "model(level)" is a 9router thinking override; strip before matching.
+function isDeepSeekModel(model) {
+  if (typeof model !== "string") return false;
+  return /^deepseek-/.test(model.replace(/\([^()]+\)\s*$/, "").trim());
+}
+
+/**
+ * @param {Array} tools - translated tools array
+ * @param {Object} [opts]
+ * @param {string|null} [opts.clientTool] - detected client ("claude" | "codex" | ...)
+ * @param {string|null} [opts.model] - model id, may carry a (level) thinking suffix
+ * @returns {{ tools: Array, stripped: Array<string> }}
+ */
+function dedupeTools(tools, opts = {}) {
   if (!Array.isArray(tools) || tools.length === 0) return { tools, stripped: [] };
   const names = tools.map(getToolName);
   const toStrip = new Set();
-  for (const rule of DEDUP_RULES) {
-    const hasTrigger = names.some((n) => rule.triggers.some((p) => matches(n, p)));
-    if (!hasTrigger) continue;
-    for (const n of names) {
-      if (rule.strip.some((p) => matches(n, p))) toStrip.add(n);
+  const toDrop = new Set(); // indices of duplicate same-name tools
+
+  // MCP-based built-in dedup: Claude clients only (existing behavior).
+  if (opts.clientTool === "claude") {
+    for (const rule of DEDUP_RULES) {
+      const hasTrigger = names.some((n) => rule.triggers.some((p) => matches(n, p)));
+      if (!hasTrigger) continue;
+      for (const n of names) {
+        if (rule.strip.some((p) => matches(n, p))) toStrip.add(n);
+      }
     }
   }
-  if (toStrip.size === 0) return { tools, stripped: [] };
-  const out = tools.filter((t) => !toStrip.has(getToolName(t)));
-  return { tools: out, stripped: Array.from(toStrip) };
+
+  // Exact-name dedup: DeepSeek upstream rejects duplicate tool names. Applies to
+  // every client × provider that serves a deepseek-* model (official API, Console Go,
+  // LiteLLM gateways); non-DeepSeek models are untouched.
+  if (isDeepSeekModel(opts.model)) {
+    const seen = new Set();
+    for (let i = 0; i < tools.length; i++) {
+      const n = getToolName(tools[i]);
+      if (!n) continue;
+      if (seen.has(n)) toDrop.add(i);
+      else seen.add(n);
+    }
+  }
+
+  if (toStrip.size === 0 && toDrop.size === 0) return { tools, stripped: [] };
+  const out = tools.filter((t, i) => !toDrop.has(i) && !toStrip.has(getToolName(t)));
+  const stripped = Array.from(toDrop).map((i) => getToolName(tools[i])).concat(Array.from(toStrip));
+  return { tools: out, stripped };
 }
 
 export { dedupeTools };

--- a/tests/translator/real/opencode-go-deepseek.real.test.js
+++ b/tests/translator/real/opencode-go-deepseek.real.test.js
@@ -1,0 +1,125 @@
+// REAL endpoint matrix for opencode-go DeepSeek models.
+//
+// Verifies, against the live upstream (https://opencode.ai/zen/go), that each client
+// request format actually WORKS for DeepSeek on the endpoint 9router routes it to:
+//
+//   Claude (/v1/messages)          → must return a Claude-shape SSE
+//   Codex (/v1/responses)          → must return an OpenAI Responses-shape SSE
+//   OpenAI (/v1/chat/completions)  → must return an OpenAI chat-shape SSE
+//
+// This is the live counterpart of tests/unit/opencode-go-transport-routing.test.js
+// (which proves the routing decision offline). A cell here fails when the upstream
+// rejects the routed endpoint+model combination — exactly the 400 that #3332 reported
+// for Claude→deepseek-v4-flash on /messages.
+//
+//   RUN_REAL=1 npx vitest run --config tests/vitest.config.js tests/translator/real/opencode-go-deepseek.real.test.js
+//
+// Requires an active opencode-go credential in the local DB (add via 9router dashboard).
+// Skips (pass) only on credential/quota/plan rejections, mirroring the other .real tests.
+import { describe, it, expect } from "vitest";
+import { getProviderCredentials } from "../../../src/sse/services/auth.js";
+import { checkAndRefreshToken } from "../../../src/sse/services/tokenRefresh.js";
+import { handleChatCore } from "../../../open-sse/handlers/chatCore.js";
+
+const RUN_REAL = process.env.RUN_REAL === "1";
+const PROVIDER = "opencode-go";
+const TIMEOUT_MS = 90000;
+const CRED_ISSUE = [401, 402, 403, 429];
+const SKIP_MSG_RE = /image|multimodal|vision|modality|unsupported|not support|reasoning_effort|deprecated|temperature|subscription|valid.*plan|embedding|quota|insufficient|model not found|context length|organization policy|disallowed|allowedmodels|failed_precondition/i;
+
+async function drainSSE(response) {
+  if (!response?.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+// One request. Returns { raw } | "skip"; throws on a real upstream rejection.
+async function runChat(model, body, sourceFormat) {
+  const credentials = await getProviderCredentials(PROVIDER, new Set(), model);
+  if (!credentials || credentials.allRateLimited) return "skip";
+  const refreshed = await checkAndRefreshToken(PROVIDER, credentials);
+
+  const result = await handleChatCore({
+    body: { ...body, model: `${PROVIDER}/${model}` },
+    modelInfo: { provider: PROVIDER, model },
+    credentials: refreshed,
+    connectionId: credentials.connectionId,
+    sourceFormatOverride: sourceFormat,
+  });
+  if (!result.success) {
+    const status = Number(result.status);
+    if (CRED_ISSUE.includes(status)) return "skip";
+    if (status >= 500 || status === 406) return "skip";
+    if (status === 400 && SKIP_MSG_RE.test(String(result.error || ""))) return "skip";
+    throw new Error(`${PROVIDER}/${model} ${sourceFormat} [${result.status}]: ${result.error}`);
+  }
+  return { raw: await drainSSE(result.response) };
+}
+
+// SSE markers: response is re-encoded back to the client's source format.
+const SSE_MARKER = {
+  openai: /chat\.completion\.chunk|"delta"|\[DONE\]/,
+  "openai-responses": /response\.|"type"\s*:\s*"response|\[DONE\]/,
+  claude: /event:\s*\w|"type"\s*:\s*"(message_start|content_block|message_delta)"/,
+};
+
+const MAX_TOKENS = 128;
+
+const BODIES = {
+  claude: () => ({
+    stream: true,
+    max_tokens: MAX_TOKENS,
+    system: [{ type: "text", text: "You are concise." }],
+    messages: [{ role: "user", content: "Reply with the single word: hi" }],
+  }),
+  openai: () => ({
+    stream: true,
+    max_tokens: MAX_TOKENS,
+    messages: [{ role: "user", content: "Reply with the single word: hi" }],
+  }),
+  "openai-responses": () => ({
+    stream: true,
+    max_output_tokens: MAX_TOKENS,
+    instructions: "You are concise.",
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "Reply with the single word: hi" }] }],
+  }),
+};
+
+// Cells: (model, format). `(max)` reproduces the 9router thinking override sent by
+// Claude Code — it must land on the same endpoint as the bare id.
+const CELLS = [
+  ["deepseek-v4-flash", "claude"],
+  ["deepseek-v4-flash(max)", "claude"],
+  ["deepseek-v4-flash", "openai-responses"],
+  ["deepseek-v4-flash", "openai"],
+  ["deepseek-v4-pro", "claude"],
+  ["deepseek-v4-pro", "openai-responses"],
+  // Control: MiniMax keeps /messages for Claude clients.
+  ["minimax-m3", "claude"],
+];
+
+describe.skipIf(!RUN_REAL)(`REAL opencode-go DeepSeek endpoint matrix`, () => {
+  it("has an active opencode-go credential", async () => {
+    const creds = await getProviderCredentials(PROVIDER, new Set(), "deepseek-v4-flash");
+    expect(creds && !creds.allRateLimited).toBe(true);
+  });
+
+  for (const [model, fmt] of CELLS) {
+    it(`${fmt}-format client → ${model} returns ${fmt}-shape SSE`, async () => {
+      const out = await runChat(model, BODIES[fmt](), fmt);
+      if (out === "skip") {
+        console.warn(`[skip] ${PROVIDER}/${model} ${fmt}: credential/quota/capability`);
+        return expect(true).toBe(true);
+      }
+      expect(out.raw.length, `${model} ${fmt}: empty SSE`).toBeGreaterThan(0);
+      expect(SSE_MARKER[fmt].test(out.raw), `${model} ${fmt}: wrong SSE shape (routed endpoint rejected?)`).toBe(true);
+    }, TIMEOUT_MS);
+  }
+});

--- a/tests/unit/opencode-go-transport-routing.test.js
+++ b/tests/unit/opencode-go-transport-routing.test.js
@@ -1,0 +1,175 @@
+// Offline routing matrix for opencode-go models.
+//
+// Drives the REAL handleChatCore guard + targetFormat resolution (open-sse/handlers/chatCore.js:86-94)
+// end-to-end; only the executor's HTTP response is mocked. The assertion target is
+// credentials.runtimeTransport — the exact field DefaultExecutor.buildUrl/buildHeaders read
+// (open-sse/executors/default.js:106,150) to pick the endpoint and auth scheme — so a wrong
+// guard decision shows up as the wrong baseUrl here, same as it would on the wire.
+//
+// Cells:
+//   - deepseek × {openai, claude, openai-responses} × {bare, (max)} — the endpoint matrix
+//     under dispute in #3278/#3332. Bare and suffixed cells must resolve identically.
+//   - glm/kimi (chat-only) + (max) — regression cells: with the thinking suffix, the guard
+//     is bypassed on master (suffix isn't stripped before the registry lookup) and these get
+//     routed to /messages, which the upstream does not serve for them.
+//   - minimax + (max) + claude — suffix must NOT block a genuinely declared format.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { executeMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+}));
+
+vi.mock("../../open-sse/executors/index.js", () => ({
+  getExecutor: () => ({
+    noAuth: true,
+    execute: executeMock,
+  }),
+}));
+
+vi.mock("../../open-sse/utils/requestLogger.js", () => ({
+  createRequestLogger: async () => ({
+    logClientRawRequest: vi.fn(),
+    logRawRequest: vi.fn(),
+    logTargetRequest: vi.fn(),
+    logProviderResponse: vi.fn(),
+    logConvertedResponse: vi.fn(),
+    logError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../open-sse/utils/stream.js", () => ({
+  COLORS: { red: "", reset: "" },
+  createPassthroughStreamWithLogger: vi.fn(() => new TransformStream()),
+}));
+
+vi.mock("uuid", () => ({
+  v4: () => "00000000-0000-4000-8000-000000000000",
+}));
+
+vi.mock("@/lib/usageDb.js", () => ({
+  trackPendingRequest: vi.fn(),
+  appendRequestLog: vi.fn(async () => {}),
+  saveRequestDetail: vi.fn(async () => {}),
+  saveRequestUsage: vi.fn(async () => {}),
+}));
+
+// image.js imports Agent from "undici" (not installed in some dev envs); the
+// prefetch path is irrelevant to routing assertions.
+vi.mock("../../open-sse/translator/concerns/image.js", () => ({
+  encodeDataUri: (mimeType, base64) => `data:${mimeType};base64,${base64}`,
+  parseDataUri: (url) => {
+    const m = /^data:([^;]+);base64,(.*)$/.exec(url);
+    return m ? { mimeType: m[1], base64: m[2] } : null;
+  },
+  fetchImageAsBase64: async () => null,
+}));
+
+const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
+
+const BASE = "https://opencode.ai/zen/go/v1";
+const ENDPOINTS = {
+  openai: `${BASE}/chat/completions`,
+  claude: `${BASE}/messages`,
+  "openai-responses": `${BASE}/responses`,
+};
+
+// Minimal non-stream provider JSON per target format — the mocked executor's response.
+const RESPONSE_BY_FORMAT = {
+  claude: {
+    id: "msg_1", type: "message", role: "assistant", model: "test",
+    content: [{ type: "text", text: "ok" }],
+    stop_reason: "end_turn", stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  },
+  openai: {
+    id: "chatcmpl-1", object: "chat.completion", model: "test",
+    choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  },
+  "openai-responses": {
+    id: "resp_1", object: "response", created_at: 0, status: "completed", model: "test",
+    output: [{
+      type: "message", id: "msg_1", role: "assistant", status: "completed",
+      content: [{ type: "output_text", text: "ok", annotations: [] }],
+    }],
+  },
+};
+
+async function route(model, sourceFormat) {
+  executeMock.mockResolvedValueOnce({
+    response: new Response(JSON.stringify(RESPONSE_BY_FORMAT[sourceFormat === "openai" ? "openai" : sourceFormat] || RESPONSE_BY_FORMAT.openai), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    url: ENDPOINTS[sourceFormat] || ENDPOINTS.openai,
+    headers: {},
+    transformedBody: null,
+  });
+
+  const credentials = { apiKey: "test-key", providerSpecificData: {} };
+  const result = await handleChatCore({
+    body: {
+      model: `opencode-go/${model}`,
+      stream: false,
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hi" }],
+    },
+    modelInfo: { provider: "opencode-go", model },
+    credentials,
+    connectionId: "ocg-route-test",
+    sourceFormatOverride: sourceFormat,
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  });
+
+  const { credentials: creds } = executeMock.mock.calls.at(-1)[0];
+  return { result, runtimeTransport: creds.runtimeTransport ?? null };
+}
+
+describe("opencode-go DeepSeek endpoint matrix (via real handleChatCore)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  for (const model of ["deepseek-v4-flash", "deepseek-v4-pro"]) {
+    for (const suffix of ["", "(max)"]) {
+      const id = model + suffix;
+      for (const [fmt, expectedUrl] of Object.entries(ENDPOINTS)) {
+        it(`routes ${id} + ${fmt}-format client to ${expectedUrl}`, async () => {
+          const { result, runtimeTransport } = await route(id, fmt);
+          expect(result.success).toBe(true);
+          expect(runtimeTransport?.baseUrl).toBe(expectedUrl);
+        });
+      }
+    }
+  }
+});
+
+describe("opencode-go thinking-suffix guard (regression)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does NOT route chat-only glm-5.2(max) to /messages on a claude-format request", async () => {
+    const { result, runtimeTransport } = await route("glm-5.2(max)", "claude");
+    expect(result.success).toBe(true);
+    expect(runtimeTransport).toBeNull(); // guard must block; falls back to chat/completions
+  });
+
+  it("does NOT route chat-only kimi-k2.6(max) to /responses on a responses-format request", async () => {
+    const { result, runtimeTransport } = await route("kimi-k2.6(max)", "openai-responses");
+    expect(result.success).toBe(true);
+    expect(runtimeTransport).toBeNull();
+  });
+
+  it("still routes minimax-m3(max) + claude-format client to /messages", async () => {
+    const { result, runtimeTransport } = await route("minimax-m3(max)", "claude");
+    expect(result.success).toBe(true);
+    expect(runtimeTransport?.baseUrl).toBe(ENDPOINTS.claude);
+  });
+
+  it("does NOT route minimax-m3(max) (no responses support) to /responses", async () => {
+    const { result, runtimeTransport } = await route("minimax-m3(max)", "openai-responses");
+    expect(result.success).toBe(true);
+    expect(runtimeTransport).toBeNull();
+  });
+});

--- a/tests/unit/tool-deduper.test.js
+++ b/tests/unit/tool-deduper.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { dedupeTools } from "../../open-sse/utils/toolDeduper.js";
+
+const BASH = (name = "Bash", desc = "Run a shell command") => ({
+  name,
+  description: desc,
+  input_schema: { type: "object", properties: { command: { type: "string" } }, required: ["command"] },
+});
+
+const FUNC_SHAPE = (name = "Bash") => ({
+  type: "function",
+  function: { name, description: "Run a shell command", parameters: { type: "object", properties: { command: { type: "string" } } } },
+});
+
+const MCP_EXA = { name: "mcp__exa__web_search_exa", description: "search" };
+
+describe("toolDeduper — MCP-equivalent built-in rules (existing behavior)", () => {
+  it("claude client + Exa MCP → drops built-in WebSearch/WebFetch", () => {
+    const { tools, stripped } = dedupeTools(
+      [MCP_EXA, { name: "WebSearch", description: "web" }, { name: "WebFetch", description: "web" }, BASH()],
+      { clientTool: "claude" }
+    );
+    expect(tools.map((t) => t.name)).toEqual(["mcp__exa__web_search_exa", "Bash"]);
+    expect(stripped.sort()).toEqual(["WebFetch", "WebSearch"]);
+  });
+
+  it("non-claude client → MCP built-in rules do NOT run (behavior preserved)", () => {
+    const { tools, stripped } = dedupeTools(
+      [MCP_EXA, { name: "WebSearch", description: "web" }],
+      { clientTool: "codex" }
+    );
+    expect(tools.map((t) => t.name)).toEqual(["mcp__exa__web_search_exa", "WebSearch"]);
+    expect(stripped).toEqual([]);
+  });
+
+  it("legacy call without opts still applies MCP rules for claude callers (back-compat shape)", () => {
+    // chatCore always passes opts now, but old direct callers keep prior behavior:
+    // without clientTool, MCP rules stay dormant (they were claude-gated anyway).
+    const { tools, stripped } = dedupeTools([MCP_EXA, { name: "WebSearch", description: "web" }]);
+    expect(tools).toHaveLength(2);
+    expect(stripped).toEqual([]);
+  });
+});
+
+describe("toolDeduper — DeepSeek same-name dedup (new)", () => {
+  it("deepseek model + duplicate tool names → keeps first definition", () => {
+    const first = BASH();
+    const dup = BASH("Bash", "duplicate description");
+    const { tools, stripped } = dedupeTools([first, dup], { model: "deepseek-v4-flash" });
+    expect(tools).toEqual([first]); // first wins, including its description
+    expect(stripped).toEqual(["Bash"]);
+  });
+
+  it("deepseek model + (max) thinking suffix → still dedups (suffix stripped before match)", () => {
+    const { tools, stripped } = dedupeTools([BASH(), BASH("Bash", "dup")], { model: "deepseek-v4-flash(max)" });
+    expect(tools).toHaveLength(1);
+    expect(stripped).toEqual(["Bash"]);
+  });
+
+  it("deepseek + 3 same-name tools → keeps first, drops both duplicates", () => {
+    const { tools, stripped } = dedupeTools([BASH(), BASH("Bash", "d1"), BASH("Bash", "d2")], { model: "deepseek-v4-pro" });
+    expect(tools).toHaveLength(1);
+    expect(stripped).toEqual(["Bash", "Bash"]);
+  });
+
+  it("deepseek + OpenAI function-shape tools → dedups by function.name", () => {
+    const { tools } = dedupeTools([FUNC_SHAPE("Bash"), FUNC_SHAPE("Bash")], { model: "deepseek-v4-flash" });
+    expect(tools).toHaveLength(1);
+    expect(tools[0].function.name).toBe("Bash");
+  });
+
+  it("non-DeepSeek model + duplicate tool names → untouched (GLM/MiniMax/Kimi accept them)", () => {
+    const tools = [BASH(), BASH("Bash", "dup")];
+    const { tools: out, stripped } = dedupeTools(tools, { model: "glm-5.2" });
+    expect(out).toBe(tools);
+    expect(stripped).toEqual([]);
+  });
+
+  it("no model declared → same-name dedup does NOT run (safe default)", () => {
+    const tools = [BASH(), BASH("Bash", "dup")];
+    const { tools: out, stripped } = dedupeTools(tools, {});
+    expect(out).toBe(tools);
+    expect(stripped).toEqual([]);
+  });
+
+  it("deepseek + distinct names → nothing stripped", () => {
+    const { tools, stripped } = dedupeTools([BASH("Bash"), BASH("ReadFile")], { model: "deepseek-v4-flash" });
+    expect(tools).toHaveLength(2);
+    expect(stripped).toEqual([]);
+  });
+
+  it("claude client + deepseek + MCP trigger → both rules apply (union stripped)", () => {
+    const { tools, stripped } = dedupeTools(
+      [MCP_EXA, { name: "WebSearch", description: "web" }, BASH(), BASH("Bash", "dup")],
+      { clientTool: "claude", model: "deepseek-v4-flash" }
+    );
+    expect(tools.map((t) => t.name)).toEqual(["mcp__exa__web_search_exa", "Bash"]);
+    expect(stripped.sort()).toEqual(["Bash", "WebSearch"]);
+  });
+});


### PR DESCRIPTION
## What

Fix: exact same-name tool dedup for DeepSeek models (`toolDeduper.js` + `chatCore.js`), plus the endpoint matrix tests that pin the behavior this PR and #3332 debate.

## Why

DeepSeek upstream rejects duplicate tool names — `400 Tool names must be unique.` — on every endpoint and format, verified live 2026-08-15:

- api.deepseek.com: flash/pro, `/chat/completions` and `/anthropic/v1/messages` → all 400
- opencode.go Console Go: deepseek-v4-flash → 400; minimax-m3 → 200
- LiteLLM gateway (jy/基元律动): flash-0731/pro → 400; glm-5.2/minimax-m2.7/kimi-k2.6 → 200
- api.z.ai GLM official: glm-5.2 → 200

The restriction is DeepSeek's own (identical across three independent gateways; GLM/MiniMax/Kimi accept duplicates everywhere). This also rules out the #3332 "fragile shim" theory — DeepSeek's own `/anthropic/v1/messages` rejects it too.

Dedup is gated by model id (`deepseek-*`, thinking suffix stripped), first definition wins; non-DeepSeek models untouched. E2E: the dup-tool Claude-shaped payload to opencode.go/deepseek-v4-flash went from 400 → 200 through the real gateway.

## Tests

- `tests/unit/tool-deduper.test.js` — 11 cases (MCP rules regression, deepseek gating incl. `(max)` and function-shape, non-deepseek untouched)
- `tests/unit/opencode-go-transport-routing.test.js` — 16-cell offline routing matrix
- `tests/translator/real/opencode-go-deepseek.real.test.js` — live matrix, `RUN_REAL=1`, 8/8

Known red (3 cells): the `(max)` suffix guard-bypass in `providerModels.js` — belongs to #3332's suffix-strip fix; the cells are its regression repro.

## Runs

```bash
npx vitest run tests/unit/tool-deduper.test.js tests/unit/opencode-go-transport-routing.test.js   # 27 pass, 3 known-red
DATA_DIR=<snapshot> RUN_REAL=1 npx vitest run --config tests/vitest.config.js tests/translator/real/opencode-go-deepseek.real.test.js  # 8/8 live
```

Relates to #3278, #3332.
