### PR TITLE
fix(antigravity): drop messages whose parts become empty after thought filtering

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -216,7 +216,7 @@ export class AntigravityExecutor extends BaseExecutor {
         };
       }
       return c;
-    });
+    }).filter(c => c.parts?.length > 0);
 
     // Sanitize tool schemas and function names before sending to Antigravity.
     let tools = body.request?.tools;


### PR DESCRIPTION
## Problem

When an assistant message contains only reasoning/thought parts (no text, no tool calls), the part filter in `open-sse/executors/antigravity.js` strips every part, leaving `parts: []`. The Antigravity/Gemini API rejects this with HTTP 400 `INVALID_ARGUMENT` ("Request contains an invalid argument."), breaking long agent conversations that include thinking-only turns.

## Fix

Filter out messages whose parts become empty after the thought-part filtering, so no empty-parts message is sent upstream.

```js
}).filter(c => c.parts?.length > 0);
```

## Verification

Reproduced the exact 400 through a live router, then confirmed the fix returns 200 with a valid stream for: thinking-only assistant turns, normal requests, and tool-call histories.