### PR TITLE
fix(chat): treat a request without a stream key as non-streaming (#3492)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -16,6 +16,7 @@ import { getExecutor } from "../executors/index.js";
 import { supportsGrokCliReasoningEffort } from "../config/grokCli.js";
 import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDetail.js";
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
+import { clientRequestedStreaming as requestedStreaming } from "./chatCore/streamMode.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
 import { detectClientTool, isNativePassthrough } from "../utils/clientDetector.js";
@@ -109,9 +110,9 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
     }
   }
 
-  const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || sourceFormat === FORMATS.GEMINI || sourceFormat === FORMATS.GEMINI_CLI;
+  const clientRequestedStreaming = requestedStreaming(body, sourceFormat);
   const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
-  let stream = providerRequiresStreaming ? true : (body.stream !== false);
+  let stream = providerRequiresStreaming ? true : clientRequestedStreaming;
 
   // Image generation models require non-streaming (Google v1internal:generateContent)
   const modelType = getModelType(alias, model);

--- a/open-sse/handlers/chatCore/streamMode.js
+++ b/open-sse/handlers/chatCore/streamMode.js
@@ -1,0 +1,24 @@
+import { FORMATS } from "../../translator/formats.js";
+
+/**
+ * Whether the client asked for an SSE-framed response.
+ *
+ * The OpenAI API defines `stream` with a default of **false**, so a body that
+ * omits the key is a non-streaming request. Reading an absent key as "stream"
+ * frames a plain `chat.completion` object as SSE: wrong content-type, plus a
+ * `data: [DONE]` glued onto valid JSON, which strict parsers reject (#3492).
+ *
+ * The Gemini and Antigravity surfaces are the exception. Their endpoints carry
+ * the mode in the path rather than the body, and this router only routes their
+ * streaming ones, so those formats always mean SSE.
+ */
+export function clientRequestedStreaming(body, sourceFormat) {
+  if (
+    sourceFormat === FORMATS.ANTIGRAVITY ||
+    sourceFormat === FORMATS.GEMINI ||
+    sourceFormat === FORMATS.GEMINI_CLI
+  ) {
+    return true;
+  }
+  return body?.stream === true;
+}

