### PR TITLE
feat(speed): send Anthropic fast mode via -fast model suffix

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -1,6 +1,7 @@
 import { detectFormat, getTargetFormat, resolveTransport } from "../services/provider.js";
 import { translateRequest } from "../translator/index.js";
 import { applyThinking, extractThinking, stripThinkingSuffix } from "../translator/concerns/thinkingUnified.js";
+import { applySpeed, hasSpeedSuffix, stripSpeedSuffix } from "../translator/concerns/speedTier.js";
 import { FORMATS } from "../translator/formats.js";
 import { normalizeClaudePassthrough, anchorClaudeCache } from "../translator/formats/claude.js";
 import { createStreamController } from "../utils/streamHandler.js";
@@ -93,7 +94,11 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   const targetFormat = modelTargetFormat || useTransport?.format || getTargetFormat(provider, credentials);
   if (useTransport && credentials) credentials.runtimeTransport = useTransport;
   const stripList = getModelStrip(alias, model);
-  const upstreamModel = getModelUpstreamId(alias, model);
+  // "-fast" opts into the provider's faster tier. Strip it before every model lookup
+  // so capabilities/thinking/upstream-id all resolve against the real model id; the
+  // provider-native field is set on the translated body further down.
+  const wantsFasterTier = hasSpeedSuffix(model);
+  const upstreamModel = getModelUpstreamId(alias, stripSpeedSuffix(model));
 
   // Inject provider-level thinking config override (only if client hasn't set)
   // on/off → extended type (body.thinking), none/low/medium/high → effort type (body.reasoning_effort)
@@ -193,6 +198,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     delete translatedBody._customToolNames;
     translatedBody.model = stripThinkingSuffix(upstreamModel);
     stripContinuityFields(translatedBody);
+  }
+
+  // Faster-tier opt-in: body.model is the real upstream id by now, so the capability
+  // lookup resolves. No-op when the model has no faster tier.
+  if (wantsFasterTier && applySpeed(provider, translatedBody)) {
+    log?.debug?.("SPEED", `${provider}/${translatedBody.model} → faster tier`);
   }
 
   // Dedupe duplicate built-in tools when equivalent MCP tools are present (Claude clients only).

