### PR TITLE
feat(opencode-go): show subscription quota on the dashboard

### DIFF
--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -21,6 +21,9 @@ export default {
   transport: {
     baseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
     headers: {},
+    usage: {
+      url: "https://opencode.ai/zen/go/v1/usage",
+    },
   },
   // Multi-endpoint: pick the transport matching the client sourceFormat to skip
   // translation. Guarded per-model by `supportedFormats` (see chatCore) because
@@ -48,4 +51,8 @@ export default {
     { id: "qwen3.7-plus", name: "Qwen 3.7 Plus", supportedFormats: ["openai", "claude"] },
     { id: "qwen3.6-plus", name: "Qwen 3.6 Plus", supportedFormats: ["openai", "claude"] },
   ],
+  features: {
+    usage: true,
+    usageApikey: true,
+  },
 };

--- a/open-sse/providers/registry/opencode-go.js
+++ b/open-sse/providers/registry/opencode-go.js
@@ -21,6 +21,9 @@ export default {
   transport: {
     baseUrl: "https://opencode.ai/zen/go/v1/chat/completions",
     headers: {},
+    usage: {
+      url: "https://opencode.ai/zen/go/v1/usage",
+    },
   },
   // Multi-endpoint: pick the transport matching the client sourceFormat to skip
   // translation. Guarded per-model by `supportedFormats` (see chatCore) because
@@ -46,4 +49,8 @@ export default {
     { id: "qwen3.7-plus", name: "Qwen 3.7 Plus", supportedFormats: ["openai", "claude"] },
     { id: "qwen3.6-plus", name: "Qwen 3.6 Plus", supportedFormats: ["openai", "claude"] },
   ],
+  features: {
+    usage: true,
+    usageApikey: true,
+  },
 };

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -21,6 +21,7 @@ import {
   getGlmUsage,
   getVercelAiGatewayUsage,
   getQoderUsage,
+  getOpencodeGoUsage,
 } from "./usage/misc.js";
 
 /**
@@ -54,6 +55,7 @@ const USAGE_HANDLERS = {
   "grok-cli": (c) => getGrokCliUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
   kimi: (c) => getKimiUsage(c.accessToken, c.apiKey, c.proxyOptions, c.providerSpecificData),
   deepseek: (c) => getDeepseekUsage(c.apiKey, c.proxyOptions),
+  "opencode-go": (c) => getOpencodeGoUsage(c.apiKey, c.proxyOptions),
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null, options = {}) {

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -22,6 +22,7 @@ import {
   getOllamaUsage,
   getVercelAiGatewayUsage,
   getQoderUsage,
+  getOpencodeGoUsage,
 } from "./usage/misc.js";
 
 /**
@@ -56,6 +57,7 @@ const USAGE_HANDLERS = {
   kimi: (c) => getKimiUsage(c.accessToken, c.apiKey, c.proxyOptions, c.providerSpecificData),
   deepseek: (c) => getDeepseekUsage(c.apiKey, c.proxyOptions),
   zed: (c) => getZedUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
+  "opencode-go": (c) => getOpencodeGoUsage(c.apiKey, c.proxyOptions),
 };
 
 export async function getUsageForProvider(connection, proxyOptions = null, options = {}) {

--- a/open-sse/services/usage/misc.js
+++ b/open-sse/services/usage/misc.js
@@ -1,9 +1,9 @@
 /**
- * Misc usage handlers (iFlow, Ollama, GLM, Vercel AI Gateway, Qoder)
+ * Misc usage handlers (iFlow, Ollama, GLM, Vercel AI Gateway, Qoder, OpenCode Go)
  */
 
 import { proxyAwareFetch } from "../../utils/proxyFetch.js";
-import { U } from "./shared.js";
+import { U, parseResetTime } from "./shared.js";
 
 export { getGlmUsage } from "./glm.js";
 
