### PR TITLE
fix(usage): release the stats listeners when a dashboard tab disconnects

### DIFF
--- a/src/app/api/usage/stream/route.js
+++ b/src/app/api/usage/stream/route.js
@@ -2,9 +2,23 @@ import { getUsageStats, statsEmitter, getActiveRequests } from "@/lib/usageDb";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request) {
   const encoder = new TextEncoder();
   const state = { closed: false, keepalive: null, send: null, sendPending: null, cachedStats: null };
+
+  // Idempotent: safe to call from request.signal abort, cancel(), or enqueue failure.
+  const cleanup = () => {
+    if (state.closed) return;
+    state.closed = true;
+    if (state.send) statsEmitter.off("update", state.send);
+    if (state.sendPending) statsEmitter.off("pending", state.sendPending);
+    if (state.keepalive) clearInterval(state.keepalive);
+  };
+
+  // request.signal fires reliably on client disconnect; ReadableStream.cancel()
+  // is not always invoked in Next.js, which caused listeners to accumulate on the
+  // process-wide statsEmitter. Same pattern as translator/console-logs/stream.
+  request?.signal?.addEventListener("abort", cleanup, { once: true });
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -23,10 +37,7 @@ export async function GET() {
           state.cachedStats = stats;
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
         } catch {
-          state.closed = true;
-          statsEmitter.off("update", state.send);
-          statsEmitter.off("pending", state.sendPending);
-          clearInterval(state.keepalive);
+          cleanup();
         }
       };
 
