### PR TITLE
fix(ssrf): judge IPv4-mapped IPv6 by address, not by spelling

### DIFF
--- a/src/shared/utils/ssrfGuard.js
+++ b/src/shared/utils/ssrfGuard.js
@@ -21,10 +21,15 @@ function ipv4ToInt(host) {
 const BLOCKED_V4_RANGES = [
   [ipv4ToInt("0.0.0.0"), 8],
   [ipv4ToInt("10.0.0.0"), 8],
+  [ipv4ToInt("100.64.0.0"), 10],      // CGNAT
   [ipv4ToInt("127.0.0.0"), 8],
-  [ipv4ToInt("169.254.0.0"), 16],
+  [ipv4ToInt("169.254.0.0"), 16],     // link-local + cloud metadata
   [ipv4ToInt("172.16.0.0"), 12],
+  [ipv4ToInt("192.0.0.0"), 24],       // IETF protocol assignments
   [ipv4ToInt("192.168.0.0"), 16],
+  [ipv4ToInt("198.18.0.0"), 15],      // benchmarking
+  [ipv4ToInt("224.0.0.0"), 4],        // multicast
+  [ipv4ToInt("240.0.0.0"), 4],        // reserved, incl. 255.255.255.255
 ];
 
 function isBlockedIpv4(host) {
@@ -92,10 +97,18 @@ function isBlockedIpv6(host) {
 }
 
 // Throw if URL targets a non-public host. Caller should map to 400.
+//
+// This is a string check: it cannot see where a hostname resolves to. A caller
+// that then opens the connection itself needs a DNS-aware layer on top —
+// see the note on #3293.
 export function assertPublicUrl(rawUrl) {
   const parsed = new URL(rawUrl);
-  const host = parsed.hostname.toLowerCase();
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Blocked URL: unsupported protocol");
+  }
+  const host = parsed.hostname.toLowerCase().replace(/\.$/, "");
 
+  if (!host) throw new Error("Blocked URL: missing host");
   if (BLOCKED_HOSTNAMES.has(host)) throw new Error("Blocked URL: internal host");
   if (BLOCKED_SUFFIXES.some((s) => host.endsWith(s))) throw new Error("Blocked URL: internal host");
   if (isBlockedIpv4(host)) throw new Error("Blocked URL: private IP");

--- a/src/shared/utils/ssrfGuard.js
+++ b/src/shared/utils/ssrfGuard.js
@@ -36,12 +36,59 @@ function isBlockedIpv4(host) {
   });
 }
 
+// Expand an IPv6 literal to its 16 bytes, or null if it is not one.
+//
+// Matching on the text is not enough: WHATWG URL canonicalizes an embedded
+// dotted quad to hextets, so `new URL("http://[::ffff:127.0.0.1]")` reports its
+// hostname as `[::ffff:7f00:1]`. A pattern written against the dotted spelling
+// therefore never matches anything that came out of the parser. Normalize to
+// bytes once and judge the address itself.
+function ipv6ToBytes(host) {
+  let text = host;
+
+  // A trailing dotted quad (::ffff:127.0.0.1) is just another spelling of the
+  // two hextets it encodes — rewrite it so one parser covers both.
+  const dotted = text.match(/^(.*:)(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (dotted) {
+    const value = ipv4ToInt(dotted[2]);
+    if (value === null) return null;
+    text = `${dotted[1]}${(value >>> 16).toString(16)}:${(value & 0xffff).toString(16)}`;
+  }
+
+  const halves = text.split("::");
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(":") : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+  const gap = halves.length === 2 ? 8 - head.length - tail.length : 0;
+  if (gap < 0 || (halves.length === 1 && head.length !== 8)) return null;
+
+  const bytes = [];
+  for (const hextet of [...head, ...Array(gap).fill("0"), ...tail]) {
+    if (!/^[0-9a-f]{1,4}$/.test(hextet)) return null;
+    const value = Number.parseInt(hextet, 16);
+    bytes.push(value >>> 8, value & 0xff);
+  }
+  return bytes.length === 16 ? bytes : null;
+}
+
 function isBlockedIpv6(host) {
-  const h = host.replace(/^\[|\]$/g, "").toLowerCase();
-  const v4Mapped = h.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (v4Mapped) return isBlockedIpv4(v4Mapped[1]);
-  if (h === "::1" || h === "::") return true;
-  return h.startsWith("fe80:") || h.startsWith("fc") || h.startsWith("fd");
+  // Drop brackets and any zone id (fe80::1%eth0).
+  const bytes = ipv6ToBytes(host.replace(/^\[|\]$/g, "").toLowerCase().split("%")[0]);
+  if (!bytes) return false;
+
+  // ::ffff:a.b.c.d (v4-mapped) and ::a.b.c.d (v4-compatible) connect to the
+  // embedded IPv4 address, so they have to be judged as IPv4 — this is also
+  // what catches :: and ::1, as 0.0.0.0 and 0.0.0.1 in 0.0.0.0/8.
+  if (bytes.slice(0, 10).every((b) => b === 0)) {
+    const embedsIpv4 =
+      (bytes[10] === 0xff && bytes[11] === 0xff) || (bytes[10] === 0 && bytes[11] === 0);
+    if (embedsIpv4) {
+      return isBlockedIpv4(bytes.slice(12).join("."));
+    }
+  }
+
+  if ((bytes[0] & 0xfe) === 0xfc) return true;                          // fc00::/7  unique-local
+  return bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80;               // fe80::/10 link-local
 }
 
 // Throw if URL targets a non-public host. Caller should map to 400.

--- a/tests/unit/ssrf-guard-ipv6-3293.test.js
+++ b/tests/unit/ssrf-guard-ipv6-3293.test.js
@@ -93,3 +93,25 @@ describe("assertPublicUrl — regressions guarded elsewhere", () => {
     allowed("http://8.8.8.8/");
   });
 });