@@ -252,5 +252,111 @@ export async function getQoderUsage(accessToken, proxyOptions = null) {
     };
   } catch (error) {
     return { message: `Qoder connected. Unable to fetch usage: ${error.message}` };
+  }
+}
+
+// OpenCode Go reports each window as a percentage consumed, not absolute counts,
+// so used is the percent and total is 100.
+//
+// Labels carry no duration on purpose: only the rolling window is a fixed span
+// (and its length is server-side plan config, absent from the payload). Weekly
+// resets on a calendar week boundary and monthly on the subscription
+// anniversary, so "7d"/"30d" would be wrong. Each row renders its own countdown
+// from resetAt anyway.
+const OPENCODE_GO_WINDOWS = [
+  { key: "rolling", label: "Rolling" },
+  { key: "weekly", label: "Weekly" },
+  { key: "monthly", label: "Monthly" },
+];
+
+// Errors come back as {type:"error", error:{type, message}} — surface the
+// message rather than echoing the raw JSON envelope at the user.
+async function readOpencodeGoError(response) {
+  const text = await response.text().catch(() => "");
+  if (!text) return "";
+  try {
+    const message = JSON.parse(text)?.error?.message;
+    if (typeof message === "string" && message.trim()) return message.trim();
+  } catch {
+    // not JSON — fall through to the raw text
+  }
+  return text.slice(0, 200);
+}
+
+/**
+ * OpenCode Go Usage
+ */
+export async function getOpencodeGoUsage(apiKey, proxyOptions = null) {
+  if (!apiKey) {
+    return { message: "OpenCode Go API key not available." };
+  }
+
+  const url = U("opencode-go").url;
+  if (!url) {
+    return { message: "OpenCode Go usage endpoint is not configured." };
+  }
+
+  try {
+    const response = await proxyAwareFetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    }, proxyOptions);
+
+    if (response.status === 401) {
+      return { message: "OpenCode Go API key invalid or expired." };
+    }
+
+    // 403 is an entitlement error, not an auth error: upstream answers it when
+    // the key authenticates but the account carries no Go subscription. Calling
+    // that an invalid key would send the user off to reissue a working one.
+    if (response.status === 403) {
+      const detail = await readOpencodeGoError(response);
+      return {
+        plan: "OpenCode Go",
+        message: detail || "OpenCode Go subscription required for this account.",
+      };
+    }
+
+    if (!response.ok) {
+      const detail = await readOpencodeGoError(response);
+      return { message: `OpenCode Go usage API error (${response.status})${detail ? `: ${detail}` : ""}` };
+    }
+
+    const data = await response.json().catch(() => null);
+    if (!data || typeof data !== "object") {
+      return { message: "OpenCode Go usage response was not JSON." };
+    }
+
+    const usage = data?.usage || {};
+    const quotas = {};
+
+    for (const { key, label } of OPENCODE_GO_WINDOWS) {
+      const window = usage[key];
+      // Upstream emits all three windows today, but the payload shape has moved
+      // once already. Skip anything unrecognised instead of emitting a 0% bar
+      // that would read as "quota untouched".
+      if (!window || typeof window !== "object") continue;
+      const percent = Number(window.percent);
+      if (!Number.isFinite(percent)) continue;
+      const used = Math.min(100, Math.max(0, percent));
+      quotas[label] = {
+        used,
+        total: 100,
+        remainingPercentage: 100 - used,
+        resetAt: parseResetTime(window.resetsAt),
+        unlimited: false,
+      };
+    }
+
+    if (Object.keys(quotas).length === 0) {
+      return { plan: "OpenCode Go", message: "OpenCode Go connected. No quota windows reported.", quotas: {} };
+    }
+
+    return { plan: "OpenCode Go", quotas };
+  } catch (error) {
+    return { message: `OpenCode Go connected. Unable to fetch usage: ${error.message}` };
   }
 }

