### PR TITLE
fix(auth): keep the real reason instead of the bare "Provider error"

### DIFF
--- a/src/sse/services/auth.js
+++ b/src/sse/services/auth.js
@@ -216,6 +216,50 @@ export async function getProviderCredentials(provider, excludeConnectionIds = nu
  * @param {string|null} model - The specific model that triggered the error
  * @returns {{ shouldFallback: boolean, cooldownMs: number }}
  */
+/**
+ * Human-readable reason for the connection's `lastError`.
+ *
+ * A non-string error used to collapse to the bare string "Provider error", which
+ * is what an operator then sees in the dashboard and in the console line below —
+ * no status, no code, nothing to act on. A failed `fetch` is exactly that case:
+ * Node reports `TypeError: fetch failed` and puts the useful part
+ * (ECONNREFUSED, ENOTFOUND, ETIMEDOUT) on `error.cause.code`.
+ *
+ * Only message-shaped fields and error codes are read. The error object is never
+ * serialized wholesale, so a request body or header that happens to be attached
+ * to it cannot leak into the stored reason.
+ */
+export function describeProviderError(errorText) {
+  const clamp = (value) => String(value).replace(/\s+/g, " ").trim().slice(0, 100);
+
+  if (typeof errorText === "string") return errorText.slice(0, 100);
+  if (!errorText || typeof errorText !== "object") return "Provider error";
+
+  const code = typeof errorText.code === "string" ? errorText.code
+    : typeof errorText.cause?.code === "string" ? errorText.cause.code
+      : null;
+
+  if (errorText instanceof Error) {
+    const message = errorText.message ? clamp(errorText.message) : errorText.name || "Provider error";
+    return code && !message.includes(code) ? clamp(`${message} (${code})`) : message;
+  }
+
+  const candidates = [
+    errorText.error?.message,
+    errorText.message,
+    typeof errorText.error === "string" ? errorText.error : null,
+    errorText.detail,
+    errorText.reason,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return code && !candidate.includes(code) ? clamp(`${candidate} (${code})`) : clamp(candidate);
+    }
+  }
+
+  return code ? clamp(`Provider error (${code})`) : "Provider error";
+}
+
 export async function markAccountUnavailable(connectionId, status, errorText, provider = null, model = null, resetsAtMs = null) {
   if (!connectionId || connectionId === "noauth") return { shouldFallback: false, cooldownMs: 0 };
   const connections = await getProviderConnections({ provider });
@@ -240,7 +284,7 @@ export async function markAccountUnavailable(connectionId, status, errorText, pr
   }
   if (!shouldFallback) return { shouldFallback: false, cooldownMs: 0 };
 
-  const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
+  const reason = describeProviderError(errorText);
   const lockUpdate = buildModelLockUpdate(githubResetAtMs ? null : model, cooldownMs);
 
   await updateProviderConnection(connectionId, {

--- a/tests/unit/provider-error-detail-3424.test.js
+++ b/tests/unit/provider-error-detail-3424.test.js
@@ -1,0 +1,72 @@
+/**
+ * #3424 (suggestion 2) — the connection's `lastError` said only "Provider error".
+ *
+ * `markAccountUnavailable` kept the text only when it was already a string:
+ *
+ *     const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
+ *
+ * A failed `fetch` is the case that matters most and is not a string: Node throws
+ * `TypeError: fetch failed` and puts the actionable part on `error.cause.code`
+ * (ECONNREFUSED, ENOTFOUND, ETIMEDOUT). The operator saw an account marked
+ * unavailable with no way to tell a wrong port from a firewall from a proxy.
+ */
+import { describe, expect, it } from "vitest";
+import { describeProviderError } from "@/sse/services/auth.js";
+
+/** The shape Node produces for a refused connection. */
+function fetchFailed(code) {
+  const error = new TypeError("fetch failed");
+  error.cause = Object.assign(new Error(`connect ${code} 127.0.0.1:11434`), { code });
+  return error;
+}
+
+describe("describeProviderError (#3424)", () => {
+  it("keeps a string reason exactly as before, clamped to 100 chars", () => {
+    expect(describeProviderError("upstream said no")).toBe("upstream said no");
+    expect(describeProviderError("x".repeat(200))).toBe("x".repeat(100));
+  });
+
+  it("names the transport failure behind `fetch failed`", () => {
+    expect(describeProviderError(fetchFailed("ECONNREFUSED"))).toBe("fetch failed (ECONNREFUSED)");
+    expect(describeProviderError(fetchFailed("ENOTFOUND"))).toBe("fetch failed (ENOTFOUND)");
+  });
+
+  it("does not repeat a code the message already carries", () => {
+    const error = Object.assign(new Error("connect ETIMEDOUT 10.0.0.5:443"), { code: "ETIMEDOUT" });
+    expect(describeProviderError(error)).toBe("connect ETIMEDOUT 10.0.0.5:443");
+  });
+
+  it("reads the usual provider JSON error shapes", () => {
+    expect(describeProviderError({ error: { message: "model not found" } })).toBe("model not found");
+    expect(describeProviderError({ message: "quota exceeded" })).toBe("quota exceeded");
+    expect(describeProviderError({ error: "invalid api key" })).toBe("invalid api key");
+    expect(describeProviderError({ detail: "no such deployment" })).toBe("no such deployment");
+  });
+
+  it("falls back to the code when there is no message at all", () => {
+    expect(describeProviderError({ code: "EAI_AGAIN" })).toBe("Provider error (EAI_AGAIN)");
+  });
+
+  it("still says 'Provider error' when there is nothing to say", () => {
+    expect(describeProviderError({})).toBe("Provider error");
+    expect(describeProviderError(null)).toBe("Provider error");
+    expect(describeProviderError(undefined)).toBe("Provider error");
+    expect(describeProviderError(42)).toBe("Provider error");
+  });
+
+  it("never serializes the error object wholesale", () => {
+    // A payload attached to the error must not end up in the stored reason.
+    const withPayload = {
+      code: "EPIPE",
+      request: { headers: { authorization: "Bearer sk-do-not-store" } },
+    };
+    const reason = describeProviderError(withPayload);
+    expect(reason).toBe("Provider error (EPIPE)");
+    expect(reason).not.toContain("sk-do-not-store");
+    expect(reason).not.toContain("authorization");
+  });
+
+  it("collapses newlines so the dashboard line stays one line", () => {
+    expect(describeProviderError({ message: "line one\nline two" })).toBe("line one line two");
+  });
+});


### PR DESCRIPTION
Addresses suggestion 2 of #3424 — the connection's `lastError` said only
`"Provider error"`. Independent of the connectivity fix in #3517, and useful for
every provider rather than just `ollama-local`.

## Problem

```js
const reason = typeof errorText === "string" ? errorText.slice(0, 100) : "Provider error";
```

Anything that is not already a string collapsed to that literal, and it is what
the dashboard shows (`lastError`) and what the console line prints. The case that
matters most is not a string: a failed `fetch` arrives as `TypeError: fetch
failed`, with the actionable part on `error.cause.code`. A wrong port, a firewall,
a DNS failure and a proxy that cannot reach the target all looked identical.

## Change

`describeProviderError(errorText)` (exported for tests) resolves, in order:

- a string — unchanged, still clamped to 100 chars;
- an `Error` — its message, with the transport code appended when the message
  does not already carry it (`fetch failed (ECONNREFUSED)`);
- a provider JSON body — `error.message`, `message`, a string `error`, `detail`,
  `reason`;
- otherwise the code alone (`Provider error (EAI_AGAIN)`), then the old literal.

Newlines are collapsed so the dashboard row stays one line.

**The error object is never serialized wholesale.** Only message-shaped fields and
codes are read, so a request body or header attached to the error cannot end up
in the stored reason. That is pinned by a test that attaches an `authorization`
header to the error and asserts it does not appear in the output.

## Tests

`tests/unit/provider-error-detail-3424.test.js` (new, 8 cases): the string path
unchanged including the 100-char clamp; `fetch failed` with ECONNREFUSED /
ENOTFOUND; no duplicated code when the message already names it; the four JSON
shapes; code-only fallback; `{}` / `null` / `undefined` / a number still yielding
`"Provider error"`; the no-wholesale-serialization guarantee; and newline
collapsing.

`npx eslint` clean on both changed files.
