### PR TITLE
fix(stream): parse the trailing NDJSON line an Ollama stream leaves behind

### DIFF
--- a/open-sse/utils/stream.js
+++ b/open-sse/utils/stream.js
@@ -387,8 +387,16 @@ export function createSSEStream(options = {}) {
         }
 
         if (buffer.trim()) {
-          const parsed = parseSSELine(buffer.trim());
-          if (parsed && !parsed.done) {
+          // Same parse as the transform loop: without targetFormat this only
+          // accepts "data: " lines, so an NDJSON provider (Ollama) lost whatever
+          // arrived without its closing newline.
+          const parsed = parseSSELine(buffer.trim(), targetFormat);
+          // parseSSELine turns the SSE sentinel "data: [DONE]" into { done: true },
+          // which must not be translated. An Ollama chunk also carries done:true,
+          // but it is the real final chunk — it holds finish_reason and the token
+          // counts — so it has to go through.
+          const isDoneSentinel = parsed?.done && targetFormat !== FORMATS.OLLAMA;
+          if (parsed && !isDoneSentinel) {
             const translated = translateResponse(targetFormat, sourceFormat, parsed, state);
 
             if (translated?._openaiIntermediate) {

--- a/tests/unit/ollama-stream-tail.test.js
+++ b/tests/unit/ollama-stream-tail.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { FORMATS } from "../../open-sse/translator/formats.js";
+import { createSSETransformStreamWithLogger } from "../../open-sse/utils/stream.js";
+
+// Ollama streams NDJSON — one raw JSON object per line, no "data: " prefix.
+// Whatever arrives without a closing newline stays in the line buffer and is
+// only parsed when the transform flushes.
+async function runOllamaStream(input) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(input));
+      controller.close();
+    },
+  });
+
+  const output = stream.pipeThrough(
+    createSSETransformStreamWithLogger(FORMATS.OLLAMA, FORMATS.OPENAI, "ollama", null, null, "gpt-oss:120b"),
+  );
+
+  const reader = output.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+const chunk = (content, done = false) => JSON.stringify({
+  model: "gpt-oss:120b",
+  created_at: "2026-08-25T00:00:00Z",
+  message: { role: "assistant", content },
+  done,
+  ...(done ? { done_reason: "stop", prompt_eval_count: 11, eval_count: 7 } : {}),
+});
+
+const deltas = (sse) => sse
+  .split("\n")
+  .filter((l) => l.startsWith("data: ") && l !== "data: [DONE]")
+  .map((l) => JSON.parse(l.slice(6)));
+
+describe("Ollama NDJSON stream: the tail left in the line buffer", () => {
+  it("delivers a content chunk that arrived without its newline", async () => {
+    const out = await runOllamaStream([chunk("hello"), chunk(" world")].join("\n"));
+    const content = deltas(out).map((c) => c.choices?.[0]?.delta?.content || "").join("");
+    expect(content).toBe("hello world");
+  });
+
+  it("delivers the final chunk — finish_reason and usage — when it arrives without its newline", async () => {
+    const out = await runOllamaStream([chunk("hello"), chunk("", true)].join("\n"));
+    const last = deltas(out).at(-1);
+    expect(last.choices[0].finish_reason).toBe("stop");
+    expect(last.usage).toEqual({ prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 });
+  });
+
+  it("is unchanged when every line is newline-terminated", async () => {
+    const out = await runOllamaStream(`${[chunk("hello"), chunk(" world"), chunk("", true)].join("\n")}\n`);
+    const parsed = deltas(out);
+    expect(parsed.map((c) => c.choices?.[0]?.delta?.content || "").join("")).toBe("hello world");
+    expect(parsed.at(-1).choices[0].finish_reason).toBe("stop");
+    expect(parsed.at(-1).usage.total_tokens).toBe(18);
+  });
+});
+
+describe("SSE providers keep their sentinel handling", () => {
+  it("does not translate a trailing data: [DONE]", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(
+          `data: ${JSON.stringify({ choices: [{ delta: { content: "hi" } }] })}\ndata: [DONE]`,
+        ));
+        controller.close();
+      },
+    });
+    const out = stream.pipeThrough(
+      createSSETransformStreamWithLogger(FORMATS.OPENAI, FORMATS.OPENAI, "openai", null, null, "gpt-4o"),
+    );
+    const reader = out.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    expect(text).toContain('"content":"hi"');
+    // The sentinel is a framing marker, not a chunk — it must not be translated.
+    expect(text).not.toContain('"done":true');
+  });
+});


