### PR TITLE
fix(translator): zai thinkingFormat sends reasoning.effort object

### DIFF
--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -58,6 +58,15 @@ export function extractThinking(body) {
     return { mode: "level", level: e };
   }
 
+  // OpenAI chat / Responses shape — check effort first (zai sends both thinking object and reasoning.effort)
+  const effort = body.reasoning_effort ?? (typeof body.reasoning === "object" ? body.reasoning?.effort : null);
+  if (typeof effort === "string" && effort) {
+    const e = effort.toLowerCase();
+    if (e === "none" || e === "off") return { mode: "none" };
+    if (e === "auto") return { mode: "auto" };
+    return { mode: "level", level: e };
+  }
+
   // Claude shape
   const t = body.thinking;
   if (t && typeof t === "object") {
@@ -67,15 +76,6 @@ export function extractThinking(body) {
       if (Number.isFinite(budget) && budget > 0) return { mode: "budget", budget };
       return { mode: "auto" };
     }
-  }
-
-  // OpenAI chat / Responses shape
-  const effort = body.reasoning_effort ?? (typeof body.reasoning === "object" ? body.reasoning?.effort : null);
-  if (typeof effort === "string" && effort) {
-    const e = effort.toLowerCase();
-    if (e === "none" || e === "off") return { mode: "none" };
-    if (e === "auto") return { mode: "auto" };
-    return { mode: "level", level: e };
   }
 
   // Gemini shape (top-level, generationConfig, or request envelope)
@@ -270,6 +270,13 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       // Z.ai ignores thinking.disabled → must use enable_thinking:false to turn off.
       if (none && canDisable) { body.enable_thinking = false; delete body.thinking; break; }
       body.thinking = { type: "enabled" };
+      // Z.ai requires reasoning.effort object (not flat reasoning_effort string).
+      const zaiLvl = toLevel(eff);
+      const zaiEffort = (zaiLvl === "minimal" || zaiLvl === "low" || zaiLvl === "medium" || zaiLvl === "high")
+        ? zaiLvl
+        : ((zaiLvl === "xhigh" || zaiLvl === "max") ? "high" : "medium");
+      body.reasoning_effort = (zaiLvl === "high" || zaiLvl === "xhigh" || zaiLvl === "max") ? "high" : "max";
+      body.reasoning = { effort: zaiEffort };
       break;
     }
     case "qwen": {

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -270,13 +270,13 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       // Z.ai ignores thinking.disabled → must use enable_thinking:false to turn off.
       if (none && canDisable) { body.enable_thinking = false; delete body.thinking; break; }
       body.thinking = { type: "enabled" };
-      // Z.ai requires reasoning.effort object (not flat reasoning_effort string).
+      // Dual fields: z.ai reads reasoning_effort (high|max); Ark reads reasoning.effort.
       const zaiLvl = toLevel(eff);
-      const zaiEffort = (zaiLvl === "minimal" || zaiLvl === "low" || zaiLvl === "medium" || zaiLvl === "high")
+      const arkLvl = (zaiLvl === "minimal" || zaiLvl === "low" || zaiLvl === "medium" || zaiLvl === "high")
         ? zaiLvl
         : ((zaiLvl === "xhigh" || zaiLvl === "max") ? "high" : "medium");
-      body.reasoning_effort = (zaiLvl === "high" || zaiLvl === "xhigh" || zaiLvl === "max") ? "high" : "max";
-      body.reasoning = { effort: zaiEffort };
+      body.reasoning_effort = zaiLvl === "high" ? "high" : "max";
+      body.reasoning = { effort: arkLvl };
       break;
     }
     case "qwen": {

--- a/tests/translator/thinking-unified.test.js
+++ b/tests/translator/thinking-unified.test.js
@@ -58,6 +58,18 @@ describe("extractThinking", () => {
   it("no intent → null", () => {
     expect(extractThinking({ messages: [] })).toBeNull();
   });
+  it("reasoning_effort wins over thinking:{type:enabled} (no budget)", () => {
+    expect(extractThinking({
+      thinking: { type: "enabled" },
+      reasoning_effort: "high",
+    })).toEqual({ mode: "level", level: "high" });
+  });
+  it("reasoning.effort wins over thinking:{type:enabled} (no budget)", () => {
+    expect(extractThinking({
+      thinking: { type: "enabled" },
+      reasoning: { effort: "medium" },
+    })).toEqual({ mode: "level", level: "medium" });
+  });
 });
 
 describe("applyThinking per provider format", () => {
@@ -113,6 +125,19 @@ describe("applyThinking per provider format", () => {
     const out = apply("openai", "glm-4.6", { reasoning_effort: "none" }, "glm");
     expect(out.enable_thinking).toBe(false);
     expect(out.thinking).toBeUndefined();
+  });
+  it.each([
+    ["high", "high", "high"],
+    ["max", "max", "high"],
+    ["xhigh", "max", "high"],
+    ["low", "max", "low"],
+    ["medium", "max", "medium"],
+    ["minimal", "max", "minimal"],
+  ])("GLM-5.x %s → reasoning_effort=%s reasoning.effort=%s", (input, zai, ark) => {
+    const out = apply("openai", "glm-5.3", { reasoning_effort: input }, "glm-cn");
+    expect(out.thinking).toEqual({ type: "enabled" });
+    expect(out.reasoning_effort).toBe(zai);
+    expect(out.reasoning).toEqual({ effort: ark });
   });
   it("Qwen on → enable_thinking + thinking_budget", () => {
     const out = apply("openai", "qwen3-max", { reasoning_effort: "medium" }, "qwen");


### PR DESCRIPTION
## Summary
- Z.ai / GLM-5.2 / GLM-5.3 ignore `thinking:{type:\"enabled\"}` and require a nested `reasoning:{effort}` object. The zai branch previously only set `thinking` and dropped the client's `reasoning_effort`, so every GLM-5.x request ran at the model's default (max).
- Check `reasoning_effort` / `reasoning.effort` before the `thinking` object in `extractThinking` so a client-supplied effort is not overwritten by `thinking:{type:\"enabled\"}` mapping to `mode:auto`.

Fixes #2721

## Test plan
- [ ] Send `reasoning_effort: \"high\"` to a glm-5.2 / glm-5.3 combo; confirm 9router console shows `THINK:high` (not `THINK:auto`)
- [ ] Confirm the upstream request body contains both `thinking:{type:\"enabled\"}` and `reasoning:{effort:\"high\"}`
- [ ] Confirm `reasoning_effort: \"minimal\"` / `\"low\"` / `\"medium\"` map to the corresponding `reasoning.effort` value
- [ ] Confirm `reasoning_effort: \"xhigh\"` / `\"max\"` map to `reasoning.effort: \"high\"` (zai's max)
- [ ] Confirm `thinking:{type:\"disabled\"}` still disables thinking when `thinkingCanDisable` is true