### PR TITLE
fix(rtk): enforce dynamic user language detection in caveman prompts

### DIFF
--- a/open-sse/rtk/cavemanPrompts.js
+++ b/open-sse/rtk/cavemanPrompts.js
@@ -20,7 +20,7 @@ const SHARED_PERSISTENCE = "ACTIVE EVERY RESPONSE. No revert after many turns. N
 
 const SHARED_NO_INVENTED_ABBREV = "No invented abbreviations. Standard well-known tech acronyms (DB, API, HTTP, URL, JSON, ID, OS, CPU) OK. Names of code symbols, function names, API names, error strings: keep verbatim.";
 
-const SHARED_PRESERVE_LANGUAGE = "CRITICAL: Dynamically match user prompt language. Reply in same language. Wenyan/classical-Chinese levels override this. Keep code/paths/commands verbatim.";
+const SHARED_PRESERVE_LANGUAGE = "CRITICAL: Remember user prompt language. Reply in same language. Wenyan/classical-Chinese levels override this. Keep code/paths/commands verbatim.";
 
 const SHARED_NO_SELF_REFERENCE = 'No self-reference. Do not name or announce the style (no "caveman mode", no "me caveman think", no "compressed mode active"). Just respond.';
 

--- a/open-sse/rtk/cavemanPrompts.js
+++ b/open-sse/rtk/cavemanPrompts.js
@@ -20,7 +20,7 @@ const SHARED_PERSISTENCE = "ACTIVE EVERY RESPONSE. No revert after many turns. N
 
 const SHARED_NO_INVENTED_ABBREV = "No invented abbreviations. Standard well-known tech acronyms (DB, API, HTTP, URL, JSON, ID, OS, CPU) OK. Names of code symbols, function names, API names, error strings: keep verbatim.";
 
-const SHARED_PRESERVE_LANGUAGE = "Preserve the user's dominant language. User wrote Vietnamese, reply Vietnamese. User wrote English, reply English. Wenyan/classical-Chinese levels override this language-preservation rule. Code identifiers, error strings, file paths, commands: keep in their original form regardless of language.";
+const SHARED_PRESERVE_LANGUAGE = "CRITICAL: Dynamically match user prompt language. Reply in same language. Wenyan/classical-Chinese levels override this. Keep code/paths/commands verbatim.";
 
 const SHARED_NO_SELF_REFERENCE = 'No self-reference. Do not name or announce the style (no "caveman mode", no "me caveman think", no "compressed mode active"). Just respond.';
 


### PR DESCRIPTION
### Summary
Fixes language drift in `open-sse/rtk/cavemanPrompts.js` where the AI unexpectedly defaults to Vietnamese instead of matching the user's prompt language.

### Problem
The previous static prompt instruction in `open-sse/rtk/cavemanPrompts.js`:
> *User wrote Vietnamese, reply Vietnamese. User wrote English, reply English.*

caused the model to over-index on Vietnamese patterns in certain edge cases, leading to unexpected language switching even during English interactions.

```bash
# Example Output
 ● Creating worktree(add-c-txt)
 Switched to worktree on branch worktree-add-c-txt
 C:\Users\ajhar\code\nitsuah-io\.claude\worktrees\add-c-txt
 ● Write(c.txt)
 Wrote 1 line to c.txt
 b
 File c.txt đã được tạo với nội dung b.  # <-- Drifted into Vietnamese
 result: File c.txt created with content b.
 Thought for 12s, searched for 9 patterns, read 26 files
```

### Solution
Updated the `SHARED_PRESERVE_LANGUAGE` instruction to enforce dynamic language detection while preserving intentional overrides:

> *"CRITICAL: Remember user prompt language. Reply in same language. Wenyan/classical-Chinese levels override this. Keep code/paths/commands verbatim."*

### Key Changes
* **Dynamic Language Detection:** Instructs the model to explicitly infer and match the user's prompt language dynamically rather than relying on hardcoded language pairs.
* **Preserves Intentional Overrides:** Maintains support for Wenyan/classical Chinese overrides where explicitly required.
* **Code Integrity:** Ensures code, file paths, and CLI commands remain verbatim regardless of output language.