### PR TITLE
fix(security): require CLI token auth for MCP plugin endpoints (GHSA-63p9, GHSA-fhh6)

### DIFF
--- a/src/app/api/mcp/[plugin]/message/route.js
+++ b/src/app/api/mcp/[plugin]/message/route.js
@@ -1,10 +1,16 @@
 import { NextResponse } from "next/server";
 import { sendToChild, findPlugin } from "@/lib/mcp/stdioSseBridge";
+import { hasValidCliToken } from "@/dashboardGuard";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(request, { params }) {
+  // Require CLI token for MCP plugin message endpoint
+  if (!(await hasValidCliToken(request))) {
+    return NextResponse.json({ error: "Unauthorized: CLI token required" }, { status: 401 });
+  }
+
   const { plugin } = await params;
   if (!findPlugin(plugin)) {
     return NextResponse.json({ error: `Unknown plugin: ${plugin}` }, { status: 404 });

--- a/src/app/api/mcp/[plugin]/sse/route.js
+++ b/src/app/api/mcp/[plugin]/sse/route.js
@@ -1,9 +1,15 @@
 import { registerSession, unregisterSession, findPlugin } from "@/lib/mcp/stdioSseBridge";
+import { hasValidCliToken } from "@/dashboardGuard";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(request, { params }) {
+  // Require CLI token for MCP plugin SSE endpoint
+  if (!(await hasValidCliToken(request))) {
+    return new Response(`Unauthorized: CLI token required`, { status: 401 });
+  }
+
   const { plugin } = await params;
   if (!findPlugin(plugin)) {
     return new Response(`Unknown plugin: ${plugin}`, { status: 404 });


### PR DESCRIPTION
## Summary
MCP plugin endpoints now require valid CLI token (NINEROUTER_CLI_TOKEN) for access, preventing unauthorized plugin invocation.

## Changes
- src/app/api/mcp/[plugin]/message/route.js: Added hasValidCliToken() authentication requirement
- src/app/api/mcp/[plugin]/sse/route.js: Added hasValidCliToken() authentication requirement

## GHSA References
- GHSA-63p9: Unauthenticated MCP message endpoint
- GHSA-fhh6: Unauthenticated MCP SSE endpoint