### PR TITLE
feat(models): report token limits on combo entries in /v1/models (#3486)

### DIFF
--- a/open-sse/services/comboLimits.js
+++ b/open-sse/services/comboLimits.js
@@ -1,0 +1,38 @@
+/**
+ * Token limits a combo pool can honour.
+ *
+ * A request routed to a combo may land on any member, so the pool can only
+ * promise what its *smallest* member accepts. Anything larger is a limit some
+ * member will reject.
+ *
+ * `capsFor` receives one member reference ("alias/model-id") and returns that
+ * model's capabilities; passing it in keeps this pure and lets the caller own
+ * the alias-to-provider mapping.
+ *
+ * Members whose capabilities carry no usable number are skipped rather than
+ * treated as zero. When no member reports one, the field comes back undefined
+ * and the caller omits it - an absent field lets a client fall back, a wrong
+ * one does not.
+ */
+export function comboTokenLimits(members, capsFor) {
+  const lowest = { contextWindow: undefined, maxOutput: undefined };
+  if (!Array.isArray(members)) return lowest;
+
+  for (const ref of members) {
+    if (typeof ref !== "string" || ref.trim() === "") continue;
+    const caps = capsFor(ref) || {};
+    for (const field of ["contextWindow", "maxOutput"]) {
+      const value = caps[field];
+      if (!Number.isFinite(value) || value <= 0) continue;
+      lowest[field] = lowest[field] === undefined ? value : Math.min(lowest[field], value);
+    }
+  }
+  return lowest;
+}
+
+/** Split a combo member reference into its provider alias and model id. */
+export function splitModelRef(ref) {
+  const slash = ref.indexOf("/");
+  if (slash === -1) return { alias: "", modelId: ref };
+  return { alias: ref.slice(0, slash), modelId: ref.slice(slash + 1) };
+}

--- a/src/app/api/v1/models/route.js
+++ b/src/app/api/v1/models/route.js
@@ -18,6 +18,7 @@ import { resolveZedModels } from "open-sse/shared/zedAuth.js";
 import { updateProviderCredentials } from "@/sse/services/tokenRefresh";
 import { resolveConnectionProxyConfig } from "@/lib/network/connectionProxy";
 import { capabilitiesFromServiceKind, getCapabilitiesForModel } from "open-sse/providers/capabilities.js";
+import { comboTokenLimits, splitModelRef } from "open-sse/services/comboLimits.js";
 
 // Per-provider live model resolvers. Each receives a connection record and
 // returns { models: [{ id, name? }, ...] } | null on failure.
@@ -292,6 +293,14 @@ export async function buildModelsList(kindFilter, options = {}) {
 
   const models = [];
 
+  const aliasToProviderId = Object.fromEntries(
+    Object.entries(PROVIDER_ID_TO_ALIAS).map(([id, alias]) => [alias, id])
+  );
+  const capsForModelRef = (ref) => {
+    const { alias, modelId } = splitModelRef(ref);
+    return getCapabilitiesForModel(aliasToProviderId[alias] || alias, modelId);
+  };
+
   // Combos first (filtered by kind). Web combos expose `kind` so AI knows search vs fetch.
   for (const combo of combos) {
     if (!comboMatchesKinds(combo, kindFilter)) continue;
@@ -302,15 +311,20 @@ export async function buildModelsList(kindFilter, options = {}) {
     };
     if (combo.kind === "webSearch" || combo.kind === "webFetch") {
       entry.kind = combo.kind;
+    } else {
+      // Same snake_case token limits individual models carry, so a client
+      // sizing its context window off /v1/models does not fall back to
+      // guessing from the name. A combo can route to any member, so the pool
+      // can only promise what its smallest member accepts.
+      const { contextWindow, maxOutput } = comboTokenLimits(combo.models, capsForModelRef);
+      if (Number.isFinite(contextWindow)) entry.context_length = contextWindow;
+      if (Number.isFinite(maxOutput)) entry.max_completion_tokens = maxOutput;
     }
     models.push(entry);
   }
 
   if (connections.length === 0) {
     // DB unavailable -> return static models, filtered by per-model kind
-    const aliasToProviderId = Object.fromEntries(
-      Object.entries(PROVIDER_ID_TO_ALIAS).map(([id, alias]) => [alias, id])
-    );
     for (const [alias, providerModels] of Object.entries(PROVIDER_MODELS)) {
       const providerId = aliasToProviderId[alias] || alias;
       if (!providerMatchesKinds(providerId, kindFilter)) continue;

--- a/tests/unit/combo-token-limits-3486.test.js
+++ b/tests/unit/combo-token-limits-3486.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { comboTokenLimits, splitModelRef } from "../../open-sse/services/comboLimits.js";
+import { getCapabilitiesForModel } from "../../open-sse/providers/capabilities.js";
+
+/**
+ * Combo entries in /v1/models carried no token metadata, so a client sizing its
+ * context window off the endpoint fell back to guessing from the model name —
+ * a 1M pool read as a 128k one, compacting at ~96k (#3486).
+ *
+ * A request routed to a combo can land on any member, so the pool can only
+ * promise what its smallest member accepts.
+ */
+const capsFor = (ref) => {
+  const { alias, modelId } = splitModelRef(ref);
+  return getCapabilitiesForModel(alias, modelId);
+};
+
+describe("splitModelRef", () => {
+  it("splits on the first slash only", () => {
+    expect(splitModelRef("openrouter/deepseek/deepseek-chat")).toEqual({
+      alias: "openrouter",
+      modelId: "deepseek/deepseek-chat",
+    });
+  });
+
+  it("treats a bare id as having no alias", () => {
+    expect(splitModelRef("gpt-5")).toEqual({ alias: "", modelId: "gpt-5" });
+  });
+});
+
+describe("comboTokenLimits", () => {
+  const caps = {
+    "a/wide": { contextWindow: 1_000_000, maxOutput: 128_000 },
+    "a/narrow": { contextWindow: 128_000, maxOutput: 64_000 },
+    "a/silent": {},
+  };
+  const stub = (ref) => caps[ref];
+
+  it("reports the smallest window in the pool", () => {
+    expect(comboTokenLimits(["a/wide", "a/narrow"], stub)).toEqual({
+      contextWindow: 128_000,
+      maxOutput: 64_000,
+    });
+  });
+
+  it("is order independent", () => {
+    expect(comboTokenLimits(["a/narrow", "a/wide"], stub)).toEqual(
+      comboTokenLimits(["a/wide", "a/narrow"], stub),
+    );
+  });
+
+  it("ignores a member that reports no limits rather than reading it as zero", () => {
+    expect(comboTokenLimits(["a/wide", "a/silent"], stub)).toEqual({
+      contextWindow: 1_000_000,
+      maxOutput: 128_000,
+    });
+  });
+
+  it("returns nothing to emit when no member reports a limit", () => {
+    expect(comboTokenLimits(["a/silent"], stub)).toEqual({
+      contextWindow: undefined,
+      maxOutput: undefined,
+    });
+  });
+
+  it("survives an empty, absent or malformed model list", () => {
+    const empty = { contextWindow: undefined, maxOutput: undefined };
+    expect(comboTokenLimits([], stub)).toEqual(empty);
+    expect(comboTokenLimits(undefined, stub)).toEqual(empty);
+    expect(comboTokenLimits([null, "", "  ", 7], stub)).toEqual(empty);
+  });
+
+  it("mixes a 1M model with a 128k one down to 128k using the real catalog", () => {
+    const limits = comboTokenLimits(
+      ["anthropic/claude-opus-4.7", "deepseek/deepseek-chat"],
+      capsFor,
+    );
+    expect(limits.contextWindow).toBe(128_000);
+  });
+
+  it("keeps the full window when every member is wide", () => {
+    const limits = comboTokenLimits(
+      ["anthropic/claude-opus-4.7", "anthropic/claude-opus-4.7"],
+      capsFor,
+    );
+    expect(limits.contextWindow).toBe(1_000_000);
+  });
+});


### PR DESCRIPTION
Fixes #3486.

## Before

The combo loop in `src/app/api/v1/models/route.js` builds a bare entry:

```js
const entry = { id: combo.name, object: "model", owned_by: "combo" };
if (combo.kind === "webSearch" || combo.kind === "webFetch") entry.kind = combo.kind;
models.push(entry);
```

while the per-provider loop below emits `context_length` and `max_completion_tokens` (#3218). So a client sizing its context window off `/v1/models` finds nothing on a combo, falls back to guessing from the name, and guesses against a pool whose members may be far wider — the 1M pool read as `deepseek: 128k` in the issue, compacting at ~96k.

## After

```json
{ "id": "deepseek-flash-mix", "object": "model", "owned_by": "combo",
  "context_length": 128000, "max_completion_tokens": 64000 }
```

**Minimum across members.** A request routed to a combo can land on any member, so the pool can only promise what its smallest member accepts — anything larger is a limit some member will reject.

Three deliberate choices:

- A member whose capabilities carry no usable number is **skipped**, not read as zero. One unknown member must not collapse the pool to nothing.
- When no member reports a limit, the field is **omitted**. An absent field lets a client fall back to its own catalog; a wrong one does not.
- **Web-search / web-fetch combos are untouched.** They are not chat models and carry no window.

Member capabilities come from `getCapabilitiesForModel`, the same source the per-provider loop already uses, so combo numbers agree with the individual entries they are made of.

## Scope

Only the two top-level snake_case fields the issue asks for. #2242 adds `capabilities.contextWindow` aggregation for combos — that is a separate, nested field, and this PR does not touch `capabilities` on combo entries, so the two should not collide.

The alias-to-provider map that the DB-unavailable branch already built is hoisted so the combo loop can share it instead of building a second one.

## Tests

`tests/unit/combo-token-limits-3486.test.js` — 9 cases:

- smallest window in the pool wins, and the result is order independent
- a member reporting no limits is ignored, not read as zero
- no member reporting a limit → nothing to emit
- empty / absent / malformed model list does not throw
- against the **real** capability catalog: `claude-opus-4.7` (1M) + `deepseek-chat` (128k) → 128,000; two wide members → 1,000,000
- `splitModelRef` splits on the first slash only, so `openrouter/deepseek/deepseek-chat` keeps its nested id

Mutation-checked — swapping `Math.min` for `Math.max` turns the two that pin the semantics red:

```
× reports the smallest window in the pool
× mixes a 1M model with a 128k one down to 128k using the real catalog
Tests  2 failed | 7 passed (9)
```

## Suite

| | Test Files | Tests |
|---|---|---|
| `origin/master`, clean | 31 failed / 162 passed | 82 failed / 1787 passed |
| with this PR | 31 failed / 163 passed | 82 failed / **1796** passed |

Same 82 pre-existing failures, +9 passing — this PR's own cases.
