### PR TITLE
fix(fallback): an expired per-model lock no longer masks an active account lock

### DIFF
--- a/open-sse/services/accountFallback.js
+++ b/open-sse/services/accountFallback.js
@@ -118,10 +118,20 @@ export function getModelLockKey(model) {
  * Reads flat field `modelLock_${model}` (or `modelLock___all` when model=null).
  */
 export function isModelLockActive(connection, model) {
-  const key = getModelLockKey(model);
-  const expiry = connection[key] || connection[MODEL_LOCK_ALL];
-  if (!expiry) return false;
-  return new Date(expiry).getTime() > Date.now();
+  const now = Date.now();
+  const stillLocked = (value) => {
+    if (!value) return false;
+    const until = new Date(value).getTime();
+    return Number.isFinite(until) && until > now;
+  };
+  // Each key is judged on its own expiry. `a || b` picked the per-model key on the
+  // truthiness of the string, so a stale one hid a still-active account-wide lock:
+  // the connection then read as free for exactly the model that had just failed,
+  // while still reading as locked for every other model. Nothing clears the stale
+  // key either -- the lazy cleanup runs only after a successful request, and an
+  // account under an `__all` lock never gets one. Same rule the sibling
+  // `getEarliestModelLockUntil` already applies when it skips expired entries.
+  return stillLocked(connection[getModelLockKey(model)]) || stillLocked(connection[MODEL_LOCK_ALL]);
 }
 
 /**

--- a/tests/unit/model-lock-precedence.test.js
+++ b/tests/unit/model-lock-precedence.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MODEL_LOCK_ALL,
+  getEarliestModelLockUntil,
+  getModelLockKey,
+  isModelLockActive,
+} from "../../open-sse/services/accountFallback.js";
+
+const MODEL = "claude-fable-5";
+const past = () => new Date(Date.now() - 60_000).toISOString();
+const future = () => new Date(Date.now() + 7 * 24 * 3600_000).toISOString();
+
+describe("isModelLockActive precedence", () => {
+  it("does not let an expired per-model lock mask an active account-wide lock", () => {
+    // The shape a GitHub account reaches after a plain 402 (two-minute per-model
+    // lock) followed by monthly exhaustion (account-wide lock until next month).
+    const connection = {
+      [getModelLockKey(MODEL)]: past(),
+      [MODEL_LOCK_ALL]: future(),
+    };
+
+    expect(isModelLockActive(connection, MODEL)).toBe(true);
+    // The asymmetry is what made this visible: the account read as locked for a
+    // model it had no history with, and free for the one that had just failed.
+    expect(isModelLockActive(connection, "some-other-model")).toBe(true);
+    // The UI badge already skipped expired entries, so routing and the dashboard
+    // disagreed about the same connection.
+    expect(getEarliestModelLockUntil(connection)).not.toBeNull();
+  });
+
+  it("keeps an active per-model lock", () => {
+    const connection = { [getModelLockKey(MODEL)]: future() };
+    expect(isModelLockActive(connection, MODEL)).toBe(true);
+    expect(isModelLockActive(connection, "other")).toBe(false);
+  });
+
+  it("releases a connection once both locks have expired", () => {
+    const connection = {
+      [getModelLockKey(MODEL)]: past(),
+      [MODEL_LOCK_ALL]: past(),
+    };
+    expect(isModelLockActive(connection, MODEL)).toBe(false);
+    expect(isModelLockActive(connection, "other")).toBe(false);
+  });
+
+  it("treats an unparseable timestamp as no lock rather than a permanent one", () => {
+    const connection = { [getModelLockKey(MODEL)]: "not-a-date" };
+    expect(isModelLockActive(connection, MODEL)).toBe(false);
+  });
+
+  it("returns false when the connection carries no lock at all", () => {
+    expect(isModelLockActive({}, MODEL)).toBe(false);
+  });
+});


### PR DESCRIPTION
## The defect

`isModelLockActive` picks the per-model key on the **truthiness of the string**, not on whether it is still in the future (`open-sse/services/accountFallback.js:120-125`):

```js
export function isModelLockActive(connection, model) {
  const key = getModelLockKey(model);
  const expiry = connection[key] || connection[MODEL_LOCK_ALL];
  if (!expiry) return false;
  return new Date(expiry).getTime() > Date.now();
}
```

So a stale `modelLock_<model>` wins over a still-active `modelLock___all`. Measured on `master` (`699edac3`):

```
modelLock_claude-fable-5 = <1 minute ago>
modelLock___all          = <7 days out>

isModelLockActive(conn, "claude-fable-5")   -> false     <- expected true
isModelLockActive(conn, "some-other-model") -> true
getEarliestModelLockUntil(conn)             -> 2026-08-31T…
```

The asymmetry is the proof: the same connection reads as **locked for a model it has no history with**, and **free for the one that just failed**.

## Why that shape is reachable

The suite already documents both halves. `tests/unit/github-monthly-usage-lock.test.js:64-79` shows a plain GitHub 402 setting `modelLock_claude-fable-5` for two minutes; `:37-57` shows monthly exhaustion setting `modelLock___all` until the next UTC month. Two minutes later the first has expired and the second has not.

The stale key is never cleared, either: `src/sse/services/auth.js:279-290` lazy-cleans only after a **successful** request, and an account under an `__all` lock never gets one.

**Symptom:** after premium-request exhaustion, the router keeps selecting the dead account for exactly the models the user was already using — `src/sse/services/auth.js:82` gates candidacy on this function — returning 402/429 per request instead of failing over. The dashboard disagrees at the same time, because `getEarliestModelLockUntil` reports the account-wide expiry.

## The fix

Judge each key on its own expiry. That is the rule the sibling `getEarliestModelLockUntil` (`:131-141`) already applies when it skips entries with `if (t <= now) continue`, so this makes the two agree rather than inventing a policy.

An unparseable timestamp is treated as no lock, so a malformed value cannot pin a connection forever.

## Verification

```
tests/unit/model-lock-precedence.test.js    5 passed, 0 failed
```

**Mutation-checked**, after confirming the edit applied: restoring the `a || b` selection fails exactly one case — the expired-per-model-lock one — and the other four stay green.

Note on the test file: I added a new one rather than extending `github-monthly-usage-lock.test.js`, because that file pulls in `src/sse/services/auth.js`, whose `open-sse/...` imports do not resolve under a plain `npx vitest` in this checkout (no `vitest.config` and no test script in `package.json`). The new file imports `accountFallback.js` by relative path and runs standalone, so it works either way.
