### PR TITLE
fix(stream): stop dropping generated images from OpenAI-format streams

### DIFF
--- a/open-sse/utils/streamHelpers.js
+++ b/open-sse/utils/streamHelpers.js
@@ -41,6 +41,11 @@ export function hasValuableContent(chunk, format) {
     return delta.content && delta.content !== "" ||
            delta.reasoning_content && delta.reasoning_content !== "" ||
            delta.tool_calls && delta.tool_calls.length > 0 ||
+           // Generated images arrive on their own chunk with nothing else in the
+           // delta, so leaving `images` out of this list dropped every one of them.
+           // The translator emits exactly this shape (gemini-to-openai.js:105) and
+           // the golden snapshot for "inlineData -> delta.images" locks it.
+           delta.images && delta.images.length > 0 ||
            chunk.choices[0].finish_reason ||
            delta.role;
   }

--- a/tests/unit/stream-keeps-generated-images.test.js
+++ b/tests/unit/stream-keeps-generated-images.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { hasValuableContent } from "../../open-sse/utils/streamHelpers.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+/**
+ * `hasValuableContent` gates every chunk on the streaming path
+ * (open-sse/utils/stream.js:315). A generated image arrives on its own chunk with
+ * nothing else in the delta, so leaving `images` out of the check dropped it — and
+ * the client received a well-formed but empty assistant message.
+ *
+ * The shape below is the one the translator emits at
+ * open-sse/translator/response/gemini-to-openai.js:105, and the one the repo's own
+ * golden snapshot locks for "image output (inlineData → delta.images)".
+ */
+const imageChunk = () => ({
+  choices: [
+    {
+      index: 0,
+      delta: {
+        images: [
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,iVBORw0KGgo=" },
+          },
+        ],
+      },
+      finish_reason: null,
+    },
+  ],
+});
+
+describe("hasValuableContent — OpenAI format", () => {
+  it("keeps a chunk carrying only a generated image", () => {
+    expect(hasValuableContent(imageChunk(), FORMATS.OPENAI)).toBeTruthy();
+  });
+
+  it("still drops a chunk whose delta is genuinely empty", () => {
+    const empty = { choices: [{ index: 0, delta: {}, finish_reason: null }] };
+    expect(hasValuableContent(empty, FORMATS.OPENAI)).toBeFalsy();
+  });
+
+  it("drops an empty images array rather than treating it as content", () => {
+    const chunk = imageChunk();
+    chunk.choices[0].delta.images = [];
+    expect(hasValuableContent(chunk, FORMATS.OPENAI)).toBeFalsy();
+  });
+
+  it("keeps the shapes it already kept", () => {
+    const text = { choices: [{ delta: { content: "hi" } }] };
+    const reasoning = { choices: [{ delta: { reasoning_content: "why" } }] };
+    const tools = { choices: [{ delta: { tool_calls: [{ index: 0 }] } }] };
+    const role = { choices: [{ delta: { role: "assistant" } }] };
+    const finish = { choices: [{ delta: {}, finish_reason: "stop" }] };
+    for (const chunk of [text, reasoning, tools, role, finish]) {
+      expect(hasValuableContent(chunk, FORMATS.OPENAI)).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## The defect

`hasValuableContent` gates every chunk on the streaming path (`open-sse/utils/stream.js:313-317`). Its OpenAI branch (`open-sse/utils/streamHelpers.js:36-46`) lists `content`, `reasoning_content`, `tool_calls`, `finish_reason` and `role` — but not `images`.

A generated image arrives on its own chunk with nothing else in the delta, so every one is discarded. Measured on `master` (`699edac3`) against the real filter:

```
chunk 1  delta={"role":"assistant"}                                    kept?  assistant
chunk 2  delta={"images":[{"type":"image_url","image_url":{"url":…}}]}  kept?  undefined   ← dropped
```

## Why this is the project's own contract, not an extension

The translator emits exactly that shape at `open-sse/translator/response/gemini-to-openai.js:99-112`, and the repo **golden-locks it**: `tests/translator/__snapshots__/golden-response-stream.test.js.snap:169-181`, under the test named *image output (inlineData → delta.images)*.

So the filter was throwing away a payload the project had already committed to producing, and the snapshot test could not catch it because it asserts the translator's output, one stage before the filter.

**Symptom:** streaming an image-generating model (`gemini-3-flash-image`, the antigravity image models) through `/v1/chat/completions` returns a well-formed but **empty** assistant message — the image never reaches the client. Non-streaming is unaffected.

## The fix

One clause, guarded on length so an empty `images` array is not promoted to content.

## Verification

```
tests/unit/stream-keeps-generated-images.test.js
  + tests/translator/golden-response-stream.test.js     11 passed, 0 failed
```

**Mutation-checked**, after confirming the edit applied: removing the clause fails exactly the image case, 1 failed / 3 passed.

## Tests

`tests/unit/stream-keeps-generated-images.test.js` — the image-only chunk must survive; a genuinely empty delta must still be dropped; an empty `images` array must still be dropped; and the five shapes that were already kept must stay kept.

I put them in a new file rather than in `tests/unit/translator-request-normalization.test.js` — the only existing importer of `streamHelpers` — because that file is **already red at HEAD** (4 of 8 failing), so a green/red signal there would be worthless.

## Not covered here

I did not touch the Claude branch of the same function. Whether it has an equivalent hole needs its own reproduction, and I would rather send that separately than guess.
