### PR TITLE
fix(providers): add a Base URL field for self-hosted TTS/STT connections

### DIFF
--- a/open-sse/providers/registry/selfhosted-stt.js
+++ b/open-sse/providers/registry/selfhosted-stt.js
@@ -30,13 +30,21 @@ export default {
   category: "apikey",
   auth: {
     apiKey: {
-      text: "Set providerSpecificData.baseUrl to the full transcriptions URL, e.g. http://host:8080/v1/audio/transcriptions. The API key is not checked by local servers; any value works.",
+      text: "Set Base URL to the full transcriptions URL, e.g. http://host:8080/v1/audio/transcriptions. The API key is not checked by local servers; any value works.",
     },
   },
   models: [
     { id: "whisper-1", name: "Whisper (self-hosted)", params: ["language", "response_format", "temperature", "prompt"], kind: "stt" },
   ],
   serviceKinds: ["stt"],
+  // Declaring this is what puts a Base URL field on the Add/Edit connection
+  // forms; the dashboard stores it as providerSpecificData.baseUrl, which is
+  // what sttCore reads as the endpoint override.
+  connectionBaseUrl: {
+    label: "Base URL",
+    placeholder: "http://stt-host:8080/v1/audio/transcriptions",
+    hint: "Full transcriptions URL. Leave empty to use http://localhost:8080/v1/audio/transcriptions.",
+  },
   sttConfig: {
     // Overridden per connection by providerSpecificData.baseUrl; this default
     // only makes the provider usable out of the box on a same-host deployment.

--- a/open-sse/providers/registry/selfhosted-tts.js
+++ b/open-sse/providers/registry/selfhosted-tts.js
@@ -24,7 +24,7 @@ export default {
   category: "apikey",
   auth: {
     apiKey: {
-      text: "Set providerSpecificData.baseUrl to the server root, e.g. http://host:8080 — /v1/audio/speech is appended. The API key is not checked by local servers; any value works.",
+      text: "Set Base URL to the server root, e.g. http://host:8880 — /v1/audio/speech is appended. The API key is not checked by local servers; any value works.",
     },
   },
   // Voice is selected as "<model>/<voice>", the same convention the OpenAI TTS
@@ -33,6 +33,15 @@ export default {
     { id: "kokoro", name: "Kokoro (self-hosted)", params: ["voice", "response_format", "speed"], kind: "tts" },
   ],
   serviceKinds: ["tts"],
+  // Declaring this is what puts a Base URL field on the Add/Edit connection
+  // forms; the dashboard stores it as providerSpecificData.baseUrl, which is
+  // what `synthesize` reads. Without it the only way to reach a server on
+  // another host was to edit the stored connection by hand.
+  connectionBaseUrl: {
+    label: "Base URL",
+    placeholder: "http://tts-host:8880",
+    hint: "Server root — /v1/audio/speech is appended. Leave empty to use http://localhost:8880.",
+  },
   ttsConfig: {
     // Overridden per connection by providerSpecificData.baseUrl; this default
     // only makes the provider usable on a same-host deployment.

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { Button, Badge, Input, Modal, Select } from "@/shared/components";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { planBulkAdd } from "@/shared/utils/bulkAdd";
+import { withConnectionBaseUrl } from "@/shared/utils/connectionBaseUrl";
 
 const BULK_PLACEHOLDER = `name1|sk-key1\nname2|sk-key2\nsk-key-only-auto-named`;
 
@@ -18,6 +19,10 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     ? (provider === "grok-web" ? "sso=xxxxx... or just the raw value" : "eyJhbGciOi...")
     : (isXaiApiKey ? "xai-..." : provider === "qoder" ? "pt-..." : "");
 
+  // Providers that serve a user-chosen endpoint (self-hosted TTS/STT) declare
+  // this in the registry; the value is stored as providerSpecificData.baseUrl.
+  const connectionBaseUrl = AI_PROVIDERS?.[provider]?.connectionBaseUrl || null;
+
   const isAzure = provider === "azure";
   const isCloudflareAi = provider === "cloudflare-ai";
   const providerRegions = AI_PROVIDERS?.[provider]?.regions || null;
@@ -30,6 +35,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     priority: 1,
     proxyPoolId: NONE_PROXY_POOL_VALUE,
     ollamaHostUrl: "",
+    baseUrl: "",
   });
   const [azureData, setAzureData] = useState({
     azureEndpoint: "",
@@ -69,6 +75,9 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     }
     if (providerRegions && region) {
       return { region };
+    }
+    if (connectionBaseUrl) {
+      return withConnectionBaseUrl(undefined, formData.baseUrl);
     }
     return undefined;
   };
@@ -233,6 +242,15 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           placeholder={isOllamaLocal ? "Ollama Local" : "Production Key"}
         />
+        {connectionBaseUrl && (
+          <Input
+            label={connectionBaseUrl.label || "Base URL"}
+            value={formData.baseUrl}
+            onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
+            placeholder={connectionBaseUrl.placeholder || ""}
+            hint={connectionBaseUrl.hint}
+          />
+        )}
         {isOllamaLocal && (
           <div className="flex gap-2">
             <Input

--- a/src/shared/components/EditConnectionModal.js
+++ b/src/shared/components/EditConnectionModal.js
@@ -8,6 +8,7 @@ import Button from "@/shared/components/Button";
 import Badge from "@/shared/components/Badge";
 import { isOpenAICompatibleProvider, isAnthropicCompatibleProvider, AI_PROVIDERS } from "@/shared/constants/providers";
 import Select from "@/shared/components/Select";
+import { withConnectionBaseUrl } from "@/shared/utils/connectionBaseUrl";
 
 export default function EditConnectionModal({ isOpen, connection, proxyPools, onSave, onClose }) {
   const [formData, setFormData] = useState({
@@ -22,6 +23,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
     organization: "",
   });
   const [cloudflareData, setCloudflareData] = useState({ accountId: "" });
+  const [baseUrl, setBaseUrl] = useState("");
   const [region, setRegion] = useState("");
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
@@ -48,6 +50,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       if (connection.provider === "cloudflare-ai" && connection.providerSpecificData) {
         setCloudflareData({ accountId: connection.providerSpecificData.accountId || "" });
       }
+      setBaseUrl(connection.providerSpecificData?.baseUrl || "");
       // Load region for providers that support it (e.g. xiaomi-tokenplan)
       const providerCfg = AI_PROVIDERS?.[connection.provider];
       if (providerCfg?.regions) {
@@ -66,6 +69,7 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
     ? (isOpenAICompatibleProvider(connection.provider) || isAnthropicCompatibleProvider(connection.provider))
     : false;
   const providerRegions = connection ? (AI_PROVIDERS?.[connection.provider]?.regions || null) : null;
+  const connectionBaseUrl = connection ? (AI_PROVIDERS?.[connection.provider]?.connectionBaseUrl || null) : null;
 
   // Build providerSpecificData for region-aware providers
   const buildRegionSpecificData = () => {
@@ -171,6 +175,14 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
       if (providerRegions && region) {
         updates.providerSpecificData = buildRegionSpecificData();
       }
+      // Endpoint override for providers that serve a user-chosen host. Merged
+      // into whatever is already stored, so proxy/region settings survive.
+      if (connectionBaseUrl) {
+        updates.providerSpecificData = withConnectionBaseUrl(
+          updates.providerSpecificData || connection.providerSpecificData,
+          baseUrl,
+        );
+      }
       
       await onSave(updates);
     } finally {
@@ -201,6 +213,15 @@ export default function EditConnectionModal({ isOpen, connection, proxyPools, on
           value={formData.priority}
           onChange={(e) => setFormData({ ...formData, priority: Number.parseInt(e.target.value, 10) || 1 })}
         />
+        {connectionBaseUrl && (
+          <Input
+            label={connectionBaseUrl.label || "Base URL"}
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            placeholder={connectionBaseUrl.placeholder || ""}
+            hint={connectionBaseUrl.hint}
+          />
+        )}
 
         {!isOAuth && (
           <>

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -29,6 +29,7 @@ function buildProviderEntry(r) {
     ...(r.thinkingConfig ? { thinkingConfig: r.thinkingConfig } : {}),
     ...(r.regions ? { regions: r.regions, defaultRegion: r.defaultRegion } : {}),
     ...(r.hasProviderSpecificData ? { hasProviderSpecificData: true } : {}),
+    ...(r.connectionBaseUrl ? { connectionBaseUrl: r.connectionBaseUrl } : {}),
     ...(r.noAuth ? { noAuth: true } : {}),
     ...(r.passthroughModels ? { passthroughModels: true } : {}),
     ...(r.hasOAuth ? { hasOAuth: true } : {}),

--- a/src/shared/utils/connectionBaseUrl.js
+++ b/src/shared/utils/connectionBaseUrl.js
@@ -1,0 +1,23 @@
+/**
+ * Base URL handling for connections whose provider declares `connectionBaseUrl`
+ * in the registry (self-hosted TTS / STT today).
+ *
+ * The value is stored as `providerSpecificData.baseUrl`, which is the key the
+ * runtime reads (`sttCore`'s endpoint override, `selfhostedTts.synthesize`).
+ * The rest of `providerSpecificData` belongs to other parts of the form — proxy
+ * settings, region — so it is merged through rather than replaced, and clearing
+ * the field removes only `baseUrl` so the provider falls back to its default.
+ *
+ * @param {object|null|undefined} providerSpecificData  the connection's current value
+ * @param {string} baseUrl                              the field's raw value
+ * @returns {object|undefined}                          undefined when nothing is left to store
+ */
+export function withConnectionBaseUrl(providerSpecificData, baseUrl) {
+  const merged = { ...(providerSpecificData || {}) };
+  const trimmed = typeof baseUrl === "string" ? baseUrl.trim() : "";
+
+  if (trimmed) merged.baseUrl = trimmed;
+  else delete merged.baseUrl;
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}

--- a/tests/unit/selfhosted-media-base-url-3467.test.js
+++ b/tests/unit/selfhosted-media-base-url-3467.test.js
@@ -1,0 +1,115 @@
+/**
+ * #3467 — self-hosted TTS/STT connections could not be pointed at another host.
+ *
+ * Both providers read their endpoint from `providerSpecificData.baseUrl`, and
+ * both registry entries told the operator to "set providerSpecificData.baseUrl"
+ * — but neither the Add nor the Edit connection form had a field for it, so a
+ * connection created through the dashboard silently used the localhost default.
+ * In Docker that address is the 9router container itself.
+ *
+ * The field is now registry-driven: a provider declares `connectionBaseUrl`,
+ * `AI_PROVIDERS` carries it to the dashboard, and the form stores the value
+ * under the key the runtime already reads. These tests pin each link of that
+ * chain plus the merge helper the forms use.
+ */
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import selfhostedTtsRegistry from "open-sse/providers/registry/selfhosted-tts.js";
+import selfhostedSttRegistry from "open-sse/providers/registry/selfhosted-stt.js";
+import selfhostedTts from "open-sse/handlers/ttsProviders/selfhostedTts.js";
+import { AI_PROVIDERS } from "@/shared/constants/providers";
+import { withConnectionBaseUrl } from "@/shared/utils/connectionBaseUrl";
+
+describe("connectionBaseUrl registry declaration (#3467)", () => {
+  for (const [id, entry] of [
+    ["selfhosted-tts", selfhostedTtsRegistry],
+    ["selfhosted-stt", selfhostedSttRegistry],
+  ]) {
+    it(`${id} declares a Base URL field with a placeholder`, () => {
+      expect(entry.connectionBaseUrl).toBeTruthy();
+      expect(entry.connectionBaseUrl.label).toBe("Base URL");
+      expect(entry.connectionBaseUrl.placeholder).toMatch(/^https?:\/\//);
+    });
+
+    it(`${id} reaches the dashboard through AI_PROVIDERS`, () => {
+      // The UI map is built from the registry with a field whitelist — a
+      // declaration that is not whitelisted never renders.
+      expect(AI_PROVIDERS[id]?.connectionBaseUrl).toEqual(entry.connectionBaseUrl);
+    });
+
+    it(`${id} keeps its localhost default for existing connections`, () => {
+      const cfg = entry.ttsConfig || entry.sttConfig;
+      expect(cfg.baseUrl).toMatch(/^http:\/\/localhost:\d+/);
+    });
+  }
+
+  it("does not add the field to providers that did not ask for it", () => {
+    expect(AI_PROVIDERS.openai?.connectionBaseUrl).toBeUndefined();
+    expect(AI_PROVIDERS["ollama-local"]?.connectionBaseUrl).toBeUndefined();
+  });
+});
+
+describe("withConnectionBaseUrl", () => {
+  it("stores a trimmed baseUrl", () => {
+    expect(withConnectionBaseUrl(undefined, "  http://tts:8880 ")).toEqual({
+      baseUrl: "http://tts:8880",
+    });
+  });
+
+  it("keeps the keys the form does not own", () => {
+    const existing = { connectionProxyEnabled: true, connectionProxyUrl: "http://proxy:3128" };
+    expect(withConnectionBaseUrl(existing, "http://tts:8880")).toEqual({
+      connectionProxyEnabled: true,
+      connectionProxyUrl: "http://proxy:3128",
+      baseUrl: "http://tts:8880",
+    });
+  });
+
+  it("clearing the field removes only baseUrl, so the provider default applies", () => {
+    const existing = { baseUrl: "http://old:8880", connectionProxyEnabled: false };
+    expect(withConnectionBaseUrl(existing, "   ")).toEqual({ connectionProxyEnabled: false });
+  });
+
+  it("returns undefined when nothing is left to store", () => {
+    expect(withConnectionBaseUrl(undefined, "")).toBeUndefined();
+    expect(withConnectionBaseUrl({ baseUrl: "http://old:8880" }, "")).toBeUndefined();
+  });
+
+  it("does not mutate the connection's stored object", () => {
+    const existing = { baseUrl: "http://old:8880" };
+    withConnectionBaseUrl(existing, "http://new:8880");
+    expect(existing).toEqual({ baseUrl: "http://old:8880" });
+  });
+});
+
+describe("the stored key is the one the runtime reads", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("self-hosted TTS posts to the connection's baseUrl", async () => {
+    const calls = [];
+    vi.stubGlobal("fetch", async (url) => {
+      calls.push(url);
+      return { ok: true, arrayBuffer: async () => new ArrayBuffer(4) };
+    });
+
+    const providerSpecificData = withConnectionBaseUrl(undefined, "http://tts-host:8880");
+    await selfhostedTts.synthesize("hello", "kokoro", { apiKey: "local", providerSpecificData });
+
+    expect(calls).toEqual(["http://tts-host:8880/v1/audio/speech"]);
+  });
+
+  it("falls back to the localhost default when the field is empty", async () => {
+    const calls = [];
+    vi.stubGlobal("fetch", async (url) => {
+      calls.push(url);
+      return { ok: true, arrayBuffer: async () => new ArrayBuffer(4) };
+    });
+
+    await selfhostedTts.synthesize("hello", "kokoro", {
+      apiKey: "local",
+      providerSpecificData: withConnectionBaseUrl(undefined, ""),
+    });
+
+    expect(calls).toEqual(["http://localhost:8880/v1/audio/speech"]);
+  });
+});


### PR DESCRIPTION
Fixes #3467.

## Problem

`selfhosted-tts` and `selfhosted-stt` both resolve their endpoint from the
connection:

- `open-sse/handlers/sttCore.js` — `credentials?.providerSpecificData?.baseUrl`
- `open-sse/handlers/ttsProviders/selfhostedTts.js` — same key, then `credentials.baseUrl`

and both registry entries' auth hints told the operator to *"set
providerSpecificData.baseUrl"*. There was no field for it in either the Add API
Key modal or the Edit Connection modal, so a connection created through the
dashboard was saved without the key and silently used the localhost default
(`:8880` / `:8080`). In Docker that address is the 9router container itself,
which is the deployment these two providers exist for.

## Change

Registry-driven rather than another hardcoded provider id:

- an entry declares `connectionBaseUrl: { label, placeholder, hint }`;
- `buildProviderEntry` (`src/shared/constants/providers.js`) whitelists it, which
  is what carries it to the dashboard;
- both modals render the field when the provider declares it and store the value
  under the key the runtime already reads.

`withConnectionBaseUrl` (new, `src/shared/utils/connectionBaseUrl.js`) merges into
whatever the connection already holds, so `connectionProxyEnabled` / `region` etc.
survive an edit — the Azure and Cloudflare branches next to it replace the whole
object, which is why the merge is explicit here. Clearing the field removes only
`baseUrl`, so the provider falls back to its default.

The two auth hints now say "Set Base URL to…" instead of naming the internal key.

## Scope

- No default endpoint changes, and no provider that does not declare the field is
  affected (pinned by a test).
- `ollama-local` keeps its existing bespoke "Ollama Host URL" field with the
  Check button; migrating it is a separate change and not needed for this bug.

## Tests

`tests/unit/selfhosted-media-base-url-3467.test.js` (new, 14 cases):

- each registry entry declares the field, and it survives the `AI_PROVIDERS`
  whitelist — the link that silently drops a declaration if forgotten;
- `openai` / `ollama-local` do not gain the field;
- `withConnectionBaseUrl` trims, merges, clears only `baseUrl`, returns
  `undefined` when nothing is left, and does not mutate the stored object;
- with `fetch` stubbed, `selfhostedTts.synthesize` posts to
  `http://tts-host:8880/v1/audio/speech` for a connection saved through the
  helper, and to the localhost default when the field is left empty — i.e. the
  key the form writes is the key the runtime reads.

Mutation check — dropping only the whitelist line in `providers.js` fails exactly:

```
× selfhosted-tts reaches the dashboard through AI_PROVIDERS
× selfhosted-stt reaches the dashboard through AI_PROVIDERS
```

Suite comparison (`cd tests && npx vitest run unit/`), same machine:

```
master      86 failed | 1439 passed | 24 skipped
this branch 86 failed | 1453 passed | 24 skipped   (+14 = the new file)
```

`node __baseline__/verify-providers.mjs` → `✅ PROVIDERS byte-for-byte equal (81 providers)`;
`verify-alias.mjs` → `✅ 117 tokens`. `npx eslint` reports no new problems on the
changed files (`EditConnectionModal.js` has a pre-existing `set-state-in-effect`
error, unchanged).
