### PR TITLE
fix(stream): fallback to next combo account on empty/null content responses

### DIFF
--- a/open-sse/config/errorConfig.js
+++ b/open-sse/config/errorConfig.js
@@ -38,6 +38,13 @@ export const BACKOFF_CONFIG = {
 // Default cooldown for transient/unknown errors
 export const TRANSIENT_COOLDOWN_MS = 30 * 1000;
 
+// Cooldown after a provider returns HTTP 200 with no usable content (null/empty
+// message, no tool_calls, no reasoning). Upstream reports success but produced
+// nothing — lock the model on this account for a few minutes so the combo/account
+// fallback loop skips straight to the next candidate instead of retrying a backend
+// that just failed silently, then automatically retries it once the lock expires.
+export const EMPTY_CONTENT_COOLDOWN_MS = 7 * 60 * 1000;
+
 // Hard cap for provider-reported rate limit cooldown (e.g. codex resets_at can be 5-6h)
 export const MAX_RATE_LIMIT_COOLDOWN_MS = 30 * 60 * 1000;
 

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -57,7 +57,7 @@ export function stripContinuityFields(body) {
   return body;
 }
 
-export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
+export async function handleChatCore({ body, modelInfo, credentials, log, onCredentialsRefreshed, onRequestSuccess, onEmptyStream, onDisconnect, clientRawRequest, connectionId, userAgent, apiKey, ccFilterNaming, rtkEnabled, headroomEnabled, headroomUrl, headroomCompressUserMessages, cavemanEnabled, cavemanLevel, ponytailEnabled, ponytailLevel, pxpipeEnabled, pxpipeMinChars, pxpipeTimeoutMs, pxpipeTransform, onPxpipeEvent, sourceFormatOverride, providerThinking }) {
   const { provider, model } = modelInfo;
   const requestStartTime = Date.now();
   // Stable per-session color so all lines of one CLI conversation share a tag
@@ -438,7 +438,7 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     return createErrorResult(statusCode, errMsg, resetsAtMs);
   }
 
-  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, pxpipe: pxpipeSummary, reqTag, log };
+  const sharedCtx = { provider, model, body, stream, translatedBody, finalBody, requestStartTime, connectionId, apiKey, clientRawRequest, onRequestSuccess, onEmptyStream, pxpipe: pxpipeSummary, reqTag, log };
   const appendLog = (extra) => appendRequestLog({ model, provider, connectionId, ...extra }).catch(() => { });
   const trackDone = () => trackPendingRequest(model, provider, connectionId, false);
 

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -7,6 +7,7 @@ import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
 import { EMPTY_CONTENT_COOLDOWN_MS } from "../../config/errorConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
