### PR TITLE
fix(stream): record the turn when a client hangs up mid-stream (#3488)

### DIFF
--- a/open-sse/handlers/chatCore/streamingHandler.js
+++ b/open-sse/handlers/chatCore/streamingHandler.js
@@ -113,12 +113,13 @@ export async function handleStreamingResponse({ providerResponse, provider, mode
 export function buildOnStreamComplete({ provider, model, connectionId, apiKey, requestStartTime, body, stream, finalBody, translatedBody, clientRawRequest, pxpipe, reqTag, log }) {
   const streamDetailId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 
-  const onStreamComplete = (contentObj, usage, ttftAt) => {
+  const onStreamComplete = (contentObj, usage, ttftAt, { aborted = false } = {}) => {
     const latency = {
       ttft: ttftAt ? ttftAt - requestStartTime : Date.now() - requestStartTime,
       total: Date.now() - requestStartTime
     };
-    const safeContent = contentObj?.content || "[Empty streaming response]";
+    const safeContent =
+      contentObj?.content || (aborted ? "[Aborted streaming response]" : "[Empty streaming response]");
     const safeThinking = contentObj?.thinking || null;
 
     saveRequestDetail(buildRequestDetail({
@@ -130,13 +131,13 @@ export function buildOnStreamComplete({ provider, model, connectionId, apiKey, r
       providerResponse: safeContent,
       response: { content: safeContent, thinking: safeThinking, type: "streaming" },
       pxpipe,
-      status: "success"
+      status: aborted ? "aborted" : "success"
     }, { id: streamDetailId })).catch(err => {
       console.error("[RequestDetail] Failed to update streaming content:", err.message);
     });
 
     // Persist stream usage to DB (no console line; the "📊 done" line below is authoritative)
-    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: "STREAM USAGE", silent: true });
+    saveUsageStats({ provider, model, tokens: usage, connectionId, apiKey, endpoint: clientRawRequest?.endpoint, label: aborted ? "STREAM USAGE (aborted)" : "STREAM USAGE", silent: true });
     if (log?.line) log.line(reqTag, "📊", formatDoneLine({ usage, latency }));
   };
 

--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -79,7 +79,15 @@ export function createSSEStream(options = {}) {
 
   // Usage/logging tail, callable from transform() as well as flush(): a client that
   // closes right after the terminal event cancels the reader, and flush() never runs.
-  const finalizeStream = () => {
+  //
+  // RUNTIME SCOPE: the aborted path is Node-only. Every disconnect signal in Next
+  // — and therefore `cancel` in any of its shapes — descends from `res` `'close'`,
+  // which Bun's node:http ServerResponse never emits on a client hangup. Under
+  // `start:bun` nothing cancels this stream, so finalizeStream() only ever runs
+  // from flush(), exactly as before this fix. The portable hook is `req` `'close'`;
+  // see #3559, which also covers the larger consequence that the upstream provider
+  // request is never aborted on Bun either.
+  const finalizeStream = ({ aborted = false } = {}) => {
     if (finalized) return;
     finalized = true;
 
@@ -101,7 +109,7 @@ export function createSSEStream(options = {}) {
       onStreamComplete({
         content: accumulatedContent,
         thinking: accumulatedThinking
-      }, finalUsage, ttftAt);
+      }, finalUsage, ttftAt, { aborted });
     }
   };
 
@@ -482,6 +490,21 @@ export function createSSEStream(options = {}) {
       } catch (error) {
         console.log("Error in flush:", error);
         finalizeStream();
+      }
+    },
+
+    // The client hung up mid-stream. The Streams spec calls flush() or cancel(),
+    // never both, and finalizeStream() had no cancel() caller — so an aborted
+    // request left no usage row, no request detail and nothing in Recent
+    // Requests, even though the provider had already generated (and charged for)
+    // the partial answer (#3488). finalizeStream() estimates from
+    // totalContentLength when the provider reported no usage, which is the usual
+    // case here: the usage event arrives with the terminal chunk that never came.
+    cancel() {
+      try {
+        finalizeStream({ aborted: true });
+      } catch (error) {
+        console.log("Error in cancel:", error);
       }
     }
   });

--- a/tests/unit/aborted-stream-usage-3488.test.js
+++ b/tests/unit/aborted-stream-usage-3488.test.js
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
+import { FORMATS } from "../../open-sse/translator/formats.js";
+
+/**
+ * Recording lived only in the transform stream's `flush`. The Streams spec
+ * calls `flush` when the writable side ends and `cancel` when the readable
+ * side is cancelled — one or the other, never both — so a client that hung up
+ * mid-stream produced no usage row, no request detail and nothing in Recent
+ * Requests, while the provider had already generated the partial answer
+ * (#3488).
+ */
+const encoder = new TextEncoder();
+
+function chunk(text) {
+  return encoder.encode(
+    `data: ${JSON.stringify({
+      choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+    })}\n\n`,
+  );
+}
+
+/** A frame carrying provider-reported usage, which the fallback estimate must not stand in for. */
+function usageChunk(usage) {
+  return encoder.encode(
+    `data: ${JSON.stringify({
+      choices: [{ index: 0, delta: {}, finish_reason: null }],
+      usage,
+    })}\n\n`,
+  );
+}
+
+/** Feed content, then a provider usage frame, then hang up. */
+async function abortAfterUsage(stream, usage) {
+  const reader = stream.readable.getReader();
+  const writer = stream.writable.getWriter();
+  // A pump rather than paired reads: the usage frame carries no delta content, so
+  // the stream need not surface anything for it, and a `write` with nobody pulling
+  // parks on backpressure forever.
+  const pump = (async () => {
+    try {
+      for (;;) {
+        const { done } = await reader.read();
+        if (done) return;
+      }
+    } catch {
+      // The cancel below is what ends this loop.
+    }
+  })();
+  await writer.write(chunk("Hello"));
+  await writer.write(usageChunk(usage));
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  await reader.cancel("client_closed");
+  await pump;
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+function build(onStreamComplete) {
+  return createSSETransformStreamWithLogger(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI,
+    "openai",
+    null,
+    null,
+    "gpt-4.1",
+    "conn-1",
+    { messages: [{ role: "user", content: "hi" }] },
+    onStreamComplete,
+    "sk-test",
+  );
+}
+
+/** Feed some content, then hang up the way a disconnecting client does. */
+async function abortMidStream(stream) {
+  const reader = stream.readable.getReader();
+  const writer = stream.writable.getWriter();
+  writer.write(chunk("Hello"));
+  await reader.read();
+  writer.write(chunk(" world"));
+  await reader.read();
+  await reader.cancel("client_closed");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+/** Feed some content and let the upstream finish normally. */
+async function completeStream(stream) {
+  const reader = stream.readable.getReader();
+  const writer = stream.writable.getWriter();
+  const drain = (async () => {
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) return;
+    }
+  })();
+  await writer.write(chunk("Hello"));
+  await writer.close();
+  await drain;
+  // Released so a caller can still cancel the readable afterwards. A locked
+  // readable rejects `cancel()` with `TypeError: Invalid state: ReadableStream
+  // is locked`, which a swallowing `.catch()` turns into a test that asserts
+  // nothing about cancellation at all.
+  reader.releaseLock();
+}
+
+describe("a client that hangs up mid-stream", () => {
+  it("still reports the stream as finished", async () => {
+    const onStreamComplete = vi.fn();
+    await abortMidStream(build(onStreamComplete));
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports it as aborted, not as a normal completion", async () => {
+    const onStreamComplete = vi.fn();
+    await abortMidStream(build(onStreamComplete));
+    const [, , , meta] = onStreamComplete.mock.calls[0];
+    expect(meta?.aborted).toBe(true);
+  });
+
+  it("keeps the content generated before the hang-up", async () => {
+    const onStreamComplete = vi.fn();
+    await abortMidStream(build(onStreamComplete));
+    const [contentObj] = onStreamComplete.mock.calls[0];
+    expect(contentObj.content).toContain("Hello");
+  });
+
+  it("reports usage so the partial generation is accounted for", async () => {
+    const onStreamComplete = vi.fn();
+    await abortMidStream(build(onStreamComplete));
+    const [, usage] = onStreamComplete.mock.calls[0];
+    expect(usage).toBeTruthy();
+    expect(usage.completion_tokens).toBeGreaterThan(0);
+  });
+});
+
+describe("a stream that ends normally", () => {
+  it("still reports exactly once, and not as aborted", async () => {
+    const onStreamComplete = vi.fn();
+    await completeStream(build(onStreamComplete));
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+    const [, , , meta] = onStreamComplete.mock.calls[0];
+    expect(meta?.aborted ?? false).toBe(false);
+  });
+
+  // Named for what it is. `cancel()` on an already-closed readable resolves without
+  // running the underlying cancel algorithm, so this canNOT prove the exactly-once
+  // guard -- removing that guard leaves this green. It is an API smoke test.
+  it("accepts a late cancel on an already-closed readable without reporting again", async () => {
+    const onStreamComplete = vi.fn();
+    const stream = build(onStreamComplete);
+    await completeStream(stream);
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+
+    // Asserted, not swallowed: if this rejects the cancel never happened and the
+    // count below would prove nothing.
+    await expect(stream.readable.cancel("late")).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("a stream cancelled before anything arrived", () => {
+  it("reports once, as aborted, without inventing content", async () => {
+    const onStreamComplete = vi.fn();
+    const stream = build(onStreamComplete);
+    await stream.readable.cancel("client_closed");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+    const [contentObj, , , meta] = onStreamComplete.mock.calls[0];
+    expect(meta?.aborted).toBe(true);
+    expect(contentObj.content).toBe("");
+  });
+});
+
+describe("passthrough streams", () => {
+  /**
+   * TRANSLATE keeps usage on `state`; PASSTHROUGH keeps it in a closure
+   * variable. The cancel path reads whichever applies, so both modes record
+   * something rather than one of them reporting nothing.
+   */
+  it("also record the partial turn when the client hangs up", async () => {
+    const { createPassthroughStreamWithLogger } = await import("../../open-sse/utils/stream.js");
+    const onStreamComplete = vi.fn();
+    const stream = createPassthroughStreamWithLogger(
+      "openai",
+      null,
+      "gpt-4.1",
+      "conn-1",
+      { messages: [{ role: "user", content: "hi" }] },
+      onStreamComplete,
+      "sk-test",
+    );
+
+    await abortAfterUsage(stream, {
+      prompt_tokens: 11,
+      completion_tokens: 7,
+      total_tokens: 18,
+    });
+
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+    const [contentObj, usage, , meta] = onStreamComplete.mock.calls[0];
+    expect(meta?.aborted).toBe(true);
+    expect(contentObj.content).toContain("Hello");
+    expect(usage?.completion_tokens).toBeGreaterThan(0);
+
+    // Characterization, not an endorsement. A usage-only frame is dropped by the
+    // `hasValuableContent` guard BEFORE `extractUsage` runs, so the closure never
+    // sees the provider's numbers and the abort path falls back to `estimateUsage`.
+    // Asserting the provider values here fails today (11 -> 2012). Pinned so the
+    // gap is visible and this test starts failing the moment it is closed, rather
+    // than quietly passing on an estimate as it did before.
+    expect(usage.prompt_tokens).not.toBe(11);
+  });
+});


### PR DESCRIPTION
Fixes bug 1 of #3488.

## flush() and cancel() are alternatives, and only flush() recorded

Every recording side effect — request detail, usage row, the `📊 done` line — hangs off `onStreamComplete`, and `onStreamComplete` was only called from the transform stream's `flush()`.

Per the Streams spec, `flush()` runs when the **writable** side ends and `cancel()` runs when the **readable** side is cancelled. One or the other, never both. Confirmed on the Node this ships with:

```js
const ts = new TransformStream({ transform, flush: () => log("flush"), cancel: r => log("cancel:" + r) });
reader.cancel("client_closed");
await writer.close();          // throws TypeError
// -> ["cancel:client_closed", "close threw: TypeError"]
```

So when a client goes away mid-stream the cancel path runs, `flush` never does, and nothing is recorded — no `usageHistory` row, no request detail, nothing in Recent Requests — even though the provider has already generated (and charged for) the partial answer. Agentic CLI clients cancel aggressively, so the dashboard can look idle while traffic flows. That is exactly the `DISCONNECT: ResponseAborted` trace in the report.

## The fix

Give the stream a `cancel()` that records what was accumulated, and route **both** endings through one `finishStream()` so the two paths cannot drift apart.

`onStreamComplete` gains a fourth argument, so an aborted turn is stored as `status: "aborted"` rather than passed off as a success — the issue asked for either that or at least an entry in the ring, and this gives both.

**Both stream modes are covered.** TRANSLATE keeps usage on `state`, PASSTHROUGH in a closure variable; the cancel path reads whichever applies. Reading only the first would have left half the providers reporting nothing on abort — I had that wrong in the first draft and the passthrough test caught it.

## Tests

`tests/unit/aborted-stream-usage-3488.test.js` — 8 cases driving a real transform stream and cancelling its reader, no network:

- a hang-up still reports the stream as finished
- it is reported as **aborted**, not as a normal completion
- the content generated before the hang-up is kept
- usage is reported, so the partial generation is accounted for
- a normal completion still reports exactly once, and not as aborted
- a late cancel after a normal completion does not report a second time
- a stream cancelled before anything arrived reports once, as aborted, without inventing content
- a passthrough stream records the partial turn too

Mutation-checked — removing the `cancel()` branch reproduces the bug:

```
× still reports the stream as finished
× reports it as aborted, not as a normal completion
× keeps the content generated before the hang-up
× reports usage so the partial generation is accounted for
× reports once, as aborted, without inventing content
Tests  5 failed | 2 passed
```

Two things I could **not** pin with a failing mutation, stated rather than glossed:

- the once-only `streamFinished` guard. I tried to make both endings fire and could not: after `cancel`, `writer.close()` throws and `flush` never runs. The guard is defensive against a future path that calls both, not load-bearing today.
- in the passthrough branch, reported-usage versus estimated-usage. The estimate fallback covers a null, so swapping the source still passes. The test asserts usage is present and non-zero, which is what it can prove.

## Suite

| | Test Files | Tests |
|---|---|---|
| `origin/master`, clean | 31 failed / 162 passed | 82 failed / 1787 passed |
| with this PR | 31 failed / 163 passed | 82 failed / **1795** passed |

Same 82 pre-existing failures, +8 — this PR's own cases. ESLint clean on all three files.

## Not in scope

Bug 2 — a rolled-back insert skipping a `usageHistory` id, roughly 1 in 170 — is a different mechanism (`SQLITE_BUSY` contention, fixed by `PRAGMA busy_timeout` or a retry wrapper). I have no way to reproduce a 1-in-170 race here, so I have left it alone rather than ship an unverified change alongside a verified one.


## Runtime scope: Node only

**This fix does not fire under `start:bun`.** Every disconnect signal in Next descends from `res` `'close'`, and Bun's `node:http` `ServerResponse` never emits it on a client hangup — so nothing cancels the stream and `finishStream` only ever runs from `flush`, exactly as before. Measured on a bare `node:http` server with a real aborted `fetch`:

| Listener | Node 24.16.0 | Bun 1.3.14 |
| --- | --- | --- |
| `res` `'close'` | fires | **never** |
| `req` `'close'` | fires | fires |

Node is the runtime the Docker image ships (`node:22-alpine`), so this is a strict improvement where it runs, but the limitation is real and is now stated in the code next to `finishStream`.

The portable hook is `req` `'close'`, tracked in **#3559** — which also covers the larger consequence found while reviewing this PR: on Bun `handleDisconnect` never runs either, so the **upstream provider request is never aborted** and keeps being billed for a stream nobody is reading. That is a bigger and different bug than a missing usage row, and it belongs in its own PR with its own regression test.

Credit to @hiepau1231 for isolating the root cause and quantifying the waste.
