### PR TITLE
fix(claude): normalize trailing assistant prefill for Claude targets

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -180,7 +180,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
       }
     }
     // Normalize newer Cowork/CC beta shapes (adaptive thinking, mid-conversation system) the API rejects
-    if (clientTool === "claude") normalizeClaudePassthrough(translatedBody, translatedBody.model);
+    if (clientTool === "claude") {
+      normalizeClaudePassthrough(translatedBody, translatedBody.model, clientRawRequest?.headers || null);
+    }
   } else {
     translatedBody = translateRequest(sourceFormat, targetFormat, upstreamModel, body, stream, credentials, provider, reqLogger, stripList, connectionId, clientTool);
     if (!translatedBody) {

--- a/open-sse/translator/concerns/assistantPrefillPolicy.js
+++ b/open-sse/translator/concerns/assistantPrefillPolicy.js
@@ -1,0 +1,56 @@
+import { CLAUDE_BLOCK, ROLE } from "../schema/index.js";
+
+const ASSISTANT_CONTINUATION_PROMPT = "Continue from the assistant response above without repeating it.";
+const INCOMPLETE_TOOL_RESULT = "Tool execution was not completed before this request continued.";
+const PRESERVE_HEADER = "x-9router-assistant-prefill";
+
+function getHeader(headers, name) {
+  if (!headers) return null;
+  if (typeof headers.get === "function") return headers.get(name);
+
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === name);
+  const value = entry?.[1];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function hasText(content) {
+  if (typeof content === "string") return !!content.trim();
+  return Array.isArray(content) && content.some(block =>
+    block?.type === CLAUDE_BLOCK.TEXT && block.text?.trim()
+  );
+}
+
+export function applyAssistantPrefillPolicy(body, rawHeaders = null) {
+  if (!Array.isArray(body?.messages)) return body;
+  if (String(getHeader(rawHeaders, PRESERVE_HEADER) || "").toLowerCase() === "preserve") return body;
+
+  const trailingAssistant = body.messages.at(-1);
+  if (trailingAssistant?.role !== ROLE.ASSISTANT) return body;
+
+  const toolUses = Array.isArray(trailingAssistant.content)
+    ? trailingAssistant.content.filter(block => block?.type === CLAUDE_BLOCK.TOOL_USE && block.id)
+    : [];
+  if (toolUses.length > 0) {
+    body.messages.push({
+      role: ROLE.USER,
+      content: toolUses.map(toolUse => ({
+        type: CLAUDE_BLOCK.TOOL_RESULT,
+        tool_use_id: toolUse.id,
+        is_error: true,
+        content: INCOMPLETE_TOOL_RESULT,
+      })),
+    });
+    return body;
+  }
+
+  if (!hasText(trailingAssistant.content)) {
+    body.messages.pop();
+    return body;
+  }
+
+  body.messages.push({
+    role: ROLE.USER,
+    content: [{ type: CLAUDE_BLOCK.TEXT, text: ASSISTANT_CONTINUATION_PROMPT }],
+  });
+  return body;
+}

--- a/open-sse/translator/formats/claude.js
+++ b/open-sse/translator/formats/claude.js
@@ -8,6 +8,7 @@ import { isValidClaudeSignature } from "../../utils/claudeSignature.js";
 import { PROVIDERS } from "../../providers/index.js";
 import { getCapabilitiesForModel } from "../../providers/capabilities.js";
 import { DEFAULT_MAX_TOKENS } from "../../config/runtimeConfig.js";
+import { applyAssistantPrefillPolicy } from "../concerns/assistantPrefillPolicy.js";
 
 const CACHE_CONTROL_5M = { type: "ephemeral" };
 const CACHE_CONTROL_1H = { type: "ephemeral", ttl: "1h" };
@@ -113,7 +114,7 @@ function buildThinkingPlaceholder(provider) {
 // 1. thinking.type "adaptive" → unsupported on Haiku
 // 2. output_config.effort → unsupported on Haiku
 // 3. role "system" messages (mid-conversation-system beta) → only top-level system is allowed
-export function normalizeClaudePassthrough(body, model = "") {
+export function normalizeClaudePassthrough(body, model = "", rawHeaders = null) {
   if (!body || typeof body !== "object") return body;
 
   // 1. Downgrade adaptive thinking for models that don't support it
@@ -188,6 +189,7 @@ export function normalizeClaudePassthrough(body, model = "") {
     }
   }
 
+  applyAssistantPrefillPolicy(body, rawHeaders);
   return body;
 }
 
@@ -318,7 +320,7 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
       }
 
       // Keep final assistant even if empty, otherwise check valid content
-      const isFinalAssistant = i === len - 1 && msg.role === "assistant";
+      const isFinalAssistant = i === len - 1 && msg.role === ROLE.ASSISTANT;
       if (isFinalAssistant || hasValidContent(msg)) {
         filtered.push(msg);
       }
@@ -329,10 +331,12 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
     filtered = fixToolUseOrdering(filtered);
 
     body.messages = filtered;
+    applyAssistantPrefillPolicy(body, rawHeaders);
+    filtered = body.messages;
 
     // Check if thinking is enabled AND last message is from user
     const lastMessage = filtered[filtered.length - 1];
-    const lastMessageIsUser = lastMessage?.role === "user";
+    const lastMessageIsUser = lastMessage?.role === ROLE.USER;
     const thinkingEnabled = body.thinking?.type === "enabled" && lastMessageIsUser;
 
     // Pass 2 (reverse): add cache_control to last assistant + handle thinking for Anthropic
@@ -340,7 +344,7 @@ export function prepareClaudeRequest(body, provider = null, apiKey = null, conne
     for (let i = filtered.length - 1; i >= 0; i--) {
       const msg = filtered[i];
 
-      if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      if (msg.role === ROLE.ASSISTANT && Array.isArray(msg.content)) {
         // Add cache_control to last non-thinking block of first (from end) assistant with content
         // thinking/redacted_thinking blocks do not support cache_control
         if (!lastAssistantProcessed && msg.content.length > 0) {

--- a/tests/translator/assistant-prefill-policy.test.js
+++ b/tests/translator/assistant-prefill-policy.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { normalizeClaudePassthrough, prepareClaudeRequest } from "../../open-sse/translator/formats/claude.js";
+
+const continuationPattern = /continue.*without repeating/i;
+
+function translated(messages, headers = null) {
+  return prepareClaudeRequest({
+    model: "claude-sonnet-4-6",
+    messages: structuredClone(messages),
+  }, "anthropic", null, null, headers);
+}
+
+function passthrough(messages, headers = null) {
+  return normalizeClaudePassthrough({
+    model: "claude-sonnet-4-6",
+    messages: structuredClone(messages),
+  }, "claude-sonnet-4-6", headers);
+}
+
+describe.each([
+  ["translated Claude target", translated],
+  ["native Claude passthrough", passthrough],
+])("assistant prefill policy — %s", (_name, run) => {
+  it("turns trailing assistant text into a continuation turn", () => {
+    const out = run([
+      { role: "user", content: "Start" },
+      { role: "assistant", content: [{ type: "text", text: "Partial answer" }] },
+    ]);
+
+    expect(out.messages.map(message => message.role)).toEqual(["user", "assistant", "user"]);
+    expect(JSON.stringify(out.messages.at(-1).content)).toMatch(continuationPattern);
+  });
+
+  it("drops an empty trailing assistant", () => {
+    const out = run([
+      { role: "user", content: "Start" },
+      { role: "assistant", content: [] },
+    ]);
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].role).toBe("user");
+  });
+
+  it("completes trailing tool_use with an error tool_result", () => {
+    const out = run([
+      { role: "user", content: "Start" },
+      { role: "assistant", content: [{ type: "tool_use", id: "tool-1", name: "lookup", input: {} }] },
+    ]);
+
+    expect(out.messages.at(-1)).toEqual({
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        is_error: true,
+        content: expect.stringMatching(/not completed/i),
+      }],
+    });
+  });
+
+  it("keeps final user unchanged", () => {
+    const out = run([{ role: "user", content: "Start" }]);
+
+    expect(out.messages).toHaveLength(1);
+    expect(out.messages[0].role).toBe("user");
+  });
+
+  it("preserves assistant prefill when explicitly requested", () => {
+    const out = run([
+      { role: "user", content: "Start" },
+      { role: "assistant", content: "Partial answer" },
+    ], { "x-9router-assistant-prefill": "preserve" });
+
+    expect(out.messages).toHaveLength(2);
+    expect(out.messages.at(-1).role).toBe("assistant");
+    expect(JSON.stringify(out.messages.at(-1))).toContain("Partial answer");
+  });
+});


### PR DESCRIPTION
## Summary

- normalize a trailing assistant turn before requests reach Claude-format targets
- apply one shared policy to both the translated path and native Claude passthrough
- keep the previous request body when `x-9router-assistant-prefill: preserve` is sent

## Problem

Anthropic-compatible Messages endpoints require a conversation to end on a user turn. Clients that resume from a partial assistant response send a trailing assistant message, and a trailing assistant `tool_use` block can arrive with no matching `tool_result`. Both shapes are rejected with HTTP 400 before reaching the model.

## Behavior

- trailing assistant text gains a user continuation turn
- trailing assistant `tool_use` blocks gain matching error `tool_result` blocks, ids preserved
- `tool_use` without an id degrades to the text/empty branch instead of emitting an undefined `tool_use_id`
- empty or invalid-signature-thinking-only trailing assistant content is dropped
- final user turns are untouched

The policy runs after tool-use ordering is fixed and before the thinking gate is computed, so the thinking gate sees the normalized turn.

## Verification

- new focused suite `tests/translator/assistant-prefill-policy.test.js`: 10/10 pass, covering both paths
- pre-fix reproduction: with sources reverted to base, the same suite fails 6/10 with the expected shapes
- focused ESLint on all four changed files: clean

The following failures reproduce byte-identically on unmodified `master`, so they are pre-existing and not introduced here:

- `tests/translator/bugs-toClaude-context.test.js`: `assistant reasoning_content becomes a thinking block`
- `tests/unit/translator-helpers-edge.test.js`: `hoists mid-conversation system messages into top-level system`
- `tests/unit/force-stream-config.test.js`: the `force-stream` mock around `open-sse/handlers/chatCore.js`
- `npm run build`: route configuration/page data collection for `/api/cli-tools/antigravity-mitm`

## Compatibility notes

- `x-9router-assistant-prefill` is a new public request header, alongside the documented `X-9Router-Token-Saver`. Happy to add a `README.md` line for it if you want it documented in this PR.
- header lookup accepts a `Headers` instance or a plain object, is case-insensitive, and handles array values.
- passthrough rebuilds `messages` before the policy runs, so the caller's body is not mutated across account-fallback attempts.
- a request whose only message is an empty assistant turn normalizes to an empty `messages` array and receives the endpoint's own validation error; that matches the existing empty-content filtering outcome and is not a regression.
