### PR TITLE
fix(stream): recover partial usage when a client disconnects before completion

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -296,12 +296,21 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const msgCount = translatedBody.messages?.length || translatedBody.input?.length || translatedBody.contents?.length || translatedBody.request?.contents?.length || 0;
   log?.debug?.("REQUEST", `${provider.toUpperCase()} | ${model} | ${msgCount} msgs`);
 
+  // Set when the response turns out to be streaming; called by the stream
+  // controller on disconnect/error to finalize the placeholder requestDetail
+  // row (flush() never runs on those paths).
+  let abandonStreamingDetail = null;
+
   const streamController = createStreamController({
     onDisconnect: (reason) => {
       trackPendingRequest(model, provider, connectionId, false);
+      abandonStreamingDetail?.(typeof reason?.reason === "string" ? reason.reason : "client_disconnected");
       if (onDisconnect) onDisconnect(reason);
     },
-    onError: () => trackPendingRequest(model, provider, connectionId, false),
+    onError: (err) => {
+      trackPendingRequest(model, provider, connectionId, false);
+      abandonStreamingDetail?.(err?.message === "stream stall timeout" ? "stall_timeout" : "stream_error");
+    },
     log, provider, model, reqTag
   });
 
@@ -456,7 +465,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   // Streaming response
-  const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
+  const { onStreamComplete, onStreamAbandoned, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
+  abandonStreamingDetail = onStreamAbandoned;
   return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, userAgent, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId });
 }
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -447,7 +447,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log, sourceFormat };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 
@@ -465,9 +465,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   }
 
   // Streaming response
-  const { onStreamComplete, onStreamAbandoned, streamDetailId } = buildOnStreamComplete({ ...sharedCtx });
+  const { onStreamComplete, onStreamAbandoned, streamDetailId, streamState } = buildOnStreamComplete({ ...sharedCtx });
   abandonStreamingDetail = onStreamAbandoned;
-  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, userAgent, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId });
+  return handleStreamingResponse({ ...sharedCtx, providerResponse, sourceFormat, targetFormat: providerResponseFormat, userAgent, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId, streamState });
 }
 
 export function isTokenExpiringSoon(expiresAt, bufferMs = 5 * 60 * 1000) {

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -8,6 +8,7 @@ import { buildAbortedResponsesTerminalBytes } from "../../utils/responsesStreamH
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { saveRequestDetail } from "@/lib/usageDb.js";
 import { SSE_HEADERS_CORS as SSE_HEADERS } from "../../utils/sseConstants.js";
+import { hasValidUsage, estimateUsage } from "../../utils/usageTracking.js";
 
 // Codex returns Responses API SSE → which client format to translate INTO, by request sourceFormat.
 // Gemini-family all map to ANTIGRAVITY decoder; unknown sources fall back to OPENAI.
@@ -22,7 +23,7 @@ const CODEX_SOURCE_TO_TARGET = {
 /**
  * Determine which SSE transform stream to use based on provider/format.
  */
-function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey }) {
+function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey, streamState }) {
   const isDroidCLI = userAgent?.toLowerCase().includes("droid") || userAgent?.toLowerCase().includes("codex-cli");
   // Responses-API providers (e.g. codex) emit Responses SSE → translate into client format
   const isResponsesProvider = PROVIDERS[provider]?.format === FORMATS.OPENAI_RESPONSES;
@@ -30,20 +31,20 @@ function buildTransformStream({ provider, sourceFormat, targetFormat, userAgent,
 
   if (needsCodexTranslation) {
     const codexTarget = CODEX_SOURCE_TO_TARGET[sourceFormat] || FORMATS.OPENAI;
-    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames);
+    return createSSETransformStreamWithLogger(FORMATS.OPENAI_RESPONSES, codexTarget, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames, streamState);
   }
 
   if (needsTranslation(targetFormat, sourceFormat)) {
-    return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames);
+    return createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider, reqLogger, toolNameMap, model, connectionId, body, onStreamComplete, apiKey, customToolNames, streamState);
   }
 
-  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey);
+  return createPassthroughStreamWithLogger(provider, reqLogger, model, connectionId, body, onStreamComplete, apiKey, streamState);
 }
 
 /**
  * Handle streaming response — pipe provider SSE through transform stream to client.
  */
