### PR TITLE
fix(translator): recover a tool result that arrived without an id

### DIFF
--- a/open-sse/translator/concerns/toolCall.js
+++ b/open-sse/translator/concerns/toolCall.js
@@ -21,9 +21,37 @@ function sanitizeToolId(id) {
   return sanitized.length > 0 ? sanitized : null;
 }
 
+// Resolve the id a tool result should carry.
+//
+// A missing id cannot be sanitized into existence, and Anthropic rejects the
+// whole request when one is absent ("tool_result.tool_use_id: Field required").
+// Pair it instead with the oldest tool call from the preceding assistant turn
+// that nothing has answered yet — that is the id upstream is expecting, and
+// OpenAI-format clients that drop tool_call_id on a turn are the reason this
+// path exists (#3362). Only if there is nothing to pair with do we generate an
+// id, which at least keeps the request well-formed.
+function resolveToolResultId(rawId, unanswered, makeFallbackId) {
+  const usable =
+    typeof rawId === "string" && rawId
+      ? (TOOL_ID_PATTERN.test(rawId) ? rawId : sanitizeToolId(rawId))
+      : null;
+
+  if (usable) {
+    const at = unanswered.indexOf(usable);
+    if (at >= 0) unanswered.splice(at, 1);
+    return usable;
+  }
+
+  return unanswered.shift() || makeFallbackId();
+}
+
 // Ensure all tool_calls have valid id field and arguments is string (some providers require it)
 export function ensureToolCallIds(body) {
   if (!body.messages || !Array.isArray(body.messages)) return body;
+
+  // Tool call ids from the most recent assistant turn that no result has
+  // claimed yet, oldest first.
+  let unanswered = [];
 
   for (let i = 0; i < body.messages.length; i++) {
     const msg = body.messages[i];
@@ -45,13 +73,8 @@ export function ensureToolCallIds(body) {
       }
     }
 
-    // Validate tool_call_id in tool messages (role: "tool")
-    if (msg.role === "tool" && msg.tool_call_id && !TOOL_ID_PATTERN.test(msg.tool_call_id)) {
-      const sanitized = sanitizeToolId(msg.tool_call_id);
-      msg.tool_call_id = sanitized || generateToolCallId(i, 0);
-    }
-
-    // Also validate tool_use blocks in content (Claude format)
+    // Validate tool_use blocks in content (Claude format) before the ids are
+    // read back out below.
     if (Array.isArray(msg.content)) {
       for (let k = 0; k < msg.content.length; k++) {
         const block = msg.content[k];
@@ -59,10 +82,27 @@ export function ensureToolCallIds(body) {
           const sanitized = sanitizeToolId(block.id);
           block.id = sanitized || generateToolCallId(i, k, block.name);
         }
-        // Validate tool_use_id in tool_result blocks
-        if (block.type === "tool_result" && block.tool_use_id && !TOOL_ID_PATTERN.test(block.tool_use_id)) {
-          const sanitized = sanitizeToolId(block.tool_use_id);
-          block.tool_use_id = sanitized || generateToolCallId(i, k);
+      }
+    }
+
+    // An assistant turn opens a new set of tool calls waiting for results, and
+    // ends whatever the previous one left open.
+    if (msg.role === "assistant") {
+      unanswered = getToolCallIds(msg);
+      continue;
+    }
+
+    // Tool result, OpenAI shape (role: "tool")
+    if (msg.role === "tool") {
+      msg.tool_call_id = resolveToolResultId(msg.tool_call_id, unanswered, () => generateToolCallId(i, 0));
+    }
+
+    // Tool result, Claude shape (tool_result block in user content)
+    if (Array.isArray(msg.content)) {
+      for (let k = 0; k < msg.content.length; k++) {
+        const block = msg.content[k];
+        if (block.type === "tool_result") {
+          block.tool_use_id = resolveToolResultId(block.tool_use_id, unanswered, () => generateToolCallId(i, k));
         }
       }
     }

--- a/tests/unit/tool-result-missing-id-3362.test.js
+++ b/tests/unit/tool-result-missing-id-3362.test.js
@@ -1,0 +1,174 @@
+// #3362 — Claude tool-result requests intermittently failed with
+// "messages.N.content.0.tool_result.tool_use_id: Field required".
+//
+// ensureToolCallIds repaired an assistant tool_call whose id was missing, but
+// both tool-result branches were guarded on the id being truthy, so a result
+// arriving without one passed through untouched and openai-to-claude emitted
+// `tool_use_id: undefined`. Anthropic rejects the whole request.
+import { describe, it, expect } from "vitest";
+import { ensureToolCallIds } from "../../open-sse/translator/concerns/toolCall.js";
+import { fixMissingToolResponses } from "../../open-sse/translator/concerns/toolCall.js";
+import { openaiToClaudeRequest } from "../../open-sse/translator/request/openai-to-claude.js";
+
+const TOOL_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function assistantCall(...ids) {
+  return {
+    role: "assistant",
+    content: null,
+    tool_calls: ids.map((id) => ({ id, type: "function", function: { name: "read_file", arguments: "{}" } })),
+  };
+}
+
+describe("tool_result id repair (#3362)", () => {
+  it("pairs a result that arrived without an id with the open tool call", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "read it" },
+        assistantCall("call_abc123"),
+        { role: "tool", content: "file contents" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[2].tool_call_id).toBe("call_abc123");
+  });
+
+  it("pairs parallel results in order", () => {
+    const body = {
+      messages: [
+        assistantCall("call_one", "call_two"),
+        { role: "tool", content: "first" },
+        { role: "tool", content: "second" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages.slice(1).map((m) => m.tool_call_id)).toEqual(["call_one", "call_two"]);
+  });
+
+  // An id already claimed by an explicit result must not be handed out again,
+  // whichever order the results arrive in.
+  it("does not hand the same id to two results", () => {
+    const inOrder = {
+      messages: [
+        assistantCall("call_one", "call_two"),
+        { role: "tool", tool_call_id: "call_one", content: "first" },
+        { role: "tool", content: "second, id dropped" },
+      ],
+    };
+
+    ensureToolCallIds(inOrder);
+
+    expect(inOrder.messages.slice(1).map((m) => m.tool_call_id)).toEqual(["call_one", "call_two"]);
+
+    const outOfOrder = {
+      messages: [
+        assistantCall("call_one", "call_two"),
+        { role: "tool", tool_call_id: "call_two", content: "second arrived first" },
+        { role: "tool", content: "the other one" },
+      ],
+    };
+
+    ensureToolCallIds(outOfOrder);
+
+    expect(outOfOrder.messages.slice(1).map((m) => m.tool_call_id)).toEqual(["call_two", "call_one"]);
+  });
+
+  it("repairs the Claude shape too (tool_result block in user content)", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: [{ type: "tool_use", id: "call_xyz", name: "read_file", input: {} }] },
+        { role: "user", content: [{ type: "tool_result", content: "ok" }] },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[1].content[0].tool_use_id).toBe("call_xyz");
+  });
+
+  it("leaves a valid id alone", () => {
+    const body = {
+      messages: [assistantCall("call_abc"), { role: "tool", tool_call_id: "call_abc", content: "ok" }],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[1].tool_call_id).toBe("call_abc");
+  });
+
+  it("still sanitizes an id that breaks Anthropic's pattern", () => {
+    const body = {
+      messages: [
+        assistantCall("call:abc/1"),
+        { role: "tool", tool_call_id: "call:abc/1", content: "ok" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    const id = body.messages[0].tool_calls[0].id;
+    expect(id).toBe("callabc1");
+    expect(body.messages[1].tool_call_id).toBe(id);
+  });
+
+  // Nothing to pair with is still not a reason to emit an absent field: a
+  // well-formed id keeps the request shape valid instead of guaranteeing a 400.
+  it("never leaves the id empty when there is no open call", () => {
+    const body = { messages: [{ role: "tool", content: "orphan" }] };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[0].tool_call_id).toBeTruthy();
+    expect(body.messages[0].tool_call_id).toMatch(TOOL_ID_PATTERN);
+  });
+
+  it("does not reuse ids across assistant turns", () => {
+    const body = {
+      messages: [
+        assistantCall("call_first"),
+        { role: "tool", tool_call_id: "call_first", content: "a" },
+        assistantCall("call_second"),
+        { role: "tool", content: "b" },
+      ],
+    };
+
+    ensureToolCallIds(body);
+
+    expect(body.messages[3].tool_call_id).toBe("call_second");
+  });
+
+  // hasToolResults() matches on the id, so before the repair a result with no
+  // id looked absent and fixMissingToolResponses spliced in an empty duplicate.
+  it("stops a duplicate empty result being inserted after it", () => {
+    const body = {
+      messages: [assistantCall("call_abc"), { role: "tool", content: "real output" }],
+    };
+
+    fixMissingToolResponses(ensureToolCallIds(body));
+
+    const results = body.messages.filter((m) => m.role === "tool");
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("real output");
+  });
+
+  it("reaches Anthropic with a tool_use_id, end to end", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "read it" },
+        assistantCall("call_abc123"),
+        { role: "tool", content: "file contents" },
+      ],
+    };
+
+    const claude = openaiToClaudeRequest("claude-sonnet-5", ensureToolCallIds(body), false);
+
+    const blocks = claude.messages.flatMap((m) => (Array.isArray(m.content) ? m.content : []));
+    const results = blocks.filter((b) => b.type === "tool_result");
+    expect(results).toHaveLength(1);
+    expect(results[0].tool_use_id).toBe("call_abc123");
+  });
+});


