### PR TITLE
fix(tunnel): accept either URL as proof the tunnel is up

### DIFF
--- a/src/lib/tunnel/cloudflare/healthCheck.js
+++ b/src/lib/tunnel/cloudflare/healthCheck.js
@@ -18,11 +18,30 @@ export async function probeUrlAlive(url) {
   }
 }
 
-export async function waitForHealth(url, cancelToken = { cancelled: false }) {
+/**
+ * Wait until one of `urls` answers /api/health, and return the URL that did.
+ *
+ * Candidates are probed in preference order on every round, and the first one to
+ * answer wins. Gating on a single URL made enable fail outright whenever THAT
+ * endpoint was the slow one — the relay mapping can take longer than the 60 s
+ * budget to propagate, and the tunnel was then reported as failed while it was
+ * already serving on its direct address.
+ *
+ * @param {string|string[]} urls  one URL, or candidates in preference order
+ * @param {{cancelled: boolean}} cancelToken
+ * @returns {Promise<string>} the URL that answered
+ */
+export async function waitForHealth(urls, cancelToken = { cancelled: false }) {
+  const candidates = (Array.isArray(urls) ? urls : [urls]).filter(Boolean);
+  if (candidates.length === 0) throw new Error("Health check requires at least one URL");
+
   const start = Date.now();
   while (Date.now() - start < HEALTH_CHECK.timeoutMs) {
     if (cancelToken.cancelled) throw new Error("cancelled");
-    if (await probeUrlAlive(url)) return true;
+    for (const url of candidates) {
+      if (cancelToken.cancelled) throw new Error("cancelled");
+      if (await probeUrlAlive(url)) return url;
+    }
     await new Promise((r) => setTimeout(r, HEALTH_CHECK.intervalMs));
   }
   throw new Error(`Health check timeout after ${HEALTH_CHECK.timeoutMs}ms`);

--- a/src/lib/tunnel/cloudflare/manager.js
+++ b/src/lib/tunnel/cloudflare/manager.js
@@ -87,14 +87,21 @@ export async function enableTunnel(localPort = 20128) {
     await updateSettings({ tunnelEnabled: true, tunnelUrl });
     console.log(`[Tunnel] registered shortId=${shortId} publicUrl=${publicUrl}`);
 
-    // Verify publicUrl first (worker route is reliable; direct *.trycloudflare.com DNS may lag)
-    await waitForHealth(publicUrl, token);
-    console.log("[Tunnel] public URL healthy");
-    // Direct tunnel probe is best-effort: DNS for *.trycloudflare.com can be slow/blocked
-    if (!(await probeUrlAlive(tunnelUrl))) {
-      console.warn("[Tunnel] direct URL not reachable yet, continuing via publicUrl");
+    // Prefer the relay (its worker route is usually the first to answer), but accept
+    // the direct *.trycloudflare.com URL too: whichever answers first proves the
+    // tunnel is up. Requiring the relay alone failed the whole enable whenever its
+    // registration lagged past the 60 s budget, even with the tunnel already serving.
+    const healthyUrl = await waitForHealth([publicUrl, tunnelUrl], token);
+    if (healthyUrl === publicUrl) {
+      console.log("[Tunnel] public URL healthy");
+      // Direct tunnel probe is best-effort: DNS for *.trycloudflare.com can be slow/blocked
+      if (!(await probeUrlAlive(tunnelUrl))) {
+        console.warn("[Tunnel] direct URL not reachable yet, continuing via publicUrl");
+      } else {
+        console.log("[Tunnel] direct URL healthy");
+      }
     } else {
-      console.log("[Tunnel] direct URL healthy");
+      console.warn(`[Tunnel] relay not answering yet, continuing via direct URL: ${healthyUrl}`);
     }
 
     console.log("[Tunnel] enable success");

--- a/tests/unit/tunnel-health-candidates-3412.test.js
+++ b/tests/unit/tunnel-health-candidates-3412.test.js
@@ -1,0 +1,89 @@
+/**
+ * #3412 (defect 1) — "Health check timeout after 60000ms" reported a tunnel as
+ * failed while it was already serving.
+ *
+ * `enableTunnel()` gated on `waitForHealth(publicUrl)` — the relay only. The
+ * direct `*.trycloudflare.com` URL was probed afterwards and only as a
+ * best-effort log line, so a relay registration that propagated slower than the
+ * 60 s budget failed the whole enable, with no retry and no grace period.
+ *
+ * The gate now takes candidates in preference order and is satisfied by whichever
+ * answers first.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveDns = vi.fn(async () => true);
+vi.mock("../../src/lib/tunnel/shared/dnsResolver.js", () => ({ resolveDns }));
+
+const { waitForHealth } = await import("../../src/lib/tunnel/cloudflare/healthCheck.js");
+const { HEALTH_CHECK } = await import("../../src/lib/tunnel/cloudflare/config.js");
+
+const RELAY = "https://rabc123.abc-tunnel.us";
+const DIRECT = "https://tall-cats-run.trycloudflare.com";
+
+/** Answer /api/health with 200 only for the listed origins. */
+function serveHealthy(...aliveOrigins) {
+  const attempts = [];
+  globalThis.fetch = vi.fn(async (url) => {
+    const origin = String(url).replace(/\/api\/health$/, "");
+    attempts.push(origin);
+    return { ok: aliveOrigins.includes(origin), status: aliveOrigins.includes(origin) ? 200 : 404 };
+  });
+  return attempts;
+}
+
+describe("tunnel health gate accepts either URL (#3412)", () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => { resolveDns.mockClear(); });
+  afterEach(() => { globalThis.fetch = realFetch; vi.useRealTimers(); });
+
+  it("returns the relay when the relay answers", async () => {
+    serveHealthy(RELAY, DIRECT);
+    await expect(waitForHealth([RELAY, DIRECT])).resolves.toBe(RELAY);
+  });
+
+  it("accepts the direct URL when the relay is not registered yet", async () => {
+    const attempts = serveHealthy(DIRECT);
+
+    await expect(waitForHealth([RELAY, DIRECT])).resolves.toBe(DIRECT);
+    // The relay keeps its preference: it is still tried first each round.
+    expect(attempts[0]).toBe(RELAY);
+  });
+
+  it("still accepts a single URL argument", async () => {
+    serveHealthy(RELAY);
+    await expect(waitForHealth(RELAY)).resolves.toBe(RELAY);
+  });
+
+  it("ignores empty candidates and rejects when there are none", async () => {
+    serveHealthy(DIRECT);
+    await expect(waitForHealth([null, DIRECT, undefined])).resolves.toBe(DIRECT);
+    await expect(waitForHealth([null, ""])).rejects.toThrow(/at least one URL/);
+  });
+
+  it("times out only when no candidate answers", async () => {
+    vi.useFakeTimers();
+    serveHealthy();
+
+    const pending = waitForHealth([RELAY, DIRECT]);
+    const assertion = expect(pending).rejects.toThrow(
+      `Health check timeout after ${HEALTH_CHECK.timeoutMs}ms`,
+    );
+    await vi.advanceTimersByTimeAsync(HEALTH_CHECK.timeoutMs + HEALTH_CHECK.intervalMs);
+    await assertion;
+  });
+
+  it("honours the cancel token", async () => {
+    serveHealthy();
+    await expect(waitForHealth([RELAY, DIRECT], { cancelled: true })).rejects.toThrow("cancelled");
+  });
+
+  it("does not probe a host whose DNS does not resolve", async () => {
+    resolveDns.mockResolvedValueOnce(false);
+    const attempts = serveHealthy(RELAY, DIRECT);
+
+    await expect(waitForHealth([RELAY, DIRECT])).resolves.toBe(DIRECT);
+    expect(attempts).toEqual([DIRECT]);
+  });
+});


### PR DESCRIPTION
Addresses **defect 1** of #3412 — `Health check timeout after 60000ms` reporting a
tunnel as failed while it was already serving. Defect 2 (the watchdog trusting PID
liveness over reachability) is deliberately untouched; see the note below.

## Problem

`enableTunnel()` verified the tunnel with

```js
await waitForHealth(publicUrl, token);   // relay only — hard gate
...
if (!(await probeUrlAlive(tunnelUrl))) { /* best-effort log line */ }
```

so the direct `*.trycloudflare.com` URL could not satisfy the check. When the
relay's registration propagated slower than the 60 s budget, enable failed
outright — no retry, no grace period — even though cloudflared was up and
answering on its own address. The code's own comment says the relay is the
reliable one and direct DNS may lag; the report is the case where that is the
wrong way round.

## Change

`waitForHealth(urls, cancelToken)` accepts candidates in preference order, probes
them in that order on **every** round, and returns the URL that answered:

```js
const healthyUrl = await waitForHealth([publicUrl, tunnelUrl], token);
```

- The relay keeps its preference, so the normal path and its logging are
  unchanged, including the existing best-effort direct probe afterwards.
- The direct URL only decides the outcome when the relay has not answered at all,
  and the manager then logs `relay not answering yet, continuing via direct URL`.
- A single string still works, so any other caller is unaffected.

## Note on defect 2

The watchdog gate (`safeRestartTunnel` → `isCloudflaredRunning()` → `process.kill(pid, 0)`)
really does treat a live PID as a healthy tunnel, and `getTunnelStatus()` reports
`enabled` from settings + PID. Changing that means deciding a re-probe cadence and
a restart policy, which is a larger behaviour change than this fix and belongs in
its own PR — happy to follow up if you want it.

## Tests

`tests/unit/tunnel-health-candidates-3412.test.js` (new, 7 cases) mocks the DNS
resolver and `fetch`: relay-answers case returns the relay; relay-down case
returns the direct URL and still shows the relay was tried first; a bare string
argument; empty candidates filtered, and an all-empty list rejected; the timeout
still raised when nothing answers (fake timers); the cancel token; and a
non-resolving host never being fetched.

Mutation check — reverting the loop to a single candidate fails exactly:

```
× accepts the direct URL when the relay is not registered yet
× does not probe a host whose DNS does not resolve
```

`npx eslint` clean on the changed files.
