### PR TITLE
fix(responses): normalize custom tool names in non-streaming conversion

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -84,6 +84,12 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
   const message = choice.message || {};
   const output = [];
 
+  // The request translator exports the collected custom tool names as an array
+  // (translator/request/openai-responses.js) and chatCore.js forwards that value
+  // verbatim, while direct callers pass a Set. Accept either, without mutating
+  // the caller's collection.
+  const customToolNameSet = customToolNames instanceof Set ? customToolNames : new Set(customToolNames || []);
+
   // Reasoning → a reasoning item (summary text), mirroring the streaming path.
   const reasoning = message.reasoning_content || message.reasoning;
   if (typeof reasoning === "string" && reasoning.length > 0) {
@@ -106,7 +112,7 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
   // tool_calls → function_call/custom_tool_call items (Responses-native tool shape).
   for (const tc of message.tool_calls || []) {
     const fn = tc.function || {};
-    const custom = customToolNames?.has(fn.name);
+    const custom = customToolNameSet.has(fn.name);
     output.push({
       type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
       id: `${custom ? "ctc" : "fc"}_${tc.id || ""}`,

--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -56,6 +56,12 @@ function chatCompletionToResponses(responseBody, customToolNames = null) {
   const message = choice.message || {};
   const output = [];
 
+  // The request translator exports the collected custom tool names as an array
+  // (translator/request/openai-responses.js) and chatCore.js forwards that value
+  // verbatim, while direct callers pass a Set. Accept either, without mutating
+  // the caller's collection.
+  const customToolNameSet = customToolNames instanceof Set ? customToolNames : new Set(customToolNames || []);
+
   const reasoning = message.reasoning_content || message.reasoning;
   if (typeof reasoning === "string" && reasoning.length > 0) {
     output.push({
@@ -75,7 +81,7 @@ function chatCompletionToResponses(responseBody, customToolNames = null) {
 
   for (const tc of message.tool_calls || []) {
     const fn = tc.function || {};
-    const custom = customToolNames?.has(fn.name);
+    const custom = customToolNameSet.has(fn.name);
     output.push({
       type: custom ? RESPONSES_ITEM.CUSTOM_TOOL_CALL : RESPONSES_ITEM.FUNCTION_CALL,
       id: `${custom ? "ctc" : "fc"}_${tc.id || ""}`,

--- a/tests/unit/openai-responses-nonstream.test.js
+++ b/tests/unit/openai-responses-nonstream.test.js
@@ -9,6 +9,7 @@ vi.mock("@/lib/usageDb.js", () => ({
 const { FORMATS } = await import("../../open-sse/translator/formats.js");
 const { translateNonStreamingResponse } = await import("../../open-sse/handlers/chatCore/nonStreamingHandler.js");
 const { handleForcedSSEToJson } = await import("../../open-sse/handlers/chatCore/sseToJsonHandler.js");
+const { openaiResponsesToOpenAIRequest } = await import("../../open-sse/translator/request/openai-responses.js");
 
 // A chat.completion body as returned by a chat-native upstream (e.g. op-ericding)
 const CHAT_TOOL_BODY = {
@@ -85,6 +86,117 @@ describe("non-stream Chat upstream for a Responses-API client (op-ericding bug)"
   });
 });
 
+// Regression guard for the custom-tool metadata type mismatch.
+//
+// The Responses request translator collects custom tool names in a Set but
+// exports them as an Array — `result._customToolNames = [...customToolNames]`
+// (open-sse/translator/request/openai-responses.js:229). chatCore.js:192 lifts
+// that value off the translated body and hands it to this consumer unchanged,
+// which asked it for `customToolNames?.has(name)`
+// (open-sse/handlers/chatCore/nonStreamingHandler.js:109). Arrays have no
+// `.has`, so a custom tool call threw *after* the provider had already answered
+// and surfaced to the client as a bodyless HTTP 500.
+//
+// The streaming path was never affected: open-sse/utils/stream.js:62 already
+// normalises with `new Set(customToolNames || [])`. Every pre-existing test in
+// this file passed a hand-built Set, so the seam between the producer and this
+// consumer was never exercised.
+describe("custom tool names supplied as the request translator's array", () => {
+  const FREEFORM = "FREEFORM-LIVE-OK";
+  const MULTILINE = [
+    "FREEFORM-BEGIN",
+    "{\"json\":\"looking\"}",
+    "Free-Tier-Combo",
+    "bridge/free-tier",
+    "FREEFORM-END"
+  ].join("\n");
+
+  const FREEFORM_TOOL = {
+    type: "custom",
+    name: "bridge_freeform",
+    description: "Echoes freeform text.",
+    format: { type: "grammar", syntax: "lark", definition: "start: /(.|\\n)+/" }
+  };
+
+  const bodyWithCall = (name, argumentsText) => {
+    const body = structuredClone(CHAT_TOOL_BODY);
+    body.choices[0].message.tool_calls[0] = {
+      id: "call_ff",
+      type: "function",
+      function: { name, arguments: argumentsText }
+    };
+    return body;
+  };
+
+  const translate = (body, customToolNames) =>
+    translateNonStreamingResponse(body, FORMATS.OPENAI, FORMATS.OPENAI_RESPONSES, customToolNames);
+
+  const customCall = (out) => (out.output || []).find((item) => item.type === "custom_tool_call");
+  const functionCall = (out) => (out.output || []).find((item) => item.type === "function_call");
+
+  it("emits custom_tool_call when the marked name arrives in an array", () => {
+    const out = translate(bodyWithCall("bridge_freeform", JSON.stringify({ input: FREEFORM })), ["bridge_freeform"]);
+    expect(customCall(out)).toMatchObject({
+      call_id: "call_ff",
+      name: "bridge_freeform",
+      input: FREEFORM
+    });
+    expect(functionCall(out)).toBeUndefined();
+  });
+
+  it("unwraps the Chat input parameter without leaking the JSON wrapper", () => {
+    const out = translate(bodyWithCall("bridge_freeform", JSON.stringify({ input: FREEFORM })), ["bridge_freeform"]);
+    expect(customCall(out).input).toBe(FREEFORM);
+    expect(customCall(out).input).not.toBe(JSON.stringify({ input: FREEFORM }));
+  });
+
+  it("preserves multi-line raw input verbatim", () => {
+    const out = translate(bodyWithCall("bridge_freeform", JSON.stringify({ input: MULTILINE })), ["bridge_freeform"]);
+    expect(customCall(out).input).toBe(MULTILINE);
+  });
+
+  it("treats an array and a Set identically", () => {
+    const body = bodyWithCall("bridge_freeform", JSON.stringify({ input: FREEFORM }));
+    expect(translate(body, ["bridge_freeform"])).toEqual(translate(body, new Set(["bridge_freeform"])));
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["an empty array", []],
+    ["an empty Set", new Set()]
+  ])("emits function_call when the collection is %s", (_label, customToolNames) => {
+    const out = translate(bodyWithCall("shell", "{\"cmd\":\"ls\"}"), customToolNames);
+    expect(functionCall(out)).toMatchObject({
+      call_id: "call_ff",
+      name: "shell",
+      arguments: "{\"cmd\":\"ls\"}"
+    });
+    expect(customCall(out)).toBeUndefined();
+  });
+
+  it("emits function_call when the array holds a different name", () => {
+    const out = translate(bodyWithCall("shell", "{\"cmd\":\"ls\"}"), ["bridge_freeform"]);
+    expect(functionCall(out)).toMatchObject({ name: "shell", arguments: "{\"cmd\":\"ls\"}" });
+    expect(customCall(out)).toBeUndefined();
+  });
+
+  it("accepts the collection the request translator actually produces", () => {
+    const translated = openaiResponsesToOpenAIRequest("cx/gpt-5.6-sol", {
+      input: [
+        { type: "additional_tools", role: "developer", tools: [FREEFORM_TOOL] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] }
+      ]
+    }, true, null);
+
+    // Pins the producer contract this consumer has to tolerate.
+    expect(Array.isArray(translated._customToolNames)).toBe(true);
+
+    const out = translate(bodyWithCall("bridge_freeform", JSON.stringify({ input: FREEFORM })), translated._customToolNames);
+    expect(customCall(out)).toMatchObject({ name: "bridge_freeform", input: FREEFORM });
+  });
+});
+
 describe("forced-SSE JSON path for a Responses-API client behind a chat upstream", () => {
   const sseCtx = (sourceFormat, targetFormat) => {
     const encoder = new TextEncoder();
@@ -127,6 +239,20 @@ describe("forced-SSE JSON path for a Responses-API client behind a chat upstream
   it("returns a custom_tool_call for a marked tool", async () => {
     const ctx = sseCtx(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI);
     ctx.customToolNames = new Set(["shell"]);
+    const result = await handleForcedSSEToJson(ctx);
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    const call = (json.output || []).find((item) => item.type === "custom_tool_call");
+    expect(call).toMatchObject({
+      call_id: "call_9",
+      name: "shell",
+      input: "{\"cmd\":\"pwd\"}"
+    });
+  });
+
+  it("returns a custom_tool_call when the marked names arrive as an array", async () => {
+    const ctx = sseCtx(FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI);
+    ctx.customToolNames = ["shell"];
     const result = await handleForcedSSEToJson(ctx);
     expect(result.success).toBe(true);
     const json = await result.response.json();


### PR DESCRIPTION
## Summary

A Responses-API client that declares a **custom tool** gets a bodyless HTTP 500 whenever the model actually calls it — *after* the provider has already answered successfully. Standard function tools are unaffected, which makes it look like a provider or routing fault rather than a translation bug.

Reproduced on `v0.5.55` and the defect is still present on `master`.

## Root cause

The Responses request translator collects custom tool names in a `Set` but exports them as an **array**:

```js
if (customToolNames.size > 0) result._customToolNames = [...customToolNames];
// open-sse/translator/request/openai-responses.js
```

`handlers/chatCore.js` lifts that value off the translated body and forwards it unchanged to the response converters, which ask it for `Set` semantics:

```js
const custom = customToolNames?.has(fn.name);
// open-sse/handlers/chatCore/nonStreamingHandler.js  (openAICompletionToResponses)
// open-sse/handlers/chatCore/sseToJsonHandler.js     (chatCompletionToResponses)
```

Arrays have no `.has`, and optional chaining only guards `null`/`undefined`, so this throws `TypeError: customToolNames?.has is not a function`. The rejection escapes the route handler and Next returns an empty 500.

Two details explain the symptom pattern:

- The `size > 0` guard means the property is **absent** when no custom tool is declared, so the optional chain short-circuits and ordinary function tools keep working.
- The throw happens inside the `for (… of message.tool_calls)` loop, i.e. only once the provider has already returned a tool call — so tokens are spent and then the request dies.

Streaming was never affected: `open-sse/utils/stream.js` already normalises with `new Set(customToolNames || [])`. This PR applies the same normalisation at the two non-streaming boundaries.

## Why it wasn't caught

Every existing test constructs `customToolNames` as a hand-built `Set`, while `tests/unit/openai-responses-custom-tools.test.js` separately asserts the producer emits an **array** (`expect(out._customToolNames).toEqual(["exec"])`). Both halves are individually correct; the seam between them was never exercised.

## The fix

Normalise at the consumer, accepting `Array | Set | null | undefined`, without mutating the caller's collection:

```js
const customToolNameSet =
  customToolNames instanceof Set ? customToolNames : new Set(customToolNames || []);
```

The producer's array contract is deliberately left alone, since existing tests pin it. `utils/stream.js` is untouched — it is already correct, and changing it would swap a copy for a shared reference for no benefit.

## Tests

Added to `tests/unit/openai-responses-nonstream.test.js` (8 cases for the non-streaming consumer, 1 for the forced-SSE→JSON consumer):

- `null`, `undefined`, `[]`, `new Set()` → `function_call`
- `["exec"]` and `new Set(["exec"])` → `custom_tool_call`, byte-identical output
- non-matching name → `function_call`
- raw input fidelity: `{"input":"…"}` unwraps, with no wrapper leakage
- multi-line payload preserved verbatim
- **the seam**: feeds the real output of `openaiResponsesToOpenAIRequest` into the converter, asserting `Array.isArray(_customToolNames)` first

Before the fix these fail with the `TypeError`; after, the file is 18/18.

Run with:

```
cd tests && npx vitest run unit/openai-responses-nonstream.test.js unit/openai-responses-custom-tools.test.js
```

I also ran the full suite before and after the change on the same machine to compare failure sets: no test that passed beforehand fails afterwards. (A plain checkout is not all-green, as `CLAUDE.md` documents, so the comparison is before/after rather than an absolute pass.)

## End-to-end verification

Built from this branch and run against a real provider: a Responses client declaring a custom tool now receives `type: "custom_tool_call"` with the raw input intact — non-streaming and streaming — and a `custom_tool_call_output` continuation resumes normally. Multi-line patch-shaped input round-trips byte-for-byte.

This matters for Codex compatibility specifically, since Codex transports `apply_patch` as a freeform custom tool, so every emitted `apply_patch` call hits this path.
