### PR TITLE
fix: default stream to false when client omits stream field

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -111,7 +111,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
 
   const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  let stream = providerRequiresStreaming ? true : (body.stream === true);
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);

--- a/tests/unit/force-stream-config.test.js
+++ b/tests/unit/force-stream-config.test.js
@@ -104,7 +104,7 @@ vi.mock("@/lib/usageDb.js", () => ({
 
 const FORCED = ["openai", "codex", "commandcode"];
 
-function makeOptions(bodyStream) {
+function makeOptions(bodyStream, provider = "openai", accept = "application/json") {
   const body = {
     model: "gpt-4.1",
     messages: [{ role: "user", content: "hello" }],
@@ -113,12 +113,12 @@ function makeOptions(bodyStream) {
 
   return {
     body,
-    modelInfo: { provider: "openai", model: "gpt-4.1" },
+    modelInfo: { provider, model: "gpt-4.1" },
     credentials: { apiKey: "sk-test" },
     clientRawRequest: {
       endpoint: "/v1/chat/completions",
       body,
-      headers: { accept: "application/json" },
+      headers: accept ? { accept } : {},
     },
     connectionId: "test-connection",
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -149,5 +149,14 @@ describe("forceStream provider config", () => {
 
     expect(executeMock).toHaveBeenCalledTimes(1);
     expect(executeMock.mock.calls[0][0].stream).toBe(true);
+  });
+
+  it.each([undefined, false, true])( "uses only an explicit true stream flag for non-forced providers (%s)", async (bodyStream) => {
+    const { handleChatCore } = await import("../../open-sse/handlers/chatCore.js");
+
+    await handleChatCore(makeOptions(bodyStream, "openrouter", ""));
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(executeMock.mock.calls[0][0].stream).toBe(bodyStream === true);
   });
 });


### PR DESCRIPTION
## Problem

The upstream stream flag defaulted to `body.stream !== false`, which evaluates to `true` when the client omits the `stream` field entirely:

```js
undefined !== false  // true
```

This caused every request without an explicit `stream` field to be forwarded as streaming to the upstream, even when the client expected a JSON response.

## Fix

Changed the default from `body.stream !== false` to `body.stream === true` in `open-sse/handlers/chatCore.js`:

```diff
- let stream = providerRequiresStreaming ? true : (body.stream !== false);
+ let stream = providerRequiresStreaming ? true : (body.stream === true);
```

After this fix:
| Client sends | Behavior |
|---|---|
| `stream: true` | Streaming (as before) |
| `stream: false` | Non-streaming JSON (as before) |
| `stream` omitted | **Non-streaming JSON (fixed)** |
| `forceStream: true` provider | Streaming (unchanged, e.g. openai/codex/commandcode) |

## Testing

- Added a new test `uses only an explicit true stream flag for non-forced providers` verifying `undefined`, `false`, and `true` body values for non-forced providers
- Existing forced-stream test for `openai`/`codex`/`commandcode` providers still passes (they keep streaming for all inputs via `forceStream`)