@@ -38,14 +49,16 @@ export async function GET() {
           const stats = { ...state.cachedStats, activeRequests, recentRequests, errorProvider };
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(stats)}\n\n`));
         } catch {
-          state.closed = true;
-          statsEmitter.off("update", state.send);
-          statsEmitter.off("pending", state.sendPending);
-          clearInterval(state.keepalive);
+          cleanup();
         }
       };
 
       await state.send();
+
+      // The first send is awaited, so the client can be gone — or that send can have
+      // failed and run cleanup — before we get here. Subscribing anyway would register
+      // handlers nothing ever removes.
+      if (state.closed) return;
 
       statsEmitter.on("update", state.send);
       statsEmitter.on("pending", state.sendPending);
@@ -55,17 +68,13 @@ export async function GET() {
         try {
           controller.enqueue(encoder.encode(": ping\n\n"));
         } catch {
-          state.closed = true;
-          clearInterval(state.keepalive);
+          cleanup();
         }
       }, 25000);
     },
 
     cancel() {
-      state.closed = true;
-      statsEmitter.off("update", state.send);
-      statsEmitter.off("pending", state.sendPending);
-      clearInterval(state.keepalive);
+      cleanup();
     },
   });
 

--- a/tests/unit/usage-stream-listener-leak.test.js
+++ b/tests/unit/usage-stream-listener-leak.test.js
@@ -1,0 +1,122 @@
+/**
+ * `/api/usage/stream` subscribes two handlers to `statsEmitter` — a process-wide
+ * singleton, `global._statsEmitter` with `setMaxListeners(50)` — and unsubscribed
+ * them only from `ReadableStream.cancel()`.
+ *
+ * The sibling SSE route already records why that is not enough
+ * (src/app/api/translator/console-logs/stream/route.js:22):
+ *
+ *     // request.signal fires reliably on client disconnect; ReadableStream.cancel()
+ *     // is not always invoked in Next.js, which caused listeners to accumulate.
+ *
+ * `console-logs/stream` therefore takes `request` and cleans up on `request.signal`.
+ * `usage/stream` was declared `export async function GET()` — no parameter at all —
+ * so it had no second path off the emitter. Every dashboard tab that closed without
+ * a `cancel()` left both handlers registered, and each surviving handler still ran
+ * the full `getActiveRequests()` + `getUsageStats()` recalculation on every emit,
+ * because its `state.closed` flag was never set.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+const statsEmitter = new EventEmitter();
+
+/** Per-test overrides for the two DB reads the route performs. */
+const db = {
+  getUsageStats: async () => ({ total: 0 }),
+  getActiveRequests: async () => ({ activeRequests: [], recentRequests: [], errorProvider: null }),
+};
+
+vi.mock("@/lib/usageDb", () => ({
+  statsEmitter,
+  getUsageStats: (...args) => db.getUsageStats(...args),
+  getActiveRequests: (...args) => db.getActiveRequests(...args),
+}));
+
+/** Listener bookkeeping is what leaks; count both events the route subscribes to. */
+const subscribed = () =>
+  statsEmitter.listenerCount("update") + statsEmitter.listenerCount("pending");
+
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+beforeEach(() => {
+  statsEmitter.removeAllListeners();
+  db.getUsageStats = async () => ({ total: 0 });
+  db.getActiveRequests = async () => ({ activeRequests: [], recentRequests: [], errorProvider: null });
+});
+afterEach(() => { statsEmitter.removeAllListeners(); });
+
+async function callRoute() {
+  const { GET } = await import("@/app/api/usage/stream/route.js");
+  const controller = new AbortController();
+  const response = await GET(
+    new Request("http://localhost/api/usage/stream", { signal: controller.signal })
+  );
+  return { controller, response };
+}
+
+/** Opens the stream and reads the first `data:` frame, so the route is fully subscribed. */
+async function openStream() {
+  const { controller, response } = await callRoute();
+  const reader = response.body.getReader();
+  await reader.read();
+  return { controller, reader };
+}
+
+describe("/api/usage/stream cleanup", () => {
+  it("unsubscribes from statsEmitter when the client aborts", async () => {
+    const { controller } = await openStream();
+    expect(subscribed()).toBe(2);
+
+    controller.abort();
+    await settle();
+
+    expect(subscribed()).toBe(0);
+  });
+
+  it("does not accumulate listeners across disconnected clients", async () => {
+    for (let i = 0; i < 30; i++) {
+      const { controller } = await openStream();
+      controller.abort();
+      await settle();
+    }
+
+    // 30 tabs x 2 handlers = 60, past the emitter's 50-listener ceiling.
+    expect(subscribed()).toBe(0);
+  });
+
+  it("still cleans up when the consumer cancels the stream instead", async () => {
+    const { reader } = await openStream();
+    expect(subscribed()).toBe(2);
+
+    await reader.cancel();
+    await settle();
+
+    expect(subscribed()).toBe(0);
+  });
+
+  it("does not subscribe at all when the client leaves during the first (awaited) stats read", async () => {
+    let abortNow;
+    const firstReadStarted = new Promise((resolve) => { abortNow = resolve; });
+    let release;
+    const firstReadFinishes = new Promise((resolve) => { release = resolve; });
+
+    db.getUsageStats = async () => {
+      abortNow();
+      await firstReadFinishes;
+      return { total: 0 };
+    };
+
+    const { controller, response } = await callRoute();
+    const reader = response.body.getReader();
+    const pending = reader.read();
+
+    await firstReadStarted;
+    controller.abort();   // client gone while `await getUsageStats()` is still in flight
+    release();
+    await pending.catch(() => {});
+    await settle();
+
+    expect(subscribed()).toBe(0);
+  });
+});


### PR DESCRIPTION
### The bug

`/api/usage/stream` subscribes two handlers to `statsEmitter` and unsubscribes them only from `ReadableStream.cancel()`:

```js
export async function GET() {          // <- no `request` parameter at all
  ...
  statsEmitter.on("update", state.send);
  statsEmitter.on("pending", state.sendPending);
```

`statsEmitter` is process-wide — `global._statsEmitter`, `setMaxListeners(50)` (`src/lib/db/repos/usageRepo.js:20-22`).

The sibling SSE route already records why `cancel()` alone is not enough, in `src/app/api/translator/console-logs/stream/route.js:22`:

```js
// request.signal fires reliably on client disconnect; ReadableStream.cancel()
// is not always invoked in Next.js, which caused listeners to accumulate.
```

`console-logs/stream` takes `request` and cleans up on `request.signal`. `usage/stream` never got the same treatment, and with no parameter it has no second path off the emitter.

The cost is not only bookkeeping. A leaked handler still has `state.closed === false`, so on every emit it runs the full `getActiveRequests()` + `getUsageStats()` recalculation on behalf of a client that is gone.

### Measurement

Opening the stream and aborting it 30 times (the dashboard tab being closed or reloaded):

| | listeners left on `statsEmitter` |
| :-- | :-- |
| before | **60** — past the emitter's own 50 ceiling |
| after | **0** |

### The fix

The same shape `console-logs/stream` already uses: one idempotent `cleanup()` wired to `request.signal`, to `cancel()`, and to every `enqueue` failure. It also replaces three hand-copied unsubscribe blocks with that one function.

One extra guard: `await state.send()` happens before the `.on()` calls, so the client can disconnect — or that first read can throw and run `cleanup()` — while it is in flight. Subscribing afterwards would register handlers nothing ever removes, so the route now returns instead.

`cancel()` still works exactly as before; there is a test asserting that specifically, so this adds a path rather than replacing one.

### Tests

`tests/unit/usage-stream-listener-leak.test.js`, 4 cases: abort unsubscribes; 30 disconnects leave nothing behind; `reader.cancel()` still cleans up; and disconnecting during the first awaited stats read subscribes nothing.

All four fail on `master` except the `cancel()` one, which passes before and after — it is there to prove the existing path was not traded away.

Mutation-checked, each reverted separately against the new tests:

| mutation | result |
| :-- | :-- |
| drop the `request.signal` wiring | 2 failed |
| drop the post-`await` `state.closed` guard | 1 failed |
| stop removing the `"pending"` listener in `cleanup()` | 3 failed |

### Suite

Full `tests/` run in a dedicated worktree, clean tree, **`CI=true` on both sides** — without it vitest silently writes two missing `golden-url-header` snapshots instead of failing on them, which both skews the count and modifies a tracked file mid-run:

```
master:      31 files / 95 cases failing
this branch: 31 files / 95 cases failing
```

Failure **sets** compared, not counts: **identical, in both directions.** No regressions, and nothing accidentally fixed.

(An earlier revision of this description quoted `32 / 96` vs `31 / 93`. Those runs were symmetric — no `CI=true` on either side — so the "no regressions" conclusion was sound, but the absolute numbers were not comparable with my other PRs. Replaced with the figures above.)
