### PR TITLE
test(golden): make the OpenAI → Kiro golden reproducible

### DIFF
--- a/tests/translator/__snapshots__/golden-request.test.js.snap
+++ b/tests/translator/__snapshots__/golden-request.test.js.snap
@@ -233,8 +233,12 @@ exports[`GOLDEN request: OpenAI → Gemini > full body (system/image/tool/tool_r
 
 exports[`GOLDEN request: OpenAI → Kiro > full body (image base64 + tool_result) 1`] = `
 {
+  "agentMode": "vibe",
   "conversationState": {
+    "agentContinuationId": "<UUID>",
+    "agentTaskType": "vibe",
     "chatTriggerType": "MANUAL",
+    "conversationId": "<UUID>",
     "currentMessage": {
       "userInputMessage": {
         "content": "[Context: Current time is <TS>
@@ -281,7 +285,11 @@ continue",
     "history": [
       {
         "userInputMessage": {
-          "content": "You are helpful.
+          "content": "[Context: Current time is <TS>
+
+<instructions>
+You are helpful.
+</instructions>
 
 What's in this image?",
           "images": [

--- a/tests/translator/golden-request.test.js
+++ b/tests/translator/golden-request.test.js
@@ -27,10 +27,16 @@ function baseBody() {
   };
 }
 
-// Khử field động: toolNameMap, kiro conversationId (uuid), timestamp trong content.
+// Khử field động: toolNameMap, uuid phiên (kiro), timestamp trong content.
+// conversationId và agentContinuationId đều là crypto.randomUUID() cho một request
+// ephemeral (utils/sessionManager.js:224) — đổi mỗi lần chạy. Thay bằng placeholder
+// thay vì xoá hẳn, để golden vẫn bắt được nếu một field biến mất.
+const UUID_KEYS = new Set(["conversationId", "agentContinuationId"]);
+
 function clean(body) {
   const s = JSON.stringify(body, (k, v) => {
-    if (k === "_toolNameMap" || k === "conversationId") return undefined;
+    if (k === "_toolNameMap") return undefined;
+    if (UUID_KEYS.has(k)) return "<UUID>";
     return v;
   }).replace(/Current time is [^"\\]+/g, "Current time is <TS>");
   return JSON.parse(s);
@@ -99,5 +105,31 @@ describe("GOLDEN request: OpenAI → Kiro", () => {
   it("full body (image base64 + tool_result)", () => {
     const out = translateRequest(FORMATS.OPENAI, FORMATS.KIRO, "claude-sonnet-4.5", baseBody(), true, { accessToken: "t" }, "kiro");
     expect(clean(out)).toMatchSnapshot();
+  });
+});
+
+// Một golden chỉ là golden nếu cùng input cho ra cùng output ở hai lần chạy.
+// Kiro đóng dấu hai uuid mới vào mọi request ephemeral; clean() trước đây chỉ khử
+// một, nên snapshot của "OpenAI → Kiro" không thể khớp ở bất kỳ lần chạy nào —
+// regenerate chỉ đẩy lỗi sang lần sau với một uuid khác.
+describe("GOLDEN request: reproducibility", () => {
+  const CASES = [
+    ["OpenAI → Claude", FORMATS.CLAUDE, "claude-opus-4-6", { apiKey: "sk-x" }, "claude"],
+    ["OpenAI → Gemini", FORMATS.GEMINI, "gemini-3-pro", { apiKey: "k" }, "gemini"],
+    ["OpenAI → Kiro", FORMATS.KIRO, "claude-sonnet-4.5", { accessToken: "t" }, "kiro"],
+  ];
+
+  for (const [name, to, model, creds, provider] of CASES) {
+    it(`${name} → identical output on two runs`, () => {
+      const once = clean(translateRequest(FORMATS.OPENAI, to, model, baseBody(), true, creds, provider));
+      const twice = clean(translateRequest(FORMATS.OPENAI, to, model, baseBody(), true, creds, provider));
+      expect(JSON.stringify(twice)).toBe(JSON.stringify(once));
+    });
+  }
+
+  it("cleaned Kiro body carries no raw uuid", () => {
+    const out = clean(translateRequest(FORMATS.OPENAI, FORMATS.KIRO, "claude-sonnet-4.5", baseBody(), true, { accessToken: "t" }, "kiro"));
+    const raw = JSON.stringify(out).match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g);
+    expect(raw).toBeNull();
   });
 });


### PR DESCRIPTION
### The bug

`GOLDEN request: OpenAI → Kiro > full body` cannot pass. Not on CI, not locally, not on the machine that recorded it — the assertion is against a value that is regenerated on every call.

The Kiro request builder stamps **two** uuids into every ephemeral request:

```js
// open-sse/translator/request/openai-to-kiro.js:397-400
conversationId,
agentContinuationId: continuationId,
```

both ultimately `crypto.randomUUID()`:

```js
// open-sse/utils/sessionManager.js:223-224
export function resolveContinuationId({ sessionId, connectionId, scope = "", ephemeral = false } = {}) {
    if (ephemeral) return crypto.randomUUID();
```

The golden's `clean()` knows about this class of field — its comment says so: `Khử field động: toolNameMap, kiro conversationId (uuid), timestamp trong content`. But it strips only `conversationId`. `agentContinuationId` was added later and never joined the list.

Three consecutive runs of the unmodified test:

```
agentContinuationId": "f10d2124-1a17-4a4d-917b-27280dec7954"
agentContinuationId": "b584d71d-9baf-4fa2-9082-bbb9e9fed999"
agentContinuationId": "237e5f28-c72d-4cd8-bcd2-4b63139bfa17"
```

So `vitest -u` does not fix it — it just re-fails on the next run with a different uuid. That is why the case has sat in the standing red without anyone regenerating it.

### The fix

Normalize both uuids to `"<UUID>"` instead of deleting them. Deleting is what let the second one slip in unnoticed: a golden that erases a field cannot tell you when a sibling field appears next to it, or when the field itself disappears. `"<UUID>"` keeps the shape under guard while removing the entropy.

Every change in the regenerated snapshot that is **not** a normalization, traced to source:

| change | source |
| :-- | :-- |
| `agentMode: "vibe"` | `openai-to-kiro.js:417` |
| `agentTaskType: "vibe"` | `openai-to-kiro.js:401` |
| `agentContinuationId` present | `openai-to-kiro.js:400` |
| history content gains `[Context: Current time is …]` + `<instructions>` wrapper | `kiroSessionReplay.js:32-36` (`prefixUserMessage`) fed by `openai-to-kiro.js:355`; the `<instructions>` tags come from `openai-to-kiro.js:166` |

All four are features that postdate the snapshot. None is a regression. The whole snapshot diff is 9 added lines and 1 removed.

### The guard

A `GOLDEN request: reproducibility` block translates each golden body **twice** and asserts the cleaned output is byte-identical — the property `toMatchSnapshot()` silently assumes and nothing was checking. It also asserts no raw uuid survives `clean()` for Kiro.

Reverting `clean()` to the old single-key strip fails both of those, which is what makes them worth having:

```
mutation: UUID_KEYS back to ["conversationId"]
  × GOLDEN request: reproducibility > OpenAI → Kiro → identical output on two runs
  × GOLDEN request: reproducibility > cleaned Kiro body carries no raw uuid
```

### Verification

Three consecutive `CI=true` runs of the file, each `9 passed` — previously impossible for this test by construction.

Full `tests/` run in a dedicated worktree, clean tree, **`CI=true` on both sides** so vitest never silently writes a missing snapshot (without it, two `golden-url-header` cases pass by being written rather than matched, and a tracked file is modified mid-run):

```
master:      31 files / 95 cases failing
this branch: 30 files / 94 cases failing
```

**Regressions: none.** One case fixed: the Kiro golden.

Independent of #3530, which fixes the *other* golden file for a different reason (it pins the recording machine's hostname/platform/Node/app version). Same lesson from opposite directions — both of these tests were red for reasons that had nothing to do with the code they were supposed to be guarding.
