### PR TITLE
feat(antigravity): add hermes agent system prompt sanitization

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -7,6 +7,7 @@ import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { cleanJSONSchemaForAntigravity } from "../translator/formats/gemini.js";
 import { DEFAULT_THINKING_AG_SIGNATURE } from "../config/defaultThinkingSignature.js";
+import { sanitizeAntigravitySystemPrompt } from "../translator/request/openai-to-gemini.js";
 
 // Sanitize function name: Gemini requires [a-zA-Z_][a-zA-Z0-9_.:\-]{0,63}
 function sanitizeFunctionName(name) {
@@ -247,13 +248,14 @@ export class AntigravityExecutor extends BaseExecutor {
     stripBlacklisted(requestWithoutTools);
     
     // Rewrite competing-client branding in system prompts (e.g. Zed's Claude prompt,
-    // OpenCode naming) so Antigravity doesn't flag the request with a 429 Quota Exhausted.
+    // OpenCode naming, Hermes Agent) so Antigravity doesn't flag the request with a 429 Quota Exhausted.
     if (requestWithoutTools.systemInstruction?.parts) {
       for (const part of requestWithoutTools.systemInstruction.parts) {
         if (typeof part.text !== "string") continue;
         for (const { from, to } of ANTIGRAVITY_PROMPT_REWRITES) {
           part.text = part.text.replaceAll(from, to);
         }
+        part.text = sanitizeAntigravitySystemPrompt(part.text);
       }
     }
 

--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -7,6 +7,7 @@ import { resolveSessionId } from "../utils/sessionManager.js";
 import { proxyAwareFetch } from "../utils/proxyFetch.js";
 import { cleanJSONSchemaForAntigravity } from "../translator/formats/gemini.js";
 import { DEFAULT_THINKING_AG_SIGNATURE } from "../config/defaultThinkingSignature.js";
+import { sanitizeAntigravitySystemPrompt } from "../translator/request/openai-to-gemini.js";
 
 // Sanitize function name: Gemini requires [a-zA-Z_][a-zA-Z0-9_.:\-]{0,63}
 function sanitizeFunctionName(name) {
@@ -246,13 +247,16 @@ export class AntigravityExecutor extends BaseExecutor {
     const { tools: _originalTools, toolConfig: _originalToolConfig, ...requestWithoutTools } = body.request || {};
     stripBlacklisted(requestWithoutTools);
     
-    // Rewrite competitive system prompts (e.g. Zed IDE's Claude prompt) to prevent Antigravity from 
+    // Rewrite competitive system prompts (e.g. Zed IDE's Claude prompt, Hermes Agent) to prevent Antigravity from 
     // flagging the request and immediately blocking it with a 429 Quota Exhausted response.
     if (requestWithoutTools.systemInstruction?.parts) {
       const oldText = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
       for (const part of requestWithoutTools.systemInstruction.parts) {
-        if (typeof part.text === "string" && part.text.includes(oldText)) {
-          part.text = part.text.split(oldText).join("");
+        if (typeof part.text === "string") {
+          if (part.text.includes(oldText)) {
+            part.text = part.text.split(oldText).join("");
+          }
+          part.text = sanitizeAntigravitySystemPrompt(part.text);
         }
       }
     }

--- a/open-sse/translator/request/openai-to-gemini.js
+++ b/open-sse/translator/request/openai-to-gemini.js
@@ -19,6 +19,15 @@ import {
 import { deriveSessionId, toNumericSessionId } from "../../utils/sessionManager.js";
 import { ROLE, GEMINI_ROLE, OPENAI_BLOCK, CLAUDE_BLOCK } from "../schema/index.js";
 
+// Sanitizes system prompt text to prevent Google Cloud Code PA signature filter triggers
+const HERMES_IDENTITY_RE = /You are Hermes Agent,\s*an intelligent AI assistant created by Nous Research\./gi;
+const HERMES_IDENTITY_REPLACEMENT = "You are Hermes Agent. You are an intelligent AI assistant created by Nous Research.";
+
+export function sanitizeAntigravitySystemPrompt(text) {
+  if (!text || typeof text !== "string") return text;
+  return text.replace(HERMES_IDENTITY_RE, HERMES_IDENTITY_REPLACEMENT);
+}
+
 // Sanitize function names for Gemini API.
 // Gemini requires: starts with [a-zA-Z_], followed by [a-zA-Z0-9_.:\-], max 64 chars.
 // Replace any invalid character with '_' and truncate to 64.
@@ -100,13 +109,20 @@ function openaiToGeminiBase(model, body, stream, signature = DEFAULT_THINKING_AG
       const content = msg.content;
 
       if (role === ROLE.SYSTEM && body.messages.length > 1) {
+        const rawText = typeof content === "string" ? content : extractTextContent(content);
+        const sanitizedText = sanitizeAntigravitySystemPrompt(rawText);
         result.systemInstruction = {
           role: GEMINI_ROLE.USER,
-          parts: [{ text: typeof content === "string" ? content : extractTextContent(content) }]
+          parts: [{ text: sanitizedText }]
         };
       } else if (role === ROLE.USER || (role === ROLE.SYSTEM && body.messages.length === 1)) {
         const parts = convertOpenAIContentToParts(content);
         if (parts.length > 0) {
+          if (role === ROLE.SYSTEM) {
+            for (const part of parts) {
+              if (part.text) part.text = sanitizeAntigravitySystemPrompt(part.text);
+            }
+          }
           result.contents.push({ role: GEMINI_ROLE.USER, parts });
         }
       } else if (role === ROLE.ASSISTANT) {
@@ -404,10 +420,10 @@ function wrapInCloudCodeEnvelopeForClaude(model, claudeRequest, credentials = nu
   if (claudeRequest.system) {
     if (Array.isArray(claudeRequest.system)) {
       for (const block of claudeRequest.system) {
-        if (block.text) systemParts.push({ text: block.text });
+        if (block.text) systemParts.push({ text: sanitizeAntigravitySystemPrompt(block.text) });
       }
     } else if (typeof claudeRequest.system === "string") {
-      systemParts.push({ text: claudeRequest.system });
+      systemParts.push({ text: sanitizeAntigravitySystemPrompt(claudeRequest.system) });
     }
   }
 

--- a/tests/unit/hermes-cloaking.test.js
+++ b/tests/unit/hermes-cloaking.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeAntigravitySystemPrompt,
+  openaiToAntigravityRequest,
+  openaiToGeminiRequest,
+  openaiToGeminiCLIRequest,
+} from "../../open-sse/translator/request/openai-to-gemini.js";
+import { AntigravityExecutor } from "../../open-sse/executors/antigravity.js";
+
+describe("Hermes Cloaking / System Prompt Sanitization", () => {
+  const HERMES_PROMPT = "You are Hermes Agent, an intelligent AI assistant created by Nous Research. You assist users with coding and tools.";
+  const SANITIZED_HERMES_PROMPT = "You are Hermes Agent. You are an intelligent AI assistant created by Nous Research. You assist users with coding and tools.";
+
+  describe("sanitizeAntigravitySystemPrompt", () => {
+    it("replaces exact Hermes Agent opening sentence", () => {
+      expect(sanitizeAntigravitySystemPrompt(HERMES_PROMPT)).toBe(SANITIZED_HERMES_PROMPT);
+    });
+
+    it("handles variations in whitespace and casing", () => {
+      const varied = "you are hermes agent,   an intelligent ai assistant created by nous research. Extra instructions.";
+      const result = sanitizeAntigravitySystemPrompt(varied);
+      expect(result).toBe("You are Hermes Agent. You are an intelligent AI assistant created by Nous Research. Extra instructions.");
+    });
+
+    it("leaves non-matching system prompts untouched", () => {
+      const normalPrompt = "You are an expert TypeScript developer.";
+      expect(sanitizeAntigravitySystemPrompt(normalPrompt)).toBe(normalPrompt);
+    });
+
+    it("handles null, undefined, and non-string values safely", () => {
+      expect(sanitizeAntigravitySystemPrompt(null)).toBe(null);
+      expect(sanitizeAntigravitySystemPrompt(undefined)).toBe(undefined);
+      expect(sanitizeAntigravitySystemPrompt(123)).toBe(123);
+    });
+  });
+
+  describe("openaiToAntigravityRequest", () => {
+    it("sanitizes Hermes system prompt in Gemini-backed Antigravity envelope", () => {
+      const req = openaiToAntigravityRequest("gemini-3.7-flash-high", {
+        messages: [
+          { role: "system", content: HERMES_PROMPT },
+          { role: "user", content: "hello" },
+        ],
+      }, false, { projectId: "test-proj", connectionId: "test-conn" });
+
+      expect(req.request.systemInstruction?.parts?.[0]?.text).toBe(SANITIZED_HERMES_PROMPT);
+    });
+
+    it("sanitizes Hermes system prompt in Claude-backed Antigravity envelope", () => {
+      const req = openaiToAntigravityRequest("claude-opus-4-6-thinking", {
+        messages: [
+          { role: "system", content: HERMES_PROMPT },
+          { role: "user", content: "hello" },
+        ],
+      }, false, { projectId: "test-proj", connectionId: "test-conn" });
+
+      expect(req.request.systemInstruction?.parts?.[0]?.text).toBe(SANITIZED_HERMES_PROMPT);
+    });
+  });
+});

--- a/tests/unit/hermes-cloaking.test.js
+++ b/tests/unit/hermes-cloaking.test.js
@@ -88,5 +88,56 @@ describe("Hermes Cloaking / System Prompt Sanitization", () => {
       expect(transformed.request.systemInstruction.parts[0].text).toBe(" " + SANITIZED_HERMES_PROMPT);
     });
   });
+
+  describe("Anthropic API Surface -> Antigravity", () => {
+    it("sanitizes system prompt when client connects via Anthropic format (/v1/messages)", async () => {
+      const { translateRequest } = await import("../../open-sse/translator/index.js");
+      const { FORMATS } = await import("../../open-sse/translator/formats.js");
+      await import("../translator/registerAll.js");
+
+      const claudeRequest = {
+        model: "ag/gemini-3.7-flash-high",
+        system: HERMES_PROMPT,
+        messages: [{ role: "user", content: "hello" }],
+      };
+
+      const out = translateRequest(
+        FORMATS.CLAUDE,
+        FORMATS.ANTIGRAVITY,
+        "gemini-3.7-flash-high",
+        claudeRequest,
+        true,
+        { projectId: "test-proj", connectionId: "test-conn" },
+        "antigravity"
+      );
+
+      expect(out.request.systemInstruction?.parts?.[0]?.text).toBe(SANITIZED_HERMES_PROMPT);
+    });
+
+    it("sanitizes system array blocks when client connects via Anthropic format", async () => {
+      const { translateRequest } = await import("../../open-sse/translator/index.js");
+      const { FORMATS } = await import("../../open-sse/translator/formats.js");
+      await import("../translator/registerAll.js");
+
+      const claudeRequest = {
+        model: "ag/gemini-3.7-flash-high",
+        system: [{ type: "text", text: HERMES_PROMPT }],
+        messages: [{ role: "user", content: "hello" }],
+      };
+
+      const out = translateRequest(
+        FORMATS.CLAUDE,
+        FORMATS.ANTIGRAVITY,
+        "gemini-3.7-flash-high",
+        claudeRequest,
+        true,
+        { projectId: "test-proj", connectionId: "test-conn" },
+        "antigravity"
+      );
+
+      expect(out.request.systemInstruction?.parts?.[0]?.text).toBe(SANITIZED_HERMES_PROMPT);
+    });
+  });
 });
+
 

--- a/tests/unit/hermes-cloaking.test.js
+++ b/tests/unit/hermes-cloaking.test.js
@@ -57,4 +57,36 @@ describe("Hermes Cloaking / System Prompt Sanitization", () => {
       expect(req.request.systemInstruction?.parts?.[0]?.text).toBe(SANITIZED_HERMES_PROMPT);
     });
   });
+
+  describe("AntigravityExecutor.transformRequest", () => {
+    it("sanitizes Hermes system prompt in transformRequest", () => {
+      const executor = new AntigravityExecutor();
+      const transformed = executor.transformRequest("gemini-3.7-flash-high", {
+        request: {
+          contents: [{ role: "user", parts: [{ text: "hi" }] }],
+          systemInstruction: {
+            parts: [{ text: HERMES_PROMPT }]
+          }
+        }
+      }, false, { projectId: "test-proj", connectionId: "test-conn" });
+
+      expect(transformed.request.systemInstruction.parts[0].text).toBe(SANITIZED_HERMES_PROMPT);
+    });
+
+    it("strips Zed Claude agent system prompt while also sanitizing", () => {
+      const executor = new AntigravityExecutor();
+      const zedPrompt = "You are a Claude agent, built on Anthropic's Claude Agent SDK. " + HERMES_PROMPT;
+      const transformed = executor.transformRequest("gemini-3.7-flash-high", {
+        request: {
+          contents: [{ role: "user", parts: [{ text: "hi" }] }],
+          systemInstruction: {
+            parts: [{ text: zedPrompt }]
+          }
+        }
+      }, false, { projectId: "test-proj", connectionId: "test-conn" });
+
+      expect(transformed.request.systemInstruction.parts[0].text).toBe(" " + SANITIZED_HERMES_PROMPT);
+    });
+  });
 });
