### PR TITLE
fix(usage): preserve nested cached_tokens in canonicalizeUsage

### DIFF
--- a/open-sse/utils/usageTracking.js
+++ b/open-sse/utils/usageTracking.js
@@ -190,7 +190,10 @@ export function canonicalizeUsage(usage) {
     prompt = prompt + cached + cacheCreation;
   } else {
     // OpenAI/Gemini path (or already-canonical input): prompt already includes cached_tokens.
-    cached = num(usage.cached_tokens);
+    // Mirror the cacheCreation fallback above: buildUsage() only ever emits the
+    // nested prompt_tokens_details.cached_tokens shape, so without this the
+    // cache-read count is silently dropped on every buildUsage()-derived usage.
+    cached = num(usage.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens);
   }
 
   const result = {

--- a/tests/unit/cached-token-usage.test.js
+++ b/tests/unit/cached-token-usage.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { canonicalizeUsage, extractUsage, mergeUsage } from "../../open-sse/utils/usageTracking.js";
 import { calculateCostFromTokens } from "../../open-sse/providers/pricing.js";
-import { toOpenAIUsage } from "../../open-sse/translator/concerns/usage.js";
+import { buildUsage, toOpenAIUsage } from "../../open-sse/translator/concerns/usage.js";
 
 // Canonical convention (single source of truth for storage + cost):
 //   prompt_tokens             = total input INCLUDING cache read + cache creation
@@ -47,6 +47,18 @@ describe("canonicalizeUsage", () => {
     expect(out.prompt_tokens).toBe(500);
     expect(out.cached_tokens).toBe(120);
     expect(out.reasoning_tokens).toBe(40);
+  });
+
+  it("reads cached_tokens from the nested buildUsage() shape", () => {
+    // buildUsage() only emits cache reads under prompt_tokens_details. The
+    // Responses translator overwrites state.usage with that shape on
+    // response.completed, so a top-level-only read silently drops the cache
+    // count for every Responses provider (codex, grok-cli, ...).
+    const out = canonicalizeUsage(
+      buildUsage({ promptTokens: 330, completionTokens: 50, totalTokens: 380, cachedTokens: 200 })
+    );
+    expect(out.prompt_tokens).toBe(330);
+    expect(out.cached_tokens).toBe(200);
   });
 
   it("handles no-cache usage", () => {


### PR DESCRIPTION
## Problem

`canonicalizeUsage()` reads cache-read tokens from the top-level `cached_tokens` field. `buildUsage()` — used by the Responses translator on `response.completed` / `response.done` — only ever emits that count under `prompt_tokens_details.cached_tokens`.

The result is that every Responses-format provider (Codex, grok-cli, …) persists `cached_tokens: 0` and bills cache hits at the full input rate.

This is the same fallback already used for `cache_creation_input_tokens`.

## Evidence

On a production instance running v0.5.55:

| Day | Codex cache-read / prompt |
|---|---|
| 2026-08-16 | 93.6% |
| 2026-08-17 18h | 81.1% (last good hour) |
| 2026-08-17 20h | **0.0%** (restored to main codebase 20:52 UTC) |
| 2026-08-18–21 | **0.0%** |

Claude is unaffected (Anthropic fold branch via `cache_read_input_tokens`). OpenRouter/Gemini still reports cache because it uses a different extractor.

## Fix

```js
cached = num(usage.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens);
```

One-line change plus a regression test that fails without it (`cached_tokens` 0 vs 200) and passes with it.

## Test plan

- [x] `npx vitest run unit/cached-token-usage.test.js` — 16 passed
- [x] Confirmed the new test fails on unpatched `canonicalizeUsage`
- [x] After merge: second Codex request in a session should persist `cached_tokens > 0` again