### PR TITLE
fix(dashboard): prevent UI crash when API key is less than 8 characters

### DIFF
--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/GenericExampleCard.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/GenericExampleCard.js
@@ -275,7 +275,7 @@ export function GenericExampleCard({ providerId, kind }) {
         {/* API Key */}
         <Row label="API Key">
           <span className="px-3 py-1.5 text-sm font-mono text-text-main bg-sidebar rounded-lg truncate block">
-            {apiKey ? `${apiKey.slice(0, 8)}${"\u2022".repeat(Math.min(20, apiKey.length - 8))}` : <span className="text-text-muted italic">No key configured</span>}
+            {apiKey ? `${apiKey.slice(0, 8)}${"\u2022".repeat(Math.min(20, Math.max(0, apiKey.length - 8)))}` : <span className="text-text-muted italic">No key configured</span>}
           </span>
         </Row>
 

--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/SttExampleCard.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/SttExampleCard.js
@@ -157,7 +157,7 @@ export function SttExampleCard({ providerId }) {
         {/* API Key */}
         <Row label="API Key">
           <span className="px-3 py-1.5 text-sm font-mono text-text-main bg-sidebar rounded-lg truncate block">
-            {apiKey ? `${apiKey.slice(0, 8)}${"\u2022".repeat(Math.min(20, apiKey.length - 8))}` : <span className="text-text-muted italic">No key configured</span>}
+            {apiKey ? `${apiKey.slice(0, 8)}${"\u2022".repeat(Math.min(20, Math.max(0, apiKey.length - 8)))}` : <span className="text-text-muted italic">No key configured</span>}
           </span>
         </Row>
 

--- a/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/TtsExampleCard.js
+++ b/src/app/(dashboard)/dashboard/media-providers/[kind]/[id]/components/TtsExampleCard.js
@@ -274,7 +274,7 @@ export function TtsExampleCard({ providerId }) {
           <Row label="API Key">
             <span className="px-3 py-1.5 text-sm font-mono text-text-main bg-sidebar rounded-lg truncate block">
               {apiKey
-                ? `${apiKey.slice(0, 8)}${"•".repeat(Math.min(20, apiKey.length - 8))}`
+                ? `${apiKey.slice(0, 8)}${"•".repeat(Math.min(20, Math.max(0, apiKey.length - 8)))}`
                 : connectionCount > 0
                   ? <span className="text-text-muted italic">Using stored key(s) · {connectionCount} connection{connectionCount > 1 ? "s" : ""}</span>
                   : <span className="text-text-muted italic">No key configured</span>}


### PR DESCRIPTION
### Problem
In the provider connection cards (`TtsExampleCard`, `GenericExampleCard`, `SttExampleCard`), the dashboard masks API keys by showing the first 8 characters and repeating a mask character (`•`) for the remaining length:
`"•".repeat(apiKey.length - 8)`

If a developer enters a short mock key or a local testing key under 8 characters (e.g., `12345`), the calculation returns a negative number (e.g., `-3`), throwing a `RangeError: Invalid count value` in JavaScript. This crashes the entire dashboard UI render phase.

### Solution
Wrap the repeat count in `Math.max(0, ...)` to ensure the masking repeat count is never negative:
`"•".repeat(Math.min(20, Math.max(0, apiKey.length - 8)))`

### Impact
- Fixes the dashboard UI page crash when dealing with short API keys.
- Improves UI robustness for local test connections and custom configurations.

### Testing
- Verified that the test suite runs successfully and the changes introduce no new regressions.