### PR TITLE
fix(ollama-compat): one decoder, one terminator, no dropped tail

### DIFF
--- a/open-sse/utils/ollamaTransform.js
+++ b/open-sse/utils/ollamaTransform.js
@@ -2,76 +2,93 @@
 export function transformToOllama(response, model) {
   let buffer = "";
   let pendingToolCalls = {};
-  
+  let doneSent = false;
+
+  // One decoder for the whole stream. A multi-byte character split across two
+  // network chunks has to be held until its remaining bytes arrive; decoding
+  // each chunk on its own turns both halves into replacement characters.
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  const encoder = new TextEncoder();
+
+  const emit = (controller, message, done) => {
+    controller.enqueue(encoder.encode(JSON.stringify({ model, message, done }) + "\n"));
+  };
+
+  // Ollama ends a stream with exactly one done:true message, and that message
+  // carries the tool calls when there are any. Emitting more than one leaves a
+  // client that keeps the last of them holding an empty message.
+  const emitDone = (controller, message) => {
+    if (doneSent) return;
+    doneSent = true;
+    emit(controller, message, true);
+  };
+
+  const handleLine = (line, controller) => {
+    if (!line.startsWith("data:")) return;
+    const data = line.slice(5).trim();
+
+    if (data === "[DONE]") {
+      emitDone(controller, { role: "assistant", content: "" });
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return; // Silently ignore parse errors
+    }
+
+    const delta = parsed.choices?.[0]?.delta || {};
+    const content = delta.content || "";
+    const toolCalls = delta.tool_calls;
+
+    if (toolCalls) {
+      for (const tc of toolCalls) {
+        const idx = tc.index;
+        if (!pendingToolCalls[idx]) {
+          pendingToolCalls[idx] = { id: tc.id, function: { name: "", arguments: "" } };
+        }
+        if (tc.function?.name) pendingToolCalls[idx].function.name += tc.function.name;
+        if (tc.function?.arguments) pendingToolCalls[idx].function.arguments += tc.function.arguments;
+      }
+    }
+
+    if (content) {
+      emit(controller, { role: "assistant", content }, false);
+    }
+
+    const finishReason = parsed.choices?.[0]?.finish_reason;
+    if (finishReason === "tool_calls" || finishReason === "stop") {
+      const toolCallsArr = Object.values(pendingToolCalls);
+      if (toolCallsArr.length > 0) {
+        const formattedCalls = toolCallsArr.map(tc => ({
+          function: {
+            name: tc.function.name,
+            arguments: (() => { try { return JSON.parse(tc.function.arguments || "{}"); } catch { return {}; } })()
+          }
+        }));
+        emitDone(controller, { role: "assistant", content: "", tool_calls: formattedCalls });
+        pendingToolCalls = {};
+      } else if (finishReason === "stop") {
+        emitDone(controller, { role: "assistant", content: "" });
+      }
+    }
+  };
+
   const transform = new TransformStream({
     transform(chunk, controller) {
-      const text = new TextDecoder().decode(chunk);
-      buffer += text;
+      buffer += decoder.decode(chunk, { stream: true });
       const lines = buffer.split("\n");
       buffer = lines.pop() || "";
 
-      for (const line of lines) {
-        if (!line.startsWith("data:")) continue;
-        const data = line.slice(5).trim();
-        
-        if (data === "[DONE]") {
-          const ollamaEnd = JSON.stringify({ model, message: { role: "assistant", content: "" }, done: true }) + "\n";
-          controller.enqueue(new TextEncoder().encode(ollamaEnd));
-          return;
-        }
-
-        try {
-          const parsed = JSON.parse(data);
-          const delta = parsed.choices?.[0]?.delta || {};
-          const content = delta.content || "";
-          const toolCalls = delta.tool_calls;
-
-          if (toolCalls) {
-            for (const tc of toolCalls) {
-              const idx = tc.index;
-              if (!pendingToolCalls[idx]) {
-                pendingToolCalls[idx] = { id: tc.id, function: { name: "", arguments: "" } };
-              }
-              if (tc.function?.name) pendingToolCalls[idx].function.name += tc.function.name;
-              if (tc.function?.arguments) pendingToolCalls[idx].function.arguments += tc.function.arguments;
-            }
-          }
-
-          if (content) {
-            const ollama = JSON.stringify({ model, message: { role: "assistant", content }, done: false }) + "\n";
-            controller.enqueue(new TextEncoder().encode(ollama));
-          }
-
-          const finishReason = parsed.choices?.[0]?.finish_reason;
-          if (finishReason === "tool_calls" || finishReason === "stop") {
-            const toolCallsArr = Object.values(pendingToolCalls);
-            if (toolCallsArr.length > 0) {
-              const formattedCalls = toolCallsArr.map(tc => ({
-                function: {
-                  name: tc.function.name,
-                  arguments: (() => { try { return JSON.parse(tc.function.arguments || "{}"); } catch { return {}; } })()
-                }
-              }));
-              const ollama = JSON.stringify({ 
-                model, 
-                message: { role: "assistant", content: "", tool_calls: formattedCalls }, 
-                done: true
-              }) + "\n";
-              controller.enqueue(new TextEncoder().encode(ollama));
-              pendingToolCalls = {};
-            } else if (finishReason === "stop") {
-              const ollamaEnd = JSON.stringify({ model, message: { role: "assistant", content: "" }, done: true }) + "\n";
-              controller.enqueue(new TextEncoder().encode(ollamaEnd));
-            }
-          }
-        } catch (e) {
-          // Silently ignore parse errors
-        }
-      }
+      for (const line of lines) handleLine(line, controller);
     },
     flush(controller) {
-      const ollamaEnd = JSON.stringify({ model, message: { role: "assistant", content: "" }, done: true }) + "\n";
-      controller.enqueue(new TextEncoder().encode(ollamaEnd));
+      // A last line that arrived without its newline is still a line.
+      buffer += decoder.decode();
+      if (buffer.trim()) handleLine(buffer.trim(), controller);
+      emitDone(controller, { role: "assistant", content: "" });
     }
   });
 
@@ -82,4 +99,3 @@ export function transformToOllama(response, model) {
     headers: { "Content-Type": "application/x-ndjson", "Access-Control-Allow-Origin": "*" }
   });
 }
