### PR TITLE
fix(responses): keep one decoder for the stream and drain the last event

### DIFF
--- a/open-sse/transformer/responsesTransformer.js
+++ b/open-sse/transformer/responsesTransformer.js
@@ -239,10 +239,18 @@ export function createResponsesApiTransformStream(logger = null) {
     }
   };
 
-  return new TransformStream({
+  // One decoder for the whole stream: a multi-byte character split across two
+  // network chunks must be held until the rest of its bytes arrive, or both
+  // halves decode to replacement characters.
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  // Fed to the transform in flush() so a message left in the buffer without its
+  // blank-line terminator still goes through the normal path.
+  const SSE_MESSAGE_TERMINATOR = encoder.encode("\n\n");
+
+  const handlers = {
     transform(chunk, controller) {
-      const text = new TextDecoder().decode(chunk);
-      logger?.logInput(text.trim());
+      const text = decoder.decode(chunk, { stream: true });
+      if (text.trim()) logger?.logInput(text.trim());
       state.buffer += text;
 
       const messages = state.buffer.split("\n\n");
@@ -425,6 +433,9 @@ export function createResponsesApiTransformStream(logger = null) {
     },
 
     flush(controller) {
+      state.buffer += decoder.decode();
+      if (state.buffer.trim()) handlers.transform(SSE_MESSAGE_TERMINATOR, controller);
+
       for (const i in state.msgItemAdded) closeMessage(controller, i);
       closeReasoning(controller);
       for (const i in state.funcCallIds) closeToolCall(controller, i);
@@ -434,6 +445,8 @@ export function createResponsesApiTransformStream(logger = null) {
       controller.enqueue(encoder.encode("data: [DONE]\n\n"));
       logger?.flush();
     }
-  });
+  };
+
+  return new TransformStream(handlers);
 }
 

--- a/tests/unit/responses-transform-stream.test.js
+++ b/tests/unit/responses-transform-stream.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { createResponsesApiTransformStream } from "../../open-sse/transformer/responsesTransformer.js";
+
+// /v1/responses re-frames a chat-completions SSE stream as Responses API events
+// for clients like Codex CLI.
+async function runResponsesTransform(chunks) {
+  const enc = new TextEncoder();
+  const source = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(typeof chunk === "string" ? enc.encode(chunk) : chunk);
+      controller.close();
+    },
+  });
+
+  const out = source.pipeThrough(createResponsesApiTransformStream(null));
+  const reader = out.getReader();
+  const dec = new TextDecoder();
+  let text = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += dec.decode(value, { stream: true });
+  }
+  text += dec.decode();
+
+  return text
+    .split("\n")
+    .filter((l) => l.startsWith("data: ") && l !== "data: [DONE]")
+    .map((l) => JSON.parse(l.slice(6)));
+}
+
+const event = (payload) => `data: ${JSON.stringify(payload)}\n\n`;
+const contentDelta = (content) => event({ choices: [{ index: 0, delta: { content } }] });
+const stop = () => event({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] });
+const textOf = (events) => events
+  .filter((e) => e.type === "response.output_text.delta")
+  .map((e) => e.delta)
+  .join("");
+
+describe("Responses API transform", () => {
+  it("survives a multi-byte character split across two network chunks", async () => {
+    const bytes = new TextEncoder().encode(contentDelta("xin chào 世界"));
+    const cut = bytes.indexOf(0xe4); // first byte of 世
+    const events = await runResponsesTransform([bytes.slice(0, cut + 1), bytes.slice(cut + 1), stop()]);
+    // A fresh decoder per chunk turned 世 into three replacement characters.
+    expect(textOf(events)).toBe("xin chào 世界");
+  });
+
+  it("delivers an event that arrived without its blank-line terminator", async () => {
+    const events = await runResponsesTransform([contentDelta("hello") + contentDelta(" world").trimEnd()]);
+    expect(textOf(events)).toBe("hello world");
+  });
+
+  it("is unchanged for a well-formed stream", async () => {
+    const events = await runResponsesTransform([contentDelta("hello"), contentDelta(" world"), stop(), "data: [DONE]\n\n"]);
+    expect(textOf(events)).toBe("hello world");
+    expect(events.at(-1).type).toBe("response.completed");
+    expect(events.at(-1).response.status).toBe("completed");
+  });
+
+  it("emits one completed event, not one per flush path", async () => {
+    const events = await runResponsesTransform([contentDelta("hi"), stop(), "data: [DONE]\n\n"]);
+    expect(events.filter((e) => e.type === "response.completed").length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`createResponsesApiTransformStream` is what `/v1/responses` uses to re-frame a chat-completions SSE stream as Responses API events — the path a Codex-style client takes against any chat-native provider. Two defects, both in the framing rather than the translation.

### A new decoder per chunk

```js
transform(chunk, controller) {
  const text = new TextDecoder().decode(chunk);
```

No `{ stream: true }`, and a fresh decoder each time, so a character whose UTF-8 bytes land on either side of a chunk boundary is decoded as two invalid fragments. Splitting `xin chào 世界` on the first byte of `世`:

```json
{"type":"response.output_text.delta","delta":"xin chào ���界", ...}
```

Nothing throws — the delta is simply wrong. Every non-ASCII answer long enough to cross a chunk boundary is exposed, which in practice means most of them.

`utils/stream.js` already carries the fix for the same hazard ("Per-stream decoder with stream:true to correctly handle multi-byte chars split across chunks"); this transform never got it.

### The pending message is never drained

```js
const messages = state.buffer.split("\n\n");
state.buffer = messages.pop() || "";
```

`flush()` closes the open items and emits `[DONE]` without looking at `state.buffer`, so an upstream that ends without the final blank line loses its last event. Feeding `hello` then ` world` with no terminator after the second:

```
delta: "hello"      ← " world" never arrives
```

## Fix

- one `TextDecoder("utf-8", { fatal: false })` for the stream, used with `{ stream: true }`, flushed in `flush()`
- `flush()` feeds the leftover buffer a `\n\n` terminator through the same `transform`, so the pending message is parsed by the existing code rather than a second copy of it

The handler object is now named (`const handlers = {...}; return new TransformStream(handlers)`) purely so `flush` can call `handlers.transform`. That keeps the ~175-line message loop exactly where it was — the diff is 17 added / 4 removed lines, no re-indentation.

`logger?.logInput` is now guarded on non-empty text so the synthetic terminator does not log a blank line.

## Verification

`tests/unit/responses-transform-stream.test.js` — the first tests this transformer has:

- a multi-byte character split across two chunks arrives intact
- an event with no blank-line terminator is delivered
- a well-formed stream is unchanged and still ends in `response.completed`
- exactly one `response.completed` is emitted, not one per exit path

Against the current file:

```
FAIL  survives a multi-byte character split across two network chunks
FAIL  delivers an event that arrived without its blank-line terminator
Tests  2 failed | 2 passed (4)
```

The other two pass either way — they are there to catch a regression from the flush change, in particular a second `response.completed`.

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1914 | 95 |

Identical failure sets — `comm` on the sorted full test names returns nothing either way. `eslint` clean.