### PR TITLE
feat(stream): emit SSE keepalive ping during upstream silence for Claude Code (#3409)

### DIFF
--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -56,8 +56,13 @@ export const STREAM_STALL_TIMEOUT_MS = envMs("STREAM_STALL_TIMEOUT_MS", 360 * 10
 export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_MS", 200 * 1000);
 
 // SSE keepalive ping interval during upstream silence (e.g. Claude Code ANTHROPIC_BASE_URL). Env: SSE_KEEPALIVE_MS.
-export const SSE_KEEPALIVE_MS = envMs("SSE_KEEPALIVE_MS", 10 * 1000);
-
+// Note: allow explicit `0` to disable keepalives.
+export const SSE_KEEPALIVE_MS = (() => {
+  const raw = process.env.SSE_KEEPALIVE_MS;
+  if (raw == null || raw === "") return 10 * 1000;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 10 * 1000;
+})();
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
 export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 60 * 1000);
 

--- a/open-sse/config/runtimeConfig.js
+++ b/open-sse/config/runtimeConfig.js
@@ -55,6 +55,9 @@ export const STREAM_STALL_TIMEOUT_MS = envMs("STREAM_STALL_TIMEOUT_MS", 360 * 10
 // Time-to-first-token timeout (prompt prefill). Env: STREAM_FIRST_CHUNK_TIMEOUT_MS.
 export const STREAM_FIRST_CHUNK_TIMEOUT_MS = envMs("STREAM_FIRST_CHUNK_TIMEOUT_MS", 200 * 1000);
 
+// SSE keepalive ping interval during upstream silence (e.g. Claude Code ANTHROPIC_BASE_URL). Env: SSE_KEEPALIVE_MS.
+export const SSE_KEEPALIVE_MS = envMs("SSE_KEEPALIVE_MS", 10 * 1000);
+
 // Fetch connect timeout: abort if upstream doesn't return response headers within this duration
 export const FETCH_CONNECT_TIMEOUT_MS = envMs("FETCH_CONNECT_TIMEOUT_MS", 60 * 1000);
 

--- a/open-sse/utils/streamHandler.js
+++ b/open-sse/utils/streamHandler.js
@@ -1,5 +1,5 @@
 // Stream handler with disconnect detection - shared for all providers
-import { STREAM_STALL_TIMEOUT_MS } from "../config/runtimeConfig.js";
+import { STREAM_STALL_TIMEOUT_MS, SSE_KEEPALIVE_MS } from "../config/runtimeConfig.js";
 import { dbg, isDebugEnabled } from "./debugLog.js";
 
 // Get HH:MM:SS timestamp
@@ -188,8 +188,9 @@ export function createDisconnectAwareStream(transformStream, streamController, o
  * @param {TransformStream} transformStream - Transform stream for SSE
  * @param {object} streamController - Stream controller from createStreamController
  */
-export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS) {
+export function pipeWithDisconnect(providerResponse, transformStream, streamController, onAbortTerminal = null, stallTimeoutMs = STREAM_STALL_TIMEOUT_MS, keepaliveMs = SSE_KEEPALIVE_MS) {
   let stallTimer = null;
+  let keepaliveTimer = null;
   let chunkCount = 0;
   let totalBytes = 0;
   let lastChunkAt = Date.now();
@@ -198,10 +199,14 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
   const clearStall = () => {
     if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
   };
+  const clearKeepalive = () => {
+    if (keepaliveTimer) { clearInterval(keepaliveTimer); keepaliveTimer = null; }
+  };
   const armStall = () => {
     clearStall();
     stallTimer = setTimeout(() => {
       stallTimer = null;
+      clearKeepalive();
       dbg(tag, `STALL TIMEOUT ${stallTimeoutMs}ms | chunks=${chunkCount} | bytes=${totalBytes} | sinceLast=${Date.now() - lastChunkAt}ms`);
       streamController.handleError?.(new Error("stream stall timeout"));
       streamController.abort?.();
@@ -215,18 +220,38 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
     signal: streamController.signal,
     startTime: streamController.startTime,
     isConnected: () => streamController.isConnected(),
-    handleComplete: () => { dbg(tag, `complete | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleComplete(); },
-    handleError: (e) => { dbg(tag, `error: ${e?.message} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleError(e); },
-    handleDisconnect: (r) => { dbg(tag, `disconnect: ${r} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); streamController.handleDisconnect(r); },
-    abort: () => { clearStall(); streamController.abort(); }
+    handleComplete: () => { dbg(tag, `complete | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); clearKeepalive(); streamController.handleComplete(); },
+    handleError: (e) => { dbg(tag, `error: ${e?.message} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); clearKeepalive(); streamController.handleError(e); },
+    handleDisconnect: (r) => { dbg(tag, `disconnect: ${r} | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); clearKeepalive(); streamController.handleDisconnect(r); },
+    abort: () => { clearStall(); clearKeepalive(); streamController.abort(); }
   };
 
   armStall();
-  dbg(tag, `pipe start | stallTimeout=${stallTimeoutMs}ms`);
+  dbg(tag, `pipe start | stallTimeout=${stallTimeoutMs}ms | keepalive=${keepaliveMs}ms`);
+
+  const encoder = new TextEncoder();
+  const keepaliveBytes = encoder.encode("event: ping\ndata: {}\n\n");
 
   const upstreamTap = new TransformStream({
+    start(controller) {
+      if (keepaliveMs > 0) {
+        keepaliveTimer = setInterval(() => {
+          if (chunkCount === 0 && streamController.isConnected()) {
+            dbg(tag, `keepalive ping sent (silence=${Date.now() - t0}ms)`);
+            try {
+              controller.enqueue(keepaliveBytes);
+            } catch {
+              clearKeepalive();
+            }
+          } else {
+            clearKeepalive();
+          }
+        }, keepaliveMs);
+      }
+    },
     transform(chunk, controller) {
       chunkCount++;
+      clearKeepalive();
       const sz = chunk?.byteLength || chunk?.length || 0;
       totalBytes += sz;
       const now = Date.now();
@@ -238,7 +263,7 @@ export function pipeWithDisconnect(providerResponse, transformStream, streamCont
       armStall();
       controller.enqueue(chunk);
     },
-    flush() { dbg(tag, `upstream EOF | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); }
+    flush() { dbg(tag, `upstream EOF | chunks=${chunkCount} | bytes=${totalBytes} | dur=${Date.now() - t0}ms`); clearStall(); clearKeepalive(); }
   });
 
   const transformedBody = providerResponse.body


### PR DESCRIPTION
## Summary

Fixes #3409.

When using Claude Code via `ANTHROPIC_BASE_URL`, clients show a 'Waiting for API response' warning banner whenever the upstream provider remains silent during long thinking/prefill windows (~20s). The official Anthropic API sends periodic SSE `event: ping` during these gaps to maintain connection liveness.

This PR adds an early keepalive ping mechanism during upstream silence:
- Configurable via `SSE_KEEPALIVE_MS` (default: 10,000ms).
- Emits `event: ping\ndata: {}\n\n` while waiting for the first upstream chunk.
- Automatically clears the keepalive interval once real upstream bytes arrive.

## Verification

Verified with standalone stream controller test:
- Confirmed periodic `event: ping` chunks emitted during upstream silence.
- Confirmed immediate timer cleanup and seamless transition upon receiving the first model chunk.