### PR TITLE
fix(usage): fetch and compute Cursor quota/usage

### DIFF
--- a/open-sse/providers/registry/cursor.js
+++ b/open-sse/providers/registry/cursor.js
@@ -24,6 +24,14 @@ export default {
       "User-Agent": "connect-es/1.6.1",
     },
     clientVersion: "3.12.17",
+    // Individual/Pro dashboard usage (Connect RPC, same Bearer token as chat).
+    // team/enterprise pooled-limit accounts and the request-based
+    // legacy fallback (cursor.com/api/usage + CSV export) aren't covered —
+    // add those REST endpoints if reports come in from those account shapes.
+    usage: {
+      usageUrl: "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+      planUrl: "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo",
+    },
   },
   models: [
     { id: "default", name: "Auto (Server Picks)" },
@@ -54,5 +62,8 @@ export default {
       accessToken: "cursorAuth/accessToken",
       machineId: "storage.serviceMachineId",
     },
+  },
+  features: {
+    usage: true,
   },
 };

--- a/open-sse/services/usage.js
+++ b/open-sse/services/usage.js
@@ -13,6 +13,7 @@ import { getMiniMaxUsage } from "./usage/minimax.js";
 import { getCodeBuddyCnUsage, getCodeBuddyIntlUsage } from "./usage/codebuddy-cn.js";
 import { getGrokCliUsage } from "./usage/grok-cli.js";
 import { getKimiUsage } from "./usage/kimi.js";