--- a/open-sse/services/usage/misc.js
+++ b/open-sse/services/usage/misc.js
@@ -1,9 +1,9 @@
 /**
- * Misc usage handlers (iFlow, Ollama, GLM, Vercel AI Gateway, Qoder)
+ * Misc usage handlers (iFlow, Ollama, GLM, Vercel AI Gateway, Qoder, OpenCode Go)
  */
 
 import { proxyAwareFetch } from "../../utils/proxyFetch.js";
-import { U } from "./shared.js";
+import { U, parseResetTime } from "./shared.js";
 
 // GLM quota endpoints (region-aware) — url from registry transport.usage
 const GLM_QUOTA_URLS = {
@@ -132,7 +132,7 @@ export async function getGlmUsage(apiKey, provider, proxyOptions = null) {
     }, proxyOptions);
 
     if (!response.ok) {
-      if (response.status === 401) {
+      if (response.status === 401 || response.status === 403) {
         return { message: "GLM API key invalid or expired." };
       }
       return { message: `GLM quota API error (${response.status}).` };
@@ -311,5 +311,111 @@ export async function getQoderUsage(accessToken, proxyOptions = null) {
     };
   } catch (error) {
     return { message: `Qoder connected. Unable to fetch usage: ${error.message}` };
+  }
+}
+
+// OpenCode Go reports each window as a percentage consumed, not absolute counts,
+// so used is the percent and total is 100.
+//
+// Labels carry no duration on purpose: only the rolling window is a fixed span
+// (and its length is server-side plan config, absent from the payload). Weekly
+// resets on a calendar week boundary and monthly on the subscription
+// anniversary, so "7d"/"30d" would be wrong. Each row renders its own countdown
+// from resetAt anyway.
+const OPENCODE_GO_WINDOWS = [
+  { key: "rolling", label: "Rolling" },
+  { key: "weekly", label: "Weekly" },
+  { key: "monthly", label: "Monthly" },
+];
+
+// Errors come back as {type:"error", error:{type, message}} — surface the
+// message rather than echoing the raw JSON envelope at the user.
+async function readOpencodeGoError(response) {
+  const text = await response.text().catch(() => "");
+  if (!text) return "";
+  try {
+    const message = JSON.parse(text)?.error?.message;
+    if (typeof message === "string" && message.trim()) return message.trim();
+  } catch {
+    // not JSON — fall through to the raw text
+  }
+  return text.slice(0, 200);
+}
+
+/**
+ * OpenCode Go Usage
+ */
+export async function getOpencodeGoUsage(apiKey, proxyOptions = null) {
+  if (!apiKey) {
+    return { message: "OpenCode Go API key not available." };
+  }
+
+  const url = U("opencode-go").url;
+  if (!url) {
+    return { message: "OpenCode Go usage endpoint is not configured." };
+  }
+
+  try {
+    const response = await proxyAwareFetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    }, proxyOptions);
+
+    if (response.status === 401) {
+      return { message: "OpenCode Go API key invalid or expired." };
+    }
+
+    // 403 is an entitlement error, not an auth error: upstream answers it when
+    // the key authenticates but the account carries no Go subscription. Calling
+    // that an invalid key would send the user off to reissue a working one.
+    if (response.status === 403) {
+      const detail = await readOpencodeGoError(response);
+      return {
+        plan: "OpenCode Go",
+        message: detail || "OpenCode Go subscription required for this account.",
+      };
+    }
+
+    if (!response.ok) {
+      const detail = await readOpencodeGoError(response);
+      return { message: `OpenCode Go usage API error (${response.status})${detail ? `: ${detail}` : ""}` };
+    }
+
+    const data = await response.json().catch(() => null);
+    if (!data || typeof data !== "object") {
+      return { message: "OpenCode Go usage response was not JSON." };
+    }
+
+    const usage = data?.usage || {};
+    const quotas = {};
+
+    for (const { key, label } of OPENCODE_GO_WINDOWS) {
+      const window = usage[key];
+      // Upstream emits all three windows today, but the payload shape has moved
+      // once already. Skip anything unrecognised instead of emitting a 0% bar
+      // that would read as "quota untouched".
+      if (!window || typeof window !== "object") continue;
+      const percent = Number(window.percent);
+      if (!Number.isFinite(percent)) continue;
+      const used = Math.min(100, Math.max(0, percent));
+      quotas[label] = {
+        used,
+        total: 100,
+        remainingPercentage: 100 - used,
+        resetAt: parseResetTime(window.resetsAt),
+        unlimited: false,
+      };
+    }
+
+    if (Object.keys(quotas).length === 0) {
+      return { plan: "OpenCode Go", message: "OpenCode Go connected. No quota windows reported.", quotas: {} };
+    }
+
+    return { plan: "OpenCode Go", quotas };
+  } catch (error) {
+    return { message: `OpenCode Go connected. Unable to fetch usage: ${error.message}` };
   }
 }

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -518,8 +518,13 @@ export function parseQuotaData(provider, data) {
         }
         break;
 
