### PR TITLE
fix(transport): send the translated body to the endpoint that speaks its format (#3418, #3439)

### DIFF
--- a/open-sse/handlers/chatCore.js
+++ b/open-sse/handlers/chatCore.js
@@ -1,4 +1,4 @@
-import { detectFormat, getTargetFormat, resolveTransport } from "../services/provider.js";
+import { detectFormat } from "../services/provider.js";
 import { translateRequest } from "../translator/index.js";
 import { applyThinking, extractThinking, stripThinkingSuffix } from "../translator/concerns/thinkingUnified.js";
 import { FORMATS } from "../translator/formats.js";
@@ -6,7 +6,7 @@ import { normalizeClaudePassthrough, anchorClaudeCache } from "../translator/for
 import { createStreamController } from "../utils/streamHandler.js";
 import { refreshWithRetry } from "../services/tokenRefresh.js";
 import { createRequestLogger } from "../utils/requestLogger.js";
-import { getModelTargetFormat, getModelSupportedFormats, getModelStrip, getModelUpstreamId, getModelType, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
+import { getModelStrip, getModelUpstreamId, getModelType, PROVIDER_ID_TO_ALIAS } from "../config/providerModels.js";
 import { PROVIDERS } from "../config/providers.js";
 import { createErrorResult, parseUpstreamError, formatProviderError } from "../utils/error.js";
 import { HTTP_STATUS, TOKEN_SAVER_HEADER } from "../config/runtimeConfig.js";
@@ -15,6 +15,7 @@ import { trackPendingRequest, appendRequestLog, saveRequestDetail } from "@/lib/
 import { getExecutor } from "../executors/index.js";
 import { supportsGrokCliReasoningEffort } from "../config/grokCli.js";
 import { buildRequestDetail, extractRequestConfig } from "./chatCore/requestDetail.js";
+import { resolveUpstreamRoute } from "./chatCore/upstreamRoute.js";
 import { handleForcedSSEToJson } from "./chatCore/sseToJsonHandler.js";
 import { handleNonStreamingResponse } from "./chatCore/nonStreamingHandler.js";
 import { handleStreamingResponse, buildOnStreamComplete } from "./chatCore/streamingHandler.js";
@@ -77,20 +78,10 @@ export async function handleChatCore({ body, modelInfo, credentials, log, onCred
   if (bypassResponse) return bypassResponse;
 
   const alias = PROVIDER_ID_TO_ALIAS[provider] || provider;
-  const modelTargetFormat = getModelTargetFormat(alias, model);
   // Multi-endpoint providers: pick transport matching sourceFormat → zero translation.
-  // Per-model guard: only use the transport when the model declares support for that
-  // sourceFormat — opencode-go models differ in endpoint support (kimi/glm only do
-  // /chat/completions), so without this guard a claude-format request would wrongly
-  // route kimi to /messages.
-  const modelSupportedFormats = getModelSupportedFormats(alias, model);
-  const runtimeTransport = resolveTransport(provider, sourceFormat);
-  // Per-model guard: when a model declares supportedFormats, only use the
-  // sourceFormat-matched transport if that format is declared (opencode-go models
-  // differ — kimi/glm only do /chat/completions). Undeclared models keep the
-  // upstream default (use the transport), preserving behavior for glm/deepseek/...
-  const useTransport = (!modelSupportedFormats || modelSupportedFormats.includes(sourceFormat)) ? runtimeTransport : null;
-  const targetFormat = modelTargetFormat || useTransport?.format || getTargetFormat(provider, credentials);
+  // A model-level targetFormat overrides that choice, and the transport follows it so
+  // the body format and the endpoint never diverge.
+  const { targetFormat, transport: useTransport } = resolveUpstreamRoute({ provider, alias, model, sourceFormat, credentials });
   if (useTransport && credentials) credentials.runtimeTransport = useTransport;
   const stripList = getModelStrip(alias, model);
   const upstreamModel = getModelUpstreamId(alias, model);

--- a/open-sse/handlers/chatCore/upstreamRoute.js
+++ b/open-sse/handlers/chatCore/upstreamRoute.js
@@ -1,0 +1,26 @@
+import { getTargetFormat, resolveTransport } from "../../services/provider.js";
+import { getModelSupportedFormats, getModelTargetFormat } from "../../config/providerModels.js";
+
+// Resolve the wire format of the outbound body and the transport that carries it.
+//
+// Invariant: the transport must speak the format the body is serialized in. A
+// multi-endpoint provider picks its endpoint, headers and auth scheme from the
+// transport, so a Claude body sent over the OpenAI transport lands on
+// /v1/chat/completions with bearer auth — the upstream parses what it can and
+// silently drops the rest (images vanish, tool schemas 400).
+export function resolveUpstreamRoute({ provider, alias, model, sourceFormat, credentials }) {
+  const modelTargetFormat = getModelTargetFormat(alias, model);
+  // Per-model guard: when a model declares supportedFormats, only use the
+  // sourceFormat-matched transport if that format is declared (opencode-go models
+  // differ — kimi/glm only do /chat/completions). Undeclared models keep the
+  // upstream default (use the transport), preserving behavior for glm/deepseek/...
+  const modelSupportedFormats = getModelSupportedFormats(alias, model);
+  const runtimeTransport = resolveTransport(provider, sourceFormat);
+  const useTransport = (!modelSupportedFormats || modelSupportedFormats.includes(sourceFormat)) ? runtimeTransport : null;
+  const targetFormat = modelTargetFormat || useTransport?.format || getTargetFormat(provider, credentials);
+  // Follow targetFormat, not sourceFormat: a model-level targetFormat overrides the
+  // matched transport, so the endpoint has to move with it. Providers without a
+  // transport for that format resolve to null, i.e. the provider default endpoint.
+  const transport = modelTargetFormat ? resolveTransport(provider, modelTargetFormat) : useTransport;
+  return { targetFormat, transport };
+}

--- a/tests/unit/upstream-route-alignment.test.js
+++ b/tests/unit/upstream-route-alignment.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { resolveUpstreamRoute } from "../../open-sse/handlers/chatCore/upstreamRoute.js";
+import { PROVIDERS } from "../../open-sse/config/providers.js";
+import { PROVIDER_MODELS } from "../../open-sse/config/providerModels.js";
+
+// Every model that pins a wire format at the model level, on a provider that has
+// more than one endpoint to choose from. These are the pairs where the body format
+// and the endpoint can disagree.
+const PINNED = [];
+for (const [alias, models] of Object.entries(PROVIDER_MODELS)) {
+  if (!Array.isArray(PROVIDERS[alias]?.transports)) continue;
+  for (const m of models || []) {
+    if (m.targetFormat) PINNED.push({ alias, model: m.id, targetFormat: m.targetFormat });
+  }
+}
+
+describe("upstream route: body format and transport agree", () => {
+  it("finds the model-pinned formats it is meant to guard", () => {
+    // Guards the loop above: if the registry ever drops these the table below
+    // would pass vacuously.
+    expect(PINNED.length).toBeGreaterThan(0);
+    expect(PINNED.map((p) => `${p.alias}/${p.model}`)).toEqual(
+      expect.arrayContaining(["minimax/MiniMax-M3", "minimax-cn/MiniMax-M3"]),
+    );
+  });
+
+  for (const { alias, model, targetFormat } of PINNED) {
+    for (const sourceFormat of ["openai", "claude"]) {
+      it(`${alias}/${model}: ${sourceFormat} client → ${targetFormat} body on the ${targetFormat} transport`, () => {
+        const route = resolveUpstreamRoute({ provider: alias, alias, model, sourceFormat, credentials: {} });
+        expect(route.targetFormat).toBe(targetFormat);
+        // Without this, an openai client got the openai transport
+        // (/v1/chat/completions, bearer auth) carrying a Claude body.
+        expect(route.transport?.format).toBe(targetFormat);
+      });
+    }
+  }
+});
+
+describe("upstream route: unpinned models keep the sourceFormat-matched transport", () => {
+  const cases = [
+    { alias: "minimax", model: "MiniMax-M2.7", sourceFormat: "openai", expected: "openai" },
+    { alias: "minimax", model: "MiniMax-M2.7", sourceFormat: "claude", expected: "claude" },
+    { alias: "deepseek", model: "deepseek-chat", sourceFormat: "claude", expected: "claude" },
+  ];
+  for (const { alias, model, sourceFormat, expected } of cases) {
+    it(`${alias}/${model} on a ${sourceFormat} client stays ${expected}`, () => {
+      const route = resolveUpstreamRoute({ provider: alias, alias, model, sourceFormat, credentials: {} });
+      expect(route.targetFormat).toBe(expected);
+      expect(route.transport?.format).toBe(expected);
+    });
+  }
+});
+
+describe("upstream route: the per-model transport guard still applies", () => {
+  // opencode-go glm-5.2 declares supportedFormats ["openai"] only, so a claude
+  // client must not be routed to /v1/messages.
+  it("does not hand a claude client the claude transport for a chat-only model", () => {
+    const route = resolveUpstreamRoute({
+      provider: "opencode-go", alias: "opencode-go", model: "glm-5.2", sourceFormat: "claude", credentials: {},
+    });
+    expect(route.transport?.format).not.toBe("claude");
+  });
+
+  it("keeps the claude transport for a model that declares it", () => {
+    const route = resolveUpstreamRoute({
+      provider: "opencode-go", alias: "opencode-go", model: "minimax-m3", sourceFormat: "claude", credentials: {},
+    });
+    expect(route.targetFormat).toBe("claude");
+    expect(route.transport?.format).toBe("claude");
+  });
+});


### PR DESCRIPTION
Closes #3418. Closes #3439.

## Problem

`chatCore` picks the upstream transport from the client's `sourceFormat`, then lets a model-level `targetFormat` override the format the body is written in — but not the transport:

```js
const useTransport = (!modelSupportedFormats || modelSupportedFormats.includes(sourceFormat)) ? runtimeTransport : null;
const targetFormat = modelTargetFormat || useTransport?.format || getTargetFormat(provider, credentials);
if (useTransport && credentials) credentials.runtimeTransport = useTransport;
```

`runtimeTransport` is what `DefaultExecutor.buildUrl` and `buildHeaders` read for the URL, the headers and the auth descriptor. So for an OpenAI-format request to a model pinned to `claude`, 9Router serializes a Claude body and posts it to the provider's OpenAI endpoint with that endpoint's bearer auth.

Upstreams parse what they recognize and drop the rest, so the failure is quiet and looks like a model problem:

- **#3418** — `minimax/MiniMax-M3` answers `I don't see any image attached`. The reporter verified the same image and key work against both `POST /v1/chat/completions` (OpenAI content) and `POST /anthropic/v1/messages` (Anthropic content) directly, which rules out the image, the credentials and M3's vision support.
- **#3439** — the same pairing with tools returns `invalid params, invalid tool type: (2013)`, because Claude's `input_schema` reaches MiniMax's OpenAI endpoint where `parameters` was expected.

## Fix

Resolve the format and the transport in one place so they cannot disagree, and let the transport follow `targetFormat` when a model pins one:

```js
const transport = modelTargetFormat ? resolveTransport(provider, modelTargetFormat) : useTransport;
```

Three models declare `targetFormat` on a provider that has more than one endpoint:

| model | before | after |
|---|---|---|
| `minimax/MiniMax-M3` | claude body → `/v1/chat/completions` | claude body → `/anthropic/v1/messages` |
| `minimax-cn/MiniMax-M3` | claude body → `/v1/chat/completions` | claude body → `/anthropic/v1/messages` |
| `xiaomi-tokenplan/mimo-v2.5-pro-claude` | claude body → `/chat/completions`, bearer | claude body → `/anthropic/v1/messages`, `x-api-key` |

Nothing else changes: without a model-level `targetFormat` the expression is the previous `useTransport`, and the per-model `supportedFormats` guard is untouched — a model that does not declare a format still never gets that transport.

I did not take the other half of #3439's proposal (dropping `targetFormat: "claude"` from MiniMax-M3). That is a product decision about which wire format M3 should speak, and it is not needed to fix either report — the Anthropic endpoint handles both the image and the tool schema, as the #3418 control tests show. Same reasoning for `mimo-v2.5-pro-claude`, whose whole point is to be Claude-native.

## Verification

`tests/unit/upstream-route-alignment.test.js` derives the model list from the registry rather than hardcoding it, so a future pinned model is covered automatically (with a guard test so the table can't pass vacuously).

Reverting the one-line fix to `const transport = useTransport;` fails exactly the three alignment cases:

```
FAIL  minimax/MiniMax-M3: openai client → claude body on the claude transport
FAIL  minimax-cn/MiniMax-M3: openai client → claude body on the claude transport
FAIL  xiaomi-tokenplan/mimo-v2.5-pro-claude: openai client → claude body on the claude transport
AssertionError: expected 'openai' to be 'claude'
Tests  3 failed | 9 passed (12)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1922 | 95 |

The failure **sets** are identical — `comm` on the sorted full test names returns nothing in either direction. The 95 are pre-existing (windsurf/kimi-coding registry drift and their snapshots) and unrelated to this change. `eslint` clean on all three files.

I have no MiniMax or Xiaomi Token Plan credentials, so I have not run a live request; what is verified here is that the body format and the endpoint now agree, which is the mechanism both issues identify.