### PR TITLE
fix(clinepass): unwrap { data, success } envelope in non-streaming responses

### DIFF
--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -304,6 +304,12 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
     }
   }
 
+  // Some OpenAI-compatible gateways (e.g. api.cline.bot) wrap the whole completion
+  // in { data: {…}, success: true }. Unwrap so the client sees a top-level `choices`.
+  if (responseBody && !Array.isArray(responseBody.choices) && Array.isArray(responseBody?.data?.choices)) {
+    responseBody = responseBody.data;
+  }
+
   reqLogger.logProviderResponse(providerResponse.status, providerResponse.statusText, providerResponse.headers, responseBody);
   if (onRequestSuccess) {
     Promise.resolve()


### PR DESCRIPTION
## Problem

`api.cline.bot` wraps non-streaming chat completions in `{ data: { ... }, success: true }`:

```json
{ data: { choices: [...], model: deepseek/deepseek-v4-flash, ... }, success: true }
```

The `openai → openai` non-stream path passes the upstream body through untranslated (`translateNonStreamingResponse` returns it as-is), so the router's JSON response has **no top-level `choices`**. Clients and the model test then fail with `Provider returned no completion choices for this model`.

## Fix

In `handleNonStreamingResponse`, unwrap the `data` envelope when it actually contains `choices`. The guard only triggers when the top level has no `choices` but `data.choices` is an array, so plain OpenAI-shaped responses are untouched.

## Verified

- Live upstream: 200 with choices under `data.choices`; after unwrap, top-level `choices` present.
- `/api/v1/chat/completions` (non-stream) now returns top-level `choices`.
- Streaming path (SSE) unaffected — upstream emits plain OpenAI chunks there.