### PR TITLE
fix(quota): give the auto-refresh countdown a single timer owner (#3470)

### DIFF
--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/index.js
@@ -29,6 +29,7 @@ import {
   setQuotaCache,
   QUOTA_CACHE_KEY,
   REFRESH_INTERVAL_MS,
+  COUNTDOWN_SECONDS,
   CLAUDE_REFRESH_INTERVAL_MS,
   DEPLETED_QUOTA_THRESHOLD,
   AUTO_REFRESH_STORAGE_KEY,
@@ -38,6 +39,7 @@ import {
   ACCOUNT_FILTER_OPTIONS,
   QUOTA_SORT_OPTIONS,
 } from "./utils";
+import { createRefreshTimers, nextCountdown } from "./refreshTimers";
 import Card from "@/shared/components/Card";
 import { ConfirmModal, EditConnectionModal } from "@/shared/components";
 import { USAGE_SUPPORTED_PROVIDERS } from "@/shared/constants/providers";
@@ -135,7 +137,7 @@ export default function ProviderLimits() {
   const [lastUpdated, setLastUpdated] = useState(null);
   const [hasHydratedAutoRefresh, setHasHydratedAutoRefresh] = useState(false);
   const [refreshingAll, setRefreshingAll] = useState(false);
-  const [countdown, setCountdown] = useState(60);
+  const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS);
   const [connectionsLoading, setConnectionsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState(null);
   const [togglingId, setTogglingId] = useState(null);
@@ -169,8 +171,6 @@ export default function ProviderLimits() {
     providerFilteredConnections: 0,
   });
 
-  const intervalRef = useRef(null);
-  const countdownRef = useRef(null);
   const tickCountRef = useRef(0);
 
   const fetchConnections = useCallback(
@@ -467,7 +467,7 @@ export default function ProviderLimits() {
     if (refreshingAll) return;
 
     setRefreshingAll(true);
-    setCountdown(60);
+    setCountdown(COUNTDOWN_SECONDS);
 
     // Throttle Claude: poll its quota every Nth auto-tick (manual force bypasses)
     const tick = (tickCountRef.current += 1);
@@ -624,65 +624,54 @@ export default function ProviderLimits() {
     updateQuotaVisibility(next, previous);
   }, [quotaVisibility, updateQuotaVisibility]);
 
-  // Auto-refresh interval
+  // One owner for both intervals. `refreshAll` is read through a ref so a new
+  // identity does not tear the timers down and restart the 60s window.
+  const refreshAllRef = useRef(refreshAll);
   useEffect(() => {
-    if (!hasHydratedAutoRefresh || !autoRefresh) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
-      }
+    refreshAllRef.current = refreshAll;
+  }, [refreshAll]);
+
+  const timers = useMemo(
+    () =>
+      createRefreshTimers({
+        onRefresh: () => refreshAllRef.current(),
+        onTick: () => setCountdown((prev) => nextCountdown(prev, COUNTDOWN_SECONDS)),
+        refreshIntervalMs: REFRESH_INTERVAL_MS,
+      }),
+    []
+  );
+
+  // Auto-refresh interval. Nothing starts while the tab is hidden — the
+  // visibilitychange handler below owns the resume.
+  useEffect(() => {
+    if (!hasHydratedAutoRefresh || !autoRefresh || document.hidden) {
+      timers.stop();
       return;
     }
-
-    // Main refresh interval
-    intervalRef.current = setInterval(() => {
-      refreshAll();
-    }, REFRESH_INTERVAL_MS);
-
-    // Countdown interval
-    countdownRef.current = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) return 60;
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      if (countdownRef.current) clearInterval(countdownRef.current);
-    };
-  }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
+    timers.start();
+    return () => timers.stop();
+  }, [autoRefresh, hasHydratedAutoRefresh, timers]);
 
   // Pause auto-refresh when tab is hidden (Page Visibility API)
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.hidden) {
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        }
-        if (countdownRef.current) {
-          clearInterval(countdownRef.current);
-          countdownRef.current = null;
-        }
+        timers.stop();
       } else if (autoRefresh && hasHydratedAutoRefresh) {
-        // Resume auto-refresh when tab becomes visible
-        intervalRef.current = setInterval(() => refreshAll(), REFRESH_INTERVAL_MS);
-        countdownRef.current = setInterval(() => {
-          setCountdown((prev) => (prev <= 1 ? 60 : prev - 1));
-        }, 1000);
+        // `start` clears first, so repeated visible events cannot stack.
+        timers.start();
       }
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
+      // A tab hidden at mount takes the effect above through its early return,
+      // which leaves no cleanup behind — so unmounting after a resume would
+      // otherwise leave both intervals running.
+      timers.stop();
     };
