### PR TITLE
fix(quota): stop the countdown from doubling after a visibility change

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -30,6 +30,7 @@ import {
   QUOTA_CACHE_KEY,
   REFRESH_INTERVAL_MS,
   CLAUDE_REFRESH_INTERVAL_MS,
+  createQuotaAutoRefresh,
   DEPLETED_QUOTA_THRESHOLD,
   AUTO_REFRESH_STORAGE_KEY,
   CONNECTIONS_PAGE_SIZE,
@@ -169,8 +170,6 @@ export default function ProviderLimits() {
     providerFilteredConnections: 0,
   });
 
-  const intervalRef = useRef(null);
-  const countdownRef = useRef(null);
   const tickCountRef = useRef(0);
 
   const fetchConnections = useCallback(
@@ -624,64 +623,20 @@ export default function ProviderLimits() {
     updateQuotaVisibility(next, previous);
   }, [quotaVisibility, updateQuotaVisibility]);
 
-  // Auto-refresh interval
+  // Auto-refresh + countdown, paused while the tab is hidden (Page Visibility API).
+  // One owner for both intervals: resuming replaces whatever is running instead of
+  // stacking a second pair, which used to make the countdown run at double speed
+  // after a hide/show cycle.
   useEffect(() => {
-    if (!hasHydratedAutoRefresh || !autoRefresh) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
-      }
-      return;
-    }
+    if (!hasHydratedAutoRefresh || !autoRefresh) return undefined;
 
-    // Main refresh interval
-    intervalRef.current = setInterval(() => {
-      refreshAll();
-    }, REFRESH_INTERVAL_MS);
+    const autoRefreshTimers = createQuotaAutoRefresh({
+      onRefresh: () => refreshAll(),
+      onTick: () => setCountdown((prev) => (prev <= 1 ? 60 : prev - 1)),
+    });
+    autoRefreshTimers.start();
 
-    // Countdown interval
-    countdownRef.current = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) return 60;
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      if (countdownRef.current) clearInterval(countdownRef.current);
-    };
-  }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
-
-  // Pause auto-refresh when tab is hidden (Page Visibility API)
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        }
-        if (countdownRef.current) {
-          clearInterval(countdownRef.current);
-          countdownRef.current = null;
-        }
-      } else if (autoRefresh && hasHydratedAutoRefresh) {
-        // Resume auto-refresh when tab becomes visible
-        intervalRef.current = setInterval(() => refreshAll(), REFRESH_INTERVAL_MS);
-        countdownRef.current = setInterval(() => {
-          setCountdown((prev) => (prev <= 1 ? 60 : prev - 1));
-        }, 1000);
-      }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
+    return () => autoRefreshTimers.stop();
   }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
 
   const sortedConnections = useMemo(

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -5,6 +5,7 @@ export const QUOTA_CACHE_KEY = "quotaCacheData";
 export const REFRESH_INTERVAL_MS = 60000;
 // Claude usage/quota endpoint rate-limits; poll it less often than other providers
 export const CLAUDE_REFRESH_INTERVAL_MS = 600000;
+export const COUNTDOWN_INTERVAL_MS = 1000;
 export const DEPLETED_QUOTA_THRESHOLD = 5;
 export const AUTO_REFRESH_STORAGE_KEY = "quotaAutoRefresh";
 export const CONNECTIONS_PAGE_SIZE = 20;
@@ -583,4 +584,75 @@ export function parseQuotaData(provider, data) {
   }
 
   return normalizedQuotas;
+}
+
+// ─── Auto-refresh timers ─────────────────────────────────────────────────────
+
+/**
+ * Owns the quota tracker's two intervals (data refresh + 1s countdown) and the
+ * Page Visibility subscription that pauses them while the tab is hidden.
+ *
+ * Both intervals live behind `startTimers`, which clears before it creates.
+ * That ordering is the point: a "visible" visibilitychange while the timers are
+ * already running used to plant a second pair and leave the first orphaned, so
+ * the countdown decremented twice per second and hit zero at double speed.
+ *
+ * @param {object} options
+ * @param {() => void} options.onRefresh   fires every `refreshIntervalMs`
+ * @param {() => void} options.onTick      fires every `tickIntervalMs`
+ * @param {Document} [options.doc]         injectable for tests
+ * @returns {{ start: () => void, stop: () => void, isRunning: () => boolean }}
+ */
+export function createQuotaAutoRefresh({
+  onRefresh,
+  onTick,
+  refreshIntervalMs = REFRESH_INTERVAL_MS,
+  tickIntervalMs = COUNTDOWN_INTERVAL_MS,
+  doc = typeof document === "undefined" ? null : document,
+} = {}) {
+  let refreshId = null;
+  let tickId = null;
+  let subscribed = false;
+
+  const clearTimers = () => {
+    if (refreshId !== null) {
+      clearInterval(refreshId);
+      refreshId = null;
+    }
+    if (tickId !== null) {
+      clearInterval(tickId);
+      tickId = null;
+    }
+  };
+
+  const startTimers = () => {
+    clearTimers();
+    refreshId = setInterval(() => onRefresh?.(), refreshIntervalMs);
+    tickId = setInterval(() => onTick?.(), tickIntervalMs);
+  };
+
+  const handleVisibilityChange = () => {
+    if (doc?.hidden) clearTimers();
+    else startTimers();
+  };
+
+  return {
+    start() {
+      if (!doc?.hidden) startTimers();
+      if (!subscribed) {
+        doc?.addEventListener?.("visibilitychange", handleVisibilityChange);
+        subscribed = true;
+      }
+    },
+    stop() {
+      clearTimers();
+      if (subscribed) {
+        doc?.removeEventListener?.("visibilitychange", handleVisibilityChange);
+        subscribed = false;
+      }
+    },
+    isRunning() {
+      return refreshId !== null;
+    },
+  };
 }