+
+describe("assertPublicUrl — reserved ranges and scheme", () => {
+  // Reserved space that the original list left out. 169.254/16 was already
+  // covered, but the neighbouring blocks are just as unroutable.
+  it("blocks reserved and non-routable IPv4 blocks", () => {
+    blocked("http://100.64.0.1/");     // CGNAT
+    blocked("http://192.0.0.1/");      // IETF protocol assignments
+    blocked("http://198.18.0.1/");     // benchmarking
+    blocked("http://239.255.255.250/"); // multicast (SSDP)
+    blocked("http://255.255.255.255/"); // reserved
+  });
+
+  it("rejects a non-http(s) scheme outright", () => {
+    blocked("file:///etc/passwd");
+    blocked("gopher://example.com/");
+    blocked("ftp://example.com/");
+  });
+
+  it("ignores a trailing dot on the hostname", () => {
+    blocked("http://localhost./");
+  });
+});

--- a/tests/unit/ssrf-guard-ipv6-3293.test.js
+++ b/tests/unit/ssrf-guard-ipv6-3293.test.js
@@ -1,0 +1,95 @@
+// #3293 — assertPublicUrl let IPv4-mapped IPv6 through, so a user-supplied
+// baseUrl of http://[::ffff:7f00:1] reached 127.0.0.1.
+//
+// The mapped-address check existed (GHSA-hj98-rc6w-m8cw) but was unreachable:
+// it matched `::ffff:` followed by a dotted quad, and WHATWG URL canonicalizes
+// that spelling to hextets before the guard ever sees it —
+// new URL("http://[::ffff:127.0.0.1]").hostname === "[::ffff:7f00:1]".
+import { describe, it, expect } from "vitest";
+import { assertPublicUrl } from "../../src/shared/utils/ssrfGuard.js";
+
+const blocked = (url) => expect(() => assertPublicUrl(url), url).toThrow();
+const allowed = (url) => expect(() => assertPublicUrl(url), url).not.toThrow();
+
+describe("assertPublicUrl — IPv4-mapped IPv6 (#3293)", () => {
+  // What the URL parser hands the guard, whichever spelling the attacker sent.
+  it("normalizes both spellings of a mapped address to the same hostname", () => {
+    expect(new URL("http://[::ffff:127.0.0.1]/").hostname).toBe("[::ffff:7f00:1]");
+    expect(new URL("http://[::ffff:169.254.169.254]/").hostname).toBe("[::ffff:a9fe:a9fe]");
+  });
+
+  it("blocks loopback written as a mapped address, in either spelling", () => {
+    blocked("http://[::ffff:127.0.0.1]/");
+    blocked("http://[::ffff:7f00:1]/");
+    blocked("http://[::ffff:127.0.0.1]:19998/embeddings");
+  });
+
+  it("blocks cloud metadata written as a mapped address", () => {
+    blocked("http://[::ffff:169.254.169.254]/latest/meta-data/");
+    blocked("http://[::ffff:a9fe:a9fe]/latest/meta-data/");
+  });
+
+  it("blocks private ranges written as a mapped address", () => {
+    blocked("http://[::ffff:10.0.0.1]/");
+    blocked("http://[::ffff:192.168.1.1]/");
+    blocked("http://[::ffff:172.16.0.1]/");
+  });
+
+  // ::a.b.c.d — the deprecated v4-compatible form connects to the same address.
+  it("blocks the v4-compatible form too", () => {
+    blocked("http://[::127.0.0.1]/");
+    blocked("http://[::169.254.169.254]/");
+  });
+});
+
+describe("assertPublicUrl — IPv6 literals", () => {
+  it("blocks loopback and unspecified, however they are written", () => {
+    blocked("http://[::1]/");
+    blocked("http://[::]/");
+    blocked("http://[0:0:0:0:0:0:0:1]/");
+  });
+
+  it("blocks unique-local fc00::/7", () => {
+    blocked("http://[fc00::1]/");
+    blocked("http://[fd00::1]/");
+    blocked("http://[fdff:ffff::1]/");
+  });
+
+  // fe80::/10 spans fe80 through febf — the old prefix test only saw "fe80:".
+  it("blocks the whole link-local fe80::/10 range", () => {
+    blocked("http://[fe80::1]/");
+    blocked("http://[fe90::1]/");
+    blocked("http://[feb0::1]/");
+    blocked("http://[fe80::1%25eth0]/");
+  });
+
+  it("still allows public IPv6", () => {
+    allowed("https://[2606:4700:4700::1111]/");
+    allowed("https://[2001:4860:4860::8888]/");
+    allowed("https://[2a00:1450:4001:800::200e]/");
+  });
+});
+
+describe("assertPublicUrl — regressions guarded elsewhere", () => {
+  it("still blocks the IPv4 forms the URL parser normalizes", () => {
+    blocked("http://127.0.0.1/");
+    blocked("http://127.1/");
+    blocked("http://2130706433/");
+    blocked("http://0177.0.0.1/");
+    blocked("http://169.254.169.254/");
+    blocked("http://10.0.0.1/");
+    blocked("http://192.168.1.1/");
+  });
+
+  it("still blocks internal hostnames", () => {
+    blocked("http://localhost/");
+    blocked("http://foo.internal/");
+    blocked("http://bar.local/");
+  });
+
+  it("still allows ordinary providers", () => {
+    allowed("https://api.openai.com/v1");
+    allowed("https://api.anthropic.com/v1/messages");
+    allowed("http://8.8.8.8/");
+  });
+});


