### PR TITLE
feat(kimi): force streaming for the Kimi Code endpoint

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -173,6 +173,12 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (passthrough) {
     log?.debug?.("PASSTHROUGH", `${clientTool} → ${provider} | native lossless`);
     translatedBody = { ...body, model: stripThinkingSuffix(upstreamModel) };
+    // Sync the negotiated stream flag into the upstream body. `stream` may differ
+    // from the client's body.stream (forceStream providers, Accept-header JSON
+    // preference): the client's stale `stream:false` must not reach a provider
+    // we just asked to stream — the response shape would disagree with the
+    // response-handling branch downstream.
+    if (translatedBody.stream !== stream) translatedBody.stream = stream;
     if (provider === "codex") {
       const suffixThinking = {};
       applyThinking(sourceFormat, upstreamModel, suffixThinking, provider);
@@ -199,6 +205,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     delete translatedBody._customToolNames;
     translatedBody.model = stripThinkingSuffix(upstreamModel);
     stripContinuityFields(translatedBody);
+    // Same-format "translation" (openai→openai via transports) skips every
+    // translator, so the client's stream flag survives verbatim. Sync it to the
+    // negotiated value — same rationale as the passthrough branch above.
+    if (translatedBody.stream !== stream) translatedBody.stream = stream;
   }
 
   // Dedupe duplicate built-in tools when equivalent MCP tools are present (Claude clients only).

--- a/open-sse/providers/registry/kimi.js
+++ b/open-sse/providers/registry/kimi.js
@@ -27,6 +27,10 @@ export default {
     baseUrl: "https://api.kimi.com/coding/v1/messages",
     format: "claude",
     urlSuffix: "?beta=true",
+    // K3/K3-256k non-streaming waits for full inference (~20s+); streaming
+    // returns first token in 2-4s. Non-streaming clients still receive JSON —
+    // chatCore converts SSE back to JSON (handleForcedSSEToJson).
+    forceStream: true,
     headers: { ...CLAUDE_API_HEADERS },
     clientId: "17e5f671-d194-4dfb-9706-5516cb48c098",
     tokenUrl: "https://auth.kimi.com/api/oauth/token",

--- a/tests/unit/force-stream-config.test.js
+++ b/tests/unit/force-stream-config.test.js
@@ -71,6 +71,8 @@ vi.mock("../../open-sse/rtk/index.js", () => ({
 vi.mock("../../open-sse/rtk/headroom.js", () => ({
   compressWithHeadroom: vi.fn(async () => null),
   formatHeadroomLog: vi.fn(() => ""),
+  formatHeadroomSizeLog: vi.fn(() => ""),
+  isHeadroomPhantomSavings: vi.fn(() => false),
 }));
 
 vi.mock("../../open-sse/providers/capabilities.js", () => ({
@@ -149,5 +151,11 @@ describe("forceStream provider config", () => {
 
     expect(executeMock).toHaveBeenCalledTimes(1);
     expect(executeMock.mock.calls[0][0].stream).toBe(true);
+    // The negotiated flag must also land in the upstream BODY, not just the
+    // stream param: openai→openai (passthrough/transport) skips translators, so
+    // a stale client body.stream:false would reach the provider and make it
+    // answer with a plain JSON body while the response path treats it as SSE.
+    const sentBody = executeMock.mock.calls[0][0].body;
+    expect(sentBody.stream).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Sets `forceStream: true` on the Kimi (Kimi Code subscription) transport.

`api.kimi.com/coding` handles non-streaming calls by waiting for full inference before responding. Measured from the gateway host, same prompt, interleaved samples:

| Window | non-streaming total | streaming total (SSE) |
|---|---|---|
| Healthy hours | ~4.9–5.5s | ~4.5–4.7s |
| Congested (429 engine_overloaded is frequent on this subscription endpoint) | **22.5s+** | **~2.5s** |

Streaming is never worse and dramatically better under congestion. Non-streaming clients are unaffected: chatCore converts the SSE back to JSON via `handleForcedSSEToJson` (same mechanism already used for openai/codex/commandcode).

## Dependencies

**Depends on #3420** (fix/chat stream-flag sync). Without it, the forced-stream request still carried the client's `stream:false` in the upstream body — the provider returned plain JSON while the response path expected SSE, producing the SSE-tainted responses described in #1396. With the flag sync, non-streaming clients get clean JSON at streaming speed.

## Test plan

- [x] `PROVIDERS.kimi.forceStream === true` after registry build
- [x] E2E matrix through the gateway (k3 / kimi-k3 × stream/non-stream): non-streaming returns `application/json` clean body; streaming returns standard SSE chunks
- [x] A/B on/off against the same upstream: streaming clients see zero difference; non-streaming clients gain the congested-window improvement above