+      case "opencode-go":
       case "deepseek":
-        // Credit balance — remainingPercentage only (no absolute remaining).
+        // Credit balance, and OpenCode Go's percent-per-window: forward
+        // remainingPercentage and never an absolute `remaining` (the UI reads
+        // `remaining` as a 0-100 percentage). For a used=percent/total=100 row
+        // the default branch happens to compute the same number, so this case
+        // is for intent and for staying correct if the shape ever changes.
         if (data.quotas) {
           Object.entries(data.quotas).forEach(([name, quota]) => {
             normalizedQuotas.push({

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -527,8 +527,13 @@ export function parseQuotaData(provider, data) {
         }
         break;
 
+      case "opencode-go":
       case "deepseek":
-        // Credit balance — remainingPercentage only (no absolute remaining).
+        // Credit balance, and OpenCode Go's percent-per-window: forward
+        // remainingPercentage and never an absolute `remaining` (the UI reads
+        // `remaining` as a 0-100 percentage). For a used=percent/total=100 row
+        // the default branch happens to compute the same number, so this case
+        // is for intent and for staying correct if the shape ever changes.
         if (data.quotas) {
           Object.entries(data.quotas).forEach(([name, quota]) => {
             normalizedQuotas.push({

--- a/tests/unit/opencode-go-usage-3334.test.js
+++ b/tests/unit/opencode-go-usage-3334.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+import {
+  USAGE_SUPPORTED_PROVIDERS,
+  USAGE_APIKEY_PROVIDERS,
+} from "../../src/shared/constants/providers.js";
+import {
+  parseQuotaData,
+  getRemainingPercentage,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+const USAGE_URL = "https://opencode.ai/zen/go/v1/usage";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Mirrors the upstream route (anomalyco/opencode
+// packages/console/app/src/routes/zen/go/v1/usage.ts): every window carries
+// status + a floored 0..100 percent + an ISO resetsAt, and all three are
+// always emitted.
+const FULL_USAGE = {
+  usage: {
+    rolling: { status: "ok", percent: 12, resetsAt: "2026-08-15T18:00:00.000Z" },
+    weekly: { status: "ok", percent: 47, resetsAt: "2026-08-20T00:00:00.000Z" },
+    monthly: { status: "rate-limited", percent: 100, resetsAt: "2026-09-01T00:00:00.000Z" },
+  },
+};
+
+describe("opencode-go registry usage flags", () => {
+  it("is listed for the apikey quota dashboard", () => {
+    expect(USAGE_SUPPORTED_PROVIDERS).toContain("opencode-go");
+    expect(USAGE_APIKEY_PROVIDERS).toContain("opencode-go");
+  });
+
+  it("carries the usage endpoint in the registry, not in the fetcher", async () => {
+    const registry = (await import("../../open-sse/providers/registry/opencode-go.js")).default;
+    expect(registry.transport.usage.url).toBe(USAGE_URL);
+  });
+});
+
+describe("getUsageForProvider(opencode-go)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GETs the usage endpoint with the Bearer apiKey", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(FULL_USAGE));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.message).toBeUndefined();
+    expect(usage.plan).toBe("OpenCode Go");
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = proxyAwareFetch.mock.calls[0];
+    expect(url).toBe(USAGE_URL);
+    expect(opts.method).toBe("GET");
+    expect(opts.headers.Authorization).toBe("Bearer oc-test");
+  });
+
+  it("maps each window to a percent bar with the remainder derived", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(FULL_USAGE));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.quotas.Rolling).toMatchObject({ used: 12, total: 100, remainingPercentage: 88 });
+    expect(usage.quotas.Weekly).toMatchObject({ used: 47, total: 100, remainingPercentage: 53 });
+    expect(usage.quotas.Monthly).toMatchObject({ used: 100, total: 100, remainingPercentage: 0 });
+    expect(usage.quotas.Weekly.resetAt).toBe("2026-08-20T00:00:00.000Z");
+  });
+
+  // Labels stay duration-free: weekly resets on a calendar week boundary and
+  // monthly on the subscription anniversary, so "7d"/"30d" would be wrong.
+  it("labels windows without asserting a span", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse(FULL_USAGE));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(Object.keys(usage.quotas)).toEqual(["Rolling", "Weekly", "Monthly"]);
+  });
+
+  it("skips a window it cannot read instead of emitting a 0% bar", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse({ usage: { rolling: { percent: 5 }, weekly: null, monthly: { percent: "n/a" } } }),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(Object.keys(usage.quotas)).toEqual(["Rolling"]);
+    expect(usage.quotas.Rolling.resetAt).toBeNull();
+  });
+
+  it("clamps a percentage outside 0..100", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ usage: { weekly: { percent: 130 } } }));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.quotas.Weekly).toMatchObject({ used: 100, remainingPercentage: 0 });
+  });
+
+  it("reports rather than throws when the payload carries no window", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ usage: {} }));
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.quotas).toEqual({});
+    expect(usage.message).toMatch(/no quota windows/i);
+  });
+
+  it("returns a message on a missing key and never calls out", async () => {
+    const missing = await getUsageForProvider({ provider: "opencode-go" });
+    expect(missing.message).toMatch(/api key/i);
+    expect(proxyAwareFetch).not.toHaveBeenCalled();
+  });
+
+  it("calls 401 an invalid key", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse({ type: "error", error: { type: "AuthError", message: "Unauthorized" } }, 401),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "bad" });
+
+    expect(usage.message).toMatch(/invalid or expired/i);
+  });
+
+  // Upstream answers 403 EntitlementError when the key is fine but the account
+  // has no Go plan. Calling that an invalid key sends the user to reissue a
+  // working one.
+  it("reports 403 as a missing subscription, not a bad key", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse(
+        { type: "error", error: { type: "EntitlementError", message: "OpenCode Go subscription required." } },
+        403,
+      ),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.message).toBe("OpenCode Go subscription required.");
+    expect(usage.message).not.toMatch(/invalid|expired/i);
+  });
+
+  it("surfaces the upstream error message rather than the JSON envelope", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      jsonResponse({ type: "error", error: { type: "ServerError", message: "upstream unavailable" } }, 503),
+    );
+
+    const usage = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+
+    expect(usage.message).toContain("503");
+    expect(usage.message).toContain("upstream unavailable");
+    expect(usage.message).not.toContain("{");
+  });
+
+  it("returns a message on a non-JSON body and on a transport failure", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(new Response("<html>gateway</html>", { status: 200 }));
+    const garbled = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+    expect(garbled.message).toMatch(/not json/i);
+
+    proxyAwareFetch.mockRejectedValueOnce(new Error("socket hang up"));
+    const down = await getUsageForProvider({ provider: "opencode-go", apiKey: "oc-test" });
+    expect(down.message).toMatch(/socket hang up/i);
+  });
+});
+
+describe("parseQuotaData(opencode-go)", () => {
+  const RAW = {
+    plan: "OpenCode Go",
+    quotas: {
+      Rolling: { used: 12, total: 100, remainingPercentage: 88, resetAt: null },
+      Monthly: { used: 90, total: 100, remainingPercentage: 10, resetAt: null },
+    },
+  };
+
+  it("forwards remainingPercentage for every window", () => {
+    const rows = parseQuotaData("opencode-go", RAW);
+
+    expect(rows.map((r) => r.name)).toEqual(["Rolling", "Monthly"]);
+    expect(rows[0]).toMatchObject({ total: 100, remainingPercentage: 88 });
+    expect(rows[1]).toMatchObject({ total: 100, remainingPercentage: 10 });
+  });
+
+  // The rendered number is what matters, and QuotaTable derives it through
+  // getRemainingPercentage — pin that, not just the field being present.
+  it("renders the remaining percentage the provider reported", () => {
+    const rows = parseQuotaData("opencode-go", RAW);
+
+    expect(rows.map(getRemainingPercentage)).toEqual([88, 10]);
+  });
+});


