### PR TITLE
fix(security): add SSRF protection via URL validation and DNS pinning (GHSA-8g4w, GHSA-6mwv, GHSA-cmhj, GHSA-qj3v)

### DIFF
--- a/open-sse/handlers/fetch/index.js
+++ b/open-sse/handlers/fetch/index.js
@@ -1,8 +1,48 @@
 // Web Fetch handler — dispatches to firecrawl, jina-reader, tavily, exa
 // Returns normalized shape across all providers
 
+import { lookup } from "node:dns/promises";
+import { Agent } from "undici";
+
 const DEFAULT_TIMEOUT_MS = 15000;
 const DEFAULT_FORMAT = "markdown";
+
+// Private/reserved IP ranges for SSRF protection
+function isPrivateIp(ip) {
+  if (!ip) return true;
+  if (ip === "::1" || ip.startsWith("fc") || ip.startsWith("fd") || ip.startsWith("fe80")) return true;
+  const v4 = ip.includes(".") ? ip.split(":").pop() : ip;
+  const parts = v4.split(".").map((n) => Number.parseInt(n, 10));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return ip.includes(":") ? false : true;
+  const [a, b] = parts;
+  if (a === 10 || a === 127 || a === 0) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
+// Resolve hostname and validate all IPs are public (SSRF guard)
+async function resolveAndValidatePublicIps(hostname) {
+  if (!hostname) return null;
+  try {
+    const records = await lookup(hostname, { all: true });
+    if (!records.length || records.some((r) => isPrivateIp(r.address))) return null;
+    return records;
+  } catch {
+    return null;
+  }
+}
+
+// Create undici Agent that pins to validated public IPs (TOCTOU fix)
+function createPinnedAgent(pinnedIps) {
+  return new Agent({
+    connect: {
+      lookup: (_h, _o, cb) => cb(null, pinnedIps.map(r => ({ address: r.address, family: r.family })))
+    }
+  });
+}
 
 /**
  * @typedef {Object} FetchResult
@@ -13,7 +53,7 @@ const DEFAULT_FORMAT = "markdown";
  */
 
 /**
- * Fetch with timeout abort.
+ * Fetch with timeout abort, SSRF protection (DNS pinning, redirect blocking).
  * @param {string} url
  * @param {RequestInit} init
  * @param {number} timeoutMs
@@ -32,7 +72,14 @@ async function tryFetch(url, init, timeoutMs) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    const res = await fetch(url, { ...init, headers: sanitizeHeaders(init.headers), signal: ctrl.signal });
+    const urlObj = new URL(url);
+    const pinnedIps = await resolveAndValidatePublicIps(urlObj.hostname);
+    if (!pinnedIps) {
+      return { ok: false, timeout: false, error: "SSRF blocked: private or invalid IP" };
+    }
+    const dispatcher = createPinnedAgent(pinnedIps);
+    // redirect: "manual" prevents a public URL redirecting to a private one (SSRF bypass)
+    const res = await fetch(url, { ...init, headers: sanitizeHeaders(init.headers), signal: ctrl.signal, redirect: "manual", dispatcher });
     return { ok: true, res };
   } catch (err) {
     const isAbort = err?.name === "AbortError";

--- a/src/app/api/auth/oidc/test/route.js
+++ b/src/app/api/auth/oidc/test/route.js
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { getSettings } from "@/lib/localDb";
 import { fetchOidcDiscovery, getPublicOrigin, probeOidcClientSecret } from "@/lib/auth/oidc";
 import { verifyDashboardAuthToken } from "@/lib/auth/dashboardSession";
+import { assertPublicUrl } from "@/shared/utils/ssrfGuard";
 
 async function canAccessTestRoute() {
   const settings = await getSettings();
@@ -36,6 +37,13 @@ export async function POST(request) {
     }
     if (!clientId) {
       return NextResponse.json({ error: "Client ID is required" }, { status: 400 });
+    }
+
+    // SSRF guard: reject internal/private/metadata targets
+    try {
+      assertPublicUrl(issuerUrl);
+    } catch (err) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
     }
 
     const discovery = await fetchOidcDiscovery(issuerUrl);

--- a/src/app/api/oauth/kiro/api-key/route.js
+++ b/src/app/api/oauth/kiro/api-key/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { KiroService } from "@/lib/oauth/services/kiro";
 import { createProviderConnection } from "@/models";
+import { assertValidAwsRegion } from "@/lib/oauth/constants/oauth";
 
 /**
  * POST /api/oauth/kiro/api-key
@@ -19,12 +20,20 @@ export async function POST(request) {
       );
     }
 
+    // Validate region (SSRF prevention)
+    const safeRegion = region || "us-east-1";
+    try {
+      assertValidAwsRegion(safeRegion);
+    } catch (err) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+
     const kiroService = new KiroService();
 
     // Validate the key against the same Amazon Q surface used for inference.
     const credential = await kiroService.validateApiKey(
       apiKey,
-      region || "us-east-1"
+      safeRegion
     );
 
     // Extract email from JWT if the key happens to be a JWT (optional display)

--- a/src/app/api/oauth/kiro/auto-import/route.js
+++ b/src/app/api/oauth/kiro/auto-import/route.js
@@ -2,6 +2,13 @@ import { NextResponse } from "next/server";
 import { readFile, readdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
+import { assertValidAwsRegion } from "@/lib/oauth/constants/oauth";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 /**
  * GET /api/oauth/kiro/auto-import
@@ -9,7 +16,10 @@ import { join } from "path";
  * For IDC (organization) tokens, also resolves clientId/clientSecret from the
  * linked client registration file so token refresh works.
  */
-export async function GET() {
+export async function GET(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const cachePath = join(homedir(), ".aws/sso/cache");
 
@@ -112,13 +122,21 @@ export async function GET() {
       }
     }
 
+    // Validate region before returning (SSRF prevention)
+    let safeRegion = region || "us-east-1";
+    try {
+      assertValidAwsRegion(safeRegion);
+    } catch {
+      safeRegion = "us-east-1";
+    }
+
     return NextResponse.json({
       found: true,
       refreshToken,
       source: foundFile,
       clientId,
       clientSecret,
-      region,
+      region: safeRegion,
       authMethod,
       profileArn,
     });

--- a/src/app/api/oauth/kiro/import/route.js
+++ b/src/app/api/oauth/kiro/import/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { KiroService } from "@/lib/oauth/services/kiro";
 import { createProviderConnection } from "@/models";
+import { assertValidAwsRegion } from "@/lib/oauth/constants/oauth";
 
 /**
  * POST /api/oauth/kiro/import
@@ -19,13 +20,21 @@ export async function POST(request) {
       );
     }
 
+    // Validate region if provided (SSRF prevention)
+    const safeRegion = region || "us-east-1";
+    try {
+      assertValidAwsRegion(safeRegion);
+    } catch (err) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+
     const kiroService = new KiroService();
     const isIdc = !!(clientId && clientSecret);
 
     // For IDC tokens, refresh via the regional OIDC endpoint with client credentials.
     // For social/builder-id tokens, use the standard social refresh endpoint.
     const providerSpecificData = isIdc
-      ? { clientId, clientSecret, region: region || "us-east-1", authMethod: "idc" }
+      ? { clientId, clientSecret, region: safeRegion, authMethod: "idc" }
       : {};
 
     const tokenData = await kiroService.refreshToken(refreshToken.trim(), providerSpecificData);

--- a/src/lib/oauth/kiroExternalIdp.js
+++ b/src/lib/oauth/kiroExternalIdp.js
@@ -1,3 +1,5 @@
+import { assertValidAwsRegion } from "./constants/oauth.js";
+
 const MICROSOFT_TOKEN_ENDPOINT_HOSTS = new Set([
   "login.microsoftonline.com",
   "login.microsoft.com",
@@ -98,8 +100,11 @@ export function normalizeKiroExternalIdpAuth(rawAuth) {
   const clientId = normalizeString(input.client_id || input.clientId);
   const tokenEndpoint = validateMicrosoftTokenEndpoint(input.token_endpoint || input.tokenEndpoint);
   const profileArn = normalizeString(input.profile_arn || input.profileArn);
-  const region = normalizeString(input.region) || DEFAULT_REGION;
+  const rawRegion = normalizeString(input.region) || DEFAULT_REGION;
   const scope = normalizeScope(input.scopes || input.scope);
+
+  // Validate region (SSRF prevention)
+  const region = assertValidAwsRegion(rawRegion);
 
   if (!accessToken) throw new Error("access_token is required");
   if (!refreshToken) throw new Error("refresh_token is required");


### PR DESCRIPTION
## Summary
Prevents Server-Side Request Forgery by validating all external URLs and AWS regions against allowlists, and pinning DNS resolution for outbound fetches.

## Changes
- src/app/api/auth/oidc/test/route.js: Added assertPublicUrl(issuerUrl) guard before fetching OIDC discovery
- src/app/api/oauth/kiro/auto-import/route.js: Added assertValidAwsRegion() validation on all region inputs
- src/app/api/oauth/kiro/import/route.js: Region validation on import
- src/app/api/oauth/kiro/api-key/route.js: Region validation on API key import
- src/lib/oauth/kiroExternalIdp.js: Region validation for external IDP token exchange
- open-sse/handlers/fetch/index.js: DNS pinning via resolveAndValidatePublicIps() + createPinnedAgent() with redirect: manual to prevent TOCTOU SSRF

## GHSA References
- GHSA-8g4w: SSRF via OIDC issuer URL
- GHSA-6mwv: SSRF via AWS region
- GHSA-cmhj: SSRF via Kiro import
- GHSA-qj3v: SSRF via open-sse fetch