+


### PR DESCRIPTION
Fixes #3358, #2938

#### Problem
Google Antigravity (`ag/*`) rejects requests that contain the default Hermes Agent system prompt with HTTP `429 RESOURCE_EXHAUSTED`. This triggers 9router's account cooldown lockout.

#### Cause
Google Cloud Code PA filters this exact competitor identity string:
> `"You are Hermes Agent, an intelligent AI assistant created by Nous Research."`

#### Solution
1. Add the `sanitizeAntigravitySystemPrompt` helper in `open-sse/translator/request/openai-to-gemini.js` to rewrite the identity string to an accepted variation:
   > `"You are Hermes Agent. You are an intelligent AI assistant created by Nous Research."`
2. Apply the sanitizer in `openaiToGeminiBase` and `wrapInCloudCodeEnvelopeForClaude`.
3. Apply the sanitizer in `AntigravityExecutor.transformRequest()` as a final safeguard for all outgoing Antigravity requests.

#### Verification
- Added unit tests in `tests/unit/hermes-cloaking.test.js`:
  - Verified exact match, whitespace variations, case-insensitivity, and safe non-string handling.
  - Verified Gemini-backed and Claude-backed Antigravity request translation.
  - Verified `AntigravityExecutor.transformRequest()` and compatibility with Zed Claude prompt stripping.
  - Verified incoming requests from the Anthropic API surface (`/v1/messages`).
- Verified all unit and translator tests pass without regressions.