### PR TITLE
fix(responses): propagate upstream usage into response.completed (#3432)

### DIFF
--- a/open-sse/transformer/responsesTransformer.js
+++ b/open-sse/transformer/responsesTransformer.js
@@ -73,7 +73,8 @@ export function createResponsesApiTransformStream(logger = null) {
     funcArgsDone: {},
     funcItemDone: {},
     buffer: "",
-    completedSent: false
+    completedSent: false,
+    usage: null
   };
 
   const encoder = new TextEncoder();
@@ -222,9 +223,28 @@ export function createResponsesApiTransformStream(logger = null) {
     }
   };
 
+  // chat.completions usage -> Responses API shape. Tolerates upstreams that
+  // already speak the Responses names, mirroring the reverse direction in
+  // translator/response/openai-responses.js.
+  const toResponsesUsage = (usage) => {
+    if (!usage || typeof usage !== "object") return null;
+    const inputTokens = usage.input_tokens ?? usage.prompt_tokens ?? 0;
+    const outputTokens = usage.output_tokens ?? usage.completion_tokens ?? 0;
+    const cachedTokens =
+      usage.input_tokens_details?.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens ?? 0;
+    const result = {
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      total_tokens: usage.total_tokens ?? inputTokens + outputTokens
+    };
+    if (cachedTokens) result.input_tokens_details = { cached_tokens: cachedTokens };
+    return result;
+  };
+
   const sendCompleted = (controller) => {
     if (!state.completedSent) {
       state.completedSent = true;
+      const usage = toResponsesUsage(state.usage);
       emit(controller, "response.completed", {
         type: "response.completed",
         response: {
@@ -233,7 +253,8 @@ export function createResponsesApiTransformStream(logger = null) {
           created_at: state.created,
           status: "completed",
           background: false,
-          error: null
+          error: null,
+          ...(usage ? { usage } : {})
         }
       });
     }
@@ -263,6 +284,10 @@ export function createResponsesApiTransformStream(logger = null) {
         } catch {
           continue;
         }
+
+        // The final chat.completions chunk carries usage with an empty choices
+        // array, so this has to be read before the guard below drops it.
+        if (parsed.usage) state.usage = parsed.usage;
 
         if (!parsed.choices?.length) continue;
         
@@ -419,7 +444,12 @@ export function createResponsesApiTransformStream(logger = null) {
           for (const i in state.msgItemAdded) closeMessage(controller, i);
           closeReasoning(controller);
           for (const i in state.funcCallIds) closeToolCall(controller, i);
-          sendCompleted(controller);
+          // With `include_usage`, upstream sends usage in a trailing chunk AFTER
+          // this one, so completing here would always drop it. Wait for flush,
+          // which runs as soon as the upstream stream ends; a stalled upstream is
+          // handled separately by the aborted-terminal synthesis in
+          // utils/responsesStreamHelpers.js, so this cannot hang.
+          if (state.usage) sendCompleted(controller);
         }
       }
     },

