### PR TITLE
fix(codebuddy-intl): preserve caller system prompts

### DIFF
--- a/open-sse/config/appConstants.js
+++ b/open-sse/config/appConstants.js
@@ -171,6 +171,7 @@ export const LOAD_CODE_ASSIST_METADATA = {
 
 // System prompts
 export const CLAUDE_SYSTEM_PROMPT = "You are Claude Code, Anthropic's official CLI for Claude.";
+export const CODEBUDDY_INTL_SYSTEM_PROMPT = "You are CodeBuddy Code.";
 export const ANTIGRAVITY_DEFAULT_SYSTEM = "You are Antigravity, a powerful agentic AI coding assistant designed by the Google Deepmind team working on Advanced Agentic Coding.You are pair programming with a USER to solve their coding task. The task may require creating a new codebase, modifying or debugging an existing codebase, or simply answering a question.**Absolute paths only****Proactiveness**";
 
 // Derive từ registry oauth.refreshLeadMs

--- a/open-sse/executors/codebuddy-intl.js
+++ b/open-sse/executors/codebuddy-intl.js
@@ -1,4 +1,15 @@
 import { DefaultExecutor } from "./default.js";
+import { CODEBUDDY_INTL_SYSTEM_PROMPT } from "../config/appConstants.js";
+import { ROLE } from "../translator/schema/index.js";
+
+function contentToText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((block) => (typeof block?.text === "string" ? block.text : ""))
+    .filter((text) => text.trim())
+    .join("\n");
+}
 
 /**
  * CodeBuddyIntlExecutor — talks to https://www.codebuddy.ai/v2/chat/completions
@@ -24,13 +35,21 @@ export class CodeBuddyIntlExecutor extends DefaultExecutor {
       transformed.reasoning_summary = "auto";
     }
 
-    // CodeBuddy rejects plain OpenAI shape (11101 invalid request): needs a
+    // CodeBuddy rejects plain OpenAI shape (11101 invalid request): it needs a
     // leading system prompt + user content as typed blocks, not a bare string.
+    // Keep the required identity first, but do not discard caller instructions.
     const source = Array.isArray(transformed.messages) ? transformed.messages : [];
-    transformed.messages = [{ role: "system", content: "You are CodeBuddy Code." }];
+    const callerInstructions = source
+      .filter((message) => message && [ROLE.SYSTEM, ROLE.DEVELOPER].includes(message.role))
+      .map((message) => contentToText(message.content))
+      .filter((text) => text.trim());
+    transformed.messages = [{
+      role: ROLE.SYSTEM,
+      content: [CODEBUDDY_INTL_SYSTEM_PROMPT, ...callerInstructions].join("\n\n"),
+    }];
     for (const message of source) {
-      if (!message || typeof message !== "object" || ["system", "developer"].includes(message.role)) continue;
-      if (message.role === "user" && typeof message.content === "string") {
+      if (!message || typeof message !== "object" || [ROLE.SYSTEM, ROLE.DEVELOPER].includes(message.role)) continue;
+      if (message.role === ROLE.USER && typeof message.content === "string") {
         transformed.messages.push({ ...message, content: [{ type: "text", text: message.content }] });
       } else {
         transformed.messages.push({ ...message });

--- a/tests/unit/codebuddy-intl-system-prompt-3344.test.js
+++ b/tests/unit/codebuddy-intl-system-prompt-3344.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { CodeBuddyIntlExecutor } from "../../open-sse/executors/codebuddy-intl.js";
+
+describe("CodeBuddyIntlExecutor system prompt handling (#3344)", () => {
+  const executor = new CodeBuddyIntlExecutor();
+
+  it("keeps caller system and developer instructions after the required CodeBuddy prompt", () => {
+    const out = executor.transformRequest("glm-5.2", {
+      messages: [
+        { role: "system", content: "Follow the repository conventions." },
+        { role: "developer", content: "Run targeted tests before replying." },
+        { role: "user", content: "Fix the failing test." },
+      ],
+    }, true, {});
+
+    expect(out.messages).toEqual([
+      {
+        role: "system",
+        content: "You are CodeBuddy Code.\n\nFollow the repository conventions.\n\nRun targeted tests before replying.",
+      },
+      { role: "user", content: [{ type: "text", text: "Fix the failing test." }] },
+    ]);
+  });
+
+  it("preserves text from typed system and developer content blocks", () => {
+    const out = executor.transformRequest("glm-5.2", {
+      messages: [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "First system instruction." },
+            { type: "text", text: "Second system instruction." },
+          ],
+        },
+        { role: "developer", content: [{ type: "input_text", text: "Developer instruction." }] },
+        { role: "user", content: "Continue." },
+      ],
+    }, true, {});
+
+    expect(out.messages[0]).toEqual({
+      role: "system",
+      content: "You are CodeBuddy Code.\n\nFirst system instruction.\nSecond system instruction.\n\nDeveloper instruction.",
+    });
+    expect(out.messages[1]).toEqual({ role: "user", content: [{ type: "text", text: "Continue." }] });
+  });
+
+  it("keeps the required CodeBuddy system prompt when the caller has no instructions", () => {
+    const out = executor.transformRequest("glm-5.2", {
+      messages: [{ role: "user", content: "Hello." }],
+    }, true, {});
+
+    expect(out.messages[0]).toEqual({ role: "system", content: "You are CodeBuddy Code." });
+  });
+});


### PR DESCRIPTION
Closes #3344

## Summary

CodeBuddy Intl needs its own leading system message, but the executor was replacing the whole system/developer context to add it. This kept the required CodeBuddy identity first and silently removed instructions sent by clients such as OpenCode.

This change keeps the required CodeBuddy message first, then appends caller system and developer instructions in their original order. Text from typed content blocks is preserved as well. User messages still use the typed text blocks required by the gateway.

## Tests

- Added regression coverage for string system/developer messages, typed text blocks, and requests with no caller instructions.
- Focused CodeBuddy tests: 8 passed.
- ESLint and git diff --check passed.
- Ran the unit suite. It still has existing failures outside this change in Kiro, Cursor, database, auth, and cloud test areas; the new CodeBuddy coverage passes.

## Scope

This fixes the missing caller-prompt behavior only. The separate Kimi K3 catalog request in the issue is left out because the provider catalog was not verified here.