### PR TITLE
feat(open-sse): support dynamic image aspect ratios for antigravity image generation

### DIFF
--- a/open-sse/handlers/imageProviders/antigravity.js
+++ b/open-sse/handlers/imageProviders/antigravity.js
@@ -1,6 +1,6 @@
 // Antigravity image adapter - delegates to the executor for correct request
 // envelope (project, model, requestType, sessionId) and auth headers.
-import { nowSec } from "./_base.js";
+import { nowSec, sizeToAspectRatio } from "./_base.js";
 import { getExecutor } from "../../executors/index.js";
 
 // Convert image input (data URI or raw base64) to Gemini inlineData part
@@ -31,6 +31,19 @@ export default {
     const executor = getExecutor("antigravity");
     if (!executor) throw new Error("Antigravity executor not found");
 
+    // Ensure we use an image model for image generation
+    const isImageModel = (m) => /image|imagen|image-generation/i.test(m || "");
+    let targetModel = isImageModel(model) ? model : "gemini-3.1-flash-image";
+
+    // If body.size is provided, resolve aspect ratio and append to model
+    if (body.size && typeof body.size === "string") {
+      const ratio = sizeToAspectRatio(body.size);
+      const suffix = ratio.replace(":", "x");
+      if (!targetModel.includes(suffix)) {
+        targetModel = `${targetModel}-${suffix}`;
+      }
+    }
+
     // Build parts: text prompt + optional input image for editing
     const parts = [{ text: body.prompt }];
     const imageInput = body.image || (Array.isArray(body.images) && body.images[0]);
@@ -44,7 +57,7 @@ export default {
     };
 
     const result = await executor.execute({
-      model,
+      model: targetModel,
       body: chatBody,
       stream: false,
       credentials,


### PR DESCRIPTION
### Problem
Gemini/Antigravity image generation requests lacked support for dynamic aspect ratios mapping from standard request dimensions.

### Solution
- Intercept non-image model calls in the Antigravity image handler to map them to `gemini-3.1-flash-image`.
- Extract `body.size` parameters and resolve them to standard aspect ratios (e.g. `16:9` -> suffix `-16x9`).
- Append the aspect ratio suffix to the target model string to request the correct dimensions from the upstream provider.

### Impact
- Enables full support for requesting different aspect ratios during image generation on Antigravity models.

### Testing
- Verified that the test suite runs successfully and the changes introduce no new regressions.