### PR TITLE
fix(headroom): set diagnostic before silent null return on Responses translation failure

### DIFF
--- a/open-sse/rtk/headroom.js
+++ b/open-sse/rtk/headroom.js
@@ -281,7 +281,10 @@ export async function compressWithHeadroom(body, { enabled, url, model, format, 
         return null;
       }
       const oai = openaiResponsesToOpenAIRequest(model, body, false);
-      if (!Array.isArray(oai?.messages)) return null;
+      if (!Array.isArray(oai?.messages)) {
+        setDiagnostic(diagnostics, "openai-responses request did not translate to messages[]");
+        return null;
+      }
       const data = await callCompress(url, oai.messages, model, timeoutMs, compressUserMessages, diagnostics || {});
       if (!data) return null;
       // input: undefined so the translator rebuilds input from the compressed


### PR DESCRIPTION
## Problem
In `compressWithHeadroom()` (`open-sse/rtk/headroom.js`), the `openai-responses` branch returns `null` without recording a diagnostic when `openaiResponsesToOpenAIRequest()` fails to produce a `messages[]` array:

```js
const oai = openaiResponsesToOpenAIRequest(model, body, false);
if (!Array.isArray(oai?.messages)) return null;
```

Every other failure path in the same function (claude branch, Kiro projection, unsupported shape, `callCompress` errors) calls `setDiagnostic(...)` before returning, so the headroom diagnostics panel shows why compression was skipped. This silent return leaves the reason blank — indistinguishable from "compression worked" — and makes Responses-format (Codex) translation failures impossible to diagnose.

## Fix
Call `setDiagnostic(diagnostics, "openai-responses request did not translate to messages[]")` before the null return, mirroring the existing claude-branch message.

## Before/After
- Before: silent `null` return on Responses translation failure; diagnostics panel stays blank.
- After: failure reason recorded via `setDiagnostic` before returning; fail-open behavior unchanged (still returns `null`).

## Testing
- `node --check open-sse/rtk/headroom.js` passes.
- No behavior change other than the diagnostics field being populated; the fail-open contract is unchanged.
- CI (docker-publish) runs the standard image build; there is no automated test job in the repo.

## Risks / Limitations
- None; strictly additive observability.
