### PR TITLE
fix(db): publish the sql.js database atomically

### DIFF
--- a/src/lib/db/adapters/sqljsAdapter.js
+++ b/src/lib/db/adapters/sqljsAdapter.js
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import initSqlJs from "sql.js";
 import { PRAGMA_SQL } from "../schema.js";
 
@@ -21,9 +22,51 @@ export async function createSqlJsAdapter(filePath) {
   let saveTimer = null;
   const SAVE_DEBOUNCE_MS = 100;
 
+  let persistSeq = 0;
+
+  /**
+   * Publish the database atomically: full image to a temp file in the SAME
+   * directory, fsync, then rename over the target.
+   *
+   * sql.js has no incremental write path — every save rewrites the whole image —
+   * and `writeFileSync` opens with O_TRUNC, so the previous version was destroyed
+   * before the new one was written. For the length of that write the file on disk
+   * was 0 bytes and then partial, which is a window that grows with the database
+   * and recurs on every save. Two consequences:
+   *
+   *   - a crash or power loss mid-write left no usable database at all, not a
+   *     stale one — sql.js is the fallback driver that always works, so this is
+   *     the driver users without build tools run on;
+   *   - another process reading the file (a backup job, `sqlite3`) saw a truncated
+   *     image and reported corruption, which the SQLite locking protocol does not
+   *     cover here because sql.js writes through the filesystem, not through SQLite.
+   *
+   * The temp file is deliberately a sibling: `rename()` is only atomic within a
+   * filesystem, so a temp in os.tmpdir() could land on another device.
+   */
   function persist() {
     const data = db.export();
-    fs.writeFileSync(filePath, Buffer.from(data));
+    const dir = path.dirname(filePath);
+    const tmpPath = path.join(dir, `.${path.basename(filePath)}.tmp-${process.pid}-${persistSeq++}`);
+
+    let fd;
+    try {
+      fd = fs.openSync(tmpPath, "w");
+      fs.writeFileSync(fd, Buffer.from(data));
+      fs.fsyncSync(fd);
+    } catch (err) {
+      if (fd !== undefined) { try { fs.closeSync(fd); } catch { /* already closed */ } }
+      try { fs.unlinkSync(tmpPath); } catch { /* nothing to clean up */ }
+      throw err;
+    }
+    fs.closeSync(fd);
+
+    try {
+      fs.renameSync(tmpPath, filePath);
+    } catch (err) {
+      try { fs.unlinkSync(tmpPath); } catch { /* nothing to clean up */ }
+      throw err;
+    }
     dirty = false;
   }
 

--- a/tests/unit/sqljs-atomic-persist.test.js
+++ b/tests/unit/sqljs-atomic-persist.test.js
@@ -1,0 +1,110 @@
+/**
+ * The sql.js fallback rewrote the database in place.
+ *
+ * sql.js has no incremental write path: every save exports the whole image and
+ * writes it back. `fs.writeFileSync` opens with O_TRUNC, so the previous version
+ * was destroyed before the new one existed — for the length of that write the file
+ * on disk was 0 bytes and then partial, a window that grows with the database and
+ * recurs on every save.
+ *
+ * sql.js is the driver that always works (no native build), so this is what a user
+ * without build tools runs on. A crash mid-write left them with no database at all.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createSqlJsAdapter } from "@/lib/db/adapters/sqljsAdapter.js";
+
+const SQLITE_MAGIC = "SQLite format 3\0";
+
+let dir;
+let dbPath;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-sqljs-"));
+  dbPath = path.join(dir, "data.sqlite");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** Everything in the db directory that is not the database itself. */
+function strayFiles() {
+  return fs.readdirSync(dir).filter((name) => name !== "data.sqlite");
+}
+
+async function seededAdapter() {
+  const adapter = await createSqlJsAdapter(dbPath);
+  adapter.run("CREATE TABLE IF NOT EXISTS t(id INTEGER PRIMARY KEY, v TEXT)");
+  adapter.run("INSERT INTO t(v) VALUES(?)", ["first"]);
+  return adapter;
+}
+
+describe("sql.js adapter persistence", () => {
+  it("writes a valid database and leaves no temp file behind", async () => {
+    const adapter = await seededAdapter();
+    adapter.close();
+
+    const buf = fs.readFileSync(dbPath);
+    expect(buf.subarray(0, SQLITE_MAGIC.length).toString("binary")).toBe(SQLITE_MAGIC);
+    expect(strayFiles()).toEqual([]);
+  });
+
+  it("keeps the previous database when the write fails mid-flight", async () => {
+    const adapter = await seededAdapter();
+    adapter.close();
+    const before = fs.readFileSync(dbPath);
+
+    const second = await createSqlJsAdapter(dbPath);
+    second.run("INSERT INTO t(v) VALUES(?)", ["second"]);
+
+    // Fail after the temp file has been opened — the crash window the old
+    // in-place write could not survive.
+    const realWrite = fs.writeFileSync;
+    vi.spyOn(fs, "writeFileSync").mockImplementation((target, data, options) => {
+      if (typeof target === "number") throw new Error("simulated disk failure");
+      return realWrite(target, data, options);
+    });
+
+    expect(() => second.close()).toThrow(/simulated disk failure/);
+
+    // The database that was already on disk is untouched, and nothing was left over.
+    expect(fs.readFileSync(dbPath)).toEqual(before);
+    expect(strayFiles()).toEqual([]);
+  });
+
+  it("stages the temp file next to the database, not in the system temp dir", async () => {
+    const adapter = await createSqlJsAdapter(dbPath);
+    adapter.run("CREATE TABLE IF NOT EXISTS t(id INTEGER PRIMARY KEY, v TEXT)");
+
+    const staged = [];
+    const realOpen = fs.openSync;
+    vi.spyOn(fs, "openSync").mockImplementation((target, flags, mode) => {
+      staged.push(String(target));
+      return realOpen(target, flags, mode);
+    });
+
+    adapter.run("INSERT INTO t(v) VALUES(?)", ["x"]);
+    adapter.close();
+
+    const tempPaths = staged.filter((p) => p.includes(".tmp-"));
+    expect(tempPaths.length).toBeGreaterThan(0);
+    // rename() is only atomic within one filesystem — a sibling guarantees that.
+    for (const p of tempPaths) expect(path.dirname(p)).toBe(dir);
+  });
+
+  it("survives repeated saves without accumulating temp files", async () => {
+    const adapter = await createSqlJsAdapter(dbPath);
+    adapter.run("CREATE TABLE IF NOT EXISTS t(id INTEGER PRIMARY KEY, v TEXT)");
+    for (let i = 0; i < 5; i++) adapter.run("INSERT INTO t(v) VALUES(?)", [`v${i}`]);
+    adapter.close();
+
+    const reopened = await createSqlJsAdapter(dbPath);
+    expect(reopened.get("SELECT COUNT(*) AS c FROM t").c).toBe(5);
+    reopened.close();
+    expect(strayFiles()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`createSqlJsAdapter` saves like this:

```js
function persist() {
  const data = db.export();
  fs.writeFileSync(filePath, Buffer.from(data));
  dirty = false;
}
```

sql.js has no incremental write path — every save exports the **whole** image — and
`writeFileSync` opens with `O_TRUNC`. So the previous database is destroyed before
the new one exists: for the length of that write the file on disk is 0 bytes, then
partial. The window grows with the database and recurs on every save (100 ms
debounce, plus `close()`, `beforeExit` and `SIGINT`).

Two consequences:

- **A crash or power loss mid-write leaves no usable database**, not a stale one.
  Per `CLAUDE.md`, sql.js is the pure-JS fallback that "always works" — it is what a
  user whose `better-sqlite3` build failed is actually running, so this is the least
  robust driver carrying the least prepared install.
- Another process reading the file — a backup job, `sqlite3`, a metrics exporter —
  can see a truncated image and report corruption. SQLite's locking protocol does
  not cover it, because sql.js writes through the filesystem rather than through
  SQLite.

## Change

Write the image to a temp file in the **same directory**, `fsync` it, then
`rename()` over the target. Both failure paths unlink the temp, so a failed save
cannot leave litter beside the database.

The temp is deliberately a sibling rather than `os.tmpdir()`: `rename()` is only
atomic within one filesystem, and a temp on another device would silently degrade
into a copy.

## Tests

`tests/unit/sqljs-atomic-persist.test.js` (new, 4 cases): a saved database carries
the `SQLite format 3` magic and leaves no stray file; a write that fails mid-flight
leaves the **previous** database byte-identical and no temp behind; the temp is
staged next to the database (asserted on the path handed to `openSync`); and five
saves round-trip to a reopened adapter with no accumulated temps.

Mutation check — restoring the in-place `writeFileSync` fails exactly:

```
× keeps the previous database when the write fails mid-flight
× stages the temp file next to the database, not in the system temp dir
```

`npx eslint` clean on both files.

Note: OmniRoute shipped the same fix for its sql.js adapter, so the shape here
should be familiar; this port keeps 9router's structure rather than importing theirs.
