### PR TITLE
fix(sse): return Anthropic Message when Claude client hits forceStream provider

### DIFF
--- a/open-sse/handlers/chatCore/sseToJsonHandler.js
+++ b/open-sse/handlers/chatCore/sseToJsonHandler.js
@@ -5,6 +5,7 @@ import { FORMATS } from "../../translator/formats.js";
 import { PROVIDERS } from "../../config/providers.js";
 import { buildRequestDetail, extractRequestConfig, saveUsageStats, formatDoneLine } from "./requestDetail.js";
 import { ROLE, RESPONSES_ITEM } from "../../translator/schema/index.js";
+import { fromOpenAIFinish } from "../../translator/concerns/finishReason.js";
 
 // Responses-API providers (e.g. codex) may emit SSE without content-type + use Responses output shape
 const isResponsesProvider = (p) => PROVIDERS[p]?.format === FORMATS.OPENAI_RESPONSES;
@@ -101,6 +102,68 @@ function chatCompletionToResponses(responseBody, customToolNames = null) {
       input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
       output_tokens: usage.completion_tokens || usage.output_tokens || 0,
       total_tokens: usage.total_tokens || (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),
+    },
+  };
+}
+
+/**
+ * Parse tool arguments (string or object) to a plain object.
+ * Inlined to avoid a circular import with nonStreamingHandler.js.
+ */
+function parseToolArguments(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Convert an OpenAI Chat Completions non-streaming body to an Anthropic Message.
+ * Used when a Claude-format client (e.g. Claude Code) hits a forceStream provider
+ * and the SDK retries non-streaming — we get back OpenAI format and must convert.
+ * Inlined (not imported from nonStreamingHandler.js) to avoid a circular import:
+ * nonStreamingHandler already imports parseSSEToOpenAIResponse from this module.
+ * Mirrors openAICompletionToClaudeMessage in nonStreamingHandler.js.
+ */
+function openAICompletionToClaudeMessage(responseBody) {
+  if (!responseBody?.choices?.[0]) return responseBody;
+  const choice = responseBody.choices[0];
+  const message = choice.message || {};
+  const content = [];
+
+  const reasoning = message.reasoning_content || message.provider_specific_fields?.reasoning_content || "";
+  if (reasoning) {
+    content.push({ type: "thinking", thinking: reasoning });
+  }
+  if (typeof message.content === "string" && message.content.length > 0) {
+    content.push({ type: "text", text: message.content });
+  }
+  for (const toolCall of message.tool_calls || []) {
+    const fn = toolCall.function || {};
+    content.push({
+      type: "tool_use",
+      id: toolCall.id || `toolu_${Date.now()}_${content.length}`,
+      name: fn.name || toolCall.name || "",
+      input: parseToolArguments(fn.arguments || toolCall.arguments),
+    });
+  }
+  if (content.length === 0) content.push({ type: "text", text: "" });
+
+  const usage = responseBody.usage || {};
+  return {
+    id: String(responseBody.id || `msg_${Date.now()}`).replace(/^chatcmpl-/, ""),
+    type: "message",
+    role: "assistant",
+    model: responseBody.model || "unknown",
+    content,
+    stop_reason: fromOpenAIFinish(choice.finish_reason, FORMATS.CLAUDE),
+    stop_sequence: null,
+    usage: {
+      input_tokens: usage.prompt_tokens || usage.input_tokens || 0,
+      output_tokens: usage.completion_tokens || usage.output_tokens || 0,
     },
   };
 }
@@ -266,6 +329,36 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
             responseId: jsonResponse.id || `resp_${Date.now()}`
           }
         };