-  }, [autoRefresh, refreshAll, hasHydratedAutoRefresh]);
+  }, [autoRefresh, hasHydratedAutoRefresh, timers]);
 
   const sortedConnections = useMemo(
     () =>

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/refreshTimers.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/refreshTimers.js
@@ -1,0 +1,49 @@
+/**
+ * Ownership of the quota tracker's auto-refresh timers.
+ *
+ * Two places used to create these intervals — the auto-refresh effect and the
+ * `visibilitychange` handler — and each only cleared what its own ref happened
+ * to point at. A hidden→visible transition that raced with the effect re-running
+ * left one pair orphaned and ticking forever, so the countdown dropped two
+ * seconds per second (#3470).
+ *
+ * `start()` always stops first, so calling it twice replaces the timers instead
+ * of doubling them, and there is exactly one owner no matter who calls.
+ */
+export function createRefreshTimers({
+  onRefresh,
+  onTick,
+  refreshIntervalMs,
+  tickMs = 1000,
+}) {
+  let refreshId = null;
+  let tickId = null;
+
+  const stop = () => {
+    if (refreshId !== null) {
+      clearInterval(refreshId);
+      refreshId = null;
+    }
+    if (tickId !== null) {
+      clearInterval(tickId);
+      tickId = null;
+    }
+  };
+
+  const start = () => {
+    stop();
+    refreshId = setInterval(() => onRefresh(), refreshIntervalMs);
+    tickId = setInterval(() => onTick(), tickMs);
+  };
+
+  return {
+    start,
+    stop,
+    isRunning: () => refreshId !== null || tickId !== null,
+  };
+}
+
+/** One countdown step. Wraps back to the full window instead of hitting zero. */
+export function nextCountdown(previous, windowSeconds) {
+  return previous <= 1 ? windowSeconds : previous - 1;
+}

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js
@@ -3,6 +3,9 @@ import { getModelsByProviderId } from "open-sse/config/providerModels.js";
 // ─── Constants ───────────────────────────────────────────────────────────────
 export const QUOTA_CACHE_KEY = "quotaCacheData";
 export const REFRESH_INTERVAL_MS = 60000;
+// The countdown counts the same window down in seconds; derived so the two
+// cannot drift apart.
+export const COUNTDOWN_SECONDS = REFRESH_INTERVAL_MS / 1000;
 // Claude usage/quota endpoint rate-limits; poll it less often than other providers
 export const CLAUDE_REFRESH_INTERVAL_MS = 600000;
 export const DEPLETED_QUOTA_THRESHOLD = 5;

--- a/tests/unit/quota-refresh-timers-3470.test.js
+++ b/tests/unit/quota-refresh-timers-3470.test.js
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createRefreshTimers,
+  nextCountdown,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/refreshTimers.js";
+import {
+  COUNTDOWN_SECONDS,
+  REFRESH_INTERVAL_MS,
+} from "../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/utils.js";
+
+/**
+ * The quota tracker created its intervals in two places — the auto-refresh
+ * effect and the `visibilitychange` handler — and each cleared only what its
+ * own ref pointed at. A second start therefore orphaned the first pair, and the
+ * countdown fell two seconds per second (#3470).
+ *
+ * `createRefreshTimers` is the single owner: `start()` stops first.
+ */
+function build() {
+  const ticks = [];
+  const refreshes = [];
+  const timers = createRefreshTimers({
+    onRefresh: () => refreshes.push(1),
+    onTick: () => ticks.push(1),
+    refreshIntervalMs: REFRESH_INTERVAL_MS,
+  });
+  return { timers, ticks, refreshes };
+}
+
+describe("createRefreshTimers", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("ticks once per second", () => {
+    const { timers, ticks } = build();
+    timers.start();
+    vi.advanceTimersByTime(5000);
+    expect(ticks.length).toBe(5);
+  });
+
+  it("does not double the tick rate when start is called twice", () => {
+    const { timers, ticks } = build();
+    timers.start();
+    // The hidden→visible resume used to add a second pair of intervals.
+    timers.start();
+    vi.advanceTimersByTime(5000);
+    expect(ticks.length).toBe(5);
+  });
+
+  it("stays single-rate across a hide/show cycle", () => {
+    const { timers, ticks } = build();
+    timers.start();
+    vi.advanceTimersByTime(2000);
+    timers.stop();
+    vi.advanceTimersByTime(10_000);
+    expect(ticks.length).toBe(2);
+    timers.start();
+    vi.advanceTimersByTime(3000);
+    expect(ticks.length).toBe(5);
+  });
+
+  it("stops both timers, and stop is idempotent", () => {
+    const { timers, ticks, refreshes } = build();
+    timers.start();
+    timers.stop();
+    timers.stop();
+    vi.advanceTimersByTime(REFRESH_INTERVAL_MS * 2);
+    expect(ticks.length).toBe(0);
+    expect(refreshes.length).toBe(0);
+    expect(timers.isRunning()).toBe(false);
+  });
+
+  it("refreshes on the configured interval, not on the tick", () => {
+    const { timers, refreshes } = build();
+    timers.start();
+    vi.advanceTimersByTime(REFRESH_INTERVAL_MS - 1000);
+    expect(refreshes.length).toBe(0);
+    vi.advanceTimersByTime(1000);
+    expect(refreshes.length).toBe(1);
+  });
+
+  it("reports whether it is running", () => {
+    const { timers } = build();
+    expect(timers.isRunning()).toBe(false);
+    timers.start();
+    expect(timers.isRunning()).toBe(true);
+    timers.stop();
+    expect(timers.isRunning()).toBe(false);
+  });
+
+  it("always calls the latest callback, so a re-render need not restart it", () => {
+    let current = "first";
+    const seen = [];
+    const timers = createRefreshTimers({
+      onRefresh: () => seen.push(current),
+      onTick: () => {},
+      refreshIntervalMs: 1000,
+    });
+    timers.start();
+    vi.advanceTimersByTime(1000);
+    current = "second";
+    vi.advanceTimersByTime(1000);
+    timers.stop();
+    expect(seen).toEqual(["first", "second"]);
+  });
+});
+
+describe("nextCountdown", () => {
+  it("counts down one second at a time", () => {
+    expect(nextCountdown(60, COUNTDOWN_SECONDS)).toBe(59);
+    expect(nextCountdown(2, COUNTDOWN_SECONDS)).toBe(1);
+  });
+
+  it("wraps to the full window instead of hitting zero", () => {
+    expect(nextCountdown(1, COUNTDOWN_SECONDS)).toBe(COUNTDOWN_SECONDS);
+    expect(nextCountdown(0, COUNTDOWN_SECONDS)).toBe(COUNTDOWN_SECONDS);
+  });
+
+  it("keeps the countdown window and the refresh interval in step", () => {
+    expect(COUNTDOWN_SECONDS).toBe(REFRESH_INTERVAL_MS / 1000);
+  });
+});


