### PR TITLE
fix(opencode): support muse models via responses api and strip max_tokens

### DIFF
--- a/open-sse/executors/opencode.js
+++ b/open-sse/executors/opencode.js
@@ -43,6 +43,9 @@ export class OpenCodeExecutor extends BaseExecutor {
 
   buildUrl(model) {
     const base = this.config.baseUrl;
+    if (/muse/i.test(model)) {
+      return `${base}/zen/v1/responses`;
+    }
     return MESSAGES_MODELS.has(model)
       ? `${base}/zen/v1/messages`
       : `${base}/zen/v1/chat/completions`;

--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -77,7 +77,8 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (bypassResponse) return bypassResponse;
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
-  const modelTargetFormat = getModelTargetFormat(alias, model);
+  const isMuseOnOpenCode = (provider === "opencode" || alias === "oc") && /muse/i.test(model);
+  const modelTargetFormat = isMuseOnOpenCode ? FORMATS.OPENAI_RESPONSES : getModelTargetFormat(alias, model);
   // Multi-endpoint providers: pick transport matching sourceFormat → zero translation.
   // Per-model guard: only use the transport when the model declares support for that
   // sourceFormat — opencode-go models differ in endpoint support (kimi/glm only do

--- a/open-sse/translator/concerns/paramSupport.js
+++ b/open-sse/translator/concerns/paramSupport.js
@@ -13,7 +13,9 @@ const STRIP_RULES = [
   // GitHub Copilot Claude (except opus/sonnet 4.6): thinking + reasoning_effort rejected. #713
   { provider: "github", match: (m) => /claude/i.test(m) && !/claude.*(opus|sonnet).*4\.6/i.test(m), drop: ["thinking", "reasoning_effort"] },
   // Cloudflare Workers AI: content must be plain string, rejects OpenAI content-part array (#1926)
-  { provider: "cloudflare-ai", flattenContent: true },
+  // OpenCode Muse models: upstream rejects /chat/completions (500) and max_tokens (400),
+  // requires Responses API endpoint and no max_tokens / max_completion_tokens.
+  { provider: "opencode", match: /muse/i, drop: ["max_tokens", "max_completion_tokens"] },
   { provider: "volcengine-ark", match: /glm-5/i, clampToModelMaxOutput: true },
   // VolcEngine Ark caps the Kimi family at max_tokens <= 32768, but the model's
   // advertised ceiling is far higher (Kimi-K2.7-Code resolves to maxOutput 262144),


### PR DESCRIPTION
### Summary
OpenCode upstream no longer supports the legacy `/zen/v1/chat/completions` endpoint for Muse models (e.g. `muse-spark-1.2-contributor-free`), returning HTTP 500 Internal Server Error. These models require the `/zen/v1/responses` endpoint.

Additionally, the `/zen/v1/responses` endpoint rejects `max_tokens` with HTTP 400 (`unknown parameter max_tokens`).

### Changes
1. **OpenCode Executor (`open-sse/executors/opencode.js`):**
   - Route `muse` models to `${baseUrl}/zen/v1/responses`.
2. **Chat Core (`open-sse/handlers/chatCore.js`):**
   - Route `targetFormat` to `FORMATS.OPENAI_RESPONSES` for muse models on OpenCode.
3. **Param Support (`open-sse/translator/concerns/paramSupport.js`):**
   - Add strip rule for `opencode` muse models to drop `max_tokens` and `max_completion_tokens`.

### Verification
- Tested `muse-spark-1.2-contributor-free` on OpenCode.
- Verified both streaming and non-streaming modes return HTTP 200 OK.