+      } else if (sourceFormat === FORMATS.CLAUDE) {
+        // Claude-format client (e.g. Claude Code) talking to a Responses-API provider
+        // (codex, grok-cli). Build an Anthropic Message so the SDK does not see
+        // "JSON but not a Message" when it retries non-streaming.
+        const claudeContent = [];
+        for (const item of (jsonResponse.output || []).filter(i => i?.type === "reasoning")) {
+          const thinkText = (item.summary || []).map(s => s.text || "").join("");
+          if (thinkText) claudeContent.push({ type: "thinking", thinking: thinkText });
+        }
+        if (textContent) claudeContent.push({ type: "text", text: textContent });
+        for (const tc of toolCalls) {
+          claudeContent.push({
+            type: "tool_use",
+            id: tc.id,
+            name: tc.function.name,
+            input: parseToolArguments(tc.function.arguments),
+          });
+        }
+        if (claudeContent.length === 0) claudeContent.push({ type: "text", text: "" });
+        const responseDone = jsonResponse.status === "completed" || jsonResponse.status === "done";
+        finalResp = {
+          id: (jsonResponse.id || `msg_${Date.now()}`).replace(/^resp_/, ""),
+          type: "message",
+          role: "assistant",
+          model: jsonResponse.model || model,
+          content: claudeContent,
+          stop_reason: hasToolCalls ? "tool_use" : (responseDone ? "end_turn" : (jsonResponse.status || "end_turn")),
+          stop_sequence: null,
+          usage: { input_tokens: inTokens, output_tokens: outTokens },
+        };
       } else {
         const message = { role: "assistant", content: textContent || (hasToolCalls ? null : "") };
         if (hasToolCalls) message.tool_calls = toolCalls;
@@ -341,15 +434,20 @@ export async function handleForcedSSEToJson({ providerResponse, sourceFormat, ta
       }
     }
 
-    // A Responses-format client (e.g. Codex) forced this provider to stream,
-    // but wants JSON back. parseSSEToOpenAIResponse yields a Chat Completions
-    // body; convert it to the Responses `output` shape so tool_calls are not
-    // lost on the non-streaming return path. Inlined (not imported from
-    // nonStreamingHandler.js) to avoid a circular import: nonStreamingHandler
-    // already imports parseSSEToOpenAIResponse from this module.
-    const finalBody = sourceFormat === FORMATS.OPENAI_RESPONSES
-      ? chatCompletionToResponses(parsed, customToolNames)
-      : parsed;
+    // The provider forced streaming but the client wants JSON. Convert the
+    // parsed OpenAI Chat Completions body to the format the client speaks.
+    // - Responses-format client: convert to Responses `output` shape (tool_calls intact).
+    // - Claude-format client: convert to Anthropic Message (type:"message") so the
+    //   Anthropic SDK (e.g. Claude Code) does not see "JSON but not a Message".
+    // - All other formats: return the OpenAI body as-is (client already speaks OpenAI).
+    let finalBody;
+    if (sourceFormat === FORMATS.OPENAI_RESPONSES) {
+      finalBody = chatCompletionToResponses(parsed, customToolNames);
+    } else if (sourceFormat === FORMATS.CLAUDE) {
+      finalBody = openAICompletionToClaudeMessage(parsed);
+    } else {
+      finalBody = parsed;
+    }
 
     return { success: true, response: new Response(JSON.stringify(finalBody), { headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" } }) };
   } catch (err) {

--- a/tests/unit/openai-responses-nonstream.test.js
+++ b/tests/unit/openai-responses-nonstream.test.js
@@ -145,4 +145,59 @@ describe("forced-SSE JSON path for a Responses-API client behind a chat upstream
     expect(json.object).toBe("chat.completion");
     expect(json.choices[0].message.tool_calls[0].function.name).toBe("shell");
   });
+
+  it("returns an Anthropic Message for a Claude-format client (forceStream provider)", async () => {
+    // Reproduces the bug: Claude Code SDK gets "JSON but not a Message" when it
+    // retries non-streaming against a provider with forceStream:true (e.g. openai,
+    // zed, codebuddy-*). The fix must return type:"message", not object:"chat.completion".
+    const result = await handleForcedSSEToJson(sseCtx(FORMATS.CLAUDE, FORMATS.OPENAI));
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    // Must be an Anthropic Message, not an OpenAI chat.completion
+    expect(json.type).toBe("message");
+    expect(json.role).toBe("assistant");
+    expect(json).not.toHaveProperty("object");
+    expect(json).not.toHaveProperty("choices");
+    // Tool call must appear as a tool_use content block
+    const tu = (json.content || []).find((b) => b.type === "tool_use");
+    expect(tu).toBeTruthy();
+    expect(tu.name).toBe("shell");
+    expect(tu.input).toEqual({ cmd: "pwd" });
+    // finish_reason "tool_calls" → stop_reason "tool_use" in Claude format
+    expect(json.stop_reason).toBe("tool_use");
+  });
+
+  it("returns an Anthropic Message with text content for a Claude-format client", async () => {
+    const encoder = new TextEncoder();
+    const raw = [
+      'data: {"id":"chatcmpl-txt","object":"chat.completion.chunk","created":1700000000,"model":"gpt-x","choices":[{"delta":{"role":"assistant","content":"Hello"},"finish_reason":null}]}',
+      'data: {"id":"chatcmpl-txt","object":"chat.completion.chunk","created":1700000000,"model":"gpt-x","choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}',
+      "data: [DONE]",
+      ""
+    ].join("\n\n");
+    const ctx = {
+      providerResponse: new Response(new ReadableStream({
+        start(controller) { controller.enqueue(encoder.encode(raw)); controller.close(); }
+      }), { headers: { "content-type": "text/event-stream" } }),
+      sourceFormat: FORMATS.CLAUDE,
+      targetFormat: FORMATS.OPENAI,
+      provider: "openai",
+      model: "gpt-x",
+      body: { model: "gpt-x", messages: [] },
+      stream: false,
+      requestStartTime: Date.now(),
+      connectionId: "test-conn",
+      clientRawRequest: { endpoint: "/v1/messages" },
+      trackDone: vi.fn(),
+      appendLog: vi.fn()
+    };
+    const result = await handleForcedSSEToJson(ctx);
+    expect(result.success).toBe(true);
+    const json = await result.response.json();
+    expect(json.type).toBe("message");
+    expect(json.role).toBe("assistant");
+    const textBlock = (json.content || []).find((b) => b.type === "text");
+    expect(textBlock?.text).toBe("Hello world");
+    expect(json.stop_reason).toBe("end_turn");
+  });
 });


### PR DESCRIPTION
## Summary

- **Bug**: Claude Code SDK gets "API returned an empty or malformed response (HTTP 200) — body is JSON but not a Message" on the non-streaming retry of a streaming request
- **Root cause**: `handleForcedSSEToJson` in `sseToJsonHandler.js` parses forced SSE into OpenAI `chat.completion` format but returned it directly to `FORMATS.CLAUDE` clients without converting it to an Anthropic `Message`
- **Affected providers**: any with `forceStream: true` — `openai`, `zed`, `codebuddy-cn`, `codebuddy-intl` (standard path) and `codex`, `grok-cli` (Codex/Responses API path)

## What changed

### `open-sse/handlers/chatCore/sseToJsonHandler.js`

Added `fromOpenAIFinish` import and inlined `openAICompletionToClaudeMessage` (mirrors the same function in `nonStreamingHandler.js`; inlined to avoid the existing circular import since `nonStreamingHandler` already imports `parseSSEToOpenAIResponse` from this module).

**Standard Chat Completions SSE path** (openai, zed, codebuddy-*):
- Before: `finalBody = parsed` (raw OpenAI `chat.completion`) for all non-Responses clients
- After: when `sourceFormat === FORMATS.CLAUDE`, converts to `{ type:"message", content:[...], stop_reason:..., ... }` via `openAICompletionToClaudeMessage`

**Codex/Responses API path** (codex, grok-cli):
- Added `sourceFormat === FORMATS.CLAUDE` branch that builds an Anthropic Message directly from Responses API output items, including `thinking` blocks from reasoning items and `tool_use` blocks from function_call items

### `tests/unit/openai-responses-nonstream.test.js`

Two new tests added to the existing forced-SSE suite:
- Verifies `handleForcedSSEToJson` returns `type:"message"` with `tool_use` content block and `stop_reason:"tool_use"` for a Claude-format client against a forceStream provider
- Verifies text content path produces proper text content block and `stop_reason:"end_turn"`

## Failure scenario (before fix)

1. Claude Code makes `stream:true` request → 9router → forceStream provider
2. Stream returns 0 SSE events → `StreamNoEventsError`
3. SDK retries with `stream:false`
4. `handleForcedSSEToJson` called → parses SSE into OpenAI format → **returns `chat.completion` body**
5. Anthropic SDK: "JSON but not a Message" (HTTP 200, no `type:"message"`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)