### PR TITLE
fix(tests): stop the headroom mock from breaking when an export is added

### DIFF
--- a/tests/unit/force-stream-config.test.js
+++ b/tests/unit/force-stream-config.test.js
@@ -68,9 +68,13 @@ vi.mock("../../open-sse/rtk/index.js", () => ({
   formatRtkLog: vi.fn(() => ""),
 }));
 
-vi.mock("../../open-sse/rtk/headroom.js", () => ({
+// Spread the real module: chatCore imports four things from here, and a factory
+// that lists only the ones it needed at the time breaks the whole file the next
+// time an export is added (it did — formatHeadroomSizeLog and
+// isHeadroomPhantomSavings). Only the call that would reach out is stubbed.
+vi.mock("../../open-sse/rtk/headroom.js", async (importOriginal) => ({
+  ...(await importOriginal()),
   compressWithHeadroom: vi.fn(async () => null),
-  formatHeadroomLog: vi.fn(() => ""),
 }));
 
 vi.mock("../../open-sse/providers/capabilities.js", () => ({


### PR DESCRIPTION
## Problem

`tests/unit/force-stream-config.test.js` mocks the headroom module with a factory that enumerates its exports:

```js
vi.mock("../../open-sse/rtk/headroom.js", () => ({
  compressWithHeadroom: vi.fn(async () => null),
  formatHeadroomLog: vi.fn(() => ""),
}));
```

`vi.mock` with a factory replaces the *whole* module, and `chatCore` imports four things from it:

```js
import { compressWithHeadroom, formatHeadroomLog, formatHeadroomSizeLog, isHeadroomPhantomSavings } from "../rtk/headroom.js";
```

So both of the file's JSON-client cases die on import, before asserting anything:

```
FAIL  keeps forced-stream providers streaming for JSON clients when body.stream is undefined
FAIL  keeps forced-stream providers streaming for JSON clients when body.stream is false
Error: [vitest] No "formatHeadroomSizeLog" export is defined on the
       "../../open-sse/rtk/headroom.js" mock. Did you forget to return it from "vi.mock"?
```

They are the cases that guard the actual behaviour the file is named for — that `forceStream` providers keep streaming for a client sending `Accept: application/json` with `stream` unset or `false`.

## Fix

Spread the real module and stub only the call the test needs to keep local:

```js
vi.mock("../../open-sse/rtk/headroom.js", async (importOriginal) => ({
  ...(await importOriginal()),
  compressWithHeadroom: vi.fn(async () => null),
}));
```

`formatHeadroomLog`, `formatHeadroomSizeLog` and `isHeadroomPhantomSavings` are pure formatters over a stats object — running the real ones is fine, and this shape does not break again the next time `headroom.js` grows an export. Adding the two missing names to the factory would fix today's failure and leave the trap in place.

## Verification

The file goes from 1 passing / 2 erroring to 3 passing.

Full offline suite (`vitest run unit auth translator`, `CI=true`, excluding `real/`), same command on both sides:

| | tests | failed |
|---|---|---|
| `origin/master` (699edac3) | 1910 | 95 |
| this branch | 1910 | 93 |

`comm` on the sorted full test names: the two above move to passing, nothing else changes. The other two files that mock `rtk/headroom.js` (`headroom.test.js`, `headroom-responses-format.test.js`) do not use a module factory and are green either way — 17 passing. `eslint` clean.