### PR TITLE
fix(proxy): never send loopback requests through the outbound proxy

### DIFF
--- a/open-sse/utils/proxyFetch.js
+++ b/open-sse/utils/proxyFetch.js
@@ -149,6 +149,37 @@ function shouldBypassMitmDns(url) {
   } catch { return false; }
 }
 
+/**
+ * Loopback targets are never reachable through an outbound proxy: the proxy would
+ * resolve `localhost` against ITS own machine. A local provider (ollama-local, a
+ * self-hosted TTS/STT, a local relay) therefore fails with a connection error the
+ * moment `HTTP_PROXY` is set in the environment — which is the normal state on a
+ * corporate Windows box. Node's own `fetch` ignores those variables entirely, so
+ * "curl works, node works, 9router does not" is the expected shape of the bug.
+ *
+ * Bypass is limited to loopback. A LAN address (a remote Ollama on 192.168.x)
+ * can legitimately need a proxy, and `NO_PROXY` still covers that case.
+ */
+export function isLoopbackTarget(targetUrl) {
+  let hostname;
+  try { hostname = new URL(targetUrl).hostname.toLowerCase(); } catch { return false; }
+
+  // URL keeps IPv6 literals in brackets.
+  const host = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+
+  // IPv4-mapped loopback. `new URL()` re-serializes `[::ffff:127.0.0.1]` as
+  // `::ffff:7f00:1`, so the dotted form alone would miss the value we actually see.
+  const hexMapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(host);
+  if (hexMapped) return ((parseInt(hexMapped[1], 16) >> 8) & 0xff) === 127;
+
+  const dottedMapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(host);
+  const ipv4 = dottedMapped ? dottedMapped[1] : host;
+  return /^127(?:\.\d{1,3}){3}$/.test(ipv4);
+}
+
 function shouldBypassByNoProxy(targetUrl, noProxyValue) {
   const noProxy = normalizeString(noProxyValue);
   if (!noProxy) return false;
@@ -168,6 +199,8 @@ function shouldBypassByNoProxy(targetUrl, noProxyValue) {
  * Get proxy URL from environment
  */
 function getEnvProxyUrl(targetUrl) {
+  if (isLoopbackTarget(targetUrl)) return null;
+
   const noProxy = process.env.NO_PROXY || process.env.no_proxy;
   if (shouldBypassByNoProxy(targetUrl, noProxy)) return null;
 
@@ -203,6 +236,7 @@ function normalizeProxyUrl(proxyUrl) {
 function resolveConnectionProxyUrl(targetUrl, proxyOptions) {
   const enabled = proxyOptions?.enabled === true || proxyOptions?.connectionProxyEnabled === true;
   if (!enabled) return null;
+  if (isLoopbackTarget(targetUrl)) return null;
 
   const proxyUrlRaw = normalizeString(proxyOptions?.url ?? proxyOptions?.connectionProxyUrl);
   if (!proxyUrlRaw) return null;

--- a/tests/unit/loopback-proxy-bypass-3424.test.js
+++ b/tests/unit/loopback-proxy-bypass-3424.test.js
@@ -1,0 +1,113 @@
+/**
+ * #3424 — `ollama-local` returned 503 "Provider error" while Ollama was reachable.
+ *
+ * `proxyAwareFetch` applied `HTTP_PROXY` / `HTTPS_PROXY` to every target, loopback
+ * included. A proxy resolves `localhost` against its OWN machine, so a request to
+ * a local provider could not succeed once those variables were set — the normal
+ * state on a corporate Windows box. That also explains the reporter's evidence:
+ * `curl` and a bare `fetch()` in Node both worked, because Node's fetch ignores
+ * the proxy environment entirely; only 9router applied it.
+ *
+ * The bypass is deliberately limited to loopback. A remote Ollama on a LAN address
+ * can legitimately need the proxy, and `NO_PROXY` still covers that.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isLoopbackTarget } from "open-sse/utils/proxyFetch.js";
+
+/**
+ * Import a fresh copy of the module with `globalThis.fetch` stubbed, so the
+ * `originalFetch` it captures at load time is the spy. Returns the spy plus the
+ * module, and restores the real fetch on teardown.
+ */
+async function withStubbedFetch(env) {
+  const realFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url: String(url), hasDispatcher: options?.dispatcher !== undefined });
+    return new Response("{}", { status: 200 });
+  };
+  vi.resetModules();
+  const previousEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    previousEnv[key] = process.env[key];
+    process.env[key] = value;
+  }
+  const mod = await import("open-sse/utils/proxyFetch.js");
+  return {
+    calls,
+    proxyAwareFetch: mod.proxyAwareFetch,
+    restore() {
+      globalThis.fetch = realFetch;
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    },
+  };
+}
+
+describe("loopback proxy bypass (#3424)", () => {
+  it("treats the ollama-local default endpoint as loopback", () => {
+    expect(isLoopbackTarget("http://localhost:11434/api/chat")).toBe(true);
+  });
+
+  it.each([
+    "http://127.0.0.1:8080",
+    "http://127.1.2.3/api",
+    "https://localhost/v1/chat/completions",
+    "http://foo.localhost:3000",
+    "http://[::1]:1234",
+    "http://[0:0:0:0:0:0:0:1]",
+  ])("bypasses %s", (url) => {
+    expect(isLoopbackTarget(url)).toBe(true);
+  });
+
+  it("bypasses IPv4-mapped loopback in both spellings", () => {
+    // `new URL()` re-serializes the dotted form as ::ffff:7f00:1, so both must match.
+    expect(isLoopbackTarget("http://[::ffff:127.0.0.1]:80")).toBe(true);
+    expect(isLoopbackTarget("http://[::ffff:7f00:1]")).toBe(true);
+  });
+
+  it.each([
+    "https://api.openai.com/v1/chat/completions",
+    "http://192.168.1.10:11434/api/chat",
+    "http://10.0.0.5:8080",
+    "http://[::ffff:192.168.1.1]",
+    "http://notlocalhost.com",
+    "http://localhost.evil.com",
+    "http://127.0.0.1.evil.com",
+  ])("still proxies %s", (url) => {
+    expect(isLoopbackTarget(url)).toBe(false);
+  });
+
+  it("does not throw on a malformed target", () => {
+    expect(isLoopbackTarget("not a url")).toBe(false);
+    expect(isLoopbackTarget("")).toBe(false);
+  });
+});
+
+describe("proxyAwareFetch honours the bypass (#3424)", () => {
+  let harness = null;
+  afterEach(() => { harness?.restore(); harness = null; });
+
+  it("does not attach a proxy dispatcher for a loopback target when HTTP_PROXY is set", async () => {
+    harness = await withStubbedFetch({ HTTP_PROXY: "http://corp-proxy:3128", NO_PROXY: "" });
+
+    await harness.proxyAwareFetch("http://localhost:11434/api/chat", { method: "POST" });
+
+    expect(harness.calls).toHaveLength(1);
+    expect(harness.calls[0].hasDispatcher).toBe(false);
+  });
+
+  it("ignores a connection-level proxy for a loopback target", async () => {
+    harness = await withStubbedFetch({ NO_PROXY: "" });
+
+    await harness.proxyAwareFetch("http://127.0.0.1:11434/api/chat", {}, {
+      connectionProxyEnabled: true,
+      connectionProxyUrl: "http://corp-proxy:3128",
+    });
+
+    expect(harness.calls).toHaveLength(1);
+    expect(harness.calls[0].hasDispatcher).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3424.

## Root cause

`proxyAwareFetch` resolves a proxy for **every** target — `HTTP_PROXY` /
`HTTPS_PROXY` from the environment, or a connection-level proxy — with no
loopback exemption. `NO_PROXY` is honoured, but nothing sets it by default.

An outbound proxy resolves `localhost` against **its own** machine, so a request
to `http://localhost:11434/api/chat` cannot succeed through one. The executor
sees a connection error, `markAccountUnavailable` writes `testStatus:
"unavailable"` with the generic `"Provider error"`, and the model is locked for
30 s — exactly the reported behaviour, including the re-locking after clearing
locks by hand.

This also explains the reporter's evidence, which otherwise looks contradictory:

| client | proxy env | result |
| :-- | :-- | :-- |
| `curl http://localhost:11434/api/tags` | shell may not carry it | works |
| `fetch()` in plain Node | **ignored** — Node's fetch does not read proxy env | works |
| 9router | applied explicitly by `proxyFetch` | fails |

The connection test passes for the same reason it is a different code path in
their setup, so the dashboard shows a healthy account whose requests all fail.

## Change

`isLoopbackTarget(url)` (exported for tests) short-circuits both proxy
resolvers — the environment one and the connection one.

Covered: `localhost` and `*.localhost`, all of `127.0.0.0/8`, `::1` (and its
expanded form), and IPv4-mapped loopback in **both** spellings — `new URL()`
re-serializes `[::ffff:127.0.0.1]` as `::ffff:7f00:1`, so matching only the
dotted form would miss the value actually seen at runtime.

Deliberately **not** covered: LAN and CGNAT ranges. A remote Ollama at
`192.168.1.10` can legitimately need the proxy, and `NO_PROXY` already handles
that case. Look-alike hosts (`localhost.evil.com`, `127.0.0.1.evil.com`) are
pinned as still-proxied by tests.

## Scope

This is the connectivity half of the report. The issue's suggestion 2 — that
`markAccountUnavailable` collapses a non-string error into the generic
`"Provider error"` and loses the diagnostics — is real and I have it as a separate
change, since it affects every provider rather than just this one. Suggestion 1
(a `/health` probe) does not appear in the current source: `ollama-local`'s
connection test uses `GET {baseUrl}/api/tags`, which is what the reporter measured
as working.

## Tests

`tests/unit/loopback-proxy-bypass-3424.test.js` (new, 18 cases): the predicate
across loopback spellings and non-loopback look-alikes, plus two behavioural
cases that import the module with `globalThis.fetch` stubbed and assert no proxy
dispatcher is attached — one with `HTTP_PROXY` set, one with a connection-level
proxy.

Mutation check — removing both guards fails exactly the two behavioural cases:

```
× does not attach a proxy dispatcher for a loopback target when HTTP_PROXY is set
× ignores a connection-level proxy for a loopback target
```

`npx eslint` clean on both changed files.
