### PR TITLE
fix(models): expose combo aggregate token limits on /v1/models

### DIFF
--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -303,6 +303,45 @@ export async function buildModelsList(kindFilter, options = {}) {
     if (combo.kind === "webSearch" || combo.kind === "webFetch") {
       entry.kind = combo.kind;
     }
+    // For LLM combos, aggregate token limits across member models:
+    // contextWindow takes the minimum (pool bottleneck) and maxOutput takes the maximum.
+    if (!combo.kind || combo.kind === LLM_KIND) {
+      if (Array.isArray(combo.models) && combo.models.length > 0) {
+        let minContext = Infinity;
+        let maxOutput = -Infinity;
+        let hasContext = false;
+        let hasMaxOutput = false;
+
+        for (const rawModel of combo.models) {
+          if (!rawModel || typeof rawModel !== "string") continue;
+          const trimmed = rawModel.trim();
+          if (!trimmed) continue;
+          const slashIdx = trimmed.indexOf("/");
+          const provider = slashIdx !== -1 ? trimmed.slice(0, slashIdx) : "";
+          const modelId = slashIdx !== -1 ? trimmed.slice(slashIdx + 1) : trimmed;
+          if (!modelId) continue;
+
+          const caps = getCapabilitiesForModel(provider, modelId);
+          if (caps) {
+            if (Number.isFinite(caps.contextWindow)) {
+              minContext = Math.min(minContext, caps.contextWindow);
+              hasContext = true;
+            }
+            if (Number.isFinite(caps.maxOutput)) {
+              maxOutput = Math.max(maxOutput, caps.maxOutput);
+              hasMaxOutput = true;
+            }
+          }
+        }
+
+        if (hasContext && Number.isFinite(minContext)) {
+          entry.context_length = minContext;
+        }
+        if (hasMaxOutput && Number.isFinite(maxOutput)) {
+          entry.max_completion_tokens = maxOutput;
+        }
+      }
+    }
     models.push(entry);
   }
 


### PR DESCRIPTION
## Summary

Combo pool entries in `/v1/models` were bare `{id, object, owned_by}` with no token metadata, unlike regular models which emit top-level `context_length` / `max_completion_tokens` since #3218. Fixes #3486.

## Problem

OpenAI-compatible clients that read `/v1/models` to size their context window fell back to their own catalog for combo models. In our case (Hermes Agent), `deepseek-flash-mix` was read as 128k while every member of the pool advertises a 1M window — causing premature context compaction at ~96k. Any OpenAI-compatible client (Cline, Codex, etc.) hits the same class of bug.

## Change

In `src/app/api/v1/models/route.js`, for LLM-kind combos (`!combo.kind || combo.kind === LLM_KIND`), aggregate token limits across member models:

- `contextWindow` → **minimum** of members (pool bottleneck — prevents clients from over-estimating the usable window)
- `maxOutput` → **maximum** of members
- Emitted as top-level snake_case `context_length` / `max_completion_tokens`, matching the regular-model convention so clients that only check top-level keys get the correct values.
- Members are resolved through the existing `getCapabilitiesForModel(provider, model)` helper; members that fail to resolve are skipped; if nothing resolves, the entry stays unchanged (fully backward compatible).
- `webSearch` / `webFetch` combos keep their existing shape untouched.

## Testing

- `unit/capabilities.test.js`, `unit/capabilities-opus-context.test.js`, `unit/capabilities-service-kind.test.js`, `unit/combo-routing.test.js`, `unit/combo-fusion.test.js` — all pass.
- `unit/combo-autoswitch.test.js` — 2 pre-existing failures, identical on clean master (verified via stash), not a regression from this change.
- Full suite: 1779 passed / 90 failed (baseline known-fails) — no regression vs baseline.
- Local verification: combo model `deepseek-flash-mix` now resolves to `context_length: 1000000`, `max_completion_tokens: 384000` from its members.