### PR DESCRIPTION
## Problem

`createSSEStream` splits incoming bytes on `\n` and keeps the remainder:

```js
const lines = buffer.split("\n");
buffer = lines.pop() || "";
```

Whatever the upstream sent without a closing newline stays in `buffer` and is only parsed in `flush()`. The transform loop parses with the format:

```js
const parsed = parseSSELine(trimmed, targetFormat);     // line 211
```

the flush does not:

```js
const parsed = parseSSELine(buffer.trim());             // line 390
if (parsed && !parsed.done) { ... }
```

`parseSSELine` only reads raw JSON lines when it is told the format is `ollama`; otherwise it requires the `data: ` prefix and returns `null`. Ollama speaks NDJSON, so its tail is discarded.

The guard on the next line compounds it. `parseSSELine` maps the SSE sentinel `data: [DONE]` to `{ done: true }`, which must not be translated — but an Ollama chunk *also* carries `done: true`, and that one is the real final chunk: it holds `done_reason` and `prompt_eval_count`/`eval_count`. `!parsed.done` cannot tell the two apart.

Measured against the current transform, feeding two NDJSON lines where the second has no trailing newline:

| input tail | client receives |
|---|---|
| `{"message":{"content":" world"},"done":false}` | only `hello` — the last token is gone |
| `{"message":{"content":""},"done":true,"done_reason":"stop","prompt_eval_count":11,"eval_count":7}` | only `hello` — **no `finish_reason`, no `usage`** |

The second is the one that hurts: an OpenAI-format client gets a stream that stops without a terminating chunk, and the token counts never reach `logUsage`.

## Fix

Give the flush the same information the loop has, and let the sentinel check depend on the format that actually produces a sentinel:

```js
const parsed = parseSSELine(buffer.trim(), targetFormat);
const isDoneSentinel = parsed?.done && targetFormat !== FORMATS.OLLAMA;
if (parsed && !isDoneSentinel) { ... }
```

Nothing changes for SSE providers: they still reach `parseSSELine` with the same argument they got before for every non-Ollama `targetFormat`, and a trailing `data: [DONE]` is still skipped.

## Verification

`tests/unit/ollama-stream-tail.test.js`, 4 tests driving the real `createSSETransformStreamWithLogger` (`ollama` → `openai`):

- a content chunk with no trailing newline arrives → full text `hello world`
- the final chunk with no trailing newline arrives → `finish_reason: "stop"` and `usage {11, 7, 18}`
- a fully newline-terminated stream is unchanged
- an OpenAI stream ending in `data: [DONE]` still does not translate the sentinel

Reverting both lines to `parseSSELine(buffer.trim())` / `!parsed.done`:

```
FAIL  delivers a content chunk that arrived without its newline
FAIL  delivers the final chunk — finish_reason and usage — when it arrives without its newline
Tests  2 failed | 2 passed (4)
```

The sentinel test passes either way, which is the point — it is there to catch a regression in the other direction.

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1914 | 95 |

Identical failure sets — `comm` on the sorted full test names returns nothing either way. `eslint` clean.

I have no Ollama instance wired up here, so this is verified against the transform rather than a live server; the NDJSON shape used in the tests is the one `ollama-to-openai.js` already parses (`message.content`, `done`, `done_reason`, `prompt_eval_count`, `eval_count`).