### PR TITLE
fix(security): require dual auth for database import/export (GHSA-qvfm)

### DIFF
--- a/src/app/api/settings/database/route.js
+++ b/src/app/api/settings/database/route.js
@@ -2,19 +2,42 @@ import { NextResponse } from "next/server";
 import { exportDb, getSettings, importDb } from "@/lib/localDb";
 import { applyOutboundProxyEnv } from "@/lib/network/outboundProxy";
 import { verifyDashboardPassword } from "@/lib/auth/dashboardSession";
+import { hasValidCliToken, hasValidToken } from "@/dashboardGuard";
 
 const CLI_TOKEN_HEADER = "x-9r-cli-token";
 const PASSWORD_HEADER = "x-9r-password";
 
-// CLI token requests are already trusted (local machine); skip password re-auth.
-function isCliRequest(request) {
-  return Boolean(request.headers.get(CLI_TOKEN_HEADER));
+// Validate CLI token AND require JWT session for browser requests.
+// CLI requests: valid CLI token + password verification (second factor).
+// Browser requests: valid JWT session + password verification.
+async function checkAuth(request, password) {
+  const cliTokenValid = await hasValidCliToken(request);
+  const jwtValid = await hasValidToken(request);
+
+  // CLI path: require valid CLI token AND password verification
+  if (cliTokenValid) {
+    if (!password || !(await verifyDashboardPassword(password))) {
+      return false;
+    }
+    return true;
+  }
+
+  // Browser path: require valid JWT session AND password verification
+  if (jwtValid) {
+    if (!password || !(await verifyDashboardPassword(password))) {
+      return false;
+    }
+    return true;
+  }
+
+  return false;
 }
 
 export async function GET(request) {
   try {
-    if (!isCliRequest(request) && !(await verifyDashboardPassword(request.headers.get(PASSWORD_HEADER)))) {
-      return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+    const password = request.headers.get(PASSWORD_HEADER);
+    if (!(await checkAuth(request, password))) {
+      return NextResponse.json({ error: "Unauthorized: CLI token + password or JWT session + password required" }, { status: 401 });
     }
     const payload = await exportDb();
     return NextResponse.json(payload);
@@ -27,8 +50,8 @@ export async function GET(request) {
 export async function POST(request) {
   try {
     const { password, ...payload } = await request.json();
-    if (!isCliRequest(request) && !(await verifyDashboardPassword(password))) {
-      return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+    if (!(await checkAuth(request, password))) {
+      return NextResponse.json({ error: "Unauthorized: CLI token + password or JWT session + password required" }, { status: 401 });
     }
     await importDb(payload);
 


### PR DESCRIPTION
## Summary
Database import/export now requires dual-factor authentication: (CLI token + password) OR (JWT session + password).

## Changes
- src/app/api/settings/database/route.js: checkAuth() now enforces dual auth for both GET (export) and POST (import)

## GHSA References
- GHSA-qvfm: Unauthorized database export/import exposing all credentials