### PR TITLE
fix(auth): prevent IP spoofing in brute-force protection (GHSA-32gc, GHSA-5mj8, GHSA-7cfm)

### DIFF
--- a/src/dashboardGuard.js
+++ b/src/dashboardGuard.js
@@ -106,14 +106,12 @@ function isLoopbackHostname(h) {
 }
 
 function isLoopbackPeer(request) {
+  // Only trust peer IP when custom-server.js has validated it via peer token.
+  // Host header is spoofable and cannot be used for security decisions.
   if (hasTrustedPeerHeaders(request)) {
     return isLoopbackHostname(request.headers.get("x-9r-real-ip"));
   }
-  // Bare `next dev` forks its server, so the wrapper never loads and no peer address
-  // reaches us. Host is spoofable, so this stays confined to development.
-  if (process.env.NODE_ENV === "development") {
-    return isLoopbackHostname(request.headers.get("host"));
-  }
+  // Without peer token, we cannot trust x-9r-real-ip or Host header.
   return false;
 }
 
@@ -121,7 +119,12 @@ export function isLocalRequest(request) {
   // Stamped by custom-server.js when forwarding headers exist: request came through
   // a reverse proxy, so the loopback socket is the proxy hop, not the end-user.
   if (request.headers.get("x-9r-via-proxy")) return false;
-  if (!isLoopbackPeer(request)) return false;
+
+  // Only trust peer IP when custom-server.js has validated it via peer token.
+  // Without peer token, we cannot trust x-9r-real-ip or Host header.
+  if (!hasTrustedPeerHeaders(request)) return false;
+  if (!isLoopbackHostname(request.headers.get("x-9r-real-ip"))) return false;
+
   const origin = request.headers.get("origin");
   if (origin) {
     try {
@@ -152,7 +155,11 @@ async function hasValidApiKey(request) {
 }
 
 async function canAccessPublicLlmApi(request) {
-  if (isLocalRequest(request)) return true;
+  // Only trust locality when custom-server.js has validated the peer via peer token.
+  // This prevents Host header spoofing from bypassing API key requirement.
+  if (hasTrustedPeerHeaders(request) && isLoopbackHostname(request.headers.get("x-9r-real-ip"))) {
+    return true;
+  }
   if (await hasValidCliToken(request)) return true;
   return await hasValidApiKey(request);
 }

--- a/src/lib/auth/loginLimiter.js
+++ b/src/lib/auth/loginLimiter.js
@@ -47,14 +47,16 @@ export function recordSuccess(ip) {
 }
 
 export function getClientIp(request) {
-  // Trusted only when custom-server.js proves it stamped the header from the TCP socket;
-  // otherwise a client could rotate the value to escape its own lockout bucket.
+  // Trusted ONLY when custom-server.js proves it stamped the header from the TCP socket;
+  // verified via per-process peer token that attacker cannot guess.
+  // Without the proof the header is just attacker-supplied input.
   if (hasTrustedPeerHeaders(request)) {
     const realIp = request.headers.get("x-9r-real-ip");
     if (realIp) return realIp;
   }
   // Behind a trusted reverse proxy that overwrites XFF with the real client IP.
-  if (process.env.TRUST_PROXY === "true") {
+  // Only trust XFF when custom-server.js validated the peer (via peer token).
+  if (process.env.TRUST_PROXY === "true" && hasTrustedPeerHeaders(request)) {
     const xff = request.headers.get("x-forwarded-for");
     if (xff) return xff.split(",")[0].trim();
   }


### PR DESCRIPTION
## Summary
Prevents attackers from spoofing their IP via X-Forwarded-For or Host headers to bypass rate limiting or access local-only endpoints.

## Changes
- src/lib/auth/loginLimiter.js: getClientIp() now requires hasTrustedPeerHeaders() before trusting X-Forwarded-For headers
- src/dashboardGuard.js: isLoopbackPeer() no longer falls back to Host header; isLocalRequest() requires valid peer token + loopback IP + origin validation

## GHSA References
- GHSA-32gc: IP spoofing via X-Forwarded-For
- GHSA-5mj8: Host header spoofing for local-only access
- GHSA-7cfm: Rate limit bypass via header spoofing