-

--- a/tests/unit/ollama-compat-stream.test.js
+++ b/tests/unit/ollama-compat-stream.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { transformToOllama } from "../../open-sse/utils/ollamaTransform.js";
+
+// /api/chat serves 9router's Ollama-compatible surface: it takes the upstream
+// OpenAI SSE stream and re-emits it as Ollama NDJSON.
+function upstream(chunks) {
+  const enc = new TextEncoder();
+  return new Response(new ReadableStream({
+    start(c) {
+      for (const chunk of chunks) c.enqueue(typeof chunk === "string" ? enc.encode(chunk) : chunk);
+      c.close();
+    },
+  }), { status: 200 });
+}
+
+async function ndjson(response) {
+  const reader = response.body.getReader();
+  const dec = new TextDecoder();
+  let text = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += dec.decode(value, { stream: true });
+  }
+  text += dec.decode();
+  return text.split("\n").filter(Boolean).map((l) => JSON.parse(l));
+}
+
+const sse = (payload) => `data: ${JSON.stringify(payload)}\n`;
+const delta = (content) => sse({ choices: [{ delta: { content } }] });
+const finish = (reason) => sse({ choices: [{ delta: {}, finish_reason: reason } ] });
+
+describe("Ollama-compatible stream: text", () => {
+  it("survives a multi-byte character split across two network chunks", async () => {
+    const bytes = new TextEncoder().encode(delta("xin chào 世界"));
+    const cut = bytes.indexOf(0xe4); // first byte of 世
+    const out = await ndjson(transformToOllama(
+      upstream([bytes.slice(0, cut + 1), bytes.slice(cut + 1), finish("stop"), "data: [DONE]\n"]),
+      "m",
+    ));
+    // Decoding each chunk separately turned 世 into three replacement characters.
+    expect(out[0].message.content).toBe("xin chào 世界");
+  });
+
+  it("ends the stream with exactly one done:true", async () => {
+    const out = await ndjson(transformToOllama(
+      upstream([delta("hi"), finish("stop"), "data: [DONE]\n"]),
+      "m",
+    ));
+    expect(out.filter((m) => m.done).length).toBe(1);
+    expect(out.at(-1)).toEqual({ model: "m", message: { role: "assistant", content: "" }, done: true });
+  });
+
+  it("delivers a content line that arrived without its newline", async () => {
+    const out = await ndjson(transformToOllama(
+      upstream([delta("hello"), delta(" world").trimEnd()]),
+      "m",
+    ));
+    expect(out.filter((m) => !m.done).map((m) => m.message.content).join("")).toBe("hello world");
+  });
+});
+
+describe("Ollama-compatible stream: tool calls", () => {
+  it("keeps the tool calls on the one terminal message", async () => {
+    const out = await ndjson(transformToOllama(upstream([
+      sse({ choices: [{ delta: { tool_calls: [{ index: 0, id: "call_1", function: { name: "get_weather", arguments: '{"city":' } }] } }] }),
+      sse({ choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '"Hanoi"}' } }] } }] }),
+      finish("tool_calls"),
+      "data: [DONE]\n",
+    ]), "m"));
+
+    const terminal = out.filter((m) => m.done);
+    // The tool-call message used to be followed by two empty done:true lines, so
+    // a client that keeps the last terminal message lost the call.
+    expect(terminal.length).toBe(1);
+    expect(terminal[0].message.tool_calls).toEqual([
+      { function: { name: "get_weather", arguments: { city: "Hanoi" } } },
+    ]);
+  });
+});


