### PR TITLE
fix(headroom): use execFileSync to avoid shell string with spaces

### DIFF
--- a/src/lib/headroom/detect.js
+++ b/src/lib/headroom/detect.js
@@ -92,7 +92,7 @@ export function findPython310() {
   let fallback = null;
   for (const candidate of pythonCandidates()) {
     try {
-      const ver = execSync(`${candidate} --version`, {
+      const ver = execFileSync(candidate, ["--version"], {
         stdio: ["ignore", "pipe", "ignore"],
         windowsHide: true,
         env: { ...process.env, PATH: EXTENDED_PATH },


### PR DESCRIPTION
## Problem
`findPython310()` in `src/lib/headroom/detect.js` runs `execSync(\`${candidate} --version\`)`. `candidate` is an interpreter path from `pythonCandidates()` — full paths from `EXTRA_BINS`, the directory next to the headroom binary, or `$HOME/.local/bin`. On any OS where that path contains a space (e.g. `/Users/First Last/.local/bin/python3`), the shell splits the command, detection fails, and the interpreter is silently skipped — leading to a wrong Python fallback even though the candidate exists.

## Fix
Replace the shell-string `execSync` with `execFileSync(candidate, ["--version"])`, which invokes the binary directly without a shell. The sibling call in the same function (`execFileSync(candidate, ["-m", "pip", "show", "headroom-ai"], ...)`) already uses this pattern. Same stdio, env, and `windowsHide` options; no quoting or ordering change.

## Before/After
- Before: shell-string injection; path containing a space splits the command and the candidate is skipped.
- After: array-based `execFileSync`; paths with spaces are handled correctly.

## Testing
- `node --check src/lib/headroom/detect.js` passes.
- Covered by existing unit tests (`tests/unit/headroom-detect.test.js`), which mock `child_process.execFileSync` — the mock surface is unchanged.
- CI (docker-publish) runs the standard image build; there is no automated test job in the repo.

## Risks / Limitations
- None identified; `execFileSync` is already the established pattern for candidate invocation in this function.
