### PR TITLE
fix(grok-cli): forward reasoning.effort for grok-4.6 (#3514)

### DIFF
--- a/open-sse/config/grokCli.js
+++ b/open-sse/config/grokCli.js
@@ -4,7 +4,12 @@ export const GROK_CLI_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 export const GROK_CLI_CLIENT_IDENTIFIER = "grok-shell";
 export const GROK_CLI_USER_AGENT = `grok-shell/${GROK_CLI_VERSION} (linux; x86_64)`;
 
+// Grok CLI models that accept `reasoning.effort`. Kept as an explicit allowlist:
+// capabilities.js reports `reasoning: true` for every grok-* model, including
+// grok-build and grok-composer-2.5-fast, which reject the field (#2538, #2539).
+const GROK_CLI_REASONING_EFFORT_MODELS = /^grok-4\.[56](?:$|-)/;
+
 export function supportsGrokCliReasoningEffort(model) {
   // ponytail: unknown models omit effort until live metadata reaches dispatch.
-  return /^grok-4\.5(?:$|-)/.test(String(model || ""));
+  return GROK_CLI_REASONING_EFFORT_MODELS.test(String(model || ""));
 }

--- a/tests/unit/grok-cli-executor.test.js
+++ b/tests/unit/grok-cli-executor.test.js
@@ -338,6 +338,41 @@ describe("GrokCliExecutor", () => {
     }
   });
 
+  it("forwards reasoning effort for grok-4.6 (#3514)", () => {
+    expect(supportsGrokCliReasoningEffort("grok-4.6")).toBe(true);
+
+    // Effort carried by the request body...
+    const explicit = executor.transformRequest("grok-4.6", {
+      model: "grok-4.6",
+      input: "hi",
+      reasoning_effort: "xhigh",
+    }, true, { connectionId: "g46-explicit" });
+    expect(explicit.model).toBe("grok-4.6");
+    expect(explicit.reasoning).toEqual({ effort: "xhigh", summary: "concise" });
+    expect(explicit.reasoning_effort).toBeUndefined();
+
+    // ...and by the virtual model suffix.
+    for (const level of ["low", "medium", "high", "xhigh"]) {
+      const out = executor.transformRequest(`grok-4.6-${level}`, {
+        model: `grok-4.6-${level}`,
+        input: "hi",
+      }, true, { connectionId: `g46-${level}` });
+      expect(out.model).toBe("grok-4.6");
+      expect(out.reasoning).toEqual({ effort: level, summary: "concise" });
+    }
+  });
+
+  it("keeps the allowlist closed around grok-4.5 / grok-4.6", () => {
+    for (const model of ["grok-4.5", "grok-4.5-xhigh", "grok-4.6", "grok-4.6-xhigh"]) {
+      expect(supportsGrokCliReasoningEffort(model)).toBe(true);
+    }
+    // Non-reasoning models keep receiving no effort (#2538, #2539), and an
+    // unseen version stays fail-closed until it is verified against the proxy.
+    for (const model of ["grok-build", "grok-composer-2.5-fast", "grok-code-fast-1", "grok-4.7", "grok-45"]) {
+      expect(supportsGrokCliReasoningEffort(model)).toBe(false);
+    }
+  });
+
   it("drops stale tool_choice and normalizes converted custom choices", () => {
     const noTools = executor.transformRequest("grok-build", {
       model: "grok-build",


### PR DESCRIPTION
Closes #3514.

## Problem

`supportsGrokCliReasoningEffort` gates whether `reasoning.effort` reaches `cli-chat-proxy.grok.com`:

```js
return /^grok-4\.5(?:$|-)/.test(String(model || ""));
```

`grok-4.6` does not match, so `transformRequest` takes the `else` branch and drops the field:

```js
} else {
  delete body.reasoning.effort;
}
...
delete body.reasoning_effort;
```

The request goes upstream as `reasoning: { summary: "concise" }` and the proxy applies its own default. Nothing is logged — `chatCore` also suppresses the `THINK:` tag for grok-cli models outside the allowlist — so the effort just disappears.

This takes the `gcli/grok-4.6-low|medium|high|xhigh` virtual models with it: their only job is to set an effort the executor then deletes.

## Fix

```js
const GROK_CLI_REASONING_EFFORT_MODELS = /^grok-4\.[56](?:$|-)/;
```

## On the alternative the issue suggests

> The exact implementation may instead use provider/model capabilities, avoiding a hard-coded allowlist.

That does not work as a drop-in. `getCapabilitiesForModel` resolves through `PATTERN_CAPABILITIES`, whose last entry is `{ pattern: "*grok*", caps: { reasoning: true, ... } }`, so every Grok model reports `reasoning: true`:

```
grok-4.5                 reasoning= true
grok-4.6                 reasoning= true
grok-build               reasoning= true
grok-composer-2.5-fast   reasoning= true
grok-code-fast-1         reasoning= true
```

`grok-build` and `grok-composer-2.5-fast` are precisely the models that reject `reasoningEffort` (#2538, #2539). Driving the gate off capabilities would send it to them again. The allowlist stays, with a comment recording why; I left the `grok-4.7`-and-later case fail-closed, matching the existing "unknown models omit effort until live metadata reaches dispatch" note.

## Deliberately not included

- **`minimal` as an effort value.** The issue lists it among Grok 4.6's accepted levels. `normalizeGrokCliEffort` currently maps it to `high`, and `EFFORT_LEVELS` is shared with grok-4.5 — I have no xAI account to check whether 4.5 accepts `minimal`, and widening it blind would turn a rejected value into a silently different one for a model I cannot test. An existing test pins the current mapping (`normalizeGrokCliEffort("minimal") === "high"`); I left it alone.
- **`grok-4.6` catalog entries.** The registry lists grok-4.5 variants only. I did not invent upstream model ids I cannot confirm; the fix works for whatever id the client sends, which is how the reporter reached grok-4.6 in the first place.

`max → xhigh` already holds, and `ultra` already falls back to `high`; both are covered by the existing "normalizes official effort aliases" test.

## Verification

Two tests added to `tests/unit/grok-cli-executor.test.js`, driving the real `GrokCliExecutor.transformRequest` — the table the issue asks for, plus the negative cases.

Reverting the pattern to `/^grok-4\.5(?:$|-)/`:

```
FAIL  unit/grok-cli-executor.test.js > GrokCliExecutor > forwards reasoning effort for grok-4.6 (#3514)
FAIL  unit/grok-cli-executor.test.js > GrokCliExecutor > keeps the allowlist closed around grok-4.5 / grok-4.6
AssertionError: expected false to be true
Tests  2 failed | 23 passed (25)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1912 | 95 |

Identical failure sets (`comm` on the sorted full test names is empty both ways); the 95 are pre-existing windsurf/kimi-coding registry drift. `eslint` clean.

No live call: I have no Grok Build subscription, so what is verified here is that the effort now reaches the request body instead of being deleted.