### PR TITLE
fix(security): require auth for headroom, tunnel, oauth, and reset-password endpoints (GHSA-g6g7, GHSA-x5c9, GHSA-86m2, GHSA-8gmq, GHSA-6g2f)

### DIFF
--- a/src/app/api/auth/reset-password/route.js
+++ b/src/app/api/auth/reset-password/route.js
@@ -1,9 +1,18 @@
 import { NextResponse } from "next/server";
 import { updateSettings } from "@/lib/localDb";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 // Reset dashboard password to default by clearing the stored hash.
 // Local-only (enforced by dashboardGuard). Never returns the default literal.
-export async function POST() {
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     await updateSettings({ password: null });
     return NextResponse.json({ success: true });

--- a/src/app/api/cli-tools/cowork-settings/route.js
+++ b/src/app/api/cli-tools/cowork-settings/route.js
@@ -8,6 +8,12 @@ import crypto from "crypto";
 import { DEFAULT_PLUGINS, LOCAL_STDIO_PLUGINS, buildManagedMcpServers } from "@/shared/constants/coworkPlugins";
 import { UPDATER_CONFIG } from "@/shared/constants/config";
 import { getConsistentMachineId } from "@/shared/utils/machineId";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 const APP_PORT = UPDATER_CONFIG.appPort;
 const CLI_TOKEN_HEADER = "x-9r-cli-token";
@@ -241,7 +247,10 @@ async function writeSkipApprovals(managedServers) {
   return { written: Object.keys(skip).length };
 }
 
-export async function GET() {
+export async function GET(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const installed = await checkInstalled();
     if (!installed) {
@@ -309,6 +318,9 @@ export async function GET() {
 }
 
 export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const { baseUrl, apiKey, models, plugins, localPlugins, customPlugins } = await request.json();
 
@@ -368,7 +380,10 @@ export async function POST(request) {
   }
 }
 
-export async function DELETE() {
+export async function DELETE(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const meta = await readJson(await getMetaPath());
     if (!meta?.appliedId) {

--- a/src/app/api/headroom/extras/route.js
+++ b/src/app/api/headroom/extras/route.js
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
 import { findPython310, getInstalledHeadroomExtras, HEADROOM_COMPRESSION_EXTRAS } from "@/lib/headroom/detect";
 import { installHeadroomExtras, uninstallHeadroomExtras, getInstallLogTail } from "@/lib/headroom/process";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 export const dynamic = "force-dynamic";
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 export async function GET(req) {
   try {
@@ -22,6 +28,9 @@ export async function GET(req) {
 }
 
 export async function POST(req) {
+  if (!(await requireAuth(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const body = await req.json().catch(() => ({}));
     const requested = Array.isArray(body?.extras) ? body.extras : [];
@@ -34,6 +43,9 @@ export async function POST(req) {
 }
 
 export async function DELETE(req) {
+  if (!(await requireAuth(req))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const body = await req.json().catch(() => ({}));
     const requested = Array.isArray(body?.extras) ? body.extras : [];

--- a/src/app/api/headroom/proxy/[...path]/route.js
+++ b/src/app/api/headroom/proxy/[...path]/route.js
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
 import { getSettings } from "@/lib/localDb";
 import { DEFAULT_HEADROOM_URL } from "@/lib/headroom/detect";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 export const dynamic = "force-dynamic";
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
@@ -57,6 +63,9 @@ function rewriteDashboardHtml(html) {
 }
 
 async function proxy(request, { params }) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const base = await getTargetBase();
     const { search } = new URL(request.url);

--- a/src/app/api/headroom/restart/route.js
+++ b/src/app/api/headroom/restart/route.js
@@ -2,8 +2,14 @@ import { NextResponse } from "next/server";
 import { getSettings } from "@/lib/localDb";
 import { restartHeadroomProxy } from "@/lib/headroom/process";
 import { DEFAULT_HEADROOM_URL, isLoopbackHeadroomUrl } from "@/lib/headroom/detect";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 export const dynamic = "force-dynamic";
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 function parsePortFromUrl(url) {
   try {
@@ -14,7 +20,10 @@ function parsePortFromUrl(url) {
   return null;
 }
 
-export async function POST() {
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const settings = await getSettings();
     const url = settings.headroomUrl || DEFAULT_HEADROOM_URL;

--- a/src/app/api/headroom/start/route.js
+++ b/src/app/api/headroom/start/route.js
@@ -2,8 +2,14 @@ import { NextResponse } from "next/server";
 import { getSettings } from "@/lib/localDb";
 import { startHeadroomProxy } from "@/lib/headroom/process";
 import { DEFAULT_HEADROOM_URL, isLoopbackHeadroomUrl } from "@/lib/headroom/detect";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 export const dynamic = "force-dynamic";
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 function parsePortFromUrl(url) {
   try {
@@ -14,7 +20,10 @@ function parsePortFromUrl(url) {
   return null;
 }
 
-export async function POST() {
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const settings = await getSettings();
     const url = settings.headroomUrl || DEFAULT_HEADROOM_URL;

--- a/src/app/api/headroom/status/route.js
+++ b/src/app/api/headroom/status/route.js
@@ -2,10 +2,19 @@ import { NextResponse } from "next/server";
 import { getSettings } from "@/lib/localDb";
 import { DEFAULT_HEADROOM_URL, getHeadroomStatus } from "@/lib/headroom/detect";
 import { getManagedPid } from "@/lib/headroom/process";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
+
+export async function GET(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const settings = await getSettings();
     const url = settings.headroomUrl || DEFAULT_HEADROOM_URL;

--- a/src/app/api/headroom/stop/route.js
+++ b/src/app/api/headroom/stop/route.js
@@ -1,9 +1,18 @@
 import { NextResponse } from "next/server";
 import { stopHeadroomProxy } from "@/lib/headroom/process";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 export const dynamic = "force-dynamic";
 
-export async function POST() {
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
+
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const result = stopHeadroomProxy();
     const status = result.stopped ? 200 : 409;

--- a/src/app/api/oauth/cursor/auto-import/route.js
+++ b/src/app/api/oauth/cursor/auto-import/route.js
@@ -4,8 +4,14 @@ import { homedir } from "os";
 import { join } from "path";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 const execFileAsync = promisify(execFile);
+
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
 
 const ACCESS_TOKEN_KEYS = ["cursorAuth/accessToken", "cursorAuth/token"];
 const MACHINE_ID_KEYS = [
@@ -174,7 +180,10 @@ async function extractTokensViaCLI(dbPath) {
  * Auto-detect and extract Cursor tokens from local SQLite database.
  * Strategy: better-sqlite3 → sqlite3 CLI → manual fallback
  */
-export async function GET() {
+export async function GET(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const platform = process.platform;
     const candidates = getCandidatePaths(platform);

--- a/src/app/api/tunnel/disable/route.js
+++ b/src/app/api/tunnel/disable/route.js
@@ -2,8 +2,17 @@ import { NextResponse } from "next/server";
 import { disableTunnel } from "@/lib/tunnel";
 import { getSettings } from "@/lib/localDb";
 import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
-export async function POST() {
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
+
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const result = await disableTunnel();
     getSettings()

--- a/src/app/api/tunnel/enable/route.js
+++ b/src/app/api/tunnel/enable/route.js
@@ -2,10 +2,19 @@ import { NextResponse } from "next/server";
 import { enableTunnel } from "@/lib/tunnel";
 import { getSettings } from "@/lib/localDb";
 import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 const DNS_WARMUP_DELAY_MS = 8000;
 
-export async function POST() {
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
+
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const result = await enableTunnel();
     getSettings()

--- a/src/app/api/tunnel/tailscale-check/route.js
+++ b/src/app/api/tunnel/tailscale-check/route.js
@@ -4,6 +4,7 @@ import { promisify } from "util";
 import { NextResponse } from "next/server";
 import { isTailscaleInstalled, isTailscaleLoggedIn, isSystemDaemonRunning, getTailscaleBin, TAILSCALE_SOCKET } from "@/lib/tunnel";
 import { getCachedPassword, loadEncryptedPassword } from "@/mitm/manager";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
 const execAsync = promisify(exec);
 const EXTENDED_PATH = `/usr/local/bin:/opt/homebrew/bin:/usr/sbin:/usr/bin:/bin:/snap/bin:${process.env.PATH || ""}`;
@@ -34,7 +35,15 @@ async function isCustomDaemonRunning() {
   }
 }
 
-export async function GET() {
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
+
+export async function GET(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const installed = isTailscaleInstalled();
     const platform = os.platform();

--- a/src/app/api/tunnel/tailscale-disable/route.js
+++ b/src/app/api/tunnel/tailscale-disable/route.js
@@ -2,8 +2,17 @@ import { NextResponse } from "next/server";
 import { disableTailscale } from "@/lib/tunnel";
 import { getSettings } from "@/lib/localDb";
 import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
-export async function POST() {
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
+
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const result = await disableTailscale();
     getSettings()

--- a/src/app/api/tunnel/tailscale-enable/route.js
+++ b/src/app/api/tunnel/tailscale-enable/route.js
@@ -2,8 +2,17 @@ import { NextResponse } from "next/server";
 import { enableTailscale } from "@/lib/tunnel";
 import { getSettings } from "@/lib/localDb";
 import { configureTunnelMonitoring } from "@/shared/services/initializeApp";
+import { hasValidCliToken, isAuthenticated } from "@/dashboardGuard";
 
-export async function POST() {
+async function requireAuth(request) {
+  if (await hasValidCliToken(request) || await isAuthenticated(request)) return true;
+  return false;
+}
+
+export async function POST(request) {
+  if (!(await requireAuth(request))) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
   try {
     const result = await enableTailscale();
     getSettings()


### PR DESCRIPTION
## Summary
All sensitive operational endpoints now require valid CLI token or JWT session.

## Changes
- Headroom routes (extras, proxy, restart, start, status, stop): Added requireAuth() check
- Tunnel routes (enable, disable, tailscale-check, tailscale-disable, tailscale-enable): Added requireAuth() check
- src/app/api/auth/reset-password/route.js: Added requireAuth() check
- src/app/api/oauth/cursor/auto-import/route.js: Added requireAuth() check
- src/app/api/cli-tools/cowork-settings/route.js: Added requireAuth() check

## GHSA References
- GHSA-g6g7: Unauthenticated headroom control endpoints
- GHSA-x5c9: Unauthenticated tunnel control endpoints
- GHSA-86m2: Unauthenticated password reset
- GHSA-8gmq: Unauthenticated OAuth auto-import
- GHSA-6g2f: Unauthenticated cowork settings