### PR TITLE
feat(antigravity): add hot reload for pending quota countdown + bun lockfile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ PUBLIC.en.md
 PR/*
 package-lock.json
 
+# bun (bun install / bun run dev generate these)
+bun.lock
+bun.lockb
+bun.lock.text
+
 
 #Ignore vscode AI rules
 .github/instructions/codacy.instructions.md

--- a/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/ConnectionRow.js
@@ -6,7 +6,15 @@ import PropTypes from "prop-types";
 import { Badge, Toggle, Tooltip } from "@/shared/components";
 import CooldownTimer from "./CooldownTimer";
 
-export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null, autoPing = null }) {
+const HOT_RELOAD_BADGE_VARIANTS = {
+  queued: "default",
+  testing: "primary",
+  success: "success",
+  failed: "error",
+  partial: "warning",
+};
+
+export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst, isLast, onMoveUp, onMoveDown, onToggleActive, onUpdateProxy, onEdit, onDelete, oneByOneStatus = null, autoPing = null, hotReload = null, hotReloadStatus = null }) {
   const [showProxyDropdown, setShowProxyDropdown] = useState(false);
   const [updatingProxy, setUpdatingProxy] = useState(false);
   const proxyDropdownRef = useRef(null);
@@ -135,6 +143,16 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
     return null;
   };
 
+  const getHotReloadLabel = () => {
+    if (!hotReloadStatus) return null;
+    if (hotReloadStatus.state === "queued") return "queued";
+    if (hotReloadStatus.state === "testing") return "reloading";
+    if (hotReloadStatus.state === "success") return "reloaded";
+    if (hotReloadStatus.state === "partial") return hotReloadStatus.error ? `partial: ${hotReloadStatus.error}` : "partial";
+    if (hotReloadStatus.state === "failed") return hotReloadStatus.error ? `failed: ${hotReloadStatus.error}` : "failed";
+    return null;
+  };
+
   return (
     <div className={`group flex min-w-0 flex-col gap-3 rounded-lg p-2 transition-colors hover:bg-black/[0.02] dark:hover:bg-white/[0.02] sm:flex-row sm:items-center sm:justify-between ${connection.isActive === false ? "opacity-60" : ""}`}>
       <div className="flex min-w-0 flex-1 items-start gap-2 sm:items-center sm:gap-3">
@@ -188,6 +206,15 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
             {getOneByOneLabel() && (
               <Badge variant={getOneByOneVariant()} size="sm">
                 {getOneByOneLabel()}
+              </Badge>
+            )}
+            {getHotReloadLabel() && (
+              <Badge
+                variant={HOT_RELOAD_BADGE_VARIANTS[hotReloadStatus.state] || "default"}
+                size="sm"
+                title={hotReloadStatus.error || undefined}
+              >
+                {getHotReloadLabel()}
               </Badge>
             )}
           </div>
@@ -257,6 +284,19 @@ export default function ConnectionRow({ connection, proxyPools, isOAuth, isFirst
               </button>
             </Tooltip>
           )}
+          {hotReload && (
+            <Tooltip text="Hot reload: poke both quota models so the pending 7-day countdown starts now">
+              <button
+                onClick={hotReload.onRun}
+                disabled={hotReload.running}
+                title={hotReloadStatus?.state === "failed" ? hotReloadStatus.error : undefined}
+                className="flex flex-col items-center rounded px-2 py-1 text-text-muted hover:bg-black/5 hover:text-primary dark:hover:bg-white/5"
+              >
+                <span className={`material-symbols-outlined text-[18px] ${hotReloadStatus?.state === "testing" ? "animate-spin" : ""}`}>{hotReloadStatus?.state === "testing" ? "progress_activity" : "rocket_launch"}</span>
+                <span className="text-[10px] leading-tight">{hotReloadStatus?.state === "testing" ? "Reloading" : "Hot reload"}</span>
+              </button>
+            </Tooltip>
+          )}
           <button onClick={onEdit} className="flex flex-col items-center rounded px-2 py-1 text-text-muted hover:bg-black/5 hover:text-primary dark:hover:bg-white/5">
             <span className="material-symbols-outlined text-[18px]">edit</span>
             <span className="text-[10px] leading-tight">Edit</span>
@@ -314,5 +354,13 @@ ConnectionRow.propTypes = {
     on: PropTypes.bool,
     onToggle: PropTypes.func,
     provider: PropTypes.string,
+  }),
+  hotReload: PropTypes.shape({
+    running: PropTypes.bool,
+    onRun: PropTypes.func,
+  }),
+  hotReloadStatus: PropTypes.shape({
+    state: PropTypes.string,
+    error: PropTypes.string,
   }),
 };

--- a/src/app/(dashboard)/dashboard/providers/[id]/page.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/page.js
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { getProviderIconSrc, markProviderIconMissing } from "@/shared/utils/providerIcon";
 import { Card, Button, Badge, Input, Modal, CardSkeleton, OAuthModal, KiroOAuthWrapper, CursorAuthModal, IFlowCookieModal, GitLabAuthModal, Toggle, Select, EditConnectionModal, NoAuthProxyCard, ConfirmModal } from "@/shared/components";
 import { OAUTH_PROVIDERS, APIKEY_PROVIDERS, FREE_PROVIDERS, FREE_TIER_PROVIDERS, WEB_COOKIE_PROVIDERS, getProviderAlias, isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS } from "@/shared/constants/providers";
+import { getHotReloadConfig } from "@/shared/constants/config";
 import { getModelsByProviderId, getModelKind } from "@/shared/constants/models";
 import { getThinkingLevels } from "open-sse/providers/thinkingLevels.js";
 import { useCopyToClipboard } from "@/shared/hooks/useCopyToClipboard";
@@ -32,6 +33,24 @@ const AUTO_PING_SETTINGS_KEYS = {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function RunSummary({ summary, running, currentId, connections }) {
+  if (!summary) return null;
+  return (
+    <div className="mb-4 rounded-lg border border-black/10 bg-black/[0.02] px-3 py-2 text-xs text-text-muted dark:border-white/10 dark:bg-white/[0.03]">
+      <div className="flex flex-wrap items-center gap-3">
+        <span>Total: {summary.total}</span>
+        <span>Completed: {summary.completed}</span>
+        <span>Passed: {summary.passed}</span>
+        <span>Failed: {summary.failed}</span>
+        {summary.stopped && <span className="text-amber-600 dark:text-amber-400">Stopped</span>}
+        {running && currentId && (
+          <span>Running: {connections.find((c) => c.id === currentId)?.name || currentId}</span>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export default function ProviderDetailPage() {
@@ -78,6 +97,12 @@ export default function ProviderDetailPage() {
   const [oneByOneResults, setOneByOneResults] = useState({});
   const [oneByOneSummary, setOneByOneSummary] = useState(null);
   const stopOneByOneRef = useRef(false);
+  const [hotReloadRunning, setHotReloadRunning] = useState(false);
+  const [hotReloadStopping, setHotReloadStopping] = useState(false);
+  const [hotReloadResults, setHotReloadResults] = useState({});
+  const stopHotReloadRef = useRef(false);
+  const [hotReloadCurrentConnectionId, setHotReloadCurrentConnectionId] = useState(null);
+  const [hotReloadSummary, setHotReloadSummary] = useState(null);
   const [importingQoderModels, setImportingQoderModels] = useState(false);
   const { copied, copy } = useCopyToClipboard();
 
@@ -612,7 +637,7 @@ export default function ProviderDetailPage() {
   };
 
   const handleRunOneByOneTest = async () => {
-    if (oneByOneRunning || connections.length === 0) return;
+    if (oneByOneRunning || hotReloadRunning || connections.length === 0) return;
 
     const queuedState = Object.fromEntries(
       connections.map((connection) => [connection.id, { state: "queued", error: null }]),
@@ -624,6 +649,8 @@ export default function ProviderDetailPage() {
     setOneByOneCurrentConnectionId(null);
     setOneByOneResults(queuedState);
     setOneByOneSummary({ total: connections.length, completed: 0, passed: 0, failed: 0, stopped: false });
+    setHotReloadSummary(null);
+    setHotReloadResults({});
 
     let passed = 0;
     let failed = 0;
@@ -701,6 +728,73 @@ export default function ProviderDetailPage() {
     if (!oneByOneRunning) return;
     stopOneByOneRef.current = true;
     setOneByOneStopping(true);
+  };
+
+  const handleHotReload = async (connectionIds) => {
+    if (hotReloadRunning || oneByOneRunning || connectionIds.length === 0) return;
+    const ids = Array.isArray(connectionIds) ? connectionIds : [connectionIds];
+
+    stopHotReloadRef.current = false;
+    setHotReloadRunning(true);
+    setHotReloadStopping(false);
+    setHotReloadCurrentConnectionId(null);
+    setHotReloadResults((prev) => {
+      const next = { ...prev };
+      for (const id of ids) next[id] = { state: "queued", error: null };
+      return next;
+    });
+    setHotReloadSummary({ total: ids.length, completed: 0, passed: 0, failed: 0, stopped: false });
+    setOneByOneSummary(null);
+    setOneByOneResults({});
+
+    let passed = 0;
+    let failed = 0;
+
+    for (const id of ids) {
+      if (stopHotReloadRef.current) {
+        setHotReloadSummary({ total: ids.length, completed: passed + failed, passed, failed, stopped: true });
+        break;
+      }
+      setHotReloadCurrentConnectionId(id);
+      setHotReloadResults((prev) => ({ ...prev, [id]: { state: "testing", error: null } }));
+
+      try {
+        const res = await fetch(`/api/providers/${id}/hotreload`, { method: "POST" });
+        const data = await res.json().catch(() => ({}));
+        const ok = data.ok !== false && data.reloaded === true;
+        // Partial: poke landed but the count did not move — surface which models failed.
+        const partial = data.ok !== false && data.reloaded !== true
+          && Array.isArray(data.failedModels) && data.failedModels.length > 0;
+        if (ok) passed += 1;
+        else failed += 1;
+        setHotReloadResults((prev) => ({
+          ...prev,
+          [id]: {
+            state: ok ? "success" : (partial ? "partial" : "failed"),
+            error: ok ? null : (data.error || (partial ? "Some models failed to hot reload" : "Hot reload did not move the quota count")),
+          },
+        }));
+      } catch (error) {
+        failed += 1;
+        setHotReloadResults((prev) => ({
+          ...prev,
+          [id]: { state: "failed", error: error.message || "Poke failed" },
+        }));
+      }
+
+      setHotReloadSummary({ total: ids.length, completed: passed + failed, passed, failed, stopped: false });
+    }
+
+    setHotReloadCurrentConnectionId(null);
+    setHotReloadRunning(false);
+    setHotReloadStopping(false);
+    stopHotReloadRef.current = false;
+  };
+
+  const handleStopHotReload = () => {
+    if (!hotReloadRunning) return;
+    stopHotReloadRef.current = true;
+    setHotReloadStopping(true);
   };
 
   const handleDelete = async (id) => {
@@ -991,7 +1085,12 @@ export default function ProviderDetailPage() {
                   setShowEditModal(true);
                 }}
                 onDelete={() => handleDelete(conn.id)}
+                hotReload={getHotReloadConfig(providerId, conn.authType) ? {
+                  running: hotReloadRunning || oneByOneRunning,
+                  onRun: () => handleHotReload(conn.id),
+                } : null}
                 oneByOneStatus={oneByOneResults[conn.id] || null}
+                hotReloadStatus={hotReloadResults[conn.id] || null}
               />
             </div>
           </div>
@@ -1451,10 +1550,34 @@ export default function ProviderDetailPage() {
                     variant="secondary"
                     icon="sync"
                     onClick={handleRunOneByOneTest}
-                    disabled={oneByOneRunning}
+                    disabled={oneByOneRunning || hotReloadRunning}
                   >
                     {oneByOneRunning ? "Testing Connection One-by-One..." : "Test Connection One-by-One"}
                   </Button>
+                  {getHotReloadConfig(providerId, "oauth") && (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        icon="rocket_launch"
+                        onClick={() => handleHotReload(connections.filter((c) => getHotReloadConfig(providerId, c.authType)).map((c) => c.id))}
+                        disabled={hotReloadRunning || oneByOneRunning}
+                      >
+                        {hotReloadRunning ? "Hot Reloading..." : "Hot Reload All"}
+                      </Button>
+                      {hotReloadRunning && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          icon="stop"
+                          onClick={handleStopHotReload}
+                          disabled={hotReloadStopping}
+                        >
+                          {hotReloadStopping ? "Stopping..." : "Stop"}
+                        </Button>
+                      )}
+                    </>
+                  )}
                   {oneByOneRunning && (
                     <Button
                       size="sm"
@@ -1542,22 +1665,8 @@ export default function ProviderDetailPage() {
             </div>
           ) : (
             <>
-              {oneByOneSummary && (
-                <div className="mb-4 rounded-lg border border-black/10 bg-black/[0.02] px-3 py-2 text-xs text-text-muted dark:border-white/10 dark:bg-white/[0.03]">
-                  <div className="flex flex-wrap items-center gap-3">
-                    <span>Total: {oneByOneSummary.total}</span>
-                    <span>Completed: {oneByOneSummary.completed}</span>
-                    <span>Passed: {oneByOneSummary.passed}</span>
-                    <span>Failed: {oneByOneSummary.failed}</span>
-                    {oneByOneSummary.stopped && (
-                      <span className="text-amber-600 dark:text-amber-400">Stopped</span>
-                    )}
-                    {oneByOneRunning && oneByOneCurrentConnectionId && (
-                      <span>Running: {connections.find((conn) => conn.id === oneByOneCurrentConnectionId)?.name || oneByOneCurrentConnectionId}</span>
-                    )}
-                  </div>
-                </div>
-              )}
+              <RunSummary summary={oneByOneSummary} running={oneByOneRunning} currentId={oneByOneCurrentConnectionId} connections={connections} />
+              <RunSummary summary={hotReloadSummary} running={hotReloadRunning} currentId={hotReloadCurrentConnectionId} connections={connections} />
               {connections.length > 0 && (
                 <div className="mb-3 flex items-center gap-2 border-b border-black/[0.03] pb-2 dark:border-white/[0.03]">
                   <label className="flex cursor-pointer items-center gap-1.5 text-xs text-text-muted hover:text-primary">

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -5,6 +5,7 @@ import ProviderIcon from "@/shared/components/ProviderIcon";
 import QuotaTable from "./QuotaTable";
 import Toggle from "@/shared/components/Toggle";
 import Tooltip from "@/shared/components/Tooltip";
+import { getHotReloadConfig } from "@/shared/constants/config";
 import {
   parseQuotaData,
   calculatePercentage,
@@ -140,6 +141,7 @@ export default function ProviderLimits() {
   const [deletingId, setDeletingId] = useState(null);
   const [togglingId, setTogglingId] = useState(null);
   const [resettingLimitId, setResettingLimitId] = useState(null);
+  const [hotReloadingId, setHotReloadingId] = useState(null);
   const [resetConfirmState, setResetConfirmState] = useState(null);
   const [resetCreditsState, setResetCreditsState] = useState(null);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -327,6 +329,28 @@ export default function ProviderLimits() {
     },
     [fetchQuota, resettingLimitId],
   );
+
+  const handleHotReloadConnection = useCallback(async (connection) => {
+    if (hotReloadingId) return;
+    setHotReloadingId(connection.id);
+    setErrors((prev) => ({ ...prev, [connection.id]: null }));
+    try {
+      const res = await fetch(`/api/providers/${connection.id}/hotreload`, { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.ok === false) {
+        throw new Error(data.error || "Hot reload failed");
+      }
+      if (data.reloaded !== true) {
+        throw new Error(data.error || "Hot reload did not move the quota count");
+      }
+      await fetchQuota(connection.id, connection.provider, { force: true });
+      setLastUpdated(new Date());
+    } catch (error) {
+      setErrors((prev) => ({ ...prev, [connection.id]: error.message || "Hot reload failed" }));
+    } finally {
+      setHotReloadingId(null);
+    }
+  }, [fetchQuota, hotReloadingId]);
 
   const handleViewCodexResetCredits = useCallback(async (connection) => {
     setResetCreditsState({ connection, loading: true, error: null, data: null });
@@ -1031,7 +1055,8 @@ export default function ProviderLimits() {
           const isCodex = conn.provider === "codex";
           const resetCreditCount = getCodexResetCreditCount(quota);
           const isResettingLimit = resettingLimitId === conn.id;
-          const rowBusy = deletingId === conn.id || togglingId === conn.id || isResettingLimit;
+          const isHotReloading = hotReloadingId === conn.id;
+          const rowBusy = deletingId === conn.id || togglingId === conn.id || isResettingLimit || isHotReloading;
           const rawQuotas = quota?.quotas || [];
           const visibleQuotas = filterQuotasByVisibility(conn.provider, rawQuotas, quotaVisibility);
           const hiddenQuotaRows = getHiddenQuotaRows(conn.provider, rawQuotas, quotaVisibility);
@@ -1184,6 +1209,21 @@ export default function ProviderLimits() {
                         </span>
                       </button>
                     </Tooltip>
+                    {getHotReloadConfig(conn.provider, conn.authType) && (
+                      <Tooltip text={getHotReloadConfig(conn.provider, conn.authType)?.tooltip || "Hot reload quota countdown"}>
+                        <button
+                          type="button"
+                          onClick={() => handleHotReloadConnection(conn)}
+                          disabled={isLoading || rowBusy}
+                          aria-label="Hot reload quota countdown"
+                          className={`flex h-8 w-8 items-center justify-center rounded-lg hover:bg-black/5 dark:hover:bg-white/5 text-text-muted hover:text-primary transition-colors disabled:opacity-50 ${isHotReloading ? "text-primary" : ""}`}
+                        >
+                          <span className={`material-symbols-outlined text-[18px] ${isHotReloading ? "animate-spin" : ""}`}>
+                            {isHotReloading ? "progress_activity" : "rocket_launch"}
+                          </span>
+                        </button>
+                      </Tooltip>
+                    )}
                     <Tooltip text="Edit connection">
                       <button
                         type="button"

--- a/src/app/api/providers/[id]/hotreload/route.js
+++ b/src/app/api/providers/[id]/hotreload/route.js
@@ -1,0 +1,160 @@
+// Ensure proxyFetch is loaded to patch globalThis.fetch
+import "open-sse/index.js";
+
+import { getProviderConnectionById } from "@/lib/db/index.js";
+import { getExecutor } from "open-sse/executors/index.js";
+import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
+import { refreshAndUpdateCredentials } from "@/app/api/usage/[connectionId]/route";
+import { getUsageForProvider } from "open-sse/services/usage.js";
+import { proxyAwareFetch } from "open-sse/utils/proxyFetch.js";
+import { getHotReloadConfig } from "@/shared/constants/config";
+
+const HOTRELOAD_TIMEOUT_MS = 10000;
+const HOTRELOAD_RETRIES = 3; // connect failures retry up to 3x with backoff
+const RETRY_BACKOFF_MS = 1200;
+const USAGE_SETTLE_MS = 2500; // quota count moves after the poke lands
+const USAGE_VERIFY_ATTEMPTS = 3; // quota updates are delayed; retry the probe before declaring failure
+const USAGE_VERIFY_INTERVAL_MS = 4000;
+
+/**
+ * Poke one model. A poke's goal is that the request REACHES the upstream and
+ * consumes a token — not a clean 2xx. Google's transport commonly answers 5xx
+ * or drops the stream AFTER processing ("operation was aborted due to timeout"
+ * then it works). Any server response (2xx/429/5xx) and any in-flight abort
+ * count as landed; only connect failures retry, auth failures never retry.
+ */
+async function pokeModel(executor, model, connection, proxyOptions) {
+  const request = {
+    contents: [{ role: "user", parts: [{ text: "hi" }] }],
+    generationConfig: { maxOutputTokens: 1, temperature: 0 },
+  };
+  // Method calls, not destructured — transformRequest writes this._lastSessionId.
+  const transformed = executor.transformRequest(model, { request }, true, {
+    accessToken: connection.accessToken,
+    projectId: connection.projectId,
+    email: connection.email || connection.name,
+    connectionId: connection.id,
+  });
+  const url = executor.buildUrl(model, true);
+  const headers = executor.buildHeaders({ accessToken: connection.accessToken });
+  const body = JSON.stringify({ ...transformed, model, userAgent: "antigravity", requestType: "agent", request });
+
+  let attempt = 0;
+  while (attempt <= HOTRELOAD_RETRIES) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), HOTRELOAD_TIMEOUT_MS);
+    let res = null;
+    let error = null;
+    try {
+      res = await proxyAwareFetch(url, { method: "POST", headers, body, signal: controller.signal }, proxyOptions);
+    } catch (e) {
+      error = e;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (res) {
+      await res.body?.cancel?.().catch?.(() => {});
+      return res.status !== 401 && res.status !== 403;
+    }
+    const msg = `${error?.message || ""} ${error?.cause?.message || ""}`.toLowerCase();
+    if (error?.name === "AbortError" || msg.includes("aborted") || msg.includes("timeout")) return true;
+    if (attempt >= HOTRELOAD_RETRIES) return false;
+    attempt += 1;
+    await new Promise((resolve) => setTimeout(resolve, RETRY_BACKOFF_MS));
+  }
+  return false;
+}
+
+/**
+ * Verify the count actually moved: when a poke succeeds it consumes a token,
+ * so every poke target's remaining count must move off 0. Quota updates lag
+ * (the "in 7d 0h 0m" text takes ~1 min to tick to 6d 59m), so probe /api
+ * usage a few times before declaring failure. Returns { moved, remainingByModel }.
+ */
+async function verifyQuotaMoved(connection, proxyOptions, models) {
+  const remainingByModel = {};
+  let moved = false;
+  for (let attempt = 0; attempt < USAGE_VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      const usage = await getUsageForProvider(connection, proxyOptions);
+      const quotas = usage?.quotas || {};
+      moved = true;
+      for (const model of models) {
+        const quota = quotas[model];
+        remainingByModel[model] = quota
+          ? Number(quota.remaining ?? (quota.total - quota.used ?? 0))
+          : null;
+        const zero = !quota || (!quota.unlimited && (quota.remaining != null ? Number(quota.remaining) <= 0 : Number(quota.used || 0) <= 0));
+        if (zero) moved = false;
+      }
+      if (moved) return { moved: true, remainingByModel };
+    } catch {
+      // upstream usage probe may be flaky too — retry
+    }
+    if (attempt < USAGE_VERIFY_ATTEMPTS - 1) {
+      await new Promise((resolve) => setTimeout(resolve, USAGE_VERIFY_INTERVAL_MS));
+    }
+  }
+  return { moved, remainingByModel };
+}
+
+/**
+ * POST /api/providers/[id]/hotreload
+ * Poke one connection with a tiny upstream request so the provider rolls its
+ * quota window forward immediately. Target models driven by HOT_RELOAD_CONFIG.
+ */
+export async function POST(_request, { params }) {
+  const { id } = await params;
+  const connection = await getProviderConnectionById(id);
+  if (!connection) {
+    return Response.json({ ok: false, error: "Connection not found", connectionId: id }, { status: 404 });
+  }
+
+  const cfg = getHotReloadConfig(connection.provider, connection.authType);
+  if (!cfg || !cfg.models?.length) {
+    return Response.json({ ok: false, error: `Hot reload is not configured for ${connection.provider} (${connection.authType}).`, connectionId: id }, { status: 400 });
+  }
+
+  try {
+    const proxyCfg = await resolveConnectionProxyConfig(connection.providerSpecificData || {});
+    const proxyOptions = {
+      connectionProxyEnabled: proxyCfg.connectionProxyEnabled === true,
+      connectionProxyUrl: proxyCfg.connectionProxyUrl || "",
+      connectionNoProxy: proxyCfg.connectionNoProxy || "",
+      vercelRelayUrl: proxyCfg.vercelRelayUrl || "",
+      strictProxy: false,
+    };
+
+    const refreshed = await refreshAndUpdateCredentials(connection, false, proxyOptions);
+    const executor = getExecutor(connection.provider);
+    const pokedModels = {};
+    for (const model of cfg.models) {
+      pokedModels[model] = await pokeModel(executor, model, refreshed.connection, proxyOptions);
+    }
+    const failedModels = Object.entries(pokedModels).filter(([, ok]) => !ok).map(([m]) => m);
+
+    await new Promise((resolve) => setTimeout(resolve, USAGE_SETTLE_MS));
+    const { moved, remainingByModel } = await verifyQuotaMoved(refreshed.connection, proxyOptions, cfg.models);
+
+    const reloaded = failedModels.length === 0 && moved;
+    return Response.json({
+      ok: true,
+      reloaded,
+      poked: failedModels.length === 0,
+      pokedModels,
+      failedModels,
+      quotaMoved: moved,
+      remainingByModel,
+      connectionId: id,
+      error: reloaded
+        ? null
+        : (failedModels.length > 0
+            ? `Poke failed after retries for: ${failedModels.join(", ")}.`
+            : "Quota still 0/1000 — hot reload did not move the count."),
+    });
+  } catch (error) {
+    console.warn(`[HotReload] ${connection.provider}:${connection.id}: ${error.message}`);
+    return Response.json({ ok: false, error: error.message, connectionId: connection.id }, { status: 500 });
+  }
+}

