### PR TITLE
fix(commandcode): strip thinking suffix from params.model

### DIFF
--- a/open-sse/translator/request/openai-to-commandcode.js
+++ b/open-sse/translator/request/openai-to-commandcode.js
@@ -13,6 +13,7 @@ import { register } from "../index.js";
 import { FORMATS } from "../formats.js";
 import { randomUUID } from "crypto";
 import { ROLE, OPENAI_BLOCK } from "../schema/index.js";
+import { stripThinkingSuffix } from "../concerns/thinkingUnified.js";
 import { DEFAULT_MAX_TOKENS } from "../../config/runtimeConfig.js";
 
 function flattenText(content) {
@@ -136,7 +137,10 @@ function convertTools(tools) {
 export function openaiToCommandCodeRequest(model, body, stream /* , credentials */) {
   const { messages, system } = convertMessages(body.messages);
   const params = {
-    model,
+    // Upstream reads params.model and rejects unknown ids — never leak the
+    // client thinking suffix "model(level)" (chatCore strips only the top-level
+    // model field; the suffix is consumed by applyThinking, not the wire).
+    model: stripThinkingSuffix(model),
     messages,
     stream: stream !== false,
     max_tokens: body.max_tokens ?? body.max_output_tokens ?? DEFAULT_MAX_TOKENS,

--- a/tests/unit/openai-to-commandcode.test.js
+++ b/tests/unit/openai-to-commandcode.test.js
@@ -28,6 +28,32 @@ describe("openaiToCommandCodeRequest — basic envelope", () => {
   });
 });
 
+describe("openaiToCommandCodeRequest — thinking suffix stripping", () => {
+  it("strips a client thinking suffix from params.model (upstream rejects it)", () => {
+    const out = openaiToCommandCodeRequest("gpt-5.6-luna(max)", {
+      messages: [{ role: "user", content: "hi" }],
+    }, true);
+
+    expect(out.params.model).toBe("gpt-5.6-luna");
+  });
+
+  it("strips the suffix from family-prefixed ids too", () => {
+    const out = openaiToCommandCodeRequest("deepseek/deepseek-v4-pro(max)", {
+      messages: [{ role: "user", content: "hi" }],
+    }, true);
+
+    expect(out.params.model).toBe("deepseek/deepseek-v4-pro");
+  });
+
+  it("leaves plain model ids untouched", () => {
+    const out = openaiToCommandCodeRequest("deepseek/deepseek-v4-pro", {
+      messages: [{ role: "user", content: "hi" }],
+    }, true);
+
+    expect(out.params.model).toBe("deepseek/deepseek-v4-pro");
+  });
+});
+
 describe("openaiToCommandCodeRequest — system handling", () => {
   it("hoists system messages to params.system (string), not messages[]", () => {
     const out = openaiToCommandCodeRequest(MODEL, {


### PR DESCRIPTION
## Problem

Requests to the CommandCode provider fail with a 403 when the client sends a thinking-level suffix on the model id:

```
HTTP 403: [commandcode/gpt-5.6-luna(max)] [403]: {"success":false,"error":{"code":"FORBIDDEN","status":403,"message":"Model/provider not recognized: anthropic:gpt-5.6-luna(max)"}}
```

The upstream `/alpha/generate` API reads the model from `params.model` and rejects unknown ids — a `gpt-5.6-luna(max)` is not a valid upstream model, so the gateway falls back to an `anthropic:` family guess and 403s.

## Root cause

- `getModelUpstreamId` (providerModels.js) intentionally re-appends the client's thinking suffix `(max)` so `applyThinking` can consume it.
- `chatCore.js` strips the suffix from the **top-level** `translatedBody.model` before dispatch.
- But the commandcode translator copies the model into the nested `params.model` **verbatim** — the suffix leaks to the wire.

Proof from a real failing request (`requestDetails`):

```json
"params": { "model": "gpt-5.6-luna(max)" },   // leaked suffix
"model":  "gpt-5.6-luna"                        // stripped (top-level only)
```

## Fix

Strip the thinking suffix when setting `params.model` in `openaiToCommandCodeRequest` (reusing `stripThinkingSuffix` from `thinkingUnified.js`). The suffix is still consumed by `applyThinking` for the thinking override; only the wire model is cleaned.

Verified: plain `gpt-5.6-luna` succeeds upstream; `gpt-5.6-luna(max)` was the only difference.

## Tests

- 3 new unit tests in `tests/unit/openai-to-commandcode.test.js` (suffix stripped for plain and family-prefixed ids, plain ids untouched).
- `npx vitest run unit/openai-to-commandcode.test.js` → 14/14 pass.
- Related suites (commandcode-to-openai, thinking-unified, thinking max-clamp, gemini-cursor-commandcode bugs) → no regressions (5 expected fails are pre-existing `it.fails`).
- `npx eslint` clean.