-export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId, pxpipe, reqTag, log }) {
+export async function handleStreamingResponse({ providerResponse, provider, model, sourceFormat, targetFormat, userAgent, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, reqLogger, toolNameMap, customToolNames, streamController, onStreamComplete, streamDetailId, pxpipe, reqTag, log, streamState }) {
   if (onRequestSuccess) {
     Promise.resolve()
       .then(onRequestSuccess)
@@ -79,7 +80,7 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
     };
   }
 
-  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey });
+  const transformStream = buildTransformStream({ provider, sourceFormat, targetFormat, userAgent, reqLogger, toolNameMap, customToolNames, model, connectionId, body, onStreamComplete, apiKey, streamState });
 
   // Responses passthrough: synthesize response.failed + [DONE] if the stream aborts/stalls before a terminal event
   const isResponsesPassthrough = sourceFormat === FORMATS.OPENAI_RESPONSES && targetFormat === FORMATS.OPENAI_RESPONSES;
@@ -109,12 +110,21 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 
 /**
  * Build onStreamComplete callback for streaming usage tracking.
+ * Also returns a mutable `streamState` object that the SSE transform stream
+ * populates on every chunk — used by onStreamAbandoned to recover partial usage.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log, sourceFormat }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
   let completed = false;
 
+  // Mutable state the transform stream populates on every chunk via syncState()
+  const streamState = { usage: null, content: "", thinking: "", ttftAt: null };
+
   const onStreamComplete = (contentObj, usage, ttftAt) => {
+    // Race guard: if the stream was already finalized by onStreamAbandoned
+    // (client disconnect that lost a race with a late upstream EOF), keep the
+    // interrupted row instead of double-writing usage.
+    if (completed) return;
     completed = true;
     const latency = {
       ttft: ttftAt ? ttftAt - requestStartTime : Date.now() - requestStartTime,
@@ -147,14 +157,28 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
   // reset. Without this, the row saved by handleStreamingResponse stays
   // "[Streaming in progress...]" with tokens 0/0 and status "success" forever.
   // Reuses streamDetailId so the ON CONFLICT(id) upsert overwrites the placeholder.
+  // Recovers partial usage accumulated in streamState by the transform stream.
   const onStreamAbandoned = (reason) => {
     if (completed) return;
     completed = true;
     const detail = `[Streaming interrupted: ${reason || "unknown"}]`;
+
+    // Use partial usage from the transform stream closure if available;
+    // fall back to an estimate so at least prompt tokens are recorded.
+    let partialUsage = streamState.usage;
+    if (!hasValidUsage(partialUsage) && streamState.content) {
+      partialUsage = estimateUsage(body, streamState.content.length, sourceFormat || "openai");
+    }
+    // Ensure completion tokens reflect only what was actually streamed, not the full estimate.
+    // estimateUsage sets completion from content length; if provider usage arrived, use it as-is.
+    const tokens = partialUsage
+      ? { ...partialUsage, completion_tokens: partialUsage.completion_tokens ?? partialUsage.output_tokens ?? 0 }
+      : { prompt_tokens: 0, completion_tokens: 0 };
+
     saveRequestDetail(buildRequestDetail({
       provider, model, connectionId,
-      latency: { ttft: 0, total: Date.now() - requestStartTime },
-      tokens: { prompt_tokens: 0, completion_tokens: 0 },
+      latency: { ttft: streamState.ttftAt ? streamState.ttftAt - requestStartTime : 0, total: Date.now() - requestStartTime },
+      tokens,
       request: extractRequestConfig(body, stream),
       providerRequest: finalBody || translatedBody || null,
       providerResponse: detail,
@@ -164,7 +188,12 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     }, { id: streamDetailId })).catch(err => {
       console.error("[RequestDetail] Failed to finalize interrupted stream:", err.message);
     });
+
+    // Write partial usage to usageHistory so accounting is not silently dropped.
+    if (hasValidUsage(tokens)) {
+      saveUsageStats({ provider, model, tokens, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE (interrupted)", silent: true });
+    }
   };
 
-  return { onStreamComplete, onStreamAbandoned, streamDetailId };
+  return { onStreamComplete, onStreamAbandoned, streamDetailId, streamState };
 }

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -112,8 +112,10 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
  */
 export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  let completed = false;
 
   const onStreamComplete = (contentObj, usage, ttftAt) => {
+    completed = true;
     const latency = {
       ttft: ttftAt ? ttftAt - requestStartTime : Date.now() - requestStartTime,
       total: Date.now() - requestStartTime
@@ -140,5 +142,29 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
   };
 
-  return { onStreamComplete, streamDetailId };
+  // Finalize the placeholder row when the stream ends without flush() ever running:
+  // client disconnect (cancel()), upstream stall timeout, or a mid-stream network
+  // reset. Without this, the row saved by handleStreamingResponse stays
+  // "[Streaming in progress...]" with tokens 0/0 and status "success" forever.
+  // Reuses streamDetailId so the ON CONFLICT(id) upsert overwrites the placeholder.
+  const onStreamAbandoned = (reason) => {
+    if (completed) return;
+    completed = true;
+    const detail = `[Streaming interrupted: ${reason || "unknown"}]`;
+    saveRequestDetail(buildRequestDetail({
+      provider, model, connectionId,
+      latency: { ttft: 0, total: Date.now() - requestStartTime },
+      tokens: { prompt_tokens: 0, completion_tokens: 0 },
+      request: extractRequestConfig(body, stream),
+      providerRequest: finalBody || translatedBody || null,
+      providerResponse: detail,
+      response: { content: detail, thinking: null, type: "streaming" },
+      pxpipe,
+      status: "cancelled"
+    }, { id: streamDetailId })).catch(err => {
+      console.error("[RequestDetail] Failed to finalize interrupted stream:", err.message);
+    });
+  };
+
+  return { onStreamComplete, onStreamAbandoned, streamDetailId };
 }

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -35,6 +35,9 @@ const STREAM_MODE = {
  * @param {object} options.body - Request body (for input token estimation)
  * @param {function} options.onStreamComplete - Callback when stream completes (content, usage)
  * @param {string} options.apiKey - API key for usage tracking
+ * @param {object} [options.streamState] - Mutable object {usage,content,thinking,ttftAt} shared with
+ *   the caller so an onStreamAbandoned path can read accumulated partial state on disconnect.
+ *   If provided, this function populates it during transform and flush.
  */
 export function createSSEStream(options = {}) {
   const {
@@ -49,7 +52,8 @@ export function createSSEStream(options = {}) {
     connectionId = null,
     body = null,
     onStreamComplete = null,
-    apiKey = null
+    apiKey = null,
+    streamState = null
   } = options;
 
   let buffer = "";
@@ -66,6 +70,15 @@ export function createSSEStream(options = {}) {
   let accumulatedContent = "";
   let accumulatedThinking = "";
   let ttftAt = null;
+
+  // Keep streamState in sync so onStreamAbandoned can read partial usage on disconnect
+  const syncState = () => {
+    if (!streamState) return;
+    streamState.content = accumulatedContent;
+    streamState.thinking = accumulatedThinking;
+    streamState.ttftAt = ttftAt;
+    streamState.usage = mode === STREAM_MODE.PASSTHROUGH ? usage : state?.usage ?? null;
+  };
   let sseLineCount = 0;
   let sseEmittedCount = 0;
   const eventTypeCounts = {};
@@ -167,6 +180,7 @@ export function createSSEStream(options = {}) {
               if (extracted) {
                 usage = mergeUsage(usage, extracted);
               }
+              syncState();
 
               const isFinishChunk = parsed.choices?.[0]?.finish_reason;
               if (isFinishChunk && !hasValidUsage(parsed.usage)) {
@@ -284,6 +298,7 @@ export function createSSEStream(options = {}) {
         // Extract usage
         const extracted = extractUsage(parsed);
         if (extracted) state.usage = mergeUsage(state.usage, extracted); // Keep original usage for logging
+        syncState();
 
         // Responses same-format passthrough: re-emit with original event framing
         if (keepsOpenAIResponsesFormat && openAIResponsesEventName) {
@@ -467,7 +482,7 @@ export function createSSEStream(options = {}) {
   });
 }
 
-export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, customToolNames = null) {
+export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, provider = null, reqLogger = null, toolNameMap = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, customToolNames = null, streamState = null) {
   return createSSEStream({
     mode: STREAM_MODE.TRANSLATE,
     targetFormat,
@@ -480,11 +495,12 @@ export function createSSETransformStreamWithLogger(targetFormat, sourceFormat, p
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    streamState
   });
 }
 
-export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null) {
+export function createPassthroughStreamWithLogger(provider = null, reqLogger = null, model = null, connectionId = null, body = null, onStreamComplete = null, apiKey = null, streamState = null) {
   return createSSEStream({
     mode: STREAM_MODE.PASSTHROUGH,
     provider,
@@ -493,6 +509,7 @@ export function createPassthroughStreamWithLogger(provider = null, reqLogger = n
     connectionId,
     body,
     onStreamComplete,
-    apiKey
+    apiKey,
+    streamState
   });
 }

--- a/tests/unit/streaming-interrupted-detail.test.js
+++ b/tests/unit/streaming-interrupted-detail.test.js
@@ -13,6 +13,7 @@ vi.mock("@/lib/usageDb.js", () => ({
 }));
 
 import { buildOnStreamComplete } from "../../open-sse/handlers/chatCore/streamingHandler.js";
+import { createPassthroughStreamWithLogger } from "../../open-sse/utils/stream.js";
 
 const ctx = {
   provider: "testprov",
@@ -77,5 +78,74 @@ describe("interrupted streaming request detail", () => {
 
     expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
     expect(mocks.saveRequestDetail.mock.calls[0][0].providerResponse).toContain("stall_timeout");
+  });
+
+  it("recovers partial provider usage from streamState when abandon fires after chunks", () => {
+    const { onStreamAbandoned, streamState } = buildOnStreamComplete({ ...ctx });
+    // Simulate transform stream having populated partial usage
+    streamState.usage = { prompt_tokens: 100, completion_tokens: 42 };
+    streamState.content = "partial response so far";
+    onStreamAbandoned("client_disconnected");
+
+    const detail = mocks.saveRequestDetail.mock.calls[0][0];
+    expect(detail.tokens.prompt_tokens).toBe(100);
+    expect(detail.tokens.completion_tokens).toBe(42);
+    expect(detail.status).toBe("cancelled");
+    // usage writer must also be called when we have valid tokens
+    expect(mocks.saveRequestUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses input estimate when provider usage missing but output content available", () => {
+    const { onStreamAbandoned, streamState } = buildOnStreamComplete({ ...ctx });
+    // No provider usage but content was streaming
+    streamState.usage = null;
+    streamState.content = "hello world this is partial";
+    onStreamAbandoned("stall_timeout");
+
+    const detail = mocks.saveRequestDetail.mock.calls[0][0];
+    // prompt_tokens should come from body estimate (non-zero)
+    expect(detail.tokens.prompt_tokens).toBeGreaterThan(0);
+    expect(detail.status).toBe("cancelled");
+  });
+
+  it("returns streamState object from buildOnStreamComplete", () => {
+    const { streamState } = buildOnStreamComplete({ ...ctx });
+    expect(streamState).toBeDefined();
+    expect(streamState).toHaveProperty("usage");
+    expect(streamState).toHaveProperty("content");
+    expect(streamState).toHaveProperty("thinking");
+    expect(streamState).toHaveProperty("ttftAt");
+  });
+
+  it("does not double-finalize when a late completion races after abandon", () => {
+    const { onStreamComplete, onStreamAbandoned } = buildOnStreamComplete({ ...ctx });
+    onStreamAbandoned("client_disconnected");
+    onStreamComplete({ content: "late eof" }, { prompt_tokens: 9, completion_tokens: 9 }, Date.now());
+
+    expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
+    expect(mocks.saveRequestDetail.mock.calls[0][0].status).toBe("cancelled");
+  });
+
+  it("populates streamState from live SSE chunks (passthrough)", async () => {
+    const streamState = { usage: null, content: "", thinking: "", ttftAt: null };
+    const ts = createPassthroughStreamWithLogger(
+      "testprov", null, "test-model", "conn-x",
+      { messages: [{ role: "user", content: "hi" }] }, null, "key", streamState
+    );
+    const writer = ts.writable.getWriter();
+    const reader = ts.readable.getReader();
+    const chunk = { choices: [{ delta: { content: "hello world" } }], usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 } };
+    // Start the read first: Node 22 TransformStream does not run transform()
+    // until the readable side has demand.
+    const readPromise = reader.read();
+    await writer.write(new TextEncoder().encode(`data: ${JSON.stringify(chunk)}\n\n`));
+    await readPromise;
+
+    expect(streamState.content).toBe("hello world");
+    expect(streamState.usage).toBeTruthy();
+    expect(streamState.ttftAt).toBeTruthy();
+
+    await reader.cancel().catch(() => {});
+    await writer.abort().catch(() => {});
   });
 });

--- a/tests/unit/streaming-interrupted-detail.test.js
+++ b/tests/unit/streaming-interrupted-detail.test.js
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  saveRequestDetail: vi.fn(),
+  saveRequestUsage: vi.fn(),
+  appendRequestLog: vi.fn(),
+}));
+
+vi.mock("@/lib/usageDb.js", () => ({
+  saveRequestDetail: mocks.saveRequestDetail,
+  saveRequestUsage: mocks.saveRequestUsage,
+  appendRequestLog: mocks.appendRequestLog,
+}));
+
+import { buildOnStreamComplete } from "../../open-sse/handlers/chatCore/streamingHandler.js";
+
+const ctx = {
+  provider: "testprov",
+  model: "test-model",
+  connectionId: "conn-12345678",
+  apiKey: "client-key",
+  requestStartTime: Date.now() - 1000,
+  body: { messages: [{ role: "user", content: "hi" }] },
+  stream: true,
+  finalBody: null,
+  translatedBody: null,
+  clientRawRequest: { endpoint: "/v1/chat/completions" },
+  pxpipe: undefined,
+  reqTag: "T1",
+  log: null,
+};
+
+describe("interrupted streaming request detail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.saveRequestDetail.mockResolvedValue(undefined);
+    mocks.saveRequestUsage.mockResolvedValue(undefined);
+  });
+
+  it("finalizes the placeholder row as cancelled with the same streamDetailId", () => {
+    const { onStreamAbandoned, streamDetailId } = buildOnStreamComplete({ ...ctx });
+    onStreamAbandoned("client_disconnected");
+
+    expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
+    const detail = mocks.saveRequestDetail.mock.calls[0][0];
+    expect(detail.id).toBe(streamDetailId);
+    expect(detail.status).toBe("cancelled");
+    expect(detail.response.content).toContain("interrupted");
+    expect(detail.response.content).toContain("client_disconnected");
+    expect(detail.tokens).toEqual({ prompt_tokens: 0, completion_tokens: 0 });
+  });
+
+  it("does not overwrite after normal completion", () => {
+    const { onStreamComplete, onStreamAbandoned } = buildOnStreamComplete({ ...ctx });
+    onStreamComplete({ content: "done" }, { prompt_tokens: 5, completion_tokens: 7 }, Date.now());
+    onStreamAbandoned("client_disconnected");
+
+    expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
+    expect(mocks.saveRequestDetail.mock.calls[0][0].status).toBe("success");
+  });
+
+  it("keeps normal completion behavior intact (success row + usage save)", () => {
+    const { onStreamComplete, streamDetailId } = buildOnStreamComplete({ ...ctx });
+    onStreamComplete({ content: "ok" }, { prompt_tokens: 3, completion_tokens: 4 }, null);
+
+    const detail = mocks.saveRequestDetail.mock.calls[0][0];
+    expect(detail.id).toBe(streamDetailId);
+    expect(detail.status).toBe("success");
+    expect(detail.response.content).toBe("ok");
+    expect(mocks.saveRequestUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("abandons only once even if both disconnect and error fire", () => {
+    const { onStreamAbandoned } = buildOnStreamComplete({ ...ctx });
+    onStreamAbandoned("stall_timeout");
+    onStreamAbandoned("client_disconnected");
+
+    expect(mocks.saveRequestDetail).toHaveBeenCalledTimes(1);
+    expect(mocks.saveRequestDetail.mock.calls[0][0].providerResponse).toContain("stall_timeout");
+  });
+});


### PR DESCRIPTION
## Problem

When a client disconnects before the upstream SSE stream completes, `flush()` on the `TransformStream` never runs. As a result, `onStreamComplete` never fires, and this leaves two accounting gaps:

1. The `requestDetails` row stays at `[Streaming in progress...]` with status `success` and tokens 0/0.
2. No `usageHistory` row is written, so prompt tokens already consumed at the provider are silently dropped from accounting.

Production audit on this deployment (v0.5.50 through v0.5.55, ~200 req/h): 37 to 73 percent of streaming requests end in this state, depending on client disconnect patterns.

## What this PR does

The first commit is PR #3175 itself (finalize interrupted `requestDetails` as `cancelled`). The second commit builds on it and additionally recovers the usage accounting:

1. `buildOnStreamComplete()` creates a mutable `streamState` object (`usage`, `content`, `thinking`, `ttftAt`) and returns it alongside the existing callbacks.
2. `createSSEStream()` accepts `streamState` and keeps it current via `syncState()` during `transform()` in both translate and passthrough modes.
3. `onStreamAbandoned()` reads provider reported partial usage from `streamState.usage`. When the provider did not send usage yet but partial output exists, it falls back to `estimateUsage(body, contentLength, sourceFormat)` so at least prompt tokens are recorded.
4. `saveUsageStats()` writes the recovered partial usage to `usageHistory`.
5. Both finalizers now share a `completed` guard, so a late upstream EOF racing a client disconnect cannot produce a double usage row. First finalizer wins.

The normal `flush()` path is unchanged.

## Tests

Nine focused tests, all passing:

1. The four original tests from #3175 (unchanged).
2. Partial provider usage is recovered from `streamState` after interruption.
3. Estimated usage is used when provider usage is absent but partial content exists.
4. `buildOnStreamComplete()` returns the expected `streamState` structure.
5. No double finalization when a late completion races after an abandon.
6. `streamState` is populated from live SSE chunks in passthrough mode.

Full suite verified against master: no new failures introduced (preexisting reds unchanged).

## Related

This PR includes and supersedes #3175. Both relate to issue #3090.