### PR DESCRIPTION
Closes #3362.

Requests carrying Claude tool history intermittently 400 upstream:

```
messages.0.content.0.tool_result.tool_use_id: Field required
```

The reporter's read — "the conversion path is dropping or failing to map the tool-call ID" — is correct. Here is the exact line.

## Root cause

`ensureToolCallIds` in `open-sse/translator/concerns/toolCall.js` repairs an assistant `tool_call` whose id is missing *or* malformed:

```js
if (!tc.id || !TOOL_ID_PATTERN.test(tc.id)) { … }   // handles absent
```

but both tool-**result** branches are guarded on the id already being truthy:

```js
if (msg.role === "tool" && msg.tool_call_id && !TOOL_ID_PATTERN.test(msg.tool_call_id)) { … }
if (block.type === "tool_result" && block.tool_use_id && !TOOL_ID_PATTERN.test(block.tool_use_id)) { … }
```

A result that arrives with **no id at all** therefore skips validation entirely, and `openai-to-claude.js:207` copies it straight through:

```js
blocks.push({ type: CLAUDE_BLOCK.TOOL_RESULT, tool_use_id: msg.tool_call_id, content: msg.content });
```

`tool_use_id: undefined` — exactly the field Anthropic reports as missing. The producer side of the id was hardened; the consumer side was not.