### PR DESCRIPTION
Fixes #3470.

## Two owners, one pair of refs

The quota tracker creates its intervals in two places, and each clears only what its own ref happens to point at:

```js
// auto-refresh effect
intervalRef.current  = setInterval(() => refreshAll(), REFRESH_INTERVAL_MS);
countdownRef.current = setInterval(tick, 1000);

// visibilitychange handler, on becoming visible
intervalRef.current  = setInterval(() => refreshAll(), REFRESH_INTERVAL_MS);
countdownRef.current = setInterval(tick, 1000);
```

The second assignment overwrites the refs. Whatever they held is orphaned — still scheduled, no longer reachable, never cleared.

Two paths reach that state:

1. **Effect re-run while hidden.** The handler clears both and nulls the refs. `refreshAll` then changes identity (it is in the effect's dep list), so the effect re-runs: its cleanup sees null refs and does nothing, and the body creates a pair **while the tab is still hidden**. Becoming visible creates a second pair on top of it.
2. **Two visible transitions in a row.** Split view and window focus changes can deliver these; the resume branch runs twice and orphans the first pair.

Either way the countdown decrements twice per second — the ~2× speed in the report. The issue guessed "multiple countdown intervals running simultaneously"; this is the mechanism.

## The fix

Ownership moves into `createRefreshTimers()`, and **`start()` stops first** — so a second start replaces the timers instead of stacking them, no matter who calls it.

Three follow-on corrections that fall out of having one owner:

- the auto-refresh effect no longer starts anything while `document.hidden` — the visibility handler owns the resume, which is what the pause feature intends
- the visibility effect stops the timers on unmount: a tab hidden at mount takes the other effect through its early return, which leaves no cleanup behind, so a resume-then-unmount used to leak both intervals
- `refreshAll` is read through a ref, so a new identity no longer tears the interval down and restarts the 60-second window mid-count

`COUNTDOWN_SECONDS` is now derived from `REFRESH_INTERVAL_MS` instead of appearing as a literal `60` in three places.

## Tests

`tests/unit/quota-refresh-timers-3470.test.js` — 10 cases on fake timers:

- one tick per second
- **`start()` twice still ticks once per second** — the bug
- hide/show cycle stays single-rate, and nothing ticks while stopped
- `stop()` is idempotent and clears both timers
- refresh fires on `REFRESH_INTERVAL_MS`, not on the tick
- `isRunning()` reflects state
- the latest callback is always used, so a re-render need not restart the timer
- `nextCountdown` counts down, wraps at 1 and 0, and `COUNTDOWN_SECONDS === REFRESH_INTERVAL_MS / 1000`

Mutation-checked — removing `stop()` from the top of `start()` reproduces the bug and reds exactly the case that pins it:

```
× does not double the tick rate when start is called twice
Tests  1 failed | 9 passed (10)
```

## Suite

| | Test Files | Tests |
|---|---|---|
| `origin/master`, clean | 31 failed / 162 passed | 82 failed / 1787 passed |
| with this PR | 31 failed / 163 passed | 82 failed / **1797** passed |

Same 82 pre-existing failures, +10 — this PR's own cases. ESLint on the touched component reports the same single pre-existing `exhaustive-deps` warning as `master`, no new ones.
