### PR TITLE
fix(cli): gate better-sqlite3 version by Node major

### DIFF
--- a/cli/hooks/sqliteRuntime.js
+++ b/cli/hooks/sqliteRuntime.js
@@ -6,7 +6,11 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
-const BETTER_SQLITE3_VERSION = "12.6.2";
+// Gate the pinned version by Node major, mirroring src/lib/db/driver.js gating
+// style: 13.x ships prebuilt binaries for current runtimes (incl. Node 26);
+// 12.6.2 stays for older ones where 13.x has no matching prebuild.
+const [NODE_MAJOR] = process.versions.node.split(".").map(Number);
+const BETTER_SQLITE3_VERSION = NODE_MAJOR >= 22 ? "13.0.3" : "12.6.2";
 const SQL_JS_VERSION = "1.14.1";
 
 function getDataDir() {


### PR DESCRIPTION
## Problem
The CLI sqlite runtime hook pins a single `better-sqlite3` version (12.6.2). 12.x ships no prebuilt binaries for current Node runtimes (Node >= 26), so on those systems the install falls back to a `node-gyp` source build and fails on machines without build tools — e.g.:

```text
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! not ok
```

The hook then silently degrades to the `sql.js` fallback, so the failure is invisible until a query behaves differently.

## Fix
Derive `NODE_MAJOR` from `process.versions.node` and gate the pinned version accordingly, mirroring the gating style already used in `src/lib/db/driver.js`:
- Node >= 22 → `better-sqlite3@13.0.3` (ships prebuilds for current runtimes, incl. Node 26)
- Node < 22 → `better-sqlite3@12.6.2` (unchanged; 13.x has no matching prebuilds there)

## Before/After
- Before: hard-pinned 12.6.2 → node-gyp source build on Node >= 26 → failure without build tools → silent sql.js fallback.
- After: version gated by Node major → prebuilt binary installed on current runtimes; older runtimes unaffected.

## Testing
- `node --check cli/hooks/sqliteRuntime.js` passes.
- Node < 22 install flow unchanged (still resolves 12.6.2).
- On Node >= 26 without build tools, first run installs the prebuilt 13.0.3 binary instead of failing node-gyp.
- CI (docker-publish) exercises the install/build path; there is no automated test job in the repo.

## Risks / Limitations
- 13.0.3 requires Node >= 22 ABI; the gate keeps older runtimes on 12.6.2 so there is no compatibility regression.