That also explains "intermittent": it depends entirely on whether the client dropped `tool_call_id` on that particular turn, which is why the same route succeeds for plain conversation and for tool turns where the id survived, and why the error appears at varying `messages.N`.

There is a second-order effect worth noting. `hasToolResults()` matches on the same field:

```js
if (msg.role === "tool" && msg.tool_call_id) return toolCallIds.includes(msg.tool_call_id);
```

With the id absent this returns false, so `fixMissingToolResponses` concluded the result was missing and spliced an empty duplicate in next to the real one.

## The fix

Sanitizing cannot invent an id, and generating a random one only trades one 400 for another — Anthropic equally rejects a `tool_result` whose id matches no `tool_use`. So the id is **recovered by pairing**: a result with no usable id takes the oldest tool call from the preceding assistant turn that nothing has answered yet.

That is the id upstream is expecting, and it holds up under the shapes the issue asks about:

- **Parallel tool calls** — results are paired in order.
- **Out-of-order results** — an id claimed by an explicit result is removed from the open set, so it is never handed to a second result.
- **Multi-turn** — an assistant turn replaces the open set, so a later result cannot pick up a stale id from an earlier turn.
- **Claude-shaped history** — `tool_result` blocks inside user content are repaired the same way as OpenAI `role: "tool"` messages.

Unchanged: a well-formed id passes through untouched, and a malformed one is still sanitized exactly as before.

When there is genuinely nothing to pair with — a result following no tool call at all — the id is generated rather than left absent. That request may still be rejected as unmatched, but a well-formed request that *might* be accepted beats one that is guaranteed to fail, and it is the same deterministic `generateToolCallId` the malformed branch already used.

The repair sits in the shared normalization pass that runs before translation, so every target consuming these ids benefits — claude, gemini, kiro, cursor — not just `openai-to-claude`. It also runs before `fixMissingToolResponses`, which is what stops the duplicate-insert above.

## On the rest of the requested fix list

Points 1–3 and 5 are covered. Point 4 (fail the conversion instead of emitting a malformed request) I did not implement: repair now succeeds for every shape that has a tool call to pair with, and turning the residual case into a hard error would break requests that currently work. Point 6 (structured id-mapping debug logging) is a separate change — this one is deliberately confined to the defect so it is easy to review and to revert.

## Verification

10 tests in `unit/tool-result-missing-id-3362.test.js`: the reporter's shape (assistant tool_call → `role: "tool"` with no id) resolves to the right id; parallel results pair in order; an id already claimed is not reissued, in both arrival orders; the Claude `tool_result` block shape is repaired; a valid id is left alone; a malformed id is still sanitized and still matches its call; an orphan result gets a well-formed id rather than `undefined`; ids are not reused across assistant turns; the duplicate empty result is no longer inserted; and an end-to-end pass through `openaiToClaudeRequest` shows a real `tool_use_id` on the emitted block.

Mutation-checked:

| mutation | result |
|---|---|
| restore the old truthy guard (return the raw id) | 8 of 10 fail |
| stop removing a claimed id from the open set | the reissue test fails |

The second mutation initially passed, which showed the test was too weak — the case only bites when the explicit result claims the *first* id. The test now covers both arrival orders.

Full suite (`npx vitest run unit translator`): **1809 passed / 95 failed**; against master's failing set the only difference is the network-dependent `unit/xai-oauth-service.test.js` timeouts, which flip between runs on an unmodified tree. The translator golden snapshots pass unchanged, which is the check that matters most here — this function runs on every request, whatever the target format. `npx eslint` reports no issues on the changed files.