### PR DESCRIPTION
Addresses the SSRF filter bypass in #3293.

**Read #3313 first — it was opened two days before this one and I missed it.** It fixes the same bypass and goes further. What is below is what I found independently; the part still worth taking from this PR is at the end.

## The bypass is real, and the existing fix is dead code

`isBlockedIpv6` already had a mapped-address check, added for GHSA-hj98-rc6w-m8cw:

```js
const v4Mapped = h.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
if (v4Mapped) return isBlockedIpv4(v4Mapped[1]);
```

It can never match. WHATWG URL canonicalizes an embedded dotted quad to hextets **before** the guard sees the hostname:

```js
new URL("http://[::ffff:127.0.0.1]/").hostname       // "[::ffff:7f00:1]"
new URL("http://[::ffff:169.254.169.254]/").hostname // "[::ffff:a9fe:a9fe]"
```

The pattern was written against a string `assertPublicUrl` is never handed. Running master's guard directly:

```
http://[::ffff:127.0.0.1]/         ALLOWED
http://[::ffff:7f00:1]/            ALLOWED
http://[::ffff:169.254.169.254]/   ALLOWED
http://[::ffff:10.0.0.1]/          ALLOWED
http://[::ffff:192.168.1.1]/       ALLOWED
http://[::1]/                      blocked
http://127.0.0.1/                  blocked
```

And it is not merely a parsing curiosity — the address connects:

```
$ node -e "http server on 127.0.0.1:19998 returning 500 + a body"
[::ffff:7f00:1]    -> HTTP 500 | body: INTERNAL-ONLY-SECRET token=abc123
127.0.0.1          -> HTTP 500 | body: INTERNAL-ONLY-SECRET token=abc123
```

A 500 is exactly the case the `custom-embedding` branch reflects (non-2xx, not 401/403), so the first 200 bytes of an internal service's response come back to the caller.

**This matters beyond the fix itself: GHSA-hj98-rc6w-m8cw is recorded as fixed, and it was not.** Whichever PR lands, that advisory needs revisiting.

## The report's other claim no longer applies

The first point — that "local" is derived from request-controlled signals, so the guard is skipped — described the state before `92259214` (GHSA-pjm4-8fpg-f9p6), which shipped in v0.5.55. `isLocalRequest` now requires `isLoopbackPeer`, backed by the per-process token `custom-server.js` stamps on sanitized requests, so a spoofed `x-9r-real-ip` no longer buys locality. That skip is now a real trust decision rather than an attacker-controlled one, so I left it alone.

## Checked and clean

Worth recording, because these are the usual suspects and the URL parser already handles all of them:

