### PR TITLE
fix(codex): preserve typed Responses system prompts

### DIFF
--- a/open-sse/executors/codex.js
+++ b/open-sse/executors/codex.js
@@ -6,6 +6,7 @@ import {
   shouldRefreshCredentials,
 } from "../services/oauthCredentialManager.js";
 import { normalizeResponsesInput } from "../translator/formats/responsesApi.js";
+import { ROLE, RESPONSES_ITEM } from "../translator/schema/index.js";
 import { fetchImageAsBase64 } from "../translator/concerns/image.js";
 import { getModelUpstreamId } from "../config/providerModels.js";
 import { getThinkingLevels } from "../providers/thinkingLevels.js";
@@ -52,6 +53,22 @@ function convertSystemToDeveloperRole(body) {
     if (!item || typeof item !== "object" || Array.isArray(item)) continue;
     const isSystemMsg = item.role === "system" && (!item.type || item.type === "message");
     if (isSystemMsg) item.role = "developer";
+  }
+}
+
+// Native Responses message items require an explicit type and typed text parts.
+// Keep this narrow: it only repairs role-bearing message-shaped items, leaving
+// tool calls, reasoning items, and already-valid typed content untouched.
+function normalizeCodexMessageItems(body) {
+  if (!Array.isArray(body.input)) return;
+  for (const item of body.input) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !item.role) continue;
+    if (!item.type) item.type = RESPONSES_ITEM.MESSAGE;
+    if (item.type !== RESPONSES_ITEM.MESSAGE || typeof item.content !== "string") continue;
+    item.content = [{
+      type: item.role === ROLE.ASSISTANT ? RESPONSES_ITEM.OUTPUT_TEXT : RESPONSES_ITEM.INPUT_TEXT,
+      text: item.content,
+    }];
   }
 }
 
@@ -406,6 +423,8 @@ export class CodexExecutor extends BaseExecutor {
 
     // Keep system prompts in body.input as role=developer so they stay in the cacheable prefix
     convertSystemToDeveloperRole(body);
+    // Repair legacy role/content shapes before the strict Codex Responses request is sent.
+    normalizeCodexMessageItems(body);
     // Strip server-generated item IDs (rs_/fc_/resp_/msg_) — Codex /responses can't resolve when store=false
     stripStoredItemReferences(body);
     // Flatten function tools + drop unsupported types

--- a/open-sse/rtk/systemInject.js
+++ b/open-sse/rtk/systemInject.js
@@ -3,6 +3,7 @@
 // native-passthrough flows. Used by caveman.js and ponytail.js.
 
 import { FORMATS } from "../translator/formats.js";
+import { ROLE, RESPONSES_ITEM } from "../translator/schema/index.js";
 
 const SEP = "\n\n";
 
@@ -22,12 +23,12 @@ export function injectSystemPrompt(body, format, prompt) {
       return;
     default:
       // OpenAI and OpenAI-shaped formats (responses/codex/cursor/kiro/ollama)
-      injectMessagesSystem(body, prompt);
+      injectMessagesSystem(body, format, prompt);
   }
 }
 
 // OpenAI-shaped: messages[] (chat) or input[] (responses) or instructions (responses string)
