### PR TITLE
fix(chat): sync negotiated stream flag into upstream body

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -167,6 +167,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (passthrough) {
     log?.debug?.("PASSTHROUGH", `${clientTool} → ${provider} | native lossless`);
     translatedBody = { ...body, model: stripThinkingSuffix(upstreamModel) };
+    // Sync the negotiated stream flag into the upstream body. `stream` may differ
+    // from the client's body.stream (forceStream providers, Accept-header JSON
+    // preference): the client's stale `stream:false` must not reach a provider
+    // we just asked to stream — the response shape would disagree with the
+    // response-handling branch downstream.
+    if (translatedBody.stream !== stream) translatedBody.stream = stream;
     if (provider === "codex") {
       const suffixThinking = {};
       applyThinking(sourceFormat, upstreamModel, suffixThinking, provider);
@@ -193,6 +199,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     delete translatedBody._customToolNames;
     translatedBody.model = stripThinkingSuffix(upstreamModel);
     stripContinuityFields(translatedBody);
+    // Same-format "translation" (openai→openai via transports) skips every
+    // translator, so the client's stream flag survives verbatim. Sync it to the
+    // negotiated value — same rationale as the passthrough branch above.
+    if (translatedBody.stream !== stream) translatedBody.stream = stream;
   }
 
   // Dedupe duplicate built-in tools when equivalent MCP tools are present (Claude clients only).

--- a/tests/unit/force-stream-config.test.js
+++ b/tests/unit/force-stream-config.test.js
@@ -71,6 +71,8 @@ vi.mock("../../open-sse/rtk/index.js", () => ({
 vi.mock("../../open-sse/rtk/headroom.js", () => ({
   compressWithHeadroom: vi.fn(async () => null),
   formatHeadroomLog: vi.fn(() => ""),
+  formatHeadroomSizeLog: vi.fn(() => ""),
+  isHeadroomPhantomSavings: vi.fn(() => false),
 }));
 
 vi.mock("../../open-sse/providers/capabilities.js", () => ({
@@ -149,5 +151,11 @@ describe("forceStream provider config", () => {
 
     expect(executeMock).toHaveBeenCalledTimes(1);
     expect(executeMock.mock.calls[0][0].stream).toBe(true);
+    // The negotiated flag must also land in the upstream BODY, not just the
+    // stream param: openai→openai (passthrough/transport) skips translators, so
+    // a stale client body.stream:false would reach the provider and make it
+    // answer with a plain JSON body while the response path treats it as SSE.
+    const sentBody = executeMock.mock.calls[0][0].body;
+    expect(sentBody.stream).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

The negotiated `stream` flag was never written back into the upstream request body on the passthrough and same-format paths, so it could disagree with the response-handling branch:

- `chatCore` computes a `stream` variable (forceStream providers force it true; Accept-header JSON preference forces it false)
- On the **passthrough** path (`translatedBody = { ...body, model }`) and the **same-format** path (openai→openai via transports skips every translator), the client's original `body.stream` survives verbatim
- A forceStream provider (openai/codex/commandcode/codebuddy-*/kimi-with-#…) then receives `stream:false` while chatCore dispatches with `stream=true` and routes the response through the streaming path

The provider answers with a **plain JSON body**, but the streaming passthrough treats each line as an SSE frame: clients receive a full JSON object with `Content-Type: text/event-stream` and a trailing `data: [DONE]` concatenated with **no separator**. `JSON.parse()` fails with `Unexpected token 'd'`.

## Fix

Two symmetric one-line syncs in `chatCore.js` (passthrough branch + same-format translation branch):

```js
if (translatedBody.stream !== stream) translatedBody.stream = stream;
```

This generalizes the executor-level fix from #1843 (commandcode `params.stream`) into the shared core, and covers every provider on these two paths — not one provider at a time.

Also repairs `tests/unit/force-stream-config.test.js` on current master: `chatCore` now imports `formatHeadroomSizeLog`/`isHeadroomPhantomSavings` but the test's headroom mock predates them — **2 of 3 tests fail on a clean v0.5.55 checkout** before this change, 3/3 after.

## Test plan

- [x] `npx vitest run tests/unit/force-stream-config.test.js` — 3/3 (was 2 failed on clean master)
- [x] New assertion added: `executeMock.mock.calls[0][0].body.stream === true` locks the invariant this PR fixes
- [x] `npm run build` passes
- [x] Full unit suite diff vs clean master: 65 failed → 65 failed (no new failures; the force-stream file goes from 2 failed to 0)
- [x] Production E2E (kimi via transports, openai client): non-streaming requests now return `application/json` with a clean body (previously SSE-tainted), streaming unchanged

## Related

- #1843 — same root cause, fixed at the commandcode executor level; this is the core-level generalization
- #1396 — SSE-tainted JSON symptom on the Claude path (stream-default + missing body flag are overlapping sub-bugs; #1401 addresses the default side, this addresses the sync side)
