### PR TITLE
fix(security): require explicit JWT_SECRET env var, remove auto-generated fallback (GHSA-jphh)

### DIFF
--- a/src/lib/auth/dashboardSession.js
+++ b/src/lib/auth/dashboardSession.js
@@ -2,22 +2,17 @@ import { SignJWT, jwtVerify } from "jose";
 import bcrypt from "bcryptjs";
 import fs from "node:fs";
 import path from "node:path";
-import crypto from "node:crypto";
 import { DATA_DIR } from "@/lib/dataDir";
 import { getSettings } from "@/lib/localDb";
 
 const DEFAULT_PASSWORD = "123456";
 
 function loadJwtSecret() {
-  if (process.env.JWT_SECRET) return process.env.JWT_SECRET;
-  const file = path.join(DATA_DIR, "jwt-secret");
-  try {
-    return fs.readFileSync(file, "utf8").trim();
-  } catch {}
-  fs.mkdirSync(DATA_DIR, { recursive: true });
-  const generated = crypto.randomBytes(32).toString("hex");
-  fs.writeFileSync(file, generated, { mode: 0o600 });
-  return generated;
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("JWT_SECRET environment variable is required. Set a strong random secret (min 32 chars) in your .env file.");
+  }
+  return secret;
 }
 
 const SECRET = new TextEncoder().encode(loadJwtSecret());


### PR DESCRIPTION
## Summary
Application now fails fast at startup if JWT_SECRET is not configured, removing the auto-generated secret file fallback which could lead to weak or predictable secrets.

## Changes
- src/lib/auth/dashboardSession.js: loadJwtSecret() now throws if JWT_SECRET is not set in environment

## GHSA References
- GHSA-jphh: Weak/predictable JWT secret from auto-generation fallback