### PR TITLE
fix(opencode): forward reasoning_effort for OpenCode zen stealth models

### DIFF
--- a/open-sse/providers/capabilities.js
+++ b/open-sse/providers/capabilities.js
@@ -42,7 +42,7 @@ export const DEFAULT_CAPABILITIES = {
   tools: true,          // function / tool calling
   reasoning: false,     // thinking / reasoning
   // thinking wire format (only meaningful when reasoning:true). null → derive from transport.format.
-  // enum: openai|claude-adaptive|claude-budget|gemini-level|gemini-budget|zai|qwen|deepseek|kimi|minimax|hunyuan|step
+  // enum: openai|claude-adaptive|claude-budget|gemini-level|gemini-budget|zai|qwen|deepseek|kimi|opencode|minimax|hunyuan|step
   thinkingFormat: null,
   thinkingCanDisable: true,  // false → model cannot turn thinking off (clamp to min instead of disable)
   thinkingRange: null,       // { min, max } for budget formats; null = no clamp
@@ -100,6 +100,16 @@ export const MODEL_CAPABILITIES = {
   // Qwen plain coder/text (no vision) — registry "vision-model" / "coder-model" aliases
   "vision-model":      { vision: true, reasoning: true, thinkingFormat: "qwen", contextWindow: 1000000 },
   "coder-model":       { reasoning: true, thinkingFormat: "qwen", contextWindow: 1000000 },
+
+  // OpenCode zen stealth/free originals — exact ids no pattern covers. Reasoning via
+  // the gateway's own reasoning_effort enum (none|low|medium|high|max), not the
+  // upstream vendor's (verified live: xhigh/minimal/auto rejected with 1210).
+  "x-preview-f-free":  { vision: true, videoInput: true, reasoning: true, thinkingFormat: "opencode", contextWindow: 1000000, maxOutput: 131072 },
+  "big-pickle":        { reasoning: true, thinkingFormat: "opencode", contextWindow: 200000, maxOutput: 32000 },
+  "muse-spark-1.2":    { vision: true, audioInput: true, videoInput: true, reasoning: true, thinkingFormat: "opencode", contextWindow: 1048576, maxOutput: 131072 },
+  "muse-spark-1.2-contributor-free": { vision: true, audioInput: true, videoInput: true, reasoning: true, thinkingFormat: "opencode", contextWindow: 1048576, maxOutput: 131072 },
+  // MiMo v2.5 free resurface — "*mimo*" patterns are non-reasoning; this one reasons.
+  "mimo-v2.5-free":    { vision: true, audioInput: true, videoInput: true, reasoning: true, thinkingFormat: "opencode", contextWindow: 200000, maxOutput: 32000 },
 
   // Kimi flagship + coding (platform + Kimi Code ids) — vision/video native
   "kimi-k3":           { vision: true, videoInput: true, reasoning: true, thinkingFormat: "kimi", thinkingCanDisable: false, contextWindow: 1048576, maxOutput: 131072 },

--- a/open-sse/providers/registry/opencode.js
+++ b/open-sse/providers/registry/opencode.js
@@ -14,6 +14,9 @@ export default {
   noAuth: true,
   transport: {
     baseUrl: "https://opencode.ai",
+    // Single OpenAI-compatible gateway for every model (claude/gpt/gemini/... ids
+    // included) → one reasoning_effort enum; overrides per-model caps format.
+    thinkingFormat: "opencode",
     headers: {
       "x-opencode-client": "desktop",
     },

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -3,6 +3,7 @@
 import { getCapabilitiesForModel } from "./capabilities.js";
 import { matchPattern } from "./pricing.js";
 import { resolveKiroEffortPath } from "../config/kiroConstants.js";
+import { PROVIDERS } from "./index.js";
 
 // Shared level sets (deduped) — verified against provider docs + wire in thinkingUnified.applyFormat.
 const L = {
@@ -25,6 +26,7 @@ const FORMAT_LEVELS = {
   zai: L.onOff,
   qwen: L.base,
   kimi: L.levelMax,
+  opencode: L.levelMax,   // zen gateway enum: none|low|medium|high|max (no xhigh/minimal)
   deepseek: L.hiMax,
   minimax: L.onOff,
   hunyuan: L.base,
@@ -49,7 +51,11 @@ export function getThinkingLevels(provider, model) {
   const hit = PATTERN_THINKING.find((entry) =>
     (!entry.provider || entry.provider === provider) && matchPattern(entry.pattern, model)
   );
-  let levels = hit?.levels || FORMAT_LEVELS[caps.thinkingFormat] || L.base;
+  // Provider-declared format wins over per-model caps (same precedence as
+  // thinkingUnified.resolveFormat) — e.g. opencode routes every model through
+  // one gateway enum regardless of the upstream vendor the id looks like.
+  const fmt = (provider && PROVIDERS[provider]?.thinkingFormat) || caps.thinkingFormat;
+  let levels = hit?.levels || FORMAT_LEVELS[fmt] || L.base;
   if (caps.thinkingCanDisable === false) levels = levels.filter((l) => l !== "none");
   return levels;
 }

--- a/open-sse/providers/thinkingLevels.js
+++ b/open-sse/providers/thinkingLevels.js
@@ -3,7 +3,6 @@
 import { getCapabilitiesForModel } from "./capabilities.js";
 import { matchPattern } from "./pricing.js";
 import { resolveKiroEffortPath } from "../config/kiroConstants.js";
-import { PROVIDERS } from "./index.js";
 
 // Shared level sets (deduped) — verified against provider docs + wire in thinkingUnified.applyFormat.
 const L = {
@@ -51,11 +50,7 @@ export function getThinkingLevels(provider, model) {
   const hit = PATTERN_THINKING.find((entry) =>
     (!entry.provider || entry.provider === provider) && matchPattern(entry.pattern, model)
   );
-  // Provider-declared format wins over per-model caps (same precedence as
-  // thinkingUnified.resolveFormat) — e.g. opencode routes every model through
-  // one gateway enum regardless of the upstream vendor the id looks like.
-  const fmt = (provider && PROVIDERS[provider]?.thinkingFormat) || caps.thinkingFormat;
-  let levels = hit?.levels || FORMAT_LEVELS[fmt] || L.base;
+  let levels = hit?.levels || FORMAT_LEVELS[caps.thinkingFormat] || L.base;
   if (caps.thinkingCanDisable === false) levels = levels.filter((l) => l !== "none");
   return levels;
 }

--- a/open-sse/translator/concerns/thinkingUnified.js
+++ b/open-sse/translator/concerns/thinkingUnified.js
@@ -293,6 +293,18 @@ function applyFormat(fmt, body, cfg, caps, supportedLevels) {
       if (effort) body.reasoning_effort = effort;
       break;
     }
+    case "opencode": {
+      // opencode zen gateway enum on OpenAI-style reasoning_effort:
+      // none|low|medium|high|max. Verified live: xhigh/minimal/auto → 400
+      // "[1210] Invalid API parameter"; omitted field → upstream default.
+      if (none && canDisable) { body.reasoning_effort = "none"; break; }
+      const level = toLevel(eff);
+      if (!level || level === "auto") break;
+      body.reasoning_effort = level === "xhigh" || level === "ultra" ? "max"
+        : level === "minimal" ? "low"
+        : level;
+      break;
+    }
     case "minimax": {
       // M3 adaptive; M2.x cannot disable (handled via canDisable clamp).
       body.thinking = { type: none && canDisable ? "disabled" : "adaptive" };

--- a/tests/unit/opencode-thinking-effort.test.js
+++ b/tests/unit/opencode-thinking-effort.test.js
@@ -52,9 +52,9 @@ describe("opencode thinking effort", () => {
     expect(out.output_config).toBeUndefined();
   });
 
-  it("UI levels expose the gateway enum (incl. max) for stealth and vendor ids", () => {
+  it("UI levels for stealth ids come from their own caps entry (gateway enum incl. max)", () => {
     expect(getThinkingLevels("opencode", "x-preview-f-free")).toEqual(["none", "low", "medium", "high", "max"]);
-    expect(getThinkingLevels("opencode", "gpt-5.6-sol")).toEqual(["none", "low", "medium", "high", "max"]);
+    expect(getThinkingLevels("opencode", "big-pickle")).toEqual(["none", "low", "medium", "high", "max"]);
   });
 
   it("other providers unaffected", () => {

--- a/tests/unit/opencode-thinking-effort.test.js
+++ b/tests/unit/opencode-thinking-effort.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { applyThinking } from "../../open-sse/translator/concerns/thinkingUnified.js";
+import { translateRequest } from "../../open-sse/translator/index.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+import { getThinkingLevels } from "../../open-sse/providers/thinkingLevels.js";
+
+// Regression: OpenCode zen stealth/free originals (x-preview-f-free aka ox-alpha,
+// big-pickle, muse-spark-1.2, mimo-v2.5-free) matched no capability pattern →
+// caps.reasoning=false → applyThinking() stripped the thinking intent entirely,
+// so reasoning_effort never reached the gateway. Verified live: zen accepts
+// reasoning_effort none|low|medium|high|max and rejects xhigh/minimal/auto.
+describe("opencode thinking effort", () => {
+  it("stealth ids resolve reasoning:true with the opencode format", () => {
+    for (const id of ["x-preview-f-free", "big-pickle", "muse-spark-1.2", "mimo-v2.5-free"]) {
+      const caps = getCapabilitiesForModel("opencode", id);
+      expect(caps.reasoning).toBe(true);
+      expect(caps.thinkingFormat).toBe("opencode");
+    }
+  });
+
+  it("claude budget intent → reasoning_effort on x-preview-f-free (was stripped)", () => {
+    const body = { messages: [{ role: "user", content: "hi" }], thinking: { type: "enabled", budget_tokens: 64000 } };
+    const out = applyThinking(FORMATS.OPENAI, "x-preview-f-free", body, "opencode");
+    expect(out.reasoning_effort).toBe("max");
+  });
+
+  it("gateway enum: xhigh/ultra clamp to max, minimal clamps to low", () => {
+    const xhigh = applyThinking(FORMATS.OPENAI, "big-pickle", { reasoning_effort: "xhigh" }, "opencode");
+    expect(xhigh.reasoning_effort).toBe("max");
+    const ultra = applyThinking(FORMATS.OPENAI, "big-pickle", { reasoning_effort: "ultra" }, "opencode");
+    expect(ultra.reasoning_effort).toBe("max");
+    const minimal = applyThinking(FORMATS.OPENAI, "big-pickle", { reasoning_effort: "minimal" }, "opencode");
+    expect(minimal.reasoning_effort).toBe("low");
+  });
+
+  it("none disables explicitly, auto omits the field (upstream default)", () => {
+    const none = applyThinking(FORMATS.OPENAI, "x-preview-f-free", { reasoning_effort: "none" }, "opencode");
+    expect(none.reasoning_effort).toBe("none");
+    const auto = applyThinking(FORMATS.OPENAI, "x-preview-f-free", { reasoning_effort: "auto" }, "opencode");
+    expect(auto.reasoning_effort).toBeUndefined();
+  });
+
+  it("provider format wins over per-model caps: claude id on opencode gets reasoning_effort, not claude thinking blocks", () => {
+    const out = translateRequest(
+      FORMATS.CLAUDE, FORMATS.OPENAI, "claude-sonnet-4-6",
+      { messages: [{ role: "user", content: "hi" }], output_config: { effort: "high" } },
+      true, null, "opencode"
+    );
+    expect(out.reasoning_effort).toBe("high");
+    expect(out.thinking).toBeUndefined();
+    expect(out.output_config).toBeUndefined();
+  });
+
+  it("UI levels expose the gateway enum (incl. max) for stealth and vendor ids", () => {
+    expect(getThinkingLevels("opencode", "x-preview-f-free")).toEqual(["none", "low", "medium", "high", "max"]);
+    expect(getThinkingLevels("opencode", "gpt-5.6-sol")).toEqual(["none", "low", "medium", "high", "max"]);
+  });
+
+  it("other providers unaffected", () => {
+    expect(getThinkingLevels("openai", "gpt-5")).toContain("xhigh");
+    expect(getThinkingLevels("openai", "gpt-5")).not.toContain("max");
+    expect(getCapabilitiesForModel("openai", "gpt-5").thinkingFormat).toBe("openai");
+  });
+});


### PR DESCRIPTION
## Problem

OpenCode zen stealth/free originals silently dropped the client's thinking setting — no `reasoning_effort` ever reached the gateway:

```
[10:22:31] 🟠 ▶ POST x-preview-f-free → opencode/x-preview-f-free · FMT: claude→openai · STREAM · 4 MSG · 12 TOOL · THINK:off · ACC:oauth
[10:23:02] 🟠 ▶ POST big-pickle → opencode/big-pickle · FMT: claude→openai · STREAM · 9 MSG · 12 TOOL · THINK:off · ACC:oauth
```

Selecting a thinking level in the dashboard or sending `thinking:{type:"enabled",budget_tokens}` / `reasoning_effort:"high"` / `model(high)` from Claude Code had no effect on upstream requests to `opencode.ai/zen` for `x-preview-f-free` (ox-alpha), `big-pickle`, `muse-spark-1.2`, `muse-spark-1.2-contributor-free`, and `mimo-v2.5-free`.

## Fix

**Root cause — missing capability entries + wrong wire format:** the zen gateway is a single OpenAI-compatible endpoint serving every vendor-named model id (claude/gpt/gemini/... included) with its own effort enum `reasoning_effort: none|low|medium|high|max`, but 9Router had no `opencode` thinking format and no caps for the stealth ids.

- `open-sse/providers/capabilities.js` — `x-preview-f-free`/`big-pickle`/`muse-spark-1.2*`/`mimo-v2.5-free` matched **no** capability pattern (`*mimo*` patterns are non-reasoning), so they resolved to `DEFAULT_CAPABILITIES` with `reasoning:false`
- With `caps.reasoning === false`, `applyThinking()` stripped the client's thinking intent entirely → field omitted upstream
- Even when reasoning was on, vendor-named ids derived their per-model format (`claude-*` → claude thinking blocks, `gpt-*` → openai `xhigh`) which zen rejects: verified live that `xhigh`/`minimal`/`auto` fail with `400 "[1210] Invalid API parameter"`
- `open-sse/providers/thinkingLevels.js` had no level table for the gateway enum

**Change — config-driven, DRY** (per `open-sse/AGENTS.md` / `docs/ARCHITECTURE.md`):

- `open-sse/providers/registry/opencode.js:17` — add `thinkingFormat: "opencode"` to `transport`, so the provider-level format overrides per-model caps (mirrors `iflow`/`codebuddy-cn` forcing `openai`); one gateway → one enum regardless of the model id's vendor name
- `open-sse/providers/capabilities.js:104-112` — exact entries for the five stealth/free ids: `reasoning:true, thinkingFormat:"opencode"` plus real vision/audio/video/contextWindow/maxOutput values
- `open-sse/translator/concerns/thinkingUnified.js:296` — new `case "opencode"` in `applyFormat()`: `none`→`"none"` (explicit disable when `thinkingCanDisable`), `auto`→omit the field (upstream default), `minimal`→`low`, `xhigh`/`ultra`→`max`; everything else passes through
- `open-sse/providers/thinkingLevels.js:28` — add `opencode: L.levelMax` (`none|low|medium|high|max`)
- Level pickers still derive solely from per-model caps (the transport-precedence change to `getThinkingLevels` was reverted) — runtime routing is untouched because `resolveFormat()` already preferred `transport.thinkingFormat`; the stealth ids expose `max` in the UI via their own caps entry

Only the `opencode` provider path is touched; other providers unchanged.

## Tests

New `tests/unit/opencode-thinking-effort.test.js` (7 cases):

- Stealth ids resolve `reasoning:true` + `thinkingFormat:"opencode"` ✓
- Claude budget intent → `reasoning_effort:"max"` on `x-preview-f-free` (previously stripped) ✓
- Gateway enum clamps: `xhigh`/`ultra`→`max`, `minimal`→`low` ✓
- `none` disables explicitly, `auto` omits the field ✓
- Provider format wins over per-model caps: claude id on opencode gets `reasoning_effort:"high"`, not claude thinking blocks ✓
- UI levels for stealth ids are `["none","low","medium","high","max"]` ✓
- Other providers unaffected (`gpt-5` keeps `xhigh`, not `max`) ✓

Existing suite: `unit/opencode-thinking-effort.test.js` + `unit/capabilities.test.js` + `translator/thinking-unified.test.js` — 55 tests all pass.

## Impact

Fixes "zen stealth models ignore thinking settings". Low risk: only the `opencode` thinking path is affected; verified upstream requests now carry `reasoning_effort: none|low|medium|high|max` per the gateway spec, and vendor-named ids no longer emit claude-style thinking blocks zen rejects.