--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -46,6 +46,9 @@ export const DEFAULT_CAPABILITIES = {
   thinkingFormat: null,
   thinkingCanDisable: true,  // false → model cannot turn thinking off (clamp to min instead of disable)
   thinkingRange: null,       // { min, max } for budget formats; null = no clamp
+  // faster-tier wire format — same model, more output tokens/s, premium priced.
+  // null → model has no faster tier. enum: claude-speed|openai-service-tier
+  speedFormat: null,
   // limits (tokens)
   contextWindow: 200000,
   maxOutput: 64000,
@@ -72,16 +75,18 @@ export function capabilitiesFromServiceKind(kind) {
  */
 export const MODEL_CAPABILITIES = {
   // Claude Opus 5, 4.6/4.7/4.8, and Kiro Sonnet 5 have 1M context + adaptive thinking (override generic claude pattern)
-  "claude-opus-5":     { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  // speedFormat: Anthropic fast mode is Opus 5 / Opus 4.8 only — it was removed on
+  // Opus 4.7 upstream, so 4.7 and older must NOT declare it.
+  "claude-opus-5":     { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", speedFormat: "claude-speed", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-5-thinking": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-5-agentic": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-5-thinking-agentic": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4.6":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4.7":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4-7":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
-  "claude-opus-4.8":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-4.8":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", speedFormat: "claude-speed", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4-6":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
-  "claude-opus-4-8":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
+  "claude-opus-4-8":   { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", speedFormat: "claude-speed", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4.8-thinking": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-opus-4-8-thinking": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },
   "claude-sonnet-4.6": { vision: true, reasoning: true, search: true, thinkingFormat: "claude-adaptive", contextWindow: 1000000, maxOutput: 128000 },

--- a/open-sse/translator/concerns/speedTier.js
+++ b/open-sse/translator/concerns/speedTier.js
@@ -1,0 +1,52 @@
+// Unified speed-tier normalization: extract client intent → apply provider-native field.
+// Config-driven: which models have a faster tier comes from capabilities.js
+// (`speedFormat`), never hardcoded per-model here. Mirrors thinkingUnified.js.
+//
+// Providers expose "run the same model faster" under different names, so the
+// capability names the wire format and this module maps it to the native field:
+//   claude-speed → body.speed = "fast"   (Anthropic fast mode)
+//
+// Intent is a "-fast" marker on the model id. It sits before the thinking suffix so
+// the two compose: "claude-opus-5-fast(low)" → model "claude-opus-5(low)" + fast tier.
+
+import { getCapabilitiesForModel } from "../../providers/capabilities.js";
+
+// "-fast", optionally followed by a thinking suffix "(level)".
+const SPEED_SUFFIX_RE = /-fast(\([^()]*\))?\s*$/;
+
+// speedFormat → the provider-native body field/value pair.
+const FORMAT_FIELDS = {
+  "claude-speed": { field: "speed", value: "fast" },
+};
+
+// True when the model id opts into the faster tier.
+export function hasSpeedSuffix(model) {
+  return typeof model === "string" && SPEED_SUFFIX_RE.test(model);
+}
+
+// Drop the "-fast" marker, keeping any thinking suffix intact (no-op when absent).
+// "claude-opus-5-fast(low)" → "claude-opus-5(low)"; "gpt-5.6-sol-fast" → "gpt-5.6-sol".
+export function stripSpeedSuffix(model) {
+  if (typeof model !== "string") return model;
+  return model.replace(SPEED_SUFFIX_RE, (_, thinkingSuffix) => thinkingSuffix || "");
+}
+
+/**
+ * Set the provider-native speed field on an already-translated body, in place.
+ *
+ * Call only when the request opted in (see `hasSpeedSuffix`); `body.model` is
+ * expected to be the real upstream id by this point. When the model has no
+ * `speedFormat` capability this is a no-op and the request runs at standard
+ * speed — a model that never had the tier (or lost it, as Opus 4.7 did) must not
+ * fail the whole request.
+ *
+ * @returns {boolean} true when a speed field was applied.
+ */
+export function applySpeed(provider, body) {
+  if (!body || typeof body !== "object") return false;
+  const { speedFormat } = getCapabilitiesForModel(provider, body.model);
+  const spec = FORMAT_FIELDS[speedFormat];
+  if (!spec) return false;
+  body[spec.field] = spec.value;
+  return true;
+}

--- a/tests/unit/speed-tier.test.js
+++ b/tests/unit/speed-tier.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySpeed,
+  hasSpeedSuffix,
+  stripSpeedSuffix,
+} from "../../open-sse/translator/concerns/speedTier.js";
+
+describe("speed tier suffix parsing", () => {
+  it("detects the -fast marker, alone or before a thinking suffix", () => {
+    expect(hasSpeedSuffix("claude-opus-5-fast")).toBe(true);
+    expect(hasSpeedSuffix("claude-opus-5-fast(low)")).toBe(true);
+    expect(hasSpeedSuffix("gpt-5.6-sol-fast")).toBe(true);
+  });
+
+  it("ignores models without the marker", () => {
+    expect(hasSpeedSuffix("claude-opus-5")).toBe(false);
+    expect(hasSpeedSuffix("claude-opus-5(max)")).toBe(false);
+    expect(hasSpeedSuffix(undefined)).toBe(false);
+  });
+
+  it("does not treat a non-trailing 'fast' as the marker", () => {
+    // "-review" virtual models must not be mangled into a speed opt-in.
+    expect(hasSpeedSuffix("gpt-5.4-fast-review")).toBe(false);
+    expect(stripSpeedSuffix("gpt-5.4-fast-review")).toBe("gpt-5.4-fast-review");
+  });
+
+  it("strips the marker while keeping the thinking suffix intact", () => {
+    expect(stripSpeedSuffix("claude-opus-5-fast")).toBe("claude-opus-5");
+    expect(stripSpeedSuffix("claude-opus-5-fast(low)")).toBe("claude-opus-5(low)");
+    expect(stripSpeedSuffix("gpt-5.6-sol-fast")).toBe("gpt-5.6-sol");
+  });
+
+  it("is a no-op for models without the marker", () => {
+    expect(stripSpeedSuffix("claude-opus-5(max)")).toBe("claude-opus-5(max)");
+  });
+});
+
+describe("applySpeed", () => {
+  it("sets Anthropic fast mode on the models that support it", () => {
+    for (const model of ["claude-opus-5", "claude-opus-4-8", "claude-opus-4.8"]) {
+      const body = { model };
+      expect(applySpeed("claude", body)).toBe(true);
+      expect(body.speed).toBe("fast");
+    }
+  });
+
+  it("leaves the body untouched for models with no faster tier", () => {
+    // Anthropic removed fast mode on Opus 4.7 — declaring it would 400 the request.
+    for (const [provider, model] of [
+      ["claude", "claude-opus-4-7"],
+      ["claude", "claude-sonnet-5"],
+      ["claude", "claude-haiku-4-5-20251001"],
+      ["codex", "gpt-5.6-sol"],
+    ]) {
+      const body = { model };
+      expect(applySpeed(provider, body)).toBe(false);
+      expect(body).toEqual({ model });
+    }
+  });
+
+  it("tolerates a missing or non-object body", () => {
+    expect(applySpeed("claude", null)).toBe(false);
+    expect(applySpeed("claude", undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`providers/registry/claude.js` sends `fast-mode-2026-02-01` in the `Anthropic-Beta` header, but Anthropic fast mode requires the beta flag **and** a top-level `speed: "fast"` on the request body.

Nothing sets `speed`, and no translator preserves it from the client body either (`request/openai-to-claude.js` has no such field, unlike `request/openai-responses.js:423`, which explicitly forwards `service_tier`). The beta flag is therefore inert today and every request runs at standard speed.

## Approach

Follows the existing `thinking` precedent rather than special-casing the provider:

- `speedFormat` capability in `providers/capabilities.js` — config-driven, sibling of `thinkingFormat`
- `translator/concerns/speedTier.js` — maps the intent to the provider's native field
- intent is a `-fast` marker on the model id, stripped in `chatCore.js` *before* every model lookup, so capabilities / thinking / upstream-id all resolve against the real model

The marker composes with the thinking suffix:
`claude-opus-5-fast(low)` → model `claude-opus-5(low)` + fast tier.

## Scope

Only Opus 5 and Opus 4.8 declare `speedFormat`. Opus 4.7 deliberately does **not** — fast mode was removed there upstream. A model without the capability drops the marker and runs at standard speed rather than failing.

The capability is a named wire format (`claude-speed`) rather than a boolean, so another provider's tier can be added as a second entry in the same map without touching the call site.

## Verification

Tested end-to-end against a live Claude Code OAuth account:

| request | result |
|---|---|
| `speed: "turbo_xyz"` | `400 "speed: Input should be 'standard' or 'fast'"` |
| `speed: "fast"` | `400 "Fast mode is not enabled for your organization. An organization admin must enable this feature."` |

The first confirms the field reaches the API and is validated; the second is an org entitlement I don't have, not a wiring problem.

**Worth flagging:** that second case is a hard `400`, not a silent downgrade. An org without the entitlement gets a failed request rather than a slow one, so the marker is only safe where fast mode is actually enabled. Happy to gate it behind a config flag or add a friendlier error if you'd prefer.

Also checked:

- `tests/unit/speed-tier.test.js` — 8 cases, including `gpt-5.4-fast-review` not being mistaken for the marker
- `verify-alias.mjs` — byte-for-byte equal (117 tokens)
- `verify-oauth-urls.mjs` — byte-for-byte equal
- provider snapshot unchanged

## Note on Codex

An earlier draft also mapped `openai-service-tier` → `service_tier: "priority"` for the gpt-5.6 family, since `executors/codex.js` already allowlists the field and normalizes `"fast"` → `"priority"`. I dropped it after measuring: on a ChatGPT-plan Codex account the field is accepted (HTTP 200) but produced no speedup across repeated runs (47.9 / 48.3 tok/s standard vs 44.7 / 43.8 tok/s with `priority`). Priority processing appears to be an OpenAI platform-API feature that the subscription backend ignores. Mentioning it in case you have an account tier where it does apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