+import { getCursorUsage } from "./usage/cursor.js";
 import { getDeepseekUsage } from "./usage/deepseek.js";
 import { resolveQoderCredentials } from "./qoderModels.js";
 import {
@@ -53,6 +54,7 @@ const USAGE_HANDLERS = {
   "codebuddy-intl": (c) => getCodeBuddyIntlUsage(c.accessToken, c.apiKey, c.providerSpecificData, c.proxyOptions),
   "grok-cli": (c) => getGrokCliUsage(c.accessToken, c.providerSpecificData, c.proxyOptions),
   kimi: (c) => getKimiUsage(c.accessToken, c.apiKey, c.proxyOptions, c.providerSpecificData),
+  cursor: (c) => getCursorUsage(c.accessToken, c.proxyOptions),
   deepseek: (c) => getDeepseekUsage(c.apiKey, c.proxyOptions),
 };
 

--- a/open-sse/services/usage/cursor.js
+++ b/open-sse/services/usage/cursor.js
@@ -1,0 +1,147 @@
+/**
+ * Cursor IDE usage handler
+ *
+ * Dashboard usage lives behind Connect RPC (api2.cursor.sh), not a plain REST
+ * endpoint — same Bearer token as chat, body is a literal empty proto "{}".
+ *
+ * Only the individual/Pro percent-of-limit path is implemented.
+ * Skipped: team/enterprise pooled-dollar display (the ratio math is the same,
+ * we just always render it as a %), the request-based legacy fallback
+ * (cursor.com/api/usage + api/usage-summary, cookie-auth), credit
+ * grants/Stripe balance, and the usage-events CSV spend history. Add those if
+ * reports show individual-Pro accounts aren't covered by this.
+ */
+import { proxyAwareFetch } from "../../utils/proxyFetch.js";
+import { U, parseResetTime } from "./shared.js";
+
+const CURSOR_CONFIG = {
+	usageUrl: U("cursor").usageUrl,
+	planUrl: U("cursor").planUrl,
+};
+
+function connectHeaders(accessToken) {
+	return {
+		Authorization: `Bearer ${accessToken}`,
+		"Content-Type": "application/json",
+		"Connect-Protocol-Version": "1",
+	};
+}
+
+async function connectPost(url, accessToken, proxyOptions) {
+	return proxyAwareFetch(
+		url,
+		{
+			method: "POST",
+			headers: connectHeaders(accessToken),
+			body: "{}",
+		},
+		proxyOptions,
+	);
+}
+
+function percentQuota(usedPercent, resetAt) {
+	const used = Math.max(0, Math.min(100, usedPercent));
+	return {
+		used,
+		total: 100,
+		remaining: Math.max(0, 100 - used),
+		resetAt,
+		unlimited: false,
+	};
+}
+
+// Best-effort plan label from GetPlanInfo — never fails the whole fetch.
+async function fetchPlanName(accessToken, proxyOptions) {
+	try {
+		const response = await connectPost(
+			CURSOR_CONFIG.planUrl,
+			accessToken,
+			proxyOptions,
+		);
+		if (!response.ok) return null;
+		const body = await response.json();
+		const name = body?.planInfo?.planName;
+		return typeof name === "string" && name.trim() ? name.trim() : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function getCursorUsage(accessToken, proxyOptions = null) {
+	if (!accessToken) {
+		return {
+			message:
+				"No Cursor access token available. Re-import your Cursor session.",
+		};
+	}
+
+	let response;
+	try {
+		response = await connectPost(
+			CURSOR_CONFIG.usageUrl,
+			accessToken,
+			proxyOptions,
+		);
+	} catch (error) {
+		return {
+			message: `Cursor connected. Unable to fetch usage: ${error.message}`,
+		};
+	}
+
+	if (!response.ok) {
+		return {
+			message: `Cursor connected. Usage API temporarily unavailable (${response.status}).`,
+		};
+	}
+
+	let usage;
+	try {
+		usage = await response.json();
+	} catch {
+		return {
+			message: "Cursor connected. Usage API returned an invalid response.",
+		};
+	}
+
+	const planUsage = usage?.planUsage;
+	if (usage?.enabled === false || !planUsage) {
+		return { message: "No active Cursor subscription." };
+	}
+
+	const limit = Number(planUsage.limit);
+	const hasLimit = Number.isFinite(limit);
+	const totalPercentUsed = Number(planUsage.totalPercentUsed);
+	const hasTotalPercent = Number.isFinite(totalPercentUsed);
+	if (!hasLimit && !hasTotalPercent) {
+		return {
+			message: "Cursor connected. Usage totals unavailable for this account.",
+		};
+	}
+
+	const resetAt = parseResetTime(usage.billingCycleEnd);
+	const quotas = {};
+
+	const totalSpend = Number(planUsage.totalSpend);
+	const remaining = Number(planUsage.remaining);
+	let usedAmount = 0;
+	if (Number.isFinite(totalSpend)) usedAmount = totalSpend;
+	else if (hasLimit && Number.isFinite(remaining))
+		usedAmount = limit - remaining;
+	const computedPercent =
+		hasLimit && limit > 0 ? (usedAmount / limit) * 100 : 0;
+	quotas["Total usage"] = percentQuota(
+		hasTotalPercent ? totalPercentUsed : computedPercent,
+		resetAt,
+	);
+
+	const autoPercentUsed = Number(planUsage.autoPercentUsed);
+	if (Number.isFinite(autoPercentUsed))
+		quotas["Auto usage"] = percentQuota(autoPercentUsed, resetAt);
+
+	const apiPercentUsed = Number(planUsage.apiPercentUsed);
+	if (Number.isFinite(apiPercentUsed))
+		quotas["API usage"] = percentQuota(apiPercentUsed, resetAt);
+
+	const plan = await fetchPlanName(accessToken, proxyOptions);
+	return { plan: plan || "Cursor", quotas };
+}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -518,6 +518,20 @@ export function parseQuotaData(provider, data) {
         }
         break;
 
+      case "cursor":
+        // Percent-of-limit quotas (Total/Auto/API usage) — same shape as claude.
+        if (data.quotas) {
+          Object.entries(data.quotas).forEach(([name, quota]) => {
+            normalizedQuotas.push({
+              name,
+              used: quota.used || 0,
+              total: quota.total || 0,
+              resetAt: quota.resetAt || null,
+            });
+          });
+        }
+        break;
+
       case "deepseek":
         // Credit balance — remainingPercentage only (no absolute remaining).
         if (data.quotas) {

--- a/tests/__baseline__/providers-baseline.json
+++ b/tests/__baseline__/providers-baseline.json
@@ -228,7 +228,11 @@
       "Content-Type": "application/connect+proto",
       "User-Agent": "connect-es/1.6.1"
     },
-    "clientVersion": "3.12.17"
+    "clientVersion": "3.12.17",
+    "usage": {
+      "usageUrl": "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+      "planUrl": "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo"
+    }
   },
   "deepgram": {
     "baseUrl": "https://api.deepgram.com/v1/listen",

--- a/tests/unit/cursor-usage.test.js
+++ b/tests/unit/cursor-usage.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../open-sse/utils/proxyFetch.js", () => ({
+  proxyAwareFetch: vi.fn(),
+}));
+
+import { proxyAwareFetch } from "../../open-sse/utils/proxyFetch.js";
+import { getUsageForProvider } from "../../open-sse/services/usage.js";
+import { USAGE_SUPPORTED_PROVIDERS } from "../../src/shared/constants/providers.js";
+import { parseQuotaData } from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+const USAGE_URL = "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage";
+const PLAN_URL = "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo";
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("cursor registry usage flags", () => {
+  it("is listed for the quota dashboard", () => {
+    expect(USAGE_SUPPORTED_PROVIDERS).toContain("cursor");
+  });
+});
+
+describe("getUsageForProvider(cursor)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("POSTs the Connect RPC endpoint with Bearer auth and an empty proto body", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({
+        enabled: true,
+        billingCycleEnd: 1735689600000,
+        planUsage: { limit: 2000, totalSpend: 500, totalPercentUsed: 25 },
+      }))
+      .mockResolvedValueOnce(jsonResponse({ planInfo: { planName: "pro" } }));
+
+    const usage = await getUsageForProvider({ provider: "cursor", accessToken: "tok" });
+
+    expect(usage.message).toBeUndefined();
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    const [url, opts] = proxyAwareFetch.mock.calls[0];
+    expect(url).toBe(USAGE_URL);
+    expect(opts.method).toBe("POST");
+    expect(opts.headers.Authorization).toBe("Bearer tok");
+    expect(opts.headers["Connect-Protocol-Version"]).toBe("1");
+    expect(opts.body).toBe("{}");
+    expect(proxyAwareFetch.mock.calls[1][0]).toBe(PLAN_URL);
+  });
+
+  it("maps totalPercentUsed straight through as a percent quota", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({
+        enabled: true,
+        billingCycleEnd: 1735689600000,
+        planUsage: { limit: 2000, totalSpend: 500, totalPercentUsed: 25, autoPercentUsed: 10 },
+      }))
+      .mockResolvedValueOnce(jsonResponse({ planInfo: { planName: "pro" } }));
+
+    const usage = await getUsageForProvider({ provider: "cursor", accessToken: "tok" });
+
+    expect(usage.plan).toBe("pro");
+    expect(usage.quotas["Total usage"]).toMatchObject({ used: 25, total: 100, remaining: 75 });
+    expect(usage.quotas["Auto usage"]).toMatchObject({ used: 10, total: 100 });
+    expect(usage.quotas["API usage"]).toBeUndefined();
+  });
+
+  it("falls back to limit/remaining ratio when totalPercentUsed is missing", async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(jsonResponse({
+        enabled: true,
+        planUsage: { limit: 1000, remaining: 750 },
+      }))
+      .mockResolvedValueOnce(jsonResponse({}, 500));
+
+    const usage = await getUsageForProvider({ provider: "cursor", accessToken: "tok" });
+
+    expect(usage.quotas["Total usage"].used).toBe(25);
+    expect(usage.plan).toBe("Cursor"); // optional plan-name lookup failed, non-fatal
+  });
+
+  it("returns a message when there's no active subscription or no token", async () => {
+    const missing = await getUsageForProvider({ provider: "cursor" });
+    expect(missing.message).toMatch(/token/i);
+    expect(proxyAwareFetch).not.toHaveBeenCalled();
+
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({ enabled: false }));
+    const disabled = await getUsageForProvider({ provider: "cursor", accessToken: "tok" });
+    expect(disabled.message).toMatch(/subscription/i);
+  });
+
+  it("returns a message on non-2xx or invalid JSON", async () => {
+    proxyAwareFetch.mockResolvedValueOnce(jsonResponse({}, 401));
+    const unauthorized = await getUsageForProvider({ provider: "cursor", accessToken: "bad" });
+    expect(unauthorized.message).toMatch(/401/);
+  });
+});
+
+describe("parseQuotaData(cursor)", () => {
+  it("forwards percent quota rows unchanged", () => {
+    const rows = parseQuotaData("cursor", {
+      plan: "pro",
+      quotas: {
+        "Total usage": { used: 25, total: 100, resetAt: null },
+      },
+    });
+    expect(rows[0]).toMatchObject({ name: "Total usage", used: 25, total: 100 });
+  });
+});