+import { convertResponsesStreamToJson } from "../../transformer/streamToJsonConverter.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
@@ -385,13 +386,31 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   let responseBody;
 
   if (contentType.includes("text/event-stream")) {
-    const sseText = await providerResponse.text();
-    const parsed = parseSSEToOpenAIResponse(sseText, model);
-    if (!parsed) {
-      appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
-      return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
+    // A provider not statically flagged forceStream (e.g. a dynamically-added
+    // openai-compatible connection) can still force SSE at the HTTP level —
+    // providerRequiresStreaming only catches known providers, so this branch
+    // is reachable even for a "true non-streaming" request. When the upstream
+    // speaks Responses API, its SSE uses response.output_text.delta-style
+    // events, not choices[].delta — parseSSEToOpenAIResponse only understands
+    // the latter and would silently yield empty content. Use the Responses-
+    // aware converter (same one handleForcedSSEToJson uses) in that case.
+    if (targetFormat === FORMATS.OPENAI_RESPONSES) {
+      try {
+        responseBody = await convertResponsesStreamToJson(providerResponse.body);
+      } catch (err) {
+        appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+        console.error(`[ChatCore] Failed to convert Responses SSE from ${provider}:`, err.message);
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `Failed to convert streaming response to JSON for ${provider}`);
+      }
+    } else {
+      const sseText = await providerResponse.text();
+      const parsed = parseSSEToOpenAIResponse(sseText, model);
+      if (!parsed) {
+        appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY}` });
+        return createErrorResult(HTTP_STATUS.BAD_GATEWAY, "Invalid SSE response for non-streaming request");
+      }
+      responseBody = parsed;
     }
-    responseBody = parsed;
   } else {
     try {
       responseBody = await providerResponse.json();

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -5,11 +5,36 @@ import { ollamaBodyToOpenAI } from "../../translator/response/ollama-to-openai.j
 import { addBufferToUsage, filterUsageForFormat } from "../../utils/usageTracking.js";
 import { createErrorResult } from "../../utils/error.js";
 import { HTTP_STATUS } from "../../config/runtimeConfig.js";
+import { EMPTY_CONTENT_COOLDOWN_MS } from "../../config/errorConfig.js";
 import { parseSSEToOpenAIResponse } from "./sseToJsonHandler.js";
 import { buildRequestDetail, extractRequestConfig, extractUsageFromResponse, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { appendRequestLog, saveRequestDetail } from "@/lib/usageDb.js";
 import { decloakToolNames } from "../../utils/claudeCloaking.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+
+/**
+ * Whether a translated response actually contains something the client can use:
+ * non-empty text, a tool call, or reasoning output. Providers occasionally answer
+ * HTTP 200 with a fully empty body (upstream hiccup that isn't a real error status) —
+ * treat that the same as an upstream failure so the account/combo fallback loop
+ * moves on instead of handing the client nothing.
+ */
+function hasUsefulContent(translatedResponse, isClaudeMessageResponse, isResponsesResponse) {
+  if (isClaudeMessageResponse) {
+    const blocks = Array.isArray(translatedResponse?.content) ? translatedResponse.content : [];
+    return blocks.some((b) => (b?.type === "text" && typeof b.text === "string" && b.text.trim().length > 0) || b?.type === "tool_use" || b?.type === "thinking");
+  }
+  if (isResponsesResponse) {
+    return Array.isArray(translatedResponse?.output) && translatedResponse.output.length > 0;
+  }
+  const msg = translatedResponse?.choices?.[0]?.message;
+  const hasToolCalls = Array.isArray(msg?.tool_calls) && msg.tool_calls.length > 0;
+  const hasText = typeof msg?.content === "string"
+    ? msg.content.trim().length > 0
+    : Array.isArray(msg?.content) && msg.content.length > 0;
+  const hasReasoning = typeof msg?.reasoning_content === "string" && msg.reasoning_content.trim().length > 0;
+  return hasToolCalls || hasText || hasReasoning;
+}
 
 function parseToolArguments(value) {
   if (!value) return {};
@@ -369,6 +394,20 @@ export async function handleNonStreamingResponse({ providerResponse, provider, m
   }
 
   reqLogger.logConvertedResponse(translatedResponse);
+
+  // Upstream answered 200 but produced nothing usable (null/empty content, no
+  // tool_calls, no reasoning) — treat as a failure so the same fallback path as a
+  // real error status kicks in: lock this account+model for EMPTY_CONTENT_COOLDOWN_MS
+  // (skips it on the next request/combo attempt) and let the caller fall through to
+  // the next account/combo member. The lock auto-expires, so it comes back into
+  // rotation on its own once the upstream presumably recovers.
+  if (!hasUsefulContent(translatedResponse, isClaudeMessageResponse, isResponsesResponse)) {
+    appendLog({ status: `FAILED ${HTTP_STATUS.BAD_GATEWAY} (empty content)` });
+    if (log?.warn) {
+      log.warn("CHATCORE", `${provider}/${model} returned HTTP 200 with empty content (finish_reason=${translatedResponse?.choices?.[0]?.finish_reason || "unknown"}) — treating as failure, locking for ${Math.round(EMPTY_CONTENT_COOLDOWN_MS / 1000)}s`);
+    }
+    return createErrorResult(HTTP_STATUS.BAD_GATEWAY, `Empty response content from ${provider}/${model}`, Date.now() + EMPTY_CONTENT_COOLDOWN_MS);
+  }
 
   const totalLatency = Date.now() - requestStartTime;
   saveRequestDetail(buildRequestDetail({

--- a/open-sse/handlers/chatCore/nonStreamingHandler.js
+++ b/open-sse/handlers/chatCore/nonStreamingHandler.js
@@ -164,10 +164,83 @@ function openAICompletionToResponses(responseBody, customToolNames = null) {
 }
 
 /**
+ * Convert a non-streaming OpenAI Responses API body (`output: [...]`) into an
+ * OpenAI Chat Completions shape (`choices: [{ message, finish_reason }]`).
+ * Mirrors the item types the streaming translator already understands
+ * (openaiResponsesToOpenAIResponse in translator/response/openai-responses.js)
+ * so both paths agree on what counts as text/reasoning/tool-call content.
+ */
+function openAIResponsesBodyToChatCompletion(responseBody) {
+  const output = Array.isArray(responseBody?.output) ? responseBody.output : [];
+  let textContent = "", reasoningContent = "";
+  const toolCalls = [];
+
+  for (const item of output) {
+    if (item?.type === RESPONSES_ITEM.MESSAGE) {
+      for (const block of item.content || []) {
+        if (block?.type === RESPONSES_ITEM.OUTPUT_TEXT && typeof block.text === "string") {
+          textContent += block.text;
+        }
+      }
+    } else if (item?.type === RESPONSES_ITEM.REASONING) {
+      for (const summary of item.summary || []) {
+        if (summary?.type === RESPONSES_ITEM.SUMMARY_TEXT && typeof summary.text === "string") {
+          reasoningContent += summary.text;
+        }
+      }
+    } else if (item?.type === RESPONSES_ITEM.FUNCTION_CALL || item?.type === RESPONSES_ITEM.CUSTOM_TOOL_CALL) {
+      const isCustom = item.type === RESPONSES_ITEM.CUSTOM_TOOL_CALL;
+      toolCalls.push({
+        id: item.call_id || item.id || `call_${toolCalls.length}`,
+        type: "function",
+        function: {
+          name: item.name || "",
+          arguments: isCustom
+            ? JSON.stringify({ input: item.input || "" })
+            : (typeof item.arguments === "string" ? item.arguments : JSON.stringify(item.arguments || {})),
+        },
+      });
+    }
+  }
+
+  const message = { role: "assistant" };
+  if (textContent) message.content = textContent;
+  if (reasoningContent) message.reasoning_content = reasoningContent;
+  if (toolCalls.length > 0) message.tool_calls = toolCalls;
+  if (!message.content && !message.tool_calls) message.content = "";
+
+  const usage = responseBody?.usage || {};
+  return {
+    id: String(responseBody?.id || `chatcmpl-${Date.now()}`).replace(/^resp_/, "chatcmpl-"),
+    object: "chat.completion",
+    created: responseBody?.created_at || Math.floor(Date.now() / 1000),
+    model: responseBody?.model || "unknown",
+    choices: [{ index: 0, message, finish_reason: toolCalls.length > 0 ? "tool_calls" : "stop" }],
+    usage: {
+      prompt_tokens: usage.prompt_tokens || usage.input_tokens || 0,
+      completion_tokens: usage.completion_tokens || usage.output_tokens || 0,
+      total_tokens: usage.total_tokens || (usage.prompt_tokens || usage.input_tokens || 0) + (usage.completion_tokens || usage.output_tokens || 0),
+    },
+  };
+}
+
+/**
  * Translate non-streaming response body from provider format → OpenAI format.
  */
 export function translateNonStreamingResponse(responseBody, targetFormat, sourceFormat, customToolNames = null) {
   if (targetFormat === sourceFormat) return responseBody;
+
+  // Provider responded in the Responses API shape (`output: []`) — every
+  // client format below expects chat.completion-shaped input (`choices: []`),
+  // so normalize once here instead of teaching each branch to parse `output[]`.
+  if (targetFormat === FORMATS.OPENAI_RESPONSES && sourceFormat !== FORMATS.OPENAI_RESPONSES) {
+    const chatBody = openAIResponsesBodyToChatCompletion(responseBody);
+    if (sourceFormat === FORMATS.OPENAI) return chatBody;
+    if (sourceFormat === FORMATS.CLAUDE) return openAICompletionToClaudeMessage(chatBody);
+    // Gemini/Ollama clients behind a Responses-shaped provider aren't handled
+    // here; fall through unchanged (pre-existing gap, unrelated to this fix).
+  }
+
   // Provider responded in OpenAI Chat Completions shape but the client speaks
   // Responses API — convert so tool_calls/text surface as Responses `output`.
   if (targetFormat === FORMATS.OPENAI && sourceFormat === FORMATS.OPENAI_RESPONSES) {

--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -108,9 +108,29 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 }
 
 /**
- * Build onStreamComplete callback for streaming usage tracking.
+ * Whether a completed stream actually produced anything: text, thinking, or
+ * output tokens (covers tool-call-only turns, which have no text/thinking but
+ * do spend completion tokens). Checking completion/output tokens specifically
+ * — not just "any usage field" — avoids false-flagging a real tool-call
+ * response as empty just because prompt tokens alone are non-zero.
  */
-export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
+function hasOutputTokens(usage) {
+  if (!usage || typeof usage !== "object") return false;
+  const n = Number(usage.completion_tokens ?? usage.output_tokens ?? usage.candidatesTokenCount ?? 0);
+  return n > 0;
+}
+
+/**
+ * Build onStreamComplete callback for streaming usage tracking.
+ * @param {Function} [onEmptyStream] - called (no args) once, after the stream
+ *   finishes, if it produced no text/thinking/output tokens at all. The
+ *   response has already been sent to the client by this point (streaming
+ *   commits to `success: true` before the body is known), so this can't
+ *   un-send it — it exists so the caller can lock the account/model out of
+ *   rotation for the *next* request (see chat.js), which is what actually
+ *   gets a retried request routed to a different backend.
+ */
+export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log, onEmptyStream }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
   const onStreamComplete = (contentObj, usage, ttftAt) => {
@@ -138,6 +158,11 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
     // Persist stream usage to DB (no console line; the "📊 done" line below is authoritative)
     saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE", silent: true });
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
+
+    if (onEmptyStream && !contentObj?.content?.trim?.() && !contentObj?.thinking?.trim?.() && !hasOutputTokens(usage)) {
+      if (log?.warn) log.warn("CHATCORE", `${provider}/${model} stream completed with no content/thinking/output tokens — locking for next request`);
+      try { onEmptyStream(); } catch (e) { console.error("[Stream] onEmptyStream failed:", e?.message || e); }
+    }
   };
 
   return { onStreamComplete, streamDetailId };

--- a/open-sse/transformer/streamToJsonConverter.js
+++ b/open-sse/transformer/streamToJsonConverter.js
@@ -12,15 +12,19 @@ function processSSEMessage(msg, state) {
 
   const eventMatch = msg.match(/^event:\s*(.+)$/m);
   const dataMatch = msg.match(/^data:\s*(.+)$/m);
-  if (!eventMatch || !dataMatch) return;
+  if (!dataMatch) return;
 
-  const eventType = eventMatch[1].trim();
   const dataStr = dataMatch[1].trim();
   if (dataStr === "[DONE]") return;
 
   let parsed;
   try { parsed = JSON.parse(dataStr); }
   catch { return; }
+
+  // Some OpenAI-compatible providers (e.g. SLG/singularityapi) send data-only
+  // SSE with no `event:` line, relying on the JSON payload's own `type` field
+  // instead — fall back to that so their streams aren't silently dropped.
+  const eventType = eventMatch ? eventMatch[1].trim() : (parsed.type || "");
 
   if (eventType === "response.created") {
     state.responseId = parsed.response?.id || state.responseId;

--- a/src/sse/handlers/chat.js
+++ b/src/sse/handlers/chat.js
@@ -18,6 +18,7 @@ import { handleComboChat, handleFusionChat, detectRequiredCapabilities } from "o
 import { augmentModelsWithCapacityAdapter, withCapacityAdapterStripping, getActiveAdapterStrategy } from "open-sse/services/capacityAdapter.js";
 import { handleBypassRequest } from "open-sse/utils/bypassHandler.js";
 import { HTTP_STATUS } from "open-sse/config/runtimeConfig.js";
+import { EMPTY_CONTENT_COOLDOWN_MS } from "open-sse/config/errorConfig.js";
 import { detectFormatByEndpoint } from "open-sse/translator/formats.js";
 import * as log from "../utils/logger.js";
 import { updateProviderCredentials, checkAndRefreshToken } from "../services/tokenRefresh.js";
@@ -295,6 +296,22 @@ async function handleSingleModelChat(body, modelStr, clientRawRequest = null, re
       },
       onRequestSuccess: async () => {
         await clearAccountError(credentials.connectionId, credentials, model);
+      },
+      // Stream finished with no text/thinking/output tokens (upstream 200'd on
+      // nothing). The response already went out to this client — this only
+      // locks the account+model so the *next* request (including this
+      // client's own empty-stream retry) skips it and falls to the next
+      // combo/account candidate, then comes back into rotation once the lock
+      // expires.
+      onEmptyStream: async () => {
+        await markAccountUnavailable(
+          credentials.connectionId,
+          HTTP_STATUS.BAD_GATEWAY,
+          `Empty streaming response from ${provider}/${model}`,
+          provider,
+          model,
+          Date.now() + EMPTY_CONTENT_COOLDOWN_MS
+        );
       }
     });
 

--- a/tests/unit/openai-responses-nonstream.test.js
+++ b/tests/unit/openai-responses-nonstream.test.js
@@ -85,6 +85,49 @@ describe("non-stream Chat upstream for a Responses-API client (op-ericding bug)"
   });
 });
 
+// A Responses API body as returned by a non-streaming `apiType: "responses"`
+// upstream (e.g. a custom OpenAI-compatible provider like SLG/singularityapi).
+const RESPONSES_TEXT_BODY = {
+  id: "resp_test123",
+  object: "response",
+  created_at: 1700000000,
+  model: "some-model",
+  output: [{
+    id: "msg_1",
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "OK", annotations: [] }]
+  }],
+  usage: { prompt_tokens: 6, completion_tokens: 2, total_tokens: 8 }
+};
+
+describe("non-stream Responses-API upstream for a Chat/Claude client", () => {
+  it("translates Responses output text into chat.completion content for an OpenAI-chat client", () => {
+    const out = translateNonStreamingResponse(RESPONSES_TEXT_BODY, FORMATS.OPENAI_RESPONSES, FORMATS.OPENAI);
+    expect(out.object).toBe("chat.completion");
+    expect(out.choices[0].message.content).toBe("OK");
+    expect(out.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("translates Responses output text into Claude message content for a Claude client", () => {
+    const out = translateNonStreamingResponse(RESPONSES_TEXT_BODY, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE);
+    expect(out.type).toBe("message");
+    const textBlock = (out.content || []).find((b) => b.type === "text");
+    expect(textBlock?.text).toBe("OK");
+  });
+
+  it("translates a Responses function_call into a Claude tool_use block", () => {
+    const body = {
+      ...RESPONSES_TEXT_BODY,
+      output: [{ type: "function_call", id: "fc_1", call_id: "call_1", name: "shell", arguments: "{\"cmd\":\"ls\"}" }]
+    };
+    const out = translateNonStreamingResponse(body, FORMATS.OPENAI_RESPONSES, FORMATS.CLAUDE);
+    const toolUse = (out.content || []).find((b) => b.type === "tool_use");
+    expect(toolUse).toMatchObject({ name: "shell", input: { cmd: "ls" } });
+  });
+});
+
 describe("forced-SSE JSON path for a Responses-API client behind a chat upstream", () => {
   const sseCtx = (sourceFormat, targetFormat) => {
     const encoder = new TextEncoder();

--- a/tests/unit/stream-to-json-converter.test.js
+++ b/tests/unit/stream-to-json-converter.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+const { convertResponsesStreamToJson } = await import("../../open-sse/transformer/streamToJsonConverter.js");
+
+function sseStream(events, { withEventLine = true } = {}) {
+  const encoder = new TextEncoder();
+  const body = events
+    .map((e) => (withEventLine ? `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n` : `data: ${JSON.stringify(e)}\n\n`))
+    .join("");
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+}
+
+const DONE_ITEM = {
+  type: "response.output_item.done",
+  output_index: 0,
+  item: { id: "msg_1", type: "message", role: "assistant", content: [{ type: "output_text", text: "OK" }] },
+};
+const COMPLETED = {
+  type: "response.completed",
+  response: { usage: { input_tokens: 6, output_tokens: 2, total_tokens: 8 } },
+};
+
+describe("convertResponsesStreamToJson", () => {
+  it("parses standard SSE with explicit event: lines", async () => {
+    const out = await convertResponsesStreamToJson(sseStream([DONE_ITEM, COMPLETED]));
+    expect(out.status).toBe("completed");
+    expect(out.output[0].content[0].text).toBe("OK");
+    expect(out.usage.output_tokens).toBe(2);
+  });
+
+  it("parses data-only SSE (no event: line, type read from JSON payload) — SLG/singularityapi-style", async () => {
+    const out = await convertResponsesStreamToJson(sseStream([DONE_ITEM, COMPLETED], { withEventLine: false }));
+    expect(out.status).toBe("completed");
+    expect(out.output[0].content[0].text).toBe("OK");
+    expect(out.usage.output_tokens).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Upstream providers occasionally return HTTP 200 with no usable content (null message, no `tool_calls`, no reasoning) instead of an error. Both the non-streaming and streaming chat paths treated any 2xx as unconditional success, so combo/account fallback never triggered and the same silently-broken account kept getting retried.
- Reuses the existing `markAccountUnavailable` / `modelLock_${model}` cooldown machinery instead of adding new state.
- Non-streaming: content is checked before the handler returns success; empty content is now turned into a 502 that flows through the standard fallback path.
- Streaming: content is not known until the stream completes, so emptiness is detected in `onStreamComplete` and the account is locked for the *next* request via a new `onEmptyStream` callback (7 minute cooldown, matches the existing cooldown pattern in `errorConfig.js`).
- Heuristic checks `tool_calls`/`content`/`reasoning_content` (non-streaming) and `completion_tokens`/`output_tokens` specifically (streaming) so legitimate tool-call-only or reasoning-only responses are not false-flagged as empty.

## Test plan
- [x] `npx vitest run` on the full suite no regressions introduced (verified via `git stash`/`git stash pop` clean-checkout comparison against the pre-existing failure baseline)
- [x] Maintainer smoke test against a real flaky provider (this was fixed based on local reproduction with a 9Router gateway seeing intermittent null-content 200s from a provider)