### PR DESCRIPTION
## Context

`POST /api/v1/api/chat` is 9router's Ollama-compatible surface. It runs the upstream answer through `transformToOllama`, which re-frames OpenAI SSE as Ollama NDJSON. The file had no test coverage; three things are wrong with it.

## 1. Non-ASCII text is corrupted at chunk boundaries

```js
const text = new TextDecoder().decode(chunk);
```

A fresh decoder per chunk, and no `{ stream: true }`. A character whose UTF-8 bytes straddle two network chunks is decoded as two invalid fragments. Feeding `xin chào 世界` with the split placed on the first byte of `世`:

```json
{"model":"m","message":{"role":"assistant","content":"xin chào ���界"},"done":false}
```

The JSON stays well-formed, so nothing errors — the text is just wrong. `stream.js` already carries the fix for exactly this ("Per-stream decoder with stream:true to correctly handle multi-byte chars split across chunks"); this path never got it.

## 2. Three terminators per stream, and tool calls lost behind them

`done: true` is emitted from three places: `finish_reason`, `data: [DONE]`, and unconditionally from `flush()`. A plain text stream ends like this:

```json
{"message":{"content":"hi"},"done":false}
{"message":{"content":""},"done":true}
{"message":{"content":""},"done":true}
{"message":{"content":""},"done":true}
```

Real Ollama sends exactly one. It matters more than tidiness, because the terminal message is where Ollama puts the tool calls:

```json
{"message":{"content":"","tool_calls":[{"function":{"name":"get_weather","arguments":{"city":"Hanoi"}}}]},"done":true}
{"message":{"content":""},"done":true}
{"message":{"content":""},"done":true}
```

A client that keeps the **last** `done: true` message — a reasonable reading of a stream that ends with one — gets an empty message and never sees the call.

## 3. The line buffer is never drained

`transform()` keeps the remainder after the last `\n` in `buffer`, and `flush()` ignores it. A final line that arrived without its newline is dropped.

## Fix

- one `TextDecoder` for the stream, `decode(chunk, { stream: true })`, flushed in `flush()`
- `emitDone()` gated on a `doneSent` flag, so the first terminal message wins — which is the one carrying the tool calls
- `flush()` runs the leftover buffer through the same line handler before terminating

The per-line body moved into a `handleLine()` closure so the flush can reuse it; the parsing, tool-call accumulation and finish-reason logic are unchanged.

## Verification

`tests/unit/ollama-compat-stream.test.js`, 4 tests driving the real transform through a `ReadableStream`:

- a multi-byte character split across two chunks arrives intact
- a text stream ends with exactly one `done: true`
- a content line with no trailing newline is delivered
- the single terminal message still carries `tool_calls`

All four fail against the current file:

```
FAIL  survives a multi-byte character split across two network chunks
FAIL  ends the stream with exactly one done:true
FAIL  delivers a content line that arrived without its newline
FAIL  keeps the tool calls on the one terminal message
Tests  4 failed (4)
```

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1914 | 95 |

Identical failure sets — `comm` on the sorted full test names returns nothing either way. `eslint` clean.

Verified against the transform rather than a live Ollama client; the NDJSON shape asserted here is the one `translator/request/openai-to-ollama.js` and `translator/response/ollama-to-openai.js` already read and write.