### PR TITLE
fix(mcp): release the bridge session when an SSE client disconnects

### DIFF
--- a/src/app/api/mcp/[plugin]/sse/route.js
+++ b/src/app/api/mcp/[plugin]/sse/route.js
@@ -11,6 +11,21 @@ export async function GET(request, { params }) {
 
   const encoder = new TextEncoder();
   let sid;
+  let released = false;
+
+  // Idempotent: request.signal abort and cancel() can both fire, and releasing twice
+  // would run the bridge's "last session leaves" branch a second time.
+  const release = () => {
+    if (released || !sid) return;
+    released = true;
+    unregisterSession(plugin, sid);
+  };
+
+  // request.signal fires reliably on client disconnect; ReadableStream.cancel() is
+  // not always invoked in Next.js (same reason as translator/console-logs/stream).
+  // unregisterSession is what reaps the spawned child, so a missed cancel() leaves
+  // sessions.size > 0 and the stdio process alive for the lifetime of the server.
+  request?.signal?.addEventListener("abort", release, { once: true });
 
   const stream = new ReadableStream({
     start(controller) {
@@ -20,7 +35,7 @@ export async function GET(request, { params }) {
       send(`event: endpoint\ndata: /api/mcp/${plugin}/message?sessionId=${sid}\n\n`);
     },
     cancel() {
-      if (sid) unregisterSession(plugin, sid);
+      release();
     },
   });
 

--- a/tests/unit/mcp-sse-session-leak.test.js
+++ b/tests/unit/mcp-sse-session-leak.test.js
@@ -1,0 +1,109 @@
+/**
+ * `/api/mcp/[plugin]/sse` registers a bridge session and releases it only from
+ * `ReadableStream.cancel()`. The repo's other SSE route records why that is not
+ * enough (src/app/api/translator/console-logs/stream/route.js:22):
+ *
+ *     // request.signal fires reliably on client disconnect; ReadableStream.cancel()
+ *     // is not always invoked in Next.js, which caused listeners to accumulate.
+ *
+ * Here the leak is not a listener. `unregisterSession` is the only thing that ever
+ * reaps the spawned child (src/lib/mcp/stdioSseBridge.js:156):
+ *
+ *     // No sessions left → kill child to avoid idle orphan process leak.
+ *     if (entry.sessions.size === 0) { entry.proc.kill(); ... }
+ *
+ * A session that is never unregistered keeps `sessions.size > 0` forever, so the
+ * child is never killed — the exact orphan the comment promises to prevent. The
+ * stdout broadcast loop cannot expose it either: it swallows send failures
+ * (`catch { /* ignore broken pipe *\/ }`), so a dead session looks alive.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const bridge = { sessions: new Map(), nextSid: 0 };
+
+vi.mock("@/lib/mcp/stdioSseBridge", () => ({
+  findPlugin: (name) => (name === "known" ? { name, command: "node", args: [] } : null),
+  registerSession: (name, sendFn) => {
+    const sid = `sid-${bridge.nextSid++}`;
+    bridge.sessions.set(sid, { name, sendFn });
+    return sid;
+  },
+  unregisterSession: (name, sid) => { bridge.sessions.delete(sid); },
+}));
+
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+beforeEach(() => { bridge.sessions.clear(); bridge.nextSid = 0; });
+afterEach(() => { bridge.sessions.clear(); });
+
+async function open(plugin = "known") {
+  const { GET } = await import("@/app/api/mcp/[plugin]/sse/route.js");
+  const controller = new AbortController();
+  const response = await GET(
+    new Request(`http://localhost/api/mcp/${plugin}/sse`, { signal: controller.signal }),
+    { params: Promise.resolve({ plugin }) }
+  );
+  return { controller, response };
+}
+
+async function openAndHandshake(plugin = "known") {
+  const { controller, response } = await open(plugin);
+  const reader = response.body.getReader();
+  await reader.read(); // the `event: endpoint` handshake frame
+  return { controller, reader };
+}
+
+describe("/api/mcp/[plugin]/sse session release", () => {
+  it("releases the bridge session when the client aborts", async () => {
+    const { controller } = await openAndHandshake();
+    expect(bridge.sessions.size).toBe(1);
+
+    controller.abort();
+    await settle();
+
+    expect(bridge.sessions.size).toBe(0);
+  });
+
+  it("does not strand a session per reconnect", async () => {
+    for (let i = 0; i < 10; i++) {
+      const { controller } = await openAndHandshake();
+      controller.abort();
+      await settle();
+    }
+
+    // Every stranded session keeps sessions.size > 0, so the child is never reaped.
+    expect(bridge.sessions.size).toBe(0);
+  });
+
+  it("still releases when the consumer cancels the stream instead", async () => {
+    const { reader } = await openAndHandshake();
+    expect(bridge.sessions.size).toBe(1);
+
+    await reader.cancel();
+    await settle();
+
+    expect(bridge.sessions.size).toBe(0);
+  });
+
+  it("releases exactly once when abort and cancel both fire", async () => {
+    const released = [];
+    const { controller, reader } = await openAndHandshake();
+    const sid = [...bridge.sessions.keys()][0];
+    const realDelete = bridge.sessions.delete.bind(bridge.sessions);
+    bridge.sessions.delete = (k) => { released.push(k); return realDelete(k); };
+
+    controller.abort();
+    await settle();
+    await reader.cancel();
+    await settle();
+
+    expect(released).toEqual([sid]);
+    bridge.sessions.delete = realDelete;
+  });
+
+  it("still 404s an unknown plugin without registering anything", async () => {
+    const { response } = await open("nope");
+    expect(response.status).toBe(404);
+    expect(bridge.sessions.size).toBe(0);
+  });
+});


### PR DESCRIPTION
### The bug

`/api/mcp/[plugin]/sse` registers a bridge session and releases it only from `ReadableStream.cancel()`:

```js
const stream = new ReadableStream({
  start(controller) { sid = registerSession(plugin, send); ... },
  cancel() { if (sid) unregisterSession(plugin, sid); },   // the only release path
});
```

The repo already records why that is not enough, in `src/app/api/translator/console-logs/stream/route.js:22`:

```js
// request.signal fires reliably on client disconnect; ReadableStream.cancel()
// is not always invoked in Next.js, which caused listeners to accumulate.
```

Here what accumulates is not a listener — it is a **child process**. `unregisterSession` is the only thing that ever reaps the spawned stdio child (`src/lib/mcp/stdioSseBridge.js:156`):

```js
// No sessions left → kill child to avoid idle orphan process leak.
if (entry.sessions.size === 0) {
  try { entry.proc.kill(); } catch {}
  getStore().delete(name);
}
```

A session that is never unregistered keeps `sessions.size > 0` forever, so that branch never runs and the child outlives every client — the exact orphan the comment prevents. It survives until the server stops or `killAllBridges()` runs at shutdown.

Nothing surfaces it, either. The stdout broadcast loop swallows send failures on purpose:

```js
for (const send of entry.sessions.values()) {
  try { send(`event: message\ndata: ${line}\n\n`); } catch { /* ignore broken pipe */ }
}
```

so a dead session is indistinguishable from a live one, and keeps being handed every frame the child emits.

### Measurement

Connecting and disconnecting 10 times, the way a client reconnects:

| | sessions left registered |
| :-- | :-- |
| before | **10** — the child is never reaped |
| after | **0** |

### The fix

The same shape `console-logs/stream` already uses: `request.signal` wired to the release, alongside the existing `cancel()`.

`release()` is idempotent — abort and cancel can both fire, and the bridge's "last session leaves" branch (`kill()` + `store.delete`) must not run twice for one session.

`cancel()` is unchanged in behaviour; there is a test asserting it still releases, so this adds a path rather than replacing one.

### Tests

`tests/unit/mcp-sse-session-leak.test.js`, 5 cases: abort releases; 10 reconnects strand nothing; `reader.cancel()` still releases; abort + cancel release exactly once; an unknown plugin still 404s without registering. The bridge is mocked, so no child process is spawned by the test.

On `master`, cases 1 and 2 fail. The other three pass before and after — they are there to prove the existing paths were not traded away.

Mutation-checked, each reverted separately:

| mutation | result |
| :-- | :-- |
| drop the `request.signal` wiring | 2 failed |
| drop the `released` idempotency guard | 1 failed |

### Suite

Full `tests/` run in a dedicated worktree, clean tree, **`CI=true` on both sides** — without it vitest silently writes two missing `golden-url-header` snapshots instead of failing on them, which both skews the count and modifies a tracked file mid-run:

```
master:      31 files / 95 cases failing
this branch: 31 files / 95 cases failing
```

Failure **sets** compared, not counts: **identical, in both directions.** No regressions, and nothing accidentally fixed.

(An earlier revision of this description quoted `32 / 96` vs `31 / 93`. Those runs were symmetric — no `CI=true` on either side — so the "no regressions" conclusion was sound, but the absolute numbers were not comparable with my other PRs. Replaced with the figures above.)

Same class as #3526 (`/api/usage/stream`), different file and different consequence; the two are independent.
