### PR TITLE
fix(usage): update dashboard stats in real time

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
+++ b/src/app/(dashboard)/dashboard/usage/components/UsageChart.js
@@ -22,7 +22,7 @@ const fmtTokens = (n) => {
 
 const fmtCost = (n) => `$${(n || 0).toFixed(4)}`;
 
-export default function UsageChart({ period = "7d" }) {
+export default function UsageChart({ period = "7d", refreshKey = 0 }) {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState("tokens");
@@ -40,7 +40,7 @@ export default function UsageChart({ period = "7d" }) {
     } finally {
       setLoading(false);
     }
-  }, [period]);
+  }, [period, refreshKey]);
 
   useEffect(() => {
     fetchData();
@@ -138,4 +138,5 @@ export default function UsageChart({ period = "7d" }) {
 
 UsageChart.propTypes = {
   period: PropTypes.string,
+  refreshKey: PropTypes.number,
 };

--- a/src/app/api/usage/stream/route.js
+++ b/src/app/api/usage/stream/route.js
@@ -2,7 +2,12 @@ import { getUsageStats, statsEmitter, getActiveRequests } from "@/lib/usageDb";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+const VALID_PERIODS = new Set(["today", "24h", "7d", "30d", "60d", "all"]);
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const requestedPeriod = searchParams.get("period") || "today";
+  const period = VALID_PERIODS.has(requestedPeriod) ? requestedPeriod : "today";
   const encoder = new TextEncoder();
   const state = { closed: false, keepalive: null, send: null, sendPending: null, cachedStats: null };
 
@@ -19,7 +24,7 @@ export async function GET() {
             controller.enqueue(encoder.encode(`data: ${JSON.stringify(quickStats)}\n\n`));
           }
           // Then do full recalc and update cache
-          const stats = await getUsageStats();
+          const stats = await getUsageStats(period);
           state.cachedStats = stats;
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
         } catch {
@@ -72,8 +77,9 @@ export async function GET() {
   return new Response(stream, {
     headers: {
       "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
+      "Cache-Control": "no-cache, no-transform",
       Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
     },
   });
 }

--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -580,8 +580,10 @@ export async function getUsageStats(period = "all") {
 
     for (const r of filtered) {
       const tokens = parseJson(r.tokens, {}) || {};
-      const promptTokens = tokens.prompt_tokens || 0;
-      const completionTokens = tokens.completion_tokens || 0;
+      // The persisted columns are normalized by saveRequestUsage and work for
+      // both OpenAI (prompt/completion) and Anthropic (input/output) shapes.
+      const promptTokens = r.promptTokens || tokens.prompt_tokens || tokens.input_tokens || 0;
+      const completionTokens = r.completionTokens || tokens.completion_tokens || tokens.output_tokens || 0;
       const cachedTokens = tokens.cached_tokens || tokens.cache_read_input_tokens || 0;
       const entryCost = r.cost || 0;
       const providerDisplayName = providerNodeNameMap[r.provider] || r.provider;

--- a/src/shared/components/UsageStats.js
+++ b/src/shared/components/UsageStats.js
@@ -216,6 +216,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
   const [periodLocal, setPeriodLocal] = useState("today");
   const isInitialLoad = useRef(true);
   const hasLoadedStats = useRef(false);
+  const statsFetchAbortRef = useRef(null);
   const period = periodProp ?? periodLocal;
   const setPeriod = setPeriodProp ?? setPeriodLocal;
 
@@ -253,6 +254,9 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
 
   // Fetch filtered stats via REST when period changes
   useEffect(() => {
+    const controller = new AbortController();
+    statsFetchAbortRef.current = controller;
+
     // First load: show full spinner; subsequent: show subtle fetching indicator
     if (isInitialLoad.current) {
       isInitialLoad.current = false;
@@ -261,7 +265,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       setFetching(true);
     }
 
-    fetch(`/api/usage/stats?period=${period}`)
+    fetch(`/api/usage/stats?period=${period}`, { signal: controller.signal })
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
         if (data) {
@@ -271,30 +275,31 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       })
       .catch(() => {})
       .finally(() => {
-        setLoading(false);
-        setFetching(false);
+        if (statsFetchAbortRef.current === controller) {
+          statsFetchAbortRef.current = null;
+          setLoading(false);
+          setFetching(false);
+        }
       });
+
+    return () => {
+      controller.abort();
+      if (statsFetchAbortRef.current === controller) statsFetchAbortRef.current = null;
+    };
   }, [period]);
 
-  // SSE connection - real-time updates for activeRequests + recentRequests only
+  // Keep the full, period-filtered snapshot current as completed requests are persisted.
   useEffect(() => {
-    const es = new EventSource("/api/usage/stream");
+    const es = new EventSource(`/api/usage/stream?period=${encodeURIComponent(period)}`);
 
     es.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data);
-        // Always merge only real-time fields, never overwrite full stats from REST
-        setStats((prev) => {
-          if (!prev) return prev;
-          return {
-            ...prev,
-            activeRequests: data.activeRequests,
-            recentRequests: data.recentRequests,
-            errorProvider: data.errorProvider,
-            pending: data.pending,
-          };
-        });
-        if (hasLoadedStats.current) setLoading(false);
+        // The SSE snapshot is newer than an in-flight initial/period REST fetch.
+        statsFetchAbortRef.current?.abort();
+        setStats(data);
+        hasLoadedStats.current = true;
+        setLoading(false);
       } catch (err) {
         console.error("[SSE CLIENT] parse error:", err);
       }
@@ -303,7 +308,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
     es.onerror = () => setLoading(false);
 
     return () => es.close();
-  }, []);
+  }, [period]);
 
   const toggleSort = useCallback((tableType, field) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -481,7 +486,7 @@ export default function UsageStats({ period: periodProp, setPeriod: setPeriodPro
       )}
 
       {/* Token / Cost chart - sync period */}
-      {loading ? spinner : <UsageChart period={period} />}
+      {loading ? spinner : <UsageChart period={period} refreshKey={stats.totalRequests} />}
 
       {/* Table with dropdown selector */}
       <div className="flex flex-col gap-3">

--- a/tests/unit/cached-token-e2e.test.js
+++ b/tests/unit/cached-token-e2e.test.js
@@ -81,4 +81,22 @@ describe("cached-token end-to-end (persist + aggregate + cost)", () => {
     expect(hist[0].tokens.prompt_tokens).toBe(1000);
     expect(hist[0].tokens.cached_tokens).toBe(600);
   });
+
+  it("Today stats count input/output-shaped usage", async () => {
+    const before = await db.getUsageStats("today");
+
+    await db.saveRequestUsage({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      connectionId: "c-input-output",
+      tokens: { input_tokens: 77, output_tokens: 23 },
+      endpoint: "/v1/messages",
+      status: "ok",
+    });
+
+    const after = await db.getUsageStats("today");
+    expect(after.totalRequests - before.totalRequests).toBe(1);
+    expect(after.totalPromptTokens - before.totalPromptTokens).toBe(77);
+    expect(after.totalCompletionTokens - before.totalCompletionTokens).toBe(23);
+  });
 });


