### PR TITLE
fix(project-id): fail fast, skip needless refetch

### DIFF
--- a/open-sse/services/projectId.js
+++ b/open-sse/services/projectId.js
@@ -122,14 +122,6 @@ export async function getProjectIdForConnection(connectionId, accessToken, provi
 }
 
 /**
- * Invalidate the cached project ID for a connection.
- * Call this when a connection's credentials are fully revoked or refreshed.
- */
-export function invalidateProjectId(connectionId) {
-    projectIdCache.delete(connectionId);
-}
-
-/**
  * Fully remove a connection: abort any in-flight fetch and delete its cached project ID.
  * Wire this into your connection close / disconnect lifecycle events to prevent memory leaks.
  *
@@ -238,7 +230,11 @@ async function onboardUser(accessToken, tierID, externalSignal, endpoints, provi
                     console.log(`[ProjectId] Successfully onboarded, project ID: ${projectId}`);
                     return projectId;
                 }
-                throw new Error("onboardUser done but no project_id in response");
+                // done:true with no usable project id is terminal: Google returns an
+                // empty cloudaicompanionProject object for accounts it won't provision.
+                // Retrying cannot change the answer, so bail out immediately.
+                console.warn("[ProjectId] onboardUser finished without a project ID (account not provisioned)");
+                return null;
             }
 
             // Server not done yet – wait and retry

--- a/src/sse/services/tokenRefresh.js
+++ b/src/sse/services/tokenRefresh.js
@@ -3,7 +3,6 @@ import * as log from "../utils/logger.js";
 import { updateProviderConnection } from "../../lib/localDb.js";
 import {
   getProjectIdForConnection,
-  invalidateProjectId,
   removeConnection,
 } from "open-sse/services/projectId.js";
 import {
@@ -114,8 +113,8 @@ function needsProjectId(provider) {
 
 /**
  * Non-blocking: fetch the project ID for a connection after a token refresh and
- * persist it to localDb.  Invalidates the stale cached value first so the fetch
- * always retrieves a fresh one.
+ * persist it to localDb.  Skipped when the connection already has a project ID –
+ * it never changes on a token rotation.
  *
  * @param {string} provider
  * @param {string} connectionId
@@ -124,10 +123,7 @@ function needsProjectId(provider) {
 function _refreshProjectId(provider, connectionId, accessToken) {
   if (!needsProjectId(provider) || !connectionId || !accessToken) return;
 
-  // Evict the stale cached entry so getProjectIdForConnection does a real fetch
-  invalidateProjectId(connectionId);
-
-  getProjectIdForConnection(connectionId, accessToken)
+  getProjectIdForConnection(connectionId, accessToken, provider)
     .then((projectId) => {
       if (!projectId) return;
       updateProviderCredentials(connectionId, { projectId }).catch((err) => {
@@ -258,8 +254,8 @@ export async function checkAndRefreshToken(provider, credentials, options = {}) 
           : creds.providerSpecificData,
       };
 
-      // Non-blocking: refresh projectId with the new access token
-      _refreshProjectId(provider, creds.connectionId, creds.accessToken);
+      // Non-blocking: fetch projectId only when the connection has none
+      if (!creds.projectId) _refreshProjectId(provider, creds.connectionId, creds.accessToken);
     }
   }
 

--- a/tests/unit/gemini-36-integration.test.js
+++ b/tests/unit/gemini-36-integration.test.js
@@ -63,6 +63,25 @@ describe("Gemini Cloud Code endpoint isolation", () => {
     expect(antigravity.transport.baseUrls).toEqual(["https://daily-cloudcode-pa.googleapis.com"]);
     removeConnection(connectionId);
   });
+  it("fails fast when onboardUser returns done:true without a project id", async () => {
+    const connectionId = "onboard-terminal-test";
+    const fetchMock = vi.fn(async (_url, init) => {
+      const body = JSON.parse(init.body);
+      if ("tierId" in body) {
+        // Google's actual response for accounts it won't provision
+        return { ok: true, json: async () => ({ done: true, response: { cloudaicompanionProject: {} } }) };
+      }
+      return { ok: true, json: async () => ({ allowedTiers: [{ id: "standard-tier", isDefault: true }] }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const projectId = await getProjectIdForConnection(connectionId, "token", "gemini-cli");
+
+    expect(projectId).toBeNull();
+    // 1 discovery + 1 onboarding call — the old code retried onboarding 5 times
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    removeConnection(connectionId);
+  });
 });
 
 describe("Gemini 3.6 Antigravity tiers", () => {


### PR DESCRIPTION
## Problem

Startup logs showed `[ProjectId] onboardUser attempt N failed: onboardUser done but no project_id in response` for all 12 antigravity/gemini-cli connections, and requests hung while these retry loops ran.

Verified live against Google's API:

1. **Wrong headers**: `_refreshProjectId` dropped the `provider` arg, so antigravity connections were re-discovered with gemini-cli headers — which Google fingerprints and refuses (documented in `appConstants.js`).
2. **Pointless refetch storm**: projectId never changes on token rotation, yet every proactive refresh invalidated the cache and re-fetched all 12 connections' project IDs.
3. **Terminal case treated as retryable**: Google returns `done:true` with an *empty* `cloudaicompanionProject: {}` object for accounts it won't provision. The old code threw + retried 5x (~2 min per account), during which requests through that account blocked, then proceeded without a projectId and failed upstream.

## Changes

- `src/sse/services/tokenRefresh.js`: pass `provider` through to `getProjectIdForConnection`; skip `_refreshProjectId` entirely when `creds.projectId` already exists.
- `open-sse/services/projectId.js`: `done:true` without a usable project id → immediate `return null` ("account not provisioned"), no retries; removed now-dead `invalidateProjectId` export.
- `tests/unit/gemini-36-integration.test.js`: regression test asserting exactly 1 discovery + 1 onboard call (old code made 6).

## Verification

- `npx vitest run tests/unit/gemini-36-integration.test.js` → 13/13 pass.
- Live API probe confirmed antigravity discovery returns its stored projectId with correct headers, and the empty-object onboard response is terminal (post-onboard `loadCodeAssist` still returns nothing).

Note: gemini-cli accounts `d224ceb8` /`cde9b81e` have no Google-side provisioned project — needs re-auth or removal, not fixable in code.