### PR TITLE
feat(models): add combo-only model exposure

### DIFF
--- a/src/app/(dashboard)/dashboard/profile/page.js
+++ b/src/app/(dashboard)/dashboard/profile/page.js
@@ -643,6 +643,21 @@ export default function ProfilePage() {
     }
   };
 
+  const updateExposeComboOnly = async (exposeComboOnly) => {
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ exposeComboOnly }),
+      });
+      if (res.ok) {
+        setSettings(prev => ({ ...prev, exposeComboOnly }));
+      }
+    } catch (err) {
+      console.error("Failed update exposeComboOnly:", err);
+    }
+  };
+
   const reloadSettings = async () => {
     try {
       const res = await fetch("/api/settings");
@@ -1427,6 +1442,31 @@ export default function ProfilePage() {
               )}
             </div>
           )}
+        </Card>
+
+        {/* Model */}
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="p-2 rounded-lg bg-orange-500/10 text-orange-500 shrink-0">
+              <span className="material-symbols-outlined text-[20px]">model_training</span>
+            </div>
+            <h3 className="text-base sm:text-lg font-semibold">Model</h3>
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start sm:items-center justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm sm:text-base">Expose Combo Only</p>
+                <p className="text-xs sm:text-sm text-text-muted">
+                  Only configured Combo models exposed through <code className="bg-bg px-1 rounded text-xs">/v1/models</code>
+                </p>
+              </div>
+              <Toggle
+                checked={settings.exposeComboOnly === true}
+                onChange={() => updateExposeComboOnly(!settings.exposeComboOnly)}
+                disabled={loading}
+              />
+            </div>
+          </div>
         </Card>
 
         {/* Routing Preferences */}

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -7,6 +7,7 @@ import {
 } from "@/shared/constants/providers";
 import { getProviderConnections, getCombos, getCustomModels, getModelAliases } from "@/lib/localDb";
 import { getDisabledModels } from "@/lib/disabledModelsDb";
+import { getSettings } from "@/lib/db/repos/settingsRepo.js";
 import { resolveKiroModels } from "open-sse/services/kiroModels.js";
 import { resolveKimchiModels } from "open-sse/services/kimchiModels.js";
 import { resolveQoderModels } from "open-sse/services/qoderModels.js";
@@ -237,6 +238,18 @@ function comboMatchesKinds(combo, kindFilter) {
   return kindFilter.includes(kind);
 }
 
