### PR TITLE
fix(auth): recognize the OIDC-only auth mode so SSO login can start

### DIFF
--- a/src/lib/auth/oidc.js
+++ b/src/lib/auth/oidc.js
@@ -48,9 +48,13 @@ export function isOidcConfigured(settings) {
   );
 }
 
+export function isOidcAuthMode(authMode) {
+  return ["sso", "oidc", "both"].includes(authMode);
+}
+
 export async function getOidcRuntimeConfig() {
   const settings = await getSettings();
-  if (!["oidc", "both"].includes(settings.authMode) || !isOidcConfigured(settings)) return null;
+  if (!isOidcAuthMode(settings.authMode) || !isOidcConfigured(settings)) return null;
 
   const issuerUrl = trimTrailingSlashes(settings.oidcIssuerUrl);
   return {

--- a/tests/unit/oidc-auth-mode.test.js
+++ b/tests/unit/oidc-auth-mode.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/localDb", () => ({
+  getSettings: mocks.getSettings,
+}));
+
+const { getOidcRuntimeConfig, isOidcAuthMode } = await import("../../src/lib/auth/oidc.js");
+
+const configuredOidcSettings = {
+  oidcIssuerUrl: "https://idp.example.com/application/o/9router/",
+  oidcClientId: "client-id",
+  oidcClientSecret: "client-secret",
+};
+
+describe("isOidcAuthMode", () => {
+  it("accepts every auth mode the dashboard writes for OIDC login", () => {
+    expect(isOidcAuthMode("sso")).toBe(true);
+    expect(isOidcAuthMode("oidc")).toBe(true);
+    expect(isOidcAuthMode("both")).toBe(true);
+  });
+
+  it("rejects password-only and missing auth modes", () => {
+    expect(isOidcAuthMode("password")).toBe(false);
+    expect(isOidcAuthMode(undefined)).toBe(false);
+  });
+});
+
+describe("getOidcRuntimeConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves a config when SSO is the only login method", async () => {
+    mocks.getSettings.mockResolvedValue({ ...configuredOidcSettings, authMode: "sso" });
+
+    const config = await getOidcRuntimeConfig();
+
+    expect(config).not.toBeNull();
+    expect(config.issuerUrl).toBe("https://idp.example.com/application/o/9router");
+    expect(config.clientId).toBe("client-id");
+  });
+
+  it("resolves a config when password and SSO login are both enabled", async () => {
+    mocks.getSettings.mockResolvedValue({ ...configuredOidcSettings, authMode: "both" });
+
+    expect(await getOidcRuntimeConfig()).not.toBeNull();
+  });
+
+  it("returns null for password-only login", async () => {
+    mocks.getSettings.mockResolvedValue({ ...configuredOidcSettings, authMode: "password" });
+
+    expect(await getOidcRuntimeConfig()).toBeNull();
+  });
+
+  it("returns null when SSO is enabled but OIDC credentials are missing", async () => {
+    mocks.getSettings.mockResolvedValue({ authMode: "sso", oidcIssuerUrl: "" });
+
+    expect(await getOidcRuntimeConfig()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Selecting **OIDC only** under Profile → Single Sign-On locks the user out of the dashboard, with no supported way back in.

Password login returns `403 Password login is disabled. Use OIDC sign in.`, and the OIDC sign-in button lands on `/login?error=oidc_not_configured`. Recovery requires editing the `settings` row in the SQLite database by hand.

To reproduce on a working OIDC configuration: save a valid issuer, client ID, and client secret with **Both**, confirm SSO sign-in works, then switch to **OIDC only** and save.

## Root Cause

The Auth Mode selector stores the literal value `sso` for OIDC only:

https://github.com/decolua/9router/blob/master/src/app/(dashboard)/dashboard/profile/page.js#L1009-L1013

`PATCH /api/settings` persists that value as-is, so `settings.authMode` becomes `"sso"`. From there the two login paths disagree:

- `POST /api/auth/login` treats `sso` as an SSO-only mode and rejects the password before checking it (`src/app/api/auth/login/route.js:43-51`).
- `GET /api/auth/oidc/start` calls `getOidcRuntimeConfig()`, which accepted only `"oidc"` and `"both"`, so it returned `null` and redirected to `/login?error=oidc_not_configured` (`src/lib/auth/oidc.js:53`).

Every other reader of the setting accepts `sso`: the login route above, `GET /api/auth/status`, and the login page (`src/app/login/page.js:131`, `["sso", "oidc", "saml", "both"]`). `getOidcRuntimeConfig` was the only place that did not. The SAML path has no equivalent gate at all, so **SAML only** works from the same selector while **OIDC only** does not.

## Fix

Accept `sso` alongside `oidc` and `both` when resolving the OIDC runtime config, through a named helper so the accepted set is explicit and testable:

```js
export function isOidcAuthMode(authMode) {
  return ["sso", "oidc", "both"].includes(authMode);
}
```

The change is deliberately narrow. It does not alter what the selector writes, does not touch settings validation, and does not change `password` or `both` behavior. Installations on `oidc` or `both` are unaffected, and installations already saved as `sso` start working without a settings migration.

## Validation & Testing

New `tests/unit/oidc-auth-mode.test.js`, following the existing `tests/unit` Vitest conventions with `@/lib/localDb` mocked:

- `getOidcRuntimeConfig` resolves a config when `authMode` is `sso`, the value the dashboard writes for OIDC only.
- It also resolves for `both`.
- It returns `null` for `password`.
- It returns `null` when an SSO mode is set but the OIDC credentials are incomplete, so the misconfiguration guard is preserved.
- `isOidcAuthMode` accepts `sso`, `oidc`, and `both`, and rejects `password` and `undefined`.

Without the source change, the three `sso` cases fail, so the tests pin the reported defect rather than the current behavior.

```
cd tests && npx vitest run --config ./vitest.config.js \
  unit/oidc-auth-mode.test.js unit/saml.test.js unit/auth-status.test.js unit/dashboard-guard.test.js

Test Files  4 passed (4)
     Tests  43 passed (43)
```

The SAML utilities, the auth status route, and the dashboard guard all still pass.
