### PR TITLE
fix(usage): stop dropping requests that share a millisecond

### DIFF
--- a/src/lib/db/repos/usageRepo.js
+++ b/src/lib/db/repos/usageRepo.js
@@ -254,27 +254,37 @@ export async function saveRequestUsage(entry) {
     // All 3 writes (history insert, daily upsert, lifetime counter) in ONE transaction.
     // better-sqlite3 is sync → no JS yield mid-transaction → no race in same process.
     db.transaction(() => {
-      const existing = db.get(
-        `SELECT id, endpoint FROM usageHistory
-         WHERE timestamp = ?
-           AND COALESCE(provider, '') = COALESCE(?, '')
-           AND COALESCE(model, '') = COALESCE(?, '')
-           AND COALESCE(connectionId, '') = COALESCE(?, '')
-           AND COALESCE(apiKey, '') = COALESCE(?, '')
-           AND promptTokens = ?
-           AND completionTokens = ?
-         ORDER BY id DESC LIMIT 1`,
-        [
-          entry.timestamp, entry.provider || null, entry.model || null,
-          entry.connectionId || null, entry.apiKey || null,
-          promptTokens, completionTokens,
-        ]
-      );
+      // Back-fill only: a row written earlier without its endpoint is the same
+      // request arriving again with one, so complete it instead of inserting.
+      //
+      // The match is deliberately limited to endpoint-less rows. `timestamp` is
+      // an ISO string with millisecond resolution, so matching on the value
+      // tuple alone also swallows genuinely distinct requests that share a
+      // millisecond — same provider, model, connection and token counts. That is
+      // ordinary under parallel load and cost real usage rows plus their
+      // totalRequestsLifetime increments.
+      const backfill = entry.endpoint
+        ? db.get(
+          `SELECT id FROM usageHistory
+           WHERE timestamp = ?
+             AND COALESCE(provider, '') = COALESCE(?, '')
+             AND COALESCE(model, '') = COALESCE(?, '')
+             AND COALESCE(connectionId, '') = COALESCE(?, '')
+             AND COALESCE(apiKey, '') = COALESCE(?, '')
+             AND promptTokens = ?
+             AND completionTokens = ?
+             AND COALESCE(endpoint, '') = ''
+           ORDER BY id DESC LIMIT 1`,
+          [
+            entry.timestamp, entry.provider || null, entry.model || null,
+            entry.connectionId || null, entry.apiKey || null,
+            promptTokens, completionTokens,
+          ]
+        )
+        : null;
 
-      if (existing) {
-        if (!existing.endpoint && entry.endpoint) {
-          db.run(`UPDATE usageHistory SET endpoint = ? WHERE id = ?`, [entry.endpoint, existing.id]);
-        }
+      if (backfill) {
+        db.run(`UPDATE usageHistory SET endpoint = ? WHERE id = ?`, [entry.endpoint, backfill.id]);
         return;
       }
 

--- a/tests/unit/usage-row-dedupe.test.js
+++ b/tests/unit/usage-row-dedupe.test.js
@@ -1,0 +1,72 @@
+// The usageHistory writer collapses a repeated save into the row it already
+// holds. The match has to stay narrow: `timestamp` is an ISO string with
+// millisecond resolution, so anything wider also swallows distinct requests
+// that happen to share a millisecond.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+let tempDir;
+let db;
+
+beforeAll(async () => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "9router-dedupe-"));
+  process.env.DATA_DIR = tempDir;
+  vi.resetModules();
+  db = await import("@/lib/db/index.js");
+  await db.initDb();
+});
+
+afterAll(() => {
+  try { if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* windows keeps the sqlite file open */ }
+});
+
+const entry = (provider, extra = {}) => ({
+  provider, model: "m", connectionId: "c1",
+  tokens: { prompt_tokens: 10, completion_tokens: 5 },
+  status: "ok", ...extra,
+});
+
+describe("usageHistory row identity", () => {
+  it("keeps every request that shares a millisecond with another", async () => {
+    const timestamp = new Date().toISOString();
+    const N = 25;
+    await Promise.all(Array.from({ length: N }, () =>
+      db.saveRequestUsage(entry("same-ms", { timestamp, endpoint: "/v1/chat" }))));
+
+    const rows = await db.getUsageHistory({ provider: "same-ms" });
+    // Matching on the value tuple alone kept exactly one of these.
+    expect(rows.length).toBe(N);
+
+    const stats = await db.getUsageStats("24h");
+    expect(stats.byProvider["same-ms"].requests).toBe(N);
+    expect(stats.byProvider["same-ms"].promptTokens).toBe(N * 10);
+  });
+
+  it("keeps them when they carry no endpoint either", async () => {
+    const timestamp = new Date().toISOString();
+    await Promise.all([
+      db.saveRequestUsage(entry("no-endpoint", { timestamp })),
+      db.saveRequestUsage(entry("no-endpoint", { timestamp })),
+    ]);
+    expect((await db.getUsageHistory({ provider: "no-endpoint" })).length).toBe(2);
+  });
+
+  it("still completes a row that was written without its endpoint", async () => {
+    const timestamp = new Date().toISOString();
+    await db.saveRequestUsage(entry("backfill", { timestamp }));
+    await db.saveRequestUsage(entry("backfill", { timestamp, endpoint: "/v1/messages" }));
+
+    const rows = await db.getUsageHistory({ provider: "backfill" });
+    expect(rows.length).toBe(1);
+    expect(rows[0].endpoint).toBe("/v1/messages");
+  });
+
+  it("does not fold a later request into an unrelated endpoint-less row", async () => {
+    const timestamp = new Date().toISOString();
+    await db.saveRequestUsage(entry("distinct", { timestamp, model: "a" }));
+    await db.saveRequestUsage(entry("distinct", { timestamp, model: "b", endpoint: "/v1/chat" }));
+    expect((await db.getUsageHistory({ provider: "distinct" })).length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Problem

`tests/unit/db-concurrent.test.js` has been failing on `master`:

```
FAIL  DB Concurrency — atomic safety > 100 parallel saveRequestUsage → no count loss
      AssertionError: expected 2 to be 100
FAIL  DB Concurrency — atomic safety > mixed concurrent: usage + details + connections + aliases
      AssertionError: expected 37 to be 50
FAIL  DB Concurrency — atomic safety > daily summary aggregates correctly under parallel writes
      AssertionError: expected 1 to be 50
```

It is not a transaction race — the driver is native `better-sqlite3` and the comment above the transaction is right that a sync driver cannot yield mid-transaction. It is the dedupe query at the top of it:

```js
const existing = db.get(
  `SELECT id, endpoint FROM usageHistory
   WHERE timestamp = ? AND ...provider/model/connectionId/apiKey...
     AND promptTokens = ? AND completionTokens = ?
   ORDER BY id DESC LIMIT 1`, [...]);

if (existing) {
  if (!existing.endpoint && entry.endpoint) {
    db.run(`UPDATE usageHistory SET endpoint = ? WHERE id = ?`, ...);
  }
  return;          // ← every other case: the row is silently dropped
}
```

`entry.timestamp` is an ISO 8601 string, so `timestamp = ?` is only **millisecond**-precise. Two genuinely different requests to the same model on the same connection that return the same prompt/completion counts within the same millisecond match this predicate, and the second one is thrown away — along with its `totalRequestsLifetime` increment and its `usageDaily` aggregation.

Every production write reaches this through `saveUsageStats`, which stamps `timestamp: new Date().toISOString()` at save time, so nothing upstream keeps them apart.

Measured directly, 100 concurrent `saveRequestUsage` calls on a fresh DB:

| timestamps | rows kept |
|---|---|
| distinct (`base + i` ms) | 100 / 100 |
| identical | **1 / 100** |

The repo's own test sees 2, 14 or 1 depending on where the millisecond boundary lands mid-loop, which is why the numbers move between runs.

## Fix

The only thing that branch ever *did* was back-fill an endpoint onto a row that was written without one. Everything else was a silent drop. So match only the rows that case is about:

```js
const backfill = entry.endpoint
  ? db.get(`SELECT id FROM usageHistory WHERE ... AND COALESCE(endpoint, '') = '' ORDER BY id DESC LIMIT 1`, [...])
  : null;

if (backfill) {
  db.run(`UPDATE usageHistory SET endpoint = ? WHERE id = ?`, [entry.endpoint, backfill.id]);
  return;
}
```

- endpoint-less row, then the same request again carrying an endpoint → still completed in place, one row **(unchanged)**
- two real requests sharing a millisecond → both stored **(was: one)**
- two endpoint-less requests sharing a millisecond → both stored **(was: one)**

## What this trades away

If some path really does save the *same* request twice with an endpoint both times, it is now counted twice. That path was already only collapsed when both saves landed in the same millisecond — one millisecond later the old code double-counted too — so this makes the behaviour consistent rather than timing-dependent. I could not find such a path: each of `streamingHandler`, `nonStreamingHandler` and `sseToJsonHandler` calls `saveUsageStats` once per request on mutually exclusive branches, and no test covers a double save. If one exists, the durable fix is a per-request id in the dedupe key rather than a value tuple — happy to do that instead if you can point me at it.

## Verification

`tests/unit/usage-row-dedupe.test.js`, 4 tests against a real temp-dir SQLite: requests sharing a millisecond survive (with and without an endpoint), the endpoint back-fill still collapses to one row, and a different model in the same millisecond is not folded into an endpoint-less row.

Restoring the wide match:

```
FAIL  unit/db-concurrent.test.js > 100 parallel saveRequestUsage → no count loss
FAIL  unit/db-concurrent.test.js > mixed concurrent: usage + details + connections + aliases
FAIL  unit/db-concurrent.test.js > daily summary aggregates correctly under parallel writes
FAIL  unit/usage-row-dedupe.test.js > keeps every request that shares a millisecond with another
FAIL  unit/usage-row-dedupe.test.js > keeps them when they carry no endpoint either
Tests  5 failed | 7 passed (12)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1914 | 92 |

The three that flipped to passing are exactly the `db-concurrent` ones above — `comm` on the sorted full test names shows nothing added. `eslint` clean.

(`db-concurrent.test.js` also reports a suite-level `EBUSY ... unlink data.sqlite` during `afterAll` on Windows, because the SQLite handle is still open when the temp dir is removed. That is pre-existing, platform-specific and unrelated; I left it alone.)