### PR TITLE
fix(usage): make the observability env vars actually reach the enable check

### DIFF
--- a/src/lib/db/repos/requestDetailsRepo.js
+++ b/src/lib/db/repos/requestDetailsRepo.js
@@ -10,32 +10,52 @@ const CONFIG_CACHE_TTL_MS = 5000;
 let cachedConfig = null;
 let cachedConfigTs = 0;
 
+/**
+ * Read an env flag that is only a signal when the operator actually set it.
+ * An unset or empty value returns null so the next source in the precedence
+ * chain decides, instead of being read as `false`.
+ */
+function explicitEnvFlag(env, name) {
+  const raw = env[name];
+  if (raw === undefined || raw.trim() === "") return null;
+  return raw.trim().toLowerCase() === "true";
+}
+
+/**
+ * Resolve whether request details are recorded, in precedence order:
+ *
+ *   1. OBSERVABILITY_ENABLED — the variable named after this feature, and the one
+ *      `.env.example` ships as `true`. It used to be unreachable: `getSettings()`
+ *      merges defaults, so `settings.enableObservability` is ALWAYS a boolean and
+ *      the `typeof … === "boolean"` guard below it never yielded to the env value.
+ *   2. ENABLE_REQUEST_LOGS — the older override, kept so existing deployments that
+ *      force it on keep working. It only decides when the variable above is unset;
+ *      it is documented for the `logs/` files, and `.env.example` ships it as
+ *      `false`, so letting it hard-disable the dashboard toggle meant a stock
+ *      `.env` silently defeated both documented ways of turning details on.
+ *   3. The dashboard toggle (`enableObservability`), which stays the default-off
+ *      answer when neither variable is set.
+ *
+ * @param {object} settings  merged settings row
+ * @param {object} env       process.env, injectable for tests
+ */
+export function resolveObservabilityEnabled(settings, env = process.env) {
+  const fromFeatureFlag = explicitEnvFlag(env, "OBSERVABILITY_ENABLED");
+  if (fromFeatureFlag !== null) return fromFeatureFlag;
+
+  const fromRequestLogs = explicitEnvFlag(env, "ENABLE_REQUEST_LOGS");
+  if (fromRequestLogs !== null) return fromRequestLogs;
+
+  return settings?.enableObservability === true;
+}
+
 async function getObservabilityConfig() {
   if (cachedConfig && (Date.now() - cachedConfigTs) < CONFIG_CACHE_TTL_MS) return cachedConfig;
   try {
     const { getSettings } = await import("./settingsRepo.js");
     const settings = await getSettings();
-    const envRequestLogs = process.env.ENABLE_REQUEST_LOGS;
-    if (envRequestLogs !== undefined) {
-      const enabled = envRequestLogs.toLowerCase() === "true";
-      cachedConfig = {
-        enabled,
-        maxRecords: settings.observabilityMaxRecords || parseInt(process.env.OBSERVABILITY_MAX_RECORDS || String(DEFAULT_MAX_RECORDS), 10),
-        batchSize: settings.observabilityBatchSize || parseInt(process.env.OBSERVABILITY_BATCH_SIZE || String(DEFAULT_BATCH_SIZE), 10),
-        flushIntervalMs: settings.observabilityFlushIntervalMs || parseInt(process.env.OBSERVABILITY_FLUSH_INTERVAL_MS || String(DEFAULT_FLUSH_INTERVAL_MS), 10),
-        maxJsonSize: (settings.observabilityMaxJsonSize || parseInt(process.env.OBSERVABILITY_MAX_JSON_SIZE || "5", 10)) * 1024,
-      };
-      cachedConfigTs = Date.now();
-      return cachedConfig;
-    }
-    const envFallback = process.env.OBSERVABILITY_ENABLED !== "false";
-    const uiFlag = typeof settings.enableObservability === "boolean";
-    const enabled = uiFlag
-      ? settings.enableObservability
-      : envFallback;
-
     cachedConfig = {
-      enabled,
+      enabled: resolveObservabilityEnabled(settings),
       maxRecords: settings.observabilityMaxRecords || parseInt(process.env.OBSERVABILITY_MAX_RECORDS || String(DEFAULT_MAX_RECORDS), 10),
       batchSize: settings.observabilityBatchSize || parseInt(process.env.OBSERVABILITY_BATCH_SIZE || String(DEFAULT_BATCH_SIZE), 10),
       flushIntervalMs: settings.observabilityFlushIntervalMs || parseInt(process.env.OBSERVABILITY_FLUSH_INTERVAL_MS || String(DEFAULT_FLUSH_INTERVAL_MS), 10),

--- a/tests/unit/observability-enabled-3427.test.js
+++ b/tests/unit/observability-enabled-3427.test.js
@@ -1,0 +1,74 @@
+/**
+ * #3427 — request details never reached the `requestDetails` table.
+ *
+ * `saveRequestDetail` returns early unless observability is enabled, and the
+ * enable check could not be satisfied the way the shipped `.env.example`
+ * documents:
+ *
+ *   ENABLE_REQUEST_LOGS=false      <- .env.example line 16
+ *   OBSERVABILITY_ENABLED=true     <- .env.example line 17
+ *
+ * `ENABLE_REQUEST_LOGS` was consulted first and `false` short-circuited the whole
+ * resolution, so `OBSERVABILITY_ENABLED` and the dashboard toggle were both
+ * ignored. And `OBSERVABILITY_ENABLED` could never apply on its own either:
+ * `getSettings()` merges defaults, so `settings.enableObservability` is always a
+ * boolean and the guard in front of the env fallback was always taken.
+ *
+ * Precedence is now OBSERVABILITY_ENABLED → ENABLE_REQUEST_LOGS → the toggle,
+ * with an unset variable meaning "no opinion" instead of "off".
+ */
+import { describe, expect, it } from "vitest";
+import { resolveObservabilityEnabled } from "@/lib/db/repos/requestDetailsRepo.js";
+
+const OFF = { enableObservability: false };
+const ON = { enableObservability: true };
+
+describe("observability enable resolution (#3427)", () => {
+  it("stays off by default, with no env vars and an untouched toggle", () => {
+    expect(resolveObservabilityEnabled(OFF, {})).toBe(false);
+  });
+
+  it("honours the dashboard toggle when no env var is set", () => {
+    expect(resolveObservabilityEnabled(ON, {})).toBe(true);
+  });
+
+  it("honours the shipped .env.example combination", () => {
+    // The exact pair `.env.example` ships. Previously resolved to false.
+    const env = { ENABLE_REQUEST_LOGS: "false", OBSERVABILITY_ENABLED: "true" };
+    expect(resolveObservabilityEnabled(OFF, env)).toBe(true);
+  });
+
+  it("lets OBSERVABILITY_ENABLED turn details on without touching the toggle", () => {
+    expect(resolveObservabilityEnabled(OFF, { OBSERVABILITY_ENABLED: "true" })).toBe(true);
+  });
+
+  it("lets OBSERVABILITY_ENABLED turn details off over an enabled toggle", () => {
+    expect(resolveObservabilityEnabled(ON, { OBSERVABILITY_ENABLED: "false" })).toBe(false);
+  });
+
+  it("keeps ENABLE_REQUEST_LOGS=true as an override, as before", () => {
+    expect(resolveObservabilityEnabled(OFF, { ENABLE_REQUEST_LOGS: "true" })).toBe(true);
+  });
+
+  it("keeps ENABLE_REQUEST_LOGS=false disabling details when it is the only signal", () => {
+    expect(resolveObservabilityEnabled(ON, { ENABLE_REQUEST_LOGS: "false" })).toBe(false);
+  });
+
+  it("treats an empty or whitespace value as unset", () => {
+    expect(resolveObservabilityEnabled(ON, { OBSERVABILITY_ENABLED: "" })).toBe(true);
+    expect(resolveObservabilityEnabled(ON, { OBSERVABILITY_ENABLED: "   " })).toBe(true);
+    expect(resolveObservabilityEnabled(OFF, { ENABLE_REQUEST_LOGS: "" })).toBe(false);
+  });
+
+  it("accepts the documented casing variants", () => {
+    expect(resolveObservabilityEnabled(OFF, { OBSERVABILITY_ENABLED: "TRUE" })).toBe(true);
+    expect(resolveObservabilityEnabled(OFF, { OBSERVABILITY_ENABLED: " true " })).toBe(true);
+    // Anything that is not "true" stays off, matching the previous parser.
+    expect(resolveObservabilityEnabled(ON, { OBSERVABILITY_ENABLED: "1" })).toBe(false);
+  });
+
+  it("does not read a missing settings row as enabled", () => {
+    expect(resolveObservabilityEnabled(undefined, {})).toBe(false);
+    expect(resolveObservabilityEnabled({}, {})).toBe(false);
+  });
+});

--- a/tests/unit/request-details-tab.test.js
+++ b/tests/unit/request-details-tab.test.js
@@ -22,7 +22,7 @@ beforeAll(async () => {
   vi.resetModules();
   db = await import("@/lib/db/index.js");
   await db.initDb();
-  await db.updateSettings({ enableObservability2: true, observabilityBatchSize: 1 });
+  await db.updateSettings({ enableObservability: true, observabilityBatchSize: 1 });
 
   const { getAdapter } = await import("@/lib/db/driver.js");
   adapter = await getAdapter();


### PR DESCRIPTION
Fixes #3427.

## Root cause

`saveRequestDetail` returns early unless observability is enabled, so the report's
symptom — `usageHistory` filling while `requestDetails` stays at 0 rows — is the
enable check, not the insert. Neither documented way of enabling it worked.

`getSettings()` returns `mergeWithDefaults(raw)`, and `enableObservability: false`
is one of those defaults. So in

```js
const uiFlag = typeof settings.enableObservability === "boolean";
const enabled = uiFlag ? settings.enableObservability : envFallback;
```

`uiFlag` is **always** true and `envFallback` is unreachable — although
`.env.example` line 17 ships `OBSERVABILITY_ENABLED=true` as the way to turn this
on. Line 16 of the same file ships `ENABLE_REQUEST_LOGS=false`, which was
consulted first and short-circuited the whole resolution, so a stock `.env` also
made the dashboard toggle inert.

Measured against the previous resolution (`node -e`, old function verbatim):

```
false  .env.example pair (LOGS=false, OBS=true), toggle off
false  OBSERVABILITY_ENABLED=true alone, toggle off
false  LOGS=false + dashboard toggle ON
true   nothing set, toggle ON
```

## Change

`resolveObservabilityEnabled(settings, env)` — exported so it is testable without
touching the DB — resolves in explicit precedence:

1. `OBSERVABILITY_ENABLED` — the variable named after the feature, and the one
   `.env.example` ships.
2. `ENABLE_REQUEST_LOGS` — the older override, kept so deployments that force it
   on are unaffected. It now decides only when the variable above is unset.
3. The dashboard toggle, which remains the default-off answer.

An unset **or empty** variable means "no opinion" rather than "off", which is what
made a stock `.env` defeat both documented paths. With nothing set at all, the
default is unchanged: off.

The one deliberate behaviour change: `ENABLE_REQUEST_LOGS=false` no longer
overrides an enabled dashboard toggle or `OBSERVABILITY_ENABLED=true`. That
variable is documented (README, gitbook, ARCHITECTURE) for the `logs/` files, and
`false` is the value the shipped example carries — so treating it as a hard
disable meant the shipped example could not be followed. If you would rather keep
the old precedence, say so and I will narrow this to the dead `OBSERVABILITY_ENABLED`
branch alone.

## Tests

`tests/unit/observability-enabled-3427.test.js` (new, 10 cases): default-off, the
toggle alone, the exact `.env.example` pair, each variable on its own in both
directions, `ENABLE_REQUEST_LOGS=true` still overriding, empty/whitespace treated
as unset, casing variants, and a missing settings row not reading as enabled.

`tests/unit/request-details-tab.test.js` also carried a typo — it wrote
`enableObservability2`, so it never enabled the feature it was exercising. Two of
its cases were red on master for that reason:

```
master        2 failed | 20 passed   (oversized field …, getDistinctProviders …)
this branch   22 passed
```

(The file still reports a suite-level `EBUSY: resource busy or locked, unlink …
data.sqlite` on Windows teardown — a pre-existing platform artifact of that test's
`afterAll`, unrelated to this change and untouched here.)

`npx eslint` clean on the changed files.