### PR DESCRIPTION
Closes #3334.

`opencode-go` connections render nothing on the quota dashboard while `ollama`, `deepseek` and `antigravity` render progress bars. The provider is a paid subscription with real rolling/weekly/monthly windows, so there is something to show.

The diagnosis in #3334 is the reporter's. I checked each of its claims against this codebase and against the upstream route source rather than taking them on trust — three hold, one does not, and the upstream source settled several details the issue could only guess at.

## What the upstream route actually returns

The endpoint is first-party but undocumented. Its implementation is `anomalyco/opencode` → `packages/console/app/src/routes/zen/go/v1/usage.ts` (added in anomalyco/opencode#16513), and it decides the whole contract:

```jsonc
{ "usage": {
    "rolling": { "status": "ok",           "percent": 12,  "resetsAt": "<ISO>" },
    "weekly":  { "status": "ok",           "percent": 47,  "resetsAt": "<ISO>" },
    "monthly": { "status": "rate-limited", "percent": 100, "resetsAt": "<ISO>" }
}}
```

Four things follow from reading it, none of which are in the issue:

- **`percent` is already a floored, clamped `0..100` integer** — `usagePercent: Math.floor(Math.min(100, (usage / limit) * 100))` in `console/core/src/subscription.ts`. So `used` is the percent and `total` is `100`; my clamp is belt-and-braces, not a scale conversion.
- **`resetsAt` is an ISO string**, `new Date(Date.now() + resetInSec * 1000).toISOString()` — handled by the shared `parseResetTime`.
- **403 is not an auth failure.** The route answers `403 EntitlementError "OpenCode Go subscription required."` when the key authenticates but the workspace has no Go plan. Folding 403 into the 401 branch — as the proposed patch does — tells a user with a perfectly good key to go reissue it. They are split here.
- **All three windows are always emitted**, so "skip an absent window" never fires in practice. The guard stays anyway, because the payload shape has already changed once since the route merged; an unreadable window is skipped rather than rendered as a `0%` bar that reads as "quota untouched".

That last point also fixes labels. I originally wrote `Weekly (7d)` / `Monthly (30d)`, copying the issue. Both are wrong: `analyzeWeeklyUsage` resets on a **calendar week** boundary (`getWeekBounds`) and `analyzeMonthlyUsage` on the **subscription anniversary** (`getMonthlyBounds(now, timeSubscribed)`), not rolling spans. The rolling window's length is server-side plan config and never appears in the payload, so `(5h)` was a guess too. Labels are now plain `Rolling` / `Weekly` / `Monthly` — each row already renders its own countdown from `resetAt`, which is the honest version of the same information.

Error bodies are `{type:"error", error:{type, message}}`, so the message is unwrapped rather than echoed as a raw JSON envelope.

## The four claims in the issue

**1. Registry `features` block — confirmed, and it is the actual blocker.** `USAGE_SUPPORTED_PROVIDERS` / `USAGE_APIKEY_PROVIDERS` are derived in `src/shared/constants/providers.js` by filtering the registry on `features.usage` / `features.usageApikey`. Without them `/api/usage/[connectionId]` returns `"Usage not available for this connection"` before any fetch happens, and `ProviderLimits` never calls for the connection.

**2. No fetcher in `misc.js` — confirmed.**

**3. No `USAGE_HANDLERS` entry — confirmed.** `getUsageForProvider` would return `"Usage API not implemented for opencode-go"`.

**4. "The default case does not pass `remainingPercentage`, causing the progress bars to fail to render" — this one is not right.** Both render paths fall back to the same arithmetic:

- `QuotaTable` → `getRemainingPercentage(quota)` → `calculatePercentage(used, total)` when `remainingPercentage` is absent.
- `ProviderLimitCard` recomputes `Math.round(((total - used) / total) * 100)` and does not read `remainingPercentage` at all.

For a `used = percent, total = 100` row both yield `100 - used` — exactly what `remainingPercentage` carries, including at the `used = 0` and `used = 100` edges. I proved it rather than reasoning about it: deleting the `case "opencode-go":` line makes the field-forwarding test fail while **"renders the remaining percentage the provider reported" still passes**. The bars would have rendered correctly without any frontend change.

I kept the frontend hunk anyway — it is one line, it puts the provider with `deepseek`/`ollama`/`kimi` where it belongs, and it keeps the row correct if the shape ever stops being a straight percentage — but it is grouped for intent, not a fix, and the comment and commit message now say so. Note also that the diff in the issue is written against the built bundle (`([e,t])=>{…}`), which is why it names `ProviderLimits/index.js`; the real `switch (provider)` is in `ProviderLimits/utils.js`.

## One more deviation

The proposal hardcodes the URL inside `misc.js`. This repo keeps usage endpoints in `transport.usage.url` and reads them through `U(id)` in `services/usage/shared.js` — that is how `glm`, `glm-cn` and `vercel-ai-gateway` work — so it is declared next to the other transports, with a guard for the case where it is absent.

## What I could not verify

**I have no OpenCode Go subscription, so I have never seen a live 200 body.** The shape above is read off the upstream source and cross-checked against four independent third-party clients that consume the same endpoint, but it is not a captured response. Every failure path therefore degrades to a `{message}` instead of throwing or rendering a wrong bar: unknown shape → "No quota windows reported", non-JSON → "response was not JSON", transport error → the error text. Usage fetchers are display-only and off the routing path, so the worst case of a shape drift is a message where bars would be.

If a maintainer or the reporter can paste one redacted 200 body, I will tighten the parser to it.

## Verification

15 tests in `unit/opencode-go-usage-3334.test.js`, following the existing `deepseek-usage.test.js` structure: the registry flags land in both derived lists, the endpoint comes from the registry, the request is a GET with `Authorization: Bearer`, the three windows map with the remainder derived, labels assert no span, an unreadable window is skipped, an out-of-range percent clamps, an empty payload returns a message, a missing key never calls out, 401 reads as an invalid key, **403 reads as a missing subscription and explicitly not as an invalid key**, an upstream error message is unwrapped from its envelope, and a non-JSON body plus a transport failure both return messages. Two `parseQuotaData` tests close it: one that the field is forwarded, one that the *rendered* percentage is right.

Mutation-checked, since a passing test proves nothing about whether it bites:

| mutation | result |
|---|---|
| drop `features` from the registry | registry test fails — `expected [...] to include 'opencode-go'` |
| fold 403 back into the 401 branch | only the 403 test fails |
| drop `case "opencode-go":` | field test fails, **render test still passes** — the evidence for claim 4 above |

Full suite (`npx vitest run unit translator`): **1808 passed / 93 failed, failing set byte-identical to master's**, `comm` empty in both directions. `npx eslint` reports no issues on the three changed files.
