### PR TITLE
fix(tests): resolve security-audit sources from the repo, not the working dir

### DIFF
--- a/tests/unit/security-audit.test.js
+++ b/tests/unit/security-audit.test.js
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
+
+// Resolve against this file, not the working directory: vitest runs with its
+// config root at tests/, so a cwd-relative "src/..." pointed at tests/src/...
+// and every readFileSync below threw ENOENT.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const fromRepo = (rel) => path.join(REPO_ROOT, rel);
 
 // ============================================================
 // AUDIT-002 (#1962): API key masking in usage stats
@@ -8,7 +15,7 @@ import path from "path";
 describe("AUDIT-002: API key masking", () => {
   it("source should contain maskApiKey function", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/db/repos/usageRepo.js"),
+      fromRepo("src/lib/db/repos/usageRepo.js"),
       "utf-8"
     );
     expect(source).toContain("function maskApiKey");
@@ -16,7 +23,7 @@ describe("AUDIT-002: API key masking", () => {
 
   it("getUsageHistory should use apiKeyMasked instead of apiKey", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/db/repos/usageRepo.js"),
+      fromRepo("src/lib/db/repos/usageRepo.js"),
       "utf-8"
     );
     // The REST response should use apiKeyMasked
@@ -31,7 +38,7 @@ describe("AUDIT-002: API key masking", () => {
 
   it("getUsageStats should use apiKeyMasked in byApiKey entries", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/db/repos/usageRepo.js"),
+      fromRepo("src/lib/db/repos/usageRepo.js"),
       "utf-8"
     );
     // Both code paths (daily summary + 24h live) should use apiKeyMasked
@@ -50,7 +57,7 @@ describe("AUDIT-002: API key masking", () => {
 
   it("byApiKey object keys should use masked key, not raw key", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/db/repos/usageRepo.js"),
+      fromRepo("src/lib/db/repos/usageRepo.js"),
       "utf-8"
     );
     // The 24h path should use apiKeyMasked in the akKey template
@@ -76,7 +83,7 @@ describe("AUDIT-003: Proxy URL validation", () => {
 
   it("source should contain validateProxyUrl function", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/network/outboundProxy.js"),
+      fromRepo("src/lib/network/outboundProxy.js"),
       "utf-8"
     );
     expect(source).toContain("function validateProxyUrl");
@@ -173,7 +180,7 @@ describe("AUDIT-003: Proxy URL validation", () => {
 describe("AUDIT-018: XSS escaping in OAuth callback", () => {
   it("source should contain escapeHtml function", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/oauth/utils/server.js"),
+      fromRepo("src/lib/oauth/utils/server.js"),
       "utf-8"
     );
     expect(source).toContain("function escapeHtml");
@@ -181,7 +188,7 @@ describe("AUDIT-018: XSS escaping in OAuth callback", () => {
 
   it("should escape ampersand, angle brackets, and quotes", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/oauth/utils/server.js"),
+      fromRepo("src/lib/oauth/utils/server.js"),
       "utf-8"
     );
     expect(source).toContain("&amp;");
@@ -193,7 +200,7 @@ describe("AUDIT-018: XSS escaping in OAuth callback", () => {
 
   it("should use safeMessage in rendered HTML, not raw message", () => {
     const source = fs.readFileSync(
-      path.resolve("src/lib/oauth/utils/server.js"),
+      fromRepo("src/lib/oauth/utils/server.js"),
       "utf-8"
     );
     expect(source).toContain("safeMessage");
@@ -209,7 +216,7 @@ describe("AUDIT-018: XSS escaping in OAuth callback", () => {
 describe("AUDIT-004: Atomic lock file for MITM startup", () => {
   it("manager.js should define LOCK_FILE constant", () => {
     const source = fs.readFileSync(
-      path.resolve("src/mitm/manager.js"),
+      fromRepo("src/mitm/manager.js"),
       "utf-8"
     );
     expect(source).toContain("LOCK_FILE");
@@ -218,7 +225,7 @@ describe("AUDIT-004: Atomic lock file for MITM startup", () => {
 
   it("should use O_EXCL flag (wx) for atomic creation", () => {
     const source = fs.readFileSync(
-      path.resolve("src/mitm/manager.js"),
+      fromRepo("src/mitm/manager.js"),
       "utf-8"
     );
     expect(source).toContain('"wx"');
@@ -227,7 +234,7 @@ describe("AUDIT-004: Atomic lock file for MITM startup", () => {
 
   it("should clean up lock file on all exit paths", () => {
     const source = fs.readFileSync(
-      path.resolve("src/mitm/manager.js"),
+      fromRepo("src/mitm/manager.js"),
       "utf-8"
     );
     const matches = source.match(/unlinkSync\(LOCK_FILE\)/g);
@@ -242,7 +249,7 @@ describe("AUDIT-004: Atomic lock file for MITM startup", () => {
 describe("AUDIT-001: Synchronous restart guard", () => {
   it("mitmIsRestarting should be set before first await expression", () => {
     const source = fs.readFileSync(
-      path.resolve("src/mitm/manager.js"),
+      fromRepo("src/mitm/manager.js"),
       "utf-8"
     );
 
@@ -273,7 +280,7 @@ describe("AUDIT-001: Synchronous restart guard", () => {
 
   it("mitmIsRestarting should be reset on max-restarts early return", () => {
     const source = fs.readFileSync(
-      path.resolve("src/mitm/manager.js"),
+      fromRepo("src/mitm/manager.js"),
       "utf-8"
     );
 


### PR DESCRIPTION
## Problem

`tests/unit/security-audit.test.js` guards five past security fixes by reading the source files and asserting the fix is still there. It locates them with a **cwd-relative** path:

```js
const source = fs.readFileSync(path.resolve("src/lib/db/repos/usageRepo.js"), "utf-8");
```

`vitest.config.js` lives in `tests/`, and `tests/README.md` says to run the suite from there:

> **Running Tests** — From the `tests/` directory: `npm test`

So `process.cwd()` is `tests/`, and every one of those reads resolves to `tests/src/...`:

```
Error: ENOENT: no such file or directory, open 'D:\...\9router\tests\src\lib\db\repos\usageRepo.js'
Error: ENOENT: no such file or directory, open 'D:\...\9router\tests\src\lib\network\outboundProxy.js'
Error: ENOENT: no such file or directory, open 'D:\...\9router\tests\src\lib\oauth\utils\server.js'
Error: ENOENT: no such file or directory, open 'D:\...\9router\tests\src\mitm\manager.js'
```

Thirteen assertions never actually inspect anything:

| audit | guards |
|---|---|
| AUDIT-002 (#1962) | API keys are masked in usage history and stats, and `byApiKey` is keyed by the masked value |
| AUDIT-003 | `validateProxyUrl` exists in the outbound proxy |
| AUDIT-018 | `escapeHtml` exists and the OAuth callback renders `safeMessage`, not the raw message |
| AUDIT-004 | the MITM lock file is created with `O_EXCL` (`wx`) and cleaned up on every exit path |
| AUDIT-001 | the MITM restart guard is set before the first `await` and reset on the max-restarts early return |

## Fix

Resolve from the test file instead of the working directory, which is what `tunnel-pid-ownership.test.js` and `open-package-external.test.js` already do:

```js
const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
const fromRepo = (rel) => path.join(REPO_ROOT, rel);
```

13 call sites rewritten; nothing else in the file changes. It was the only test in the suite reading sources by cwd — `grep` for `process.cwd()` and `path.resolve("` across `tests/` returns nothing else.

## Verification

**No production change is needed.** With the paths fixed, all 21 tests in the file pass — the guarded properties are still in the source (`function maskApiKey` ×1, `validateProxyUrl` ×2, `escapeHtml` ×2, `LOCK_FILE` ×9). The guards were dormant, not violated.

The restored assertions do bite. Renaming `escapeHtml` → `renderRaw` in `src/lib/oauth/utils/server.js` (reverted afterwards):

```
FAIL  unit/security-audit.test.js > AUDIT-018: XSS escaping in OAuth callback > source should contain escapeHtml function
Tests  1 failed | 20 passed (21)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1910 | 82 |

The 13 that flipped to passing are exactly the ones above — `comm` on the sorted full test names shows 13 removed and **nothing added**. The remaining 82 are unrelated pre-existing failures (windsurf registry is commented out of `registry/index.js` so `PROVIDERS.windsurf` is undefined, `cursor-agent-proto` drift, an incomplete `vi.mock` of `rtk/headroom.js` in `force-stream-config`, and stale golden snapshots); I left them alone rather than mix unrelated repairs into this change.

`eslint` clean.