### PR DESCRIPTION
## Problem

The Usage dashboard does not update aggregate metrics after a request completes. Total requests, input tokens, output tokens, cached tokens, estimated cost, breakdown tables, and the chart remain stale until the page is reloaded or the selected period changes.

For providers that report Anthropic-shaped usage (`input_tokens` and `output_tokens`), Today and 24h totals can also remain at zero even though the request was persisted.

## Root cause

The SSE endpoint recalculates usage after persisted requests, but the client discards the aggregate fields and only merges active requests, recent requests, pending state, and provider errors.

The stream also calls `getUsageStats()` without the selected period, producing an all-time snapshot that cannot safely replace the period-filtered REST response. In addition, the Today/24h aggregation path reads only `prompt_tokens` and `completion_tokens` from the raw token payload instead of using the normalized SQLite columns.

## Fix

- pass the selected period to the SSE endpoint and recalculate the matching snapshot
- replace client usage state with the complete period-filtered SSE snapshot
- abort stale REST requests when newer SSE data arrives
- reconnect the stream when the selected period changes
- refresh the usage chart when the request total changes
- aggregate Today/24h tokens from normalized persisted columns, with raw-field fallbacks
- send SSE headers that prevent intermediary response transformation and buffering
- add regression coverage for `input_tokens` and `output_tokens`

## Verification

- `git diff --check`
- JavaScript syntax checks passed for the API route, usage repository, and regression test
- Node SQLite integration smoke test passed: the Today SSE snapshot excluded a ten-day-old request and reported the new request as 1 request, 77 input tokens, and 23 output tokens

The full Vitest and ESLint suites were not run because dependencies are not installed in this workspace.