-function injectMessagesSystem(body, prompt) {
+function injectMessagesSystem(body, format, prompt) {
   // OpenAI Responses API: top-level string field
   if (typeof body.instructions === "string") {
     body.instructions = body.instructions
@@ -41,15 +42,36 @@ function injectMessagesSystem(body, prompt) {
     : null;
   if (!arr) return;
 
-  const idx = arr.findIndex(m => m && (m.role === "system" || m.role === "developer"));
+  const isResponses = format === FORMATS.OPENAI_RESPONSES;
+  const idx = arr.findIndex(m => m && (m.role === ROLE.SYSTEM || m.role === ROLE.DEVELOPER));
   if (idx >= 0) {
-    appendToOpenAIMessage(arr[idx], prompt);
+    appendToOpenAIMessage(arr[idx], prompt, isResponses);
   } else {
-    arr.unshift({ role: "system", content: prompt });
+    arr.unshift(isResponses
+      ? {
+          type: RESPONSES_ITEM.MESSAGE,
+          role: ROLE.SYSTEM,
+          content: [{ type: RESPONSES_ITEM.INPUT_TEXT, text: prompt }],
+        }
+      : { role: ROLE.SYSTEM, content: prompt });
   }
 }
 
-function appendToOpenAIMessage(msg, prompt) {
+function appendToOpenAIMessage(msg, prompt, isResponses) {
+  if (isResponses) {
+    // Responses API message items must carry both a message type and typed content.
+    // This path is used when a native Responses request has no top-level instructions.
+    msg.type = RESPONSES_ITEM.MESSAGE;
+    if (typeof msg.content === "string") {
+      msg.content = [{ type: RESPONSES_ITEM.INPUT_TEXT, text: `${msg.content}${SEP}${prompt}` }];
+    } else if (Array.isArray(msg.content)) {
+      msg.content.push({ type: RESPONSES_ITEM.INPUT_TEXT, text: prompt });
+    } else {
+      msg.content = [{ type: RESPONSES_ITEM.INPUT_TEXT, text: prompt }];
+    }
+    return;
+  }
+
   if (typeof msg.content === "string") {
     msg.content = `${msg.content}${SEP}${prompt}`;
   } else if (Array.isArray(msg.content)) {

--- a/tests/unit/codex-responses-system-injection.test.js
+++ b/tests/unit/codex-responses-system-injection.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { CodexExecutor } from "../../open-sse/executors/codex.js";
+import { injectSystemPrompt } from "../../open-sse/rtk/systemInject.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+const USER_MESSAGE = {
+  type: "message",
+  role: "user",
+  content: [{ type: "input_text", text: "Fix the failing test." }],
+};
+
+describe("Responses system-prompt injection", () => {
+  it("adds a typed message item when a Responses request has no instructions", () => {
+    const body = { input: [structuredClone(USER_MESSAGE)] };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "Use concise code changes.");
+
+    expect(body.input).toEqual([
+      {
+        type: "message",
+        role: "system",
+        content: [{ type: "input_text", text: "Use concise code changes." }],
+      },
+      USER_MESSAGE,
+    ]);
+  });
+
+  it("keeps Responses developer content typed when appending another instruction", () => {
+    const body = {
+      input: [
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "Keep tests focused." }] },
+        structuredClone(USER_MESSAGE),
+      ],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "Avoid unrelated refactors.");
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "developer",
+      content: [
+        { type: "input_text", text: "Keep tests focused." },
+        { type: "input_text", text: "Avoid unrelated refactors." },
+      ],
+    });
+  });
+
+  it("allows Caveman and Ponytail to append to the same Responses message", () => {
+    const body = { input: [structuredClone(USER_MESSAGE)] };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "Respond tersely.");
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "Prefer the smallest safe diff.");
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "system",
+      content: [
+        { type: "input_text", text: "Respond tersely." },
+        { type: "input_text", text: "Prefer the smallest safe diff." },
+      ],
+    });
+  });
+
+  it("retains the Chat Completions string shape", () => {
+    const body = { messages: [{ role: "user", content: "Hello" }] };
+
+    injectSystemPrompt(body, FORMATS.OPENAI, "Use concise code changes.");
+
+    expect(body.messages[0]).toEqual({ role: "system", content: "Use concise code changes." });
+  });
+});
+
+describe("CodexExecutor Responses normalization", () => {
+  it("preserves the typed injection through the final Codex transform", () => {
+    const body = {
+      model: "gpt-5.6-terra",
+      input: [structuredClone(USER_MESSAGE)],
+    };
+
+    injectSystemPrompt(body, FORMATS.OPENAI_RESPONSES, "Use concise code changes.");
+    new CodexExecutor().transformRequest("gpt-5.6-terra", body, true, {});
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "Use concise code changes." }],
+    });
+  });
+
+  it("repairs a legacy role/content item before the Codex request is dispatched", () => {
+    const body = {
+      model: "gpt-5.6-terra",
+      input: [
+        { role: "system", content: "Use concise code changes." },
+        structuredClone(USER_MESSAGE),
+      ],
+    };
+
+    new CodexExecutor().transformRequest("gpt-5.6-terra", body, true, {});
+
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "developer",
+      content: [{ type: "input_text", text: "Use concise code changes." }],
+    });
+    expect(body.input[1]).toEqual(USER_MESSAGE);
+  });
+
+  it("does not rewrite typed tool-call history", () => {
+    const toolCall = { type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" };
+    const body = {
+      model: "gpt-5.6-terra",
+      input: [structuredClone(toolCall), structuredClone(USER_MESSAGE)],
+    };
+
+    new CodexExecutor().transformRequest("gpt-5.6-terra", body, true, {});
+
+    expect(body.input[0]).toEqual(toolCall);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve the OpenAI Responses message contract when Ponytail or Caveman injects a system instruction without top-level instructions
- defensively normalize legacy role/content message items before sending them to the strict Codex Responses endpoint
- cover typed injection, repeated saver injection, legacy-shape repair, tool-history preservation, and Chat Completions compatibility

## Verification
- `./tests/node_modules/.bin/vitest run --config tests/vitest.config.js` with the focused Codex, Responses, Caveman, and Headroom suites: 9 files passed, 51 tests passed, 2 expected failures
- `./node_modules/.bin/eslint open-sse/rtk/systemInject.js open-sse/executors/codex.js tests/unit/codex-responses-system-injection.test.js`
- `git diff --check`

## Notes
- `tests/unit/codex-image-fetch.test.js` has 2 unrelated failures that reproduce unchanged on `upstream/master`; this PR does not modify that path.

Closes #3323