### PR TITLE
fix(oauth): stop leaking the callback server and its poll timer on failure

### DIFF
--- a/src/lib/oauth/services/antigravity.js
+++ b/src/lib/oauth/services/antigravity.js
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import open from "open";
 import { ANTIGRAVITY_CONFIG, getOAuthClientMetadata } from "../constants/oauth.js";
 import { getServerCredentials } from "../config/index.js";
-import { startLocalServer } from "../utils/server.js";
+import { startLocalServer, waitForCallbackParams } from "../utils/server.js";
 import { spinner as createSpinner } from "../utils/ui.js";
 
 /**
@@ -227,6 +227,7 @@ export class AntigravityService {
   async connect() {
     const spinner = createSpinner("Starting Antigravity OAuth...").start();
 
+    let closeServer = null;
     try {
       spinner.text = "Starting local server...";
 
@@ -235,6 +236,7 @@ export class AntigravityService {
       const { port, close } = await startLocalServer((params) => {
         callbackParams = params;
       });
+      closeServer = close;
 
       const redirectUri = `http://localhost:${port}/callback`;
       spinner.succeed(`Local server started on port ${port}`);
@@ -254,19 +256,7 @@ export class AntigravityService {
       // Wait for callback
       spinner.start("Waiting for Antigravity authorization...");
 
-      await new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error("Authentication timeout (5 minutes)"));
-        }, 300000);
-
-        const checkInterval = setInterval(() => {
-          if (callbackParams) {
-            clearInterval(checkInterval);
-            clearTimeout(timeout);
-            resolve();
-          }
-        }, 100);
-      });
+      await waitForCallbackParams(() => callbackParams);
 
       close();
 
@@ -313,6 +303,11 @@ export class AntigravityService {
     } catch (error) {
       spinner.fail(`Failed: ${error.message}`);
       throw error;
+    } finally {
+      // Every failure between here and the inline close() used to leak the
+      // callback server: the timeout, a callback carrying an error, a failed
+      // token exchange. Closing twice is a no-op.
+      closeServer?.();
     }
   }
 }

--- a/src/lib/oauth/services/codex.js
+++ b/src/lib/oauth/services/codex.js
@@ -2,7 +2,7 @@ import open from "open";
 import { OAuthService } from "./oauth.js";
 import { CODEX_CONFIG } from "../constants/oauth.js";
 import { getServerCredentials } from "../config/index.js";
-import { startLocalServer } from "../utils/server.js";
+import { startLocalServer, waitForCallbackParams } from "../utils/server.js";
 import { generatePKCE } from "../utils/pkce.js";
 import { spinner as createSpinner } from "../utils/ui.js";
 
@@ -72,6 +72,7 @@ export class CodexService extends OAuthService {
   async connect() {
     const spinner = createSpinner("Starting Codex OAuth...").start();
 
+    let closeServer = null;
     try {
       spinner.text = "Starting local server...";
 
@@ -81,6 +82,7 @@ export class CodexService extends OAuthService {
       const { port, close } = await startLocalServer((params) => {
         callbackParams = params;
       }, fixedPort);
+      closeServer = close;
 
       const redirectUri = `http://localhost:${port}/auth/callback`;
       spinner.succeed(`Local server started on port ${port}`);
@@ -100,19 +102,7 @@ export class CodexService extends OAuthService {
       // Wait for callback
       spinner.start("Waiting for OpenAI authorization...");
 
-      await new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error("Authentication timeout (5 minutes)"));
-        }, 300000);
-
-        const checkInterval = setInterval(() => {
-          if (callbackParams) {
-            clearInterval(checkInterval);
-            clearTimeout(timeout);
-            resolve();
-          }
-        }, 100);
-      });
+      await waitForCallbackParams(() => callbackParams);
 
       close();
 
@@ -139,6 +129,11 @@ export class CodexService extends OAuthService {
     } catch (error) {
       spinner.fail(`Failed: ${error.message}`);
       throw error;
+    } finally {
+      // Every failure between here and the inline close() used to leak the
+      // callback server: the timeout, a callback carrying an error, a failed
+      // token exchange. Closing twice is a no-op.
+      closeServer?.();
     }
   }
 }

--- a/src/lib/oauth/services/gemini.js
+++ b/src/lib/oauth/services/gemini.js
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import open from "open";
 import { GEMINI_CONFIG, getOAuthClientMetadata } from "../constants/oauth.js";
 import { getServerCredentials } from "../config/index.js";
-import { startLocalServer } from "../utils/server.js";
+import { startLocalServer, waitForCallbackParams } from "../utils/server.js";
 import { spinner as createSpinner } from "../utils/ui.js";
 
 /**
@@ -158,6 +158,7 @@ export class GeminiCLIService {
   async connect() {
     const spinner = createSpinner("Starting Gemini OAuth...").start();
 
+    let closeServer = null;
     try {
       spinner.text = "Starting local server...";
 
@@ -166,6 +167,7 @@ export class GeminiCLIService {
       const { port, close } = await startLocalServer((params) => {
         callbackParams = params;
       });
+      closeServer = close;
 
       const redirectUri = `http://localhost:${port}/callback`;
       spinner.succeed(`Local server started on port ${port}`);
@@ -185,19 +187,7 @@ export class GeminiCLIService {
       // Wait for callback
       spinner.start("Waiting for Google authorization...");
 
-      await new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error("Authentication timeout (5 minutes)"));
-        }, 300000);
-
-        const checkInterval = setInterval(() => {
-          if (callbackParams) {
-            clearInterval(checkInterval);
-            clearTimeout(timeout);
-            resolve();
-          }
-        }, 100);
-      });
+      await waitForCallbackParams(() => callbackParams);
 
       close();
 
@@ -234,6 +224,11 @@ export class GeminiCLIService {
     } catch (error) {
       spinner.fail(`Failed: ${error.message}`);
       throw error;
+    } finally {
+      // Every failure between here and the inline close() used to leak the
+      // callback server: the timeout, a callback carrying an error, a failed
+      // token exchange. Closing twice is a no-op.
+      closeServer?.();
     }
   }
 }

--- a/src/lib/oauth/services/iflow.js
+++ b/src/lib/oauth/services/iflow.js
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import open from "open";
 import { IFLOW_CONFIG } from "../constants/oauth.js";
 import { getServerCredentials } from "../config/index.js";
-import { startLocalServer } from "../utils/server.js";
+import { startLocalServer, waitForCallbackParams } from "../utils/server.js";
 import { spinner as createSpinner } from "../utils/ui.js";
 
 /**
@@ -125,6 +125,7 @@ export class IFlowService {
   async connect() {
     const spinner = createSpinner("Starting iFlow OAuth...").start();
 
+    let closeServer = null;
     try {
       spinner.text = "Starting local server...";
 
@@ -133,6 +134,7 @@ export class IFlowService {
       const { port, close } = await startLocalServer((params) => {
         callbackParams = params;
       });
+      closeServer = close;
 
       const redirectUri = `http://localhost:${port}/callback`;
       spinner.succeed(`Local server started on port ${port}`);
@@ -152,19 +154,7 @@ export class IFlowService {
       // Wait for callback
       spinner.start("Waiting for iFlow authorization...");
 
-      await new Promise((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error("Authentication timeout (5 minutes)"));
-        }, 300000);
-
-        const checkInterval = setInterval(() => {
-          if (callbackParams) {
-            clearInterval(checkInterval);
-            clearTimeout(timeout);
-            resolve();
-          }
-        }, 100);
-      });
+      await waitForCallbackParams(() => callbackParams);
 
       close();
 
@@ -196,6 +186,11 @@ export class IFlowService {
     } catch (error) {
       spinner.fail(`Failed: ${error.message}`);
       throw error;
+    } finally {
+      // Every failure between here and the inline close() used to leak the
+      // callback server: the timeout, a callback carrying an error, a failed
+      // token exchange. Closing twice is a no-op.
+      closeServer?.();
     }
   }
 }

--- a/src/lib/oauth/services/oauth.js
+++ b/src/lib/oauth/services/oauth.js
@@ -1,5 +1,5 @@
 import open from "open";
-import { startLocalServer } from "../utils/server.js";
+import { startLocalServer, waitForCallbackParams } from "../utils/server.js";
 import { generatePKCE } from "../utils/pkce.js";
 import { spinner as createSpinner } from "../utils/ui.js";
 import { OAUTH_TIMEOUT } from "../constants/oauth.js";
@@ -51,22 +51,13 @@ export class OAuthService {
       waitForCallback: async () => {
         spinner.start(`Waiting for ${providerName} authorization...`);
 
-        await new Promise((resolve, reject) => {
-          const timeout = setTimeout(() => {
-            reject(new Error("Authentication timeout (5 minutes)"));
-          }, OAUTH_TIMEOUT);
-
-          const checkInterval = setInterval(() => {
-            if (callbackParams) {
-              clearInterval(checkInterval);
-              clearTimeout(timeout);
-              resolve();
-            }
-          }, 100);
-        });
-
-        spinner.stop();
-        close();
+        try {
+          await waitForCallbackParams(() => callbackParams, OAUTH_TIMEOUT);
+        } finally {
+          // A timed-out wait used to return without ever closing the callback server.
+          spinner.stop();
+          close();
+        }
 
         if (callbackParams.error) {
           throw new Error(callbackParams.error_description || callbackParams.error);

--- a/src/lib/oauth/utils/server.js
+++ b/src/lib/oauth/utils/server.js
@@ -1,6 +1,6 @@
 import http from "http";
 import { URL } from "url";
-import { CODEX_CONFIG, TRAE_CONFIG, WINDSURF_CONFIG, ZED_HOSTED_CONFIG } from "../constants/oauth.js";
+import { CODEX_CONFIG, OAUTH_TIMEOUT, TRAE_CONFIG, WINDSURF_CONFIG, ZED_HOSTED_CONFIG } from "../constants/oauth.js";
 
 // Loopback origin guard for local callback proxies.
 // Legit OAuth redirects are top-level navigations (no `Origin` header); a cross-site
@@ -93,6 +93,42 @@ export function startLocalServer(onCallback, fixedPort = null) {
         reject(err);
       }
     });
+  });
+}
+
+/**
+ * Poll until the OAuth callback has stored its params, or give up.
+ *
+ * Both timers are cleared on every exit. The hand-rolled copies of this loop
+ * cleared them only on the success branch, so a wait that timed out left a
+ * 100ms interval running for the life of the process.
+ *
+ * @param {Function} getParams - Returns the callback params once they arrive
+ * @param {number} timeoutMs - Deadline in milliseconds
+ * @param {number} pollMs - Poll period in milliseconds
+ * @returns {Promise<Object>} - Callback params
+ */
+export function waitForCallbackParams(getParams, timeoutMs = OAUTH_TIMEOUT, pollMs = 100) {
+  return new Promise((resolve, reject) => {
+    let interval = null;
+    let timeout = null;
+    const stop = () => {
+      if (interval) { clearInterval(interval); interval = null; }
+      if (timeout) { clearTimeout(timeout); timeout = null; }
+    };
+
+    timeout = setTimeout(() => {
+      stop();
+      reject(new Error("Authentication timeout (5 minutes)"));
+    }, timeoutMs);
+
+    interval = setInterval(() => {
+      const params = getParams();
+      if (params) {
+        stop();
+        resolve(params);
+      }
+    }, pollMs);
   });
 }
 

