### PR TITLE
fix(tunnel): draw the public subdomain from a CSPRNG

### DIFF
--- a/src/lib/tunnel/shared/state.js
+++ b/src/lib/tunnel/shared/state.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { randomInt } from "crypto";
 import { DATA_DIR } from "@/lib/dataDir.js";
 
 const TUNNEL_DIR = path.join(DATA_DIR, "tunnel");
@@ -30,10 +31,21 @@ export function clearState() {
   } catch { /* ignore */ }
 }
 
+/**
+ * The public tunnel subdomain (`https://r<shortId>.abc-tunnel.us`) is what stands
+ * between the open internet and this machine's dashboard and /v1 gateway, so it is
+ * a secret, not a display name.
+ *
+ * `Math.random()` is not a CSPRNG: V8 seeds a xorshift128+ generator whose internal
+ * state can be recovered from a small number of observed outputs, after which every
+ * other value it produces in the same process is predictable — including ids handed
+ * out elsewhere. `crypto.randomInt` draws from the OS CSPRNG and is rejection-sampled,
+ * so it is also free of the modulo bias a `% length` mapping would introduce.
+ */
 export function generateShortId() {
   let result = "";
   for (let i = 0; i < SHORT_ID_LENGTH; i++) {
-    result += SHORT_ID_CHARS.charAt(Math.floor(Math.random() * SHORT_ID_CHARS.length));
+    result += SHORT_ID_CHARS.charAt(randomInt(0, SHORT_ID_CHARS.length));
   }
   return result;
 }

--- a/tests/unit/tunnel-shortid-csprng.test.js
+++ b/tests/unit/tunnel-shortid-csprng.test.js
@@ -1,0 +1,59 @@
+/**
+ * The public tunnel subdomain is a capability, not a label.
+ *
+ * `generateShortId()` produces the `<shortId>` in
+ * `https://r<shortId>.abc-tunnel.us`, which is the address the dashboard and the
+ * /v1 gateway answer on once a quick tunnel is up. It was drawn with
+ * `Math.random()`, which is not a CSPRNG: V8's xorshift128+ state can be recovered
+ * from a handful of observed outputs, and every later value from the same process
+ * — this id included — is then predictable.
+ */
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import { generateShortId } from "@/lib/tunnel/shared/state.js";
+
+const CHARSET = "abcdefghijklmnpqrstuvwxyz23456789";
+
+describe("tunnel short id", () => {
+  it("keeps its length and alphabet", () => {
+    for (let i = 0; i < 500; i++) {
+      const id = generateShortId();
+      expect(id).toHaveLength(6);
+      for (const char of id) expect(CHARSET).toContain(char);
+    }
+  });
+
+  it("keeps excluding the characters that misread aloud", () => {
+    // `o`, `0` and `1` are absent from the alphabet on purpose — a tunnel URL gets
+    // dictated and typed. (`l` and `i` are present; this pins the actual set.)
+    const ids = Array.from({ length: 500 }, generateShortId).join("");
+    for (const char of ["o", "0", "1"]) expect(ids).not.toContain(char);
+  });
+
+  it("does not repeat itself across a large draw", () => {
+    const ids = new Set(Array.from({ length: 5_000 }, generateShortId));
+    // 33^6 ≈ 1.29e9 — the birthday bound over 5k draws makes even one collision
+    // unlikely (~1%), and a generator stuck in a short cycle would blow past it.
+    expect(ids.size).toBeGreaterThan(4_990);
+  });
+
+  it("uses the whole alphabet", () => {
+    const seen = new Set(Array.from({ length: 3_000 }, generateShortId).join(""));
+    // 18k characters over 33 symbols: a symbol never appearing would mean the
+    // mapping cannot reach it, not bad luck.
+    expect(seen.size).toBe(CHARSET.length);
+  });
+
+  it("is drawn from the crypto module, not Math.random", () => {
+    const src = fs.readFileSync(
+      new URL("../../src/lib/tunnel/shared/state.js", import.meta.url),
+      "utf8"
+    );
+    const body = src.slice(src.indexOf("export function generateShortId"));
+    // Comments may name Math.random while explaining why it is not used, so this
+    // looks at the function body, not the whole file.
+    expect(body).toContain("randomInt(0, SHORT_ID_CHARS.length)");
+    expect(/Math\.random\s*\(\)/.test(body)).toBe(false);
+    expect(src).toMatch(/from "crypto"|from "node:crypto"/);
+  });
+});


### PR DESCRIPTION
## What the value is

`generateShortId()` (`src/lib/tunnel/shared/state.js`) produces the `<shortId>` in

```
https://r<shortId>.abc-tunnel.us
```

which `enableTunnel()` registers as the tunnel's public address. While a quick
tunnel is up, that hostname is what the dashboard and the `/v1` gateway answer on
from the open internet. It is a capability, not a display name — and with
`INITIAL_PASSWORD` defaulting to `123456`, it is often the outermost layer.

## The defect

```js
result += SHORT_ID_CHARS.charAt(Math.floor(Math.random() * SHORT_ID_CHARS.length));
```

`Math.random()` is not a CSPRNG. V8 seeds a xorshift128+ generator whose internal
state can be recovered from a small number of observed outputs; every value the
same process yields afterwards is then predictable. Several other ids in this
process come from the same source (request-detail ids, savepoint names), so
observing them is not far-fetched.

`crypto.randomInt(0, n)` draws from the OS CSPRNG and rejection-samples, so it also
avoids the modulo bias that a `% length` mapping introduces.

## Scope

Length (6) and alphabet (33 chars, `o`/`0`/`1` deliberately excluded so a URL can be
dictated) are **unchanged**, so registrations and URLs already in flight keep working.

Worth saying plainly: 33^6 ≈ **1.3e9** is a thin keyspace for an internet-facing
namespace regardless of the generator. Widening it changes the URL shape and the
registration contract, so it is your call rather than something to slip into this
change.

## Tests

`tests/unit/tunnel-shortid-csprng.test.js` (new, 5 cases): length and alphabet held
over 500 draws; the excluded characters pinned to the actual set (`o`, `0`, `1` —
`l` and `i` are present); no repeats across 5000 draws (a generator stuck in a short
cycle would blow past the birthday bound); the whole alphabet reachable over ~18k
characters; and the function body drawing from `crypto`, checked on the body rather
than the file so the explanatory comment does not satisfy its own assertion.

Mutation check — restoring the `Math.random()` line fails exactly:

```
× is drawn from the crypto module, not Math.random
```

`npx eslint` clean on both files.
