### PR TITLE
fix(model): route to custom node when prefix collides with built-in provider alias

### DIFF
--- a/src/sse/services/model.js
+++ b/src/sse/services/model.js
@@ -1,20 +1,12 @@
 // Re-export from open-sse with localDb integration
 import { getModelAliases, getComboByName, getProviderNodes } from "@/lib/localDb";
 import { parseModel as parseModelCore, resolveModelAliasFromMap, getModelInfoCore } from "open-sse/services/model.js";
-import REGISTRY from "open-sse/providers/registry/index.js";
 
 // Local provider alias overrides (HMR-friendly, applied on top of open-sse map)
 const LOCAL_PROVIDER_ALIASES = {
   xmtp: "xiaomi-tokenplan",
   "xiaomi-tokenplan": "xiaomi-tokenplan",
 };
-
-const RESERVED_PROVIDER_PREFIXES = new Set(Object.keys(LOCAL_PROVIDER_ALIASES));
-for (const entry of REGISTRY) {
-  RESERVED_PROVIDER_PREFIXES.add(entry.id);
-  if (entry.alias) RESERVED_PROVIDER_PREFIXES.add(entry.alias);
-  for (const alias of entry.aliases || []) RESERVED_PROVIDER_PREFIXES.add(alias);
-}
 
 export function parseModel(modelStr) {
   const parsed = parseModelCore(modelStr);
@@ -39,27 +31,31 @@ export async function getModelInfo(modelStr) {
   const parsed = parseModel(modelStr);
 
   if (!parsed.isAlias) {
-    // Provider-node prefixes are user-defined. They must not override built-in
-    // provider ids/aliases such as `cf`, `cloudflare-ai`, `openai`, or `hf`.
-    if (!RESERVED_PROVIDER_PREFIXES.has(parsed.providerAlias)) {
-      const openaiNodes = await getProviderNodes({ type: "openai-compatible" });
-      const matchedOpenAI = openaiNodes.find((node) => node.prefix === parsed.providerAlias);
-      if (matchedOpenAI) {
-        return { provider: matchedOpenAI.id, model: parsed.model };
-      }
-
-      const anthropicNodes = await getProviderNodes({ type: "anthropic-compatible" });
-      const matchedAnthropic = anthropicNodes.find((node) => node.prefix === parsed.providerAlias);
-      if (matchedAnthropic) {
-        return { provider: matchedAnthropic.id, model: parsed.model };
-      }
-
-      const embeddingNodes = await getProviderNodes({ type: "custom-embedding" });
-      const matchedEmbedding = embeddingNodes.find((node) => node.prefix === parsed.providerAlias);
-      if (matchedEmbedding) {
-        return { provider: matchedEmbedding.id, model: parsed.model };
-      }
+    // Provider-node prefixes are user-defined. Check custom nodes first — if the
+    // user explicitly created a node with a given prefix, route to it even when
+    // the prefix collides with a built-in provider id/alias (e.g. a custom
+    // "tokenrouter" node with prefix "tr"). The user's credentials are stored
+    // under the node ID; routing to the built-in provider instead would fail
+    // with "No credentials for provider". When no custom node matches, fall
+    // through to the built-in provider resolution below.
+    const openaiNodes = await getProviderNodes({ type: "openai-compatible" });
+    const matchedOpenAI = openaiNodes.find((node) => node.prefix === parsed.providerAlias);
+    if (matchedOpenAI) {
+      return { provider: matchedOpenAI.id, model: parsed.model };
     }
+
+    const anthropicNodes = await getProviderNodes({ type: "anthropic-compatible" });
+    const matchedAnthropic = anthropicNodes.find((node) => node.prefix === parsed.providerAlias);
+    if (matchedAnthropic) {
+      return { provider: matchedAnthropic.id, model: parsed.model };
+    }
+
+    const embeddingNodes = await getProviderNodes({ type: "custom-embedding" });
+    const matchedEmbedding = embeddingNodes.find((node) => node.prefix === parsed.providerAlias);
+    if (matchedEmbedding) {
+      return { provider: matchedEmbedding.id, model: parsed.model };
+    }
+
     return {
       provider: parsed.provider,
       model: parsed.model

--- a/tests/unit/model-routing.test.js
+++ b/tests/unit/model-routing.test.js
@@ -38,10 +38,13 @@ describe("model routing", () => {
     else process.env.DATA_DIR = originalDataDir;
   });
 
-  it("keeps built-in provider aliases ahead of compatible node prefixes", async () => {
+  it("routes to custom node when its prefix collides with a built-in provider alias", async () => {
     const ctx = await setupDb();
     cleanup = ctx.cleanup;
 
+    // User explicitly creates a custom node with prefix "cf" (cloudflare-ai alias).
+    // Credentials are stored under the node ID, so routing must go to the node,
+    // not the built-in provider (which would have no credentials).
     await ctx.createProviderNode({
       id: "openai-compatible-chat-test",
       type: "openai-compatible",
@@ -53,8 +56,33 @@ describe("model routing", () => {
 
     await expect(ctx.getModelInfo("cf/@cf/black-forest-labs/flux-2-klein-9b"))
       .resolves.toEqual({
-        provider: "cloudflare-ai",
+        provider: "openai-compatible-chat-test",
         model: "@cf/black-forest-labs/flux-2-klein-9b",
+      });
+  });
+
+  it("routes to custom node when prefix matches built-in tokenrouter alias (tr)", async () => {
+    const ctx = await setupDb();
+    cleanup = ctx.cleanup;
+
+    // Reproduces: user creates a custom openai-compatible node named "tokenrouter"
+    // with prefix "tr". The built-in provider "tokenrouter" also has alias "tr".
+    // Previously, the reserved-prefix guard skipped the custom node lookup and
+    // routed to the built-in provider, which had no credentials →
+    // "No active credentials for provider: tokenrouter".
+    await ctx.createProviderNode({
+      id: "openai-compatible-chat-tr-node",
+      type: "openai-compatible",
+      name: "tokenrouter",
+      prefix: "tr",
+      apiType: "chat",
+      baseUrl: "https://api.tokenrouter.com/v1",
+    });
+
+    await expect(ctx.getModelInfo("tr/qwen/qwen3.8-max-free"))
+      .resolves.toEqual({
+        provider: "openai-compatible-chat-tr-node",
+        model: "qwen/qwen3.8-max-free",
       });
   });
 


### PR DESCRIPTION
## Problem

When a user creates a custom openai-compatible node whose prefix matches a built-in provider alias, requests to that prefix fail with `No active credentials for provider: <name>`.

**Reproduction:**
1. Create a custom openai-compatible node named `tokenrouter` with prefix `tr` (the built-in `tokenrouter` provider also uses alias `tr`)
2. Add an API key connection to that node
3. Send a request with model `tr/qwen/qwen3.8-max-free`
4. Result: `No active credentials for provider: tokenrouter`

**Root cause:** In `src/sse/services/model.js`, the `RESERVED_PROVIDER_PREFIXES` guard skips the custom-node lookup when the prefix matches any built-in provider id/alias. The request is routed to the built-in provider, but the user's credentials are stored under the custom node's ID → credential lookup returns 0 results.

This is a regression of #1756 (same symptom, same root cause pattern).

## Fix

Check custom provider nodes **first**. If the user explicitly created a node with a given prefix, route to it even when the prefix collides with a built-in provider id/alias. Only fall through to built-in provider resolution when no custom node matches.

This is the correct precedence: explicit user configuration (a created node + stored credentials) should always win over implicit built-in defaults.

## Changes

- `src/sse/services/model.js` — remove `RESERVED_PROVIDER_PREFIXES` guard; always check custom nodes before falling back to built-in resolution
- `tests/unit/model-routing.test.js` — update collision test to assert custom-node-first behavior; add regression test for the `tr`/tokenrouter case

## Testing

- Existing test `still routes non-reserved compatible node prefixes` still passes (unchanged behavior for non-colliding prefixes)
- Updated test verifies custom node wins over built-in `cf` (cloudflare-ai) alias
- New test reproduces the exact `tr`/tokenrouter scenario from the bug report