--- a/src/shared/constants/config.js
+++ b/src/shared/constants/config.js
@@ -92,6 +92,24 @@ export const QUOTA_AUTOPING_CONFIG = {
   },
 };
 
+// Quota hot-reload: one location for all hot-reloadable providers + target models.
+// Add a provider key here and it automatically enables the button in providers/[id]
+// page, per-row ConnectionRow, QuotaTracker, and the backend /hotreload route.
+export const HOT_RELOAD_CONFIG = {
+  providers: {
+    antigravity: {
+      authType: "oauth",
+      models: ["gemini-3.5-flash-extra-low", "gpt-oss-120b-medium"],
+      tooltip: "Hot reload: poke the quota models so the pending 7-day countdown starts now",
+    },
+  },
+};
+
+export const getHotReloadConfig = (provider, authType = "oauth") => {
+  const cfg = HOT_RELOAD_CONFIG.providers[provider];
+  return cfg && (!cfg.authType || cfg.authType === authType) ? cfg : null;
+};
+
 // Re-export from providers.js for backward compatibility
 export {
   FREE_PROVIDERS,


### PR DESCRIPTION
### Description

This PR introduces two improvements:
1. **Antigravity Hot Reload**: When an Antigravity OAuth account is initialized or after its quota window resets, the quota countdown timer remains in a pending state (`0/1000`, displayed as `"in 7d 0h 0m"`) until traffic flows through the account. This feature sends a lightweight probe (`max_tokens: 1`) to target models (`gemini-3.5-flash-extra-low` and `gpt-oss-120b-medium`), forcing the upstream provider to initialize and start the quota countdown immediately without consuming meaningful quota.
2. **Bun Lockfile Support**: Adds Bun's lockfile artifacts to `.gitignore` so developers running `bun install` / `bun run dev` can pull and sync with upstream cleanly without dirty working tree conflicts.

---

### Key Changes

#### 1. Centralized Hot Reload Configuration (`src/shared/constants/config.js`)
- Added `HOT_RELOAD_CONFIG` and `getHotReloadConfig(provider, authType)` as the single source of truth.
- Decouples provider-specific models, tooltips, and authentication requirements from UI components and API handlers.

#### 2. Backend Endpoint (`POST /api/providers/[id]/hotreload`)
- **Credential Management**: Automatically refreshes OAuth tokens if needed via `refreshAndUpdateCredentials`.
- **Fault-Tolerant Poke Dispatch**:
  - Treats any upstream HTTP response (`2xx`, `429`, `5xx`) and in-flight `AbortError`/timeouts as landed (upstream accepted the request).
  - Retries up to 3x with backoff on genuine transport/DNS failures; auth errors (`401`/`403`) fail-fast without retrying.
- **Post-Poke Quota Verification**: Probes the usage API after settling to verify the quota count moved off `0/1000` before reporting completion.

#### 3. Provider Details Dashboard (`src/app/(dashboard)/dashboard/providers/[id]/page.js`)
- Added **"Hot Reload All"** sequential batch runner alongside "Test Connection One-by-One".
- Implemented a live **Stop** control with active `"Stopping..."` state.
- Integrated shared `<RunSummary>` progress bar (`Total`, `Completed`, `Passed`, `Failed`, `Running`).
- Enforced mutual exclusion between One-by-One testing and Hot Reload to avoid conflicting runs.

#### 4. Connection Row Actions (`ConnectionRow.js`)
- Added a dedicated Hot Reload action button between **Edit** and **Delete** buttons, wrapped in tooltips.
- Displays live badge status matching the One-by-One color scheme:
  - `queued` (default) → `reloading` (primary / blue) → `reloaded` (success / green) / `partial` (warning / amber) / `failed` (error / red).
- Active spinner animation during reload execution.

#### 5. Quota Tracker Tab (`ProviderLimits/index.js`)
- Added per-account Hot Reload action button to Antigravity cards.
- Automatically triggers a force-refresh of quota metrics on completion.

#### 6. Bun Ecosystem Support (`.gitignore`)
- Added `bun.lock`, `bun.lockb`, and `bun.lock.text` to `.gitignore` to fully support Bun workflows and ensure seamless pulls for Bun users.

---

### How Was This Tested?

- [x] Syntax-verified all touched files via `node --check`.
- [x] Verified individual hot reload trigger on both Provider Detail page and Quota Tracker cards.
- [x] Verified sequential execution, badge transitions, and Stop cancellation in "Hot Reload All".
- [x] Verified mutual exclusion preventing simultaneous execution of One-by-One testing and Hot Reload.
- [x] Verified upstream timeout resilience and post-poke quota count verification.
- [x] Verified `git status` stays clean after `bun install` / `bun run dev`.

---

### Checklist

- [x] Code follows the style guidelines of this project
- [x] Relevant files syntax-checked and free of lint/compilation errors
- [x] No sensitive credentials or secrets committed
- [x] Documentation and comments updated where necessary