```
http://127.1/             -> hostname 127.0.0.1   blocked
http://2130706433/        -> hostname 127.0.0.1   blocked
http://0177.0.0.1/        -> hostname 127.0.0.1   blocked
http://0x7f000001/        -> hostname 127.0.0.1   blocked
http://[0:0:0:0:0:0:0:1]/ -> hostname [::1]       blocked
```

Decimal, octal and hex IPv4 notation are not bypasses here.

## The fix

Parse the IPv6 literal to its 16 bytes and judge the address instead of matching text. `::ffff:a.b.c.d` and the v4-compatible `::a.b.c.d` go to the IPv4 range check, since that is the address the OS connects to. That subsumes the special cases: `::` and `::1` come out as `0.0.0.0` and `0.0.0.1`, both inside the existing `0.0.0.0/8` rule, so the spelling of the loopback literal stops mattering. A zone id (`fe80::1%eth0`) is stripped before parsing.

Two ranges widen correctly as a result: `fe80::/10` spans fe80–febf (the old test matched the literal prefix `"fe80:"` and missed `fe90::`, `feb0::`), and `fc00::/7` is checked on the address rather than an `"fc"`/`"fd"` string prefix.

A second commit widens the reserved list — CGNAT (100.64/10), 192.0.0/24, benchmarking (198.18/15), multicast (224/4), reserved (240/4, which covers 255.255.255.255) — and rejects non-http(s) schemes, since `assertPublicUrl` accepted `file://` and `gopher://` despite its name. One of the three call sites guarded the scheme itself; the guard should not depend on that. A trailing dot (`localhost.`) now normalizes away.

Public IPv6 is unaffected: Cloudflare's `2606:4700:4700::1111` and Google's `2001:4860:4860::8888` still pass.

## How this compares to #3313

#3313 adds a DNS-aware undici dispatcher that validates every resolved address at the socket, which also closes rebinding and redirect hops — strictly more than this PR does. I applied its source to master and ran **my 15 tests against it: all pass.** I went looking for a weakness in its address handling and did not find one; the scoped-literal case I expected to slip through (`fe80::1%eth0`) is blocked there too.

**So on the overlapping ground, take #3313.** Two things here do not overlap:

**1. The dead-code finding above.** #3313 replaces `isBlockedIpv6` wholesale without noting that the mapped check already present could never fire, so the advisory record stays wrong unless someone says it.

**2. Sink coverage.** Three call sites share this guard, and #3313 hardens one:

| sink | does 9router open the socket? | after #3313 |
|---|---|---|
| `POST /api/provider-nodes/validate` | yes | DNS-aware ✅ |
| web-search `baseUrl` override → `open-sse/handlers/search/index.js:103` | yes, plain `fetch` | string check only ⚠️ |
| `/v1/web/fetch` (`src/sse/handlers/fetch.js`) | **no** — the URL is passed as a body field to Firecrawl / Jina / Tavily / Exa | string check is the right level ✅ |

The third row is worth stating so nobody "hardens" it by reflex: there is no socket of ours to pin, so DNS validation would buy nothing there. The second is a real remaining gap and the natural follow-up once `fetchPublicUrl` from #3313 exists — I deliberately did not reimplement that dispatcher here rather than submit a second copy of someone else's design.

Note also that pinning a resolved IP (the approach already in `open-sse/translator/concerns/image.js`) is **not** a drop-in for the validate route: pinning plus following a redirect to a different host would connect to the wrong address, so #3313's per-connect lookup hook is the correct shape for a redirect-following caller. That is why this PR does not carry one.

## Still open either way

- **`fetchOidcDiscovery`** (`POST /api/auth/oidc/test`) has no guard at all. I did not add one: an enterprise OIDC issuer on an internal network is a legitimate configuration, so blanket-blocking private addresses could break working setups. That needs the maintainer's intent, not my guess.

## Verification

15 tests in `unit/ssrf-guard-ipv6-3293.test.js`: both spellings of a mapped loopback and of metadata, mapped RFC1918, the v4-compatible form, every spelling of `::1`, `fc00::/7`, the full `fe80::/10` range, a zone id, public IPv6 still allowed, the pre-existing IPv4 and hostname rules still blocking, the newly-added reserved blocks, non-http schemes, and a trailing dot. One test pins the canonicalization itself (`new URL(...).hostname === "[::ffff:7f00:1]"`), since that is the fact the old check got wrong.

**5 of them fail on unpatched master** — the tests reproduce the vulnerability, they do not merely describe it.

Full suite (`npx vitest run unit translator`): 1806 passed / 95 failed; against master's failing set the only difference is the network-dependent `unit/xai-oauth-service.test.js` timeouts, which flip between runs on an unmodified tree. `npx eslint` reports no issues on the changed files.

If a maintainer prefers, I am happy to redo this privately through a draft security advisory instead of a public PR — the bypass is already public in #3293, which is why I posted it here.