--- a/tests/unit/quota-auto-refresh-3470.test.js
+++ b/tests/unit/quota-auto-refresh-3470.test.js
@@ -1,0 +1,165 @@
+/**
+ * #3470 — the Quota Tracker countdown accelerated after a visibility change.
+ *
+ * The tracker used to create its two intervals in two places: the auto-refresh
+ * effect, and the `visibilitychange` handler's "resume" branch. The resume
+ * branch overwrote `intervalRef` / `countdownRef` without clearing them first,
+ * so any pair already running was orphaned — unreachable, never cleared, and
+ * still calling `setCountdown`. One extra pair is one extra decrement per
+ * second, which is the reported ~2x countdown.
+ *
+ * Measured against the old wiring (same fake timers as below): after one
+ * hide/show cycle in which the effect had re-run while hidden, 10 s of ticks
+ * produced 20 decrements. `createQuotaAutoRefresh` clears before it starts, so
+ * the same sequence produces 10.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  COUNTDOWN_INTERVAL_MS,
+  REFRESH_INTERVAL_MS,
+  createQuotaAutoRefresh,
+} from "@/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+/** Minimal stand-in for `document` — only `hidden` and the two listener calls. */
+function fakeDocument() {
+  const listeners = new Map();
+  return {
+    hidden: false,
+    addEventListener(type, fn) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(fn);
+    },
+    removeEventListener(type, fn) {
+      listeners.get(type)?.delete(fn);
+    },
+    listenerCount(type) {
+      return listeners.get(type)?.size ?? 0;
+    },
+    /** Flip `hidden` and deliver the event the browser would deliver. */
+    setHidden(hidden) {
+      this.hidden = hidden;
+      for (const fn of listeners.get("visibilitychange") ?? []) fn();
+    },
+    /** A visibilitychange that does not change `hidden` (browser split view). */
+    dispatchVisibilityChange() {
+      for (const fn of listeners.get("visibilitychange") ?? []) fn();
+    },
+  };
+}
+
+function setup(overrides = {}) {
+  const doc = fakeDocument();
+  const ticks = { count: 0 };
+  const refreshes = { count: 0 };
+  const timers = createQuotaAutoRefresh({
+    onRefresh: () => (refreshes.count += 1),
+    onTick: () => (ticks.count += 1),
+    doc,
+    ...overrides,
+  });
+  return { doc, ticks, refreshes, timers };
+}
+
+const seconds = (n) => vi.advanceTimersByTime(n * COUNTDOWN_INTERVAL_MS);
+
+describe("quota tracker auto-refresh timers (#3470)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("ticks once per second and refreshes on the refresh interval", () => {
+    const { timers, ticks, refreshes } = setup();
+    timers.start();
+
+    seconds(10);
+    expect(ticks.count).toBe(10);
+    expect(refreshes.count).toBe(0);
+
+    vi.advanceTimersByTime(REFRESH_INTERVAL_MS);
+    expect(refreshes.count).toBe(1);
+
+    timers.stop();
+  });
+
+  it("keeps one tick per second across a hide/show cycle", () => {
+    const { doc, timers, ticks } = setup();
+    timers.start();
+
+    seconds(3);
+    doc.setHidden(true);
+    seconds(30); // hidden: the tracker must not poll or count down
+    expect(ticks.count).toBe(3);
+
+    doc.setHidden(false);
+    seconds(10);
+    expect(ticks.count).toBe(13);
+
+    timers.stop();
+  });
+
+  it("does not stack a second countdown when 'visible' is reported twice", () => {
+    const { doc, timers, ticks } = setup();
+    timers.start();
+
+    // Some browsers deliver visibilitychange without `hidden` having flipped —
+    // reported from split view. Resuming twice must not double the rate.
+    doc.dispatchVisibilityChange();
+    doc.dispatchVisibilityChange();
+
+    seconds(10);
+    expect(ticks.count).toBe(10);
+
+    timers.stop();
+  });
+
+  it("does not stack when start() is called on an already-running tracker", () => {
+    const { timers, ticks } = setup();
+    timers.start();
+    timers.start();
+
+    seconds(10);
+    expect(ticks.count).toBe(10);
+
+    timers.stop();
+  });
+
+  it("starts paused when the tab is already hidden", () => {
+    const { doc, timers, ticks } = setup();
+    doc.hidden = true;
+    timers.start();
+
+    seconds(10);
+    expect(ticks.count).toBe(0);
+    expect(timers.isRunning()).toBe(false);
+
+    doc.setHidden(false);
+    seconds(5);
+    expect(ticks.count).toBe(5);
+
+    timers.stop();
+  });
+
+  it("stop() clears the timers and unsubscribes", () => {
+    const { doc, timers, ticks } = setup();
+    timers.start();
+    expect(doc.listenerCount("visibilitychange")).toBe(1);
+
+    timers.stop();
+    expect(timers.isRunning()).toBe(false);
+
+    seconds(10);
+    doc.setHidden(false); // a stray event after unmount must not restart anything
+    seconds(10);
+    expect(ticks.count).toBe(0);
+    expect(doc.listenerCount("visibilitychange")).toBe(0);
+  });
+
+  it("subscribes once even if start() is repeated", () => {
+    const { doc, timers } = setup();
+    timers.start();
+    timers.start();
+    expect(doc.listenerCount("visibilitychange")).toBe(1);
+
+    timers.stop();
+    expect(doc.listenerCount("visibilitychange")).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #3470.

## Root cause

The tracker created its two intervals in **two** places:

- the auto-refresh effect, and
- the `visibilitychange` handler's resume branch, which assigned
  `intervalRef` / `countdownRef` **without clearing them first**.

So any pair that was already running got orphaned — unreachable, never cleared,
and still calling `setCountdown`. One extra pair is one extra decrement per
second, which is the reported ~2x countdown.

Two sequences reach that state, and the report describes both:

1. The effect re-runs while the tab is hidden (`refreshAll` changes identity),
   plants a pair, and the later "visible" event overwrites the refs.
2. A `visibilitychange` that reports `hidden === false` while timers are already
   running — what browser split view (Vivaldi/Brave) delivers.

## Measured on `master`

Replaying the old wiring under fake timers, after one hide/show cycle:

```
ticks while hidden: 5     (the pause is ineffective once the effect re-runs)
ticks in 10s after resume: 20     (expected 10)
```

## Fix

`createQuotaAutoRefresh` (in the same folder's `utils.js`) now owns both
intervals **and** the visibility subscription, and the component keeps a single
effect. Starting always clears what it replaces, so no resume path can stack a
second pair. It also starts paused when the tab is already hidden, which is what
the "pause auto-refresh when hidden" comment intended.

Net effect on the component: 57 lines of duplicated interval bookkeeping
replaced by 12.

## Tests

`tests/unit/quota-auto-refresh-3470.test.js` (new, 7 cases) drives the helper
with `vi.useFakeTimers()` and a fake `document`, covering: 1 tick/s, refresh on
the 60 s interval, a hide/show cycle, a duplicate "visible" event, a repeated
`start()`, creation while hidden, and `stop()` unsubscribing so a stray event
after unmount cannot restart anything.

Mutation check — dropping only the `clearTimers()` at the top of `startTimers`
fails exactly the two stacking cases:

```
× does not stack a second countdown when 'visible' is reported twice
× does not stack when start() is called on an already-running tracker
```

Suite comparison (`cd tests && npx vitest run unit/`), same machine:

```
master      86 failed | 1439 passed | 24 skipped
this branch 86 failed | 1446 passed | 24 skipped   (+7 = the new file)
```

`npx eslint` on both changed files reports no new problems (the one
`exhaustive-deps` warning in `ProviderLimits/index.js` is pre-existing and
untouched).
