### PR TITLE
feat(antigravity): support image-to-image editing

### DIFF
--- a/open-sse/executors/antigravity.js
+++ b/open-sse/executors/antigravity.js
@@ -150,9 +150,13 @@ export class AntigravityExecutor extends BaseExecutor {
       const contents = [];
       const srcContents = body.request?.contents || body.contents || [];
       for (const c of srcContents) {
-        const textParts = (c.parts || []).filter(p => p.text !== undefined).map(p => ({ text: p.text }));
-        if (textParts.length > 0) {
-          contents.push({ role: c.role || "user", parts: textParts });
+        const allowedParts = (c.parts || []).filter(p => p.text !== undefined || p.inlineData !== undefined).map(p => {
+          if (p.text !== undefined) return { text: p.text };
+          if (p.inlineData !== undefined) return { inlineData: p.inlineData };
+          return p;
+        });
+        if (allowedParts.length > 0) {
+          contents.push({ role: c.role || "user", parts: allowedParts });
         }
       }
 

--- a/open-sse/handlers/imageProviders/antigravity.js
+++ b/open-sse/handlers/imageProviders/antigravity.js
@@ -1,18 +1,32 @@
 // Antigravity image adapter - delegates to the executor for correct request
 // envelope (project, model, requestType, sessionId) and auth headers.
-import { nowSec } from "./_base.js";
+import { nowSec, urlToBase64 } from "./_base.js";
 import { getExecutor } from "../../executors/index.js";
 
-// Convert image input (data URI or raw base64) to Gemini inlineData part
-function resolveImageInput(input) {
+// Convert image input (data URI, raw base64, or HTTP URL) to Gemini inlineData part
+async function resolveImageInput(input) {
   if (!input || typeof input !== "string") return null;
+  
+  // Handle HTTP URLs by fetching and converting to base64
+  if (input.startsWith("http://") || input.startsWith("https://")) {
+    try {
+      const b64 = await urlToBase64(input);
+      // For simplicity, we assume PNG or JPEG. The mimeType might not perfectly match the URL,
+      // but Gemini accepts image/jpeg or image/png generically for valid base64 images.
+      return { inlineData: { mimeType: "image/jpeg", data: b64 } };
+    } catch (e) {
+      console.warn("Failed to fetch image URL:", e.message);
+      return null;
+    }
+  }
+
   // data:image/png;base64,... format
   const dataUriMatch = input.match(/^data:(image\/[^;]+);base64,(.+)$/);
   if (dataUriMatch) {
     return { inlineData: { mimeType: dataUriMatch[1], data: dataUriMatch[2] } };
   }
   // Raw base64 string (assume PNG)
-  if (/^[A-Za-z0-9+/]/.test(input) && input.length > 100 && !input.startsWith("http")) {
+  if (/^[A-Za-z0-9+/]/.test(input) && input.length > 100) {
     return { inlineData: { mimeType: "image/png", data: input } };
   }
   return null;
@@ -35,7 +49,7 @@ export default {
     const parts = [{ text: body.prompt }];
     const imageInput = body.image || (Array.isArray(body.images) && body.images[0]);
     if (imageInput) {
-      const inlineData = resolveImageInput(imageInput);
+      const inlineData = await resolveImageInput(imageInput);
       if (inlineData) parts.unshift(inlineData);
     }
 
@@ -62,9 +76,20 @@ export default {
   normalize: (responseBody, prompt) => {
     const candidates = responseBody.candidates || responseBody.response?.candidates || [];
     const parts = candidates[0]?.content?.parts || [];
-    const images = parts.filter((p) => p.inlineData?.data).map((p) => ({
-      b64_json: p.inlineData.data,
-    }));
+    
+    const images = [];
+
+    for (const p of parts) {
+      if (p.inlineData?.data) {
+        images.push({ b64_json: p.inlineData.data });
+      } else if (p.text) {
+        const b64Matches = [...p.text.matchAll(/!\[.*?\]\(data:image\/[^;]+;base64,([^)]+)\)/g)];
+        for (const match of b64Matches) {
+          images.push({ b64_json: match[1] });
+        }
+      }
+    }
+
     return {
       created: nowSec(),
       data: images.length > 0 ? images : [{ b64_json: "", revised_prompt: prompt }],

--- a/open-sse/providers/registry/antigravity.js
+++ b/open-sse/providers/registry/antigravity.js
@@ -62,7 +62,7 @@ export default {
     { id: "gpt-oss-120b-medium", name: "GPT-OSS 120B (Medium)" },
     { id: "gemini-3-flash", name: "Gemini 3 Flash", thinking: false },
     // Image generation models
-    { id: "gemini-3.1-flash-image", name: "Gemini 3.1 Flash (Image)", kind: "image", imageGen: true, capabilities: ["textToImage"] },
+    { id: "gemini-3.1-flash-image", name: "Gemini 3.1 Flash (Image)", kind: "image", imageGen: true, capabilities: ["textToImage", "edit"] },
   ],
   oauth: {
     authorizeUrl: "https://accounts.google.com/o/oauth2/v2/auth",


### PR DESCRIPTION

## Description

This PR introduces robust support for image generation and image-to-image editing using the native `/v1/images/generations` endpoint in the Antigravity provider. It properly routes image payloads to Gemini while maintaining clean abstraction boundaries.

### Key Changes
- **Multimodal Support in Executor**: Updated `AntigravityExecutor` to allow `inlineData` in request parts. This prevents the executor from filtering out base64 images, unlocking image-to-image capabilities for Gemini natively.
- **HTTP URL Fetching**: Enhanced `resolveImageInput` in the Antigravity image provider to automatically fetch HTTP/HTTPS image URLs and convert them to base64. This ensures seamless compatibility with the 9Router WebUI (which passes URLs by default in the image test dashboard).
- **Markdown Base64 Extraction**: Improved the `normalize` fallback mechanism. If the model refuses to output raw inline data and instead returns a markdown image (e.g., `![image](data:image/png;base64,...)`), the provider will regex-extract the base64 string and map it correctly to the OpenAI `b64_json` structure.
- **Enabled Edit Capability**: Added the `edit` capability flag to `gemini-3.1-flash-image` in the registry. This surfaces the "Ref Image" input field in the 9Router dashboard specifically for this model.

## Verification
- Tested generating text-to-image via `/v1/images/generations`.
- Tested image-to-image editing natively through the 9Router WebUI dashboard (via `dashboard/media-providers/image/antigravity`).
- Verified HTTP image URLs are successfully processed without failures.
- Ensured zero error-throwing on model generation refusals (gracefully falls back to empty Base64 to prevent application crashes).