--- a/tests/unit/responses-usage-3432.test.js
+++ b/tests/unit/responses-usage-3432.test.js
@@ -1,0 +1,127 @@
+/**
+ * Regression test for #3432:
+ * /v1/responses never emitted a `usage` object on `response.completed`, so
+ * Responses API clients saw all-zero token counts and no cache-hit data.
+ *
+ * The upstream chat.completions stream carries usage on a final chunk whose
+ * `choices` array is EMPTY, which the transformer skipped before reading it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createResponsesApiTransformStream } from "../../open-sse/transformer/responsesTransformer.js";
+
+const encoder = new TextEncoder();
+
+function upstream(chunks) {
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    }
+  });
+}
+
+async function runTransform(chunks) {
+  const stream = upstream(chunks).pipeThrough(createResponsesApiTransformStream());
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+function completedPayload(sse) {
+  const block = sse
+    .split("\n\n")
+    .find((b) => b.startsWith("event: response.completed"));
+  if (!block) return null;
+  return JSON.parse(block.match(/^data:\s*(.+)$/m)[1]);
+}
+
+const TEXT_CHUNK = `data: ${JSON.stringify({
+  id: "chatcmpl-1",
+  choices: [{ index: 0, delta: { content: "391" }, finish_reason: null }]
+})}\n\n`;
+
+const FINISH_CHUNK = `data: ${JSON.stringify({
+  id: "chatcmpl-1",
+  choices: [{ index: 0, delta: {}, finish_reason: "stop" }]
+})}\n\n`;
+
+// The shape a real upstream sends: usage arrives with choices: [].
+const USAGE_CHUNK = `data: ${JSON.stringify({
+  id: "chatcmpl-1",
+  choices: [],
+  usage: {
+    prompt_tokens: 884,
+    completion_tokens: 37,
+    total_tokens: 921,
+    prompt_tokens_details: { cached_tokens: 256 }
+  }
+})}\n\n`;
+
+describe("responsesTransformer usage propagation (#3432)", () => {
+  it("emits usage on response.completed in Responses API shape", async () => {
+    const sse = await runTransform([TEXT_CHUNK, USAGE_CHUNK, FINISH_CHUNK, "data: [DONE]\n\n"]);
+    const completed = completedPayload(sse);
+
+    expect(completed).not.toBeNull();
+    expect(completed.response.usage).toEqual({
+      input_tokens: 884,
+      output_tokens: 37,
+      total_tokens: 921,
+      input_tokens_details: { cached_tokens: 256 }
+    });
+  });
+
+  it("reads usage even when it arrives after the finish chunk", async () => {
+    const sse = await runTransform([TEXT_CHUNK, FINISH_CHUNK, USAGE_CHUNK, "data: [DONE]\n\n"]);
+    expect(completedPayload(sse).response.usage.input_tokens).toBe(884);
+  });
+
+  it("omits input_tokens_details when the upstream reports no cached tokens", async () => {
+    const noCache = `data: ${JSON.stringify({
+      id: "chatcmpl-1",
+      choices: [],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+    })}\n\n`;
+    const sse = await runTransform([TEXT_CHUNK, noCache, FINISH_CHUNK, "data: [DONE]\n\n"]);
+    const usage = completedPayload(sse).response.usage;
+
+    expect(usage).toEqual({ input_tokens: 10, output_tokens: 5, total_tokens: 15 });
+    expect(usage.input_tokens_details).toBeUndefined();
+  });
+
+  it("accepts an upstream that already speaks Responses usage names", async () => {
+    const native = `data: ${JSON.stringify({
+      id: "chatcmpl-1",
+      choices: [],
+      usage: {
+        input_tokens: 7,
+        output_tokens: 3,
+        total_tokens: 10,
+        input_tokens_details: { cached_tokens: 2 }
+      }
+    })}\n\n`;
+    const sse = await runTransform([TEXT_CHUNK, native, FINISH_CHUNK, "data: [DONE]\n\n"]);
+
+    expect(completedPayload(sse).response.usage).toEqual({
+      input_tokens: 7,
+      output_tokens: 3,
+      total_tokens: 10,
+      input_tokens_details: { cached_tokens: 2 }
+    });
+  });
+
+  it("still completes without a usage key when the upstream sends none", async () => {
+    const sse = await runTransform([TEXT_CHUNK, FINISH_CHUNK, "data: [DONE]\n\n"]);
+    const completed = completedPayload(sse);
+
+    expect(completed.response.status).toBe("completed");
+    expect(completed.response).not.toHaveProperty("usage");
+  });
+});


### PR DESCRIPTION
Fixes #3432.

## Problem

`/v1/responses` never emitted a `usage` object on `response.completed`, so Responses API clients
(pi-coding-agent / PiDeck in the report) read all-zero token counts and could not report cost or
cache-hit rate. `streamToJsonConverter.js` already expects `parsed.response?.usage`, so non-streaming
JSON came back zeroed for the same reason.

## Root cause

Two things dropped it, and fixing only the first is not enough.

**1. The usage chunk is the one the loop discards.** With `include_usage` the upstream sends usage in
a trailing chunk whose `choices` array is empty:

```
data: {"choices":[],"usage":{"prompt_tokens":884,"completion_tokens":37,...}}
```

`if (!parsed.choices?.length) continue;` skips it before any usage handling could run — which is why
`grep -n usage responsesTransformer.js` returned nothing to hook into.

**2. That chunk arrives after finish_reason.** `sendCompleted()` fired from the `finish_reason`
branch, so even once usage is captured, the completed event had already been emitted and
`completedSent` latched.

## Fix

- Read `parsed.usage` into state **above** the `choices` guard.
- From the `finish_reason` branch, emit `response.completed` only when usage is already in hand.
  Otherwise leave it to `flush()`, which runs as soon as the upstream stream ends. A stalled upstream
  cannot hang here — that path is covered by the aborted-terminal synthesis in
  `open-sse/utils/responsesStreamHelpers.js` (`buildAbortedResponsesTerminalBytes`), which is
  independent of this transformer.
- Map to the Responses shape (`input_tokens` / `output_tokens` / `total_tokens` /
  `input_tokens_details.cached_tokens`), accepting either chat.completions or Responses field names —
  mirroring how the reverse direction reads it in `translator/response/openai-responses.js`.

Item-close events (`output_item.done`, reasoning, tool calls) still fire at `finish_reason` exactly
as before; only the terminal event moves, and only when usage has not arrived yet.

## Compatibility

A stream whose upstream reports no usage still emits `response.completed` with no `usage` key — the
field is spread in conditionally, so no client sees a new zero-filled object where there was
previously nothing. Pinned by a test.

## Tests

`tests/unit/responses-usage-3432.test.js` (new, 5 cases): usage before finish, usage after finish
(the real ordering), no cached tokens, an upstream already using Responses field names, and the
no-usage case. It fails **4/5 on master** and passes 5/5 here.

```
npx vitest run unit/responses-usage-3432.test.js                     5/5 pass
+ responses-abort-terminal, openai-responses-terminal-event,
  openai-responses-nonstream, openai-responses-multiturn,
  openai-responses-custom-tools, openai-responses-empty-toolcalls,
  headroom-responses-format, responses-prompt-cache-key-3216,
  github-responses-routing                                          42/42 pass (10 files)
npx eslint <both changed files>                                     clean
```

Full suite for comparison, same machine:

```
master                    93 failed | 1776 passed  (1945)
this branch               93 failed | 1781 passed  (1950)
```

Identical failure set — the 93 are pre-existing here (saml, db-benchmark, db-concurrent,
embeddings.cloud, kimchi, GOLDEN buildUrl, …), unrelated to this change. The delta is exactly the 5
tests this PR adds.
