### PR TITLE
fix(providers): let self-hosted TTS/STT/embedding set their base URL (#3467)

### DIFF
--- a/open-sse/providers/registry/ollama-local.js
+++ b/open-sse/providers/registry/ollama-local.js
@@ -11,6 +11,11 @@ export default {
     website: "https://ollama.com",
   },
   category: "apikey",
+  // The connection's own endpoint, stored as providerSpecificData.baseUrl.
+  baseUrlField: {
+    label: "Ollama Host URL",
+    placeholder: "http://localhost:11434",
+  },
   transport: {
     baseUrl: "http://localhost:11434/api/chat",
     format: "ollama",

--- a/open-sse/providers/registry/selfhosted-embedding.js
+++ b/open-sse/providers/registry/selfhosted-embedding.js
@@ -40,6 +40,12 @@ export default {
     website: "https://github.com/ggml-org/llama.cpp",
   },
   category: "apikey",
+  // Same gap as the TTS and STT entries.
+  baseUrlField: {
+    label: "Base URL",
+    placeholder: "http://localhost:8080/v1",
+    help: "OpenAI base URL — /embeddings is appended.",
+  },
   auth: {
     apiKey: {
       // Note the /v1: the adapter appends "/embeddings" to whatever it is given,

--- a/open-sse/providers/registry/selfhosted-stt.js
+++ b/open-sse/providers/registry/selfhosted-stt.js
@@ -28,6 +28,13 @@ export default {
     website: "https://github.com/ggml-org/whisper.cpp",
   },
   category: "apikey",
+  // See the TTS entry: without this the dashboard cannot point the connection
+  // at a separately hosted server.
+  baseUrlField: {
+    label: "Base URL",
+    placeholder: "http://localhost:8080/v1/audio/transcriptions",
+    help: "Full transcriptions endpoint.",
+  },
   auth: {
     apiKey: {
       text: "Set providerSpecificData.baseUrl to the full transcriptions URL, e.g. http://host:8080/v1/audio/transcriptions. The API key is not checked by local servers; any value works.",

--- a/open-sse/providers/registry/selfhosted-tts.js
+++ b/open-sse/providers/registry/selfhosted-tts.js
@@ -22,6 +22,14 @@ export default {
     website: "https://github.com/remsky/Kokoro-FastAPI",
   },
   category: "apikey",
+  // Without this the dashboard saves no baseUrl and the connection silently
+  // falls back to the localhost default below, which in Docker points at the
+  // 9router container itself.
+  baseUrlField: {
+    label: "Base URL",
+    placeholder: "http://localhost:8880",
+    help: "Server root — /v1/audio/speech is appended.",
+  },
   auth: {
     apiKey: {
       text: "Set providerSpecificData.baseUrl to the server root, e.g. http://host:8080 — /v1/audio/speech is appended. The API key is not checked by local servers; any value works.",

--- a/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
+++ b/src/app/(dashboard)/dashboard/providers/[id]/AddApiKeyModal.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { Button, Badge, Input, Modal, Select } from "@/shared/components";
 import { AI_PROVIDERS } from "@/shared/constants/providers";
 import { planBulkAdd } from "@/shared/utils/bulkAdd";
+import { buildProviderSpecificData as buildSpecificData } from "@/shared/utils/providerSpecificData";
 
 const BULK_PLACEHOLDER = `name1|sk-key1\nname2|sk-key2\nsk-key-only-auto-named`;
 
@@ -18,6 +19,9 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     ? (provider === "grok-web" ? "sso=xxxxx... or just the raw value" : "eyJhbGciOi...")
     : (isXaiApiKey ? "xai-..." : provider === "qoder" ? "pt-..." : "");
 
+  // Providers whose endpoint is per-connection declare it in the registry.
+  const baseUrlField = AI_PROVIDERS?.[provider]?.baseUrlField || null;
+
   const isAzure = provider === "azure";
   const isCloudflareAi = provider === "cloudflare-ai";
   const providerRegions = AI_PROVIDERS?.[provider]?.regions || null;
@@ -29,7 +33,7 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
     defaultModel: "",
     priority: 1,
     proxyPoolId: NONE_PROXY_POOL_VALUE,
-    ollamaHostUrl: "",
+    baseUrl: "",
   });
   const [azureData, setAzureData] = useState({
     azureEndpoint: "",
@@ -52,26 +56,17 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
   const [bulkText, setBulkText] = useState("");
   const [bulkResult, setBulkResult] = useState(null); // { success, failed }
 
-  const buildProviderSpecificData = () => {
-    if (isOllamaLocal && formData.ollamaHostUrl.trim()) {
-      return { baseUrl: formData.ollamaHostUrl.trim() };
-    }
-    if (isAzure) {
-      return {
-        azureEndpoint: azureData.azureEndpoint,
-        apiVersion: azureData.apiVersion,
-        deployment: azureData.deployment,
-        organization: azureData.organization,
-      };
-    }
-    if (isCloudflareAi) {
-      return { accountId: cloudflareData.accountId };
-    }
-    if (providerRegions && region) {
-      return { region };
-    }
-    return undefined;
-  };
+  const buildProviderSpecificData = () =>
+    buildSpecificData({
+      hasBaseUrlField: Boolean(baseUrlField),
+      baseUrl: formData.baseUrl,
+      isAzure,
+      azureData,
+      isCloudflareAi,
+      cloudflareData,
+      region,
+      hasRegions: Boolean(providerRegions),
+    });
 
   const handleValidate = async () => {
     setValidating(true);
@@ -233,13 +228,14 @@ export default function AddApiKeyModal({ isOpen, provider, providerName, isCompa
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           placeholder={isOllamaLocal ? "Ollama Local" : "Production Key"}
         />
-        {isOllamaLocal && (
+        {baseUrlField && (
           <div className="flex gap-2">
             <Input
-              label="Ollama Host URL"
-              value={formData.ollamaHostUrl}
-              onChange={(e) => setFormData({ ...formData, ollamaHostUrl: e.target.value })}
-              placeholder="http://localhost:11434"
+              label={baseUrlField.label}
+              value={formData.baseUrl}
+              onChange={(e) => setFormData({ ...formData, baseUrl: e.target.value })}
+              placeholder={baseUrlField.placeholder}
+              hint={baseUrlField.help}
               className="flex-1"
             />
             <div className="pt-6">

--- a/src/shared/constants/providers.js
+++ b/src/shared/constants/providers.js
@@ -29,6 +29,7 @@ function buildProviderEntry(r) {
     ...(r.thinkingConfig ? { thinkingConfig: r.thinkingConfig } : {}),
     ...(r.regions ? { regions: r.regions, defaultRegion: r.defaultRegion } : {}),
     ...(r.hasProviderSpecificData ? { hasProviderSpecificData: true } : {}),
+    ...(r.baseUrlField ? { baseUrlField: r.baseUrlField } : {}),
     ...(r.noAuth ? { noAuth: true } : {}),
     ...(r.passthroughModels ? { passthroughModels: true } : {}),
     ...(r.hasOAuth ? { hasOAuth: true } : {}),

--- a/src/shared/utils/providerSpecificData.js
+++ b/src/shared/utils/providerSpecificData.js
@@ -1,0 +1,42 @@
+/**
+ * Build the `providerSpecificData` a new connection is saved with.
+ *
+ * Kept out of the modal so the shape can be tested without rendering: the
+ * saved value is what the executors read, and a connection saved without it
+ * silently falls back to a built-in default — which is how self-hosted TTS and
+ * STT connections ended up pointing at the 9router container itself (#3467).
+ *
+ * `baseUrl` is included for any provider whose registry entry declares a
+ * `baseUrlField`, and only when the user actually typed something: an empty
+ * box means "keep the provider's default", not "save an empty endpoint".
+ */
+export function buildProviderSpecificData({
+  hasBaseUrlField = false,
+  baseUrl = "",
+  isAzure = false,
+  azureData = null,
+  isCloudflareAi = false,
+  cloudflareData = null,
+  region = "",
+  hasRegions = false,
+} = {}) {
+  if (hasBaseUrlField) {
+    const trimmed = String(baseUrl || "").trim();
+    return trimmed ? { baseUrl: trimmed } : undefined;
+  }
+  if (isAzure) {
+    return {
+      azureEndpoint: azureData?.azureEndpoint,
+      apiVersion: azureData?.apiVersion,
+      deployment: azureData?.deployment,
+      organization: azureData?.organization,
+    };
+  }
+  if (isCloudflareAi) {
+    return { accountId: cloudflareData?.accountId };
+  }
+  if (hasRegions && region) {
+    return { region };
+  }
+  return undefined;
+}

--- a/tests/unit/provider-base-url-field-3467.test.js
+++ b/tests/unit/provider-base-url-field-3467.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProviderSpecificData } from "../../src/shared/utils/providerSpecificData.js";
+import REGISTRY from "../../open-sse/providers/registry/index.js";
+
+/**
+ * Self-hosted TTS/STT/embedding connections read their endpoint from
+ * `providerSpecificData.baseUrl`, and their registry entries tell the user to
+ * set it — but the dashboard rendered no field for it, so every connection
+ * created through the UI was saved without one and fell back to a localhost
+ * default. In Docker that default is the 9router container itself (#3467).
+ *
+ * The field is now declared in the registry and read from there, so a provider
+ * that needs a per-connection endpoint cannot be added without one again.
+ */
+const entry = (id) => REGISTRY.find((r) => r.id === id);
+
+describe("registry: providers with a per-connection endpoint declare it", () => {
+  it.each([
+    "selfhosted-tts",
+    "selfhosted-stt",
+    "selfhosted-embedding",
+    "ollama-local",
+  ])("%s declares a baseUrlField", (id) => {
+    const field = entry(id)?.baseUrlField;
+    expect(field, `${id} must declare baseUrlField`).toBeTruthy();
+    expect(typeof field.label).toBe("string");
+    expect(field.label.length).toBeGreaterThan(0);
+    expect(typeof field.placeholder).toBe("string");
+  });
+
+  it("each placeholder matches the default that provider actually falls back to", () => {
+    expect(entry("selfhosted-tts").baseUrlField.placeholder).toBe(
+      entry("selfhosted-tts").ttsConfig.baseUrl,
+    );
+    expect(entry("selfhosted-stt").baseUrlField.placeholder).toBe(
+      entry("selfhosted-stt").sttConfig.baseUrl,
+    );
+  });
+
+  it("providers with a fixed endpoint do not declare one", () => {
+    for (const id of ["openai", "anthropic", "gemini"]) {
+      const e = entry(id);
+      if (e) expect(e.baseUrlField, `${id}`).toBeUndefined();
+    }
+  });
+});
+
+describe("buildProviderSpecificData", () => {
+  it("saves a trimmed baseUrl when the provider declares the field", () => {
+    expect(
+      buildProviderSpecificData({ hasBaseUrlField: true, baseUrl: "  http://tts:8880 " }),
+    ).toEqual({ baseUrl: "http://tts:8880" });
+  });
+
+  it("saves nothing when the box is left empty, so the default still applies", () => {
+    for (const value of ["", "   ", undefined, null]) {
+      expect(buildProviderSpecificData({ hasBaseUrlField: true, baseUrl: value })).toBeUndefined();
+    }
+  });
+
+  it("ignores a typed baseUrl for a provider that does not declare the field", () => {
+    expect(
+      buildProviderSpecificData({ hasBaseUrlField: false, baseUrl: "http://nope" }),
+    ).toBeUndefined();
+  });
+
+  it("still builds the Azure shape", () => {
+    expect(
+      buildProviderSpecificData({
+        isAzure: true,
+        azureData: {
+          azureEndpoint: "https://x.openai.azure.com",
+          apiVersion: "2024-10-01-preview",
+          deployment: "gpt-4o",
+          organization: "org",
+        },
+      }),
+    ).toEqual({
+      azureEndpoint: "https://x.openai.azure.com",
+      apiVersion: "2024-10-01-preview",
+      deployment: "gpt-4o",
+      organization: "org",
+    });
+  });
+
+  it("still builds the Cloudflare and region shapes", () => {
+    expect(
+      buildProviderSpecificData({ isCloudflareAi: true, cloudflareData: { accountId: "acc" } }),
+    ).toEqual({ accountId: "acc" });
+    expect(buildProviderSpecificData({ hasRegions: true, region: "eu" })).toEqual({ region: "eu" });
+    expect(buildProviderSpecificData({ hasRegions: true, region: "" })).toBeUndefined();
+  });
+
+  it("returns nothing for an ordinary provider", () => {
+    expect(buildProviderSpecificData()).toBeUndefined();
+    expect(buildProviderSpecificData({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #3467.

## The backend asks for a value the UI never collects

All three self-hosted providers read their endpoint from `providerSpecificData.baseUrl`, and their registry entries tell the user to set it:

```js
// selfhosted-tts
text: "Set providerSpecificData.baseUrl to the server root, e.g. http://host:8080 — /v1/audio/speech is appended."
```

The dashboard renders no field for it. So a connection created through the UI is saved without one and falls back to the built-in default:

| provider | default it falls back to |
|---|---|
| Self-hosted TTS | `http://localhost:8880` |
| Self-hosted STT | `http://localhost:8080/v1/audio/transcriptions` |
| Self-hosted Embedding | `http://localhost:8080/v1` |

Inside Docker `localhost` is the 9router container itself, so a separately hosted server is simply unreachable — and nothing in the UI says why.

## One mechanism, not two

The modal already had a base-URL field. It was hardcoded to a single provider:

```js
const isOllamaLocal = provider === "ollama-local";
...
{isOllamaLocal && <Input label="Ollama Host URL" placeholder="http://localhost:11434" ... />}
```

Rather than adding a second special case beside it, a provider whose endpoint is per-connection now declares it:

```js
baseUrlField: { label: "Base URL", placeholder: "http://localhost:8880", help: "Server root — /v1/audio/speech is appended." }
```

`buildProviderEntry` passes it through to the UI (next to `regions`, `authType`, `authHint`, which already work this way), and the modal renders whatever the registry declares. `ollama-local` moves onto the same mechanism with its label and placeholder preserved exactly, so there is one path instead of two.

Each placeholder is that provider's **real** fallback, so the box shows what the connection would otherwise silently use.

## Testability

`buildProviderSpecificData` moves out of the modal into `src/shared/utils/providerSpecificData.js`, so the saved shape can be tested without rendering — the saved value is what the executors read, and that is exactly what was wrong here.

Behaviour preserved: an empty box still saves nothing. Empty means "keep the provider's default", not "save an empty endpoint".

## Tests

`tests/unit/provider-base-url-field-3467.test.js` — 12 cases:

- all four providers declare a `baseUrlField` with a non-empty label and a placeholder
- each placeholder equals the default that provider actually falls back to (`ttsConfig.baseUrl`, `sttConfig.baseUrl`) — so the two cannot drift
- providers with a fixed endpoint declare none
- a typed value is trimmed and saved; empty / whitespace / `undefined` / `null` save nothing
- a typed value is ignored for a provider that does not declare the field
- the Azure, Cloudflare and region shapes are unchanged

Mutation-checked, twice:

```
# remove the baseUrl branch from the builder
× saves a trimmed baseUrl when the provider declares the field      1 failed | 11 passed

# remove baseUrlField from the selfhosted-tts registry entry
× selfhosted-tts declares a baseUrlField
× each placeholder matches the default that provider actually falls back to
                                                                    2 failed | 10 passed
```

## Suite

| | Test Files | Tests |
|---|---|---|
| `origin/master`, clean | 31 failed / 162 passed | 82 failed / 1787 passed |
| with this PR | 31 failed / 163 passed | 82 failed / **1799** passed |

Same 82 pre-existing failures, +12 — this PR's own cases. ESLint clean on both touched files.

## Not in scope

There is no generic edit modal for an API-key connection, so this covers creation. Changing an existing connection's endpoint still means recreating it — worth a separate issue if you want it.
