### PR TITLE
fix(responses): preserve usage in completed events

### DIFF
--- a/open-sse/transformer/responsesTransformer.js
+++ b/open-sse/transformer/responsesTransformer.js
@@ -10,8 +10,8 @@ import path from "path";
 function toResponsesUsage(usage) {
   if (!usage || typeof usage !== "object") return null;
 
-  const inputTokens = Number.isFinite(usage.prompt_tokens) ? usage.prompt_tokens : 0;
-  const outputTokens = Number.isFinite(usage.completion_tokens) ? usage.completion_tokens : 0;
+  const inputTokens = [usage.input_tokens, usage.prompt_tokens].find(Number.isFinite) ?? 0;
+  const outputTokens = [usage.output_tokens, usage.completion_tokens].find(Number.isFinite) ?? 0;
   const responseUsage = {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
@@ -19,8 +19,14 @@ function toResponsesUsage(usage) {
       ? usage.total_tokens
       : inputTokens + outputTokens
   };
-  const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
-  const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens;
+  const cachedTokens = [
+    usage.input_tokens_details?.cached_tokens,
+    usage.prompt_tokens_details?.cached_tokens
+  ].find(Number.isFinite);
+  const reasoningTokens = [
+    usage.output_tokens_details?.reasoning_tokens,
+    usage.completion_tokens_details?.reasoning_tokens
+  ].find(Number.isFinite);
 
   if (Number.isFinite(cachedTokens)) {
     responseUsage.input_tokens_details = { cached_tokens: cachedTokens };

--- a/open-sse/transformer/responsesTransformer.js
+++ b/open-sse/transformer/responsesTransformer.js
@@ -7,6 +7,31 @@
 import fs from "fs";
 import path from "path";
 
+function toResponsesUsage(usage) {
+  if (!usage || typeof usage !== "object") return null;
+
+  const inputTokens = Number.isFinite(usage.prompt_tokens) ? usage.prompt_tokens : 0;
+  const outputTokens = Number.isFinite(usage.completion_tokens) ? usage.completion_tokens : 0;
+  const responseUsage = {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: Number.isFinite(usage.total_tokens)
+      ? usage.total_tokens
+      : inputTokens + outputTokens
+  };
+  const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
+  const reasoningTokens = usage.completion_tokens_details?.reasoning_tokens;
+
+  if (Number.isFinite(cachedTokens)) {
+    responseUsage.input_tokens_details = { cached_tokens: cachedTokens };
+  }
+  if (Number.isFinite(reasoningTokens)) {
+    responseUsage.output_tokens_details = { reasoning_tokens: reasoningTokens };
+  }
+
+  return responseUsage;
+}
+
 // Create log directory for responses (Node.js only)
 export function createResponsesLogger(model, logsDir = null) {
   // Skip logging in worker environment (no fs)
@@ -73,6 +98,7 @@ export function createResponsesApiTransformStream(logger = null) {
     funcArgsDone: {},
     funcItemDone: {},
     buffer: "",
+    usage: null,
     completedSent: false
   };
 
@@ -233,7 +259,8 @@ export function createResponsesApiTransformStream(logger = null) {
           created_at: state.created,
           status: "completed",
           background: false,
-          error: null
+          error: null,
+          ...(state.usage ? { usage: state.usage } : {})
         }
       });
     }
@@ -262,6 +289,10 @@ export function createResponsesApiTransformStream(logger = null) {
           parsed = JSON.parse(dataStr);
         } catch {
           continue;
+        }
+
+        if (parsed.usage) {
+          state.usage = toResponsesUsage(parsed.usage);
         }
 
         if (!parsed.choices?.length) continue;
@@ -419,7 +450,6 @@ export function createResponsesApiTransformStream(logger = null) {
           for (const i in state.msgItemAdded) closeMessage(controller, i);
           closeReasoning(controller);
           for (const i in state.funcCallIds) closeToolCall(controller, i);
-          sendCompleted(controller);
         }
       }
     },
@@ -436,4 +466,3 @@ export function createResponsesApiTransformStream(logger = null) {
     }
   });
 }
-

--- a/tests/unit/responses-transformer-usage.test.js
+++ b/tests/unit/responses-transformer-usage.test.js
@@ -11,14 +11,26 @@ const CHAT_COMPLETIONS_STREAM = [
   "",
 ].join("\n\n");
 