+function comboToEntry(combo) {
+  const entry = {
+    id: combo.name,
+    object: "model",
+    owned_by: "combo",
+  };
+  if (combo.kind === "webSearch" || combo.kind === "webFetch") {
+    entry.kind = combo.kind;
+  }
+  return entry;
+}
+
 /**
  * Build OpenAI-format models list filtered by service kinds.
  * @param {string[]} kindFilter - List of service kinds to include (e.g. ["llm"], ["webSearch","webFetch"]).
@@ -259,6 +272,25 @@ export async function buildModelsList(kindFilter, options = {}) {
     combos = await getCombos();
   } catch (e) {
     console.log("Could not fetch combos");
+  }
+
+  let settings = {};
+  try {
+    settings = await getSettings();
+  } catch (e) {
+    console.log("Could not fetch settings, using defaults");
+  }
+  if (settings.exposeComboOnly) {
+    const seenModelIds = new Set();
+    const comboOnlyModels = [];
+    for (const combo of combos) {
+      if (!comboMatchesKinds(combo, kindFilter)) continue;
+      const entry = comboToEntry(combo);
+      if (seenModelIds.has(entry.id)) continue;
+      seenModelIds.add(entry.id);
+      comboOnlyModels.push(entry);
+    }
+    return comboOnlyModels;
   }
 
   let customModels = [];
@@ -295,15 +327,7 @@ export async function buildModelsList(kindFilter, options = {}) {
   // Combos first (filtered by kind). Web combos expose `kind` so AI knows search vs fetch.
   for (const combo of combos) {
     if (!comboMatchesKinds(combo, kindFilter)) continue;
-    const entry = {
-      id: combo.name,
-      object: "model",
-      owned_by: "combo",
-    };
-    if (combo.kind === "webSearch" || combo.kind === "webFetch") {
-      entry.kind = combo.kind;
-    }
-    models.push(entry);
+    models.push(comboToEntry(combo));
   }
 
   if (connections.length === 0) {

--- a/src/lib/db/repos/settingsRepo.js
+++ b/src/lib/db/repos/settingsRepo.js
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS = {
   comboStrategy: "fallback",
   comboStickyRoundRobinLimit: 1,
   comboStrategies: {},
+  exposeComboOnly: false,
   capacityAdapter: {
     vision: { enabled: true, roundRobin: false, models: [] },
     pdf: { enabled: false, roundRobin: false, models: [] },

--- a/tests/unit/models-route.test.js
+++ b/tests/unit/models-route.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/db/repos/settingsRepo.js", () => ({
+  getSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/db/repos/combosRepo.js", () => ({
+  getCombos: vi.fn(),
+}));
+
+vi.mock("@/lib/db/repos/connectionsRepo.js", () => ({
+  getProviderConnections: vi.fn(),
+}));
+
+vi.mock("@/lib/db/repos/aliasRepo.js", () => ({
+  getCustomModels: vi.fn().mockResolvedValue([]),
+  getModelAliases: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/lib/db/repos/disabledModelsRepo.js", () => ({
+  getDisabledModels: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/shared/constants/providers.js", () => ({
+  PROVIDER_ID_TO_ALIAS: {},
+  PROVIDER_MODELS: {},
+  AI_PROVIDERS: {},
+  getProviderAlias: vi.fn().mockReturnValue(null),
+  isOpenAICompatibleProvider: vi.fn().mockReturnValue(false),
+  isAnthropicCompatibleProvider: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/shared/utils/modelCapabilities.js", () => ({
+  getCapabilitiesForModel: vi.fn().mockReturnValue(null),
+}));
+
+const { getSettings } = await import("@/lib/db/repos/settingsRepo.js");
+const { getCombos } = await import("@/lib/db/repos/combosRepo.js");
+const { getProviderConnections } = await import("@/lib/db/repos/connectionsRepo.js");
+const { buildModelsList } = await import("@/app/api/v1/models/route.js");
+
+describe("buildModelsList with exposeComboOnly", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("default-off includes Combo and provider model entries", async () => {
+    getSettings.mockResolvedValue({ exposeComboOnly: false });
+    getCombos.mockResolvedValue([
+      { name: "my-combo", kind: "llm", models: ["gpt-4"] },
+    ]);
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        providerSpecificData: {},
+      },
+    ]);
+
+    const result = await buildModelsList(["llm"]);
+
+    const comboEntries = result.filter((m) => m.owned_by === "combo");
+    const providerEntries = result.filter((m) => m.owned_by !== "combo");
+
+    expect(comboEntries.length).toBeGreaterThan(0);
+    expect(providerEntries.length).toBeGreaterThan(0);
+  });
+
+  it("enabled returns only kind-matching Combos", async () => {
+    getSettings.mockResolvedValue({ exposeComboOnly: true });
+    getCombos.mockResolvedValue([
+      { name: "llm-combo", kind: "llm", models: ["gpt-4"] },
+      { name: "web-combo", kind: "webSearch", models: ["search-model"] },
+    ]);
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        providerSpecificData: {},
+      },
+    ]);
+
+    const result = await buildModelsList(["llm"]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "llm-combo",
+      owned_by: "combo",
+    });
+  });
+
+  it("enabled with no kind-matching Combo produces empty list", async () => {
+    getSettings.mockResolvedValue({ exposeComboOnly: true });
+    getCombos.mockResolvedValue([
+      { name: "web-combo", kind: "webSearch", models: ["search-model"] },
+    ]);
+    getProviderConnections.mockResolvedValue([
+      {
+        provider: "openai",
+        isActive: true,
+        providerSpecificData: {},
+      },
+    ]);
+
+    const result = await buildModelsList(["llm"]);
+
+    expect(result).toEqual([]);
+  });
+
+  it("enabled with web kind filter returns only webSearch/webFetch Combos and preserves kind field", async () => {
+    getSettings.mockResolvedValue({ exposeComboOnly: true });
+    getCombos.mockResolvedValue([
+      { name: "llm-combo", kind: "llm", models: ["gpt-4"] },
+      { name: "search-combo", kind: "webSearch", models: ["search-model"] },
+      { name: "fetch-combo", kind: "webFetch", models: ["fetch-model"] },
+    ]);
+    getProviderConnections.mockResolvedValue([]);
+
+    const result = await buildModelsList(["webSearch", "webFetch"], { exposeComboOnly: true });
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      id: "search-combo",
+      owned_by: "combo",
+      kind: "webSearch",
+    });
+    expect(result[1]).toMatchObject({
+      id: "fetch-combo",
+      owned_by: "combo",
+      kind: "webFetch",
+    });
+    expect(result.every((m) => m.owned_by === "combo")).toBe(true);
+    expect(result.every((m) => m.kind === "webSearch" || m.kind === "webFetch")).toBe(true);
+  });
+});


### PR DESCRIPTION
Add a Profile setting for exposing configured Combo models only.

When enabled, model-list endpoints return deduplicated Combos matching the requested kind and skip provider, alias, custom, and dynamic catalogs. Include focused coverage for the default and combo-only listing behavior.

When using a combo to define a unified model configuration and treating providers as the actual backend service providers, if the client supports automatically retrieving the model list through the /v1/models interface, it should not retrieve the model list configured by providers. Adding this configuration to allow only the models configured by the combo will be more user-friendly.