### PR DESCRIPTION
## Summary
- register Cursor's Connect RPC dashboard endpoints (`api2.cursor.sh` `DashboardService/GetCurrentPeriodUsage` + `GetPlanInfo`) in the provider registry and flip `features.usage` so cursor joins `USAGE_SUPPORTED_PROVIDERS`
- add `getCursorUsage` (`open-sse/services/usage/cursor.js`): POSTs `GetCurrentPeriodUsage` with the existing Bearer token + empty proto body, maps `totalPercentUsed`/`autoPercentUsed`/`apiPercentUsed` into the same percent-quota shape Claude/Codex already use, with a best-effort plan name from `GetPlanInfo`
- wire the new handler into `USAGE_HANDLERS` and add the `cursor` case to `parseQuotaData`

## Root cause
`getUsageForProvider` had no `cursor` entry in `USAGE_HANDLERS` at all, so every Cursor connection just fell through to the generic `{ message: "Usage API not implemented for cursor" }` fallback — no request was ever made and the dashboard never showed real quota data.

## Scope
Individual/Pro percent-of-limit accounts only. Team/enterprise pooled-dollar accounts and the request-based legacy fallback (`cursor.com/api/usage` + CSV export) aren't covered — noted inline in the registry so it's easy to pick up if reports come in from those account shapes.

## Tests
- `cd tests && npx vitest run unit/cursor-usage.test.js` (new — request shape, percent mapping, ratio fallback, error paths)
- `node tests/__baseline__/verify-providers.mjs` (registry snapshot re-verified byte-for-byte, only the new `usage`/`features` fields differ, both already excluded from the diff check)
- Manually verified against a live Cursor Pro connection in the dashboard — Total/Auto/API usage now render with correct percentages and reset countdown.