-function createChatCompletionsStream() {
+function createChatCompletionsStream(stream = CHAT_COMPLETIONS_STREAM) {
   const encoder = new TextEncoder();
   return new ReadableStream({
     start(controller) {
-      controller.enqueue(encoder.encode(CHAT_COMPLETIONS_STREAM));
+      controller.enqueue(encoder.encode(stream));
       controller.close();
     },
   });
+}
+
+async function readCompletedResponse(stream = CHAT_COMPLETIONS_STREAM) {
+  const output = await readStream(
+    createChatCompletionsStream(stream).pipeThrough(createResponsesApiTransformStream()),
+  );
+  const completedData = output
+    .split("\n\n")
+    .find((event) => event.startsWith("event: response.completed"))
+    ?.match(/^data: (.+)$/m)?.[1];
+
+  return JSON.parse(completedData).response;
 }
 
 async function readStream(stream) {
@@ -36,22 +48,64 @@ async function readStream(stream) {
 }
 
 describe("Responses API transformer usage", () => {
-  it("includes final Chat Completions usage in response.completed", async () => {
-    const output = await readStream(
-      createChatCompletionsStream().pipeThrough(createResponsesApiTransformStream()),
-    );
-    const completedData = output
-      .split("\n\n")
-      .find((event) => event.startsWith("event: response.completed"))
-      ?.match(/^data: (.+)$/m)?.[1];
+  it("includes Chat Completions usage that arrives after finish_reason", async () => {
+    const response = await readCompletedResponse();
 
-    expect(JSON.parse(completedData).response.usage).toEqual({
+    expect(response.usage).toEqual({
       input_tokens: 884,
       output_tokens: 37,
       total_tokens: 921,
       input_tokens_details: { cached_tokens: 256 },
       output_tokens_details: { reasoning_tokens: 12 },
     });
+  });
+
+  it("accepts usage already shaped like a Responses API payload", async () => {
+    const stream = [
+      'data: {"id":"chatcmpl-native","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+      'data: {"id":"chatcmpl-native","choices":[],"usage":{"input_tokens":20,"output_tokens":5,"total_tokens":25,"input_tokens_details":{"cached_tokens":7},"output_tokens_details":{"reasoning_tokens":3}}}',
+      "data: [DONE]",
+      "",
+    ].join("\n\n");
+
+    const response = await readCompletedResponse(stream);
+
+    expect(response.usage).toEqual({
+      input_tokens: 20,
+      output_tokens: 5,
+      total_tokens: 25,
+      input_tokens_details: { cached_tokens: 7 },
+      output_tokens_details: { reasoning_tokens: 3 },
+    });
+  });
+
+  it("omits token detail objects when the upstream usage has no details", async () => {
+    const stream = [
+      'data: {"id":"chatcmpl-no-details","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+      'data: {"id":"chatcmpl-no-details","choices":[],"usage":{"prompt_tokens":8,"completion_tokens":2}}',
+      "data: [DONE]",
+      "",
+    ].join("\n\n");
+
+    const response = await readCompletedResponse(stream);
+
+    expect(response.usage).toEqual({
+      input_tokens: 8,
+      output_tokens: 2,
+      total_tokens: 10,
+    });
+  });
+
+  it("omits usage when the upstream stream sends no usage chunk", async () => {
+    const stream = [
+      'data: {"id":"chatcmpl-no-usage","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+      "data: [DONE]",
+      "",
+    ].join("\n\n");
+
+    const response = await readCompletedResponse(stream);
+
+    expect(response).not.toHaveProperty("usage");
   });
 
   it("preserves transformed usage in a non-streaming Responses body", async () => {

--- a/tests/unit/responses-transformer-usage.test.js
+++ b/tests/unit/responses-transformer-usage.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { convertResponsesStreamToJson } from "../../open-sse/transformer/streamToJsonConverter.js";
+import { createResponsesApiTransformStream } from "../../open-sse/transformer/responsesTransformer.js";
+
+const CHAT_COMPLETIONS_STREAM = [
+  'data: {"id":"chatcmpl-usage","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}',
+  'data: {"id":"chatcmpl-usage","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+  'data: {"id":"chatcmpl-usage","choices":[],"usage":{"prompt_tokens":884,"completion_tokens":37,"total_tokens":921,"prompt_tokens_details":{"cached_tokens":256},"completion_tokens_details":{"reasoning_tokens":12}}}',
+  "data: [DONE]",
+  "",
+].join("\n\n");
+
+function createChatCompletionsStream() {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(CHAT_COMPLETIONS_STREAM));
+      controller.close();
+    },
+  });
+}
+
+async function readStream(stream) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    output += decoder.decode(value, { stream: true });
+  }
+
+  return output + decoder.decode();
+}
+
+describe("Responses API transformer usage", () => {
+  it("includes final Chat Completions usage in response.completed", async () => {
+    const output = await readStream(
+      createChatCompletionsStream().pipeThrough(createResponsesApiTransformStream()),
+    );
+    const completedData = output
+      .split("\n\n")
+      .find((event) => event.startsWith("event: response.completed"))
+      ?.match(/^data: (.+)$/m)?.[1];
+
+    expect(JSON.parse(completedData).response.usage).toEqual({
+      input_tokens: 884,
+      output_tokens: 37,
+      total_tokens: 921,
+      input_tokens_details: { cached_tokens: 256 },
+      output_tokens_details: { reasoning_tokens: 12 },
+    });
+  });
+
+  it("preserves transformed usage in a non-streaming Responses body", async () => {
+    const responsesStream = createChatCompletionsStream().pipeThrough(
+      createResponsesApiTransformStream(),
+    );
+
+    await expect(convertResponsesStreamToJson(responsesStream)).resolves.toMatchObject({
+      usage: {
+        input_tokens: 884,
+        output_tokens: 37,
+        total_tokens: 921,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- capture usage-only Chat Completions SSE chunks before skipping empty choices
- map prompt, completion, total, cached, and reasoning token counts to the Responses API usage shape
- defer response.completed until stream flush so a trailing usage chunk is included
- add regression coverage for streaming and forced non-streaming Responses output

Fixes #3432

## Testing

- 2 focused regression tests passed
- 39 Responses-related tests passed
- node syntax checks passed for both changed files
- git diff --check passed

The full test command was also attempted: 1,018 tests passed and 101 skipped, but the checkout-wide run is not clean in this environment because multiple unrelated suites require missing optional/root dependencies, cloud fixtures, OS-specific snapshots, or localhost binding unavailable in the sandbox.

## AI assistance

The implementation and tests were prepared with Codex assistance and verified locally with the commands above.