### PR TITLE
fix(codebuddy-cn): make the system-prompt length gate tunable and loud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,12 @@ NEXT_PUBLIC_CLOUD_URL=https://9router.com
 # Optional SearXNG endpoint for the built-in unauthenticated web-search provider.
 # SEARXNG_URL=http://searxng:8080/search
 
+# CodeBuddy CN replaces a system prompt that looks like a coding-agent identity,
+# because Tencent's content filter rejects those requests. Prompts longer than
+# this many characters are treated as agent prompts too; raise it if a long
+# hand-written system prompt is being replaced, or set 0 to match on the
+# identity markers alone. Default 2000.
+# CODEBUDDY_SYSTEM_PROMPT_MAX_LEN=2000
+
 # Currently unused by application runtime (kept as reference)
 # INSTANCE_NAME=9router

--- a/open-sse/executors/codebuddy-cn.js
+++ b/open-sse/executors/codebuddy-cn.js
@@ -1,5 +1,21 @@
 import { DefaultExecutor } from "./default.js";
 
+// Length is a blunt stand-in for "this is an agent prompt": a hand-written
+// project system prompt (conventions, architecture notes) runs past 2000 chars
+// easily and gets replaced too (#3339). The catch-all stays on by default —
+// it is what keeps an agent CLI the regex does not know about from tripping
+// the filter — but the limit is now tunable, and 0 turns it off so only the
+// identity markers decide.
+const DEFAULT_SYSTEM_PROMPT_MAX_LEN = 2000;
+
+function systemPromptMaxLen() {
+  const raw = process.env.CODEBUDDY_SYSTEM_PROMPT_MAX_LEN?.trim();
+  if (!raw) return DEFAULT_SYSTEM_PROMPT_MAX_LEN;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) return DEFAULT_SYSTEM_PROMPT_MAX_LEN;
+  return parsed;
+}
+
 /**
  * CodeBuddyExecutor — talks to https://copilot.tencent.com/v2/chat/completions
  *
@@ -33,12 +49,22 @@ export class CodeBuddyExecutor extends DefaultExecutor {
         : Array.isArray(content)
           ? content.map((b) => (b && typeof b.text === "string" ? b.text : "")).join("\n")
           : "";
+    const maxLen = systemPromptMaxLen();
     if (Array.isArray(transformed.messages)) {
       transformed.messages = transformed.messages.map((message) => {
         if (!message || message.role !== "system") return message;
         const text = flatten(message.content);
         if (!text) return message;
-        if (text.length > 2000 || AGENT_PATTERN.test(text)) {
+        const matchedAgent = AGENT_PATTERN.test(text);
+        const tooLong = maxLen > 0 && text.length > maxLen;
+        if (matchedAgent || tooLong) {
+          // Dropping the caller's system prompt is destructive, so say which
+          // rule fired: a length false positive is otherwise invisible.
+          console.warn(
+            matchedAgent
+              ? "[codebuddy-cn] system prompt replaced: agent identity marker"
+              : `[codebuddy-cn] system prompt replaced: ${text.length} chars > CODEBUDDY_SYSTEM_PROMPT_MAX_LEN (${maxLen})`,
+          );
           return typeof message.content === "string"
             ? { ...message, content: NEUTRAL_PROMPT }
             : { ...message, content: [{ type: "text", text: NEUTRAL_PROMPT }] };

--- a/tests/unit/codebuddy-system-prompt-len-3339.test.js
+++ b/tests/unit/codebuddy-system-prompt-len-3339.test.js
@@ -1,0 +1,112 @@
+// #3339 — CodeBuddy CN replaces a system prompt that looks like a coding-agent
+// identity, because Tencent's filter rejects those. The length half of that
+// test was a hard-coded 2000 with no signal, so a long hand-written project
+// prompt was silently swapped for the neutral one.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CodeBuddyExecutor } from "../../open-sse/executors/codebuddy-cn.js";
+
+const NEUTRAL = "You are a helpful AI assistant that helps with software engineering tasks.";
+const AGENT_PROMPT = "You are Claude Code, Anthropic's official CLI for Claude.";
+
+// Long, but plainly a human-written project prompt: no agent identity marker.
+const LONG_PROJECT_PROMPT = `Project conventions. ${"Prefer small, focused functions and explicit names. ".repeat(60)}`;
+
+function run(body, exec = new CodeBuddyExecutor()) {
+  return exec.transformRequest("glm-5.2", body, false, {});
+}
+
+function systemOf(out) {
+  const message = out.messages.find((m) => m.role === "system");
+  return typeof message?.content === "string"
+    ? message.content
+    : message?.content?.map((b) => b.text).join("\n");
+}
+
+describe("CodeBuddyExecutor system prompt length gate (#3339)", () => {
+  const ENV_KEY = "CODEBUDDY_SYSTEM_PROMPT_MAX_LEN";
+  let warn;
+
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete process.env[ENV_KEY];
+    warn.mockRestore();
+  });
+
+  it("still replaces an agent identity prompt", () => {
+    const out = run({ messages: [{ role: "system", content: AGENT_PROMPT }] });
+    expect(systemOf(out)).toBe(NEUTRAL);
+  });
+
+  it("leaves a short project prompt alone and stays quiet", () => {
+    const out = run({ messages: [{ role: "system", content: "Answer in French." }] });
+    expect(systemOf(out)).toBe("Answer in French.");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the 2000-char default when the env var is unset", () => {
+    expect(LONG_PROJECT_PROMPT.length).toBeGreaterThan(2000);
+    const out = run({ messages: [{ role: "system", content: LONG_PROJECT_PROMPT }] });
+    expect(systemOf(out)).toBe(NEUTRAL);
+  });
+
+  it("honours a raised limit so a long project prompt survives", () => {
+    process.env[ENV_KEY] = "20000";
+    const out = run({ messages: [{ role: "system", content: LONG_PROJECT_PROMPT }] });
+    expect(systemOf(out)).toBe(LONG_PROJECT_PROMPT);
+  });
+
+  it("treats 0 as 'identity markers only'", () => {
+    process.env[ENV_KEY] = "0";
+
+    const kept = run({ messages: [{ role: "system", content: LONG_PROJECT_PROMPT }] });
+    expect(systemOf(kept)).toBe(LONG_PROJECT_PROMPT);
+
+    // A raised/disabled limit must never let an agent prompt through — that is
+    // the case the filter actually rejects.
+    const agent = run({ messages: [{ role: "system", content: AGENT_PROMPT }] });
+    expect(systemOf(agent)).toBe(NEUTRAL);
+  });
+
+  it("falls back to the default on a junk or negative value", () => {
+    for (const value of ["abc", "-1", "1.5", ""]) {
+      process.env[ENV_KEY] = value;
+      const out = run({ messages: [{ role: "system", content: LONG_PROJECT_PROMPT }] });
+      expect(systemOf(out), `value ${JSON.stringify(value)}`).toBe(NEUTRAL);
+    }
+  });
+
+  it("names the rule that fired so a false positive is diagnosable", () => {
+    run({ messages: [{ role: "system", content: LONG_PROJECT_PROMPT }] });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("CODEBUDDY_SYSTEM_PROMPT_MAX_LEN");
+    expect(warn.mock.calls[0][0]).toContain(String(LONG_PROJECT_PROMPT.length));
+
+    warn.mockClear();
+    run({ messages: [{ role: "system", content: AGENT_PROMPT }] });
+    expect(warn.mock.calls[0][0]).toContain("agent identity marker");
+  });
+
+  it("preserves typed-block content shape on replacement", () => {
+    const out = run({
+      messages: [{ role: "system", content: [{ type: "text", text: AGENT_PROMPT }] }],
+    });
+    const message = out.messages.find((m) => m.role === "system");
+    expect(message.content).toEqual([{ type: "text", text: NEUTRAL }]);
+  });
+
+  it("does not touch user or assistant messages", () => {
+    const out = run({
+      messages: [
+        { role: "user", content: LONG_PROJECT_PROMPT },
+        { role: "assistant", content: AGENT_PROMPT },
+      ],
+    });
+    expect(out.messages[0].content).toBe(LONG_PROJECT_PROMPT);
+    expect(out.messages[1].content).toBe(AGENT_PROMPT);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #3339.

`CodeBuddyExecutor.transformRequest` swaps a system prompt for a neutral one when it looks like a coding-agent identity, because Tencent's content filter rejects those outright (#2071). The detector is an identity regex **OR** `text.length > 2000`, and the length half is the problem:

```js
if (text.length > 2000 || AGENT_PATTERN.test(text)) { /* replace */ }
```

2000 characters is not much. A hand-written project system prompt — coding conventions, architecture notes, a `CLAUDE.md` pasted into the client — clears it easily and gets replaced with **no error, no log, nothing**. What the user sees is a model that quietly ignores its instructions, with no thread to pull. The report is accurate; I reproduced the path in `open-sse/executors/codebuddy-cn.js:41` on master.

## What this does not change

The length catch-all **stays on, at 2000, by default.** It is not decoration: the regex enumerates specific agents (`you are claude code`, `cursor|windsurf|cline|aider|…`, `<agent-identity>`, …) and cannot know the next one. The length rule is what stops an unrecognised agent CLI from tripping the filter and failing the whole request. Removing it — the issue's second option — trades a silent degradation for a hard 400 on clients that work today, so I did not take it.

The identity regex is also untouched and still evaluated independently of the limit. Raising or disabling the length rule cannot let a *known* agent prompt through; there is a test that pins exactly that.

## What changes

**`CODEBUDDY_SYSTEM_PROMPT_MAX_LEN`** — raise it when a long legitimate prompt is being eaten, or set `0` to drop the length rule and let the identity markers decide alone. Unset keeps today's behaviour exactly. Junk (`abc`, `1.5`) and negative values fall back to the default rather than silently disabling the guard, which is the failure mode you want from a safety heuristic. Documented in `.env.example` alongside the other optional knobs.

**The replacement is no longer silent.** It logs which rule fired:

```
[codebuddy-cn] system prompt replaced: agent identity marker
[codebuddy-cn] system prompt replaced: 3162 chars > CODEBUDDY_SYSTEM_PROMPT_MAX_LEN (2000)
```

The second line names both the measurement and the knob, so a user hitting the false positive can see the cause and the fix in one line. This is arguably the more important half of the fix — the issue title says "silently", and that is the part that made it hard to diagnose.

## Something related I noticed

`open-sse/executors/codebuddy-intl.js:31` does the same thing far more bluntly, and unconditionally:

```js
transformed.messages = [{ role: "system", content: "You are CodeBuddy Code." }];
for (const message of source) {
  if (!message || typeof message !== "object" || ["system", "developer"].includes(message.role)) continue;
  ...
}
```

Every system and developer message is dropped on `codebuddy-intl`, at any length, agent prompt or not. The comment explains the gateway needs *a* leading system prompt — which does not by itself require discarding the caller's. I have left it alone: I have no `codebuddy-intl` account to check how strict that gateway is, and guessing there would risk a regression of the same class as #2071. Happy to follow up if a maintainer confirms the intent, or to file it separately.

## Verification

9 tests in `unit/codebuddy-system-prompt-len-3339.test.js`: an agent prompt is still replaced; a short prompt is untouched and logs nothing; the default is still 2000 when the var is unset; a raised limit lets a long project prompt survive; `0` means identity-markers-only **and still catches an agent prompt**; junk/negative/empty values fall back to the default; the warning names the rule, the length and the env var; typed-block content (`[{type:"text",text}]`) keeps its shape on replacement; user and assistant messages are never touched.

Mutation-checked so the tests are known to bite:

| mutation | result |
|---|---|
| restore the hard-coded `text.length > 2000` | the raised-limit and `0` tests fail |
| delete the `console.warn` | the "names the rule that fired" test fails |

The pre-existing `unit/codebuddy-reasoning-optin.test.js` (#2071) still passes. Full suite (`npx vitest run unit translator`): **1817 passed / 93 failed, failing set byte-identical to master's**, `comm` empty in both directions. `npx eslint` reports no issues on the changed files.