--- a/tests/unit/oauth-callback-wait.test.js
+++ b/tests/unit/oauth-callback-wait.test.js
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import http from "http";
+import { startLocalServer, waitForCallbackParams } from "../../src/lib/oauth/utils/server.js";
+
+describe("waitForCallbackParams", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("resolves with the params once the callback stores them", async () => {
+    let params = null;
+    const waiting = waitForCallbackParams(() => params, 300000);
+    await vi.advanceTimersByTimeAsync(250);
+    params = { code: "abc", state: "xyz" };
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(waiting).resolves.toEqual({ code: "abc", state: "xyz" });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("leaves no timer behind when the wait times out", async () => {
+    const waiting = waitForCallbackParams(() => null, 300000);
+    const rejected = expect(waiting).rejects.toThrow(/Authentication timeout/);
+    await vi.advanceTimersByTimeAsync(300000);
+    await rejected;
+    // The hand-rolled loops cleared their interval only on the success branch,
+    // so a timed-out wait kept polling every 100ms for the life of the process.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops polling as soon as it settles", async () => {
+    let calls = 0;
+    const waiting = waitForCallbackParams(() => (++calls >= 3 ? { code: "ok" } : null), 300000);
+    await vi.advanceTimersByTimeAsync(300);
+    await waiting;
+    const settledAt = calls;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(calls).toBe(settledAt);
+  });
+});
+
+// The callback server is bound to a port; a flow that gives up without closing
+// it holds that port until the process exits. Codex uses a fixed port (1455),
+// so the leak turns the next attempt into EADDRINUSE.
+function isListening(port) {
+  return new Promise((resolve) => {
+    const probe = http.createServer(() => {});
+    probe.once("error", (err) => resolve(err.code === "EADDRINUSE"));
+    probe.listen(port, "127.0.0.1", () => probe.close(() => resolve(false)));
+  });
+}
+
+describe("startLocalServer", () => {
+  it("frees the port once closed, and tolerates a second close", async () => {
+    const { port, close } = await startLocalServer(() => {});
+    expect(await isListening(port)).toBe(true);
+    close();
+    expect(() => close()).not.toThrow();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(await isListening(port)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Five browser OAuth flows — `antigravity`, `codex`, `gemini`, `iflow`, and the generic `OAuthService` — wait for the loopback callback with the same hand-rolled loop:

```js
await new Promise((resolve, reject) => {
  const timeout = setTimeout(() => {
    reject(new Error("Authentication timeout (5 minutes)"));
  }, 300000);

  const checkInterval = setInterval(() => {
    if (callbackParams) {
      clearInterval(checkInterval);   // success branch only
      clearTimeout(timeout);
      resolve();
    }
  }, 100);
});
```

**The interval is cleared only when the callback arrives.** If the user closes the browser tab, denies consent, or just walks away, the timeout rejects and the interval keeps firing every 100ms — a ref'd timer, so it also keeps the event loop alive.

**The callback server leaks with it.** In `antigravity`, `codex`, `gemini` and `iflow`, `close()` sits in the middle of `connect()` and the surrounding `try` has only a `catch` that re-throws:

```js
const { port, close } = await startLocalServer(...);
...
close();                     // never reached if anything above threw
...
} catch (error) {
  spinner.fail(...);
  throw error;
}                            // no finally
```

So the timeout — and every later failure: a callback carrying `error`, a missing `code`, a failed token exchange, `loadCodeAssist` throwing "No Google Cloud Project found" — leaves the HTTP server bound. `OAuthService.startAuthFlow` has the narrower version of the same hole: it closes after the wait, so only the timeout path leaks.

For the dynamic-port flows that is a port and fd held until the process exits. **`codex` binds the fixed port 1455** (`CODEX_CONFIG.fixedPort`), and `startLocalServer` turns a busy fixed port into a hard error, so one abandoned Codex login makes the next one fail:

```
Port 1455 is already in use. Please close other applications using this port.
```

The fixed-port proxies in the same file (`startCodexProxy`, `startXaiProxy`, `startTraeProxy`, `startWindsurfProxy`, `startZedProxy`) already clear their timeout and close their server in a `stop*()` helper. It is only these five that don't.

## Fix

One helper in `src/lib/oauth/utils/server.js` that clears both timers on every exit:

```js
export function waitForCallbackParams(getParams, timeoutMs = OAUTH_TIMEOUT, pollMs = 100) {
  ...
  const stop = () => { if (interval) {...} if (timeout) {...} };
  timeout = setTimeout(() => { stop(); reject(...); }, timeoutMs);
  interval = setInterval(() => { const params = getParams(); if (params) { stop(); resolve(params); } }, pollMs);
}
```

and a `finally` at each call site so `close()` always runs. The existing mid-function `close()` calls stay where they are — a second `server.close()` is a no-op in Node (verified: no throw, no `error` event), so the success path is byte-for-byte the same flow it was.

Net: 74 lines removed, 83 added, most of that the helper and its docs.

## Verification

`tests/unit/oauth-callback-wait.test.js`, 4 tests, fake timers plus one real socket:

- resolves with the params, no timer left behind
- **times out and leaves no timer behind** — the assertion the old loops fail
- stops calling `getParams` once settled
- `startLocalServer`: the port is free after `close()`, and a second `close()` does not throw

Removing the `stop()` from the timeout branch (i.e. restoring the old behaviour):

```
FAIL  unit/oauth-callback-wait.test.js > waitForCallbackParams > leaves no timer behind when the wait times out
AssertionError: expected 1 to be +0
Tests  1 failed | 3 passed (4)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1914 | 95 |

Identical failure sets — `comm` on the sorted full test names returns nothing in either direction. The 95 are pre-existing and unrelated. `eslint` clean on all six changed files.

The interactive halves (a real browser round-trip, a real 5-minute timeout) I could not run end to end; what is verified is the timer and socket behaviour the flows depend on.

## One thing I left alone

`src/lib/oauth/utils/server.js` also exports a `waitForCallback(timeoutMs)` that never settles on success — it assigns `resolve.__onCallback = onCallback` instead of calling `resolve`, so the only way out is the timeout rejection. Nothing imports it (`grep` across `src/`, `cli/`, `open-sse/`, `tests/` finds only the definition and the unrelated local one in `oauth.js`). I did not touch it here to keep this change to the leak; happy to remove it in a follow-up if you'd like.