--- a/tests/unit/stream-mode-default-3492.test.js
+++ b/tests/unit/stream-mode-default-3492.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { clientRequestedStreaming } from "../../open-sse/handlers/chatCore/streamMode.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+/**
+ * chatCore resolved the response framing with `body.stream !== false`, which
+ * reads an absent `stream` key as "stream". The OpenAI API defines `stream`
+ * with a default of false, so a body without the key is a non-streaming
+ * request — and the response came back as `text/event-stream` with a
+ * `data: [DONE]` appended to a plain `chat.completion` object, which strict
+ * JSON clients cannot parse (#3492).
+ *
+ * chatCore now reads the mode from here:
+ *   let stream = providerRequiresStreaming ? true : clientRequestedStreaming;
+ */
+const chat = (extra = {}) => ({
+  model: "deepseek-chat",
+  messages: [{ role: "user", content: "say OK" }],
+  ...extra,
+});
+
+describe("clientRequestedStreaming", () => {
+  it("reads a body with no stream key as non-streaming", () => {
+    expect(clientRequestedStreaming(chat(), FORMATS.OPENAI)).toBe(false);
+  });
+
+  it("reads an explicit stream:false as non-streaming", () => {
+    expect(clientRequestedStreaming(chat({ stream: false }), FORMATS.OPENAI)).toBe(false);
+  });
+
+  it("reads an explicit stream:true as streaming", () => {
+    expect(clientRequestedStreaming(chat({ stream: true }), FORMATS.OPENAI)).toBe(true);
+  });
+
+  it("does not treat a truthy non-boolean as a request to stream", () => {
+    for (const value of ["true", 1, {}]) {
+      expect(clientRequestedStreaming(chat({ stream: value }), FORMATS.OPENAI)).toBe(false);
+    }
+  });
+
+  it("keeps the Gemini and Antigravity surfaces on SSE regardless of the body", () => {
+    for (const format of [FORMATS.GEMINI, FORMATS.GEMINI_CLI, FORMATS.ANTIGRAVITY]) {
+      expect(clientRequestedStreaming(chat(), format)).toBe(true);
+      expect(clientRequestedStreaming(chat({ stream: false }), format)).toBe(true);
+    }
+  });
+
+  it("treats the Claude surface like OpenAI", () => {
+    expect(clientRequestedStreaming(chat(), FORMATS.CLAUDE)).toBe(false);
+    expect(clientRequestedStreaming(chat({ stream: true }), FORMATS.CLAUDE)).toBe(true);
+  });
+
+  it("survives a missing body", () => {
+    expect(clientRequestedStreaming(undefined, FORMATS.OPENAI)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #3492.

## Cause

`chatCore.js` resolved the response framing with:

```js
const clientRequestedStreaming = body.stream === true || sourceFormat === FORMATS.ANTIGRAVITY || ...;
const providerRequiresStreaming = PROVIDERS[provider]?.forceStream === true;
let stream = providerRequiresStreaming ? true : (body.stream !== false);
```

The OpenAI API defines `stream` with a default of **false**, so a body that omits the key is a non-streaming request. `!== false` reads an absent key as *stream*, so the handler took the SSE branch for a payload it had already built as a complete `chat.completion` object — `text/event-stream` on the wire, plus `data: [DONE]` concatenated onto valid JSON, exactly as the issue reports.

The predicate that was actually wanted is on the line above: `clientRequestedStreaming` is computed there and used further down for the forced-stream-to-JSON branch, but never for this decision.

## Why it looked healthy

The `Accept: application/json` branch below only ever forces non-streaming:

```js
if (clientPrefersJson && !clientPrefersSSE && body.stream !== true && !providerRequiresStreaming) stream = false;
```

so clients that happen to send that header were rescued. A client that sends no `Accept` header — the `curl` reproduction in the issue — was not. Interactive chat UIs stream and look fine; only programmatic `generateText` / `generateObject` callers break.

## The change

Move the predicate into `open-sse/handlers/chatCore/streamMode.js` and read the mode from it:

```js
let stream = providerRequiresStreaming ? true : clientRequestedStreaming;
```

Three lines in `chatCore.js`. The Gemini / Gemini-CLI / Antigravity carve-out is preserved verbatim — those endpoints carry the mode in the path rather than the body, and only their streaming variants are routed here.

Nothing else moves: `stream: true` still streams, explicit `stream: false` still returns JSON, `forceStream` providers still stream upstream and are converted to JSON by the existing `handleForcedSSEToJson` branch, and the `Accept` and `deepseek-tui` adjustments below only ever set `stream = false`, so they are unaffected.

## Tests

`tests/unit/stream-mode-default-3492.test.js` — 7 cases against the extracted predicate, no mocks:

- no `stream` key → non-streaming
- `stream: false` → non-streaming
- `stream: true` → streaming
- `"true"`, `1`, `{}` → non-streaming (a truthy non-boolean is not a request to stream)
- Gemini / Gemini-CLI / Antigravity → streaming regardless of the body
- the Claude surface behaves like OpenAI
- a missing body does not throw

Mutation-checked — restoring `!== false` turns 4 of the 7 red:

```
× reads a body with no stream key as non-streaming
× does not treat a truthy non-boolean as a request to stream
× treats the Claude surface like OpenAI
× survives a missing body
Tests  4 failed | 3 passed (7)
```

## Suite

Measured both endpoints on the full unit suite:

| | Test Files | Tests |
|---|---|---|
| `origin/master`, clean | 31 failed / 162 passed | 82 failed / 1787 passed |
| with this PR | 31 failed / 163 passed | 82 failed / **1794** passed |

Same 82 pre-existing failures, +7 passing — this PR's own cases. No test changes state because of it.
