### PR TITLE
fix(translator): correctly route Claude thinking to Ollama `think` param

### DIFF
--- a/open-sse/providers/registry/ollama-local.js
+++ b/open-sse/providers/registry/ollama-local.js
@@ -14,6 +14,7 @@ export default {
   transport: {
     baseUrl: "http://localhost:11434/api/chat",
     format: "ollama",
+    thinkingFormat: "ollama",
   },
   serviceKinds: ["llm"],
 };

--- a/open-sse/providers/registry/ollama.js
+++ b/open-sse/providers/registry/ollama.js
@@ -21,6 +21,7 @@ export default {
     baseUrl: "https://ollama.com/api/chat",
     validateUrl: "https://ollama.com/api/tags",
     format: "ollama",
+    thinkingFormat: "ollama",
   },
   models: [
     { id: "gpt-oss:120b", name: "GPT OSS 120B" },

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -3,6 +3,7 @@
 import { getCapabilitiesForModel } from "./capabilities.js";
 import { matchPattern } from "./pricing.js";
 import { resolveKiroEffortPath } from "../config/kiroConstants.js";
+import { PROVIDERS } from "./index.js";
 
 // Shared level sets (deduped) — verified against provider docs + wire in thinkingUnified.applyFormat.
 const L = {
@@ -29,6 +30,7 @@ const FORMAT_LEVELS = {
   minimax: L.onOff,
   hunyuan: L.base,
   step: L.base,
+  ollama: L.levelMax,
 };
 
 const CODEX_GPT_5_6_LEVELS = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
@@ -39,6 +41,9 @@ const PATTERN_THINKING = [
   { provider: "codex", pattern: "*gpt-5.6-terra*", levels: [...CODEX_GPT_5_6_LEVELS, "ultra"] },
   { provider: "codex", pattern: "*gpt-5.6-luna*", levels: CODEX_GPT_5_6_LEVELS },
   { pattern: "*codex*", levels: ["low", "medium", "high", "xhigh"] }, // codex cannot disable thinking
+  // Ollama GPT-OSS only supports low/medium/high (no max, per Ollama docs)
+  { provider: "ollama", pattern: "*gpt-oss*", levels: ["none", "low", "medium", "high"] },
+  { provider: "ollama-local", pattern: "*gpt-oss*", levels: ["none", "low", "medium", "high"] },
 ];
 
 // Returns valid thinking levels for a model, or null when the model has no reasoning.
@@ -49,7 +54,10 @@ export function getThinkingLevels(provider, model) {
   const hit = PATTERN_THINKING.find((entry) =>
     (!entry.provider || entry.provider === provider) && matchPattern(entry.pattern, model)
   );
-  let levels = hit?.levels || FORMAT_LEVELS[caps.thinkingFormat] || L.base;
+  // Provider-level thinkingFormat override (e.g., ollama→ollama) takes priority over per-model caps
+  const providerFmt = provider ? PROVIDERS[provider]?.thinkingFormat : null;
+  const fmt = providerFmt || caps.thinkingFormat;
+  let levels = hit?.levels || FORMAT_LEVELS[fmt] || L.base;
   if (caps.thinkingCanDisable === false) levels = levels.filter((l) => l !== "none");
   return levels;
 }

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -19,6 +19,7 @@ const FORMAT_TO_NATIVE = {
   vertex: "gemini-budget",
   antigravity: "gemini-budget",
   kiro: "kiro",
+  ollama: "ollama",
 };
 
 // Strip a trailing thinking suffix "model(value)" → "model" (no-op when absent).
@@ -67,6 +68,25 @@ export function extractThinking(body) {
       if (Number.isFinite(budget) && budget > 0) return { mode: "budget", budget };
       return { mode: "auto" };
     }
+  }
+
+  // Ollama shape — `think` at top level (boolean or string low/medium/high/max)
+  if (body.think !== undefined) {
+    const tv = body.think;
+    if (tv === false) return { mode: "none" };
+    if (tv === true) return { mode: "auto" };
+    if (typeof tv === "string") {
+      const e = tv.toLowerCase().trim();
+      if (e === "none" || e === "off" || e === "false") return { mode: "none" };
+      if (e === "auto" || e === "true") return { mode: "auto" };
+      if (e === "minimal" || e === "low" || e === "medium" || e === "high" || e === "max" || e === "xhigh") {
+        return { mode: "level", level: e === "xhigh" ? "max" : e };
+      }
+      if (e) return { mode: "level", level: e };
+    }
+    // Numeric or other truthy → auto, falsy → none
+    if (tv) return { mode: "auto" };
+    return { mode: "none" };
   }
 
   // OpenAI chat / Responses shape
@@ -157,6 +177,21 @@ function toKimiReasoningEffort(cfg) {
   return null;
 }
 
+function toOllamaThink(cfg, supportedLevels) {
+  if (!cfg) return null;
+  if (cfg.mode === "auto") return true;
+  const level = toLevel(cfg);
+  if (!level || level === "auto") return true;
+  if (level === "minimal") return "low";
+  if (level === "xhigh") return "max";
+  if (["low", "medium", "high", "max"].includes(level)) {
+    // gpt-oss only supports low/medium/high — clamp max→high when unsupported
+    if (level === "max" && supportedLevels && !supportedLevels.includes("max")) return "high";
+    return level;
+  }
+  return "medium";
+}
+
 const GEMINI_LEVEL_OUTPUT_FLOOR = {
   minimal: 4096,
   low: 8192,
@@ -217,6 +252,7 @@ function stripAll(body) {
   delete body.enable_thinking;
   delete body.thinking_budget;
   delete body.output_config;
+  delete body.think;
   if (body.generationConfig) delete body.generationConfig.thinkingConfig;
   if (body.request?.generationConfig) delete body.request.generationConfig.thinkingConfig;
 }
@@ -291,6 +327,12 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       if (none && canDisable) { body.thinking = { type: "disabled" }; break; }
       const effort = toKimiReasoningEffort(eff);
       if (effort) body.reasoning_effort = effort;
+      break;
+    }
+    case "ollama": {
+      if (none && canDisable) { body.think = false; break; }
+      const out = toOllamaThink(eff, supportedLevels);
+      if (out !== null && out !== undefined) body.think = out;
       break;
     }
     case "minimax": {


### PR DESCRIPTION
## Problem

Ollama API calls were ignoring the client's thinking setting and always sent `THINK:auto`:

```
[17:13:57] 🟠 ▶ POST claude-sonnet-4-6 → ollama/deepseek-v4-pro:0813-cloud · FMT: claude→ollama · STREAM · 2 MSG · 98 TOOL · THINK:auto · ACC:key_prd
[17:14:01] 🟠 ▶ POST claude-sonnet-4-6 → ollama/deepseek-v4-pro:0813-cloud · FMT: claude→ollama · STREAM · 6 MSG · 98 TOOL · THINK:auto · ACC:key_prd
[17:14:03] 🟠 ▶ POST claude-sonnet-4-6 → ollama/deepseek-v4-pro:0813-cloud · FMT: claude→ollama · STREAM · 168 MSG · 109 TOOL · THINK:auto · ACC:key_prd
[17:14:07] 🟠 ▶ POST claude-sonnet-4-6 → ollama/deepseek-v4-pro:0813-cloud · FMT: claude→ollama · STREAM · 8 MSG · 98 TOOL · THINK:auto · ACC:key_prd
```

Changing thinking in Claude Code (disabled / `model(low|medium|high|max)` / `model(none)` / `budget_tokens`) had no effect on the upstream Ollama request.

## Fix

**Root cause — wrong wire format:** Ollama Cloud/Local uses top-level `think: boolean | "low"|"medium"|"high"|"max"` (see [Ollama `ChatRequest.think`](https://docs.ollama.com/api/chat) / `api/types.go:ThinkValue`), but 9Router had no `ollama` thinking format.

- `open-sse/translator/concerns/thinkingUnified.js:11` `FORMAT_TO_NATIVE` had no `ollama` entry
- `open-sse/providers/registry/ollama.js:20` / `ollama-local.js:14` had no `thinkingFormat`, so `resolveFormat()` in `thinkingUnified.js:109` fell back to per-model `getCapabilitiesForModel()` (`*deepseek-v4*`→`deepseek`, `*gpt-oss*`→`openai`, `*kimi*`→`kimi`) and emitted `thinking:{type:"enabled"} + reasoning_effort:"high"` which Ollama ignores → default `auto`
- `open-sse/translator/request/openai-to-ollama.js:21` never forwarded thinking fields
- `extractThinking()` didn't know `think`, so `open-sse/handlers/chatCore.js:218` `log.fmtThink(extractThinking(translatedBody))` always saw `thinking.enabled` → `auto`

**Change — config-driven, DRY** (per `open-sse/AGENTS.md` / `docs/ARCHITECTURE.md`):

- `open-sse/providers/registry/ollama.js:23` + `ollama-local.js:17` — add `thinkingFormat: "ollama"` to `transport` so `PROVIDERS[provider].thinkingFormat` overrides per-model caps (mirrors `iflow`/`codebuddy-cn` forcing `openai`)
- `open-sse/translator/concerns/thinkingUnified.js:11` — add `ollama: "ollama"` to `FORMAT_TO_NATIVE`
- `open-sse/translator/concerns/thinkingUnified.js:73` — add `body.think` extraction (prior to OpenAI `reasoning_effort` check)
- `open-sse/translator/concerns/thinkingUnified.js:232` — `stripAll()` now deletes `body.think` before re-apply
- `open-sse/translator/concerns/thinkingUnified.js:180` + `:332` — add `toOllamaThink(cfg, supportedLevels)` and `case "ollama"` in `applyFormat()`: `none→false` (clamped to `low` when `thinkingCanDisable===false`), `auto→true`, `minimal→low`, `xhigh→max`, clamp `max→high` when `supportedLevels` excludes `max` (e.g. `gpt-oss`)
- `open-sse/providers/thinkingLevels.js:3,33,54` — add `ollama: L.levelMax`, import `PROVIDERS`, prioritize `PROVIDERS[provider].thinkingFormat` over `caps.thinkingFormat`, add `*gpt-oss*` patterns for `ollama`/`ollama-local` → `[none,low,medium,high]` (per Ollama docs GPT-OSS only supports `low/medium/high`)

Only `ollama`/`ollama-local` paths are touched; other providers unchanged.

## Tests

- **Manual repro** via `translateRequest(FORMATS.CLAUDE→OLLAMA)` / `translateRequest(FORMATS.OPENAI→OLLAMA)` + `extractThinking` / `fmtThink`:
  - `disabled` → `{think:false}` → `off` ✓
  - `auto` (`thinking:enabled`) → `{think:true}` → `auto` ✓
  - `output_config.effort: low/medium/high/max` or suffix `model(high)` / `model(none)` → `think:"low"|"high"|"max"|false` correctly ✓
  - `budget_tokens 1024→low, 25000→high, 50000→max` ✓
  - `openai reasoning_effort:none→false, high→"high", absent→no think` ✓
  - `gpt-oss:max` clamped to `high` ✓
  - Variant `off/low/high/max` previously all `auto`, now `["off","low","high","max"]` ✓
  - Non-reasoning `ollama/llama3.2` correctly strips `think` ✓
- Existing suite: `translator/thinking-unified.test.js` (44), `unit/thinking` (16), `unit/capabilities` (16) all pass. Full `translator/` suite shows same pre-existing snapshot drift vs pristine (`0.5.50→0.5.55`) — **zero new regressions**.

## Impact

Fixes "Ollama always `THINK:auto`" issue. Low risk: only `ollama`/`ollama-local` thinking path is affected; verified upstream JSON now contains `"think":false|true|"low"|"medium"|"high"|"max"` as per Ollama spec.
