### PR TITLE
feat(backoff): make 429 cooldown schedule configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,14 @@ DATA_DIR=/var/lib/9router
 PORT=20128
 NODE_ENV=production
 
+# Optional 429 account/model lock backoff. Defaults retain the current schedule:
+# 2s, 4s, 8s... capped at 5 minutes, with at most 15 backoff levels.
+# Each value is optional and must be a positive integer. Invalid values use that
+# knob's default; a max below the base is rejected as a complete schedule.
+# BACKOFF_BASE_MS=2000
+# BACKOFF_MAX_MS=300000
+# BACKOFF_MAX_LEVEL=15
+
 # Recommended security and ops variables
 API_KEY_SECRET=endpoint-proxy-api-key-secret
 MACHINE_ID_SALT=endpoint-proxy-salt

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -64,6 +64,25 @@ docker run -d \
   decolua/9router:latest
 ```
 
+### Configure 429 account backoff
+
+When an upstream rate limit is detected, 9Router temporarily locks the affected
+account/model using exponential backoff. The default is unchanged: `2s`, `4s`,
+`8s` and so on, capped at `5 minutes` for up to `15` levels. Operators can tune
+that schedule for providers with different quota-reset windows:
+
+```bash
+-e BACKOFF_BASE_MS=2000 \
+-e BACKOFF_MAX_MS=300000 \
+-e BACKOFF_MAX_LEVEL=15
+```
+
+Each value is optional and must be a positive integer. Malformed values use
+that knob's default; a cap below the base is rejected as a contradictory
+schedule and uses the unchanged defaults. These settings govern account/model
+locks after rate-limit fallback, not provider-specific retry mechanisms or
+provider `Retry-After` hints.
+
 ## Optional Headroom sidecar
 
 The 9Router image does not bundle Python or Headroom. To use Headroom in Docker, run it as a separate service and point 9Router at that proxy:

--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -28,12 +28,39 @@ export const DEFAULT_ERROR_MESSAGES = {
   504: "Gateway timeout"
 };
 
-// Exponential backoff config for rate limits
-export const BACKOFF_CONFIG = {
+// Exponential backoff config for rate limits. The defaults preserve the
+// historical 2s -> 5m schedule when no environment variables are supplied.
+const DEFAULT_BACKOFF_CONFIG = Object.freeze({
   base: 2000,
   max: 5 * 60 * 1000,
   maxLevel: 15
-};
+});
+
+function parsePositiveInteger(value) {
+  if (typeof value !== "string" || !/^\d+$/.test(value.trim())) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function resolveBackoffConfig(env = process.env) {
+  const base = parsePositiveInteger(env.BACKOFF_BASE_MS);
+  const max = parsePositiveInteger(env.BACKOFF_MAX_MS);
+  const maxLevel = parsePositiveInteger(env.BACKOFF_MAX_LEVEL);
+
+  const config = {
+    base: base ?? DEFAULT_BACKOFF_CONFIG.base,
+    max: max ?? DEFAULT_BACKOFF_CONFIG.max,
+    maxLevel: maxLevel ?? DEFAULT_BACKOFF_CONFIG.maxLevel
+  };
+
+  // Each knob can be tuned independently, but a cap below the initial delay
+  // is contradictory and would make the schedule hard to reason about.
+  if (config.max < config.base) return DEFAULT_BACKOFF_CONFIG;
+
+  return Object.freeze(config);
+}
+
+export const BACKOFF_CONFIG = resolveBackoffConfig();
 
 // Default cooldown for transient/unknown errors
 export const TRANSIENT_COOLDOWN_MS = 30 * 1000;

--- a/tests/unit/rate-limit-backoff-config.test.js
+++ b/tests/unit/rate-limit-backoff-config.test.js
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ENV_KEYS = ["BACKOFF_BASE_MS", "BACKOFF_MAX_MS", "BACKOFF_MAX_LEVEL"];
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+function clearBackoffEnv() {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+async function loadBackoff(config = {}) {
+  clearBackoffEnv();
+  Object.assign(process.env, config);
+  vi.resetModules();
+  const [errorConfig, accountFallback] = await Promise.all([
+    import("../../open-sse/config/errorConfig.js"),
+    import("../../open-sse/services/accountFallback.js")
+  ]);
+  return { ...errorConfig, ...accountFallback };
+}
+
+afterEach(() => {
+  clearBackoffEnv();
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value !== undefined) process.env[key] = value;
+  }
+  vi.resetModules();
+});
+
+describe("configurable 429 account backoff (#3343)", () => {
+  it("keeps the historical schedule when no environment configuration is supplied", async () => {
+    const { BACKOFF_CONFIG, getQuotaCooldown, checkFallbackError } = await loadBackoff();
+
+    expect(BACKOFF_CONFIG).toEqual({ base: 2000, max: 300000, maxLevel: 15 });
+    expect(getQuotaCooldown(1)).toBe(2000);
+    expect(getQuotaCooldown(2)).toBe(4000);
+    expect(checkFallbackError(429, "", 0)).toMatchObject({ cooldownMs: 2000, newBackoffLevel: 1 });
+  });
+
+  it("uses a configured schedule for both 429 status and rate-limit text matches", async () => {
+    const { BACKOFF_CONFIG, getQuotaCooldown, checkFallbackError, applyErrorState } = await loadBackoff({
+      BACKOFF_BASE_MS: "3000",
+      BACKOFF_MAX_MS: "10000",
+      BACKOFF_MAX_LEVEL: "5"
+    });
+
+    expect(BACKOFF_CONFIG).toEqual({ base: 3000, max: 10000, maxLevel: 5 });
+    expect(getQuotaCooldown(1)).toBe(3000);
+    expect(getQuotaCooldown(3)).toBe(10000);
+    expect(checkFallbackError(429, "", 0)).toMatchObject({ cooldownMs: 3000, newBackoffLevel: 1 });
+    expect(checkFallbackError(500, "provider rate limit", 1)).toMatchObject({ cooldownMs: 6000, newBackoffLevel: 2 });
+    expect(checkFallbackError(429, "", 5)).toMatchObject({ cooldownMs: 10000, newBackoffLevel: 5 });
+
+    const nextAccount = applyErrorState({ id: "account-1", backoffLevel: 2 }, 429, "rate limit");
+    expect(nextAccount.backoffLevel).toBe(3);
+    expect(new Date(nextAccount.rateLimitedUntil).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("lets each valid knob override its default without requiring the other knobs", async () => {
+    const { BACKOFF_CONFIG, getQuotaCooldown } = await loadBackoff({
+      BACKOFF_MAX_MS: "10000"
+    });
+
+    expect(BACKOFF_CONFIG).toEqual({ base: 2000, max: 10000, maxLevel: 15 });
+    expect(getQuotaCooldown(4)).toBe(10000);
+  });
+
+  it("falls back per invalid knob and rejects a contradictory schedule", async () => {
+    const { BACKOFF_CONFIG, getQuotaCooldown } = await loadBackoff({
+      BACKOFF_BASE_MS: "5000",
+      BACKOFF_MAX_MS: "2000",
+      BACKOFF_MAX_LEVEL: "not-a-number"
+    });
+
+    expect(BACKOFF_CONFIG).toEqual({ base: 2000, max: 300000, maxLevel: 15 });
+    expect(getQuotaCooldown(1)).toBe(2000);
+
+    const withMalformedLevel = await loadBackoff({
+      BACKOFF_BASE_MS: "3000",
+      BACKOFF_MAX_MS: "10000",
+      BACKOFF_MAX_LEVEL: "not-a-number"
+    });
+    expect(withMalformedLevel.BACKOFF_CONFIG).toEqual({ base: 3000, max: 10000, maxLevel: 15 });
+  });
+});


### PR DESCRIPTION
## Summary

429 fallback locks used one fixed schedule for every provider: 2s, 4s, 8s, capped at 5 minutes. That works for some quota windows, but is too aggressive for others and unnecessarily long for providers that recover faster.

This adds three optional environment variables for tuning that account/model lock schedule:

- `BACKOFF_BASE_MS`  first cooldown delay (default: `2000`)
- `BACKOFF_MAX_MS`  maximum cooldown delay (default: `300000`)
- `BACKOFF_MAX_LEVEL`  maximum stored backoff level (default: `15`)

Each setting can be changed independently. Invalid values use that setting's existing default. A cap below the base delay is rejected as a contradictory configuration and retains the complete default schedule.

The default behavior is unchanged when no variables are set.

## Scope

- Applied only to the existing account/model lock backoff used after rate-limit fallback.
- Documented in `.env.example` and `DOCKER.md`.
- Deliberately does not add a global `BACKOFF_DISABLED` switch, provider-specific overrides, or alter provider `Retry-After` handling.

## Verification

- Added regression coverage for defaults, custom status/text-rule cooldowns, max-level/cap behavior, independent overrides, malformed values, contradictory values, and persisted account state.
- Focused suite: `25` tests passed across the backoff, account-reset, Kiro error-rule, and executor-retry suites.
- `eslint` passed for changed JavaScript files.
- `git diff --check` passed.

Closes #3343
